### PR TITLE
[fix][make] add linker flags to tests/demo_ivfpq_indexing target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,10 @@ tests/test_blas: tests/test_blas.cpp
 
 
 tests/demo_ivfpq_indexing: tests/demo_ivfpq_indexing.cpp $(LIBNAME).a
-	$(CC) -o $@ $(CFLAGS) -g -O3 $< $(LIBNAME).a  $(BLASLDFLAGS)
+	$(CC) -o $@ $(CFLAGS) -g -O3 $< $(LIBNAME).a $(LDFLAGS) $(BLASLDFLAGS)
 
 tests/demo_sift1M: tests/demo_sift1M.cpp $(LIBNAME).a
-	$(CC) -o $@ $(CFLAGS) $< $(LIBNAME).a  $(BLASLDFLAGS)
+	$(CC) -o $@ $(CFLAGS) $< $(LIBNAME).a $(BLASLDFLAGS)
 
 
 #############################


### PR DESCRIPTION
before:
```
/usr/local/opt/llvm/bin/clang++ -o tests/demo_ivfpq_indexing -fPIC -m64 -Wall -g -O3 -msse4 -mpopcnt -fopenmp -Wno-sign-compare -Dnullptr=NULL -I/usr/local/opt/llvm/include -Doverride= -g -O3 tests/demo_i
vfpq_indexing.cpp libfaiss.a  -framework Accelerate
ld: library not found for -lomp
clang-3.9: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [tests/demo_ivfpq_indexing] Error 1
```

after:
```
λ make
/usr/local/opt/llvm/bin/clang++ -o tests/demo_ivfpq_indexing -fPIC -m64 -Wall -g -O3 -msse4 -mpopcnt -fopenmp -Wno-sign-compare -Dnullptr=NULL -I/usr/local/opt/llvm/include -Doverride= -g -O3 tests/demo_i
vfpq_indexing.cpp libfaiss.a -g -fPIC -fopenmp -L/usr/local/opt/llvm/lib -framework Accelerate
# success
```