### PR TITLE
Changing a few settings for MKL on Ubuntu

### DIFF
--- a/example_makefiles/makefile.inc.Linux
+++ b/example_makefiles/makefile.inc.Linux
@@ -38,17 +38,18 @@ FAISSSHAREDFLAGS=-shared
 #
 #   https://software.intel.com/en-us/articles/intel-mkl-link-line-advisor
 #
-# for a start on setting the link flags. On version IntelComposerXE
-# 2015.0.090, the following flags work
+# The latest version can be downloaded here:
 #
-# MKLROOT=$(HOME)/fbsource/fbcode/third-party2//IntelComposerXE/2015.0.090/gcc-4.8.1-glibc-2.17/c3f970a/mkl
+#   https://registrationcenter.intel.com/en/forms/?productid=2558&licensetype=2
+#
+# The folloing settings are working on the latest version (as Mar. 17):
+#
+# MKLROOT=/opt/intel/compilers_and_libraries_2017.2.174/linux/mkl/
 #
 # BLASLDFLAGS=-Wl,--no-as-needed -L$(MKLROOT)/lib/intel64   -lmkl_intel_ilp64 \
 # -lmkl_core -lmkl_gnu_thread -ldl -lpthread
 #
-# the ilp64 means that the integers are 64-bit.
-#
-# BLASLDFLAGS=-DFINTEGER=long
+# BLASCFLAGS=-DFINTEGER=long
 #
 # you may have to set the LD_LIBRARY_PATH=$MKLROOT/lib/intel64 at runtime
 #

--- a/example_makefiles/makefile.inc.Linux
+++ b/example_makefiles/makefile.inc.Linux
@@ -38,13 +38,14 @@ FAISSSHAREDFLAGS=-shared
 #
 #   https://software.intel.com/en-us/articles/intel-mkl-link-line-advisor
 #
-# The latest version can be downloaded here:
+# The latest tested version is MLK 2017.0.098 (2017 Initial Release) and can
+# be downloaded here:
 #
 #   https://registrationcenter.intel.com/en/forms/?productid=2558&licensetype=2
 #
-# The folloing settings are working on the latest version (as Mar. 17):
+# The following settings are working if MLK is installed on its default folder:
 #
-# MKLROOT=/opt/intel/compilers_and_libraries_2017.2.174/linux/mkl/
+# MKLROOT=/opt/intel/compilers_and_libraries/linux/mkl/
 #
 # BLASLDFLAGS=-Wl,--no-as-needed -L$(MKLROOT)/lib/intel64   -lmkl_intel_ilp64 \
 # -lmkl_core -lmkl_gnu_thread -ldl -lpthread


### PR DESCRIPTION
This is my current configuration for MKL on Ubuntu.
I also corrected the `BLASLDFLAGS=-DFINTEGER=long` line (it should be `BLASCFLAGS`).