### PR TITLE
Removed numpy directory from include directory

### DIFF
--- a/example_makefiles/makefile.inc.Linux
+++ b/example_makefiles/makefile.inc.Linux
@@ -111,7 +111,7 @@ SWIGEXEC=swig
 # python3 -c "import numpy ; print(numpy.get_include())"
 # 
 
-PYTHONCFLAGS=-I/usr/include/python2.7/ -I/usr/lib64/python2.7/site-packages/numpy/core/include/numpy/
+PYTHONCFLAGS=-I/usr/include/python2.7/ -I/usr/lib64/python2.7/site-packages/numpy/core/include/
 
 
 ###########################################################################


### PR DESCRIPTION
swiggfaiss_wrap.cxx already include <numpy/arrayobject.h>, if compiled with -I/usr/lib64/python2.7/site-packages/numpy/core/include/numpy, file will be searched at /usr/lib64/python2.7/site-packages/numpy/core/include/numpy/numpy/arrayobject.h and will not be found.