### PR TITLE
Include stddef.h as well

### DIFF
--- a/example_makefiles/makefile.inc.Linux
+++ b/example_makefiles/makefile.inc.Linux
@@ -11,7 +11,7 @@
 
 CC=g++
 
-CFLAGS=-fPIC -m64 -Wall -g -O3  -msse4 -mpopcnt -fopenmp -Wno-sign-compare -Dnullptr=NULL -Doverride= -fopenmp
+CFLAGS=-fPIC -m64 -Wall -g -O3  -msse4 -mpopcnt -fopenmp -Wno-sign-compare -include stddef.h -Dnullptr=NULL -Doverride= -fopenmp
 LDFLAGS=-g -fPIC  -fopenmp
 
 # common linux flags


### PR DESCRIPTION
Hello! I tried to compile Faiss on Fedora 24 with GCC 6.3.1, but the compilation, unfortunately, failed.

```
$ make
g++ -fPIC -m64 -Wall -g -O3  -msse4 -mpopcnt -fopenmp -Wno-sign-compare -Dnullptr=NULL -Doverride= -fopenmp -c hamming.cpp -o hamming.o  
<command-line>:0:9: error: 'NULL' was not declared in this scope
<command-line>:0:9: error: 'NULL' was not declared in this scope
```

I found two options for addressing this problem: to either substitute `NULL` with the “magical” `0` or to explicitly include `stddef.h` via command-line. I believe the latter option is more portable. It successfully worked for me on both Fedora 24 and CentOS 7 (GCC 4.8.5).

The present pull request contains the above-mentioned change to `makefile.inc.Linux`.