### PR TITLE
correct utils::nextHighestPowerOf2

### DIFF
--- a/gpu/utils/StaticUtils.h
+++ b/gpu/utils/StaticUtils.h
@@ -61,7 +61,7 @@ static_assert(!isPowerOf2(3333), "isPowerOf2");
 
 template <typename T>
 constexpr __host__ __device__ T nextHighestPowerOf2(T v) {
-  return (isPowerOf2(v) ? (T) 2 * v : (1 << (log2(v) + 1)));
+  return (isPowerOf2(v) ? (T) 2 * v : ((T)1 << (log2(v) + 1)));
 }
 
 static_assert(nextHighestPowerOf2(1) == 2, "nextHighestPowerOf2");
@@ -72,5 +72,8 @@ static_assert(nextHighestPowerOf2(4) == 8, "nextHighestPowerOf2");
 static_assert(nextHighestPowerOf2(15) == 16, "nextHighestPowerOf2");
 static_assert(nextHighestPowerOf2(16) == 32, "nextHighestPowerOf2");
 static_assert(nextHighestPowerOf2(17) == 32, "nextHighestPowerOf2");
+
+static_assert(nextHighestPowerOf2(1536000000u) == 2147483648u, "nextHighestPowerOf2");
+static_assert(nextHighestPowerOf2<size_t>(2147483648) == (size_t)4294967296, "nextHighestPowerOf2");
 
 } } } // namespace


### PR DESCRIPTION
The bit shift was done as int and not as current type (size_t for example), thus the computed next highest power of 2 was wrong on large numbers.

It seems to solve issue #108 (or at least it does not fail right aways, computations are not finished yet)

