### PR TITLE
add support for Nvidia GPUs with CUDA compute capability 6.1

### DIFF
--- a/gpu/utils/DeviceDefs.cuh
+++ b/gpu/utils/DeviceDefs.cuh
@@ -14,7 +14,7 @@
 namespace faiss { namespace gpu {
 
 #ifdef __CUDA_ARCH__
-#if __CUDA_ARCH__ <= 600
+#if __CUDA_ARCH__ <= 610
 constexpr int kWarpSize = 32;
 #else
 #error Unknown __CUDA_ARCH__; please define parameters for compute capability


### PR DESCRIPTION
Add support for Nvidia GPUs with CUDA compute capability 6.1: GeForce Titan X (Pascal)/Xp/10*0, Quadro P*000, Tesla P4*, ...
