### PR TITLE
swig-3.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,16 @@ FROM nvidia/cuda:8.0-devel-ubuntu16.04
 MAINTAINER Pierre Letessier <pletessier@ina.fr>
 
 RUN apt-get update -y
-RUN apt-get install -y libopenblas-dev python-numpy python-dev swig git python-pip wget
+RUN apt-get install -y libopenblas-dev libpcre3 libpcre3-dev python-numpy python-dev git python-pip wget
+
+RUN mkdir /opt/swig && cd /opt/swig && \
+    wget http://downloads.sourceforge.net/swig/swig-3.0.1.tar.gz && \
+    tar -xvzf swig-3.0.1.tar.gz && cd swig-3.0.1 && \
+    ./configure --prefix=/usr && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -fr swig-3.0.1.tar.gz swig-3.0.1
 
 RUN pip install matplotlib
 

--- a/Makefile
+++ b/Makefile
@@ -169,3 +169,7 @@ endif
 ifeq ($(shell command -v $(SWIGEXEC) 2>/dev/null),)
 	$(error Cannot find $(SWIGEXEC), please refer to $(CURDIR)/makefile.inc to set up your environment)
 endif
+ifneq ($(shell $(SWIGEXEC) -version | grep 'SWIG Version'), 'SWIG Version 3.0.1')
+	$(error $(SWIGEXEC) wrong version number, please install swig version 3.0.1)
+endif
+

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,20 @@ python/_swigfaiss.so: python/swigfaiss_wrap.cxx $(LIBNAME).a
 _swigfaiss.so: python/_swigfaiss.so
 	cp python/_swigfaiss.so python/swigfaiss.py .
 
+
+#############################
+# Docker
+
+DOCKER ?= docker
+DOCKER_IMAGE = faiss
+
+docker/build:
+	$(DOCKER) build -t $(DOCKER_IMAGE) .
+
+docker/py:
+	$(DOCKER) run --rm -itv ${PWD}/python:/opt/faiss/python --entrypoint make $(DOCKER_IMAGE) clean py
+
+
 #############################
 # Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ all: .env_ok $(LIBNAME).a tests/demo_ivfpq_indexing
 
 py: _swigfaiss.so
 
+.PHONY: .env_ok .swig_ok
 
 
 #############################
@@ -74,7 +75,7 @@ HFILES = IndexFlat.h Index.h IndexLSH.h IndexPQ.h IndexIVF.h \
     Clustering.h hamming.h AutoTune.h IndexScalarQuantizer.h FaissException.h
 
 # also silently generates python/swigfaiss.py
-python/swigfaiss_wrap.cxx: swigfaiss.swig $(HFILES)
+python/swigfaiss_wrap.cxx: .swig_ok swigfaiss.swig $(HFILES)
 	$(SWIGEXEC) -python -c++ -Doverride= -o $@ $<
 
 


### PR DESCRIPTION
Enforce swig-3.0.1 to avoid using a newer version of swig. 

This solves an issue where [the generated code didn't match the documentation](https://github.com/facebookresearch/faiss/issues/165)

`apt-cache policy swig` was unable to find version 3.0.1, this is why swig is installed from source.
