### PR TITLE
fix bug in Clustering::train when nredo > 1

### DIFF
--- a/Clustering.cpp
+++ b/Clustering.cpp
@@ -195,10 +195,12 @@ void Clustering::train (idx_t nx, const float *x_in, Index & index) {
                 centroids = buf_centroids;
                 best_err = err;
             }
-            index.reset ();
         }
     }
-
+    if (nredo > 1) {
+       index.reset ();
+       index.add (k, centroids.data());
+    }
 }
 
 float kmeans_clustering (size_t d, size_t n, size_t k,


### PR DESCRIPTION
Fix the bug https://github.com/facebookresearch/faiss/issues/219

when nredo > 1, we should set index with centroids, it saves the best centroids with best_err.