### PR TITLE
Fix makefile.inc.Mac.brew

### DIFF
--- a/example_makefiles/makefile.inc.Mac.brew
+++ b/example_makefiles/makefile.inc.Mac.brew
@@ -4,7 +4,7 @@
 # Tested on macOS Sierra (10.12.2) with llvm installed using Homebrew (https://brew.sh)
 # brew install llvm
 CC=/usr/local/opt/llvm/bin/clang++
-CFLAGS=-fPIC -m64 -Wall -g -O3 -msse4 -mpopcnt -fopenmp -Wno-sign-compare -Dnullptr=NULL -I/usr/local/opt/llvm/include -std=c++11
+CFLAGS=-fPIC -m64 -Wall -g -O3 -msse4 -mpopcnt -fopenmp -Wno-sign-compare -I/usr/local/opt/llvm/include -std=c++11
 LDFLAGS=-g -fPIC -fopenmp -L/usr/local/opt/llvm/lib
 
 # common mac flags


### PR DESCRIPTION
Removing old flag `-Dnullptr=NULL` that causes issues with installation on osx with brew.