### PR TITLE
Add C API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/bin/
+/c_api/bin/
+/c_api/gpu/bin/
 /makefile.inc
 /tests/demo_ivfpq_indexing
 *.swp

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,6 +23,9 @@ section "Docker instructions" below).
 Alternatively, steps 1 and 3 can be built via the cmake scripts (see below).
 
 
+It is also possible to build a pure C interface. This optional process is
+described separately (please see the [C interface installation file](c_api/INSTALL.md))
+
 General compilation instructions
 ================================
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD+Patents license found in the
 # LICENSE file in the root directory of this source tree.
 
-.SUFFIXES: .cpp .o
+.SUFFIXES: .c .cpp .o
 
 
 MAKEFILE_INC=makefile.inc
@@ -37,9 +37,12 @@ $(LIBNAME).a: $(LIBOBJ)
 	ar r $(LIBNAME).a $^
 
 $(LIBNAME).$(SHAREDEXT): $(LIBOBJ)
-	$(CC) $(LDFLAGS) $(FAISSSHAREDFLAGS) -o $(LIBNAME).$(SHAREDEXT) $^ $(BLASLDFLAGS)
+	$(CXX) $(LDFLAGS) $(FAISSSHAREDFLAGS) -o $(LIBNAME).$(SHAREDEXT) $^ $(BLASLDFLAGS)
 
 .cpp.o:
+	$(CXX) $(CXXFLAGS) -c $< -o $@ $(FLAGS) $(EXTRAFLAGS)
+
+.c.o:
 	$(CC) $(CFLAGS) -c $< -o $@ $(FLAGS) $(EXTRAFLAGS)
 
 utils.o:             EXTRAFLAGS=$(BLASCFLAGS)
@@ -57,13 +60,13 @@ BLASLDFLAGSSO ?= $(BLASLDFLAGS)
 # pure C++ test in the test directory
 
 tests/test_blas: tests/test_blas.cpp
-	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS) $(BLASLDFLAGS) $(BLASCFLAGS)
+	$(CXX) $(CXXFLAGS) $< -o $@ $(LDFLAGS) $(BLASLDFLAGS) $(BLASCFLAGS)
 
 demos/demo_ivfpq_indexing: demos/demo_ivfpq_indexing.cpp $(LIBNAME).a
-	$(CC) -o $@ $(CFLAGS) $< $(LIBNAME).a $(LDFLAGS) $(BLASLDFLAGS)
+	$(CXX) -o $@ $(CFLAGS) $< $(LIBNAME).a $(LDFLAGS) $(BLASLDFLAGS)
 
 demos/demo_sift1M: demos/demo_sift1M.cpp $(LIBNAME).a
-	$(CC) -o $@ $(CFLAGS) $< $(LIBNAME).a $(LDFLAGS) $(BLASLDFLAGS)
+	$(CXX) -o $@ $(CFLAGS) $< $(LIBNAME).a $(LDFLAGS) $(BLASLDFLAGS)
 
 
 #############################
@@ -81,7 +84,7 @@ python/swigfaiss_wrap.cxx: swigfaiss.swig $(HFILES)
 
 # extension is .so even on the mac
 python/_swigfaiss.so: python/swigfaiss_wrap.cxx $(LIBNAME).a
-	$(CC) -I. $(CFLAGS) $(LDFLAGS) $(PYTHONCFLAGS) $(SHAREDFLAGS) \
+	$(CXX) -I. $(CXXFLAGS) $(LDFLAGS) $(PYTHONCFLAGS) $(SHAREDFLAGS) \
 	-o $@ $^ $(BLASLDFLAGSSO)
 
 _swigfaiss.so: python/_swigfaiss.so
@@ -164,8 +167,8 @@ clean:
 ifeq ($(wildcard $(MAKEFILE_INC)),)
 	$(error Cannot find $(MAKEFILE_INC). Did you forget to copy the relevant file from ./example_makefiles?)
 endif
-ifeq ($(shell command -v $(CC) 2>/dev/null),)
-	$(error Cannot find $(CC), please refer to $(CURDIR)/makefile.inc to set up your environment)
+ifeq ($(shell command -v $(CXX) 2>/dev/null),)
+	$(error Cannot find $(CXX), please refer to $(CURDIR)/makefile.inc to set up your environment)
 endif
 
 .swig_ok: .env_ok

--- a/c_api/AutoTune_c.cpp
+++ b/c_api/AutoTune_c.cpp
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#include <cstring>
+#include "AutoTune.h"
+#include "AutoTune_c.h"
+#include "macros_impl.h"
+
+using faiss::Index;
+using faiss::ParameterRange;
+using faiss::ParameterSpace;
+
+/** Build and index with the sequence of processing steps described in
+ *  the string.
+ */
+int faiss_index_factory(FaissIndex** p_index, int d, const char* description, FaissMetricType metric) {
+    try {
+        *p_index = reinterpret_cast<FaissIndex*>(faiss::index_factory(
+            d, description, static_cast<faiss::MetricType>(metric)));
+    } CATCH_AND_HANDLE
+}
+
+const char* faiss_ParameterRange_name(const FaissParameterRange* range) {
+    return reinterpret_cast<const ParameterRange*>(range)->name.c_str();
+}
+
+void faiss_ParameterRange_values(FaissParameterRange* range, double** p_values, size_t* p_size) {
+    auto& values = reinterpret_cast<ParameterRange*>(range)->values;
+    *p_values = values.data();
+    *p_size = values.size();
+}
+
+int faiss_ParameterSpace_new(FaissParameterSpace** space) {
+    try {
+        auto new_space = new ParameterSpace();
+        *space = reinterpret_cast<FaissParameterSpace*>(new_space);
+    } CATCH_AND_HANDLE
+}
+
+DEFINE_DESTRUCTOR(ParameterSpace)
+
+size_t faiss_ParameterSpace_n_combinations(const FaissParameterSpace* space) {
+    return reinterpret_cast<const ParameterSpace*>(space)->n_combinations();
+}
+
+int faiss_ParameterSpace_combination_name(const FaissParameterSpace* space, size_t cno, char* char_buffer, size_t size) {
+    try {
+        auto rep = reinterpret_cast<const ParameterSpace*>(space)->combination_name(cno);
+        strncpy(char_buffer, rep.c_str(), size);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_ParameterSpace_set_index_parameters(const FaissParameterSpace* space, FaissIndex* cindex, const char* param_string) {
+    try {
+        auto index = reinterpret_cast<Index*>(cindex);
+        reinterpret_cast<const ParameterSpace*>(space)->set_index_parameters(index, param_string);
+    } CATCH_AND_HANDLE
+}
+
+/// set a combination of parameters on an index
+int faiss_ParameterSpace_set_index_parameters_cno(const FaissParameterSpace* space, FaissIndex* cindex, size_t cno) {
+    try {
+        auto index = reinterpret_cast<Index*>(cindex);
+        reinterpret_cast<const ParameterSpace*>(space)->set_index_parameters(index, cno);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_ParameterSpace_set_index_parameter(const FaissParameterSpace* space, FaissIndex* cindex, const char * name, double value) {
+    try {
+        auto index = reinterpret_cast<Index*>(cindex);
+        reinterpret_cast<const ParameterSpace*>(space)->set_index_parameter(index, name, value);
+    } CATCH_AND_HANDLE
+}
+
+void faiss_ParameterSpace_display(const FaissParameterSpace* space) {
+    reinterpret_cast<const ParameterSpace*>(space)->display();
+}
+
+int faiss_ParameterSpace_add_range(FaissParameterSpace* space, const char* name, FaissParameterRange** p_range) {
+    try {
+        ParameterRange& range = reinterpret_cast<ParameterSpace*>(space)->add_range(name);
+        if (p_range) {
+            *p_range = reinterpret_cast<FaissParameterRange*>(&range);
+        }
+    } CATCH_AND_HANDLE
+}

--- a/c_api/AutoTune_c.h
+++ b/c_api/AutoTune_c.h
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c -*-
+
+#ifndef FAISS_AUTO_TUNE_C_H
+#define FAISS_AUTO_TUNE_C_H
+
+#include "faiss_c.h"
+#include "Index_c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Build and index with the sequence of processing steps described in
+ *  the string.
+ */
+int faiss_index_factory(FaissIndex** p_index, int d, const char* description, FaissMetricType metric);
+
+/// possible values of a parameter, sorted from least to most expensive/accurate
+FAISS_DECLARE_CLASS(ParameterRange)
+
+FAISS_DECLARE_GETTER(ParameterRange, const char*, name)
+
+/// Getter for the values in the range. The output values are invalidated
+/// upon any other modification of the range.
+void faiss_ParameterRange_values(FaissParameterRange*, double**, size_t*);
+
+/** Uses a-priori knowledge on the Faiss indexes to extract tunable parameters.
+ */
+FAISS_DECLARE_CLASS(ParameterSpace)
+
+/// Parameter space default constructor
+int faiss_ParameterSpace_new(FaissParameterSpace** space);
+
+/// nb of combinations, = product of values sizes
+size_t faiss_ParameterSpace_n_combinations(const FaissParameterSpace*);
+
+/// get string representation of the combination
+/// by writing it to the given character buffer.
+/// A buffer size of 1000 ensures that the full name is collected.
+int faiss_ParameterSpace_combination_name(const FaissParameterSpace*, size_t, char*, size_t);
+
+/// set a combination of parameters described by a string
+int faiss_ParameterSpace_set_index_parameters(const FaissParameterSpace*, FaissIndex*, const char *);
+
+/// set a combination of parameters on an index
+int faiss_ParameterSpace_set_index_parameters_cno(const FaissParameterSpace*, FaissIndex*, size_t);
+
+/// set one of the parameters
+int faiss_ParameterSpace_set_index_parameter(const FaissParameterSpace*, FaissIndex*, const char *, double);
+
+/// print a description on stdout
+void faiss_ParameterSpace_display(const FaissParameterSpace*);
+
+/// add a new parameter (or return it if it exists)
+int faiss_ParameterSpace_add_range(FaissParameterSpace*, const char*, FaissParameterRange**);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/c_api/AuxIndexStructures_c.cpp
+++ b/c_api/AuxIndexStructures_c.cpp
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#include "AuxIndexStructures_c.h"
+#include "AuxIndexStructures.h"
+#include "macros_impl.h"
+#include <iostream>
+
+extern "C" {
+
+using faiss::BufferList;
+using faiss::IDSelector;
+using faiss::IDSelectorBatch;
+using faiss::IDSelectorRange;
+using faiss::RangeSearchResult;
+using faiss::RangeSearchPartialResult;
+
+DEFINE_GETTER(RangeSearchResult, size_t, nq)
+
+int faiss_RangeSearchResult_new(FaissRangeSearchResult** p_rsr, idx_t nq) {
+    try {
+        *p_rsr = reinterpret_cast<FaissRangeSearchResult*>(
+            new RangeSearchResult(nq));
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_RangeSearchResult_new_with(FaissRangeSearchResult** p_rsr, idx_t nq, int alloc_lims) {
+    try {
+        *p_rsr = reinterpret_cast<FaissRangeSearchResult*>(
+            new RangeSearchResult(nq, static_cast<bool>(alloc_lims)));
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+/// called when lims contains the nb of elements result entries
+/// for each query
+int faiss_RangeSearchResult_do_allocation(FaissRangeSearchResult* rsr) {
+    try {
+        reinterpret_cast<RangeSearchResult*>(rsr)->do_allocation();
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+DEFINE_DESTRUCTOR(RangeSearchResult)
+
+/// getter for buffer_size
+DEFINE_GETTER(RangeSearchResult, size_t, buffer_size)
+
+/// getter for lims: size (nq + 1)
+void faiss_RangeSearchResult_lims(
+    FaissRangeSearchResult* rsr, size_t** lims);
+
+/// getter for labels and respective distances (not sorted):
+/// result for query i is labels[lims[i]:lims[i+1]]
+void faiss_RangeSearchResult_labels(
+    FaissRangeSearchResult* rsr, idx_t** labels, float** distances);
+
+
+DEFINE_DESTRUCTOR(IDSelector)
+
+int faiss_IDSelector_is_member(const FaissIDSelector* sel, idx_t id)  {
+    return reinterpret_cast<const IDSelector*>(sel)->is_member(id);
+}
+
+
+DEFINE_DESTRUCTOR(IDSelectorRange)
+
+DEFINE_GETTER(IDSelectorRange, idx_t, imin)
+DEFINE_GETTER(IDSelectorRange, idx_t, imax)
+
+int faiss_IDSelectorRange_new(FaissIDSelectorRange** p_sel, idx_t imin, idx_t imax) {
+    try {
+        *p_sel = reinterpret_cast<FaissIDSelectorRange*>(
+            new IDSelectorRange(imin, imax)
+        );
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+DEFINE_GETTER(IDSelectorBatch, int, nbits)
+DEFINE_GETTER(IDSelectorBatch, idx_t, mask)
+
+int faiss_IDSelectorBatch_new(FaissIDSelectorBatch** p_sel, long n, const idx_t* indices) {
+    try {
+        *p_sel = reinterpret_cast<FaissIDSelectorBatch*>(
+            new IDSelectorBatch(n, indices)
+        );
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+// Below are structures used only by Index implementations
+
+DEFINE_DESTRUCTOR(BufferList)
+
+DEFINE_GETTER(BufferList, size_t, buffer_size)
+DEFINE_GETTER(BufferList, size_t, wp)
+
+int faiss_BufferList_append_buffer(FaissBufferList* bl) {
+    try {
+        reinterpret_cast<BufferList*>(bl)->append_buffer();
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_BufferList_new(FaissBufferList** p_bl, size_t buffer_size) {
+    try {
+        *p_bl = reinterpret_cast<FaissBufferList*>(
+            new BufferList(buffer_size)
+        );
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_BufferList_add(FaissBufferList* bl, idx_t id, float dis) {
+    try {
+        reinterpret_cast<BufferList*>(bl)->add(id, dis);
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+/// copy elemnts ofs:ofs+n-1 seen as linear data in the buffers to
+/// tables dest_ids, dest_dis
+int faiss_BufferList_copy_range(
+    FaissBufferList* bl, size_t ofs, size_t n, idx_t *dest_ids, float *dest_dis) {
+    try {
+        reinterpret_cast<BufferList*>(bl)->copy_range(ofs, n, dest_ids, dest_dis);
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+DEFINE_GETTER_PERMISSIVE(RangeSearchPartialResult, FaissRangeSearchResult*, res)
+
+int faiss_RangeSearchPartialResult_new(
+    FaissRangeSearchPartialResult** p_res, FaissRangeSearchResult* res_in) {
+    try {
+        *p_res = reinterpret_cast<FaissRangeSearchPartialResult*>(
+            new RangeSearchPartialResult(
+                reinterpret_cast<RangeSearchResult*>(res_in))
+        );
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_RangeSearchPartialResult_finalize(
+    FaissRangeSearchPartialResult* res) {
+    try {
+        reinterpret_cast<RangeSearchPartialResult*>(res)->finalize();
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+/// called by range_search before do_allocation
+int faiss_RangeSearchPartialResult_set_lims(
+    FaissRangeSearchPartialResult* res) {
+    try {
+        reinterpret_cast<RangeSearchPartialResult*>(res)->set_lims();
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+/// called by range_search after do_allocation
+int faiss_RangeSearchPartialResult_set_result(
+    FaissRangeSearchPartialResult* res, int incremental) {
+    try {
+        reinterpret_cast<RangeSearchPartialResult*>(res)->set_result(
+            static_cast<bool>(incremental));
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+DEFINE_GETTER_SUBCLASS(QueryResult, RangeSearchPartialResult, idx_t, qno)
+DEFINE_GETTER_SUBCLASS(QueryResult, RangeSearchPartialResult, size_t, nres)
+DEFINE_GETTER_SUBCLASS_PERMISSIVE(QueryResult, RangeSearchPartialResult, FaissRangeSearchPartialResult*, pres)
+
+int faiss_RangeSearchPartialResult_new_result(
+    FaissRangeSearchPartialResult* res, idx_t qno, FaissQueryResult** qr) {
+
+    try {
+        RangeSearchPartialResult::QueryResult* q = 
+            &reinterpret_cast<RangeSearchPartialResult*>(res)->new_result(qno);
+        if (qr) {
+            *qr = reinterpret_cast<FaissQueryResult*>(q);
+        }
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_QueryResult_add(FaissQueryResult* qr, float dis, idx_t id) {
+    try {
+        reinterpret_cast<RangeSearchPartialResult::QueryResult*>(qr)->add(dis, id);
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+}

--- a/c_api/AuxIndexStructures_c.cpp
+++ b/c_api/AuxIndexStructures_c.cpp
@@ -56,21 +56,23 @@ DEFINE_DESTRUCTOR(RangeSearchResult)
 DEFINE_GETTER(RangeSearchResult, size_t, buffer_size)
 
 /// getter for lims: size (nq + 1)
-void faiss_RangeSearchResult_lims(
-    FaissRangeSearchResult* rsr, size_t** lims);
+void faiss_RangeSearchResult_lims(FaissRangeSearchResult* rsr, size_t** lims) {
+    *lims = reinterpret_cast<RangeSearchResult*>(rsr)->lims;
+}
 
 /// getter for labels and respective distances (not sorted):
 /// result for query i is labels[lims[i]:lims[i+1]]
-void faiss_RangeSearchResult_labels(
-    FaissRangeSearchResult* rsr, idx_t** labels, float** distances);
-
+void faiss_RangeSearchResult_labels(FaissRangeSearchResult* rsr, idx_t** labels, float** distances) {
+    auto sr = reinterpret_cast<RangeSearchResult*>(rsr);
+    *labels = sr->labels;
+    *distances = sr->distances;
+}
 
 DEFINE_DESTRUCTOR(IDSelector)
 
 int faiss_IDSelector_is_member(const FaissIDSelector* sel, idx_t id)  {
     return reinterpret_cast<const IDSelector*>(sel)->is_member(id);
 }
-
 
 DEFINE_DESTRUCTOR(IDSelectorRange)
 

--- a/c_api/AuxIndexStructures_c.h
+++ b/c_api/AuxIndexStructures_c.h
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c -*-
+
+#ifndef FAISS_AUX_INDEX_STRUCTURES_C_H
+#define FAISS_AUX_INDEX_STRUCTURES_C_H
+
+#include "Index_c.h"
+#include "faiss_c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+FAISS_DECLARE_CLASS(RangeSearchResult)
+
+FAISS_DECLARE_GETTER(RangeSearchResult, size_t, nq)
+
+int faiss_RangeSearchResult_new(FaissRangeSearchResult** p_rsr, idx_t nq);
+
+int faiss_RangeSearchResult_new_with(FaissRangeSearchResult** p_rsr, idx_t nq, int alloc_lims);
+
+/// called when lims contains the nb of elements result entries
+/// for each query
+int faiss_RangeSearchResult_do_allocation(FaissRangeSearchResult* rsr);
+
+FAISS_DECLARE_DESTRUCTOR(RangeSearchResult)
+
+/// getter for buffer_size
+FAISS_DECLARE_GETTER(RangeSearchResult, size_t, buffer_size)
+
+/// getter for lims: size (nq + 1)
+void faiss_RangeSearchResult_lims(
+    FaissRangeSearchResult* rsr, size_t** lims);
+
+/// getter for labels and respective distances (not sorted):
+/// result for query i is labels[lims[i]:lims[i+1]]
+void faiss_RangeSearchResult_labels(
+    FaissRangeSearchResult* rsr, idx_t** labels, float** distances);
+
+
+/** Encapsulates a set of ids to remove. */
+FAISS_DECLARE_CLASS(IDSelector)
+FAISS_DECLARE_DESTRUCTOR(IDSelector)
+
+int faiss_IDSelector_is_member(const FaissIDSelector* sel, idx_t id);
+
+/** remove ids between [imni, imax) */
+FAISS_DECLARE_CLASS(IDSelectorRange)
+FAISS_DECLARE_DESTRUCTOR(IDSelectorRange)
+
+FAISS_DECLARE_GETTER(IDSelectorRange, idx_t, imin)
+FAISS_DECLARE_GETTER(IDSelectorRange, idx_t, imax)
+
+int faiss_IDSelectorRange_new(FaissIDSelectorRange** p_sel, idx_t imin, idx_t imax);
+
+/** Remove ids from a set. Repetitions of ids in the indices set
+ * passed to the constructor does not hurt performance. The hash
+ * function used for the bloom filter and GCC's implementation of
+ * unordered_set are just the least significant bits of the id. This
+ * works fine for random ids or ids in sequences but will produce many
+ * hash collisions if lsb's are always the same */
+FAISS_DECLARE_CLASS(IDSelectorBatch)
+
+FAISS_DECLARE_GETTER(IDSelectorBatch, int, nbits)
+FAISS_DECLARE_GETTER(IDSelectorBatch, idx_t, mask)
+
+int faiss_IDSelectorBatch_new(FaissIDSelectorBatch** p_sel, long n, const idx_t* indices);
+
+// Below are structures used only by Index implementations
+
+/** List of temporary buffers used to store results before they are
+ *  copied to the RangeSearchResult object. */
+FAISS_DECLARE_CLASS(BufferList)
+FAISS_DECLARE_DESTRUCTOR(BufferList)
+
+FAISS_DECLARE_GETTER(BufferList, size_t, buffer_size)
+FAISS_DECLARE_GETTER(BufferList, size_t, wp)
+
+typedef struct FaissBuffer {
+    idx_t *ids;
+    float *dis;
+} FaissBuffer;
+
+int faiss_BufferList_append_buffer(FaissBufferList* bl);
+
+int faiss_BufferList_new(FaissBufferList** p_bl, size_t buffer_size);
+
+int faiss_BufferList_add(FaissBufferList* bl, idx_t id, float dis);
+
+/// copy elemnts ofs:ofs+n-1 seen as linear data in the buffers to
+/// tables dest_ids, dest_dis
+int faiss_BufferList_copy_range(
+    FaissBufferList* bl, size_t ofs, size_t n, idx_t *dest_ids, float *dest_dis);
+
+/// the entries in the buffers are split per query
+FAISS_DECLARE_CLASS(RangeSearchPartialResult)
+
+FAISS_DECLARE_GETTER(RangeSearchPartialResult, FaissRangeSearchResult*, res)
+
+int faiss_RangeSearchPartialResult_new(
+    FaissRangeSearchPartialResult** p_res, FaissRangeSearchResult* res_in);
+
+int faiss_RangeSearchPartialResult_finalize(
+    FaissRangeSearchPartialResult* res);
+
+/// called by range_search before do_allocation
+int faiss_RangeSearchPartialResult_set_lims(
+    FaissRangeSearchPartialResult* res);
+
+/// called by range_search after do_allocation
+int faiss_RangeSearchPartialResult_set_result(
+    FaissRangeSearchPartialResult* res, int incremental);
+
+/// result structure for a single query
+FAISS_DECLARE_CLASS(QueryResult)
+FAISS_DECLARE_GETTER(QueryResult, idx_t, qno)
+FAISS_DECLARE_GETTER(QueryResult, size_t, nres)
+FAISS_DECLARE_GETTER(QueryResult, FaissRangeSearchPartialResult*, pres)
+
+int faiss_RangeSearchPartialResult_new_result(
+    FaissRangeSearchPartialResult* res, idx_t qno, FaissQueryResult** qr);
+
+int faiss_QueryResult_add(FaissQueryResult* qr, float dis, idx_t id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/c_api/Clustering_c.cpp
+++ b/c_api/Clustering_c.cpp
@@ -110,10 +110,10 @@ void faiss_Clustering_free(FaissClustering* clustering) {
     delete reinterpret_cast<Clustering*>(clustering);
 }
 
-int kmeans_clustering (size_t d, size_t n, size_t k,
-                       const float *x,
-                       float *centroids,
-                       float *q_error) {
+int faiss_kmeans_clustering (size_t d, size_t n, size_t k,
+                             const float *x,
+                             float *centroids,
+                             float *q_error) {
     try {
         float out = faiss::kmeans_clustering(d, n, k, x, centroids);
         if (q_error) {

--- a/c_api/Clustering_c.cpp
+++ b/c_api/Clustering_c.cpp
@@ -21,7 +21,6 @@ using faiss::Clustering;
 using faiss::ClusteringParameters;
 using faiss::Index;
 
-
 DEFINE_GETTER(Clustering, int, niter)
 DEFINE_GETTER(Clustering, int, nredo)
 DEFINE_GETTER(Clustering, int, verbose)
@@ -51,6 +50,21 @@ void faiss_ClusteringParameters_init(FaissClusteringParameters* params) {
     params->spherical = d.spherical;
     params->update_index = d.update_index;
     params->verbose = d.verbose;   
+}
+
+// This conversion is required because the two types are not memory-compatible
+inline ClusteringParameters from_faiss_c(const FaissClusteringParameters* params) {
+    ClusteringParameters o;
+    o.frozen_centroids = params->frozen_centroids;
+    o.max_points_per_centroid = params->max_points_per_centroid;
+    o.min_points_per_centroid = params->min_points_per_centroid;
+    o.niter = params->niter;
+    o.nredo = params->nredo;
+    o.seed = params->seed;
+    o.spherical = params->spherical;
+    o.update_index = params->update_index;
+    o.verbose = params->verbose;
+    return o;
 }
 
 /// getter for centroids (size = k * d)
@@ -90,7 +104,7 @@ int faiss_Clustering_new(FaissClustering** p_clustering, int d, int k) {
 int faiss_Clustering_new_with_params(
     FaissClustering** p_clustering, int d, int k, const FaissClusteringParameters* cp) {
     try {
-        Clustering* c = new Clustering(d, k, *reinterpret_cast<const ClusteringParameters*>(cp));
+        Clustering* c = new Clustering(d, k, from_faiss_c(cp));
         *p_clustering = reinterpret_cast<FaissClustering*>(c);
         return 0;
     } CATCH_AND_HANDLE

--- a/c_api/Clustering_c.cpp
+++ b/c_api/Clustering_c.cpp
@@ -40,6 +40,19 @@ DEFINE_GETTER(Clustering, size_t, d)
 /// getter for k
 DEFINE_GETTER(Clustering, size_t, k)
 
+void faiss_ClusteringParameters_init(FaissClusteringParameters* params) {
+    ClusteringParameters d;
+    params->frozen_centroids = d.frozen_centroids;
+    params->max_points_per_centroid = d.max_points_per_centroid;
+    params->min_points_per_centroid = d.min_points_per_centroid;
+    params->niter = d.niter;
+    params->nredo = d.nredo;
+    params->seed = d.seed;
+    params->spherical = d.spherical;
+    params->update_index = d.update_index;
+    params->verbose = d.verbose;   
+}
+
 /// getter for centroids (size = k * d)
 void faiss_Clustering_centroids(
     FaissClustering* clustering, float** centroids, size_t* size) {

--- a/c_api/Clustering_c.cpp
+++ b/c_api/Clustering_c.cpp
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#include "Clustering_c.h"
+#include "Clustering.h"
+#include "Index.h"
+#include <vector>
+#include "macros_impl.h"
+
+extern "C" {
+
+using faiss::Clustering;
+using faiss::ClusteringParameters;
+using faiss::Index;
+
+
+DEFINE_GETTER(Clustering, int, niter)
+DEFINE_GETTER(Clustering, int, nredo)
+DEFINE_GETTER(Clustering, int, verbose)
+DEFINE_GETTER(Clustering, int, spherical)
+DEFINE_GETTER(Clustering, int, update_index)
+DEFINE_GETTER(Clustering, int, frozen_centroids)
+
+DEFINE_GETTER(Clustering, int, min_points_per_centroid)
+DEFINE_GETTER(Clustering, int, max_points_per_centroid)
+
+DEFINE_GETTER(Clustering, int, seed)
+
+/// getter for d
+DEFINE_GETTER(Clustering, size_t, d)
+
+/// getter for k
+DEFINE_GETTER(Clustering, size_t, k)
+
+/// getter for centroids (size = k * d)
+void faiss_Clustering_centroids(
+    FaissClustering* clustering, float** centroids, size_t* size) {
+    std::vector<float>& v = reinterpret_cast<Clustering*>(clustering)->centroids;
+    if (centroids) {
+        *centroids = v.data();
+    }
+    if (size) {
+        *size = v.size();
+    }
+}
+
+/// getter for objective values (sum of distances reported by index)
+/// over iterations
+void faiss_Clustering_obj(
+    FaissClustering* clustering, float** obj, size_t* size) {
+    std::vector<float>& v = reinterpret_cast<Clustering*>(clustering)->obj;
+    if (obj) {
+        *obj = v.data();
+    }
+    if (size) {
+        *size = v.size();
+    }
+}
+
+/// the only mandatory parameters are k and d
+int faiss_Clustering_new(FaissClustering** p_clustering, int d, int k) {
+    try {
+        Clustering* c = new Clustering(d, k);
+        *p_clustering = reinterpret_cast<FaissClustering*>(c);
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_Clustering_new_with_params(
+    FaissClustering** p_clustering, int d, int k, const FaissClusteringParameters* cp) {
+    try {
+        Clustering* c = new Clustering(d, k, *reinterpret_cast<const ClusteringParameters*>(cp));
+        *p_clustering = reinterpret_cast<FaissClustering*>(c);
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+/// Index is used during the assignment stage
+int faiss_Clustering_train(
+    FaissClustering* clustering, idx_t n, const float* x, FaissIndex* index) {
+    try {
+        reinterpret_cast<Clustering*>(clustering)->train(
+            n, x, *reinterpret_cast<Index*>(index));
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+void faiss_Clustering_free(FaissClustering* clustering) {
+    delete reinterpret_cast<Clustering*>(clustering);
+}
+
+int kmeans_clustering (size_t d, size_t n, size_t k,
+                       const float *x,
+                       float *centroids,
+                       float *q_error) {
+    try {
+        float out = faiss::kmeans_clustering(d, n, k, x, centroids);
+        if (q_error) {
+            *q_error = out;
+        }
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+}

--- a/c_api/Clustering_c.h
+++ b/c_api/Clustering_c.h
@@ -26,10 +26,10 @@ typedef struct FaissClusteringParameters {
     int niter;          ///< clustering iterations
     int nredo;          ///< redo clustering this many times and keep best
 
-    bool verbose;
-    bool spherical;     ///< do we want normalized centroids?
-    bool update_index;  ///< update index after each iteration?
-    bool frozen_centroids;  ///< use the centroids provided as input and do not change them during iterations
+    int verbose;       ///< (bool)
+    int spherical;     ///< (bool) do we want normalized centroids?
+    int update_index;  ///< (bool) update index after each iteration?
+    int frozen_centroids;  ///< (bool) use the centroids provided as input and do not change them during iterations
 
     int min_points_per_centroid; ///< otherwise you get a warning
     int max_points_per_centroid;  ///< to limit size of dataset

--- a/c_api/Clustering_c.h
+++ b/c_api/Clustering_c.h
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved
+// -*- c -*-
+
+#ifndef FAISS_CLUSTERING_C_H
+#define FAISS_CLUSTERING_C_H
+
+#include "Index_c.h"
+#include "faiss_c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Class for the clustering parameters. Can be passed to the
+ * constructor of the Clustering object.
+ */
+typedef struct FaissClusteringParameters {
+    int niter;          ///< clustering iterations
+    int nredo;          ///< redo clustering this many times and keep best
+
+    bool verbose;
+    bool spherical;     ///< do we want normalized centroids?
+    bool update_index;  ///< update index after each iteration?
+    bool frozen_centroids;  ///< use the centroids provided as input and do not change them during iterations
+
+    int min_points_per_centroid; ///< otherwise you get a warning
+    int max_points_per_centroid;  ///< to limit size of dataset
+
+    int seed; ///< seed for the random number generator
+} FaissClusteringParameters;
+
+
+/// Sets the ClusteringParameters object with reasonable defaults
+void faiss_ClusteringParameters_init(FaissClusteringParameters* params);
+
+
+/** clustering based on assignment - centroid update iterations
+ *
+ * The clustering is based on an Index object that assigns training
+ * points to the centroids. Therefore, at each iteration the centroids
+ * are added to the index.
+ *
+ * On output, the centoids table is set to the latest version
+ * of the centroids and they are also added to the index. If the
+ * centroids table it is not empty on input, it is also used for
+ * initialization.
+ *
+ * To do several clusterings, just call train() several times on
+ * different training sets, clearing the centroid table in between.
+ */
+FAISS_DECLARE_CLASS(Clustering)
+
+FAISS_DECLARE_GETTER(Clustering, int, niter)
+FAISS_DECLARE_GETTER(Clustering, int, nredo)
+FAISS_DECLARE_GETTER(Clustering, int, verbose)
+FAISS_DECLARE_GETTER(Clustering, int, spherical)
+FAISS_DECLARE_GETTER(Clustering, int, update_index)
+FAISS_DECLARE_GETTER(Clustering, int, frozen_centroids)
+
+FAISS_DECLARE_GETTER(Clustering, int, min_points_per_centroid)
+FAISS_DECLARE_GETTER(Clustering, int, max_points_per_centroid)
+
+FAISS_DECLARE_GETTER(Clustering, int, seed)
+
+/// getter for d
+FAISS_DECLARE_GETTER(Clustering, size_t, d)
+
+/// getter for k
+FAISS_DECLARE_GETTER(Clustering, size_t, k)
+
+/// getter for centroids (size = k * d)
+void faiss_Clustering_centroids(
+    FaissClustering* clustering, float** centroids, size_t* size);
+
+/// getter for objective values (sum of distances reported by index)
+/// over iterations
+void faiss_Clustering_obj(
+    FaissClustering* clustering, float** obj, size_t* size);
+
+/// the only mandatory parameters are k and d
+int faiss_Clustering_new(FaissClustering** p_clustering, int d, int k);
+
+int faiss_Clustering_new_with_params(
+    FaissClustering** p_clustering, int d, int k, const FaissClusteringParameters* cp);
+
+int faiss_Clustering_train(
+    FaissClustering* clustering, idx_t n, const float* x, FaissIndex* index);
+
+void faiss_Clustering_free(FaissClustering* clustering);
+
+/** simplified interface
+ *
+ * @param d dimension of the data
+ * @param n nb of training vectors
+ * @param k nb of output centroids
+ * @param x training set (size n * d)
+ * @param centroids output centroids (size k * d)
+ * @param q_error final quantization error
+ * @return error code
+ */
+int kmeans_clustering (size_t d, size_t n, size_t k,
+                       const float *x,
+                       float *centroids,
+                       float *q_error);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/c_api/Clustering_c.h
+++ b/c_api/Clustering_c.h
@@ -106,7 +106,7 @@ void faiss_Clustering_free(FaissClustering* clustering);
  * @param q_error final quantization error
  * @return error code
  */
-int kmeans_clustering (size_t d, size_t n, size_t k,
+int faiss_kmeans_clustering (size_t d, size_t n, size_t k,
                        const float *x,
                        float *centroids,
                        float *q_error);

--- a/c_api/INSTALL.md
+++ b/c_api/INSTALL.md
@@ -1,0 +1,100 @@
+Faiss C API
+===========
+
+Faiss provides a pure C interface, which can subsequently be used either in pure C programs or to produce bindings for programming languages with Foreign Function Interface (FFI) support. Although this is not required for the Python interface, some other programming languages (e.g. Rust and Julia) do not have SWIG support.
+
+Compilation instructions
+------------------------
+
+The full contents of the pure C API are in the ["c_api"](c_api/) folder.
+Please be sure to follow the instructions on [building the main C++ library](../INSTALL.md#step-1-compiling-the-c-faiss) first.
+Then, enter the [c_api](c_api/) directory and run
+
+  `make`
+
+This builds the dynamic library "faiss_c", containing the full implementation of Faiss and the necessary wrappers for the C interface. It does not depend on libfaiss.a or the C++ standard library. It will also build an example program `bin/example_c`.
+
+Using the API
+-------------
+
+The C API is composed of:
+
+- A set of C header files comprising the main Faiss interfaces, converted for use in C. Each file follows the format `«name»_c.h`, where `«name»` is the respective name from the C++ API. For example, the file [Index_c.h](./Index_c.h) file corresponds to the base `Index` API. Functions are declared with the `faiss_` prefix (e.g. `faiss_IndexFlat_new`), whereas new types have the `Faiss` prefix (e.g. `FaissIndex`, `FaissMetricType`, ...).
+- A dynamic library, compiled from the sources in the same folder, encloses the implementation of the library and wrapper functions.
+
+The index factory is available via the `faiss_index_factory` function in `AutoTune_c.h`:
+
+```c
+FaissIndex* index = NULL;
+int c = faiss_index_factory(&index, 64, "Flat", METRIC_L2);
+if (c) {
+    // operation failed
+}
+```
+
+Most operations that you would find as member functions are available with the format `faiss_«classname»_«member»`.
+
+```c
+idx_t ntotal = faiss_Index_ntotal(index);
+```
+
+Since this is C, the index needs to be freed manually in the end:
+
+```c
+faiss_Index_free(index);
+```
+
+Error handling is done by examining the error code returned by operations with recoverable errors.
+The code identifies the type of exception that rose from the implementation. Fetching the 
+corresponding error message can be done by calling the function `faiss_get_last_error()` from
+`error_c.h`. Getter functions and `free` functions do not return an error code.
+
+```c
+int c = faiss_Index_add(index, nb, xb);
+if (c) {
+    printf("%s", faiss_get_last_error());
+    exit(-1);
+}
+```
+
+An example is included, which is built automatically for the target `all`. It can also be built separately:
+
+  `make bin/example_c`
+
+Building with GPU support
+-------------------------
+
+For GPU support, a separate dynamic library in the "c_api/gpu" directory needs to be built.
+
+  `make`
+
+The "gpufaiss_c" dynamic library contains the GPU and CPU implementations of Faiss, which means that
+it can be used in place of "faiss_c". Like in the C++ API, end programs still need to dynamically link
+with the CUDA runtime and cuBLAS libraries.
+
+Using the GPU with the C API
+----------------------------
+
+A standard GPU resurces object can be obtained by the name `FaissStandardGpuResources`:
+
+```c
+FaissStandardGpuResources* gpu_res = NULL;
+int c = faiss_StandardGpuResources_new(&gpu_res);
+if (c) {
+    printf("%s", faiss_get_last_error());
+    exit(-1);
+}
+```
+
+Similarly to the C++ API, a CPU index can be converted to a GPU index:
+
+```c
+FaissIndex* cpu_index = NULL;
+int c = faiss_index_factory(&cpu_index, d, "Flat", METRIC_L2);
+if (c) { /* ... */ }
+FaissGpuIndex* gpu_index = NULL;
+c = faiss_index_cpu_to_gpu(gpu_res, 0, cpu_index, &gpu_index);
+if (c) { /* ... */ }
+```
+
+A more complete example is available by the name `bin/example_gpu_c`.

--- a/c_api/INSTALL.md
+++ b/c_api/INSTALL.md
@@ -69,8 +69,8 @@ For GPU support, a separate dynamic library in the "c_api/gpu" directory needs t
   `make`
 
 The "gpufaiss_c" dynamic library contains the GPU and CPU implementations of Faiss, which means that
-it can be used in place of "faiss_c". Like in the C++ API, end programs still need to dynamically link
-with the CUDA runtime and cuBLAS libraries.
+it can be used in place of "faiss_c". The same library will dynamically link with the CUDA runtime
+and cuBLAS.
 
 Using the GPU with the C API
 ----------------------------

--- a/c_api/IndexFlat_c.cpp
+++ b/c_api/IndexFlat_c.cpp
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#include "IndexFlat_c.h"
+#include "IndexFlat.h"
+#include "macros_impl.h"
+
+extern "C" {
+
+using faiss::IndexFlat;
+using faiss::IndexFlatIP;
+using faiss::IndexFlatL2;
+using faiss::IndexFlatL2BaseShift;
+using faiss::IndexRefineFlat;
+using faiss::IndexFlat1D;
+
+int faiss_IndexFlat_new(FaissIndexFlat** p_index) {
+    try {
+        *p_index = reinterpret_cast<FaissIndexFlat*>(new IndexFlat());
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexFlat_new_with(FaissIndexFlat** p_index, idx_t d, FaissMetricType metric) {
+    try {
+        IndexFlat* index = new IndexFlat(d, static_cast<faiss::MetricType>(metric));
+        *p_index = reinterpret_cast<FaissIndexFlat*>(index);
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+DEFINE_DESTRUCTOR(IndexFlat)
+
+int faiss_IndexFlat_compute_distance_subset(
+    FaissIndex* index,
+    idx_t n,
+    const float *x,
+    idx_t k,
+    float *distances,
+    const idx_t *labels) {
+    try {
+        reinterpret_cast<IndexFlat*>(index)->compute_distance_subset(
+            n, x, k, distances, labels);
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexFlatIP_new(FaissIndexFlatIP** p_index) {
+    try {
+        IndexFlatIP* index = new IndexFlatIP();
+        *p_index = reinterpret_cast<FaissIndexFlatIP*>(index);
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexFlatIP_new_with(FaissIndexFlatIP** p_index, idx_t d) {
+    try {
+        IndexFlatIP* index = new IndexFlatIP(d);
+        *p_index = reinterpret_cast<FaissIndexFlatIP*>(index);
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexFlatL2_new(FaissIndexFlatL2** p_index) {
+    try {
+        IndexFlatL2* index = new IndexFlatL2();
+        *p_index = reinterpret_cast<FaissIndexFlatL2*>(index);
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexFlatL2_new_with(FaissIndexFlatL2** p_index, idx_t d) {
+    try {
+        IndexFlatL2* index = new IndexFlatL2(d);
+        *p_index = reinterpret_cast<FaissIndexFlatL2*>(index);
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexFlatL2BaseShift_new(FaissIndexFlatL2BaseShift** p_index, idx_t d, size_t nshift, const float *shift) {
+    try {
+        IndexFlatL2BaseShift* index = new IndexFlatL2BaseShift(d, nshift, shift);
+        *p_index = reinterpret_cast<FaissIndexFlatL2BaseShift*>(index);
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexRefineFlat_new(FaissIndexRefineFlat** p_index, FaissIndex* base_index) {
+    try {
+        IndexRefineFlat* index = new IndexRefineFlat(
+            reinterpret_cast<faiss::Index*>(base_index));
+        *p_index = reinterpret_cast<FaissIndexRefineFlat*>(index);
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+DEFINE_DESTRUCTOR(IndexRefineFlat)
+
+int faiss_IndexFlat1D_new(FaissIndexFlat1D** p_index) {
+    try {
+        IndexFlat1D* index = new IndexFlat1D();
+        *p_index = reinterpret_cast<FaissIndexFlat1D*>(index);
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexFlat1D_new_with(FaissIndexFlat1D** p_index, int continuous_update) {
+    try {
+        IndexFlat1D* index = new IndexFlat1D(static_cast<bool>(continuous_update));
+        *p_index = reinterpret_cast<FaissIndexFlat1D*>(index);
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexFlat1D_update_permutation(FaissIndexFlat1D* index) {
+    try {
+        reinterpret_cast<IndexFlat1D*>(index)->update_permutation();
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
+}

--- a/c_api/IndexFlat_c.cpp
+++ b/c_api/IndexFlat_c.cpp
@@ -11,10 +11,12 @@
 
 #include "IndexFlat_c.h"
 #include "IndexFlat.h"
+#include "Index.h"
 #include "macros_impl.h"
 
 extern "C" {
 
+using faiss::Index;
 using faiss::IndexFlat;
 using faiss::IndexFlatIP;
 using faiss::IndexFlatL2;
@@ -38,6 +40,19 @@ int faiss_IndexFlat_new_with(FaissIndexFlat** p_index, idx_t d, FaissMetricType 
 }
 
 DEFINE_DESTRUCTOR(IndexFlat)
+
+void faiss_IndexFlat_xb(FaissIndexFlat* index, float** p_xb, size_t* p_size) {
+    auto& xb = reinterpret_cast<IndexFlat*>(index)->xb;
+    *p_xb = xb.data();
+    if (p_size) {
+        *p_size = xb.size();
+    }
+}
+
+FaissIndexFlat* faiss_IndexFlat_cast(FaissIndex* index) {
+    return reinterpret_cast<FaissIndexFlat*>(
+        dynamic_cast<IndexFlat*>(reinterpret_cast<Index*>(index)));
+}
 
 int faiss_IndexFlat_compute_distance_subset(
     FaissIndex* index,

--- a/c_api/IndexFlat_c.h
+++ b/c_api/IndexFlat_c.h
@@ -29,6 +29,24 @@ int faiss_IndexFlat_create(FaissIndexFlat** p_index);
 
 int faiss_IndexFlat_create_with(FaissIndexFlat** p_index, idx_t d, FaissMetricType metric);
 
+/** get a pointer to the index's internal data (the `xb` field). The outputs
+ * become invalid after any data addition or removal operation.
+ * 
+ * @param index   opaque pointer to index object
+ * @param p_xb    output, the pointer to the beginning of `xb`.
+ * @param p_size  output, the current size of `sb` in number of float values.
+ */
+void faiss_IndexFlat_xb(FaissIndexFlat* index, float** p_xb, size_t* p_size);
+
+
+/** attempt a dynamic cast from. This function can be used to
+ * check whether the underlying index is a flat index.
+ * 
+ * @param index opaque pointer to index object
+ * @return the same pointer if the index is a flat index, NULL otherwise
+ */
+FaissIndexFlat* faiss_IndexFlat_cast(FaissIndex* index);
+
 FAISS_DECLARE_DESTRUCTOR(IndexFlat)
 
 /** compute distance with a subset of vectors

--- a/c_api/IndexFlat_c.h
+++ b/c_api/IndexFlat_c.h
@@ -49,14 +49,14 @@ int faiss_IndexFlat_compute_distance_subset(
     const idx_t *labels);
 
 /** Opaque type for IndexFlatIP */
-FAISS_DECLARE_CLASS_INHERITED(IndexFlatIP, IndexFlat)
+FAISS_DECLARE_CLASS_INHERITED(IndexFlatIP, Index)
 
 int faiss_IndexFlatIP_new(FaissIndexFlatIP** p_index);
 
 int faiss_IndexFlatIP_new_with(FaissIndexFlatIP** p_index, idx_t d);
 
 /** Opaque type for IndexFlatL2 */
-FAISS_DECLARE_CLASS_INHERITED(IndexFlatL2, IndexFlat)
+FAISS_DECLARE_CLASS_INHERITED(IndexFlatL2, Index)
 
 int faiss_IndexFlatL2_new(FaissIndexFlatL2** p_index);
 
@@ -66,7 +66,7 @@ int faiss_IndexFlatL2_new_with(FaissIndexFlatL2** p_index, idx_t d);
  *
  * same as an IndexFlatL2 but a value is subtracted from each distance
  */
-FAISS_DECLARE_CLASS_INHERITED(IndexFlatL2BaseShift, IndexFlatL2)
+FAISS_DECLARE_CLASS_INHERITED(IndexFlatL2BaseShift, Index)
 
 int faiss_IndexFlatL2BaseShift_new(FaissIndexFlatL2BaseShift** p_index, idx_t d, size_t nshift, const float *shift);
 
@@ -85,7 +85,7 @@ FAISS_DECLARE_DESTRUCTOR(IndexRefineFlat)
  * 
  * optimized version for 1D "vectors"
  */
-FAISS_DECLARE_CLASS_INHERITED(IndexFlat1D, IndexFlatL2)
+FAISS_DECLARE_CLASS_INHERITED(IndexFlat1D, Index)
 
 int faiss_IndexFlat1D_new(FaissIndexFlat1D** p_index);
 int faiss_IndexFlat1D_new_with(FaissIndexFlat1D** p_index, int continuous_update);

--- a/c_api/IndexFlat_c.h
+++ b/c_api/IndexFlat_c.h
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved
+// -*- c -*-
+
+#ifndef FAISS_INDEX_FLAT_C_H
+#define FAISS_INDEX_FLAT_C_H
+
+#include "Index_c.h"
+#include "faiss_c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// forward declaration
+typedef enum FaissMetricType FaissMetricType;
+
+/** Opaque type for IndexFlat */
+FAISS_DECLARE_CLASS_INHERITED(IndexFlat, Index)
+
+int faiss_IndexFlat_create(FaissIndexFlat** p_index);
+
+int faiss_IndexFlat_create_with(FaissIndexFlat** p_index, idx_t d, FaissMetricType metric);
+
+FAISS_DECLARE_DESTRUCTOR(IndexFlat)
+
+/** compute distance with a subset of vectors
+ *
+ * @param index   opaque pointer to index object
+ * @param x       query vectors, size n * d
+ * @param labels  indices of the vectors that should be compared
+ *                for each query vector, size n * k
+ * @param distances
+ *                corresponding output distances, size n * k
+ */
+int faiss_IndexFlat_compute_distance_subset(
+    FaissIndex *index,
+    idx_t n,
+    const float *x,
+    idx_t k,
+    float *distances,
+    const idx_t *labels);
+
+/** Opaque type for IndexFlatIP */
+FAISS_DECLARE_CLASS_INHERITED(IndexFlatIP, IndexFlat)
+
+int faiss_IndexFlatIP_new(FaissIndexFlatIP** p_index);
+
+int faiss_IndexFlatIP_new_with(FaissIndexFlatIP** p_index, idx_t d);
+
+/** Opaque type for IndexFlatL2 */
+FAISS_DECLARE_CLASS_INHERITED(IndexFlatL2, IndexFlat)
+
+int faiss_IndexFlatL2_new(FaissIndexFlatL2** p_index);
+
+int faiss_IndexFlatL2_new_with(FaissIndexFlatL2** p_index, idx_t d);
+
+/** Opaque type for IndexFlatL2BaseShift
+ *
+ * same as an IndexFlatL2 but a value is subtracted from each distance
+ */
+FAISS_DECLARE_CLASS_INHERITED(IndexFlatL2BaseShift, IndexFlatL2)
+
+int faiss_IndexFlatL2BaseShift_new(FaissIndexFlatL2BaseShift** p_index, idx_t d, size_t nshift, const float *shift);
+
+/** Opaque type for IndexRefineFlat
+ *
+ * Index that queries in a base_index (a fast one) and refines the
+ * results with an exact search, hopefully improving the results.
+ */
+FAISS_DECLARE_CLASS_INHERITED(IndexRefineFlat, Index)
+
+int faiss_IndexRefineFlat_new(FaissIndexRefineFlat** p_index, FaissIndex* base_index);
+
+FAISS_DECLARE_DESTRUCTOR(IndexRefineFlat)
+
+/** Opaque type for IndexFlat1D
+ * 
+ * optimized version for 1D "vectors"
+ */
+FAISS_DECLARE_CLASS_INHERITED(IndexFlat1D, IndexFlatL2)
+
+int faiss_IndexFlat1D_new(FaissIndexFlat1D** p_index);
+int faiss_IndexFlat1D_new_with(FaissIndexFlat1D** p_index, int continuous_update);
+
+int faiss_IndexFlat1D_update_permutation(FaissIndexFlat1D* index);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/c_api/IndexFlat_c.h
+++ b/c_api/IndexFlat_c.h
@@ -25,9 +25,9 @@ typedef enum FaissMetricType FaissMetricType;
 /** Opaque type for IndexFlat */
 FAISS_DECLARE_CLASS_INHERITED(IndexFlat, Index)
 
-int faiss_IndexFlat_create(FaissIndexFlat** p_index);
+int faiss_IndexFlat_new(FaissIndexFlat** p_index);
 
-int faiss_IndexFlat_create_with(FaissIndexFlat** p_index, idx_t d, FaissMetricType metric);
+int faiss_IndexFlat_new_with(FaissIndexFlat** p_index, idx_t d, FaissMetricType metric);
 
 /** get a pointer to the index's internal data (the `xb` field). The outputs
  * become invalid after any data addition or removal operation.
@@ -38,9 +38,8 @@ int faiss_IndexFlat_create_with(FaissIndexFlat** p_index, idx_t d, FaissMetricTy
  */
 void faiss_IndexFlat_xb(FaissIndexFlat* index, float** p_xb, size_t* p_size);
 
-
-/** attempt a dynamic cast from. This function can be used to
- * check whether the underlying index is a flat index.
+/** attempt a dynamic cast to a flat index, thus checking
+ * check whether the underlying index type is `IndexFlat`.
  * 
  * @param index opaque pointer to index object
  * @return the same pointer if the index is a flat index, NULL otherwise

--- a/c_api/IndexIVFFlat_c.cpp
+++ b/c_api/IndexIVFFlat_c.cpp
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#include "Index_c.h"
+#include "Clustering_c.h"
+#include "IndexIVFFlat_c.h"
+#include "IndexIVFFlat.h"
+#include "macros_impl.h"
+
+using faiss::Index;
+using faiss::IndexIVFFlat;
+using faiss::MetricType;
+
+DEFINE_DESTRUCTOR(IndexIVFFlat)
+
+int faiss_IndexIVFFlat_new(FaissIndexIVFFlat** p_index) {
+    try {
+        *p_index = reinterpret_cast<FaissIndexIVFFlat*>(new IndexIVFFlat());
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexIVFFlat_new_with(FaissIndexIVFFlat** p_index,
+    FaissIndex* quantizer, size_t d, size_t nlist)
+{
+    try {
+        auto q = reinterpret_cast<Index*>(quantizer);
+        *p_index = reinterpret_cast<FaissIndexIVFFlat*>(new IndexIVFFlat(q, d, nlist));
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexIVFFlat_new_with_metric(
+    FaissIndexIVFFlat** p_index, FaissIndex* quantizer, size_t d, size_t nlist,
+    FaissMetricType metric)
+{
+    try {
+        auto q = reinterpret_cast<Index*>(quantizer);
+        auto m = static_cast<MetricType>(metric);
+        *p_index = reinterpret_cast<FaissIndexIVFFlat*>(new IndexIVFFlat(q, d, nlist, m));
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexIVFFlat_add_core(FaissIndexIVFFlat* index, idx_t n, 
+    const float * x, const long *xids, const long *precomputed_idx)
+{
+    try {
+        reinterpret_cast<IndexIVFFlat*>(index)->add_core(n, x, xids, precomputed_idx);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexIVFFlat_update_vectors(FaissIndexIVFFlat* index, int nv,
+    idx_t *idx, const float *v)
+{
+    try {
+        reinterpret_cast<IndexIVFFlat*>(index)->update_vectors(nv, idx, v);
+    } CATCH_AND_HANDLE
+}

--- a/c_api/IndexIVFFlat_c.h
+++ b/c_api/IndexIVFFlat_c.h
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c -*-
+
+#ifndef FAISS_INDEX_IVF_FLAT_C_H
+#define FAISS_INDEX_IVF_FLAT_C_H
+
+#include "faiss_c.h"
+#include "Index_c.h"
+#include "Clustering_c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Inverted file with stored vectors. Here the inverted file
+ * pre-selects the vectors to be searched, but they are not otherwise
+ * encoded, the code array just contains the raw float entries.
+ */
+FAISS_DECLARE_CLASS(IndexIVFFlat)
+FAISS_DECLARE_DESTRUCTOR(IndexIVFFlat)
+
+int faiss_IndexIVFFlat_new(FaissIndexIVFFlat** p_index);
+
+int faiss_IndexIVFFlat_new_with(FaissIndexIVFFlat** p_index,
+    FaissIndex* quantizer, size_t d, size_t nlist);
+
+int faiss_IndexIVFFlat_new_with_metric(
+    FaissIndexIVFFlat** p_index, FaissIndex* quantizer, size_t d, size_t nlist,
+    FaissMetricType metric);
+
+int faiss_IndexIVFFlat_add_core(FaissIndexIVFFlat* index, idx_t n, 
+    const float * x, const long *xids, const long *precomputed_idx);
+
+/** Update a subset of vectors.
+ *
+ * The index must have a direct_map
+ *
+ * @param nv     nb of vectors to update
+ * @param idx    vector indices to update, size nv
+ * @param v      vectors of new values, size nv*d
+ */
+int faiss_IndexIVFFlat_update_vectors(FaissIndexIVFFlat* index, int nv,
+    idx_t *idx, const float *v);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif

--- a/c_api/IndexIVF_c.cpp
+++ b/c_api/IndexIVF_c.cpp
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#include "Index_c.h"
+#include "Clustering_c.h"
+#include "IndexIVF_c.h"
+#include "IndexIVF.h"
+#include "macros_impl.h"
+
+using faiss::IndexIVF;
+using faiss::IndexIVFFlat;
+using faiss::IndexIVFStats;
+
+DEFINE_DESTRUCTOR(IndexIVF)
+
+/// number of possible key values
+DEFINE_GETTER(IndexIVF, size_t, nlist)
+/// number of probes at query time
+DEFINE_GETTER(IndexIVF, size_t, nprobe)
+/// quantizer that maps vectors to inverted lists
+DEFINE_GETTER_PERMISSIVE(IndexIVF, FaissIndex*, quantizer)
+
+/**
+ * = 0: use the quantizer as index in a kmeans training
+ * = 1: just pass on the training set to the train() of the quantizer
+ * = 2: kmeans training on a flat index + add the centroids to the quantizer
+ */
+DEFINE_GETTER(IndexIVF, char, quantizer_trains_alone)
+
+/// whether object owns the quantizer
+DEFINE_GETTER(IndexIVF, int, own_fields)
+
+using faiss::IndexIVF;
+
+int faiss_IndexIVF_merge_from(
+    FaissIndexIVF* index, FaissIndexIVF* other, idx_t add_id) {
+    try {
+        reinterpret_cast<IndexIVF*>(index)->merge_from(
+            *reinterpret_cast<IndexIVF*>(other), add_id);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexIVF_copy_subset_to(
+    const FaissIndexIVF* index, FaissIndexIVF* other, int subset_type, long a1,
+    long a2) {
+    try {
+        reinterpret_cast<const IndexIVF*>(index)->copy_subset_to(
+            *reinterpret_cast<IndexIVF*>(other), subset_type, a1, a2);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexIVF_search_preassigned (const FaissIndexIVF* index,
+    idx_t n, const float *x, idx_t k, const idx_t *assign,
+    const float *centroid_dis, float *distances, idx_t *labels,
+    int store_pairs) {
+    try {
+        reinterpret_cast<const IndexIVF*>(index)->search_preassigned(
+            n, x, k, assign, centroid_dis, distances, labels, store_pairs);
+   } CATCH_AND_HANDLE
+}
+
+size_t faiss_IndexIVF_get_list_size(const FaissIndexIVF* index, size_t list_no) {
+    return reinterpret_cast<const IndexIVF*>(index)->get_list_size(list_no);
+}
+
+int faiss_IndexIVF_make_direct_map(FaissIndexIVF* index,
+    int new_maintain_direct_map) {
+    try {
+        reinterpret_cast<IndexIVF*>(index)->make_direct_map(
+            static_cast<bool>(new_maintain_direct_map));
+    } CATCH_AND_HANDLE
+}
+
+double faiss_IndexIVF_imbalance_factor (const FaissIndexIVF* index) {
+    return reinterpret_cast<const IndexIVF*>(index)->imbalance_factor();
+}
+
+/// display some stats about the inverted lists
+void faiss_IndexIVF_print_stats (const FaissIndexIVF* index) {
+    reinterpret_cast<const IndexIVF*>(index)->print_stats();
+}
+
+void faiss_IndexIVFStats_reset(FaissIndexIVFStats* stats) {
+    reinterpret_cast<IndexIVFStats*>(stats)->reset();    
+}
+
+DEFINE_DESTRUCTOR(IndexIVFFlat)
+
+int faiss_IndexIVFFlat_new(FaissIndexIVFFlat** p_index) {
+    try {
+        *p_index = reinterpret_cast<FaissIndexIVFFlat*>(new IndexIVFFlat());
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexIVFFlat_new_with(FaissIndexIVFFlat** p_index,
+    FaissIndex* quantizer, size_t d, size_t nlist);
+
+int faiss_IndexIVFFlat_new_with_metric(
+    FaissIndexIVFFlat** p_index, FaissIndex* quantizer, size_t d, size_t nlist,
+    FaissMetricType metric);
+
+int faiss_IndexIVFFlat_add_core(FaissIndexIVFFlat* index, idx_t n, 
+    const float * x, const long *xids, const long *precomputed_idx);
+
+/** Update a subset of vectors.
+ *
+ * The index must have a direct_map
+ *
+ * @param nv     nb of vectors to update
+ * @param idx    vector indices to update, size nv
+ * @param v      vectors of new values, size nv*d
+ */
+int faiss_IndexIVFFlat_update_vectors(FaissIndexIVFFlat* index, int nv,
+    idx_t *idx, const float *v);

--- a/c_api/IndexIVF_c.cpp
+++ b/c_api/IndexIVF_c.cpp
@@ -16,7 +16,6 @@
 #include "macros_impl.h"
 
 using faiss::IndexIVF;
-using faiss::IndexIVFFlat;
 using faiss::IndexIVFStats;
 
 DEFINE_DESTRUCTOR(IndexIVF)
@@ -91,32 +90,3 @@ void faiss_IndexIVF_print_stats (const FaissIndexIVF* index) {
 void faiss_IndexIVFStats_reset(FaissIndexIVFStats* stats) {
     reinterpret_cast<IndexIVFStats*>(stats)->reset();    
 }
-
-DEFINE_DESTRUCTOR(IndexIVFFlat)
-
-int faiss_IndexIVFFlat_new(FaissIndexIVFFlat** p_index) {
-    try {
-        *p_index = reinterpret_cast<FaissIndexIVFFlat*>(new IndexIVFFlat());
-    } CATCH_AND_HANDLE
-}
-
-int faiss_IndexIVFFlat_new_with(FaissIndexIVFFlat** p_index,
-    FaissIndex* quantizer, size_t d, size_t nlist);
-
-int faiss_IndexIVFFlat_new_with_metric(
-    FaissIndexIVFFlat** p_index, FaissIndex* quantizer, size_t d, size_t nlist,
-    FaissMetricType metric);
-
-int faiss_IndexIVFFlat_add_core(FaissIndexIVFFlat* index, idx_t n, 
-    const float * x, const long *xids, const long *precomputed_idx);
-
-/** Update a subset of vectors.
- *
- * The index must have a direct_map
- *
- * @param nv     nb of vectors to update
- * @param idx    vector indices to update, size nv
- * @param v      vectors of new values, size nv*d
- */
-int faiss_IndexIVFFlat_update_vectors(FaissIndexIVFFlat* index, int nv,
-    idx_t *idx, const float *v);

--- a/c_api/IndexIVF_c.h
+++ b/c_api/IndexIVF_c.h
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c -*-
+
+#ifndef FAISS_INDEX_IVF_C_H
+#define FAISS_INDEX_IVF_C_H
+
+#include "faiss_c.h"
+#include "Index_c.h"
+#include "Clustering_c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Index based on a inverted file (IVF)
+ *
+ * In the inverted file, the quantizer (an Index instance) provides a
+ * quantization index for each vector to be added. The quantization
+ * index maps to a list (aka inverted list or posting list), where the
+ * id of the vector is then stored.
+ *
+ * At search time, the vector to be searched is also quantized, and
+ * only the list corresponding to the quantization index is
+ * searched. This speeds up the search by making it
+ * non-exhaustive. This can be relaxed using multi-probe search: a few
+ * (nprobe) quantization indices are selected and several inverted
+ * lists are visited.
+ *
+ * Sub-classes implement a post-filtering of the index that refines
+ * the distance estimation from the query to databse vectors.
+ */
+FAISS_DECLARE_CLASS_INHERITED(IndexIVF, Index)
+FAISS_DECLARE_DESTRUCTOR(IndexIVF)
+
+/// number of possible key values
+FAISS_DECLARE_GETTER(IndexIVF, size_t, nlist)
+/// number of probes at query time
+FAISS_DECLARE_GETTER(IndexIVF, size_t, nprobe)
+/// quantizer that maps vectors to inverted lists
+FAISS_DECLARE_GETTER(IndexIVF, FaissIndex*, quantizer)
+/**
+ * = 0: use the quantizer as index in a kmeans training
+ * = 1: just pass on the training set to the train() of the quantizer
+ * = 2: kmeans training on a flat index + add the centroids to the quantizer
+ */
+FAISS_DECLARE_GETTER(IndexIVF, char, quantizer_trains_alone)
+
+/// whether object owns the quantizer
+FAISS_DECLARE_GETTER(IndexIVF, int, own_fields)
+
+/** moves the entries from another dataset to self. On output,
+ * other is empty. add_id is added to all moved ids (for
+ * sequential ids, this would be this->ntotal */
+int faiss_IndexIVF_merge_from(
+    FaissIndexIVF* index, FaissIndexIVF* other, idx_t add_id);
+
+/** copy a subset of the entries index to the other index
+ *
+ * if subset_type == 0: copies ids in [a1, a2)
+ * if subset_type == 1: copies ids if id % a1 == a2
+ * if subset_type == 2: copies inverted lists such that a1
+ *                      elements are left before and a2 elements are after
+ */
+int faiss_IndexIVF_copy_subset_to(
+    const FaissIndexIVF* index, FaissIndexIVF* other, int subset_type, long a1,
+    long a2);
+
+/** search a set of vectors, that are pre-quantized by the IVF
+ *  quantizer. Fill in the corresponding heaps with the query
+ *  results. search() calls this.
+ *
+ * @param n      nb of vectors to query
+ * @param x      query vectors, size nx * d
+ * @param assign coarse quantization indices, size nx * nprobe
+ * @param centroid_dis
+ *               distances to coarse centroids, size nx * nprobe
+ * @param distance
+ *               output distances, size n * k
+ * @param labels output labels, size n * k
+ * @param store_pairs store inv list index + inv list offset
+ *                     instead in upper/lower 32 bit of result,
+ *                     instead of ids (used for reranking).
+ */
+int faiss_IndexIVF_search_preassigned (const FaissIndexIVF* index,
+    idx_t n, const float *x, idx_t k, const idx_t *assign,
+    const float *centroid_dis, float *distances, idx_t *labels,
+    int store_pairs);
+
+size_t faiss_IndexIVF_get_list_size(const FaissIndexIVF* index,
+    size_t list_no);
+
+/** intialize a direct map
+ *
+ * @param new_maintain_direct_map    if true, create a direct map,
+ *                                   else clear it
+ */
+int faiss_IndexIVF_make_direct_map(FaissIndexIVF* index,
+    int new_maintain_direct_map);
+
+/// 1= perfectly balanced, >1: imbalanced
+double faiss_IndexIVF_imbalance_factor (const FaissIndexIVF* index);
+
+/// display some stats about the inverted lists
+void faiss_IndexIVF_print_stats (const FaissIndexIVF* index);
+
+
+typedef struct FaissIndexIVFStats {
+    size_t nq;       // nb of queries run
+    size_t nlist;    // nb of inverted lists scanned
+    size_t ndis;     // nb of distancs computed
+} FaissIndexIVFStats;
+
+void faiss_IndexIVFStats_reset(FaissIndexIVFStats* stats);
+
+inline void faiss_IndexIVFStats_init(FaissIndexIVFStats* stats) {
+    faiss_IndexIVFStats_reset(stats);
+}
+
+/** Inverted file with stored vectors. Here the inverted file
+ * pre-selects the vectors to be searched, but they are not otherwise
+ * encoded, the code array just contains the raw float entries.
+ */
+FAISS_DECLARE_CLASS(IndexIVFFlat)
+FAISS_DECLARE_DESTRUCTOR(IndexIVFFlat)
+
+int faiss_IndexIVFFlat_new(FaissIndexIVFFlat** p_index);
+
+int faiss_IndexIVFFlat_new_with(FaissIndexIVFFlat** p_index,
+    FaissIndex* quantizer, size_t d, size_t nlist);
+
+int faiss_IndexIVFFlat_new_with_metric(
+    FaissIndexIVFFlat** p_index, FaissIndex* quantizer, size_t d, size_t nlist,
+    FaissMetricType metric);
+
+int faiss_IndexIVFFlat_add_core(FaissIndexIVFFlat* index, idx_t n, 
+    const float * x, const long *xids, const long *precomputed_idx);
+
+/** Update a subset of vectors.
+ *
+ * The index must have a direct_map
+ *
+ * @param nv     nb of vectors to update
+ * @param idx    vector indices to update, size nv
+ * @param v      vectors of new values, size nv*d
+ */
+int faiss_IndexIVFFlat_update_vectors(FaissIndexIVFFlat* index, int nv,
+    idx_t *idx, const float *v);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif

--- a/c_api/Index_c.cpp
+++ b/c_api/Index_c.cpp
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#include "Index_c.h"
+#include "Index.h"
+#include "macros_impl.h"
+
+extern "C" {
+
+DEFINE_DESTRUCTOR(Index)
+
+DEFINE_GETTER(Index, int, d)
+
+DEFINE_GETTER(Index, int, is_trained)
+
+DEFINE_GETTER(Index, idx_t, ntotal)
+
+DEFINE_GETTER(Index, FaissMetricType, metric_type)
+
+int faiss_Index_train(FaissIndex* index, idx_t n, const float* x) {
+    try {
+        reinterpret_cast<faiss::Index*>(index)->train(n, x);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_Index_add(FaissIndex* index, idx_t n, const float* x) {
+    try {
+        reinterpret_cast<faiss::Index*>(index)->add(n, x);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_Index_add_with_ids(FaissIndex* index, idx_t n, const float* x, const long* xids) {
+    try {
+        reinterpret_cast<faiss::Index*>(index)->add_with_ids(n, x, xids);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_Index_search(const FaissIndex* index, idx_t n, const float* x, idx_t k,
+                       float* distances, idx_t* labels) {
+    try {
+        reinterpret_cast<const faiss::Index*>(index)->search(n, x, k, distances, labels);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_Index_range_search(const FaissIndex* index, idx_t n, const float* x, float radius,
+                             FaissRangeSearchResult* result) {
+    try {
+        reinterpret_cast<const faiss::Index*>(index)->range_search(
+            n, x, radius, reinterpret_cast<faiss::RangeSearchResult*>(result));
+    } CATCH_AND_HANDLE
+}
+
+int faiss_Index_assign(FaissIndex* index, idx_t n, const float * x, idx_t * labels, idx_t k) {
+    try {
+        reinterpret_cast<faiss::Index*>(index)->assign(n, x, labels, k);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_Index_reset(FaissIndex* index) {
+    try {
+        reinterpret_cast<faiss::Index*>(index)->reset();
+    } CATCH_AND_HANDLE
+}
+
+int faiss_Index_remove_ids(FaissIndex* index, const FaissIDSelector* sel, long* n_removed) {
+    try {
+        long n = reinterpret_cast<faiss::Index*>(index)->remove_ids(
+            *reinterpret_cast<const faiss::IDSelector*>(sel));
+        if (n_removed) {
+            *n_removed = n;
+        }
+    } CATCH_AND_HANDLE
+}
+
+int faiss_Index_reconstruct(const FaissIndex* index, idx_t key, float* recons) {
+    try {
+        reinterpret_cast<const faiss::Index*>(index)->reconstruct(key, recons);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_Index_reconstruct_n (const FaissIndex* index, idx_t i0, idx_t ni, float* recons) {
+    try {
+        reinterpret_cast<const faiss::Index*>(index)->reconstruct_n(i0, ni, recons);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_Index_compute_residual(const FaissIndex* index, const float* x, float* residual, idx_t key) {
+    try {
+        reinterpret_cast<const faiss::Index*>(index)->compute_residual(x, residual, key);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_Index_display(const FaissIndex* index) {
+    try {
+        reinterpret_cast<const faiss::Index*>(index)->display();
+    } CATCH_AND_HANDLE
+}
+
+}

--- a/c_api/Index_c.h
+++ b/c_api/Index_c.h
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved
+// -*- c -*-
+
+#ifndef FAISS_INDEX_C_H
+#define FAISS_INDEX_C_H
+
+#include <stdio.h>
+#include "faiss_c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// forward declaration required here
+FAISS_DECLARE_CLASS(RangeSearchResult)
+
+//typedef struct FaissRangeSearchResult_H FaissRangeSearchResult;
+typedef struct FaissIDSelector_H FaissIDSelector;
+
+/// Some algorithms support both an inner product version and a L2 search version.
+typedef enum FaissMetricType {
+    METRIC_INNER_PRODUCT = 0,
+    METRIC_L2 = 1,
+} FaissMetricType;
+
+/// Opaque type for referencing to an index object
+FAISS_DECLARE_CLASS(Index)
+FAISS_DECLARE_DESTRUCTOR(Index)
+
+/// Getter for d
+FAISS_DECLARE_GETTER(Index, int, d)
+
+/// Getter for is_trained
+FAISS_DECLARE_GETTER(Index, int, is_trained)
+
+/// Getter for ntotal
+FAISS_DECLARE_GETTER(Index, idx_t, ntotal)
+
+/// Getter for metric_type
+FAISS_DECLARE_GETTER(Index, FaissMetricType, metric_type)
+
+/** Perform training on a representative set of vectors
+ *
+ * @param index  opaque pointer to index object
+ * @param n      nb of training vectors
+ * @param x      training vecors, size n * d
+ */
+int faiss_Index_train(FaissIndex* index, idx_t n, const float* x);
+
+/** Add n vectors of dimension d to the index.
+ *
+ * Vectors are implicitly assigned labels ntotal .. ntotal + n - 1
+ * This function slices the input vectors in chuncks smaller than
+ * blocksize_add and calls add_core.
+ * @param index  opaque pointer to index object
+ * @param x      input matrix, size n * d
+ */
+int faiss_Index_add(FaissIndex* index, idx_t n, const float* x);
+
+/** Same as add, but stores xids instead of sequential ids.
+ *
+ * The default implementation fails with an assertion, as it is
+ * not supported by all indexes.
+ *
+ * @param index  opaque pointer to index object
+ * @param xids   if non-null, ids to store for the vectors (size n)
+ */
+int faiss_Index_add_with_ids(FaissIndex* index, idx_t n, const float* x, const long* xids);
+
+/** query n vectors of dimension d to the index.
+ *
+ * return at most k vectors. If there are not enough results for a
+ * query, the result array is padded with -1s.
+ *
+ * @param index       opaque pointer to index object
+ * @param x           input vectors to search, size n * d
+ * @param labels      output labels of the NNs, size n*k
+ * @param distances   output pairwise distances, size n*k
+ */
+int faiss_Index_search(const FaissIndex* index, idx_t n, const float* x, idx_t k,
+                       float* distances, idx_t* labels);
+
+/** query n vectors of dimension d to the index.
+ *
+ * return all vectors with distance < radius. Note that many
+ * indexes do not implement the range_search (only the k-NN search
+ * is mandatory).
+ *
+ * @param index       opaque pointer to index object
+ * @param x           input vectors to search, size n * d
+ * @param radius      search radius
+ * @param result      result table
+ */
+int faiss_Index_range_search(const FaissIndex* index, idx_t n, const float* x,
+                             float radius, FaissRangeSearchResult* result);
+
+/** return the indexes of the k vectors closest to the query x.
+ *
+ * This function is identical as search but only return labels of neighbors.
+ * @param index       opaque pointer to index object
+ * @param x           input vectors to search, size n * d
+ * @param labels      output labels of the NNs, size n*k
+ */
+int faiss_Index_assign(FaissIndex* index, idx_t n, const float * x, idx_t * labels, idx_t k);
+
+/** removes all elements from the database.
+ * @param index       opaque pointer to index object
+ */
+int faiss_Index_reset(FaissIndex* index);
+
+/** removes IDs from the index. Not supported by all indexes
+ * @param index       opaque pointer to index object
+ * @param nremove     output for the number of IDs removed
+ */
+int faiss_Index_remove_ids(FaissIndex* index, const FaissIDSelector* sel, long* n_removed);
+
+/** Reconstruct a stored vector (or an approximation if lossy coding)
+ *
+ * this function may not be defined for some indexes
+ * @param index       opaque pointer to index object
+ * @param key         id of the vector to reconstruct
+ * @param recons      reconstucted vector (size d)
+ */
+int faiss_Index_reconstruct(const FaissIndex* index, idx_t key, float* recons);
+
+/** Reconstruct vectors i0 to i0 + ni - 1
+ *
+ * this function may not be defined for some indexes
+ * @param index       opaque pointer to index object
+ * @param recons      reconstucted vector (size ni * d)
+ */
+int faiss_Index_reconstruct_n (const FaissIndex* index, idx_t i0, idx_t ni, float* recons);
+
+/** Computes a residual vector after indexing encoding.
+ *
+ * The residual vector is the difference between a vector and the
+ * reconstruction that can be decoded from its representation in
+ * the index. The residual can be used for multiple-stage indexing
+ * methods, like IndexIVF's methods.
+ *
+ * @param index       opaque pointer to index object
+ * @param x           input vector, size d
+ * @param residual    output residual vector, size d
+ * @param key         encoded index, as returned by search and assign
+ */
+int faiss_Index_compute_residual(const FaissIndex* index, const float* x, float* residual, idx_t key);
+
+/** Display the actual class name and some more info
+ * @param index       opaque pointer to index object
+ */
+int faiss_Index_display(const FaissIndex* index);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/c_api/Makefile
+++ b/c_api/Makefile
@@ -14,7 +14,7 @@ DEBUGFLAG=-DNDEBUG # no debugging
 LIBNAME=libfaiss
 CLIBNAME=libfaiss_c
 LIBCOBJ=error_impl.o Index_c.o IndexFlat_c.o Clustering_c.o \
-	AuxIndexStructures_c.o AutoTune_c.o IndexIVF_c.o
+	AuxIndexStructures_c.o AutoTune_c.o IndexIVF_c.o IndexIVFFlat_c.o
 
 # Build shared object file by default
 all: $(CLIBNAME).$(SHAREDEXT)
@@ -48,6 +48,9 @@ IndexFlat_c.o: IndexFlat_c.cpp IndexFlat_c.h ../IndexFlat.h macros_impl.h
 
 IndexIVF_c.o: CFLAGS += -I.. $(DEBUGFLAG)
 IndexIVF_c.o: IndexIVF_c.cpp IndexIVF_c.h ../IndexIVF.h macros_impl.h
+
+IndexIVFFlat_c.o: CFLAGS += -I.. $(DEBUGFLAG)
+IndexIVFFlat_c.o: IndexIVFFlat_c.cpp IndexIVFFlat_c.h ../IndexIVFFlat.h macros_impl.h
 
 Clustering_c.o: CFLAGS += -I.. $(DEBUGFLAG)
 Clustering_c.o: Clustering_c.cpp Clustering_c.h ../Clustering.h macros_impl.h

--- a/c_api/Makefile
+++ b/c_api/Makefile
@@ -1,0 +1,58 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD+Patents license found in the
+# LICENSE file in the root directory of this source tree.
+
+.SUFFIXES: .cpp .o
+
+# C API
+
+include ../makefile.inc
+
+LIBNAME=libfaiss
+CLIBNAME=libfaiss_c
+LIBCOBJ=error_impl.o Index_c.o IndexFlat_c.o Clustering_c.o \
+	AuxIndexStructures_c.o AutoTune_c.o IndexIVF_c.o
+
+# Build shared object file by default
+all: $(CLIBNAME).$(SHAREDEXT)
+
+# Build static library (requires consumers to link with libstdc++)
+$(CLIBNAME).a: $(LIBCOBJ) ../$(LIBNAME).a
+	ar r $@ $^
+
+# Build dynamic library
+$(CLIBNAME).$(SHAREDEXT): $(LIBCOBJ) ../$(LIBNAME).a
+	$(CXX) $(LDFLAGS) $(FAISSSHAREDFLAGS) -o $@ \
+	-Wl,--whole-archive $^ $(BLASLDFLAGS) -Wl,--no-whole-archive -static-libstdc++
+
+bin/example_c: example_c.c $(CLIBNAME).$(SHAREDEXT)
+	$(CC) $(CFLAGS) -std=c99 -I. -I.. -L. -o $@ example_c.c \
+	$(LDFLAGS) -lm $(BLASLDFLAGS) -lfaiss_c
+
+clean:
+	rm -f $(CLIBNAME).a $(CLIBNAME).$(SHAREDEXT)* *.o
+
+# Dependencies
+
+error_impl.o: CFLAGS += -I..
+error_impl.o: error_impl.cpp error_c.h error_impl.h macros_impl.h
+
+Index_c.o: CFLAGS += -I..
+Index_c.o: Index_c.cpp Index_c.h ../Index.h macros_impl.h
+
+IndexFlat_c.o: CFLAGS += -I..
+IndexFlat_c.o: IndexFlat_c.cpp IndexFlat_c.h ../IndexFlat.h macros_impl.h
+
+IndexIVF_c.o: CFLAGS += -I..
+IndexIVF_c.o: IndexIVF_c.cpp IndexIVF_c.h ../IndexIVF.h macros_impl.h
+
+Clustering_c.o: CFLAGS += -I..
+Clustering_c.o: Clustering_c.cpp Clustering_c.h ../Clustering.h macros_impl.h
+
+AutoTune_c.o: CFLAGS += -I..
+AutoTune_c.o: AutoTune_c.cpp AutoTune_c.h ../AutoTune.h macros_impl.h
+
+AuxIndexStructures_c.o: CFLAGS += -I..
+AuxIndexStructures_c.o: AuxIndexStructures_c.cpp AuxIndexStructures_c.h ../AuxIndexStructures.h macros_impl.h

--- a/c_api/Makefile
+++ b/c_api/Makefile
@@ -9,6 +9,7 @@
 # C API
 
 include ../makefile.inc
+DEBUGFLAG=-DNDEBUG # no debugging
 
 LIBNAME=libfaiss
 CLIBNAME=libfaiss_c
@@ -36,23 +37,23 @@ clean:
 
 # Dependencies
 
-error_impl.o: CFLAGS += -I..
+error_impl.o: CFLAGS += -I.. $(DEBUGFLAG)
 error_impl.o: error_impl.cpp error_c.h error_impl.h macros_impl.h
 
-Index_c.o: CFLAGS += -I..
+Index_c.o: CFLAGS += -I.. $(DEBUGFLAG)
 Index_c.o: Index_c.cpp Index_c.h ../Index.h macros_impl.h
 
-IndexFlat_c.o: CFLAGS += -I..
+IndexFlat_c.o: CFLAGS += -I.. $(DEBUGFLAG)
 IndexFlat_c.o: IndexFlat_c.cpp IndexFlat_c.h ../IndexFlat.h macros_impl.h
 
-IndexIVF_c.o: CFLAGS += -I..
+IndexIVF_c.o: CFLAGS += -I.. $(DEBUGFLAG)
 IndexIVF_c.o: IndexIVF_c.cpp IndexIVF_c.h ../IndexIVF.h macros_impl.h
 
-Clustering_c.o: CFLAGS += -I..
+Clustering_c.o: CFLAGS += -I.. $(DEBUGFLAG)
 Clustering_c.o: Clustering_c.cpp Clustering_c.h ../Clustering.h macros_impl.h
 
-AutoTune_c.o: CFLAGS += -I..
+AutoTune_c.o: CFLAGS += -I.. $(DEBUGFLAG)
 AutoTune_c.o: AutoTune_c.cpp AutoTune_c.h ../AutoTune.h macros_impl.h
 
-AuxIndexStructures_c.o: CFLAGS += -I..
+AuxIndexStructures_c.o: CFLAGS += -I.. $(DEBUGFLAG)
 AuxIndexStructures_c.o: AuxIndexStructures_c.cpp AuxIndexStructures_c.h ../AuxIndexStructures.h macros_impl.h

--- a/c_api/Makefile
+++ b/c_api/Makefile
@@ -32,7 +32,7 @@ bin/example_c: example_c.c $(CLIBNAME).$(SHAREDEXT)
 	$(LDFLAGS) -lm $(BLASLDFLAGS) -lfaiss_c
 
 clean:
-	rm -f $(CLIBNAME).a $(CLIBNAME).$(SHAREDEXT)* *.o
+	rm -f $(CLIBNAME).a $(CLIBNAME).$(SHAREDEXT)* *.o bin/example_c
 
 # Dependencies
 

--- a/c_api/error_c.h
+++ b/c_api/error_c.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c -*-
+
+#ifndef FAISS_ERROR_C_H
+#define FAISS_ERROR_C_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum FaissErrorCode {
+    OK = 0,
+    UNKNOWN_EXCEPT = -1,
+    FAISS_EXCEPT = -2,
+    STD_EXCEPT = -4
+} FaissErrorCode;
+
+/**
+ * Get the error message of the last failed operation performed by Faiss.
+ * The given pointer is only invalid until another Faiss function is
+ * called.
+ */
+const char* faiss_get_last_error();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/c_api/error_impl.cpp
+++ b/c_api/error_impl.cpp
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#include "error_c.h"
+#include "error_impl.h"
+#include "FaissException.h"
+#include <exception>
+
+thread_local std::exception_ptr faiss_last_exception;
+
+const char* faiss_get_last_error() {
+    if (faiss_last_exception) {
+        try {
+            std::rethrow_exception(faiss_last_exception);
+        } catch (std::exception& e) {
+            return e.what();
+        }
+    }
+    return nullptr;
+}

--- a/c_api/error_impl.h
+++ b/c_api/error_impl.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#include <exception>
+
+/** global variable for holding the last exception thrown by
+ * calls to Faiss functions through the C API
+ */
+extern thread_local std::exception_ptr faiss_last_exception;

--- a/c_api/example_c.c
+++ b/c_api/example_c.c
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c -*-
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "error_c.h"
+#include "Index_c.h"
+#include "IndexFlat_c.h"
+#include "AutoTune_c.h"
+
+#define FAISS_TRY(C)                                       \
+    {                                                      \
+        int __c = C;                                       \
+        if (__c) {                                         \
+            fprintf(stderr, "%s", faiss_get_last_error()); \
+            exit(-1);                                      \
+        }                                                  \
+    }
+
+inline double drand() {
+    return (double)rand() / (double)RAND_MAX;
+}
+
+int main() {
+    time_t seed = time(NULL);
+    srand(seed);
+    printf("Generating some data...\n");
+    int d = 128;                           // dimension
+    int nb = 100000;                       // database size
+    int nq = 10000;                        // nb of queries
+    float *xb = malloc(d * nb * sizeof(float));
+    float *xq = malloc(d * nq * sizeof(float));
+
+    for(int i = 0; i < nb; i++) {
+        for(int j = 0; j < d; j++) xb[d * i + j] = drand();
+        xb[d * i] += i / 1000.;
+    }
+    for(int i = 0; i < nq; i++) {
+        for(int j = 0; j < d; j++) xq[d * i + j] = drand();
+        xq[d * i] += i / 1000.;
+    }
+
+    printf("Building an index...\n");
+
+    FaissIndex* index = NULL;
+    FAISS_TRY(faiss_index_factory(&index, d, "Flat", METRIC_L2));  // use factory to create index
+    printf("is_trained = %s\n", faiss_Index_is_trained(index) ? "true" : "false");
+    FAISS_TRY(faiss_Index_add(index, nb, xb));                     // add vectors to the index
+    printf("ntotal = %ld\n", faiss_Index_ntotal(index));
+
+    printf("Searching...\n");
+    int k = 5;
+
+    {       // sanity check: search 5 first vectors of xb
+        long *I = malloc(k * 5 * sizeof(long));
+        float *D = malloc(k * 5 * sizeof(float));
+        FAISS_TRY(faiss_Index_search(index, 5, xb, k, D, I));
+        printf("I=\n");
+        for(int i = 0; i < 5; i++) {
+            for(int j = 0; j < k; j++) printf("%5ld (d=%2.3f)  ", I[i * k + j], D[i * k + j]);
+            printf("\n");
+        }
+        free(I);
+        free(D);
+    }
+    {       // search xq
+        long *I = malloc(k * nq * sizeof(long));
+        float *D = malloc(k * nq * sizeof(float));
+        FAISS_TRY(faiss_Index_search(index, 5, xb, k, D, I));
+        printf("I=\n");
+        for(int i = 0; i < 5; i++) {
+            for(int j = 0; j < k; j++) printf("%5ld (d=%2.3f)  ", I[i * k + j], D[i * k + j]);
+            printf("\n");
+        }
+        free(I);
+        free(D);
+    }
+
+    printf("Freeing index...\n");
+    faiss_Index_free(index);
+    printf("Done.\n");
+
+    return 0;
+}

--- a/c_api/example_c.c
+++ b/c_api/example_c.c
@@ -20,8 +20,7 @@
 
 #define FAISS_TRY(C)                                       \
     {                                                      \
-        int __c = C;                                       \
-        if (__c) {                                         \
+        if (C) {                                           \
             fprintf(stderr, "%s", faiss_get_last_error()); \
             exit(-1);                                      \
         }                                                  \

--- a/c_api/faiss_c.h
+++ b/c_api/faiss_c.h
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c -*-
+
+/// Macros and typedefs for C wrapper API declarations
+
+#ifndef FAISS_C_H
+#define FAISS_C_H
+
+typedef long idx_t;    ///< all indices are this type
+
+/// Declare an opaque type for a class type `clazz`.
+#define FAISS_DECLARE_CLASS(clazz) \
+    typedef struct Faiss ## clazz ## _H Faiss ## clazz;
+
+/// Declare an opaque type for a class type `clazz`, while
+/// actually aliasing it to an existing parent class type `parent`.
+#define FAISS_DECLARE_CLASS_INHERITED(clazz, parent) \
+    typedef struct Faiss ## parent ## _H Faiss ## clazz;
+
+/// Declare a getter for the field `name` in class `clazz`,
+/// of return type `ty`
+#define FAISS_DECLARE_GETTER(clazz, ty, name) \
+    ty faiss_ ## clazz ## _ ## name (const Faiss ## clazz *);
+
+/// Declare a setter for the field `name` in class `clazz`,
+/// in which the user provides a value of type `ty`
+#define FAISS_DECLARE_SETTER(clazz, ty, name) \
+    void faiss_ ## clazz ## _set_ ## name (Faiss ## clazz *, ty); \
+
+/// Declare a getter and setter for the field `name` in class `clazz`.
+#define FAISS_DECLARE_GETTER_SETTER(clazz, ty, name) \
+    FAISS_DECLARE_GETTER(clazz, ty, name) \
+    FAISS_DECLARE_SETTER(clazz, ty, name)
+    
+/// Declare a destructor function which frees an object of
+/// type `clazz`.
+#define FAISS_DECLARE_DESTRUCTOR(clazz) \
+    void faiss_ ## clazz ## _free (Faiss ## clazz *obj);
+
+#endif

--- a/c_api/gpu/GpuAutoTune_c.cpp
+++ b/c_api/gpu/GpuAutoTune_c.cpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#include "GpuAutoTune_c.h"
+#include "macros_impl.h"
+#include "Index.h"
+#include "gpu/GpuAutoTune.h"
+#include "gpu/GpuClonerOptions.h"
+
+using faiss::Index;
+using faiss::gpu::GpuResources;
+using faiss::gpu::GpuClonerOptions;
+
+int faiss_index_gpu_to_cpu(const FaissIndex* gpu_index, FaissIndex** p_out) {
+    try {
+        auto cpu_index = faiss::gpu::index_gpu_to_cpu(
+            reinterpret_cast<const Index*>(gpu_index)
+        );
+        *p_out = reinterpret_cast<FaissIndex*>(cpu_index);
+    } CATCH_AND_HANDLE
+}
+
+/// converts any CPU index that can be converted to GPU
+int faiss_index_cpu_to_gpu(FaissGpuResources* resources, int device, const FaissIndex *index, FaissGpuIndex** p_out) {
+    try {
+        auto res = reinterpret_cast<GpuResources*>(resources);
+        auto gpu_index = faiss::gpu::index_cpu_to_gpu(
+            res, device, reinterpret_cast<const Index*>(index)
+        );
+        *p_out = reinterpret_cast<FaissGpuIndex*>(gpu_index);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_index_cpu_to_gpu_with_options(
+    FaissGpuResources* resources, int device,
+    const FaissIndex *index, const FaissGpuClonerOptions* options,
+    FaissGpuIndex** p_out)
+{
+    try {
+        auto res = reinterpret_cast<GpuResources*>(resources);
+        auto gpu_index = faiss::gpu::index_cpu_to_gpu(
+            res, device, reinterpret_cast<const Index*>(index),
+            reinterpret_cast<const GpuClonerOptions*>(options));
+        *p_out = reinterpret_cast<FaissGpuIndex*>(gpu_index);
+    } CATCH_AND_HANDLE
+}

--- a/c_api/gpu/GpuAutoTune_c.h
+++ b/c_api/gpu/GpuAutoTune_c.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c -*-
+
+#ifndef FAISS_GPU_AUTO_TUNE_C_H
+#define FAISS_GPU_AUTO_TUNE_C_H
+
+#include "faiss_c.h"
+#include "GpuClonerOptions_c.h"
+#include "GpuResources_c.h"
+#include "GpuIndex_c.h"
+#include "Index_c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// converts any GPU index inside gpu_index to a CPU index
+int faiss_index_gpu_to_cpu(const FaissIndex* gpu_index, FaissIndex** p_out);
+
+/// converts any CPU index that can be converted to GPU
+int faiss_index_cpu_to_gpu(
+    FaissGpuResources* resources, int device,
+    const FaissIndex *index, FaissGpuIndex** p_out);
+
+/// converts any CPU index that can be converted to GPU
+int faiss_index_cpu_to_gpu_with_options(
+    FaissGpuResources* resources, int device,
+    const FaissIndex *index, const FaissGpuClonerOptions* options,
+    FaissGpuIndex** p_out);
+
+/// parameter space and setters for GPU indexes
+FAISS_DECLARE_CLASS_INHERITED(GpuParameterSpace, ParameterSpace)
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/c_api/gpu/GpuClonerOptions_c.cpp
+++ b/c_api/gpu/GpuClonerOptions_c.cpp
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#include "GpuClonerOptions_c.h"
+#include "gpu/GpuClonerOptions.h"
+#include "macros_impl.h"
+
+using faiss::gpu::IndicesOptions;
+using faiss::gpu::GpuClonerOptions;
+using faiss::gpu::GpuMultipleClonerOptions;
+
+int faiss_GpuClonerOptions_new(FaissGpuClonerOptions** p) {
+    try {
+        *p = reinterpret_cast<FaissGpuClonerOptions*>(new GpuClonerOptions());
+    } CATCH_AND_HANDLE
+}
+
+DEFINE_DESTRUCTOR(GpuClonerOptions)
+
+DEFINE_GETTER(GpuClonerOptions, FaissIndicesOptions, indicesOptions)
+DEFINE_GETTER(GpuClonerOptions, int, useFloat16CoarseQuantizer)
+DEFINE_GETTER(GpuClonerOptions, int, useFloat16)
+DEFINE_GETTER(GpuClonerOptions, int, usePrecomputed)
+DEFINE_GETTER(GpuClonerOptions, long, reserveVecs)
+DEFINE_GETTER(GpuClonerOptions, int, storeTransposed)
+DEFINE_GETTER(GpuClonerOptions, int, verbose)
+DEFINE_GETTER(GpuMultipleClonerOptions, int, shard)
+DEFINE_GETTER(GpuMultipleClonerOptions, int, shard_type)
+
+DEFINE_SETTER_STATIC(GpuClonerOptions, IndicesOptions, FaissIndicesOptions, indicesOptions)
+DEFINE_SETTER_STATIC(GpuClonerOptions, bool, int, useFloat16CoarseQuantizer)
+DEFINE_SETTER_STATIC(GpuClonerOptions, bool, int, useFloat16)
+DEFINE_SETTER_STATIC(GpuClonerOptions, bool, int, usePrecomputed)
+DEFINE_SETTER(GpuClonerOptions, long, reserveVecs)
+DEFINE_SETTER_STATIC(GpuClonerOptions, bool, int, storeTransposed)
+DEFINE_SETTER_STATIC(GpuClonerOptions, bool, int, verbose)
+DEFINE_SETTER_STATIC(GpuMultipleClonerOptions, bool, int, shard)
+DEFINE_SETTER(GpuMultipleClonerOptions, int, shard_type)

--- a/c_api/gpu/GpuClonerOptions_c.h
+++ b/c_api/gpu/GpuClonerOptions_c.h
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c -*-
+
+#ifndef FAISS_GPU_CLONER_OPTIONS_C_H
+#define FAISS_GPU_CLONER_OPTIONS_C_H
+
+#include "faiss_c.h"
+#include "GpuIndicesOptions_c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+FAISS_DECLARE_CLASS(GpuClonerOptions)
+
+FAISS_DECLARE_DESTRUCTOR(GpuClonerOptions)
+
+// Default constructor for GpuClonerOptions
+int faiss_GpuClonerOptions_new(FaissGpuClonerOptions**);
+
+/// how should indices be stored on index types that support indices
+/// (anything but GpuIndexFlat*)?
+FAISS_DECLARE_GETTER_SETTER(GpuClonerOptions, FaissIndicesOptions, indicesOptions)
+
+/// (boolean) is the coarse quantizer in float16?
+FAISS_DECLARE_GETTER_SETTER(GpuClonerOptions, int, useFloat16CoarseQuantizer)
+
+/// (boolean) for GpuIndexIVFFlat, is storage in float16?
+/// for GpuIndexIVFPQ, are intermediate calculations in float16?
+FAISS_DECLARE_GETTER_SETTER(GpuClonerOptions, int, useFloat16)
+
+/// (boolean) use precomputed tables?
+FAISS_DECLARE_GETTER_SETTER(GpuClonerOptions, int, usePrecomputed)
+
+/// reserve vectors in the invfiles?
+FAISS_DECLARE_GETTER_SETTER(GpuClonerOptions, long, reserveVecs)
+
+/// (boolean) For GpuIndexFlat, store data in transposed layout?
+FAISS_DECLARE_GETTER_SETTER(GpuClonerOptions, int, storeTransposed)
+
+/// (boolean) Set verbose options on the index
+FAISS_DECLARE_GETTER_SETTER(GpuClonerOptions, int, verbose)
+
+FAISS_DECLARE_CLASS_INHERITED(GpuMultipleClonerOptions, GpuClonerOptions)
+
+/// (boolean) Whether to shard the index across GPUs, versus replication
+/// across GPUs
+FAISS_DECLARE_GETTER_SETTER(GpuMultipleClonerOptions, int, shard)
+
+/// IndexIVF::copy_subset_to subset type
+FAISS_DECLARE_GETTER_SETTER(GpuMultipleClonerOptions, int, shard_type)
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/c_api/gpu/GpuIndex_c.cpp
+++ b/c_api/gpu/GpuIndex_c.cpp
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#include "gpu/GpuIndex.h"
+#include "GpuIndex_c.h"
+#include "macros_impl.h"
+
+using faiss::gpu::GpuIndexConfig;
+
+DEFINE_GETTER(GpuIndexConfig, int, device)

--- a/c_api/gpu/GpuIndex_c.h
+++ b/c_api/gpu/GpuIndex_c.h
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c -*-
+
+#ifndef FAISS_GPU_INDEX_C_H
+#define FAISS_GPU_INDEX_C_H
+
+#include "faiss_c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+FAISS_DECLARE_CLASS(GpuIndexConfig)
+
+FAISS_DECLARE_GETTER(GpuIndexConfig, int, device)
+
+FAISS_DECLARE_CLASS_INHERITED(GpuIndex, Index)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/c_api/gpu/GpuIndicesOptions_c.h
+++ b/c_api/gpu/GpuIndicesOptions_c.h
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c -*-
+
+#ifndef FAISS_GPU_INDICES_OPTIONS_C_H
+#define FAISS_GPU_INDICES_OPTIONS_C_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// How user vector index data is stored on the GPU
+typedef enum FaissIndicesOptions {
+  /// The user indices are only stored on the CPU; the GPU returns
+  /// (inverted list, offset) to the CPU which is then translated to
+  /// the real user index.
+  INDICES_CPU = 0,
+  /// The indices are not stored at all, on either the CPU or
+  /// GPU. Only (inverted list, offset) is returned to the user as the
+  /// index.
+  INDICES_IVF = 1,
+  /// Indices are stored as 32 bit integers on the GPU, but returned
+  /// as 64 bit integers
+  INDICES_32_BIT = 2,
+  /// Indices are stored as 64 bit integers on the GPU
+  INDICES_64_BIT = 3,
+} FaissIndicesOptions;
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/c_api/gpu/GpuResources_c.cpp
+++ b/c_api/gpu/GpuResources_c.cpp
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#include "gpu/GpuResources_c.h"
+#include "gpu/GpuResources.h"
+#include "macros_impl.h"
+
+using faiss::gpu::GpuResources;
+
+DEFINE_DESTRUCTOR(GpuResources)
+
+int faiss_GpuResources_initializeForDevice(FaissGpuResources* res, int device) {
+    try {
+        reinterpret_cast<GpuResources*>(res)->initializeForDevice(device);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_GpuResources_getBlasHandle(FaissGpuResources* res, int device, cublasHandle_t* out) {
+    try {
+        auto o = reinterpret_cast<GpuResources*>(res)->getBlasHandle(device);
+        *out = o;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_GpuResources_getDefaultStream(FaissGpuResources* res, int device, cudaStream_t* out) {
+    try {
+        auto o = reinterpret_cast<GpuResources*>(res)->getDefaultStream(device);
+        *out = o;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_GpuResources_getPinnedMemory(FaissGpuResources* res, void** p_buffer, size_t* p_size) {
+    try {
+        auto o = reinterpret_cast<GpuResources*>(res)->getPinnedMemory();
+        *p_buffer = o.first;
+        *p_size = o.second;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_GpuResources_getAsyncCopyStream(FaissGpuResources* res, int device, cudaStream_t* out) {
+    try {
+        auto o = reinterpret_cast<GpuResources*>(res)->getAsyncCopyStream(device);
+        *out = o;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_GpuResources_getBlasHandleCurrentDevice(FaissGpuResources* res, cublasHandle_t* out) {
+    try {
+        auto o = reinterpret_cast<GpuResources*>(res)->getBlasHandleCurrentDevice();
+        *out = o;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_GpuResources_getDefaultStreamCurrentDevice(FaissGpuResources* res, cudaStream_t* out) {
+    try {
+        auto o = reinterpret_cast<GpuResources*>(res)->getDefaultStreamCurrentDevice();
+        *out = o;
+    } CATCH_AND_HANDLE
+}
+
+int faiss_GpuResources_syncDefaultStream(FaissGpuResources* res, int device) {
+    try {
+        reinterpret_cast<GpuResources*>(res)->syncDefaultStream(device);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_GpuResources_syncDefaultStreamCurrentDevice(FaissGpuResources* res) {
+    try {
+        reinterpret_cast<GpuResources*>(res)->syncDefaultStreamCurrentDevice();
+    } CATCH_AND_HANDLE
+}
+
+int faiss_GpuResources_getAsyncCopyStreamCurrentDevice(FaissGpuResources* res, cudaStream_t* out) {
+    try {
+        auto o = reinterpret_cast<GpuResources*>(res)->getAsyncCopyStreamCurrentDevice();
+        *out = o;
+    } CATCH_AND_HANDLE
+}
+

--- a/c_api/gpu/GpuResources_c.h
+++ b/c_api/gpu/GpuResources_c.h
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c -*-
+
+#ifndef FAISS_GPU_RESOURCES_C_H
+#define FAISS_GPU_RESOURCES_C_H
+
+#include <cuda_runtime_api.h>
+#include <cublas.h>
+#include "faiss_c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Base class of GPU-side resource provider; hides provision of
+/// cuBLAS handles, CUDA streams and a temporary memory manager
+FAISS_DECLARE_CLASS(GpuResources)
+
+FAISS_DECLARE_DESTRUCTOR(GpuResources)
+
+/// Call to pre-allocate resources for a particular device. If this is
+/// not called, then resources will be allocated at the first time
+/// of demand
+int faiss_GpuResources_initializeForDevice(FaissGpuResources*, int);
+
+/// Returns the cuBLAS handle that we use for the given device
+int faiss_GpuResources_getBlasHandle(FaissGpuResources*, int, cublasHandle_t*);
+
+/// Returns the stream that we order all computation on for the
+/// given device
+int faiss_GpuResources_getDefaultStream(FaissGpuResources*, int, cudaStream_t*);
+
+/// Returns the available CPU pinned memory buffer
+int faiss_GpuResources_getPinnedMemory(FaissGpuResources*, void**, size_t*);
+
+/// Returns the stream on which we perform async CPU <-> GPU copies
+int faiss_GpuResources_getAsyncCopyStream(FaissGpuResources*, int, cudaStream_t*);
+
+/// Calls getBlasHandle with the current device
+int faiss_GpuResources_getBlasHandleCurrentDevice(FaissGpuResources*, cublasHandle_t*);
+
+/// Calls getDefaultStream with the current device
+int faiss_GpuResources_getDefaultStreamCurrentDevice(FaissGpuResources*, cudaStream_t*);
+
+/// Synchronizes the CPU with respect to the default stream for the
+/// given device
+// equivalent to cudaDeviceSynchronize(getDefaultStream(device))
+int faiss_GpuResources_syncDefaultStream(FaissGpuResources*, int);
+
+/// Calls syncDefaultStream for the current device
+int faiss_GpuResources_syncDefaultStreamCurrentDevice(FaissGpuResources*);
+
+/// Calls getAsyncCopyStream for the current device
+int faiss_GpuResources_getAsyncCopyStreamCurrentDevice(FaissGpuResources*, cudaStream_t*);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/c_api/gpu/Makefile
+++ b/c_api/gpu/Makefile
@@ -28,12 +28,13 @@ $(CLIBNAME).a: $(LIBGPUCOBJ) ../../gpu/$(LIBNAME).a
 $(CLIBNAME).$(SHAREDEXT): $(LIBCOBJ) $(LIBGPUCOBJ) ../../libfaiss.a ../../gpu/$(LIBNAME).a
 	$(CXX) $(LDFLAGS) $(FAISSSHAREDFLAGS) $(CUDACFLAGS) -o $@ \
 	-Wl,--whole-archive $(LIBCOBJ) ../../libfaiss.a $(BLASLDFLAGS) \
-	-Wl,--no-whole-archive -static-libstdc++ $(LIBGPUCOBJ) ../../gpu/$(LIBNAME).a
+	-Wl,--no-whole-archive -static-libstdc++ $(LIBGPUCOBJ) ../../gpu/$(LIBNAME).a \
+	-L$(CUDAROOT)/lib64 -lcublas -lcudart
 
 # Build GPU example
 bin/example_gpu_c: example_gpu_c.c $(CLIBNAME).$(SHAREDEXT)
 	$(CC) $(CFLAGS) $(CUDACFLAGS) -std=c99 -I. -I.. -o $@ example_gpu_c.c \
-	-L$(CUDAROOT)/lib64 -L. -lgpufaiss_c -lcublas -lcudart
+	-L. -lgpufaiss_c 
 
 clean:
 	rm -f $(CLIBNAME).a $(CLIBNAME).$(SHAREDEXT)* *.o bin/example_gpu_c

--- a/c_api/gpu/Makefile
+++ b/c_api/gpu/Makefile
@@ -9,6 +9,7 @@
 # C API with GPU support
 
 include ../../makefile.inc
+DEBUGFLAG=-DNDEBUG # no debugging
 
 LIBNAME=libgpufaiss
 CLIBNAME=libgpufaiss_c
@@ -41,17 +42,17 @@ clean:
 
 # Dependencies
 
-GpuAutoTune_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS)
+GpuAutoTune_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
 GpuAutoTune_c.o: GpuAutoTune_c.cpp GpuAutoTune_c.h ../../gpu/GpuAutoTune.h ../Index_c.h ../macros_impl.h
 
-GpuClonerOptions_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS)
+GpuClonerOptions_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
 GpuClonerOptions_c.o: GpuClonerOptions_c.cpp GpuClonerOptions_c.h GpuIndicesOptions_c.h ../../gpu/GpuClonerOptions.h ../macros_impl.h
 
-GpuIndex_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS)
+GpuIndex_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
 GpuIndex_c.o: GpuIndex_c.cpp GpuIndex_c.h ../../gpu/GpuIndex.h ../macros_impl.h
 
-GpuResources_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS)
+GpuResources_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
 GpuResources_c.o: GpuResources_c.cpp GpuResources_c.h ../../gpu/GpuResources.h ../macros_impl.h
 
-StandardGpuResources_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS)
+StandardGpuResources_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
 StandardGpuResources_c.o: StandardGpuResources_c.cpp StandardGpuResources_c.h ../../gpu/StandardGpuResources.h ../macros_impl.h

--- a/c_api/gpu/Makefile
+++ b/c_api/gpu/Makefile
@@ -12,28 +12,31 @@ include ../../makefile.inc
 
 LIBNAME=libgpufaiss
 CLIBNAME=libgpufaiss_c
-LIBOBJ=GpuAutoTune_c.o GpuClonerOptions_c.o GpuIndex_c.o GpuResources_c.o \
+LIBGPUCOBJ=GpuAutoTune_c.o GpuClonerOptions_c.o GpuIndex_c.o GpuResources_c.o \
 	StandardGpuResources_c.o
+LIBCOBJ=../error_impl.o ../Index_c.o ../IndexFlat_c.o ../Clustering_c.o \
+	../AuxIndexStructures_c.o ../AutoTune_c.o ../IndexIVF_c.o
 
 # Build shared object file by default
-all: $(CLIBNAME).$(SHAREDEXT)
+all: $(CLIBNAME).$(SHAREDEXT) bin/example_gpu_c
 
 # Build static library (requires consumers to link with libstdc++)
-$(CLIBNAME).a: $(LIBCOBJ) ../../gpu/$(LIBNAME).a
+$(CLIBNAME).a: $(LIBGPUCOBJ) ../../gpu/$(LIBNAME).a
 	ar r $@ $^
 
 # Build dynamic library
-$(CLIBNAME).$(SHAREDEXT): $(LIBOBJ) ../../gpu/$(LIBNAME).a
-	$(CXX) $(LDFLAGS) -static-libstdc++ $(FAISSSHAREDFLAGS) -o $@ $^ \
-	$(BLASLDFLAGS) -L.. -lfaiss_c
+$(CLIBNAME).$(SHAREDEXT): $(LIBCOBJ) $(LIBGPUCOBJ) ../../libfaiss.a ../../gpu/$(LIBNAME).a
+	$(CXX) $(LDFLAGS) $(FAISSSHAREDFLAGS) $(CUDACFLAGS) -o $@ \
+	-Wl,--whole-archive $(LIBCOBJ) ../../libfaiss.a $(BLASLDFLAGS) \
+	-Wl,--no-whole-archive -static-libstdc++ $(LIBGPUCOBJ) ../../gpu/$(LIBNAME).a
 
 # Build GPU example
 bin/example_gpu_c: example_gpu_c.c $(CLIBNAME).$(SHAREDEXT)
-	$(CC) $(CFLAGS) $(CUDACFLAGS) -std=c99 -I. -I.. $(LDFLAGS) -o $@ example_gpu_c.c \
-	-L$(CUDAROOT)/lib64 -L. -L.. -lgpufaiss_c -lfaiss_c -lcublas -lcudart
+	$(CC) $(CFLAGS) $(CUDACFLAGS) -std=c99 -I. -I.. -o $@ example_gpu_c.c \
+	-L$(CUDAROOT)/lib64 -L. -lgpufaiss_c -lcublas -lcudart
 
 clean:
-	rm -f $(CLIBNAME).a $(CLIBNAME).$(SHAREDEXT)* *.o
+	rm -f $(CLIBNAME).a $(CLIBNAME).$(SHAREDEXT)* *.o bin/example_gpu_c
 
 # Dependencies
 

--- a/c_api/gpu/Makefile
+++ b/c_api/gpu/Makefile
@@ -1,0 +1,53 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD+Patents license found in the
+# LICENSE file in the root directory of this source tree.
+
+.SUFFIXES: .cpp .o
+
+# C API with GPU support
+
+include ../../makefile.inc
+
+LIBNAME=libgpufaiss
+CLIBNAME=libgpufaiss_c
+LIBOBJ=GpuAutoTune_c.o GpuClonerOptions_c.o GpuIndex_c.o GpuResources_c.o \
+	StandardGpuResources_c.o
+
+# Build shared object file by default
+all: $(CLIBNAME).$(SHAREDEXT)
+
+# Build static library (requires consumers to link with libstdc++)
+$(CLIBNAME).a: $(LIBCOBJ) ../../gpu/$(LIBNAME).a
+	ar r $@ $^
+
+# Build dynamic library
+$(CLIBNAME).$(SHAREDEXT): $(LIBOBJ) ../../gpu/$(LIBNAME).a
+	$(CXX) $(LDFLAGS) -static-libstdc++ $(FAISSSHAREDFLAGS) -o $@ $^ \
+	$(BLASLDFLAGS) -L.. -lfaiss_c
+
+# Build GPU example
+bin/example_gpu_c: example_gpu_c.c $(CLIBNAME).$(SHAREDEXT)
+	$(CC) $(CFLAGS) $(CUDACFLAGS) -std=c99 -I. -I.. $(LDFLAGS) -o $@ example_gpu_c.c \
+	-L$(CUDAROOT)/lib64 -L. -L.. -lgpufaiss_c -lfaiss_c -lcublas -lcudart
+
+clean:
+	rm -f $(CLIBNAME).a $(CLIBNAME).$(SHAREDEXT)* *.o
+
+# Dependencies
+
+GpuAutoTune_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS)
+GpuAutoTune_c.o: GpuAutoTune_c.cpp GpuAutoTune_c.h ../../gpu/GpuAutoTune.h ../Index_c.h ../macros_impl.h
+
+GpuClonerOptions_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS)
+GpuClonerOptions_c.o: GpuClonerOptions_c.cpp GpuClonerOptions_c.h GpuIndicesOptions_c.h ../../gpu/GpuClonerOptions.h ../macros_impl.h
+
+GpuIndex_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS)
+GpuIndex_c.o: GpuIndex_c.cpp GpuIndex_c.h ../../gpu/GpuIndex.h ../macros_impl.h
+
+GpuResources_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS)
+GpuResources_c.o: GpuResources_c.cpp GpuResources_c.h ../../gpu/GpuResources.h ../macros_impl.h
+
+StandardGpuResources_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS)
+StandardGpuResources_c.o: StandardGpuResources_c.cpp StandardGpuResources_c.h ../../gpu/StandardGpuResources.h ../macros_impl.h

--- a/c_api/gpu/StandardGpuResources_c.cpp
+++ b/c_api/gpu/StandardGpuResources_c.cpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#include "gpu/StandardGpuResources_c.h"
+#include "gpu/StandardGpuResources.h"
+#include "macros_impl.h"
+
+using faiss::gpu::StandardGpuResources;
+
+DEFINE_DESTRUCTOR(StandardGpuResources)
+
+int faiss_StandardGpuResources_new(FaissStandardGpuResources** p_res) {
+    try {
+        auto p = new StandardGpuResources();
+        *p_res = reinterpret_cast<FaissStandardGpuResources*>(p);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_StandardGpuResources_noTempMemory(FaissStandardGpuResources* res) {
+    try {
+        reinterpret_cast<StandardGpuResources*>(res)->noTempMemory();
+    } CATCH_AND_HANDLE
+}
+
+int faiss_StandardGpuResources_setTempMemory(FaissStandardGpuResources* res, size_t size) {
+    try {
+        reinterpret_cast<StandardGpuResources*>(res)->setTempMemory(size);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_StandardGpuResources_setTempMemoryFraction(FaissStandardGpuResources* res, float fraction) {
+    try {
+        reinterpret_cast<StandardGpuResources*>(res)->setTempMemoryFraction(fraction);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_StandardGpuResources_setPinnedMemory(FaissStandardGpuResources* res, size_t size) {
+    try {
+        reinterpret_cast<StandardGpuResources*>(res)->setPinnedMemory(size);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_StandardGpuResources_setDefaultStream(FaissStandardGpuResources* res, int device, cudaStream_t stream) {
+    try {
+        reinterpret_cast<StandardGpuResources*>(res)->setDefaultStream(device, stream);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_StandardGpuResources_setDefaultNullStreamAllDevices(FaissStandardGpuResources* res) {
+    try {
+        reinterpret_cast<StandardGpuResources*>(res)->setDefaultNullStreamAllDevices();
+    } CATCH_AND_HANDLE
+}

--- a/c_api/gpu/StandardGpuResources_c.h
+++ b/c_api/gpu/StandardGpuResources_c.h
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c -*-
+
+#ifndef FAISS_STANDARD_GPURESOURCES_C_H
+#define FAISS_STANDARD_GPURESOURCES_C_H
+
+#include <cuda_runtime_api.h>
+#include "faiss_c.h"
+#include "gpu/GpuResources_c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Default implementation of GpuResources that allocates a cuBLAS
+/// stream and 2 streams for use, as well as temporary memory
+FAISS_DECLARE_CLASS_INHERITED(StandardGpuResources, GpuResources)
+
+FAISS_DECLARE_DESTRUCTOR(StandardGpuResources)
+
+/// Default constructor for StandardGpuResources
+int faiss_StandardGpuResources_new(FaissStandardGpuResources**);
+
+/// Disable allocation of temporary memory; all temporary memory
+/// requests will call cudaMalloc / cudaFree at the point of use
+int faiss_StandardGpuResources_noTempMemory(FaissStandardGpuResources*);
+
+/// Specify that we wish to use a certain fixed size of memory on
+/// all devices as temporary memory
+int faiss_StandardGpuResources_setTempMemory(FaissStandardGpuResources*, size_t size);
+
+/// Specify that we wish to use a certain fraction of memory on
+/// all devices as temporary memory
+int faiss_StandardGpuResources_setTempMemoryFraction(FaissStandardGpuResources*, float fraction);
+
+/// Set amount of pinned memory to allocate, for async GPU <-> CPU
+/// transfers
+int faiss_StandardGpuResources_setPinnedMemory(FaissStandardGpuResources*, size_t size);
+
+/// Called to change the stream for work ordering
+int faiss_StandardGpuResources_setDefaultStream(FaissStandardGpuResources*, int device, cudaStream_t stream);
+
+/// Called to change the work ordering streams to the null stream
+/// for all devices
+int faiss_StandardGpuResources_setDefaultNullStreamAllDevices(FaissStandardGpuResources*);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/c_api/gpu/example_gpu_c.c
+++ b/c_api/gpu/example_gpu_c.c
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c -*-
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "error_c.h"
+#include "Index_c.h"
+#include "AutoTune_c.h"
+#include "GpuAutoTune_c.h"
+#include "StandardGpuResources_c.h"
+
+#define FAISS_TRY(C)                                       \
+    {                                                      \
+        int __c = C;                                       \
+        if (__c) {                                         \
+            fprintf(stderr, "%s", faiss_get_last_error()); \
+            exit(-1);                                      \
+        }                                                  \
+    }
+
+inline double drand() {
+    return (double)rand() / (double)RAND_MAX;
+}
+
+int main() {
+    time_t seed = time(NULL);
+    srand(seed);
+    printf("Generating some data...\n");
+    int d = 128;                           // dimension
+    int nb = 100000;                       // database size
+    int nq = 10000;                        // nb of queries
+    float *xb = malloc(d * nb * sizeof(float));
+    float *xq = malloc(d * nq * sizeof(float));
+
+    for(int i = 0; i < nb; i++) {
+        for(int j = 0; j < d; j++) xb[d * i + j] = drand();
+        xb[d * i] += i / 1000.;
+    }
+    for(int i = 0; i < nq; i++) {
+        for(int j = 0; j < d; j++) xq[d * i + j] = drand();
+        xq[d * i] += i / 1000.;
+    }
+
+    printf("Loading standard GPU resources...\n");
+    FaissStandardGpuResources* gpu_res = NULL;
+    FAISS_TRY(faiss_StandardGpuResources_new(&gpu_res));
+
+    printf("Building an index...\n");
+    FaissIndex* cpu_index = NULL;
+    FAISS_TRY(faiss_index_factory(&cpu_index, d, "Flat", METRIC_L2));  // use factory to create index
+
+    printf("Moving index to the GPU...\n");
+    FaissGpuIndex* index = NULL;
+    FaissGpuClonerOptions* options = NULL;
+    FAISS_TRY(faiss_GpuClonerOptions_new(&options));
+    FAISS_TRY(faiss_index_cpu_to_gpu_with_options(gpu_res, 0, cpu_index, options, &index));
+
+    printf("is_trained = %s\n", faiss_Index_is_trained(index) ? "true" : "false");
+    FAISS_TRY(faiss_Index_add(index, nb, xb));                     // add vectors to the index
+    printf("ntotal = %ld\n", faiss_Index_ntotal(index));
+
+    printf("Searching...\n");
+    int k = 5;
+
+    {       // sanity check: search 5 first vectors of xb
+        long *I = malloc(k * 5 * sizeof(long));
+        float *D = malloc(k * 5 * sizeof(float));
+        FAISS_TRY(faiss_Index_search(index, 5, xb, k, D, I));
+        printf("I=\n");
+        for(int i = 0; i < 5; i++) {
+            for(int j = 0; j < k; j++) printf("%5ld (d=%2.3f)  ", I[i * k + j], D[i * k + j]);
+            printf("\n");
+        }
+        free(I);
+        free(D);
+    }
+    {       // search xq
+        long *I = malloc(k * nq * sizeof(long));
+        float *D = malloc(k * nq * sizeof(float));
+        FAISS_TRY(faiss_Index_search(index, 5, xb, k, D, I));
+        printf("I=\n");
+        for(int i = 0; i < 5; i++) {
+            for(int j = 0; j < k; j++) printf("%5ld (d=%2.3f)  ", I[i * k + j], D[i * k + j]);
+            printf("\n");
+        }
+        free(I);
+        free(D);
+    }
+
+    printf("Freeing index...\n");
+    faiss_Index_free(index);
+    printf("Freeing GPU resources...\n");
+    faiss_GpuResources_free(gpu_res);
+    faiss_GpuClonerOptions_free(options);
+    printf("Done.\n");
+
+    return 0;
+}

--- a/c_api/gpu/example_gpu_c.c
+++ b/c_api/gpu/example_gpu_c.c
@@ -21,8 +21,7 @@
 
 #define FAISS_TRY(C)                                       \
     {                                                      \
-        int __c = C;                                       \
-        if (__c) {                                         \
+        if (C) {                                           \
             fprintf(stderr, "%s", faiss_get_last_error()); \
             exit(-1);                                      \
         }                                                  \

--- a/c_api/gpu/macros_impl.h
+++ b/c_api/gpu/macros_impl.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#ifndef GPU_MACROS_IMPL_H
+#define GPU_MACROS_IMPL_H
+#include "../macros_impl.h"
+
+#undef DEFINE_GETTER
+#define DEFINE_GETTER(clazz, ty, name)                               \
+    ty faiss_ ## clazz ## _ ## name (const Faiss ## clazz *obj) {    \
+        return static_cast< ty >(                                    \
+            reinterpret_cast< const faiss::gpu::clazz *>(obj)-> name \
+        );                                                           \
+    }
+
+#undef DEFINE_SETTER
+#define DEFINE_SETTER(clazz, ty, name)                                    \
+    void faiss_ ## clazz ## _set_ ## name (Faiss ## clazz *obj, ty val) { \
+        reinterpret_cast< faiss::gpu::clazz *>(obj)-> name = val;              \
+    }
+
+#undef DEFINE_SETTER_STATIC
+#define DEFINE_SETTER_STATIC(clazz, ty_to, ty_from, name)                      \
+    void faiss_ ## clazz ## _set_ ## name (Faiss ## clazz *obj, ty_from val) { \
+        reinterpret_cast< faiss::gpu::clazz *>(obj)-> name =                   \
+            static_cast< ty_to >(val);                                         \
+    }
+
+#undef DEFINE_DESTRUCTOR
+#define DEFINE_DESTRUCTOR(clazz)                           \
+    void faiss_ ## clazz ## _free (Faiss ## clazz *obj) {  \
+        delete reinterpret_cast<faiss::gpu::clazz *>(obj); \
+    }
+
+#endif

--- a/c_api/macros_impl.h
+++ b/c_api/macros_impl.h
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+/// Utility macros for the C wrapper implementation.
+
+#ifndef MACROS_IMPL_H
+#define MACROS_IMPL_H
+
+#include "faiss_c.h"
+#include "FaissException.h"
+#include "error_impl.h"
+#include <iostream>
+
+#ifdef NDEBUG
+#define CATCH_AND_HANDLE                              \
+    catch (faiss::FaissException& e) {                \
+        faiss_last_exception =                        \
+            std::make_exception_ptr(e);               \
+        return -2;                                    \
+    } catch (std::exception& e) {                     \
+        faiss_last_exception =                        \
+            std::make_exception_ptr(e);               \
+        return -4;                                    \
+    } catch (...) {                                   \
+        faiss_last_exception =                        \
+            std::make_exception_ptr(                  \
+                std::runtime_error("Unknown error")); \
+        return -1;                                    \
+    } return 0;
+#else
+#define CATCH_AND_HANDLE                              \
+    catch (faiss::FaissException& e) {                \
+        std::cerr << e.what() << '\n';                \
+        faiss_last_exception =                        \
+            std::make_exception_ptr(e);               \
+        return -2;                                    \
+    } catch (std::exception& e) {                     \
+        std::cerr << e.what() << '\n';                \
+        faiss_last_exception =                        \
+            std::make_exception_ptr(e);               \
+        return -4;                                    \
+    } catch (...) {                                   \
+        std::cerr << "Unrecognized exception!\n";     \
+        faiss_last_exception =                        \
+            std::make_exception_ptr(                  \
+                std::runtime_error("Unknown error")); \
+        return -1;                                    \
+    } return 0;
+#endif
+
+#define DEFINE_GETTER(clazz, ty, name)                            \
+    ty faiss_ ## clazz ## _ ## name (const Faiss ## clazz *obj) { \
+        return static_cast< ty >(                                 \
+            reinterpret_cast< const faiss::clazz *>(obj)-> name   \
+        );                                                        \
+    }
+
+#define DEFINE_GETTER_SUBCLASS(clazz, parent, ty, name)                \
+    ty faiss_ ## clazz ## _ ## name (const Faiss ## clazz *obj) {      \
+        return static_cast< ty >(                                      \
+            reinterpret_cast<const faiss::parent::clazz *>(obj)-> name \
+        );                                                             \
+    }
+
+#define DEFINE_GETTER_PERMISSIVE(clazz, ty, name)                 \
+    ty faiss_ ## clazz ## _ ## name (const Faiss ## clazz *obj) { \
+        return ( ty ) (                                           \
+            reinterpret_cast<const faiss::clazz *>(obj)-> name    \
+        );                                                        \
+    }
+
+#define DEFINE_GETTER_SUBCLASS_PERMISSIVE(clazz, parent, ty, name)     \
+    ty faiss_ ## clazz ## _ ## name (const Faiss ## clazz *obj) {      \
+        return ( ty ) (                                                \
+            reinterpret_cast<const faiss::parent::clazz *>(obj)-> name \
+        );                                                             \
+    }
+
+#define DEFINE_SETTER(clazz, ty, name)                                    \
+    void faiss_ ## clazz ## _set_ ## name (Faiss ## clazz *obj, ty val) { \
+        reinterpret_cast< faiss::clazz *>(obj)-> name = val;              \
+    }
+
+#define DEFINE_SETTER_STATIC(clazz, ty_to, ty_from, name)                      \
+    void faiss_ ## clazz ## _set_ ## name (Faiss ## clazz *obj, ty_from val) { \
+        reinterpret_cast< faiss::clazz *>(obj)-> name =                        \
+            static_cast< ty_to >(val);                                         \
+    }
+
+#define DEFINE_DESTRUCTOR(clazz)                           \
+    void faiss_ ## clazz ## _free (Faiss ## clazz *obj) {  \
+        delete reinterpret_cast<faiss::clazz *>(obj);      \
+    }
+
+#endif

--- a/c_api/macros_impl.h
+++ b/c_api/macros_impl.h
@@ -17,6 +17,7 @@
 #include "faiss_c.h"
 #include "FaissException.h"
 #include "error_impl.h"
+#include <stdexcept>
 #include <iostream>
 
 #ifdef NDEBUG

--- a/example_makefiles/makefile.inc.Linux
+++ b/example_makefiles/makefile.inc.Linux
@@ -9,9 +9,11 @@
 # tested on CentOS 7, Ubuntu 16 and Ubuntu 14, see below to adjust flags to distribution.
 
 
-CC=g++
+CC=gcc
+CXX=g++
 
-CFLAGS=-fPIC -m64 -Wall -g -O3 -mavx -msse4 -mpopcnt -fopenmp -Wno-sign-compare -std=c++11 -fopenmp
+CFLAGS=-fPIC -m64 -Wall -g -O3 -mavx -msse4 -mpopcnt -fopenmp -Wno-sign-compare -fopenmp
+CXXFLAGS=$(CFLAGS) -std=c++11
 LDFLAGS=-g -fPIC  -fopenmp
 
 # common linux flags
@@ -124,7 +126,7 @@ PYTHONCFLAGS=-I/usr/include/python2.7/ -I/usr/lib64/python2.7/site-packages/nump
 
 
 # a C++ compiler that supports c++11
-CC11=g++
+CXX11=g++
 
 # root of the cuda 8 installation
 CUDAROOT=/usr/local/cuda-8.0/
@@ -141,7 +143,7 @@ NVCCFLAGS= $(CUDAFLAGS) \
    -gencode arch=compute_52,code="compute_52" \
    -gencode arch=compute_60,code="compute_60" \
    --std c++11 -lineinfo \
-   -ccbin $(CC11) -DFAISS_USE_FLOAT16
+   -ccbin $(CXX11) -DFAISS_USE_FLOAT16
 
 # BLAS LD flags for nvcc (used to generate an executable)
 # if BLASLDFLAGS contains several flags, each one may

--- a/example_makefiles/makefile.inc.Mac.brew
+++ b/example_makefiles/makefile.inc.Mac.brew
@@ -4,7 +4,8 @@
 # Tested on macOS Sierra (10.12.2) with llvm installed using Homebrew (https://brew.sh)
 # brew install llvm
 CC=/usr/local/opt/llvm/bin/clang++
-CFLAGS=-fPIC -m64 -Wall -g -O3 -msse4 -mpopcnt -fopenmp -Wno-sign-compare -I/usr/local/opt/llvm/include -std=c++11
+CFLAGS=-fPIC -m64 -Wall -g -O3 -msse4 -mpopcnt -fopenmp -Wno-sign-compare -I/usr/local/opt/llvm/include
+CXXFLAGS=$(CFLAGS) -std=c++11
 LLVM_VERSION_PATH=$(shell ls -rt /usr/local/Cellar/llvm/ | tail -n1)
 LDFLAGS=-g -fPIC -fopenmp -L/usr/local/opt/llvm/lib -L/usr/local/Cellar/llvm/${LLVM_VERSION_PATH}/lib
 

--- a/example_makefiles/makefile.inc.Mac.port
+++ b/example_makefiles/makefile.inc.Mac.port
@@ -9,7 +9,8 @@
 # port install g++-mp-6
 CC=/opt/local/bin/g++-mp-6
 
-CFLAGS=-fPIC -m64 -Wall -g -O3  -msse4 -mpopcnt -fopenmp -Wno-sign-compare -std=c++11
+CFLAGS=-fPIC -m64 -Wall -g -O3  -msse4 -mpopcnt -fopenmp -Wno-sign-compare
+CXXFLAGS=$(CFLAGS) -std=c++11
 LDFLAGS=-g -fPIC  -fopenmp
 
 

--- a/gpu/Makefile
+++ b/gpu/Makefile
@@ -74,7 +74,7 @@ CUOBJ=      impl/BroadcastSum.o \
 
 
 .cpp.o:
-	$(CC11) -std=c++11 -fPIC -m64 -Wall -g -Wno-sign-compare -O3 -fopenmp \
+	$(CXX11) -fPIC -m64 -Wall -g -Wno-sign-compare -O3 -fopenmp \
          -c $< -o $@ $(EXTRAFLAGS) $(CUDACFLAGS)
 
 .cu.o:

--- a/gpu/Makefile
+++ b/gpu/Makefile
@@ -74,7 +74,7 @@ CUOBJ=      impl/BroadcastSum.o \
 
 
 .cpp.o:
-	$(CXX11) -fPIC -m64 -Wall -g -Wno-sign-compare -O3 -fopenmp \
+	$(CXX11) $(CXXFLAGS) -fPIC -m64 -Wall -g -Wno-sign-compare -O3 -fopenmp \
          -c $< -o $@ $(EXTRAFLAGS) $(CUDACFLAGS)
 
 .cu.o:


### PR DESCRIPTION
As previously mentioned in #293, this PR provides a pure C interface to Faiss, which can subsequently be used either in pure C programs or to produce bindings for programming languages with Foreign Function Interface (FFI) support. Although Python doesn't need this, some languages (e.g. Rust and Julia) do not have SWIG support.

This is not a complete API, but provides enough constructs for most tasks, and can be incrementally extended in future contributions.

### Building and Using

The new contents are in the "c_api" folder. In particular, header files in the format "###_c.h" and "gpu/###_c.h" are the pure C APIs that users would include in their project. "###_c.cpp" are their respective wrapper implementations. "macros_impl.h" is a C++ header file containing helper macros.

After building the static library "libfaiss.a", enter the directory and run:

```sh
make
```

This builds a dynamic library `faiss_c", containing the full implementation of Faiss and the necessary wrappers for the C interface. It does not depend on libfaiss.a or the C++ standard library. A C example is included, which can be built as thus:

```sh
make bin/example_c
```

For GPU support, a separate dynamic library in the "c_api/gpu" directory needs to be built and linked.

```sh
make
make bin/example_gpu_c
```

This is a substantial addition, which admittedly may take some time to evaluate. I do have a few concerns which might have to be addressed before merging:

- Although the new code is fairly documented, the building instructions were not included yet. Should there be a new section in INSTALL.md?
- Should the dynamic library with GPU support work standalone? Maybe I should change it so that "libgpufaiss_c.so" can work without "libfaiss_c.so"? This would also make the example easier to run, since it needs to link with both files at the moment.
- There is still no test suite. I could look into this if deemed important.
- It relies on Makefiles rather than CMake. While I understand that there's been a shift towards CMake, this what could be arranged in short-term.
- Not exactly an issue in this PR, but one can identify some hard asserts in the main implementation which would be more useful if they were recoverable at this level. For example, certain GPU index functions could throw an exception if a CUDA function failed instead of aborting. Would you consider such changes in the future?
