### PR TITLE
Fixed missing malloc.h include error on osx

### DIFF
--- a/IndexScalarQuantizer.cpp
+++ b/IndexScalarQuantizer.cpp
@@ -11,7 +11,11 @@
 #include <cstdio>
 #include <algorithm>
 
+#ifdef __APPLE__
+#include <stdlib.h>
+#else
 #include <malloc.h>
+#endif
 
 #include <omp.h>
 


### PR DESCRIPTION
Added precompiler macros around malloc.h since it does not exist on osx and causes a build failure. Tested on OSX 10.12.6 (Sierra)

Another solution would be to change
#include <malloc.h>
to
#include "malloc.h"

Not sure which one is preferred.