### PR TITLE
Implement remove_ids in IndexPQ

### DIFF
--- a/IndexPQ.cpp
+++ b/IndexPQ.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 
 #include "FaissAssert.h"
+#include "AuxIndexStructures.h"
 #include "hamming.h"
 
 namespace faiss {
@@ -83,6 +84,27 @@ void IndexPQ::add (idx_t n, const float *x)
     ntotal += n;
 }
 
+
+long IndexPQ::remove_ids (const IDSelector & sel)
+{
+    idx_t j = 0;
+    for (idx_t i = 0; i < ntotal; i++) {
+        if (sel.is_member (i)) {
+            // should be removed
+        } else {
+            if (i > j) {
+                memmove (&codes[pq.code_size * j], &codes[pq.code_size * i], pq.code_size);
+            }
+            j++;
+        }
+    }
+    long nremove = ntotal - j;
+    if (nremove > 0) {
+        ntotal = j;
+        codes.resize (ntotal * d);
+    }
+    return nremove;
+}
 
 
 void IndexPQ::reset()

--- a/IndexPQ.cpp
+++ b/IndexPQ.cpp
@@ -101,7 +101,7 @@ long IndexPQ::remove_ids (const IDSelector & sel)
     long nremove = ntotal - j;
     if (nremove > 0) {
         ntotal = j;
-        codes.resize (ntotal * d);
+        codes.resize (ntotal * pq.code_size);
     }
     return nremove;
 }

--- a/IndexPQ.h
+++ b/IndexPQ.h
@@ -83,6 +83,11 @@ struct IndexPQ: Index {
 
     Search_type_t search_type;
 
+    /** remove some ids. NB that Because of the structure of the
+     * indexing structre, the semantics of this operation are
+     * different from the usual ones: the new ids are shifted */
+    long remove_ids(const IDSelector& sel) override;
+
     // just encode the sign of the components, instead of using the PQ encoder
     // used only for the queries
     bool encode_signs;


### PR DESCRIPTION
Hi,

I found remove_ids was not implemented in IndexPQ when playing with faiss and made a patch of it like what was done in IndexFlat, hope you can take a review.