### PR TITLE
- Add install target for the faiss library and headers to the

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,3 +55,8 @@ endif(BUILD_TUTORIAL)
 if(BUILD_TEST)
     add_subdirectory(tests)
 endif(BUILD_TEST)
+# Install libraries
+install(TARGETS ${faiss_lib}
+        ARCHIVE DESTINATION lib
+        )
+install(FILES ${faiss_cpu_headers} DESTINATION include/faiss)


### PR DESCRIPTION
CMakeLists.txt, so we can install the libs and headers with make
install.