### PR TITLE
[C API] Fix libgpufaiss_c with extended API

### DIFF
--- a/c_api/Makefile
+++ b/c_api/Makefile
@@ -16,14 +16,15 @@ CLIBNAME=libfaiss_c
 LIBCOBJ=error_impl.o Index_c.o IndexFlat_c.o Clustering_c.o AuxIndexStructures_c.o \
 	AutoTune_c.o IndexIVF_c.o IndexIVFFlat_c.o IndexLSH_c.o index_io_c.o MetaIndexes_c.o
 
-# Build shared object file by default
-all: $(CLIBNAME).$(SHAREDEXT)
+# Build static and shared object files by default
+all: $(CLIBNAME).a $(CLIBNAME).$(SHAREDEXT)
 
-# Build static library (requires consumers to link with libstdc++)
-$(CLIBNAME).a: $(LIBCOBJ) ../$(LIBNAME).a
+# Build static object file containing the wrapper implementation only.
+# Consumers are required to link with libfaiss.a and libstdc++.
+$(CLIBNAME).a: $(LIBCOBJ)
 	ar r $@ $^
 
-# Build dynamic library
+# Build dynamic library (independent object)
 $(CLIBNAME).$(SHAREDEXT): $(LIBCOBJ) ../$(LIBNAME).a
 	$(CXX) $(LDFLAGS) $(FAISSSHAREDFLAGS) -o $@ \
 	-Wl,--whole-archive $^ $(BLASLDFLAGS) -Wl,--no-whole-archive -static-libstdc++

--- a/c_api/gpu/Makefile
+++ b/c_api/gpu/Makefile
@@ -15,13 +15,14 @@ LIBNAME=libgpufaiss
 CLIBNAME=libgpufaiss_c
 LIBGPUCOBJ=GpuAutoTune_c.o GpuClonerOptions_c.o GpuIndex_c.o GpuResources_c.o \
 	StandardGpuResources_c.o
-LIBCOBJ=../error_impl.o ../Index_c.o ../IndexFlat_c.o ../Clustering_c.o \
-	../AuxIndexStructures_c.o ../AutoTune_c.o ../IndexIVF_c.o
+LIBCOBJ=../libfaiss_c.a
 
 # Build shared object file by default
-all: $(CLIBNAME).$(SHAREDEXT) bin/example_gpu_c
+all: $(CLIBNAME).$(SHAREDEXT)
 
-# Build static library (requires consumers to link with libstdc++)
+# Build static object file containing the wrapper implementation only.
+# Consumers are required to link with the C++ standard library and remaining
+# portions of this library: libfaiss_c.a, libfaiss.a, libgpufaiss.a, and libstdc++.
 $(CLIBNAME).a: $(LIBGPUCOBJ) ../../gpu/$(LIBNAME).a
 	ar r $@ $^
 


### PR DESCRIPTION
I just noticed a tiny issue in the previous extension to the C API, which this PR corrects.
The new object files from #425 were not being included in the GPU shared object because `c_api/gpu/Makefile` was keeping its own replicated list of object files.
I adjusted the libgpufaiss_c.so building process so that it fetches the complete archive file built from c_api/Makefile, thus potentially avoiding these mistakes in the future.

- Change `libfaiss_c.a` and `libgpufaiss_c.a` targets to only include the C interface's wrapper implementations
- Include `libfaiss_c.a` target on `c_api`'s `make all`
- Build `libgpufaiss_c.so` with `libfaiss_c.a` instead of the "*_c.o" object files in the parent directory