### PR TITLE
Support for index.assign in Python

### DIFF
--- a/faiss.py
+++ b/faiss.py
@@ -105,6 +105,13 @@ def handle_Index(the_class):
         assert ids.shape == (n, ), 'not same nb of vectors as ids'
         self.add_with_ids_c(n, swig_ptr(x), swig_ptr(ids))
 
+    def replacement_assign(self, x, k):
+        n, d = x.shape
+        assert d == self.d
+        labels = np.empty((n, k), dtype=np.int64)
+        self.assign_c(n, swig_ptr(x), swig_ptr(labels), k)
+        return labels
+
     def replacement_train(self, x):
         assert x.flags.contiguous
         n, d = x.shape
@@ -171,6 +178,7 @@ def handle_Index(the_class):
 
     replace_method(the_class, 'add', replacement_add)
     replace_method(the_class, 'add_with_ids', replacement_add_with_ids)
+    replace_method(the_class, 'assign', replacement_assign)
     replace_method(the_class, 'train', replacement_train)
     replace_method(the_class, 'search', replacement_search)
     replace_method(the_class, 'remove_ids', replacement_remove_ids)


### PR DESCRIPTION
I noticed that the `assign` method in the Python interface was not adapted to a high level API, like the other operations (`add`, `search`, `reconstruct`, ...). Steps to reproduce the issue:

```python
import numpy as np
import faiss
index = faiss.index_factory(2, "Flat")
index.add(np.array([[1, 2], [3, 4]], dtype=np.float32))
# can't call `assign` like this because it's still a low-level SWIG function
labels = index.assign(np.array([[0, 0]], dtype=np.float32), 1)
```

```txt
TypeError: assign() missing 1 required positional argument: 'labels'
```

With these changes, the code above now works as expected. One could indeed use `search` instead, but I did not need to fetch the distances in my use case.