### PR TITLE
Make c_api compatible with configure'd makefile

### DIFF
--- a/c_api/Makefile
+++ b/c_api/Makefile
@@ -26,47 +26,47 @@ $(CLIBNAME).a: $(LIBCOBJ)
 
 # Build dynamic library (independent object)
 $(CLIBNAME).$(SHAREDEXT): $(LIBCOBJ) ../$(LIBNAME).a
-	$(CXX) $(LDFLAGS) $(FAISSSHAREDFLAGS) -o $@ \
-	-Wl,--whole-archive $^ $(BLASLDFLAGS) -Wl,--no-whole-archive -static-libstdc++
+	$(CXX) $(LDFLAGS) $(LIBS) $(SHAREDFLAGS) -o $@ \
+	-Wl,--whole-archive $^ -Wl,--no-whole-archive -static-libstdc++
 
 bin/example_c: example_c.c $(CLIBNAME).$(SHAREDEXT)
 	$(CC) $(CFLAGS) -std=c99 -I. -I.. -L. -o $@ example_c.c \
-	$(LDFLAGS) -lm $(BLASLDFLAGS) -lfaiss_c
+	$(LDFLAGS) -lm -lfaiss_c
 
 clean:
 	rm -f $(CLIBNAME).a $(CLIBNAME).$(SHAREDEXT)* *.o bin/example_c
 
 # Dependencies
 
-error_impl.o: CFLAGS += -I.. $(DEBUGFLAG)
+error_impl.o: CXXFLAGS += -I.. $(DEBUGFLAG)
 error_impl.o: error_impl.cpp error_c.h error_impl.h macros_impl.h
 
-index_io_c.o: CFLAGS += -I.. $(DEBUGFLAG)
+index_io_c.o: CXXFLAGS += -I.. $(DEBUGFLAG)
 index_io_c.o: index_io_c.cpp error_impl.cpp ../index_io.h macros_impl.h
 
-Index_c.o: CFLAGS += -I.. $(DEBUGFLAG)
+Index_c.o: CXXFLAGS += -I.. $(DEBUGFLAG)
 Index_c.o: Index_c.cpp Index_c.h ../Index.h macros_impl.h
 
-IndexFlat_c.o: CFLAGS += -I.. $(DEBUGFLAG)
+IndexFlat_c.o: CXXFLAGS += -I.. $(DEBUGFLAG)
 IndexFlat_c.o: IndexFlat_c.cpp IndexFlat_c.h ../IndexFlat.h macros_impl.h
 
-IndexIVF_c.o: CFLAGS += -I.. $(DEBUGFLAG)
+IndexIVF_c.o: CXXFLAGS += -I.. $(DEBUGFLAG)
 IndexIVF_c.o: IndexIVF_c.cpp IndexIVF_c.h ../IndexIVF.h macros_impl.h
 
-IndexIVFFlat_c.o: CFLAGS += -I.. $(DEBUGFLAG)
+IndexIVFFlat_c.o: CXXFLAGS += -I.. $(DEBUGFLAG)
 IndexIVFFlat_c.o: IndexIVFFlat_c.cpp IndexIVFFlat_c.h ../IndexIVFFlat.h macros_impl.h
 
-IndexLSH_c.o: CFLAGS += -I.. $(DEBUGFLAG)
+IndexLSH_c.o: CXXFLAGS += -I.. $(DEBUGFLAG)
 IndexLSH_c.o: IndexLSH_c.cpp IndexLSH_c.h ../IndexLSH.h macros_impl.h
 
-Clustering_c.o: CFLAGS += -I.. $(DEBUGFLAG)
+Clustering_c.o: CXXFLAGS += -I.. $(DEBUGFLAG)
 Clustering_c.o: Clustering_c.cpp Clustering_c.h ../Clustering.h macros_impl.h
 
-AutoTune_c.o: CFLAGS += -I.. $(DEBUGFLAG)
+AutoTune_c.o: CXXFLAGS += -I.. $(DEBUGFLAG)
 AutoTune_c.o: AutoTune_c.cpp AutoTune_c.h ../AutoTune.h macros_impl.h
 
-AuxIndexStructures_c.o: CFLAGS += -I.. $(DEBUGFLAG)
+AuxIndexStructures_c.o: CXXFLAGS += -I.. $(DEBUGFLAG)
 AuxIndexStructures_c.o: AuxIndexStructures_c.cpp AuxIndexStructures_c.h ../AuxIndexStructures.h macros_impl.h
 
-MetaIndexes_c.o: CFLAGS += -I.. $(DEBUGFLAG)
+MetaIndexes_c.o: CXXFLAGS += -I.. $(DEBUGFLAG)
 MetaIndexes_c.o: MetaIndexes_c.cpp MetaIndexes_c.h ../MetaIndexes.h macros_impl.h

--- a/c_api/example_c.c
+++ b/c_api/example_c.c
@@ -27,7 +27,7 @@
         }                                                  \
     }
 
-inline double drand() {
+double drand() {
     return (double)rand() / (double)RAND_MAX;
 }
 

--- a/c_api/gpu/Makefile
+++ b/c_api/gpu/Makefile
@@ -28,10 +28,10 @@ $(CLIBNAME).a: $(LIBGPUCOBJ) ../../gpu/$(LIBNAME).a
 
 # Build dynamic library
 $(CLIBNAME).$(SHAREDEXT): $(LIBCOBJ) $(LIBGPUCOBJ) ../../libfaiss.a ../../gpu/$(LIBNAME).a
-	$(CXX) $(LDFLAGS) $(FAISSSHAREDFLAGS) $(CUDACFLAGS) -o $@ \
-	-Wl,--whole-archive $(LIBCOBJ) ../../libfaiss.a $(BLASLDFLAGS) \
+	$(CXX) $(LDFLAGS) $(SHAREDFLAGS) $(CUDACFLAGS) $(LIBS) -o $@ \
+	-Wl,--whole-archive $(LIBCOBJ) ../../libfaiss.a \
 	-Wl,--no-whole-archive -static-libstdc++ $(LIBGPUCOBJ) ../../gpu/$(LIBNAME).a \
-	-L$(CUDAROOT)/lib64 -lcublas -lcudart
+	$(NVCCLDFLAGS) $(NVCCLIBS)
 
 # Build GPU example
 bin/example_gpu_c: example_gpu_c.c $(CLIBNAME).$(SHAREDEXT)
@@ -43,17 +43,17 @@ clean:
 
 # Dependencies
 
-GpuAutoTune_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
+GpuAutoTune_c.o: CXXFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
 GpuAutoTune_c.o: GpuAutoTune_c.cpp GpuAutoTune_c.h ../../gpu/GpuAutoTune.h ../Index_c.h ../macros_impl.h
 
-GpuClonerOptions_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
+GpuClonerOptions_c.o: CXXFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
 GpuClonerOptions_c.o: GpuClonerOptions_c.cpp GpuClonerOptions_c.h GpuIndicesOptions_c.h ../../gpu/GpuClonerOptions.h ../macros_impl.h
 
-GpuIndex_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
+GpuIndex_c.o: CXXFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
 GpuIndex_c.o: GpuIndex_c.cpp GpuIndex_c.h ../../gpu/GpuIndex.h ../macros_impl.h
 
-GpuResources_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
+GpuResources_c.o: CXXFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
 GpuResources_c.o: GpuResources_c.cpp GpuResources_c.h ../../gpu/GpuResources.h ../macros_impl.h
 
-StandardGpuResources_c.o: CFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
+StandardGpuResources_c.o: CXXFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
 StandardGpuResources_c.o: StandardGpuResources_c.cpp StandardGpuResources_c.h ../../gpu/StandardGpuResources.h ../macros_impl.h

--- a/c_api/gpu/example_gpu_c.c
+++ b/c_api/gpu/example_gpu_c.c
@@ -27,7 +27,7 @@
         }                                                  \
     }
 
-inline double drand() {
+double drand() {
     return (double)rand() / (double)RAND_MAX;
 }
 


### PR DESCRIPTION
Here are the necessary adjustments to the building process of the C API after #466. It is mostly a change of environment variable flags. I also removed the use of `inline` in the respective example files, which was not needed and could bring compilation issues.