### PR TITLE
Fix gpu/tests rename compile errors using CMake

### DIFF
--- a/gpu/CMakeLists.txt
+++ b/gpu/CMakeLists.txt
@@ -25,4 +25,4 @@ list(REMOVE_ITEM faiss_gpu_cpp ${CMAKE_CURRENT_SOURCE_DIR}/perf/PerfIVFPQAdd.cpp
 list(REMOVE_ITEM faiss_gpu_cpp ${CMAKE_CURRENT_SOURCE_DIR}/perf/WriteIndex.cpp)
 
 cuda_add_library(${faiss_lib_gpu} STATIC ${faiss_gpu_headers} ${faiss_gpu_cpp} ${faiss_gpu_cuh} ${faiss_gpu_cu})
-add_subdirectory(test)
+add_subdirectory(tests)

--- a/gpu/tests/TestGpuIndexFlat.cpp
+++ b/gpu/tests/TestGpuIndexFlat.cpp
@@ -12,7 +12,7 @@
 #include "../GpuIndexFlat.h"
 #include "../StandardGpuResources.h"
 #include "../utils/DeviceUtils.h"
-#include "../test/TestUtils.h"
+#include "../tests/TestUtils.h"
 #include <gtest/gtest.h>
 #include <sstream>
 #include <vector>

--- a/gpu/tests/TestGpuIndexIVFFlat.cpp
+++ b/gpu/tests/TestGpuIndexIVFFlat.cpp
@@ -13,7 +13,7 @@
 #include "../GpuIndexIVFFlat.h"
 #include "../StandardGpuResources.h"
 #include "../utils/DeviceUtils.h"
-#include "../test/TestUtils.h"
+#include "../tests/TestUtils.h"
 #include <cmath>
 #include <gtest/gtest.h>
 #include <glog/logging.h>

--- a/gpu/tests/TestGpuIndexIVFPQ.cpp
+++ b/gpu/tests/TestGpuIndexIVFPQ.cpp
@@ -13,7 +13,7 @@
 #include "../GpuIndexIVFPQ.h"
 #include "../StandardGpuResources.h"
 #include "../utils/DeviceUtils.h"
-#include "../test/TestUtils.h"
+#include "../tests/TestUtils.h"
 #include <cmath>
 #include <gtest/gtest.h>
 #include <sstream>

--- a/gpu/tests/TestGpuSelect.cu
+++ b/gpu/tests/TestGpuSelect.cu
@@ -13,7 +13,7 @@
 #include "../utils/WarpSelectKernel.cuh"
 #include "../utils/HostTensor.cuh"
 #include "../utils/DeviceTensor.cuh"
-#include "../test/TestUtils.h"
+#include "../tests/TestUtils.h"
 #include <algorithm>
 #include <gtest/gtest.h>
 #include <sstream>

--- a/gpu/tests/TestUtils.cpp
+++ b/gpu/tests/TestUtils.cpp
@@ -8,7 +8,7 @@
 
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-#include "../test/TestUtils.h"
+#include "../tests/TestUtils.h"
 #include "../../utils.h"
 #include <cmath>
 #include <gtest/gtest.h>


### PR DESCRIPTION
It seems like the `gpu/test` directory was renamed to `gpu/tests` without adjusting some make files and certain include paths. This caused the `gpu/tests` to not build anymore. This fixes this problem.