### PR TITLE
Fix linking order for misc/test_blas in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ demos: libfaiss.a
 # Misc
 
 misc/test_blas: misc/test_blas.cpp
-	$(CXX) $(CXXFLAG) $(LDFLAGS) $(LIBS) -o $@ $^
+	$(CXX) $(CXXFLAG) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 
 #############################


### PR DESCRIPTION
Fixes #487.