### PR TITLE
[C API] Rearrange lib linking order

### DIFF
--- a/c_api/Makefile
+++ b/c_api/Makefile
@@ -26,8 +26,8 @@ $(CLIBNAME).a: $(LIBCOBJ)
 
 # Build dynamic library (independent object)
 $(CLIBNAME).$(SHAREDEXT): $(LIBCOBJ) ../$(LIBNAME).a
-	$(CXX) $(LDFLAGS) $(LIBS) $(SHAREDFLAGS) -o $@ \
-	-Wl,--whole-archive $^ -Wl,--no-whole-archive -static-libstdc++
+	$(CXX) $(LDFLAGS) $(SHAREDFLAGS) -o $@ \
+	-Wl,--whole-archive $^ -Wl,--no-whole-archive $(LIBS) -static-libstdc++
 
 bin/example_c: example_c.c $(CLIBNAME).$(SHAREDEXT)
 	$(CC) $(CFLAGS) -std=c99 -I. -I.. -L. -o $@ example_c.c \

--- a/c_api/gpu/Makefile
+++ b/c_api/gpu/Makefile
@@ -28,9 +28,9 @@ $(CLIBNAME).a: $(LIBGPUCOBJ) ../../gpu/$(LIBNAME).a
 
 # Build dynamic library
 $(CLIBNAME).$(SHAREDEXT): $(LIBCOBJ) $(LIBGPUCOBJ) ../../libfaiss.a ../../gpu/$(LIBNAME).a
-	$(CXX) $(LDFLAGS) $(SHAREDFLAGS) $(CUDACFLAGS) $(LIBS) -o $@ \
+	$(CXX) $(LDFLAGS) $(SHAREDFLAGS) $(CUDACFLAGS) -o $@ \
 	-Wl,--whole-archive $(LIBCOBJ) ../../libfaiss.a \
-	-Wl,--no-whole-archive -static-libstdc++ $(LIBGPUCOBJ) ../../gpu/$(LIBNAME).a \
+	-Wl,--no-whole-archive -static-libstdc++ $(LIBGPUCOBJ) $(LIBS) ../../gpu/$(LIBNAME).a \
 	$(NVCCLDFLAGS) $(NVCCLIBS)
 
 # Build GPU example


### PR DESCRIPTION
Turns out that the Makefiles in the C interface also had the library linking order issue as the one in #487, and solved in #489. It seemed to work locally, but it failed when trying to get Travis to compile the Rust bindings.