### PR TITLE
Facebook sync

### DIFF
--- a/AutoTune.h
+++ b/AutoTune.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #ifndef FAISS_AUTO_TUNE_H
@@ -15,6 +14,7 @@
 #include <vector>
 
 #include "Index.h"
+#include "IndexBinary.h"
 
 namespace faiss {
 
@@ -202,6 +202,8 @@ struct ParameterSpace {
  *  the string. */
 Index *index_factory (int d, const char *description,
                       MetricType metric = METRIC_L2);
+
+IndexBinary *index_binary_factory (int d, const char *description);
 
 
 

--- a/AuxIndexStructures.h
+++ b/AuxIndexStructures.h
@@ -6,13 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved
 // -*- c++ -*-
+
 // Auxiliary index structures, that are used in indexes but that can
 // be forward-declared
 
 #ifndef FAISS_AUX_INDEX_STRUCTURES_H
 #define FAISS_AUX_INDEX_STRUCTURES_H
+
+#include <stdint.h>
 
 #include <vector>
 #include <unordered_set>
@@ -157,9 +159,7 @@ struct RangeSearchPartialResult: BufferList {
     /// begin a new result
     QueryResult & new_result (idx_t qno);
 
-
     void finalize ();
-
 
     /// called by range_search before do_allocation
     void set_lims ();
@@ -168,6 +168,46 @@ struct RangeSearchPartialResult: BufferList {
     void set_result (bool incremental = false);
 
 };
+
+/***********************************************************
+ * Abstract I/O objects
+ ***********************************************************/
+
+
+struct IOReader {
+    // fread
+    virtual size_t operator()(
+         void *ptr, size_t size, size_t nitems) = 0;
+
+    // return a file number that can be memory-mapped
+    virtual int fileno ();
+
+    virtual ~IOReader() {}
+};
+
+struct IOWriter {
+    // fwrite
+    virtual size_t operator()(
+         const void *ptr, size_t size, size_t nitems) = 0;
+
+    // return a file number that can be memory-mapped
+    virtual int fileno ();
+
+    virtual ~IOWriter() {}
+};
+
+
+struct VectorIOReader:IOReader {
+    const std::vector<uint8_t> data;
+    size_t rp = 0;
+    size_t operator()(void *ptr, size_t size, size_t nitems) override;
+};
+
+struct VectorIOWriter:IOWriter {
+    std::vector<uint8_t> data;
+    size_t operator()(const void *ptr, size_t size, size_t nitems) override;
+};
+
 
 
 }; // namespace faiss

--- a/Clustering.cpp
+++ b/Clustering.cpp
@@ -6,12 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* Copyright 2004-present Facebook. All Rights Reserved.
-   kmeans clustering routines
-*/
+// -*- c++ -*-
 
 #include "Clustering.h"
-
 
 
 #include <cmath>

--- a/Clustering.h
+++ b/Clustering.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved
 // -*- c++ -*-
 
 #ifndef FAISS_CLUSTERING_H

--- a/FaissAssert.h
+++ b/FaissAssert.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
 
 #ifndef FAISS_ASSERT_INCLUDED
 #define FAISS_ASSERT_INCLUDED

--- a/FaissException.cpp
+++ b/FaissException.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
 
 #include "FaissException.h"
 

--- a/FaissException.h
+++ b/FaissException.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
 
 #ifndef FAISS_EXCEPTION_INCLUDED
 #define FAISS_EXCEPTION_INCLUDED

--- a/Heap.cpp
+++ b/Heap.cpp
@@ -6,20 +6,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* Copyright 2004-present Facebook. All Rights Reserved. */
+// -*- c++ -*-
+
 /* Function for soft heap */
 
 #include "Heap.h"
 
 
 namespace faiss {
-
-
-
-
-
-
-
 
 
 template <typename C>
@@ -124,9 +118,6 @@ template class HeapArray<CMin <float, long> >;
 template class HeapArray<CMax <float, long> >;
 template class HeapArray<CMin <int, long> >;
 template class HeapArray<CMax <int, long> >;
-
-
-
 
 
 }  // END namespace fasis

--- a/Heap.h
+++ b/Heap.h
@@ -6,8 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* Copyright 2004-present Facebook. All Rights Reserved.
- *
+// -*- c++ -*-
+
+/*
  * C++ support for heaps. The set of functions is tailored for
  * efficient similarity search.
  *
@@ -29,7 +30,6 @@
 #include <cstdio>
 
 #include <limits>
-
 
 
 namespace faiss {
@@ -488,8 +488,6 @@ void indirect_heap_push (size_t k,
     }
     bh_ids[i] = id;
 }
-
-
 
 
 } // namespace faiss

--- a/Index.cpp
+++ b/Index.cpp
@@ -6,12 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved
+// -*- c++ -*-
 
 #include "IndexFlat.h"
 #include "FaissAssert.h"
 
 #include <cstring>
+
 
 namespace faiss {
 

--- a/Index.h
+++ b/Index.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved
 // -*- c++ -*-
 
 #ifndef FAISS_INDEX_H

--- a/IndexBinary.cpp
+++ b/IndexBinary.cpp
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+#include "IndexBinary.h"
+#include "FaissAssert.h"
+
+#include <cstring>
+
+namespace faiss {
+
+IndexBinary::~IndexBinary() {}
+
+void IndexBinary::train(idx_t, const uint8_t *) {
+  // Does nothing by default.
+}
+
+void IndexBinary::range_search(idx_t, const uint8_t *, int,
+                               RangeSearchResult *) const {
+  FAISS_THROW_MSG("range search not implemented");
+}
+
+void IndexBinary::assign(idx_t n, const uint8_t *x, idx_t *labels, idx_t k) {
+  int *distances = new int[n * k];
+  ScopeDeleter<int> del(distances);
+  search(n, x, k, distances, labels);
+}
+
+void IndexBinary::add_with_ids(idx_t, const uint8_t *, const long *) {
+  FAISS_THROW_MSG("add_with_ids not implemented for this type of index");
+}
+
+long IndexBinary::remove_ids(const IDSelector&) {
+  FAISS_THROW_MSG("remove_ids not implemented for this type of index");
+  return -1;
+}
+
+void IndexBinary::reconstruct(idx_t, uint8_t *) const {
+  FAISS_THROW_MSG("reconstruct not implemented for this type of index");
+}
+
+void IndexBinary::reconstruct_n(idx_t i0, idx_t ni, uint8_t *recons) const {
+  for (idx_t i = 0; i < ni; i++) {
+    reconstruct(i0 + i, recons + i * d);
+  }
+}
+
+void IndexBinary::search_and_reconstruct(idx_t n, const uint8_t *x, idx_t k,
+                                         int32_t *distances, idx_t *labels,
+                                         uint8_t *recons) const {
+  search(n, x, k, distances, labels);
+  for (idx_t i = 0; i < n; ++i) {
+    for (idx_t j = 0; j < k; ++j) {
+      idx_t ij = i * k + j;
+      idx_t key = labels[ij];
+      uint8_t *reconstructed = recons + ij * d;
+      if (key < 0) {
+        // Fill with NaNs
+        memset(reconstructed, -1, sizeof(*reconstructed) * d);
+      } else {
+        reconstruct(key, reconstructed);
+      }
+    }
+  }
+}
+
+void IndexBinary::display() const {
+  printf("Index: %s  -> %ld elements\n", typeid (*this).name(), ntotal);
+}
+
+
+}  // namespace faiss

--- a/IndexBinary.h
+++ b/IndexBinary.h
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+#ifndef FAISS_INDEX_BINARY_H
+#define FAISS_INDEX_BINARY_H
+
+#include <cstdio>
+#include <typeinfo>
+#include <string>
+#include <sstream>
+
+#include "FaissAssert.h"
+#include "Index.h"
+
+
+namespace faiss {
+
+
+/// Forward declarations see AuxIndexStructures.h
+struct IDSelector;
+struct RangeSearchResult;
+
+/** Abstract structure for a binary index.
+ *
+ * Supports adding vertices and searching them.
+ *
+ * All queries are symmetric because there is no distinction between codes and
+ * vectors.
+ */
+struct IndexBinary {
+  typedef long idx_t;    ///< all indices are this type
+
+  int d;                 ///< vector dimension
+  int code_size;   ///< number of bytes per vector ( = d / 8 )
+  idx_t ntotal;          ///< total nb of indexed vectors
+  bool verbose;          ///< verbosity level
+
+  /// set if the Index does not require training, or if training is done already
+  bool is_trained;
+
+  /// type of metric this index uses for search
+  MetricType metric_type;
+
+  explicit IndexBinary(idx_t d = 0, MetricType metric = METRIC_L2)
+      : d(d),
+        code_size(d / 8),
+        ntotal(0),
+        verbose(false),
+        is_trained(true),
+        metric_type(metric) {
+        FAISS_THROW_IF_NOT(d % 8 == 0);
+      }
+
+  virtual ~IndexBinary();
+
+
+  /** Perform training on a representative set of vectors.
+   *
+   * @param n      nb of training vectors
+   * @param x      training vecors, size n * d / 8
+   */
+  virtual void train(idx_t n, const uint8_t *x);
+
+  /** Add n vectors of dimension d to the index.
+   *
+   * Vectors are implicitly assigned labels ntotal .. ntotal + n - 1
+   * @param x      input matrix, size n * d / 8
+   */
+  virtual void add(idx_t n, const uint8_t *x) = 0;
+
+  /** Same as add, but stores xids instead of sequential ids.
+   *
+   * The default implementation fails with an assertion, as it is
+   * not supported by all indexes.
+   *
+   * @param xids if non-null, ids to store for the vectors (size n)
+   */
+  virtual void add_with_ids(idx_t n, const uint8_t *x, const long *xids);
+
+  /** Query n vectors of dimension d to the index.
+   *
+   * return at most k vectors. If there are not enough results for a
+   * query, the result array is padded with -1s.
+   *
+   * @param x           input vectors to search, size n * d / 8
+   * @param labels      output labels of the NNs, size n*k
+   * @param distances   output pairwise distances, size n*k
+   */
+  virtual void search(idx_t n, const uint8_t *x, idx_t k,
+                      int32_t *distances, idx_t *labels) const = 0;
+
+  /** Query n vectors of dimension d to the index.
+   *
+   * return all vectors with distance < radius. Note that many
+   * indexes do not implement the range_search (only the k-NN search
+   * is mandatory).
+   *
+   * @param x           input vectors to search, size n * d / 8
+   * @param radius      search radius
+   * @param result      result table
+   */
+  virtual void range_search(idx_t n, const uint8_t *x, int radius,
+                            RangeSearchResult *result) const;
+
+  /** Return the indexes of the k vectors closest to the query x.
+   *
+   * This function is identical to search but only returns labels of neighbors.
+   * @param x           input vectors to search, size n * d / 8
+   * @param labels      output labels of the NNs, size n*k
+   */
+  void assign(idx_t n, const uint8_t *x, idx_t *labels, idx_t k = 1);
+
+  /// Removes all elements from the database.
+  virtual void reset() = 0;
+
+  /** Removes IDs from the index. Not supported by all indexes.
+   */
+  virtual long remove_ids(const IDSelector& sel);
+
+  /** Reconstruct a stored vector.
+   *
+   * This function may not be defined for some indexes.
+   * @param key         id of the vector to reconstruct
+   * @param recons      reconstucted vector (size d / 8)
+   */
+  virtual void reconstruct(idx_t key, uint8_t *recons) const;
+
+
+  /** Reconstruct vectors i0 to i0 + ni - 1.
+   *
+   * This function may not be defined for some indexes.
+   * @param recons      reconstucted vectors (size ni * d / 8)
+   */
+  virtual void reconstruct_n(idx_t i0, idx_t ni, uint8_t *recons) const;
+
+  /** Similar to search, but also reconstructs the stored vectors (or an
+   * approximation in the case of lossy coding) for the search results.
+   *
+   * If there are not enough results for a query, the resulting array
+   * is padded with -1s.
+   *
+   * @param recons      reconstructed vectors size (n, k, d)
+   **/
+  virtual void search_and_reconstruct(idx_t n, const uint8_t *x, idx_t k,
+                                      int32_t *distances, idx_t *labels,
+                                      uint8_t *recons) const;
+
+  /** Display the actual class name and some more info. */
+  void display() const;
+};
+
+
+}  // namespace faiss
+
+#endif  // FAISS_INDEX_BINARY_H

--- a/IndexBinaryFlat.cpp
+++ b/IndexBinaryFlat.cpp
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+#include "IndexBinaryFlat.h"
+
+#include <cstring>
+#include "hamming.h"
+#include "utils.h"
+#include "Heap.h"
+#include "FaissAssert.h"
+#include "AuxIndexStructures.h"
+
+namespace faiss {
+
+IndexBinaryFlat::IndexBinaryFlat(idx_t d)
+    : IndexBinary(d) {}
+
+void IndexBinaryFlat::add(idx_t n, const uint8_t *x) {
+  xb.insert(xb.end(), x, x + n * code_size);
+  ntotal += n;
+}
+
+void IndexBinaryFlat::reset() {
+  xb.clear();
+  ntotal = 0;
+}
+
+void IndexBinaryFlat::search(idx_t n, const uint8_t *x, idx_t k,
+                             int32_t *distances, idx_t *labels) const {
+  const size_t block_size = query_batch_size;
+  for (size_t s = 0; s < n; s += block_size) {
+    idx_t nn = block_size;
+    if (s + block_size > n) {
+      nn = n - s;
+    }
+
+    if (use_heap) {
+      // We see the distances and labels as heaps.
+      int_maxheap_array_t res = {
+        size_t(nn), size_t(k), labels + s * k, distances + s * k
+      };
+
+      hammings_knn_hc(&res, x + s * code_size, xb.data(), ntotal, code_size,
+                      /* ordered = */ true);
+    } else {
+      hammings_knn_mc(x + s * code_size, xb.data(), nn, ntotal, k, code_size,
+                      distances, labels);
+    }
+  }
+}
+
+long IndexBinaryFlat::remove_ids(const IDSelector& sel) {
+  idx_t j = 0;
+  for (idx_t i = 0; i < ntotal; i++) {
+    if (sel.is_member(i)) {
+      // should be removed
+    } else {
+      if (i > j) {
+        memmove(&xb[code_size * j], &xb[code_size * i], sizeof(xb[0]) * code_size);
+      }
+      j++;
+    }
+  }
+  long nremove = ntotal - j;
+  if (nremove > 0) {
+    ntotal = j;
+    xb.resize(ntotal * code_size);
+  }
+  return nremove;
+}
+
+void IndexBinaryFlat::reconstruct(idx_t key, uint8_t *recons) const {
+  memcpy(recons, &(xb[code_size * key]), sizeof(*recons) * code_size);
+}
+
+
+}  // namespace faiss

--- a/IndexBinaryFlat.h
+++ b/IndexBinaryFlat.h
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+#ifndef INDEX_BINARY_FLAT_H
+#define INDEX_BINARY_FLAT_H
+
+#include <vector>
+
+#include "IndexBinary.h"
+
+namespace faiss {
+
+
+/** Index that stores the full vectors and performs exhaustive search. */
+struct IndexBinaryFlat : IndexBinary {
+  /// database vectors, size ntotal * d / 8
+  std::vector<uint8_t> xb;
+
+  /** Select between using a heap or counting to select the k smallest values
+   * when scanning inverted lists.
+   */
+  bool use_heap = true;
+
+  size_t query_batch_size = 32;
+
+  explicit IndexBinaryFlat(idx_t d);
+
+  void add(idx_t n, const uint8_t *x) override;
+
+  void reset() override;
+
+  void search(idx_t n, const uint8_t *x, idx_t k,
+              int32_t *distances, idx_t *labels) const override;
+
+  void reconstruct(idx_t key, uint8_t *recons) const override;
+
+  /** Remove some ids. Note that because of the indexing structure,
+   * the semantics of this operation are different from the usual ones:
+   * the new ids are shifted. */
+  long remove_ids(const IDSelector& sel) override;
+
+  IndexBinaryFlat() {}
+};
+
+
+}  // namespace faiss
+
+#endif  // INDEX_BINARY_FLAT_H

--- a/IndexBinaryIVF.cpp
+++ b/IndexBinaryIVF.cpp
@@ -1,0 +1,626 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved
+// -*- c++ -*-
+
+#include "IndexBinaryIVF.h"
+
+#include <cstdio>
+#include <memory>
+
+#include "hamming.h"
+#include "utils.h"
+
+#include "AuxIndexStructures.h"
+#include "FaissAssert.h"
+#include "IndexFlat.h"
+
+
+namespace faiss {
+
+
+IndexBinaryIVF::IndexBinaryIVF(IndexBinary *quantizer, size_t d, size_t nlist)
+    : IndexBinary(d),
+      invlists(new ArrayInvertedLists(nlist, code_size)),
+      own_invlists(true),
+      nprobe(1),
+      max_codes(0),
+      maintain_direct_map(false),
+      quantizer(quantizer),
+      nlist(nlist),
+      own_fields(false) {
+  FAISS_THROW_IF_NOT (d == quantizer->d);
+  is_trained = quantizer->is_trained && (quantizer->ntotal == nlist);
+
+  cp.niter = 10;
+}
+
+IndexBinaryIVF::IndexBinaryIVF()
+    : invlists(nullptr),
+      own_invlists(false),
+      nprobe(1),
+      max_codes(0),
+      maintain_direct_map(false),
+      quantizer(nullptr),
+      nlist(0),
+      own_fields(false) {}
+
+void IndexBinaryIVF::add(idx_t n, const uint8_t *x) {
+  add_with_ids(n, x, nullptr);
+}
+
+void IndexBinaryIVF::add_with_ids(idx_t n, const uint8_t *x, const long *xids) {
+  add_core(n, x, xids, nullptr);
+}
+
+void IndexBinaryIVF::add_core(idx_t n, const uint8_t *x, const long *xids,
+                              const long *precomputed_idx) {
+  FAISS_THROW_IF_NOT(is_trained);
+  assert(invlists);
+  FAISS_THROW_IF_NOT_MSG(!(maintain_direct_map && xids),
+                         "cannot have direct map and add with ids");
+
+  const long * idx;
+
+  std::unique_ptr<long[]> scoped_idx;
+
+  if (precomputed_idx) {
+    idx = precomputed_idx;
+  } else {
+    scoped_idx.reset(new long[n]);
+    quantizer->assign(n, x, scoped_idx.get());
+    idx = scoped_idx.get();
+  }
+
+  long n_add = 0;
+  for (size_t i = 0; i < n; i++) {
+    long id = xids ? xids[i] : ntotal + i;
+    long list_no = idx[i];
+
+    if (list_no < 0)
+      continue;
+    const uint8_t *xi = x + i * code_size;
+    size_t offset = invlists->add_entry(list_no, id, xi);
+
+    if (maintain_direct_map)
+      direct_map.push_back(list_no << 32 | offset);
+    n_add++;
+  }
+  if (verbose) {
+    printf("IndexBinaryIVF::add_with_ids: added %ld / %ld vectors\n",
+           n_add, n);
+  }
+  ntotal += n_add;
+}
+
+void IndexBinaryIVF::make_direct_map(bool new_maintain_direct_map) {
+  // nothing to do
+  if (new_maintain_direct_map == maintain_direct_map)
+    return;
+
+  if (new_maintain_direct_map) {
+    direct_map.resize(ntotal, -1);
+    for (size_t key = 0; key < nlist; key++) {
+      size_t list_size = invlists->list_size(key);
+      const idx_t *idlist = invlists->get_ids(key);
+
+      for (long ofs = 0; ofs < list_size; ofs++) {
+        FAISS_THROW_IF_NOT_MSG(0 <= idlist[ofs] && idlist[ofs] < ntotal,
+                               "direct map supported only for seuquential ids");
+        direct_map[idlist[ofs]] = key << 32 | ofs;
+      }
+    }
+  } else {
+    direct_map.clear();
+  }
+  maintain_direct_map = new_maintain_direct_map;
+}
+
+void IndexBinaryIVF::search(idx_t n, const uint8_t *x, idx_t k,
+                            int32_t *distances, idx_t *labels) const {
+  std::unique_ptr<idx_t[]> idx(new idx_t[n * nprobe]);
+  std::unique_ptr<int32_t[]> coarse_dis(new int32_t[n * nprobe]);
+
+  quantizer->search(n, x, nprobe, coarse_dis.get(), idx.get());
+
+  invlists->prefetch_lists(idx.get(), n * nprobe);
+
+  search_preassigned(n, x, k, idx.get(), coarse_dis.get(),
+                     distances, labels, false);
+}
+
+void IndexBinaryIVF::reconstruct(idx_t key, uint8_t *recons) const {
+  FAISS_THROW_IF_NOT_MSG(direct_map.size() == ntotal,
+                         "direct map is not initialized");
+  long list_no = direct_map[key] >> 32;
+  long offset = direct_map[key] & 0xffffffff;
+  reconstruct_from_offset(list_no, offset, recons);
+}
+
+void IndexBinaryIVF::reconstruct_n(idx_t i0, idx_t ni, uint8_t *recons) const {
+  FAISS_THROW_IF_NOT(ni == 0 || (i0 >= 0 && i0 + ni <= ntotal));
+
+  for (long list_no = 0; list_no < nlist; list_no++) {
+    size_t list_size = invlists->list_size(list_no);
+    const Index::idx_t *idlist = invlists->get_ids(list_no);
+
+    for (long offset = 0; offset < list_size; offset++) {
+      long id = idlist[offset];
+      if (!(id >= i0 && id < i0 + ni)) {
+        continue;
+      }
+
+      uint8_t *reconstructed = recons + (id - i0) * d;
+      reconstruct_from_offset(list_no, offset, reconstructed);
+    }
+  }
+}
+
+void IndexBinaryIVF::search_and_reconstruct(idx_t n, const uint8_t *x, idx_t k,
+                                            int32_t *distances, idx_t *labels,
+                                            uint8_t *recons) const {
+  std::unique_ptr<idx_t[]> idx(new long[n * nprobe]);
+  std::unique_ptr<int32_t[]> coarse_dis(new int32_t[n * nprobe]);
+
+  quantizer->search(n, x, nprobe, coarse_dis.get(), idx.get());
+
+  invlists->prefetch_lists(idx.get(), n * nprobe);
+
+  // search_preassigned() with `store_pairs` enabled to obtain the list_no
+  // and offset into `codes` for reconstruction
+  search_preassigned(n, x, k, idx.get(), coarse_dis.get(),
+                     distances, labels, /* store_pairs */true);
+  for (idx_t i = 0; i < n; ++i) {
+    for (idx_t j = 0; j < k; ++j) {
+      idx_t ij = i * k + j;
+      idx_t key = labels[ij];
+      uint8_t *reconstructed = recons + ij * d;
+      if (key < 0) {
+        // Fill with NaNs
+        memset(reconstructed, -1, sizeof(*reconstructed) * d);
+      } else {
+        int list_no = key >> 32;
+        int offset = key & 0xffffffff;
+
+        // Update label to the actual id
+        labels[ij] = invlists->get_single_id(list_no, offset);
+
+        reconstruct_from_offset(list_no, offset, reconstructed);
+      }
+    }
+  }
+}
+
+void IndexBinaryIVF::reconstruct_from_offset(long list_no, long offset,
+                                             uint8_t *recons) const {
+  memcpy(recons, invlists->get_single_code(list_no, offset), code_size);
+}
+
+void IndexBinaryIVF::reset() {
+  direct_map.clear();
+  invlists->reset();
+  ntotal = 0;
+}
+
+long IndexBinaryIVF::remove_ids(const IDSelector& sel) {
+  FAISS_THROW_IF_NOT_MSG(!maintain_direct_map,
+                         "direct map remove not implemented");
+
+  std::vector<long> toremove(nlist);
+
+#pragma omp parallel for
+  for (long i = 0; i < nlist; i++) {
+    long l0 = invlists->list_size (i), l = l0, j = 0;
+    const idx_t *idsi = invlists->get_ids(i);
+    while (j < l) {
+      if (sel.is_member(idsi[j])) {
+        l--;
+        invlists->update_entry(
+          i, j,
+          invlists->get_single_id(i, l),
+          invlists->get_single_code(i, l));
+      } else {
+        j++;
+      }
+    }
+    toremove[i] = l0 - l;
+  }
+  // this will not run well in parallel on ondisk because of possible shrinks
+  long nremove = 0;
+  for (long i = 0; i < nlist; i++) {
+    if (toremove[i] > 0) {
+      nremove += toremove[i];
+      invlists->resize(
+        i, invlists->list_size(i) - toremove[i]);
+    }
+  }
+  ntotal -= nremove;
+  return nremove;
+}
+
+void IndexBinaryIVF::train(idx_t n, const uint8_t *x) {
+  if (verbose)
+    printf("Training level-1 quantizer\n");
+
+  train_q1(n, x, verbose);
+
+  is_trained = true;
+}
+
+double IndexBinaryIVF::imbalance_factor () const {
+  std::vector<int> hist(nlist);
+
+  for (int i = 0; i < nlist; i++) {
+    hist[i] = invlists->list_size(i);
+  }
+
+  return faiss::imbalance_factor(nlist, hist.data());
+}
+
+void IndexBinaryIVF::print_stats() const {
+  std::vector<int> sizes(40);
+  for (int i = 0; i < nlist; i++) {
+    for (int j = 0; j < sizes.size(); j++) {
+      if ((invlists->list_size(i) >> j) == 0) {
+        sizes[j]++;
+        break;
+      }
+    }
+  }
+  for (int i = 0; i < sizes.size(); i++) {
+    if (sizes[i]) {
+      printf("list size in < %d: %d instances\n", 1 << i, sizes[i]);
+    }
+  }
+}
+
+void IndexBinaryIVF::merge_from(IndexBinaryIVF &other, idx_t add_id) {
+  // minimal sanity checks
+  FAISS_THROW_IF_NOT(other.d == d);
+  FAISS_THROW_IF_NOT(other.nlist == nlist);
+  FAISS_THROW_IF_NOT(other.code_size == code_size);
+  FAISS_THROW_IF_NOT_MSG((!maintain_direct_map &&
+                          !other.maintain_direct_map),
+                         "direct map copy not implemented");
+  FAISS_THROW_IF_NOT_MSG(typeid (*this) == typeid (other),
+                         "can only merge indexes of the same type");
+
+  InvertedLists *oivf = other.invlists;
+#pragma omp parallel for
+  for (long i = 0; i < nlist; i++) {
+    size_t list_size = oivf->list_size(i);
+    const idx_t * ids = oivf->get_ids(i);
+    if (add_id == 0) {
+      invlists->add_entries(i, list_size, ids,
+                            oivf->get_codes(i));
+    } else {
+      std::vector <idx_t> new_ids(list_size);
+
+      for (size_t j = 0; j < list_size; j++) {
+        new_ids [j] = ids[j] + add_id;
+      }
+
+      invlists->add_entries(i, list_size, new_ids.data(),
+                            oivf->get_codes(i));
+    }
+    oivf->resize(i, 0);
+  }
+
+  ntotal += other.ntotal;
+  other.ntotal = 0;
+}
+
+void IndexBinaryIVF::replace_invlists(InvertedLists *il, bool own) {
+  FAISS_THROW_IF_NOT(il->nlist == nlist &&
+                     il->code_size == code_size);
+  if (own_invlists) {
+    delete invlists;
+  }
+  invlists = il;
+  own_invlists = own;
+}
+
+
+namespace {
+
+
+void binary_to_real(int d, const uint8_t *x_in, float *x_out) {
+  for (int j = 0; j < d; ++j) {
+    if ((x_in[j / 8] & (1 << (j % 8))) == 0) {
+      x_out[j] = -1.0;
+    } else {
+      x_out[j] = 1.0;
+    }
+  }
+}
+
+void real_to_binary(int d, const float *x_in, uint8_t *x_out) {
+  for (int j = 0; j < d; ++j) {
+    if (x_in[j] > 0) {
+      x_out[j / 8] |= (1 << (j % 8));
+    } else {
+      x_out[j / 8] &= ~(1 << (j % 8));
+    }
+  }
+}
+
+
+} // namespace
+
+
+void IndexBinaryIVF::train_q1(size_t n, const uint8_t *x, bool verbose) {
+  if (quantizer->is_trained && (quantizer->ntotal == nlist)) {
+    if (verbose)
+      printf("IVF quantizer does not need training.\n");
+  } else {
+    if (verbose)
+      printf("Training level-1 quantizer on %ld vectors in %dD\n", n, d);
+
+    Clustering clus(d, nlist, cp);
+    quantizer->reset();
+
+    std::unique_ptr<float[]> x_f(new float[n * d]);
+    for (int i = 0; i < n; ++i) {
+      binary_to_real(d,
+                     x + i * code_size,
+                     x_f.get() + i * d);
+    }
+
+    IndexFlatL2 index_tmp(d);
+
+    clus.train(n, x_f.get(), index_tmp);
+
+    std::unique_ptr<uint8_t[]> x_b(new uint8_t[clus.k * code_size]);
+    for (int i = 0; i < clus.k; ++i) {
+      real_to_binary(d,
+                     clus.centroids.data() + i * d,
+                     x_b.get() + i * code_size);
+    }
+    quantizer->add(clus.k, x_b.get());
+    quantizer->is_trained = true;
+  }
+}
+
+
+namespace {
+
+
+template<class HammingComputer, bool store_pairs>
+void search_knn_hamming_heap(const IndexBinaryIVF& ivf,
+                             size_t nx,
+                             const uint8_t *x,
+                             const long *keys,
+                             int_maxheap_array_t *res,
+                             const IVFSearchParameters *params) {
+  const size_t k = res->k;
+  size_t nlistv = 0, ndis = 0;
+  long nprobe = params ? params->nprobe : ivf.nprobe;
+  long max_codes = params ? params->max_codes : ivf.max_codes;
+
+#pragma omp parallel for reduction(+: nlistv, ndis)
+  for (size_t i = 0; i < nx; i++) {
+    const uint8_t *xi = x + i * ivf.code_size;
+    const long * keysi = keys + i * nprobe;
+    int32_t * __restrict disi = res->get_val(i);
+    long * __restrict idxi = res->get_ids(i);
+    maxheap_heapify(k, disi, idxi);
+
+    size_t nscan = 0;
+
+    for (size_t ik = 0; ik < nprobe; ik++) {
+      long key = keysi[ik];  /* select the list  */
+      if (key < 0) {
+        // not enough centroids for multiprobe
+        continue;
+      }
+      FAISS_THROW_IF_NOT_FMT (
+        key < (long) ivf.nlist,
+        "Invalid key=%ld  at ik=%ld nlist=%ld\n",
+        key, ik, ivf.nlist);
+
+      nlistv++;
+      size_t list_size = ivf.invlists->list_size(key);
+      const uint8_t *list_vecs = (const uint8_t*)ivf.invlists->get_codes(key);
+      const Index::idx_t *ids = store_pairs
+        ? nullptr
+        : ivf.invlists->get_ids(key);
+      HammingComputer hc(xi, ivf.code_size);
+
+      for (size_t j = 0; j < list_size; j++) {
+        const uint8_t * yj = list_vecs + ivf.code_size * j;
+
+        int32_t disij = hc.hamming(yj);
+
+        if (disij < disi[0]) {
+          maxheap_pop(k, disi, idxi);
+          long id = store_pairs ? (key << 32 | j) : ids[j];
+          maxheap_push(k, disi, idxi, disij, id);
+        }
+      }
+      nscan += list_size;
+      if (max_codes && nscan >= max_codes)
+        break;
+    }
+    ndis += nscan;
+    maxheap_reorder(k, disi, idxi);
+  }
+  indexIVF_stats.nq += nx;
+  indexIVF_stats.nlist += nlistv;
+  indexIVF_stats.ndis += ndis;
+}
+
+template<class HammingComputer, bool store_pairs>
+void search_knn_hamming_count(const IndexBinaryIVF& ivf,
+                              size_t nx,
+                              const uint8_t *x,
+                              const long *keys,
+                              int k,
+                              int32_t *distances,
+                              long *labels,
+                              const IVFSearchParameters *params) {
+  const int nBuckets = ivf.d + 1;
+  std::vector<int> all_counters(nx * nBuckets, 0);
+  std::unique_ptr<long[]> all_ids_per_dis(new long[nx * nBuckets * k]);
+
+  long nprobe = params ? params->nprobe : ivf.nprobe;
+  long max_codes = params ? params->max_codes : ivf.max_codes;
+
+  std::vector<HCounterState<HammingComputer>> cs;
+  for (size_t i = 0; i < nx; ++i) {
+    cs.push_back(HCounterState<HammingComputer>(
+                   all_counters.data() + i * nBuckets,
+                   all_ids_per_dis.get() + i * nBuckets * k,
+                   x + i * ivf.code_size,
+                   ivf.d,
+                   k
+                 ));
+  }
+
+  size_t nlistv = 0, ndis = 0;
+
+#pragma omp parallel for reduction(+: nlistv, ndis)
+  for (size_t i = 0; i < nx; i++) {
+    const long * keysi = keys + i * nprobe;
+    HCounterState<HammingComputer>& csi = cs[i];
+
+    size_t nscan = 0;
+
+    for (size_t ik = 0; ik < nprobe; ik++) {
+      long key = keysi[ik];  /* select the list  */
+      if (key < 0) {
+        // not enough centroids for multiprobe
+        continue;
+      }
+      FAISS_THROW_IF_NOT_FMT (
+        key < (long) ivf.nlist,
+        "Invalid key=%ld  at ik=%ld nlist=%ld\n",
+        key, ik, ivf.nlist);
+
+      nlistv++;
+      size_t list_size = ivf.invlists->list_size(key);
+      const uint8_t *list_vecs = (const uint8_t*)ivf.invlists->get_codes(key);
+      const Index::idx_t *ids = store_pairs
+        ? nullptr
+        : ivf.invlists->get_ids(key);
+
+      for (size_t j = 0; j < list_size; j++) {
+        const uint8_t * yj = list_vecs + ivf.code_size * j;
+
+        long id = store_pairs ? (key << 32 | j) : ids[j];
+        csi.update_counter(yj, id);
+      }
+      nscan += list_size;
+      if (max_codes && nscan >= max_codes)
+        break;
+    }
+    ndis += nscan;
+
+    int nres = 0;
+    for (int b = 0; b < nBuckets && nres < k; b++) {
+      for (int l = 0; l < csi.counters[b] && nres < k; l++) {
+        labels[i * k + nres] = csi.ids_per_dis[b * k + l];
+        distances[i * k + nres] = b;
+        nres++;
+      }
+    }
+  }
+  indexIVF_stats.nq += nx;
+  indexIVF_stats.nlist += nlistv;
+  indexIVF_stats.ndis += ndis;
+}
+
+
+template<class HammingComputer>
+void search_knn_hamming(const IndexBinaryIVF& ivf,
+                        size_t nx,
+                        const uint8_t *x,
+                        const long *keys,
+                        int k,
+                        int32_t *distances,
+                        long *labels,
+                        bool store_pairs,
+                        bool use_heap,
+                        const IVFSearchParameters *params) {
+  if (use_heap) {
+    int_maxheap_array_t res = {
+      size_t(nx), size_t(k), labels, distances};
+    if (store_pairs) {
+        search_knn_hamming_heap<HammingComputer, true>(
+            ivf, nx, x, keys, &res, params);
+    } else {
+        search_knn_hamming_heap<HammingComputer, false>(
+            ivf, nx, x, keys, &res, params);
+    }
+  } else {
+    if (store_pairs) {
+      search_knn_hamming_count<HammingComputer, true>(
+           ivf, nx, x, keys, k, distances, labels, params);
+    } else {
+      search_knn_hamming_count<HammingComputer, false>(
+           ivf, nx, x, keys, k, distances, labels, params);
+    }
+  }
+}
+
+
+}  // namespace
+
+
+void IndexBinaryIVF::search_preassigned(idx_t n, const uint8_t *x, idx_t k,
+                                        const idx_t *idx,
+                                        const int32_t * /* coarse_dis */,
+                                        int32_t *distances, idx_t *labels,
+                                        bool store_pairs,
+                                        const IVFSearchParameters *params
+                                        ) const {
+  switch (code_size) {
+#define HANNDLE_CS(cs)                                  \
+    case cs:                                            \
+      search_knn_hamming<HammingComputer ## cs>(        \
+            *this, n, x, idx, k, distances,             \
+            labels, store_pairs, use_heap, params);     \
+      break;
+      HANNDLE_CS(4);
+      HANNDLE_CS(8);
+      HANNDLE_CS(16);
+      HANNDLE_CS(20);
+      HANNDLE_CS(32);
+      HANNDLE_CS(64);
+#undef HANNDLE_CS
+
+    default:
+      if (code_size % 8 == 0) {
+        search_knn_hamming<HammingComputerM8>(
+             *this, n, x, idx, k, distances,
+             labels, store_pairs, use_heap, params);
+      } else if (code_size % 4 == 0) {
+          search_knn_hamming<HammingComputerM4>(
+             *this, n, x, idx, k, distances,
+             labels, store_pairs, use_heap, params);
+      } else {
+          search_knn_hamming<HammingComputerDefault>(
+             *this, n, x, idx, k, distances,
+             labels, store_pairs, use_heap, params);
+      }
+      break;
+  }
+}
+
+IndexBinaryIVF::~IndexBinaryIVF() {
+  if (own_invlists) {
+    delete invlists;
+  }
+
+  if (own_fields) {
+    delete quantizer;
+  }
+}
+
+
+}  // namespace faiss

--- a/IndexBinaryIVF.h
+++ b/IndexBinaryIVF.h
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+#ifndef FAISS_INDEX_BINARY_IVF_H
+#define FAISS_INDEX_BINARY_IVF_H
+
+
+#include <vector>
+
+#include "IndexBinary.h"
+#include "IndexIVF.h"
+#include "Clustering.h"
+#include "Heap.h"
+
+
+namespace faiss {
+
+
+/** Index based on a inverted file (IVF)
+ *
+ * In the inverted file, the quantizer (an IndexBinary instance) provides a
+ * quantization index for each vector to be added. The quantization
+ * index maps to a list (aka inverted list or posting list), where the
+ * id of the vector is stored.
+ *
+ * The inverted list object is required only after trainng. If none is
+ * set externally, an ArrayInvertedLists is used automatically.
+ *
+ * At search time, the vector to be searched is also quantized, and
+ * only the list corresponding to the quantization index is
+ * searched. This speeds up the search by making it
+ * non-exhaustive. This can be relaxed using multi-probe search: a few
+ * (nprobe) quantization indices are selected and several inverted
+ * lists are visited.
+ */
+struct IndexBinaryIVF : IndexBinary {
+    /// Acess to the actual data
+    InvertedLists *invlists;
+    bool own_invlists;
+
+    size_t nprobe;            ///< number of probes at query time
+    size_t max_codes;         ///< max nb of codes to visit to do a query
+
+    /** Select between using a heap or counting to select the k smallest values
+     * when scanning inverted lists.
+     */
+    bool use_heap = true;
+
+    /// map for direct access to the elements. Enables reconstruct().
+    bool maintain_direct_map;
+    std::vector<long> direct_map;
+
+    IndexBinary *quantizer;   ///< quantizer that maps vectors to inverted lists
+    size_t nlist;             ///< number of possible key values
+
+    /**
+     * = 0: use the quantizer as index in a kmeans training
+     * = 1: just pass on the training set to the train() of the quantizer
+     * = 2: kmeans training on a flat index + add the centroids to the quantizer
+     */
+    bool own_fields;          ///< whether object owns the quantizer
+
+    ClusteringParameters cp; ///< to override default clustering params
+
+    /// Trains the quantizer and calls train_residual to train sub-quantizers
+    void train_q1(size_t n, const uint8_t *x, bool verbose);
+
+    /** The Inverted file takes a quantizer (an IndexBinary) on input,
+     * which implements the function mapping a vector to a list
+     * identifier. The pointer is borrowed: the quantizer should not
+     * be deleted while the IndexBinaryIVF is in use.
+     */
+    IndexBinaryIVF(IndexBinary *quantizer, size_t d, size_t nlist);
+
+    IndexBinaryIVF();
+
+    ~IndexBinaryIVF() override;
+
+    void reset() override;
+
+    /// Trains the quantizer and calls train_residual to train sub-quantizers
+    void train(idx_t n, const uint8_t *x) override;
+
+    /// Quantizes x and calls add_with_key
+    void add(idx_t n, const uint8_t *x) override;
+
+    void add_with_ids(idx_t n, const uint8_t *x, const long *xids) override;
+
+    /// same as add_with_ids, with precomputed coarse quantizer
+    void add_core (idx_t n, const uint8_t * x, const long *xids,
+                   const long *precomputed_idx);
+
+    /** Search a set of vectors, that are pre-quantized by the IVF
+     *  quantizer. Fill in the corresponding heaps with the query
+     *  results. search() calls this.
+     *
+     * @param n      nb of vectors to query
+     * @param x      query vectors, size nx * d
+     * @param assign coarse quantization indices, size nx * nprobe
+     * @param centroid_dis
+     *               distances to coarse centroids, size nx * nprobe
+     * @param distance
+     *               output distances, size n * k
+     * @param labels output labels, size n * k
+     * @param store_pairs store inv list index + inv list offset
+     *                     instead in upper/lower 32 bit of result,
+     *                     instead of ids (used for reranking).
+     * @param params used to override the object's search parameters
+     */
+    void search_preassigned(idx_t n, const uint8_t *x, idx_t k,
+                            const idx_t *assign,
+                            const int32_t *centroid_dis,
+                            int32_t *distances, idx_t *labels,
+                            bool store_pairs,
+                            const IVFSearchParameters *params=nullptr
+                            ) const;
+
+    /** assign the vectors, then call search_preassign */
+    virtual void search(idx_t n, const uint8_t *x, idx_t k,
+                        int32_t *distances, idx_t *labels) const override;
+
+    void reconstruct(idx_t key, uint8_t *recons) const override;
+
+    /** Reconstruct a subset of the indexed vectors.
+     *
+     * Overrides default implementation to bypass reconstruct() which requires
+     * direct_map to be maintained.
+     *
+     * @param i0     first vector to reconstruct
+     * @param ni     nb of vectors to reconstruct
+     * @param recons output array of reconstructed vectors, size ni * d / 8
+     */
+    void reconstruct_n(idx_t i0, idx_t ni, uint8_t *recons) const override;
+
+    /** Similar to search, but also reconstructs the stored vectors (or an
+     * approximation in the case of lossy coding) for the search results.
+     *
+     * Overrides default implementation to avoid having to maintain direct_map
+     * and instead fetch the code offsets through the `store_pairs` flag in
+     * search_preassigned().
+     *
+     * @param recons      reconstructed vectors size (n, k, d / 8)
+     */
+    void search_and_reconstruct(idx_t n, const uint8_t *x, idx_t k,
+                                int32_t *distances, idx_t *labels,
+                                uint8_t *recons) const override;
+
+    /** Reconstruct a vector given the location in terms of (inv list index +
+     * inv list offset) instead of the id.
+     *
+     * Useful for reconstructing when the direct_map is not maintained and
+     * the inv list offset is computed by search_preassigned() with
+     * `store_pairs` set.
+     */
+    virtual void reconstruct_from_offset(long list_no, long offset,
+                                         uint8_t* recons) const;
+
+
+    /// Dataset manipulation functions
+
+    long remove_ids(const IDSelector& sel) override;
+
+    /** moves the entries from another dataset to self. On output,
+     * other is empty. add_id is added to all moved ids (for
+     * sequential ids, this would be this->ntotal */
+    virtual void merge_from(IndexBinaryIVF& other, idx_t add_id);
+
+    size_t get_list_size(size_t list_no) const
+    { return invlists->list_size(list_no); }
+
+    /** intialize a direct map
+     *
+     * @param new_maintain_direct_map    if true, create a direct map,
+     *                                   else clear it
+     */
+    void make_direct_map(bool new_maintain_direct_map=true);
+
+    /// 1= perfectly balanced, >1: imbalanced
+    double imbalance_factor() const;
+
+    /// display some stats about the inverted lists
+    void print_stats() const;
+
+    void replace_invlists(InvertedLists *il, bool own=false);
+};
+
+
+}  // namespace faiss
+
+#endif  // FAISS_INDEX_BINARY_IVF_H

--- a/IndexFlat.cpp
+++ b/IndexFlat.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved
+// -*- c++ -*-
 
 #include "IndexFlat.h"
 
@@ -17,6 +17,7 @@
 #include "FaissAssert.h"
 
 #include "AuxIndexStructures.h"
+
 
 namespace faiss {
 

--- a/IndexFlat.h
+++ b/IndexFlat.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved
 // -*- c++ -*-
 
 #ifndef INDEX_FLAT_H
@@ -24,7 +23,7 @@ struct IndexFlat: Index {
     /// database vectors, size ntotal * d
     std::vector<float> xb;
 
-    explicit IndexFlat (idx_t d, MetricType metric = METRIC_INNER_PRODUCT);
+    explicit IndexFlat (idx_t d, MetricType metric = METRIC_L2);
 
     void add(idx_t n, const float* x) override;
 

--- a/IndexHNSW.cpp
+++ b/IndexHNSW.cpp
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// -*- c++ -*-
+
 #include "IndexHNSW.h"
 
 
@@ -1694,19 +1696,17 @@ struct PQDis: HNSW::DistanceComputer {
         return accu;
     }
 
-
-    PQDis(const IndexPQ & storage, const float *q = nullptr):
-        pq(storage.pq)
-    {
-        precomputed_table.resize(pq.M * pq.ksub);
-        nb = storage.ntotal;
-        d = storage.d;
-        codes = storage.codes.data();
-        code_size = pq.code_size;
-        FAISS_ASSERT(pq.ksub == 256);
-        FAISS_ASSERT(pq.sdc_table.size() == pq.ksub * pq.ksub * pq.M);
-        sdc = pq.sdc_table.data();
-        ndis = 0;
+    PQDis(const IndexPQ& storage, const float* /*q*/ = nullptr)
+        : pq(storage.pq) {
+      precomputed_table.resize(pq.M * pq.ksub);
+      nb = storage.ntotal;
+      d = storage.d;
+      codes = storage.codes.data();
+      code_size = pq.code_size;
+      FAISS_ASSERT(pq.ksub == 256);
+      FAISS_ASSERT(pq.sdc_table.size() == pq.ksub * pq.ksub * pq.M);
+      sdc = pq.sdc_table.data();
+      ndis = 0;
     }
 
     void set_query(const float *x) override {
@@ -1771,15 +1771,13 @@ struct SQDis: HNSW::DistanceComputer {
         return dc->compute_code_distance (codei, codej);
     }
 
-
-    SQDis(const IndexScalarQuantizer & storage, const float *q = nullptr):
-        sq(storage.sq)
-    {
-        nb = storage.ntotal;
-        d = storage.d;
-        codes = storage.codes.data();
-        code_size = sq.code_size;
-        dc = sq.get_distance_computer();
+    SQDis(const IndexScalarQuantizer& storage, const float* /*q*/ = nullptr)
+        : sq(storage.sq) {
+      nb = storage.ntotal;
+      d = storage.d;
+      codes = storage.codes.data();
+      code_size = sq.code_size;
+      dc = sq.get_distance_computer();
     }
 
     void set_query(const float *x) override {

--- a/IndexHNSW.h
+++ b/IndexHNSW.h
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// -*- c++ -*-
+
 #pragma once
 
 #include <vector>
@@ -320,5 +322,4 @@ struct IndexHNSW2Level: IndexHNSW {
 };
 
 
-
-};
+}

--- a/IndexIVF.cpp
+++ b/IndexIVF.cpp
@@ -6,9 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* Copyright 2004-present Facebook. All Rights Reserved.
-   Inverted list structure.
-*/
+// -*- c++ -*-
 
 #include "IndexIVF.h"
 
@@ -367,9 +365,10 @@ void IndexIVF::search_and_reconstruct (idx_t n, const float *x, idx_t k,
     }
 }
 
-void IndexIVF::reconstruct_from_offset (long list_no, long offset,
-                                        float* recons) const
-{
+void IndexIVF::reconstruct_from_offset(
+    long /*list_no*/,
+    long /*offset*/,
+    float* /*recons*/) const {
   FAISS_THROW_MSG ("reconstruct_from_offset not implemented");
 }
 
@@ -605,7 +604,6 @@ void IndexIVFStats::reset()
 
 
 IndexIVFStats indexIVF_stats;
-
 
 
 } // namespace faiss

--- a/IndexIVF.h
+++ b/IndexIVF.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #ifndef FAISS_INDEX_IVF_H
@@ -143,6 +142,12 @@ struct ArrayInvertedLists: InvertedLists {
 };
 
 
+struct IVFSearchParameters {
+    size_t nprobe;            ///< number of probes at query time
+    size_t max_codes;         ///< max nb of codes to visit to do a query
+    virtual ~IVFSearchParameters () {}
+};
+
 /** Index based on a inverted file (IVF)
  *
  * In the inverted file, the quantizer (an Index instance) provides a
@@ -213,12 +218,15 @@ struct IndexIVF: Index, Level1Quantizer {
      * @param store_pairs store inv list index + inv list offset
      *                     instead in upper/lower 32 bit of result,
      *                     instead of ids (used for reranking).
+     * @param params used to override the object's search parameters
      */
     virtual void search_preassigned (idx_t n, const float *x, idx_t k,
                                      const idx_t *assign,
                                      const float *centroid_dis,
                                      float *distances, idx_t *labels,
-                                     bool store_pairs) const = 0;
+                                     bool store_pairs,
+                                     const IVFSearchParameters *params=nullptr
+                                     ) const = 0;
 
     /** assign the vectors, then call search_preassign */
     virtual void search (idx_t n, const float *x, idx_t k,
@@ -317,11 +325,7 @@ struct IndexIVFStats {
 extern IndexIVFStats indexIVF_stats;
 
 
-
 } // namespace faiss
-
-
-
 
 
 #endif

--- a/IndexIVFFlat.cpp
+++ b/IndexIVFFlat.cpp
@@ -6,9 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* Copyright 2004-present Facebook. All Rights Reserved.
-   Inverted list structure.
-*/
+// -*- c++ -*-
 
 #include "IndexIVFFlat.h"
 
@@ -86,13 +84,17 @@ void IndexIVFFlat::add_core (idx_t n, const float * x, const long *xids,
 
 namespace {
 
-void search_knn_inner_product (const IndexIVFFlat & ivf,
-                               size_t nx,
-                               const float * x,
-                               const long * keys,
-                               float_minheap_array_t * res,
-                               bool store_pairs)
+
+template<MetricType metric, bool store_pairs, class C>
+void search_knn_for_ivf (const IndexIVFFlat & ivf,
+                         size_t nx,
+                         const float * x,
+                         const long * keys,
+                         HeapArray<C> * res,
+                         const IVFSearchParameters *params)
 {
+    long nprobe = params ? params->nprobe : ivf.nprobe;
+    long max_codes = params ? params->max_codes : ivf.max_codes;
 
     const size_t k = res->k;
     size_t nlistv = 0, ndis = 0;
@@ -101,13 +103,13 @@ void search_knn_inner_product (const IndexIVFFlat & ivf,
 #pragma omp parallel for reduction(+: nlistv, ndis)
     for (size_t i = 0; i < nx; i++) {
         const float * xi = x + i * d;
-        const long * keysi = keys + i * ivf.nprobe;
+        const long * keysi = keys + i * nprobe;
         float * __restrict simi = res->get_val (i);
         long * __restrict idxi = res->get_ids (i);
-        minheap_heapify (k, simi, idxi);
+        heap_heapify<C> (k, simi, idxi);
         size_t nscan = 0;
 
-        for (size_t ik = 0; ik < ivf.nprobe; ik++) {
+        for (size_t ik = 0; ik < nprobe; ik++) {
             long key = keysi[ik];  /* select the list  */
             if (key < 0) {
                 // not enough centroids for multiprobe
@@ -127,19 +129,20 @@ void search_knn_inner_product (const IndexIVFFlat & ivf,
 
             for (size_t j = 0; j < list_size; j++) {
                 const float * yj = list_vecs + d * j;
-                float ip = fvec_inner_product (xi, yj, d);
-                if (ip > simi[0]) {
-                    minheap_pop (k, simi, idxi);
+                float dis = metric == METRIC_INNER_PRODUCT ?
+                    fvec_inner_product (xi, yj, d) : fvec_L2sqr (xi, yj, d);
+                if (C::cmp (simi[0], dis)) {
+                    heap_pop<C> (k, simi, idxi);
                     long id = store_pairs ? (key << 32 | j) : ids[j];
-                    minheap_push (k, simi, idxi, ip, id);
+                    heap_push<C> (k, simi, idxi, dis, id);
                 }
             }
             nscan += list_size;
-            if (ivf.max_codes && nscan >= ivf.max_codes)
+            if (max_codes && nscan >= max_codes)
                 break;
         }
         ndis += nscan;
-        minheap_reorder (k, simi, idxi);
+        heap_reorder<C> (k, simi, idxi);
     }
     indexIVF_stats.nq += nx;
     indexIVF_stats.nlist += nlistv;
@@ -147,83 +150,38 @@ void search_knn_inner_product (const IndexIVFFlat & ivf,
 }
 
 
-void search_knn_L2sqr (const IndexIVFFlat &ivf,
-                       size_t nx,
-                       const float * x,
-                       const long * keys,
-                       float_maxheap_array_t * res,
-                       bool store_pairs)
-{
-    const size_t k = res->k;
-    size_t nlistv = 0, ndis = 0;
-    size_t d = ivf.d;
-#pragma omp parallel for reduction(+: nlistv, ndis)
-    for (size_t i = 0; i < nx; i++) {
-        const float * xi = x + i * d;
-        const long * keysi = keys + i * ivf.nprobe;
-        float * __restrict disi = res->get_val (i);
-        long * __restrict idxi = res->get_ids (i);
-        maxheap_heapify (k, disi, idxi);
-
-        size_t nscan = 0;
-
-        for (size_t ik = 0; ik < ivf.nprobe; ik++) {
-            long key = keysi[ik];  /* select the list  */
-            if (key < 0) {
-                // not enough centroids for multiprobe
-                continue;
-            }
-            FAISS_THROW_IF_NOT_FMT (
-                key < (long) ivf.nlist,
-                "Invalid key=%ld  at ik=%ld nlist=%ld\n",
-                key, ik, ivf.nlist);
-
-            nlistv++;
-            size_t list_size = ivf.invlists->list_size(key);
-            const float * list_vecs =
-                (const float*)ivf.invlists->get_codes (key);
-            const Index::idx_t * ids = store_pairs ? nullptr :
-                ivf.invlists->get_ids (key);
-
-            for (size_t j = 0; j < list_size; j++) {
-                const float * yj = list_vecs + d * j;
-                float disij = fvec_L2sqr (xi, yj, d);
-                if (disij < disi[0]) {
-                    maxheap_pop (k, disi, idxi);
-                    long id = store_pairs ? (key << 32 | j) : ids[j];
-                    maxheap_push (k, disi, idxi, disij, id);
-                }
-            }
-            nscan += list_size;
-            if (ivf.max_codes && nscan >= ivf.max_codes)
-                break;
-        }
-        ndis += nscan;
-        maxheap_reorder (k, disi, idxi);
-    }
-    indexIVF_stats.nq += nx;
-    indexIVF_stats.nlist += nlistv;
-    indexIVF_stats.ndis += ndis;
-}
 
 
 } // anonymous namespace
 
 void IndexIVFFlat::search_preassigned (idx_t n, const float *x, idx_t k,
-                                     const idx_t *idx,
-                                      const float * /* coarse_dis */,
-                                      float *distances, idx_t *labels,
-                                      bool store_pairs) const
+                                       const idx_t *idx,
+                                       const float * /* coarse_dis */,
+                                       float *distances, idx_t *labels,
+                                       bool store_pairs,
+                                       const IVFSearchParameters *params) const
 {
    if (metric_type == METRIC_INNER_PRODUCT) {
         float_minheap_array_t res = {
             size_t(n), size_t(k), labels, distances};
-        search_knn_inner_product (*this, n, x, idx, &res, store_pairs);
+        if (store_pairs) {
+            search_knn_for_ivf<METRIC_INNER_PRODUCT, true, CMin<float, long> >
+                (*this, n, x, idx, &res, params);
+        } else {
+            search_knn_for_ivf<METRIC_INNER_PRODUCT, false, CMin<float, long> >
+                (*this, n, x, idx, &res, params);
+        }
 
     } else if (metric_type == METRIC_L2) {
         float_maxheap_array_t res = {
             size_t(n), size_t(k), labels, distances};
-        search_knn_L2sqr (*this, n, x, idx, &res, store_pairs);
+        if (store_pairs) {
+            search_knn_for_ivf<METRIC_L2, true, CMax<float, long> >
+                (*this, n, x, idx, &res, params);
+        } else {
+            search_knn_for_ivf<METRIC_L2, false, CMax<float, long> >
+                (*this, n, x, idx, &res, params);
+        }
     }
 }
 
@@ -321,6 +279,264 @@ void IndexIVFFlat::reconstruct_from_offset (long list_no, long offset,
 {
     memcpy (recons, invlists->get_single_code (list_no, offset), code_size);
 }
+
+/*****************************************
+ * IndexIVFFlatDedup implementation
+ ******************************************/
+
+IndexIVFFlatDedup::IndexIVFFlatDedup (
+            Index * quantizer, size_t d, size_t nlist_,
+            MetricType metric_type):
+    IndexIVFFlat (quantizer, d, nlist_, metric_type)
+{}
+
+// from Python's stringobject.c
+static uint64_t hash_bytes (const uint8_t *bytes, long n) {
+    const uint8_t *p = bytes;
+    uint64_t x = (uint64_t)(*p) << 7;
+    long len = n;
+    while (--len >= 0) {
+        x = (1000003*x) ^ *p++;
+    }
+    x ^= n;
+    return x;
+}
+
+
+void IndexIVFFlatDedup::train(idx_t n, const float* x)
+{
+    std::unordered_map<uint64_t, idx_t> map;
+    float * x2 = new float [n * d];
+    ScopeDeleter<float> del (x2);
+
+    long n2 = 0;
+    for (long i = 0; i < n; i++) {
+        uint64_t hash = hash_bytes((uint8_t *)(x + i * d), code_size);
+        if (map.count(hash) &&
+            !memcmp (x2 + map[hash] * d, x + i * d, code_size)) {
+            // is duplicate, skip
+        } else {
+            map [hash] = n2;
+            memcpy (x2 + n2 * d, x + i * d, code_size);
+            n2 ++;
+        }
+    }
+    if (verbose) {
+        printf ("IndexIVFFlatDedup::train: train on %ld points after dedup "
+                "(was %ld points)\n", n2, n);
+    }
+    IndexIVFFlat::train (n2, x2);
+}
+
+
+
+void IndexIVFFlatDedup::add_with_ids(
+           idx_t na, const float* x, const long* xids)
+{
+
+    FAISS_THROW_IF_NOT (is_trained);
+    assert (invlists);
+    FAISS_THROW_IF_NOT_MSG (
+           !maintain_direct_map,
+           "IVFFlatDedup not implemented with direct_map");
+    long * idx = new long [na];
+    ScopeDeleter<long> del (idx);
+    quantizer->assign (na, x, idx);
+
+    long n_add = 0, n_dup = 0;
+    // TODO make a omp loop with this
+    for (size_t i = 0; i < na; i++) {
+        idx_t id = xids ? xids[i] : ntotal + i;
+        long list_no = idx [i];
+
+        if (list_no < 0) {
+            continue;
+        }
+        const float *xi = x + i * d;
+
+        // search if there is already an entry with that id
+        const uint8_t * codes = invlists->get_codes (list_no);
+        long n = invlists->list_size (list_no);
+        long offset = -1;
+        for (long o = 0; o < n; o++) {
+            if (!memcmp (codes + o * code_size,
+                         xi, code_size)) {
+                offset = o;
+                break;
+            }
+        }
+
+        if (offset == -1) { // not found
+            invlists->add_entry (list_no, id, (const uint8_t*) xi);
+        } else {
+            // mark equivalence
+            idx_t id2 = invlists->get_single_id (list_no, offset);
+            std::pair<idx_t, idx_t> pair (id2, id);
+            instances.insert (pair);
+            n_dup ++;
+        }
+        n_add++;
+    }
+    if (verbose) {
+        printf("IndexIVFFlat::add_with_ids: added %ld / %ld vectors"
+               " (out of which %ld are duplicates)\n",
+               n_add, na, n_dup);
+    }
+    ntotal += n_add;
+}
+
+void IndexIVFFlatDedup::search_preassigned (
+           idx_t n, const float *x, idx_t k,
+           const idx_t *assign,
+           const float *centroid_dis,
+           float *distances, idx_t *labels,
+           bool store_pairs,
+           const IVFSearchParameters *params) const
+{
+    FAISS_THROW_IF_NOT_MSG (
+           !store_pairs, "store_pairs not supported in IVFDedup");
+
+    IndexIVFFlat::search_preassigned (n, x, k, assign, centroid_dis,
+                                      distances, labels, false,
+                                      params);
+
+    std::vector <idx_t> labels2 (k);
+    std::vector <float> dis2 (k);
+
+    for (long i = 0; i < n; i++) {
+        idx_t *labels1 = labels + i * k;
+        float *dis1 = distances + i * k;
+        long j = 0;
+        for (; j < k; j++) {
+            if (instances.find (labels1[j]) != instances.end ()) {
+                // a duplicate: special handling
+                break;
+            }
+        }
+        if (j < k) {
+            // there are duplicates, special handling
+            long j0 = j;
+            long rp = j;
+            while (j < k) {
+                auto range = instances.equal_range (labels1[rp]);
+                float dis = dis1[rp];
+                labels2[j] = labels1[rp];
+                dis2[j] = dis;
+                j ++;
+                for (auto it = range.first; j < k && it != range.second; ++it) {
+                    labels2[j] = it->second;
+                    dis2[j] = dis;
+                    j++;
+                }
+                rp++;
+            }
+            memcpy (labels1 + j0, labels2.data() + j0,
+                    sizeof(labels1[0]) * (k - j0));
+            memcpy (dis1 + j0, dis2.data() + j0,
+                    sizeof(dis2[0]) * (k - j0));
+        }
+    }
+
+}
+
+
+long IndexIVFFlatDedup::remove_ids(const IDSelector& sel)
+{
+    std::unordered_map<idx_t, idx_t> replace;
+    std::vector<std::pair<idx_t, idx_t> > toadd;
+    for (auto it = instances.begin(); it != instances.end(); ) {
+        if (sel.is_member(it->first)) {
+            // then we erase this entry
+            if (!sel.is_member(it->second)) {
+                // if the second is not erased
+                if (replace.count(it->first) == 0) {
+                    replace[it->first] = it->second;
+                } else { // remember we should add an element
+                    std::pair<idx_t, idx_t> new_entry (
+                          replace[it->first], it->second);
+                    toadd.push_back(new_entry);
+                }
+            }
+            it = instances.erase(it);
+        } else {
+            if (sel.is_member(it->second)) {
+                it = instances.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    instances.insert (toadd.begin(), toadd.end());
+
+    // mostly copied from IndexIVF.cpp
+
+    FAISS_THROW_IF_NOT_MSG (!maintain_direct_map,
+                    "direct map remove not implemented");
+
+    std::vector<long> toremove(nlist);
+
+#pragma omp parallel for
+    for (long i = 0; i < nlist; i++) {
+        long l0 = invlists->list_size (i), l = l0, j = 0;
+        const idx_t *idsi = invlists->get_ids (i);
+        while (j < l) {
+            if (sel.is_member (idsi[j])) {
+                if (replace.count(idsi[j]) == 0) {
+                    l--;
+                    invlists->update_entry (
+                        i, j,
+                        invlists->get_single_id (i, l),
+                        invlists->get_single_code (i, l));
+                } else {
+                    invlists->update_entry (
+                        i, j,
+                        replace[idsi[j]],
+                        invlists->get_single_code (i, j));
+                    j++;
+                }
+            } else {
+                j++;
+            }
+        }
+        toremove[i] = l0 - l;
+    }
+    // this will not run well in parallel on ondisk because of possible shrinks
+    long nremove = 0;
+    for (long i = 0; i < nlist; i++) {
+        if (toremove[i] > 0) {
+            nremove += toremove[i];
+            invlists->resize(
+                i, invlists->list_size(i) - toremove[i]);
+        }
+    }
+    ntotal -= nremove;
+    return nremove;
+}
+
+
+void IndexIVFFlatDedup::range_search(
+        idx_t ,
+        const float* ,
+        float ,
+        RangeSearchResult* ) const
+{
+    FAISS_THROW_MSG ("not implemented");
+}
+
+void IndexIVFFlatDedup::update_vectors (int , idx_t *, const float *)
+{
+    FAISS_THROW_MSG ("not implemented");
+}
+
+
+void IndexIVFFlatDedup::reconstruct_from_offset (
+         long , long ,
+         float* ) const
+{
+    FAISS_THROW_MSG ("not implemented");
+}
+
 
 
 

--- a/IndexIVFPQ.h
+++ b/IndexIVFPQ.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #ifndef FAISS_INDEX_IVFPQ_H
@@ -21,6 +20,11 @@
 
 namespace faiss {
 
+struct IVFPQSearchParameters: IVFSearchParameters {
+    size_t scan_table_threshold;   ///< use table computation or on-the-fly?
+    int polysemous_ht;             ///< Hamming thresh for polysemous filtering
+    ~IVFPQSearchParameters () {}
+};
 
 
 /** Inverted file with Product Quantizer encoding. Each residual
@@ -103,7 +107,9 @@ struct IndexIVFPQ: IndexIVF {
                              const idx_t *assign,
                              const float *centroid_dis,
                              float *distances, idx_t *labels,
-                             bool store_pairs) const override;
+                             bool store_pairs,
+                             const IVFSearchParameters *params=nullptr
+                             ) const override;
 
     /// build precomputed table
     void precompute_table ();
@@ -181,7 +187,9 @@ struct IndexIVFPQR: IndexIVFPQ {
                              const idx_t *assign,
                              const float *centroid_dis,
                              float *distances, idx_t *labels,
-                             bool store_pairs) const override;
+                             bool store_pairs,
+                             const IVFSearchParameters *params=nullptr
+                             ) const override;
 
     IndexIVFPQR();
 };
@@ -242,11 +250,7 @@ struct Index2Layer: Index {
 };
 
 
-
 } // namespace faiss
-
-
-
 
 
 #endif

--- a/IndexLSH.cpp
+++ b/IndexLSH.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
 
 #include "IndexLSH.h"
 
@@ -18,6 +18,7 @@
 #include "utils.h"
 #include "hamming.h"
 #include "FaissAssert.h"
+
 
 namespace faiss {
 
@@ -146,8 +147,8 @@ void IndexLSH::search (
 
     int_maxheap_array_t res = { size_t(n), size_t(k), labels, idistances};
 
-    hammings_knn (&res, qcodes, codes.data(),
-                  ntotal, bytes_per_vec, true);
+    hammings_knn_hc (&res, qcodes, codes.data(),
+                     ntotal, bytes_per_vec, true);
 
 
     // convert distances to floats
@@ -174,7 +175,6 @@ void IndexLSH::reset() {
     codes.clear();
     ntotal = 0;
 }
-
 
 
 } // namespace faiss

--- a/IndexLSH.h
+++ b/IndexLSH.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #ifndef INDEX_LSH_H
@@ -73,12 +72,7 @@ struct IndexLSH:Index {
 };
 
 
-
 }
-
-
-
-
 
 
 #endif

--- a/IndexPQ.cpp
+++ b/IndexPQ.cpp
@@ -6,9 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* Copyright 2004-present Facebook. All Rights Reserved.
-   Index based on product quantiztion.
-*/
+// -*- c++ -*-
 
 #include "IndexPQ.h"
 
@@ -203,13 +201,13 @@ void IndexPQ::search (idx_t n, const float *x, idx_t k,
 
             if (search_type == ST_HE) {
 
-                hammings_knn (&res, q_codes, codes.data(),
-                              ntotal, pq.code_size, true);
+                hammings_knn_hc (&res, q_codes, codes.data(),
+                                 ntotal, pq.code_size, true);
 
             } else if (search_type == ST_generalized_HE) {
 
-                generalized_hammings_knn (&res, q_codes, codes.data(),
-                                          ntotal, pq.code_size, true);
+                generalized_hammings_knn_hc (&res, q_codes, codes.data(),
+                                             ntotal, pq.code_size, true);
             }
 
             // convert distances to floats
@@ -1092,5 +1090,4 @@ void MultiIndexQuantizer2::search(
 }
 
 
-
-} // END namespace faiss
+} // namespace faiss

--- a/IndexPQ.h
+++ b/IndexPQ.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #ifndef FAISS_INDEX_PQ_H
@@ -63,6 +62,8 @@ struct IndexPQ: Index {
 
     void reconstruct(idx_t key, float* recons) const override;
 
+    long remove_ids(const IDSelector& sel) override;
+
     /******************************************************
      * Polysemous codes implementation
      ******************************************************/
@@ -82,11 +83,6 @@ struct IndexPQ: Index {
     };
 
     Search_type_t search_type;
-
-    /** remove some ids. NB that Because of the structure of the
-     * indexing structre, the semantics of this operation are
-     * different from the usual ones: the new ids are shifted */
-    long remove_ids(const IDSelector& sel) override;
 
     // just encode the sign of the components, instead of using the PQ encoder
     // used only for the queries
@@ -187,7 +183,6 @@ struct MultiIndexQuantizer2: MultiIndexQuantizer {
 
 
 } // namespace faiss
-
 
 
 #endif

--- a/IndexScalarQuantizer.h
+++ b/IndexScalarQuantizer.h
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// -*- c++ -*-
+
 #ifndef FAISS_INDEX_SCALAR_QUANTIZER_H
 #define FAISS_INDEX_SCALAR_QUANTIZER_H
 
@@ -34,6 +36,7 @@ struct ScalarQuantizer {
         QT_4bit,             ///< 4 bits per component
         QT_8bit_uniform,     ///< same, shared range for all dimensions
         QT_4bit_uniform,
+        QT_fp16,
     };
 
     QuantizerType qtype;
@@ -160,7 +163,9 @@ struct IndexIVFScalarQuantizer: IndexIVF {
                              const idx_t *assign,
                              const float *centroid_dis,
                              float *distances, idx_t *labels,
-                             bool store_pairs) const override;
+                             bool store_pairs,
+                             const IVFSearchParameters *params=nullptr
+                             ) const override;
 
     void reconstruct_from_offset (long list_no, long offset,
                                   float* recons) const override;

--- a/MetaIndexes.cpp
+++ b/MetaIndexes.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved
 // -*- c++ -*-
 
 #include "MetaIndexes.h"
@@ -729,8 +728,4 @@ IndexSplitVectors::~IndexSplitVectors ()
 }
 
 
-
-
-
-
-}; // namespace faiss
+} // namespace faiss

--- a/MetaIndexes.h
+++ b/MetaIndexes.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #ifndef META_INDEXES_H
@@ -170,8 +169,7 @@ struct IndexSplitVectors: Index {
 };
 
 
-
-}
+} // namespace faiss
 
 
 #endif

--- a/OnDiskInvertedLists.h
+++ b/OnDiskInvertedLists.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
+// -*- c++ -*-
 
 #ifndef FAISS_ON_DISK_INVERTED_LISTS_H
 #define FAISS_ON_DISK_INVERTED_LISTS_H
@@ -73,8 +73,7 @@ struct OnDiskInvertedLists: InvertedLists {
     size_t totsize;
     uint8_t *ptr; // mmap base pointer
     bool read_only;  /// are inverted lists mapped read-only
-    bool use_madvise; // use madvice for prefetching
-    
+
     OnDiskInvertedLists (size_t nlist, size_t code_size,
                          const char *filename);
 
@@ -116,8 +115,6 @@ struct OnDiskInvertedLists: InvertedLists {
     // empty constructor for the I/O functions
     OnDiskInvertedLists ();
 };
-
-
 
 
 } // namespace faiss

--- a/PolysemousTraining.cpp
+++ b/PolysemousTraining.cpp
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// -*- c++ -*-
+
 #include "PolysemousTraining.h"
 
 #include <cstdlib>
@@ -944,7 +946,6 @@ void PolysemousTraining::optimize_pq_for_hamming (ProductQuantizer &pq,
     pq.compute_sdc_table ();
 
 }
-
 
 
 } // namespace faiss

--- a/PolysemousTraining.h
+++ b/PolysemousTraining.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #ifndef FAISS_POLYSEMOUS_TRAINING_INCLUDED
@@ -17,8 +16,6 @@
 
 
 namespace faiss {
-
-
 
 
 /// parameters used for the simulated annealing method
@@ -154,7 +151,6 @@ struct PolysemousTraining: SimulatedAnnealingParameters {
     void optimize_reproduce_distances (ProductQuantizer &pq) const;
 
 };
-
 
 
 } // namespace faiss

--- a/ProductQuantizer.cpp
+++ b/ProductQuantizer.cpp
@@ -6,9 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* Copyright 2004-present Facebook. All Rights Reserved.
-   Index based on product quantiztion.
-*/
+// -*- c++ -*-
 
 #include "ProductQuantizer.h"
 
@@ -38,8 +36,6 @@ int sgemm_ (const char *transa, const char *transb, FINTEGER *m, FINTEGER *
 
 
 namespace faiss {
-
-
 
 
 /* compute an estimator using look-up tables for typical values of M */
@@ -659,10 +655,6 @@ void ProductQuantizer::search_sdc (const uint8_t * qcodes,
     }
 
 }
-
-
-
-
 
 
 } // namespace faiss

--- a/ProductQuantizer.h
+++ b/ProductQuantizer.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #ifndef FAISS_PRODUCT_QUANTIZER_H
@@ -169,7 +168,6 @@ struct ProductQuantizer {
                      bool init_finalize_heap = true) const;
 
 };
-
 
 
 } // namespace faiss

--- a/VectorTransform.cpp
+++ b/VectorTransform.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved
 // -*- c++ -*-
 
 #include "VectorTransform.h"

--- a/VectorTransform.h
+++ b/VectorTransform.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #ifndef FAISS_VECTOR_TRANSFORM_H
@@ -304,9 +303,7 @@ struct IndexPreTransform: Index {
 };
 
 
-
 } // namespace faiss
-
 
 
 #endif

--- a/benchs/bench_gpu_1bn.py
+++ b/benchs/bench_gpu_1bn.py
@@ -552,10 +552,7 @@ def compute_populated_index(preproc):
     t0 = time.time()
 
     for i in range(ngpu):
-        if ngpu == 1:
-            index_src = faiss.index_gpu_to_cpu(gpu_index)
-        else:
-            index_src = faiss.index_gpu_to_cpu(gpu_index.at(i))
+        index_src = faiss.index_gpu_to_cpu(gpu_index.at(i))
         print "  index %d size %d" % (i, index_src.ntotal)
         index_src.copy_subset_to(indexall, 0, 0, nb)
 

--- a/benchs/bench_vector_ops.py
+++ b/benchs/bench_vector_ops.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD+Patents license found in the
+# LICENSE file in the root directory of this source tree.
+
+#! /usr/bin/env python2
+
+import numpy as np
+import faiss
+import time
+
+xd = 100
+yd = 1000000
+
+np.random.seed(1234)
+
+faiss.omp_set_num_threads(1)
+
+print 'xd=%d yd=%d' % (xd, yd)
+
+print 'Running inner products test..'
+for d in 3, 4, 12, 36, 64:
+
+    x = faiss.rand(xd * d).reshape(xd, d)
+    y = faiss.rand(yd * d).reshape(yd, d)
+
+    distances = np.empty((xd, yd), dtype='float32')
+
+    t0 = time.time()
+    for i in xrange(xd):
+        faiss.fvec_inner_products_ny(faiss.swig_ptr(distances[i]),
+                                     faiss.swig_ptr(x[i]),
+                                     faiss.swig_ptr(y),
+                                     d, yd)
+    t1 = time.time()
+
+    # sparse verification
+    ntry = 100
+    num, denom = 0, 0
+    for t in range(ntry):
+        xi = np.random.randint(xd)
+        yi = np.random.randint(yd)
+        num += abs(distances[xi, yi] - np.dot(x[xi], y[yi]))
+        denom += abs(distances[xi, yi])
+
+    print 'd=%d t=%.3f s diff=%g' % (d, t1 - t0, num / denom)
+
+
+print 'Running L2sqr test..'
+for d in 3, 4, 12, 36, 64:
+
+    x = faiss.rand(xd * d).reshape(xd, d)
+    y = faiss.rand(yd * d).reshape(yd, d)
+
+    distances = np.empty((xd, yd), dtype='float32')
+
+    t0 = time.time()
+    for i in xrange(xd):
+        faiss.fvec_L2sqr_ny(faiss.swig_ptr(distances[i]),
+                            faiss.swig_ptr(x[i]),
+                            faiss.swig_ptr(y),
+                            d, yd)
+    t1 = time.time()
+
+    # sparse verification
+    ntry = 100
+    num, denom = 0, 0
+    for t in range(ntry):
+        xi = np.random.randint(xd)
+        yi = np.random.randint(yd)
+        num += abs(distances[xi, yi] - np.sum((x[xi] - y[yi]) ** 2))
+        denom += abs(distances[xi, yi])
+
+    print 'd=%d t=%.3f s diff=%g' % (d, t1 - t0, num / denom)

--- a/benchs/link_and_code/README.md
+++ b/benchs/link_and_code/README.md
@@ -1,5 +1,6 @@
 
 
+
 README for the link & code implementation
 =========================================
 
@@ -10,14 +11,12 @@ Link & code is an indexing method that combines HNSW indexing with
 compression and exploits the neighborhood structure of the similarity
 graph to improve the reconstruction. It is described in
 
-```
 @inproceedings{link_and_code,
    author = {Matthijs Douze and Alexandre Sablayrolles and Herv\'e J\'egou},
    title = {Link and code: Fast indexing with graphs and compact regression codes},
    booktitle = {CVPR},
    year = {2018}
 }
-```
 
 ArXiV [here](https://arxiv.org/abs/1804.09996)
 
@@ -30,7 +29,7 @@ The test runs with 3 files:
 
 - `datasets.py`: code to load the datasets. The example code runs on the
   deep1b and bigann datasets. See the [toplevel README](../README.md)
-  on how to download them. They should be put in a directory, edit
+  on how to downlod them. They should be put in a directory, edit
   datasets.py to set the path.
 
 - `neighbor_codec.py`: this is where the representation is trained.
@@ -62,7 +61,7 @@ Set `bdir` to a scratch directory.
 
 Explanation of the flags:
 
-- `--db deep100M`: dataset to process
+- `--db deep1M`: dataset to process
 
 - `--M0 6`: number of links on the base level (L6)
 
@@ -135,7 +134,7 @@ python bench_link_and_code.py \
    --beta_nsq 1 --beta_k 1  \
    --beta_centroids $bdir/deep1M_PQ40_M6_nsq0.npy \
    --neigh_recons_codes $bdir/deep1M_PQ36_M6_nsq0_codes.npy \
-   --k_reorder 0,5 --efSearch 16,64,256,1024
+   --k_reorder 0 --efSearch 16,64,256,1024
 ```
 
 The arguments are similar to the previous table. Note that nsq = 0 is

--- a/benchs/link_and_code/bench_link_and_code.py
+++ b/benchs/link_and_code/bench_link_and_code.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD+Patents license found in the
+# LICENSE file in the root directory of this source tree.
+
 #!/usr/bin/env python2
 
 import os

--- a/benchs/link_and_code/datasets.py
+++ b/benchs/link_and_code/datasets.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD+Patents license found in the
+# LICENSE file in the root directory of this source tree.
+
 #! /usr/bin/env python2
 
 """

--- a/benchs/link_and_code/neighbor_codec.py
+++ b/benchs/link_and_code/neighbor_codec.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD+Patents license found in the
+# LICENSE file in the root directory of this source tree.
+
 #! /usr/bin/env python2
 
 """

--- a/demos/demo_imi_flat.cpp
+++ b/demos/demo_imi_flat.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved
 
 
 #include <cmath>

--- a/demos/demo_imi_pq.cpp
+++ b/demos/demo_imi_pq.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved
 
 
 #include <cmath>

--- a/demos/demo_ivfpq_indexing.cpp
+++ b/demos/demo_ivfpq_indexing.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved
 
 
 #include <cmath>

--- a/demos/demo_sift1M.cpp
+++ b/demos/demo_sift1M.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
- // Copyright 2004-present Facebook. All Rights Reserved
 
 
 #include <cmath>

--- a/gpu/GpuAutoTune.cpp
+++ b/gpu/GpuAutoTune.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "GpuAutoTune.h"
 #include <typeinfo>
 

--- a/gpu/GpuAutoTune.h
+++ b/gpu/GpuAutoTune.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #pragma once
 
 #include "../Index.h"

--- a/gpu/GpuClonerOptions.cpp
+++ b/gpu/GpuClonerOptions.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "GpuClonerOptions.h"
 
 namespace faiss { namespace gpu {

--- a/gpu/GpuClonerOptions.h
+++ b/gpu/GpuClonerOptions.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #pragma once
 
 #include "GpuIndicesOptions.h"

--- a/gpu/GpuFaissAssert.h
+++ b/gpu/GpuFaissAssert.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #ifndef GPU_FAISS_ASSERT_INCLUDED
 #define GPU_FAISS_ASSERT_INCLUDED

--- a/gpu/GpuIndex.cu
+++ b/gpu/GpuIndex.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "GpuIndex.h"
 #include "../FaissAssert.h"

--- a/gpu/GpuIndex.h
+++ b/gpu/GpuIndex.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/GpuIndexFlat.cu
+++ b/gpu/GpuIndexFlat.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "GpuIndexFlat.h"
 #include "../IndexFlat.h"

--- a/gpu/GpuIndexFlat.h
+++ b/gpu/GpuIndexFlat.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/GpuIndexIVF.cu
+++ b/gpu/GpuIndexIVF.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "GpuIndexIVF.h"
 #include "../FaissAssert.h"

--- a/gpu/GpuIndexIVF.h
+++ b/gpu/GpuIndexIVF.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/GpuIndexIVFFlat.cu
+++ b/gpu/GpuIndexIVFFlat.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "GpuIndexIVFFlat.h"
 #include "../IndexFlat.h"

--- a/gpu/GpuIndexIVFFlat.h
+++ b/gpu/GpuIndexIVFFlat.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/GpuIndexIVFPQ.cu
+++ b/gpu/GpuIndexIVFPQ.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "GpuIndexIVFPQ.h"
 #include "../IndexFlat.h"

--- a/gpu/GpuIndexIVFPQ.h
+++ b/gpu/GpuIndexIVFPQ.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/GpuIndicesOptions.h
+++ b/gpu/GpuIndicesOptions.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/GpuResources.cpp
+++ b/gpu/GpuResources.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "GpuResources.h"
 #include "utils/DeviceUtils.h"

--- a/gpu/GpuResources.h
+++ b/gpu/GpuResources.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/IndexProxy.cpp
+++ b/gpu/IndexProxy.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "IndexProxy.h"
 #include "../FaissAssert.h"

--- a/gpu/IndexProxy.h
+++ b/gpu/IndexProxy.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/StandardGpuResources.cpp
+++ b/gpu/StandardGpuResources.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "StandardGpuResources.h"
 #include "../FaissAssert.h"

--- a/gpu/StandardGpuResources.h
+++ b/gpu/StandardGpuResources.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/impl/BroadcastSum.cu
+++ b/gpu/impl/BroadcastSum.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include <algorithm>
 #include "../../FaissAssert.h"

--- a/gpu/impl/BroadcastSum.cuh
+++ b/gpu/impl/BroadcastSum.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/impl/Distance.cu
+++ b/gpu/impl/Distance.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "Distance.cuh"
 #include "BroadcastSum.cuh"

--- a/gpu/impl/Distance.cuh
+++ b/gpu/impl/Distance.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/impl/FlatIndex.cu
+++ b/gpu/impl/FlatIndex.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "FlatIndex.cuh"
 #include "Distance.cuh"

--- a/gpu/impl/FlatIndex.cuh
+++ b/gpu/impl/FlatIndex.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/impl/IVFBase.cu
+++ b/gpu/impl/IVFBase.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "IVFBase.cuh"
 #include "../GpuResources.h"

--- a/gpu/impl/IVFBase.cuh
+++ b/gpu/impl/IVFBase.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/impl/IVFFlat.cu
+++ b/gpu/impl/IVFFlat.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "IVFFlat.cuh"
 #include "../GpuResources.h"

--- a/gpu/impl/IVFFlat.cuh
+++ b/gpu/impl/IVFFlat.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/impl/IVFFlatScan.cu
+++ b/gpu/impl/IVFFlatScan.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "IVFFlatScan.cuh"
 #include "../GpuResources.h"

--- a/gpu/impl/IVFFlatScan.cuh
+++ b/gpu/impl/IVFFlatScan.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/impl/IVFPQ.cu
+++ b/gpu/impl/IVFPQ.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "IVFPQ.cuh"
 #include "../GpuResources.h"

--- a/gpu/impl/IVFPQ.cuh
+++ b/gpu/impl/IVFPQ.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/impl/IVFUtils.cu
+++ b/gpu/impl/IVFUtils.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "IVFUtils.cuh"
 #include "../utils/DeviceUtils.h"

--- a/gpu/impl/IVFUtils.cuh
+++ b/gpu/impl/IVFUtils.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/impl/IVFUtilsSelect1.cu
+++ b/gpu/impl/IVFUtilsSelect1.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "IVFUtils.cuh"
 #include "../utils/DeviceUtils.h"

--- a/gpu/impl/IVFUtilsSelect2.cu
+++ b/gpu/impl/IVFUtilsSelect2.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "IVFUtils.cuh"
 #include "../utils/DeviceUtils.h"

--- a/gpu/impl/InvertedListAppend.cu
+++ b/gpu/impl/InvertedListAppend.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "InvertedListAppend.cuh"
 #include "../../FaissAssert.h"

--- a/gpu/impl/InvertedListAppend.cuh
+++ b/gpu/impl/InvertedListAppend.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/impl/L2Norm.cu
+++ b/gpu/impl/L2Norm.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "L2Norm.cuh"
 #include "../../FaissAssert.h"

--- a/gpu/impl/L2Norm.cuh
+++ b/gpu/impl/L2Norm.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/impl/L2Select.cu
+++ b/gpu/impl/L2Select.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "L2Select.cuh"
 #include "../../FaissAssert.h"

--- a/gpu/impl/L2Select.cuh
+++ b/gpu/impl/L2Select.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/impl/PQCodeDistances.cu
+++ b/gpu/impl/PQCodeDistances.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "PQCodeDistances.cuh"
 

--- a/gpu/impl/PQCodeDistances.cuh
+++ b/gpu/impl/PQCodeDistances.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/impl/PQCodeLoad.cuh
+++ b/gpu/impl/PQCodeLoad.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/impl/PQScanMultiPassNoPrecomputed.cu
+++ b/gpu/impl/PQScanMultiPassNoPrecomputed.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "PQScanMultiPassNoPrecomputed.cuh"
 #include "../GpuResources.h"

--- a/gpu/impl/PQScanMultiPassNoPrecomputed.cuh
+++ b/gpu/impl/PQScanMultiPassNoPrecomputed.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/impl/PQScanMultiPassPrecomputed.cu
+++ b/gpu/impl/PQScanMultiPassPrecomputed.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "PQScanMultiPassPrecomputed.cuh"
 #include "../GpuResources.h"

--- a/gpu/impl/PQScanMultiPassPrecomputed.cuh
+++ b/gpu/impl/PQScanMultiPassPrecomputed.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/impl/RemapIndices.cpp
+++ b/gpu/impl/RemapIndices.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "RemapIndices.h"
 #include "../../FaissAssert.h"

--- a/gpu/impl/RemapIndices.h
+++ b/gpu/impl/RemapIndices.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/impl/VectorResidual.cu
+++ b/gpu/impl/VectorResidual.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "VectorResidual.cuh"
 #include "../../FaissAssert.h"
 #include "../utils/ConversionOperators.cuh"

--- a/gpu/impl/VectorResidual.cuh
+++ b/gpu/impl/VectorResidual.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/perf/CompareFlat.cu
+++ b/gpu/perf/CompareFlat.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "../../IndexFlat.h"
 #include "../../utils.h"

--- a/gpu/perf/CompareIVFFlat.cu
+++ b/gpu/perf/CompareIVFFlat.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "../../IndexIVFFlat.h"
 #include "../../index_io.h"

--- a/gpu/perf/CompareIVFPQ.cu
+++ b/gpu/perf/CompareIVFPQ.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "../../IndexIVFPQ.h"
 #include "../../index_io.h"

--- a/gpu/perf/CompareIVFPQGrid.cu
+++ b/gpu/perf/CompareIVFPQGrid.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "../../IndexIVFPQ.h"
 #include "../../index_io.h"

--- a/gpu/perf/IndexWrapper-inl.h
+++ b/gpu/perf/IndexWrapper-inl.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "../../FaissAssert.h"
 

--- a/gpu/perf/IndexWrapper.h
+++ b/gpu/perf/IndexWrapper.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/perf/PerfClustering.cpp
+++ b/gpu/perf/PerfClustering.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "../../utils.h"
 #include "../../Clustering.h"

--- a/gpu/perf/PerfIVFPQAdd.cpp
+++ b/gpu/perf/PerfIVFPQAdd.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 
 #include <cuda_profiler_api.h>

--- a/gpu/perf/PerfSelect.cu
+++ b/gpu/perf/PerfSelect.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "../utils/DeviceUtils.h"
 #include "../utils/BlockSelectKernel.cuh"

--- a/gpu/perf/WriteIndex.cpp
+++ b/gpu/perf/WriteIndex.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "../../IndexIVFFlat.h"
 #include "../../IndexIVFPQ.h"

--- a/gpu/test/TestGpuIndexFlat.cpp
+++ b/gpu/test/TestGpuIndexFlat.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "../../IndexFlat.h"
 #include "../GpuIndexFlat.h"

--- a/gpu/test/TestGpuIndexIVFFlat.cpp
+++ b/gpu/test/TestGpuIndexIVFFlat.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "../../IndexFlat.h"
 #include "../../IndexIVFFlat.h"

--- a/gpu/test/TestGpuIndexIVFPQ.cpp
+++ b/gpu/test/TestGpuIndexIVFPQ.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "../../IndexFlat.h"
 #include "../../IndexIVFPQ.h"

--- a/gpu/test/TestGpuSelect.cu
+++ b/gpu/test/TestGpuSelect.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "../utils/DeviceUtils.h"
 #include "../utils/BlockSelectKernel.cuh"

--- a/gpu/test/TestUtils.cpp
+++ b/gpu/test/TestUtils.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "../test/TestUtils.h"
 #include "../../utils.h"
@@ -64,14 +63,17 @@ std::vector<float> randVecs(size_t num, size_t dim) {
   return v;
 }
 
-void compareIndices(const std::vector<float>& queryVecs,
-                    faiss::Index& refIndex,
-                    faiss::Index& testIndex,
-                    int numQuery, int dim, int k,
-                    const std::string& configMsg,
-                    float maxRelativeError,
-                    float pctMaxDiff1,
-                    float pctMaxDiffN) {
+void compareIndices(
+    const std::vector<float>& queryVecs,
+    faiss::Index& refIndex,
+    faiss::Index& testIndex,
+    int numQuery,
+    int /*dim*/,
+    int k,
+    const std::string& configMsg,
+    float maxRelativeError,
+    float pctMaxDiff1,
+    float pctMaxDiffN) {
   // Compare
   std::vector<float> refDistance(numQuery * k, 0);
   std::vector<faiss::Index::idx_t> refIndices(numQuery * k, -1);

--- a/gpu/test/TestUtils.h
+++ b/gpu/test/TestUtils.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/test/test_gpu_index.py
+++ b/gpu/test/test_gpu_index.py
@@ -112,9 +112,3 @@ class EvalIVFPQAccuracy(unittest.TestCase):
         res = faiss.StandardGpuResources()
         gpu_index = faiss.index_cpu_to_gpu(res, 0, index)
         faiss.GpuParameterSpace().set_index_parameter(gpu_index, "nprobe", 3)
-
-
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/gpu/utils/BlockSelectFloat.cu
+++ b/gpu/utils/BlockSelectFloat.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "blockselect/BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/BlockSelectHalf.cu
+++ b/gpu/utils/BlockSelectHalf.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "blockselect/BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/BlockSelectKernel.cuh
+++ b/gpu/utils/BlockSelectKernel.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #pragma once
 
 #include "Float16.cuh"

--- a/gpu/utils/Comparators.cuh
+++ b/gpu/utils/Comparators.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/ConversionOperators.cuh
+++ b/gpu/utils/ConversionOperators.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/CopyUtils.cuh
+++ b/gpu/utils/CopyUtils.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/DeviceDefs.cuh
+++ b/gpu/utils/DeviceDefs.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 
@@ -28,7 +27,7 @@ constexpr int kWarpSize = 32;
 // This is a memory barrier for intra-warp writes to shared memory.
 __forceinline__ __device__ void warpFence() {
 
-#if __CUDA_ARCH__ >= 700
+#if CUDA_VERSION >= 9000
   __syncwarp();
 #else
   // For the time being, assume synchronicity.

--- a/gpu/utils/DeviceMemory.cpp
+++ b/gpu/utils/DeviceMemory.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "DeviceMemory.h"
 #include "DeviceUtils.h"

--- a/gpu/utils/DeviceMemory.h
+++ b/gpu/utils/DeviceMemory.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/DeviceTensor-inl.cuh
+++ b/gpu/utils/DeviceTensor-inl.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include <utility> // std::move
 

--- a/gpu/utils/DeviceTensor.cuh
+++ b/gpu/utils/DeviceTensor.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/DeviceUtils.cpp
+++ b/gpu/utils/DeviceUtils.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "DeviceUtils.h"
 #include "../../FaissAssert.h"

--- a/gpu/utils/DeviceUtils.h
+++ b/gpu/utils/DeviceUtils.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/DeviceVector.cuh
+++ b/gpu/utils/DeviceVector.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/Float16.cu
+++ b/gpu/utils/Float16.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "Float16.cuh"
 #include "nvidia/fp16_emu.cuh"

--- a/gpu/utils/Float16.cuh
+++ b/gpu/utils/Float16.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/HostTensor-inl.cuh
+++ b/gpu/utils/HostTensor-inl.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 namespace faiss { namespace gpu {
 

--- a/gpu/utils/HostTensor.cuh
+++ b/gpu/utils/HostTensor.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/Limits.cuh
+++ b/gpu/utils/Limits.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/LoadStoreOperators.cuh
+++ b/gpu/utils/LoadStoreOperators.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/MathOperators.cuh
+++ b/gpu/utils/MathOperators.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/MatrixMult.cu
+++ b/gpu/utils/MatrixMult.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "MatrixMult.cuh"
 #include "DeviceMemory.h"

--- a/gpu/utils/MatrixMult.cuh
+++ b/gpu/utils/MatrixMult.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/MemorySpace.cpp
+++ b/gpu/utils/MemorySpace.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "MemorySpace.h"
 #include <cuda_runtime.h>

--- a/gpu/utils/MemorySpace.h
+++ b/gpu/utils/MemorySpace.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/MergeNetworkUtils.cuh
+++ b/gpu/utils/MergeNetworkUtils.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #pragma once
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/MergeNetworkWarp.cuh
+++ b/gpu/utils/MergeNetworkWarp.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #pragma once
 
 #include "DeviceDefs.cuh"

--- a/gpu/utils/NoTypeTensor.cuh
+++ b/gpu/utils/NoTypeTensor.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/Pair.cuh
+++ b/gpu/utils/Pair.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/PtxUtils.cuh
+++ b/gpu/utils/PtxUtils.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/ReductionOperators.cuh
+++ b/gpu/utils/ReductionOperators.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/Reductions.cuh
+++ b/gpu/utils/Reductions.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/Select.cuh
+++ b/gpu/utils/Select.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #pragma once
 
 #include "Comparators.cuh"

--- a/gpu/utils/StackDeviceMemory.cpp
+++ b/gpu/utils/StackDeviceMemory.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "StackDeviceMemory.h"
 #include "DeviceUtils.h"

--- a/gpu/utils/StackDeviceMemory.h
+++ b/gpu/utils/StackDeviceMemory.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/StaticUtils.h
+++ b/gpu/utils/StaticUtils.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/Tensor-inl.cuh
+++ b/gpu/utils/Tensor-inl.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "../GpuFaissAssert.h"
 #include "DeviceUtils.h"

--- a/gpu/utils/Tensor.cuh
+++ b/gpu/utils/Tensor.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/ThrustAllocator.cuh
+++ b/gpu/utils/ThrustAllocator.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/Timer.cpp
+++ b/gpu/utils/Timer.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "Timer.h"
 #include "DeviceUtils.h"

--- a/gpu/utils/Timer.h
+++ b/gpu/utils/Timer.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/Transpose.cuh
+++ b/gpu/utils/Transpose.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/WarpSelectFloat.cu
+++ b/gpu/utils/WarpSelectFloat.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "warpselect/WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/WarpSelectHalf.cu
+++ b/gpu/utils/WarpSelectHalf.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "warpselect/WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/WarpSelectKernel.cuh
+++ b/gpu/utils/WarpSelectKernel.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #pragma once
 
 #include "Float16.cuh"

--- a/gpu/utils/WarpShuffles.cuh
+++ b/gpu/utils/WarpShuffles.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/WorkerThread.cpp
+++ b/gpu/utils/WorkerThread.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "WorkerThread.h"
 #include "../../FaissAssert.h"

--- a/gpu/utils/WorkerThread.h
+++ b/gpu/utils/WorkerThread.h
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once
 

--- a/gpu/utils/blockselect/BlockSelectFloat1.cu
+++ b/gpu/utils/blockselect/BlockSelectFloat1.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectFloat128.cu
+++ b/gpu/utils/blockselect/BlockSelectFloat128.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectFloat256.cu
+++ b/gpu/utils/blockselect/BlockSelectFloat256.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectFloat32.cu
+++ b/gpu/utils/blockselect/BlockSelectFloat32.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectFloat64.cu
+++ b/gpu/utils/blockselect/BlockSelectFloat64.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectFloatF1024.cu
+++ b/gpu/utils/blockselect/BlockSelectFloatF1024.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectFloatF512.cu
+++ b/gpu/utils/blockselect/BlockSelectFloatF512.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectFloatT1024.cu
+++ b/gpu/utils/blockselect/BlockSelectFloatT1024.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectFloatT512.cu
+++ b/gpu/utils/blockselect/BlockSelectFloatT512.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectHalf1.cu
+++ b/gpu/utils/blockselect/BlockSelectHalf1.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectHalf128.cu
+++ b/gpu/utils/blockselect/BlockSelectHalf128.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectHalf256.cu
+++ b/gpu/utils/blockselect/BlockSelectHalf256.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectHalf32.cu
+++ b/gpu/utils/blockselect/BlockSelectHalf32.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectHalf64.cu
+++ b/gpu/utils/blockselect/BlockSelectHalf64.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectHalfF1024.cu
+++ b/gpu/utils/blockselect/BlockSelectHalfF1024.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectHalfF512.cu
+++ b/gpu/utils/blockselect/BlockSelectHalfF512.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectHalfT1024.cu
+++ b/gpu/utils/blockselect/BlockSelectHalfT1024.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectHalfT512.cu
+++ b/gpu/utils/blockselect/BlockSelectHalfT512.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "BlockSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/blockselect/BlockSelectImpl.cuh
+++ b/gpu/utils/blockselect/BlockSelectImpl.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #pragma once
 
 #include "../BlockSelectKernel.cuh"

--- a/gpu/utils/warpselect/WarpSelectFloat1.cu
+++ b/gpu/utils/warpselect/WarpSelectFloat1.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectFloat128.cu
+++ b/gpu/utils/warpselect/WarpSelectFloat128.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectFloat256.cu
+++ b/gpu/utils/warpselect/WarpSelectFloat256.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectFloat32.cu
+++ b/gpu/utils/warpselect/WarpSelectFloat32.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectFloat64.cu
+++ b/gpu/utils/warpselect/WarpSelectFloat64.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectFloatF1024.cu
+++ b/gpu/utils/warpselect/WarpSelectFloatF1024.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectFloatF512.cu
+++ b/gpu/utils/warpselect/WarpSelectFloatF512.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectFloatT1024.cu
+++ b/gpu/utils/warpselect/WarpSelectFloatT1024.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectFloatT512.cu
+++ b/gpu/utils/warpselect/WarpSelectFloatT512.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectHalf1.cu
+++ b/gpu/utils/warpselect/WarpSelectHalf1.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectHalf128.cu
+++ b/gpu/utils/warpselect/WarpSelectHalf128.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectHalf256.cu
+++ b/gpu/utils/warpselect/WarpSelectHalf256.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectHalf32.cu
+++ b/gpu/utils/warpselect/WarpSelectHalf32.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectHalf64.cu
+++ b/gpu/utils/warpselect/WarpSelectHalf64.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectHalfF1024.cu
+++ b/gpu/utils/warpselect/WarpSelectHalfF1024.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectHalfF512.cu
+++ b/gpu/utils/warpselect/WarpSelectHalfF512.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectHalfT1024.cu
+++ b/gpu/utils/warpselect/WarpSelectHalfT1024.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectHalfT512.cu
+++ b/gpu/utils/warpselect/WarpSelectHalfT512.cu
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "WarpSelectImpl.cuh"
 
 namespace faiss { namespace gpu {

--- a/gpu/utils/warpselect/WarpSelectImpl.cuh
+++ b/gpu/utils/warpselect/WarpSelectImpl.cuh
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 #include "../WarpSelectKernel.cuh"
 #include "../Limits.cuh"
 

--- a/index_io.h
+++ b/index_io.h
@@ -6,36 +6,46 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//  Copyright 2004-present Facebook. All Rights Reserved
 // -*- c++ -*-
+
 // I/O code for indexes
 
 #ifndef FAISS_INDEX_IO_H
 #define FAISS_INDEX_IO_H
 
+
 #include <cstdio>
 
 namespace faiss {
 
+
 struct Index;
+struct IndexBinary;
 struct VectorTransform;
 struct IndexIVF;
 struct ProductQuantizer;
 struct IOReader;
 struct IOWriter;
 
-void write_index (const Index *idx, FILE *f);
 void write_index (const Index *idx, const char *fname);
-
+void write_index (const Index *idx, FILE *f);
 void write_index (const Index *idx, IOWriter *writer);
+
+void write_index_binary (const IndexBinary *idx, const char *fname);
+void write_index_binary (const IndexBinary *idx, FILE *f);
+void write_index_binary (const IndexBinary *idx, IOWriter *writer);
 
 
 const int IO_FLAG_MMAP = 1;
 const int IO_FLAG_READ_ONLY = 2;
 
-Index *read_index (FILE * f, int io_flags = 0);
 Index *read_index (const char *fname, int io_flags = 0);
+Index *read_index (FILE * f, int io_flags = 0);
 Index *read_index (IOReader *reader, int io_flags = 0);
+
+IndexBinary *read_index_binary (const char *fname, int io_flags = 0);
+IndexBinary *read_index_binary (FILE * f, int io_flags = 0);
+IndexBinary *read_index_binary (IOReader *reader, int io_flags = 0);
 
 
 void write_VectorTransform (const VectorTransform *vt, const char *fname);
@@ -59,21 +69,9 @@ struct Cloner {
     virtual ~Cloner() {}
 };
 
-struct IOReader {
-    // fread
-    virtual size_t operator()(
-        void *ptr, size_t size, size_t nitems) = 0;
-    virtual ~IOReader() {}
-};
 
-struct IOWriter {
-    // fwrite
-    virtual size_t operator()(
-        const void *ptr, size_t size, size_t nitems) = 0;   
 
-    virtual ~IOWriter() {}
-};
+} // namespace faiss
 
-}
 
 #endif

--- a/makefile.inc.in
+++ b/makefile.inc.in
@@ -6,7 +6,6 @@
 
 CXX          = @CXX@
 CXXCPP       = @CXXCPP@
-# NOTE: Change to `-DFINTEGER=long` if using MKL.
 # TODO: Investigate the LAPACKE wrapper for LAPACK, which defines the correct
 #   type for FORTRAN integers.
 CPPFLAGS     = -DFINTEGER=int @CPPFLAGS@

--- a/python/swigfaiss.py
+++ b/python/swigfaiss.py
@@ -126,6 +126,9 @@ class FloatVector(_object):
 
     def resize(self, n):
         return _swigfaiss.FloatVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss.FloatVector_swap(self, other)
     __swig_destroy__ = _swigfaiss.delete_FloatVector
     __del__ = lambda self: None
 FloatVector_swigregister = _swigfaiss.FloatVector_swigregister
@@ -162,6 +165,9 @@ class DoubleVector(_object):
 
     def resize(self, n):
         return _swigfaiss.DoubleVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss.DoubleVector_swap(self, other)
     __swig_destroy__ = _swigfaiss.delete_DoubleVector
     __del__ = lambda self: None
 DoubleVector_swigregister = _swigfaiss.DoubleVector_swigregister
@@ -198,10 +204,52 @@ class ByteVector(_object):
 
     def resize(self, n):
         return _swigfaiss.ByteVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss.ByteVector_swap(self, other)
     __swig_destroy__ = _swigfaiss.delete_ByteVector
     __del__ = lambda self: None
 ByteVector_swigregister = _swigfaiss.ByteVector_swigregister
 ByteVector_swigregister(ByteVector)
+
+class CharVector(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, CharVector, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, CharVector, name)
+    __repr__ = _swig_repr
+
+    def __init__(self):
+        this = _swigfaiss.new_CharVector()
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+
+    def push_back(self, arg2):
+        return _swigfaiss.CharVector_push_back(self, arg2)
+
+    def clear(self):
+        return _swigfaiss.CharVector_clear(self)
+
+    def data(self):
+        return _swigfaiss.CharVector_data(self)
+
+    def size(self):
+        return _swigfaiss.CharVector_size(self)
+
+    def at(self, n):
+        return _swigfaiss.CharVector_at(self, n)
+
+    def resize(self, n):
+        return _swigfaiss.CharVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss.CharVector_swap(self, other)
+    __swig_destroy__ = _swigfaiss.delete_CharVector
+    __del__ = lambda self: None
+CharVector_swigregister = _swigfaiss.CharVector_swigregister
+CharVector_swigregister(CharVector)
 
 class Uint64Vector(_object):
     __swig_setmethods__ = {}
@@ -234,6 +282,9 @@ class Uint64Vector(_object):
 
     def resize(self, n):
         return _swigfaiss.Uint64Vector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss.Uint64Vector_swap(self, other)
     __swig_destroy__ = _swigfaiss.delete_Uint64Vector
     __del__ = lambda self: None
 Uint64Vector_swigregister = _swigfaiss.Uint64Vector_swigregister
@@ -270,6 +321,9 @@ class LongVector(_object):
 
     def resize(self, n):
         return _swigfaiss.LongVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss.LongVector_swap(self, other)
     __swig_destroy__ = _swigfaiss.delete_LongVector
     __del__ = lambda self: None
 LongVector_swigregister = _swigfaiss.LongVector_swigregister
@@ -306,6 +360,9 @@ class IntVector(_object):
 
     def resize(self, n):
         return _swigfaiss.IntVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss.IntVector_swap(self, other)
     __swig_destroy__ = _swigfaiss.delete_IntVector
     __del__ = lambda self: None
 IntVector_swigregister = _swigfaiss.IntVector_swigregister
@@ -342,6 +399,9 @@ class VectorTransformVector(_object):
 
     def resize(self, n):
         return _swigfaiss.VectorTransformVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss.VectorTransformVector_swap(self, other)
     __swig_destroy__ = _swigfaiss.delete_VectorTransformVector
     __del__ = lambda self: None
 VectorTransformVector_swigregister = _swigfaiss.VectorTransformVector_swigregister
@@ -378,6 +438,9 @@ class OperatingPointVector(_object):
 
     def resize(self, n):
         return _swigfaiss.OperatingPointVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss.OperatingPointVector_swap(self, other)
     __swig_destroy__ = _swigfaiss.delete_OperatingPointVector
     __del__ = lambda self: None
 OperatingPointVector_swigregister = _swigfaiss.OperatingPointVector_swigregister
@@ -414,6 +477,9 @@ class InvertedListsPtrVector(_object):
 
     def resize(self, n):
         return _swigfaiss.InvertedListsPtrVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss.InvertedListsPtrVector_swap(self, other)
     __swig_destroy__ = _swigfaiss.delete_InvertedListsPtrVector
     __del__ = lambda self: None
 InvertedListsPtrVector_swigregister = _swigfaiss.InvertedListsPtrVector_swigregister
@@ -450,6 +516,9 @@ class FloatVectorVector(_object):
 
     def resize(self, n):
         return _swigfaiss.FloatVectorVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss.FloatVectorVector_swap(self, other)
     __swig_destroy__ = _swigfaiss.delete_FloatVectorVector
     __del__ = lambda self: None
 FloatVectorVector_swigregister = _swigfaiss.FloatVectorVector_swigregister
@@ -486,6 +555,9 @@ class ByteVectorVector(_object):
 
     def resize(self, n):
         return _swigfaiss.ByteVectorVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss.ByteVectorVector_swap(self, other)
     __swig_destroy__ = _swigfaiss.delete_ByteVectorVector
     __del__ = lambda self: None
 ByteVectorVector_swigregister = _swigfaiss.ByteVectorVector_swigregister
@@ -522,6 +594,9 @@ class LongVectorVector(_object):
 
     def resize(self, n):
         return _swigfaiss.LongVectorVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss.LongVectorVector_swap(self, other)
     __swig_destroy__ = _swigfaiss.delete_LongVectorVector
     __del__ = lambda self: None
 LongVectorVector_swigregister = _swigfaiss.LongVectorVector_swigregister
@@ -548,13 +623,17 @@ def fvec2bitvec(x, b, d):
     return _swigfaiss.fvec2bitvec(x, b, d)
 fvec2bitvec = _swigfaiss.fvec2bitvec
 
+def hammings_knn_hc(ha, a, b, nb, ncodes, ordered):
+    return _swigfaiss.hammings_knn_hc(ha, a, b, nb, ncodes, ordered)
+hammings_knn_hc = _swigfaiss.hammings_knn_hc
+
 def hammings_knn(ha, a, b, nb, ncodes, ordered):
     return _swigfaiss.hammings_knn(ha, a, b, nb, ncodes, ordered)
 hammings_knn = _swigfaiss.hammings_knn
 
-def hammings_knn_core(ha, a, b, nb, ncodes):
-    return _swigfaiss.hammings_knn_core(ha, a, b, nb, ncodes)
-hammings_knn_core = _swigfaiss.hammings_knn_core
+def hammings_knn_mc(a, b, na, nb, k, ncodes, distances, labels):
+    return _swigfaiss.hammings_knn_mc(a, b, na, nb, k, ncodes, distances, labels)
+hammings_knn_mc = _swigfaiss.hammings_knn_mc
 
 def hamming_count_thres(bs1, bs2, n1, n2, ht, ncodes, nptr):
     return _swigfaiss.hamming_count_thres(bs1, bs2, n1, n2, ht, ncodes, nptr)
@@ -591,6 +670,7 @@ class HammingComputer4(_object):
     __del__ = lambda self: None
 HammingComputer4_swigregister = _swigfaiss.HammingComputer4_swigregister
 HammingComputer4_swigregister(HammingComputer4)
+cvar = _swigfaiss.cvar
 
 class HammingComputer8(_object):
     __swig_setmethods__ = {}
@@ -981,9 +1061,9 @@ GenHammingComputerM8_swigregister = _swigfaiss.GenHammingComputerM8_swigregister
 GenHammingComputerM8_swigregister(GenHammingComputerM8)
 
 
-def generalized_hammings_knn(ha, a, b, nb, code_size, ordered=True):
-    return _swigfaiss.generalized_hammings_knn(ha, a, b, nb, code_size, ordered)
-generalized_hammings_knn = _swigfaiss.generalized_hammings_knn
+def generalized_hammings_knn_hc(ha, a, b, nb, code_size, ordered=True):
+    return _swigfaiss.generalized_hammings_knn_hc(ha, a, b, nb, code_size, ordered)
+generalized_hammings_knn_hc = _swigfaiss.generalized_hammings_knn_hc
 
 def get_num_gpus():
     return _swigfaiss.get_num_gpus()
@@ -1256,7 +1336,6 @@ class Index(_object):
         return _swigfaiss.Index_display(self)
 Index_swigregister = _swigfaiss.Index_swigregister
 Index_swigregister(Index)
-cvar = _swigfaiss.cvar
 
 class ClusteringParameters(_object):
     __swig_setmethods__ = {}
@@ -2407,6 +2486,9 @@ class IndexPQ(Index):
 
     def reconstruct(self, key, recons):
         return _swigfaiss.IndexPQ_reconstruct(self, key, recons)
+
+    def remove_ids(self, sel):
+        return _swigfaiss.IndexPQ_remove_ids(self, sel)
     __swig_setmethods__["do_polysemous_training"] = _swigfaiss.IndexPQ_do_polysemous_training_set
     __swig_getmethods__["do_polysemous_training"] = _swigfaiss.IndexPQ_do_polysemous_training_get
     if _newclass:
@@ -2425,9 +2507,6 @@ class IndexPQ(Index):
     __swig_getmethods__["search_type"] = _swigfaiss.IndexPQ_search_type_get
     if _newclass:
         search_type = _swig_property(_swigfaiss.IndexPQ_search_type_get, _swigfaiss.IndexPQ_search_type_set)
-
-    def remove_ids(self, sel):
-        return _swigfaiss.IndexPQ_remove_ids(self, sel)
     __swig_setmethods__["encode_signs"] = _swigfaiss.IndexPQ_encode_signs_set
     __swig_getmethods__["encode_signs"] = _swigfaiss.IndexPQ_encode_signs_get
     if _newclass:
@@ -2711,6 +2790,32 @@ class ArrayInvertedLists(InvertedLists):
 ArrayInvertedLists_swigregister = _swigfaiss.ArrayInvertedLists_swigregister
 ArrayInvertedLists_swigregister(ArrayInvertedLists)
 
+class IVFSearchParameters(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, IVFSearchParameters, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, IVFSearchParameters, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["nprobe"] = _swigfaiss.IVFSearchParameters_nprobe_set
+    __swig_getmethods__["nprobe"] = _swigfaiss.IVFSearchParameters_nprobe_get
+    if _newclass:
+        nprobe = _swig_property(_swigfaiss.IVFSearchParameters_nprobe_get, _swigfaiss.IVFSearchParameters_nprobe_set)
+    __swig_setmethods__["max_codes"] = _swigfaiss.IVFSearchParameters_max_codes_set
+    __swig_getmethods__["max_codes"] = _swigfaiss.IVFSearchParameters_max_codes_get
+    if _newclass:
+        max_codes = _swig_property(_swigfaiss.IVFSearchParameters_max_codes_get, _swigfaiss.IVFSearchParameters_max_codes_set)
+    __swig_destroy__ = _swigfaiss.delete_IVFSearchParameters
+    __del__ = lambda self: None
+
+    def __init__(self):
+        this = _swigfaiss.new_IVFSearchParameters()
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+IVFSearchParameters_swigregister = _swigfaiss.IVFSearchParameters_swigregister
+IVFSearchParameters_swigregister(IVFSearchParameters)
+
 class IndexIVF(Index, Level1Quantizer):
     __swig_setmethods__ = {}
     for _s in [Index, Level1Quantizer]:
@@ -2765,8 +2870,8 @@ class IndexIVF(Index, Level1Quantizer):
     def train_residual(self, n, x):
         return _swigfaiss.IndexIVF_train_residual(self, n, x)
 
-    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs):
-        return _swigfaiss.IndexIVF_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs)
+    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params=None):
+        return _swigfaiss.IndexIVF_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params)
 
     def search(self, n, x, k, distances, labels):
         return _swigfaiss.IndexIVF_search(self, n, x, k, distances, labels)
@@ -2854,6 +2959,7 @@ class ScalarQuantizer(_object):
     QT_4bit = _swigfaiss.ScalarQuantizer_QT_4bit
     QT_8bit_uniform = _swigfaiss.ScalarQuantizer_QT_8bit_uniform
     QT_4bit_uniform = _swigfaiss.ScalarQuantizer_QT_4bit_uniform
+    QT_fp16 = _swigfaiss.ScalarQuantizer_QT_fp16
     __swig_setmethods__["qtype"] = _swigfaiss.ScalarQuantizer_qtype_set
     __swig_getmethods__["qtype"] = _swigfaiss.ScalarQuantizer_qtype_get
     if _newclass:
@@ -2986,8 +3092,8 @@ class IndexIVFScalarQuantizer(IndexIVF):
     def add_with_ids(self, n, x, xids):
         return _swigfaiss.IndexIVFScalarQuantizer_add_with_ids(self, n, x, xids)
 
-    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs):
-        return _swigfaiss.IndexIVFScalarQuantizer_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs)
+    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params=None):
+        return _swigfaiss.IndexIVFScalarQuantizer_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params)
 
     def reconstruct_from_offset(self, list_no, offset, recons):
         return _swigfaiss.IndexIVFScalarQuantizer_reconstruct_from_offset(self, list_no, offset, recons)
@@ -3418,8 +3524,8 @@ class IndexIVFFlat(IndexIVF):
     def add_with_ids(self, n, x, xids):
         return _swigfaiss.IndexIVFFlat_add_with_ids(self, n, x, xids)
 
-    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs):
-        return _swigfaiss.IndexIVFFlat_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs)
+    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params=None):
+        return _swigfaiss.IndexIVFFlat_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params)
 
     def range_search(self, n, x, radius, result):
         return _swigfaiss.IndexIVFFlat_range_search(self, n, x, radius, result)
@@ -3440,6 +3546,53 @@ class IndexIVFFlat(IndexIVF):
     __del__ = lambda self: None
 IndexIVFFlat_swigregister = _swigfaiss.IndexIVFFlat_swigregister
 IndexIVFFlat_swigregister(IndexIVFFlat)
+
+class IndexIVFFlatDedup(IndexIVFFlat):
+    __swig_setmethods__ = {}
+    for _s in [IndexIVFFlat]:
+        __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
+    __setattr__ = lambda self, name, value: _swig_setattr(self, IndexIVFFlatDedup, name, value)
+    __swig_getmethods__ = {}
+    for _s in [IndexIVFFlat]:
+        __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
+    __getattr__ = lambda self, name: _swig_getattr(self, IndexIVFFlatDedup, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["instances"] = _swigfaiss.IndexIVFFlatDedup_instances_set
+    __swig_getmethods__["instances"] = _swigfaiss.IndexIVFFlatDedup_instances_get
+    if _newclass:
+        instances = _swig_property(_swigfaiss.IndexIVFFlatDedup_instances_get, _swigfaiss.IndexIVFFlatDedup_instances_set)
+
+    def train(self, n, x):
+        return _swigfaiss.IndexIVFFlatDedup_train(self, n, x)
+
+    def add_with_ids(self, n, x, xids):
+        return _swigfaiss.IndexIVFFlatDedup_add_with_ids(self, n, x, xids)
+
+    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params=None):
+        return _swigfaiss.IndexIVFFlatDedup_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params)
+
+    def remove_ids(self, sel):
+        return _swigfaiss.IndexIVFFlatDedup_remove_ids(self, sel)
+
+    def range_search(self, n, x, radius, result):
+        return _swigfaiss.IndexIVFFlatDedup_range_search(self, n, x, radius, result)
+
+    def update_vectors(self, nv, idx, v):
+        return _swigfaiss.IndexIVFFlatDedup_update_vectors(self, nv, idx, v)
+
+    def reconstruct_from_offset(self, list_no, offset, recons):
+        return _swigfaiss.IndexIVFFlatDedup_reconstruct_from_offset(self, list_no, offset, recons)
+
+    def __init__(self, *args):
+        this = _swigfaiss.new_IndexIVFFlatDedup(*args)
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+    __swig_destroy__ = _swigfaiss.delete_IndexIVFFlatDedup
+    __del__ = lambda self: None
+IndexIVFFlatDedup_swigregister = _swigfaiss.IndexIVFFlatDedup_swigregister
+IndexIVFFlatDedup_swigregister(IndexIVFFlatDedup)
 
 class OnDiskInvertedLists(InvertedLists):
     __swig_setmethods__ = {}
@@ -3534,6 +3687,36 @@ class OnDiskInvertedLists(InvertedLists):
 OnDiskInvertedLists_swigregister = _swigfaiss.OnDiskInvertedLists_swigregister
 OnDiskInvertedLists_swigregister(OnDiskInvertedLists)
 
+class IVFPQSearchParameters(IVFSearchParameters):
+    __swig_setmethods__ = {}
+    for _s in [IVFSearchParameters]:
+        __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
+    __setattr__ = lambda self, name, value: _swig_setattr(self, IVFPQSearchParameters, name, value)
+    __swig_getmethods__ = {}
+    for _s in [IVFSearchParameters]:
+        __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
+    __getattr__ = lambda self, name: _swig_getattr(self, IVFPQSearchParameters, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["scan_table_threshold"] = _swigfaiss.IVFPQSearchParameters_scan_table_threshold_set
+    __swig_getmethods__["scan_table_threshold"] = _swigfaiss.IVFPQSearchParameters_scan_table_threshold_get
+    if _newclass:
+        scan_table_threshold = _swig_property(_swigfaiss.IVFPQSearchParameters_scan_table_threshold_get, _swigfaiss.IVFPQSearchParameters_scan_table_threshold_set)
+    __swig_setmethods__["polysemous_ht"] = _swigfaiss.IVFPQSearchParameters_polysemous_ht_set
+    __swig_getmethods__["polysemous_ht"] = _swigfaiss.IVFPQSearchParameters_polysemous_ht_get
+    if _newclass:
+        polysemous_ht = _swig_property(_swigfaiss.IVFPQSearchParameters_polysemous_ht_get, _swigfaiss.IVFPQSearchParameters_polysemous_ht_set)
+    __swig_destroy__ = _swigfaiss.delete_IVFPQSearchParameters
+    __del__ = lambda self: None
+
+    def __init__(self):
+        this = _swigfaiss.new_IVFPQSearchParameters()
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+IVFPQSearchParameters_swigregister = _swigfaiss.IVFPQSearchParameters_swigregister
+IVFPQSearchParameters_swigregister(IVFPQSearchParameters)
+
 class IndexIVFPQ(IndexIVF):
     __swig_setmethods__ = {}
     for _s in [IndexIVF]:
@@ -3604,8 +3787,8 @@ class IndexIVFPQ(IndexIVF):
     def decode_multiple(self, n, keys, xcodes, x):
         return _swigfaiss.IndexIVFPQ_decode_multiple(self, n, keys, xcodes, x)
 
-    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs):
-        return _swigfaiss.IndexIVFPQ_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs)
+    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params=None):
+        return _swigfaiss.IndexIVFPQ_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params)
 
     def precompute_table(self):
         return _swigfaiss.IndexIVFPQ_precompute_table(self)
@@ -3734,8 +3917,8 @@ class IndexIVFPQR(IndexIVFPQ):
     def merge_from(self, other, add_id):
         return _swigfaiss.IndexIVFPQR_merge_from(self, other, add_id)
 
-    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs):
-        return _swigfaiss.IndexIVFPQR_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs)
+    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params=None):
+        return _swigfaiss.IndexIVFPQR_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params)
 
     def __init__(self, *args):
         this = _swigfaiss.new_IndexIVFPQR(*args)
@@ -3814,6 +3997,252 @@ class Index2Layer(Index):
         return _swigfaiss.Index2Layer_transfer_to_IVFPQ(self, other)
 Index2Layer_swigregister = _swigfaiss.Index2Layer_swigregister
 Index2Layer_swigregister(Index2Layer)
+
+class IndexBinary(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, IndexBinary, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, IndexBinary, name)
+
+    def __init__(self, *args, **kwargs):
+        raise AttributeError("No constructor defined - class is abstract")
+    __repr__ = _swig_repr
+    __swig_setmethods__["d"] = _swigfaiss.IndexBinary_d_set
+    __swig_getmethods__["d"] = _swigfaiss.IndexBinary_d_get
+    if _newclass:
+        d = _swig_property(_swigfaiss.IndexBinary_d_get, _swigfaiss.IndexBinary_d_set)
+    __swig_setmethods__["code_size"] = _swigfaiss.IndexBinary_code_size_set
+    __swig_getmethods__["code_size"] = _swigfaiss.IndexBinary_code_size_get
+    if _newclass:
+        code_size = _swig_property(_swigfaiss.IndexBinary_code_size_get, _swigfaiss.IndexBinary_code_size_set)
+    __swig_setmethods__["ntotal"] = _swigfaiss.IndexBinary_ntotal_set
+    __swig_getmethods__["ntotal"] = _swigfaiss.IndexBinary_ntotal_get
+    if _newclass:
+        ntotal = _swig_property(_swigfaiss.IndexBinary_ntotal_get, _swigfaiss.IndexBinary_ntotal_set)
+    __swig_setmethods__["verbose"] = _swigfaiss.IndexBinary_verbose_set
+    __swig_getmethods__["verbose"] = _swigfaiss.IndexBinary_verbose_get
+    if _newclass:
+        verbose = _swig_property(_swigfaiss.IndexBinary_verbose_get, _swigfaiss.IndexBinary_verbose_set)
+    __swig_setmethods__["is_trained"] = _swigfaiss.IndexBinary_is_trained_set
+    __swig_getmethods__["is_trained"] = _swigfaiss.IndexBinary_is_trained_get
+    if _newclass:
+        is_trained = _swig_property(_swigfaiss.IndexBinary_is_trained_get, _swigfaiss.IndexBinary_is_trained_set)
+    __swig_setmethods__["metric_type"] = _swigfaiss.IndexBinary_metric_type_set
+    __swig_getmethods__["metric_type"] = _swigfaiss.IndexBinary_metric_type_get
+    if _newclass:
+        metric_type = _swig_property(_swigfaiss.IndexBinary_metric_type_get, _swigfaiss.IndexBinary_metric_type_set)
+    __swig_destroy__ = _swigfaiss.delete_IndexBinary
+    __del__ = lambda self: None
+
+    def train(self, n, x):
+        return _swigfaiss.IndexBinary_train(self, n, x)
+
+    def add(self, n, x):
+        return _swigfaiss.IndexBinary_add(self, n, x)
+
+    def add_with_ids(self, n, x, xids):
+        return _swigfaiss.IndexBinary_add_with_ids(self, n, x, xids)
+
+    def search(self, n, x, k, distances, labels):
+        return _swigfaiss.IndexBinary_search(self, n, x, k, distances, labels)
+
+    def range_search(self, n, x, radius, result):
+        return _swigfaiss.IndexBinary_range_search(self, n, x, radius, result)
+
+    def assign(self, n, x, labels, k=1):
+        return _swigfaiss.IndexBinary_assign(self, n, x, labels, k)
+
+    def reset(self):
+        return _swigfaiss.IndexBinary_reset(self)
+
+    def remove_ids(self, sel):
+        return _swigfaiss.IndexBinary_remove_ids(self, sel)
+
+    def reconstruct(self, key, recons):
+        return _swigfaiss.IndexBinary_reconstruct(self, key, recons)
+
+    def reconstruct_n(self, i0, ni, recons):
+        return _swigfaiss.IndexBinary_reconstruct_n(self, i0, ni, recons)
+
+    def search_and_reconstruct(self, n, x, k, distances, labels, recons):
+        return _swigfaiss.IndexBinary_search_and_reconstruct(self, n, x, k, distances, labels, recons)
+
+    def display(self):
+        return _swigfaiss.IndexBinary_display(self)
+IndexBinary_swigregister = _swigfaiss.IndexBinary_swigregister
+IndexBinary_swigregister(IndexBinary)
+
+class IndexBinaryFlat(IndexBinary):
+    __swig_setmethods__ = {}
+    for _s in [IndexBinary]:
+        __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
+    __setattr__ = lambda self, name, value: _swig_setattr(self, IndexBinaryFlat, name, value)
+    __swig_getmethods__ = {}
+    for _s in [IndexBinary]:
+        __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
+    __getattr__ = lambda self, name: _swig_getattr(self, IndexBinaryFlat, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["xb"] = _swigfaiss.IndexBinaryFlat_xb_set
+    __swig_getmethods__["xb"] = _swigfaiss.IndexBinaryFlat_xb_get
+    if _newclass:
+        xb = _swig_property(_swigfaiss.IndexBinaryFlat_xb_get, _swigfaiss.IndexBinaryFlat_xb_set)
+    __swig_setmethods__["use_heap"] = _swigfaiss.IndexBinaryFlat_use_heap_set
+    __swig_getmethods__["use_heap"] = _swigfaiss.IndexBinaryFlat_use_heap_get
+    if _newclass:
+        use_heap = _swig_property(_swigfaiss.IndexBinaryFlat_use_heap_get, _swigfaiss.IndexBinaryFlat_use_heap_set)
+    __swig_setmethods__["query_batch_size"] = _swigfaiss.IndexBinaryFlat_query_batch_size_set
+    __swig_getmethods__["query_batch_size"] = _swigfaiss.IndexBinaryFlat_query_batch_size_get
+    if _newclass:
+        query_batch_size = _swig_property(_swigfaiss.IndexBinaryFlat_query_batch_size_get, _swigfaiss.IndexBinaryFlat_query_batch_size_set)
+
+    def add(self, n, x):
+        return _swigfaiss.IndexBinaryFlat_add(self, n, x)
+
+    def reset(self):
+        return _swigfaiss.IndexBinaryFlat_reset(self)
+
+    def search(self, n, x, k, distances, labels):
+        return _swigfaiss.IndexBinaryFlat_search(self, n, x, k, distances, labels)
+
+    def reconstruct(self, key, recons):
+        return _swigfaiss.IndexBinaryFlat_reconstruct(self, key, recons)
+
+    def remove_ids(self, sel):
+        return _swigfaiss.IndexBinaryFlat_remove_ids(self, sel)
+
+    def __init__(self, *args):
+        this = _swigfaiss.new_IndexBinaryFlat(*args)
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+    __swig_destroy__ = _swigfaiss.delete_IndexBinaryFlat
+    __del__ = lambda self: None
+IndexBinaryFlat_swigregister = _swigfaiss.IndexBinaryFlat_swigregister
+IndexBinaryFlat_swigregister(IndexBinaryFlat)
+
+class IndexBinaryIVF(IndexBinary):
+    __swig_setmethods__ = {}
+    for _s in [IndexBinary]:
+        __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
+    __setattr__ = lambda self, name, value: _swig_setattr(self, IndexBinaryIVF, name, value)
+    __swig_getmethods__ = {}
+    for _s in [IndexBinary]:
+        __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
+    __getattr__ = lambda self, name: _swig_getattr(self, IndexBinaryIVF, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["invlists"] = _swigfaiss.IndexBinaryIVF_invlists_set
+    __swig_getmethods__["invlists"] = _swigfaiss.IndexBinaryIVF_invlists_get
+    if _newclass:
+        invlists = _swig_property(_swigfaiss.IndexBinaryIVF_invlists_get, _swigfaiss.IndexBinaryIVF_invlists_set)
+    __swig_setmethods__["own_invlists"] = _swigfaiss.IndexBinaryIVF_own_invlists_set
+    __swig_getmethods__["own_invlists"] = _swigfaiss.IndexBinaryIVF_own_invlists_get
+    if _newclass:
+        own_invlists = _swig_property(_swigfaiss.IndexBinaryIVF_own_invlists_get, _swigfaiss.IndexBinaryIVF_own_invlists_set)
+    __swig_setmethods__["nprobe"] = _swigfaiss.IndexBinaryIVF_nprobe_set
+    __swig_getmethods__["nprobe"] = _swigfaiss.IndexBinaryIVF_nprobe_get
+    if _newclass:
+        nprobe = _swig_property(_swigfaiss.IndexBinaryIVF_nprobe_get, _swigfaiss.IndexBinaryIVF_nprobe_set)
+    __swig_setmethods__["max_codes"] = _swigfaiss.IndexBinaryIVF_max_codes_set
+    __swig_getmethods__["max_codes"] = _swigfaiss.IndexBinaryIVF_max_codes_get
+    if _newclass:
+        max_codes = _swig_property(_swigfaiss.IndexBinaryIVF_max_codes_get, _swigfaiss.IndexBinaryIVF_max_codes_set)
+    __swig_setmethods__["use_heap"] = _swigfaiss.IndexBinaryIVF_use_heap_set
+    __swig_getmethods__["use_heap"] = _swigfaiss.IndexBinaryIVF_use_heap_get
+    if _newclass:
+        use_heap = _swig_property(_swigfaiss.IndexBinaryIVF_use_heap_get, _swigfaiss.IndexBinaryIVF_use_heap_set)
+    __swig_setmethods__["maintain_direct_map"] = _swigfaiss.IndexBinaryIVF_maintain_direct_map_set
+    __swig_getmethods__["maintain_direct_map"] = _swigfaiss.IndexBinaryIVF_maintain_direct_map_get
+    if _newclass:
+        maintain_direct_map = _swig_property(_swigfaiss.IndexBinaryIVF_maintain_direct_map_get, _swigfaiss.IndexBinaryIVF_maintain_direct_map_set)
+    __swig_setmethods__["direct_map"] = _swigfaiss.IndexBinaryIVF_direct_map_set
+    __swig_getmethods__["direct_map"] = _swigfaiss.IndexBinaryIVF_direct_map_get
+    if _newclass:
+        direct_map = _swig_property(_swigfaiss.IndexBinaryIVF_direct_map_get, _swigfaiss.IndexBinaryIVF_direct_map_set)
+    __swig_setmethods__["quantizer"] = _swigfaiss.IndexBinaryIVF_quantizer_set
+    __swig_getmethods__["quantizer"] = _swigfaiss.IndexBinaryIVF_quantizer_get
+    if _newclass:
+        quantizer = _swig_property(_swigfaiss.IndexBinaryIVF_quantizer_get, _swigfaiss.IndexBinaryIVF_quantizer_set)
+    __swig_setmethods__["nlist"] = _swigfaiss.IndexBinaryIVF_nlist_set
+    __swig_getmethods__["nlist"] = _swigfaiss.IndexBinaryIVF_nlist_get
+    if _newclass:
+        nlist = _swig_property(_swigfaiss.IndexBinaryIVF_nlist_get, _swigfaiss.IndexBinaryIVF_nlist_set)
+    __swig_setmethods__["own_fields"] = _swigfaiss.IndexBinaryIVF_own_fields_set
+    __swig_getmethods__["own_fields"] = _swigfaiss.IndexBinaryIVF_own_fields_get
+    if _newclass:
+        own_fields = _swig_property(_swigfaiss.IndexBinaryIVF_own_fields_get, _swigfaiss.IndexBinaryIVF_own_fields_set)
+    __swig_setmethods__["cp"] = _swigfaiss.IndexBinaryIVF_cp_set
+    __swig_getmethods__["cp"] = _swigfaiss.IndexBinaryIVF_cp_get
+    if _newclass:
+        cp = _swig_property(_swigfaiss.IndexBinaryIVF_cp_get, _swigfaiss.IndexBinaryIVF_cp_set)
+
+    def train_q1(self, n, x, verbose):
+        return _swigfaiss.IndexBinaryIVF_train_q1(self, n, x, verbose)
+
+    def __init__(self, *args):
+        this = _swigfaiss.new_IndexBinaryIVF(*args)
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+    __swig_destroy__ = _swigfaiss.delete_IndexBinaryIVF
+    __del__ = lambda self: None
+
+    def reset(self):
+        return _swigfaiss.IndexBinaryIVF_reset(self)
+
+    def train(self, n, x):
+        return _swigfaiss.IndexBinaryIVF_train(self, n, x)
+
+    def add(self, n, x):
+        return _swigfaiss.IndexBinaryIVF_add(self, n, x)
+
+    def add_with_ids(self, n, x, xids):
+        return _swigfaiss.IndexBinaryIVF_add_with_ids(self, n, x, xids)
+
+    def add_core(self, n, x, xids, precomputed_idx):
+        return _swigfaiss.IndexBinaryIVF_add_core(self, n, x, xids, precomputed_idx)
+
+    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params=None):
+        return _swigfaiss.IndexBinaryIVF_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params)
+
+    def search(self, n, x, k, distances, labels):
+        return _swigfaiss.IndexBinaryIVF_search(self, n, x, k, distances, labels)
+
+    def reconstruct(self, key, recons):
+        return _swigfaiss.IndexBinaryIVF_reconstruct(self, key, recons)
+
+    def reconstruct_n(self, i0, ni, recons):
+        return _swigfaiss.IndexBinaryIVF_reconstruct_n(self, i0, ni, recons)
+
+    def search_and_reconstruct(self, n, x, k, distances, labels, recons):
+        return _swigfaiss.IndexBinaryIVF_search_and_reconstruct(self, n, x, k, distances, labels, recons)
+
+    def reconstruct_from_offset(self, list_no, offset, recons):
+        return _swigfaiss.IndexBinaryIVF_reconstruct_from_offset(self, list_no, offset, recons)
+
+    def remove_ids(self, sel):
+        return _swigfaiss.IndexBinaryIVF_remove_ids(self, sel)
+
+    def merge_from(self, other, add_id):
+        return _swigfaiss.IndexBinaryIVF_merge_from(self, other, add_id)
+
+    def get_list_size(self, list_no):
+        return _swigfaiss.IndexBinaryIVF_get_list_size(self, list_no)
+
+    def make_direct_map(self, new_maintain_direct_map=True):
+        return _swigfaiss.IndexBinaryIVF_make_direct_map(self, new_maintain_direct_map)
+
+    def imbalance_factor(self):
+        return _swigfaiss.IndexBinaryIVF_imbalance_factor(self)
+
+    def print_stats(self):
+        return _swigfaiss.IndexBinaryIVF_print_stats(self)
+
+    def replace_invlists(self, il, own=False):
+        return _swigfaiss.IndexBinaryIVF_replace_invlists(self, il, own)
+IndexBinaryIVF_swigregister = _swigfaiss.IndexBinaryIVF_swigregister
+IndexBinaryIVF_swigregister(IndexBinaryIVF)
 
 class IndexIDMap(Index):
     __swig_setmethods__ = {}
@@ -4039,9 +4468,17 @@ def write_index(*args):
     return _swigfaiss.write_index(*args)
 write_index = _swigfaiss.write_index
 
+def write_index_binary(*args):
+    return _swigfaiss.write_index_binary(*args)
+write_index_binary = _swigfaiss.write_index_binary
+
 def read_index(*args):
     return _swigfaiss.read_index(*args)
 read_index = _swigfaiss.read_index
+
+def read_index_binary(*args):
+    return _swigfaiss.read_index_binary(*args)
+read_index_binary = _swigfaiss.read_index_binary
 
 def write_VectorTransform(vt, fname):
     return _swigfaiss.write_VectorTransform(vt, fname)
@@ -4090,40 +4527,6 @@ Cloner_swigregister = _swigfaiss.Cloner_swigregister
 Cloner_swigregister(Cloner)
 IO_FLAG_MMAP = cvar.IO_FLAG_MMAP
 IO_FLAG_READ_ONLY = cvar.IO_FLAG_READ_ONLY
-
-class IOReader(_object):
-    __swig_setmethods__ = {}
-    __setattr__ = lambda self, name, value: _swig_setattr(self, IOReader, name, value)
-    __swig_getmethods__ = {}
-    __getattr__ = lambda self, name: _swig_getattr(self, IOReader, name)
-
-    def __init__(self, *args, **kwargs):
-        raise AttributeError("No constructor defined - class is abstract")
-    __repr__ = _swig_repr
-
-    def __call__(self, ptr, size, nitems):
-        return _swigfaiss.IOReader___call__(self, ptr, size, nitems)
-    __swig_destroy__ = _swigfaiss.delete_IOReader
-    __del__ = lambda self: None
-IOReader_swigregister = _swigfaiss.IOReader_swigregister
-IOReader_swigregister(IOReader)
-
-class IOWriter(_object):
-    __swig_setmethods__ = {}
-    __setattr__ = lambda self, name, value: _swig_setattr(self, IOWriter, name, value)
-    __swig_getmethods__ = {}
-    __getattr__ = lambda self, name: _swig_getattr(self, IOWriter, name)
-
-    def __init__(self, *args, **kwargs):
-        raise AttributeError("No constructor defined - class is abstract")
-    __repr__ = _swig_repr
-
-    def __call__(self, ptr, size, nitems):
-        return _swigfaiss.IOWriter___call__(self, ptr, size, nitems)
-    __swig_destroy__ = _swigfaiss.delete_IOWriter
-    __del__ = lambda self: None
-IOWriter_swigregister = _swigfaiss.IOWriter_swigregister
-IOWriter_swigregister(IOWriter)
 
 class AutoTuneCriterion(_object):
     __swig_setmethods__ = {}
@@ -4402,6 +4805,10 @@ ParameterSpace_swigregister(ParameterSpace)
 def index_factory(*args):
     return _swigfaiss.index_factory(*args)
 index_factory = _swigfaiss.index_factory
+
+def index_binary_factory(d, description):
+    return _swigfaiss.index_binary_factory(d, description)
+index_binary_factory = _swigfaiss.index_binary_factory
 
 def swig_ptr(a):
     return _swigfaiss.swig_ptr(a)
@@ -4858,6 +5265,107 @@ class RangeSearchPartialResult(BufferList):
     __del__ = lambda self: None
 RangeSearchPartialResult_swigregister = _swigfaiss.RangeSearchPartialResult_swigregister
 RangeSearchPartialResult_swigregister(RangeSearchPartialResult)
+
+class IOReader(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, IOReader, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, IOReader, name)
+
+    def __init__(self, *args, **kwargs):
+        raise AttributeError("No constructor defined - class is abstract")
+    __repr__ = _swig_repr
+
+    def __call__(self, ptr, size, nitems):
+        return _swigfaiss.IOReader___call__(self, ptr, size, nitems)
+
+    def fileno(self):
+        return _swigfaiss.IOReader_fileno(self)
+    __swig_destroy__ = _swigfaiss.delete_IOReader
+    __del__ = lambda self: None
+IOReader_swigregister = _swigfaiss.IOReader_swigregister
+IOReader_swigregister(IOReader)
+
+class IOWriter(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, IOWriter, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, IOWriter, name)
+
+    def __init__(self, *args, **kwargs):
+        raise AttributeError("No constructor defined - class is abstract")
+    __repr__ = _swig_repr
+
+    def __call__(self, ptr, size, nitems):
+        return _swigfaiss.IOWriter___call__(self, ptr, size, nitems)
+
+    def fileno(self):
+        return _swigfaiss.IOWriter_fileno(self)
+    __swig_destroy__ = _swigfaiss.delete_IOWriter
+    __del__ = lambda self: None
+IOWriter_swigregister = _swigfaiss.IOWriter_swigregister
+IOWriter_swigregister(IOWriter)
+
+class VectorIOReader(IOReader):
+    __swig_setmethods__ = {}
+    for _s in [IOReader]:
+        __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
+    __setattr__ = lambda self, name, value: _swig_setattr(self, VectorIOReader, name, value)
+    __swig_getmethods__ = {}
+    for _s in [IOReader]:
+        __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
+    __getattr__ = lambda self, name: _swig_getattr(self, VectorIOReader, name)
+    __repr__ = _swig_repr
+    __swig_getmethods__["data"] = _swigfaiss.VectorIOReader_data_get
+    if _newclass:
+        data = _swig_property(_swigfaiss.VectorIOReader_data_get)
+    __swig_setmethods__["rp"] = _swigfaiss.VectorIOReader_rp_set
+    __swig_getmethods__["rp"] = _swigfaiss.VectorIOReader_rp_get
+    if _newclass:
+        rp = _swig_property(_swigfaiss.VectorIOReader_rp_get, _swigfaiss.VectorIOReader_rp_set)
+
+    def __call__(self, ptr, size, nitems):
+        return _swigfaiss.VectorIOReader___call__(self, ptr, size, nitems)
+
+    def __init__(self):
+        this = _swigfaiss.new_VectorIOReader()
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+    __swig_destroy__ = _swigfaiss.delete_VectorIOReader
+    __del__ = lambda self: None
+VectorIOReader_swigregister = _swigfaiss.VectorIOReader_swigregister
+VectorIOReader_swigregister(VectorIOReader)
+
+class VectorIOWriter(IOWriter):
+    __swig_setmethods__ = {}
+    for _s in [IOWriter]:
+        __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
+    __setattr__ = lambda self, name, value: _swig_setattr(self, VectorIOWriter, name, value)
+    __swig_getmethods__ = {}
+    for _s in [IOWriter]:
+        __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
+    __getattr__ = lambda self, name: _swig_getattr(self, VectorIOWriter, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["data"] = _swigfaiss.VectorIOWriter_data_set
+    __swig_getmethods__["data"] = _swigfaiss.VectorIOWriter_data_get
+    if _newclass:
+        data = _swig_property(_swigfaiss.VectorIOWriter_data_get, _swigfaiss.VectorIOWriter_data_set)
+
+    def __call__(self, ptr, size, nitems):
+        return _swigfaiss.VectorIOWriter___call__(self, ptr, size, nitems)
+
+    def __init__(self):
+        this = _swigfaiss.new_VectorIOWriter()
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+    __swig_destroy__ = _swigfaiss.delete_VectorIOWriter
+    __del__ = lambda self: None
+VectorIOWriter_swigregister = _swigfaiss.VectorIOWriter_swigregister
+VectorIOWriter_swigregister(VectorIOWriter)
 
 
 def ignore_SIGTTIN():

--- a/python/swigfaiss.swig
+++ b/python/swigfaiss.swig
@@ -83,6 +83,9 @@ extern "C" {
 #include "MetaIndexes.h"
 #include "FaissAssert.h"
 
+#include "IndexBinaryFlat.h"
+#include "IndexBinaryIVF.h"
+
 #include "index_io.h"
 
 #include "utils.h"
@@ -118,14 +121,19 @@ namespace std {
         size_t size();
         T at (size_t n) const;
         void resize (size_t n);
+        void swap (vector<T> & other);
     };
 };
+
 
 
 %template(FloatVector) std::vector<float>;
 %template(DoubleVector) std::vector<double>;
 %template(ByteVector) std::vector<uint8_t>;
-%template(Uint64Vector) std::vector<uint64_t>;
+%template(CharVector) std::vector<char>;
+// NOTE(hoss): Using unsigned long instead of uint64_t because OSX defines
+//   uint64_t as unsigned long long, which SWIG is not aware of.
+%template(Uint64Vector) std::vector<unsigned long>;
 %template(LongVector) std::vector<long>;
 %template(IntVector) std::vector<int>;
 %template(VectorTransformVector) std::vector<faiss::VectorTransform*>;
@@ -259,6 +267,9 @@ int get_num_gpus()
 %ignore faiss::IndexIVFPQ::alloc_type;
 %include "IndexIVFPQ.h"
 
+%include "IndexBinary.h"
+%include "IndexBinaryFlat.h"
+%include "IndexBinaryIVF.h"
 
 
 
@@ -418,6 +429,7 @@ struct AsyncIndexSearchC {
 #endif
 
 %newobject read_index;
+%newobject read_binary_index;
 %newobject read_VectorTransform;
 %newobject read_ProductQuantizer;
 %newobject clone_index;
@@ -430,6 +442,7 @@ struct AsyncIndexSearchC {
     DOWNCAST ( IndexIVFPQR )
     DOWNCAST ( IndexIVFPQ )
     DOWNCAST ( IndexIVFScalarQuantizer )
+    DOWNCAST ( IndexIVFFlatDedup )
     DOWNCAST ( IndexIVFFlat )
     DOWNCAST ( IndexIVF )
     DOWNCAST ( IndexFlat )
@@ -450,7 +463,26 @@ struct AsyncIndexSearchC {
     DOWNCAST_GPU ( GpuIndexFlat )
 #endif
     // default for non-recognized classes
-    DOWNCAST( Index )
+    DOWNCAST ( Index )
+    if ($1 == NULL)
+    {
+#ifdef SWIGPYTHON
+        $result = SWIG_Py_Void();
+#endif
+        // Lua does not need a push for nil
+    } else {
+        assert(false);
+    }
+#ifdef SWIGLUA
+    SWIG_arg++;
+#endif
+}
+
+%typemap(out) faiss::IndexBinary * {
+    DOWNCAST ( IndexBinaryIVF )
+    DOWNCAST ( IndexBinaryFlat )
+      // default for non-recognized classes
+    DOWNCAST ( IndexBinary )
     if ($1 == NULL)
     {
 #ifdef SWIGPYTHON
@@ -502,6 +534,7 @@ faiss::VectorTransform * downcast_VectorTransform (faiss::VectorTransform *vt);
 %include "index_io.h"
 
 %newobject index_factory;
+%newobject index_binary_factory;
 
 %include "AutoTune.h"
 
@@ -557,6 +590,9 @@ PyObject *swig_ptr (PyObject *a)
     }
     if(PyArray_TYPE(ao) == NPY_UINT8) {
         return SWIG_NewPointerObj(data, SWIGTYPE_p_unsigned_char, 0);
+    }
+    if(PyArray_TYPE(ao) == NPY_INT8) {
+        return SWIG_NewPointerObj(data, SWIGTYPE_p_char, 0);
     }
     if(PyArray_TYPE(ao) == NPY_UINT64) {
         return SWIG_NewPointerObj(data, SWIGTYPE_p_unsigned_long, 0);

--- a/python/swigfaiss_gpu.py
+++ b/python/swigfaiss_gpu.py
@@ -126,6 +126,9 @@ class FloatVector(_object):
 
     def resize(self, n):
         return _swigfaiss_gpu.FloatVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss_gpu.FloatVector_swap(self, other)
     __swig_destroy__ = _swigfaiss_gpu.delete_FloatVector
     __del__ = lambda self: None
 FloatVector_swigregister = _swigfaiss_gpu.FloatVector_swigregister
@@ -162,6 +165,9 @@ class DoubleVector(_object):
 
     def resize(self, n):
         return _swigfaiss_gpu.DoubleVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss_gpu.DoubleVector_swap(self, other)
     __swig_destroy__ = _swigfaiss_gpu.delete_DoubleVector
     __del__ = lambda self: None
 DoubleVector_swigregister = _swigfaiss_gpu.DoubleVector_swigregister
@@ -198,10 +204,52 @@ class ByteVector(_object):
 
     def resize(self, n):
         return _swigfaiss_gpu.ByteVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss_gpu.ByteVector_swap(self, other)
     __swig_destroy__ = _swigfaiss_gpu.delete_ByteVector
     __del__ = lambda self: None
 ByteVector_swigregister = _swigfaiss_gpu.ByteVector_swigregister
 ByteVector_swigregister(ByteVector)
+
+class CharVector(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, CharVector, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, CharVector, name)
+    __repr__ = _swig_repr
+
+    def __init__(self):
+        this = _swigfaiss_gpu.new_CharVector()
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+
+    def push_back(self, arg2):
+        return _swigfaiss_gpu.CharVector_push_back(self, arg2)
+
+    def clear(self):
+        return _swigfaiss_gpu.CharVector_clear(self)
+
+    def data(self):
+        return _swigfaiss_gpu.CharVector_data(self)
+
+    def size(self):
+        return _swigfaiss_gpu.CharVector_size(self)
+
+    def at(self, n):
+        return _swigfaiss_gpu.CharVector_at(self, n)
+
+    def resize(self, n):
+        return _swigfaiss_gpu.CharVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss_gpu.CharVector_swap(self, other)
+    __swig_destroy__ = _swigfaiss_gpu.delete_CharVector
+    __del__ = lambda self: None
+CharVector_swigregister = _swigfaiss_gpu.CharVector_swigregister
+CharVector_swigregister(CharVector)
 
 class Uint64Vector(_object):
     __swig_setmethods__ = {}
@@ -234,6 +282,9 @@ class Uint64Vector(_object):
 
     def resize(self, n):
         return _swigfaiss_gpu.Uint64Vector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss_gpu.Uint64Vector_swap(self, other)
     __swig_destroy__ = _swigfaiss_gpu.delete_Uint64Vector
     __del__ = lambda self: None
 Uint64Vector_swigregister = _swigfaiss_gpu.Uint64Vector_swigregister
@@ -270,6 +321,9 @@ class LongVector(_object):
 
     def resize(self, n):
         return _swigfaiss_gpu.LongVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss_gpu.LongVector_swap(self, other)
     __swig_destroy__ = _swigfaiss_gpu.delete_LongVector
     __del__ = lambda self: None
 LongVector_swigregister = _swigfaiss_gpu.LongVector_swigregister
@@ -306,6 +360,9 @@ class IntVector(_object):
 
     def resize(self, n):
         return _swigfaiss_gpu.IntVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss_gpu.IntVector_swap(self, other)
     __swig_destroy__ = _swigfaiss_gpu.delete_IntVector
     __del__ = lambda self: None
 IntVector_swigregister = _swigfaiss_gpu.IntVector_swigregister
@@ -342,6 +399,9 @@ class VectorTransformVector(_object):
 
     def resize(self, n):
         return _swigfaiss_gpu.VectorTransformVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss_gpu.VectorTransformVector_swap(self, other)
     __swig_destroy__ = _swigfaiss_gpu.delete_VectorTransformVector
     __del__ = lambda self: None
 VectorTransformVector_swigregister = _swigfaiss_gpu.VectorTransformVector_swigregister
@@ -378,6 +438,9 @@ class OperatingPointVector(_object):
 
     def resize(self, n):
         return _swigfaiss_gpu.OperatingPointVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss_gpu.OperatingPointVector_swap(self, other)
     __swig_destroy__ = _swigfaiss_gpu.delete_OperatingPointVector
     __del__ = lambda self: None
 OperatingPointVector_swigregister = _swigfaiss_gpu.OperatingPointVector_swigregister
@@ -414,6 +477,9 @@ class InvertedListsPtrVector(_object):
 
     def resize(self, n):
         return _swigfaiss_gpu.InvertedListsPtrVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss_gpu.InvertedListsPtrVector_swap(self, other)
     __swig_destroy__ = _swigfaiss_gpu.delete_InvertedListsPtrVector
     __del__ = lambda self: None
 InvertedListsPtrVector_swigregister = _swigfaiss_gpu.InvertedListsPtrVector_swigregister
@@ -450,6 +516,9 @@ class FloatVectorVector(_object):
 
     def resize(self, n):
         return _swigfaiss_gpu.FloatVectorVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss_gpu.FloatVectorVector_swap(self, other)
     __swig_destroy__ = _swigfaiss_gpu.delete_FloatVectorVector
     __del__ = lambda self: None
 FloatVectorVector_swigregister = _swigfaiss_gpu.FloatVectorVector_swigregister
@@ -486,6 +555,9 @@ class ByteVectorVector(_object):
 
     def resize(self, n):
         return _swigfaiss_gpu.ByteVectorVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss_gpu.ByteVectorVector_swap(self, other)
     __swig_destroy__ = _swigfaiss_gpu.delete_ByteVectorVector
     __del__ = lambda self: None
 ByteVectorVector_swigregister = _swigfaiss_gpu.ByteVectorVector_swigregister
@@ -522,6 +594,9 @@ class LongVectorVector(_object):
 
     def resize(self, n):
         return _swigfaiss_gpu.LongVectorVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss_gpu.LongVectorVector_swap(self, other)
     __swig_destroy__ = _swigfaiss_gpu.delete_LongVectorVector
     __del__ = lambda self: None
 LongVectorVector_swigregister = _swigfaiss_gpu.LongVectorVector_swigregister
@@ -558,6 +633,9 @@ class GpuResourcesVector(_object):
 
     def resize(self, n):
         return _swigfaiss_gpu.GpuResourcesVector_resize(self, n)
+
+    def swap(self, other):
+        return _swigfaiss_gpu.GpuResourcesVector_swap(self, other)
     __swig_destroy__ = _swigfaiss_gpu.delete_GpuResourcesVector
     __del__ = lambda self: None
 GpuResourcesVector_swigregister = _swigfaiss_gpu.GpuResourcesVector_swigregister
@@ -584,13 +662,17 @@ def fvec2bitvec(x, b, d):
     return _swigfaiss_gpu.fvec2bitvec(x, b, d)
 fvec2bitvec = _swigfaiss_gpu.fvec2bitvec
 
+def hammings_knn_hc(ha, a, b, nb, ncodes, ordered):
+    return _swigfaiss_gpu.hammings_knn_hc(ha, a, b, nb, ncodes, ordered)
+hammings_knn_hc = _swigfaiss_gpu.hammings_knn_hc
+
 def hammings_knn(ha, a, b, nb, ncodes, ordered):
     return _swigfaiss_gpu.hammings_knn(ha, a, b, nb, ncodes, ordered)
 hammings_knn = _swigfaiss_gpu.hammings_knn
 
-def hammings_knn_core(ha, a, b, nb, ncodes):
-    return _swigfaiss_gpu.hammings_knn_core(ha, a, b, nb, ncodes)
-hammings_knn_core = _swigfaiss_gpu.hammings_knn_core
+def hammings_knn_mc(a, b, na, nb, k, ncodes, distances, labels):
+    return _swigfaiss_gpu.hammings_knn_mc(a, b, na, nb, k, ncodes, distances, labels)
+hammings_knn_mc = _swigfaiss_gpu.hammings_knn_mc
 
 def hamming_count_thres(bs1, bs2, n1, n2, ht, ncodes, nptr):
     return _swigfaiss_gpu.hamming_count_thres(bs1, bs2, n1, n2, ht, ncodes, nptr)
@@ -627,6 +709,7 @@ class HammingComputer4(_object):
     __del__ = lambda self: None
 HammingComputer4_swigregister = _swigfaiss_gpu.HammingComputer4_swigregister
 HammingComputer4_swigregister(HammingComputer4)
+cvar = _swigfaiss_gpu.cvar
 
 class HammingComputer8(_object):
     __swig_setmethods__ = {}
@@ -1017,9 +1100,9 @@ GenHammingComputerM8_swigregister = _swigfaiss_gpu.GenHammingComputerM8_swigregi
 GenHammingComputerM8_swigregister(GenHammingComputerM8)
 
 
-def generalized_hammings_knn(ha, a, b, nb, code_size, ordered=True):
-    return _swigfaiss_gpu.generalized_hammings_knn(ha, a, b, nb, code_size, ordered)
-generalized_hammings_knn = _swigfaiss_gpu.generalized_hammings_knn
+def generalized_hammings_knn_hc(ha, a, b, nb, code_size, ordered=True):
+    return _swigfaiss_gpu.generalized_hammings_knn_hc(ha, a, b, nb, code_size, ordered)
+generalized_hammings_knn_hc = _swigfaiss_gpu.generalized_hammings_knn_hc
 
 def get_num_gpus():
     return _swigfaiss_gpu.get_num_gpus()
@@ -1400,7 +1483,6 @@ class Index(_object):
         return _swigfaiss_gpu.Index_display(self)
 Index_swigregister = _swigfaiss_gpu.Index_swigregister
 Index_swigregister(Index)
-cvar = _swigfaiss_gpu.cvar
 
 class ClusteringParameters(_object):
     __swig_setmethods__ = {}
@@ -2551,6 +2633,9 @@ class IndexPQ(Index):
 
     def reconstruct(self, key, recons):
         return _swigfaiss_gpu.IndexPQ_reconstruct(self, key, recons)
+
+    def remove_ids(self, sel):
+        return _swigfaiss_gpu.IndexPQ_remove_ids(self, sel)
     __swig_setmethods__["do_polysemous_training"] = _swigfaiss_gpu.IndexPQ_do_polysemous_training_set
     __swig_getmethods__["do_polysemous_training"] = _swigfaiss_gpu.IndexPQ_do_polysemous_training_get
     if _newclass:
@@ -2569,9 +2654,6 @@ class IndexPQ(Index):
     __swig_getmethods__["search_type"] = _swigfaiss_gpu.IndexPQ_search_type_get
     if _newclass:
         search_type = _swig_property(_swigfaiss_gpu.IndexPQ_search_type_get, _swigfaiss_gpu.IndexPQ_search_type_set)
-
-    def remove_ids(self, sel):
-        return _swigfaiss_gpu.IndexPQ_remove_ids(self, sel)
     __swig_setmethods__["encode_signs"] = _swigfaiss_gpu.IndexPQ_encode_signs_set
     __swig_getmethods__["encode_signs"] = _swigfaiss_gpu.IndexPQ_encode_signs_get
     if _newclass:
@@ -2855,6 +2937,32 @@ class ArrayInvertedLists(InvertedLists):
 ArrayInvertedLists_swigregister = _swigfaiss_gpu.ArrayInvertedLists_swigregister
 ArrayInvertedLists_swigregister(ArrayInvertedLists)
 
+class IVFSearchParameters(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, IVFSearchParameters, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, IVFSearchParameters, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["nprobe"] = _swigfaiss_gpu.IVFSearchParameters_nprobe_set
+    __swig_getmethods__["nprobe"] = _swigfaiss_gpu.IVFSearchParameters_nprobe_get
+    if _newclass:
+        nprobe = _swig_property(_swigfaiss_gpu.IVFSearchParameters_nprobe_get, _swigfaiss_gpu.IVFSearchParameters_nprobe_set)
+    __swig_setmethods__["max_codes"] = _swigfaiss_gpu.IVFSearchParameters_max_codes_set
+    __swig_getmethods__["max_codes"] = _swigfaiss_gpu.IVFSearchParameters_max_codes_get
+    if _newclass:
+        max_codes = _swig_property(_swigfaiss_gpu.IVFSearchParameters_max_codes_get, _swigfaiss_gpu.IVFSearchParameters_max_codes_set)
+    __swig_destroy__ = _swigfaiss_gpu.delete_IVFSearchParameters
+    __del__ = lambda self: None
+
+    def __init__(self):
+        this = _swigfaiss_gpu.new_IVFSearchParameters()
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+IVFSearchParameters_swigregister = _swigfaiss_gpu.IVFSearchParameters_swigregister
+IVFSearchParameters_swigregister(IVFSearchParameters)
+
 class IndexIVF(Index, Level1Quantizer):
     __swig_setmethods__ = {}
     for _s in [Index, Level1Quantizer]:
@@ -2909,8 +3017,8 @@ class IndexIVF(Index, Level1Quantizer):
     def train_residual(self, n, x):
         return _swigfaiss_gpu.IndexIVF_train_residual(self, n, x)
 
-    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs):
-        return _swigfaiss_gpu.IndexIVF_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs)
+    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params=None):
+        return _swigfaiss_gpu.IndexIVF_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params)
 
     def search(self, n, x, k, distances, labels):
         return _swigfaiss_gpu.IndexIVF_search(self, n, x, k, distances, labels)
@@ -2998,6 +3106,7 @@ class ScalarQuantizer(_object):
     QT_4bit = _swigfaiss_gpu.ScalarQuantizer_QT_4bit
     QT_8bit_uniform = _swigfaiss_gpu.ScalarQuantizer_QT_8bit_uniform
     QT_4bit_uniform = _swigfaiss_gpu.ScalarQuantizer_QT_4bit_uniform
+    QT_fp16 = _swigfaiss_gpu.ScalarQuantizer_QT_fp16
     __swig_setmethods__["qtype"] = _swigfaiss_gpu.ScalarQuantizer_qtype_set
     __swig_getmethods__["qtype"] = _swigfaiss_gpu.ScalarQuantizer_qtype_get
     if _newclass:
@@ -3130,8 +3239,8 @@ class IndexIVFScalarQuantizer(IndexIVF):
     def add_with_ids(self, n, x, xids):
         return _swigfaiss_gpu.IndexIVFScalarQuantizer_add_with_ids(self, n, x, xids)
 
-    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs):
-        return _swigfaiss_gpu.IndexIVFScalarQuantizer_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs)
+    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params=None):
+        return _swigfaiss_gpu.IndexIVFScalarQuantizer_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params)
 
     def reconstruct_from_offset(self, list_no, offset, recons):
         return _swigfaiss_gpu.IndexIVFScalarQuantizer_reconstruct_from_offset(self, list_no, offset, recons)
@@ -3562,8 +3671,8 @@ class IndexIVFFlat(IndexIVF):
     def add_with_ids(self, n, x, xids):
         return _swigfaiss_gpu.IndexIVFFlat_add_with_ids(self, n, x, xids)
 
-    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs):
-        return _swigfaiss_gpu.IndexIVFFlat_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs)
+    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params=None):
+        return _swigfaiss_gpu.IndexIVFFlat_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params)
 
     def range_search(self, n, x, radius, result):
         return _swigfaiss_gpu.IndexIVFFlat_range_search(self, n, x, radius, result)
@@ -3584,6 +3693,53 @@ class IndexIVFFlat(IndexIVF):
     __del__ = lambda self: None
 IndexIVFFlat_swigregister = _swigfaiss_gpu.IndexIVFFlat_swigregister
 IndexIVFFlat_swigregister(IndexIVFFlat)
+
+class IndexIVFFlatDedup(IndexIVFFlat):
+    __swig_setmethods__ = {}
+    for _s in [IndexIVFFlat]:
+        __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
+    __setattr__ = lambda self, name, value: _swig_setattr(self, IndexIVFFlatDedup, name, value)
+    __swig_getmethods__ = {}
+    for _s in [IndexIVFFlat]:
+        __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
+    __getattr__ = lambda self, name: _swig_getattr(self, IndexIVFFlatDedup, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["instances"] = _swigfaiss_gpu.IndexIVFFlatDedup_instances_set
+    __swig_getmethods__["instances"] = _swigfaiss_gpu.IndexIVFFlatDedup_instances_get
+    if _newclass:
+        instances = _swig_property(_swigfaiss_gpu.IndexIVFFlatDedup_instances_get, _swigfaiss_gpu.IndexIVFFlatDedup_instances_set)
+
+    def train(self, n, x):
+        return _swigfaiss_gpu.IndexIVFFlatDedup_train(self, n, x)
+
+    def add_with_ids(self, n, x, xids):
+        return _swigfaiss_gpu.IndexIVFFlatDedup_add_with_ids(self, n, x, xids)
+
+    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params=None):
+        return _swigfaiss_gpu.IndexIVFFlatDedup_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params)
+
+    def remove_ids(self, sel):
+        return _swigfaiss_gpu.IndexIVFFlatDedup_remove_ids(self, sel)
+
+    def range_search(self, n, x, radius, result):
+        return _swigfaiss_gpu.IndexIVFFlatDedup_range_search(self, n, x, radius, result)
+
+    def update_vectors(self, nv, idx, v):
+        return _swigfaiss_gpu.IndexIVFFlatDedup_update_vectors(self, nv, idx, v)
+
+    def reconstruct_from_offset(self, list_no, offset, recons):
+        return _swigfaiss_gpu.IndexIVFFlatDedup_reconstruct_from_offset(self, list_no, offset, recons)
+
+    def __init__(self, *args):
+        this = _swigfaiss_gpu.new_IndexIVFFlatDedup(*args)
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+    __swig_destroy__ = _swigfaiss_gpu.delete_IndexIVFFlatDedup
+    __del__ = lambda self: None
+IndexIVFFlatDedup_swigregister = _swigfaiss_gpu.IndexIVFFlatDedup_swigregister
+IndexIVFFlatDedup_swigregister(IndexIVFFlatDedup)
 
 class OnDiskInvertedLists(InvertedLists):
     __swig_setmethods__ = {}
@@ -3678,6 +3834,36 @@ class OnDiskInvertedLists(InvertedLists):
 OnDiskInvertedLists_swigregister = _swigfaiss_gpu.OnDiskInvertedLists_swigregister
 OnDiskInvertedLists_swigregister(OnDiskInvertedLists)
 
+class IVFPQSearchParameters(IVFSearchParameters):
+    __swig_setmethods__ = {}
+    for _s in [IVFSearchParameters]:
+        __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
+    __setattr__ = lambda self, name, value: _swig_setattr(self, IVFPQSearchParameters, name, value)
+    __swig_getmethods__ = {}
+    for _s in [IVFSearchParameters]:
+        __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
+    __getattr__ = lambda self, name: _swig_getattr(self, IVFPQSearchParameters, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["scan_table_threshold"] = _swigfaiss_gpu.IVFPQSearchParameters_scan_table_threshold_set
+    __swig_getmethods__["scan_table_threshold"] = _swigfaiss_gpu.IVFPQSearchParameters_scan_table_threshold_get
+    if _newclass:
+        scan_table_threshold = _swig_property(_swigfaiss_gpu.IVFPQSearchParameters_scan_table_threshold_get, _swigfaiss_gpu.IVFPQSearchParameters_scan_table_threshold_set)
+    __swig_setmethods__["polysemous_ht"] = _swigfaiss_gpu.IVFPQSearchParameters_polysemous_ht_set
+    __swig_getmethods__["polysemous_ht"] = _swigfaiss_gpu.IVFPQSearchParameters_polysemous_ht_get
+    if _newclass:
+        polysemous_ht = _swig_property(_swigfaiss_gpu.IVFPQSearchParameters_polysemous_ht_get, _swigfaiss_gpu.IVFPQSearchParameters_polysemous_ht_set)
+    __swig_destroy__ = _swigfaiss_gpu.delete_IVFPQSearchParameters
+    __del__ = lambda self: None
+
+    def __init__(self):
+        this = _swigfaiss_gpu.new_IVFPQSearchParameters()
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+IVFPQSearchParameters_swigregister = _swigfaiss_gpu.IVFPQSearchParameters_swigregister
+IVFPQSearchParameters_swigregister(IVFPQSearchParameters)
+
 class IndexIVFPQ(IndexIVF):
     __swig_setmethods__ = {}
     for _s in [IndexIVF]:
@@ -3748,8 +3934,8 @@ class IndexIVFPQ(IndexIVF):
     def decode_multiple(self, n, keys, xcodes, x):
         return _swigfaiss_gpu.IndexIVFPQ_decode_multiple(self, n, keys, xcodes, x)
 
-    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs):
-        return _swigfaiss_gpu.IndexIVFPQ_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs)
+    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params=None):
+        return _swigfaiss_gpu.IndexIVFPQ_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params)
 
     def precompute_table(self):
         return _swigfaiss_gpu.IndexIVFPQ_precompute_table(self)
@@ -3878,8 +4064,8 @@ class IndexIVFPQR(IndexIVFPQ):
     def merge_from(self, other, add_id):
         return _swigfaiss_gpu.IndexIVFPQR_merge_from(self, other, add_id)
 
-    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs):
-        return _swigfaiss_gpu.IndexIVFPQR_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs)
+    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params=None):
+        return _swigfaiss_gpu.IndexIVFPQR_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params)
 
     def __init__(self, *args):
         this = _swigfaiss_gpu.new_IndexIVFPQR(*args)
@@ -3958,6 +4144,252 @@ class Index2Layer(Index):
         return _swigfaiss_gpu.Index2Layer_transfer_to_IVFPQ(self, other)
 Index2Layer_swigregister = _swigfaiss_gpu.Index2Layer_swigregister
 Index2Layer_swigregister(Index2Layer)
+
+class IndexBinary(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, IndexBinary, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, IndexBinary, name)
+
+    def __init__(self, *args, **kwargs):
+        raise AttributeError("No constructor defined - class is abstract")
+    __repr__ = _swig_repr
+    __swig_setmethods__["d"] = _swigfaiss_gpu.IndexBinary_d_set
+    __swig_getmethods__["d"] = _swigfaiss_gpu.IndexBinary_d_get
+    if _newclass:
+        d = _swig_property(_swigfaiss_gpu.IndexBinary_d_get, _swigfaiss_gpu.IndexBinary_d_set)
+    __swig_setmethods__["code_size"] = _swigfaiss_gpu.IndexBinary_code_size_set
+    __swig_getmethods__["code_size"] = _swigfaiss_gpu.IndexBinary_code_size_get
+    if _newclass:
+        code_size = _swig_property(_swigfaiss_gpu.IndexBinary_code_size_get, _swigfaiss_gpu.IndexBinary_code_size_set)
+    __swig_setmethods__["ntotal"] = _swigfaiss_gpu.IndexBinary_ntotal_set
+    __swig_getmethods__["ntotal"] = _swigfaiss_gpu.IndexBinary_ntotal_get
+    if _newclass:
+        ntotal = _swig_property(_swigfaiss_gpu.IndexBinary_ntotal_get, _swigfaiss_gpu.IndexBinary_ntotal_set)
+    __swig_setmethods__["verbose"] = _swigfaiss_gpu.IndexBinary_verbose_set
+    __swig_getmethods__["verbose"] = _swigfaiss_gpu.IndexBinary_verbose_get
+    if _newclass:
+        verbose = _swig_property(_swigfaiss_gpu.IndexBinary_verbose_get, _swigfaiss_gpu.IndexBinary_verbose_set)
+    __swig_setmethods__["is_trained"] = _swigfaiss_gpu.IndexBinary_is_trained_set
+    __swig_getmethods__["is_trained"] = _swigfaiss_gpu.IndexBinary_is_trained_get
+    if _newclass:
+        is_trained = _swig_property(_swigfaiss_gpu.IndexBinary_is_trained_get, _swigfaiss_gpu.IndexBinary_is_trained_set)
+    __swig_setmethods__["metric_type"] = _swigfaiss_gpu.IndexBinary_metric_type_set
+    __swig_getmethods__["metric_type"] = _swigfaiss_gpu.IndexBinary_metric_type_get
+    if _newclass:
+        metric_type = _swig_property(_swigfaiss_gpu.IndexBinary_metric_type_get, _swigfaiss_gpu.IndexBinary_metric_type_set)
+    __swig_destroy__ = _swigfaiss_gpu.delete_IndexBinary
+    __del__ = lambda self: None
+
+    def train(self, n, x):
+        return _swigfaiss_gpu.IndexBinary_train(self, n, x)
+
+    def add(self, n, x):
+        return _swigfaiss_gpu.IndexBinary_add(self, n, x)
+
+    def add_with_ids(self, n, x, xids):
+        return _swigfaiss_gpu.IndexBinary_add_with_ids(self, n, x, xids)
+
+    def search(self, n, x, k, distances, labels):
+        return _swigfaiss_gpu.IndexBinary_search(self, n, x, k, distances, labels)
+
+    def range_search(self, n, x, radius, result):
+        return _swigfaiss_gpu.IndexBinary_range_search(self, n, x, radius, result)
+
+    def assign(self, n, x, labels, k=1):
+        return _swigfaiss_gpu.IndexBinary_assign(self, n, x, labels, k)
+
+    def reset(self):
+        return _swigfaiss_gpu.IndexBinary_reset(self)
+
+    def remove_ids(self, sel):
+        return _swigfaiss_gpu.IndexBinary_remove_ids(self, sel)
+
+    def reconstruct(self, key, recons):
+        return _swigfaiss_gpu.IndexBinary_reconstruct(self, key, recons)
+
+    def reconstruct_n(self, i0, ni, recons):
+        return _swigfaiss_gpu.IndexBinary_reconstruct_n(self, i0, ni, recons)
+
+    def search_and_reconstruct(self, n, x, k, distances, labels, recons):
+        return _swigfaiss_gpu.IndexBinary_search_and_reconstruct(self, n, x, k, distances, labels, recons)
+
+    def display(self):
+        return _swigfaiss_gpu.IndexBinary_display(self)
+IndexBinary_swigregister = _swigfaiss_gpu.IndexBinary_swigregister
+IndexBinary_swigregister(IndexBinary)
+
+class IndexBinaryFlat(IndexBinary):
+    __swig_setmethods__ = {}
+    for _s in [IndexBinary]:
+        __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
+    __setattr__ = lambda self, name, value: _swig_setattr(self, IndexBinaryFlat, name, value)
+    __swig_getmethods__ = {}
+    for _s in [IndexBinary]:
+        __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
+    __getattr__ = lambda self, name: _swig_getattr(self, IndexBinaryFlat, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["xb"] = _swigfaiss_gpu.IndexBinaryFlat_xb_set
+    __swig_getmethods__["xb"] = _swigfaiss_gpu.IndexBinaryFlat_xb_get
+    if _newclass:
+        xb = _swig_property(_swigfaiss_gpu.IndexBinaryFlat_xb_get, _swigfaiss_gpu.IndexBinaryFlat_xb_set)
+    __swig_setmethods__["use_heap"] = _swigfaiss_gpu.IndexBinaryFlat_use_heap_set
+    __swig_getmethods__["use_heap"] = _swigfaiss_gpu.IndexBinaryFlat_use_heap_get
+    if _newclass:
+        use_heap = _swig_property(_swigfaiss_gpu.IndexBinaryFlat_use_heap_get, _swigfaiss_gpu.IndexBinaryFlat_use_heap_set)
+    __swig_setmethods__["query_batch_size"] = _swigfaiss_gpu.IndexBinaryFlat_query_batch_size_set
+    __swig_getmethods__["query_batch_size"] = _swigfaiss_gpu.IndexBinaryFlat_query_batch_size_get
+    if _newclass:
+        query_batch_size = _swig_property(_swigfaiss_gpu.IndexBinaryFlat_query_batch_size_get, _swigfaiss_gpu.IndexBinaryFlat_query_batch_size_set)
+
+    def add(self, n, x):
+        return _swigfaiss_gpu.IndexBinaryFlat_add(self, n, x)
+
+    def reset(self):
+        return _swigfaiss_gpu.IndexBinaryFlat_reset(self)
+
+    def search(self, n, x, k, distances, labels):
+        return _swigfaiss_gpu.IndexBinaryFlat_search(self, n, x, k, distances, labels)
+
+    def reconstruct(self, key, recons):
+        return _swigfaiss_gpu.IndexBinaryFlat_reconstruct(self, key, recons)
+
+    def remove_ids(self, sel):
+        return _swigfaiss_gpu.IndexBinaryFlat_remove_ids(self, sel)
+
+    def __init__(self, *args):
+        this = _swigfaiss_gpu.new_IndexBinaryFlat(*args)
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+    __swig_destroy__ = _swigfaiss_gpu.delete_IndexBinaryFlat
+    __del__ = lambda self: None
+IndexBinaryFlat_swigregister = _swigfaiss_gpu.IndexBinaryFlat_swigregister
+IndexBinaryFlat_swigregister(IndexBinaryFlat)
+
+class IndexBinaryIVF(IndexBinary):
+    __swig_setmethods__ = {}
+    for _s in [IndexBinary]:
+        __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
+    __setattr__ = lambda self, name, value: _swig_setattr(self, IndexBinaryIVF, name, value)
+    __swig_getmethods__ = {}
+    for _s in [IndexBinary]:
+        __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
+    __getattr__ = lambda self, name: _swig_getattr(self, IndexBinaryIVF, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["invlists"] = _swigfaiss_gpu.IndexBinaryIVF_invlists_set
+    __swig_getmethods__["invlists"] = _swigfaiss_gpu.IndexBinaryIVF_invlists_get
+    if _newclass:
+        invlists = _swig_property(_swigfaiss_gpu.IndexBinaryIVF_invlists_get, _swigfaiss_gpu.IndexBinaryIVF_invlists_set)
+    __swig_setmethods__["own_invlists"] = _swigfaiss_gpu.IndexBinaryIVF_own_invlists_set
+    __swig_getmethods__["own_invlists"] = _swigfaiss_gpu.IndexBinaryIVF_own_invlists_get
+    if _newclass:
+        own_invlists = _swig_property(_swigfaiss_gpu.IndexBinaryIVF_own_invlists_get, _swigfaiss_gpu.IndexBinaryIVF_own_invlists_set)
+    __swig_setmethods__["nprobe"] = _swigfaiss_gpu.IndexBinaryIVF_nprobe_set
+    __swig_getmethods__["nprobe"] = _swigfaiss_gpu.IndexBinaryIVF_nprobe_get
+    if _newclass:
+        nprobe = _swig_property(_swigfaiss_gpu.IndexBinaryIVF_nprobe_get, _swigfaiss_gpu.IndexBinaryIVF_nprobe_set)
+    __swig_setmethods__["max_codes"] = _swigfaiss_gpu.IndexBinaryIVF_max_codes_set
+    __swig_getmethods__["max_codes"] = _swigfaiss_gpu.IndexBinaryIVF_max_codes_get
+    if _newclass:
+        max_codes = _swig_property(_swigfaiss_gpu.IndexBinaryIVF_max_codes_get, _swigfaiss_gpu.IndexBinaryIVF_max_codes_set)
+    __swig_setmethods__["use_heap"] = _swigfaiss_gpu.IndexBinaryIVF_use_heap_set
+    __swig_getmethods__["use_heap"] = _swigfaiss_gpu.IndexBinaryIVF_use_heap_get
+    if _newclass:
+        use_heap = _swig_property(_swigfaiss_gpu.IndexBinaryIVF_use_heap_get, _swigfaiss_gpu.IndexBinaryIVF_use_heap_set)
+    __swig_setmethods__["maintain_direct_map"] = _swigfaiss_gpu.IndexBinaryIVF_maintain_direct_map_set
+    __swig_getmethods__["maintain_direct_map"] = _swigfaiss_gpu.IndexBinaryIVF_maintain_direct_map_get
+    if _newclass:
+        maintain_direct_map = _swig_property(_swigfaiss_gpu.IndexBinaryIVF_maintain_direct_map_get, _swigfaiss_gpu.IndexBinaryIVF_maintain_direct_map_set)
+    __swig_setmethods__["direct_map"] = _swigfaiss_gpu.IndexBinaryIVF_direct_map_set
+    __swig_getmethods__["direct_map"] = _swigfaiss_gpu.IndexBinaryIVF_direct_map_get
+    if _newclass:
+        direct_map = _swig_property(_swigfaiss_gpu.IndexBinaryIVF_direct_map_get, _swigfaiss_gpu.IndexBinaryIVF_direct_map_set)
+    __swig_setmethods__["quantizer"] = _swigfaiss_gpu.IndexBinaryIVF_quantizer_set
+    __swig_getmethods__["quantizer"] = _swigfaiss_gpu.IndexBinaryIVF_quantizer_get
+    if _newclass:
+        quantizer = _swig_property(_swigfaiss_gpu.IndexBinaryIVF_quantizer_get, _swigfaiss_gpu.IndexBinaryIVF_quantizer_set)
+    __swig_setmethods__["nlist"] = _swigfaiss_gpu.IndexBinaryIVF_nlist_set
+    __swig_getmethods__["nlist"] = _swigfaiss_gpu.IndexBinaryIVF_nlist_get
+    if _newclass:
+        nlist = _swig_property(_swigfaiss_gpu.IndexBinaryIVF_nlist_get, _swigfaiss_gpu.IndexBinaryIVF_nlist_set)
+    __swig_setmethods__["own_fields"] = _swigfaiss_gpu.IndexBinaryIVF_own_fields_set
+    __swig_getmethods__["own_fields"] = _swigfaiss_gpu.IndexBinaryIVF_own_fields_get
+    if _newclass:
+        own_fields = _swig_property(_swigfaiss_gpu.IndexBinaryIVF_own_fields_get, _swigfaiss_gpu.IndexBinaryIVF_own_fields_set)
+    __swig_setmethods__["cp"] = _swigfaiss_gpu.IndexBinaryIVF_cp_set
+    __swig_getmethods__["cp"] = _swigfaiss_gpu.IndexBinaryIVF_cp_get
+    if _newclass:
+        cp = _swig_property(_swigfaiss_gpu.IndexBinaryIVF_cp_get, _swigfaiss_gpu.IndexBinaryIVF_cp_set)
+
+    def train_q1(self, n, x, verbose):
+        return _swigfaiss_gpu.IndexBinaryIVF_train_q1(self, n, x, verbose)
+
+    def __init__(self, *args):
+        this = _swigfaiss_gpu.new_IndexBinaryIVF(*args)
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+    __swig_destroy__ = _swigfaiss_gpu.delete_IndexBinaryIVF
+    __del__ = lambda self: None
+
+    def reset(self):
+        return _swigfaiss_gpu.IndexBinaryIVF_reset(self)
+
+    def train(self, n, x):
+        return _swigfaiss_gpu.IndexBinaryIVF_train(self, n, x)
+
+    def add(self, n, x):
+        return _swigfaiss_gpu.IndexBinaryIVF_add(self, n, x)
+
+    def add_with_ids(self, n, x, xids):
+        return _swigfaiss_gpu.IndexBinaryIVF_add_with_ids(self, n, x, xids)
+
+    def add_core(self, n, x, xids, precomputed_idx):
+        return _swigfaiss_gpu.IndexBinaryIVF_add_core(self, n, x, xids, precomputed_idx)
+
+    def search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params=None):
+        return _swigfaiss_gpu.IndexBinaryIVF_search_preassigned(self, n, x, k, assign, centroid_dis, distances, labels, store_pairs, params)
+
+    def search(self, n, x, k, distances, labels):
+        return _swigfaiss_gpu.IndexBinaryIVF_search(self, n, x, k, distances, labels)
+
+    def reconstruct(self, key, recons):
+        return _swigfaiss_gpu.IndexBinaryIVF_reconstruct(self, key, recons)
+
+    def reconstruct_n(self, i0, ni, recons):
+        return _swigfaiss_gpu.IndexBinaryIVF_reconstruct_n(self, i0, ni, recons)
+
+    def search_and_reconstruct(self, n, x, k, distances, labels, recons):
+        return _swigfaiss_gpu.IndexBinaryIVF_search_and_reconstruct(self, n, x, k, distances, labels, recons)
+
+    def reconstruct_from_offset(self, list_no, offset, recons):
+        return _swigfaiss_gpu.IndexBinaryIVF_reconstruct_from_offset(self, list_no, offset, recons)
+
+    def remove_ids(self, sel):
+        return _swigfaiss_gpu.IndexBinaryIVF_remove_ids(self, sel)
+
+    def merge_from(self, other, add_id):
+        return _swigfaiss_gpu.IndexBinaryIVF_merge_from(self, other, add_id)
+
+    def get_list_size(self, list_no):
+        return _swigfaiss_gpu.IndexBinaryIVF_get_list_size(self, list_no)
+
+    def make_direct_map(self, new_maintain_direct_map=True):
+        return _swigfaiss_gpu.IndexBinaryIVF_make_direct_map(self, new_maintain_direct_map)
+
+    def imbalance_factor(self):
+        return _swigfaiss_gpu.IndexBinaryIVF_imbalance_factor(self)
+
+    def print_stats(self):
+        return _swigfaiss_gpu.IndexBinaryIVF_print_stats(self)
+
+    def replace_invlists(self, il, own=False):
+        return _swigfaiss_gpu.IndexBinaryIVF_replace_invlists(self, il, own)
+IndexBinaryIVF_swigregister = _swigfaiss_gpu.IndexBinaryIVF_swigregister
+IndexBinaryIVF_swigregister(IndexBinaryIVF)
 
 class IndexIDMap(Index):
     __swig_setmethods__ = {}
@@ -4769,9 +5201,17 @@ def write_index(*args):
     return _swigfaiss_gpu.write_index(*args)
 write_index = _swigfaiss_gpu.write_index
 
+def write_index_binary(*args):
+    return _swigfaiss_gpu.write_index_binary(*args)
+write_index_binary = _swigfaiss_gpu.write_index_binary
+
 def read_index(*args):
     return _swigfaiss_gpu.read_index(*args)
 read_index = _swigfaiss_gpu.read_index
+
+def read_index_binary(*args):
+    return _swigfaiss_gpu.read_index_binary(*args)
+read_index_binary = _swigfaiss_gpu.read_index_binary
 
 def write_VectorTransform(vt, fname):
     return _swigfaiss_gpu.write_VectorTransform(vt, fname)
@@ -4820,40 +5260,6 @@ Cloner_swigregister = _swigfaiss_gpu.Cloner_swigregister
 Cloner_swigregister(Cloner)
 IO_FLAG_MMAP = cvar.IO_FLAG_MMAP
 IO_FLAG_READ_ONLY = cvar.IO_FLAG_READ_ONLY
-
-class IOReader(_object):
-    __swig_setmethods__ = {}
-    __setattr__ = lambda self, name, value: _swig_setattr(self, IOReader, name, value)
-    __swig_getmethods__ = {}
-    __getattr__ = lambda self, name: _swig_getattr(self, IOReader, name)
-
-    def __init__(self, *args, **kwargs):
-        raise AttributeError("No constructor defined - class is abstract")
-    __repr__ = _swig_repr
-
-    def __call__(self, ptr, size, nitems):
-        return _swigfaiss_gpu.IOReader___call__(self, ptr, size, nitems)
-    __swig_destroy__ = _swigfaiss_gpu.delete_IOReader
-    __del__ = lambda self: None
-IOReader_swigregister = _swigfaiss_gpu.IOReader_swigregister
-IOReader_swigregister(IOReader)
-
-class IOWriter(_object):
-    __swig_setmethods__ = {}
-    __setattr__ = lambda self, name, value: _swig_setattr(self, IOWriter, name, value)
-    __swig_getmethods__ = {}
-    __getattr__ = lambda self, name: _swig_getattr(self, IOWriter, name)
-
-    def __init__(self, *args, **kwargs):
-        raise AttributeError("No constructor defined - class is abstract")
-    __repr__ = _swig_repr
-
-    def __call__(self, ptr, size, nitems):
-        return _swigfaiss_gpu.IOWriter___call__(self, ptr, size, nitems)
-    __swig_destroy__ = _swigfaiss_gpu.delete_IOWriter
-    __del__ = lambda self: None
-IOWriter_swigregister = _swigfaiss_gpu.IOWriter_swigregister
-IOWriter_swigregister(IOWriter)
 
 class AutoTuneCriterion(_object):
     __swig_setmethods__ = {}
@@ -5132,6 +5538,10 @@ ParameterSpace_swigregister(ParameterSpace)
 def index_factory(*args):
     return _swigfaiss_gpu.index_factory(*args)
 index_factory = _swigfaiss_gpu.index_factory
+
+def index_binary_factory(d, description):
+    return _swigfaiss_gpu.index_binary_factory(d, description)
+index_binary_factory = _swigfaiss_gpu.index_binary_factory
 
 def index_gpu_to_cpu(gpu_index):
     return _swigfaiss_gpu.index_gpu_to_cpu(gpu_index)
@@ -5628,6 +6038,107 @@ class RangeSearchPartialResult(BufferList):
     __del__ = lambda self: None
 RangeSearchPartialResult_swigregister = _swigfaiss_gpu.RangeSearchPartialResult_swigregister
 RangeSearchPartialResult_swigregister(RangeSearchPartialResult)
+
+class IOReader(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, IOReader, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, IOReader, name)
+
+    def __init__(self, *args, **kwargs):
+        raise AttributeError("No constructor defined - class is abstract")
+    __repr__ = _swig_repr
+
+    def __call__(self, ptr, size, nitems):
+        return _swigfaiss_gpu.IOReader___call__(self, ptr, size, nitems)
+
+    def fileno(self):
+        return _swigfaiss_gpu.IOReader_fileno(self)
+    __swig_destroy__ = _swigfaiss_gpu.delete_IOReader
+    __del__ = lambda self: None
+IOReader_swigregister = _swigfaiss_gpu.IOReader_swigregister
+IOReader_swigregister(IOReader)
+
+class IOWriter(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, IOWriter, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, IOWriter, name)
+
+    def __init__(self, *args, **kwargs):
+        raise AttributeError("No constructor defined - class is abstract")
+    __repr__ = _swig_repr
+
+    def __call__(self, ptr, size, nitems):
+        return _swigfaiss_gpu.IOWriter___call__(self, ptr, size, nitems)
+
+    def fileno(self):
+        return _swigfaiss_gpu.IOWriter_fileno(self)
+    __swig_destroy__ = _swigfaiss_gpu.delete_IOWriter
+    __del__ = lambda self: None
+IOWriter_swigregister = _swigfaiss_gpu.IOWriter_swigregister
+IOWriter_swigregister(IOWriter)
+
+class VectorIOReader(IOReader):
+    __swig_setmethods__ = {}
+    for _s in [IOReader]:
+        __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
+    __setattr__ = lambda self, name, value: _swig_setattr(self, VectorIOReader, name, value)
+    __swig_getmethods__ = {}
+    for _s in [IOReader]:
+        __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
+    __getattr__ = lambda self, name: _swig_getattr(self, VectorIOReader, name)
+    __repr__ = _swig_repr
+    __swig_getmethods__["data"] = _swigfaiss_gpu.VectorIOReader_data_get
+    if _newclass:
+        data = _swig_property(_swigfaiss_gpu.VectorIOReader_data_get)
+    __swig_setmethods__["rp"] = _swigfaiss_gpu.VectorIOReader_rp_set
+    __swig_getmethods__["rp"] = _swigfaiss_gpu.VectorIOReader_rp_get
+    if _newclass:
+        rp = _swig_property(_swigfaiss_gpu.VectorIOReader_rp_get, _swigfaiss_gpu.VectorIOReader_rp_set)
+
+    def __call__(self, ptr, size, nitems):
+        return _swigfaiss_gpu.VectorIOReader___call__(self, ptr, size, nitems)
+
+    def __init__(self):
+        this = _swigfaiss_gpu.new_VectorIOReader()
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+    __swig_destroy__ = _swigfaiss_gpu.delete_VectorIOReader
+    __del__ = lambda self: None
+VectorIOReader_swigregister = _swigfaiss_gpu.VectorIOReader_swigregister
+VectorIOReader_swigregister(VectorIOReader)
+
+class VectorIOWriter(IOWriter):
+    __swig_setmethods__ = {}
+    for _s in [IOWriter]:
+        __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
+    __setattr__ = lambda self, name, value: _swig_setattr(self, VectorIOWriter, name, value)
+    __swig_getmethods__ = {}
+    for _s in [IOWriter]:
+        __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
+    __getattr__ = lambda self, name: _swig_getattr(self, VectorIOWriter, name)
+    __repr__ = _swig_repr
+    __swig_setmethods__["data"] = _swigfaiss_gpu.VectorIOWriter_data_set
+    __swig_getmethods__["data"] = _swigfaiss_gpu.VectorIOWriter_data_get
+    if _newclass:
+        data = _swig_property(_swigfaiss_gpu.VectorIOWriter_data_get, _swigfaiss_gpu.VectorIOWriter_data_set)
+
+    def __call__(self, ptr, size, nitems):
+        return _swigfaiss_gpu.VectorIOWriter___call__(self, ptr, size, nitems)
+
+    def __init__(self):
+        this = _swigfaiss_gpu.new_VectorIOWriter()
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+    __swig_destroy__ = _swigfaiss_gpu.delete_VectorIOWriter
+    __del__ = lambda self: None
+VectorIOWriter_swigregister = _swigfaiss_gpu.VectorIOWriter_swigregister
+VectorIOWriter_swigregister(VectorIOWriter)
 
 
 def ignore_SIGTTIN():

--- a/python/swigfaiss_gpu_wrap.cpp
+++ b/python/swigfaiss_gpu_wrap.cpp
@@ -3043,172 +3043,183 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 #define SWIGTYPE_p_faiss__IDSelectorRange swig_types[37]
 #define SWIGTYPE_p_faiss__IOReader swig_types[38]
 #define SWIGTYPE_p_faiss__IOWriter swig_types[39]
-#define SWIGTYPE_p_faiss__Index swig_types[40]
-#define SWIGTYPE_p_faiss__Index2Layer swig_types[41]
-#define SWIGTYPE_p_faiss__IndexFlat swig_types[42]
-#define SWIGTYPE_p_faiss__IndexFlat1D swig_types[43]
-#define SWIGTYPE_p_faiss__IndexFlatIP swig_types[44]
-#define SWIGTYPE_p_faiss__IndexFlatL2 swig_types[45]
-#define SWIGTYPE_p_faiss__IndexFlatL2BaseShift swig_types[46]
-#define SWIGTYPE_p_faiss__IndexHNSW swig_types[47]
-#define SWIGTYPE_p_faiss__IndexHNSW2Level swig_types[48]
-#define SWIGTYPE_p_faiss__IndexHNSWFlat swig_types[49]
-#define SWIGTYPE_p_faiss__IndexHNSWPQ swig_types[50]
-#define SWIGTYPE_p_faiss__IndexHNSWSQ swig_types[51]
-#define SWIGTYPE_p_faiss__IndexIDMap swig_types[52]
-#define SWIGTYPE_p_faiss__IndexIDMap2 swig_types[53]
-#define SWIGTYPE_p_faiss__IndexIVF swig_types[54]
-#define SWIGTYPE_p_faiss__IndexIVFFlat swig_types[55]
-#define SWIGTYPE_p_faiss__IndexIVFPQ swig_types[56]
-#define SWIGTYPE_p_faiss__IndexIVFPQR swig_types[57]
-#define SWIGTYPE_p_faiss__IndexIVFPQStats swig_types[58]
-#define SWIGTYPE_p_faiss__IndexIVFScalarQuantizer swig_types[59]
-#define SWIGTYPE_p_faiss__IndexIVFStats swig_types[60]
-#define SWIGTYPE_p_faiss__IndexLSH swig_types[61]
-#define SWIGTYPE_p_faiss__IndexPQ swig_types[62]
-#define SWIGTYPE_p_faiss__IndexPQStats swig_types[63]
-#define SWIGTYPE_p_faiss__IndexPreTransform swig_types[64]
-#define SWIGTYPE_p_faiss__IndexRefineFlat swig_types[65]
-#define SWIGTYPE_p_faiss__IndexScalarQuantizer swig_types[66]
-#define SWIGTYPE_p_faiss__IndexShards swig_types[67]
-#define SWIGTYPE_p_faiss__IndexSplitVectors swig_types[68]
-#define SWIGTYPE_p_faiss__IntersectionCriterion swig_types[69]
-#define SWIGTYPE_p_faiss__InvertedLists swig_types[70]
-#define SWIGTYPE_p_faiss__Level1Quantizer swig_types[71]
-#define SWIGTYPE_p_faiss__LinearTransform swig_types[72]
-#define SWIGTYPE_p_faiss__LockLevels swig_types[73]
-#define SWIGTYPE_p_faiss__MultiIndexQuantizer swig_types[74]
-#define SWIGTYPE_p_faiss__MultiIndexQuantizer2 swig_types[75]
-#define SWIGTYPE_p_faiss__NormalizationTransform swig_types[76]
-#define SWIGTYPE_p_faiss__OPQMatrix swig_types[77]
-#define SWIGTYPE_p_faiss__OnDiskInvertedLists swig_types[78]
-#define SWIGTYPE_p_faiss__OnDiskInvertedLists__OngoingPrefetch swig_types[79]
-#define SWIGTYPE_p_faiss__OneRecallAtRCriterion swig_types[80]
-#define SWIGTYPE_p_faiss__OperatingPoint swig_types[81]
-#define SWIGTYPE_p_faiss__OperatingPoints swig_types[82]
-#define SWIGTYPE_p_faiss__PCAMatrix swig_types[83]
-#define SWIGTYPE_p_faiss__ParameterRange swig_types[84]
-#define SWIGTYPE_p_faiss__ParameterSpace swig_types[85]
-#define SWIGTYPE_p_faiss__PermutationObjective swig_types[86]
-#define SWIGTYPE_p_faiss__PolysemousTraining swig_types[87]
-#define SWIGTYPE_p_faiss__ProductQuantizer swig_types[88]
-#define SWIGTYPE_p_faiss__RandomGenerator swig_types[89]
-#define SWIGTYPE_p_faiss__RandomRotationMatrix swig_types[90]
-#define SWIGTYPE_p_faiss__RangeSearchPartialResult swig_types[91]
-#define SWIGTYPE_p_faiss__RangeSearchPartialResult__QueryResult swig_types[92]
-#define SWIGTYPE_p_faiss__RangeSearchResult swig_types[93]
-#define SWIGTYPE_p_faiss__ReconstructFromNeighbors swig_types[94]
-#define SWIGTYPE_p_faiss__RemapDimensionsTransform swig_types[95]
-#define SWIGTYPE_p_faiss__ReproduceDistancesObjective swig_types[96]
-#define SWIGTYPE_p_faiss__ScalarQuantizer swig_types[97]
-#define SWIGTYPE_p_faiss__ScalarQuantizer__DistanceComputer swig_types[98]
-#define SWIGTYPE_p_faiss__SimulatedAnnealingOptimizer swig_types[99]
-#define SWIGTYPE_p_faiss__SimulatedAnnealingParameters swig_types[100]
-#define SWIGTYPE_p_faiss__VectorTransform swig_types[101]
-#define SWIGTYPE_p_faiss__VisitedTable swig_types[102]
-#define SWIGTYPE_p_faiss__gpu__FlatIndex swig_types[103]
-#define SWIGTYPE_p_faiss__gpu__GpuClonerOptions swig_types[104]
-#define SWIGTYPE_p_faiss__gpu__GpuIndex swig_types[105]
-#define SWIGTYPE_p_faiss__gpu__GpuIndexConfig swig_types[106]
-#define SWIGTYPE_p_faiss__gpu__GpuIndexFlat swig_types[107]
-#define SWIGTYPE_p_faiss__gpu__GpuIndexFlatConfig swig_types[108]
-#define SWIGTYPE_p_faiss__gpu__GpuIndexFlatIP swig_types[109]
-#define SWIGTYPE_p_faiss__gpu__GpuIndexFlatL2 swig_types[110]
-#define SWIGTYPE_p_faiss__gpu__GpuIndexIVF swig_types[111]
-#define SWIGTYPE_p_faiss__gpu__GpuIndexIVFConfig swig_types[112]
-#define SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat swig_types[113]
-#define SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlatConfig swig_types[114]
-#define SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ swig_types[115]
-#define SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQConfig swig_types[116]
-#define SWIGTYPE_p_faiss__gpu__GpuMultipleClonerOptions swig_types[117]
-#define SWIGTYPE_p_faiss__gpu__GpuParameterSpace swig_types[118]
-#define SWIGTYPE_p_faiss__gpu__GpuResources swig_types[119]
-#define SWIGTYPE_p_faiss__gpu__IndexProxy swig_types[120]
-#define SWIGTYPE_p_faiss__gpu__StandardGpuResources swig_types[121]
-#define SWIGTYPE_p_float swig_types[122]
-#define SWIGTYPE_p_idx_t swig_types[123]
-#define SWIGTYPE_p_int swig_types[124]
-#define SWIGTYPE_p_long swig_types[125]
-#define SWIGTYPE_p_p_faiss__ArrayInvertedLists swig_types[126]
-#define SWIGTYPE_p_p_faiss__Index swig_types[127]
-#define SWIGTYPE_p_p_faiss__Index2Layer swig_types[128]
-#define SWIGTYPE_p_p_faiss__IndexFlat swig_types[129]
-#define SWIGTYPE_p_p_faiss__IndexFlat1D swig_types[130]
-#define SWIGTYPE_p_p_faiss__IndexFlatIP swig_types[131]
-#define SWIGTYPE_p_p_faiss__IndexFlatL2 swig_types[132]
-#define SWIGTYPE_p_p_faiss__IndexFlatL2BaseShift swig_types[133]
-#define SWIGTYPE_p_p_faiss__IndexHNSW swig_types[134]
-#define SWIGTYPE_p_p_faiss__IndexHNSW2Level swig_types[135]
-#define SWIGTYPE_p_p_faiss__IndexHNSWFlat swig_types[136]
-#define SWIGTYPE_p_p_faiss__IndexHNSWPQ swig_types[137]
-#define SWIGTYPE_p_p_faiss__IndexHNSWSQ swig_types[138]
-#define SWIGTYPE_p_p_faiss__IndexIDMap swig_types[139]
-#define SWIGTYPE_p_p_faiss__IndexIDMap2 swig_types[140]
-#define SWIGTYPE_p_p_faiss__IndexIVF swig_types[141]
-#define SWIGTYPE_p_p_faiss__IndexIVFFlat swig_types[142]
-#define SWIGTYPE_p_p_faiss__IndexIVFPQ swig_types[143]
-#define SWIGTYPE_p_p_faiss__IndexIVFPQR swig_types[144]
-#define SWIGTYPE_p_p_faiss__IndexIVFScalarQuantizer swig_types[145]
-#define SWIGTYPE_p_p_faiss__IndexLSH swig_types[146]
-#define SWIGTYPE_p_p_faiss__IndexPQ swig_types[147]
-#define SWIGTYPE_p_p_faiss__IndexPreTransform swig_types[148]
-#define SWIGTYPE_p_p_faiss__IndexRefineFlat swig_types[149]
-#define SWIGTYPE_p_p_faiss__IndexScalarQuantizer swig_types[150]
-#define SWIGTYPE_p_p_faiss__IndexShards swig_types[151]
-#define SWIGTYPE_p_p_faiss__IndexSplitVectors swig_types[152]
-#define SWIGTYPE_p_p_faiss__InvertedLists swig_types[153]
-#define SWIGTYPE_p_p_faiss__LinearTransform swig_types[154]
-#define SWIGTYPE_p_p_faiss__MultiIndexQuantizer swig_types[155]
-#define SWIGTYPE_p_p_faiss__MultiIndexQuantizer2 swig_types[156]
-#define SWIGTYPE_p_p_faiss__NormalizationTransform swig_types[157]
-#define SWIGTYPE_p_p_faiss__OPQMatrix swig_types[158]
-#define SWIGTYPE_p_p_faiss__OnDiskInvertedLists swig_types[159]
-#define SWIGTYPE_p_p_faiss__PCAMatrix swig_types[160]
-#define SWIGTYPE_p_p_faiss__RandomRotationMatrix swig_types[161]
-#define SWIGTYPE_p_p_faiss__RemapDimensionsTransform swig_types[162]
-#define SWIGTYPE_p_p_faiss__VectorTransform swig_types[163]
-#define SWIGTYPE_p_p_faiss__gpu__GpuIndex swig_types[164]
-#define SWIGTYPE_p_p_faiss__gpu__GpuIndexFlat swig_types[165]
-#define SWIGTYPE_p_p_faiss__gpu__GpuIndexFlatIP swig_types[166]
-#define SWIGTYPE_p_p_faiss__gpu__GpuIndexFlatL2 swig_types[167]
-#define SWIGTYPE_p_p_faiss__gpu__GpuIndexIVF swig_types[168]
-#define SWIGTYPE_p_p_faiss__gpu__GpuIndexIVFFlat swig_types[169]
-#define SWIGTYPE_p_p_faiss__gpu__GpuIndexIVFPQ swig_types[170]
-#define SWIGTYPE_p_p_faiss__gpu__GpuResources swig_types[171]
-#define SWIGTYPE_p_p_faiss__gpu__IndexProxy swig_types[172]
-#define SWIGTYPE_p_p_faiss__gpu__StandardGpuResources swig_types[173]
-#define SWIGTYPE_p_p_void swig_types[174]
-#define SWIGTYPE_p_std__functionT_void_ffaiss__Index_pF_t swig_types[175]
-#define SWIGTYPE_p_std__listT_faiss__OnDiskInvertedLists__Slot_t swig_types[176]
-#define SWIGTYPE_p_std__pairT_void_p_unsigned_long_t swig_types[177]
-#define SWIGTYPE_p_std__unordered_mapT_long_long_t swig_types[178]
-#define SWIGTYPE_p_std__vectorT_cudaStream_t_t swig_types[179]
-#define SWIGTYPE_p_std__vectorT_double_t swig_types[180]
-#define SWIGTYPE_p_std__vectorT_faiss__BufferList__Buffer_t swig_types[181]
-#define SWIGTYPE_p_std__vectorT_faiss__Index_p_t swig_types[182]
-#define SWIGTYPE_p_std__vectorT_faiss__InvertedLists_p_t swig_types[183]
-#define SWIGTYPE_p_std__vectorT_faiss__OnDiskInvertedLists__List_t swig_types[184]
-#define SWIGTYPE_p_std__vectorT_faiss__OperatingPoint_t swig_types[185]
-#define SWIGTYPE_p_std__vectorT_faiss__ParameterRange_t swig_types[186]
-#define SWIGTYPE_p_std__vectorT_faiss__RangeSearchPartialResult__QueryResult_t swig_types[187]
-#define SWIGTYPE_p_std__vectorT_faiss__VectorTransform_p_t swig_types[188]
-#define SWIGTYPE_p_std__vectorT_faiss__gpu__GpuResources_p_t swig_types[189]
-#define SWIGTYPE_p_std__vectorT_float_t swig_types[190]
-#define SWIGTYPE_p_std__vectorT_int_t swig_types[191]
-#define SWIGTYPE_p_std__vectorT_long_t swig_types[192]
-#define SWIGTYPE_p_std__vectorT_omp_lock_t_t swig_types[193]
-#define SWIGTYPE_p_std__vectorT_std__vectorT_float_t_t swig_types[194]
-#define SWIGTYPE_p_std__vectorT_std__vectorT_long_t_t swig_types[195]
-#define SWIGTYPE_p_std__vectorT_std__vectorT_uint8_t_t_t swig_types[196]
-#define SWIGTYPE_p_std__vectorT_unsigned_char_t swig_types[197]
-#define SWIGTYPE_p_std__vectorT_unsigned_long_t swig_types[198]
-#define SWIGTYPE_p_storage_idx_t swig_types[199]
-#define SWIGTYPE_p_uint32_t swig_types[200]
-#define SWIGTYPE_p_unsigned_char swig_types[201]
-#define SWIGTYPE_p_unsigned_long swig_types[202]
-#define SWIGTYPE_p_void swig_types[203]
-static swig_type_info *swig_types[205];
-static swig_module_info swig_module = {swig_types, 204, 0, 0, 0, 0};
+#define SWIGTYPE_p_faiss__IVFPQSearchParameters swig_types[40]
+#define SWIGTYPE_p_faiss__IVFSearchParameters swig_types[41]
+#define SWIGTYPE_p_faiss__Index swig_types[42]
+#define SWIGTYPE_p_faiss__Index2Layer swig_types[43]
+#define SWIGTYPE_p_faiss__IndexBinary swig_types[44]
+#define SWIGTYPE_p_faiss__IndexBinaryFlat swig_types[45]
+#define SWIGTYPE_p_faiss__IndexBinaryIVF swig_types[46]
+#define SWIGTYPE_p_faiss__IndexFlat swig_types[47]
+#define SWIGTYPE_p_faiss__IndexFlat1D swig_types[48]
+#define SWIGTYPE_p_faiss__IndexFlatIP swig_types[49]
+#define SWIGTYPE_p_faiss__IndexFlatL2 swig_types[50]
+#define SWIGTYPE_p_faiss__IndexFlatL2BaseShift swig_types[51]
+#define SWIGTYPE_p_faiss__IndexHNSW swig_types[52]
+#define SWIGTYPE_p_faiss__IndexHNSW2Level swig_types[53]
+#define SWIGTYPE_p_faiss__IndexHNSWFlat swig_types[54]
+#define SWIGTYPE_p_faiss__IndexHNSWPQ swig_types[55]
+#define SWIGTYPE_p_faiss__IndexHNSWSQ swig_types[56]
+#define SWIGTYPE_p_faiss__IndexIDMap swig_types[57]
+#define SWIGTYPE_p_faiss__IndexIDMap2 swig_types[58]
+#define SWIGTYPE_p_faiss__IndexIVF swig_types[59]
+#define SWIGTYPE_p_faiss__IndexIVFFlat swig_types[60]
+#define SWIGTYPE_p_faiss__IndexIVFFlatDedup swig_types[61]
+#define SWIGTYPE_p_faiss__IndexIVFPQ swig_types[62]
+#define SWIGTYPE_p_faiss__IndexIVFPQR swig_types[63]
+#define SWIGTYPE_p_faiss__IndexIVFPQStats swig_types[64]
+#define SWIGTYPE_p_faiss__IndexIVFScalarQuantizer swig_types[65]
+#define SWIGTYPE_p_faiss__IndexIVFStats swig_types[66]
+#define SWIGTYPE_p_faiss__IndexLSH swig_types[67]
+#define SWIGTYPE_p_faiss__IndexPQ swig_types[68]
+#define SWIGTYPE_p_faiss__IndexPQStats swig_types[69]
+#define SWIGTYPE_p_faiss__IndexPreTransform swig_types[70]
+#define SWIGTYPE_p_faiss__IndexRefineFlat swig_types[71]
+#define SWIGTYPE_p_faiss__IndexScalarQuantizer swig_types[72]
+#define SWIGTYPE_p_faiss__IndexShards swig_types[73]
+#define SWIGTYPE_p_faiss__IndexSplitVectors swig_types[74]
+#define SWIGTYPE_p_faiss__IntersectionCriterion swig_types[75]
+#define SWIGTYPE_p_faiss__InvertedLists swig_types[76]
+#define SWIGTYPE_p_faiss__Level1Quantizer swig_types[77]
+#define SWIGTYPE_p_faiss__LinearTransform swig_types[78]
+#define SWIGTYPE_p_faiss__LockLevels swig_types[79]
+#define SWIGTYPE_p_faiss__MultiIndexQuantizer swig_types[80]
+#define SWIGTYPE_p_faiss__MultiIndexQuantizer2 swig_types[81]
+#define SWIGTYPE_p_faiss__NormalizationTransform swig_types[82]
+#define SWIGTYPE_p_faiss__OPQMatrix swig_types[83]
+#define SWIGTYPE_p_faiss__OnDiskInvertedLists swig_types[84]
+#define SWIGTYPE_p_faiss__OnDiskInvertedLists__OngoingPrefetch swig_types[85]
+#define SWIGTYPE_p_faiss__OneRecallAtRCriterion swig_types[86]
+#define SWIGTYPE_p_faiss__OperatingPoint swig_types[87]
+#define SWIGTYPE_p_faiss__OperatingPoints swig_types[88]
+#define SWIGTYPE_p_faiss__PCAMatrix swig_types[89]
+#define SWIGTYPE_p_faiss__ParameterRange swig_types[90]
+#define SWIGTYPE_p_faiss__ParameterSpace swig_types[91]
+#define SWIGTYPE_p_faiss__PermutationObjective swig_types[92]
+#define SWIGTYPE_p_faiss__PolysemousTraining swig_types[93]
+#define SWIGTYPE_p_faiss__ProductQuantizer swig_types[94]
+#define SWIGTYPE_p_faiss__RandomGenerator swig_types[95]
+#define SWIGTYPE_p_faiss__RandomRotationMatrix swig_types[96]
+#define SWIGTYPE_p_faiss__RangeSearchPartialResult swig_types[97]
+#define SWIGTYPE_p_faiss__RangeSearchPartialResult__QueryResult swig_types[98]
+#define SWIGTYPE_p_faiss__RangeSearchResult swig_types[99]
+#define SWIGTYPE_p_faiss__ReconstructFromNeighbors swig_types[100]
+#define SWIGTYPE_p_faiss__RemapDimensionsTransform swig_types[101]
+#define SWIGTYPE_p_faiss__ReproduceDistancesObjective swig_types[102]
+#define SWIGTYPE_p_faiss__ScalarQuantizer swig_types[103]
+#define SWIGTYPE_p_faiss__ScalarQuantizer__DistanceComputer swig_types[104]
+#define SWIGTYPE_p_faiss__SimulatedAnnealingOptimizer swig_types[105]
+#define SWIGTYPE_p_faiss__SimulatedAnnealingParameters swig_types[106]
+#define SWIGTYPE_p_faiss__VectorIOReader swig_types[107]
+#define SWIGTYPE_p_faiss__VectorIOWriter swig_types[108]
+#define SWIGTYPE_p_faiss__VectorTransform swig_types[109]
+#define SWIGTYPE_p_faiss__VisitedTable swig_types[110]
+#define SWIGTYPE_p_faiss__gpu__FlatIndex swig_types[111]
+#define SWIGTYPE_p_faiss__gpu__GpuClonerOptions swig_types[112]
+#define SWIGTYPE_p_faiss__gpu__GpuIndex swig_types[113]
+#define SWIGTYPE_p_faiss__gpu__GpuIndexConfig swig_types[114]
+#define SWIGTYPE_p_faiss__gpu__GpuIndexFlat swig_types[115]
+#define SWIGTYPE_p_faiss__gpu__GpuIndexFlatConfig swig_types[116]
+#define SWIGTYPE_p_faiss__gpu__GpuIndexFlatIP swig_types[117]
+#define SWIGTYPE_p_faiss__gpu__GpuIndexFlatL2 swig_types[118]
+#define SWIGTYPE_p_faiss__gpu__GpuIndexIVF swig_types[119]
+#define SWIGTYPE_p_faiss__gpu__GpuIndexIVFConfig swig_types[120]
+#define SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat swig_types[121]
+#define SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlatConfig swig_types[122]
+#define SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ swig_types[123]
+#define SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQConfig swig_types[124]
+#define SWIGTYPE_p_faiss__gpu__GpuMultipleClonerOptions swig_types[125]
+#define SWIGTYPE_p_faiss__gpu__GpuParameterSpace swig_types[126]
+#define SWIGTYPE_p_faiss__gpu__GpuResources swig_types[127]
+#define SWIGTYPE_p_faiss__gpu__IndexProxy swig_types[128]
+#define SWIGTYPE_p_faiss__gpu__StandardGpuResources swig_types[129]
+#define SWIGTYPE_p_float swig_types[130]
+#define SWIGTYPE_p_idx_t swig_types[131]
+#define SWIGTYPE_p_int swig_types[132]
+#define SWIGTYPE_p_long swig_types[133]
+#define SWIGTYPE_p_p_faiss__ArrayInvertedLists swig_types[134]
+#define SWIGTYPE_p_p_faiss__Index swig_types[135]
+#define SWIGTYPE_p_p_faiss__Index2Layer swig_types[136]
+#define SWIGTYPE_p_p_faiss__IndexFlat swig_types[137]
+#define SWIGTYPE_p_p_faiss__IndexFlat1D swig_types[138]
+#define SWIGTYPE_p_p_faiss__IndexFlatIP swig_types[139]
+#define SWIGTYPE_p_p_faiss__IndexFlatL2 swig_types[140]
+#define SWIGTYPE_p_p_faiss__IndexFlatL2BaseShift swig_types[141]
+#define SWIGTYPE_p_p_faiss__IndexHNSW swig_types[142]
+#define SWIGTYPE_p_p_faiss__IndexHNSW2Level swig_types[143]
+#define SWIGTYPE_p_p_faiss__IndexHNSWFlat swig_types[144]
+#define SWIGTYPE_p_p_faiss__IndexHNSWPQ swig_types[145]
+#define SWIGTYPE_p_p_faiss__IndexHNSWSQ swig_types[146]
+#define SWIGTYPE_p_p_faiss__IndexIDMap swig_types[147]
+#define SWIGTYPE_p_p_faiss__IndexIDMap2 swig_types[148]
+#define SWIGTYPE_p_p_faiss__IndexIVF swig_types[149]
+#define SWIGTYPE_p_p_faiss__IndexIVFFlat swig_types[150]
+#define SWIGTYPE_p_p_faiss__IndexIVFFlatDedup swig_types[151]
+#define SWIGTYPE_p_p_faiss__IndexIVFPQ swig_types[152]
+#define SWIGTYPE_p_p_faiss__IndexIVFPQR swig_types[153]
+#define SWIGTYPE_p_p_faiss__IndexIVFScalarQuantizer swig_types[154]
+#define SWIGTYPE_p_p_faiss__IndexLSH swig_types[155]
+#define SWIGTYPE_p_p_faiss__IndexPQ swig_types[156]
+#define SWIGTYPE_p_p_faiss__IndexPreTransform swig_types[157]
+#define SWIGTYPE_p_p_faiss__IndexRefineFlat swig_types[158]
+#define SWIGTYPE_p_p_faiss__IndexScalarQuantizer swig_types[159]
+#define SWIGTYPE_p_p_faiss__IndexShards swig_types[160]
+#define SWIGTYPE_p_p_faiss__IndexSplitVectors swig_types[161]
+#define SWIGTYPE_p_p_faiss__InvertedLists swig_types[162]
+#define SWIGTYPE_p_p_faiss__LinearTransform swig_types[163]
+#define SWIGTYPE_p_p_faiss__MultiIndexQuantizer swig_types[164]
+#define SWIGTYPE_p_p_faiss__MultiIndexQuantizer2 swig_types[165]
+#define SWIGTYPE_p_p_faiss__NormalizationTransform swig_types[166]
+#define SWIGTYPE_p_p_faiss__OPQMatrix swig_types[167]
+#define SWIGTYPE_p_p_faiss__OnDiskInvertedLists swig_types[168]
+#define SWIGTYPE_p_p_faiss__PCAMatrix swig_types[169]
+#define SWIGTYPE_p_p_faiss__RandomRotationMatrix swig_types[170]
+#define SWIGTYPE_p_p_faiss__RemapDimensionsTransform swig_types[171]
+#define SWIGTYPE_p_p_faiss__VectorTransform swig_types[172]
+#define SWIGTYPE_p_p_faiss__gpu__GpuIndex swig_types[173]
+#define SWIGTYPE_p_p_faiss__gpu__GpuIndexFlat swig_types[174]
+#define SWIGTYPE_p_p_faiss__gpu__GpuIndexFlatIP swig_types[175]
+#define SWIGTYPE_p_p_faiss__gpu__GpuIndexFlatL2 swig_types[176]
+#define SWIGTYPE_p_p_faiss__gpu__GpuIndexIVF swig_types[177]
+#define SWIGTYPE_p_p_faiss__gpu__GpuIndexIVFFlat swig_types[178]
+#define SWIGTYPE_p_p_faiss__gpu__GpuIndexIVFPQ swig_types[179]
+#define SWIGTYPE_p_p_faiss__gpu__GpuResources swig_types[180]
+#define SWIGTYPE_p_p_faiss__gpu__IndexProxy swig_types[181]
+#define SWIGTYPE_p_p_faiss__gpu__StandardGpuResources swig_types[182]
+#define SWIGTYPE_p_p_void swig_types[183]
+#define SWIGTYPE_p_std__functionT_void_ffaiss__Index_pF_t swig_types[184]
+#define SWIGTYPE_p_std__listT_faiss__OnDiskInvertedLists__Slot_t swig_types[185]
+#define SWIGTYPE_p_std__pairT_void_p_unsigned_long_t swig_types[186]
+#define SWIGTYPE_p_std__unordered_mapT_long_long_t swig_types[187]
+#define SWIGTYPE_p_std__unordered_multimapT_long_long_t swig_types[188]
+#define SWIGTYPE_p_std__vectorT_char_t swig_types[189]
+#define SWIGTYPE_p_std__vectorT_cudaStream_t_t swig_types[190]
+#define SWIGTYPE_p_std__vectorT_double_t swig_types[191]
+#define SWIGTYPE_p_std__vectorT_faiss__BufferList__Buffer_t swig_types[192]
+#define SWIGTYPE_p_std__vectorT_faiss__Index_p_t swig_types[193]
+#define SWIGTYPE_p_std__vectorT_faiss__InvertedLists_p_t swig_types[194]
+#define SWIGTYPE_p_std__vectorT_faiss__OnDiskInvertedLists__List_t swig_types[195]
+#define SWIGTYPE_p_std__vectorT_faiss__OperatingPoint_t swig_types[196]
+#define SWIGTYPE_p_std__vectorT_faiss__ParameterRange_t swig_types[197]
+#define SWIGTYPE_p_std__vectorT_faiss__RangeSearchPartialResult__QueryResult_t swig_types[198]
+#define SWIGTYPE_p_std__vectorT_faiss__VectorTransform_p_t swig_types[199]
+#define SWIGTYPE_p_std__vectorT_faiss__gpu__GpuResources_p_t swig_types[200]
+#define SWIGTYPE_p_std__vectorT_float_t swig_types[201]
+#define SWIGTYPE_p_std__vectorT_int_t swig_types[202]
+#define SWIGTYPE_p_std__vectorT_long_t swig_types[203]
+#define SWIGTYPE_p_std__vectorT_omp_lock_t_t swig_types[204]
+#define SWIGTYPE_p_std__vectorT_std__vectorT_float_t_t swig_types[205]
+#define SWIGTYPE_p_std__vectorT_std__vectorT_long_t_t swig_types[206]
+#define SWIGTYPE_p_std__vectorT_std__vectorT_uint8_t_t_t swig_types[207]
+#define SWIGTYPE_p_std__vectorT_unsigned_char_t swig_types[208]
+#define SWIGTYPE_p_std__vectorT_unsigned_long_t swig_types[209]
+#define SWIGTYPE_p_storage_idx_t swig_types[210]
+#define SWIGTYPE_p_uint32_t swig_types[211]
+#define SWIGTYPE_p_unsigned_char swig_types[212]
+#define SWIGTYPE_p_unsigned_long swig_types[213]
+#define SWIGTYPE_p_void swig_types[214]
+static swig_type_info *swig_types[216];
+static swig_module_info swig_module = {swig_types, 215, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3356,6 +3367,9 @@ extern "C" {
 #include "IndexHNSW.h"
 #include "MetaIndexes.h"
 #include "FaissAssert.h"
+
+#include "IndexBinaryFlat.h"
+#include "IndexBinaryIVF.h"
 
 #include "index_io.h"
 
@@ -3705,116 +3719,6 @@ SWIG_From_unsigned_SS_char  (unsigned char value)
 }
 
 
-SWIGINTERN int
-SWIG_AsVal_long (PyObject *obj, long* val)
-{
-#if PY_VERSION_HEX < 0x03000000
-  if (PyInt_Check(obj)) {
-    if (val) *val = PyInt_AsLong(obj);
-    return SWIG_OK;
-  } else
-#endif
-  if (PyLong_Check(obj)) {
-    long v = PyLong_AsLong(obj);
-    if (!PyErr_Occurred()) {
-      if (val) *val = v;
-      return SWIG_OK;
-    } else {
-      PyErr_Clear();
-      return SWIG_OverflowError;
-    }
-  }
-#ifdef SWIG_PYTHON_CAST_MODE
-  {
-    int dispatch = 0;
-    long v = PyInt_AsLong(obj);
-    if (!PyErr_Occurred()) {
-      if (val) *val = v;
-      return SWIG_AddCast(SWIG_OK);
-    } else {
-      PyErr_Clear();
-    }
-    if (!dispatch) {
-      double d;
-      int res = SWIG_AddCast(SWIG_AsVal_double (obj,&d));
-      if (SWIG_IsOK(res) && SWIG_CanCastAsInteger(&d, LONG_MIN, LONG_MAX)) {
-	if (val) *val = (long)(d);
-	return res;
-      }
-    }
-  }
-#endif
-  return SWIG_TypeError;
-}
-
-
-SWIGINTERN int
-SWIG_AsVal_int (PyObject * obj, int *val)
-{
-  long v;
-  int res = SWIG_AsVal_long (obj, &v);
-  if (SWIG_IsOK(res)) {
-    if ((v < INT_MIN || v > INT_MAX)) {
-      return SWIG_OverflowError;
-    } else {
-      if (val) *val = static_cast< int >(v);
-    }
-  }  
-  return res;
-}
-
-
-SWIGINTERNINLINE PyObject*
-  SWIG_From_int  (int value)
-{
-  return PyInt_FromLong((long) value);
-}
-
-
-#include <string>
-
-
-
-#include "gpu/StandardGpuResources.h"
-#include "gpu/GpuIndicesOptions.h"
-#include "gpu/GpuClonerOptions.h"
-#include "gpu/utils/MemorySpace.h"
-#include "gpu/GpuIndex.h"
-#include "gpu/GpuIndexFlat.h"
-#include "gpu/GpuIndexIVF.h"
-#include "gpu/GpuIndexIVFPQ.h"
-#include "gpu/GpuIndexIVFFlat.h"
-#include "gpu/IndexProxy.h"
-#include "gpu/GpuAutoTune.h"
-
-int get_num_gpus()
-{
-    return faiss::gpu::getNumDevices();
-}
-
-
-
-SWIGINTERN int
-SWIG_AsVal_bool (PyObject *obj, bool *val)
-{
-  int r;
-  if (!PyBool_Check(obj))
-    return SWIG_ERROR;
-  r = PyObject_IsTrue(obj);
-  if (r == -1)
-    return SWIG_ERROR;
-  if (val) *val = r ? true : false;
-  return SWIG_OK;
-}
-
-
-SWIGINTERNINLINE PyObject*
-  SWIG_From_bool  (bool value)
-{
-  return PyBool_FromLong(value ? 1 : 0);
-}
-
-
 SWIGINTERN swig_type_info*
 SWIG_pchar_descriptor(void)
 {
@@ -3942,33 +3846,89 @@ SWIG_AsCharPtrAndSize(PyObject *obj, char** cptr, size_t* psize, int *alloc)
 
 
 SWIGINTERN int
-SWIG_AsPtr_std_string (PyObject * obj, std::string **val) 
-{
-  char* buf = 0 ; size_t size = 0; int alloc = SWIG_OLDOBJ;
-  if (SWIG_IsOK((SWIG_AsCharPtrAndSize(obj, &buf, &size, &alloc)))) {
-    if (buf) {
-      if (val) *val = new std::string(buf, size - 1);
-      if (alloc == SWIG_NEWOBJ) delete[] buf;
-      return SWIG_NEWOBJ;
-    } else {
-      if (val) *val = 0;
-      return SWIG_OLDOBJ;
-    }
-  } else {
-    static int init = 0;
-    static swig_type_info* descriptor = 0;
-    if (!init) {
-      descriptor = SWIG_TypeQuery("std::string" " *");
-      init = 1;
-    }
-    if (descriptor) {
-      std::string *vptr;
-      int res = SWIG_ConvertPtr(obj, (void**)&vptr, descriptor, 0);
-      if (SWIG_IsOK(res) && val) *val = vptr;
+SWIG_AsCharArray(PyObject * obj, char *val, size_t size)
+{ 
+  char* cptr = 0; size_t csize = 0; int alloc = SWIG_OLDOBJ;
+  int res = SWIG_AsCharPtrAndSize(obj, &cptr, &csize, &alloc);
+  if (SWIG_IsOK(res)) {
+    /* special case of single char conversion when we don't need space for NUL */
+    if (size == 1 && csize == 2 && cptr && !cptr[1]) --csize;
+    if (csize <= size) {
+      if (val) {
+	if (csize) memcpy(val, cptr, csize*sizeof(char));
+	if (csize < size) memset(val + csize, 0, (size - csize)*sizeof(char));
+      }
+      if (alloc == SWIG_NEWOBJ) {
+	delete[] cptr;
+	res = SWIG_DelNewMask(res);
+      }      
       return res;
     }
+    if (alloc == SWIG_NEWOBJ) delete[] cptr;
   }
-  return SWIG_ERROR;
+  return SWIG_TypeError;
+}
+
+
+SWIGINTERN int
+SWIG_AsVal_long (PyObject *obj, long* val)
+{
+#if PY_VERSION_HEX < 0x03000000
+  if (PyInt_Check(obj)) {
+    if (val) *val = PyInt_AsLong(obj);
+    return SWIG_OK;
+  } else
+#endif
+  if (PyLong_Check(obj)) {
+    long v = PyLong_AsLong(obj);
+    if (!PyErr_Occurred()) {
+      if (val) *val = v;
+      return SWIG_OK;
+    } else {
+      PyErr_Clear();
+      return SWIG_OverflowError;
+    }
+  }
+#ifdef SWIG_PYTHON_CAST_MODE
+  {
+    int dispatch = 0;
+    long v = PyInt_AsLong(obj);
+    if (!PyErr_Occurred()) {
+      if (val) *val = v;
+      return SWIG_AddCast(SWIG_OK);
+    } else {
+      PyErr_Clear();
+    }
+    if (!dispatch) {
+      double d;
+      int res = SWIG_AddCast(SWIG_AsVal_double (obj,&d));
+      if (SWIG_IsOK(res) && SWIG_CanCastAsInteger(&d, LONG_MIN, LONG_MAX)) {
+	if (val) *val = (long)(d);
+	return res;
+      }
+    }
+  }
+#endif
+  return SWIG_TypeError;
+}
+
+
+SWIGINTERN int
+SWIG_AsVal_char (PyObject * obj, char *val)
+{    
+  int res = SWIG_AsCharArray(obj, val, 1);
+  if (!SWIG_IsOK(res)) {
+    long v;
+    res = SWIG_AddCast(SWIG_AsVal_long (obj, &v));
+    if (SWIG_IsOK(res)) {
+      if ((CHAR_MIN <= v) && (v <= CHAR_MAX)) {
+	if (val) *val = static_cast< char >(v);
+      } else {
+	res = SWIG_OverflowError;
+      }
+    }
+  }
+  return res;
 }
 
 
@@ -4001,54 +3961,10 @@ SWIG_FromCharPtrAndSize(const char* carray, size_t size)
 }
 
 
-SWIGINTERNINLINE PyObject *
-SWIG_From_std_string  (const std::string& s)
-{
-  return SWIG_FromCharPtrAndSize(s.data(), s.size());
-}
-
-
-SWIGINTERN int
-SWIG_AsCharArray(PyObject * obj, char *val, size_t size)
+SWIGINTERNINLINE PyObject * 
+SWIG_FromCharPtr(const char *cptr)
 { 
-  char* cptr = 0; size_t csize = 0; int alloc = SWIG_OLDOBJ;
-  int res = SWIG_AsCharPtrAndSize(obj, &cptr, &csize, &alloc);
-  if (SWIG_IsOK(res)) {
-    /* special case of single char conversion when we don't need space for NUL */
-    if (size == 1 && csize == 2 && cptr && !cptr[1]) --csize;
-    if (csize <= size) {
-      if (val) {
-	if (csize) memcpy(val, cptr, csize*sizeof(char));
-	if (csize < size) memset(val + csize, 0, (size - csize)*sizeof(char));
-      }
-      if (alloc == SWIG_NEWOBJ) {
-	delete[] cptr;
-	res = SWIG_DelNewMask(res);
-      }      
-      return res;
-    }
-    if (alloc == SWIG_NEWOBJ) delete[] cptr;
-  }
-  return SWIG_TypeError;
-}
-
-
-SWIGINTERN int
-SWIG_AsVal_char (PyObject * obj, char *val)
-{    
-  int res = SWIG_AsCharArray(obj, val, 1);
-  if (!SWIG_IsOK(res)) {
-    long v;
-    res = SWIG_AddCast(SWIG_AsVal_long (obj, &v));
-    if (SWIG_IsOK(res)) {
-      if ((CHAR_MIN <= v) && (v <= CHAR_MAX)) {
-	if (val) *val = static_cast< char >(v);
-      } else {
-	res = SWIG_OverflowError;
-      }
-    }
-  }
-  return res;
+  return SWIG_FromCharPtrAndSize(cptr, (cptr ? strlen(cptr) : 0));
 }
 
 
@@ -4056,6 +3972,111 @@ SWIGINTERNINLINE PyObject *
 SWIG_From_char  (char c) 
 { 
   return SWIG_FromCharPtrAndSize(&c,1);
+}
+
+
+SWIGINTERN int
+SWIG_AsVal_int (PyObject * obj, int *val)
+{
+  long v;
+  int res = SWIG_AsVal_long (obj, &v);
+  if (SWIG_IsOK(res)) {
+    if ((v < INT_MIN || v > INT_MAX)) {
+      return SWIG_OverflowError;
+    } else {
+      if (val) *val = static_cast< int >(v);
+    }
+  }  
+  return res;
+}
+
+
+SWIGINTERNINLINE PyObject*
+  SWIG_From_int  (int value)
+{
+  return PyInt_FromLong((long) value);
+}
+
+
+#include <string>
+
+
+
+#include "gpu/StandardGpuResources.h"
+#include "gpu/GpuIndicesOptions.h"
+#include "gpu/GpuClonerOptions.h"
+#include "gpu/utils/MemorySpace.h"
+#include "gpu/GpuIndex.h"
+#include "gpu/GpuIndexFlat.h"
+#include "gpu/GpuIndexIVF.h"
+#include "gpu/GpuIndexIVFPQ.h"
+#include "gpu/GpuIndexIVFFlat.h"
+#include "gpu/IndexProxy.h"
+#include "gpu/GpuAutoTune.h"
+
+int get_num_gpus()
+{
+    return faiss::gpu::getNumDevices();
+}
+
+
+
+SWIGINTERN int
+SWIG_AsVal_bool (PyObject *obj, bool *val)
+{
+  int r;
+  if (!PyBool_Check(obj))
+    return SWIG_ERROR;
+  r = PyObject_IsTrue(obj);
+  if (r == -1)
+    return SWIG_ERROR;
+  if (val) *val = r ? true : false;
+  return SWIG_OK;
+}
+
+
+SWIGINTERNINLINE PyObject*
+  SWIG_From_bool  (bool value)
+{
+  return PyBool_FromLong(value ? 1 : 0);
+}
+
+
+SWIGINTERN int
+SWIG_AsPtr_std_string (PyObject * obj, std::string **val) 
+{
+  char* buf = 0 ; size_t size = 0; int alloc = SWIG_OLDOBJ;
+  if (SWIG_IsOK((SWIG_AsCharPtrAndSize(obj, &buf, &size, &alloc)))) {
+    if (buf) {
+      if (val) *val = new std::string(buf, size - 1);
+      if (alloc == SWIG_NEWOBJ) delete[] buf;
+      return SWIG_NEWOBJ;
+    } else {
+      if (val) *val = 0;
+      return SWIG_OLDOBJ;
+    }
+  } else {
+    static int init = 0;
+    static swig_type_info* descriptor = 0;
+    if (!init) {
+      descriptor = SWIG_TypeQuery("std::string" " *");
+      init = 1;
+    }
+    if (descriptor) {
+      std::string *vptr;
+      int res = SWIG_ConvertPtr(obj, (void**)&vptr, descriptor, 0);
+      if (SWIG_IsOK(res) && val) *val = vptr;
+      return res;
+    }
+  }
+  return SWIG_ERROR;
+}
+
+
+SWIGINTERNINLINE PyObject *
+SWIG_From_std_string  (const std::string& s)
+{
+  return SWIG_FromCharPtrAndSize(s.data(), s.size());
 }
 
 
@@ -4096,6 +4117,9 @@ PyObject *swig_ptr (PyObject *a)
     }
     if(PyArray_TYPE(ao) == NPY_UINT8) {
         return SWIG_NewPointerObj(data, SWIGTYPE_p_unsigned_char, 0);
+    }
+    if(PyArray_TYPE(ao) == NPY_INT8) {
+        return SWIG_NewPointerObj(data, SWIGTYPE_p_char, 0);
     }
     if(PyArray_TYPE(ao) == NPY_UINT64) {
         return SWIG_NewPointerObj(data, SWIGTYPE_p_unsigned_long, 0);
@@ -4359,6 +4383,39 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_FloatVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< float > *arg1 = (std::vector< float > *) 0 ;
+  std::vector< float > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:FloatVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_float_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "FloatVector_swap" "', argument " "1"" of type '" "std::vector< float > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< float > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_float_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "FloatVector_swap" "', argument " "2"" of type '" "std::vector< float > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "FloatVector_swap" "', argument " "2"" of type '" "std::vector< float > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< float > * >(argp2);
+  (arg1)->swap(*arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_delete_FloatVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   std::vector< float > *arg1 = (std::vector< float > *) 0 ;
@@ -4549,6 +4606,39 @@ SWIGINTERN PyObject *_wrap_DoubleVector_resize(PyObject *SWIGUNUSEDPARM(self), P
   } 
   arg2 = static_cast< size_t >(val2);
   (arg1)->resize(arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_DoubleVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< double > *arg1 = (std::vector< double > *) 0 ;
+  std::vector< double > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:DoubleVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_double_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DoubleVector_swap" "', argument " "1"" of type '" "std::vector< double > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< double > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_double_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "DoubleVector_swap" "', argument " "2"" of type '" "std::vector< double > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "DoubleVector_swap" "', argument " "2"" of type '" "std::vector< double > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< double > * >(argp2);
+  (arg1)->swap(*arg2);
   resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
@@ -4753,6 +4843,39 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_ByteVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< uint8_t > *arg1 = (std::vector< uint8_t > *) 0 ;
+  std::vector< unsigned char > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:ByteVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ByteVector_swap" "', argument " "1"" of type '" "std::vector< uint8_t > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< uint8_t > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_unsigned_char_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ByteVector_swap" "', argument " "2"" of type '" "std::vector< unsigned char > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "ByteVector_swap" "', argument " "2"" of type '" "std::vector< unsigned char > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< unsigned char > * >(argp2);
+  (arg1)->swap(*arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_delete_ByteVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   std::vector< uint8_t > *arg1 = (std::vector< uint8_t > *) 0 ;
@@ -4781,12 +4904,242 @@ SWIGINTERN PyObject *ByteVector_swigregister(PyObject *SWIGUNUSEDPARM(self), PyO
   return SWIG_Py_Void();
 }
 
+SWIGINTERN PyObject *_wrap_new_CharVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_CharVector")) SWIG_fail;
+  result = (std::vector< char > *)new std::vector< char >();
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_char_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CharVector_push_back(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *arg1 = (std::vector< char > *) 0 ;
+  char arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  char val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:CharVector_push_back",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CharVector_push_back" "', argument " "1"" of type '" "std::vector< char > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< char > * >(argp1);
+  ecode2 = SWIG_AsVal_char(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "CharVector_push_back" "', argument " "2"" of type '" "char""'");
+  } 
+  arg2 = static_cast< char >(val2);
+  (arg1)->push_back(arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CharVector_clear(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *arg1 = (std::vector< char > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:CharVector_clear",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CharVector_clear" "', argument " "1"" of type '" "std::vector< char > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< char > * >(argp1);
+  (arg1)->clear();
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CharVector_data(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *arg1 = (std::vector< char > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  char *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:CharVector_data",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CharVector_data" "', argument " "1"" of type '" "std::vector< char > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< char > * >(argp1);
+  result = (char *)(arg1)->data();
+  resultobj = SWIG_FromCharPtr((const char *)result);
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CharVector_size(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *arg1 = (std::vector< char > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:CharVector_size",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CharVector_size" "', argument " "1"" of type '" "std::vector< char > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< char > * >(argp1);
+  result = (size_t)(arg1)->size();
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CharVector_at(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *arg1 = (std::vector< char > *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  char result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:CharVector_at",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CharVector_at" "', argument " "1"" of type '" "std::vector< char > const *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< char > * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "CharVector_at" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  result = (char)((std::vector< char > const *)arg1)->at(arg2);
+  resultobj = SWIG_From_char(static_cast< char >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CharVector_resize(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *arg1 = (std::vector< char > *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:CharVector_resize",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CharVector_resize" "', argument " "1"" of type '" "std::vector< char > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< char > * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "CharVector_resize" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  (arg1)->resize(arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CharVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *arg1 = (std::vector< char > *) 0 ;
+  std::vector< char > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:CharVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CharVector_swap" "', argument " "1"" of type '" "std::vector< char > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< char > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_char_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "CharVector_swap" "', argument " "2"" of type '" "std::vector< char > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CharVector_swap" "', argument " "2"" of type '" "std::vector< char > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< char > * >(argp2);
+  (arg1)->swap(*arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_CharVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *arg1 = (std::vector< char > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_CharVector",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_char_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_CharVector" "', argument " "1"" of type '" "std::vector< char > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< char > * >(argp1);
+  delete arg1;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *CharVector_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_std__vectorT_char_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
 SWIGINTERN PyObject *_wrap_new_Uint64Vector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::vector< uint64_t > *result = 0 ;
+  std::vector< unsigned long > *result = 0 ;
   
   if (!PyArg_ParseTuple(args,(char *)":new_Uint64Vector")) SWIG_fail;
-  result = (std::vector< uint64_t > *)new std::vector< uint64_t >();
+  result = (std::vector< unsigned long > *)new std::vector< unsigned long >();
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_unsigned_long_t, SWIG_POINTER_NEW |  0 );
   return resultobj;
 fail:
@@ -4796,7 +5149,7 @@ fail:
 
 SWIGINTERN PyObject *_wrap_Uint64Vector_push_back(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::vector< uint64_t > *arg1 = (std::vector< uint64_t > *) 0 ;
+  std::vector< unsigned long > *arg1 = (std::vector< unsigned long > *) 0 ;
   unsigned long arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -4808,9 +5161,9 @@ SWIGINTERN PyObject *_wrap_Uint64Vector_push_back(PyObject *SWIGUNUSEDPARM(self)
   if (!PyArg_ParseTuple(args,(char *)"OO:Uint64Vector_push_back",&obj0,&obj1)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_long_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_push_back" "', argument " "1"" of type '" "std::vector< uint64_t > *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_push_back" "', argument " "1"" of type '" "std::vector< unsigned long > *""'"); 
   }
-  arg1 = reinterpret_cast< std::vector< uint64_t > * >(argp1);
+  arg1 = reinterpret_cast< std::vector< unsigned long > * >(argp1);
   ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
   if (!SWIG_IsOK(ecode2)) {
     SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "Uint64Vector_push_back" "', argument " "2"" of type '" "unsigned long""'");
@@ -4826,7 +5179,7 @@ fail:
 
 SWIGINTERN PyObject *_wrap_Uint64Vector_clear(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::vector< uint64_t > *arg1 = (std::vector< uint64_t > *) 0 ;
+  std::vector< unsigned long > *arg1 = (std::vector< unsigned long > *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -4834,9 +5187,9 @@ SWIGINTERN PyObject *_wrap_Uint64Vector_clear(PyObject *SWIGUNUSEDPARM(self), Py
   if (!PyArg_ParseTuple(args,(char *)"O:Uint64Vector_clear",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_long_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_clear" "', argument " "1"" of type '" "std::vector< uint64_t > *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_clear" "', argument " "1"" of type '" "std::vector< unsigned long > *""'"); 
   }
-  arg1 = reinterpret_cast< std::vector< uint64_t > * >(argp1);
+  arg1 = reinterpret_cast< std::vector< unsigned long > * >(argp1);
   (arg1)->clear();
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -4847,7 +5200,7 @@ fail:
 
 SWIGINTERN PyObject *_wrap_Uint64Vector_data(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::vector< uint64_t > *arg1 = (std::vector< uint64_t > *) 0 ;
+  std::vector< unsigned long > *arg1 = (std::vector< unsigned long > *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -4856,9 +5209,9 @@ SWIGINTERN PyObject *_wrap_Uint64Vector_data(PyObject *SWIGUNUSEDPARM(self), PyO
   if (!PyArg_ParseTuple(args,(char *)"O:Uint64Vector_data",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_long_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_data" "', argument " "1"" of type '" "std::vector< uint64_t > *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_data" "', argument " "1"" of type '" "std::vector< unsigned long > *""'"); 
   }
-  arg1 = reinterpret_cast< std::vector< uint64_t > * >(argp1);
+  arg1 = reinterpret_cast< std::vector< unsigned long > * >(argp1);
   result = (unsigned long *)(arg1)->data();
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_unsigned_long, 0 |  0 );
   return resultobj;
@@ -4869,7 +5222,7 @@ fail:
 
 SWIGINTERN PyObject *_wrap_Uint64Vector_size(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::vector< uint64_t > *arg1 = (std::vector< uint64_t > *) 0 ;
+  std::vector< unsigned long > *arg1 = (std::vector< unsigned long > *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -4878,9 +5231,9 @@ SWIGINTERN PyObject *_wrap_Uint64Vector_size(PyObject *SWIGUNUSEDPARM(self), PyO
   if (!PyArg_ParseTuple(args,(char *)"O:Uint64Vector_size",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_long_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_size" "', argument " "1"" of type '" "std::vector< uint64_t > *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_size" "', argument " "1"" of type '" "std::vector< unsigned long > *""'"); 
   }
-  arg1 = reinterpret_cast< std::vector< uint64_t > * >(argp1);
+  arg1 = reinterpret_cast< std::vector< unsigned long > * >(argp1);
   result = (size_t)(arg1)->size();
   resultobj = SWIG_From_size_t(static_cast< size_t >(result));
   return resultobj;
@@ -4891,7 +5244,7 @@ fail:
 
 SWIGINTERN PyObject *_wrap_Uint64Vector_at(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::vector< uint64_t > *arg1 = (std::vector< uint64_t > *) 0 ;
+  std::vector< unsigned long > *arg1 = (std::vector< unsigned long > *) 0 ;
   size_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -4904,15 +5257,15 @@ SWIGINTERN PyObject *_wrap_Uint64Vector_at(PyObject *SWIGUNUSEDPARM(self), PyObj
   if (!PyArg_ParseTuple(args,(char *)"OO:Uint64Vector_at",&obj0,&obj1)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_long_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_at" "', argument " "1"" of type '" "std::vector< uint64_t > const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_at" "', argument " "1"" of type '" "std::vector< unsigned long > const *""'"); 
   }
-  arg1 = reinterpret_cast< std::vector< uint64_t > * >(argp1);
+  arg1 = reinterpret_cast< std::vector< unsigned long > * >(argp1);
   ecode2 = SWIG_AsVal_size_t(obj1, &val2);
   if (!SWIG_IsOK(ecode2)) {
     SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "Uint64Vector_at" "', argument " "2"" of type '" "size_t""'");
   } 
   arg2 = static_cast< size_t >(val2);
-  result = (unsigned long)((std::vector< uint64_t > const *)arg1)->at(arg2);
+  result = (unsigned long)((std::vector< unsigned long > const *)arg1)->at(arg2);
   resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
   return resultobj;
 fail:
@@ -4922,7 +5275,7 @@ fail:
 
 SWIGINTERN PyObject *_wrap_Uint64Vector_resize(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::vector< uint64_t > *arg1 = (std::vector< uint64_t > *) 0 ;
+  std::vector< unsigned long > *arg1 = (std::vector< unsigned long > *) 0 ;
   size_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -4934,9 +5287,9 @@ SWIGINTERN PyObject *_wrap_Uint64Vector_resize(PyObject *SWIGUNUSEDPARM(self), P
   if (!PyArg_ParseTuple(args,(char *)"OO:Uint64Vector_resize",&obj0,&obj1)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_long_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_resize" "', argument " "1"" of type '" "std::vector< uint64_t > *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_resize" "', argument " "1"" of type '" "std::vector< unsigned long > *""'"); 
   }
-  arg1 = reinterpret_cast< std::vector< uint64_t > * >(argp1);
+  arg1 = reinterpret_cast< std::vector< unsigned long > * >(argp1);
   ecode2 = SWIG_AsVal_size_t(obj1, &val2);
   if (!SWIG_IsOK(ecode2)) {
     SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "Uint64Vector_resize" "', argument " "2"" of type '" "size_t""'");
@@ -4950,9 +5303,42 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Uint64Vector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< unsigned long > *arg1 = (std::vector< unsigned long > *) 0 ;
+  std::vector< unsigned long > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:Uint64Vector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_long_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_swap" "', argument " "1"" of type '" "std::vector< unsigned long > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< unsigned long > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_unsigned_long_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Uint64Vector_swap" "', argument " "2"" of type '" "std::vector< unsigned long > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "Uint64Vector_swap" "', argument " "2"" of type '" "std::vector< unsigned long > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< unsigned long > * >(argp2);
+  (arg1)->swap(*arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_delete_Uint64Vector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::vector< uint64_t > *arg1 = (std::vector< uint64_t > *) 0 ;
+  std::vector< unsigned long > *arg1 = (std::vector< unsigned long > *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -4960,9 +5346,9 @@ SWIGINTERN PyObject *_wrap_delete_Uint64Vector(PyObject *SWIGUNUSEDPARM(self), P
   if (!PyArg_ParseTuple(args,(char *)"O:delete_Uint64Vector",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_long_t, SWIG_POINTER_DISOWN |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_Uint64Vector" "', argument " "1"" of type '" "std::vector< uint64_t > *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_Uint64Vector" "', argument " "1"" of type '" "std::vector< unsigned long > *""'"); 
   }
-  arg1 = reinterpret_cast< std::vector< uint64_t > * >(argp1);
+  arg1 = reinterpret_cast< std::vector< unsigned long > * >(argp1);
   delete arg1;
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -5140,6 +5526,39 @@ SWIGINTERN PyObject *_wrap_LongVector_resize(PyObject *SWIGUNUSEDPARM(self), PyO
   } 
   arg2 = static_cast< size_t >(val2);
   (arg1)->resize(arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_LongVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< long > *arg1 = (std::vector< long > *) 0 ;
+  std::vector< long > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:LongVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_long_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "LongVector_swap" "', argument " "1"" of type '" "std::vector< long > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< long > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_long_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "LongVector_swap" "', argument " "2"" of type '" "std::vector< long > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "LongVector_swap" "', argument " "2"" of type '" "std::vector< long > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< long > * >(argp2);
+  (arg1)->swap(*arg2);
   resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
@@ -5344,6 +5763,39 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_IntVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< int > *arg1 = (std::vector< int > *) 0 ;
+  std::vector< int > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IntVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_int_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IntVector_swap" "', argument " "1"" of type '" "std::vector< int > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< int > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_int_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IntVector_swap" "', argument " "2"" of type '" "std::vector< int > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IntVector_swap" "', argument " "2"" of type '" "std::vector< int > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< int > * >(argp2);
+  (arg1)->swap(*arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_delete_IntVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   std::vector< int > *arg1 = (std::vector< int > *) 0 ;
@@ -5534,6 +5986,39 @@ SWIGINTERN PyObject *_wrap_VectorTransformVector_resize(PyObject *SWIGUNUSEDPARM
   } 
   arg2 = static_cast< size_t >(val2);
   (arg1)->resize(arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorTransformVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< faiss::VectorTransform * > *arg1 = (std::vector< faiss::VectorTransform * > *) 0 ;
+  std::vector< faiss::VectorTransform * > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:VectorTransformVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_faiss__VectorTransform_p_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorTransformVector_swap" "', argument " "1"" of type '" "std::vector< faiss::VectorTransform * > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< faiss::VectorTransform * > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_faiss__VectorTransform_p_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorTransformVector_swap" "', argument " "2"" of type '" "std::vector< faiss::VectorTransform * > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorTransformVector_swap" "', argument " "2"" of type '" "std::vector< faiss::VectorTransform * > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< faiss::VectorTransform * > * >(argp2);
+  (arg1)->swap(*arg2);
   resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
@@ -5746,6 +6231,39 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_OperatingPointVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< faiss::OperatingPoint > *arg1 = (std::vector< faiss::OperatingPoint > *) 0 ;
+  std::vector< faiss::OperatingPoint > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:OperatingPointVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_faiss__OperatingPoint_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "OperatingPointVector_swap" "', argument " "1"" of type '" "std::vector< faiss::OperatingPoint > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< faiss::OperatingPoint > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_faiss__OperatingPoint_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "OperatingPointVector_swap" "', argument " "2"" of type '" "std::vector< faiss::OperatingPoint > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "OperatingPointVector_swap" "', argument " "2"" of type '" "std::vector< faiss::OperatingPoint > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< faiss::OperatingPoint > * >(argp2);
+  (arg1)->swap(*arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_delete_OperatingPointVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   std::vector< faiss::OperatingPoint > *arg1 = (std::vector< faiss::OperatingPoint > *) 0 ;
@@ -5936,6 +6454,39 @@ SWIGINTERN PyObject *_wrap_InvertedListsPtrVector_resize(PyObject *SWIGUNUSEDPAR
   } 
   arg2 = static_cast< size_t >(val2);
   (arg1)->resize(arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_InvertedListsPtrVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< faiss::InvertedLists * > *arg1 = (std::vector< faiss::InvertedLists * > *) 0 ;
+  std::vector< faiss::InvertedLists * > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:InvertedListsPtrVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_faiss__InvertedLists_p_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InvertedListsPtrVector_swap" "', argument " "1"" of type '" "std::vector< faiss::InvertedLists * > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< faiss::InvertedLists * > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_faiss__InvertedLists_p_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "InvertedListsPtrVector_swap" "', argument " "2"" of type '" "std::vector< faiss::InvertedLists * > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "InvertedListsPtrVector_swap" "', argument " "2"" of type '" "std::vector< faiss::InvertedLists * > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< faiss::InvertedLists * > * >(argp2);
+  (arg1)->swap(*arg2);
   resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
@@ -6148,6 +6699,39 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_FloatVectorVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< std::vector< float > > *arg1 = (std::vector< std::vector< float > > *) 0 ;
+  std::vector< std::vector< float > > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:FloatVectorVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_std__vectorT_float_t_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "FloatVectorVector_swap" "', argument " "1"" of type '" "std::vector< std::vector< float > > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< std::vector< float > > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_std__vectorT_float_t_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "FloatVectorVector_swap" "', argument " "2"" of type '" "std::vector< std::vector< float > > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "FloatVectorVector_swap" "', argument " "2"" of type '" "std::vector< std::vector< float > > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< std::vector< float > > * >(argp2);
+  (arg1)->swap(*arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_delete_FloatVectorVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   std::vector< std::vector< float > > *arg1 = (std::vector< std::vector< float > > *) 0 ;
@@ -6346,6 +6930,39 @@ SWIGINTERN PyObject *_wrap_ByteVectorVector_resize(PyObject *SWIGUNUSEDPARM(self
   } 
   arg2 = static_cast< size_t >(val2);
   (arg1)->resize(arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_ByteVectorVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< std::vector< unsigned char > > *arg1 = (std::vector< std::vector< unsigned char > > *) 0 ;
+  std::vector< std::vector< unsigned char > > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:ByteVectorVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_std__vectorT_uint8_t_t_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ByteVectorVector_swap" "', argument " "1"" of type '" "std::vector< std::vector< unsigned char > > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< std::vector< unsigned char > > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_std__vectorT_uint8_t_t_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ByteVectorVector_swap" "', argument " "2"" of type '" "std::vector< std::vector< unsigned char > > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "ByteVectorVector_swap" "', argument " "2"" of type '" "std::vector< std::vector< unsigned char > > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< std::vector< unsigned char > > * >(argp2);
+  (arg1)->swap(*arg2);
   resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
@@ -6558,6 +7175,39 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_LongVectorVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< std::vector< long > > *arg1 = (std::vector< std::vector< long > > *) 0 ;
+  std::vector< std::vector< long > > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:LongVectorVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_std__vectorT_long_t_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "LongVectorVector_swap" "', argument " "1"" of type '" "std::vector< std::vector< long > > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< std::vector< long > > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_std__vectorT_long_t_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "LongVectorVector_swap" "', argument " "2"" of type '" "std::vector< std::vector< long > > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "LongVectorVector_swap" "', argument " "2"" of type '" "std::vector< std::vector< long > > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< std::vector< long > > * >(argp2);
+  (arg1)->swap(*arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_delete_LongVectorVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   std::vector< std::vector< long > > *arg1 = (std::vector< std::vector< long > > *) 0 ;
@@ -6755,6 +7405,39 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_GpuResourcesVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< faiss::gpu::GpuResources * > *arg1 = (std::vector< faiss::gpu::GpuResources * > *) 0 ;
+  std::vector< faiss::gpu::GpuResources * > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:GpuResourcesVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_faiss__gpu__GpuResources_p_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "GpuResourcesVector_swap" "', argument " "1"" of type '" "std::vector< faiss::gpu::GpuResources * > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< faiss::gpu::GpuResources * > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_faiss__gpu__GpuResources_p_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "GpuResourcesVector_swap" "', argument " "2"" of type '" "std::vector< faiss::gpu::GpuResources * > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "GpuResourcesVector_swap" "', argument " "2"" of type '" "std::vector< faiss::gpu::GpuResources * > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< faiss::gpu::GpuResources * > * >(argp2);
+  (arg1)->swap(*arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_delete_GpuResourcesVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   std::vector< faiss::gpu::GpuResources * > *arg1 = (std::vector< faiss::gpu::GpuResources * > *) 0 ;
@@ -6782,6 +7465,29 @@ SWIGINTERN PyObject *GpuResourcesVector_swigregister(PyObject *SWIGUNUSEDPARM(se
   SWIG_TypeNewClientData(SWIGTYPE_p_std__vectorT_faiss__gpu__GpuResources_p_t, SWIG_NewClientData(obj));
   return SWIG_Py_Void();
 }
+
+SWIGINTERN int Swig_var_hamming_batch_size_set(PyObject *_val) {
+  {
+    size_t val;
+    int res = SWIG_AsVal_size_t(_val, &val);
+    if (!SWIG_IsOK(res)) {
+      SWIG_exception_fail(SWIG_ArgError(res), "in variable '""faiss::hamming_batch_size""' of type '""size_t""'");
+    }
+    faiss::hamming_batch_size = static_cast< size_t >(val);
+  }
+  return 0;
+fail:
+  return 1;
+}
+
+
+SWIGINTERN PyObject *Swig_var_hamming_batch_size_get(void) {
+  PyObject *pyobj = 0;
+  
+  pyobj = SWIG_From_size_t(static_cast< size_t >(faiss::hamming_batch_size));
+  return pyobj;
+}
+
 
 SWIGINTERN PyObject *_wrap_popcount64(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
@@ -7038,6 +7744,82 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_hammings_knn_hc(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::int_maxheap_array_t *arg1 = (faiss::int_maxheap_array_t *) 0 ;
+  uint8_t *arg2 = (uint8_t *) 0 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  size_t arg4 ;
+  size_t arg5 ;
+  int arg6 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  size_t val4 ;
+  int ecode4 = 0 ;
+  size_t val5 ;
+  int ecode5 = 0 ;
+  int val6 ;
+  int ecode6 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOO:hammings_knn_hc",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__HeapArrayT_faiss__CMaxT_int_long_t_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "hammings_knn_hc" "', argument " "1"" of type '" "faiss::int_maxheap_array_t *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::int_maxheap_array_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "hammings_knn_hc" "', argument " "2"" of type '" "uint8_t const *""'"); 
+  }
+  arg2 = reinterpret_cast< uint8_t * >(argp2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "hammings_knn_hc" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_size_t(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "hammings_knn_hc" "', argument " "4"" of type '" "size_t""'");
+  } 
+  arg4 = static_cast< size_t >(val4);
+  ecode5 = SWIG_AsVal_size_t(obj4, &val5);
+  if (!SWIG_IsOK(ecode5)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "hammings_knn_hc" "', argument " "5"" of type '" "size_t""'");
+  } 
+  arg5 = static_cast< size_t >(val5);
+  ecode6 = SWIG_AsVal_int(obj5, &val6);
+  if (!SWIG_IsOK(ecode6)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "hammings_knn_hc" "', argument " "6"" of type '" "int""'");
+  } 
+  arg6 = static_cast< int >(val6);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      faiss::hammings_knn_hc(arg1,(unsigned char const *)arg2,(unsigned char const *)arg3,arg4,arg5,arg6);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_hammings_knn(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::int_maxheap_array_t *arg1 = (faiss::int_maxheap_array_t *) 0 ;
@@ -7114,59 +7896,86 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_hammings_knn_core(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_hammings_knn_mc(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  faiss::int_maxheap_array_t *arg1 = (faiss::int_maxheap_array_t *) 0 ;
+  uint8_t *arg1 = (uint8_t *) 0 ;
   uint8_t *arg2 = (uint8_t *) 0 ;
-  uint8_t *arg3 = (uint8_t *) 0 ;
+  size_t arg3 ;
   size_t arg4 ;
   size_t arg5 ;
+  size_t arg6 ;
+  int32_t *arg7 = (int32_t *) 0 ;
+  long *arg8 = (long *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 = 0 ;
   int res2 = 0 ;
-  void *argp3 = 0 ;
-  int res3 = 0 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
   size_t val4 ;
   int ecode4 = 0 ;
   size_t val5 ;
   int ecode5 = 0 ;
+  size_t val6 ;
+  int ecode6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
   PyObject * obj3 = 0 ;
   PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
   
-  if (!PyArg_ParseTuple(args,(char *)"OOOOO:hammings_knn_core",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__HeapArrayT_faiss__CMaxT_int_long_t_t, 0 |  0 );
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOO:hammings_knn_mc",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_unsigned_char, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "hammings_knn_core" "', argument " "1"" of type '" "faiss::int_maxheap_array_t *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "hammings_knn_mc" "', argument " "1"" of type '" "uint8_t const *""'"); 
   }
-  arg1 = reinterpret_cast< faiss::int_maxheap_array_t * >(argp1);
+  arg1 = reinterpret_cast< uint8_t * >(argp1);
   res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_unsigned_char, 0 |  0 );
   if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "hammings_knn_core" "', argument " "2"" of type '" "uint8_t const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "hammings_knn_mc" "', argument " "2"" of type '" "uint8_t const *""'"); 
   }
   arg2 = reinterpret_cast< uint8_t * >(argp2);
-  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
-  if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "hammings_knn_core" "', argument " "3"" of type '" "uint8_t const *""'"); 
-  }
-  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "hammings_knn_mc" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
   ecode4 = SWIG_AsVal_size_t(obj3, &val4);
   if (!SWIG_IsOK(ecode4)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "hammings_knn_core" "', argument " "4"" of type '" "size_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "hammings_knn_mc" "', argument " "4"" of type '" "size_t""'");
   } 
   arg4 = static_cast< size_t >(val4);
   ecode5 = SWIG_AsVal_size_t(obj4, &val5);
   if (!SWIG_IsOK(ecode5)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "hammings_knn_core" "', argument " "5"" of type '" "size_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "hammings_knn_mc" "', argument " "5"" of type '" "size_t""'");
   } 
   arg5 = static_cast< size_t >(val5);
+  ecode6 = SWIG_AsVal_size_t(obj5, &val6);
+  if (!SWIG_IsOK(ecode6)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "hammings_knn_mc" "', argument " "6"" of type '" "size_t""'");
+  } 
+  arg6 = static_cast< size_t >(val6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "hammings_knn_mc" "', argument " "7"" of type '" "int32_t *""'"); 
+  }
+  arg7 = reinterpret_cast< int32_t * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "hammings_knn_mc" "', argument " "8"" of type '" "long *""'"); 
+  }
+  arg8 = reinterpret_cast< long * >(argp8);
   {
     Py_BEGIN_ALLOW_THREADS
     try {
-      faiss::hammings_knn_core(arg1,(unsigned char const *)arg2,(unsigned char const *)arg3,arg4,arg5);
+      faiss::hammings_knn_mc((unsigned char const *)arg1,(unsigned char const *)arg2,arg3,arg4,arg5,arg6,arg7,arg8);
     } catch(faiss::FaissException & e) {
       PyEval_RestoreThread(_save);
       PyErr_SetString(PyExc_RuntimeError, e.what());
@@ -10674,7 +11483,7 @@ SWIGINTERN PyObject *GenHammingComputerM8_swigregister(PyObject *SWIGUNUSEDPARM(
   return SWIG_Py_Void();
 }
 
-SWIGINTERN PyObject *_wrap_generalized_hammings_knn__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_generalized_hammings_knn_hc__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::int_maxheap_array_t *arg1 = (faiss::int_maxheap_array_t *) 0 ;
   uint8_t *arg2 = (uint8_t *) 0 ;
@@ -10701,41 +11510,41 @@ SWIGINTERN PyObject *_wrap_generalized_hammings_knn__SWIG_0(PyObject *SWIGUNUSED
   PyObject * obj4 = 0 ;
   PyObject * obj5 = 0 ;
   
-  if (!PyArg_ParseTuple(args,(char *)"OOOOOO:generalized_hammings_knn",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOO:generalized_hammings_knn_hc",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__HeapArrayT_faiss__CMaxT_int_long_t_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "generalized_hammings_knn" "', argument " "1"" of type '" "faiss::int_maxheap_array_t *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "generalized_hammings_knn_hc" "', argument " "1"" of type '" "faiss::int_maxheap_array_t *""'"); 
   }
   arg1 = reinterpret_cast< faiss::int_maxheap_array_t * >(argp1);
   res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_unsigned_char, 0 |  0 );
   if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "generalized_hammings_knn" "', argument " "2"" of type '" "uint8_t const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "generalized_hammings_knn_hc" "', argument " "2"" of type '" "uint8_t const *""'"); 
   }
   arg2 = reinterpret_cast< uint8_t * >(argp2);
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "generalized_hammings_knn" "', argument " "3"" of type '" "uint8_t const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "generalized_hammings_knn_hc" "', argument " "3"" of type '" "uint8_t const *""'"); 
   }
   arg3 = reinterpret_cast< uint8_t * >(argp3);
   ecode4 = SWIG_AsVal_size_t(obj3, &val4);
   if (!SWIG_IsOK(ecode4)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "generalized_hammings_knn" "', argument " "4"" of type '" "size_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "generalized_hammings_knn_hc" "', argument " "4"" of type '" "size_t""'");
   } 
   arg4 = static_cast< size_t >(val4);
   ecode5 = SWIG_AsVal_size_t(obj4, &val5);
   if (!SWIG_IsOK(ecode5)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "generalized_hammings_knn" "', argument " "5"" of type '" "size_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "generalized_hammings_knn_hc" "', argument " "5"" of type '" "size_t""'");
   } 
   arg5 = static_cast< size_t >(val5);
   ecode6 = SWIG_AsVal_int(obj5, &val6);
   if (!SWIG_IsOK(ecode6)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "generalized_hammings_knn" "', argument " "6"" of type '" "int""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "generalized_hammings_knn_hc" "', argument " "6"" of type '" "int""'");
   } 
   arg6 = static_cast< int >(val6);
   {
     Py_BEGIN_ALLOW_THREADS
     try {
-      faiss::generalized_hammings_knn(arg1,(unsigned char const *)arg2,(unsigned char const *)arg3,arg4,arg5,arg6);
+      faiss::generalized_hammings_knn_hc(arg1,(unsigned char const *)arg2,(unsigned char const *)arg3,arg4,arg5,arg6);
     } catch(faiss::FaissException & e) {
       PyEval_RestoreThread(_save);
       PyErr_SetString(PyExc_RuntimeError, e.what());
@@ -10750,7 +11559,7 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_generalized_hammings_knn__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_generalized_hammings_knn_hc__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::int_maxheap_array_t *arg1 = (faiss::int_maxheap_array_t *) 0 ;
   uint8_t *arg2 = (uint8_t *) 0 ;
@@ -10773,36 +11582,36 @@ SWIGINTERN PyObject *_wrap_generalized_hammings_knn__SWIG_1(PyObject *SWIGUNUSED
   PyObject * obj3 = 0 ;
   PyObject * obj4 = 0 ;
   
-  if (!PyArg_ParseTuple(args,(char *)"OOOOO:generalized_hammings_knn",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"OOOOO:generalized_hammings_knn_hc",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__HeapArrayT_faiss__CMaxT_int_long_t_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "generalized_hammings_knn" "', argument " "1"" of type '" "faiss::int_maxheap_array_t *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "generalized_hammings_knn_hc" "', argument " "1"" of type '" "faiss::int_maxheap_array_t *""'"); 
   }
   arg1 = reinterpret_cast< faiss::int_maxheap_array_t * >(argp1);
   res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_unsigned_char, 0 |  0 );
   if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "generalized_hammings_knn" "', argument " "2"" of type '" "uint8_t const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "generalized_hammings_knn_hc" "', argument " "2"" of type '" "uint8_t const *""'"); 
   }
   arg2 = reinterpret_cast< uint8_t * >(argp2);
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "generalized_hammings_knn" "', argument " "3"" of type '" "uint8_t const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "generalized_hammings_knn_hc" "', argument " "3"" of type '" "uint8_t const *""'"); 
   }
   arg3 = reinterpret_cast< uint8_t * >(argp3);
   ecode4 = SWIG_AsVal_size_t(obj3, &val4);
   if (!SWIG_IsOK(ecode4)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "generalized_hammings_knn" "', argument " "4"" of type '" "size_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "generalized_hammings_knn_hc" "', argument " "4"" of type '" "size_t""'");
   } 
   arg4 = static_cast< size_t >(val4);
   ecode5 = SWIG_AsVal_size_t(obj4, &val5);
   if (!SWIG_IsOK(ecode5)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "generalized_hammings_knn" "', argument " "5"" of type '" "size_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "generalized_hammings_knn_hc" "', argument " "5"" of type '" "size_t""'");
   } 
   arg5 = static_cast< size_t >(val5);
   {
     Py_BEGIN_ALLOW_THREADS
     try {
-      faiss::generalized_hammings_knn(arg1,(unsigned char const *)arg2,(unsigned char const *)arg3,arg4,arg5);
+      faiss::generalized_hammings_knn_hc(arg1,(unsigned char const *)arg2,(unsigned char const *)arg3,arg4,arg5);
     } catch(faiss::FaissException & e) {
       PyEval_RestoreThread(_save);
       PyErr_SetString(PyExc_RuntimeError, e.what());
@@ -10817,7 +11626,7 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_generalized_hammings_knn(PyObject *self, PyObject *args) {
+SWIGINTERN PyObject *_wrap_generalized_hammings_knn_hc(PyObject *self, PyObject *args) {
   Py_ssize_t argc;
   PyObject *argv[7] = {
     0
@@ -10853,7 +11662,7 @@ SWIGINTERN PyObject *_wrap_generalized_hammings_knn(PyObject *self, PyObject *ar
               _v = SWIG_CheckState(res);
             }
             if (_v) {
-              return _wrap_generalized_hammings_knn__SWIG_1(self, args);
+              return _wrap_generalized_hammings_knn_hc__SWIG_1(self, args);
             }
           }
         }
@@ -10889,7 +11698,7 @@ SWIGINTERN PyObject *_wrap_generalized_hammings_knn(PyObject *self, PyObject *ar
                 _v = SWIG_CheckState(res);
               }
               if (_v) {
-                return _wrap_generalized_hammings_knn__SWIG_0(self, args);
+                return _wrap_generalized_hammings_knn_hc__SWIG_0(self, args);
               }
             }
           }
@@ -10899,10 +11708,10 @@ SWIGINTERN PyObject *_wrap_generalized_hammings_knn(PyObject *self, PyObject *ar
   }
   
 fail:
-  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'generalized_hammings_knn'.\n"
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'generalized_hammings_knn_hc'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    faiss::generalized_hammings_knn(faiss::int_maxheap_array_t *,uint8_t const *,uint8_t const *,size_t,size_t,int)\n"
-    "    faiss::generalized_hammings_knn(faiss::int_maxheap_array_t *,uint8_t const *,uint8_t const *,size_t,size_t)\n");
+    "    faiss::generalized_hammings_knn_hc(faiss::int_maxheap_array_t *,uint8_t const *,uint8_t const *,size_t,size_t,int)\n"
+    "    faiss::generalized_hammings_knn_hc(faiss::int_maxheap_array_t *,uint8_t const *,uint8_t const *,size_t,size_t)\n");
   return 0;
 }
 
@@ -30896,6 +31705,50 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_IndexPQ_remove_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexPQ *arg1 = (faiss::IndexPQ *) 0 ;
+  faiss::IDSelector *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexPQ_remove_ids",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexPQ, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexPQ_remove_ids" "', argument " "1"" of type '" "faiss::IndexPQ *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexPQ * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_faiss__IDSelector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexPQ_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IndexPQ_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::IDSelector * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (long)(arg1)->remove_ids((faiss::IDSelector const &)*arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_IndexPQ_do_polysemous_training_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::IndexPQ *arg1 = (faiss::IndexPQ *) 0 ;
@@ -31046,50 +31899,6 @@ SWIGINTERN PyObject *_wrap_IndexPQ_search_type_get(PyObject *SWIGUNUSEDPARM(self
   arg1 = reinterpret_cast< faiss::IndexPQ * >(argp1);
   result = (faiss::IndexPQ::Search_type_t) ((arg1)->search_type);
   resultobj = SWIG_From_int(static_cast< int >(result));
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_IndexPQ_remove_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  faiss::IndexPQ *arg1 = (faiss::IndexPQ *) 0 ;
-  faiss::IDSelector *arg2 = 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  long result;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OO:IndexPQ_remove_ids",&obj0,&obj1)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexPQ, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexPQ_remove_ids" "', argument " "1"" of type '" "faiss::IndexPQ *""'"); 
-  }
-  arg1 = reinterpret_cast< faiss::IndexPQ * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_faiss__IDSelector,  0  | 0);
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexPQ_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
-  }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IndexPQ_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
-  }
-  arg2 = reinterpret_cast< faiss::IDSelector * >(argp2);
-  {
-    Py_BEGIN_ALLOW_THREADS
-    try {
-      result = (long)(arg1)->remove_ids((faiss::IDSelector const &)*arg2);
-    } catch(faiss::FaissException & e) {
-      PyEval_RestoreThread(_save);
-      PyErr_SetString(PyExc_RuntimeError, e.what());
-      SWIG_fail;
-    }
-    Py_END_ALLOW_THREADS
-  }
-  resultobj = SWIG_From_long(static_cast< long >(result));
   return resultobj;
 fail:
   return NULL;
@@ -34394,6 +35203,161 @@ SWIGINTERN PyObject *ArrayInvertedLists_swigregister(PyObject *SWIGUNUSEDPARM(se
   return SWIG_Py_Void();
 }
 
+SWIGINTERN PyObject *_wrap_IVFSearchParameters_nprobe_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFSearchParameters *arg1 = (faiss::IVFSearchParameters *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IVFSearchParameters_nprobe_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IVFSearchParameters_nprobe_set" "', argument " "1"" of type '" "faiss::IVFSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFSearchParameters * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IVFSearchParameters_nprobe_set" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  if (arg1) (arg1)->nprobe = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IVFSearchParameters_nprobe_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFSearchParameters *arg1 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IVFSearchParameters_nprobe_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IVFSearchParameters_nprobe_get" "', argument " "1"" of type '" "faiss::IVFSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFSearchParameters * >(argp1);
+  result = (size_t) ((arg1)->nprobe);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IVFSearchParameters_max_codes_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFSearchParameters *arg1 = (faiss::IVFSearchParameters *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IVFSearchParameters_max_codes_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IVFSearchParameters_max_codes_set" "', argument " "1"" of type '" "faiss::IVFSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFSearchParameters * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IVFSearchParameters_max_codes_set" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  if (arg1) (arg1)->max_codes = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IVFSearchParameters_max_codes_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFSearchParameters *arg1 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IVFSearchParameters_max_codes_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IVFSearchParameters_max_codes_get" "', argument " "1"" of type '" "faiss::IVFSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFSearchParameters * >(argp1);
+  result = (size_t) ((arg1)->max_codes);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_IVFSearchParameters(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFSearchParameters *arg1 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_IVFSearchParameters",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFSearchParameters, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IVFSearchParameters" "', argument " "1"" of type '" "faiss::IVFSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFSearchParameters * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      delete arg1;
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IVFSearchParameters(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFSearchParameters *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_IVFSearchParameters")) SWIG_fail;
+  result = (faiss::IVFSearchParameters *)new faiss::IVFSearchParameters();
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IVFSearchParameters, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *IVFSearchParameters_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IVFSearchParameters, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
 SWIGINTERN PyObject *_wrap_IndexIVF_invlists_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::IndexIVF *arg1 = (faiss::IndexIVF *) 0 ;
@@ -34936,7 +35900,119 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_IndexIVF_search_preassigned(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_IndexIVF_search_preassigned__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVF *arg1 = (faiss::IndexIVF *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  faiss::Index::idx_t arg4 ;
+  faiss::Index::idx_t *arg5 = (faiss::Index::idx_t *) 0 ;
+  float *arg6 = (float *) 0 ;
+  float *arg7 = (float *) 0 ;
+  faiss::Index::idx_t *arg8 = (faiss::Index::idx_t *) 0 ;
+  bool arg9 ;
+  faiss::IVFSearchParameters *arg10 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  void *argp10 = 0 ;
+  int res10 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  PyObject * obj9 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOO:IndexIVF_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVF_search_preassigned" "', argument " "1"" of type '" "faiss::IndexIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVF_search_preassigned" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVF_search_preassigned" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexIVF_search_preassigned" "', argument " "4"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::Index::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexIVF_search_preassigned" "', argument " "5"" of type '" "faiss::Index::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::Index::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexIVF_search_preassigned" "', argument " "6"" of type '" "float const *""'"); 
+  }
+  arg6 = reinterpret_cast< float * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexIVF_search_preassigned" "', argument " "7"" of type '" "float *""'"); 
+  }
+  arg7 = reinterpret_cast< float * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexIVF_search_preassigned" "', argument " "8"" of type '" "faiss::Index::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::Index::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexIVF_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  res10 = SWIG_ConvertPtr(obj9, &argp10,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res10)) {
+    SWIG_exception_fail(SWIG_ArgError(res10), "in method '" "IndexIVF_search_preassigned" "', argument " "10"" of type '" "faiss::IVFSearchParameters const *""'"); 
+  }
+  arg10 = reinterpret_cast< faiss::IVFSearchParameters * >(argp10);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVF const *)arg1)->search_preassigned(arg2,(float const *)arg3,arg4,(faiss::Index::idx_t const *)arg5,(float const *)arg6,arg7,arg8,arg9,(faiss::IVFSearchParameters const *)arg10);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVF_search_preassigned__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::IndexIVF *arg1 = (faiss::IndexIVF *) 0 ;
   faiss::Index::idx_t arg2 ;
@@ -35036,6 +36112,137 @@ SWIGINTERN PyObject *_wrap_IndexIVF_search_preassigned(PyObject *SWIGUNUSEDPARM(
   return resultobj;
 fail:
   return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVF_search_preassigned(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[11] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 10) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 9) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVF, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      return _wrap_IndexIVF_search_preassigned__SWIG_1(self, args);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  if (argc == 10) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVF, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      void *vptr = 0;
+                      int res = SWIG_ConvertPtr(argv[9], &vptr, SWIGTYPE_p_faiss__IVFSearchParameters, 0);
+                      _v = SWIG_CheckState(res);
+                      if (_v) {
+                        return _wrap_IndexIVF_search_preassigned__SWIG_0(self, args);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexIVF_search_preassigned'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexIVF::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool,faiss::IVFSearchParameters const *) const\n"
+    "    faiss::IndexIVF::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool) const\n");
+  return 0;
 }
 
 
@@ -38001,7 +39208,119 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_IndexIVFScalarQuantizer_search_preassigned(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_IndexIVFScalarQuantizer_search_preassigned__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFScalarQuantizer *arg1 = (faiss::IndexIVFScalarQuantizer *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  faiss::Index::idx_t arg4 ;
+  faiss::Index::idx_t *arg5 = (faiss::Index::idx_t *) 0 ;
+  float *arg6 = (float *) 0 ;
+  float *arg7 = (float *) 0 ;
+  faiss::Index::idx_t *arg8 = (faiss::Index::idx_t *) 0 ;
+  bool arg9 ;
+  faiss::IVFSearchParameters *arg10 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  void *argp10 = 0 ;
+  int res10 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  PyObject * obj9 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOO:IndexIVFScalarQuantizer_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "1"" of type '" "faiss::IndexIVFScalarQuantizer const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFScalarQuantizer * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "4"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::Index::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "5"" of type '" "faiss::Index::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::Index::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "6"" of type '" "float const *""'"); 
+  }
+  arg6 = reinterpret_cast< float * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "7"" of type '" "float *""'"); 
+  }
+  arg7 = reinterpret_cast< float * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "8"" of type '" "faiss::Index::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::Index::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  res10 = SWIG_ConvertPtr(obj9, &argp10,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res10)) {
+    SWIG_exception_fail(SWIG_ArgError(res10), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "10"" of type '" "faiss::IVFSearchParameters const *""'"); 
+  }
+  arg10 = reinterpret_cast< faiss::IVFSearchParameters * >(argp10);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVFScalarQuantizer const *)arg1)->search_preassigned(arg2,(float const *)arg3,arg4,(faiss::Index::idx_t const *)arg5,(float const *)arg6,arg7,arg8,arg9,(faiss::IVFSearchParameters const *)arg10);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFScalarQuantizer_search_preassigned__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::IndexIVFScalarQuantizer *arg1 = (faiss::IndexIVFScalarQuantizer *) 0 ;
   faiss::Index::idx_t arg2 ;
@@ -38101,6 +39420,137 @@ SWIGINTERN PyObject *_wrap_IndexIVFScalarQuantizer_search_preassigned(PyObject *
   return resultobj;
 fail:
   return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFScalarQuantizer_search_preassigned(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[11] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 10) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 9) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFScalarQuantizer, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      return _wrap_IndexIVFScalarQuantizer_search_preassigned__SWIG_1(self, args);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  if (argc == 10) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFScalarQuantizer, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      void *vptr = 0;
+                      int res = SWIG_ConvertPtr(argv[9], &vptr, SWIGTYPE_p_faiss__IVFSearchParameters, 0);
+                      _v = SWIG_CheckState(res);
+                      if (_v) {
+                        return _wrap_IndexIVFScalarQuantizer_search_preassigned__SWIG_0(self, args);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexIVFScalarQuantizer_search_preassigned'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexIVFScalarQuantizer::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool,faiss::IVFSearchParameters const *) const\n"
+    "    faiss::IndexIVFScalarQuantizer::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool) const\n");
+  return 0;
 }
 
 
@@ -43407,7 +44857,119 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_IndexIVFFlat_search_preassigned(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_IndexIVFFlat_search_preassigned__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlat *arg1 = (faiss::IndexIVFFlat *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  faiss::Index::idx_t arg4 ;
+  faiss::Index::idx_t *arg5 = (faiss::Index::idx_t *) 0 ;
+  float *arg6 = (float *) 0 ;
+  float *arg7 = (float *) 0 ;
+  faiss::Index::idx_t *arg8 = (faiss::Index::idx_t *) 0 ;
+  bool arg9 ;
+  faiss::IVFSearchParameters *arg10 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  void *argp10 = 0 ;
+  int res10 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  PyObject * obj9 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOO:IndexIVFFlat_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "1"" of type '" "faiss::IndexIVFFlat const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlat * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "4"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::Index::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "5"" of type '" "faiss::Index::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::Index::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "6"" of type '" "float const *""'"); 
+  }
+  arg6 = reinterpret_cast< float * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "7"" of type '" "float *""'"); 
+  }
+  arg7 = reinterpret_cast< float * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "8"" of type '" "faiss::Index::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::Index::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  res10 = SWIG_ConvertPtr(obj9, &argp10,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res10)) {
+    SWIG_exception_fail(SWIG_ArgError(res10), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "10"" of type '" "faiss::IVFSearchParameters const *""'"); 
+  }
+  arg10 = reinterpret_cast< faiss::IVFSearchParameters * >(argp10);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVFFlat const *)arg1)->search_preassigned(arg2,(float const *)arg3,arg4,(faiss::Index::idx_t const *)arg5,(float const *)arg6,arg7,arg8,arg9,(faiss::IVFSearchParameters const *)arg10);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlat_search_preassigned__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::IndexIVFFlat *arg1 = (faiss::IndexIVFFlat *) 0 ;
   faiss::Index::idx_t arg2 ;
@@ -43507,6 +45069,137 @@ SWIGINTERN PyObject *_wrap_IndexIVFFlat_search_preassigned(PyObject *SWIGUNUSEDP
   return resultobj;
 fail:
   return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlat_search_preassigned(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[11] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 10) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 9) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFFlat, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      return _wrap_IndexIVFFlat_search_preassigned__SWIG_1(self, args);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  if (argc == 10) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFFlat, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      void *vptr = 0;
+                      int res = SWIG_ConvertPtr(argv[9], &vptr, SWIGTYPE_p_faiss__IVFSearchParameters, 0);
+                      _v = SWIG_CheckState(res);
+                      if (_v) {
+                        return _wrap_IndexIVFFlat_search_preassigned__SWIG_0(self, args);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexIVFFlat_search_preassigned'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexIVFFlat::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool,faiss::IVFSearchParameters const *) const\n"
+    "    faiss::IndexIVFFlat::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool) const\n");
+  return 0;
 }
 
 
@@ -43815,6 +45508,980 @@ SWIGINTERN PyObject *IndexIVFFlat_swigregister(PyObject *SWIGUNUSEDPARM(self), P
   PyObject *obj;
   if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
   SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IndexIVFFlat, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_instances_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t > arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexIVFFlatDedup_instances_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_instances_set" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__unordered_multimapT_long_long_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexIVFFlatDedup_instances_set" "', argument " "2"" of type '" "std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t >""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IndexIVFFlatDedup_instances_set" "', argument " "2"" of type '" "std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t >""'");
+    } else {
+      std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t > * temp = reinterpret_cast< std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t > * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  if (arg1) (arg1)->instances = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_instances_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t > result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexIVFFlatDedup_instances_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_instances_get" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  result =  ((arg1)->instances);
+  resultobj = SWIG_NewPointerObj((new std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t >(static_cast< const std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t >& >(result))), SWIGTYPE_p_std__unordered_multimapT_long_long_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexIVFFlatDedup__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::Index *arg1 = (faiss::Index *) 0 ;
+  size_t arg2 ;
+  size_t arg3 ;
+  faiss::MetricType arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
+  int val4 ;
+  int ecode4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  faiss::IndexIVFFlatDedup *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:new_IndexIVFFlatDedup",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__Index, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_IndexIVFFlatDedup" "', argument " "1"" of type '" "faiss::Index *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::Index * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "new_IndexIVFFlatDedup" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "new_IndexIVFFlatDedup" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  ecode4 = SWIG_AsVal_int(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "new_IndexIVFFlatDedup" "', argument " "4"" of type '" "faiss::MetricType""'");
+  } 
+  arg4 = static_cast< faiss::MetricType >(val4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexIVFFlatDedup *)new faiss::IndexIVFFlatDedup(arg1,arg2,arg3,arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IndexIVFFlatDedup, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexIVFFlatDedup__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::Index *arg1 = (faiss::Index *) 0 ;
+  size_t arg2 ;
+  size_t arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  faiss::IndexIVFFlatDedup *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:new_IndexIVFFlatDedup",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__Index, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_IndexIVFFlatDedup" "', argument " "1"" of type '" "faiss::Index *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::Index * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "new_IndexIVFFlatDedup" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "new_IndexIVFFlatDedup" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexIVFFlatDedup *)new faiss::IndexIVFFlatDedup(arg1,arg2,arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IndexIVFFlatDedup, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_train(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexIVFFlatDedup_train",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_train" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFFlatDedup_train" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFFlatDedup_train" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->train(arg2,(float const *)arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_add_with_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  long *arg4 = (long *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexIVFFlatDedup_add_with_ids",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_add_with_ids" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFFlatDedup_add_with_ids" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFFlatDedup_add_with_ids" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexIVFFlatDedup_add_with_ids" "', argument " "4"" of type '" "long const *""'"); 
+  }
+  arg4 = reinterpret_cast< long * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->add_with_ids(arg2,(float const *)arg3,(long const *)arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_search_preassigned__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  faiss::Index::idx_t arg4 ;
+  faiss::Index::idx_t *arg5 = (faiss::Index::idx_t *) 0 ;
+  float *arg6 = (float *) 0 ;
+  float *arg7 = (float *) 0 ;
+  faiss::Index::idx_t *arg8 = (faiss::Index::idx_t *) 0 ;
+  bool arg9 ;
+  faiss::IVFSearchParameters *arg10 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  void *argp10 = 0 ;
+  int res10 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  PyObject * obj9 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOO:IndexIVFFlatDedup_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "4"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::Index::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "5"" of type '" "faiss::Index::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::Index::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "6"" of type '" "float const *""'"); 
+  }
+  arg6 = reinterpret_cast< float * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "7"" of type '" "float *""'"); 
+  }
+  arg7 = reinterpret_cast< float * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "8"" of type '" "faiss::Index::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::Index::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  res10 = SWIG_ConvertPtr(obj9, &argp10,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res10)) {
+    SWIG_exception_fail(SWIG_ArgError(res10), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "10"" of type '" "faiss::IVFSearchParameters const *""'"); 
+  }
+  arg10 = reinterpret_cast< faiss::IVFSearchParameters * >(argp10);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVFFlatDedup const *)arg1)->search_preassigned(arg2,(float const *)arg3,arg4,(faiss::Index::idx_t const *)arg5,(float const *)arg6,arg7,arg8,arg9,(faiss::IVFSearchParameters const *)arg10);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_search_preassigned__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  faiss::Index::idx_t arg4 ;
+  faiss::Index::idx_t *arg5 = (faiss::Index::idx_t *) 0 ;
+  float *arg6 = (float *) 0 ;
+  float *arg7 = (float *) 0 ;
+  faiss::Index::idx_t *arg8 = (faiss::Index::idx_t *) 0 ;
+  bool arg9 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOO:IndexIVFFlatDedup_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "4"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::Index::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "5"" of type '" "faiss::Index::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::Index::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "6"" of type '" "float const *""'"); 
+  }
+  arg6 = reinterpret_cast< float * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "7"" of type '" "float *""'"); 
+  }
+  arg7 = reinterpret_cast< float * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "8"" of type '" "faiss::Index::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::Index::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVFFlatDedup const *)arg1)->search_preassigned(arg2,(float const *)arg3,arg4,(faiss::Index::idx_t const *)arg5,(float const *)arg6,arg7,arg8,arg9);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_search_preassigned(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[11] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 10) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 9) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      return _wrap_IndexIVFFlatDedup_search_preassigned__SWIG_1(self, args);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  if (argc == 10) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      void *vptr = 0;
+                      int res = SWIG_ConvertPtr(argv[9], &vptr, SWIGTYPE_p_faiss__IVFSearchParameters, 0);
+                      _v = SWIG_CheckState(res);
+                      if (_v) {
+                        return _wrap_IndexIVFFlatDedup_search_preassigned__SWIG_0(self, args);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexIVFFlatDedup_search_preassigned'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexIVFFlatDedup::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool,faiss::IVFSearchParameters const *) const\n"
+    "    faiss::IndexIVFFlatDedup::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool) const\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_remove_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  faiss::IDSelector *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexIVFFlatDedup_remove_ids",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_remove_ids" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_faiss__IDSelector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexIVFFlatDedup_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IndexIVFFlatDedup_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::IDSelector * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (long)(arg1)->remove_ids((faiss::IDSelector const &)*arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_range_search(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  float arg4 ;
+  faiss::RangeSearchResult *arg5 = (faiss::RangeSearchResult *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  float val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOO:IndexIVFFlatDedup_range_search",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_range_search" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFFlatDedup_range_search" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFFlatDedup_range_search" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  ecode4 = SWIG_AsVal_float(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexIVFFlatDedup_range_search" "', argument " "4"" of type '" "float""'");
+  } 
+  arg4 = static_cast< float >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_faiss__RangeSearchResult, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexIVFFlatDedup_range_search" "', argument " "5"" of type '" "faiss::RangeSearchResult *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::RangeSearchResult * >(argp5);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVFFlatDedup const *)arg1)->range_search(arg2,(float const *)arg3,arg4,arg5);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_update_vectors(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  int arg2 ;
+  faiss::Index::idx_t *arg3 = (faiss::Index::idx_t *) 0 ;
+  float *arg4 = (float *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexIVFFlatDedup_update_vectors",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_update_vectors" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFFlatDedup_update_vectors" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFFlatDedup_update_vectors" "', argument " "3"" of type '" "faiss::Index::idx_t *""'"); 
+  }
+  arg3 = reinterpret_cast< faiss::Index::idx_t * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexIVFFlatDedup_update_vectors" "', argument " "4"" of type '" "float const *""'"); 
+  }
+  arg4 = reinterpret_cast< float * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->update_vectors(arg2,arg3,(float const *)arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_reconstruct_from_offset(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  long arg2 ;
+  long arg3 ;
+  float *arg4 = (float *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  long val3 ;
+  int ecode3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexIVFFlatDedup_reconstruct_from_offset",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_reconstruct_from_offset" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFFlatDedup_reconstruct_from_offset" "', argument " "2"" of type '" "long""'");
+  } 
+  arg2 = static_cast< long >(val2);
+  ecode3 = SWIG_AsVal_long(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IndexIVFFlatDedup_reconstruct_from_offset" "', argument " "3"" of type '" "long""'");
+  } 
+  arg3 = static_cast< long >(val3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexIVFFlatDedup_reconstruct_from_offset" "', argument " "4"" of type '" "float *""'"); 
+  }
+  arg4 = reinterpret_cast< float * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVFFlatDedup const *)arg1)->reconstruct_from_offset(arg2,arg3,arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexIVFFlatDedup__SWIG_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_IndexIVFFlatDedup")) SWIG_fail;
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexIVFFlatDedup *)new faiss::IndexIVFFlatDedup();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IndexIVFFlatDedup, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexIVFFlatDedup(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[5] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 4) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 0) {
+    return _wrap_new_IndexIVFFlatDedup__SWIG_2(self, args);
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__Index, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_size_t(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_size_t(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          return _wrap_new_IndexIVFFlatDedup__SWIG_1(self, args);
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__Index, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_size_t(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_size_t(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          {
+            int res = SWIG_AsVal_int(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            return _wrap_new_IndexIVFFlatDedup__SWIG_0(self, args);
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'new_IndexIVFFlatDedup'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexIVFFlatDedup::IndexIVFFlatDedup(faiss::Index *,size_t,size_t,faiss::MetricType)\n"
+    "    faiss::IndexIVFFlatDedup::IndexIVFFlatDedup(faiss::Index *,size_t,size_t)\n"
+    "    faiss::IndexIVFFlatDedup::IndexIVFFlatDedup()\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_IndexIVFFlatDedup(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_IndexIVFFlatDedup",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IndexIVFFlatDedup" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  delete arg1;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *IndexIVFFlatDedup_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IndexIVFFlatDedup, SWIG_NewClientData(obj));
   return SWIG_Py_Void();
 }
 
@@ -45022,6 +47689,161 @@ SWIGINTERN PyObject *OnDiskInvertedLists_swigregister(PyObject *SWIGUNUSEDPARM(s
   PyObject *obj;
   if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
   SWIG_TypeNewClientData(SWIGTYPE_p_faiss__OnDiskInvertedLists, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_IVFPQSearchParameters_scan_table_threshold_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFPQSearchParameters *arg1 = (faiss::IVFPQSearchParameters *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IVFPQSearchParameters_scan_table_threshold_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFPQSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IVFPQSearchParameters_scan_table_threshold_set" "', argument " "1"" of type '" "faiss::IVFPQSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFPQSearchParameters * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IVFPQSearchParameters_scan_table_threshold_set" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  if (arg1) (arg1)->scan_table_threshold = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IVFPQSearchParameters_scan_table_threshold_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFPQSearchParameters *arg1 = (faiss::IVFPQSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IVFPQSearchParameters_scan_table_threshold_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFPQSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IVFPQSearchParameters_scan_table_threshold_get" "', argument " "1"" of type '" "faiss::IVFPQSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFPQSearchParameters * >(argp1);
+  result = (size_t) ((arg1)->scan_table_threshold);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IVFPQSearchParameters_polysemous_ht_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFPQSearchParameters *arg1 = (faiss::IVFPQSearchParameters *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IVFPQSearchParameters_polysemous_ht_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFPQSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IVFPQSearchParameters_polysemous_ht_set" "', argument " "1"" of type '" "faiss::IVFPQSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFPQSearchParameters * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IVFPQSearchParameters_polysemous_ht_set" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  if (arg1) (arg1)->polysemous_ht = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IVFPQSearchParameters_polysemous_ht_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFPQSearchParameters *arg1 = (faiss::IVFPQSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  int result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IVFPQSearchParameters_polysemous_ht_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFPQSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IVFPQSearchParameters_polysemous_ht_get" "', argument " "1"" of type '" "faiss::IVFPQSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFPQSearchParameters * >(argp1);
+  result = (int) ((arg1)->polysemous_ht);
+  resultobj = SWIG_From_int(static_cast< int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_IVFPQSearchParameters(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFPQSearchParameters *arg1 = (faiss::IVFPQSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_IVFPQSearchParameters",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFPQSearchParameters, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IVFPQSearchParameters" "', argument " "1"" of type '" "faiss::IVFPQSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFPQSearchParameters * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      delete arg1;
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IVFPQSearchParameters(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFPQSearchParameters *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_IVFPQSearchParameters")) SWIG_fail;
+  result = (faiss::IVFPQSearchParameters *)new faiss::IVFPQSearchParameters();
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IVFPQSearchParameters, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *IVFPQSearchParameters_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IVFPQSearchParameters, SWIG_NewClientData(obj));
   return SWIG_Py_Void();
 }
 
@@ -46484,7 +49306,119 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_IndexIVFPQ_search_preassigned(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_IndexIVFPQ_search_preassigned__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFPQ *arg1 = (faiss::IndexIVFPQ *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  faiss::Index::idx_t arg4 ;
+  faiss::Index::idx_t *arg5 = (faiss::Index::idx_t *) 0 ;
+  float *arg6 = (float *) 0 ;
+  float *arg7 = (float *) 0 ;
+  faiss::Index::idx_t *arg8 = (faiss::Index::idx_t *) 0 ;
+  bool arg9 ;
+  faiss::IVFSearchParameters *arg10 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  void *argp10 = 0 ;
+  int res10 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  PyObject * obj9 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOO:IndexIVFPQ_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFPQ, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "1"" of type '" "faiss::IndexIVFPQ const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFPQ * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "4"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::Index::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "5"" of type '" "faiss::Index::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::Index::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "6"" of type '" "float const *""'"); 
+  }
+  arg6 = reinterpret_cast< float * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "7"" of type '" "float *""'"); 
+  }
+  arg7 = reinterpret_cast< float * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "8"" of type '" "faiss::Index::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::Index::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  res10 = SWIG_ConvertPtr(obj9, &argp10,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res10)) {
+    SWIG_exception_fail(SWIG_ArgError(res10), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "10"" of type '" "faiss::IVFSearchParameters const *""'"); 
+  }
+  arg10 = reinterpret_cast< faiss::IVFSearchParameters * >(argp10);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVFPQ const *)arg1)->search_preassigned(arg2,(float const *)arg3,arg4,(faiss::Index::idx_t const *)arg5,(float const *)arg6,arg7,arg8,arg9,(faiss::IVFSearchParameters const *)arg10);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFPQ_search_preassigned__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::IndexIVFPQ *arg1 = (faiss::IndexIVFPQ *) 0 ;
   faiss::Index::idx_t arg2 ;
@@ -46584,6 +49518,137 @@ SWIGINTERN PyObject *_wrap_IndexIVFPQ_search_preassigned(PyObject *SWIGUNUSEDPAR
   return resultobj;
 fail:
   return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFPQ_search_preassigned(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[11] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 10) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 9) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFPQ, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      return _wrap_IndexIVFPQ_search_preassigned__SWIG_1(self, args);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  if (argc == 10) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFPQ, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      void *vptr = 0;
+                      int res = SWIG_ConvertPtr(argv[9], &vptr, SWIGTYPE_p_faiss__IVFSearchParameters, 0);
+                      _v = SWIG_CheckState(res);
+                      if (_v) {
+                        return _wrap_IndexIVFPQ_search_preassigned__SWIG_0(self, args);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexIVFPQ_search_preassigned'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexIVFPQ::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool,faiss::IVFSearchParameters const *) const\n"
+    "    faiss::IndexIVFPQ::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool) const\n");
+  return 0;
 }
 
 
@@ -48199,7 +51264,119 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_IndexIVFPQR_search_preassigned(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_IndexIVFPQR_search_preassigned__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFPQR *arg1 = (faiss::IndexIVFPQR *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  faiss::Index::idx_t arg4 ;
+  faiss::Index::idx_t *arg5 = (faiss::Index::idx_t *) 0 ;
+  float *arg6 = (float *) 0 ;
+  float *arg7 = (float *) 0 ;
+  faiss::Index::idx_t *arg8 = (faiss::Index::idx_t *) 0 ;
+  bool arg9 ;
+  faiss::IVFSearchParameters *arg10 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  void *argp10 = 0 ;
+  int res10 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  PyObject * obj9 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOO:IndexIVFPQR_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFPQR, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "1"" of type '" "faiss::IndexIVFPQR const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFPQR * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "4"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::Index::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "5"" of type '" "faiss::Index::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::Index::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "6"" of type '" "float const *""'"); 
+  }
+  arg6 = reinterpret_cast< float * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "7"" of type '" "float *""'"); 
+  }
+  arg7 = reinterpret_cast< float * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "8"" of type '" "faiss::Index::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::Index::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  res10 = SWIG_ConvertPtr(obj9, &argp10,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res10)) {
+    SWIG_exception_fail(SWIG_ArgError(res10), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "10"" of type '" "faiss::IVFSearchParameters const *""'"); 
+  }
+  arg10 = reinterpret_cast< faiss::IVFSearchParameters * >(argp10);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVFPQR const *)arg1)->search_preassigned(arg2,(float const *)arg3,arg4,(faiss::Index::idx_t const *)arg5,(float const *)arg6,arg7,arg8,arg9,(faiss::IVFSearchParameters const *)arg10);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFPQR_search_preassigned__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::IndexIVFPQR *arg1 = (faiss::IndexIVFPQR *) 0 ;
   faiss::Index::idx_t arg2 ;
@@ -48299,6 +51476,137 @@ SWIGINTERN PyObject *_wrap_IndexIVFPQR_search_preassigned(PyObject *SWIGUNUSEDPA
   return resultobj;
 fail:
   return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFPQR_search_preassigned(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[11] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 10) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 9) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFPQR, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      return _wrap_IndexIVFPQR_search_preassigned__SWIG_1(self, args);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  if (argc == 10) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFPQR, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      void *vptr = 0;
+                      int res = SWIG_ConvertPtr(argv[9], &vptr, SWIGTYPE_p_faiss__IVFSearchParameters, 0);
+                      _v = SWIG_CheckState(res);
+                      if (_v) {
+                        return _wrap_IndexIVFPQR_search_preassigned__SWIG_0(self, args);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexIVFPQR_search_preassigned'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexIVFPQR::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool,faiss::IVFSearchParameters const *) const\n"
+    "    faiss::IndexIVFPQR::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool) const\n");
+  return 0;
 }
 
 
@@ -49331,6 +52639,3854 @@ SWIGINTERN PyObject *Index2Layer_swigregister(PyObject *SWIGUNUSEDPARM(self), Py
   PyObject *obj;
   if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
   SWIG_TypeNewClientData(SWIGTYPE_p_faiss__Index2Layer, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_IndexBinary_d_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinary_d_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_d_set" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_d_set" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  if (arg1) (arg1)->d = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_d_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  int result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinary_d_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_d_get" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  result = (int) ((arg1)->d);
+  resultobj = SWIG_From_int(static_cast< int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_code_size_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinary_code_size_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_code_size_set" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_code_size_set" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  if (arg1) (arg1)->code_size = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_code_size_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  int result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinary_code_size_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_code_size_get" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  result = (int) ((arg1)->code_size);
+  resultobj = SWIG_From_int(static_cast< int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_ntotal_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinary_ntotal_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_ntotal_set" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_ntotal_set" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  if (arg1) (arg1)->ntotal = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_ntotal_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::IndexBinary::idx_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinary_ntotal_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_ntotal_get" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  result = (faiss::IndexBinary::idx_t) ((arg1)->ntotal);
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_verbose_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinary_verbose_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_verbose_set" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_bool(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_verbose_set" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  if (arg1) (arg1)->verbose = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_verbose_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  bool result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinary_verbose_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_verbose_get" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  result = (bool) ((arg1)->verbose);
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_is_trained_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinary_is_trained_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_is_trained_set" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_bool(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_is_trained_set" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  if (arg1) (arg1)->is_trained = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_is_trained_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  bool result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinary_is_trained_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_is_trained_get" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  result = (bool) ((arg1)->is_trained);
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_metric_type_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::MetricType arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinary_metric_type_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_metric_type_set" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_metric_type_set" "', argument " "2"" of type '" "faiss::MetricType""'");
+  } 
+  arg2 = static_cast< faiss::MetricType >(val2);
+  if (arg1) (arg1)->metric_type = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_metric_type_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::MetricType result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinary_metric_type_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_metric_type_get" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  result = (faiss::MetricType) ((arg1)->metric_type);
+  resultobj = SWIG_From_int(static_cast< int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_IndexBinary(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_IndexBinary",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IndexBinary" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      delete arg1;
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_train(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinary_train",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_train" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_train" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_train" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->train(arg2,(uint8_t const *)arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_add(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinary_add",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_add" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_add" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_add" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->add(arg2,(uint8_t const *)arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_add_with_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  long *arg4 = (long *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexBinary_add_with_ids",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_add_with_ids" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_add_with_ids" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_add_with_ids" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexBinary_add_with_ids" "', argument " "4"" of type '" "long const *""'"); 
+  }
+  arg4 = reinterpret_cast< long * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->add_with_ids(arg2,(uint8_t const *)arg3,(long const *)arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_search(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t arg4 ;
+  int32_t *arg5 = (int32_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg6 = (faiss::IndexBinary::idx_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOO:IndexBinary_search",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_search" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_search" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_search" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinary_search" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::IndexBinary::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinary_search" "', argument " "5"" of type '" "int32_t *""'"); 
+  }
+  arg5 = reinterpret_cast< int32_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexBinary_search" "', argument " "6"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg6 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp6);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinary const *)arg1)->search(arg2,(uint8_t const *)arg3,arg4,arg5,arg6);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_range_search(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  int arg4 ;
+  faiss::RangeSearchResult *arg5 = (faiss::RangeSearchResult *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  int val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOO:IndexBinary_range_search",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_range_search" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_range_search" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_range_search" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_int(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinary_range_search" "', argument " "4"" of type '" "int""'");
+  } 
+  arg4 = static_cast< int >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_faiss__RangeSearchResult, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinary_range_search" "', argument " "5"" of type '" "faiss::RangeSearchResult *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::RangeSearchResult * >(argp5);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinary const *)arg1)->range_search(arg2,(uint8_t const *)arg3,arg4,arg5);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_assign__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg4 = (faiss::IndexBinary::idx_t *) 0 ;
+  faiss::IndexBinary::idx_t arg5 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  long val5 ;
+  int ecode5 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOO:IndexBinary_assign",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_assign" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_assign" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_assign" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexBinary_assign" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg4 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp4);
+  ecode5 = SWIG_AsVal_long(obj4, &val5);
+  if (!SWIG_IsOK(ecode5)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "IndexBinary_assign" "', argument " "5"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg5 = static_cast< faiss::IndexBinary::idx_t >(val5);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->assign(arg2,(uint8_t const *)arg3,arg4,arg5);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_assign__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg4 = (faiss::IndexBinary::idx_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexBinary_assign",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_assign" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_assign" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_assign" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexBinary_assign" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg4 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->assign(arg2,(uint8_t const *)arg3,arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_assign(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[6] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 5) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 4) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinary, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_unsigned_char, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          void *vptr = 0;
+          int res = SWIG_ConvertPtr(argv[3], &vptr, SWIGTYPE_p_long, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            return _wrap_IndexBinary_assign__SWIG_1(self, args);
+          }
+        }
+      }
+    }
+  }
+  if (argc == 5) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinary, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_unsigned_char, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          void *vptr = 0;
+          int res = SWIG_ConvertPtr(argv[3], &vptr, SWIGTYPE_p_long, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            {
+              int res = SWIG_AsVal_long(argv[4], NULL);
+              _v = SWIG_CheckState(res);
+            }
+            if (_v) {
+              return _wrap_IndexBinary_assign__SWIG_0(self, args);
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexBinary_assign'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexBinary::assign(faiss::IndexBinary::idx_t,uint8_t const *,faiss::IndexBinary::idx_t *,faiss::IndexBinary::idx_t)\n"
+    "    faiss::IndexBinary::assign(faiss::IndexBinary::idx_t,uint8_t const *,faiss::IndexBinary::idx_t *)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_reset(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinary_reset",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_reset" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->reset();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_remove_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IDSelector *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinary_remove_ids",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_remove_ids" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_faiss__IDSelector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinary_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IndexBinary_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::IDSelector * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (long)(arg1)->remove_ids((faiss::IDSelector const &)*arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_reconstruct(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinary_reconstruct",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_reconstruct" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_reconstruct" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_reconstruct" "', argument " "3"" of type '" "uint8_t *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinary const *)arg1)->reconstruct(arg2,arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_reconstruct_n(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  faiss::IndexBinary::idx_t arg3 ;
+  uint8_t *arg4 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  long val3 ;
+  int ecode3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexBinary_reconstruct_n",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_reconstruct_n" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_reconstruct_n" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  ecode3 = SWIG_AsVal_long(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IndexBinary_reconstruct_n" "', argument " "3"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg3 = static_cast< faiss::IndexBinary::idx_t >(val3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexBinary_reconstruct_n" "', argument " "4"" of type '" "uint8_t *""'"); 
+  }
+  arg4 = reinterpret_cast< uint8_t * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinary const *)arg1)->reconstruct_n(arg2,arg3,arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_search_and_reconstruct(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t arg4 ;
+  int32_t *arg5 = (int32_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg6 = (faiss::IndexBinary::idx_t *) 0 ;
+  uint8_t *arg7 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOO:IndexBinary_search_and_reconstruct",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_search_and_reconstruct" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_search_and_reconstruct" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_search_and_reconstruct" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinary_search_and_reconstruct" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::IndexBinary::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinary_search_and_reconstruct" "', argument " "5"" of type '" "int32_t *""'"); 
+  }
+  arg5 = reinterpret_cast< int32_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexBinary_search_and_reconstruct" "', argument " "6"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg6 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexBinary_search_and_reconstruct" "', argument " "7"" of type '" "uint8_t *""'"); 
+  }
+  arg7 = reinterpret_cast< uint8_t * >(argp7);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinary const *)arg1)->search_and_reconstruct(arg2,(uint8_t const *)arg3,arg4,arg5,arg6,arg7);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_display(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinary_display",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_display" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinary const *)arg1)->display();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *IndexBinary_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IndexBinary, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_xb_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  std::vector< uint8_t > *arg2 = (std::vector< uint8_t > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryFlat_xb_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_xb_set" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_std__vectorT_unsigned_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryFlat_xb_set" "', argument " "2"" of type '" "std::vector< uint8_t > *""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< uint8_t > * >(argp2);
+  if (arg1) (arg1)->xb = *arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_xb_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  std::vector< uint8_t > *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryFlat_xb_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_xb_get" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  result = (std::vector< uint8_t > *)& ((arg1)->xb);
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_unsigned_char_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_use_heap_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryFlat_use_heap_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_use_heap_set" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  ecode2 = SWIG_AsVal_bool(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryFlat_use_heap_set" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  if (arg1) (arg1)->use_heap = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_use_heap_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  bool result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryFlat_use_heap_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_use_heap_get" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  result = (bool) ((arg1)->use_heap);
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_query_batch_size_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryFlat_query_batch_size_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_query_batch_size_set" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryFlat_query_batch_size_set" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  if (arg1) (arg1)->query_batch_size = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_query_batch_size_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryFlat_query_batch_size_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_query_batch_size_get" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  result = (size_t) ((arg1)->query_batch_size);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexBinaryFlat__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary::idx_t arg1 ;
+  long val1 ;
+  int ecode1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::IndexBinaryFlat *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:new_IndexBinaryFlat",&obj0)) SWIG_fail;
+  ecode1 = SWIG_AsVal_long(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "new_IndexBinaryFlat" "', argument " "1"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg1 = static_cast< faiss::IndexBinary::idx_t >(val1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinaryFlat *)new faiss::IndexBinaryFlat(arg1);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IndexBinaryFlat, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_add(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinaryFlat_add",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_add" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryFlat_add" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryFlat_add" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->add(arg2,(uint8_t const *)arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_reset(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryFlat_reset",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_reset" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->reset();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_search(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t arg4 ;
+  int32_t *arg5 = (int32_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg6 = (faiss::IndexBinary::idx_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOO:IndexBinaryFlat_search",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_search" "', argument " "1"" of type '" "faiss::IndexBinaryFlat const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryFlat_search" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryFlat_search" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinaryFlat_search" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::IndexBinary::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinaryFlat_search" "', argument " "5"" of type '" "int32_t *""'"); 
+  }
+  arg5 = reinterpret_cast< int32_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexBinaryFlat_search" "', argument " "6"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg6 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp6);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryFlat const *)arg1)->search(arg2,(uint8_t const *)arg3,arg4,arg5,arg6);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_reconstruct(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinaryFlat_reconstruct",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_reconstruct" "', argument " "1"" of type '" "faiss::IndexBinaryFlat const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryFlat_reconstruct" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryFlat_reconstruct" "', argument " "3"" of type '" "uint8_t *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryFlat const *)arg1)->reconstruct(arg2,arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_remove_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  faiss::IDSelector *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryFlat_remove_ids",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_remove_ids" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_faiss__IDSelector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryFlat_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IndexBinaryFlat_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::IDSelector * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (long)(arg1)->remove_ids((faiss::IDSelector const &)*arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexBinaryFlat__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_IndexBinaryFlat")) SWIG_fail;
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinaryFlat *)new faiss::IndexBinaryFlat();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IndexBinaryFlat, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexBinaryFlat(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[2] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 1) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 0) {
+    return _wrap_new_IndexBinaryFlat__SWIG_1(self, args);
+  }
+  if (argc == 1) {
+    int _v;
+    {
+      int res = SWIG_AsVal_long(argv[0], NULL);
+      _v = SWIG_CheckState(res);
+    }
+    if (_v) {
+      return _wrap_new_IndexBinaryFlat__SWIG_0(self, args);
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'new_IndexBinaryFlat'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexBinaryFlat::IndexBinaryFlat(faiss::IndexBinary::idx_t)\n"
+    "    faiss::IndexBinaryFlat::IndexBinaryFlat()\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_IndexBinaryFlat(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_IndexBinaryFlat",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IndexBinaryFlat" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  delete arg1;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *IndexBinaryFlat_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IndexBinaryFlat, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_invlists_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::InvertedLists *arg2 = (faiss::InvertedLists *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_invlists_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_invlists_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_faiss__InvertedLists, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryIVF_invlists_set" "', argument " "2"" of type '" "faiss::InvertedLists *""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::InvertedLists * >(argp2);
+  if (arg1) (arg1)->invlists = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_invlists_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::InvertedLists *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_invlists_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_invlists_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (faiss::InvertedLists *) ((arg1)->invlists);
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__InvertedLists, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_own_invlists_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_own_invlists_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_own_invlists_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_bool(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_own_invlists_set" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  if (arg1) (arg1)->own_invlists = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_own_invlists_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  bool result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_own_invlists_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_own_invlists_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (bool) ((arg1)->own_invlists);
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_nprobe_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_nprobe_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_nprobe_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_nprobe_set" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  if (arg1) (arg1)->nprobe = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_nprobe_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_nprobe_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_nprobe_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (size_t) ((arg1)->nprobe);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_max_codes_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_max_codes_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_max_codes_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_max_codes_set" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  if (arg1) (arg1)->max_codes = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_max_codes_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_max_codes_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_max_codes_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (size_t) ((arg1)->max_codes);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_use_heap_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_use_heap_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_use_heap_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_bool(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_use_heap_set" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  if (arg1) (arg1)->use_heap = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_use_heap_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  bool result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_use_heap_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_use_heap_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (bool) ((arg1)->use_heap);
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_maintain_direct_map_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_maintain_direct_map_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_maintain_direct_map_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_bool(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_maintain_direct_map_set" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  if (arg1) (arg1)->maintain_direct_map = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_maintain_direct_map_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  bool result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_maintain_direct_map_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_maintain_direct_map_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (bool) ((arg1)->maintain_direct_map);
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_direct_map_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  std::vector< long > *arg2 = (std::vector< long > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_direct_map_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_direct_map_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_std__vectorT_long_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryIVF_direct_map_set" "', argument " "2"" of type '" "std::vector< long > *""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< long > * >(argp2);
+  if (arg1) (arg1)->direct_map = *arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_direct_map_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  std::vector< long > *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_direct_map_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_direct_map_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (std::vector< long > *)& ((arg1)->direct_map);
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_long_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_quantizer_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary *arg2 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_quantizer_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_quantizer_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_faiss__IndexBinary, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryIVF_quantizer_set" "', argument " "2"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::IndexBinary * >(argp2);
+  if (arg1) (arg1)->quantizer = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_quantizer_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::IndexBinary *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_quantizer_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_quantizer_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (faiss::IndexBinary *) ((arg1)->quantizer);
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_nlist_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_nlist_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_nlist_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_nlist_set" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  if (arg1) (arg1)->nlist = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_nlist_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_nlist_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_nlist_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (size_t) ((arg1)->nlist);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_own_fields_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_own_fields_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_own_fields_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_bool(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_own_fields_set" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  if (arg1) (arg1)->own_fields = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_own_fields_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  bool result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_own_fields_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_own_fields_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (bool) ((arg1)->own_fields);
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_cp_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::ClusteringParameters *arg2 = (faiss::ClusteringParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_cp_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_cp_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_faiss__ClusteringParameters, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryIVF_cp_set" "', argument " "2"" of type '" "faiss::ClusteringParameters *""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::ClusteringParameters * >(argp2);
+  if (arg1) (arg1)->cp = *arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_cp_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::ClusteringParameters *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_cp_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_cp_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (faiss::ClusteringParameters *)& ((arg1)->cp);
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__ClusteringParameters, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_train_q1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  size_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  bool arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  bool val4 ;
+  int ecode4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexBinaryIVF_train_q1",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_train_q1" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_train_q1" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_train_q1" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_bool(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinaryIVF_train_q1" "', argument " "4"" of type '" "bool""'");
+  } 
+  arg4 = static_cast< bool >(val4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->train_q1(arg2,(uint8_t const *)arg3,arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexBinaryIVF__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  size_t arg2 ;
+  size_t arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  faiss::IndexBinaryIVF *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:new_IndexBinaryIVF",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_IndexBinaryIVF" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "new_IndexBinaryIVF" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "new_IndexBinaryIVF" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinaryIVF *)new faiss::IndexBinaryIVF(arg1,arg2,arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IndexBinaryIVF, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexBinaryIVF__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_IndexBinaryIVF")) SWIG_fail;
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinaryIVF *)new faiss::IndexBinaryIVF();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IndexBinaryIVF, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexBinaryIVF(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[4] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 3) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 0) {
+    return _wrap_new_IndexBinaryIVF__SWIG_1(self, args);
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinary, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_size_t(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_size_t(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          return _wrap_new_IndexBinaryIVF__SWIG_0(self, args);
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'new_IndexBinaryIVF'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexBinaryIVF::IndexBinaryIVF(faiss::IndexBinary *,size_t,size_t)\n"
+    "    faiss::IndexBinaryIVF::IndexBinaryIVF()\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_IndexBinaryIVF(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_IndexBinaryIVF",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IndexBinaryIVF" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      delete arg1;
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_reset(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_reset",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_reset" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->reset();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_train(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinaryIVF_train",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_train" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_train" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_train" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->train(arg2,(uint8_t const *)arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_add(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinaryIVF_add",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_add" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_add" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_add" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->add(arg2,(uint8_t const *)arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_add_with_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  long *arg4 = (long *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexBinaryIVF_add_with_ids",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_add_with_ids" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_add_with_ids" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_add_with_ids" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexBinaryIVF_add_with_ids" "', argument " "4"" of type '" "long const *""'"); 
+  }
+  arg4 = reinterpret_cast< long * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->add_with_ids(arg2,(uint8_t const *)arg3,(long const *)arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_add_core(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  long *arg4 = (long *) 0 ;
+  long *arg5 = (long *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOO:IndexBinaryIVF_add_core",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_add_core" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_add_core" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_add_core" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexBinaryIVF_add_core" "', argument " "4"" of type '" "long const *""'"); 
+  }
+  arg4 = reinterpret_cast< long * >(argp4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinaryIVF_add_core" "', argument " "5"" of type '" "long const *""'"); 
+  }
+  arg5 = reinterpret_cast< long * >(argp5);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->add_core(arg2,(uint8_t const *)arg3,(long const *)arg4,(long const *)arg5);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_search_preassigned__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t arg4 ;
+  faiss::IndexBinary::idx_t *arg5 = (faiss::IndexBinary::idx_t *) 0 ;
+  int32_t *arg6 = (int32_t *) 0 ;
+  int32_t *arg7 = (int32_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg8 = (faiss::IndexBinary::idx_t *) 0 ;
+  bool arg9 ;
+  faiss::IVFSearchParameters *arg10 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  void *argp10 = 0 ;
+  int res10 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  PyObject * obj9 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOO:IndexBinaryIVF_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::IndexBinary::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "5"" of type '" "faiss::IndexBinary::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "6"" of type '" "int32_t const *""'"); 
+  }
+  arg6 = reinterpret_cast< int32_t * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "7"" of type '" "int32_t *""'"); 
+  }
+  arg7 = reinterpret_cast< int32_t * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "8"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  res10 = SWIG_ConvertPtr(obj9, &argp10,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res10)) {
+    SWIG_exception_fail(SWIG_ArgError(res10), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "10"" of type '" "faiss::IVFSearchParameters const *""'"); 
+  }
+  arg10 = reinterpret_cast< faiss::IVFSearchParameters * >(argp10);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryIVF const *)arg1)->search_preassigned(arg2,(uint8_t const *)arg3,arg4,(faiss::IndexBinary::idx_t const *)arg5,(int32_t const *)arg6,arg7,arg8,arg9,(faiss::IVFSearchParameters const *)arg10);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_search_preassigned__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t arg4 ;
+  faiss::IndexBinary::idx_t *arg5 = (faiss::IndexBinary::idx_t *) 0 ;
+  int32_t *arg6 = (int32_t *) 0 ;
+  int32_t *arg7 = (int32_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg8 = (faiss::IndexBinary::idx_t *) 0 ;
+  bool arg9 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOO:IndexBinaryIVF_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::IndexBinary::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "5"" of type '" "faiss::IndexBinary::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "6"" of type '" "int32_t const *""'"); 
+  }
+  arg6 = reinterpret_cast< int32_t * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "7"" of type '" "int32_t *""'"); 
+  }
+  arg7 = reinterpret_cast< int32_t * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "8"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryIVF const *)arg1)->search_preassigned(arg2,(uint8_t const *)arg3,arg4,(faiss::IndexBinary::idx_t const *)arg5,(int32_t const *)arg6,arg7,arg8,arg9);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_search_preassigned(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[11] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 10) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 9) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinaryIVF, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_unsigned_char, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_int, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_int, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      return _wrap_IndexBinaryIVF_search_preassigned__SWIG_1(self, args);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  if (argc == 10) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinaryIVF, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_unsigned_char, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_int, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_int, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      void *vptr = 0;
+                      int res = SWIG_ConvertPtr(argv[9], &vptr, SWIGTYPE_p_faiss__IVFSearchParameters, 0);
+                      _v = SWIG_CheckState(res);
+                      if (_v) {
+                        return _wrap_IndexBinaryIVF_search_preassigned__SWIG_0(self, args);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexBinaryIVF_search_preassigned'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexBinaryIVF::search_preassigned(faiss::IndexBinary::idx_t,uint8_t const *,faiss::IndexBinary::idx_t,faiss::IndexBinary::idx_t const *,int32_t const *,int32_t *,faiss::IndexBinary::idx_t *,bool,faiss::IVFSearchParameters const *) const\n"
+    "    faiss::IndexBinaryIVF::search_preassigned(faiss::IndexBinary::idx_t,uint8_t const *,faiss::IndexBinary::idx_t,faiss::IndexBinary::idx_t const *,int32_t const *,int32_t *,faiss::IndexBinary::idx_t *,bool) const\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_search(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t arg4 ;
+  int32_t *arg5 = (int32_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg6 = (faiss::IndexBinary::idx_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOO:IndexBinaryIVF_search",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_search" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_search" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_search" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinaryIVF_search" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::IndexBinary::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinaryIVF_search" "', argument " "5"" of type '" "int32_t *""'"); 
+  }
+  arg5 = reinterpret_cast< int32_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexBinaryIVF_search" "', argument " "6"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg6 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp6);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryIVF const *)arg1)->search(arg2,(uint8_t const *)arg3,arg4,arg5,arg6);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_reconstruct(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinaryIVF_reconstruct",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_reconstruct" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_reconstruct" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_reconstruct" "', argument " "3"" of type '" "uint8_t *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryIVF const *)arg1)->reconstruct(arg2,arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_reconstruct_n(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  faiss::IndexBinary::idx_t arg3 ;
+  uint8_t *arg4 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  long val3 ;
+  int ecode3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexBinaryIVF_reconstruct_n",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_reconstruct_n" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_reconstruct_n" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  ecode3 = SWIG_AsVal_long(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IndexBinaryIVF_reconstruct_n" "', argument " "3"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg3 = static_cast< faiss::IndexBinary::idx_t >(val3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexBinaryIVF_reconstruct_n" "', argument " "4"" of type '" "uint8_t *""'"); 
+  }
+  arg4 = reinterpret_cast< uint8_t * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryIVF const *)arg1)->reconstruct_n(arg2,arg3,arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_search_and_reconstruct(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t arg4 ;
+  int32_t *arg5 = (int32_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg6 = (faiss::IndexBinary::idx_t *) 0 ;
+  uint8_t *arg7 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOO:IndexBinaryIVF_search_and_reconstruct",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_search_and_reconstruct" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_search_and_reconstruct" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_search_and_reconstruct" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinaryIVF_search_and_reconstruct" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::IndexBinary::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinaryIVF_search_and_reconstruct" "', argument " "5"" of type '" "int32_t *""'"); 
+  }
+  arg5 = reinterpret_cast< int32_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexBinaryIVF_search_and_reconstruct" "', argument " "6"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg6 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexBinaryIVF_search_and_reconstruct" "', argument " "7"" of type '" "uint8_t *""'"); 
+  }
+  arg7 = reinterpret_cast< uint8_t * >(argp7);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryIVF const *)arg1)->search_and_reconstruct(arg2,(uint8_t const *)arg3,arg4,arg5,arg6,arg7);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_reconstruct_from_offset(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  long arg2 ;
+  long arg3 ;
+  uint8_t *arg4 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  long val3 ;
+  int ecode3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexBinaryIVF_reconstruct_from_offset",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_reconstruct_from_offset" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_reconstruct_from_offset" "', argument " "2"" of type '" "long""'");
+  } 
+  arg2 = static_cast< long >(val2);
+  ecode3 = SWIG_AsVal_long(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IndexBinaryIVF_reconstruct_from_offset" "', argument " "3"" of type '" "long""'");
+  } 
+  arg3 = static_cast< long >(val3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexBinaryIVF_reconstruct_from_offset" "', argument " "4"" of type '" "uint8_t *""'"); 
+  }
+  arg4 = reinterpret_cast< uint8_t * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryIVF const *)arg1)->reconstruct_from_offset(arg2,arg3,arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_remove_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IDSelector *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_remove_ids",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_remove_ids" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_faiss__IDSelector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryIVF_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IndexBinaryIVF_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::IDSelector * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (long)(arg1)->remove_ids((faiss::IDSelector const &)*arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_merge_from(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinaryIVF *arg2 = 0 ;
+  faiss::IndexBinary::idx_t arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  long val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinaryIVF_merge_from",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_merge_from" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_faiss__IndexBinaryIVF,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryIVF_merge_from" "', argument " "2"" of type '" "faiss::IndexBinaryIVF &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IndexBinaryIVF_merge_from" "', argument " "2"" of type '" "faiss::IndexBinaryIVF &""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp2);
+  ecode3 = SWIG_AsVal_long(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IndexBinaryIVF_merge_from" "', argument " "3"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg3 = static_cast< faiss::IndexBinary::idx_t >(val3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->merge_from(*arg2,arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_get_list_size(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_get_list_size",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_get_list_size" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_get_list_size" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (size_t)((faiss::IndexBinaryIVF const *)arg1)->get_list_size(arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_make_direct_map__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_make_direct_map",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_make_direct_map" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_bool(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_make_direct_map" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->make_direct_map(arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_make_direct_map__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_make_direct_map",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_make_direct_map" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->make_direct_map();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_make_direct_map(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[3] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 2) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 1) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinaryIVF, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_IndexBinaryIVF_make_direct_map__SWIG_1(self, args);
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinaryIVF, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_bool(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        return _wrap_IndexBinaryIVF_make_direct_map__SWIG_0(self, args);
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexBinaryIVF_make_direct_map'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexBinaryIVF::make_direct_map(bool)\n"
+    "    faiss::IndexBinaryIVF::make_direct_map()\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_imbalance_factor(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  double result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_imbalance_factor",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_imbalance_factor" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (double)((faiss::IndexBinaryIVF const *)arg1)->imbalance_factor();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_From_double(static_cast< double >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_print_stats(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_print_stats",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_print_stats" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryIVF const *)arg1)->print_stats();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_replace_invlists__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::InvertedLists *arg2 = (faiss::InvertedLists *) 0 ;
+  bool arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  bool val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinaryIVF_replace_invlists",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_replace_invlists" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_faiss__InvertedLists, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryIVF_replace_invlists" "', argument " "2"" of type '" "faiss::InvertedLists *""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::InvertedLists * >(argp2);
+  ecode3 = SWIG_AsVal_bool(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IndexBinaryIVF_replace_invlists" "', argument " "3"" of type '" "bool""'");
+  } 
+  arg3 = static_cast< bool >(val3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->replace_invlists(arg2,arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_replace_invlists__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::InvertedLists *arg2 = (faiss::InvertedLists *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_replace_invlists",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_replace_invlists" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_faiss__InvertedLists, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryIVF_replace_invlists" "', argument " "2"" of type '" "faiss::InvertedLists *""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::InvertedLists * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->replace_invlists(arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_replace_invlists(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[4] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 3) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinaryIVF, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_faiss__InvertedLists, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_IndexBinaryIVF_replace_invlists__SWIG_1(self, args);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinaryIVF, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_faiss__InvertedLists, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        {
+          int res = SWIG_AsVal_bool(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          return _wrap_IndexBinaryIVF_replace_invlists__SWIG_0(self, args);
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexBinaryIVF_replace_invlists'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexBinaryIVF::replace_invlists(faiss::InvertedLists *,bool)\n"
+    "    faiss::IndexBinaryIVF::replace_invlists(faiss::InvertedLists *)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *IndexBinaryIVF_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IndexBinaryIVF, SWIG_NewClientData(obj));
   return SWIG_Py_Void();
 }
 
@@ -57794,120 +64950,125 @@ SWIGINTERN PyObject *_wrap_downcast_index(PyObject *SWIGUNUSEDPARM(self), PyObje
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,0);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,0);
     } else
     /*@SWIG@*/
     
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,0);
     } else
     /*@SWIG@*/
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,0);
     } else
@@ -57956,37 +65117,37 @@ SWIGINTERN PyObject *_wrap_downcast_VectorTransform(PyObject *SWIGUNUSEDPARM(sel
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::RemapDimensionsTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__RemapDimensionsTransform,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::OPQMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__OPQMatrix,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::PCAMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__PCAMatrix,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::RandomRotationMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__RandomRotationMatrix,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::LinearTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__LinearTransform,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::NormalizationTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__NormalizationTransform,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::VectorTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__VectorTransform,0);
     } else
@@ -58005,46 +65166,6 @@ fail:
 
 
 SWIGINTERN PyObject *_wrap_write_index__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  faiss::Index *arg1 = (faiss::Index *) 0 ;
-  FILE *arg2 = (FILE *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OO:write_index",&obj0,&obj1)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__Index, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "write_index" "', argument " "1"" of type '" "faiss::Index const *""'"); 
-  }
-  arg1 = reinterpret_cast< faiss::Index * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_FILE, 0 |  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "write_index" "', argument " "2"" of type '" "FILE *""'"); 
-  }
-  arg2 = reinterpret_cast< FILE * >(argp2);
-  {
-    Py_BEGIN_ALLOW_THREADS
-    try {
-      faiss::write_index((faiss::Index const *)arg1,arg2);
-    } catch(faiss::FaissException & e) {
-      PyEval_RestoreThread(_save);
-      PyErr_SetString(PyExc_RuntimeError, e.what());
-      SWIG_fail;
-    }
-    Py_END_ALLOW_THREADS
-  }
-  resultobj = SWIG_Py_Void();
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_write_index__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::Index *arg1 = (faiss::Index *) 0 ;
   char *arg2 = (char *) 0 ;
@@ -58083,6 +65204,46 @@ SWIGINTERN PyObject *_wrap_write_index__SWIG_1(PyObject *SWIGUNUSEDPARM(self), P
   return resultobj;
 fail:
   if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_write_index__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::Index *arg1 = (faiss::Index *) 0 ;
+  FILE *arg2 = (FILE *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:write_index",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__Index, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "write_index" "', argument " "1"" of type '" "faiss::Index const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::Index * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_FILE, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "write_index" "', argument " "2"" of type '" "FILE *""'"); 
+  }
+  arg2 = reinterpret_cast< FILE * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      faiss::write_index((faiss::Index const *)arg1,arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
   return NULL;
 }
 
@@ -58149,7 +65310,7 @@ SWIGINTERN PyObject *_wrap_write_index(PyObject *self, PyObject *args) {
       int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_FILE, 0);
       _v = SWIG_CheckState(res);
       if (_v) {
-        return _wrap_write_index__SWIG_0(self, args);
+        return _wrap_write_index__SWIG_1(self, args);
       }
     }
   }
@@ -58176,7 +65337,7 @@ SWIGINTERN PyObject *_wrap_write_index(PyObject *self, PyObject *args) {
       int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
       _v = SWIG_CheckState(res);
       if (_v) {
-        return _wrap_write_index__SWIG_1(self, args);
+        return _wrap_write_index__SWIG_0(self, args);
       }
     }
   }
@@ -58184,9 +65345,196 @@ SWIGINTERN PyObject *_wrap_write_index(PyObject *self, PyObject *args) {
 fail:
   SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'write_index'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    faiss::write_index(faiss::Index const *,FILE *)\n"
     "    faiss::write_index(faiss::Index const *,char const *)\n"
+    "    faiss::write_index(faiss::Index const *,FILE *)\n"
     "    faiss::write_index(faiss::Index const *,faiss::IOWriter *)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_write_index_binary__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  char *arg2 = (char *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:write_index_binary",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "write_index_binary" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "write_index_binary" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      faiss::write_index_binary((faiss::IndexBinary const *)arg1,(char const *)arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_write_index_binary__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  FILE *arg2 = (FILE *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:write_index_binary",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "write_index_binary" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_FILE, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "write_index_binary" "', argument " "2"" of type '" "FILE *""'"); 
+  }
+  arg2 = reinterpret_cast< FILE * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      faiss::write_index_binary((faiss::IndexBinary const *)arg1,arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_write_index_binary__SWIG_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IOWriter *arg2 = (faiss::IOWriter *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:write_index_binary",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "write_index_binary" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_faiss__IOWriter, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "write_index_binary" "', argument " "2"" of type '" "faiss::IOWriter *""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::IOWriter * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      faiss::write_index_binary((faiss::IndexBinary const *)arg1,arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_write_index_binary(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[3] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 2) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinary, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_FILE, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_write_index_binary__SWIG_1(self, args);
+      }
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinary, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_faiss__IOWriter, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_write_index_binary__SWIG_2(self, args);
+      }
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinary, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_write_index_binary__SWIG_0(self, args);
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'write_index_binary'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::write_index_binary(faiss::IndexBinary const *,char const *)\n"
+    "    faiss::write_index_binary(faiss::IndexBinary const *,FILE *)\n"
+    "    faiss::write_index_binary(faiss::IndexBinary const *,faiss::IOWriter *)\n");
   return 0;
 }
 
@@ -58220,339 +65568,6 @@ SWIGINTERN PyObject *Swig_var_IO_FLAG_READ_ONLY_get(void) {
 
 
 SWIGINTERN PyObject *_wrap_read_index__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  FILE *arg1 = (FILE *) 0 ;
-  int arg2 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int val2 ;
-  int ecode2 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  faiss::Index *result = 0 ;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OO:read_index",&obj0,&obj1)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_FILE, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index" "', argument " "1"" of type '" "FILE *""'"); 
-  }
-  arg1 = reinterpret_cast< FILE * >(argp1);
-  ecode2 = SWIG_AsVal_int(obj1, &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "read_index" "', argument " "2"" of type '" "int""'");
-  } 
-  arg2 = static_cast< int >(val2);
-  {
-    Py_BEGIN_ALLOW_THREADS
-    try {
-      result = (faiss::Index *)faiss::read_index(arg1,arg2);
-    } catch(faiss::FaissException & e) {
-      PyEval_RestoreThread(_save);
-      PyErr_SetString(PyExc_RuntimeError, e.what());
-      SWIG_fail;
-    }
-    Py_END_ALLOW_THREADS
-  }
-  {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIDMap *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexShards *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVF *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexFlat *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexPQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexLSH *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::Index2Layer *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
-    if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
-    if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
-    if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
-    if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    
-    // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::Index *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    if (result == NULL)
-    {
-      resultobj = SWIG_Py_Void();
-      
-      // Lua does not need a push for nil
-    } else {
-      assert(false);
-    }
-    
-    
-    
-  }
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_read_index__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  FILE *arg1 = (FILE *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  PyObject * obj0 = 0 ;
-  faiss::Index *result = 0 ;
-  
-  if (!PyArg_ParseTuple(args,(char *)"O:read_index",&obj0)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_FILE, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index" "', argument " "1"" of type '" "FILE *""'"); 
-  }
-  arg1 = reinterpret_cast< FILE * >(argp1);
-  {
-    Py_BEGIN_ALLOW_THREADS
-    try {
-      result = (faiss::Index *)faiss::read_index(arg1);
-    } catch(faiss::FaissException & e) {
-      PyEval_RestoreThread(_save);
-      PyErr_SetString(PyExc_RuntimeError, e.what());
-      SWIG_fail;
-    }
-    Py_END_ALLOW_THREADS
-  }
-  {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIDMap *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexShards *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVF *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexFlat *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexPQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexLSH *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::Index2Layer *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
-    if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
-    if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
-    if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
-    if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    
-    // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::Index *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    if (result == NULL)
-    {
-      resultobj = SWIG_Py_Void();
-      
-      // Lua does not need a push for nil
-    } else {
-      assert(false);
-    }
-    
-    
-    
-  }
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_read_index__SWIG_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   char *arg1 = (char *) 0 ;
   int arg2 ;
@@ -58588,120 +65603,125 @@ SWIGINTERN PyObject *_wrap_read_index__SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -58726,7 +65746,7 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_read_index__SWIG_3(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_read_index__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   char *arg1 = (char *) 0 ;
   int res1 ;
@@ -58753,120 +65773,125 @@ SWIGINTERN PyObject *_wrap_read_index__SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -58887,6 +65912,349 @@ SWIGINTERN PyObject *_wrap_read_index__SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
   return resultobj;
 fail:
   if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index__SWIG_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  FILE *arg1 = (FILE *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  faiss::Index *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:read_index",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_FILE, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index" "', argument " "1"" of type '" "FILE *""'"); 
+  }
+  arg1 = reinterpret_cast< FILE * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "read_index" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::Index *)faiss::read_index(arg1,arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIDMap *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexShards *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexPQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexLSH *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::Index2Layer *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
+    if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
+    if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
+    if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
+    if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::Index *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index__SWIG_3(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  FILE *arg1 = (FILE *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::Index *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:read_index",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_FILE, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index" "', argument " "1"" of type '" "FILE *""'"); 
+  }
+  arg1 = reinterpret_cast< FILE * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::Index *)faiss::read_index(arg1);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIDMap *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexShards *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexPQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexLSH *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::Index2Layer *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
+    if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
+    if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
+    if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
+    if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::Index *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  return resultobj;
+fail:
   return NULL;
 }
 
@@ -58926,120 +66294,125 @@ SWIGINTERN PyObject *_wrap_read_index__SWIG_4(PyObject *SWIGUNUSEDPARM(self), Py
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -59088,120 +66461,125 @@ SWIGINTERN PyObject *_wrap_read_index__SWIG_5(PyObject *SWIGUNUSEDPARM(self), Py
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -59242,7 +66620,7 @@ SWIGINTERN PyObject *_wrap_read_index(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_FILE, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      return _wrap_read_index__SWIG_1(self, args);
+      return _wrap_read_index__SWIG_3(self, args);
     }
   }
   if (argc == 1) {
@@ -59259,22 +66637,7 @@ SWIGINTERN PyObject *_wrap_read_index(PyObject *self, PyObject *args) {
     int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      return _wrap_read_index__SWIG_3(self, args);
-    }
-  }
-  if (argc == 2) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_FILE, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      {
-        int res = SWIG_AsVal_int(argv[1], NULL);
-        _v = SWIG_CheckState(res);
-      }
-      if (_v) {
-        return _wrap_read_index__SWIG_0(self, args);
-      }
+      return _wrap_read_index__SWIG_1(self, args);
     }
   }
   if (argc == 2) {
@@ -59294,7 +66657,8 @@ SWIGINTERN PyObject *_wrap_read_index(PyObject *self, PyObject *args) {
   }
   if (argc == 2) {
     int _v;
-    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_FILE, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
       {
@@ -59306,16 +66670,519 @@ SWIGINTERN PyObject *_wrap_read_index(PyObject *self, PyObject *args) {
       }
     }
   }
+  if (argc == 2) {
+    int _v;
+    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_int(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        return _wrap_read_index__SWIG_0(self, args);
+      }
+    }
+  }
   
 fail:
   SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'read_index'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    faiss::read_index(FILE *,int)\n"
-    "    faiss::read_index(FILE *)\n"
     "    faiss::read_index(char const *,int)\n"
     "    faiss::read_index(char const *)\n"
+    "    faiss::read_index(FILE *,int)\n"
+    "    faiss::read_index(FILE *)\n"
     "    faiss::read_index(faiss::IOReader *,int)\n"
     "    faiss::read_index(faiss::IOReader *)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index_binary__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  char *arg1 = (char *) 0 ;
+  int arg2 ;
+  int res1 ;
+  char *buf1 = 0 ;
+  int alloc1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  faiss::IndexBinary *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:read_index_binary",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_AsCharPtrAndSize(obj0, &buf1, NULL, &alloc1);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index_binary" "', argument " "1"" of type '" "char const *""'");
+  }
+  arg1 = reinterpret_cast< char * >(buf1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "read_index_binary" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinary *)faiss::read_index_binary((char const *)arg1,arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryIVF,0);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryFlat,0);
+    } else
+    /*@SWIG@*/
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinary *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinary,0);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  return resultobj;
+fail:
+  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index_binary__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  char *arg1 = (char *) 0 ;
+  int res1 ;
+  char *buf1 = 0 ;
+  int alloc1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::IndexBinary *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:read_index_binary",&obj0)) SWIG_fail;
+  res1 = SWIG_AsCharPtrAndSize(obj0, &buf1, NULL, &alloc1);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index_binary" "', argument " "1"" of type '" "char const *""'");
+  }
+  arg1 = reinterpret_cast< char * >(buf1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinary *)faiss::read_index_binary((char const *)arg1);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryIVF,0);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryFlat,0);
+    } else
+    /*@SWIG@*/
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinary *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinary,0);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  return resultobj;
+fail:
+  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index_binary__SWIG_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  FILE *arg1 = (FILE *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  faiss::IndexBinary *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:read_index_binary",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_FILE, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index_binary" "', argument " "1"" of type '" "FILE *""'"); 
+  }
+  arg1 = reinterpret_cast< FILE * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "read_index_binary" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinary *)faiss::read_index_binary(arg1,arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryIVF,0);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryFlat,0);
+    } else
+    /*@SWIG@*/
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinary *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinary,0);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index_binary__SWIG_3(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  FILE *arg1 = (FILE *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::IndexBinary *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:read_index_binary",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_FILE, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index_binary" "', argument " "1"" of type '" "FILE *""'"); 
+  }
+  arg1 = reinterpret_cast< FILE * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinary *)faiss::read_index_binary(arg1);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryIVF,0);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryFlat,0);
+    } else
+    /*@SWIG@*/
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinary *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinary,0);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index_binary__SWIG_4(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IOReader *arg1 = (faiss::IOReader *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  faiss::IndexBinary *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:read_index_binary",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOReader, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index_binary" "', argument " "1"" of type '" "faiss::IOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IOReader * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "read_index_binary" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinary *)faiss::read_index_binary(arg1,arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryIVF,0);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryFlat,0);
+    } else
+    /*@SWIG@*/
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinary *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinary,0);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index_binary__SWIG_5(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IOReader *arg1 = (faiss::IOReader *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::IndexBinary *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:read_index_binary",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOReader, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index_binary" "', argument " "1"" of type '" "faiss::IOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IOReader * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinary *)faiss::read_index_binary(arg1);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryIVF,0);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryFlat,0);
+    } else
+    /*@SWIG@*/
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinary *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinary,0);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index_binary(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[3] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 2) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 1) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_FILE, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_read_index_binary__SWIG_3(self, args);
+    }
+  }
+  if (argc == 1) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IOReader, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_read_index_binary__SWIG_5(self, args);
+    }
+  }
+  if (argc == 1) {
+    int _v;
+    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_read_index_binary__SWIG_1(self, args);
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IOReader, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_int(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        return _wrap_read_index_binary__SWIG_4(self, args);
+      }
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_FILE, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_int(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        return _wrap_read_index_binary__SWIG_2(self, args);
+      }
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_int(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        return _wrap_read_index_binary__SWIG_0(self, args);
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'read_index_binary'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::read_index_binary(char const *,int)\n"
+    "    faiss::read_index_binary(char const *)\n"
+    "    faiss::read_index_binary(FILE *,int)\n"
+    "    faiss::read_index_binary(FILE *)\n"
+    "    faiss::read_index_binary(faiss::IOReader *,int)\n"
+    "    faiss::read_index_binary(faiss::IOReader *)\n");
   return 0;
 }
 
@@ -59390,37 +67257,37 @@ SWIGINTERN PyObject *_wrap_read_VectorTransform(PyObject *SWIGUNUSEDPARM(self), 
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::RemapDimensionsTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__RemapDimensionsTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::OPQMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__OPQMatrix,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::PCAMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__PCAMatrix,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::RandomRotationMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__RandomRotationMatrix,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::LinearTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__LinearTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::NormalizationTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__NormalizationTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::VectorTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__VectorTransform,SWIG_POINTER_OWN);
     } else
@@ -59544,120 +67411,125 @@ SWIGINTERN PyObject *_wrap_clone_index(PyObject *SWIGUNUSEDPARM(self), PyObject 
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -59715,37 +67587,37 @@ SWIGINTERN PyObject *_wrap_Cloner_clone_VectorTransform(PyObject *SWIGUNUSEDPARM
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::RemapDimensionsTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__RemapDimensionsTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::OPQMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__OPQMatrix,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::PCAMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__PCAMatrix,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::RandomRotationMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__RandomRotationMatrix,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::LinearTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__LinearTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::NormalizationTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__NormalizationTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::VectorTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__VectorTransform,SWIG_POINTER_OWN);
     } else
@@ -59798,120 +67670,125 @@ SWIGINTERN PyObject *_wrap_Cloner_clone_Index(PyObject *SWIGUNUSEDPARM(self), Py
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,0);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,0);
     } else
     /*@SWIG@*/
     
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,0);
     } else
     /*@SWIG@*/
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,0);
     } else
@@ -60023,196 +67900,6 @@ SWIGINTERN PyObject *Cloner_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObjec
   PyObject *obj;
   if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
   SWIG_TypeNewClientData(SWIGTYPE_p_faiss__Cloner, SWIG_NewClientData(obj));
-  return SWIG_Py_Void();
-}
-
-SWIGINTERN PyObject *_wrap_IOReader___call__(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  faiss::IOReader *arg1 = (faiss::IOReader *) 0 ;
-  void *arg2 = (void *) 0 ;
-  size_t arg3 ;
-  size_t arg4 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int res2 ;
-  size_t val3 ;
-  int ecode3 = 0 ;
-  size_t val4 ;
-  int ecode4 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  PyObject * obj2 = 0 ;
-  PyObject * obj3 = 0 ;
-  size_t result;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OOOO:IOReader___call__",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOReader, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IOReader___call__" "', argument " "1"" of type '" "faiss::IOReader *""'"); 
-  }
-  arg1 = reinterpret_cast< faiss::IOReader * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IOReader___call__" "', argument " "2"" of type '" "void *""'"); 
-  }
-  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
-  if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IOReader___call__" "', argument " "3"" of type '" "size_t""'");
-  } 
-  arg3 = static_cast< size_t >(val3);
-  ecode4 = SWIG_AsVal_size_t(obj3, &val4);
-  if (!SWIG_IsOK(ecode4)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IOReader___call__" "', argument " "4"" of type '" "size_t""'");
-  } 
-  arg4 = static_cast< size_t >(val4);
-  {
-    Py_BEGIN_ALLOW_THREADS
-    try {
-      result = (size_t)(arg1)->operator ()(arg2,arg3,arg4);
-    } catch(faiss::FaissException & e) {
-      PyEval_RestoreThread(_save);
-      PyErr_SetString(PyExc_RuntimeError, e.what());
-      SWIG_fail;
-    }
-    Py_END_ALLOW_THREADS
-  }
-  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_delete_IOReader(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  faiss::IOReader *arg1 = (faiss::IOReader *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  PyObject * obj0 = 0 ;
-  
-  if (!PyArg_ParseTuple(args,(char *)"O:delete_IOReader",&obj0)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOReader, SWIG_POINTER_DISOWN |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IOReader" "', argument " "1"" of type '" "faiss::IOReader *""'"); 
-  }
-  arg1 = reinterpret_cast< faiss::IOReader * >(argp1);
-  {
-    Py_BEGIN_ALLOW_THREADS
-    try {
-      delete arg1;
-    } catch(faiss::FaissException & e) {
-      PyEval_RestoreThread(_save);
-      PyErr_SetString(PyExc_RuntimeError, e.what());
-      SWIG_fail;
-    }
-    Py_END_ALLOW_THREADS
-  }
-  resultobj = SWIG_Py_Void();
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *IOReader_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *obj;
-  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
-  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IOReader, SWIG_NewClientData(obj));
-  return SWIG_Py_Void();
-}
-
-SWIGINTERN PyObject *_wrap_IOWriter___call__(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  faiss::IOWriter *arg1 = (faiss::IOWriter *) 0 ;
-  void *arg2 = (void *) 0 ;
-  size_t arg3 ;
-  size_t arg4 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int res2 ;
-  size_t val3 ;
-  int ecode3 = 0 ;
-  size_t val4 ;
-  int ecode4 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  PyObject * obj2 = 0 ;
-  PyObject * obj3 = 0 ;
-  size_t result;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OOOO:IOWriter___call__",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOWriter, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IOWriter___call__" "', argument " "1"" of type '" "faiss::IOWriter *""'"); 
-  }
-  arg1 = reinterpret_cast< faiss::IOWriter * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IOWriter___call__" "', argument " "2"" of type '" "void const *""'"); 
-  }
-  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
-  if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IOWriter___call__" "', argument " "3"" of type '" "size_t""'");
-  } 
-  arg3 = static_cast< size_t >(val3);
-  ecode4 = SWIG_AsVal_size_t(obj3, &val4);
-  if (!SWIG_IsOK(ecode4)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IOWriter___call__" "', argument " "4"" of type '" "size_t""'");
-  } 
-  arg4 = static_cast< size_t >(val4);
-  {
-    Py_BEGIN_ALLOW_THREADS
-    try {
-      result = (size_t)(arg1)->operator ()((void const *)arg2,arg3,arg4);
-    } catch(faiss::FaissException & e) {
-      PyEval_RestoreThread(_save);
-      PyErr_SetString(PyExc_RuntimeError, e.what());
-      SWIG_fail;
-    }
-    Py_END_ALLOW_THREADS
-  }
-  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_delete_IOWriter(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  faiss::IOWriter *arg1 = (faiss::IOWriter *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  PyObject * obj0 = 0 ;
-  
-  if (!PyArg_ParseTuple(args,(char *)"O:delete_IOWriter",&obj0)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOWriter, SWIG_POINTER_DISOWN |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IOWriter" "', argument " "1"" of type '" "faiss::IOWriter *""'"); 
-  }
-  arg1 = reinterpret_cast< faiss::IOWriter * >(argp1);
-  {
-    Py_BEGIN_ALLOW_THREADS
-    try {
-      delete arg1;
-    } catch(faiss::FaissException & e) {
-      PyEval_RestoreThread(_save);
-      PyErr_SetString(PyExc_RuntimeError, e.what());
-      SWIG_fail;
-    }
-    Py_END_ALLOW_THREADS
-  }
-  resultobj = SWIG_Py_Void();
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *IOWriter_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *obj;
-  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
-  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IOWriter, SWIG_NewClientData(obj));
   return SWIG_Py_Void();
 }
 
@@ -63176,120 +70863,125 @@ SWIGINTERN PyObject *_wrap_index_factory__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -63350,120 +71042,125 @@ SWIGINTERN PyObject *_wrap_index_factory__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -63544,6 +71241,78 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_index_binary_factory(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  int arg1 ;
+  char *arg2 = (char *) 0 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  faiss::IndexBinary *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:index_binary_factory",&obj0,&obj1)) SWIG_fail;
+  ecode1 = SWIG_AsVal_int(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "index_binary_factory" "', argument " "1"" of type '" "int""'");
+  } 
+  arg1 = static_cast< int >(val1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "index_binary_factory" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinary *)faiss::index_binary_factory(arg1,(char const *)arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryIVF,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinary *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinary,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_index_gpu_to_cpu(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::Index *arg1 = (faiss::Index *) 0 ;
@@ -63570,120 +71339,125 @@ SWIGINTERN PyObject *_wrap_index_gpu_to_cpu(PyObject *SWIGUNUSEDPARM(self), PyOb
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -63759,120 +71533,125 @@ SWIGINTERN PyObject *_wrap_index_cpu_to_gpu__SWIG_0(PyObject *SWIGUNUSEDPARM(sel
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -63939,120 +71718,125 @@ SWIGINTERN PyObject *_wrap_index_cpu_to_gpu__SWIG_1(PyObject *SWIGUNUSEDPARM(sel
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -64201,120 +71985,125 @@ SWIGINTERN PyObject *_wrap_index_cpu_to_gpu_multiple__SWIG_0(PyObject *SWIGUNUSE
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -64387,120 +72176,125 @@ SWIGINTERN PyObject *_wrap_index_cpu_to_gpu_multiple__SWIG_1(PyObject *SWIGUNUSE
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::IndexProxy *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__IndexProxy,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,412,DOWNCAST_GPU@*/
+    /*@SWIG:swigfaiss.swig,423,DOWNCAST_GPU@*/
     if (dynamic_cast<faiss::gpu::GpuIndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__gpu__GpuIndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -71477,6 +79271,502 @@ SWIGINTERN PyObject *RangeSearchPartialResult_swigregister(PyObject *SWIGUNUSEDP
   return SWIG_Py_Void();
 }
 
+SWIGINTERN PyObject *_wrap_IOReader___call__(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IOReader *arg1 = (faiss::IOReader *) 0 ;
+  void *arg2 = (void *) 0 ;
+  size_t arg3 ;
+  size_t arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
+  size_t val4 ;
+  int ecode4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IOReader___call__",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOReader, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IOReader___call__" "', argument " "1"" of type '" "faiss::IOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IOReader * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IOReader___call__" "', argument " "2"" of type '" "void *""'"); 
+  }
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IOReader___call__" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  ecode4 = SWIG_AsVal_size_t(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IOReader___call__" "', argument " "4"" of type '" "size_t""'");
+  } 
+  arg4 = static_cast< size_t >(val4);
+  result = (size_t)(arg1)->operator ()(arg2,arg3,arg4);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IOReader_fileno(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IOReader *arg1 = (faiss::IOReader *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  int result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IOReader_fileno",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOReader, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IOReader_fileno" "', argument " "1"" of type '" "faiss::IOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IOReader * >(argp1);
+  result = (int)(arg1)->fileno();
+  resultobj = SWIG_From_int(static_cast< int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_IOReader(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IOReader *arg1 = (faiss::IOReader *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_IOReader",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOReader, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IOReader" "', argument " "1"" of type '" "faiss::IOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IOReader * >(argp1);
+  delete arg1;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *IOReader_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IOReader, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_IOWriter___call__(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IOWriter *arg1 = (faiss::IOWriter *) 0 ;
+  void *arg2 = (void *) 0 ;
+  size_t arg3 ;
+  size_t arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
+  size_t val4 ;
+  int ecode4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IOWriter___call__",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IOWriter___call__" "', argument " "1"" of type '" "faiss::IOWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IOWriter * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IOWriter___call__" "', argument " "2"" of type '" "void const *""'"); 
+  }
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IOWriter___call__" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  ecode4 = SWIG_AsVal_size_t(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IOWriter___call__" "', argument " "4"" of type '" "size_t""'");
+  } 
+  arg4 = static_cast< size_t >(val4);
+  result = (size_t)(arg1)->operator ()((void const *)arg2,arg3,arg4);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IOWriter_fileno(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IOWriter *arg1 = (faiss::IOWriter *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  int result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IOWriter_fileno",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IOWriter_fileno" "', argument " "1"" of type '" "faiss::IOWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IOWriter * >(argp1);
+  result = (int)(arg1)->fileno();
+  resultobj = SWIG_From_int(static_cast< int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_IOWriter(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IOWriter *arg1 = (faiss::IOWriter *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_IOWriter",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOWriter, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IOWriter" "', argument " "1"" of type '" "faiss::IOWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IOWriter * >(argp1);
+  delete arg1;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *IOWriter_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IOWriter, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_VectorIOReader_data_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOReader *arg1 = (faiss::VectorIOReader *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  std::vector< uint8_t > *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:VectorIOReader_data_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOReader, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorIOReader_data_get" "', argument " "1"" of type '" "faiss::VectorIOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOReader * >(argp1);
+  result = (std::vector< uint8_t > *)& ((arg1)->data);
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_unsigned_char_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorIOReader_rp_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOReader *arg1 = (faiss::VectorIOReader *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:VectorIOReader_rp_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOReader, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorIOReader_rp_set" "', argument " "1"" of type '" "faiss::VectorIOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOReader * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "VectorIOReader_rp_set" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  if (arg1) (arg1)->rp = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorIOReader_rp_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOReader *arg1 = (faiss::VectorIOReader *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:VectorIOReader_rp_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOReader, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorIOReader_rp_get" "', argument " "1"" of type '" "faiss::VectorIOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOReader * >(argp1);
+  result = (size_t) ((arg1)->rp);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorIOReader___call__(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOReader *arg1 = (faiss::VectorIOReader *) 0 ;
+  void *arg2 = (void *) 0 ;
+  size_t arg3 ;
+  size_t arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
+  size_t val4 ;
+  int ecode4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:VectorIOReader___call__",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOReader, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorIOReader___call__" "', argument " "1"" of type '" "faiss::VectorIOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOReader * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorIOReader___call__" "', argument " "2"" of type '" "void *""'"); 
+  }
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "VectorIOReader___call__" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  ecode4 = SWIG_AsVal_size_t(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "VectorIOReader___call__" "', argument " "4"" of type '" "size_t""'");
+  } 
+  arg4 = static_cast< size_t >(val4);
+  result = (size_t)(arg1)->operator ()(arg2,arg3,arg4);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_VectorIOReader(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOReader *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_VectorIOReader")) SWIG_fail;
+  result = (faiss::VectorIOReader *)new faiss::VectorIOReader();
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__VectorIOReader, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_VectorIOReader(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOReader *arg1 = (faiss::VectorIOReader *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_VectorIOReader",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOReader, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_VectorIOReader" "', argument " "1"" of type '" "faiss::VectorIOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOReader * >(argp1);
+  delete arg1;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *VectorIOReader_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__VectorIOReader, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_VectorIOWriter_data_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOWriter *arg1 = (faiss::VectorIOWriter *) 0 ;
+  std::vector< uint8_t > *arg2 = (std::vector< uint8_t > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:VectorIOWriter_data_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorIOWriter_data_set" "', argument " "1"" of type '" "faiss::VectorIOWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOWriter * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_std__vectorT_unsigned_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorIOWriter_data_set" "', argument " "2"" of type '" "std::vector< uint8_t > *""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< uint8_t > * >(argp2);
+  if (arg1) (arg1)->data = *arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorIOWriter_data_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOWriter *arg1 = (faiss::VectorIOWriter *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  std::vector< uint8_t > *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:VectorIOWriter_data_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorIOWriter_data_get" "', argument " "1"" of type '" "faiss::VectorIOWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOWriter * >(argp1);
+  result = (std::vector< uint8_t > *)& ((arg1)->data);
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_unsigned_char_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorIOWriter___call__(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOWriter *arg1 = (faiss::VectorIOWriter *) 0 ;
+  void *arg2 = (void *) 0 ;
+  size_t arg3 ;
+  size_t arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
+  size_t val4 ;
+  int ecode4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:VectorIOWriter___call__",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorIOWriter___call__" "', argument " "1"" of type '" "faiss::VectorIOWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOWriter * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorIOWriter___call__" "', argument " "2"" of type '" "void const *""'"); 
+  }
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "VectorIOWriter___call__" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  ecode4 = SWIG_AsVal_size_t(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "VectorIOWriter___call__" "', argument " "4"" of type '" "size_t""'");
+  } 
+  arg4 = static_cast< size_t >(val4);
+  result = (size_t)(arg1)->operator ()((void const *)arg2,arg3,arg4);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_VectorIOWriter(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOWriter *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_VectorIOWriter")) SWIG_fail;
+  result = (faiss::VectorIOWriter *)new faiss::VectorIOWriter();
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__VectorIOWriter, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_VectorIOWriter(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOWriter *arg1 = (faiss::VectorIOWriter *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_VectorIOWriter",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOWriter, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_VectorIOWriter" "', argument " "1"" of type '" "faiss::VectorIOWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOWriter * >(argp1);
+  delete arg1;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *VectorIOWriter_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__VectorIOWriter, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
 SWIGINTERN PyObject *_wrap_ignore_SIGTTIN(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   
@@ -71726,6 +80016,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"FloatVector_size", _wrap_FloatVector_size, METH_VARARGS, NULL},
 	 { (char *)"FloatVector_at", _wrap_FloatVector_at, METH_VARARGS, NULL},
 	 { (char *)"FloatVector_resize", _wrap_FloatVector_resize, METH_VARARGS, NULL},
+	 { (char *)"FloatVector_swap", _wrap_FloatVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_FloatVector", _wrap_delete_FloatVector, METH_VARARGS, NULL},
 	 { (char *)"FloatVector_swigregister", FloatVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_DoubleVector", _wrap_new_DoubleVector, METH_VARARGS, NULL},
@@ -71735,6 +80026,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"DoubleVector_size", _wrap_DoubleVector_size, METH_VARARGS, NULL},
 	 { (char *)"DoubleVector_at", _wrap_DoubleVector_at, METH_VARARGS, NULL},
 	 { (char *)"DoubleVector_resize", _wrap_DoubleVector_resize, METH_VARARGS, NULL},
+	 { (char *)"DoubleVector_swap", _wrap_DoubleVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_DoubleVector", _wrap_delete_DoubleVector, METH_VARARGS, NULL},
 	 { (char *)"DoubleVector_swigregister", DoubleVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_ByteVector", _wrap_new_ByteVector, METH_VARARGS, NULL},
@@ -71744,8 +80036,19 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"ByteVector_size", _wrap_ByteVector_size, METH_VARARGS, NULL},
 	 { (char *)"ByteVector_at", _wrap_ByteVector_at, METH_VARARGS, NULL},
 	 { (char *)"ByteVector_resize", _wrap_ByteVector_resize, METH_VARARGS, NULL},
+	 { (char *)"ByteVector_swap", _wrap_ByteVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_ByteVector", _wrap_delete_ByteVector, METH_VARARGS, NULL},
 	 { (char *)"ByteVector_swigregister", ByteVector_swigregister, METH_VARARGS, NULL},
+	 { (char *)"new_CharVector", _wrap_new_CharVector, METH_VARARGS, NULL},
+	 { (char *)"CharVector_push_back", _wrap_CharVector_push_back, METH_VARARGS, NULL},
+	 { (char *)"CharVector_clear", _wrap_CharVector_clear, METH_VARARGS, NULL},
+	 { (char *)"CharVector_data", _wrap_CharVector_data, METH_VARARGS, NULL},
+	 { (char *)"CharVector_size", _wrap_CharVector_size, METH_VARARGS, NULL},
+	 { (char *)"CharVector_at", _wrap_CharVector_at, METH_VARARGS, NULL},
+	 { (char *)"CharVector_resize", _wrap_CharVector_resize, METH_VARARGS, NULL},
+	 { (char *)"CharVector_swap", _wrap_CharVector_swap, METH_VARARGS, NULL},
+	 { (char *)"delete_CharVector", _wrap_delete_CharVector, METH_VARARGS, NULL},
+	 { (char *)"CharVector_swigregister", CharVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_Uint64Vector", _wrap_new_Uint64Vector, METH_VARARGS, NULL},
 	 { (char *)"Uint64Vector_push_back", _wrap_Uint64Vector_push_back, METH_VARARGS, NULL},
 	 { (char *)"Uint64Vector_clear", _wrap_Uint64Vector_clear, METH_VARARGS, NULL},
@@ -71753,6 +80056,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"Uint64Vector_size", _wrap_Uint64Vector_size, METH_VARARGS, NULL},
 	 { (char *)"Uint64Vector_at", _wrap_Uint64Vector_at, METH_VARARGS, NULL},
 	 { (char *)"Uint64Vector_resize", _wrap_Uint64Vector_resize, METH_VARARGS, NULL},
+	 { (char *)"Uint64Vector_swap", _wrap_Uint64Vector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_Uint64Vector", _wrap_delete_Uint64Vector, METH_VARARGS, NULL},
 	 { (char *)"Uint64Vector_swigregister", Uint64Vector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_LongVector", _wrap_new_LongVector, METH_VARARGS, NULL},
@@ -71762,6 +80066,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"LongVector_size", _wrap_LongVector_size, METH_VARARGS, NULL},
 	 { (char *)"LongVector_at", _wrap_LongVector_at, METH_VARARGS, NULL},
 	 { (char *)"LongVector_resize", _wrap_LongVector_resize, METH_VARARGS, NULL},
+	 { (char *)"LongVector_swap", _wrap_LongVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_LongVector", _wrap_delete_LongVector, METH_VARARGS, NULL},
 	 { (char *)"LongVector_swigregister", LongVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_IntVector", _wrap_new_IntVector, METH_VARARGS, NULL},
@@ -71771,6 +80076,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"IntVector_size", _wrap_IntVector_size, METH_VARARGS, NULL},
 	 { (char *)"IntVector_at", _wrap_IntVector_at, METH_VARARGS, NULL},
 	 { (char *)"IntVector_resize", _wrap_IntVector_resize, METH_VARARGS, NULL},
+	 { (char *)"IntVector_swap", _wrap_IntVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_IntVector", _wrap_delete_IntVector, METH_VARARGS, NULL},
 	 { (char *)"IntVector_swigregister", IntVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_VectorTransformVector", _wrap_new_VectorTransformVector, METH_VARARGS, NULL},
@@ -71780,6 +80086,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"VectorTransformVector_size", _wrap_VectorTransformVector_size, METH_VARARGS, NULL},
 	 { (char *)"VectorTransformVector_at", _wrap_VectorTransformVector_at, METH_VARARGS, NULL},
 	 { (char *)"VectorTransformVector_resize", _wrap_VectorTransformVector_resize, METH_VARARGS, NULL},
+	 { (char *)"VectorTransformVector_swap", _wrap_VectorTransformVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_VectorTransformVector", _wrap_delete_VectorTransformVector, METH_VARARGS, NULL},
 	 { (char *)"VectorTransformVector_swigregister", VectorTransformVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_OperatingPointVector", _wrap_new_OperatingPointVector, METH_VARARGS, NULL},
@@ -71789,6 +80096,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"OperatingPointVector_size", _wrap_OperatingPointVector_size, METH_VARARGS, NULL},
 	 { (char *)"OperatingPointVector_at", _wrap_OperatingPointVector_at, METH_VARARGS, NULL},
 	 { (char *)"OperatingPointVector_resize", _wrap_OperatingPointVector_resize, METH_VARARGS, NULL},
+	 { (char *)"OperatingPointVector_swap", _wrap_OperatingPointVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_OperatingPointVector", _wrap_delete_OperatingPointVector, METH_VARARGS, NULL},
 	 { (char *)"OperatingPointVector_swigregister", OperatingPointVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_InvertedListsPtrVector", _wrap_new_InvertedListsPtrVector, METH_VARARGS, NULL},
@@ -71798,6 +80106,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"InvertedListsPtrVector_size", _wrap_InvertedListsPtrVector_size, METH_VARARGS, NULL},
 	 { (char *)"InvertedListsPtrVector_at", _wrap_InvertedListsPtrVector_at, METH_VARARGS, NULL},
 	 { (char *)"InvertedListsPtrVector_resize", _wrap_InvertedListsPtrVector_resize, METH_VARARGS, NULL},
+	 { (char *)"InvertedListsPtrVector_swap", _wrap_InvertedListsPtrVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_InvertedListsPtrVector", _wrap_delete_InvertedListsPtrVector, METH_VARARGS, NULL},
 	 { (char *)"InvertedListsPtrVector_swigregister", InvertedListsPtrVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_FloatVectorVector", _wrap_new_FloatVectorVector, METH_VARARGS, NULL},
@@ -71807,6 +80116,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"FloatVectorVector_size", _wrap_FloatVectorVector_size, METH_VARARGS, NULL},
 	 { (char *)"FloatVectorVector_at", _wrap_FloatVectorVector_at, METH_VARARGS, NULL},
 	 { (char *)"FloatVectorVector_resize", _wrap_FloatVectorVector_resize, METH_VARARGS, NULL},
+	 { (char *)"FloatVectorVector_swap", _wrap_FloatVectorVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_FloatVectorVector", _wrap_delete_FloatVectorVector, METH_VARARGS, NULL},
 	 { (char *)"FloatVectorVector_swigregister", FloatVectorVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_ByteVectorVector", _wrap_new_ByteVectorVector, METH_VARARGS, NULL},
@@ -71816,6 +80126,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"ByteVectorVector_size", _wrap_ByteVectorVector_size, METH_VARARGS, NULL},
 	 { (char *)"ByteVectorVector_at", _wrap_ByteVectorVector_at, METH_VARARGS, NULL},
 	 { (char *)"ByteVectorVector_resize", _wrap_ByteVectorVector_resize, METH_VARARGS, NULL},
+	 { (char *)"ByteVectorVector_swap", _wrap_ByteVectorVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_ByteVectorVector", _wrap_delete_ByteVectorVector, METH_VARARGS, NULL},
 	 { (char *)"ByteVectorVector_swigregister", ByteVectorVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_LongVectorVector", _wrap_new_LongVectorVector, METH_VARARGS, NULL},
@@ -71825,6 +80136,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"LongVectorVector_size", _wrap_LongVectorVector_size, METH_VARARGS, NULL},
 	 { (char *)"LongVectorVector_at", _wrap_LongVectorVector_at, METH_VARARGS, NULL},
 	 { (char *)"LongVectorVector_resize", _wrap_LongVectorVector_resize, METH_VARARGS, NULL},
+	 { (char *)"LongVectorVector_swap", _wrap_LongVectorVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_LongVectorVector", _wrap_delete_LongVectorVector, METH_VARARGS, NULL},
 	 { (char *)"LongVectorVector_swigregister", LongVectorVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_GpuResourcesVector", _wrap_new_GpuResourcesVector, METH_VARARGS, NULL},
@@ -71834,6 +80146,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"GpuResourcesVector_size", _wrap_GpuResourcesVector_size, METH_VARARGS, NULL},
 	 { (char *)"GpuResourcesVector_at", _wrap_GpuResourcesVector_at, METH_VARARGS, NULL},
 	 { (char *)"GpuResourcesVector_resize", _wrap_GpuResourcesVector_resize, METH_VARARGS, NULL},
+	 { (char *)"GpuResourcesVector_swap", _wrap_GpuResourcesVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_GpuResourcesVector", _wrap_delete_GpuResourcesVector, METH_VARARGS, NULL},
 	 { (char *)"GpuResourcesVector_swigregister", GpuResourcesVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"popcount64", _wrap_popcount64, METH_VARARGS, NULL},
@@ -71841,8 +80154,9 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"bitvec_print", _wrap_bitvec_print, METH_VARARGS, NULL},
 	 { (char *)"fvecs2bitvecs", _wrap_fvecs2bitvecs, METH_VARARGS, NULL},
 	 { (char *)"fvec2bitvec", _wrap_fvec2bitvec, METH_VARARGS, NULL},
+	 { (char *)"hammings_knn_hc", _wrap_hammings_knn_hc, METH_VARARGS, NULL},
 	 { (char *)"hammings_knn", _wrap_hammings_knn, METH_VARARGS, NULL},
-	 { (char *)"hammings_knn_core", _wrap_hammings_knn_core, METH_VARARGS, NULL},
+	 { (char *)"hammings_knn_mc", _wrap_hammings_knn_mc, METH_VARARGS, NULL},
 	 { (char *)"hamming_count_thres", _wrap_hamming_count_thres, METH_VARARGS, NULL},
 	 { (char *)"match_hamming_thres", _wrap_match_hamming_thres, METH_VARARGS, NULL},
 	 { (char *)"crosshamming_count_thres", _wrap_crosshamming_count_thres, METH_VARARGS, NULL},
@@ -71967,7 +80281,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"GenHammingComputerM8_hamming", _wrap_GenHammingComputerM8_hamming, METH_VARARGS, NULL},
 	 { (char *)"delete_GenHammingComputerM8", _wrap_delete_GenHammingComputerM8, METH_VARARGS, NULL},
 	 { (char *)"GenHammingComputerM8_swigregister", GenHammingComputerM8_swigregister, METH_VARARGS, NULL},
-	 { (char *)"generalized_hammings_knn", _wrap_generalized_hammings_knn, METH_VARARGS, NULL},
+	 { (char *)"generalized_hammings_knn_hc", _wrap_generalized_hammings_knn_hc, METH_VARARGS, NULL},
 	 { (char *)"get_num_gpus", _wrap_get_num_gpus, METH_VARARGS, NULL},
 	 { (char *)"delete_GpuResources", _wrap_delete_GpuResources, METH_VARARGS, NULL},
 	 { (char *)"GpuResources_initializeForDevice", _wrap_GpuResources_initializeForDevice, METH_VARARGS, NULL},
@@ -72412,13 +80726,13 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"IndexPQ_reset", _wrap_IndexPQ_reset, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_reconstruct_n", _wrap_IndexPQ_reconstruct_n, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_reconstruct", _wrap_IndexPQ_reconstruct, METH_VARARGS, NULL},
+	 { (char *)"IndexPQ_remove_ids", _wrap_IndexPQ_remove_ids, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_do_polysemous_training_set", _wrap_IndexPQ_do_polysemous_training_set, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_do_polysemous_training_get", _wrap_IndexPQ_do_polysemous_training_get, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_polysemous_training_set", _wrap_IndexPQ_polysemous_training_set, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_polysemous_training_get", _wrap_IndexPQ_polysemous_training_get, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_search_type_set", _wrap_IndexPQ_search_type_set, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_search_type_get", _wrap_IndexPQ_search_type_get, METH_VARARGS, NULL},
-	 { (char *)"IndexPQ_remove_ids", _wrap_IndexPQ_remove_ids, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_encode_signs_set", _wrap_IndexPQ_encode_signs_set, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_encode_signs_get", _wrap_IndexPQ_encode_signs_get, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_polysemous_ht_set", _wrap_IndexPQ_polysemous_ht_set, METH_VARARGS, NULL},
@@ -72504,6 +80818,13 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"ArrayInvertedLists_resize", _wrap_ArrayInvertedLists_resize, METH_VARARGS, NULL},
 	 { (char *)"delete_ArrayInvertedLists", _wrap_delete_ArrayInvertedLists, METH_VARARGS, NULL},
 	 { (char *)"ArrayInvertedLists_swigregister", ArrayInvertedLists_swigregister, METH_VARARGS, NULL},
+	 { (char *)"IVFSearchParameters_nprobe_set", _wrap_IVFSearchParameters_nprobe_set, METH_VARARGS, NULL},
+	 { (char *)"IVFSearchParameters_nprobe_get", _wrap_IVFSearchParameters_nprobe_get, METH_VARARGS, NULL},
+	 { (char *)"IVFSearchParameters_max_codes_set", _wrap_IVFSearchParameters_max_codes_set, METH_VARARGS, NULL},
+	 { (char *)"IVFSearchParameters_max_codes_get", _wrap_IVFSearchParameters_max_codes_get, METH_VARARGS, NULL},
+	 { (char *)"delete_IVFSearchParameters", _wrap_delete_IVFSearchParameters, METH_VARARGS, NULL},
+	 { (char *)"new_IVFSearchParameters", _wrap_new_IVFSearchParameters, METH_VARARGS, NULL},
+	 { (char *)"IVFSearchParameters_swigregister", IVFSearchParameters_swigregister, METH_VARARGS, NULL},
 	 { (char *)"IndexIVF_invlists_set", _wrap_IndexIVF_invlists_set, METH_VARARGS, NULL},
 	 { (char *)"IndexIVF_invlists_get", _wrap_IndexIVF_invlists_get, METH_VARARGS, NULL},
 	 { (char *)"IndexIVF_own_invlists_set", _wrap_IndexIVF_own_invlists_set, METH_VARARGS, NULL},
@@ -72726,6 +81047,18 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"new_IndexIVFFlat", _wrap_new_IndexIVFFlat, METH_VARARGS, NULL},
 	 { (char *)"delete_IndexIVFFlat", _wrap_delete_IndexIVFFlat, METH_VARARGS, NULL},
 	 { (char *)"IndexIVFFlat_swigregister", IndexIVFFlat_swigregister, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_instances_set", _wrap_IndexIVFFlatDedup_instances_set, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_instances_get", _wrap_IndexIVFFlatDedup_instances_get, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_train", _wrap_IndexIVFFlatDedup_train, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_add_with_ids", _wrap_IndexIVFFlatDedup_add_with_ids, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_search_preassigned", _wrap_IndexIVFFlatDedup_search_preassigned, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_remove_ids", _wrap_IndexIVFFlatDedup_remove_ids, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_range_search", _wrap_IndexIVFFlatDedup_range_search, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_update_vectors", _wrap_IndexIVFFlatDedup_update_vectors, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_reconstruct_from_offset", _wrap_IndexIVFFlatDedup_reconstruct_from_offset, METH_VARARGS, NULL},
+	 { (char *)"new_IndexIVFFlatDedup", _wrap_new_IndexIVFFlatDedup, METH_VARARGS, NULL},
+	 { (char *)"delete_IndexIVFFlatDedup", _wrap_delete_IndexIVFFlatDedup, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_swigregister", IndexIVFFlatDedup_swigregister, METH_VARARGS, NULL},
 	 { (char *)"OnDiskInvertedLists_lists_set", _wrap_OnDiskInvertedLists_lists_set, METH_VARARGS, NULL},
 	 { (char *)"OnDiskInvertedLists_lists_get", _wrap_OnDiskInvertedLists_lists_get, METH_VARARGS, NULL},
 	 { (char *)"OnDiskInvertedLists_slots_set", _wrap_OnDiskInvertedLists_slots_set, METH_VARARGS, NULL},
@@ -72758,6 +81091,13 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"OnDiskInvertedLists_free_slot", _wrap_OnDiskInvertedLists_free_slot, METH_VARARGS, NULL},
 	 { (char *)"new_OnDiskInvertedLists", _wrap_new_OnDiskInvertedLists, METH_VARARGS, NULL},
 	 { (char *)"OnDiskInvertedLists_swigregister", OnDiskInvertedLists_swigregister, METH_VARARGS, NULL},
+	 { (char *)"IVFPQSearchParameters_scan_table_threshold_set", _wrap_IVFPQSearchParameters_scan_table_threshold_set, METH_VARARGS, NULL},
+	 { (char *)"IVFPQSearchParameters_scan_table_threshold_get", _wrap_IVFPQSearchParameters_scan_table_threshold_get, METH_VARARGS, NULL},
+	 { (char *)"IVFPQSearchParameters_polysemous_ht_set", _wrap_IVFPQSearchParameters_polysemous_ht_set, METH_VARARGS, NULL},
+	 { (char *)"IVFPQSearchParameters_polysemous_ht_get", _wrap_IVFPQSearchParameters_polysemous_ht_get, METH_VARARGS, NULL},
+	 { (char *)"delete_IVFPQSearchParameters", _wrap_delete_IVFPQSearchParameters, METH_VARARGS, NULL},
+	 { (char *)"new_IVFPQSearchParameters", _wrap_new_IVFPQSearchParameters, METH_VARARGS, NULL},
+	 { (char *)"IVFPQSearchParameters_swigregister", IVFPQSearchParameters_swigregister, METH_VARARGS, NULL},
 	 { (char *)"IndexIVFPQ_by_residual_set", _wrap_IndexIVFPQ_by_residual_set, METH_VARARGS, NULL},
 	 { (char *)"IndexIVFPQ_by_residual_get", _wrap_IndexIVFPQ_by_residual_get, METH_VARARGS, NULL},
 	 { (char *)"IndexIVFPQ_use_precomputed_table_set", _wrap_IndexIVFPQ_use_precomputed_table_set, METH_VARARGS, NULL},
@@ -72855,6 +81195,90 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"Index2Layer_reset", _wrap_Index2Layer_reset, METH_VARARGS, NULL},
 	 { (char *)"Index2Layer_transfer_to_IVFPQ", _wrap_Index2Layer_transfer_to_IVFPQ, METH_VARARGS, NULL},
 	 { (char *)"Index2Layer_swigregister", Index2Layer_swigregister, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_d_set", _wrap_IndexBinary_d_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_d_get", _wrap_IndexBinary_d_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_code_size_set", _wrap_IndexBinary_code_size_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_code_size_get", _wrap_IndexBinary_code_size_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_ntotal_set", _wrap_IndexBinary_ntotal_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_ntotal_get", _wrap_IndexBinary_ntotal_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_verbose_set", _wrap_IndexBinary_verbose_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_verbose_get", _wrap_IndexBinary_verbose_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_is_trained_set", _wrap_IndexBinary_is_trained_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_is_trained_get", _wrap_IndexBinary_is_trained_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_metric_type_set", _wrap_IndexBinary_metric_type_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_metric_type_get", _wrap_IndexBinary_metric_type_get, METH_VARARGS, NULL},
+	 { (char *)"delete_IndexBinary", _wrap_delete_IndexBinary, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_train", _wrap_IndexBinary_train, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_add", _wrap_IndexBinary_add, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_add_with_ids", _wrap_IndexBinary_add_with_ids, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_search", _wrap_IndexBinary_search, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_range_search", _wrap_IndexBinary_range_search, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_assign", _wrap_IndexBinary_assign, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_reset", _wrap_IndexBinary_reset, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_remove_ids", _wrap_IndexBinary_remove_ids, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_reconstruct", _wrap_IndexBinary_reconstruct, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_reconstruct_n", _wrap_IndexBinary_reconstruct_n, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_search_and_reconstruct", _wrap_IndexBinary_search_and_reconstruct, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_display", _wrap_IndexBinary_display, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_swigregister", IndexBinary_swigregister, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_xb_set", _wrap_IndexBinaryFlat_xb_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_xb_get", _wrap_IndexBinaryFlat_xb_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_use_heap_set", _wrap_IndexBinaryFlat_use_heap_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_use_heap_get", _wrap_IndexBinaryFlat_use_heap_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_query_batch_size_set", _wrap_IndexBinaryFlat_query_batch_size_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_query_batch_size_get", _wrap_IndexBinaryFlat_query_batch_size_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_add", _wrap_IndexBinaryFlat_add, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_reset", _wrap_IndexBinaryFlat_reset, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_search", _wrap_IndexBinaryFlat_search, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_reconstruct", _wrap_IndexBinaryFlat_reconstruct, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_remove_ids", _wrap_IndexBinaryFlat_remove_ids, METH_VARARGS, NULL},
+	 { (char *)"new_IndexBinaryFlat", _wrap_new_IndexBinaryFlat, METH_VARARGS, NULL},
+	 { (char *)"delete_IndexBinaryFlat", _wrap_delete_IndexBinaryFlat, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_swigregister", IndexBinaryFlat_swigregister, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_invlists_set", _wrap_IndexBinaryIVF_invlists_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_invlists_get", _wrap_IndexBinaryIVF_invlists_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_own_invlists_set", _wrap_IndexBinaryIVF_own_invlists_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_own_invlists_get", _wrap_IndexBinaryIVF_own_invlists_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_nprobe_set", _wrap_IndexBinaryIVF_nprobe_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_nprobe_get", _wrap_IndexBinaryIVF_nprobe_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_max_codes_set", _wrap_IndexBinaryIVF_max_codes_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_max_codes_get", _wrap_IndexBinaryIVF_max_codes_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_use_heap_set", _wrap_IndexBinaryIVF_use_heap_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_use_heap_get", _wrap_IndexBinaryIVF_use_heap_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_maintain_direct_map_set", _wrap_IndexBinaryIVF_maintain_direct_map_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_maintain_direct_map_get", _wrap_IndexBinaryIVF_maintain_direct_map_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_direct_map_set", _wrap_IndexBinaryIVF_direct_map_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_direct_map_get", _wrap_IndexBinaryIVF_direct_map_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_quantizer_set", _wrap_IndexBinaryIVF_quantizer_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_quantizer_get", _wrap_IndexBinaryIVF_quantizer_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_nlist_set", _wrap_IndexBinaryIVF_nlist_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_nlist_get", _wrap_IndexBinaryIVF_nlist_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_own_fields_set", _wrap_IndexBinaryIVF_own_fields_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_own_fields_get", _wrap_IndexBinaryIVF_own_fields_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_cp_set", _wrap_IndexBinaryIVF_cp_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_cp_get", _wrap_IndexBinaryIVF_cp_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_train_q1", _wrap_IndexBinaryIVF_train_q1, METH_VARARGS, NULL},
+	 { (char *)"new_IndexBinaryIVF", _wrap_new_IndexBinaryIVF, METH_VARARGS, NULL},
+	 { (char *)"delete_IndexBinaryIVF", _wrap_delete_IndexBinaryIVF, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_reset", _wrap_IndexBinaryIVF_reset, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_train", _wrap_IndexBinaryIVF_train, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_add", _wrap_IndexBinaryIVF_add, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_add_with_ids", _wrap_IndexBinaryIVF_add_with_ids, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_add_core", _wrap_IndexBinaryIVF_add_core, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_search_preassigned", _wrap_IndexBinaryIVF_search_preassigned, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_search", _wrap_IndexBinaryIVF_search, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_reconstruct", _wrap_IndexBinaryIVF_reconstruct, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_reconstruct_n", _wrap_IndexBinaryIVF_reconstruct_n, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_search_and_reconstruct", _wrap_IndexBinaryIVF_search_and_reconstruct, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_reconstruct_from_offset", _wrap_IndexBinaryIVF_reconstruct_from_offset, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_remove_ids", _wrap_IndexBinaryIVF_remove_ids, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_merge_from", _wrap_IndexBinaryIVF_merge_from, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_get_list_size", _wrap_IndexBinaryIVF_get_list_size, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_make_direct_map", _wrap_IndexBinaryIVF_make_direct_map, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_imbalance_factor", _wrap_IndexBinaryIVF_imbalance_factor, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_print_stats", _wrap_IndexBinaryIVF_print_stats, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_replace_invlists", _wrap_IndexBinaryIVF_replace_invlists, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_swigregister", IndexBinaryIVF_swigregister, METH_VARARGS, NULL},
 	 { (char *)"IndexIDMap_index_set", _wrap_IndexIDMap_index_set, METH_VARARGS, NULL},
 	 { (char *)"IndexIDMap_index_get", _wrap_IndexIDMap_index_get, METH_VARARGS, NULL},
 	 { (char *)"IndexIDMap_own_fields_set", _wrap_IndexIDMap_own_fields_set, METH_VARARGS, NULL},
@@ -73064,7 +81488,9 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"downcast_index", _wrap_downcast_index, METH_VARARGS, NULL},
 	 { (char *)"downcast_VectorTransform", _wrap_downcast_VectorTransform, METH_VARARGS, NULL},
 	 { (char *)"write_index", _wrap_write_index, METH_VARARGS, NULL},
+	 { (char *)"write_index_binary", _wrap_write_index_binary, METH_VARARGS, NULL},
 	 { (char *)"read_index", _wrap_read_index, METH_VARARGS, NULL},
+	 { (char *)"read_index_binary", _wrap_read_index_binary, METH_VARARGS, NULL},
 	 { (char *)"write_VectorTransform", _wrap_write_VectorTransform, METH_VARARGS, NULL},
 	 { (char *)"read_VectorTransform", _wrap_read_VectorTransform, METH_VARARGS, NULL},
 	 { (char *)"read_ProductQuantizer", _wrap_read_ProductQuantizer, METH_VARARGS, NULL},
@@ -73076,12 +81502,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"delete_Cloner", _wrap_delete_Cloner, METH_VARARGS, NULL},
 	 { (char *)"new_Cloner", _wrap_new_Cloner, METH_VARARGS, NULL},
 	 { (char *)"Cloner_swigregister", Cloner_swigregister, METH_VARARGS, NULL},
-	 { (char *)"IOReader___call__", _wrap_IOReader___call__, METH_VARARGS, NULL},
-	 { (char *)"delete_IOReader", _wrap_delete_IOReader, METH_VARARGS, NULL},
-	 { (char *)"IOReader_swigregister", IOReader_swigregister, METH_VARARGS, NULL},
-	 { (char *)"IOWriter___call__", _wrap_IOWriter___call__, METH_VARARGS, NULL},
-	 { (char *)"delete_IOWriter", _wrap_delete_IOWriter, METH_VARARGS, NULL},
-	 { (char *)"IOWriter_swigregister", IOWriter_swigregister, METH_VARARGS, NULL},
 	 { (char *)"AutoTuneCriterion_nq_set", _wrap_AutoTuneCriterion_nq_set, METH_VARARGS, NULL},
 	 { (char *)"AutoTuneCriterion_nq_get", _wrap_AutoTuneCriterion_nq_get, METH_VARARGS, NULL},
 	 { (char *)"AutoTuneCriterion_nnn_set", _wrap_AutoTuneCriterion_nnn_set, METH_VARARGS, NULL},
@@ -73164,6 +81584,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"delete_ParameterSpace", _wrap_delete_ParameterSpace, METH_VARARGS, NULL},
 	 { (char *)"ParameterSpace_swigregister", ParameterSpace_swigregister, METH_VARARGS, NULL},
 	 { (char *)"index_factory", _wrap_index_factory, METH_VARARGS, NULL},
+	 { (char *)"index_binary_factory", _wrap_index_binary_factory, METH_VARARGS, NULL},
 	 { (char *)"index_gpu_to_cpu", _wrap_index_gpu_to_cpu, METH_VARARGS, NULL},
 	 { (char *)"index_cpu_to_gpu", _wrap_index_cpu_to_gpu, METH_VARARGS, NULL},
 	 { (char *)"index_cpu_to_gpu_multiple", _wrap_index_cpu_to_gpu_multiple, METH_VARARGS, NULL},
@@ -73308,6 +81729,27 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"RangeSearchPartialResult_set_result", _wrap_RangeSearchPartialResult_set_result, METH_VARARGS, NULL},
 	 { (char *)"delete_RangeSearchPartialResult", _wrap_delete_RangeSearchPartialResult, METH_VARARGS, NULL},
 	 { (char *)"RangeSearchPartialResult_swigregister", RangeSearchPartialResult_swigregister, METH_VARARGS, NULL},
+	 { (char *)"IOReader___call__", _wrap_IOReader___call__, METH_VARARGS, NULL},
+	 { (char *)"IOReader_fileno", _wrap_IOReader_fileno, METH_VARARGS, NULL},
+	 { (char *)"delete_IOReader", _wrap_delete_IOReader, METH_VARARGS, NULL},
+	 { (char *)"IOReader_swigregister", IOReader_swigregister, METH_VARARGS, NULL},
+	 { (char *)"IOWriter___call__", _wrap_IOWriter___call__, METH_VARARGS, NULL},
+	 { (char *)"IOWriter_fileno", _wrap_IOWriter_fileno, METH_VARARGS, NULL},
+	 { (char *)"delete_IOWriter", _wrap_delete_IOWriter, METH_VARARGS, NULL},
+	 { (char *)"IOWriter_swigregister", IOWriter_swigregister, METH_VARARGS, NULL},
+	 { (char *)"VectorIOReader_data_get", _wrap_VectorIOReader_data_get, METH_VARARGS, NULL},
+	 { (char *)"VectorIOReader_rp_set", _wrap_VectorIOReader_rp_set, METH_VARARGS, NULL},
+	 { (char *)"VectorIOReader_rp_get", _wrap_VectorIOReader_rp_get, METH_VARARGS, NULL},
+	 { (char *)"VectorIOReader___call__", _wrap_VectorIOReader___call__, METH_VARARGS, NULL},
+	 { (char *)"new_VectorIOReader", _wrap_new_VectorIOReader, METH_VARARGS, NULL},
+	 { (char *)"delete_VectorIOReader", _wrap_delete_VectorIOReader, METH_VARARGS, NULL},
+	 { (char *)"VectorIOReader_swigregister", VectorIOReader_swigregister, METH_VARARGS, NULL},
+	 { (char *)"VectorIOWriter_data_set", _wrap_VectorIOWriter_data_set, METH_VARARGS, NULL},
+	 { (char *)"VectorIOWriter_data_get", _wrap_VectorIOWriter_data_get, METH_VARARGS, NULL},
+	 { (char *)"VectorIOWriter___call__", _wrap_VectorIOWriter___call__, METH_VARARGS, NULL},
+	 { (char *)"new_VectorIOWriter", _wrap_new_VectorIOWriter, METH_VARARGS, NULL},
+	 { (char *)"delete_VectorIOWriter", _wrap_delete_VectorIOWriter, METH_VARARGS, NULL},
+	 { (char *)"VectorIOWriter_swigregister", VectorIOWriter_swigregister, METH_VARARGS, NULL},
 	 { (char *)"ignore_SIGTTIN", _wrap_ignore_SIGTTIN, METH_VARARGS, NULL},
 	 { (char *)"MapLong2Long_map_set", _wrap_MapLong2Long_map_set, METH_VARARGS, NULL},
 	 { (char *)"MapLong2Long_map_get", _wrap_MapLong2Long_map_get, METH_VARARGS, NULL},
@@ -73389,6 +81831,9 @@ static void *_p_p_faiss__NormalizationTransformTo_p_p_faiss__VectorTransform(voi
 static void *_p_faiss__gpu__GpuMultipleClonerOptionsTo_p_faiss__gpu__GpuClonerOptions(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::gpu::GpuClonerOptions *)  ((faiss::gpu::GpuMultipleClonerOptions *) x));
 }
+static void *_p_faiss__IndexIVFFlatDedupTo_p_faiss__IndexIVFFlat(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexIVFFlat *)  ((faiss::IndexIVFFlatDedup *) x));
+}
 static void *_p_faiss__IDSelectorBatchTo_p_faiss__IDSelector(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::IDSelector *)  ((faiss::IDSelectorBatch *) x));
 }
@@ -73431,6 +81876,9 @@ static void *_p_p_faiss__ArrayInvertedListsTo_p_p_faiss__InvertedLists(void *x, 
 static void *_p_p_faiss__OnDiskInvertedListsTo_p_p_faiss__InvertedLists(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::InvertedLists **)  ((faiss::OnDiskInvertedLists **) x));
 }
+static void *_p_faiss__VectorIOReaderTo_p_faiss__IOReader(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IOReader *)  ((faiss::VectorIOReader *) x));
+}
 static void *_p_faiss__IndexFlat1DTo_p_faiss__IndexFlatL2(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::IndexFlatL2 *)  ((faiss::IndexFlat1D *) x));
 }
@@ -73445,6 +81893,9 @@ static void *_p_faiss__IndexIVFPQTo_p_faiss__IndexIVF(void *x, int *SWIGUNUSEDPA
 }
 static void *_p_faiss__IndexIVFFlatTo_p_faiss__IndexIVF(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::IndexIVF *)  ((faiss::IndexIVFFlat *) x));
+}
+static void *_p_faiss__IndexIVFFlatDedupTo_p_faiss__IndexIVF(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexIVF *) (faiss::IndexIVFFlat *) ((faiss::IndexIVFFlatDedup *) x));
 }
 static void *_p_faiss__IndexIVFPQRTo_p_faiss__IndexIVF(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::IndexIVF *) (faiss::IndexIVFPQ *) ((faiss::IndexIVFPQR *) x));
@@ -73500,8 +81951,14 @@ static void *_p_faiss__SimulatedAnnealingOptimizerTo_p_faiss__SimulatedAnnealing
 static void *_p_faiss__ClusteringTo_p_faiss__ClusteringParameters(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::ClusteringParameters *)  ((faiss::Clustering *) x));
 }
+static void *_p_faiss__IVFPQSearchParametersTo_p_faiss__IVFSearchParameters(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IVFSearchParameters *)  ((faiss::IVFPQSearchParameters *) x));
+}
 static void *_p_p_faiss__IndexPQTo_p_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::Index **)  ((faiss::IndexPQ **) x));
+}
+static void *_p_p_faiss__IndexIVFFlatDedupTo_p_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index **) (faiss::IndexIVF *)(faiss::IndexIVFFlat *) ((faiss::IndexIVFFlatDedup **) x));
 }
 static void *_p_p_faiss__IndexPreTransformTo_p_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::Index **)  ((faiss::IndexPreTransform **) x));
@@ -73512,11 +81969,11 @@ static void *_p_p_faiss__IndexSplitVectorsTo_p_p_faiss__Index(void *x, int *SWIG
 static void *_p_p_faiss__IndexIDMap2To_p_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::Index **) (faiss::IndexIDMap *) ((faiss::IndexIDMap2 **) x));
 }
-static void *_p_p_faiss__gpu__GpuIndexIVFFlatTo_p_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index **) (faiss::gpu::GpuIndex *)(faiss::gpu::GpuIndexIVF *) ((faiss::gpu::GpuIndexIVFFlat **) x));
-}
 static void *_p_p_faiss__IndexIVFFlatTo_p_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::Index **) (faiss::IndexIVF *) ((faiss::IndexIVFFlat **) x));
+}
+static void *_p_p_faiss__gpu__GpuIndexIVFFlatTo_p_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index **) (faiss::gpu::GpuIndex *)(faiss::gpu::GpuIndexIVF *) ((faiss::gpu::GpuIndexIVFFlat **) x));
 }
 static void *_p_p_faiss__MultiIndexQuantizerTo_p_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::Index **)  ((faiss::MultiIndexQuantizer **) x));
@@ -73608,6 +82065,9 @@ static void *_p_p_faiss__IndexShardsTo_p_p_faiss__Index(void *x, int *SWIGUNUSED
 static void *_p_faiss__IndexPQTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::Index *)  ((faiss::IndexPQ *) x));
 }
+static void *_p_faiss__IndexIVFFlatDedupTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *) (faiss::IndexIVF *)(faiss::IndexIVFFlat *) ((faiss::IndexIVFFlatDedup *) x));
+}
 static void *_p_faiss__IndexPreTransformTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::Index *)  ((faiss::IndexPreTransform *) x));
 }
@@ -73617,11 +82077,11 @@ static void *_p_faiss__IndexSplitVectorsTo_p_faiss__Index(void *x, int *SWIGUNUS
 static void *_p_faiss__IndexIDMap2To_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::Index *) (faiss::IndexIDMap *) ((faiss::IndexIDMap2 *) x));
 }
-static void *_p_faiss__gpu__GpuIndexIVFFlatTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *) (faiss::gpu::GpuIndex *)(faiss::gpu::GpuIndexIVF *) ((faiss::gpu::GpuIndexIVFFlat *) x));
-}
 static void *_p_faiss__IndexIVFFlatTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::Index *) (faiss::IndexIVF *) ((faiss::IndexIVFFlat *) x));
+}
+static void *_p_faiss__gpu__GpuIndexIVFFlatTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *) (faiss::gpu::GpuIndex *)(faiss::gpu::GpuIndexIVF *) ((faiss::gpu::GpuIndexIVFFlat *) x));
 }
 static void *_p_faiss__MultiIndexQuantizerTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::Index *)  ((faiss::MultiIndexQuantizer *) x));
@@ -73713,6 +82173,12 @@ static void *_p_faiss__IndexShardsTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM
 static void *_p_faiss__gpu__GpuParameterSpaceTo_p_faiss__ParameterSpace(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::ParameterSpace *)  ((faiss::gpu::GpuParameterSpace *) x));
 }
+static void *_p_faiss__IndexBinaryFlatTo_p_faiss__IndexBinary(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexBinary *)  ((faiss::IndexBinaryFlat *) x));
+}
+static void *_p_faiss__IndexBinaryIVFTo_p_faiss__IndexBinary(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexBinary *)  ((faiss::IndexBinaryIVF *) x));
+}
 static void *_p_faiss__MultiIndexQuantizer2To_p_faiss__MultiIndexQuantizer(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::MultiIndexQuantizer *)  ((faiss::MultiIndexQuantizer2 *) x));
 }
@@ -73728,6 +82194,9 @@ static void *_p_faiss__IndexIVFPQTo_p_faiss__Level1Quantizer(void *x, int *SWIGU
 static void *_p_faiss__IndexIVFFlatTo_p_faiss__Level1Quantizer(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::Level1Quantizer *) (faiss::IndexIVF *) ((faiss::IndexIVFFlat *) x));
 }
+static void *_p_faiss__IndexIVFFlatDedupTo_p_faiss__Level1Quantizer(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Level1Quantizer *) (faiss::IndexIVF *)(faiss::IndexIVFFlat *) ((faiss::IndexIVFFlatDedup *) x));
+}
 static void *_p_faiss__IndexIVFPQRTo_p_faiss__Level1Quantizer(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::Level1Quantizer *) (faiss::IndexIVF *)(faiss::IndexIVFPQ *) ((faiss::IndexIVFPQR *) x));
 }
@@ -73742,6 +82211,9 @@ static void *_p_faiss__gpu__StandardGpuResourcesTo_p_faiss__gpu__GpuResources(vo
 }
 static void *_p_p_faiss__gpu__StandardGpuResourcesTo_p_p_faiss__gpu__GpuResources(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::gpu::GpuResources **)  ((faiss::gpu::StandardGpuResources **) x));
+}
+static void *_p_faiss__VectorIOWriterTo_p_faiss__IOWriter(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IOWriter *)  ((faiss::VectorIOWriter *) x));
 }
 static swig_type_info _swigt__p_Crev = {"_p_Crev", "Crev *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_FILE = {"_p_FILE", "FILE *", 0, 0, (void*)0, 0};
@@ -73783,8 +82255,13 @@ static swig_type_info _swigt__p_faiss__IDSelectorBatch = {"_p_faiss__IDSelectorB
 static swig_type_info _swigt__p_faiss__IDSelectorRange = {"_p_faiss__IDSelectorRange", "faiss::IDSelectorRange *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IOReader = {"_p_faiss__IOReader", "faiss::IOReader *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IOWriter = {"_p_faiss__IOWriter", "faiss::IOWriter *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_faiss__IVFPQSearchParameters = {"_p_faiss__IVFPQSearchParameters", "faiss::IVFPQSearchParameters *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_faiss__IVFSearchParameters = {"_p_faiss__IVFSearchParameters", "faiss::IVFSearchParameters *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__Index = {"_p_faiss__Index", "faiss::Index *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__Index2Layer = {"_p_faiss__Index2Layer", "faiss::Index2Layer *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_faiss__IndexBinary = {"_p_faiss__IndexBinary", "faiss::IndexBinary *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_faiss__IndexBinaryFlat = {"_p_faiss__IndexBinaryFlat", "faiss::IndexBinaryFlat *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_faiss__IndexBinaryIVF = {"_p_faiss__IndexBinaryIVF", "faiss::IndexBinaryIVF *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IndexFlat = {"_p_faiss__IndexFlat", "faiss::IndexFlat *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IndexFlat1D = {"_p_faiss__IndexFlat1D", "faiss::IndexFlat1D *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IndexFlatIP = {"_p_faiss__IndexFlatIP", "faiss::IndexFlatIP *", 0, 0, (void*)0, 0};
@@ -73799,6 +82276,7 @@ static swig_type_info _swigt__p_faiss__IndexIDMap = {"_p_faiss__IndexIDMap", "fa
 static swig_type_info _swigt__p_faiss__IndexIDMap2 = {"_p_faiss__IndexIDMap2", "faiss::IndexIDMap2 *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IndexIVF = {"_p_faiss__IndexIVF", "faiss::IndexIVF *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IndexIVFFlat = {"_p_faiss__IndexIVFFlat", "faiss::IndexIVFFlat *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_faiss__IndexIVFFlatDedup = {"_p_faiss__IndexIVFFlatDedup", "faiss::IndexIVFFlatDedup *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IndexIVFPQ = {"_p_faiss__IndexIVFPQ", "faiss::IndexIVFPQ *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IndexIVFPQR = {"_p_faiss__IndexIVFPQR", "faiss::IndexIVFPQR *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IndexIVFPQStats = {"_p_faiss__IndexIVFPQStats", "faiss::IndexIVFPQStats *", 0, 0, (void*)0, 0};
@@ -73844,6 +82322,8 @@ static swig_type_info _swigt__p_faiss__ScalarQuantizer = {"_p_faiss__ScalarQuant
 static swig_type_info _swigt__p_faiss__ScalarQuantizer__DistanceComputer = {"_p_faiss__ScalarQuantizer__DistanceComputer", "faiss::ScalarQuantizer::DistanceComputer *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__SimulatedAnnealingOptimizer = {"_p_faiss__SimulatedAnnealingOptimizer", "faiss::SimulatedAnnealingOptimizer *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__SimulatedAnnealingParameters = {"_p_faiss__SimulatedAnnealingParameters", "faiss::SimulatedAnnealingParameters *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_faiss__VectorIOReader = {"_p_faiss__VectorIOReader", "faiss::VectorIOReader *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_faiss__VectorIOWriter = {"_p_faiss__VectorIOWriter", "faiss::VectorIOWriter *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__VectorTransform = {"_p_faiss__VectorTransform", "faiss::VectorTransform *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__VisitedTable = {"_p_faiss__VisitedTable", "faiss::VisitedTable *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__gpu__FlatIndex = {"_p_faiss__gpu__FlatIndex", "faiss::gpu::FlatIndex *", 0, 0, (void*)0, 0};
@@ -73868,14 +82348,15 @@ static swig_type_info _swigt__p_faiss__gpu__StandardGpuResources = {"_p_faiss__g
 static swig_type_info _swigt__p_float = {"_p_float", "float *|faiss::HeapArray< faiss::CMin< float,long > >::T *|faiss::HeapArray< faiss::CMax< float,long > >::T *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_idx_t = {"_p_idx_t", "idx_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_int = {"_p_int", "int *|int32_t *|hamdis_t *|faiss::HeapArray< faiss::CMin< int,long > >::T *|faiss::HeapArray< faiss::CMax< int,long > >::T *|faiss::IndexHNSW::storage_idx_t *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_long = {"_p_long", "long *|faiss::HeapArray< faiss::CMax< float,long > >::TI *|faiss::HeapArray< faiss::CMin< float,long > >::TI *|faiss::AutoTuneCriterion::idx_t *|faiss::ReconstructFromNeighbors::idx_t *|faiss::HNSW::idx_t *|faiss::InvertedLists::idx_t *|faiss::Index::idx_t *|faiss::RangeSearchResult::idx_t *|faiss::IDSelector::idx_t *|faiss::BufferList::idx_t *|faiss::HeapArray< faiss::CMin< int,long > >::TI *|faiss::HeapArray< faiss::CMax< int,long > >::TI *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_long = {"_p_long", "faiss::HeapArray< faiss::CMax< float,long > >::TI *|faiss::HeapArray< faiss::CMin< float,long > >::TI *|faiss::BufferList::idx_t *|faiss::IDSelector::idx_t *|faiss::RangeSearchResult::idx_t *|faiss::Index::idx_t *|faiss::InvertedLists::idx_t *|faiss::HNSW::idx_t *|faiss::ReconstructFromNeighbors::idx_t *|faiss::IndexBinary::idx_t *|faiss::AutoTuneCriterion::idx_t *|faiss::HeapArray< faiss::CMax< int,long > >::TI *|faiss::HeapArray< faiss::CMin< int,long > >::TI *|long *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_faiss__Index = {"_p_p_faiss__Index", "faiss::Index **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_faiss__IndexPQ = {"_p_p_faiss__IndexPQ", 0, 0, 0, 0, 0};
+static swig_type_info _swigt__p_p_faiss__IndexIVFFlatDedup = {"_p_p_faiss__IndexIVFFlatDedup", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_p_faiss__IndexPreTransform = {"_p_p_faiss__IndexPreTransform", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_p_faiss__IndexSplitVectors = {"_p_p_faiss__IndexSplitVectors", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_p_faiss__IndexIDMap2 = {"_p_p_faiss__IndexIDMap2", 0, 0, 0, 0, 0};
-static swig_type_info _swigt__p_p_faiss__gpu__GpuIndexIVFFlat = {"_p_p_faiss__gpu__GpuIndexIVFFlat", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_p_faiss__IndexIVFFlat = {"_p_p_faiss__IndexIVFFlat", 0, 0, 0, 0, 0};
+static swig_type_info _swigt__p_p_faiss__gpu__GpuIndexIVFFlat = {"_p_p_faiss__gpu__GpuIndexIVFFlat", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_p_faiss__MultiIndexQuantizer = {"_p_p_faiss__MultiIndexQuantizer", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_p_faiss__IndexScalarQuantizer = {"_p_p_faiss__IndexScalarQuantizer", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_p_faiss__IndexIVFScalarQuantizer = {"_p_p_faiss__IndexIVFScalarQuantizer", 0, 0, 0, 0, 0};
@@ -73922,6 +82403,8 @@ static swig_type_info _swigt__p_std__functionT_void_ffaiss__Index_pF_t = {"_p_st
 static swig_type_info _swigt__p_std__listT_faiss__OnDiskInvertedLists__Slot_t = {"_p_std__listT_faiss__OnDiskInvertedLists__Slot_t", "std::list< faiss::OnDiskInvertedLists::Slot > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__pairT_void_p_unsigned_long_t = {"_p_std__pairT_void_p_unsigned_long_t", "std::pair< void *,unsigned long > *|std::pair< void *,size_t > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__unordered_mapT_long_long_t = {"_p_std__unordered_mapT_long_long_t", "std::unordered_map< long,long > *|std::unordered_map< faiss::Index::idx_t,faiss::Index::idx_t > *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_std__unordered_multimapT_long_long_t = {"_p_std__unordered_multimapT_long_long_t", "std::unordered_multimap< long,long > *|std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t > *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_std__vectorT_char_t = {"_p_std__vectorT_char_t", "std::vector< char > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__vectorT_cudaStream_t_t = {"_p_std__vectorT_cudaStream_t_t", "std::vector< cudaStream_t > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__vectorT_double_t = {"_p_std__vectorT_double_t", "std::vector< double > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__vectorT_faiss__BufferList__Buffer_t = {"_p_std__vectorT_faiss__BufferList__Buffer_t", "std::vector< faiss::BufferList::Buffer > *", 0, 0, (void*)0, 0};
@@ -73941,7 +82424,7 @@ static swig_type_info _swigt__p_std__vectorT_std__vectorT_float_t_t = {"_p_std__
 static swig_type_info _swigt__p_std__vectorT_std__vectorT_long_t_t = {"_p_std__vectorT_std__vectorT_long_t_t", "std::vector< std::vector< long > > *|std::vector< std::vector< faiss::InvertedLists::idx_t > > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__vectorT_std__vectorT_uint8_t_t_t = {"_p_std__vectorT_std__vectorT_uint8_t_t_t", "std::vector< std::vector< unsigned char > > *|std::vector< std::vector< uint8_t > > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__vectorT_unsigned_char_t = {"_p_std__vectorT_unsigned_char_t", "std::vector< unsigned char > *|std::vector< uint8_t > *|std::vector< faiss::IndexLSH::uint8_t > *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__vectorT_unsigned_long_t = {"_p_std__vectorT_unsigned_long_t", "std::vector< unsigned long > *|std::vector< size_t > *|std::vector< uint64_t > *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_std__vectorT_unsigned_long_t = {"_p_std__vectorT_unsigned_long_t", "std::vector< unsigned long > *|std::vector< size_t > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_storage_idx_t = {"_p_storage_idx_t", "storage_idx_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_uint32_t = {"_p_uint32_t", "uint32_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_char = {"_p_unsigned_char", "unsigned char *|uint8_t *", 0, 0, (void*)0, 0};
@@ -73989,8 +82472,13 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_faiss__IDSelectorRange,
   &_swigt__p_faiss__IOReader,
   &_swigt__p_faiss__IOWriter,
+  &_swigt__p_faiss__IVFPQSearchParameters,
+  &_swigt__p_faiss__IVFSearchParameters,
   &_swigt__p_faiss__Index,
   &_swigt__p_faiss__Index2Layer,
+  &_swigt__p_faiss__IndexBinary,
+  &_swigt__p_faiss__IndexBinaryFlat,
+  &_swigt__p_faiss__IndexBinaryIVF,
   &_swigt__p_faiss__IndexFlat,
   &_swigt__p_faiss__IndexFlat1D,
   &_swigt__p_faiss__IndexFlatIP,
@@ -74005,6 +82493,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_faiss__IndexIDMap2,
   &_swigt__p_faiss__IndexIVF,
   &_swigt__p_faiss__IndexIVFFlat,
+  &_swigt__p_faiss__IndexIVFFlatDedup,
   &_swigt__p_faiss__IndexIVFPQ,
   &_swigt__p_faiss__IndexIVFPQR,
   &_swigt__p_faiss__IndexIVFPQStats,
@@ -74050,6 +82539,8 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_faiss__ScalarQuantizer__DistanceComputer,
   &_swigt__p_faiss__SimulatedAnnealingOptimizer,
   &_swigt__p_faiss__SimulatedAnnealingParameters,
+  &_swigt__p_faiss__VectorIOReader,
+  &_swigt__p_faiss__VectorIOWriter,
   &_swigt__p_faiss__VectorTransform,
   &_swigt__p_faiss__VisitedTable,
   &_swigt__p_faiss__gpu__FlatIndex,
@@ -74092,6 +82583,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_p_faiss__IndexIDMap2,
   &_swigt__p_p_faiss__IndexIVF,
   &_swigt__p_p_faiss__IndexIVFFlat,
+  &_swigt__p_p_faiss__IndexIVFFlatDedup,
   &_swigt__p_p_faiss__IndexIVFPQ,
   &_swigt__p_p_faiss__IndexIVFPQR,
   &_swigt__p_p_faiss__IndexIVFScalarQuantizer,
@@ -74128,6 +82620,8 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_std__listT_faiss__OnDiskInvertedLists__Slot_t,
   &_swigt__p_std__pairT_void_p_unsigned_long_t,
   &_swigt__p_std__unordered_mapT_long_long_t,
+  &_swigt__p_std__unordered_multimapT_long_long_t,
+  &_swigt__p_std__vectorT_char_t,
   &_swigt__p_std__vectorT_cudaStream_t_t,
   &_swigt__p_std__vectorT_double_t,
   &_swigt__p_std__vectorT_faiss__BufferList__Buffer_t,
@@ -74193,10 +82687,15 @@ static swig_cast_info _swigc__p_faiss__HeapArrayT_faiss__CMinT_int_long_t_t[] = 
 static swig_cast_info _swigc__p_faiss__IDSelector[] = {  {&_swigt__p_faiss__IDSelector, 0, 0, 0},  {&_swigt__p_faiss__IDSelectorBatch, _p_faiss__IDSelectorBatchTo_p_faiss__IDSelector, 0, 0},  {&_swigt__p_faiss__IDSelectorRange, _p_faiss__IDSelectorRangeTo_p_faiss__IDSelector, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IDSelectorBatch[] = {  {&_swigt__p_faiss__IDSelectorBatch, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IDSelectorRange[] = {  {&_swigt__p_faiss__IDSelectorRange, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_faiss__IOReader[] = {  {&_swigt__p_faiss__IOReader, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_faiss__IOWriter[] = {  {&_swigt__p_faiss__IOWriter, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_faiss__Index[] = {  {&_swigt__p_faiss__IndexPQ, _p_faiss__IndexPQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexPreTransform, _p_faiss__IndexPreTransformTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__Index, 0, 0, 0},  {&_swigt__p_faiss__IndexSplitVectors, _p_faiss__IndexSplitVectorsTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIDMap2, _p_faiss__IndexIDMap2To_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__gpu__GpuIndexIVFFlat, _p_faiss__gpu__GpuIndexIVFFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFFlat, _p_faiss__IndexIVFFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__MultiIndexQuantizer, _p_faiss__MultiIndexQuantizerTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexScalarQuantizer, _p_faiss__IndexScalarQuantizerTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFScalarQuantizer, _p_faiss__IndexIVFScalarQuantizerTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexRefineFlat, _p_faiss__IndexRefineFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__gpu__GpuIndexIVFPQ, _p_faiss__gpu__GpuIndexIVFPQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFPQ, _p_faiss__IndexIVFPQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexLSH, _p_faiss__IndexLSHTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSWSQ, _p_faiss__IndexHNSWSQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__gpu__IndexProxy, _p_faiss__gpu__IndexProxyTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__gpu__GpuIndex, _p_faiss__gpu__GpuIndexTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIDMap, _p_faiss__IndexIDMapTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSW2Level, _p_faiss__IndexHNSW2LevelTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__Index2Layer, _p_faiss__Index2LayerTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlatL2, _p_faiss__IndexFlatL2To_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__gpu__GpuIndexFlatL2, _p_faiss__gpu__GpuIndexFlatL2To_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSWFlat, _p_faiss__IndexHNSWFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFPQR, _p_faiss__IndexIVFPQRTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlat1D, _p_faiss__IndexFlat1DTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlat, _p_faiss__IndexFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__gpu__GpuIndexFlat, _p_faiss__gpu__GpuIndexFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlatIP, _p_faiss__IndexFlatIPTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__gpu__GpuIndexFlatIP, _p_faiss__gpu__GpuIndexFlatIPTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSW, _p_faiss__IndexHNSWTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSWPQ, _p_faiss__IndexHNSWPQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlatL2BaseShift, _p_faiss__IndexFlatL2BaseShiftTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__gpu__GpuIndexIVF, _p_faiss__gpu__GpuIndexIVFTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVF, _p_faiss__IndexIVFTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__MultiIndexQuantizer2, _p_faiss__MultiIndexQuantizer2To_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexShards, _p_faiss__IndexShardsTo_p_faiss__Index, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IOReader[] = {  {&_swigt__p_faiss__IOReader, 0, 0, 0},  {&_swigt__p_faiss__VectorIOReader, _p_faiss__VectorIOReaderTo_p_faiss__IOReader, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IOWriter[] = {  {&_swigt__p_faiss__IOWriter, 0, 0, 0},  {&_swigt__p_faiss__VectorIOWriter, _p_faiss__VectorIOWriterTo_p_faiss__IOWriter, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IVFPQSearchParameters[] = {  {&_swigt__p_faiss__IVFPQSearchParameters, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IVFSearchParameters[] = {  {&_swigt__p_faiss__IVFSearchParameters, 0, 0, 0},  {&_swigt__p_faiss__IVFPQSearchParameters, _p_faiss__IVFPQSearchParametersTo_p_faiss__IVFSearchParameters, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__Index[] = {  {&_swigt__p_faiss__IndexPQ, _p_faiss__IndexPQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFFlatDedup, _p_faiss__IndexIVFFlatDedupTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexPreTransform, _p_faiss__IndexPreTransformTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__Index, 0, 0, 0},  {&_swigt__p_faiss__IndexSplitVectors, _p_faiss__IndexSplitVectorsTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIDMap2, _p_faiss__IndexIDMap2To_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFFlat, _p_faiss__IndexIVFFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__gpu__GpuIndexIVFFlat, _p_faiss__gpu__GpuIndexIVFFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__MultiIndexQuantizer, _p_faiss__MultiIndexQuantizerTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexScalarQuantizer, _p_faiss__IndexScalarQuantizerTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFScalarQuantizer, _p_faiss__IndexIVFScalarQuantizerTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexRefineFlat, _p_faiss__IndexRefineFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFPQ, _p_faiss__IndexIVFPQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__gpu__GpuIndexIVFPQ, _p_faiss__gpu__GpuIndexIVFPQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexLSH, _p_faiss__IndexLSHTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSWSQ, _p_faiss__IndexHNSWSQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__gpu__IndexProxy, _p_faiss__gpu__IndexProxyTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__gpu__GpuIndex, _p_faiss__gpu__GpuIndexTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIDMap, _p_faiss__IndexIDMapTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSW2Level, _p_faiss__IndexHNSW2LevelTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__Index2Layer, _p_faiss__Index2LayerTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlatL2, _p_faiss__IndexFlatL2To_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__gpu__GpuIndexFlatL2, _p_faiss__gpu__GpuIndexFlatL2To_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSWFlat, _p_faiss__IndexHNSWFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFPQR, _p_faiss__IndexIVFPQRTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlat1D, _p_faiss__IndexFlat1DTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlat, _p_faiss__IndexFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__gpu__GpuIndexFlat, _p_faiss__gpu__GpuIndexFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlatIP, _p_faiss__IndexFlatIPTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__gpu__GpuIndexFlatIP, _p_faiss__gpu__GpuIndexFlatIPTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSW, _p_faiss__IndexHNSWTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSWPQ, _p_faiss__IndexHNSWPQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlatL2BaseShift, _p_faiss__IndexFlatL2BaseShiftTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__gpu__GpuIndexIVF, _p_faiss__gpu__GpuIndexIVFTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVF, _p_faiss__IndexIVFTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__MultiIndexQuantizer2, _p_faiss__MultiIndexQuantizer2To_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexShards, _p_faiss__IndexShardsTo_p_faiss__Index, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__Index2Layer[] = {  {&_swigt__p_faiss__Index2Layer, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IndexBinary[] = {  {&_swigt__p_faiss__IndexBinaryFlat, _p_faiss__IndexBinaryFlatTo_p_faiss__IndexBinary, 0, 0},  {&_swigt__p_faiss__IndexBinary, 0, 0, 0},  {&_swigt__p_faiss__IndexBinaryIVF, _p_faiss__IndexBinaryIVFTo_p_faiss__IndexBinary, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IndexBinaryFlat[] = {  {&_swigt__p_faiss__IndexBinaryFlat, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IndexBinaryIVF[] = {  {&_swigt__p_faiss__IndexBinaryIVF, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IndexFlat[] = {  {&_swigt__p_faiss__IndexFlat, 0, 0, 0},  {&_swigt__p_faiss__IndexFlatL2, _p_faiss__IndexFlatL2To_p_faiss__IndexFlat, 0, 0},  {&_swigt__p_faiss__IndexFlat1D, _p_faiss__IndexFlat1DTo_p_faiss__IndexFlat, 0, 0},  {&_swigt__p_faiss__IndexFlatL2BaseShift, _p_faiss__IndexFlatL2BaseShiftTo_p_faiss__IndexFlat, 0, 0},  {&_swigt__p_faiss__IndexFlatIP, _p_faiss__IndexFlatIPTo_p_faiss__IndexFlat, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IndexFlat1D[] = {  {&_swigt__p_faiss__IndexFlat1D, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IndexFlatIP[] = {  {&_swigt__p_faiss__IndexFlatIP, 0, 0, 0},{0, 0, 0, 0}};
@@ -74209,8 +82708,9 @@ static swig_cast_info _swigc__p_faiss__IndexHNSWPQ[] = {  {&_swigt__p_faiss__Ind
 static swig_cast_info _swigc__p_faiss__IndexHNSWSQ[] = {  {&_swigt__p_faiss__IndexHNSWSQ, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IndexIDMap[] = {  {&_swigt__p_faiss__IndexIDMap2, _p_faiss__IndexIDMap2To_p_faiss__IndexIDMap, 0, 0},  {&_swigt__p_faiss__IndexIDMap, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IndexIDMap2[] = {  {&_swigt__p_faiss__IndexIDMap2, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_faiss__IndexIVF[] = {  {&_swigt__p_faiss__IndexIVF, 0, 0, 0},  {&_swigt__p_faiss__IndexIVFScalarQuantizer, _p_faiss__IndexIVFScalarQuantizerTo_p_faiss__IndexIVF, 0, 0},  {&_swigt__p_faiss__IndexIVFPQ, _p_faiss__IndexIVFPQTo_p_faiss__IndexIVF, 0, 0},  {&_swigt__p_faiss__IndexIVFFlat, _p_faiss__IndexIVFFlatTo_p_faiss__IndexIVF, 0, 0},  {&_swigt__p_faiss__IndexIVFPQR, _p_faiss__IndexIVFPQRTo_p_faiss__IndexIVF, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_faiss__IndexIVFFlat[] = {  {&_swigt__p_faiss__IndexIVFFlat, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IndexIVF[] = {  {&_swigt__p_faiss__IndexIVF, 0, 0, 0},  {&_swigt__p_faiss__IndexIVFScalarQuantizer, _p_faiss__IndexIVFScalarQuantizerTo_p_faiss__IndexIVF, 0, 0},  {&_swigt__p_faiss__IndexIVFPQ, _p_faiss__IndexIVFPQTo_p_faiss__IndexIVF, 0, 0},  {&_swigt__p_faiss__IndexIVFFlat, _p_faiss__IndexIVFFlatTo_p_faiss__IndexIVF, 0, 0},  {&_swigt__p_faiss__IndexIVFFlatDedup, _p_faiss__IndexIVFFlatDedupTo_p_faiss__IndexIVF, 0, 0},  {&_swigt__p_faiss__IndexIVFPQR, _p_faiss__IndexIVFPQRTo_p_faiss__IndexIVF, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IndexIVFFlat[] = {  {&_swigt__p_faiss__IndexIVFFlat, 0, 0, 0},  {&_swigt__p_faiss__IndexIVFFlatDedup, _p_faiss__IndexIVFFlatDedupTo_p_faiss__IndexIVFFlat, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IndexIVFFlatDedup[] = {  {&_swigt__p_faiss__IndexIVFFlatDedup, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IndexIVFPQ[] = {  {&_swigt__p_faiss__IndexIVFPQ, 0, 0, 0},  {&_swigt__p_faiss__IndexIVFPQR, _p_faiss__IndexIVFPQRTo_p_faiss__IndexIVFPQ, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IndexIVFPQR[] = {  {&_swigt__p_faiss__IndexIVFPQR, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IndexIVFPQStats[] = {  {&_swigt__p_faiss__IndexIVFPQStats, 0, 0, 0},{0, 0, 0, 0}};
@@ -74226,7 +82726,7 @@ static swig_cast_info _swigc__p_faiss__IndexShards[] = {  {&_swigt__p_faiss__Ind
 static swig_cast_info _swigc__p_faiss__IndexSplitVectors[] = {  {&_swigt__p_faiss__IndexSplitVectors, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IntersectionCriterion[] = {  {&_swigt__p_faiss__IntersectionCriterion, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__InvertedLists[] = {  {&_swigt__p_faiss__InvertedLists, 0, 0, 0},  {&_swigt__p_faiss__ArrayInvertedLists, _p_faiss__ArrayInvertedListsTo_p_faiss__InvertedLists, 0, 0},  {&_swigt__p_faiss__OnDiskInvertedLists, _p_faiss__OnDiskInvertedListsTo_p_faiss__InvertedLists, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_faiss__Level1Quantizer[] = {  {&_swigt__p_faiss__Level1Quantizer, 0, 0, 0},  {&_swigt__p_faiss__IndexIVF, _p_faiss__IndexIVFTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFScalarQuantizer, _p_faiss__IndexIVFScalarQuantizerTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFPQ, _p_faiss__IndexIVFPQTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFFlat, _p_faiss__IndexIVFFlatTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFPQR, _p_faiss__IndexIVFPQRTo_p_faiss__Level1Quantizer, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__Level1Quantizer[] = {  {&_swigt__p_faiss__Level1Quantizer, 0, 0, 0},  {&_swigt__p_faiss__IndexIVF, _p_faiss__IndexIVFTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFScalarQuantizer, _p_faiss__IndexIVFScalarQuantizerTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFPQ, _p_faiss__IndexIVFPQTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFFlat, _p_faiss__IndexIVFFlatTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFFlatDedup, _p_faiss__IndexIVFFlatDedupTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFPQR, _p_faiss__IndexIVFPQRTo_p_faiss__Level1Quantizer, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__LinearTransform[] = {  {&_swigt__p_faiss__RandomRotationMatrix, _p_faiss__RandomRotationMatrixTo_p_faiss__LinearTransform, 0, 0},  {&_swigt__p_faiss__PCAMatrix, _p_faiss__PCAMatrixTo_p_faiss__LinearTransform, 0, 0},  {&_swigt__p_faiss__OPQMatrix, _p_faiss__OPQMatrixTo_p_faiss__LinearTransform, 0, 0},  {&_swigt__p_faiss__LinearTransform, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__LockLevels[] = {  {&_swigt__p_faiss__LockLevels, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__MultiIndexQuantizer[] = {  {&_swigt__p_faiss__MultiIndexQuantizer, 0, 0, 0},  {&_swigt__p_faiss__MultiIndexQuantizer2, _p_faiss__MultiIndexQuantizer2To_p_faiss__MultiIndexQuantizer, 0, 0},{0, 0, 0, 0}};
@@ -74256,6 +82756,8 @@ static swig_cast_info _swigc__p_faiss__ScalarQuantizer[] = {  {&_swigt__p_faiss_
 static swig_cast_info _swigc__p_faiss__ScalarQuantizer__DistanceComputer[] = {  {&_swigt__p_faiss__ScalarQuantizer__DistanceComputer, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__SimulatedAnnealingOptimizer[] = {  {&_swigt__p_faiss__SimulatedAnnealingOptimizer, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__SimulatedAnnealingParameters[] = {  {&_swigt__p_faiss__SimulatedAnnealingParameters, 0, 0, 0},  {&_swigt__p_faiss__PolysemousTraining, _p_faiss__PolysemousTrainingTo_p_faiss__SimulatedAnnealingParameters, 0, 0},  {&_swigt__p_faiss__SimulatedAnnealingOptimizer, _p_faiss__SimulatedAnnealingOptimizerTo_p_faiss__SimulatedAnnealingParameters, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__VectorIOReader[] = {  {&_swigt__p_faiss__VectorIOReader, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__VectorIOWriter[] = {  {&_swigt__p_faiss__VectorIOWriter, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__VectorTransform[] = {  {&_swigt__p_faiss__RandomRotationMatrix, _p_faiss__RandomRotationMatrixTo_p_faiss__VectorTransform, 0, 0},  {&_swigt__p_faiss__PCAMatrix, _p_faiss__PCAMatrixTo_p_faiss__VectorTransform, 0, 0},  {&_swigt__p_faiss__OPQMatrix, _p_faiss__OPQMatrixTo_p_faiss__VectorTransform, 0, 0},  {&_swigt__p_faiss__VectorTransform, 0, 0, 0},  {&_swigt__p_faiss__LinearTransform, _p_faiss__LinearTransformTo_p_faiss__VectorTransform, 0, 0},  {&_swigt__p_faiss__RemapDimensionsTransform, _p_faiss__RemapDimensionsTransformTo_p_faiss__VectorTransform, 0, 0},  {&_swigt__p_faiss__NormalizationTransform, _p_faiss__NormalizationTransformTo_p_faiss__VectorTransform, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__VisitedTable[] = {  {&_swigt__p_faiss__VisitedTable, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__gpu__FlatIndex[] = {  {&_swigt__p_faiss__gpu__FlatIndex, 0, 0, 0},{0, 0, 0, 0}};
@@ -74282,11 +82784,12 @@ static swig_cast_info _swigc__p_idx_t[] = {  {&_swigt__p_idx_t, 0, 0, 0},{0, 0, 
 static swig_cast_info _swigc__p_int[] = {  {&_swigt__p_int, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_long[] = {  {&_swigt__p_long, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__IndexPQ[] = {{&_swigt__p_p_faiss__IndexPQ, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_p_faiss__IndexIVFFlatDedup[] = {{&_swigt__p_p_faiss__IndexIVFFlatDedup, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__IndexPreTransform[] = {{&_swigt__p_p_faiss__IndexPreTransform, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__IndexSplitVectors[] = {{&_swigt__p_p_faiss__IndexSplitVectors, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__IndexIDMap2[] = {{&_swigt__p_p_faiss__IndexIDMap2, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_p_faiss__gpu__GpuIndexIVFFlat[] = {{&_swigt__p_p_faiss__gpu__GpuIndexIVFFlat, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__IndexIVFFlat[] = {{&_swigt__p_p_faiss__IndexIVFFlat, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_p_faiss__gpu__GpuIndexIVFFlat[] = {{&_swigt__p_p_faiss__gpu__GpuIndexIVFFlat, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__MultiIndexQuantizer[] = {{&_swigt__p_p_faiss__MultiIndexQuantizer, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__IndexScalarQuantizer[] = {{&_swigt__p_p_faiss__IndexScalarQuantizer, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__IndexIVFScalarQuantizer[] = {{&_swigt__p_p_faiss__IndexIVFScalarQuantizer, 0, 0, 0},{0, 0, 0, 0}};
@@ -74316,7 +82819,7 @@ static swig_cast_info _swigc__p_p_faiss__gpu__GpuIndexIVF[] = {{&_swigt__p_p_fai
 static swig_cast_info _swigc__p_p_faiss__IndexIVF[] = {{&_swigt__p_p_faiss__IndexIVF, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__MultiIndexQuantizer2[] = {{&_swigt__p_p_faiss__MultiIndexQuantizer2, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__IndexShards[] = {{&_swigt__p_p_faiss__IndexShards, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_p_faiss__Index[] = {  {&_swigt__p_p_faiss__IndexPQ, _p_p_faiss__IndexPQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexPreTransform, _p_p_faiss__IndexPreTransformTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__Index, 0, 0, 0},  {&_swigt__p_p_faiss__IndexSplitVectors, _p_p_faiss__IndexSplitVectorsTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIDMap2, _p_p_faiss__IndexIDMap2To_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__gpu__GpuIndexIVFFlat, _p_p_faiss__gpu__GpuIndexIVFFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFFlat, _p_p_faiss__IndexIVFFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__MultiIndexQuantizer, _p_p_faiss__MultiIndexQuantizerTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexScalarQuantizer, _p_p_faiss__IndexScalarQuantizerTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFScalarQuantizer, _p_p_faiss__IndexIVFScalarQuantizerTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexRefineFlat, _p_p_faiss__IndexRefineFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__gpu__GpuIndexIVFPQ, _p_p_faiss__gpu__GpuIndexIVFPQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFPQ, _p_p_faiss__IndexIVFPQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexLSH, _p_p_faiss__IndexLSHTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSWSQ, _p_p_faiss__IndexHNSWSQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__gpu__IndexProxy, _p_p_faiss__gpu__IndexProxyTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__gpu__GpuIndex, _p_p_faiss__gpu__GpuIndexTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIDMap, _p_p_faiss__IndexIDMapTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSW2Level, _p_p_faiss__IndexHNSW2LevelTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__Index2Layer, _p_p_faiss__Index2LayerTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__gpu__GpuIndexFlatL2, _p_p_faiss__gpu__GpuIndexFlatL2To_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlatL2, _p_p_faiss__IndexFlatL2To_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSWFlat, _p_p_faiss__IndexHNSWFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFPQR, _p_p_faiss__IndexIVFPQRTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlat1D, _p_p_faiss__IndexFlat1DTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__gpu__GpuIndexFlat, _p_p_faiss__gpu__GpuIndexFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlat, _p_p_faiss__IndexFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__gpu__GpuIndexFlatIP, _p_p_faiss__gpu__GpuIndexFlatIPTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlatIP, _p_p_faiss__IndexFlatIPTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSW, _p_p_faiss__IndexHNSWTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSWPQ, _p_p_faiss__IndexHNSWPQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlatL2BaseShift, _p_p_faiss__IndexFlatL2BaseShiftTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__gpu__GpuIndexIVF, _p_p_faiss__gpu__GpuIndexIVFTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVF, _p_p_faiss__IndexIVFTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__MultiIndexQuantizer2, _p_p_faiss__MultiIndexQuantizer2To_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexShards, _p_p_faiss__IndexShardsTo_p_p_faiss__Index, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_p_faiss__Index[] = {  {&_swigt__p_p_faiss__IndexPQ, _p_p_faiss__IndexPQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFFlatDedup, _p_p_faiss__IndexIVFFlatDedupTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexPreTransform, _p_p_faiss__IndexPreTransformTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__Index, 0, 0, 0},  {&_swigt__p_p_faiss__IndexSplitVectors, _p_p_faiss__IndexSplitVectorsTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIDMap2, _p_p_faiss__IndexIDMap2To_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFFlat, _p_p_faiss__IndexIVFFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__gpu__GpuIndexIVFFlat, _p_p_faiss__gpu__GpuIndexIVFFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__MultiIndexQuantizer, _p_p_faiss__MultiIndexQuantizerTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexScalarQuantizer, _p_p_faiss__IndexScalarQuantizerTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFScalarQuantizer, _p_p_faiss__IndexIVFScalarQuantizerTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexRefineFlat, _p_p_faiss__IndexRefineFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__gpu__GpuIndexIVFPQ, _p_p_faiss__gpu__GpuIndexIVFPQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFPQ, _p_p_faiss__IndexIVFPQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexLSH, _p_p_faiss__IndexLSHTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSWSQ, _p_p_faiss__IndexHNSWSQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__gpu__IndexProxy, _p_p_faiss__gpu__IndexProxyTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__gpu__GpuIndex, _p_p_faiss__gpu__GpuIndexTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIDMap, _p_p_faiss__IndexIDMapTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSW2Level, _p_p_faiss__IndexHNSW2LevelTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__Index2Layer, _p_p_faiss__Index2LayerTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__gpu__GpuIndexFlatL2, _p_p_faiss__gpu__GpuIndexFlatL2To_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlatL2, _p_p_faiss__IndexFlatL2To_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSWFlat, _p_p_faiss__IndexHNSWFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFPQR, _p_p_faiss__IndexIVFPQRTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlat1D, _p_p_faiss__IndexFlat1DTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__gpu__GpuIndexFlat, _p_p_faiss__gpu__GpuIndexFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlat, _p_p_faiss__IndexFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__gpu__GpuIndexFlatIP, _p_p_faiss__gpu__GpuIndexFlatIPTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlatIP, _p_p_faiss__IndexFlatIPTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSW, _p_p_faiss__IndexHNSWTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSWPQ, _p_p_faiss__IndexHNSWPQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlatL2BaseShift, _p_p_faiss__IndexFlatL2BaseShiftTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__gpu__GpuIndexIVF, _p_p_faiss__gpu__GpuIndexIVFTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVF, _p_p_faiss__IndexIVFTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__MultiIndexQuantizer2, _p_p_faiss__MultiIndexQuantizer2To_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexShards, _p_p_faiss__IndexShardsTo_p_p_faiss__Index, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__ArrayInvertedLists[] = {{&_swigt__p_p_faiss__ArrayInvertedLists, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__OnDiskInvertedLists[] = {{&_swigt__p_p_faiss__OnDiskInvertedLists, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__InvertedLists[] = {  {&_swigt__p_p_faiss__InvertedLists, 0, 0, 0},  {&_swigt__p_p_faiss__ArrayInvertedLists, _p_p_faiss__ArrayInvertedListsTo_p_p_faiss__InvertedLists, 0, 0},  {&_swigt__p_p_faiss__OnDiskInvertedLists, _p_p_faiss__OnDiskInvertedListsTo_p_p_faiss__InvertedLists, 0, 0},{0, 0, 0, 0}};
@@ -74334,6 +82837,8 @@ static swig_cast_info _swigc__p_std__functionT_void_ffaiss__Index_pF_t[] = {  {&
 static swig_cast_info _swigc__p_std__listT_faiss__OnDiskInvertedLists__Slot_t[] = {  {&_swigt__p_std__listT_faiss__OnDiskInvertedLists__Slot_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__pairT_void_p_unsigned_long_t[] = {  {&_swigt__p_std__pairT_void_p_unsigned_long_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__unordered_mapT_long_long_t[] = {  {&_swigt__p_std__unordered_mapT_long_long_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_std__unordered_multimapT_long_long_t[] = {  {&_swigt__p_std__unordered_multimapT_long_long_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_std__vectorT_char_t[] = {  {&_swigt__p_std__vectorT_char_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__vectorT_cudaStream_t_t[] = {  {&_swigt__p_std__vectorT_cudaStream_t_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__vectorT_double_t[] = {  {&_swigt__p_std__vectorT_double_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__vectorT_faiss__BufferList__Buffer_t[] = {  {&_swigt__p_std__vectorT_faiss__BufferList__Buffer_t, 0, 0, 0},{0, 0, 0, 0}};
@@ -74401,8 +82906,13 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_faiss__IDSelectorRange,
   _swigc__p_faiss__IOReader,
   _swigc__p_faiss__IOWriter,
+  _swigc__p_faiss__IVFPQSearchParameters,
+  _swigc__p_faiss__IVFSearchParameters,
   _swigc__p_faiss__Index,
   _swigc__p_faiss__Index2Layer,
+  _swigc__p_faiss__IndexBinary,
+  _swigc__p_faiss__IndexBinaryFlat,
+  _swigc__p_faiss__IndexBinaryIVF,
   _swigc__p_faiss__IndexFlat,
   _swigc__p_faiss__IndexFlat1D,
   _swigc__p_faiss__IndexFlatIP,
@@ -74417,6 +82927,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_faiss__IndexIDMap2,
   _swigc__p_faiss__IndexIVF,
   _swigc__p_faiss__IndexIVFFlat,
+  _swigc__p_faiss__IndexIVFFlatDedup,
   _swigc__p_faiss__IndexIVFPQ,
   _swigc__p_faiss__IndexIVFPQR,
   _swigc__p_faiss__IndexIVFPQStats,
@@ -74462,6 +82973,8 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_faiss__ScalarQuantizer__DistanceComputer,
   _swigc__p_faiss__SimulatedAnnealingOptimizer,
   _swigc__p_faiss__SimulatedAnnealingParameters,
+  _swigc__p_faiss__VectorIOReader,
+  _swigc__p_faiss__VectorIOWriter,
   _swigc__p_faiss__VectorTransform,
   _swigc__p_faiss__VisitedTable,
   _swigc__p_faiss__gpu__FlatIndex,
@@ -74504,6 +83017,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_p_faiss__IndexIDMap2,
   _swigc__p_p_faiss__IndexIVF,
   _swigc__p_p_faiss__IndexIVFFlat,
+  _swigc__p_p_faiss__IndexIVFFlatDedup,
   _swigc__p_p_faiss__IndexIVFPQ,
   _swigc__p_p_faiss__IndexIVFPQR,
   _swigc__p_p_faiss__IndexIVFScalarQuantizer,
@@ -74540,6 +83054,8 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_std__listT_faiss__OnDiskInvertedLists__Slot_t,
   _swigc__p_std__pairT_void_p_unsigned_long_t,
   _swigc__p_std__unordered_mapT_long_long_t,
+  _swigc__p_std__unordered_multimapT_long_long_t,
+  _swigc__p_std__vectorT_char_t,
   _swigc__p_std__vectorT_cudaStream_t_t,
   _swigc__p_std__vectorT_double_t,
   _swigc__p_std__vectorT_faiss__BufferList__Buffer_t,
@@ -75256,6 +83772,7 @@ SWIG_init(void) {
   SWIG_InstallConstants(d,swig_const_table);
   
   PyDict_SetItemString(md,(char *)"cvar", SWIG_globals());
+  SWIG_addvarlink(SWIG_globals(),(char *)"hamming_batch_size",Swig_var_hamming_batch_size_get, Swig_var_hamming_batch_size_set);
   SWIG_addvarlink(SWIG_globals(),(char *)"distance_compute_blas_threshold",Swig_var_distance_compute_blas_threshold_get, Swig_var_distance_compute_blas_threshold_set);
   SWIG_Python_SetConstant(d, "METRIC_INNER_PRODUCT",SWIG_From_int(static_cast< int >(faiss::METRIC_INNER_PRODUCT)));
   SWIG_Python_SetConstant(d, "METRIC_L2",SWIG_From_int(static_cast< int >(faiss::METRIC_L2)));
@@ -75279,6 +83796,7 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "ScalarQuantizer_QT_4bit",SWIG_From_int(static_cast< int >(faiss::ScalarQuantizer::QT_4bit)));
   SWIG_Python_SetConstant(d, "ScalarQuantizer_QT_8bit_uniform",SWIG_From_int(static_cast< int >(faiss::ScalarQuantizer::QT_8bit_uniform)));
   SWIG_Python_SetConstant(d, "ScalarQuantizer_QT_4bit_uniform",SWIG_From_int(static_cast< int >(faiss::ScalarQuantizer::QT_4bit_uniform)));
+  SWIG_Python_SetConstant(d, "ScalarQuantizer_QT_fp16",SWIG_From_int(static_cast< int >(faiss::ScalarQuantizer::QT_fp16)));
   SWIG_Python_SetConstant(d, "ScalarQuantizer_RS_minmax",SWIG_From_int(static_cast< int >(faiss::ScalarQuantizer::RS_minmax)));
   SWIG_Python_SetConstant(d, "ScalarQuantizer_RS_meanstd",SWIG_From_int(static_cast< int >(faiss::ScalarQuantizer::RS_meanstd)));
   SWIG_Python_SetConstant(d, "ScalarQuantizer_RS_quantiles",SWIG_From_int(static_cast< int >(faiss::ScalarQuantizer::RS_quantiles)));

--- a/python/swigfaiss_wrap.cpp
+++ b/python/swigfaiss_wrap.cpp
@@ -3041,138 +3041,149 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 #define SWIGTYPE_p_faiss__IDSelectorRange swig_types[35]
 #define SWIGTYPE_p_faiss__IOReader swig_types[36]
 #define SWIGTYPE_p_faiss__IOWriter swig_types[37]
-#define SWIGTYPE_p_faiss__Index swig_types[38]
-#define SWIGTYPE_p_faiss__Index2Layer swig_types[39]
-#define SWIGTYPE_p_faiss__IndexFlat swig_types[40]
-#define SWIGTYPE_p_faiss__IndexFlat1D swig_types[41]
-#define SWIGTYPE_p_faiss__IndexFlatIP swig_types[42]
-#define SWIGTYPE_p_faiss__IndexFlatL2 swig_types[43]
-#define SWIGTYPE_p_faiss__IndexFlatL2BaseShift swig_types[44]
-#define SWIGTYPE_p_faiss__IndexHNSW swig_types[45]
-#define SWIGTYPE_p_faiss__IndexHNSW2Level swig_types[46]
-#define SWIGTYPE_p_faiss__IndexHNSWFlat swig_types[47]
-#define SWIGTYPE_p_faiss__IndexHNSWPQ swig_types[48]
-#define SWIGTYPE_p_faiss__IndexHNSWSQ swig_types[49]
-#define SWIGTYPE_p_faiss__IndexIDMap swig_types[50]
-#define SWIGTYPE_p_faiss__IndexIDMap2 swig_types[51]
-#define SWIGTYPE_p_faiss__IndexIVF swig_types[52]
-#define SWIGTYPE_p_faiss__IndexIVFFlat swig_types[53]
-#define SWIGTYPE_p_faiss__IndexIVFPQ swig_types[54]
-#define SWIGTYPE_p_faiss__IndexIVFPQR swig_types[55]
-#define SWIGTYPE_p_faiss__IndexIVFPQStats swig_types[56]
-#define SWIGTYPE_p_faiss__IndexIVFScalarQuantizer swig_types[57]
-#define SWIGTYPE_p_faiss__IndexIVFStats swig_types[58]
-#define SWIGTYPE_p_faiss__IndexLSH swig_types[59]
-#define SWIGTYPE_p_faiss__IndexPQ swig_types[60]
-#define SWIGTYPE_p_faiss__IndexPQStats swig_types[61]
-#define SWIGTYPE_p_faiss__IndexPreTransform swig_types[62]
-#define SWIGTYPE_p_faiss__IndexRefineFlat swig_types[63]
-#define SWIGTYPE_p_faiss__IndexScalarQuantizer swig_types[64]
-#define SWIGTYPE_p_faiss__IndexShards swig_types[65]
-#define SWIGTYPE_p_faiss__IndexSplitVectors swig_types[66]
-#define SWIGTYPE_p_faiss__IntersectionCriterion swig_types[67]
-#define SWIGTYPE_p_faiss__InvertedLists swig_types[68]
-#define SWIGTYPE_p_faiss__Level1Quantizer swig_types[69]
-#define SWIGTYPE_p_faiss__LinearTransform swig_types[70]
-#define SWIGTYPE_p_faiss__LockLevels swig_types[71]
-#define SWIGTYPE_p_faiss__MultiIndexQuantizer swig_types[72]
-#define SWIGTYPE_p_faiss__MultiIndexQuantizer2 swig_types[73]
-#define SWIGTYPE_p_faiss__NormalizationTransform swig_types[74]
-#define SWIGTYPE_p_faiss__OPQMatrix swig_types[75]
-#define SWIGTYPE_p_faiss__OnDiskInvertedLists swig_types[76]
-#define SWIGTYPE_p_faiss__OnDiskInvertedLists__OngoingPrefetch swig_types[77]
-#define SWIGTYPE_p_faiss__OneRecallAtRCriterion swig_types[78]
-#define SWIGTYPE_p_faiss__OperatingPoint swig_types[79]
-#define SWIGTYPE_p_faiss__OperatingPoints swig_types[80]
-#define SWIGTYPE_p_faiss__PCAMatrix swig_types[81]
-#define SWIGTYPE_p_faiss__ParameterRange swig_types[82]
-#define SWIGTYPE_p_faiss__ParameterSpace swig_types[83]
-#define SWIGTYPE_p_faiss__PermutationObjective swig_types[84]
-#define SWIGTYPE_p_faiss__PolysemousTraining swig_types[85]
-#define SWIGTYPE_p_faiss__ProductQuantizer swig_types[86]
-#define SWIGTYPE_p_faiss__RandomGenerator swig_types[87]
-#define SWIGTYPE_p_faiss__RandomRotationMatrix swig_types[88]
-#define SWIGTYPE_p_faiss__RangeSearchPartialResult swig_types[89]
-#define SWIGTYPE_p_faiss__RangeSearchPartialResult__QueryResult swig_types[90]
-#define SWIGTYPE_p_faiss__RangeSearchResult swig_types[91]
-#define SWIGTYPE_p_faiss__ReconstructFromNeighbors swig_types[92]
-#define SWIGTYPE_p_faiss__RemapDimensionsTransform swig_types[93]
-#define SWIGTYPE_p_faiss__ReproduceDistancesObjective swig_types[94]
-#define SWIGTYPE_p_faiss__ScalarQuantizer swig_types[95]
-#define SWIGTYPE_p_faiss__ScalarQuantizer__DistanceComputer swig_types[96]
-#define SWIGTYPE_p_faiss__SimulatedAnnealingOptimizer swig_types[97]
-#define SWIGTYPE_p_faiss__SimulatedAnnealingParameters swig_types[98]
-#define SWIGTYPE_p_faiss__VectorTransform swig_types[99]
-#define SWIGTYPE_p_faiss__VisitedTable swig_types[100]
-#define SWIGTYPE_p_float swig_types[101]
-#define SWIGTYPE_p_idx_t swig_types[102]
-#define SWIGTYPE_p_int swig_types[103]
-#define SWIGTYPE_p_long swig_types[104]
-#define SWIGTYPE_p_p_faiss__ArrayInvertedLists swig_types[105]
-#define SWIGTYPE_p_p_faiss__Index swig_types[106]
-#define SWIGTYPE_p_p_faiss__Index2Layer swig_types[107]
-#define SWIGTYPE_p_p_faiss__IndexFlat swig_types[108]
-#define SWIGTYPE_p_p_faiss__IndexFlat1D swig_types[109]
-#define SWIGTYPE_p_p_faiss__IndexFlatIP swig_types[110]
-#define SWIGTYPE_p_p_faiss__IndexFlatL2 swig_types[111]
-#define SWIGTYPE_p_p_faiss__IndexFlatL2BaseShift swig_types[112]
-#define SWIGTYPE_p_p_faiss__IndexHNSW swig_types[113]
-#define SWIGTYPE_p_p_faiss__IndexHNSW2Level swig_types[114]
-#define SWIGTYPE_p_p_faiss__IndexHNSWFlat swig_types[115]
-#define SWIGTYPE_p_p_faiss__IndexHNSWPQ swig_types[116]
-#define SWIGTYPE_p_p_faiss__IndexHNSWSQ swig_types[117]
-#define SWIGTYPE_p_p_faiss__IndexIDMap swig_types[118]
-#define SWIGTYPE_p_p_faiss__IndexIDMap2 swig_types[119]
-#define SWIGTYPE_p_p_faiss__IndexIVF swig_types[120]
-#define SWIGTYPE_p_p_faiss__IndexIVFFlat swig_types[121]
-#define SWIGTYPE_p_p_faiss__IndexIVFPQ swig_types[122]
-#define SWIGTYPE_p_p_faiss__IndexIVFPQR swig_types[123]
-#define SWIGTYPE_p_p_faiss__IndexIVFScalarQuantizer swig_types[124]
-#define SWIGTYPE_p_p_faiss__IndexLSH swig_types[125]
-#define SWIGTYPE_p_p_faiss__IndexPQ swig_types[126]
-#define SWIGTYPE_p_p_faiss__IndexPreTransform swig_types[127]
-#define SWIGTYPE_p_p_faiss__IndexRefineFlat swig_types[128]
-#define SWIGTYPE_p_p_faiss__IndexScalarQuantizer swig_types[129]
-#define SWIGTYPE_p_p_faiss__IndexShards swig_types[130]
-#define SWIGTYPE_p_p_faiss__IndexSplitVectors swig_types[131]
-#define SWIGTYPE_p_p_faiss__InvertedLists swig_types[132]
-#define SWIGTYPE_p_p_faiss__LinearTransform swig_types[133]
-#define SWIGTYPE_p_p_faiss__MultiIndexQuantizer swig_types[134]
-#define SWIGTYPE_p_p_faiss__MultiIndexQuantizer2 swig_types[135]
-#define SWIGTYPE_p_p_faiss__NormalizationTransform swig_types[136]
-#define SWIGTYPE_p_p_faiss__OPQMatrix swig_types[137]
-#define SWIGTYPE_p_p_faiss__OnDiskInvertedLists swig_types[138]
-#define SWIGTYPE_p_p_faiss__PCAMatrix swig_types[139]
-#define SWIGTYPE_p_p_faiss__RandomRotationMatrix swig_types[140]
-#define SWIGTYPE_p_p_faiss__RemapDimensionsTransform swig_types[141]
-#define SWIGTYPE_p_p_faiss__VectorTransform swig_types[142]
-#define SWIGTYPE_p_std__listT_faiss__OnDiskInvertedLists__Slot_t swig_types[143]
-#define SWIGTYPE_p_std__unordered_mapT_long_long_t swig_types[144]
-#define SWIGTYPE_p_std__vectorT_double_t swig_types[145]
-#define SWIGTYPE_p_std__vectorT_faiss__BufferList__Buffer_t swig_types[146]
-#define SWIGTYPE_p_std__vectorT_faiss__Index_p_t swig_types[147]
-#define SWIGTYPE_p_std__vectorT_faiss__InvertedLists_p_t swig_types[148]
-#define SWIGTYPE_p_std__vectorT_faiss__OnDiskInvertedLists__List_t swig_types[149]
-#define SWIGTYPE_p_std__vectorT_faiss__OperatingPoint_t swig_types[150]
-#define SWIGTYPE_p_std__vectorT_faiss__ParameterRange_t swig_types[151]
-#define SWIGTYPE_p_std__vectorT_faiss__RangeSearchPartialResult__QueryResult_t swig_types[152]
-#define SWIGTYPE_p_std__vectorT_faiss__VectorTransform_p_t swig_types[153]
-#define SWIGTYPE_p_std__vectorT_float_t swig_types[154]
-#define SWIGTYPE_p_std__vectorT_int_t swig_types[155]
-#define SWIGTYPE_p_std__vectorT_long_t swig_types[156]
-#define SWIGTYPE_p_std__vectorT_omp_lock_t_t swig_types[157]
-#define SWIGTYPE_p_std__vectorT_std__vectorT_float_t_t swig_types[158]
-#define SWIGTYPE_p_std__vectorT_std__vectorT_long_t_t swig_types[159]
-#define SWIGTYPE_p_std__vectorT_std__vectorT_uint8_t_t_t swig_types[160]
-#define SWIGTYPE_p_std__vectorT_unsigned_char_t swig_types[161]
-#define SWIGTYPE_p_std__vectorT_unsigned_long_t swig_types[162]
-#define SWIGTYPE_p_storage_idx_t swig_types[163]
-#define SWIGTYPE_p_uint32_t swig_types[164]
-#define SWIGTYPE_p_unsigned_char swig_types[165]
-#define SWIGTYPE_p_unsigned_long swig_types[166]
-#define SWIGTYPE_p_void swig_types[167]
-static swig_type_info *swig_types[169];
-static swig_module_info swig_module = {swig_types, 168, 0, 0, 0, 0};
+#define SWIGTYPE_p_faiss__IVFPQSearchParameters swig_types[38]
+#define SWIGTYPE_p_faiss__IVFSearchParameters swig_types[39]
+#define SWIGTYPE_p_faiss__Index swig_types[40]
+#define SWIGTYPE_p_faiss__Index2Layer swig_types[41]
+#define SWIGTYPE_p_faiss__IndexBinary swig_types[42]
+#define SWIGTYPE_p_faiss__IndexBinaryFlat swig_types[43]
+#define SWIGTYPE_p_faiss__IndexBinaryIVF swig_types[44]
+#define SWIGTYPE_p_faiss__IndexFlat swig_types[45]
+#define SWIGTYPE_p_faiss__IndexFlat1D swig_types[46]
+#define SWIGTYPE_p_faiss__IndexFlatIP swig_types[47]
+#define SWIGTYPE_p_faiss__IndexFlatL2 swig_types[48]
+#define SWIGTYPE_p_faiss__IndexFlatL2BaseShift swig_types[49]
+#define SWIGTYPE_p_faiss__IndexHNSW swig_types[50]
+#define SWIGTYPE_p_faiss__IndexHNSW2Level swig_types[51]
+#define SWIGTYPE_p_faiss__IndexHNSWFlat swig_types[52]
+#define SWIGTYPE_p_faiss__IndexHNSWPQ swig_types[53]
+#define SWIGTYPE_p_faiss__IndexHNSWSQ swig_types[54]
+#define SWIGTYPE_p_faiss__IndexIDMap swig_types[55]
+#define SWIGTYPE_p_faiss__IndexIDMap2 swig_types[56]
+#define SWIGTYPE_p_faiss__IndexIVF swig_types[57]
+#define SWIGTYPE_p_faiss__IndexIVFFlat swig_types[58]
+#define SWIGTYPE_p_faiss__IndexIVFFlatDedup swig_types[59]
+#define SWIGTYPE_p_faiss__IndexIVFPQ swig_types[60]
+#define SWIGTYPE_p_faiss__IndexIVFPQR swig_types[61]
+#define SWIGTYPE_p_faiss__IndexIVFPQStats swig_types[62]
+#define SWIGTYPE_p_faiss__IndexIVFScalarQuantizer swig_types[63]
+#define SWIGTYPE_p_faiss__IndexIVFStats swig_types[64]
+#define SWIGTYPE_p_faiss__IndexLSH swig_types[65]
+#define SWIGTYPE_p_faiss__IndexPQ swig_types[66]
+#define SWIGTYPE_p_faiss__IndexPQStats swig_types[67]
+#define SWIGTYPE_p_faiss__IndexPreTransform swig_types[68]
+#define SWIGTYPE_p_faiss__IndexRefineFlat swig_types[69]
+#define SWIGTYPE_p_faiss__IndexScalarQuantizer swig_types[70]
+#define SWIGTYPE_p_faiss__IndexShards swig_types[71]
+#define SWIGTYPE_p_faiss__IndexSplitVectors swig_types[72]
+#define SWIGTYPE_p_faiss__IntersectionCriterion swig_types[73]
+#define SWIGTYPE_p_faiss__InvertedLists swig_types[74]
+#define SWIGTYPE_p_faiss__Level1Quantizer swig_types[75]
+#define SWIGTYPE_p_faiss__LinearTransform swig_types[76]
+#define SWIGTYPE_p_faiss__LockLevels swig_types[77]
+#define SWIGTYPE_p_faiss__MultiIndexQuantizer swig_types[78]
+#define SWIGTYPE_p_faiss__MultiIndexQuantizer2 swig_types[79]
+#define SWIGTYPE_p_faiss__NormalizationTransform swig_types[80]
+#define SWIGTYPE_p_faiss__OPQMatrix swig_types[81]
+#define SWIGTYPE_p_faiss__OnDiskInvertedLists swig_types[82]
+#define SWIGTYPE_p_faiss__OnDiskInvertedLists__OngoingPrefetch swig_types[83]
+#define SWIGTYPE_p_faiss__OneRecallAtRCriterion swig_types[84]
+#define SWIGTYPE_p_faiss__OperatingPoint swig_types[85]
+#define SWIGTYPE_p_faiss__OperatingPoints swig_types[86]
+#define SWIGTYPE_p_faiss__PCAMatrix swig_types[87]
+#define SWIGTYPE_p_faiss__ParameterRange swig_types[88]
+#define SWIGTYPE_p_faiss__ParameterSpace swig_types[89]
+#define SWIGTYPE_p_faiss__PermutationObjective swig_types[90]
+#define SWIGTYPE_p_faiss__PolysemousTraining swig_types[91]
+#define SWIGTYPE_p_faiss__ProductQuantizer swig_types[92]
+#define SWIGTYPE_p_faiss__RandomGenerator swig_types[93]
+#define SWIGTYPE_p_faiss__RandomRotationMatrix swig_types[94]
+#define SWIGTYPE_p_faiss__RangeSearchPartialResult swig_types[95]
+#define SWIGTYPE_p_faiss__RangeSearchPartialResult__QueryResult swig_types[96]
+#define SWIGTYPE_p_faiss__RangeSearchResult swig_types[97]
+#define SWIGTYPE_p_faiss__ReconstructFromNeighbors swig_types[98]
+#define SWIGTYPE_p_faiss__RemapDimensionsTransform swig_types[99]
+#define SWIGTYPE_p_faiss__ReproduceDistancesObjective swig_types[100]
+#define SWIGTYPE_p_faiss__ScalarQuantizer swig_types[101]
+#define SWIGTYPE_p_faiss__ScalarQuantizer__DistanceComputer swig_types[102]
+#define SWIGTYPE_p_faiss__SimulatedAnnealingOptimizer swig_types[103]
+#define SWIGTYPE_p_faiss__SimulatedAnnealingParameters swig_types[104]
+#define SWIGTYPE_p_faiss__VectorIOReader swig_types[105]
+#define SWIGTYPE_p_faiss__VectorIOWriter swig_types[106]
+#define SWIGTYPE_p_faiss__VectorTransform swig_types[107]
+#define SWIGTYPE_p_faiss__VisitedTable swig_types[108]
+#define SWIGTYPE_p_float swig_types[109]
+#define SWIGTYPE_p_idx_t swig_types[110]
+#define SWIGTYPE_p_int swig_types[111]
+#define SWIGTYPE_p_long swig_types[112]
+#define SWIGTYPE_p_p_faiss__ArrayInvertedLists swig_types[113]
+#define SWIGTYPE_p_p_faiss__Index swig_types[114]
+#define SWIGTYPE_p_p_faiss__Index2Layer swig_types[115]
+#define SWIGTYPE_p_p_faiss__IndexFlat swig_types[116]
+#define SWIGTYPE_p_p_faiss__IndexFlat1D swig_types[117]
+#define SWIGTYPE_p_p_faiss__IndexFlatIP swig_types[118]
+#define SWIGTYPE_p_p_faiss__IndexFlatL2 swig_types[119]
+#define SWIGTYPE_p_p_faiss__IndexFlatL2BaseShift swig_types[120]
+#define SWIGTYPE_p_p_faiss__IndexHNSW swig_types[121]
+#define SWIGTYPE_p_p_faiss__IndexHNSW2Level swig_types[122]
+#define SWIGTYPE_p_p_faiss__IndexHNSWFlat swig_types[123]
+#define SWIGTYPE_p_p_faiss__IndexHNSWPQ swig_types[124]
+#define SWIGTYPE_p_p_faiss__IndexHNSWSQ swig_types[125]
+#define SWIGTYPE_p_p_faiss__IndexIDMap swig_types[126]
+#define SWIGTYPE_p_p_faiss__IndexIDMap2 swig_types[127]
+#define SWIGTYPE_p_p_faiss__IndexIVF swig_types[128]
+#define SWIGTYPE_p_p_faiss__IndexIVFFlat swig_types[129]
+#define SWIGTYPE_p_p_faiss__IndexIVFFlatDedup swig_types[130]
+#define SWIGTYPE_p_p_faiss__IndexIVFPQ swig_types[131]
+#define SWIGTYPE_p_p_faiss__IndexIVFPQR swig_types[132]
+#define SWIGTYPE_p_p_faiss__IndexIVFScalarQuantizer swig_types[133]
+#define SWIGTYPE_p_p_faiss__IndexLSH swig_types[134]
+#define SWIGTYPE_p_p_faiss__IndexPQ swig_types[135]
+#define SWIGTYPE_p_p_faiss__IndexPreTransform swig_types[136]
+#define SWIGTYPE_p_p_faiss__IndexRefineFlat swig_types[137]
+#define SWIGTYPE_p_p_faiss__IndexScalarQuantizer swig_types[138]
+#define SWIGTYPE_p_p_faiss__IndexShards swig_types[139]
+#define SWIGTYPE_p_p_faiss__IndexSplitVectors swig_types[140]
+#define SWIGTYPE_p_p_faiss__InvertedLists swig_types[141]
+#define SWIGTYPE_p_p_faiss__LinearTransform swig_types[142]
+#define SWIGTYPE_p_p_faiss__MultiIndexQuantizer swig_types[143]
+#define SWIGTYPE_p_p_faiss__MultiIndexQuantizer2 swig_types[144]
+#define SWIGTYPE_p_p_faiss__NormalizationTransform swig_types[145]
+#define SWIGTYPE_p_p_faiss__OPQMatrix swig_types[146]
+#define SWIGTYPE_p_p_faiss__OnDiskInvertedLists swig_types[147]
+#define SWIGTYPE_p_p_faiss__PCAMatrix swig_types[148]
+#define SWIGTYPE_p_p_faiss__RandomRotationMatrix swig_types[149]
+#define SWIGTYPE_p_p_faiss__RemapDimensionsTransform swig_types[150]
+#define SWIGTYPE_p_p_faiss__VectorTransform swig_types[151]
+#define SWIGTYPE_p_std__listT_faiss__OnDiskInvertedLists__Slot_t swig_types[152]
+#define SWIGTYPE_p_std__unordered_mapT_long_long_t swig_types[153]
+#define SWIGTYPE_p_std__unordered_multimapT_long_long_t swig_types[154]
+#define SWIGTYPE_p_std__vectorT_char_t swig_types[155]
+#define SWIGTYPE_p_std__vectorT_double_t swig_types[156]
+#define SWIGTYPE_p_std__vectorT_faiss__BufferList__Buffer_t swig_types[157]
+#define SWIGTYPE_p_std__vectorT_faiss__Index_p_t swig_types[158]
+#define SWIGTYPE_p_std__vectorT_faiss__InvertedLists_p_t swig_types[159]
+#define SWIGTYPE_p_std__vectorT_faiss__OnDiskInvertedLists__List_t swig_types[160]
+#define SWIGTYPE_p_std__vectorT_faiss__OperatingPoint_t swig_types[161]
+#define SWIGTYPE_p_std__vectorT_faiss__ParameterRange_t swig_types[162]
+#define SWIGTYPE_p_std__vectorT_faiss__RangeSearchPartialResult__QueryResult_t swig_types[163]
+#define SWIGTYPE_p_std__vectorT_faiss__VectorTransform_p_t swig_types[164]
+#define SWIGTYPE_p_std__vectorT_float_t swig_types[165]
+#define SWIGTYPE_p_std__vectorT_int_t swig_types[166]
+#define SWIGTYPE_p_std__vectorT_long_t swig_types[167]
+#define SWIGTYPE_p_std__vectorT_omp_lock_t_t swig_types[168]
+#define SWIGTYPE_p_std__vectorT_std__vectorT_float_t_t swig_types[169]
+#define SWIGTYPE_p_std__vectorT_std__vectorT_long_t_t swig_types[170]
+#define SWIGTYPE_p_std__vectorT_std__vectorT_uint8_t_t_t swig_types[171]
+#define SWIGTYPE_p_std__vectorT_unsigned_char_t swig_types[172]
+#define SWIGTYPE_p_std__vectorT_unsigned_long_t swig_types[173]
+#define SWIGTYPE_p_storage_idx_t swig_types[174]
+#define SWIGTYPE_p_uint32_t swig_types[175]
+#define SWIGTYPE_p_unsigned_char swig_types[176]
+#define SWIGTYPE_p_unsigned_long swig_types[177]
+#define SWIGTYPE_p_void swig_types[178]
+static swig_type_info *swig_types[180];
+static swig_module_info swig_module = {swig_types, 179, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3320,6 +3331,9 @@ extern "C" {
 #include "IndexHNSW.h"
 #include "MetaIndexes.h"
 #include "FaissAssert.h"
+
+#include "IndexBinaryFlat.h"
+#include "IndexBinaryIVF.h"
 
 #include "index_io.h"
 
@@ -3669,102 +3683,6 @@ SWIG_From_unsigned_SS_char  (unsigned char value)
 }
 
 
-SWIGINTERN int
-SWIG_AsVal_long (PyObject *obj, long* val)
-{
-#if PY_VERSION_HEX < 0x03000000
-  if (PyInt_Check(obj)) {
-    if (val) *val = PyInt_AsLong(obj);
-    return SWIG_OK;
-  } else
-#endif
-  if (PyLong_Check(obj)) {
-    long v = PyLong_AsLong(obj);
-    if (!PyErr_Occurred()) {
-      if (val) *val = v;
-      return SWIG_OK;
-    } else {
-      PyErr_Clear();
-      return SWIG_OverflowError;
-    }
-  }
-#ifdef SWIG_PYTHON_CAST_MODE
-  {
-    int dispatch = 0;
-    long v = PyInt_AsLong(obj);
-    if (!PyErr_Occurred()) {
-      if (val) *val = v;
-      return SWIG_AddCast(SWIG_OK);
-    } else {
-      PyErr_Clear();
-    }
-    if (!dispatch) {
-      double d;
-      int res = SWIG_AddCast(SWIG_AsVal_double (obj,&d));
-      if (SWIG_IsOK(res) && SWIG_CanCastAsInteger(&d, LONG_MIN, LONG_MAX)) {
-	if (val) *val = (long)(d);
-	return res;
-      }
-    }
-  }
-#endif
-  return SWIG_TypeError;
-}
-
-
-SWIGINTERN int
-SWIG_AsVal_int (PyObject * obj, int *val)
-{
-  long v;
-  int res = SWIG_AsVal_long (obj, &v);
-  if (SWIG_IsOK(res)) {
-    if ((v < INT_MIN || v > INT_MAX)) {
-      return SWIG_OverflowError;
-    } else {
-      if (val) *val = static_cast< int >(v);
-    }
-  }  
-  return res;
-}
-
-
-SWIGINTERNINLINE PyObject*
-  SWIG_From_int  (int value)
-{
-  return PyInt_FromLong((long) value);
-}
-
-
-#include <string>
-
-
-int get_num_gpus()
-{
-    return 0;
-}
-
-
-SWIGINTERN int
-SWIG_AsVal_bool (PyObject *obj, bool *val)
-{
-  int r;
-  if (!PyBool_Check(obj))
-    return SWIG_ERROR;
-  r = PyObject_IsTrue(obj);
-  if (r == -1)
-    return SWIG_ERROR;
-  if (val) *val = r ? true : false;
-  return SWIG_OK;
-}
-
-
-SWIGINTERNINLINE PyObject*
-  SWIG_From_bool  (bool value)
-{
-  return PyBool_FromLong(value ? 1 : 0);
-}
-
-
 SWIGINTERN swig_type_info*
 SWIG_pchar_descriptor(void)
 {
@@ -3892,33 +3810,89 @@ SWIG_AsCharPtrAndSize(PyObject *obj, char** cptr, size_t* psize, int *alloc)
 
 
 SWIGINTERN int
-SWIG_AsPtr_std_string (PyObject * obj, std::string **val) 
-{
-  char* buf = 0 ; size_t size = 0; int alloc = SWIG_OLDOBJ;
-  if (SWIG_IsOK((SWIG_AsCharPtrAndSize(obj, &buf, &size, &alloc)))) {
-    if (buf) {
-      if (val) *val = new std::string(buf, size - 1);
-      if (alloc == SWIG_NEWOBJ) delete[] buf;
-      return SWIG_NEWOBJ;
-    } else {
-      if (val) *val = 0;
-      return SWIG_OLDOBJ;
-    }
-  } else {
-    static int init = 0;
-    static swig_type_info* descriptor = 0;
-    if (!init) {
-      descriptor = SWIG_TypeQuery("std::string" " *");
-      init = 1;
-    }
-    if (descriptor) {
-      std::string *vptr;
-      int res = SWIG_ConvertPtr(obj, (void**)&vptr, descriptor, 0);
-      if (SWIG_IsOK(res) && val) *val = vptr;
+SWIG_AsCharArray(PyObject * obj, char *val, size_t size)
+{ 
+  char* cptr = 0; size_t csize = 0; int alloc = SWIG_OLDOBJ;
+  int res = SWIG_AsCharPtrAndSize(obj, &cptr, &csize, &alloc);
+  if (SWIG_IsOK(res)) {
+    /* special case of single char conversion when we don't need space for NUL */
+    if (size == 1 && csize == 2 && cptr && !cptr[1]) --csize;
+    if (csize <= size) {
+      if (val) {
+	if (csize) memcpy(val, cptr, csize*sizeof(char));
+	if (csize < size) memset(val + csize, 0, (size - csize)*sizeof(char));
+      }
+      if (alloc == SWIG_NEWOBJ) {
+	delete[] cptr;
+	res = SWIG_DelNewMask(res);
+      }      
       return res;
     }
+    if (alloc == SWIG_NEWOBJ) delete[] cptr;
   }
-  return SWIG_ERROR;
+  return SWIG_TypeError;
+}
+
+
+SWIGINTERN int
+SWIG_AsVal_long (PyObject *obj, long* val)
+{
+#if PY_VERSION_HEX < 0x03000000
+  if (PyInt_Check(obj)) {
+    if (val) *val = PyInt_AsLong(obj);
+    return SWIG_OK;
+  } else
+#endif
+  if (PyLong_Check(obj)) {
+    long v = PyLong_AsLong(obj);
+    if (!PyErr_Occurred()) {
+      if (val) *val = v;
+      return SWIG_OK;
+    } else {
+      PyErr_Clear();
+      return SWIG_OverflowError;
+    }
+  }
+#ifdef SWIG_PYTHON_CAST_MODE
+  {
+    int dispatch = 0;
+    long v = PyInt_AsLong(obj);
+    if (!PyErr_Occurred()) {
+      if (val) *val = v;
+      return SWIG_AddCast(SWIG_OK);
+    } else {
+      PyErr_Clear();
+    }
+    if (!dispatch) {
+      double d;
+      int res = SWIG_AddCast(SWIG_AsVal_double (obj,&d));
+      if (SWIG_IsOK(res) && SWIG_CanCastAsInteger(&d, LONG_MIN, LONG_MAX)) {
+	if (val) *val = (long)(d);
+	return res;
+      }
+    }
+  }
+#endif
+  return SWIG_TypeError;
+}
+
+
+SWIGINTERN int
+SWIG_AsVal_char (PyObject * obj, char *val)
+{    
+  int res = SWIG_AsCharArray(obj, val, 1);
+  if (!SWIG_IsOK(res)) {
+    long v;
+    res = SWIG_AddCast(SWIG_AsVal_long (obj, &v));
+    if (SWIG_IsOK(res)) {
+      if ((CHAR_MIN <= v) && (v <= CHAR_MAX)) {
+	if (val) *val = static_cast< char >(v);
+      } else {
+	res = SWIG_OverflowError;
+      }
+    }
+  }
+  return res;
 }
 
 
@@ -3951,54 +3925,10 @@ SWIG_FromCharPtrAndSize(const char* carray, size_t size)
 }
 
 
-SWIGINTERNINLINE PyObject *
-SWIG_From_std_string  (const std::string& s)
-{
-  return SWIG_FromCharPtrAndSize(s.data(), s.size());
-}
-
-
-SWIGINTERN int
-SWIG_AsCharArray(PyObject * obj, char *val, size_t size)
+SWIGINTERNINLINE PyObject * 
+SWIG_FromCharPtr(const char *cptr)
 { 
-  char* cptr = 0; size_t csize = 0; int alloc = SWIG_OLDOBJ;
-  int res = SWIG_AsCharPtrAndSize(obj, &cptr, &csize, &alloc);
-  if (SWIG_IsOK(res)) {
-    /* special case of single char conversion when we don't need space for NUL */
-    if (size == 1 && csize == 2 && cptr && !cptr[1]) --csize;
-    if (csize <= size) {
-      if (val) {
-	if (csize) memcpy(val, cptr, csize*sizeof(char));
-	if (csize < size) memset(val + csize, 0, (size - csize)*sizeof(char));
-      }
-      if (alloc == SWIG_NEWOBJ) {
-	delete[] cptr;
-	res = SWIG_DelNewMask(res);
-      }      
-      return res;
-    }
-    if (alloc == SWIG_NEWOBJ) delete[] cptr;
-  }
-  return SWIG_TypeError;
-}
-
-
-SWIGINTERN int
-SWIG_AsVal_char (PyObject * obj, char *val)
-{    
-  int res = SWIG_AsCharArray(obj, val, 1);
-  if (!SWIG_IsOK(res)) {
-    long v;
-    res = SWIG_AddCast(SWIG_AsVal_long (obj, &v));
-    if (SWIG_IsOK(res)) {
-      if ((CHAR_MIN <= v) && (v <= CHAR_MAX)) {
-	if (val) *val = static_cast< char >(v);
-      } else {
-	res = SWIG_OverflowError;
-      }
-    }
-  }
-  return res;
+  return SWIG_FromCharPtrAndSize(cptr, (cptr ? strlen(cptr) : 0));
 }
 
 
@@ -4006,6 +3936,97 @@ SWIGINTERNINLINE PyObject *
 SWIG_From_char  (char c) 
 { 
   return SWIG_FromCharPtrAndSize(&c,1);
+}
+
+
+SWIGINTERN int
+SWIG_AsVal_int (PyObject * obj, int *val)
+{
+  long v;
+  int res = SWIG_AsVal_long (obj, &v);
+  if (SWIG_IsOK(res)) {
+    if ((v < INT_MIN || v > INT_MAX)) {
+      return SWIG_OverflowError;
+    } else {
+      if (val) *val = static_cast< int >(v);
+    }
+  }  
+  return res;
+}
+
+
+SWIGINTERNINLINE PyObject*
+  SWIG_From_int  (int value)
+{
+  return PyInt_FromLong((long) value);
+}
+
+
+#include <string>
+
+
+int get_num_gpus()
+{
+    return 0;
+}
+
+
+SWIGINTERN int
+SWIG_AsVal_bool (PyObject *obj, bool *val)
+{
+  int r;
+  if (!PyBool_Check(obj))
+    return SWIG_ERROR;
+  r = PyObject_IsTrue(obj);
+  if (r == -1)
+    return SWIG_ERROR;
+  if (val) *val = r ? true : false;
+  return SWIG_OK;
+}
+
+
+SWIGINTERNINLINE PyObject*
+  SWIG_From_bool  (bool value)
+{
+  return PyBool_FromLong(value ? 1 : 0);
+}
+
+
+SWIGINTERN int
+SWIG_AsPtr_std_string (PyObject * obj, std::string **val) 
+{
+  char* buf = 0 ; size_t size = 0; int alloc = SWIG_OLDOBJ;
+  if (SWIG_IsOK((SWIG_AsCharPtrAndSize(obj, &buf, &size, &alloc)))) {
+    if (buf) {
+      if (val) *val = new std::string(buf, size - 1);
+      if (alloc == SWIG_NEWOBJ) delete[] buf;
+      return SWIG_NEWOBJ;
+    } else {
+      if (val) *val = 0;
+      return SWIG_OLDOBJ;
+    }
+  } else {
+    static int init = 0;
+    static swig_type_info* descriptor = 0;
+    if (!init) {
+      descriptor = SWIG_TypeQuery("std::string" " *");
+      init = 1;
+    }
+    if (descriptor) {
+      std::string *vptr;
+      int res = SWIG_ConvertPtr(obj, (void**)&vptr, descriptor, 0);
+      if (SWIG_IsOK(res) && val) *val = vptr;
+      return res;
+    }
+  }
+  return SWIG_ERROR;
+}
+
+
+SWIGINTERNINLINE PyObject *
+SWIG_From_std_string  (const std::string& s)
+{
+  return SWIG_FromCharPtrAndSize(s.data(), s.size());
 }
 
 
@@ -4046,6 +4067,9 @@ PyObject *swig_ptr (PyObject *a)
     }
     if(PyArray_TYPE(ao) == NPY_UINT8) {
         return SWIG_NewPointerObj(data, SWIGTYPE_p_unsigned_char, 0);
+    }
+    if(PyArray_TYPE(ao) == NPY_INT8) {
+        return SWIG_NewPointerObj(data, SWIGTYPE_p_char, 0);
     }
     if(PyArray_TYPE(ao) == NPY_UINT64) {
         return SWIG_NewPointerObj(data, SWIGTYPE_p_unsigned_long, 0);
@@ -4309,6 +4333,39 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_FloatVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< float > *arg1 = (std::vector< float > *) 0 ;
+  std::vector< float > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:FloatVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_float_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "FloatVector_swap" "', argument " "1"" of type '" "std::vector< float > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< float > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_float_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "FloatVector_swap" "', argument " "2"" of type '" "std::vector< float > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "FloatVector_swap" "', argument " "2"" of type '" "std::vector< float > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< float > * >(argp2);
+  (arg1)->swap(*arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_delete_FloatVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   std::vector< float > *arg1 = (std::vector< float > *) 0 ;
@@ -4499,6 +4556,39 @@ SWIGINTERN PyObject *_wrap_DoubleVector_resize(PyObject *SWIGUNUSEDPARM(self), P
   } 
   arg2 = static_cast< size_t >(val2);
   (arg1)->resize(arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_DoubleVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< double > *arg1 = (std::vector< double > *) 0 ;
+  std::vector< double > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:DoubleVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_double_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "DoubleVector_swap" "', argument " "1"" of type '" "std::vector< double > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< double > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_double_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "DoubleVector_swap" "', argument " "2"" of type '" "std::vector< double > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "DoubleVector_swap" "', argument " "2"" of type '" "std::vector< double > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< double > * >(argp2);
+  (arg1)->swap(*arg2);
   resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
@@ -4703,6 +4793,39 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_ByteVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< uint8_t > *arg1 = (std::vector< uint8_t > *) 0 ;
+  std::vector< unsigned char > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:ByteVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ByteVector_swap" "', argument " "1"" of type '" "std::vector< uint8_t > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< uint8_t > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_unsigned_char_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ByteVector_swap" "', argument " "2"" of type '" "std::vector< unsigned char > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "ByteVector_swap" "', argument " "2"" of type '" "std::vector< unsigned char > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< unsigned char > * >(argp2);
+  (arg1)->swap(*arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_delete_ByteVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   std::vector< uint8_t > *arg1 = (std::vector< uint8_t > *) 0 ;
@@ -4731,12 +4854,242 @@ SWIGINTERN PyObject *ByteVector_swigregister(PyObject *SWIGUNUSEDPARM(self), PyO
   return SWIG_Py_Void();
 }
 
+SWIGINTERN PyObject *_wrap_new_CharVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_CharVector")) SWIG_fail;
+  result = (std::vector< char > *)new std::vector< char >();
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_char_t, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CharVector_push_back(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *arg1 = (std::vector< char > *) 0 ;
+  char arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  char val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:CharVector_push_back",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CharVector_push_back" "', argument " "1"" of type '" "std::vector< char > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< char > * >(argp1);
+  ecode2 = SWIG_AsVal_char(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "CharVector_push_back" "', argument " "2"" of type '" "char""'");
+  } 
+  arg2 = static_cast< char >(val2);
+  (arg1)->push_back(arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CharVector_clear(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *arg1 = (std::vector< char > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:CharVector_clear",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CharVector_clear" "', argument " "1"" of type '" "std::vector< char > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< char > * >(argp1);
+  (arg1)->clear();
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CharVector_data(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *arg1 = (std::vector< char > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  char *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:CharVector_data",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CharVector_data" "', argument " "1"" of type '" "std::vector< char > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< char > * >(argp1);
+  result = (char *)(arg1)->data();
+  resultobj = SWIG_FromCharPtr((const char *)result);
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CharVector_size(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *arg1 = (std::vector< char > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:CharVector_size",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CharVector_size" "', argument " "1"" of type '" "std::vector< char > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< char > * >(argp1);
+  result = (size_t)(arg1)->size();
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CharVector_at(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *arg1 = (std::vector< char > *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  char result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:CharVector_at",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CharVector_at" "', argument " "1"" of type '" "std::vector< char > const *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< char > * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "CharVector_at" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  result = (char)((std::vector< char > const *)arg1)->at(arg2);
+  resultobj = SWIG_From_char(static_cast< char >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CharVector_resize(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *arg1 = (std::vector< char > *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:CharVector_resize",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CharVector_resize" "', argument " "1"" of type '" "std::vector< char > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< char > * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "CharVector_resize" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  (arg1)->resize(arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CharVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *arg1 = (std::vector< char > *) 0 ;
+  std::vector< char > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:CharVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CharVector_swap" "', argument " "1"" of type '" "std::vector< char > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< char > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_char_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "CharVector_swap" "', argument " "2"" of type '" "std::vector< char > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CharVector_swap" "', argument " "2"" of type '" "std::vector< char > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< char > * >(argp2);
+  (arg1)->swap(*arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_CharVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< char > *arg1 = (std::vector< char > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_CharVector",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_char_t, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_CharVector" "', argument " "1"" of type '" "std::vector< char > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< char > * >(argp1);
+  delete arg1;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *CharVector_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_std__vectorT_char_t, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
 SWIGINTERN PyObject *_wrap_new_Uint64Vector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::vector< uint64_t > *result = 0 ;
+  std::vector< unsigned long > *result = 0 ;
   
   if (!PyArg_ParseTuple(args,(char *)":new_Uint64Vector")) SWIG_fail;
-  result = (std::vector< uint64_t > *)new std::vector< uint64_t >();
+  result = (std::vector< unsigned long > *)new std::vector< unsigned long >();
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_unsigned_long_t, SWIG_POINTER_NEW |  0 );
   return resultobj;
 fail:
@@ -4746,7 +5099,7 @@ fail:
 
 SWIGINTERN PyObject *_wrap_Uint64Vector_push_back(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::vector< uint64_t > *arg1 = (std::vector< uint64_t > *) 0 ;
+  std::vector< unsigned long > *arg1 = (std::vector< unsigned long > *) 0 ;
   unsigned long arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -4758,9 +5111,9 @@ SWIGINTERN PyObject *_wrap_Uint64Vector_push_back(PyObject *SWIGUNUSEDPARM(self)
   if (!PyArg_ParseTuple(args,(char *)"OO:Uint64Vector_push_back",&obj0,&obj1)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_long_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_push_back" "', argument " "1"" of type '" "std::vector< uint64_t > *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_push_back" "', argument " "1"" of type '" "std::vector< unsigned long > *""'"); 
   }
-  arg1 = reinterpret_cast< std::vector< uint64_t > * >(argp1);
+  arg1 = reinterpret_cast< std::vector< unsigned long > * >(argp1);
   ecode2 = SWIG_AsVal_unsigned_SS_long(obj1, &val2);
   if (!SWIG_IsOK(ecode2)) {
     SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "Uint64Vector_push_back" "', argument " "2"" of type '" "unsigned long""'");
@@ -4776,7 +5129,7 @@ fail:
 
 SWIGINTERN PyObject *_wrap_Uint64Vector_clear(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::vector< uint64_t > *arg1 = (std::vector< uint64_t > *) 0 ;
+  std::vector< unsigned long > *arg1 = (std::vector< unsigned long > *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -4784,9 +5137,9 @@ SWIGINTERN PyObject *_wrap_Uint64Vector_clear(PyObject *SWIGUNUSEDPARM(self), Py
   if (!PyArg_ParseTuple(args,(char *)"O:Uint64Vector_clear",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_long_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_clear" "', argument " "1"" of type '" "std::vector< uint64_t > *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_clear" "', argument " "1"" of type '" "std::vector< unsigned long > *""'"); 
   }
-  arg1 = reinterpret_cast< std::vector< uint64_t > * >(argp1);
+  arg1 = reinterpret_cast< std::vector< unsigned long > * >(argp1);
   (arg1)->clear();
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -4797,7 +5150,7 @@ fail:
 
 SWIGINTERN PyObject *_wrap_Uint64Vector_data(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::vector< uint64_t > *arg1 = (std::vector< uint64_t > *) 0 ;
+  std::vector< unsigned long > *arg1 = (std::vector< unsigned long > *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -4806,9 +5159,9 @@ SWIGINTERN PyObject *_wrap_Uint64Vector_data(PyObject *SWIGUNUSEDPARM(self), PyO
   if (!PyArg_ParseTuple(args,(char *)"O:Uint64Vector_data",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_long_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_data" "', argument " "1"" of type '" "std::vector< uint64_t > *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_data" "', argument " "1"" of type '" "std::vector< unsigned long > *""'"); 
   }
-  arg1 = reinterpret_cast< std::vector< uint64_t > * >(argp1);
+  arg1 = reinterpret_cast< std::vector< unsigned long > * >(argp1);
   result = (unsigned long *)(arg1)->data();
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_unsigned_long, 0 |  0 );
   return resultobj;
@@ -4819,7 +5172,7 @@ fail:
 
 SWIGINTERN PyObject *_wrap_Uint64Vector_size(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::vector< uint64_t > *arg1 = (std::vector< uint64_t > *) 0 ;
+  std::vector< unsigned long > *arg1 = (std::vector< unsigned long > *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -4828,9 +5181,9 @@ SWIGINTERN PyObject *_wrap_Uint64Vector_size(PyObject *SWIGUNUSEDPARM(self), PyO
   if (!PyArg_ParseTuple(args,(char *)"O:Uint64Vector_size",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_long_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_size" "', argument " "1"" of type '" "std::vector< uint64_t > *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_size" "', argument " "1"" of type '" "std::vector< unsigned long > *""'"); 
   }
-  arg1 = reinterpret_cast< std::vector< uint64_t > * >(argp1);
+  arg1 = reinterpret_cast< std::vector< unsigned long > * >(argp1);
   result = (size_t)(arg1)->size();
   resultobj = SWIG_From_size_t(static_cast< size_t >(result));
   return resultobj;
@@ -4841,7 +5194,7 @@ fail:
 
 SWIGINTERN PyObject *_wrap_Uint64Vector_at(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::vector< uint64_t > *arg1 = (std::vector< uint64_t > *) 0 ;
+  std::vector< unsigned long > *arg1 = (std::vector< unsigned long > *) 0 ;
   size_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -4854,15 +5207,15 @@ SWIGINTERN PyObject *_wrap_Uint64Vector_at(PyObject *SWIGUNUSEDPARM(self), PyObj
   if (!PyArg_ParseTuple(args,(char *)"OO:Uint64Vector_at",&obj0,&obj1)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_long_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_at" "', argument " "1"" of type '" "std::vector< uint64_t > const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_at" "', argument " "1"" of type '" "std::vector< unsigned long > const *""'"); 
   }
-  arg1 = reinterpret_cast< std::vector< uint64_t > * >(argp1);
+  arg1 = reinterpret_cast< std::vector< unsigned long > * >(argp1);
   ecode2 = SWIG_AsVal_size_t(obj1, &val2);
   if (!SWIG_IsOK(ecode2)) {
     SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "Uint64Vector_at" "', argument " "2"" of type '" "size_t""'");
   } 
   arg2 = static_cast< size_t >(val2);
-  result = (unsigned long)((std::vector< uint64_t > const *)arg1)->at(arg2);
+  result = (unsigned long)((std::vector< unsigned long > const *)arg1)->at(arg2);
   resultobj = SWIG_From_unsigned_SS_long(static_cast< unsigned long >(result));
   return resultobj;
 fail:
@@ -4872,7 +5225,7 @@ fail:
 
 SWIGINTERN PyObject *_wrap_Uint64Vector_resize(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::vector< uint64_t > *arg1 = (std::vector< uint64_t > *) 0 ;
+  std::vector< unsigned long > *arg1 = (std::vector< unsigned long > *) 0 ;
   size_t arg2 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
@@ -4884,9 +5237,9 @@ SWIGINTERN PyObject *_wrap_Uint64Vector_resize(PyObject *SWIGUNUSEDPARM(self), P
   if (!PyArg_ParseTuple(args,(char *)"OO:Uint64Vector_resize",&obj0,&obj1)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_long_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_resize" "', argument " "1"" of type '" "std::vector< uint64_t > *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_resize" "', argument " "1"" of type '" "std::vector< unsigned long > *""'"); 
   }
-  arg1 = reinterpret_cast< std::vector< uint64_t > * >(argp1);
+  arg1 = reinterpret_cast< std::vector< unsigned long > * >(argp1);
   ecode2 = SWIG_AsVal_size_t(obj1, &val2);
   if (!SWIG_IsOK(ecode2)) {
     SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "Uint64Vector_resize" "', argument " "2"" of type '" "size_t""'");
@@ -4900,9 +5253,42 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_Uint64Vector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< unsigned long > *arg1 = (std::vector< unsigned long > *) 0 ;
+  std::vector< unsigned long > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:Uint64Vector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_long_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "Uint64Vector_swap" "', argument " "1"" of type '" "std::vector< unsigned long > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< unsigned long > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_unsigned_long_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "Uint64Vector_swap" "', argument " "2"" of type '" "std::vector< unsigned long > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "Uint64Vector_swap" "', argument " "2"" of type '" "std::vector< unsigned long > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< unsigned long > * >(argp2);
+  (arg1)->swap(*arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_delete_Uint64Vector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::vector< uint64_t > *arg1 = (std::vector< uint64_t > *) 0 ;
+  std::vector< unsigned long > *arg1 = (std::vector< unsigned long > *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   PyObject * obj0 = 0 ;
@@ -4910,9 +5296,9 @@ SWIGINTERN PyObject *_wrap_delete_Uint64Vector(PyObject *SWIGUNUSEDPARM(self), P
   if (!PyArg_ParseTuple(args,(char *)"O:delete_Uint64Vector",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_unsigned_long_t, SWIG_POINTER_DISOWN |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_Uint64Vector" "', argument " "1"" of type '" "std::vector< uint64_t > *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_Uint64Vector" "', argument " "1"" of type '" "std::vector< unsigned long > *""'"); 
   }
-  arg1 = reinterpret_cast< std::vector< uint64_t > * >(argp1);
+  arg1 = reinterpret_cast< std::vector< unsigned long > * >(argp1);
   delete arg1;
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -5090,6 +5476,39 @@ SWIGINTERN PyObject *_wrap_LongVector_resize(PyObject *SWIGUNUSEDPARM(self), PyO
   } 
   arg2 = static_cast< size_t >(val2);
   (arg1)->resize(arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_LongVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< long > *arg1 = (std::vector< long > *) 0 ;
+  std::vector< long > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:LongVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_long_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "LongVector_swap" "', argument " "1"" of type '" "std::vector< long > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< long > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_long_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "LongVector_swap" "', argument " "2"" of type '" "std::vector< long > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "LongVector_swap" "', argument " "2"" of type '" "std::vector< long > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< long > * >(argp2);
+  (arg1)->swap(*arg2);
   resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
@@ -5294,6 +5713,39 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_IntVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< int > *arg1 = (std::vector< int > *) 0 ;
+  std::vector< int > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IntVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_int_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IntVector_swap" "', argument " "1"" of type '" "std::vector< int > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< int > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_int_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IntVector_swap" "', argument " "2"" of type '" "std::vector< int > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IntVector_swap" "', argument " "2"" of type '" "std::vector< int > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< int > * >(argp2);
+  (arg1)->swap(*arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_delete_IntVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   std::vector< int > *arg1 = (std::vector< int > *) 0 ;
@@ -5484,6 +5936,39 @@ SWIGINTERN PyObject *_wrap_VectorTransformVector_resize(PyObject *SWIGUNUSEDPARM
   } 
   arg2 = static_cast< size_t >(val2);
   (arg1)->resize(arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorTransformVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< faiss::VectorTransform * > *arg1 = (std::vector< faiss::VectorTransform * > *) 0 ;
+  std::vector< faiss::VectorTransform * > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:VectorTransformVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_faiss__VectorTransform_p_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorTransformVector_swap" "', argument " "1"" of type '" "std::vector< faiss::VectorTransform * > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< faiss::VectorTransform * > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_faiss__VectorTransform_p_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorTransformVector_swap" "', argument " "2"" of type '" "std::vector< faiss::VectorTransform * > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "VectorTransformVector_swap" "', argument " "2"" of type '" "std::vector< faiss::VectorTransform * > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< faiss::VectorTransform * > * >(argp2);
+  (arg1)->swap(*arg2);
   resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
@@ -5696,6 +6181,39 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_OperatingPointVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< faiss::OperatingPoint > *arg1 = (std::vector< faiss::OperatingPoint > *) 0 ;
+  std::vector< faiss::OperatingPoint > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:OperatingPointVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_faiss__OperatingPoint_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "OperatingPointVector_swap" "', argument " "1"" of type '" "std::vector< faiss::OperatingPoint > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< faiss::OperatingPoint > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_faiss__OperatingPoint_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "OperatingPointVector_swap" "', argument " "2"" of type '" "std::vector< faiss::OperatingPoint > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "OperatingPointVector_swap" "', argument " "2"" of type '" "std::vector< faiss::OperatingPoint > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< faiss::OperatingPoint > * >(argp2);
+  (arg1)->swap(*arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_delete_OperatingPointVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   std::vector< faiss::OperatingPoint > *arg1 = (std::vector< faiss::OperatingPoint > *) 0 ;
@@ -5886,6 +6404,39 @@ SWIGINTERN PyObject *_wrap_InvertedListsPtrVector_resize(PyObject *SWIGUNUSEDPAR
   } 
   arg2 = static_cast< size_t >(val2);
   (arg1)->resize(arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_InvertedListsPtrVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< faiss::InvertedLists * > *arg1 = (std::vector< faiss::InvertedLists * > *) 0 ;
+  std::vector< faiss::InvertedLists * > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:InvertedListsPtrVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_faiss__InvertedLists_p_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InvertedListsPtrVector_swap" "', argument " "1"" of type '" "std::vector< faiss::InvertedLists * > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< faiss::InvertedLists * > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_faiss__InvertedLists_p_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "InvertedListsPtrVector_swap" "', argument " "2"" of type '" "std::vector< faiss::InvertedLists * > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "InvertedListsPtrVector_swap" "', argument " "2"" of type '" "std::vector< faiss::InvertedLists * > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< faiss::InvertedLists * > * >(argp2);
+  (arg1)->swap(*arg2);
   resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
@@ -6098,6 +6649,39 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_FloatVectorVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< std::vector< float > > *arg1 = (std::vector< std::vector< float > > *) 0 ;
+  std::vector< std::vector< float > > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:FloatVectorVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_std__vectorT_float_t_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "FloatVectorVector_swap" "', argument " "1"" of type '" "std::vector< std::vector< float > > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< std::vector< float > > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_std__vectorT_float_t_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "FloatVectorVector_swap" "', argument " "2"" of type '" "std::vector< std::vector< float > > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "FloatVectorVector_swap" "', argument " "2"" of type '" "std::vector< std::vector< float > > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< std::vector< float > > * >(argp2);
+  (arg1)->swap(*arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_delete_FloatVectorVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   std::vector< std::vector< float > > *arg1 = (std::vector< std::vector< float > > *) 0 ;
@@ -6296,6 +6880,39 @@ SWIGINTERN PyObject *_wrap_ByteVectorVector_resize(PyObject *SWIGUNUSEDPARM(self
   } 
   arg2 = static_cast< size_t >(val2);
   (arg1)->resize(arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_ByteVectorVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< std::vector< unsigned char > > *arg1 = (std::vector< std::vector< unsigned char > > *) 0 ;
+  std::vector< std::vector< unsigned char > > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:ByteVectorVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_std__vectorT_uint8_t_t_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ByteVectorVector_swap" "', argument " "1"" of type '" "std::vector< std::vector< unsigned char > > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< std::vector< unsigned char > > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_std__vectorT_uint8_t_t_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "ByteVectorVector_swap" "', argument " "2"" of type '" "std::vector< std::vector< unsigned char > > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "ByteVectorVector_swap" "', argument " "2"" of type '" "std::vector< std::vector< unsigned char > > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< std::vector< unsigned char > > * >(argp2);
+  (arg1)->swap(*arg2);
   resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
@@ -6508,6 +7125,39 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_LongVectorVector_swap(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  std::vector< std::vector< long > > *arg1 = (std::vector< std::vector< long > > *) 0 ;
+  std::vector< std::vector< long > > *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:LongVectorVector_swap",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_std__vectorT_std__vectorT_long_t_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "LongVectorVector_swap" "', argument " "1"" of type '" "std::vector< std::vector< long > > *""'"); 
+  }
+  arg1 = reinterpret_cast< std::vector< std::vector< long > > * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_std__vectorT_long_t_t,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "LongVectorVector_swap" "', argument " "2"" of type '" "std::vector< std::vector< long > > &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "LongVectorVector_swap" "', argument " "2"" of type '" "std::vector< std::vector< long > > &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< std::vector< long > > * >(argp2);
+  (arg1)->swap(*arg2);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_delete_LongVectorVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   std::vector< std::vector< long > > *arg1 = (std::vector< std::vector< long > > *) 0 ;
@@ -6535,6 +7185,29 @@ SWIGINTERN PyObject *LongVectorVector_swigregister(PyObject *SWIGUNUSEDPARM(self
   SWIG_TypeNewClientData(SWIGTYPE_p_std__vectorT_std__vectorT_long_t_t, SWIG_NewClientData(obj));
   return SWIG_Py_Void();
 }
+
+SWIGINTERN int Swig_var_hamming_batch_size_set(PyObject *_val) {
+  {
+    size_t val;
+    int res = SWIG_AsVal_size_t(_val, &val);
+    if (!SWIG_IsOK(res)) {
+      SWIG_exception_fail(SWIG_ArgError(res), "in variable '""faiss::hamming_batch_size""' of type '""size_t""'");
+    }
+    faiss::hamming_batch_size = static_cast< size_t >(val);
+  }
+  return 0;
+fail:
+  return 1;
+}
+
+
+SWIGINTERN PyObject *Swig_var_hamming_batch_size_get(void) {
+  PyObject *pyobj = 0;
+  
+  pyobj = SWIG_From_size_t(static_cast< size_t >(faiss::hamming_batch_size));
+  return pyobj;
+}
+
 
 SWIGINTERN PyObject *_wrap_popcount64(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
@@ -6791,6 +7464,82 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_hammings_knn_hc(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::int_maxheap_array_t *arg1 = (faiss::int_maxheap_array_t *) 0 ;
+  uint8_t *arg2 = (uint8_t *) 0 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  size_t arg4 ;
+  size_t arg5 ;
+  int arg6 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  size_t val4 ;
+  int ecode4 = 0 ;
+  size_t val5 ;
+  int ecode5 = 0 ;
+  int val6 ;
+  int ecode6 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOO:hammings_knn_hc",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__HeapArrayT_faiss__CMaxT_int_long_t_t, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "hammings_knn_hc" "', argument " "1"" of type '" "faiss::int_maxheap_array_t *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::int_maxheap_array_t * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "hammings_knn_hc" "', argument " "2"" of type '" "uint8_t const *""'"); 
+  }
+  arg2 = reinterpret_cast< uint8_t * >(argp2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "hammings_knn_hc" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_size_t(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "hammings_knn_hc" "', argument " "4"" of type '" "size_t""'");
+  } 
+  arg4 = static_cast< size_t >(val4);
+  ecode5 = SWIG_AsVal_size_t(obj4, &val5);
+  if (!SWIG_IsOK(ecode5)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "hammings_knn_hc" "', argument " "5"" of type '" "size_t""'");
+  } 
+  arg5 = static_cast< size_t >(val5);
+  ecode6 = SWIG_AsVal_int(obj5, &val6);
+  if (!SWIG_IsOK(ecode6)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "hammings_knn_hc" "', argument " "6"" of type '" "int""'");
+  } 
+  arg6 = static_cast< int >(val6);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      faiss::hammings_knn_hc(arg1,(unsigned char const *)arg2,(unsigned char const *)arg3,arg4,arg5,arg6);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_hammings_knn(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::int_maxheap_array_t *arg1 = (faiss::int_maxheap_array_t *) 0 ;
@@ -6867,59 +7616,86 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_hammings_knn_core(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_hammings_knn_mc(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  faiss::int_maxheap_array_t *arg1 = (faiss::int_maxheap_array_t *) 0 ;
+  uint8_t *arg1 = (uint8_t *) 0 ;
   uint8_t *arg2 = (uint8_t *) 0 ;
-  uint8_t *arg3 = (uint8_t *) 0 ;
+  size_t arg3 ;
   size_t arg4 ;
   size_t arg5 ;
+  size_t arg6 ;
+  int32_t *arg7 = (int32_t *) 0 ;
+  long *arg8 = (long *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 = 0 ;
   int res2 = 0 ;
-  void *argp3 = 0 ;
-  int res3 = 0 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
   size_t val4 ;
   int ecode4 = 0 ;
   size_t val5 ;
   int ecode5 = 0 ;
+  size_t val6 ;
+  int ecode6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
   PyObject * obj3 = 0 ;
   PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
   
-  if (!PyArg_ParseTuple(args,(char *)"OOOOO:hammings_knn_core",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__HeapArrayT_faiss__CMaxT_int_long_t_t, 0 |  0 );
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOO:hammings_knn_mc",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_unsigned_char, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "hammings_knn_core" "', argument " "1"" of type '" "faiss::int_maxheap_array_t *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "hammings_knn_mc" "', argument " "1"" of type '" "uint8_t const *""'"); 
   }
-  arg1 = reinterpret_cast< faiss::int_maxheap_array_t * >(argp1);
+  arg1 = reinterpret_cast< uint8_t * >(argp1);
   res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_unsigned_char, 0 |  0 );
   if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "hammings_knn_core" "', argument " "2"" of type '" "uint8_t const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "hammings_knn_mc" "', argument " "2"" of type '" "uint8_t const *""'"); 
   }
   arg2 = reinterpret_cast< uint8_t * >(argp2);
-  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
-  if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "hammings_knn_core" "', argument " "3"" of type '" "uint8_t const *""'"); 
-  }
-  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "hammings_knn_mc" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
   ecode4 = SWIG_AsVal_size_t(obj3, &val4);
   if (!SWIG_IsOK(ecode4)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "hammings_knn_core" "', argument " "4"" of type '" "size_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "hammings_knn_mc" "', argument " "4"" of type '" "size_t""'");
   } 
   arg4 = static_cast< size_t >(val4);
   ecode5 = SWIG_AsVal_size_t(obj4, &val5);
   if (!SWIG_IsOK(ecode5)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "hammings_knn_core" "', argument " "5"" of type '" "size_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "hammings_knn_mc" "', argument " "5"" of type '" "size_t""'");
   } 
   arg5 = static_cast< size_t >(val5);
+  ecode6 = SWIG_AsVal_size_t(obj5, &val6);
+  if (!SWIG_IsOK(ecode6)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "hammings_knn_mc" "', argument " "6"" of type '" "size_t""'");
+  } 
+  arg6 = static_cast< size_t >(val6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "hammings_knn_mc" "', argument " "7"" of type '" "int32_t *""'"); 
+  }
+  arg7 = reinterpret_cast< int32_t * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "hammings_knn_mc" "', argument " "8"" of type '" "long *""'"); 
+  }
+  arg8 = reinterpret_cast< long * >(argp8);
   {
     Py_BEGIN_ALLOW_THREADS
     try {
-      faiss::hammings_knn_core(arg1,(unsigned char const *)arg2,(unsigned char const *)arg3,arg4,arg5);
+      faiss::hammings_knn_mc((unsigned char const *)arg1,(unsigned char const *)arg2,arg3,arg4,arg5,arg6,arg7,arg8);
     } catch(faiss::FaissException & e) {
       PyEval_RestoreThread(_save);
       PyErr_SetString(PyExc_RuntimeError, e.what());
@@ -10427,7 +11203,7 @@ SWIGINTERN PyObject *GenHammingComputerM8_swigregister(PyObject *SWIGUNUSEDPARM(
   return SWIG_Py_Void();
 }
 
-SWIGINTERN PyObject *_wrap_generalized_hammings_knn__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_generalized_hammings_knn_hc__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::int_maxheap_array_t *arg1 = (faiss::int_maxheap_array_t *) 0 ;
   uint8_t *arg2 = (uint8_t *) 0 ;
@@ -10454,41 +11230,41 @@ SWIGINTERN PyObject *_wrap_generalized_hammings_knn__SWIG_0(PyObject *SWIGUNUSED
   PyObject * obj4 = 0 ;
   PyObject * obj5 = 0 ;
   
-  if (!PyArg_ParseTuple(args,(char *)"OOOOOO:generalized_hammings_knn",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOO:generalized_hammings_knn_hc",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__HeapArrayT_faiss__CMaxT_int_long_t_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "generalized_hammings_knn" "', argument " "1"" of type '" "faiss::int_maxheap_array_t *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "generalized_hammings_knn_hc" "', argument " "1"" of type '" "faiss::int_maxheap_array_t *""'"); 
   }
   arg1 = reinterpret_cast< faiss::int_maxheap_array_t * >(argp1);
   res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_unsigned_char, 0 |  0 );
   if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "generalized_hammings_knn" "', argument " "2"" of type '" "uint8_t const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "generalized_hammings_knn_hc" "', argument " "2"" of type '" "uint8_t const *""'"); 
   }
   arg2 = reinterpret_cast< uint8_t * >(argp2);
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "generalized_hammings_knn" "', argument " "3"" of type '" "uint8_t const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "generalized_hammings_knn_hc" "', argument " "3"" of type '" "uint8_t const *""'"); 
   }
   arg3 = reinterpret_cast< uint8_t * >(argp3);
   ecode4 = SWIG_AsVal_size_t(obj3, &val4);
   if (!SWIG_IsOK(ecode4)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "generalized_hammings_knn" "', argument " "4"" of type '" "size_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "generalized_hammings_knn_hc" "', argument " "4"" of type '" "size_t""'");
   } 
   arg4 = static_cast< size_t >(val4);
   ecode5 = SWIG_AsVal_size_t(obj4, &val5);
   if (!SWIG_IsOK(ecode5)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "generalized_hammings_knn" "', argument " "5"" of type '" "size_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "generalized_hammings_knn_hc" "', argument " "5"" of type '" "size_t""'");
   } 
   arg5 = static_cast< size_t >(val5);
   ecode6 = SWIG_AsVal_int(obj5, &val6);
   if (!SWIG_IsOK(ecode6)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "generalized_hammings_knn" "', argument " "6"" of type '" "int""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode6), "in method '" "generalized_hammings_knn_hc" "', argument " "6"" of type '" "int""'");
   } 
   arg6 = static_cast< int >(val6);
   {
     Py_BEGIN_ALLOW_THREADS
     try {
-      faiss::generalized_hammings_knn(arg1,(unsigned char const *)arg2,(unsigned char const *)arg3,arg4,arg5,arg6);
+      faiss::generalized_hammings_knn_hc(arg1,(unsigned char const *)arg2,(unsigned char const *)arg3,arg4,arg5,arg6);
     } catch(faiss::FaissException & e) {
       PyEval_RestoreThread(_save);
       PyErr_SetString(PyExc_RuntimeError, e.what());
@@ -10503,7 +11279,7 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_generalized_hammings_knn__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_generalized_hammings_knn_hc__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::int_maxheap_array_t *arg1 = (faiss::int_maxheap_array_t *) 0 ;
   uint8_t *arg2 = (uint8_t *) 0 ;
@@ -10526,36 +11302,36 @@ SWIGINTERN PyObject *_wrap_generalized_hammings_knn__SWIG_1(PyObject *SWIGUNUSED
   PyObject * obj3 = 0 ;
   PyObject * obj4 = 0 ;
   
-  if (!PyArg_ParseTuple(args,(char *)"OOOOO:generalized_hammings_knn",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"OOOOO:generalized_hammings_knn_hc",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__HeapArrayT_faiss__CMaxT_int_long_t_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "generalized_hammings_knn" "', argument " "1"" of type '" "faiss::int_maxheap_array_t *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "generalized_hammings_knn_hc" "', argument " "1"" of type '" "faiss::int_maxheap_array_t *""'"); 
   }
   arg1 = reinterpret_cast< faiss::int_maxheap_array_t * >(argp1);
   res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_unsigned_char, 0 |  0 );
   if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "generalized_hammings_knn" "', argument " "2"" of type '" "uint8_t const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "generalized_hammings_knn_hc" "', argument " "2"" of type '" "uint8_t const *""'"); 
   }
   arg2 = reinterpret_cast< uint8_t * >(argp2);
   res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
   if (!SWIG_IsOK(res3)) {
-    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "generalized_hammings_knn" "', argument " "3"" of type '" "uint8_t const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "generalized_hammings_knn_hc" "', argument " "3"" of type '" "uint8_t const *""'"); 
   }
   arg3 = reinterpret_cast< uint8_t * >(argp3);
   ecode4 = SWIG_AsVal_size_t(obj3, &val4);
   if (!SWIG_IsOK(ecode4)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "generalized_hammings_knn" "', argument " "4"" of type '" "size_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "generalized_hammings_knn_hc" "', argument " "4"" of type '" "size_t""'");
   } 
   arg4 = static_cast< size_t >(val4);
   ecode5 = SWIG_AsVal_size_t(obj4, &val5);
   if (!SWIG_IsOK(ecode5)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "generalized_hammings_knn" "', argument " "5"" of type '" "size_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "generalized_hammings_knn_hc" "', argument " "5"" of type '" "size_t""'");
   } 
   arg5 = static_cast< size_t >(val5);
   {
     Py_BEGIN_ALLOW_THREADS
     try {
-      faiss::generalized_hammings_knn(arg1,(unsigned char const *)arg2,(unsigned char const *)arg3,arg4,arg5);
+      faiss::generalized_hammings_knn_hc(arg1,(unsigned char const *)arg2,(unsigned char const *)arg3,arg4,arg5);
     } catch(faiss::FaissException & e) {
       PyEval_RestoreThread(_save);
       PyErr_SetString(PyExc_RuntimeError, e.what());
@@ -10570,7 +11346,7 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_generalized_hammings_knn(PyObject *self, PyObject *args) {
+SWIGINTERN PyObject *_wrap_generalized_hammings_knn_hc(PyObject *self, PyObject *args) {
   Py_ssize_t argc;
   PyObject *argv[7] = {
     0
@@ -10606,7 +11382,7 @@ SWIGINTERN PyObject *_wrap_generalized_hammings_knn(PyObject *self, PyObject *ar
               _v = SWIG_CheckState(res);
             }
             if (_v) {
-              return _wrap_generalized_hammings_knn__SWIG_1(self, args);
+              return _wrap_generalized_hammings_knn_hc__SWIG_1(self, args);
             }
           }
         }
@@ -10642,7 +11418,7 @@ SWIGINTERN PyObject *_wrap_generalized_hammings_knn(PyObject *self, PyObject *ar
                 _v = SWIG_CheckState(res);
               }
               if (_v) {
-                return _wrap_generalized_hammings_knn__SWIG_0(self, args);
+                return _wrap_generalized_hammings_knn_hc__SWIG_0(self, args);
               }
             }
           }
@@ -10652,10 +11428,10 @@ SWIGINTERN PyObject *_wrap_generalized_hammings_knn(PyObject *self, PyObject *ar
   }
   
 fail:
-  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'generalized_hammings_knn'.\n"
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'generalized_hammings_knn_hc'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    faiss::generalized_hammings_knn(faiss::int_maxheap_array_t *,uint8_t const *,uint8_t const *,size_t,size_t,int)\n"
-    "    faiss::generalized_hammings_knn(faiss::int_maxheap_array_t *,uint8_t const *,uint8_t const *,size_t,size_t)\n");
+    "    faiss::generalized_hammings_knn_hc(faiss::int_maxheap_array_t *,uint8_t const *,uint8_t const *,size_t,size_t,int)\n"
+    "    faiss::generalized_hammings_knn_hc(faiss::int_maxheap_array_t *,uint8_t const *,uint8_t const *,size_t,size_t)\n");
   return 0;
 }
 
@@ -29640,6 +30416,50 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_IndexPQ_remove_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexPQ *arg1 = (faiss::IndexPQ *) 0 ;
+  faiss::IDSelector *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexPQ_remove_ids",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexPQ, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexPQ_remove_ids" "', argument " "1"" of type '" "faiss::IndexPQ *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexPQ * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_faiss__IDSelector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexPQ_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IndexPQ_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::IDSelector * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (long)(arg1)->remove_ids((faiss::IDSelector const &)*arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_IndexPQ_do_polysemous_training_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::IndexPQ *arg1 = (faiss::IndexPQ *) 0 ;
@@ -29790,50 +30610,6 @@ SWIGINTERN PyObject *_wrap_IndexPQ_search_type_get(PyObject *SWIGUNUSEDPARM(self
   arg1 = reinterpret_cast< faiss::IndexPQ * >(argp1);
   result = (faiss::IndexPQ::Search_type_t) ((arg1)->search_type);
   resultobj = SWIG_From_int(static_cast< int >(result));
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_IndexPQ_remove_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  faiss::IndexPQ *arg1 = (faiss::IndexPQ *) 0 ;
-  faiss::IDSelector *arg2 = 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  long result;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OO:IndexPQ_remove_ids",&obj0,&obj1)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexPQ, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexPQ_remove_ids" "', argument " "1"" of type '" "faiss::IndexPQ *""'"); 
-  }
-  arg1 = reinterpret_cast< faiss::IndexPQ * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_faiss__IDSelector,  0  | 0);
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexPQ_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
-  }
-  if (!argp2) {
-    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IndexPQ_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
-  }
-  arg2 = reinterpret_cast< faiss::IDSelector * >(argp2);
-  {
-    Py_BEGIN_ALLOW_THREADS
-    try {
-      result = (long)(arg1)->remove_ids((faiss::IDSelector const &)*arg2);
-    } catch(faiss::FaissException & e) {
-      PyEval_RestoreThread(_save);
-      PyErr_SetString(PyExc_RuntimeError, e.what());
-      SWIG_fail;
-    }
-    Py_END_ALLOW_THREADS
-  }
-  resultobj = SWIG_From_long(static_cast< long >(result));
   return resultobj;
 fail:
   return NULL;
@@ -33138,6 +33914,161 @@ SWIGINTERN PyObject *ArrayInvertedLists_swigregister(PyObject *SWIGUNUSEDPARM(se
   return SWIG_Py_Void();
 }
 
+SWIGINTERN PyObject *_wrap_IVFSearchParameters_nprobe_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFSearchParameters *arg1 = (faiss::IVFSearchParameters *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IVFSearchParameters_nprobe_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IVFSearchParameters_nprobe_set" "', argument " "1"" of type '" "faiss::IVFSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFSearchParameters * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IVFSearchParameters_nprobe_set" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  if (arg1) (arg1)->nprobe = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IVFSearchParameters_nprobe_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFSearchParameters *arg1 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IVFSearchParameters_nprobe_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IVFSearchParameters_nprobe_get" "', argument " "1"" of type '" "faiss::IVFSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFSearchParameters * >(argp1);
+  result = (size_t) ((arg1)->nprobe);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IVFSearchParameters_max_codes_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFSearchParameters *arg1 = (faiss::IVFSearchParameters *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IVFSearchParameters_max_codes_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IVFSearchParameters_max_codes_set" "', argument " "1"" of type '" "faiss::IVFSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFSearchParameters * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IVFSearchParameters_max_codes_set" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  if (arg1) (arg1)->max_codes = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IVFSearchParameters_max_codes_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFSearchParameters *arg1 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IVFSearchParameters_max_codes_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IVFSearchParameters_max_codes_get" "', argument " "1"" of type '" "faiss::IVFSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFSearchParameters * >(argp1);
+  result = (size_t) ((arg1)->max_codes);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_IVFSearchParameters(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFSearchParameters *arg1 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_IVFSearchParameters",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFSearchParameters, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IVFSearchParameters" "', argument " "1"" of type '" "faiss::IVFSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFSearchParameters * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      delete arg1;
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IVFSearchParameters(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFSearchParameters *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_IVFSearchParameters")) SWIG_fail;
+  result = (faiss::IVFSearchParameters *)new faiss::IVFSearchParameters();
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IVFSearchParameters, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *IVFSearchParameters_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IVFSearchParameters, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
 SWIGINTERN PyObject *_wrap_IndexIVF_invlists_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::IndexIVF *arg1 = (faiss::IndexIVF *) 0 ;
@@ -33680,7 +34611,119 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_IndexIVF_search_preassigned(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_IndexIVF_search_preassigned__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVF *arg1 = (faiss::IndexIVF *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  faiss::Index::idx_t arg4 ;
+  faiss::Index::idx_t *arg5 = (faiss::Index::idx_t *) 0 ;
+  float *arg6 = (float *) 0 ;
+  float *arg7 = (float *) 0 ;
+  faiss::Index::idx_t *arg8 = (faiss::Index::idx_t *) 0 ;
+  bool arg9 ;
+  faiss::IVFSearchParameters *arg10 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  void *argp10 = 0 ;
+  int res10 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  PyObject * obj9 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOO:IndexIVF_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVF_search_preassigned" "', argument " "1"" of type '" "faiss::IndexIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVF_search_preassigned" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVF_search_preassigned" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexIVF_search_preassigned" "', argument " "4"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::Index::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexIVF_search_preassigned" "', argument " "5"" of type '" "faiss::Index::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::Index::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexIVF_search_preassigned" "', argument " "6"" of type '" "float const *""'"); 
+  }
+  arg6 = reinterpret_cast< float * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexIVF_search_preassigned" "', argument " "7"" of type '" "float *""'"); 
+  }
+  arg7 = reinterpret_cast< float * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexIVF_search_preassigned" "', argument " "8"" of type '" "faiss::Index::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::Index::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexIVF_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  res10 = SWIG_ConvertPtr(obj9, &argp10,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res10)) {
+    SWIG_exception_fail(SWIG_ArgError(res10), "in method '" "IndexIVF_search_preassigned" "', argument " "10"" of type '" "faiss::IVFSearchParameters const *""'"); 
+  }
+  arg10 = reinterpret_cast< faiss::IVFSearchParameters * >(argp10);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVF const *)arg1)->search_preassigned(arg2,(float const *)arg3,arg4,(faiss::Index::idx_t const *)arg5,(float const *)arg6,arg7,arg8,arg9,(faiss::IVFSearchParameters const *)arg10);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVF_search_preassigned__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::IndexIVF *arg1 = (faiss::IndexIVF *) 0 ;
   faiss::Index::idx_t arg2 ;
@@ -33780,6 +34823,137 @@ SWIGINTERN PyObject *_wrap_IndexIVF_search_preassigned(PyObject *SWIGUNUSEDPARM(
   return resultobj;
 fail:
   return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVF_search_preassigned(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[11] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 10) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 9) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVF, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      return _wrap_IndexIVF_search_preassigned__SWIG_1(self, args);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  if (argc == 10) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVF, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      void *vptr = 0;
+                      int res = SWIG_ConvertPtr(argv[9], &vptr, SWIGTYPE_p_faiss__IVFSearchParameters, 0);
+                      _v = SWIG_CheckState(res);
+                      if (_v) {
+                        return _wrap_IndexIVF_search_preassigned__SWIG_0(self, args);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexIVF_search_preassigned'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexIVF::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool,faiss::IVFSearchParameters const *) const\n"
+    "    faiss::IndexIVF::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool) const\n");
+  return 0;
 }
 
 
@@ -36745,7 +37919,119 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_IndexIVFScalarQuantizer_search_preassigned(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_IndexIVFScalarQuantizer_search_preassigned__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFScalarQuantizer *arg1 = (faiss::IndexIVFScalarQuantizer *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  faiss::Index::idx_t arg4 ;
+  faiss::Index::idx_t *arg5 = (faiss::Index::idx_t *) 0 ;
+  float *arg6 = (float *) 0 ;
+  float *arg7 = (float *) 0 ;
+  faiss::Index::idx_t *arg8 = (faiss::Index::idx_t *) 0 ;
+  bool arg9 ;
+  faiss::IVFSearchParameters *arg10 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  void *argp10 = 0 ;
+  int res10 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  PyObject * obj9 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOO:IndexIVFScalarQuantizer_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "1"" of type '" "faiss::IndexIVFScalarQuantizer const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFScalarQuantizer * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "4"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::Index::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "5"" of type '" "faiss::Index::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::Index::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "6"" of type '" "float const *""'"); 
+  }
+  arg6 = reinterpret_cast< float * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "7"" of type '" "float *""'"); 
+  }
+  arg7 = reinterpret_cast< float * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "8"" of type '" "faiss::Index::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::Index::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  res10 = SWIG_ConvertPtr(obj9, &argp10,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res10)) {
+    SWIG_exception_fail(SWIG_ArgError(res10), "in method '" "IndexIVFScalarQuantizer_search_preassigned" "', argument " "10"" of type '" "faiss::IVFSearchParameters const *""'"); 
+  }
+  arg10 = reinterpret_cast< faiss::IVFSearchParameters * >(argp10);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVFScalarQuantizer const *)arg1)->search_preassigned(arg2,(float const *)arg3,arg4,(faiss::Index::idx_t const *)arg5,(float const *)arg6,arg7,arg8,arg9,(faiss::IVFSearchParameters const *)arg10);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFScalarQuantizer_search_preassigned__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::IndexIVFScalarQuantizer *arg1 = (faiss::IndexIVFScalarQuantizer *) 0 ;
   faiss::Index::idx_t arg2 ;
@@ -36845,6 +38131,137 @@ SWIGINTERN PyObject *_wrap_IndexIVFScalarQuantizer_search_preassigned(PyObject *
   return resultobj;
 fail:
   return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFScalarQuantizer_search_preassigned(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[11] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 10) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 9) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFScalarQuantizer, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      return _wrap_IndexIVFScalarQuantizer_search_preassigned__SWIG_1(self, args);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  if (argc == 10) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFScalarQuantizer, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      void *vptr = 0;
+                      int res = SWIG_ConvertPtr(argv[9], &vptr, SWIGTYPE_p_faiss__IVFSearchParameters, 0);
+                      _v = SWIG_CheckState(res);
+                      if (_v) {
+                        return _wrap_IndexIVFScalarQuantizer_search_preassigned__SWIG_0(self, args);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexIVFScalarQuantizer_search_preassigned'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexIVFScalarQuantizer::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool,faiss::IVFSearchParameters const *) const\n"
+    "    faiss::IndexIVFScalarQuantizer::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool) const\n");
+  return 0;
 }
 
 
@@ -42151,7 +43568,119 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_IndexIVFFlat_search_preassigned(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_IndexIVFFlat_search_preassigned__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlat *arg1 = (faiss::IndexIVFFlat *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  faiss::Index::idx_t arg4 ;
+  faiss::Index::idx_t *arg5 = (faiss::Index::idx_t *) 0 ;
+  float *arg6 = (float *) 0 ;
+  float *arg7 = (float *) 0 ;
+  faiss::Index::idx_t *arg8 = (faiss::Index::idx_t *) 0 ;
+  bool arg9 ;
+  faiss::IVFSearchParameters *arg10 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  void *argp10 = 0 ;
+  int res10 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  PyObject * obj9 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOO:IndexIVFFlat_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "1"" of type '" "faiss::IndexIVFFlat const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlat * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "4"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::Index::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "5"" of type '" "faiss::Index::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::Index::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "6"" of type '" "float const *""'"); 
+  }
+  arg6 = reinterpret_cast< float * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "7"" of type '" "float *""'"); 
+  }
+  arg7 = reinterpret_cast< float * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "8"" of type '" "faiss::Index::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::Index::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  res10 = SWIG_ConvertPtr(obj9, &argp10,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res10)) {
+    SWIG_exception_fail(SWIG_ArgError(res10), "in method '" "IndexIVFFlat_search_preassigned" "', argument " "10"" of type '" "faiss::IVFSearchParameters const *""'"); 
+  }
+  arg10 = reinterpret_cast< faiss::IVFSearchParameters * >(argp10);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVFFlat const *)arg1)->search_preassigned(arg2,(float const *)arg3,arg4,(faiss::Index::idx_t const *)arg5,(float const *)arg6,arg7,arg8,arg9,(faiss::IVFSearchParameters const *)arg10);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlat_search_preassigned__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::IndexIVFFlat *arg1 = (faiss::IndexIVFFlat *) 0 ;
   faiss::Index::idx_t arg2 ;
@@ -42251,6 +43780,137 @@ SWIGINTERN PyObject *_wrap_IndexIVFFlat_search_preassigned(PyObject *SWIGUNUSEDP
   return resultobj;
 fail:
   return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlat_search_preassigned(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[11] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 10) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 9) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFFlat, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      return _wrap_IndexIVFFlat_search_preassigned__SWIG_1(self, args);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  if (argc == 10) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFFlat, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      void *vptr = 0;
+                      int res = SWIG_ConvertPtr(argv[9], &vptr, SWIGTYPE_p_faiss__IVFSearchParameters, 0);
+                      _v = SWIG_CheckState(res);
+                      if (_v) {
+                        return _wrap_IndexIVFFlat_search_preassigned__SWIG_0(self, args);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexIVFFlat_search_preassigned'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexIVFFlat::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool,faiss::IVFSearchParameters const *) const\n"
+    "    faiss::IndexIVFFlat::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool) const\n");
+  return 0;
 }
 
 
@@ -42559,6 +44219,980 @@ SWIGINTERN PyObject *IndexIVFFlat_swigregister(PyObject *SWIGUNUSEDPARM(self), P
   PyObject *obj;
   if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
   SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IndexIVFFlat, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_instances_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t > arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexIVFFlatDedup_instances_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_instances_set" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__unordered_multimapT_long_long_t,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexIVFFlatDedup_instances_set" "', argument " "2"" of type '" "std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t >""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IndexIVFFlatDedup_instances_set" "', argument " "2"" of type '" "std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t >""'");
+    } else {
+      std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t > * temp = reinterpret_cast< std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t > * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  if (arg1) (arg1)->instances = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_instances_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t > result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexIVFFlatDedup_instances_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_instances_get" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  result =  ((arg1)->instances);
+  resultobj = SWIG_NewPointerObj((new std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t >(static_cast< const std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t >& >(result))), SWIGTYPE_p_std__unordered_multimapT_long_long_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexIVFFlatDedup__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::Index *arg1 = (faiss::Index *) 0 ;
+  size_t arg2 ;
+  size_t arg3 ;
+  faiss::MetricType arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
+  int val4 ;
+  int ecode4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  faiss::IndexIVFFlatDedup *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:new_IndexIVFFlatDedup",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__Index, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_IndexIVFFlatDedup" "', argument " "1"" of type '" "faiss::Index *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::Index * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "new_IndexIVFFlatDedup" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "new_IndexIVFFlatDedup" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  ecode4 = SWIG_AsVal_int(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "new_IndexIVFFlatDedup" "', argument " "4"" of type '" "faiss::MetricType""'");
+  } 
+  arg4 = static_cast< faiss::MetricType >(val4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexIVFFlatDedup *)new faiss::IndexIVFFlatDedup(arg1,arg2,arg3,arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IndexIVFFlatDedup, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexIVFFlatDedup__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::Index *arg1 = (faiss::Index *) 0 ;
+  size_t arg2 ;
+  size_t arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  faiss::IndexIVFFlatDedup *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:new_IndexIVFFlatDedup",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__Index, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_IndexIVFFlatDedup" "', argument " "1"" of type '" "faiss::Index *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::Index * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "new_IndexIVFFlatDedup" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "new_IndexIVFFlatDedup" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexIVFFlatDedup *)new faiss::IndexIVFFlatDedup(arg1,arg2,arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IndexIVFFlatDedup, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_train(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexIVFFlatDedup_train",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_train" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFFlatDedup_train" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFFlatDedup_train" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->train(arg2,(float const *)arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_add_with_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  long *arg4 = (long *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexIVFFlatDedup_add_with_ids",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_add_with_ids" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFFlatDedup_add_with_ids" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFFlatDedup_add_with_ids" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexIVFFlatDedup_add_with_ids" "', argument " "4"" of type '" "long const *""'"); 
+  }
+  arg4 = reinterpret_cast< long * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->add_with_ids(arg2,(float const *)arg3,(long const *)arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_search_preassigned__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  faiss::Index::idx_t arg4 ;
+  faiss::Index::idx_t *arg5 = (faiss::Index::idx_t *) 0 ;
+  float *arg6 = (float *) 0 ;
+  float *arg7 = (float *) 0 ;
+  faiss::Index::idx_t *arg8 = (faiss::Index::idx_t *) 0 ;
+  bool arg9 ;
+  faiss::IVFSearchParameters *arg10 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  void *argp10 = 0 ;
+  int res10 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  PyObject * obj9 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOO:IndexIVFFlatDedup_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "4"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::Index::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "5"" of type '" "faiss::Index::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::Index::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "6"" of type '" "float const *""'"); 
+  }
+  arg6 = reinterpret_cast< float * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "7"" of type '" "float *""'"); 
+  }
+  arg7 = reinterpret_cast< float * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "8"" of type '" "faiss::Index::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::Index::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  res10 = SWIG_ConvertPtr(obj9, &argp10,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res10)) {
+    SWIG_exception_fail(SWIG_ArgError(res10), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "10"" of type '" "faiss::IVFSearchParameters const *""'"); 
+  }
+  arg10 = reinterpret_cast< faiss::IVFSearchParameters * >(argp10);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVFFlatDedup const *)arg1)->search_preassigned(arg2,(float const *)arg3,arg4,(faiss::Index::idx_t const *)arg5,(float const *)arg6,arg7,arg8,arg9,(faiss::IVFSearchParameters const *)arg10);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_search_preassigned__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  faiss::Index::idx_t arg4 ;
+  faiss::Index::idx_t *arg5 = (faiss::Index::idx_t *) 0 ;
+  float *arg6 = (float *) 0 ;
+  float *arg7 = (float *) 0 ;
+  faiss::Index::idx_t *arg8 = (faiss::Index::idx_t *) 0 ;
+  bool arg9 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOO:IndexIVFFlatDedup_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "4"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::Index::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "5"" of type '" "faiss::Index::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::Index::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "6"" of type '" "float const *""'"); 
+  }
+  arg6 = reinterpret_cast< float * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "7"" of type '" "float *""'"); 
+  }
+  arg7 = reinterpret_cast< float * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "8"" of type '" "faiss::Index::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::Index::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexIVFFlatDedup_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVFFlatDedup const *)arg1)->search_preassigned(arg2,(float const *)arg3,arg4,(faiss::Index::idx_t const *)arg5,(float const *)arg6,arg7,arg8,arg9);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_search_preassigned(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[11] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 10) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 9) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      return _wrap_IndexIVFFlatDedup_search_preassigned__SWIG_1(self, args);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  if (argc == 10) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      void *vptr = 0;
+                      int res = SWIG_ConvertPtr(argv[9], &vptr, SWIGTYPE_p_faiss__IVFSearchParameters, 0);
+                      _v = SWIG_CheckState(res);
+                      if (_v) {
+                        return _wrap_IndexIVFFlatDedup_search_preassigned__SWIG_0(self, args);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexIVFFlatDedup_search_preassigned'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexIVFFlatDedup::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool,faiss::IVFSearchParameters const *) const\n"
+    "    faiss::IndexIVFFlatDedup::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool) const\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_remove_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  faiss::IDSelector *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexIVFFlatDedup_remove_ids",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_remove_ids" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_faiss__IDSelector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexIVFFlatDedup_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IndexIVFFlatDedup_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::IDSelector * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (long)(arg1)->remove_ids((faiss::IDSelector const &)*arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_range_search(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  float arg4 ;
+  faiss::RangeSearchResult *arg5 = (faiss::RangeSearchResult *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  float val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOO:IndexIVFFlatDedup_range_search",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_range_search" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFFlatDedup_range_search" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFFlatDedup_range_search" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  ecode4 = SWIG_AsVal_float(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexIVFFlatDedup_range_search" "', argument " "4"" of type '" "float""'");
+  } 
+  arg4 = static_cast< float >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_faiss__RangeSearchResult, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexIVFFlatDedup_range_search" "', argument " "5"" of type '" "faiss::RangeSearchResult *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::RangeSearchResult * >(argp5);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVFFlatDedup const *)arg1)->range_search(arg2,(float const *)arg3,arg4,arg5);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_update_vectors(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  int arg2 ;
+  faiss::Index::idx_t *arg3 = (faiss::Index::idx_t *) 0 ;
+  float *arg4 = (float *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexIVFFlatDedup_update_vectors",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_update_vectors" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFFlatDedup_update_vectors" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFFlatDedup_update_vectors" "', argument " "3"" of type '" "faiss::Index::idx_t *""'"); 
+  }
+  arg3 = reinterpret_cast< faiss::Index::idx_t * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexIVFFlatDedup_update_vectors" "', argument " "4"" of type '" "float const *""'"); 
+  }
+  arg4 = reinterpret_cast< float * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->update_vectors(arg2,arg3,(float const *)arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFFlatDedup_reconstruct_from_offset(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  long arg2 ;
+  long arg3 ;
+  float *arg4 = (float *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  long val3 ;
+  int ecode3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexIVFFlatDedup_reconstruct_from_offset",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFFlatDedup_reconstruct_from_offset" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFFlatDedup_reconstruct_from_offset" "', argument " "2"" of type '" "long""'");
+  } 
+  arg2 = static_cast< long >(val2);
+  ecode3 = SWIG_AsVal_long(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IndexIVFFlatDedup_reconstruct_from_offset" "', argument " "3"" of type '" "long""'");
+  } 
+  arg3 = static_cast< long >(val3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexIVFFlatDedup_reconstruct_from_offset" "', argument " "4"" of type '" "float *""'"); 
+  }
+  arg4 = reinterpret_cast< float * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVFFlatDedup const *)arg1)->reconstruct_from_offset(arg2,arg3,arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexIVFFlatDedup__SWIG_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_IndexIVFFlatDedup")) SWIG_fail;
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexIVFFlatDedup *)new faiss::IndexIVFFlatDedup();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IndexIVFFlatDedup, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexIVFFlatDedup(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[5] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 4) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 0) {
+    return _wrap_new_IndexIVFFlatDedup__SWIG_2(self, args);
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__Index, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_size_t(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_size_t(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          return _wrap_new_IndexIVFFlatDedup__SWIG_1(self, args);
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__Index, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_size_t(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_size_t(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          {
+            int res = SWIG_AsVal_int(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            return _wrap_new_IndexIVFFlatDedup__SWIG_0(self, args);
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'new_IndexIVFFlatDedup'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexIVFFlatDedup::IndexIVFFlatDedup(faiss::Index *,size_t,size_t,faiss::MetricType)\n"
+    "    faiss::IndexIVFFlatDedup::IndexIVFFlatDedup(faiss::Index *,size_t,size_t)\n"
+    "    faiss::IndexIVFFlatDedup::IndexIVFFlatDedup()\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_IndexIVFFlatDedup(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFFlatDedup *arg1 = (faiss::IndexIVFFlatDedup *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_IndexIVFFlatDedup",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFFlatDedup, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IndexIVFFlatDedup" "', argument " "1"" of type '" "faiss::IndexIVFFlatDedup *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFFlatDedup * >(argp1);
+  delete arg1;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *IndexIVFFlatDedup_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IndexIVFFlatDedup, SWIG_NewClientData(obj));
   return SWIG_Py_Void();
 }
 
@@ -43766,6 +46400,161 @@ SWIGINTERN PyObject *OnDiskInvertedLists_swigregister(PyObject *SWIGUNUSEDPARM(s
   PyObject *obj;
   if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
   SWIG_TypeNewClientData(SWIGTYPE_p_faiss__OnDiskInvertedLists, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_IVFPQSearchParameters_scan_table_threshold_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFPQSearchParameters *arg1 = (faiss::IVFPQSearchParameters *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IVFPQSearchParameters_scan_table_threshold_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFPQSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IVFPQSearchParameters_scan_table_threshold_set" "', argument " "1"" of type '" "faiss::IVFPQSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFPQSearchParameters * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IVFPQSearchParameters_scan_table_threshold_set" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  if (arg1) (arg1)->scan_table_threshold = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IVFPQSearchParameters_scan_table_threshold_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFPQSearchParameters *arg1 = (faiss::IVFPQSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IVFPQSearchParameters_scan_table_threshold_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFPQSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IVFPQSearchParameters_scan_table_threshold_get" "', argument " "1"" of type '" "faiss::IVFPQSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFPQSearchParameters * >(argp1);
+  result = (size_t) ((arg1)->scan_table_threshold);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IVFPQSearchParameters_polysemous_ht_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFPQSearchParameters *arg1 = (faiss::IVFPQSearchParameters *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IVFPQSearchParameters_polysemous_ht_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFPQSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IVFPQSearchParameters_polysemous_ht_set" "', argument " "1"" of type '" "faiss::IVFPQSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFPQSearchParameters * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IVFPQSearchParameters_polysemous_ht_set" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  if (arg1) (arg1)->polysemous_ht = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IVFPQSearchParameters_polysemous_ht_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFPQSearchParameters *arg1 = (faiss::IVFPQSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  int result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IVFPQSearchParameters_polysemous_ht_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFPQSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IVFPQSearchParameters_polysemous_ht_get" "', argument " "1"" of type '" "faiss::IVFPQSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFPQSearchParameters * >(argp1);
+  result = (int) ((arg1)->polysemous_ht);
+  resultobj = SWIG_From_int(static_cast< int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_IVFPQSearchParameters(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFPQSearchParameters *arg1 = (faiss::IVFPQSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_IVFPQSearchParameters",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IVFPQSearchParameters, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IVFPQSearchParameters" "', argument " "1"" of type '" "faiss::IVFPQSearchParameters *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IVFPQSearchParameters * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      delete arg1;
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IVFPQSearchParameters(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IVFPQSearchParameters *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_IVFPQSearchParameters")) SWIG_fail;
+  result = (faiss::IVFPQSearchParameters *)new faiss::IVFPQSearchParameters();
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IVFPQSearchParameters, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *IVFPQSearchParameters_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IVFPQSearchParameters, SWIG_NewClientData(obj));
   return SWIG_Py_Void();
 }
 
@@ -45228,7 +48017,119 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_IndexIVFPQ_search_preassigned(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_IndexIVFPQ_search_preassigned__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFPQ *arg1 = (faiss::IndexIVFPQ *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  faiss::Index::idx_t arg4 ;
+  faiss::Index::idx_t *arg5 = (faiss::Index::idx_t *) 0 ;
+  float *arg6 = (float *) 0 ;
+  float *arg7 = (float *) 0 ;
+  faiss::Index::idx_t *arg8 = (faiss::Index::idx_t *) 0 ;
+  bool arg9 ;
+  faiss::IVFSearchParameters *arg10 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  void *argp10 = 0 ;
+  int res10 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  PyObject * obj9 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOO:IndexIVFPQ_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFPQ, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "1"" of type '" "faiss::IndexIVFPQ const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFPQ * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "4"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::Index::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "5"" of type '" "faiss::Index::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::Index::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "6"" of type '" "float const *""'"); 
+  }
+  arg6 = reinterpret_cast< float * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "7"" of type '" "float *""'"); 
+  }
+  arg7 = reinterpret_cast< float * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "8"" of type '" "faiss::Index::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::Index::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  res10 = SWIG_ConvertPtr(obj9, &argp10,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res10)) {
+    SWIG_exception_fail(SWIG_ArgError(res10), "in method '" "IndexIVFPQ_search_preassigned" "', argument " "10"" of type '" "faiss::IVFSearchParameters const *""'"); 
+  }
+  arg10 = reinterpret_cast< faiss::IVFSearchParameters * >(argp10);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVFPQ const *)arg1)->search_preassigned(arg2,(float const *)arg3,arg4,(faiss::Index::idx_t const *)arg5,(float const *)arg6,arg7,arg8,arg9,(faiss::IVFSearchParameters const *)arg10);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFPQ_search_preassigned__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::IndexIVFPQ *arg1 = (faiss::IndexIVFPQ *) 0 ;
   faiss::Index::idx_t arg2 ;
@@ -45328,6 +48229,137 @@ SWIGINTERN PyObject *_wrap_IndexIVFPQ_search_preassigned(PyObject *SWIGUNUSEDPAR
   return resultobj;
 fail:
   return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFPQ_search_preassigned(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[11] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 10) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 9) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFPQ, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      return _wrap_IndexIVFPQ_search_preassigned__SWIG_1(self, args);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  if (argc == 10) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFPQ, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      void *vptr = 0;
+                      int res = SWIG_ConvertPtr(argv[9], &vptr, SWIGTYPE_p_faiss__IVFSearchParameters, 0);
+                      _v = SWIG_CheckState(res);
+                      if (_v) {
+                        return _wrap_IndexIVFPQ_search_preassigned__SWIG_0(self, args);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexIVFPQ_search_preassigned'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexIVFPQ::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool,faiss::IVFSearchParameters const *) const\n"
+    "    faiss::IndexIVFPQ::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool) const\n");
+  return 0;
 }
 
 
@@ -46943,7 +49975,119 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_IndexIVFPQR_search_preassigned(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_IndexIVFPQR_search_preassigned__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexIVFPQR *arg1 = (faiss::IndexIVFPQR *) 0 ;
+  faiss::Index::idx_t arg2 ;
+  float *arg3 = (float *) 0 ;
+  faiss::Index::idx_t arg4 ;
+  faiss::Index::idx_t *arg5 = (faiss::Index::idx_t *) 0 ;
+  float *arg6 = (float *) 0 ;
+  float *arg7 = (float *) 0 ;
+  faiss::Index::idx_t *arg8 = (faiss::Index::idx_t *) 0 ;
+  bool arg9 ;
+  faiss::IVFSearchParameters *arg10 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  void *argp10 = 0 ;
+  int res10 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  PyObject * obj9 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOO:IndexIVFPQR_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexIVFPQR, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "1"" of type '" "faiss::IndexIVFPQR const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexIVFPQR * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "2"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::Index::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "3"" of type '" "float const *""'"); 
+  }
+  arg3 = reinterpret_cast< float * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "4"" of type '" "faiss::Index::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::Index::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "5"" of type '" "faiss::Index::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::Index::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "6"" of type '" "float const *""'"); 
+  }
+  arg6 = reinterpret_cast< float * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_float, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "7"" of type '" "float *""'"); 
+  }
+  arg7 = reinterpret_cast< float * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "8"" of type '" "faiss::Index::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::Index::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  res10 = SWIG_ConvertPtr(obj9, &argp10,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res10)) {
+    SWIG_exception_fail(SWIG_ArgError(res10), "in method '" "IndexIVFPQR_search_preassigned" "', argument " "10"" of type '" "faiss::IVFSearchParameters const *""'"); 
+  }
+  arg10 = reinterpret_cast< faiss::IVFSearchParameters * >(argp10);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexIVFPQR const *)arg1)->search_preassigned(arg2,(float const *)arg3,arg4,(faiss::Index::idx_t const *)arg5,(float const *)arg6,arg7,arg8,arg9,(faiss::IVFSearchParameters const *)arg10);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFPQR_search_preassigned__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::IndexIVFPQR *arg1 = (faiss::IndexIVFPQR *) 0 ;
   faiss::Index::idx_t arg2 ;
@@ -47043,6 +50187,137 @@ SWIGINTERN PyObject *_wrap_IndexIVFPQR_search_preassigned(PyObject *SWIGUNUSEDPA
   return resultobj;
 fail:
   return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexIVFPQR_search_preassigned(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[11] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 10) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 9) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFPQR, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      return _wrap_IndexIVFPQR_search_preassigned__SWIG_1(self, args);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  if (argc == 10) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexIVFPQR, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_float, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_float, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_float, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      void *vptr = 0;
+                      int res = SWIG_ConvertPtr(argv[9], &vptr, SWIGTYPE_p_faiss__IVFSearchParameters, 0);
+                      _v = SWIG_CheckState(res);
+                      if (_v) {
+                        return _wrap_IndexIVFPQR_search_preassigned__SWIG_0(self, args);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexIVFPQR_search_preassigned'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexIVFPQR::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool,faiss::IVFSearchParameters const *) const\n"
+    "    faiss::IndexIVFPQR::search_preassigned(faiss::Index::idx_t,float const *,faiss::Index::idx_t,faiss::Index::idx_t const *,float const *,float *,faiss::Index::idx_t *,bool) const\n");
+  return 0;
 }
 
 
@@ -48075,6 +51350,3854 @@ SWIGINTERN PyObject *Index2Layer_swigregister(PyObject *SWIGUNUSEDPARM(self), Py
   PyObject *obj;
   if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
   SWIG_TypeNewClientData(SWIGTYPE_p_faiss__Index2Layer, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_IndexBinary_d_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinary_d_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_d_set" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_d_set" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  if (arg1) (arg1)->d = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_d_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  int result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinary_d_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_d_get" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  result = (int) ((arg1)->d);
+  resultobj = SWIG_From_int(static_cast< int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_code_size_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinary_code_size_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_code_size_set" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_code_size_set" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  if (arg1) (arg1)->code_size = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_code_size_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  int result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinary_code_size_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_code_size_get" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  result = (int) ((arg1)->code_size);
+  resultobj = SWIG_From_int(static_cast< int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_ntotal_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinary_ntotal_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_ntotal_set" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_ntotal_set" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  if (arg1) (arg1)->ntotal = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_ntotal_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::IndexBinary::idx_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinary_ntotal_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_ntotal_get" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  result = (faiss::IndexBinary::idx_t) ((arg1)->ntotal);
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_verbose_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinary_verbose_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_verbose_set" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_bool(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_verbose_set" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  if (arg1) (arg1)->verbose = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_verbose_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  bool result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinary_verbose_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_verbose_get" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  result = (bool) ((arg1)->verbose);
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_is_trained_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinary_is_trained_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_is_trained_set" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_bool(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_is_trained_set" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  if (arg1) (arg1)->is_trained = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_is_trained_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  bool result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinary_is_trained_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_is_trained_get" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  result = (bool) ((arg1)->is_trained);
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_metric_type_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::MetricType arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinary_metric_type_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_metric_type_set" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_metric_type_set" "', argument " "2"" of type '" "faiss::MetricType""'");
+  } 
+  arg2 = static_cast< faiss::MetricType >(val2);
+  if (arg1) (arg1)->metric_type = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_metric_type_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::MetricType result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinary_metric_type_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_metric_type_get" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  result = (faiss::MetricType) ((arg1)->metric_type);
+  resultobj = SWIG_From_int(static_cast< int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_IndexBinary(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_IndexBinary",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IndexBinary" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      delete arg1;
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_train(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinary_train",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_train" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_train" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_train" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->train(arg2,(uint8_t const *)arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_add(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinary_add",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_add" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_add" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_add" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->add(arg2,(uint8_t const *)arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_add_with_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  long *arg4 = (long *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexBinary_add_with_ids",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_add_with_ids" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_add_with_ids" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_add_with_ids" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexBinary_add_with_ids" "', argument " "4"" of type '" "long const *""'"); 
+  }
+  arg4 = reinterpret_cast< long * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->add_with_ids(arg2,(uint8_t const *)arg3,(long const *)arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_search(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t arg4 ;
+  int32_t *arg5 = (int32_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg6 = (faiss::IndexBinary::idx_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOO:IndexBinary_search",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_search" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_search" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_search" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinary_search" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::IndexBinary::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinary_search" "', argument " "5"" of type '" "int32_t *""'"); 
+  }
+  arg5 = reinterpret_cast< int32_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexBinary_search" "', argument " "6"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg6 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp6);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinary const *)arg1)->search(arg2,(uint8_t const *)arg3,arg4,arg5,arg6);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_range_search(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  int arg4 ;
+  faiss::RangeSearchResult *arg5 = (faiss::RangeSearchResult *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  int val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOO:IndexBinary_range_search",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_range_search" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_range_search" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_range_search" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_int(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinary_range_search" "', argument " "4"" of type '" "int""'");
+  } 
+  arg4 = static_cast< int >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_faiss__RangeSearchResult, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinary_range_search" "', argument " "5"" of type '" "faiss::RangeSearchResult *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::RangeSearchResult * >(argp5);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinary const *)arg1)->range_search(arg2,(uint8_t const *)arg3,arg4,arg5);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_assign__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg4 = (faiss::IndexBinary::idx_t *) 0 ;
+  faiss::IndexBinary::idx_t arg5 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  long val5 ;
+  int ecode5 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOO:IndexBinary_assign",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_assign" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_assign" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_assign" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexBinary_assign" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg4 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp4);
+  ecode5 = SWIG_AsVal_long(obj4, &val5);
+  if (!SWIG_IsOK(ecode5)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "IndexBinary_assign" "', argument " "5"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg5 = static_cast< faiss::IndexBinary::idx_t >(val5);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->assign(arg2,(uint8_t const *)arg3,arg4,arg5);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_assign__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg4 = (faiss::IndexBinary::idx_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexBinary_assign",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_assign" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_assign" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_assign" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexBinary_assign" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg4 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->assign(arg2,(uint8_t const *)arg3,arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_assign(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[6] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 5) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 4) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinary, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_unsigned_char, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          void *vptr = 0;
+          int res = SWIG_ConvertPtr(argv[3], &vptr, SWIGTYPE_p_long, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            return _wrap_IndexBinary_assign__SWIG_1(self, args);
+          }
+        }
+      }
+    }
+  }
+  if (argc == 5) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinary, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_unsigned_char, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          void *vptr = 0;
+          int res = SWIG_ConvertPtr(argv[3], &vptr, SWIGTYPE_p_long, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            {
+              int res = SWIG_AsVal_long(argv[4], NULL);
+              _v = SWIG_CheckState(res);
+            }
+            if (_v) {
+              return _wrap_IndexBinary_assign__SWIG_0(self, args);
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexBinary_assign'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexBinary::assign(faiss::IndexBinary::idx_t,uint8_t const *,faiss::IndexBinary::idx_t *,faiss::IndexBinary::idx_t)\n"
+    "    faiss::IndexBinary::assign(faiss::IndexBinary::idx_t,uint8_t const *,faiss::IndexBinary::idx_t *)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_reset(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinary_reset",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_reset" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->reset();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_remove_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IDSelector *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinary_remove_ids",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_remove_ids" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_faiss__IDSelector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinary_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IndexBinary_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::IDSelector * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (long)(arg1)->remove_ids((faiss::IDSelector const &)*arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_reconstruct(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinary_reconstruct",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_reconstruct" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_reconstruct" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_reconstruct" "', argument " "3"" of type '" "uint8_t *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinary const *)arg1)->reconstruct(arg2,arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_reconstruct_n(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  faiss::IndexBinary::idx_t arg3 ;
+  uint8_t *arg4 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  long val3 ;
+  int ecode3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexBinary_reconstruct_n",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_reconstruct_n" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_reconstruct_n" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  ecode3 = SWIG_AsVal_long(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IndexBinary_reconstruct_n" "', argument " "3"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg3 = static_cast< faiss::IndexBinary::idx_t >(val3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexBinary_reconstruct_n" "', argument " "4"" of type '" "uint8_t *""'"); 
+  }
+  arg4 = reinterpret_cast< uint8_t * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinary const *)arg1)->reconstruct_n(arg2,arg3,arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_search_and_reconstruct(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t arg4 ;
+  int32_t *arg5 = (int32_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg6 = (faiss::IndexBinary::idx_t *) 0 ;
+  uint8_t *arg7 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOO:IndexBinary_search_and_reconstruct",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_search_and_reconstruct" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinary_search_and_reconstruct" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinary_search_and_reconstruct" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinary_search_and_reconstruct" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::IndexBinary::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinary_search_and_reconstruct" "', argument " "5"" of type '" "int32_t *""'"); 
+  }
+  arg5 = reinterpret_cast< int32_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexBinary_search_and_reconstruct" "', argument " "6"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg6 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexBinary_search_and_reconstruct" "', argument " "7"" of type '" "uint8_t *""'"); 
+  }
+  arg7 = reinterpret_cast< uint8_t * >(argp7);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinary const *)arg1)->search_and_reconstruct(arg2,(uint8_t const *)arg3,arg4,arg5,arg6,arg7);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinary_display(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinary_display",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinary_display" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinary const *)arg1)->display();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *IndexBinary_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IndexBinary, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_xb_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  std::vector< uint8_t > *arg2 = (std::vector< uint8_t > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryFlat_xb_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_xb_set" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_std__vectorT_unsigned_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryFlat_xb_set" "', argument " "2"" of type '" "std::vector< uint8_t > *""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< uint8_t > * >(argp2);
+  if (arg1) (arg1)->xb = *arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_xb_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  std::vector< uint8_t > *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryFlat_xb_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_xb_get" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  result = (std::vector< uint8_t > *)& ((arg1)->xb);
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_unsigned_char_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_use_heap_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryFlat_use_heap_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_use_heap_set" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  ecode2 = SWIG_AsVal_bool(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryFlat_use_heap_set" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  if (arg1) (arg1)->use_heap = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_use_heap_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  bool result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryFlat_use_heap_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_use_heap_get" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  result = (bool) ((arg1)->use_heap);
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_query_batch_size_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryFlat_query_batch_size_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_query_batch_size_set" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryFlat_query_batch_size_set" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  if (arg1) (arg1)->query_batch_size = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_query_batch_size_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryFlat_query_batch_size_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_query_batch_size_get" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  result = (size_t) ((arg1)->query_batch_size);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexBinaryFlat__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary::idx_t arg1 ;
+  long val1 ;
+  int ecode1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::IndexBinaryFlat *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:new_IndexBinaryFlat",&obj0)) SWIG_fail;
+  ecode1 = SWIG_AsVal_long(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "new_IndexBinaryFlat" "', argument " "1"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg1 = static_cast< faiss::IndexBinary::idx_t >(val1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinaryFlat *)new faiss::IndexBinaryFlat(arg1);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IndexBinaryFlat, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_add(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinaryFlat_add",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_add" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryFlat_add" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryFlat_add" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->add(arg2,(uint8_t const *)arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_reset(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryFlat_reset",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_reset" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->reset();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_search(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t arg4 ;
+  int32_t *arg5 = (int32_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg6 = (faiss::IndexBinary::idx_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOO:IndexBinaryFlat_search",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_search" "', argument " "1"" of type '" "faiss::IndexBinaryFlat const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryFlat_search" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryFlat_search" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinaryFlat_search" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::IndexBinary::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinaryFlat_search" "', argument " "5"" of type '" "int32_t *""'"); 
+  }
+  arg5 = reinterpret_cast< int32_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexBinaryFlat_search" "', argument " "6"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg6 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp6);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryFlat const *)arg1)->search(arg2,(uint8_t const *)arg3,arg4,arg5,arg6);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_reconstruct(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinaryFlat_reconstruct",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_reconstruct" "', argument " "1"" of type '" "faiss::IndexBinaryFlat const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryFlat_reconstruct" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryFlat_reconstruct" "', argument " "3"" of type '" "uint8_t *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryFlat const *)arg1)->reconstruct(arg2,arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryFlat_remove_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  faiss::IDSelector *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryFlat_remove_ids",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryFlat_remove_ids" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_faiss__IDSelector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryFlat_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IndexBinaryFlat_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::IDSelector * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (long)(arg1)->remove_ids((faiss::IDSelector const &)*arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexBinaryFlat__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_IndexBinaryFlat")) SWIG_fail;
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinaryFlat *)new faiss::IndexBinaryFlat();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IndexBinaryFlat, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexBinaryFlat(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[2] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 1) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 0) {
+    return _wrap_new_IndexBinaryFlat__SWIG_1(self, args);
+  }
+  if (argc == 1) {
+    int _v;
+    {
+      int res = SWIG_AsVal_long(argv[0], NULL);
+      _v = SWIG_CheckState(res);
+    }
+    if (_v) {
+      return _wrap_new_IndexBinaryFlat__SWIG_0(self, args);
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'new_IndexBinaryFlat'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexBinaryFlat::IndexBinaryFlat(faiss::IndexBinary::idx_t)\n"
+    "    faiss::IndexBinaryFlat::IndexBinaryFlat()\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_IndexBinaryFlat(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryFlat *arg1 = (faiss::IndexBinaryFlat *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_IndexBinaryFlat",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryFlat, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IndexBinaryFlat" "', argument " "1"" of type '" "faiss::IndexBinaryFlat *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryFlat * >(argp1);
+  delete arg1;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *IndexBinaryFlat_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IndexBinaryFlat, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_invlists_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::InvertedLists *arg2 = (faiss::InvertedLists *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_invlists_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_invlists_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_faiss__InvertedLists, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryIVF_invlists_set" "', argument " "2"" of type '" "faiss::InvertedLists *""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::InvertedLists * >(argp2);
+  if (arg1) (arg1)->invlists = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_invlists_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::InvertedLists *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_invlists_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_invlists_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (faiss::InvertedLists *) ((arg1)->invlists);
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__InvertedLists, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_own_invlists_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_own_invlists_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_own_invlists_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_bool(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_own_invlists_set" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  if (arg1) (arg1)->own_invlists = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_own_invlists_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  bool result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_own_invlists_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_own_invlists_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (bool) ((arg1)->own_invlists);
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_nprobe_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_nprobe_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_nprobe_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_nprobe_set" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  if (arg1) (arg1)->nprobe = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_nprobe_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_nprobe_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_nprobe_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (size_t) ((arg1)->nprobe);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_max_codes_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_max_codes_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_max_codes_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_max_codes_set" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  if (arg1) (arg1)->max_codes = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_max_codes_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_max_codes_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_max_codes_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (size_t) ((arg1)->max_codes);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_use_heap_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_use_heap_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_use_heap_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_bool(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_use_heap_set" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  if (arg1) (arg1)->use_heap = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_use_heap_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  bool result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_use_heap_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_use_heap_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (bool) ((arg1)->use_heap);
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_maintain_direct_map_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_maintain_direct_map_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_maintain_direct_map_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_bool(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_maintain_direct_map_set" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  if (arg1) (arg1)->maintain_direct_map = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_maintain_direct_map_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  bool result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_maintain_direct_map_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_maintain_direct_map_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (bool) ((arg1)->maintain_direct_map);
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_direct_map_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  std::vector< long > *arg2 = (std::vector< long > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_direct_map_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_direct_map_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_std__vectorT_long_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryIVF_direct_map_set" "', argument " "2"" of type '" "std::vector< long > *""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< long > * >(argp2);
+  if (arg1) (arg1)->direct_map = *arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_direct_map_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  std::vector< long > *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_direct_map_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_direct_map_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (std::vector< long > *)& ((arg1)->direct_map);
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_long_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_quantizer_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary *arg2 = (faiss::IndexBinary *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_quantizer_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_quantizer_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_faiss__IndexBinary, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryIVF_quantizer_set" "', argument " "2"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::IndexBinary * >(argp2);
+  if (arg1) (arg1)->quantizer = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_quantizer_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::IndexBinary *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_quantizer_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_quantizer_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (faiss::IndexBinary *) ((arg1)->quantizer);
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_nlist_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_nlist_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_nlist_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_nlist_set" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  if (arg1) (arg1)->nlist = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_nlist_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_nlist_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_nlist_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (size_t) ((arg1)->nlist);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_own_fields_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_own_fields_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_own_fields_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_bool(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_own_fields_set" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  if (arg1) (arg1)->own_fields = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_own_fields_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  bool result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_own_fields_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_own_fields_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (bool) ((arg1)->own_fields);
+  resultobj = SWIG_From_bool(static_cast< bool >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_cp_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::ClusteringParameters *arg2 = (faiss::ClusteringParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_cp_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_cp_set" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_faiss__ClusteringParameters, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryIVF_cp_set" "', argument " "2"" of type '" "faiss::ClusteringParameters *""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::ClusteringParameters * >(argp2);
+  if (arg1) (arg1)->cp = *arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_cp_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::ClusteringParameters *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_cp_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_cp_get" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  result = (faiss::ClusteringParameters *)& ((arg1)->cp);
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__ClusteringParameters, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_train_q1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  size_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  bool arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  bool val4 ;
+  int ecode4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexBinaryIVF_train_q1",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_train_q1" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_train_q1" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_train_q1" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_bool(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinaryIVF_train_q1" "', argument " "4"" of type '" "bool""'");
+  } 
+  arg4 = static_cast< bool >(val4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->train_q1(arg2,(uint8_t const *)arg3,arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexBinaryIVF__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  size_t arg2 ;
+  size_t arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  faiss::IndexBinaryIVF *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:new_IndexBinaryIVF",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_IndexBinaryIVF" "', argument " "1"" of type '" "faiss::IndexBinary *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "new_IndexBinaryIVF" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "new_IndexBinaryIVF" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinaryIVF *)new faiss::IndexBinaryIVF(arg1,arg2,arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IndexBinaryIVF, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexBinaryIVF__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_IndexBinaryIVF")) SWIG_fail;
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinaryIVF *)new faiss::IndexBinaryIVF();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__IndexBinaryIVF, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_IndexBinaryIVF(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[4] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 3) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 0) {
+    return _wrap_new_IndexBinaryIVF__SWIG_1(self, args);
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinary, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_size_t(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_size_t(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          return _wrap_new_IndexBinaryIVF__SWIG_0(self, args);
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'new_IndexBinaryIVF'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexBinaryIVF::IndexBinaryIVF(faiss::IndexBinary *,size_t,size_t)\n"
+    "    faiss::IndexBinaryIVF::IndexBinaryIVF()\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_IndexBinaryIVF(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_IndexBinaryIVF",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IndexBinaryIVF" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      delete arg1;
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_reset(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_reset",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_reset" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->reset();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_train(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinaryIVF_train",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_train" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_train" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_train" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->train(arg2,(uint8_t const *)arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_add(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinaryIVF_add",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_add" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_add" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_add" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->add(arg2,(uint8_t const *)arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_add_with_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  long *arg4 = (long *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexBinaryIVF_add_with_ids",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_add_with_ids" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_add_with_ids" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_add_with_ids" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexBinaryIVF_add_with_ids" "', argument " "4"" of type '" "long const *""'"); 
+  }
+  arg4 = reinterpret_cast< long * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->add_with_ids(arg2,(uint8_t const *)arg3,(long const *)arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_add_core(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  long *arg4 = (long *) 0 ;
+  long *arg5 = (long *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOO:IndexBinaryIVF_add_core",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_add_core" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_add_core" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_add_core" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexBinaryIVF_add_core" "', argument " "4"" of type '" "long const *""'"); 
+  }
+  arg4 = reinterpret_cast< long * >(argp4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinaryIVF_add_core" "', argument " "5"" of type '" "long const *""'"); 
+  }
+  arg5 = reinterpret_cast< long * >(argp5);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->add_core(arg2,(uint8_t const *)arg3,(long const *)arg4,(long const *)arg5);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_search_preassigned__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t arg4 ;
+  faiss::IndexBinary::idx_t *arg5 = (faiss::IndexBinary::idx_t *) 0 ;
+  int32_t *arg6 = (int32_t *) 0 ;
+  int32_t *arg7 = (int32_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg8 = (faiss::IndexBinary::idx_t *) 0 ;
+  bool arg9 ;
+  faiss::IVFSearchParameters *arg10 = (faiss::IVFSearchParameters *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  void *argp10 = 0 ;
+  int res10 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  PyObject * obj9 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOOO:IndexBinaryIVF_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8,&obj9)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::IndexBinary::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "5"" of type '" "faiss::IndexBinary::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "6"" of type '" "int32_t const *""'"); 
+  }
+  arg6 = reinterpret_cast< int32_t * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "7"" of type '" "int32_t *""'"); 
+  }
+  arg7 = reinterpret_cast< int32_t * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "8"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  res10 = SWIG_ConvertPtr(obj9, &argp10,SWIGTYPE_p_faiss__IVFSearchParameters, 0 |  0 );
+  if (!SWIG_IsOK(res10)) {
+    SWIG_exception_fail(SWIG_ArgError(res10), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "10"" of type '" "faiss::IVFSearchParameters const *""'"); 
+  }
+  arg10 = reinterpret_cast< faiss::IVFSearchParameters * >(argp10);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryIVF const *)arg1)->search_preassigned(arg2,(uint8_t const *)arg3,arg4,(faiss::IndexBinary::idx_t const *)arg5,(int32_t const *)arg6,arg7,arg8,arg9,(faiss::IVFSearchParameters const *)arg10);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_search_preassigned__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t arg4 ;
+  faiss::IndexBinary::idx_t *arg5 = (faiss::IndexBinary::idx_t *) 0 ;
+  int32_t *arg6 = (int32_t *) 0 ;
+  int32_t *arg7 = (int32_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg8 = (faiss::IndexBinary::idx_t *) 0 ;
+  bool arg9 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  void *argp8 = 0 ;
+  int res8 = 0 ;
+  bool val9 ;
+  int ecode9 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  PyObject * obj7 = 0 ;
+  PyObject * obj8 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOOOO:IndexBinaryIVF_search_preassigned",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6,&obj7,&obj8)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::IndexBinary::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "5"" of type '" "faiss::IndexBinary::idx_t const *""'"); 
+  }
+  arg5 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "6"" of type '" "int32_t const *""'"); 
+  }
+  arg6 = reinterpret_cast< int32_t * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "7"" of type '" "int32_t *""'"); 
+  }
+  arg7 = reinterpret_cast< int32_t * >(argp7);
+  res8 = SWIG_ConvertPtr(obj7, &argp8,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res8)) {
+    SWIG_exception_fail(SWIG_ArgError(res8), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "8"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg8 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp8);
+  ecode9 = SWIG_AsVal_bool(obj8, &val9);
+  if (!SWIG_IsOK(ecode9)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode9), "in method '" "IndexBinaryIVF_search_preassigned" "', argument " "9"" of type '" "bool""'");
+  } 
+  arg9 = static_cast< bool >(val9);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryIVF const *)arg1)->search_preassigned(arg2,(uint8_t const *)arg3,arg4,(faiss::IndexBinary::idx_t const *)arg5,(int32_t const *)arg6,arg7,arg8,arg9);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_search_preassigned(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[11] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 10) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 9) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinaryIVF, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_unsigned_char, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_int, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_int, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      return _wrap_IndexBinaryIVF_search_preassigned__SWIG_1(self, args);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  if (argc == 10) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinaryIVF, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_long(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_unsigned_char, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          {
+            int res = SWIG_AsVal_long(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_long, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              void *vptr = 0;
+              int res = SWIG_ConvertPtr(argv[5], &vptr, SWIGTYPE_p_int, 0);
+              _v = SWIG_CheckState(res);
+              if (_v) {
+                void *vptr = 0;
+                int res = SWIG_ConvertPtr(argv[6], &vptr, SWIGTYPE_p_int, 0);
+                _v = SWIG_CheckState(res);
+                if (_v) {
+                  void *vptr = 0;
+                  int res = SWIG_ConvertPtr(argv[7], &vptr, SWIGTYPE_p_long, 0);
+                  _v = SWIG_CheckState(res);
+                  if (_v) {
+                    {
+                      int res = SWIG_AsVal_bool(argv[8], NULL);
+                      _v = SWIG_CheckState(res);
+                    }
+                    if (_v) {
+                      void *vptr = 0;
+                      int res = SWIG_ConvertPtr(argv[9], &vptr, SWIGTYPE_p_faiss__IVFSearchParameters, 0);
+                      _v = SWIG_CheckState(res);
+                      if (_v) {
+                        return _wrap_IndexBinaryIVF_search_preassigned__SWIG_0(self, args);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexBinaryIVF_search_preassigned'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexBinaryIVF::search_preassigned(faiss::IndexBinary::idx_t,uint8_t const *,faiss::IndexBinary::idx_t,faiss::IndexBinary::idx_t const *,int32_t const *,int32_t *,faiss::IndexBinary::idx_t *,bool,faiss::IVFSearchParameters const *) const\n"
+    "    faiss::IndexBinaryIVF::search_preassigned(faiss::IndexBinary::idx_t,uint8_t const *,faiss::IndexBinary::idx_t,faiss::IndexBinary::idx_t const *,int32_t const *,int32_t *,faiss::IndexBinary::idx_t *,bool) const\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_search(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t arg4 ;
+  int32_t *arg5 = (int32_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg6 = (faiss::IndexBinary::idx_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOO:IndexBinaryIVF_search",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_search" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_search" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_search" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinaryIVF_search" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::IndexBinary::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinaryIVF_search" "', argument " "5"" of type '" "int32_t *""'"); 
+  }
+  arg5 = reinterpret_cast< int32_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexBinaryIVF_search" "', argument " "6"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg6 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp6);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryIVF const *)arg1)->search(arg2,(uint8_t const *)arg3,arg4,arg5,arg6);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_reconstruct(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinaryIVF_reconstruct",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_reconstruct" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_reconstruct" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_reconstruct" "', argument " "3"" of type '" "uint8_t *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryIVF const *)arg1)->reconstruct(arg2,arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_reconstruct_n(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  faiss::IndexBinary::idx_t arg3 ;
+  uint8_t *arg4 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  long val3 ;
+  int ecode3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexBinaryIVF_reconstruct_n",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_reconstruct_n" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_reconstruct_n" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  ecode3 = SWIG_AsVal_long(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IndexBinaryIVF_reconstruct_n" "', argument " "3"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg3 = static_cast< faiss::IndexBinary::idx_t >(val3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexBinaryIVF_reconstruct_n" "', argument " "4"" of type '" "uint8_t *""'"); 
+  }
+  arg4 = reinterpret_cast< uint8_t * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryIVF const *)arg1)->reconstruct_n(arg2,arg3,arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_search_and_reconstruct(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinary::idx_t arg2 ;
+  uint8_t *arg3 = (uint8_t *) 0 ;
+  faiss::IndexBinary::idx_t arg4 ;
+  int32_t *arg5 = (int32_t *) 0 ;
+  faiss::IndexBinary::idx_t *arg6 = (faiss::IndexBinary::idx_t *) 0 ;
+  uint8_t *arg7 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long val4 ;
+  int ecode4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  void *argp6 = 0 ;
+  int res6 = 0 ;
+  void *argp7 = 0 ;
+  int res7 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  PyObject * obj5 = 0 ;
+  PyObject * obj6 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOOOO:IndexBinaryIVF_search_and_reconstruct",&obj0,&obj1,&obj2,&obj3,&obj4,&obj5,&obj6)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_search_and_reconstruct" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_search_and_reconstruct" "', argument " "2"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg2 = static_cast< faiss::IndexBinary::idx_t >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "IndexBinaryIVF_search_and_reconstruct" "', argument " "3"" of type '" "uint8_t const *""'"); 
+  }
+  arg3 = reinterpret_cast< uint8_t * >(argp3);
+  ecode4 = SWIG_AsVal_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IndexBinaryIVF_search_and_reconstruct" "', argument " "4"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg4 = static_cast< faiss::IndexBinary::idx_t >(val4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5,SWIGTYPE_p_int, 0 |  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "IndexBinaryIVF_search_and_reconstruct" "', argument " "5"" of type '" "int32_t *""'"); 
+  }
+  arg5 = reinterpret_cast< int32_t * >(argp5);
+  res6 = SWIG_ConvertPtr(obj5, &argp6,SWIGTYPE_p_long, 0 |  0 );
+  if (!SWIG_IsOK(res6)) {
+    SWIG_exception_fail(SWIG_ArgError(res6), "in method '" "IndexBinaryIVF_search_and_reconstruct" "', argument " "6"" of type '" "faiss::IndexBinary::idx_t *""'"); 
+  }
+  arg6 = reinterpret_cast< faiss::IndexBinary::idx_t * >(argp6);
+  res7 = SWIG_ConvertPtr(obj6, &argp7,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res7)) {
+    SWIG_exception_fail(SWIG_ArgError(res7), "in method '" "IndexBinaryIVF_search_and_reconstruct" "', argument " "7"" of type '" "uint8_t *""'"); 
+  }
+  arg7 = reinterpret_cast< uint8_t * >(argp7);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryIVF const *)arg1)->search_and_reconstruct(arg2,(uint8_t const *)arg3,arg4,arg5,arg6,arg7);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_reconstruct_from_offset(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  long arg2 ;
+  long arg3 ;
+  uint8_t *arg4 = (uint8_t *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long val2 ;
+  int ecode2 = 0 ;
+  long val3 ;
+  int ecode3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IndexBinaryIVF_reconstruct_from_offset",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_reconstruct_from_offset" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_reconstruct_from_offset" "', argument " "2"" of type '" "long""'");
+  } 
+  arg2 = static_cast< long >(val2);
+  ecode3 = SWIG_AsVal_long(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IndexBinaryIVF_reconstruct_from_offset" "', argument " "3"" of type '" "long""'");
+  } 
+  arg3 = static_cast< long >(val3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_unsigned_char, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "IndexBinaryIVF_reconstruct_from_offset" "', argument " "4"" of type '" "uint8_t *""'"); 
+  }
+  arg4 = reinterpret_cast< uint8_t * >(argp4);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryIVF const *)arg1)->reconstruct_from_offset(arg2,arg3,arg4);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_remove_ids(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IDSelector *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  long result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_remove_ids",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_remove_ids" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_faiss__IDSelector,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryIVF_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IndexBinaryIVF_remove_ids" "', argument " "2"" of type '" "faiss::IDSelector const &""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::IDSelector * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (long)(arg1)->remove_ids((faiss::IDSelector const &)*arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_From_long(static_cast< long >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_merge_from(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::IndexBinaryIVF *arg2 = 0 ;
+  faiss::IndexBinary::idx_t arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  long val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinaryIVF_merge_from",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_merge_from" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_faiss__IndexBinaryIVF,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryIVF_merge_from" "', argument " "2"" of type '" "faiss::IndexBinaryIVF &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "IndexBinaryIVF_merge_from" "', argument " "2"" of type '" "faiss::IndexBinaryIVF &""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp2);
+  ecode3 = SWIG_AsVal_long(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IndexBinaryIVF_merge_from" "', argument " "3"" of type '" "faiss::IndexBinary::idx_t""'");
+  } 
+  arg3 = static_cast< faiss::IndexBinary::idx_t >(val3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->merge_from(*arg2,arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_get_list_size(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_get_list_size",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_get_list_size" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_get_list_size" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (size_t)((faiss::IndexBinaryIVF const *)arg1)->get_list_size(arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_make_direct_map__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  bool arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  bool val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_make_direct_map",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_make_direct_map" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  ecode2 = SWIG_AsVal_bool(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "IndexBinaryIVF_make_direct_map" "', argument " "2"" of type '" "bool""'");
+  } 
+  arg2 = static_cast< bool >(val2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->make_direct_map(arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_make_direct_map__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_make_direct_map",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_make_direct_map" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->make_direct_map();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_make_direct_map(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[3] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 2) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 1) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinaryIVF, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_IndexBinaryIVF_make_direct_map__SWIG_1(self, args);
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinaryIVF, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_bool(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        return _wrap_IndexBinaryIVF_make_direct_map__SWIG_0(self, args);
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexBinaryIVF_make_direct_map'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexBinaryIVF::make_direct_map(bool)\n"
+    "    faiss::IndexBinaryIVF::make_direct_map()\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_imbalance_factor(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  double result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_imbalance_factor",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_imbalance_factor" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (double)((faiss::IndexBinaryIVF const *)arg1)->imbalance_factor();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_From_double(static_cast< double >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_print_stats(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IndexBinaryIVF_print_stats",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_print_stats" "', argument " "1"" of type '" "faiss::IndexBinaryIVF const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      ((faiss::IndexBinaryIVF const *)arg1)->print_stats();
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_replace_invlists__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::InvertedLists *arg2 = (faiss::InvertedLists *) 0 ;
+  bool arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  bool val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:IndexBinaryIVF_replace_invlists",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_replace_invlists" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_faiss__InvertedLists, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryIVF_replace_invlists" "', argument " "2"" of type '" "faiss::InvertedLists *""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::InvertedLists * >(argp2);
+  ecode3 = SWIG_AsVal_bool(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IndexBinaryIVF_replace_invlists" "', argument " "3"" of type '" "bool""'");
+  } 
+  arg3 = static_cast< bool >(val3);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->replace_invlists(arg2,arg3);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_replace_invlists__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinaryIVF *arg1 = (faiss::IndexBinaryIVF *) 0 ;
+  faiss::InvertedLists *arg2 = (faiss::InvertedLists *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:IndexBinaryIVF_replace_invlists",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinaryIVF, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IndexBinaryIVF_replace_invlists" "', argument " "1"" of type '" "faiss::IndexBinaryIVF *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinaryIVF * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_faiss__InvertedLists, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IndexBinaryIVF_replace_invlists" "', argument " "2"" of type '" "faiss::InvertedLists *""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::InvertedLists * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      (arg1)->replace_invlists(arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IndexBinaryIVF_replace_invlists(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[4] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 3) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinaryIVF, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_faiss__InvertedLists, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_IndexBinaryIVF_replace_invlists__SWIG_1(self, args);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinaryIVF, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_faiss__InvertedLists, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        {
+          int res = SWIG_AsVal_bool(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          return _wrap_IndexBinaryIVF_replace_invlists__SWIG_0(self, args);
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'IndexBinaryIVF_replace_invlists'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::IndexBinaryIVF::replace_invlists(faiss::InvertedLists *,bool)\n"
+    "    faiss::IndexBinaryIVF::replace_invlists(faiss::InvertedLists *)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *IndexBinaryIVF_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IndexBinaryIVF, SWIG_NewClientData(obj));
   return SWIG_Py_Void();
 }
 
@@ -50588,92 +57711,97 @@ SWIGINTERN PyObject *_wrap_downcast_index(PyObject *SWIGUNUSEDPARM(self), PyObje
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,0);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,0);
     } else
@@ -50685,7 +57813,7 @@ SWIGINTERN PyObject *_wrap_downcast_index(PyObject *SWIGUNUSEDPARM(self), PyObje
     
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,0);
     } else
@@ -50734,37 +57862,37 @@ SWIGINTERN PyObject *_wrap_downcast_VectorTransform(PyObject *SWIGUNUSEDPARM(sel
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::RemapDimensionsTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__RemapDimensionsTransform,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::OPQMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__OPQMatrix,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::PCAMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__PCAMatrix,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::RandomRotationMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__RandomRotationMatrix,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::LinearTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__LinearTransform,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::NormalizationTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__NormalizationTransform,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::VectorTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__VectorTransform,0);
     } else
@@ -50783,46 +57911,6 @@ fail:
 
 
 SWIGINTERN PyObject *_wrap_write_index__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  faiss::Index *arg1 = (faiss::Index *) 0 ;
-  FILE *arg2 = (FILE *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OO:write_index",&obj0,&obj1)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__Index, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "write_index" "', argument " "1"" of type '" "faiss::Index const *""'"); 
-  }
-  arg1 = reinterpret_cast< faiss::Index * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_FILE, 0 |  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "write_index" "', argument " "2"" of type '" "FILE *""'"); 
-  }
-  arg2 = reinterpret_cast< FILE * >(argp2);
-  {
-    Py_BEGIN_ALLOW_THREADS
-    try {
-      faiss::write_index((faiss::Index const *)arg1,arg2);
-    } catch(faiss::FaissException & e) {
-      PyEval_RestoreThread(_save);
-      PyErr_SetString(PyExc_RuntimeError, e.what());
-      SWIG_fail;
-    }
-    Py_END_ALLOW_THREADS
-  }
-  resultobj = SWIG_Py_Void();
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_write_index__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   faiss::Index *arg1 = (faiss::Index *) 0 ;
   char *arg2 = (char *) 0 ;
@@ -50861,6 +57949,46 @@ SWIGINTERN PyObject *_wrap_write_index__SWIG_1(PyObject *SWIGUNUSEDPARM(self), P
   return resultobj;
 fail:
   if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_write_index__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::Index *arg1 = (faiss::Index *) 0 ;
+  FILE *arg2 = (FILE *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:write_index",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__Index, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "write_index" "', argument " "1"" of type '" "faiss::Index const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::Index * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_FILE, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "write_index" "', argument " "2"" of type '" "FILE *""'"); 
+  }
+  arg2 = reinterpret_cast< FILE * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      faiss::write_index((faiss::Index const *)arg1,arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
   return NULL;
 }
 
@@ -50927,7 +58055,7 @@ SWIGINTERN PyObject *_wrap_write_index(PyObject *self, PyObject *args) {
       int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_FILE, 0);
       _v = SWIG_CheckState(res);
       if (_v) {
-        return _wrap_write_index__SWIG_0(self, args);
+        return _wrap_write_index__SWIG_1(self, args);
       }
     }
   }
@@ -50954,7 +58082,7 @@ SWIGINTERN PyObject *_wrap_write_index(PyObject *self, PyObject *args) {
       int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
       _v = SWIG_CheckState(res);
       if (_v) {
-        return _wrap_write_index__SWIG_1(self, args);
+        return _wrap_write_index__SWIG_0(self, args);
       }
     }
   }
@@ -50962,9 +58090,196 @@ SWIGINTERN PyObject *_wrap_write_index(PyObject *self, PyObject *args) {
 fail:
   SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'write_index'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    faiss::write_index(faiss::Index const *,FILE *)\n"
     "    faiss::write_index(faiss::Index const *,char const *)\n"
+    "    faiss::write_index(faiss::Index const *,FILE *)\n"
     "    faiss::write_index(faiss::Index const *,faiss::IOWriter *)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_write_index_binary__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  char *arg2 = (char *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:write_index_binary",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "write_index_binary" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "write_index_binary" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      faiss::write_index_binary((faiss::IndexBinary const *)arg1,(char const *)arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_write_index_binary__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  FILE *arg2 = (FILE *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:write_index_binary",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "write_index_binary" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_FILE, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "write_index_binary" "', argument " "2"" of type '" "FILE *""'"); 
+  }
+  arg2 = reinterpret_cast< FILE * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      faiss::write_index_binary((faiss::IndexBinary const *)arg1,arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_write_index_binary__SWIG_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IndexBinary *arg1 = (faiss::IndexBinary *) 0 ;
+  faiss::IOWriter *arg2 = (faiss::IOWriter *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:write_index_binary",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IndexBinary, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "write_index_binary" "', argument " "1"" of type '" "faiss::IndexBinary const *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IndexBinary * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_faiss__IOWriter, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "write_index_binary" "', argument " "2"" of type '" "faiss::IOWriter *""'"); 
+  }
+  arg2 = reinterpret_cast< faiss::IOWriter * >(argp2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      faiss::write_index_binary((faiss::IndexBinary const *)arg1,arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_write_index_binary(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[3] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 2) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinary, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_FILE, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_write_index_binary__SWIG_1(self, args);
+      }
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinary, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_faiss__IOWriter, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_write_index_binary__SWIG_2(self, args);
+      }
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IndexBinary, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_write_index_binary__SWIG_0(self, args);
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'write_index_binary'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::write_index_binary(faiss::IndexBinary const *,char const *)\n"
+    "    faiss::write_index_binary(faiss::IndexBinary const *,FILE *)\n"
+    "    faiss::write_index_binary(faiss::IndexBinary const *,faiss::IOWriter *)\n");
   return 0;
 }
 
@@ -50998,307 +58313,6 @@ SWIGINTERN PyObject *Swig_var_IO_FLAG_READ_ONLY_get(void) {
 
 
 SWIGINTERN PyObject *_wrap_read_index__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  FILE *arg1 = (FILE *) 0 ;
-  int arg2 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int val2 ;
-  int ecode2 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  faiss::Index *result = 0 ;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OO:read_index",&obj0,&obj1)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_FILE, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index" "', argument " "1"" of type '" "FILE *""'"); 
-  }
-  arg1 = reinterpret_cast< FILE * >(argp1);
-  ecode2 = SWIG_AsVal_int(obj1, &val2);
-  if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "read_index" "', argument " "2"" of type '" "int""'");
-  } 
-  arg2 = static_cast< int >(val2);
-  {
-    Py_BEGIN_ALLOW_THREADS
-    try {
-      result = (faiss::Index *)faiss::read_index(arg1,arg2);
-    } catch(faiss::FaissException & e) {
-      PyEval_RestoreThread(_save);
-      PyErr_SetString(PyExc_RuntimeError, e.what());
-      SWIG_fail;
-    }
-    Py_END_ALLOW_THREADS
-  }
-  {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIDMap *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexShards *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVF *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexFlat *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexPQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexLSH *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::Index2Layer *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    
-    
-    
-    
-    
-    
-    // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::Index *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    if (result == NULL)
-    {
-      resultobj = SWIG_Py_Void();
-      
-      // Lua does not need a push for nil
-    } else {
-      assert(false);
-    }
-    
-    
-    
-  }
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_read_index__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  FILE *arg1 = (FILE *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  PyObject * obj0 = 0 ;
-  faiss::Index *result = 0 ;
-  
-  if (!PyArg_ParseTuple(args,(char *)"O:read_index",&obj0)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_FILE, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index" "', argument " "1"" of type '" "FILE *""'"); 
-  }
-  arg1 = reinterpret_cast< FILE * >(argp1);
-  {
-    Py_BEGIN_ALLOW_THREADS
-    try {
-      result = (faiss::Index *)faiss::read_index(arg1);
-    } catch(faiss::FaissException & e) {
-      PyEval_RestoreThread(_save);
-      PyErr_SetString(PyExc_RuntimeError, e.what());
-      SWIG_fail;
-    }
-    Py_END_ALLOW_THREADS
-  }
-  {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIDMap *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexShards *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexIVF *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexFlat *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexPQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexLSH *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::Index2Layer *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    
-    
-    
-    
-    
-    
-    // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
-    if (dynamic_cast<faiss::Index *> (result)) {
-      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
-    } else
-    /*@SWIG@*/
-    if (result == NULL)
-    {
-      resultobj = SWIG_Py_Void();
-      
-      // Lua does not need a push for nil
-    } else {
-      assert(false);
-    }
-    
-    
-    
-  }
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_read_index__SWIG_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   char *arg1 = (char *) 0 ;
   int arg2 ;
@@ -51334,92 +58348,97 @@ SWIGINTERN PyObject *_wrap_read_index__SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
@@ -51431,7 +58450,7 @@ SWIGINTERN PyObject *_wrap_read_index__SWIG_2(PyObject *SWIGUNUSEDPARM(self), Py
     
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -51456,7 +58475,7 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_read_index__SWIG_3(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_read_index__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   char *arg1 = (char *) 0 ;
   int res1 ;
@@ -51483,92 +58502,97 @@ SWIGINTERN PyObject *_wrap_read_index__SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
@@ -51580,7 +58604,7 @@ SWIGINTERN PyObject *_wrap_read_index__SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
     
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -51601,6 +58625,317 @@ SWIGINTERN PyObject *_wrap_read_index__SWIG_3(PyObject *SWIGUNUSEDPARM(self), Py
   return resultobj;
 fail:
   if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index__SWIG_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  FILE *arg1 = (FILE *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  faiss::Index *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:read_index",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_FILE, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index" "', argument " "1"" of type '" "FILE *""'"); 
+  }
+  arg1 = reinterpret_cast< FILE * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "read_index" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::Index *)faiss::read_index(arg1,arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIDMap *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexShards *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexPQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexLSH *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::Index2Layer *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    
+    
+    
+    
+    
+    
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::Index *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index__SWIG_3(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  FILE *arg1 = (FILE *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::Index *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:read_index",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_FILE, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index" "', argument " "1"" of type '" "FILE *""'"); 
+  }
+  arg1 = reinterpret_cast< FILE * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::Index *)faiss::read_index(arg1);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIDMap *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexShards *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexPQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexLSH *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::Index2Layer *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    
+    
+    
+    
+    
+    
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::Index *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  return resultobj;
+fail:
   return NULL;
 }
 
@@ -51640,92 +58975,97 @@ SWIGINTERN PyObject *_wrap_read_index__SWIG_4(PyObject *SWIGUNUSEDPARM(self), Py
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
@@ -51737,7 +59077,7 @@ SWIGINTERN PyObject *_wrap_read_index__SWIG_4(PyObject *SWIGUNUSEDPARM(self), Py
     
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -51786,92 +59126,97 @@ SWIGINTERN PyObject *_wrap_read_index__SWIG_5(PyObject *SWIGUNUSEDPARM(self), Py
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
@@ -51883,7 +59228,7 @@ SWIGINTERN PyObject *_wrap_read_index__SWIG_5(PyObject *SWIGUNUSEDPARM(self), Py
     
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -51924,7 +59269,7 @@ SWIGINTERN PyObject *_wrap_read_index(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_FILE, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      return _wrap_read_index__SWIG_1(self, args);
+      return _wrap_read_index__SWIG_3(self, args);
     }
   }
   if (argc == 1) {
@@ -51941,22 +59286,7 @@ SWIGINTERN PyObject *_wrap_read_index(PyObject *self, PyObject *args) {
     int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      return _wrap_read_index__SWIG_3(self, args);
-    }
-  }
-  if (argc == 2) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_FILE, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      {
-        int res = SWIG_AsVal_int(argv[1], NULL);
-        _v = SWIG_CheckState(res);
-      }
-      if (_v) {
-        return _wrap_read_index__SWIG_0(self, args);
-      }
+      return _wrap_read_index__SWIG_1(self, args);
     }
   }
   if (argc == 2) {
@@ -51976,7 +59306,8 @@ SWIGINTERN PyObject *_wrap_read_index(PyObject *self, PyObject *args) {
   }
   if (argc == 2) {
     int _v;
-    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_FILE, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
       {
@@ -51988,16 +59319,519 @@ SWIGINTERN PyObject *_wrap_read_index(PyObject *self, PyObject *args) {
       }
     }
   }
+  if (argc == 2) {
+    int _v;
+    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_int(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        return _wrap_read_index__SWIG_0(self, args);
+      }
+    }
+  }
   
 fail:
   SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'read_index'.\n"
     "  Possible C/C++ prototypes are:\n"
-    "    faiss::read_index(FILE *,int)\n"
-    "    faiss::read_index(FILE *)\n"
     "    faiss::read_index(char const *,int)\n"
     "    faiss::read_index(char const *)\n"
+    "    faiss::read_index(FILE *,int)\n"
+    "    faiss::read_index(FILE *)\n"
     "    faiss::read_index(faiss::IOReader *,int)\n"
     "    faiss::read_index(faiss::IOReader *)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index_binary__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  char *arg1 = (char *) 0 ;
+  int arg2 ;
+  int res1 ;
+  char *buf1 = 0 ;
+  int alloc1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  faiss::IndexBinary *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:read_index_binary",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_AsCharPtrAndSize(obj0, &buf1, NULL, &alloc1);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index_binary" "', argument " "1"" of type '" "char const *""'");
+  }
+  arg1 = reinterpret_cast< char * >(buf1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "read_index_binary" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinary *)faiss::read_index_binary((char const *)arg1,arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryIVF,0);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryFlat,0);
+    } else
+    /*@SWIG@*/
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinary *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinary,0);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  return resultobj;
+fail:
+  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index_binary__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  char *arg1 = (char *) 0 ;
+  int res1 ;
+  char *buf1 = 0 ;
+  int alloc1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::IndexBinary *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:read_index_binary",&obj0)) SWIG_fail;
+  res1 = SWIG_AsCharPtrAndSize(obj0, &buf1, NULL, &alloc1);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index_binary" "', argument " "1"" of type '" "char const *""'");
+  }
+  arg1 = reinterpret_cast< char * >(buf1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinary *)faiss::read_index_binary((char const *)arg1);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryIVF,0);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryFlat,0);
+    } else
+    /*@SWIG@*/
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinary *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinary,0);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  return resultobj;
+fail:
+  if (alloc1 == SWIG_NEWOBJ) delete[] buf1;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index_binary__SWIG_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  FILE *arg1 = (FILE *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  faiss::IndexBinary *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:read_index_binary",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_FILE, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index_binary" "', argument " "1"" of type '" "FILE *""'"); 
+  }
+  arg1 = reinterpret_cast< FILE * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "read_index_binary" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinary *)faiss::read_index_binary(arg1,arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryIVF,0);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryFlat,0);
+    } else
+    /*@SWIG@*/
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinary *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinary,0);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index_binary__SWIG_3(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  FILE *arg1 = (FILE *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::IndexBinary *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:read_index_binary",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_FILE, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index_binary" "', argument " "1"" of type '" "FILE *""'"); 
+  }
+  arg1 = reinterpret_cast< FILE * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinary *)faiss::read_index_binary(arg1);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryIVF,0);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryFlat,0);
+    } else
+    /*@SWIG@*/
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinary *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinary,0);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index_binary__SWIG_4(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IOReader *arg1 = (faiss::IOReader *) 0 ;
+  int arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  faiss::IndexBinary *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:read_index_binary",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOReader, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index_binary" "', argument " "1"" of type '" "faiss::IOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IOReader * >(argp1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "read_index_binary" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinary *)faiss::read_index_binary(arg1,arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryIVF,0);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryFlat,0);
+    } else
+    /*@SWIG@*/
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinary *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinary,0);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index_binary__SWIG_5(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IOReader *arg1 = (faiss::IOReader *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  faiss::IndexBinary *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:read_index_binary",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOReader, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "read_index_binary" "', argument " "1"" of type '" "faiss::IOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IOReader * >(argp1);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinary *)faiss::read_index_binary(arg1);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryIVF,0);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryFlat,0);
+    } else
+    /*@SWIG@*/
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinary *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinary,0);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_read_index_binary(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[3] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 2) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 1) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_FILE, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_read_index_binary__SWIG_3(self, args);
+    }
+  }
+  if (argc == 1) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IOReader, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_read_index_binary__SWIG_5(self, args);
+    }
+  }
+  if (argc == 1) {
+    int _v;
+    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_read_index_binary__SWIG_1(self, args);
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_faiss__IOReader, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_int(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        return _wrap_read_index_binary__SWIG_4(self, args);
+      }
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_FILE, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_int(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        return _wrap_read_index_binary__SWIG_2(self, args);
+      }
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    int res = SWIG_AsCharPtrAndSize(argv[0], 0, NULL, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_int(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        return _wrap_read_index_binary__SWIG_0(self, args);
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'read_index_binary'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    faiss::read_index_binary(char const *,int)\n"
+    "    faiss::read_index_binary(char const *)\n"
+    "    faiss::read_index_binary(FILE *,int)\n"
+    "    faiss::read_index_binary(FILE *)\n"
+    "    faiss::read_index_binary(faiss::IOReader *,int)\n"
+    "    faiss::read_index_binary(faiss::IOReader *)\n");
   return 0;
 }
 
@@ -52072,37 +59906,37 @@ SWIGINTERN PyObject *_wrap_read_VectorTransform(PyObject *SWIGUNUSEDPARM(self), 
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::RemapDimensionsTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__RemapDimensionsTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::OPQMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__OPQMatrix,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::PCAMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__PCAMatrix,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::RandomRotationMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__RandomRotationMatrix,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::LinearTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__LinearTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::NormalizationTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__NormalizationTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::VectorTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__VectorTransform,SWIG_POINTER_OWN);
     } else
@@ -52226,92 +60060,97 @@ SWIGINTERN PyObject *_wrap_clone_index(PyObject *SWIGUNUSEDPARM(self), PyObject 
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
@@ -52323,7 +60162,7 @@ SWIGINTERN PyObject *_wrap_clone_index(PyObject *SWIGUNUSEDPARM(self), PyObject 
     
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -52381,37 +60220,37 @@ SWIGINTERN PyObject *_wrap_Cloner_clone_VectorTransform(PyObject *SWIGUNUSEDPARM
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::RemapDimensionsTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__RemapDimensionsTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::OPQMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__OPQMatrix,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::PCAMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__PCAMatrix,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::RandomRotationMatrix *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__RandomRotationMatrix,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::LinearTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__LinearTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::NormalizationTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__NormalizationTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::VectorTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__VectorTransform,SWIG_POINTER_OWN);
     } else
@@ -52464,92 +60303,97 @@ SWIGINTERN PyObject *_wrap_Cloner_clone_Index(PyObject *SWIGUNUSEDPARM(self), Py
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,0);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,0);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,0);
     } else
@@ -52561,7 +60405,7 @@ SWIGINTERN PyObject *_wrap_Cloner_clone_Index(PyObject *SWIGUNUSEDPARM(self), Py
     
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,0);
     } else
@@ -52673,196 +60517,6 @@ SWIGINTERN PyObject *Cloner_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObjec
   PyObject *obj;
   if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
   SWIG_TypeNewClientData(SWIGTYPE_p_faiss__Cloner, SWIG_NewClientData(obj));
-  return SWIG_Py_Void();
-}
-
-SWIGINTERN PyObject *_wrap_IOReader___call__(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  faiss::IOReader *arg1 = (faiss::IOReader *) 0 ;
-  void *arg2 = (void *) 0 ;
-  size_t arg3 ;
-  size_t arg4 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int res2 ;
-  size_t val3 ;
-  int ecode3 = 0 ;
-  size_t val4 ;
-  int ecode4 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  PyObject * obj2 = 0 ;
-  PyObject * obj3 = 0 ;
-  size_t result;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OOOO:IOReader___call__",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOReader, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IOReader___call__" "', argument " "1"" of type '" "faiss::IOReader *""'"); 
-  }
-  arg1 = reinterpret_cast< faiss::IOReader * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IOReader___call__" "', argument " "2"" of type '" "void *""'"); 
-  }
-  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
-  if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IOReader___call__" "', argument " "3"" of type '" "size_t""'");
-  } 
-  arg3 = static_cast< size_t >(val3);
-  ecode4 = SWIG_AsVal_size_t(obj3, &val4);
-  if (!SWIG_IsOK(ecode4)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IOReader___call__" "', argument " "4"" of type '" "size_t""'");
-  } 
-  arg4 = static_cast< size_t >(val4);
-  {
-    Py_BEGIN_ALLOW_THREADS
-    try {
-      result = (size_t)(arg1)->operator ()(arg2,arg3,arg4);
-    } catch(faiss::FaissException & e) {
-      PyEval_RestoreThread(_save);
-      PyErr_SetString(PyExc_RuntimeError, e.what());
-      SWIG_fail;
-    }
-    Py_END_ALLOW_THREADS
-  }
-  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_delete_IOReader(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  faiss::IOReader *arg1 = (faiss::IOReader *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  PyObject * obj0 = 0 ;
-  
-  if (!PyArg_ParseTuple(args,(char *)"O:delete_IOReader",&obj0)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOReader, SWIG_POINTER_DISOWN |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IOReader" "', argument " "1"" of type '" "faiss::IOReader *""'"); 
-  }
-  arg1 = reinterpret_cast< faiss::IOReader * >(argp1);
-  {
-    Py_BEGIN_ALLOW_THREADS
-    try {
-      delete arg1;
-    } catch(faiss::FaissException & e) {
-      PyEval_RestoreThread(_save);
-      PyErr_SetString(PyExc_RuntimeError, e.what());
-      SWIG_fail;
-    }
-    Py_END_ALLOW_THREADS
-  }
-  resultobj = SWIG_Py_Void();
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *IOReader_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *obj;
-  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
-  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IOReader, SWIG_NewClientData(obj));
-  return SWIG_Py_Void();
-}
-
-SWIGINTERN PyObject *_wrap_IOWriter___call__(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  faiss::IOWriter *arg1 = (faiss::IOWriter *) 0 ;
-  void *arg2 = (void *) 0 ;
-  size_t arg3 ;
-  size_t arg4 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int res2 ;
-  size_t val3 ;
-  int ecode3 = 0 ;
-  size_t val4 ;
-  int ecode4 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  PyObject * obj2 = 0 ;
-  PyObject * obj3 = 0 ;
-  size_t result;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OOOO:IOWriter___call__",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOWriter, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IOWriter___call__" "', argument " "1"" of type '" "faiss::IOWriter *""'"); 
-  }
-  arg1 = reinterpret_cast< faiss::IOWriter * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IOWriter___call__" "', argument " "2"" of type '" "void const *""'"); 
-  }
-  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
-  if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IOWriter___call__" "', argument " "3"" of type '" "size_t""'");
-  } 
-  arg3 = static_cast< size_t >(val3);
-  ecode4 = SWIG_AsVal_size_t(obj3, &val4);
-  if (!SWIG_IsOK(ecode4)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IOWriter___call__" "', argument " "4"" of type '" "size_t""'");
-  } 
-  arg4 = static_cast< size_t >(val4);
-  {
-    Py_BEGIN_ALLOW_THREADS
-    try {
-      result = (size_t)(arg1)->operator ()((void const *)arg2,arg3,arg4);
-    } catch(faiss::FaissException & e) {
-      PyEval_RestoreThread(_save);
-      PyErr_SetString(PyExc_RuntimeError, e.what());
-      SWIG_fail;
-    }
-    Py_END_ALLOW_THREADS
-  }
-  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_delete_IOWriter(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  faiss::IOWriter *arg1 = (faiss::IOWriter *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  PyObject * obj0 = 0 ;
-  
-  if (!PyArg_ParseTuple(args,(char *)"O:delete_IOWriter",&obj0)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOWriter, SWIG_POINTER_DISOWN |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IOWriter" "', argument " "1"" of type '" "faiss::IOWriter *""'"); 
-  }
-  arg1 = reinterpret_cast< faiss::IOWriter * >(argp1);
-  {
-    Py_BEGIN_ALLOW_THREADS
-    try {
-      delete arg1;
-    } catch(faiss::FaissException & e) {
-      PyEval_RestoreThread(_save);
-      PyErr_SetString(PyExc_RuntimeError, e.what());
-      SWIG_fail;
-    }
-    Py_END_ALLOW_THREADS
-  }
-  resultobj = SWIG_Py_Void();
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *IOWriter_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *obj;
-  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
-  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IOWriter, SWIG_NewClientData(obj));
   return SWIG_Py_Void();
 }
 
@@ -55826,92 +63480,97 @@ SWIGINTERN PyObject *_wrap_index_factory__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
@@ -55923,7 +63582,7 @@ SWIGINTERN PyObject *_wrap_index_factory__SWIG_0(PyObject *SWIGUNUSEDPARM(self),
     
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -55984,92 +63643,97 @@ SWIGINTERN PyObject *_wrap_index_factory__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
     Py_END_ALLOW_THREADS
   }
   {
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIDMap *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIDMap,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexShards *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexShards,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQR *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQR,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexIVFFlatDedup *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlatDedup,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVFFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVFFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexIVF *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexIVF,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexScalarQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexScalarQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexLSH *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexLSH,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexPreTransform *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexPreTransform,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::MultiIndexQuantizer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__MultiIndexQuantizer,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWFlat *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWFlat,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWPQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWPQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSWSQ *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSWSQ,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::IndexHNSW2Level *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexHNSW2Level,SWIG_POINTER_OWN);
     } else
     /*@SWIG@*/
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index2Layer *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index2Layer,SWIG_POINTER_OWN);
     } else
@@ -56081,7 +63745,7 @@ SWIGINTERN PyObject *_wrap_index_factory__SWIG_1(PyObject *SWIGUNUSEDPARM(self),
     
     
     // default for non-recognized classes
-    /*@SWIG:swigfaiss.swig,406,DOWNCAST@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
     if (dynamic_cast<faiss::Index *> (result)) {
       resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__Index,SWIG_POINTER_OWN);
     } else
@@ -56159,6 +63823,78 @@ fail:
     "    faiss::index_factory(int,char const *,faiss::MetricType)\n"
     "    faiss::index_factory(int,char const *)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_index_binary_factory(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  int arg1 ;
+  char *arg2 = (char *) 0 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  int res2 ;
+  char *buf2 = 0 ;
+  int alloc2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  faiss::IndexBinary *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:index_binary_factory",&obj0,&obj1)) SWIG_fail;
+  ecode1 = SWIG_AsVal_int(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "index_binary_factory" "', argument " "1"" of type '" "int""'");
+  } 
+  arg1 = static_cast< int >(val1);
+  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "index_binary_factory" "', argument " "2"" of type '" "char const *""'");
+  }
+  arg2 = reinterpret_cast< char * >(buf2);
+  {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+      result = (faiss::IndexBinary *)faiss::index_binary_factory(arg1,(char const *)arg2);
+    } catch(faiss::FaissException & e) {
+      PyEval_RestoreThread(_save);
+      PyErr_SetString(PyExc_RuntimeError, e.what());
+      SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+  }
+  {
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryIVF *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryIVF,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinaryFlat *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinaryFlat,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    // default for non-recognized classes
+    /*@SWIG:swigfaiss.swig,417,DOWNCAST@*/
+    if (dynamic_cast<faiss::IndexBinary *> (result)) {
+      resultobj = SWIG_NewPointerObj(result,SWIGTYPE_p_faiss__IndexBinary,SWIG_POINTER_OWN);
+    } else
+    /*@SWIG@*/
+    if (result == NULL)
+    {
+      resultobj = SWIG_Py_Void();
+      
+      // Lua does not need a push for nil
+    } else {
+      assert(false);
+    }
+    
+    
+    
+  }
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return resultobj;
+fail:
+  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
+  return NULL;
 }
 
 
@@ -62905,6 +70641,502 @@ SWIGINTERN PyObject *RangeSearchPartialResult_swigregister(PyObject *SWIGUNUSEDP
   return SWIG_Py_Void();
 }
 
+SWIGINTERN PyObject *_wrap_IOReader___call__(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IOReader *arg1 = (faiss::IOReader *) 0 ;
+  void *arg2 = (void *) 0 ;
+  size_t arg3 ;
+  size_t arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
+  size_t val4 ;
+  int ecode4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IOReader___call__",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOReader, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IOReader___call__" "', argument " "1"" of type '" "faiss::IOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IOReader * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IOReader___call__" "', argument " "2"" of type '" "void *""'"); 
+  }
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IOReader___call__" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  ecode4 = SWIG_AsVal_size_t(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IOReader___call__" "', argument " "4"" of type '" "size_t""'");
+  } 
+  arg4 = static_cast< size_t >(val4);
+  result = (size_t)(arg1)->operator ()(arg2,arg3,arg4);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IOReader_fileno(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IOReader *arg1 = (faiss::IOReader *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  int result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IOReader_fileno",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOReader, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IOReader_fileno" "', argument " "1"" of type '" "faiss::IOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IOReader * >(argp1);
+  result = (int)(arg1)->fileno();
+  resultobj = SWIG_From_int(static_cast< int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_IOReader(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IOReader *arg1 = (faiss::IOReader *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_IOReader",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOReader, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IOReader" "', argument " "1"" of type '" "faiss::IOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IOReader * >(argp1);
+  delete arg1;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *IOReader_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IOReader, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_IOWriter___call__(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IOWriter *arg1 = (faiss::IOWriter *) 0 ;
+  void *arg2 = (void *) 0 ;
+  size_t arg3 ;
+  size_t arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
+  size_t val4 ;
+  int ecode4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:IOWriter___call__",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IOWriter___call__" "', argument " "1"" of type '" "faiss::IOWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IOWriter * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "IOWriter___call__" "', argument " "2"" of type '" "void const *""'"); 
+  }
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "IOWriter___call__" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  ecode4 = SWIG_AsVal_size_t(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "IOWriter___call__" "', argument " "4"" of type '" "size_t""'");
+  } 
+  arg4 = static_cast< size_t >(val4);
+  result = (size_t)(arg1)->operator ()((void const *)arg2,arg3,arg4);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_IOWriter_fileno(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IOWriter *arg1 = (faiss::IOWriter *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  int result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:IOWriter_fileno",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "IOWriter_fileno" "', argument " "1"" of type '" "faiss::IOWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IOWriter * >(argp1);
+  result = (int)(arg1)->fileno();
+  resultobj = SWIG_From_int(static_cast< int >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_IOWriter(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::IOWriter *arg1 = (faiss::IOWriter *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_IOWriter",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__IOWriter, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_IOWriter" "', argument " "1"" of type '" "faiss::IOWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::IOWriter * >(argp1);
+  delete arg1;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *IOWriter_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__IOWriter, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_VectorIOReader_data_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOReader *arg1 = (faiss::VectorIOReader *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  std::vector< uint8_t > *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:VectorIOReader_data_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOReader, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorIOReader_data_get" "', argument " "1"" of type '" "faiss::VectorIOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOReader * >(argp1);
+  result = (std::vector< uint8_t > *)& ((arg1)->data);
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_unsigned_char_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorIOReader_rp_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOReader *arg1 = (faiss::VectorIOReader *) 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:VectorIOReader_rp_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOReader, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorIOReader_rp_set" "', argument " "1"" of type '" "faiss::VectorIOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOReader * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "VectorIOReader_rp_set" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  if (arg1) (arg1)->rp = arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorIOReader_rp_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOReader *arg1 = (faiss::VectorIOReader *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:VectorIOReader_rp_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOReader, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorIOReader_rp_get" "', argument " "1"" of type '" "faiss::VectorIOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOReader * >(argp1);
+  result = (size_t) ((arg1)->rp);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorIOReader___call__(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOReader *arg1 = (faiss::VectorIOReader *) 0 ;
+  void *arg2 = (void *) 0 ;
+  size_t arg3 ;
+  size_t arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
+  size_t val4 ;
+  int ecode4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:VectorIOReader___call__",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOReader, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorIOReader___call__" "', argument " "1"" of type '" "faiss::VectorIOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOReader * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorIOReader___call__" "', argument " "2"" of type '" "void *""'"); 
+  }
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "VectorIOReader___call__" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  ecode4 = SWIG_AsVal_size_t(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "VectorIOReader___call__" "', argument " "4"" of type '" "size_t""'");
+  } 
+  arg4 = static_cast< size_t >(val4);
+  result = (size_t)(arg1)->operator ()(arg2,arg3,arg4);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_VectorIOReader(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOReader *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_VectorIOReader")) SWIG_fail;
+  result = (faiss::VectorIOReader *)new faiss::VectorIOReader();
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__VectorIOReader, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_VectorIOReader(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOReader *arg1 = (faiss::VectorIOReader *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_VectorIOReader",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOReader, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_VectorIOReader" "', argument " "1"" of type '" "faiss::VectorIOReader *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOReader * >(argp1);
+  delete arg1;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *VectorIOReader_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__VectorIOReader, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_VectorIOWriter_data_set(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOWriter *arg1 = (faiss::VectorIOWriter *) 0 ;
+  std::vector< uint8_t > *arg2 = (std::vector< uint8_t > *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:VectorIOWriter_data_set",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorIOWriter_data_set" "', argument " "1"" of type '" "faiss::VectorIOWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOWriter * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_std__vectorT_unsigned_char_t, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorIOWriter_data_set" "', argument " "2"" of type '" "std::vector< uint8_t > *""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< uint8_t > * >(argp2);
+  if (arg1) (arg1)->data = *arg2;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorIOWriter_data_get(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOWriter *arg1 = (faiss::VectorIOWriter *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  std::vector< uint8_t > *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:VectorIOWriter_data_get",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorIOWriter_data_get" "', argument " "1"" of type '" "faiss::VectorIOWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOWriter * >(argp1);
+  result = (std::vector< uint8_t > *)& ((arg1)->data);
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_unsigned_char_t, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_VectorIOWriter___call__(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOWriter *arg1 = (faiss::VectorIOWriter *) 0 ;
+  void *arg2 = (void *) 0 ;
+  size_t arg3 ;
+  size_t arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
+  size_t val4 ;
+  int ecode4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:VectorIOWriter___call__",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "VectorIOWriter___call__" "', argument " "1"" of type '" "faiss::VectorIOWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOWriter * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "VectorIOWriter___call__" "', argument " "2"" of type '" "void const *""'"); 
+  }
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "VectorIOWriter___call__" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  ecode4 = SWIG_AsVal_size_t(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "VectorIOWriter___call__" "', argument " "4"" of type '" "size_t""'");
+  } 
+  arg4 = static_cast< size_t >(val4);
+  result = (size_t)(arg1)->operator ()((void const *)arg2,arg3,arg4);
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_VectorIOWriter(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOWriter *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_VectorIOWriter")) SWIG_fail;
+  result = (faiss::VectorIOWriter *)new faiss::VectorIOWriter();
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_faiss__VectorIOWriter, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_VectorIOWriter(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  faiss::VectorIOWriter *arg1 = (faiss::VectorIOWriter *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_VectorIOWriter",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_faiss__VectorIOWriter, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_VectorIOWriter" "', argument " "1"" of type '" "faiss::VectorIOWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< faiss::VectorIOWriter * >(argp1);
+  delete arg1;
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *VectorIOWriter_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_faiss__VectorIOWriter, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
 SWIGINTERN PyObject *_wrap_ignore_SIGTTIN(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   
@@ -63154,6 +71386,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"FloatVector_size", _wrap_FloatVector_size, METH_VARARGS, NULL},
 	 { (char *)"FloatVector_at", _wrap_FloatVector_at, METH_VARARGS, NULL},
 	 { (char *)"FloatVector_resize", _wrap_FloatVector_resize, METH_VARARGS, NULL},
+	 { (char *)"FloatVector_swap", _wrap_FloatVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_FloatVector", _wrap_delete_FloatVector, METH_VARARGS, NULL},
 	 { (char *)"FloatVector_swigregister", FloatVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_DoubleVector", _wrap_new_DoubleVector, METH_VARARGS, NULL},
@@ -63163,6 +71396,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"DoubleVector_size", _wrap_DoubleVector_size, METH_VARARGS, NULL},
 	 { (char *)"DoubleVector_at", _wrap_DoubleVector_at, METH_VARARGS, NULL},
 	 { (char *)"DoubleVector_resize", _wrap_DoubleVector_resize, METH_VARARGS, NULL},
+	 { (char *)"DoubleVector_swap", _wrap_DoubleVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_DoubleVector", _wrap_delete_DoubleVector, METH_VARARGS, NULL},
 	 { (char *)"DoubleVector_swigregister", DoubleVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_ByteVector", _wrap_new_ByteVector, METH_VARARGS, NULL},
@@ -63172,8 +71406,19 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"ByteVector_size", _wrap_ByteVector_size, METH_VARARGS, NULL},
 	 { (char *)"ByteVector_at", _wrap_ByteVector_at, METH_VARARGS, NULL},
 	 { (char *)"ByteVector_resize", _wrap_ByteVector_resize, METH_VARARGS, NULL},
+	 { (char *)"ByteVector_swap", _wrap_ByteVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_ByteVector", _wrap_delete_ByteVector, METH_VARARGS, NULL},
 	 { (char *)"ByteVector_swigregister", ByteVector_swigregister, METH_VARARGS, NULL},
+	 { (char *)"new_CharVector", _wrap_new_CharVector, METH_VARARGS, NULL},
+	 { (char *)"CharVector_push_back", _wrap_CharVector_push_back, METH_VARARGS, NULL},
+	 { (char *)"CharVector_clear", _wrap_CharVector_clear, METH_VARARGS, NULL},
+	 { (char *)"CharVector_data", _wrap_CharVector_data, METH_VARARGS, NULL},
+	 { (char *)"CharVector_size", _wrap_CharVector_size, METH_VARARGS, NULL},
+	 { (char *)"CharVector_at", _wrap_CharVector_at, METH_VARARGS, NULL},
+	 { (char *)"CharVector_resize", _wrap_CharVector_resize, METH_VARARGS, NULL},
+	 { (char *)"CharVector_swap", _wrap_CharVector_swap, METH_VARARGS, NULL},
+	 { (char *)"delete_CharVector", _wrap_delete_CharVector, METH_VARARGS, NULL},
+	 { (char *)"CharVector_swigregister", CharVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_Uint64Vector", _wrap_new_Uint64Vector, METH_VARARGS, NULL},
 	 { (char *)"Uint64Vector_push_back", _wrap_Uint64Vector_push_back, METH_VARARGS, NULL},
 	 { (char *)"Uint64Vector_clear", _wrap_Uint64Vector_clear, METH_VARARGS, NULL},
@@ -63181,6 +71426,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"Uint64Vector_size", _wrap_Uint64Vector_size, METH_VARARGS, NULL},
 	 { (char *)"Uint64Vector_at", _wrap_Uint64Vector_at, METH_VARARGS, NULL},
 	 { (char *)"Uint64Vector_resize", _wrap_Uint64Vector_resize, METH_VARARGS, NULL},
+	 { (char *)"Uint64Vector_swap", _wrap_Uint64Vector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_Uint64Vector", _wrap_delete_Uint64Vector, METH_VARARGS, NULL},
 	 { (char *)"Uint64Vector_swigregister", Uint64Vector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_LongVector", _wrap_new_LongVector, METH_VARARGS, NULL},
@@ -63190,6 +71436,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"LongVector_size", _wrap_LongVector_size, METH_VARARGS, NULL},
 	 { (char *)"LongVector_at", _wrap_LongVector_at, METH_VARARGS, NULL},
 	 { (char *)"LongVector_resize", _wrap_LongVector_resize, METH_VARARGS, NULL},
+	 { (char *)"LongVector_swap", _wrap_LongVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_LongVector", _wrap_delete_LongVector, METH_VARARGS, NULL},
 	 { (char *)"LongVector_swigregister", LongVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_IntVector", _wrap_new_IntVector, METH_VARARGS, NULL},
@@ -63199,6 +71446,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"IntVector_size", _wrap_IntVector_size, METH_VARARGS, NULL},
 	 { (char *)"IntVector_at", _wrap_IntVector_at, METH_VARARGS, NULL},
 	 { (char *)"IntVector_resize", _wrap_IntVector_resize, METH_VARARGS, NULL},
+	 { (char *)"IntVector_swap", _wrap_IntVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_IntVector", _wrap_delete_IntVector, METH_VARARGS, NULL},
 	 { (char *)"IntVector_swigregister", IntVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_VectorTransformVector", _wrap_new_VectorTransformVector, METH_VARARGS, NULL},
@@ -63208,6 +71456,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"VectorTransformVector_size", _wrap_VectorTransformVector_size, METH_VARARGS, NULL},
 	 { (char *)"VectorTransformVector_at", _wrap_VectorTransformVector_at, METH_VARARGS, NULL},
 	 { (char *)"VectorTransformVector_resize", _wrap_VectorTransformVector_resize, METH_VARARGS, NULL},
+	 { (char *)"VectorTransformVector_swap", _wrap_VectorTransformVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_VectorTransformVector", _wrap_delete_VectorTransformVector, METH_VARARGS, NULL},
 	 { (char *)"VectorTransformVector_swigregister", VectorTransformVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_OperatingPointVector", _wrap_new_OperatingPointVector, METH_VARARGS, NULL},
@@ -63217,6 +71466,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"OperatingPointVector_size", _wrap_OperatingPointVector_size, METH_VARARGS, NULL},
 	 { (char *)"OperatingPointVector_at", _wrap_OperatingPointVector_at, METH_VARARGS, NULL},
 	 { (char *)"OperatingPointVector_resize", _wrap_OperatingPointVector_resize, METH_VARARGS, NULL},
+	 { (char *)"OperatingPointVector_swap", _wrap_OperatingPointVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_OperatingPointVector", _wrap_delete_OperatingPointVector, METH_VARARGS, NULL},
 	 { (char *)"OperatingPointVector_swigregister", OperatingPointVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_InvertedListsPtrVector", _wrap_new_InvertedListsPtrVector, METH_VARARGS, NULL},
@@ -63226,6 +71476,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"InvertedListsPtrVector_size", _wrap_InvertedListsPtrVector_size, METH_VARARGS, NULL},
 	 { (char *)"InvertedListsPtrVector_at", _wrap_InvertedListsPtrVector_at, METH_VARARGS, NULL},
 	 { (char *)"InvertedListsPtrVector_resize", _wrap_InvertedListsPtrVector_resize, METH_VARARGS, NULL},
+	 { (char *)"InvertedListsPtrVector_swap", _wrap_InvertedListsPtrVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_InvertedListsPtrVector", _wrap_delete_InvertedListsPtrVector, METH_VARARGS, NULL},
 	 { (char *)"InvertedListsPtrVector_swigregister", InvertedListsPtrVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_FloatVectorVector", _wrap_new_FloatVectorVector, METH_VARARGS, NULL},
@@ -63235,6 +71486,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"FloatVectorVector_size", _wrap_FloatVectorVector_size, METH_VARARGS, NULL},
 	 { (char *)"FloatVectorVector_at", _wrap_FloatVectorVector_at, METH_VARARGS, NULL},
 	 { (char *)"FloatVectorVector_resize", _wrap_FloatVectorVector_resize, METH_VARARGS, NULL},
+	 { (char *)"FloatVectorVector_swap", _wrap_FloatVectorVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_FloatVectorVector", _wrap_delete_FloatVectorVector, METH_VARARGS, NULL},
 	 { (char *)"FloatVectorVector_swigregister", FloatVectorVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_ByteVectorVector", _wrap_new_ByteVectorVector, METH_VARARGS, NULL},
@@ -63244,6 +71496,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"ByteVectorVector_size", _wrap_ByteVectorVector_size, METH_VARARGS, NULL},
 	 { (char *)"ByteVectorVector_at", _wrap_ByteVectorVector_at, METH_VARARGS, NULL},
 	 { (char *)"ByteVectorVector_resize", _wrap_ByteVectorVector_resize, METH_VARARGS, NULL},
+	 { (char *)"ByteVectorVector_swap", _wrap_ByteVectorVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_ByteVectorVector", _wrap_delete_ByteVectorVector, METH_VARARGS, NULL},
 	 { (char *)"ByteVectorVector_swigregister", ByteVectorVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_LongVectorVector", _wrap_new_LongVectorVector, METH_VARARGS, NULL},
@@ -63253,6 +71506,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"LongVectorVector_size", _wrap_LongVectorVector_size, METH_VARARGS, NULL},
 	 { (char *)"LongVectorVector_at", _wrap_LongVectorVector_at, METH_VARARGS, NULL},
 	 { (char *)"LongVectorVector_resize", _wrap_LongVectorVector_resize, METH_VARARGS, NULL},
+	 { (char *)"LongVectorVector_swap", _wrap_LongVectorVector_swap, METH_VARARGS, NULL},
 	 { (char *)"delete_LongVectorVector", _wrap_delete_LongVectorVector, METH_VARARGS, NULL},
 	 { (char *)"LongVectorVector_swigregister", LongVectorVector_swigregister, METH_VARARGS, NULL},
 	 { (char *)"popcount64", _wrap_popcount64, METH_VARARGS, NULL},
@@ -63260,8 +71514,9 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"bitvec_print", _wrap_bitvec_print, METH_VARARGS, NULL},
 	 { (char *)"fvecs2bitvecs", _wrap_fvecs2bitvecs, METH_VARARGS, NULL},
 	 { (char *)"fvec2bitvec", _wrap_fvec2bitvec, METH_VARARGS, NULL},
+	 { (char *)"hammings_knn_hc", _wrap_hammings_knn_hc, METH_VARARGS, NULL},
 	 { (char *)"hammings_knn", _wrap_hammings_knn, METH_VARARGS, NULL},
-	 { (char *)"hammings_knn_core", _wrap_hammings_knn_core, METH_VARARGS, NULL},
+	 { (char *)"hammings_knn_mc", _wrap_hammings_knn_mc, METH_VARARGS, NULL},
 	 { (char *)"hamming_count_thres", _wrap_hamming_count_thres, METH_VARARGS, NULL},
 	 { (char *)"match_hamming_thres", _wrap_match_hamming_thres, METH_VARARGS, NULL},
 	 { (char *)"crosshamming_count_thres", _wrap_crosshamming_count_thres, METH_VARARGS, NULL},
@@ -63386,7 +71641,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"GenHammingComputerM8_hamming", _wrap_GenHammingComputerM8_hamming, METH_VARARGS, NULL},
 	 { (char *)"delete_GenHammingComputerM8", _wrap_delete_GenHammingComputerM8, METH_VARARGS, NULL},
 	 { (char *)"GenHammingComputerM8_swigregister", GenHammingComputerM8_swigregister, METH_VARARGS, NULL},
-	 { (char *)"generalized_hammings_knn", _wrap_generalized_hammings_knn, METH_VARARGS, NULL},
+	 { (char *)"generalized_hammings_knn_hc", _wrap_generalized_hammings_knn_hc, METH_VARARGS, NULL},
 	 { (char *)"get_num_gpus", _wrap_get_num_gpus, METH_VARARGS, NULL},
 	 { (char *)"getmillisecs", _wrap_getmillisecs, METH_VARARGS, NULL},
 	 { (char *)"get_mem_usage_kb", _wrap_get_mem_usage_kb, METH_VARARGS, NULL},
@@ -63802,13 +72057,13 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"IndexPQ_reset", _wrap_IndexPQ_reset, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_reconstruct_n", _wrap_IndexPQ_reconstruct_n, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_reconstruct", _wrap_IndexPQ_reconstruct, METH_VARARGS, NULL},
+	 { (char *)"IndexPQ_remove_ids", _wrap_IndexPQ_remove_ids, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_do_polysemous_training_set", _wrap_IndexPQ_do_polysemous_training_set, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_do_polysemous_training_get", _wrap_IndexPQ_do_polysemous_training_get, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_polysemous_training_set", _wrap_IndexPQ_polysemous_training_set, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_polysemous_training_get", _wrap_IndexPQ_polysemous_training_get, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_search_type_set", _wrap_IndexPQ_search_type_set, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_search_type_get", _wrap_IndexPQ_search_type_get, METH_VARARGS, NULL},
-	 { (char *)"IndexPQ_remove_ids", _wrap_IndexPQ_remove_ids, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_encode_signs_set", _wrap_IndexPQ_encode_signs_set, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_encode_signs_get", _wrap_IndexPQ_encode_signs_get, METH_VARARGS, NULL},
 	 { (char *)"IndexPQ_polysemous_ht_set", _wrap_IndexPQ_polysemous_ht_set, METH_VARARGS, NULL},
@@ -63894,6 +72149,13 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"ArrayInvertedLists_resize", _wrap_ArrayInvertedLists_resize, METH_VARARGS, NULL},
 	 { (char *)"delete_ArrayInvertedLists", _wrap_delete_ArrayInvertedLists, METH_VARARGS, NULL},
 	 { (char *)"ArrayInvertedLists_swigregister", ArrayInvertedLists_swigregister, METH_VARARGS, NULL},
+	 { (char *)"IVFSearchParameters_nprobe_set", _wrap_IVFSearchParameters_nprobe_set, METH_VARARGS, NULL},
+	 { (char *)"IVFSearchParameters_nprobe_get", _wrap_IVFSearchParameters_nprobe_get, METH_VARARGS, NULL},
+	 { (char *)"IVFSearchParameters_max_codes_set", _wrap_IVFSearchParameters_max_codes_set, METH_VARARGS, NULL},
+	 { (char *)"IVFSearchParameters_max_codes_get", _wrap_IVFSearchParameters_max_codes_get, METH_VARARGS, NULL},
+	 { (char *)"delete_IVFSearchParameters", _wrap_delete_IVFSearchParameters, METH_VARARGS, NULL},
+	 { (char *)"new_IVFSearchParameters", _wrap_new_IVFSearchParameters, METH_VARARGS, NULL},
+	 { (char *)"IVFSearchParameters_swigregister", IVFSearchParameters_swigregister, METH_VARARGS, NULL},
 	 { (char *)"IndexIVF_invlists_set", _wrap_IndexIVF_invlists_set, METH_VARARGS, NULL},
 	 { (char *)"IndexIVF_invlists_get", _wrap_IndexIVF_invlists_get, METH_VARARGS, NULL},
 	 { (char *)"IndexIVF_own_invlists_set", _wrap_IndexIVF_own_invlists_set, METH_VARARGS, NULL},
@@ -64116,6 +72378,18 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"new_IndexIVFFlat", _wrap_new_IndexIVFFlat, METH_VARARGS, NULL},
 	 { (char *)"delete_IndexIVFFlat", _wrap_delete_IndexIVFFlat, METH_VARARGS, NULL},
 	 { (char *)"IndexIVFFlat_swigregister", IndexIVFFlat_swigregister, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_instances_set", _wrap_IndexIVFFlatDedup_instances_set, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_instances_get", _wrap_IndexIVFFlatDedup_instances_get, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_train", _wrap_IndexIVFFlatDedup_train, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_add_with_ids", _wrap_IndexIVFFlatDedup_add_with_ids, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_search_preassigned", _wrap_IndexIVFFlatDedup_search_preassigned, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_remove_ids", _wrap_IndexIVFFlatDedup_remove_ids, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_range_search", _wrap_IndexIVFFlatDedup_range_search, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_update_vectors", _wrap_IndexIVFFlatDedup_update_vectors, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_reconstruct_from_offset", _wrap_IndexIVFFlatDedup_reconstruct_from_offset, METH_VARARGS, NULL},
+	 { (char *)"new_IndexIVFFlatDedup", _wrap_new_IndexIVFFlatDedup, METH_VARARGS, NULL},
+	 { (char *)"delete_IndexIVFFlatDedup", _wrap_delete_IndexIVFFlatDedup, METH_VARARGS, NULL},
+	 { (char *)"IndexIVFFlatDedup_swigregister", IndexIVFFlatDedup_swigregister, METH_VARARGS, NULL},
 	 { (char *)"OnDiskInvertedLists_lists_set", _wrap_OnDiskInvertedLists_lists_set, METH_VARARGS, NULL},
 	 { (char *)"OnDiskInvertedLists_lists_get", _wrap_OnDiskInvertedLists_lists_get, METH_VARARGS, NULL},
 	 { (char *)"OnDiskInvertedLists_slots_set", _wrap_OnDiskInvertedLists_slots_set, METH_VARARGS, NULL},
@@ -64148,6 +72422,13 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"OnDiskInvertedLists_free_slot", _wrap_OnDiskInvertedLists_free_slot, METH_VARARGS, NULL},
 	 { (char *)"new_OnDiskInvertedLists", _wrap_new_OnDiskInvertedLists, METH_VARARGS, NULL},
 	 { (char *)"OnDiskInvertedLists_swigregister", OnDiskInvertedLists_swigregister, METH_VARARGS, NULL},
+	 { (char *)"IVFPQSearchParameters_scan_table_threshold_set", _wrap_IVFPQSearchParameters_scan_table_threshold_set, METH_VARARGS, NULL},
+	 { (char *)"IVFPQSearchParameters_scan_table_threshold_get", _wrap_IVFPQSearchParameters_scan_table_threshold_get, METH_VARARGS, NULL},
+	 { (char *)"IVFPQSearchParameters_polysemous_ht_set", _wrap_IVFPQSearchParameters_polysemous_ht_set, METH_VARARGS, NULL},
+	 { (char *)"IVFPQSearchParameters_polysemous_ht_get", _wrap_IVFPQSearchParameters_polysemous_ht_get, METH_VARARGS, NULL},
+	 { (char *)"delete_IVFPQSearchParameters", _wrap_delete_IVFPQSearchParameters, METH_VARARGS, NULL},
+	 { (char *)"new_IVFPQSearchParameters", _wrap_new_IVFPQSearchParameters, METH_VARARGS, NULL},
+	 { (char *)"IVFPQSearchParameters_swigregister", IVFPQSearchParameters_swigregister, METH_VARARGS, NULL},
 	 { (char *)"IndexIVFPQ_by_residual_set", _wrap_IndexIVFPQ_by_residual_set, METH_VARARGS, NULL},
 	 { (char *)"IndexIVFPQ_by_residual_get", _wrap_IndexIVFPQ_by_residual_get, METH_VARARGS, NULL},
 	 { (char *)"IndexIVFPQ_use_precomputed_table_set", _wrap_IndexIVFPQ_use_precomputed_table_set, METH_VARARGS, NULL},
@@ -64245,6 +72526,90 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"Index2Layer_reset", _wrap_Index2Layer_reset, METH_VARARGS, NULL},
 	 { (char *)"Index2Layer_transfer_to_IVFPQ", _wrap_Index2Layer_transfer_to_IVFPQ, METH_VARARGS, NULL},
 	 { (char *)"Index2Layer_swigregister", Index2Layer_swigregister, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_d_set", _wrap_IndexBinary_d_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_d_get", _wrap_IndexBinary_d_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_code_size_set", _wrap_IndexBinary_code_size_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_code_size_get", _wrap_IndexBinary_code_size_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_ntotal_set", _wrap_IndexBinary_ntotal_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_ntotal_get", _wrap_IndexBinary_ntotal_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_verbose_set", _wrap_IndexBinary_verbose_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_verbose_get", _wrap_IndexBinary_verbose_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_is_trained_set", _wrap_IndexBinary_is_trained_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_is_trained_get", _wrap_IndexBinary_is_trained_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_metric_type_set", _wrap_IndexBinary_metric_type_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_metric_type_get", _wrap_IndexBinary_metric_type_get, METH_VARARGS, NULL},
+	 { (char *)"delete_IndexBinary", _wrap_delete_IndexBinary, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_train", _wrap_IndexBinary_train, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_add", _wrap_IndexBinary_add, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_add_with_ids", _wrap_IndexBinary_add_with_ids, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_search", _wrap_IndexBinary_search, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_range_search", _wrap_IndexBinary_range_search, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_assign", _wrap_IndexBinary_assign, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_reset", _wrap_IndexBinary_reset, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_remove_ids", _wrap_IndexBinary_remove_ids, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_reconstruct", _wrap_IndexBinary_reconstruct, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_reconstruct_n", _wrap_IndexBinary_reconstruct_n, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_search_and_reconstruct", _wrap_IndexBinary_search_and_reconstruct, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_display", _wrap_IndexBinary_display, METH_VARARGS, NULL},
+	 { (char *)"IndexBinary_swigregister", IndexBinary_swigregister, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_xb_set", _wrap_IndexBinaryFlat_xb_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_xb_get", _wrap_IndexBinaryFlat_xb_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_use_heap_set", _wrap_IndexBinaryFlat_use_heap_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_use_heap_get", _wrap_IndexBinaryFlat_use_heap_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_query_batch_size_set", _wrap_IndexBinaryFlat_query_batch_size_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_query_batch_size_get", _wrap_IndexBinaryFlat_query_batch_size_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_add", _wrap_IndexBinaryFlat_add, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_reset", _wrap_IndexBinaryFlat_reset, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_search", _wrap_IndexBinaryFlat_search, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_reconstruct", _wrap_IndexBinaryFlat_reconstruct, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_remove_ids", _wrap_IndexBinaryFlat_remove_ids, METH_VARARGS, NULL},
+	 { (char *)"new_IndexBinaryFlat", _wrap_new_IndexBinaryFlat, METH_VARARGS, NULL},
+	 { (char *)"delete_IndexBinaryFlat", _wrap_delete_IndexBinaryFlat, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryFlat_swigregister", IndexBinaryFlat_swigregister, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_invlists_set", _wrap_IndexBinaryIVF_invlists_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_invlists_get", _wrap_IndexBinaryIVF_invlists_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_own_invlists_set", _wrap_IndexBinaryIVF_own_invlists_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_own_invlists_get", _wrap_IndexBinaryIVF_own_invlists_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_nprobe_set", _wrap_IndexBinaryIVF_nprobe_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_nprobe_get", _wrap_IndexBinaryIVF_nprobe_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_max_codes_set", _wrap_IndexBinaryIVF_max_codes_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_max_codes_get", _wrap_IndexBinaryIVF_max_codes_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_use_heap_set", _wrap_IndexBinaryIVF_use_heap_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_use_heap_get", _wrap_IndexBinaryIVF_use_heap_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_maintain_direct_map_set", _wrap_IndexBinaryIVF_maintain_direct_map_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_maintain_direct_map_get", _wrap_IndexBinaryIVF_maintain_direct_map_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_direct_map_set", _wrap_IndexBinaryIVF_direct_map_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_direct_map_get", _wrap_IndexBinaryIVF_direct_map_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_quantizer_set", _wrap_IndexBinaryIVF_quantizer_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_quantizer_get", _wrap_IndexBinaryIVF_quantizer_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_nlist_set", _wrap_IndexBinaryIVF_nlist_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_nlist_get", _wrap_IndexBinaryIVF_nlist_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_own_fields_set", _wrap_IndexBinaryIVF_own_fields_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_own_fields_get", _wrap_IndexBinaryIVF_own_fields_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_cp_set", _wrap_IndexBinaryIVF_cp_set, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_cp_get", _wrap_IndexBinaryIVF_cp_get, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_train_q1", _wrap_IndexBinaryIVF_train_q1, METH_VARARGS, NULL},
+	 { (char *)"new_IndexBinaryIVF", _wrap_new_IndexBinaryIVF, METH_VARARGS, NULL},
+	 { (char *)"delete_IndexBinaryIVF", _wrap_delete_IndexBinaryIVF, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_reset", _wrap_IndexBinaryIVF_reset, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_train", _wrap_IndexBinaryIVF_train, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_add", _wrap_IndexBinaryIVF_add, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_add_with_ids", _wrap_IndexBinaryIVF_add_with_ids, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_add_core", _wrap_IndexBinaryIVF_add_core, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_search_preassigned", _wrap_IndexBinaryIVF_search_preassigned, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_search", _wrap_IndexBinaryIVF_search, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_reconstruct", _wrap_IndexBinaryIVF_reconstruct, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_reconstruct_n", _wrap_IndexBinaryIVF_reconstruct_n, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_search_and_reconstruct", _wrap_IndexBinaryIVF_search_and_reconstruct, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_reconstruct_from_offset", _wrap_IndexBinaryIVF_reconstruct_from_offset, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_remove_ids", _wrap_IndexBinaryIVF_remove_ids, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_merge_from", _wrap_IndexBinaryIVF_merge_from, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_get_list_size", _wrap_IndexBinaryIVF_get_list_size, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_make_direct_map", _wrap_IndexBinaryIVF_make_direct_map, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_imbalance_factor", _wrap_IndexBinaryIVF_imbalance_factor, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_print_stats", _wrap_IndexBinaryIVF_print_stats, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_replace_invlists", _wrap_IndexBinaryIVF_replace_invlists, METH_VARARGS, NULL},
+	 { (char *)"IndexBinaryIVF_swigregister", IndexBinaryIVF_swigregister, METH_VARARGS, NULL},
 	 { (char *)"IndexIDMap_index_set", _wrap_IndexIDMap_index_set, METH_VARARGS, NULL},
 	 { (char *)"IndexIDMap_index_get", _wrap_IndexIDMap_index_get, METH_VARARGS, NULL},
 	 { (char *)"IndexIDMap_own_fields_set", _wrap_IndexIDMap_own_fields_set, METH_VARARGS, NULL},
@@ -64309,7 +72674,9 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"downcast_index", _wrap_downcast_index, METH_VARARGS, NULL},
 	 { (char *)"downcast_VectorTransform", _wrap_downcast_VectorTransform, METH_VARARGS, NULL},
 	 { (char *)"write_index", _wrap_write_index, METH_VARARGS, NULL},
+	 { (char *)"write_index_binary", _wrap_write_index_binary, METH_VARARGS, NULL},
 	 { (char *)"read_index", _wrap_read_index, METH_VARARGS, NULL},
+	 { (char *)"read_index_binary", _wrap_read_index_binary, METH_VARARGS, NULL},
 	 { (char *)"write_VectorTransform", _wrap_write_VectorTransform, METH_VARARGS, NULL},
 	 { (char *)"read_VectorTransform", _wrap_read_VectorTransform, METH_VARARGS, NULL},
 	 { (char *)"read_ProductQuantizer", _wrap_read_ProductQuantizer, METH_VARARGS, NULL},
@@ -64321,12 +72688,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"delete_Cloner", _wrap_delete_Cloner, METH_VARARGS, NULL},
 	 { (char *)"new_Cloner", _wrap_new_Cloner, METH_VARARGS, NULL},
 	 { (char *)"Cloner_swigregister", Cloner_swigregister, METH_VARARGS, NULL},
-	 { (char *)"IOReader___call__", _wrap_IOReader___call__, METH_VARARGS, NULL},
-	 { (char *)"delete_IOReader", _wrap_delete_IOReader, METH_VARARGS, NULL},
-	 { (char *)"IOReader_swigregister", IOReader_swigregister, METH_VARARGS, NULL},
-	 { (char *)"IOWriter___call__", _wrap_IOWriter___call__, METH_VARARGS, NULL},
-	 { (char *)"delete_IOWriter", _wrap_delete_IOWriter, METH_VARARGS, NULL},
-	 { (char *)"IOWriter_swigregister", IOWriter_swigregister, METH_VARARGS, NULL},
 	 { (char *)"AutoTuneCriterion_nq_set", _wrap_AutoTuneCriterion_nq_set, METH_VARARGS, NULL},
 	 { (char *)"AutoTuneCriterion_nq_get", _wrap_AutoTuneCriterion_nq_get, METH_VARARGS, NULL},
 	 { (char *)"AutoTuneCriterion_nnn_set", _wrap_AutoTuneCriterion_nnn_set, METH_VARARGS, NULL},
@@ -64409,6 +72770,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"delete_ParameterSpace", _wrap_delete_ParameterSpace, METH_VARARGS, NULL},
 	 { (char *)"ParameterSpace_swigregister", ParameterSpace_swigregister, METH_VARARGS, NULL},
 	 { (char *)"index_factory", _wrap_index_factory, METH_VARARGS, NULL},
+	 { (char *)"index_binary_factory", _wrap_index_binary_factory, METH_VARARGS, NULL},
 	 { (char *)"swig_ptr", _wrap_swig_ptr, METH_VARARGS, NULL},
 	 { (char *)"rev_swig_ptr", _wrap_rev_swig_ptr, METH_VARARGS, NULL},
 	 { (char *)"float_minheap_array_t_nh_set", _wrap_float_minheap_array_t_nh_set, METH_VARARGS, NULL},
@@ -64545,6 +72907,27 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"RangeSearchPartialResult_set_result", _wrap_RangeSearchPartialResult_set_result, METH_VARARGS, NULL},
 	 { (char *)"delete_RangeSearchPartialResult", _wrap_delete_RangeSearchPartialResult, METH_VARARGS, NULL},
 	 { (char *)"RangeSearchPartialResult_swigregister", RangeSearchPartialResult_swigregister, METH_VARARGS, NULL},
+	 { (char *)"IOReader___call__", _wrap_IOReader___call__, METH_VARARGS, NULL},
+	 { (char *)"IOReader_fileno", _wrap_IOReader_fileno, METH_VARARGS, NULL},
+	 { (char *)"delete_IOReader", _wrap_delete_IOReader, METH_VARARGS, NULL},
+	 { (char *)"IOReader_swigregister", IOReader_swigregister, METH_VARARGS, NULL},
+	 { (char *)"IOWriter___call__", _wrap_IOWriter___call__, METH_VARARGS, NULL},
+	 { (char *)"IOWriter_fileno", _wrap_IOWriter_fileno, METH_VARARGS, NULL},
+	 { (char *)"delete_IOWriter", _wrap_delete_IOWriter, METH_VARARGS, NULL},
+	 { (char *)"IOWriter_swigregister", IOWriter_swigregister, METH_VARARGS, NULL},
+	 { (char *)"VectorIOReader_data_get", _wrap_VectorIOReader_data_get, METH_VARARGS, NULL},
+	 { (char *)"VectorIOReader_rp_set", _wrap_VectorIOReader_rp_set, METH_VARARGS, NULL},
+	 { (char *)"VectorIOReader_rp_get", _wrap_VectorIOReader_rp_get, METH_VARARGS, NULL},
+	 { (char *)"VectorIOReader___call__", _wrap_VectorIOReader___call__, METH_VARARGS, NULL},
+	 { (char *)"new_VectorIOReader", _wrap_new_VectorIOReader, METH_VARARGS, NULL},
+	 { (char *)"delete_VectorIOReader", _wrap_delete_VectorIOReader, METH_VARARGS, NULL},
+	 { (char *)"VectorIOReader_swigregister", VectorIOReader_swigregister, METH_VARARGS, NULL},
+	 { (char *)"VectorIOWriter_data_set", _wrap_VectorIOWriter_data_set, METH_VARARGS, NULL},
+	 { (char *)"VectorIOWriter_data_get", _wrap_VectorIOWriter_data_get, METH_VARARGS, NULL},
+	 { (char *)"VectorIOWriter___call__", _wrap_VectorIOWriter___call__, METH_VARARGS, NULL},
+	 { (char *)"new_VectorIOWriter", _wrap_new_VectorIOWriter, METH_VARARGS, NULL},
+	 { (char *)"delete_VectorIOWriter", _wrap_delete_VectorIOWriter, METH_VARARGS, NULL},
+	 { (char *)"VectorIOWriter_swigregister", VectorIOWriter_swigregister, METH_VARARGS, NULL},
 	 { (char *)"ignore_SIGTTIN", _wrap_ignore_SIGTTIN, METH_VARARGS, NULL},
 	 { (char *)"MapLong2Long_map_set", _wrap_MapLong2Long_map_set, METH_VARARGS, NULL},
 	 { (char *)"MapLong2Long_map_get", _wrap_MapLong2Long_map_get, METH_VARARGS, NULL},
@@ -64560,62 +72943,23 @@ static PyMethodDef SwigMethods[] = {
 
 /* -------- TYPE CONVERSION AND EQUIVALENCE RULES (BEGIN) -------- */
 
+static void *_p_faiss__IndexHNSWFlatTo_p_faiss__IndexHNSW(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexHNSW *)  ((faiss::IndexHNSWFlat *) x));
+}
+static void *_p_faiss__IndexHNSWSQTo_p_faiss__IndexHNSW(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexHNSW *)  ((faiss::IndexHNSWSQ *) x));
+}
+static void *_p_faiss__IndexHNSWPQTo_p_faiss__IndexHNSW(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexHNSW *)  ((faiss::IndexHNSWPQ *) x));
+}
+static void *_p_faiss__IndexHNSW2LevelTo_p_faiss__IndexHNSW(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexHNSW *)  ((faiss::IndexHNSW2Level *) x));
+}
+static void *_p_faiss__IndexIDMap2To_p_faiss__IndexIDMap(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexIDMap *)  ((faiss::IndexIDMap2 *) x));
+}
 static void *_p_faiss__IndexIVFPQRTo_p_faiss__IndexIVFPQ(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::IndexIVFPQ *)  ((faiss::IndexIVFPQR *) x));
-}
-static void *_p_faiss__IndexFlatL2To_p_faiss__IndexFlat(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::IndexFlat *)  ((faiss::IndexFlatL2 *) x));
-}
-static void *_p_faiss__IndexFlat1DTo_p_faiss__IndexFlat(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::IndexFlat *) (faiss::IndexFlatL2 *) ((faiss::IndexFlat1D *) x));
-}
-static void *_p_faiss__IndexFlatIPTo_p_faiss__IndexFlat(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::IndexFlat *)  ((faiss::IndexFlatIP *) x));
-}
-static void *_p_faiss__IndexFlatL2BaseShiftTo_p_faiss__IndexFlat(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::IndexFlat *) (faiss::IndexFlatL2 *) ((faiss::IndexFlatL2BaseShift *) x));
-}
-static void *_p_faiss__OneRecallAtRCriterionTo_p_faiss__AutoTuneCriterion(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::AutoTuneCriterion *)  ((faiss::OneRecallAtRCriterion *) x));
-}
-static void *_p_faiss__IntersectionCriterionTo_p_faiss__AutoTuneCriterion(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::AutoTuneCriterion *)  ((faiss::IntersectionCriterion *) x));
-}
-static void *_p_faiss__ReproduceDistancesObjectiveTo_p_faiss__PermutationObjective(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::PermutationObjective *)  ((faiss::ReproduceDistancesObjective *) x));
-}
-static void *_p_faiss__IndexFlat1DTo_p_faiss__IndexFlatL2(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::IndexFlatL2 *)  ((faiss::IndexFlat1D *) x));
-}
-static void *_p_faiss__IndexFlatL2BaseShiftTo_p_faiss__IndexFlatL2(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::IndexFlatL2 *)  ((faiss::IndexFlatL2BaseShift *) x));
-}
-static void *_p_faiss__IndexIVFTo_p_faiss__Level1Quantizer(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Level1Quantizer *)  ((faiss::IndexIVF *) x));
-}
-static void *_p_faiss__IndexIVFScalarQuantizerTo_p_faiss__Level1Quantizer(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Level1Quantizer *) (faiss::IndexIVF *) ((faiss::IndexIVFScalarQuantizer *) x));
-}
-static void *_p_faiss__IndexIVFPQTo_p_faiss__Level1Quantizer(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Level1Quantizer *) (faiss::IndexIVF *) ((faiss::IndexIVFPQ *) x));
-}
-static void *_p_faiss__IndexIVFFlatTo_p_faiss__Level1Quantizer(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Level1Quantizer *) (faiss::IndexIVF *) ((faiss::IndexIVFFlat *) x));
-}
-static void *_p_faiss__IndexIVFPQRTo_p_faiss__Level1Quantizer(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Level1Quantizer *) (faiss::IndexIVF *)(faiss::IndexIVFPQ *) ((faiss::IndexIVFPQR *) x));
-}
-static void *_p_faiss__MultiIndexQuantizer2To_p_faiss__MultiIndexQuantizer(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::MultiIndexQuantizer *)  ((faiss::MultiIndexQuantizer2 *) x));
-}
-static void *_p_faiss__RandomRotationMatrixTo_p_faiss__LinearTransform(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::LinearTransform *)  ((faiss::RandomRotationMatrix *) x));
-}
-static void *_p_faiss__PCAMatrixTo_p_faiss__LinearTransform(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::LinearTransform *)  ((faiss::PCAMatrix *) x));
-}
-static void *_p_faiss__OPQMatrixTo_p_faiss__LinearTransform(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::LinearTransform *)  ((faiss::OPQMatrix *) x));
 }
 static void *_p_faiss__RandomRotationMatrixTo_p_faiss__VectorTransform(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::VectorTransform *) (faiss::LinearTransform *) ((faiss::RandomRotationMatrix *) x));
@@ -64635,6 +72979,15 @@ static void *_p_faiss__RemapDimensionsTransformTo_p_faiss__VectorTransform(void 
 static void *_p_faiss__NormalizationTransformTo_p_faiss__VectorTransform(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::VectorTransform *)  ((faiss::NormalizationTransform *) x));
 }
+static void *_p_faiss__RandomRotationMatrixTo_p_faiss__LinearTransform(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::LinearTransform *)  ((faiss::RandomRotationMatrix *) x));
+}
+static void *_p_faiss__PCAMatrixTo_p_faiss__LinearTransform(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::LinearTransform *)  ((faiss::PCAMatrix *) x));
+}
+static void *_p_faiss__OPQMatrixTo_p_faiss__LinearTransform(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::LinearTransform *)  ((faiss::OPQMatrix *) x));
+}
 static void *_p_p_faiss__RandomRotationMatrixTo_p_p_faiss__VectorTransform(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::VectorTransform **) (faiss::LinearTransform *) ((faiss::RandomRotationMatrix **) x));
 }
@@ -64653,14 +73006,32 @@ static void *_p_p_faiss__RemapDimensionsTransformTo_p_p_faiss__VectorTransform(v
 static void *_p_p_faiss__NormalizationTransformTo_p_p_faiss__VectorTransform(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::VectorTransform **)  ((faiss::NormalizationTransform **) x));
 }
+static void *_p_faiss__IndexIVFFlatDedupTo_p_faiss__IndexIVFFlat(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexIVFFlat *)  ((faiss::IndexIVFFlatDedup *) x));
+}
+static void *_p_faiss__IDSelectorBatchTo_p_faiss__IDSelector(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IDSelector *)  ((faiss::IDSelectorBatch *) x));
+}
+static void *_p_faiss__IDSelectorRangeTo_p_faiss__IDSelector(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IDSelector *)  ((faiss::IDSelectorRange *) x));
+}
 static void *_p_faiss__RangeSearchPartialResultTo_p_faiss__BufferList(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::BufferList *)  ((faiss::RangeSearchPartialResult *) x));
 }
-static void *_p_p_faiss__ArrayInvertedListsTo_p_p_faiss__InvertedLists(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::InvertedLists **)  ((faiss::ArrayInvertedLists **) x));
+static void *_p_faiss__ReproduceDistancesObjectiveTo_p_faiss__PermutationObjective(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::PermutationObjective *)  ((faiss::ReproduceDistancesObjective *) x));
 }
-static void *_p_p_faiss__OnDiskInvertedListsTo_p_p_faiss__InvertedLists(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::InvertedLists **)  ((faiss::OnDiskInvertedLists **) x));
+static void *_p_faiss__IndexFlatL2To_p_faiss__IndexFlat(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexFlat *)  ((faiss::IndexFlatL2 *) x));
+}
+static void *_p_faiss__IndexFlat1DTo_p_faiss__IndexFlat(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexFlat *) (faiss::IndexFlatL2 *) ((faiss::IndexFlat1D *) x));
+}
+static void *_p_faiss__IndexFlatIPTo_p_faiss__IndexFlat(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexFlat *)  ((faiss::IndexFlatIP *) x));
+}
+static void *_p_faiss__IndexFlatL2BaseShiftTo_p_faiss__IndexFlat(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexFlat *) (faiss::IndexFlatL2 *) ((faiss::IndexFlatL2BaseShift *) x));
 }
 static void *_p_faiss__ArrayInvertedListsTo_p_faiss__InvertedLists(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::InvertedLists *)  ((faiss::ArrayInvertedLists *) x));
@@ -64668,86 +73039,47 @@ static void *_p_faiss__ArrayInvertedListsTo_p_faiss__InvertedLists(void *x, int 
 static void *_p_faiss__OnDiskInvertedListsTo_p_faiss__InvertedLists(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::InvertedLists *)  ((faiss::OnDiskInvertedLists *) x));
 }
-static void *_p_faiss__IndexPreTransformTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *)  ((faiss::IndexPreTransform *) x));
+static void *_p_p_faiss__ArrayInvertedListsTo_p_p_faiss__InvertedLists(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::InvertedLists **)  ((faiss::ArrayInvertedLists **) x));
 }
-static void *_p_faiss__IndexIVFTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *)  ((faiss::IndexIVF *) x));
+static void *_p_p_faiss__OnDiskInvertedListsTo_p_p_faiss__InvertedLists(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::InvertedLists **)  ((faiss::OnDiskInvertedLists **) x));
 }
-static void *_p_faiss__IndexFlatL2To_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *) (faiss::IndexFlat *) ((faiss::IndexFlatL2 *) x));
+static void *_p_faiss__VectorIOReaderTo_p_faiss__IOReader(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IOReader *)  ((faiss::VectorIOReader *) x));
 }
-static void *_p_faiss__IndexHNSWFlatTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *) (faiss::IndexHNSW *) ((faiss::IndexHNSWFlat *) x));
+static void *_p_faiss__IndexFlat1DTo_p_faiss__IndexFlatL2(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexFlatL2 *)  ((faiss::IndexFlat1D *) x));
 }
-static void *_p_faiss__Index2LayerTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *)  ((faiss::Index2Layer *) x));
+static void *_p_faiss__IndexFlatL2BaseShiftTo_p_faiss__IndexFlatL2(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexFlatL2 *)  ((faiss::IndexFlatL2BaseShift *) x));
 }
-static void *_p_faiss__IndexFlatIPTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *) (faiss::IndexFlat *) ((faiss::IndexFlatIP *) x));
+static void *_p_faiss__IndexIVFScalarQuantizerTo_p_faiss__IndexIVF(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexIVF *)  ((faiss::IndexIVFScalarQuantizer *) x));
 }
-static void *_p_faiss__IndexHNSWTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *)  ((faiss::IndexHNSW *) x));
+static void *_p_faiss__IndexIVFPQTo_p_faiss__IndexIVF(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexIVF *)  ((faiss::IndexIVFPQ *) x));
 }
-static void *_p_faiss__IndexHNSWPQTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *) (faiss::IndexHNSW *) ((faiss::IndexHNSWPQ *) x));
+static void *_p_faiss__IndexIVFFlatTo_p_faiss__IndexIVF(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexIVF *)  ((faiss::IndexIVFFlat *) x));
 }
-static void *_p_faiss__IndexIVFFlatTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *) (faiss::IndexIVF *) ((faiss::IndexIVFFlat *) x));
+static void *_p_faiss__IndexIVFFlatDedupTo_p_faiss__IndexIVF(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexIVF *) (faiss::IndexIVFFlat *) ((faiss::IndexIVFFlatDedup *) x));
 }
-static void *_p_faiss__IndexLSHTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *)  ((faiss::IndexLSH *) x));
+static void *_p_faiss__IndexIVFPQRTo_p_faiss__IndexIVF(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexIVF *) (faiss::IndexIVFPQ *) ((faiss::IndexIVFPQR *) x));
 }
-static void *_p_faiss__IndexFlatTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *)  ((faiss::IndexFlat *) x));
+static void *_p_faiss__PolysemousTrainingTo_p_faiss__SimulatedAnnealingParameters(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::SimulatedAnnealingParameters *)  ((faiss::PolysemousTraining *) x));
 }
-static void *_p_faiss__IndexIVFPQRTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *) (faiss::IndexIVF *)(faiss::IndexIVFPQ *) ((faiss::IndexIVFPQR *) x));
+static void *_p_faiss__SimulatedAnnealingOptimizerTo_p_faiss__SimulatedAnnealingParameters(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::SimulatedAnnealingParameters *)  ((faiss::SimulatedAnnealingOptimizer *) x));
 }
-static void *_p_faiss__IndexFlat1DTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *) (faiss::IndexFlat *)(faiss::IndexFlatL2 *) ((faiss::IndexFlat1D *) x));
+static void *_p_faiss__ClusteringTo_p_faiss__ClusteringParameters(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::ClusteringParameters *)  ((faiss::Clustering *) x));
 }
-static void *_p_faiss__IndexFlatL2BaseShiftTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *) (faiss::IndexFlat *)(faiss::IndexFlatL2 *) ((faiss::IndexFlatL2BaseShift *) x));
-}
-static void *_p_faiss__IndexShardsTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *)  ((faiss::IndexShards *) x));
-}
-static void *_p_faiss__IndexHNSW2LevelTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *) (faiss::IndexHNSW *) ((faiss::IndexHNSW2Level *) x));
-}
-static void *_p_faiss__IndexIDMap2To_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *) (faiss::IndexIDMap *) ((faiss::IndexIDMap2 *) x));
-}
-static void *_p_faiss__IndexSplitVectorsTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *)  ((faiss::IndexSplitVectors *) x));
-}
-static void *_p_faiss__IndexRefineFlatTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *)  ((faiss::IndexRefineFlat *) x));
-}
-static void *_p_faiss__IndexHNSWSQTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *) (faiss::IndexHNSW *) ((faiss::IndexHNSWSQ *) x));
-}
-static void *_p_faiss__MultiIndexQuantizer2To_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *) (faiss::MultiIndexQuantizer *) ((faiss::MultiIndexQuantizer2 *) x));
-}
-static void *_p_faiss__IndexPQTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *)  ((faiss::IndexPQ *) x));
-}
-static void *_p_faiss__IndexIDMapTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *)  ((faiss::IndexIDMap *) x));
-}
-static void *_p_faiss__IndexIVFPQTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *) (faiss::IndexIVF *) ((faiss::IndexIVFPQ *) x));
-}
-static void *_p_faiss__IndexIVFScalarQuantizerTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *) (faiss::IndexIVF *) ((faiss::IndexIVFScalarQuantizer *) x));
-}
-static void *_p_faiss__IndexScalarQuantizerTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *)  ((faiss::IndexScalarQuantizer *) x));
-}
-static void *_p_faiss__MultiIndexQuantizerTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::Index *)  ((faiss::MultiIndexQuantizer *) x));
+static void *_p_faiss__IVFPQSearchParametersTo_p_faiss__IVFSearchParameters(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IVFSearchParameters *)  ((faiss::IVFPQSearchParameters *) x));
 }
 static void *_p_p_faiss__IndexPreTransformTo_p_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::Index **)  ((faiss::IndexPreTransform **) x));
@@ -64781,6 +73113,9 @@ static void *_p_p_faiss__IndexLSHTo_p_p_faiss__Index(void *x, int *SWIGUNUSEDPAR
 }
 static void *_p_p_faiss__IndexFlatTo_p_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::Index **)  ((faiss::IndexFlat **) x));
+}
+static void *_p_p_faiss__IndexIVFFlatDedupTo_p_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index **) (faiss::IndexIVF *)(faiss::IndexIVFFlat *) ((faiss::IndexIVFFlatDedup **) x));
 }
 static void *_p_p_faiss__IndexIVFPQRTo_p_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::Index **) (faiss::IndexIVF *)(faiss::IndexIVFPQ *) ((faiss::IndexIVFPQR **) x));
@@ -64830,47 +73165,125 @@ static void *_p_p_faiss__IndexScalarQuantizerTo_p_p_faiss__Index(void *x, int *S
 static void *_p_p_faiss__MultiIndexQuantizerTo_p_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((faiss::Index **)  ((faiss::MultiIndexQuantizer **) x));
 }
-static void *_p_faiss__ClusteringTo_p_faiss__ClusteringParameters(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::ClusteringParameters *)  ((faiss::Clustering *) x));
+static void *_p_faiss__IndexPreTransformTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *)  ((faiss::IndexPreTransform *) x));
 }
-static void *_p_faiss__PolysemousTrainingTo_p_faiss__SimulatedAnnealingParameters(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::SimulatedAnnealingParameters *)  ((faiss::PolysemousTraining *) x));
+static void *_p_faiss__IndexIVFTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *)  ((faiss::IndexIVF *) x));
 }
-static void *_p_faiss__SimulatedAnnealingOptimizerTo_p_faiss__SimulatedAnnealingParameters(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::SimulatedAnnealingParameters *)  ((faiss::SimulatedAnnealingOptimizer *) x));
+static void *_p_faiss__IndexFlatL2To_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *) (faiss::IndexFlat *) ((faiss::IndexFlatL2 *) x));
 }
-static void *_p_faiss__IndexHNSWFlatTo_p_faiss__IndexHNSW(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::IndexHNSW *)  ((faiss::IndexHNSWFlat *) x));
+static void *_p_faiss__IndexHNSWFlatTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *) (faiss::IndexHNSW *) ((faiss::IndexHNSWFlat *) x));
 }
-static void *_p_faiss__IndexHNSWSQTo_p_faiss__IndexHNSW(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::IndexHNSW *)  ((faiss::IndexHNSWSQ *) x));
+static void *_p_faiss__Index2LayerTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *)  ((faiss::Index2Layer *) x));
 }
-static void *_p_faiss__IndexHNSWPQTo_p_faiss__IndexHNSW(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::IndexHNSW *)  ((faiss::IndexHNSWPQ *) x));
+static void *_p_faiss__IndexFlatIPTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *) (faiss::IndexFlat *) ((faiss::IndexFlatIP *) x));
 }
-static void *_p_faiss__IndexHNSW2LevelTo_p_faiss__IndexHNSW(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::IndexHNSW *)  ((faiss::IndexHNSW2Level *) x));
+static void *_p_faiss__IndexHNSWTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *)  ((faiss::IndexHNSW *) x));
 }
-static void *_p_faiss__IndexIVFScalarQuantizerTo_p_faiss__IndexIVF(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::IndexIVF *)  ((faiss::IndexIVFScalarQuantizer *) x));
+static void *_p_faiss__IndexHNSWPQTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *) (faiss::IndexHNSW *) ((faiss::IndexHNSWPQ *) x));
 }
-static void *_p_faiss__IndexIVFPQTo_p_faiss__IndexIVF(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::IndexIVF *)  ((faiss::IndexIVFPQ *) x));
+static void *_p_faiss__IndexIVFFlatTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *) (faiss::IndexIVF *) ((faiss::IndexIVFFlat *) x));
 }
-static void *_p_faiss__IndexIVFFlatTo_p_faiss__IndexIVF(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::IndexIVF *)  ((faiss::IndexIVFFlat *) x));
+static void *_p_faiss__IndexLSHTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *)  ((faiss::IndexLSH *) x));
 }
-static void *_p_faiss__IndexIVFPQRTo_p_faiss__IndexIVF(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::IndexIVF *) (faiss::IndexIVFPQ *) ((faiss::IndexIVFPQR *) x));
+static void *_p_faiss__IndexFlatTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *)  ((faiss::IndexFlat *) x));
 }
-static void *_p_faiss__IDSelectorBatchTo_p_faiss__IDSelector(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::IDSelector *)  ((faiss::IDSelectorBatch *) x));
+static void *_p_faiss__IndexIVFFlatDedupTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *) (faiss::IndexIVF *)(faiss::IndexIVFFlat *) ((faiss::IndexIVFFlatDedup *) x));
 }
-static void *_p_faiss__IDSelectorRangeTo_p_faiss__IDSelector(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::IDSelector *)  ((faiss::IDSelectorRange *) x));
+static void *_p_faiss__IndexIVFPQRTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *) (faiss::IndexIVF *)(faiss::IndexIVFPQ *) ((faiss::IndexIVFPQR *) x));
 }
-static void *_p_faiss__IndexIDMap2To_p_faiss__IndexIDMap(void *x, int *SWIGUNUSEDPARM(newmemory)) {
-    return (void *)((faiss::IndexIDMap *)  ((faiss::IndexIDMap2 *) x));
+static void *_p_faiss__IndexFlat1DTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *) (faiss::IndexFlat *)(faiss::IndexFlatL2 *) ((faiss::IndexFlat1D *) x));
+}
+static void *_p_faiss__IndexFlatL2BaseShiftTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *) (faiss::IndexFlat *)(faiss::IndexFlatL2 *) ((faiss::IndexFlatL2BaseShift *) x));
+}
+static void *_p_faiss__IndexShardsTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *)  ((faiss::IndexShards *) x));
+}
+static void *_p_faiss__IndexHNSW2LevelTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *) (faiss::IndexHNSW *) ((faiss::IndexHNSW2Level *) x));
+}
+static void *_p_faiss__IndexIDMap2To_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *) (faiss::IndexIDMap *) ((faiss::IndexIDMap2 *) x));
+}
+static void *_p_faiss__IndexSplitVectorsTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *)  ((faiss::IndexSplitVectors *) x));
+}
+static void *_p_faiss__IndexRefineFlatTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *)  ((faiss::IndexRefineFlat *) x));
+}
+static void *_p_faiss__IndexHNSWSQTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *) (faiss::IndexHNSW *) ((faiss::IndexHNSWSQ *) x));
+}
+static void *_p_faiss__MultiIndexQuantizer2To_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *) (faiss::MultiIndexQuantizer *) ((faiss::MultiIndexQuantizer2 *) x));
+}
+static void *_p_faiss__IndexPQTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *)  ((faiss::IndexPQ *) x));
+}
+static void *_p_faiss__IndexIDMapTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *)  ((faiss::IndexIDMap *) x));
+}
+static void *_p_faiss__IndexIVFPQTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *) (faiss::IndexIVF *) ((faiss::IndexIVFPQ *) x));
+}
+static void *_p_faiss__IndexIVFScalarQuantizerTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *) (faiss::IndexIVF *) ((faiss::IndexIVFScalarQuantizer *) x));
+}
+static void *_p_faiss__IndexScalarQuantizerTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *)  ((faiss::IndexScalarQuantizer *) x));
+}
+static void *_p_faiss__MultiIndexQuantizerTo_p_faiss__Index(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Index *)  ((faiss::MultiIndexQuantizer *) x));
+}
+static void *_p_faiss__IndexBinaryFlatTo_p_faiss__IndexBinary(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexBinary *)  ((faiss::IndexBinaryFlat *) x));
+}
+static void *_p_faiss__IndexBinaryIVFTo_p_faiss__IndexBinary(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IndexBinary *)  ((faiss::IndexBinaryIVF *) x));
+}
+static void *_p_faiss__MultiIndexQuantizer2To_p_faiss__MultiIndexQuantizer(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::MultiIndexQuantizer *)  ((faiss::MultiIndexQuantizer2 *) x));
+}
+static void *_p_faiss__IndexIVFTo_p_faiss__Level1Quantizer(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Level1Quantizer *)  ((faiss::IndexIVF *) x));
+}
+static void *_p_faiss__IndexIVFScalarQuantizerTo_p_faiss__Level1Quantizer(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Level1Quantizer *) (faiss::IndexIVF *) ((faiss::IndexIVFScalarQuantizer *) x));
+}
+static void *_p_faiss__IndexIVFPQTo_p_faiss__Level1Quantizer(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Level1Quantizer *) (faiss::IndexIVF *) ((faiss::IndexIVFPQ *) x));
+}
+static void *_p_faiss__IndexIVFFlatTo_p_faiss__Level1Quantizer(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Level1Quantizer *) (faiss::IndexIVF *) ((faiss::IndexIVFFlat *) x));
+}
+static void *_p_faiss__IndexIVFFlatDedupTo_p_faiss__Level1Quantizer(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Level1Quantizer *) (faiss::IndexIVF *)(faiss::IndexIVFFlat *) ((faiss::IndexIVFFlatDedup *) x));
+}
+static void *_p_faiss__IndexIVFPQRTo_p_faiss__Level1Quantizer(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::Level1Quantizer *) (faiss::IndexIVF *)(faiss::IndexIVFPQ *) ((faiss::IndexIVFPQR *) x));
+}
+static void *_p_faiss__OneRecallAtRCriterionTo_p_faiss__AutoTuneCriterion(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::AutoTuneCriterion *)  ((faiss::OneRecallAtRCriterion *) x));
+}
+static void *_p_faiss__IntersectionCriterionTo_p_faiss__AutoTuneCriterion(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::AutoTuneCriterion *)  ((faiss::IntersectionCriterion *) x));
+}
+static void *_p_faiss__VectorIOWriterTo_p_faiss__IOWriter(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((faiss::IOWriter *)  ((faiss::VectorIOWriter *) x));
 }
 static swig_type_info _swigt__p_Crev = {"_p_Crev", "Crev *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_FILE = {"_p_FILE", "FILE *", 0, 0, (void*)0, 0};
@@ -64910,8 +73323,13 @@ static swig_type_info _swigt__p_faiss__IDSelectorBatch = {"_p_faiss__IDSelectorB
 static swig_type_info _swigt__p_faiss__IDSelectorRange = {"_p_faiss__IDSelectorRange", "faiss::IDSelectorRange *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IOReader = {"_p_faiss__IOReader", "faiss::IOReader *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IOWriter = {"_p_faiss__IOWriter", "faiss::IOWriter *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_faiss__IVFPQSearchParameters = {"_p_faiss__IVFPQSearchParameters", "faiss::IVFPQSearchParameters *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_faiss__IVFSearchParameters = {"_p_faiss__IVFSearchParameters", "faiss::IVFSearchParameters *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__Index = {"_p_faiss__Index", "faiss::Index *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__Index2Layer = {"_p_faiss__Index2Layer", "faiss::Index2Layer *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_faiss__IndexBinary = {"_p_faiss__IndexBinary", "faiss::IndexBinary *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_faiss__IndexBinaryFlat = {"_p_faiss__IndexBinaryFlat", "faiss::IndexBinaryFlat *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_faiss__IndexBinaryIVF = {"_p_faiss__IndexBinaryIVF", "faiss::IndexBinaryIVF *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IndexFlat = {"_p_faiss__IndexFlat", "faiss::IndexFlat *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IndexFlat1D = {"_p_faiss__IndexFlat1D", "faiss::IndexFlat1D *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IndexFlatIP = {"_p_faiss__IndexFlatIP", "faiss::IndexFlatIP *", 0, 0, (void*)0, 0};
@@ -64926,6 +73344,7 @@ static swig_type_info _swigt__p_faiss__IndexIDMap = {"_p_faiss__IndexIDMap", "fa
 static swig_type_info _swigt__p_faiss__IndexIDMap2 = {"_p_faiss__IndexIDMap2", "faiss::IndexIDMap2 *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IndexIVF = {"_p_faiss__IndexIVF", "faiss::IndexIVF *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IndexIVFFlat = {"_p_faiss__IndexIVFFlat", "faiss::IndexIVFFlat *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_faiss__IndexIVFFlatDedup = {"_p_faiss__IndexIVFFlatDedup", "faiss::IndexIVFFlatDedup *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IndexIVFPQ = {"_p_faiss__IndexIVFPQ", "faiss::IndexIVFPQ *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IndexIVFPQR = {"_p_faiss__IndexIVFPQR", "faiss::IndexIVFPQR *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__IndexIVFPQStats = {"_p_faiss__IndexIVFPQStats", "faiss::IndexIVFPQStats *", 0, 0, (void*)0, 0};
@@ -64971,12 +73390,14 @@ static swig_type_info _swigt__p_faiss__ScalarQuantizer = {"_p_faiss__ScalarQuant
 static swig_type_info _swigt__p_faiss__ScalarQuantizer__DistanceComputer = {"_p_faiss__ScalarQuantizer__DistanceComputer", "faiss::ScalarQuantizer::DistanceComputer *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__SimulatedAnnealingOptimizer = {"_p_faiss__SimulatedAnnealingOptimizer", "faiss::SimulatedAnnealingOptimizer *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__SimulatedAnnealingParameters = {"_p_faiss__SimulatedAnnealingParameters", "faiss::SimulatedAnnealingParameters *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_faiss__VectorIOReader = {"_p_faiss__VectorIOReader", "faiss::VectorIOReader *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_faiss__VectorIOWriter = {"_p_faiss__VectorIOWriter", "faiss::VectorIOWriter *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__VectorTransform = {"_p_faiss__VectorTransform", "faiss::VectorTransform *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_faiss__VisitedTable = {"_p_faiss__VisitedTable", "faiss::VisitedTable *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_float = {"_p_float", "float *|faiss::HeapArray< faiss::CMin< float,long > >::T *|faiss::HeapArray< faiss::CMax< float,long > >::T *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_idx_t = {"_p_idx_t", "idx_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_int = {"_p_int", "int *|int32_t *|hamdis_t *|faiss::HeapArray< faiss::CMin< int,long > >::T *|faiss::HeapArray< faiss::CMax< int,long > >::T *|faiss::IndexHNSW::storage_idx_t *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_long = {"_p_long", "long *|faiss::HeapArray< faiss::CMax< float,long > >::TI *|faiss::HeapArray< faiss::CMin< float,long > >::TI *|faiss::AutoTuneCriterion::idx_t *|faiss::ReconstructFromNeighbors::idx_t *|faiss::HNSW::idx_t *|faiss::InvertedLists::idx_t *|faiss::Index::idx_t *|faiss::RangeSearchResult::idx_t *|faiss::IDSelector::idx_t *|faiss::BufferList::idx_t *|faiss::HeapArray< faiss::CMin< int,long > >::TI *|faiss::HeapArray< faiss::CMax< int,long > >::TI *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_long = {"_p_long", "faiss::HeapArray< faiss::CMax< float,long > >::TI *|faiss::HeapArray< faiss::CMin< float,long > >::TI *|faiss::BufferList::idx_t *|faiss::IDSelector::idx_t *|faiss::RangeSearchResult::idx_t *|faiss::Index::idx_t *|faiss::InvertedLists::idx_t *|faiss::HNSW::idx_t *|faiss::ReconstructFromNeighbors::idx_t *|faiss::IndexBinary::idx_t *|faiss::AutoTuneCriterion::idx_t *|faiss::HeapArray< faiss::CMax< int,long > >::TI *|faiss::HeapArray< faiss::CMin< int,long > >::TI *|long *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_faiss__Index = {"_p_p_faiss__Index", "faiss::Index **", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_faiss__IndexPreTransform = {"_p_p_faiss__IndexPreTransform", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_p_faiss__IndexIVF = {"_p_p_faiss__IndexIVF", 0, 0, 0, 0, 0};
@@ -64989,6 +73410,7 @@ static swig_type_info _swigt__p_p_faiss__IndexHNSW = {"_p_p_faiss__IndexHNSW", 0
 static swig_type_info _swigt__p_p_faiss__IndexIVFFlat = {"_p_p_faiss__IndexIVFFlat", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_p_faiss__IndexLSH = {"_p_p_faiss__IndexLSH", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_p_faiss__IndexIVFPQR = {"_p_p_faiss__IndexIVFPQR", 0, 0, 0, 0, 0};
+static swig_type_info _swigt__p_p_faiss__IndexIVFFlatDedup = {"_p_p_faiss__IndexIVFFlatDedup", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_p_faiss__IndexFlat = {"_p_p_faiss__IndexFlat", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_p_faiss__IndexFlat1D = {"_p_p_faiss__IndexFlat1D", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_p_faiss__IndexFlatL2BaseShift = {"_p_p_faiss__IndexFlatL2BaseShift", 0, 0, 0, 0, 0};
@@ -65017,6 +73439,8 @@ static swig_type_info _swigt__p_p_faiss__RemapDimensionsTransform = {"_p_p_faiss
 static swig_type_info _swigt__p_p_faiss__NormalizationTransform = {"_p_p_faiss__NormalizationTransform", 0, 0, 0, 0, 0};
 static swig_type_info _swigt__p_std__listT_faiss__OnDiskInvertedLists__Slot_t = {"_p_std__listT_faiss__OnDiskInvertedLists__Slot_t", "std::list< faiss::OnDiskInvertedLists::Slot > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__unordered_mapT_long_long_t = {"_p_std__unordered_mapT_long_long_t", "std::unordered_map< long,long > *|std::unordered_map< faiss::Index::idx_t,faiss::Index::idx_t > *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_std__unordered_multimapT_long_long_t = {"_p_std__unordered_multimapT_long_long_t", "std::unordered_multimap< long,long > *|std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t > *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_std__vectorT_char_t = {"_p_std__vectorT_char_t", "std::vector< char > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__vectorT_double_t = {"_p_std__vectorT_double_t", "std::vector< double > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__vectorT_faiss__BufferList__Buffer_t = {"_p_std__vectorT_faiss__BufferList__Buffer_t", "std::vector< faiss::BufferList::Buffer > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__vectorT_faiss__Index_p_t = {"_p_std__vectorT_faiss__Index_p_t", "std::vector< faiss::Index * > *", 0, 0, (void*)0, 0};
@@ -65034,7 +73458,7 @@ static swig_type_info _swigt__p_std__vectorT_std__vectorT_float_t_t = {"_p_std__
 static swig_type_info _swigt__p_std__vectorT_std__vectorT_long_t_t = {"_p_std__vectorT_std__vectorT_long_t_t", "std::vector< std::vector< long > > *|std::vector< std::vector< faiss::InvertedLists::idx_t > > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__vectorT_std__vectorT_uint8_t_t_t = {"_p_std__vectorT_std__vectorT_uint8_t_t_t", "std::vector< std::vector< unsigned char > > *|std::vector< std::vector< uint8_t > > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__vectorT_unsigned_char_t = {"_p_std__vectorT_unsigned_char_t", "std::vector< unsigned char > *|std::vector< uint8_t > *|std::vector< faiss::IndexLSH::uint8_t > *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_std__vectorT_unsigned_long_t = {"_p_std__vectorT_unsigned_long_t", "std::vector< unsigned long > *|std::vector< size_t > *|std::vector< uint64_t > *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_std__vectorT_unsigned_long_t = {"_p_std__vectorT_unsigned_long_t", "std::vector< unsigned long > *|std::vector< size_t > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_storage_idx_t = {"_p_storage_idx_t", "storage_idx_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_uint32_t = {"_p_uint32_t", "uint32_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_unsigned_char = {"_p_unsigned_char", "unsigned char *|uint8_t *", 0, 0, (void*)0, 0};
@@ -65080,8 +73504,13 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_faiss__IDSelectorRange,
   &_swigt__p_faiss__IOReader,
   &_swigt__p_faiss__IOWriter,
+  &_swigt__p_faiss__IVFPQSearchParameters,
+  &_swigt__p_faiss__IVFSearchParameters,
   &_swigt__p_faiss__Index,
   &_swigt__p_faiss__Index2Layer,
+  &_swigt__p_faiss__IndexBinary,
+  &_swigt__p_faiss__IndexBinaryFlat,
+  &_swigt__p_faiss__IndexBinaryIVF,
   &_swigt__p_faiss__IndexFlat,
   &_swigt__p_faiss__IndexFlat1D,
   &_swigt__p_faiss__IndexFlatIP,
@@ -65096,6 +73525,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_faiss__IndexIDMap2,
   &_swigt__p_faiss__IndexIVF,
   &_swigt__p_faiss__IndexIVFFlat,
+  &_swigt__p_faiss__IndexIVFFlatDedup,
   &_swigt__p_faiss__IndexIVFPQ,
   &_swigt__p_faiss__IndexIVFPQR,
   &_swigt__p_faiss__IndexIVFPQStats,
@@ -65141,6 +73571,8 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_faiss__ScalarQuantizer__DistanceComputer,
   &_swigt__p_faiss__SimulatedAnnealingOptimizer,
   &_swigt__p_faiss__SimulatedAnnealingParameters,
+  &_swigt__p_faiss__VectorIOReader,
+  &_swigt__p_faiss__VectorIOWriter,
   &_swigt__p_faiss__VectorTransform,
   &_swigt__p_faiss__VisitedTable,
   &_swigt__p_float,
@@ -65164,6 +73596,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_p_faiss__IndexIDMap2,
   &_swigt__p_p_faiss__IndexIVF,
   &_swigt__p_p_faiss__IndexIVFFlat,
+  &_swigt__p_p_faiss__IndexIVFFlatDedup,
   &_swigt__p_p_faiss__IndexIVFPQ,
   &_swigt__p_p_faiss__IndexIVFPQR,
   &_swigt__p_p_faiss__IndexIVFScalarQuantizer,
@@ -65187,6 +73620,8 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_p_faiss__VectorTransform,
   &_swigt__p_std__listT_faiss__OnDiskInvertedLists__Slot_t,
   &_swigt__p_std__unordered_mapT_long_long_t,
+  &_swigt__p_std__unordered_multimapT_long_long_t,
+  &_swigt__p_std__vectorT_char_t,
   &_swigt__p_std__vectorT_double_t,
   &_swigt__p_std__vectorT_faiss__BufferList__Buffer_t,
   &_swigt__p_std__vectorT_faiss__Index_p_t,
@@ -65248,10 +73683,15 @@ static swig_cast_info _swigc__p_faiss__HeapArrayT_faiss__CMinT_int_long_t_t[] = 
 static swig_cast_info _swigc__p_faiss__IDSelector[] = {  {&_swigt__p_faiss__IDSelector, 0, 0, 0},  {&_swigt__p_faiss__IDSelectorBatch, _p_faiss__IDSelectorBatchTo_p_faiss__IDSelector, 0, 0},  {&_swigt__p_faiss__IDSelectorRange, _p_faiss__IDSelectorRangeTo_p_faiss__IDSelector, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IDSelectorBatch[] = {  {&_swigt__p_faiss__IDSelectorBatch, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IDSelectorRange[] = {  {&_swigt__p_faiss__IDSelectorRange, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_faiss__IOReader[] = {  {&_swigt__p_faiss__IOReader, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_faiss__IOWriter[] = {  {&_swigt__p_faiss__IOWriter, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_faiss__Index[] = {  {&_swigt__p_faiss__IndexPreTransform, _p_faiss__IndexPreTransformTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVF, _p_faiss__IndexIVFTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlatL2, _p_faiss__IndexFlatL2To_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSWFlat, _p_faiss__IndexHNSWFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__Index2Layer, _p_faiss__Index2LayerTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSWPQ, _p_faiss__IndexHNSWPQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSW, _p_faiss__IndexHNSWTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFFlat, _p_faiss__IndexIVFFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlatIP, _p_faiss__IndexFlatIPTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFPQR, _p_faiss__IndexIVFPQRTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexLSH, _p_faiss__IndexLSHTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlat, _p_faiss__IndexFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlat1D, _p_faiss__IndexFlat1DTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlatL2BaseShift, _p_faiss__IndexFlatL2BaseShiftTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexShards, _p_faiss__IndexShardsTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSW2Level, _p_faiss__IndexHNSW2LevelTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIDMap2, _p_faiss__IndexIDMap2To_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexSplitVectors, _p_faiss__IndexSplitVectorsTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__Index, 0, 0, 0},  {&_swigt__p_faiss__IndexRefineFlat, _p_faiss__IndexRefineFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSWSQ, _p_faiss__IndexHNSWSQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__MultiIndexQuantizer2, _p_faiss__MultiIndexQuantizer2To_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexPQ, _p_faiss__IndexPQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIDMap, _p_faiss__IndexIDMapTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFPQ, _p_faiss__IndexIVFPQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFScalarQuantizer, _p_faiss__IndexIVFScalarQuantizerTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexScalarQuantizer, _p_faiss__IndexScalarQuantizerTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__MultiIndexQuantizer, _p_faiss__MultiIndexQuantizerTo_p_faiss__Index, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IOReader[] = {  {&_swigt__p_faiss__IOReader, 0, 0, 0},  {&_swigt__p_faiss__VectorIOReader, _p_faiss__VectorIOReaderTo_p_faiss__IOReader, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IOWriter[] = {  {&_swigt__p_faiss__IOWriter, 0, 0, 0},  {&_swigt__p_faiss__VectorIOWriter, _p_faiss__VectorIOWriterTo_p_faiss__IOWriter, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IVFPQSearchParameters[] = {  {&_swigt__p_faiss__IVFPQSearchParameters, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IVFSearchParameters[] = {  {&_swigt__p_faiss__IVFSearchParameters, 0, 0, 0},  {&_swigt__p_faiss__IVFPQSearchParameters, _p_faiss__IVFPQSearchParametersTo_p_faiss__IVFSearchParameters, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__Index[] = {  {&_swigt__p_faiss__IndexPreTransform, _p_faiss__IndexPreTransformTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVF, _p_faiss__IndexIVFTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlatL2, _p_faiss__IndexFlatL2To_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSWFlat, _p_faiss__IndexHNSWFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__Index2Layer, _p_faiss__Index2LayerTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSWPQ, _p_faiss__IndexHNSWPQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFFlat, _p_faiss__IndexIVFFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSW, _p_faiss__IndexHNSWTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlatIP, _p_faiss__IndexFlatIPTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFPQR, _p_faiss__IndexIVFPQRTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFFlatDedup, _p_faiss__IndexIVFFlatDedupTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexLSH, _p_faiss__IndexLSHTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlat, _p_faiss__IndexFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlat1D, _p_faiss__IndexFlat1DTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexFlatL2BaseShift, _p_faiss__IndexFlatL2BaseShiftTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexShards, _p_faiss__IndexShardsTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSW2Level, _p_faiss__IndexHNSW2LevelTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIDMap2, _p_faiss__IndexIDMap2To_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexSplitVectors, _p_faiss__IndexSplitVectorsTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__Index, 0, 0, 0},  {&_swigt__p_faiss__IndexRefineFlat, _p_faiss__IndexRefineFlatTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexHNSWSQ, _p_faiss__IndexHNSWSQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__MultiIndexQuantizer2, _p_faiss__MultiIndexQuantizer2To_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexPQ, _p_faiss__IndexPQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIDMap, _p_faiss__IndexIDMapTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFPQ, _p_faiss__IndexIVFPQTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexIVFScalarQuantizer, _p_faiss__IndexIVFScalarQuantizerTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__IndexScalarQuantizer, _p_faiss__IndexScalarQuantizerTo_p_faiss__Index, 0, 0},  {&_swigt__p_faiss__MultiIndexQuantizer, _p_faiss__MultiIndexQuantizerTo_p_faiss__Index, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__Index2Layer[] = {  {&_swigt__p_faiss__Index2Layer, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IndexBinary[] = {  {&_swigt__p_faiss__IndexBinaryFlat, _p_faiss__IndexBinaryFlatTo_p_faiss__IndexBinary, 0, 0},  {&_swigt__p_faiss__IndexBinary, 0, 0, 0},  {&_swigt__p_faiss__IndexBinaryIVF, _p_faiss__IndexBinaryIVFTo_p_faiss__IndexBinary, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IndexBinaryFlat[] = {  {&_swigt__p_faiss__IndexBinaryFlat, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IndexBinaryIVF[] = {  {&_swigt__p_faiss__IndexBinaryIVF, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IndexFlat[] = {  {&_swigt__p_faiss__IndexFlat, 0, 0, 0},  {&_swigt__p_faiss__IndexFlatL2, _p_faiss__IndexFlatL2To_p_faiss__IndexFlat, 0, 0},  {&_swigt__p_faiss__IndexFlat1D, _p_faiss__IndexFlat1DTo_p_faiss__IndexFlat, 0, 0},  {&_swigt__p_faiss__IndexFlatL2BaseShift, _p_faiss__IndexFlatL2BaseShiftTo_p_faiss__IndexFlat, 0, 0},  {&_swigt__p_faiss__IndexFlatIP, _p_faiss__IndexFlatIPTo_p_faiss__IndexFlat, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IndexFlat1D[] = {  {&_swigt__p_faiss__IndexFlat1D, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IndexFlatIP[] = {  {&_swigt__p_faiss__IndexFlatIP, 0, 0, 0},{0, 0, 0, 0}};
@@ -65264,8 +73704,9 @@ static swig_cast_info _swigc__p_faiss__IndexHNSWPQ[] = {  {&_swigt__p_faiss__Ind
 static swig_cast_info _swigc__p_faiss__IndexHNSWSQ[] = {  {&_swigt__p_faiss__IndexHNSWSQ, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IndexIDMap[] = {  {&_swigt__p_faiss__IndexIDMap2, _p_faiss__IndexIDMap2To_p_faiss__IndexIDMap, 0, 0},  {&_swigt__p_faiss__IndexIDMap, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IndexIDMap2[] = {  {&_swigt__p_faiss__IndexIDMap2, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_faiss__IndexIVF[] = {  {&_swigt__p_faiss__IndexIVF, 0, 0, 0},  {&_swigt__p_faiss__IndexIVFScalarQuantizer, _p_faiss__IndexIVFScalarQuantizerTo_p_faiss__IndexIVF, 0, 0},  {&_swigt__p_faiss__IndexIVFPQ, _p_faiss__IndexIVFPQTo_p_faiss__IndexIVF, 0, 0},  {&_swigt__p_faiss__IndexIVFFlat, _p_faiss__IndexIVFFlatTo_p_faiss__IndexIVF, 0, 0},  {&_swigt__p_faiss__IndexIVFPQR, _p_faiss__IndexIVFPQRTo_p_faiss__IndexIVF, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_faiss__IndexIVFFlat[] = {  {&_swigt__p_faiss__IndexIVFFlat, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IndexIVF[] = {  {&_swigt__p_faiss__IndexIVF, 0, 0, 0},  {&_swigt__p_faiss__IndexIVFScalarQuantizer, _p_faiss__IndexIVFScalarQuantizerTo_p_faiss__IndexIVF, 0, 0},  {&_swigt__p_faiss__IndexIVFPQ, _p_faiss__IndexIVFPQTo_p_faiss__IndexIVF, 0, 0},  {&_swigt__p_faiss__IndexIVFFlat, _p_faiss__IndexIVFFlatTo_p_faiss__IndexIVF, 0, 0},  {&_swigt__p_faiss__IndexIVFFlatDedup, _p_faiss__IndexIVFFlatDedupTo_p_faiss__IndexIVF, 0, 0},  {&_swigt__p_faiss__IndexIVFPQR, _p_faiss__IndexIVFPQRTo_p_faiss__IndexIVF, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IndexIVFFlat[] = {  {&_swigt__p_faiss__IndexIVFFlat, 0, 0, 0},  {&_swigt__p_faiss__IndexIVFFlatDedup, _p_faiss__IndexIVFFlatDedupTo_p_faiss__IndexIVFFlat, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__IndexIVFFlatDedup[] = {  {&_swigt__p_faiss__IndexIVFFlatDedup, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IndexIVFPQ[] = {  {&_swigt__p_faiss__IndexIVFPQ, 0, 0, 0},  {&_swigt__p_faiss__IndexIVFPQR, _p_faiss__IndexIVFPQRTo_p_faiss__IndexIVFPQ, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IndexIVFPQR[] = {  {&_swigt__p_faiss__IndexIVFPQR, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IndexIVFPQStats[] = {  {&_swigt__p_faiss__IndexIVFPQStats, 0, 0, 0},{0, 0, 0, 0}};
@@ -65281,7 +73722,7 @@ static swig_cast_info _swigc__p_faiss__IndexShards[] = {  {&_swigt__p_faiss__Ind
 static swig_cast_info _swigc__p_faiss__IndexSplitVectors[] = {  {&_swigt__p_faiss__IndexSplitVectors, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__IntersectionCriterion[] = {  {&_swigt__p_faiss__IntersectionCriterion, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__InvertedLists[] = {  {&_swigt__p_faiss__InvertedLists, 0, 0, 0},  {&_swigt__p_faiss__ArrayInvertedLists, _p_faiss__ArrayInvertedListsTo_p_faiss__InvertedLists, 0, 0},  {&_swigt__p_faiss__OnDiskInvertedLists, _p_faiss__OnDiskInvertedListsTo_p_faiss__InvertedLists, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_faiss__Level1Quantizer[] = {  {&_swigt__p_faiss__Level1Quantizer, 0, 0, 0},  {&_swigt__p_faiss__IndexIVF, _p_faiss__IndexIVFTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFScalarQuantizer, _p_faiss__IndexIVFScalarQuantizerTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFPQ, _p_faiss__IndexIVFPQTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFFlat, _p_faiss__IndexIVFFlatTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFPQR, _p_faiss__IndexIVFPQRTo_p_faiss__Level1Quantizer, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__Level1Quantizer[] = {  {&_swigt__p_faiss__Level1Quantizer, 0, 0, 0},  {&_swigt__p_faiss__IndexIVF, _p_faiss__IndexIVFTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFScalarQuantizer, _p_faiss__IndexIVFScalarQuantizerTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFPQ, _p_faiss__IndexIVFPQTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFFlat, _p_faiss__IndexIVFFlatTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFFlatDedup, _p_faiss__IndexIVFFlatDedupTo_p_faiss__Level1Quantizer, 0, 0},  {&_swigt__p_faiss__IndexIVFPQR, _p_faiss__IndexIVFPQRTo_p_faiss__Level1Quantizer, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__LinearTransform[] = {  {&_swigt__p_faiss__RandomRotationMatrix, _p_faiss__RandomRotationMatrixTo_p_faiss__LinearTransform, 0, 0},  {&_swigt__p_faiss__PCAMatrix, _p_faiss__PCAMatrixTo_p_faiss__LinearTransform, 0, 0},  {&_swigt__p_faiss__OPQMatrix, _p_faiss__OPQMatrixTo_p_faiss__LinearTransform, 0, 0},  {&_swigt__p_faiss__LinearTransform, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__LockLevels[] = {  {&_swigt__p_faiss__LockLevels, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__MultiIndexQuantizer[] = {  {&_swigt__p_faiss__MultiIndexQuantizer, 0, 0, 0},  {&_swigt__p_faiss__MultiIndexQuantizer2, _p_faiss__MultiIndexQuantizer2To_p_faiss__MultiIndexQuantizer, 0, 0},{0, 0, 0, 0}};
@@ -65311,6 +73752,8 @@ static swig_cast_info _swigc__p_faiss__ScalarQuantizer[] = {  {&_swigt__p_faiss_
 static swig_cast_info _swigc__p_faiss__ScalarQuantizer__DistanceComputer[] = {  {&_swigt__p_faiss__ScalarQuantizer__DistanceComputer, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__SimulatedAnnealingOptimizer[] = {  {&_swigt__p_faiss__SimulatedAnnealingOptimizer, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__SimulatedAnnealingParameters[] = {  {&_swigt__p_faiss__SimulatedAnnealingParameters, 0, 0, 0},  {&_swigt__p_faiss__PolysemousTraining, _p_faiss__PolysemousTrainingTo_p_faiss__SimulatedAnnealingParameters, 0, 0},  {&_swigt__p_faiss__SimulatedAnnealingOptimizer, _p_faiss__SimulatedAnnealingOptimizerTo_p_faiss__SimulatedAnnealingParameters, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__VectorIOReader[] = {  {&_swigt__p_faiss__VectorIOReader, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_faiss__VectorIOWriter[] = {  {&_swigt__p_faiss__VectorIOWriter, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__VectorTransform[] = {  {&_swigt__p_faiss__RandomRotationMatrix, _p_faiss__RandomRotationMatrixTo_p_faiss__VectorTransform, 0, 0},  {&_swigt__p_faiss__PCAMatrix, _p_faiss__PCAMatrixTo_p_faiss__VectorTransform, 0, 0},  {&_swigt__p_faiss__OPQMatrix, _p_faiss__OPQMatrixTo_p_faiss__VectorTransform, 0, 0},  {&_swigt__p_faiss__VectorTransform, 0, 0, 0},  {&_swigt__p_faiss__LinearTransform, _p_faiss__LinearTransformTo_p_faiss__VectorTransform, 0, 0},  {&_swigt__p_faiss__RemapDimensionsTransform, _p_faiss__RemapDimensionsTransformTo_p_faiss__VectorTransform, 0, 0},  {&_swigt__p_faiss__NormalizationTransform, _p_faiss__NormalizationTransformTo_p_faiss__VectorTransform, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_faiss__VisitedTable[] = {  {&_swigt__p_faiss__VisitedTable, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_float[] = {  {&_swigt__p_float, 0, 0, 0},{0, 0, 0, 0}};
@@ -65328,6 +73771,7 @@ static swig_cast_info _swigc__p_p_faiss__IndexHNSW[] = {{&_swigt__p_p_faiss__Ind
 static swig_cast_info _swigc__p_p_faiss__IndexIVFFlat[] = {{&_swigt__p_p_faiss__IndexIVFFlat, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__IndexLSH[] = {{&_swigt__p_p_faiss__IndexLSH, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__IndexIVFPQR[] = {{&_swigt__p_p_faiss__IndexIVFPQR, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_p_faiss__IndexIVFFlatDedup[] = {{&_swigt__p_p_faiss__IndexIVFFlatDedup, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__IndexFlat[] = {{&_swigt__p_p_faiss__IndexFlat, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__IndexFlat1D[] = {{&_swigt__p_p_faiss__IndexFlat1D, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__IndexFlatL2BaseShift[] = {{&_swigt__p_p_faiss__IndexFlatL2BaseShift, 0, 0, 0},{0, 0, 0, 0}};
@@ -65344,7 +73788,7 @@ static swig_cast_info _swigc__p_p_faiss__IndexIVFPQ[] = {{&_swigt__p_p_faiss__In
 static swig_cast_info _swigc__p_p_faiss__IndexIVFScalarQuantizer[] = {{&_swigt__p_p_faiss__IndexIVFScalarQuantizer, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__IndexScalarQuantizer[] = {{&_swigt__p_p_faiss__IndexScalarQuantizer, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__MultiIndexQuantizer[] = {{&_swigt__p_p_faiss__MultiIndexQuantizer, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_p_faiss__Index[] = {  {&_swigt__p_p_faiss__IndexPreTransform, _p_p_faiss__IndexPreTransformTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVF, _p_p_faiss__IndexIVFTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlatL2, _p_p_faiss__IndexFlatL2To_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSWFlat, _p_p_faiss__IndexHNSWFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__Index2Layer, _p_p_faiss__Index2LayerTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSWPQ, _p_p_faiss__IndexHNSWPQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlatIP, _p_p_faiss__IndexFlatIPTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSW, _p_p_faiss__IndexHNSWTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFFlat, _p_p_faiss__IndexIVFFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexLSH, _p_p_faiss__IndexLSHTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFPQR, _p_p_faiss__IndexIVFPQRTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlat, _p_p_faiss__IndexFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlat1D, _p_p_faiss__IndexFlat1DTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlatL2BaseShift, _p_p_faiss__IndexFlatL2BaseShiftTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexShards, _p_p_faiss__IndexShardsTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSW2Level, _p_p_faiss__IndexHNSW2LevelTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIDMap2, _p_p_faiss__IndexIDMap2To_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexSplitVectors, _p_p_faiss__IndexSplitVectorsTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__Index, 0, 0, 0},  {&_swigt__p_p_faiss__IndexRefineFlat, _p_p_faiss__IndexRefineFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSWSQ, _p_p_faiss__IndexHNSWSQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__MultiIndexQuantizer2, _p_p_faiss__MultiIndexQuantizer2To_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexPQ, _p_p_faiss__IndexPQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIDMap, _p_p_faiss__IndexIDMapTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFPQ, _p_p_faiss__IndexIVFPQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFScalarQuantizer, _p_p_faiss__IndexIVFScalarQuantizerTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexScalarQuantizer, _p_p_faiss__IndexScalarQuantizerTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__MultiIndexQuantizer, _p_p_faiss__MultiIndexQuantizerTo_p_p_faiss__Index, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_p_faiss__Index[] = {  {&_swigt__p_p_faiss__IndexPreTransform, _p_p_faiss__IndexPreTransformTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVF, _p_p_faiss__IndexIVFTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlatL2, _p_p_faiss__IndexFlatL2To_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSWFlat, _p_p_faiss__IndexHNSWFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__Index2Layer, _p_p_faiss__Index2LayerTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSWPQ, _p_p_faiss__IndexHNSWPQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlatIP, _p_p_faiss__IndexFlatIPTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSW, _p_p_faiss__IndexHNSWTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFFlat, _p_p_faiss__IndexIVFFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexLSH, _p_p_faiss__IndexLSHTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFPQR, _p_p_faiss__IndexIVFPQRTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFFlatDedup, _p_p_faiss__IndexIVFFlatDedupTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlat, _p_p_faiss__IndexFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlat1D, _p_p_faiss__IndexFlat1DTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexFlatL2BaseShift, _p_p_faiss__IndexFlatL2BaseShiftTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexShards, _p_p_faiss__IndexShardsTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSW2Level, _p_p_faiss__IndexHNSW2LevelTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIDMap2, _p_p_faiss__IndexIDMap2To_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexSplitVectors, _p_p_faiss__IndexSplitVectorsTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__Index, 0, 0, 0},  {&_swigt__p_p_faiss__IndexRefineFlat, _p_p_faiss__IndexRefineFlatTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexHNSWSQ, _p_p_faiss__IndexHNSWSQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__MultiIndexQuantizer2, _p_p_faiss__MultiIndexQuantizer2To_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexPQ, _p_p_faiss__IndexPQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIDMap, _p_p_faiss__IndexIDMapTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFPQ, _p_p_faiss__IndexIVFPQTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexIVFScalarQuantizer, _p_p_faiss__IndexIVFScalarQuantizerTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__IndexScalarQuantizer, _p_p_faiss__IndexScalarQuantizerTo_p_p_faiss__Index, 0, 0},  {&_swigt__p_p_faiss__MultiIndexQuantizer, _p_p_faiss__MultiIndexQuantizerTo_p_p_faiss__Index, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__ArrayInvertedLists[] = {{&_swigt__p_p_faiss__ArrayInvertedLists, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__OnDiskInvertedLists[] = {{&_swigt__p_p_faiss__OnDiskInvertedLists, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_faiss__InvertedLists[] = {  {&_swigt__p_p_faiss__InvertedLists, 0, 0, 0},  {&_swigt__p_p_faiss__ArrayInvertedLists, _p_p_faiss__ArrayInvertedListsTo_p_p_faiss__InvertedLists, 0, 0},  {&_swigt__p_p_faiss__OnDiskInvertedLists, _p_p_faiss__OnDiskInvertedListsTo_p_p_faiss__InvertedLists, 0, 0},{0, 0, 0, 0}};
@@ -65357,6 +73801,8 @@ static swig_cast_info _swigc__p_p_faiss__NormalizationTransform[] = {{&_swigt__p
 static swig_cast_info _swigc__p_p_faiss__VectorTransform[] = {  {&_swigt__p_p_faiss__RandomRotationMatrix, _p_p_faiss__RandomRotationMatrixTo_p_p_faiss__VectorTransform, 0, 0},  {&_swigt__p_p_faiss__PCAMatrix, _p_p_faiss__PCAMatrixTo_p_p_faiss__VectorTransform, 0, 0},  {&_swigt__p_p_faiss__OPQMatrix, _p_p_faiss__OPQMatrixTo_p_p_faiss__VectorTransform, 0, 0},  {&_swigt__p_p_faiss__VectorTransform, 0, 0, 0},  {&_swigt__p_p_faiss__LinearTransform, _p_p_faiss__LinearTransformTo_p_p_faiss__VectorTransform, 0, 0},  {&_swigt__p_p_faiss__RemapDimensionsTransform, _p_p_faiss__RemapDimensionsTransformTo_p_p_faiss__VectorTransform, 0, 0},  {&_swigt__p_p_faiss__NormalizationTransform, _p_p_faiss__NormalizationTransformTo_p_p_faiss__VectorTransform, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__listT_faiss__OnDiskInvertedLists__Slot_t[] = {  {&_swigt__p_std__listT_faiss__OnDiskInvertedLists__Slot_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__unordered_mapT_long_long_t[] = {  {&_swigt__p_std__unordered_mapT_long_long_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_std__unordered_multimapT_long_long_t[] = {  {&_swigt__p_std__unordered_multimapT_long_long_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_std__vectorT_char_t[] = {  {&_swigt__p_std__vectorT_char_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__vectorT_double_t[] = {  {&_swigt__p_std__vectorT_double_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__vectorT_faiss__BufferList__Buffer_t[] = {  {&_swigt__p_std__vectorT_faiss__BufferList__Buffer_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__vectorT_faiss__Index_p_t[] = {  {&_swigt__p_std__vectorT_faiss__Index_p_t, 0, 0, 0},{0, 0, 0, 0}};
@@ -65420,8 +73866,13 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_faiss__IDSelectorRange,
   _swigc__p_faiss__IOReader,
   _swigc__p_faiss__IOWriter,
+  _swigc__p_faiss__IVFPQSearchParameters,
+  _swigc__p_faiss__IVFSearchParameters,
   _swigc__p_faiss__Index,
   _swigc__p_faiss__Index2Layer,
+  _swigc__p_faiss__IndexBinary,
+  _swigc__p_faiss__IndexBinaryFlat,
+  _swigc__p_faiss__IndexBinaryIVF,
   _swigc__p_faiss__IndexFlat,
   _swigc__p_faiss__IndexFlat1D,
   _swigc__p_faiss__IndexFlatIP,
@@ -65436,6 +73887,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_faiss__IndexIDMap2,
   _swigc__p_faiss__IndexIVF,
   _swigc__p_faiss__IndexIVFFlat,
+  _swigc__p_faiss__IndexIVFFlatDedup,
   _swigc__p_faiss__IndexIVFPQ,
   _swigc__p_faiss__IndexIVFPQR,
   _swigc__p_faiss__IndexIVFPQStats,
@@ -65481,6 +73933,8 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_faiss__ScalarQuantizer__DistanceComputer,
   _swigc__p_faiss__SimulatedAnnealingOptimizer,
   _swigc__p_faiss__SimulatedAnnealingParameters,
+  _swigc__p_faiss__VectorIOReader,
+  _swigc__p_faiss__VectorIOWriter,
   _swigc__p_faiss__VectorTransform,
   _swigc__p_faiss__VisitedTable,
   _swigc__p_float,
@@ -65504,6 +73958,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_p_faiss__IndexIDMap2,
   _swigc__p_p_faiss__IndexIVF,
   _swigc__p_p_faiss__IndexIVFFlat,
+  _swigc__p_p_faiss__IndexIVFFlatDedup,
   _swigc__p_p_faiss__IndexIVFPQ,
   _swigc__p_p_faiss__IndexIVFPQR,
   _swigc__p_p_faiss__IndexIVFScalarQuantizer,
@@ -65527,6 +73982,8 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_p_faiss__VectorTransform,
   _swigc__p_std__listT_faiss__OnDiskInvertedLists__Slot_t,
   _swigc__p_std__unordered_mapT_long_long_t,
+  _swigc__p_std__unordered_multimapT_long_long_t,
+  _swigc__p_std__vectorT_char_t,
   _swigc__p_std__vectorT_double_t,
   _swigc__p_std__vectorT_faiss__BufferList__Buffer_t,
   _swigc__p_std__vectorT_faiss__Index_p_t,
@@ -66241,6 +74698,7 @@ SWIG_init(void) {
   SWIG_InstallConstants(d,swig_const_table);
   
   PyDict_SetItemString(md,(char *)"cvar", SWIG_globals());
+  SWIG_addvarlink(SWIG_globals(),(char *)"hamming_batch_size",Swig_var_hamming_batch_size_get, Swig_var_hamming_batch_size_set);
   SWIG_addvarlink(SWIG_globals(),(char *)"distance_compute_blas_threshold",Swig_var_distance_compute_blas_threshold_get, Swig_var_distance_compute_blas_threshold_set);
   SWIG_Python_SetConstant(d, "METRIC_INNER_PRODUCT",SWIG_From_int(static_cast< int >(faiss::METRIC_INNER_PRODUCT)));
   SWIG_Python_SetConstant(d, "METRIC_L2",SWIG_From_int(static_cast< int >(faiss::METRIC_L2)));
@@ -66264,6 +74722,7 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "ScalarQuantizer_QT_4bit",SWIG_From_int(static_cast< int >(faiss::ScalarQuantizer::QT_4bit)));
   SWIG_Python_SetConstant(d, "ScalarQuantizer_QT_8bit_uniform",SWIG_From_int(static_cast< int >(faiss::ScalarQuantizer::QT_8bit_uniform)));
   SWIG_Python_SetConstant(d, "ScalarQuantizer_QT_4bit_uniform",SWIG_From_int(static_cast< int >(faiss::ScalarQuantizer::QT_4bit_uniform)));
+  SWIG_Python_SetConstant(d, "ScalarQuantizer_QT_fp16",SWIG_From_int(static_cast< int >(faiss::ScalarQuantizer::QT_fp16)));
   SWIG_Python_SetConstant(d, "ScalarQuantizer_RS_minmax",SWIG_From_int(static_cast< int >(faiss::ScalarQuantizer::RS_minmax)));
   SWIG_Python_SetConstant(d, "ScalarQuantizer_RS_meanstd",SWIG_From_int(static_cast< int >(faiss::ScalarQuantizer::RS_meanstd)));
   SWIG_Python_SetConstant(d, "ScalarQuantizer_RS_quantiles",SWIG_From_int(static_cast< int >(faiss::ScalarQuantizer::RS_quantiles)));

--- a/tests/test_binary_factory.py
+++ b/tests/test_binary_factory.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD+Patents license found in the
+# LICENSE file in the root directory of this source tree.
+
+#! /usr/bin/env python2
+
+import unittest
+import faiss
+
+
+class TestBinaryFactory(unittest.TestCase):
+
+    def test_factory_1(self):
+
+        index = faiss.index_binary_factory(16, "BIVF10")
+        assert index.invlists is not None
+
+    def test_factory_2(self):
+
+        index = faiss.index_binary_factory(16, "BFlat")
+        assert index.code_size == 2

--- a/tests/test_binary_flat.cpp
+++ b/tests/test_binary_flat.cpp
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+
+#include <gtest/gtest.h>
+
+#include <faiss/IndexBinaryFlat.h>
+#include <faiss/hamming.h>
+
+TEST(BinaryFlat, accuracy) {
+  // dimension of the vectors to index
+  int d = 64;
+
+  // size of the database we plan to index
+  size_t nb = 1000;
+
+  // make the index object and train it
+  faiss::IndexBinaryFlat index(d);
+
+  srand(35);
+
+  std::vector<uint8_t> database(nb * (d / 8));
+  for (size_t i = 0; i < nb * (d / 8); i++) {
+    database[i] = rand() % 0x100;
+  }
+
+  { // populating the database
+    index.add(nb, database.data());
+  }
+
+  int nq = 200;
+
+  { // searching the database
+
+    std::vector<uint8_t> queries(nq * (d / 8));
+    for (size_t i = 0; i < nq * (d / 8); i++) {
+      queries[i] = rand() % 0x100;
+    }
+
+    int k = 5;
+    std::vector<faiss::IndexBinary::idx_t> nns(k * nq);
+    std::vector<int>                     dis(k * nq);
+
+    index.search(nq, queries.data(), k, dis.data(), nns.data());
+
+    for (size_t i = 0; i < nq; ++i) {
+      faiss::HammingComputer8 hc(queries.data() + i * (d / 8), d / 8);
+      hamdis_t dist_min = hc.hamming(database.data());
+      for (size_t j = 1; j < nb; ++j) {
+        hamdis_t dist = hc.hamming(database.data() + j * (d / 8));
+        if (dist < dist_min) {
+          dist_min = dist;
+        }
+      }
+      EXPECT_EQ(dist_min, dis[k * i]);
+    }
+  }
+}

--- a/tests/test_binary_io.py
+++ b/tests/test_binary_io.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD+Patents license found in the
+# LICENSE file in the root directory of this source tree.
+
+#! /usr/bin/env python2
+
+"""Binary indexes (de)serialization"""
+
+import numpy as np
+import unittest
+import faiss
+import os
+
+def make_binary_dataset(d, nb, nt, nq):
+    assert d % 8 == 0
+    x = np.random.randint(256, size=(nb + nq + nt, int(d / 8))).astype('uint8')
+    return x[:nt], x[nt:-nq], x[-nq:]
+
+
+class TestBinaryFlat(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        unittest.TestCase.__init__(self, *args, **kwargs)
+        d = 32
+        nt = 0
+        nb = 1500
+        nq = 500
+
+        (_, self.xb, self.xq) = make_binary_dataset(d, nb, nt, nq)
+
+    def test_flat(self):
+        d = self.xq.shape[1] * 8
+
+        index = faiss.IndexBinaryFlat(d)
+        index.add(self.xb)
+        D, I = index.search(self.xq, 3)
+
+        tmpnam = os.tempnam()
+        try:
+            faiss.write_index_binary(index, tmpnam)
+
+            index2 = faiss.read_index_binary(tmpnam)
+
+            D2, I2 = index2.search(self.xq, 3)
+
+            assert (I2 == I).all()
+            assert (D2 == D).all()
+
+        finally:
+            os.remove(tmpnam)
+
+
+class TestBinaryIVF(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        unittest.TestCase.__init__(self, *args, **kwargs)
+        d = 32
+        nt = 200
+        nb = 1500
+        nq = 500
+
+        (self.xt, self.xb, self.xq) = make_binary_dataset(d, nb, nt, nq)
+
+    def test_ivf_flat(self):
+        d = self.xq.shape[1] * 8
+
+        quantizer = faiss.IndexBinaryFlat(d)
+        index = faiss.IndexBinaryIVF(quantizer, d, 8)
+        index.cp.min_points_per_centroid = 5    # quiet warning
+        index.nprobe = 4
+        index.train(self.xt)
+        index.add(self.xb)
+        D, I = index.search(self.xq, 3)
+
+        tmpnam = os.tempnam()
+
+        try:
+            faiss.write_index_binary(index, tmpnam)
+
+            index2 = faiss.read_index_binary(tmpnam)
+
+            D2, I2 = index2.search(self.xq, 3)
+
+            assert (I2 == I).all()
+            assert (D2 == D).all()
+
+        finally:
+            os.remove(tmpnam)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -47,3 +47,7 @@ class TestFactory(unittest.TestCase):
         index = faiss.index_factory(12, "PCAR8,IVF10,PQ4")
         faiss.ParameterSpace().set_index_parameter(index, "nprobe", 3)
         assert faiss.downcast_index(index.index).nprobe == 3
+
+    def test_factory_4(self):
+        index = faiss.index_factory(12, "IVF10,FlatDedup")
+        assert index.instances is not None

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -224,7 +224,7 @@ class TestScalarQuantizer(unittest.TestCase):
         D, I = index.search(xq, 10)
         nok['flat'] = (I[:, 0] == I_ref[:, 0]).sum()
 
-        for qname in "QT_4bit QT_4bit_uniform QT_8bit QT_8bit_uniform".split():
+        for qname in "QT_4bit QT_4bit_uniform QT_8bit QT_8bit_uniform QT_fp16".split():
             qtype = getattr(faiss.ScalarQuantizer, qname)
             index = faiss.IndexIVFScalarQuantizer(quantizer, d, ncent,
                                                   qtype, faiss.METRIC_L2)
@@ -236,6 +236,7 @@ class TestScalarQuantizer(unittest.TestCase):
 
             nok[qname] = (I[:, 0] == I_ref[:, 0]).sum()
         print(nok, nq)
+
         self.assertGreaterEqual(nok['flat'], nq * 0.6)
         # The tests below are a bit fragile, it happens that the
         # ordering between uniform and non-uniform are reverted,
@@ -245,6 +246,7 @@ class TestScalarQuantizer(unittest.TestCase):
         self.assertGreaterEqual(nok['QT_8bit'], nok['QT_4bit'])
         self.assertGreaterEqual(nok['QT_8bit'], nok['QT_8bit_uniform'])
         self.assertGreaterEqual(nok['QT_4bit'], nok['QT_4bit_uniform'])
+        self.assertGreaterEqual(nok['QT_fp16'], nok['QT_8bit'])
 
     def test_4variants(self):
         d = 32
@@ -260,7 +262,7 @@ class TestScalarQuantizer(unittest.TestCase):
 
         nok = {}
 
-        for qname in "QT_4bit QT_4bit_uniform QT_8bit QT_8bit_uniform".split():
+        for qname in "QT_4bit QT_4bit_uniform QT_8bit QT_8bit_uniform QT_fp16".split():
             qtype = getattr(faiss.ScalarQuantizer, qname)
             index = faiss.IndexScalarQuantizer(d, qtype, faiss.METRIC_L2)
             index.train(xt)
@@ -270,10 +272,13 @@ class TestScalarQuantizer(unittest.TestCase):
 
             nok[qname] = (I[:, 0] == I_ref[:, 0]).sum()
 
+        print(nok, nq)
+
         self.assertGreaterEqual(nok['QT_8bit'], nq * 0.9)
         self.assertGreaterEqual(nok['QT_8bit'], nok['QT_4bit'])
         self.assertGreaterEqual(nok['QT_8bit'], nok['QT_8bit_uniform'])
         self.assertGreaterEqual(nok['QT_4bit'], nok['QT_4bit_uniform'])
+        self.assertGreaterEqual(nok['QT_fp16'], nok['QT_8bit'])
 
 
 class TestRangeSearch(unittest.TestCase):
@@ -474,78 +479,6 @@ class TestHNSW(unittest.TestCase):
 
         self.io_and_retest(index, Dhnsw, Ihnsw)
 
-
-def make_binary_dataset(d, nb, nt, nq):
-    assert d % 8 == 0
-    x = np.random.randint(256, size=(nb + nq + nt, int(d / 8))).astype('uint8')
-    return x[:nt], x[nt:-nq], x[-nq:]
-
-
-def binary_to_float(x):
-    n, d = x.shape
-    x8 = x.reshape(n * d, -1)
-    c8 = 2 * ((x8 >> np.arange(8)) & 1).astype('int8') - 1
-    return c8.astype('float32').reshape(n, d * 8)
-
-
-def binary_dis(x, y):
-    return sum([faiss.popcount64(int(xi ^ yi)) for xi, yi in zip(x, y)])
-
-
-class TestBinaryPQ(unittest.TestCase):
-    """ Use a PQ that mimicks a binary encoder """
-
-    def test_encode_to_binary(self):
-        d = 256
-        nt = 256
-        nb = 1500
-        nq = 500
-        (xt, xb, xq) = make_binary_dataset(d, nb, nt, nq)
-        pq = faiss.ProductQuantizer(d, int(d / 8), 8)
-
-        centroids = binary_to_float(
-            np.tile(np.arange(256), int(d / 8)).astype('uint8').reshape(-1, 1))
-
-        faiss.copy_array_to_vector(centroids.ravel(), pq.centroids)
-        pq.is_trained = True
-
-        codes = pq.compute_codes(binary_to_float(xb))
-
-        assert np.all(codes == xb)
-
-        indexpq = faiss.IndexPQ(d, int(d / 8), 8)
-        indexpq.pq = pq
-        indexpq.is_trained = True
-
-        indexpq.add(binary_to_float(xb))
-        D, I = indexpq.search(binary_to_float(xq), 3)
-
-        for i in range(nq):
-            for j, dj in zip(I[i], D[i]):
-                ref_dis = binary_dis(xq[i], xb[j])
-                assert 4 * ref_dis == dj
-
-        nlist = 32
-        quantizer = faiss.IndexFlatL2(d)
-        # pretext class for training
-        iflat = faiss.IndexIVFFlat(quantizer, d, nlist)
-        iflat.train(binary_to_float(xt))
-
-        indexivfpq = faiss.IndexIVFPQ(quantizer, d, nlist, int(d / 8), 8)
-
-        indexivfpq.pq = pq
-        indexivfpq.is_trained = True
-        indexivfpq.by_residual = False
-
-        indexivfpq.add(binary_to_float(xb))
-        indexivfpq.nprobe = 4
-
-        D, I = indexivfpq.search(binary_to_float(xq), 3)
-
-        for i in range(nq):
-            for j, dj in zip(I[i], D[i]):
-                ref_dis = binary_dis(xq[i], xb[j])
-                assert 4 * ref_dis == dj
 
 
 if __name__ == '__main__':

--- a/tests/test_index_binary.py
+++ b/tests/test_index_binary.py
@@ -138,7 +138,7 @@ class TestBinaryIVF(unittest.TestCase):
         index.add(self.xb)
         Divfflat, _ = index.search(self.xq, 1)
 
-        self.assertGreaterEqual((self.Dref == Divfflat).sum(), 452)
+        self.assertGreaterEqual((self.Dref == Divfflat).sum(), 448)
 
 
 

--- a/tests/test_index_binary.py
+++ b/tests/test_index_binary.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD+Patents license found in the
+# LICENSE file in the root directory of this source tree.
+
+#! /usr/bin/env python2
+
+"""this is a basic test script for simple indices work"""
+
+import numpy as np
+import unittest
+import faiss
+
+
+def make_binary_dataset(d, nb, nt, nq):
+    assert d % 8 == 0
+    rs = np.random.RandomState(123)
+    x = rs.randint(256, size=(nb + nq + nt, int(d / 8))).astype('uint8')
+    return x[:nt], x[nt:-nq], x[-nq:]
+
+
+def binary_to_float(x):
+    n, d = x.shape
+    x8 = x.reshape(n * d, -1)
+    c8 = 2 * ((x8 >> np.arange(8)) & 1).astype('int8') - 1
+    return c8.astype('float32').reshape(n, d * 8)
+
+
+def binary_dis(x, y):
+    return sum(faiss.popcount64(int(xi ^ yi)) for xi, yi in zip(x, y))
+
+
+class TestBinaryPQ(unittest.TestCase):
+    """ Use a PQ that mimicks a binary encoder """
+
+    def test_encode_to_binary(self):
+        d = 256
+        nt = 256
+        nb = 1500
+        nq = 500
+        (xt, xb, xq) = make_binary_dataset(d, nb, nt, nq)
+        pq = faiss.ProductQuantizer(d, int(d / 8), 8)
+
+        centroids = binary_to_float(
+            np.tile(np.arange(256), int(d / 8)).astype('uint8').reshape(-1, 1))
+
+        faiss.copy_array_to_vector(centroids.ravel(), pq.centroids)
+        pq.is_trained = True
+
+        codes = pq.compute_codes(binary_to_float(xb))
+
+        assert np.all(codes == xb)
+
+        indexpq = faiss.IndexPQ(d, int(d / 8), 8)
+        indexpq.pq = pq
+        indexpq.is_trained = True
+
+        indexpq.add(binary_to_float(xb))
+        D, I = indexpq.search(binary_to_float(xq), 3)
+
+        for i in range(nq):
+            for j, dj in zip(I[i], D[i]):
+                ref_dis = binary_dis(xq[i], xb[j])
+                assert 4 * ref_dis == dj
+
+        nlist = 32
+        quantizer = faiss.IndexFlatL2(d)
+        # pretext class for training
+        iflat = faiss.IndexIVFFlat(quantizer, d, nlist)
+        iflat.train(binary_to_float(xt))
+
+        indexivfpq = faiss.IndexIVFPQ(quantizer, d, nlist, int(d / 8), 8)
+
+        indexivfpq.pq = pq
+        indexivfpq.is_trained = True
+        indexivfpq.by_residual = False
+
+        indexivfpq.add(binary_to_float(xb))
+        indexivfpq.nprobe = 4
+
+        D, I = indexivfpq.search(binary_to_float(xq), 3)
+
+        for i in range(nq):
+            for j, dj in zip(I[i], D[i]):
+                ref_dis = binary_dis(xq[i], xb[j])
+                assert 4 * ref_dis == dj
+
+
+class TestBinaryFlat(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        unittest.TestCase.__init__(self, *args, **kwargs)
+        d = 32
+        nt = 0
+        nb = 1500
+        nq = 500
+
+        (_, self.xb, self.xq) = make_binary_dataset(d, nb, nt, nq)
+
+    def test_flat(self):
+        d = self.xq.shape[1] * 8
+        nq = self.xq.shape[0]
+
+        index = faiss.IndexBinaryFlat(d)
+        index.add(self.xb)
+        D, I = index.search(self.xq, 3)
+
+        for i in range(nq):
+            for j, dj in zip(I[i], D[i]):
+                ref_dis = binary_dis(self.xq[i], self.xb[j])
+                assert dj == ref_dis
+
+
+class TestBinaryIVF(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        unittest.TestCase.__init__(self, *args, **kwargs)
+        d = 32
+        nt = 200
+        nb = 1500
+        nq = 500
+
+        (self.xt, self.xb, self.xq) = make_binary_dataset(d, nb, nt, nq)
+        index = faiss.IndexBinaryFlat(d)
+        index.add(self.xb)
+        Dref, Iref = index.search(self.xq, 1)
+        self.Dref = Dref
+
+    def test_ivf_flat(self):
+        d = self.xq.shape[1] * 8
+
+        quantizer = faiss.IndexBinaryFlat(d)
+        index = faiss.IndexBinaryIVF(quantizer, d, 8)
+        index.cp.min_points_per_centroid = 5    # quiet warning
+        index.nprobe = 4
+        index.train(self.xt)
+        index.add(self.xb)
+        Divfflat, _ = index.search(self.xq, 1)
+
+        self.assertGreaterEqual((self.Dref == Divfflat).sum(), 452)
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_ivfpq_indexing.cpp
+++ b/tests/test_ivfpq_indexing.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved
 
 #include <cstdio>
 #include <cstdlib>

--- a/tests/test_params_override.cpp
+++ b/tests/test_params_override.cpp
@@ -1,0 +1,231 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <faiss/IndexIVF.h>
+#include <faiss/IndexBinaryIVF.h>
+#include <faiss/AutoTune.h>
+
+using namespace faiss;
+
+namespace {
+
+typedef Index::idx_t idx_t;
+
+
+// dimension of the vectors to index
+int d = 32;
+
+// size of the database we plan to index
+size_t nb = 1000;
+
+// nb of queries
+size_t nq = 200;
+
+
+
+std::vector<float> make_data(size_t n)
+{
+    std::vector <float> database (n * d);
+    for (size_t i = 0; i < n * d; i++) {
+        database[i] = drand48();
+    }
+    return database;
+}
+
+std::unique_ptr<IndexIVF> make_index(const char *index_type,
+                                     MetricType metric,
+                                     const std::vector<float> & x)
+{
+
+    auto index = std::unique_ptr<IndexIVF>
+        (dynamic_cast<IndexIVF*>(index_factory(d, index_type, metric)));
+    index->train(nb, x.data());
+    index->add(nb, x.data());
+    return index;
+}
+
+std::vector<idx_t> search_index(IndexIVF *index, const float *xq) {
+    int k = 10;
+    std::vector<idx_t> I(k * nq);
+    std::vector<float> D(k * nq);
+    index->search (nq, xq, k, D.data(), I.data());
+    return I;
+}
+
+std::vector<idx_t> search_index_with_params(
+        IndexIVF *index, const float *xq, IVFSearchParameters *params) {
+    int k = 10;
+    std::vector<idx_t> I(k * nq);
+    std::vector<float> D(k * nq);
+
+    std::vector<idx_t> Iq(params->nprobe * nq);
+    std::vector<float> Dq(params->nprobe * nq);
+
+    index->quantizer->search(nq, xq, params->nprobe,
+                             Dq.data(), Iq.data());
+    index->search_preassigned(nq, xq, k, Iq.data(), Dq.data(),
+                              D.data(), I.data(),
+                              false, params);
+    return I;
+}
+
+
+
+
+/*************************************************************
+ * Test functions for a given index type
+ *************************************************************/
+
+int test_params_override (const char *index_key, MetricType metric) {
+    std::vector<float> xb = make_data(nb); // database vectors
+    auto index = make_index(index_key, metric, xb);
+    index->train(nb, xb.data());
+    index->add(nb, xb.data());
+    std::vector<float> xq = make_data(nq);
+    index->nprobe = 2;
+    auto res2ref = search_index(index.get(), xq.data());
+    index->nprobe = 9;
+    auto res9ref = search_index(index.get(), xq.data());
+    index->nprobe = 1;
+
+    IVFSearchParameters params;
+    params.max_codes = 0;
+    params.nprobe = 2;
+    auto res2new = search_index_with_params(index.get(), xq.data(), &params);
+    params.nprobe = 9;
+    auto res9new = search_index_with_params(index.get(), xq.data(), &params);
+
+    if (res2ref != res2new)
+        return 2;
+
+    if (res9ref != res9new)
+        return 9;
+
+    return 0;
+}
+
+
+}  // namespace
+
+
+/*************************************************************
+ * Test entry points
+ *************************************************************/
+
+TEST(TPO, IVFFlat) {
+    int err1 = test_params_override ("IVF32,Flat", METRIC_L2);
+    EXPECT_EQ(err1, 0);
+    int err2 = test_params_override ("IVF32,Flat", METRIC_INNER_PRODUCT);
+    EXPECT_EQ(err2, 0);
+}
+
+TEST(TPO, IVFPQ) {
+    int err1 = test_params_override ("IVF32,PQ8np", METRIC_L2);
+    EXPECT_EQ(err1, 0);
+    int err2 = test_params_override ("IVF32,PQ8np", METRIC_INNER_PRODUCT);
+    EXPECT_EQ(err2, 0);
+}
+
+TEST(TPO, IVFSQ) {
+    int err1 = test_params_override ("IVF32,SQ8", METRIC_L2);
+    EXPECT_EQ(err1, 0);
+    int err2 = test_params_override ("IVF32,SQ8", METRIC_INNER_PRODUCT);
+    EXPECT_EQ(err2, 0);
+}
+
+
+
+/*************************************************************
+ * Same for binary indexes
+ *************************************************************/
+
+
+std::vector<uint8_t> make_data_binary(size_t n) {
+    std::vector <uint8_t> database (n * d / 8);
+    for (size_t i = 0; i < n * d / 8; i++) {
+        database[i] = lrand48();
+    }
+    return database;
+}
+
+std::unique_ptr<IndexBinaryIVF> make_index(const char *index_type,
+                                     const std::vector<uint8_t> & x)
+{
+
+    auto index = std::unique_ptr<IndexBinaryIVF>
+        (dynamic_cast<IndexBinaryIVF*>(index_binary_factory (d, index_type)));
+    index->train(nb, x.data());
+    index->add(nb, x.data());
+    return index;
+}
+
+std::vector<idx_t> search_index(IndexBinaryIVF *index, const uint8_t *xq) {
+    int k = 10;
+    std::vector<idx_t> I(k * nq);
+    std::vector<int32_t> D(k * nq);
+    index->search (nq, xq, k, D.data(), I.data());
+    return I;
+}
+
+std::vector<idx_t> search_index_with_params(
+        IndexBinaryIVF *index, const uint8_t *xq, IVFSearchParameters *params) {
+    int k = 10;
+    std::vector<idx_t> I(k * nq);
+    std::vector<int32_t> D(k * nq);
+
+    std::vector<idx_t> Iq(params->nprobe * nq);
+    std::vector<int32_t> Dq(params->nprobe * nq);
+
+    index->quantizer->search(nq, xq, params->nprobe,
+                             Dq.data(), Iq.data());
+    index->search_preassigned(nq, xq, k, Iq.data(), Dq.data(),
+                              D.data(), I.data(),
+                              false, params);
+    return I;
+}
+
+int test_params_override_binary (const char *index_key) {
+    std::vector<uint8_t> xb = make_data_binary(nb); // database vectors
+    auto index = make_index (index_key, xb);
+    index->train(nb, xb.data());
+    index->add(nb, xb.data());
+    std::vector<uint8_t> xq = make_data_binary(nq);
+    index->nprobe = 2;
+    auto res2ref = search_index(index.get(), xq.data());
+    index->nprobe = 9;
+    auto res9ref = search_index(index.get(), xq.data());
+    index->nprobe = 1;
+
+    IVFSearchParameters params;
+    params.max_codes = 0;
+    params.nprobe = 2;
+    auto res2new = search_index_with_params(index.get(), xq.data(), &params);
+    params.nprobe = 9;
+    auto res9new = search_index_with_params(index.get(), xq.data(), &params);
+
+    if (res2ref != res2new)
+        return 2;
+
+    if (res9ref != res9new)
+        return 9;
+
+    return 0;
+}
+
+TEST(TPOB, IVF) {
+    int err1 = test_params_override_binary ("BIVF32");
+    EXPECT_EQ(err1, 0);
+}

--- a/utils.cpp
+++ b/utils.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved
 // -*- c++ -*-
 
 #include "utils.h"
@@ -428,12 +427,12 @@ float fvec_L2sqr_ref (const float * x,
                      size_t d)
 {
     size_t i;
-    float res_ = 0;
+    float res = 0;
     for (i = 0; i < d; i++) {
         const float tmp = x[i] - y[i];
-       res_ += tmp * tmp;
+       res += tmp * tmp;
     }
-    return res_;
+    return res;
 }
 
 float fvec_inner_product_ref (const float * x,
@@ -441,20 +440,20 @@ float fvec_inner_product_ref (const float * x,
                              size_t d)
 {
     size_t i;
-    float res_ = 0;
+    float res = 0;
     for (i = 0; i < d; i++)
-       res_ += x[i] * y[i];
-    return res_;
+       res += x[i] * y[i];
+    return res;
 }
 
 float fvec_norm_L2sqr_ref (const float * __restrict x,
                           size_t d)
 {
     size_t i;
-    double res_ = 0;
+    double res = 0;
     for (i = 0; i < d; i++)
-       res_ += x[i] * x[i];
-    return res_;
+       res += x[i] * x[i];
+    return res;
 }
 
 
@@ -763,8 +762,8 @@ static void knn_inner_product_sse (const float * x,
 
 #pragma omp parallel for
     for (size_t i = 0; i < nx; i++) {
-        const float * x_ = x + i * d;
-        const float * y_ = y;
+        const float * x_i = x + i * d;
+        const float * y_j = y;
 
         float * __restrict simi = res->get_val(i);
         long * __restrict idxi = res->get_ids (i);
@@ -772,13 +771,13 @@ static void knn_inner_product_sse (const float * x,
         minheap_heapify (k, simi, idxi);
 
         for (size_t j = 0; j < ny; j++) {
-            float ip = fvec_inner_product (x_, y_, d);
+            float ip = fvec_inner_product (x_i, y_j, d);
 
             if (ip > simi[0]) {
                 minheap_pop (k, simi, idxi);
                 minheap_push (k, simi, idxi, ip, j);
             }
-            y_ += d;
+            y_j += d;
         }
         minheap_reorder (k, simi, idxi);
     }
@@ -795,21 +794,21 @@ static void knn_L2sqr_sse (
 
 #pragma omp parallel for
     for (size_t i = 0; i < nx; i++) {
-        const float * x_ = x + i * d;
-        const float * y_ = y;
+        const float * x_i = x + i * d;
+        const float * y_j = y;
         size_t j;
         float * __restrict simi = res->get_val(i);
         long * __restrict idxi = res->get_ids (i);
 
         maxheap_heapify (k, simi, idxi);
         for (j = 0; j < ny; j++) {
-            float disij = fvec_L2sqr (x_, y_, d);
+            float disij = fvec_L2sqr (x_i, y_j, d);
 
             if (disij < simi[0]) {
                 maxheap_pop (k, simi, idxi);
                 maxheap_push (k, simi, idxi, disij, j);
             }
-            y_ += d;
+            y_j += d;
         }
         maxheap_reorder (k, simi, idxi);
     }

--- a/utils.h
+++ b/utils.h
@@ -6,9 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/** Copyright 2004-present Facebook. All Rights Reserved
- * -*- c++ -*-
- *
+// -*- c++ -*-
+
+/*
  *  A few utilitary functions for similarity search:
  * - random generators
  * - optimized exhaustive distance and knn search functions


### PR DESCRIPTION
Changelog:
+ Support for binary indexes (`IndexBinaryFlat`, `IndexBinaryIVF`)
+ Support fp16 encoding in scalar quantizer 
+ Support for deduplication in `IndexIVFFlat` (Duplicate vectors are identified and removed at add time and added back at search time. factory: "FlatDedup")
+ Support for index serialization
+ Add a method to add preassigned embeddings 

Bugs:
+ Fix MMAP bug for normal indexes 
+ Fix propagation of io_flags in read func 
+ CUDA 9 Faiss k-selection fixes 

TODO:
- doxygen