### PR TITLE
update conda install info for release 1.3.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,8 +15,6 @@ Currently we support faiss-cpu on both Linux and OSX platforms. We also provide 
 You can easily install it by
 
 ```
-# Install conda dependencies
-conda install numpy mkl libgcc
 # CPU version only
 conda install faiss-cpu -c pytorch
 # Make sure you have CUDA installed before installing faiss-gpu, otherwise it falls back to CPU version

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,17 +8,19 @@ INSTALL file for Faiss (Fair AI Similarity Search)
 Install via Conda
 -----------------
 
-The easiest way to install FAISS is from anaconda. We regularly push stable releases to conda channel. FAISS conda package depends on mkl and numpy package shipped in conda.
+The easiest way to install FAISS is from anaconda. We regularly push stable releases to conda channel. FAISS conda package is built with conda gcc, depends on libgcc, mkl and numpy package shipped in conda in runtime.
 
 Currently we support faiss-cpu on both Linux and OSX platforms. We also provide faiss-gpu compiled with CUDA8.0/CUDA9.0/CUDA9.1 on Linux systems.
 
 You can easily install it by
 
 ```
+# Install conda dependencies
+conda install numpy mkl libgcc
 # CPU version only
 conda install faiss-cpu -c pytorch
 # Make sure you have CUDA installed before installing faiss-gpu, otherwise it falls back to CPU version
-conda install faiss-gpu -c pytorch # [DEFAULT]For CUDA8.0, comes with cudatoolkit8.0
+conda install faiss-gpu -c pytorch # [DEFAULT]For CUDA8.0
 conda install faiss-gpu cuda90 -c pytorch # For CUDA9.0
 conda install faiss-gpu cuda91 -c pytorch # For CUDA9.1
 # cuda90/cuda91 shown above is a feature, it doesn't install CUDA for you.


### PR DESCRIPTION
Add libgcc as runtime dependency since we use gcc in conda to compile and it links libstdc++ and libgomp.