### PR TITLE
Replace os.tempnam with tempfile for python3

### DIFF
--- a/tests/test_binary_io.py
+++ b/tests/test_binary_io.py
@@ -12,6 +12,7 @@ import numpy as np
 import unittest
 import faiss
 import os
+import tempfile
 
 def make_binary_dataset(d, nb, nt, nq):
     assert d % 8 == 0
@@ -37,7 +38,7 @@ class TestBinaryFlat(unittest.TestCase):
         index.add(self.xb)
         D, I = index.search(self.xq, 3)
 
-        tmpnam = os.tempnam()
+        tmpnam = tempfile.NamedTemporaryFile().name
         try:
             faiss.write_index_binary(index, tmpnam)
 
@@ -74,7 +75,7 @@ class TestBinaryIVF(unittest.TestCase):
         index.add(self.xb)
         D, I = index.search(self.xq, 3)
 
-        tmpnam = os.tempnam()
+        tmpnam = tempfile.NamedTemporaryFile().name
 
         try:
             faiss.write_index_binary(index, tmpnam)


### PR DESCRIPTION
Hi, when executing tests in python3 I found some tests were failed.
`os.tempname` that was eliminated in python3. causes the error.
Used tempfile.NamedTemporaryFile().name instead.
This test script is also valid for python2.7.