### PR TITLE
[C API] Multi-GPU functions

### DIFF
--- a/c_api/Index_c.h
+++ b/c_api/Index_c.h
@@ -12,7 +12,7 @@
 #ifndef FAISS_INDEX_C_H
 #define FAISS_INDEX_C_H
 
-#include <stdio.h>
+#include <stddef.h>
 #include "faiss_c.h"
 
 #ifdef __cplusplus

--- a/c_api/gpu/GpuAutoTune_c.cpp
+++ b/c_api/gpu/GpuAutoTune_c.cpp
@@ -57,13 +57,13 @@ int faiss_index_cpu_to_gpu_with_options(
 }
 
 int faiss_index_cpu_to_gpu_multiple(
-    FaissGpuResources** resources_vec, size_t resources_vec_size,
-    int* devices, size_t devices_size,
+    FaissGpuResources* const* resources_vec,
+    const int* devices, size_t devices_size,
     const FaissIndex* index, FaissGpuIndex** p_out)
 {
     try {
-        std::vector<GpuResources*> res(resources_vec_size);
-        for (auto i = 0u; i < resources_vec_size; ++i) {
+        std::vector<GpuResources*> res(devices_size);
+        for (auto i = 0u; i < devices_size; ++i) {
             res[i] = reinterpret_cast<GpuResources*>(resources_vec[i]);
         }
 

--- a/c_api/gpu/GpuAutoTune_c.cpp
+++ b/c_api/gpu/GpuAutoTune_c.cpp
@@ -10,14 +10,17 @@
 // -*- c++ -*-
 
 #include "GpuAutoTune_c.h"
+#include "GpuClonerOptions_c.h"
 #include "macros_impl.h"
 #include "Index.h"
 #include "gpu/GpuAutoTune.h"
 #include "gpu/GpuClonerOptions.h"
+#include <vector>
 
 using faiss::Index;
 using faiss::gpu::GpuResources;
 using faiss::gpu::GpuClonerOptions;
+using faiss::gpu::GpuMultipleClonerOptions;
 
 int faiss_index_gpu_to_cpu(const FaissIndex* gpu_index, FaissIndex** p_out) {
     try {
@@ -49,6 +52,46 @@ int faiss_index_cpu_to_gpu_with_options(
         auto gpu_index = faiss::gpu::index_cpu_to_gpu(
             res, device, reinterpret_cast<const Index*>(index),
             reinterpret_cast<const GpuClonerOptions*>(options));
+        *p_out = reinterpret_cast<FaissGpuIndex*>(gpu_index);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_index_cpu_to_gpu_multiple(
+    FaissGpuResources** resources_vec, size_t resources_vec_size,
+    int* devices, size_t devices_size,
+    const FaissIndex* index, FaissGpuIndex** p_out)
+{
+    try {
+        std::vector<GpuResources*> res(resources_vec_size);
+        for (auto i = 0u; i < resources_vec_size; ++i) {
+            res[i] = reinterpret_cast<GpuResources*>(resources_vec[i]);
+        }
+
+        std::vector<int> dev(devices, devices + devices_size);
+
+        auto gpu_index = faiss::gpu::index_cpu_to_gpu_multiple(
+            res, dev, reinterpret_cast<const Index*>(index));
+        *p_out = reinterpret_cast<FaissGpuIndex*>(gpu_index);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_index_cpu_to_gpu_multiple_with_options(
+    FaissGpuResources** resources_vec, size_t resources_vec_size,
+    int* devices, size_t devices_size,
+    const FaissIndex* index, const FaissGpuMultipleClonerOptions* options,
+    FaissGpuIndex** p_out)
+{
+    try {
+        std::vector<GpuResources*> res(resources_vec_size);
+        for (auto i = 0u; i < resources_vec_size; ++i) {
+            res[i] = reinterpret_cast<GpuResources*>(resources_vec[i]);
+        }
+
+        std::vector<int> dev(devices, devices + devices_size);
+
+        auto gpu_index = faiss::gpu::index_cpu_to_gpu_multiple(
+            res, dev, reinterpret_cast<const Index*>(index),
+            reinterpret_cast<const GpuMultipleClonerOptions*>(options));
         *p_out = reinterpret_cast<FaissGpuIndex*>(gpu_index);
     } CATCH_AND_HANDLE
 }

--- a/c_api/gpu/GpuAutoTune_c.h
+++ b/c_api/gpu/GpuAutoTune_c.h
@@ -36,6 +36,17 @@ int faiss_index_cpu_to_gpu_with_options(
     const FaissIndex *index, const FaissGpuClonerOptions* options,
     FaissGpuIndex** p_out);
 
+int faiss_index_cpu_to_gpu_multiple(
+    FaissGpuResources** resources_vec, size_t resources_vec_size,
+    int* devices, size_t devices_size,
+    const FaissIndex* index, FaissGpuIndex** p_out);
+
+int faiss_index_cpu_to_gpu_multiple_with_options(
+    FaissGpuResources** resources_vec, size_t resources_vec_size,
+    int* devices, size_t devices_size,
+    const FaissIndex* index, const FaissGpuMultipleClonerOptions* options,
+    FaissGpuIndex** p_out);
+
 /// parameter space and setters for GPU indexes
 FAISS_DECLARE_CLASS_INHERITED(GpuParameterSpace, ParameterSpace)
 

--- a/c_api/gpu/GpuAutoTune_c.h
+++ b/c_api/gpu/GpuAutoTune_c.h
@@ -12,6 +12,7 @@
 #ifndef FAISS_GPU_AUTO_TUNE_C_H
 #define FAISS_GPU_AUTO_TUNE_C_H
 
+#include <stddef.h>
 #include "faiss_c.h"
 #include "GpuClonerOptions_c.h"
 #include "GpuResources_c.h"
@@ -36,14 +37,14 @@ int faiss_index_cpu_to_gpu_with_options(
     const FaissIndex *index, const FaissGpuClonerOptions* options,
     FaissGpuIndex** p_out);
 
+/// converts any CPU index that can be converted to GPU
 int faiss_index_cpu_to_gpu_multiple(
-    FaissGpuResources** resources_vec, size_t resources_vec_size,
-    int* devices, size_t devices_size,
+    FaissGpuResources* const* resources_vec, const int* devices, size_t devices_size,
     const FaissIndex* index, FaissGpuIndex** p_out);
 
+/// converts any CPU index that can be converted to GPU
 int faiss_index_cpu_to_gpu_multiple_with_options(
-    FaissGpuResources** resources_vec, size_t resources_vec_size,
-    int* devices, size_t devices_size,
+    FaissGpuResources* const* resources_vec, const int* devices, size_t devices_size,
     const FaissIndex* index, const FaissGpuMultipleClonerOptions* options,
     FaissGpuIndex** p_out);
 

--- a/c_api/gpu/GpuClonerOptions_c.cpp
+++ b/c_api/gpu/GpuClonerOptions_c.cpp
@@ -23,6 +23,12 @@ int faiss_GpuClonerOptions_new(FaissGpuClonerOptions** p) {
     } CATCH_AND_HANDLE
 }
 
+int faiss_GpuMultipleClonerOptions_new(FaissGpuMultipleClonerOptions** p) {
+    try {
+        *p = reinterpret_cast<FaissGpuMultipleClonerOptions*>(new GpuMultipleClonerOptions());
+    } CATCH_AND_HANDLE
+}
+
 DEFINE_DESTRUCTOR(GpuClonerOptions)
 
 DEFINE_GETTER(GpuClonerOptions, FaissIndicesOptions, indicesOptions)

--- a/c_api/gpu/GpuClonerOptions_c.cpp
+++ b/c_api/gpu/GpuClonerOptions_c.cpp
@@ -30,6 +30,7 @@ int faiss_GpuMultipleClonerOptions_new(FaissGpuMultipleClonerOptions** p) {
 }
 
 DEFINE_DESTRUCTOR(GpuClonerOptions)
+DEFINE_DESTRUCTOR(GpuMultipleClonerOptions)
 
 DEFINE_GETTER(GpuClonerOptions, FaissIndicesOptions, indicesOptions)
 DEFINE_GETTER(GpuClonerOptions, int, useFloat16CoarseQuantizer)

--- a/c_api/gpu/GpuClonerOptions_c.h
+++ b/c_api/gpu/GpuClonerOptions_c.h
@@ -23,7 +23,7 @@ FAISS_DECLARE_CLASS(GpuClonerOptions)
 
 FAISS_DECLARE_DESTRUCTOR(GpuClonerOptions)
 
-// Default constructor for GpuClonerOptions
+/// Default constructor for GpuClonerOptions
 int faiss_GpuClonerOptions_new(FaissGpuClonerOptions**);
 
 /// how should indices be stored on index types that support indices
@@ -53,7 +53,7 @@ FAISS_DECLARE_CLASS_INHERITED(GpuMultipleClonerOptions, GpuClonerOptions)
 
 FAISS_DECLARE_DESTRUCTOR(GpuMultipleClonerOptions)
 
-// Default constructor for GpuMultipleClonerOptions
+/// Default constructor for GpuMultipleClonerOptions
 int faiss_GpuMultipleClonerOptions_new(FaissGpuMultipleClonerOptions**);
 
 /// (boolean) Whether to shard the index across GPUs, versus replication

--- a/c_api/gpu/GpuClonerOptions_c.h
+++ b/c_api/gpu/GpuClonerOptions_c.h
@@ -51,6 +51,11 @@ FAISS_DECLARE_GETTER_SETTER(GpuClonerOptions, int, verbose)
 
 FAISS_DECLARE_CLASS_INHERITED(GpuMultipleClonerOptions, GpuClonerOptions)
 
+FAISS_DECLARE_DESTRUCTOR(GpuMultipleClonerOptions)
+
+// Default constructor for GpuMultipleClonerOptions
+int faiss_GpuMultipleClonerOptions_new(FaissGpuMultipleClonerOptions**);
+
 /// (boolean) Whether to shard the index across GPUs, versus replication
 /// across GPUs
 FAISS_DECLARE_GETTER_SETTER(GpuMultipleClonerOptions, int, shard)


### PR DESCRIPTION
This PR provides access to the `cpu_to_gpu_multiple` function and other related data types. A few minor tweaks to the C API are included as well:

- fix doc comment in `FaissGpuClonerOptions` constructor
- include `stddef.h` instead of `stdio.h` in the `Index_c.h` header file

A small check for validation would be much appreciated: Is it safe to assume that the arguments `resources` and `devices` are required to have the same length?