### PR TITLE
IVFPQ filtering with polysemous codes

### DIFF
--- a/IndexIVFPQ.cpp
+++ b/IndexIVFPQ.cpp
@@ -744,6 +744,11 @@ struct InvertedListScanner: QueryTables {
         list_size = list_size_in;
         list_codes = list_codes_in;
         list_ids = list_ids_in;
+        
+        if (by_residual && polysemous_ht != 0) {
+            ivfpq.quantizer->compute_residual (qi, residual_vec, key);
+            pq.compute_code (residual_vec, q_code.data());
+        }
     }
 
     /*****************************************************


### PR DESCRIPTION
Query data is coded when "by_residuals" are closed, but it's empty when "by_residuals" are opened, it's just a mistake.
So, I added "compute_residual" and "compute_code" at "init_list".