### PR TITLE
For #669. Adding install target to gpu Makefile

### DIFF
--- a/gpu/Makefile
+++ b/gpu/Makefile
@@ -85,4 +85,12 @@ depend:
 	    $(CXXCPP) $(CPPFLAGS) -x c++ -MM $$i; \
 	done > depend
 
+install: libgpufaiss.a libgpufaiss.$(SHAREDEXT) installdirs
+	cp libgpufaiss.a libgpufaiss.$(SHAREDEXT) $(DESTDIR)$(libdir)
+	cp *.h $(DESTDIR)$(includedir)/faiss/gpu
+	cp --parents **/**.h $(DESTDIR)$(includedir)/faiss/gpu
+
+installdirs:
+	$(MKDIR_P) $(DESTDIR)$(libdir) $(DESTDIR)$(includedir)/faiss/gpu
+
 .PHONY: all clean


### PR DESCRIPTION
This trivial change installs both the FAISS non-gpu and gpu library artifacts into the same output location so that downstream projects can build against them. 