### PR TITLE
ondisk demo bug fix: data needs to be added with ids

### DIFF
--- a/demos/demo_ondisk_ivf.py
+++ b/demos/demo_ondisk_ivf.py
@@ -51,7 +51,7 @@ if 1 <= stage <= 4:
     i0, i1 = int(bno * xb.shape[0] / 4), int((bno + 1) * xb.shape[0] / 4)
     index = faiss.read_index(tmpdir + "trained.index")
     print("adding vectors %d:%d" % (i0, i1))
-    index.add(xb[i0:i1])
+    index.add_with_ids(xb[i0:i1], np.arange(i0, i1))
     print("write " + tmpdir + "block_%d.index" % bno)
     faiss.write_index(index, tmpdir + "block_%d.index" % bno)
 


### PR DESCRIPTION
When data is being added to each index block, it needs to explicitly identify ids. Otherwise, the ids are automatically assumed to be the index of each individual data block, so every block has the same ids (in the range of 0 to 250,000).