### PR TITLE
fix: gpu compilation with cuda 10.1

### DIFF
--- a/gpu/utils/Tensor.cuh
+++ b/gpu/utils/Tensor.cuh
@@ -359,7 +359,7 @@ bool canUseIndexType() {
 
 template <typename IndexType, typename T, typename... U>
 bool canUseIndexType(const T& arg, const U&... args) {
-  return arg.canUseIndexType<IndexType>() &&
+  return arg.template canUseIndexType<IndexType>() &&
     canUseIndexType(args...);
 }
 


### PR DESCRIPTION
The GPU compilation fails with g++ 8.3.1 and cuda 10.1
With this proposed fix the compilation works locally

Contributes to #751