### PR TITLE
Update cpp tutorial makefile for GPU part

### DIFF
--- a/tutorial/cpp/Makefile
+++ b/tutorial/cpp/Makefile
@@ -20,8 +20,8 @@ gpu: $(GPU_TARGETS)
 $(CPU_TARGETS): %: %.cpp ../../libfaiss.a
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -I../../.. $(LIBS)
 
-$(GPU_TARGETS): %: %.cpp ../../libfaiss.a ../../gpu/libgpufaiss.a
-	$(NVCC) $(NVCCFLAGS) -o $@ $^ $(NVCCLDFLAGS) -I../../.. $(NVCCLIBS)
+$(GPU_TARGETS): %: %.cpp ../../libfaiss.a
+	$(CXX) $(CXXFLAGS) $(CUDACFLAGS) -o $@ $^ $(LDFLAGS) -I../../.. $(LIBS)
 
 clean:
 	rm -f $(CPU_TARGETS) $(GPU_TARGETS)

--- a/tutorial/cpp/Makefile
+++ b/tutorial/cpp/Makefile
@@ -21,7 +21,7 @@ $(CPU_TARGETS): %: %.cpp ../../libfaiss.a
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -I../../.. $(LIBS)
 
 $(GPU_TARGETS): %: %.cpp ../../libfaiss.a
-	$(CXX) $(CXXFLAGS) $(CUDACFLAGS) -o $@ $^ $(LDFLAGS) -I../../.. $(LIBS)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -I../../.. $(LIBS)
 
 clean:
 	rm -f $(CPU_TARGETS) $(GPU_TARGETS)

--- a/tutorial/cpp/Makefile
+++ b/tutorial/cpp/Makefile
@@ -17,10 +17,7 @@ cpu: $(CPU_TARGETS)
 
 gpu: $(GPU_TARGETS)
 
-$(CPU_TARGETS): %: %.cpp ../../libfaiss.a
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -I../../.. $(LIBS)
-
-$(GPU_TARGETS): %: %.cpp ../../libfaiss.a
+%: %.cpp ../../libfaiss.a
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -I../../.. $(LIBS)
 
 clean:


### PR DESCRIPTION
Since faiss GPU library is not separated with CPU library anymore, the makefile for tutorial need be updated. 

~~`$(CUDACFLAGS)` may not be generated by ./configure, however,  you can add `CUDACFLAGS   = -I $(CUDA_ROOT)/include` in the makefile.inc or use modifed makefile.inc from example_makefiles accordingly.~~