### PR TITLE
tutorial build add CPPFLAGS which contains cuda include path

### DIFF
--- a/tutorial/cpp/Makefile
+++ b/tutorial/cpp/Makefile
@@ -18,7 +18,7 @@ cpu: $(CPU_TARGETS)
 gpu: $(GPU_TARGETS)
 
 %: %.cpp ../../libfaiss.a
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) -I../../.. $(LIBS)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $@ $^ $(LDFLAGS) -I../../.. $(LIBS)
 
 clean:
 	rm -f $(CPU_TARGETS) $(GPU_TARGETS)


### PR DESCRIPTION
when using custom cuda
```
./configure --with-cuda /path/to/cuda
```
CPPFLAGS contains cuda include path
run tutorial build with make gpu will fail for finding no cuda.h
