### PR TITLE
[C API] Update for compatibility with v1.5

### DIFF
--- a/c_api/AutoTune_c.cpp
+++ b/c_api/AutoTune_c.cpp
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/AutoTune_c.h
+++ b/c_api/AutoTune_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/AuxIndexStructures_c.cpp
+++ b/c_api/AuxIndexStructures_c.cpp
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/AuxIndexStructures_c.cpp
+++ b/c_api/AuxIndexStructures_c.cpp
@@ -14,14 +14,13 @@
 #include "macros_impl.h"
 #include <iostream>
 
-extern "C" {
-
 using faiss::BufferList;
 using faiss::IDSelector;
 using faiss::IDSelectorBatch;
 using faiss::IDSelectorRange;
 using faiss::RangeSearchResult;
 using faiss::RangeSearchPartialResult;
+using faiss::RangeQueryResult;
 
 DEFINE_GETTER(RangeSearchResult, size_t, nq)
 
@@ -140,6 +139,17 @@ int faiss_BufferList_copy_range(
     } CATCH_AND_HANDLE
 }
 
+DEFINE_GETTER(RangeQueryResult, idx_t, qno)
+DEFINE_GETTER(RangeQueryResult, size_t, nres)
+DEFINE_GETTER_PERMISSIVE(RangeQueryResult, FaissRangeSearchPartialResult*, pres)
+
+int faiss_RangeQueryResult_add(FaissRangeQueryResult* qr, float dis, idx_t id) {
+    try {
+        reinterpret_cast<RangeQueryResult*>(qr)->add(dis, id);
+        return 0;
+    } CATCH_AND_HANDLE
+}
+
 DEFINE_GETTER_PERMISSIVE(RangeSearchPartialResult, FaissRangeSearchResult*, res)
 
 int faiss_RangeSearchPartialResult_new(
@@ -170,38 +180,15 @@ int faiss_RangeSearchPartialResult_set_lims(
     } CATCH_AND_HANDLE
 }
 
-/// called by range_search after do_allocation
-int faiss_RangeSearchPartialResult_set_result(
-    FaissRangeSearchPartialResult* res, int incremental) {
-    try {
-        reinterpret_cast<RangeSearchPartialResult*>(res)->set_result(
-            static_cast<bool>(incremental));
-        return 0;
-    } CATCH_AND_HANDLE
-}
-
-DEFINE_GETTER_SUBCLASS(QueryResult, RangeSearchPartialResult, idx_t, qno)
-DEFINE_GETTER_SUBCLASS(QueryResult, RangeSearchPartialResult, size_t, nres)
-DEFINE_GETTER_SUBCLASS_PERMISSIVE(QueryResult, RangeSearchPartialResult, FaissRangeSearchPartialResult*, pres)
-
 int faiss_RangeSearchPartialResult_new_result(
-    FaissRangeSearchPartialResult* res, idx_t qno, FaissQueryResult** qr) {
+    FaissRangeSearchPartialResult* res, idx_t qno, FaissRangeQueryResult** qr) {
 
     try {
-        RangeSearchPartialResult::QueryResult* q = 
+        auto q = 
             &reinterpret_cast<RangeSearchPartialResult*>(res)->new_result(qno);
         if (qr) {
-            *qr = reinterpret_cast<FaissQueryResult*>(q);
+            *qr = reinterpret_cast<FaissRangeQueryResult*>(&q);
         }
         return 0;
     } CATCH_AND_HANDLE
-}
-
-int faiss_QueryResult_add(FaissQueryResult* qr, float dis, idx_t id) {
-    try {
-        reinterpret_cast<RangeSearchPartialResult::QueryResult*>(qr)->add(dis, id);
-        return 0;
-    } CATCH_AND_HANDLE
-}
-
 }

--- a/c_api/AuxIndexStructures_c.h
+++ b/c_api/AuxIndexStructures_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/AuxIndexStructures_c.h
+++ b/c_api/AuxIndexStructures_c.h
@@ -103,6 +103,15 @@ int faiss_BufferList_copy_range(
 /// the entries in the buffers are split per query
 FAISS_DECLARE_CLASS(RangeSearchPartialResult)
 
+/// result structure for a single query
+FAISS_DECLARE_CLASS(RangeQueryResult)
+FAISS_DECLARE_GETTER(RangeQueryResult, idx_t, qno)
+FAISS_DECLARE_GETTER(RangeQueryResult, size_t, nres)
+FAISS_DECLARE_GETTER(RangeQueryResult, FaissRangeSearchPartialResult*, pres)
+
+int faiss_RangeQueryResult_add(FaissRangeQueryResult* qr, float dis, idx_t id);
+
+
 FAISS_DECLARE_GETTER(RangeSearchPartialResult, FaissRangeSearchResult*, res)
 
 int faiss_RangeSearchPartialResult_new(
@@ -115,20 +124,8 @@ int faiss_RangeSearchPartialResult_finalize(
 int faiss_RangeSearchPartialResult_set_lims(
     FaissRangeSearchPartialResult* res);
 
-/// called by range_search after do_allocation
-int faiss_RangeSearchPartialResult_set_result(
-    FaissRangeSearchPartialResult* res, int incremental);
-
-/// result structure for a single query
-FAISS_DECLARE_CLASS(QueryResult)
-FAISS_DECLARE_GETTER(QueryResult, idx_t, qno)
-FAISS_DECLARE_GETTER(QueryResult, size_t, nres)
-FAISS_DECLARE_GETTER(QueryResult, FaissRangeSearchPartialResult*, pres)
-
 int faiss_RangeSearchPartialResult_new_result(
-    FaissRangeSearchPartialResult* res, idx_t qno, FaissQueryResult** qr);
-
-int faiss_QueryResult_add(FaissQueryResult* qr, float dis, idx_t id);
+    FaissRangeSearchPartialResult* res, idx_t qno, FaissRangeQueryResult** qr);
 
 #ifdef __cplusplus
 }

--- a/c_api/Clustering_c.cpp
+++ b/c_api/Clustering_c.cpp
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/Clustering_c.h
+++ b/c_api/Clustering_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/IndexFlat_c.cpp
+++ b/c_api/IndexFlat_c.cpp
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/IndexFlat_c.h
+++ b/c_api/IndexFlat_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/IndexIVFFlat_c.cpp
+++ b/c_api/IndexIVFFlat_c.cpp
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/IndexIVFFlat_c.h
+++ b/c_api/IndexIVFFlat_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/IndexIVF_c.cpp
+++ b/c_api/IndexIVF_c.cpp
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/IndexIVF_c.cpp
+++ b/c_api/IndexIVF_c.cpp
@@ -80,12 +80,12 @@ int faiss_IndexIVF_make_direct_map(FaissIndexIVF* index,
 }
 
 double faiss_IndexIVF_imbalance_factor (const FaissIndexIVF* index) {
-    return reinterpret_cast<const IndexIVF*>(index)->imbalance_factor();
+    return reinterpret_cast<const IndexIVF*>(index)->invlists->imbalance_factor();
 }
 
 /// display some stats about the inverted lists
 void faiss_IndexIVF_print_stats (const FaissIndexIVF* index) {
-    reinterpret_cast<const IndexIVF*>(index)->print_stats();
+    reinterpret_cast<const IndexIVF*>(index)->invlists->print_stats();
 }
 
 void faiss_IndexIVFStats_reset(FaissIndexIVFStats* stats) {

--- a/c_api/IndexIVF_c.h
+++ b/c_api/IndexIVF_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/IndexIVF_c.h
+++ b/c_api/IndexIVF_c.h
@@ -106,10 +106,13 @@ size_t faiss_IndexIVF_get_list_size(const FaissIndexIVF* index,
 int faiss_IndexIVF_make_direct_map(FaissIndexIVF* index,
     int new_maintain_direct_map);
 
-/// 1= perfectly balanced, >1: imbalanced
+/** Check the inverted lists' imbalance factor.
+ *
+ * 1= perfectly balanced, >1: imbalanced
+ */
 double faiss_IndexIVF_imbalance_factor (const FaissIndexIVF* index);
 
-/// display some stats about the inverted lists
+/// display some stats about the inverted lists of the index
 void faiss_IndexIVF_print_stats (const FaissIndexIVF* index);
 
 

--- a/c_api/IndexLSH_c.cpp
+++ b/c_api/IndexLSH_c.cpp
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/IndexLSH_c.h
+++ b/c_api/IndexLSH_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/IndexShards_c.cpp
+++ b/c_api/IndexShards_c.cpp
@@ -1,0 +1,44 @@
+#include "IndexShards_c.h"
+#include "IndexShards.h"
+#include "macros_impl.h"
+
+using faiss::Index;
+using faiss::IndexShards;
+
+DEFINE_GETTER(IndexShards, int, own_fields)
+DEFINE_SETTER(IndexShards, int, own_fields)
+
+DEFINE_GETTER(IndexShards, int, successive_ids)
+DEFINE_SETTER(IndexShards, int, successive_ids)
+
+int faiss_IndexShards_new(FaissIndexShards** p_index, idx_t d) {
+    try {
+        auto out = new IndexShards(d);
+        *p_index = reinterpret_cast<FaissIndexShards*>(out);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexShards_new_with_options(FaissIndexShards** p_index, idx_t d, int threaded, int successive_ids) {
+    try {
+        auto out = new IndexShards(d, static_cast<bool>(threaded), static_cast<bool>(successive_ids));
+        *p_index = reinterpret_cast<FaissIndexShards*>(out);
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexShards_add_shard(FaissIndexShards* index, FaissIndex* shard) {
+    try {
+        reinterpret_cast<IndexShards*>(index)->add_shard(
+            reinterpret_cast<Index*>(shard));
+    } CATCH_AND_HANDLE
+}
+
+int faiss_IndexShards_sync_with_shard_indexes(FaissIndexShards* index) {
+    try {
+        reinterpret_cast<IndexShards*>(index)->sync_with_shard_indexes();
+    } CATCH_AND_HANDLE
+}
+
+FaissIndex* faiss_IndexShards_at(FaissIndexShards* index, int i) {
+    auto shard = reinterpret_cast<IndexShards*>(index)->at(i);
+    return reinterpret_cast<FaissIndex*>(shard);
+}

--- a/c_api/IndexShards_c.h
+++ b/c_api/IndexShards_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/IndexShards_c.h
+++ b/c_api/IndexShards_c.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD+Patents license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#ifndef INDEXSHARDS_C_H
+#define INDEXSHARDS_C_H
+
+#include "faiss_c.h"
+#include "Index_c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Index that concatenates the results from several sub-indexes
+ */
+FAISS_DECLARE_CLASS_INHERITED(IndexShards, Index)
+
+FAISS_DECLARE_GETTER_SETTER(IndexShards, int, own_fields)
+FAISS_DECLARE_GETTER_SETTER(IndexShards, int, successive_ids)
+
+int faiss_IndexShards_new(FaissIndexShards** p_index, idx_t d);
+
+int faiss_IndexShards_new_with_options(FaissIndexShards** p_index, idx_t d, int threaded, int successive_ids);
+
+int faiss_IndexShards_add_shard(FaissIndexShards* index, FaissIndex* shard);
+
+/// update metric_type and ntotal
+int faiss_IndexShards_sync_with_shard_indexes(FaissIndexShards* index);
+
+FaissIndex* faiss_IndexShards_at(FaissIndexShards* index, int i);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/c_api/Index_c.cpp
+++ b/c_api/Index_c.cpp
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/Index_c.h
+++ b/c_api/Index_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/Makefile
+++ b/c_api/Makefile
@@ -1,7 +1,6 @@
-# Copyright (c) 2015-present, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates.
 #
-# This source code is licensed under the BSD+Patents license found in the
+# This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
 .SUFFIXES: .cpp .o

--- a/c_api/Makefile
+++ b/c_api/Makefile
@@ -13,8 +13,9 @@ DEBUGFLAG=-DNDEBUG # no debugging
 
 LIBNAME=libfaiss
 CLIBNAME=libfaiss_c
-LIBCOBJ=error_impl.o Index_c.o IndexFlat_c.o Clustering_c.o AuxIndexStructures_c.o \
-	AutoTune_c.o IndexIVF_c.o IndexIVFFlat_c.o IndexLSH_c.o index_io_c.o MetaIndexes_c.o
+LIBCOBJ=error_impl.o Index_c.o IndexFlat_c.o Clustering_c.o AutoTune_c.o \
+	AuxIndexStructures_c.o IndexIVF_c.o IndexIVFFlat_c.o IndexLSH_c.o \
+	index_io_c.o MetaIndexes_c.o IndexShards_c.o
 
 # Build static and shared object files by default
 all: $(CLIBNAME).a $(CLIBNAME).$(SHAREDEXT)
@@ -58,6 +59,9 @@ IndexIVFFlat_c.o: IndexIVFFlat_c.cpp IndexIVFFlat_c.h ../IndexIVFFlat.h macros_i
 
 IndexLSH_c.o: CXXFLAGS += -I.. $(DEBUGFLAG)
 IndexLSH_c.o: IndexLSH_c.cpp IndexLSH_c.h ../IndexLSH.h macros_impl.h
+
+IndexShards_c.o: CXXFLAGS += -I.. $(DEBUGFLAG)
+IndexShards_c.o: IndexShards_c.cpp IndexShards_c.h ../Index.h ../IndexShards.h macros_impl.h
 
 Clustering_c.o: CXXFLAGS += -I.. $(DEBUGFLAG)
 Clustering_c.o: Clustering_c.cpp Clustering_c.h ../Clustering.h macros_impl.h

--- a/c_api/MetaIndexes_c.cpp
+++ b/c_api/MetaIndexes_c.cpp
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/MetaIndexes_c.cpp
+++ b/c_api/MetaIndexes_c.cpp
@@ -16,7 +16,6 @@
 using faiss::Index;
 using faiss::IndexIDMap;
 using faiss::IndexIDMap2;
-using faiss::IndexShards;
 
 DEFINE_GETTER(IndexIDMap, int, own_fields)
 DEFINE_SETTER(IndexIDMap, int, own_fields)
@@ -49,58 +48,3 @@ int faiss_IndexIDMap2_construct_rev_map(FaissIndexIDMap2* index) {
     } CATCH_AND_HANDLE
 }
 
-DEFINE_GETTER(IndexShards, int, own_fields)
-DEFINE_SETTER(IndexShards, int, own_fields)
-
-DEFINE_GETTER(IndexShards, int, threaded)
-DEFINE_SETTER(IndexShards, int, threaded)
-
-DEFINE_GETTER(IndexShards, int, successive_ids)
-DEFINE_SETTER(IndexShards, int, successive_ids)
-
-int faiss_IndexShards_new(FaissIndexShards** p_index, idx_t d) {
-    try {
-        auto out = new IndexShards(d);
-        *p_index = reinterpret_cast<FaissIndexShards*>(out);
-    } CATCH_AND_HANDLE
-}
-
-int faiss_IndexShards_new_with_options(FaissIndexShards** p_index, idx_t d, int threaded, int successive_ids) {
-    try {
-        auto out = new IndexShards(d, static_cast<bool>(threaded), static_cast<bool>(successive_ids));
-        *p_index = reinterpret_cast<FaissIndexShards*>(out);
-    } CATCH_AND_HANDLE
-}
-
-/** get a pointer to the index' shards (the `shard_indexes` field). The
- * outputs of this function become invalid after any operation that can modify the index.
- * 
- * @param index   opaque pointer to index object
- * @param p_shard_indexes    output, the pointer to the beginning of `shard_indexes`.
- * @param p_size  output, the current length of `shard_indexes`.
- */
-void faiss_IndexShards_shard_indexes(FaissIndexShards* index, FaissIndex** p_shard_indexes, size_t* p_size) {
-    auto idx = reinterpret_cast<IndexShards*>(index);
-    if (p_shard_indexes)
-        *p_shard_indexes = reinterpret_cast<FaissIndex*>(idx->shard_indexes.data());
-    if (p_size)
-        *p_size = idx->shard_indexes.size();
-}
-
-int faiss_IndexShards_add_shard(FaissIndexShards* index, FaissIndex* shard) {
-    try {
-        reinterpret_cast<IndexShards*>(index)->add_shard(
-            reinterpret_cast<Index*>(shard));
-    } CATCH_AND_HANDLE
-}
-
-int faiss_IndexShards_sync_with_shard_indexes(FaissIndexShards* index) {
-    try {
-        reinterpret_cast<IndexShards*>(index)->sync_with_shard_indexes();
-    } CATCH_AND_HANDLE
-}
-
-FaissIndex* faiss_IndexShards_at(FaissIndexShards* index, int i) {
-    auto shard = reinterpret_cast<IndexShards*>(index)->at(i);
-    return reinterpret_cast<FaissIndex*>(shard);
-}

--- a/c_api/MetaIndexes_c.h
+++ b/c_api/MetaIndexes_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/MetaIndexes_c.h
+++ b/c_api/MetaIndexes_c.h
@@ -44,34 +44,6 @@ int faiss_IndexIDMap2_new(FaissIndexIDMap2** p_index, FaissIndex* index);
 /// make the rev_map from scratch
 int faiss_IndexIDMap2_construct_rev_map(FaissIndexIDMap2* index);
 
-/** Index that concatenates the results from several sub-indexes
- */
-FAISS_DECLARE_CLASS_INHERITED(IndexShards, Index)
-
-FAISS_DECLARE_GETTER_SETTER(IndexShards, int, own_fields)
-FAISS_DECLARE_GETTER_SETTER(IndexShards, int, threaded)
-FAISS_DECLARE_GETTER_SETTER(IndexShards, int, successive_ids)
-
-int faiss_IndexShards_new(FaissIndexShards** p_index, idx_t d);
-
-int faiss_IndexShards_new_with_options(FaissIndexShards** p_index, idx_t d, int threaded, int successive_ids);
-
-/** get a pointer to the index' shards (the `shard_indexes` field). The
- * outputs of this function become invalid after any operation that can modify the index.
- * 
- * @param index   opaque pointer to index object
- * @param p_shard_indexes    output, the pointer to the beginning of `shard_indexes`.
- * @param p_size  output, the current length of `shard_indexes`.
- */
-void faiss_IndexShards_shard_indexes(FaissIndexShards* index, FaissIndex** p_shard_indexes, size_t* p_size);
-
-int faiss_IndexShards_add_shard(FaissIndexShards* index, FaissIndex* shard);
-
-/// update metric_type and ntotal
-int faiss_IndexShards_sync_with_shard_indexes(FaissIndexShards* index);
-
-FaissIndex* faiss_IndexShards_at(FaissIndexShards* index, int i);
-
 #ifdef __cplusplus
 }
 #endif

--- a/c_api/error_c.h
+++ b/c_api/error_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/error_c.h
+++ b/c_api/error_c.h
@@ -16,10 +16,16 @@
 extern "C" {
 #endif
 
+/// An error code which depends on the exception thrown from the previous 
+/// operation. See `faiss_get_last_error` to retrieve the error message.
 typedef enum FaissErrorCode {
+    /// No error
     OK = 0,
+    /// Any exception other than Faiss or standard C++ library exceptions
     UNKNOWN_EXCEPT = -1,
+    /// Faiss library exception
     FAISS_EXCEPT = -2,
+    /// Standard C++ library exception
     STD_EXCEPT = -4
 } FaissErrorCode;
 

--- a/c_api/error_impl.cpp
+++ b/c_api/error_impl.cpp
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/error_impl.h
+++ b/c_api/error_impl.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/example_c.c
+++ b/c_api/example_c.c
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/faiss_c.h
+++ b/c_api/faiss_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/gpu/GpuAutoTune_c.cpp
+++ b/c_api/gpu/GpuAutoTune_c.cpp
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/gpu/GpuAutoTune_c.h
+++ b/c_api/gpu/GpuAutoTune_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/gpu/GpuClonerOptions_c.cpp
+++ b/c_api/gpu/GpuClonerOptions_c.cpp
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/gpu/GpuClonerOptions_c.h
+++ b/c_api/gpu/GpuClonerOptions_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/gpu/GpuIndex_c.cpp
+++ b/c_api/gpu/GpuIndex_c.cpp
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/gpu/GpuIndex_c.h
+++ b/c_api/gpu/GpuIndex_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/gpu/GpuIndicesOptions_c.h
+++ b/c_api/gpu/GpuIndicesOptions_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/gpu/GpuResources_c.cpp
+++ b/c_api/gpu/GpuResources_c.cpp
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/gpu/GpuResources_c.h
+++ b/c_api/gpu/GpuResources_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/gpu/Makefile
+++ b/c_api/gpu/Makefile
@@ -1,7 +1,6 @@
-# Copyright (c) 2015-present, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates.
 #
-# This source code is licensed under the BSD+Patents license found in the
+# This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
 .SUFFIXES: .cpp .o

--- a/c_api/gpu/StandardGpuResources_c.cpp
+++ b/c_api/gpu/StandardGpuResources_c.cpp
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/gpu/StandardGpuResources_c.cpp
+++ b/c_api/gpu/StandardGpuResources_c.cpp
@@ -36,12 +36,6 @@ int faiss_StandardGpuResources_setTempMemory(FaissStandardGpuResources* res, siz
     } CATCH_AND_HANDLE
 }
 
-int faiss_StandardGpuResources_setTempMemoryFraction(FaissStandardGpuResources* res, float fraction) {
-    try {
-        reinterpret_cast<StandardGpuResources*>(res)->setTempMemoryFraction(fraction);
-    } CATCH_AND_HANDLE
-}
-
 int faiss_StandardGpuResources_setPinnedMemory(FaissStandardGpuResources* res, size_t size) {
     try {
         reinterpret_cast<StandardGpuResources*>(res)->setPinnedMemory(size);

--- a/c_api/gpu/StandardGpuResources_c.h
+++ b/c_api/gpu/StandardGpuResources_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/gpu/StandardGpuResources_c.h
+++ b/c_api/gpu/StandardGpuResources_c.h
@@ -37,10 +37,6 @@ int faiss_StandardGpuResources_noTempMemory(FaissStandardGpuResources*);
 /// all devices as temporary memory
 int faiss_StandardGpuResources_setTempMemory(FaissStandardGpuResources*, size_t size);
 
-/// Specify that we wish to use a certain fraction of memory on
-/// all devices as temporary memory
-int faiss_StandardGpuResources_setTempMemoryFraction(FaissStandardGpuResources*, float fraction);
-
 /// Set amount of pinned memory to allocate, for async GPU <-> CPU
 /// transfers
 int faiss_StandardGpuResources_setPinnedMemory(FaissStandardGpuResources*, size_t size);

--- a/c_api/gpu/example_gpu_c.c
+++ b/c_api/gpu/example_gpu_c.c
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/gpu/macros_impl.h
+++ b/c_api/gpu/macros_impl.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/index_io_c.cpp
+++ b/c_api/index_io_c.cpp
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/index_io_c.h
+++ b/c_api/index_io_c.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 

--- a/c_api/macros_impl.h
+++ b/c_api/macros_impl.h
@@ -1,8 +1,7 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD+Patents license found in the
+ * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 


### PR DESCRIPTION
The recent major updates to faiss included a few API changes which made the C API no longer compile. The changes made (small summary below) aim to make things work again, rather than exposing the latest features. The latter can be done in future PRs, and I'll be listening to related issues in the event that someone is interested in them.

- Move `IndexShards` (out of MetaIndexes_c) into a dedicated module IndexShards_c
- Remove getter/setters to unreachable fields and non-existing methods in the latest API
- Reimplement faiss_IndexIVF_imbalance_factor (to retrieve the same output from the inner `invlists`)
- Remove `FaissQueryResult`, provide `FaissRangeQueryResult` instead
- Minor documentation tweaks
- The C API was relicensed to MIT for consistency with the rest of the project. Hopefully this change is desirable, do you agree?