### PR TITLE
Facebook sync (Jun 2019)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
             - libblas-dev
             - liblapack-dev
             - python-numpy
+            - python-scipy
             - python-dev
 #            - swig3.0
       env:
@@ -26,6 +27,7 @@ matrix:
             - libatlas-base-dev
             - liblapack-dev
             - python-numpy
+            - python-scipy
             - python-dev
 #            - swig3.0
       env:
@@ -38,6 +40,7 @@ matrix:
             - libopenblas-dev
             - liblapack-dev
             - python-numpy
+            - python-scipy
             - python-dev
 #            - swig3.0
       env:
@@ -50,6 +53,7 @@ matrix:
             - libopenblas-dev
             - liblapack-dev
             - python-numpy
+            - python-scipy
             - python-dev
 #            - swig3.0
       env:
@@ -58,16 +62,16 @@ matrix:
         - LD_LIBRARY_PATH="/usr/local/clang/lib"
     - os: osx
       env:
-        - MATRIX_EVAL="brew update && brew install gcc@6 numpy swig; brew link --overwrite gcc@6; export CC=gcc-6 CXX=g++-6"
+        - MATRIX_EVAL="brew update && brew install gcc@6 numpy scipy swig; brew link --overwrite gcc@6; export CC=gcc-6 CXX=g++-6"
     - os: osx
       env:
-        - MATRIX_EVAL="brew update && brew install llvm numpy swig; brew link --overwrite llvm; export CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++"
+        - MATRIX_EVAL="brew update && brew install llvm numpy scipy swig; brew link --overwrite llvm; export CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++"
         - LDFLAGS="-L/usr/local/opt/llvm/lib"
         - CPPFLAGS="-I/usr/local/opt/llvm/include"
   allow_failures:
     - os: osx
       env:
-        - MATRIX_EVAL="brew update && brew install gcc@6 numpy swig; brew link --overwrite gcc@6; export CC=gcc-6 CXX=g++-6"
+        - MATRIX_EVAL="brew update && brew install gcc@6 numpy scipy swig; brew link --overwrite gcc@6; export CC=gcc-6 CXX=g++-6"
 
 before_install:
   - eval "$MATRIX_EVAL"

--- a/AutoTune.h
+++ b/AutoTune.h
@@ -87,7 +87,7 @@ struct OperatingPoint {
     double perf;     ///< performance measure (output of a Criterion)
     double t;        ///< corresponding execution time (ms)
     std::string key; ///< key that identifies this op pt
-    long cno;        ///< integer identifer
+    int64_t cno;        ///< integer identifer
 };
 
 struct OperatingPoints {

--- a/AutoTune.h
+++ b/AutoTune.h
@@ -12,6 +12,7 @@
 
 #include <vector>
 #include <unordered_map>
+#include <stdint.h>
 
 #include "Index.h"
 #include "IndexBinary.h"

--- a/Clustering.cpp
+++ b/Clustering.cpp
@@ -44,7 +44,7 @@ Clustering::Clustering (int d, int k, const ClusteringParameters &cp):
 
 
 
-static double imbalance_factor (int n, int k, long *assign) {
+static double imbalance_factor (int n, int k, int64_t *assign) {
     std::vector<int> hist(k, 0);
     for (int i = 0; i < n; i++)
         hist[assign[i]]++;

--- a/Heap.cpp
+++ b/Heap.cpp
@@ -33,7 +33,7 @@ void HeapArray<C>::reorder ()
 
 template <typename C>
 void HeapArray<C>::addn (size_t nj, const T *vin, TI j0,
-                         size_t i0, long ni)
+                         size_t i0, int64_t ni)
 {
     if (ni == -1) ni = nh;
     assert (i0 >= 0 && i0 + ni <= nh);
@@ -56,7 +56,7 @@ void HeapArray<C>::addn (size_t nj, const T *vin, TI j0,
 template <typename C>
 void HeapArray<C>::addn_with_ids (
      size_t nj, const T *vin, const TI *id_in,
-     long id_stride, size_t i0, long ni)
+     int64_t id_stride, size_t i0, int64_t ni)
 {
     if (id_in == nullptr) {
         addn (nj, vin, 0, i0, ni);
@@ -88,7 +88,7 @@ void HeapArray<C>::per_line_extrema (
 {
 #pragma omp parallel for
     for (size_t j = 0; j < nh; j++) {
-        long imin = -1;
+        int64_t imin = -1;
         typename C::T xval = C::Crev::neutral ();
         const typename C::T * x_ = val + j * k;
         for (size_t i = 0; i < k; i++)
@@ -113,10 +113,10 @@ void HeapArray<C>::per_line_extrema (
 
 // explicit instanciations
 
-template struct HeapArray<CMin <float, long> >;
-template struct HeapArray<CMax <float, long> >;
-template struct HeapArray<CMin <int, long> >;
-template struct HeapArray<CMax <int, long> >;
+template struct HeapArray<CMin <float, int64_t> >;
+template struct HeapArray<CMax <float, int64_t> >;
+template struct HeapArray<CMin <int, int64_t> >;
+template struct HeapArray<CMax <int, int64_t> >;
 
 
 }  // END namespace fasis

--- a/Heap.h
+++ b/Heap.h
@@ -143,33 +143,33 @@ void heap_push (size_t k,
 
 
 
-/* Partial instanciation for heaps with TI = long */
+/* Partial instanciation for heaps with TI = int64_t */
 
 template <typename T> inline
-void minheap_pop (size_t k, T * bh_val, long * bh_ids)
+void minheap_pop (size_t k, T * bh_val, int64_t * bh_ids)
 {
-    heap_pop<CMin<T, long> > (k, bh_val, bh_ids);
+    heap_pop<CMin<T, int64_t> > (k, bh_val, bh_ids);
 }
 
 
 template <typename T> inline
-void minheap_push (size_t k, T * bh_val, long * bh_ids, T val, long ids)
+void minheap_push (size_t k, T * bh_val, int64_t * bh_ids, T val, int64_t ids)
 {
-    heap_push<CMin<T, long> > (k, bh_val, bh_ids, val, ids);
+    heap_push<CMin<T, int64_t> > (k, bh_val, bh_ids, val, ids);
 }
 
 
 template <typename T> inline
-void maxheap_pop (size_t k, T * bh_val, long * bh_ids)
+void maxheap_pop (size_t k, T * bh_val, int64_t * bh_ids)
 {
-    heap_pop<CMax<T, long> > (k, bh_val, bh_ids);
+    heap_pop<CMax<T, int64_t> > (k, bh_val, bh_ids);
 }
 
 
 template <typename T> inline
-void maxheap_push (size_t k, T * bh_val, long * bh_ids, T val, long ids)
+void maxheap_push (size_t k, T * bh_val, int64_t * bh_ids, T val, int64_t ids)
 {
-    heap_push<CMax<T, long> > (k, bh_val, bh_ids, val, ids);
+    heap_push<CMax<T, int64_t> > (k, bh_val, bh_ids, val, ids);
 }
 
 
@@ -210,12 +210,12 @@ void heap_heapify (
 template <typename T> inline
 void minheap_heapify (
         size_t k, T *  bh_val,
-        long * bh_ids,
+        int64_t * bh_ids,
         const T * x = nullptr,
-        const long * ids = nullptr,
+        const int64_t * ids = nullptr,
         size_t k0 = 0)
 {
-    heap_heapify< CMin<T, long> > (k, bh_val, bh_ids, x, ids, k0);
+    heap_heapify< CMin<T, int64_t> > (k, bh_val, bh_ids, x, ids, k0);
 }
 
 
@@ -223,12 +223,12 @@ template <typename T> inline
 void maxheap_heapify (
         size_t k,
         T * bh_val,
-        long * bh_ids,
+        int64_t * bh_ids,
          const T * x = nullptr,
-         const long * ids = nullptr,
+         const int64_t * ids = nullptr,
          size_t k0 = 0)
 {
-    heap_heapify< CMax<T, long> > (k, bh_val, bh_ids, x, ids, k0);
+    heap_heapify< CMax<T, int64_t> > (k, bh_val, bh_ids, x, ids, k0);
 }
 
 
@@ -264,20 +264,20 @@ void heap_addn (size_t k,
 }
 
 
-/* Partial instanciation for heaps with TI = long */
+/* Partial instanciation for heaps with TI = int64_t */
 
 template <typename T> inline
-void minheap_addn (size_t k, T * bh_val, long * bh_ids,
-                   const T * x, const long * ids, size_t n)
+void minheap_addn (size_t k, T * bh_val, int64_t * bh_ids,
+                   const T * x, const int64_t * ids, size_t n)
 {
-    heap_addn<CMin<T, long> > (k, bh_val, bh_ids, x, ids, n);
+    heap_addn<CMin<T, int64_t> > (k, bh_val, bh_ids, x, ids, n);
 }
 
 template <typename T> inline
-void maxheap_addn (size_t k, T * bh_val, long * bh_ids,
-                   const T * x, const long * ids, size_t n)
+void maxheap_addn (size_t k, T * bh_val, int64_t * bh_ids,
+                   const T * x, const int64_t * ids, size_t n)
 {
-    heap_addn<CMax<T, long> > (k, bh_val, bh_ids, x, ids, n);
+    heap_addn<CMax<T, int64_t> > (k, bh_val, bh_ids, x, ids, n);
 }
 
 
@@ -322,15 +322,15 @@ size_t heap_reorder (size_t k, typename C::T * bh_val, typename C::TI * bh_ids)
 }
 
 template <typename T> inline
-size_t minheap_reorder (size_t k, T * bh_val, long * bh_ids)
+size_t minheap_reorder (size_t k, T * bh_val, int64_t * bh_ids)
 {
-    return heap_reorder< CMin<T, long> > (k, bh_val, bh_ids);
+    return heap_reorder< CMin<T, int64_t> > (k, bh_val, bh_ids);
 }
 
 template <typename T> inline
-size_t maxheap_reorder (size_t k, T * bh_val, long * bh_ids)
+size_t maxheap_reorder (size_t k, T * bh_val, int64_t * bh_ids)
 {
-    return heap_reorder< CMax<T, long> > (k, bh_val, bh_ids);
+    return heap_reorder< CMax<T, int64_t> > (k, bh_val, bh_ids);
 }
 
 
@@ -373,7 +373,7 @@ struct HeapArray {
      * @param ni    nb of elements to update (-1 = use nh)
      */
     void addn (size_t nj, const T *vin, TI j0 = 0,
-               size_t i0 = 0, long ni = -1);
+               size_t i0 = 0, int64_t ni = -1);
 
     /** same as addn
      *
@@ -382,7 +382,7 @@ struct HeapArray {
      */
     void addn_with_ids (
         size_t nj, const T *vin, const TI *id_in = nullptr,
-        long id_stride = 0, size_t i0 = 0, long ni = -1);
+        int64_t id_stride = 0, size_t i0 = 0, int64_t ni = -1);
 
     /// reorder all the heaps
     void reorder ();
@@ -398,11 +398,11 @@ struct HeapArray {
 
 
 /* Define useful heaps */
-typedef HeapArray<CMin<float, long> > float_minheap_array_t;
-typedef HeapArray<CMin<int, long> > int_minheap_array_t;
+typedef HeapArray<CMin<float, int64_t> > float_minheap_array_t;
+typedef HeapArray<CMin<int, int64_t> > int_minheap_array_t;
 
-typedef HeapArray<CMax<float, long> > float_maxheap_array_t;
-typedef HeapArray<CMax<int, long> > int_maxheap_array_t;
+typedef HeapArray<CMax<float, int64_t> > float_maxheap_array_t;
+typedef HeapArray<CMax<int, int64_t> > int_maxheap_array_t;
 
 // The heap templates are instanciated explicitly in Heap.cpp
 

--- a/Heap.h
+++ b/Heap.h
@@ -27,6 +27,7 @@
 
 #include <cassert>
 #include <cstdio>
+#include <stdint.h>
 
 #include <limits>
 

--- a/Index.cpp
+++ b/Index.cpp
@@ -7,8 +7,9 @@
 
 // -*- c++ -*-
 
-#include "IndexFlat.h"
+#include "AuxIndexStructures.h"
 #include "FaissAssert.h"
+#include "utils.h"
 
 #include <cstring>
 
@@ -41,11 +42,11 @@ void Index::assign (idx_t n, const float * x, idx_t * labels, idx_t k)
 void Index::add_with_ids(
     idx_t /*n*/,
     const float* /*x*/,
-    const long* /*xids*/) {
+    const int64_t* /*xids*/) {
   FAISS_THROW_MSG ("add_with_ids not implemented for this type of index");
 }
 
-long Index::remove_ids(const IDSelector& /*sel*/) {
+size_t Index::remove_ids(const IDSelector& /*sel*/) {
   FAISS_THROW_MSG ("remove_ids not implemented for this type of index");
   return -1;
 }
@@ -94,5 +95,52 @@ void Index::compute_residual (const float * x,
 void Index::display () const {
   printf ("Index: %s  -> %ld elements\n", typeid (*this).name(), ntotal);
 }
+
+
+namespace {
+
+
+// storage that explicitly reconstructs vectors before computing distances
+struct GenericDistanceComputer : DistanceComputer {
+  size_t d;
+  const Index& storage;
+  std::vector<float> buf;
+  const float *q;
+
+  explicit GenericDistanceComputer(const Index& storage)
+      : storage(storage) {
+    d = storage.d;
+    buf.resize(d * 2);
+  }
+
+  float operator () (idx_t i) override {
+    storage.reconstruct(i, buf.data());
+    return fvec_L2sqr(q, buf.data(), d);
+  }
+
+  float symmetric_dis(idx_t i, idx_t j) override {
+    storage.reconstruct(i, buf.data());
+    storage.reconstruct(j, buf.data() + d);
+    return fvec_L2sqr(buf.data() + d, buf.data(), d);
+  }
+
+  void set_query(const float *x) override {
+    q = x;
+  }
+
+};
+
+
+}  // namespace
+
+
+DistanceComputer * Index::get_distance_computer() const {
+    if (metric_type == METRIC_L2) {
+        return new GenericDistanceComputer(*this);
+    } else {
+        FAISS_THROW_MSG ("get_distance_computer() not implemented");
+    }
+}
+
 
 }

--- a/Index.cpp
+++ b/Index.cpp
@@ -42,7 +42,7 @@ void Index::assign (idx_t n, const float * x, idx_t * labels, idx_t k)
 void Index::add_with_ids(
     idx_t /*n*/,
     const float* /*x*/,
-    const int64_t* /*xids*/) {
+    const idx_t* /*xids*/) {
   FAISS_THROW_MSG ("add_with_ids not implemented for this type of index");
 }
 

--- a/Index.h
+++ b/Index.h
@@ -42,14 +42,24 @@ namespace faiss {
 
 /// Some algorithms support both an inner product version and a L2 search version.
 enum MetricType {
-    METRIC_INNER_PRODUCT = 0,
-    METRIC_L2 = 1,
+    METRIC_INNER_PRODUCT = 0,  ///< maximum inner product search
+    METRIC_L2 = 1,             ///< squared L2 search
+    METRIC_L1,                 ///< L1 (aka cityblock)
+    METRIC_Linf,               ///< infinity distance
+    METRIC_Lp,                 ///< L_p distance, p is given by metric_arg
+
+    /// some additional metrics defined in scipy.spatial.distance
+    METRIC_Canberra = 20,
+    METRIC_BrayCurtis,
+    METRIC_JensenShannon,
+
 };
 
 
 /// Forward declarations see AuxIndexStructures.h
 struct IDSelector;
 struct RangeSearchResult;
+struct DistanceComputer;
 
 /** Abstract structure for an index
  *
@@ -67,18 +77,21 @@ struct Index {
     idx_t ntotal;          ///< total nb of indexed vectors
     bool verbose;          ///< verbosity level
 
-    /// set if the Index does not require training, or if training is done already
+    /// set if the Index does not require training, or if training is
+    /// done already
     bool is_trained;
 
     /// type of metric this index uses for search
     MetricType metric_type;
+    float metric_arg;     ///< argument of the metric type
 
     explicit Index (idx_t d = 0, MetricType metric = METRIC_L2):
                     d(d),
                     ntotal(0),
                     verbose(false),
                     is_trained(true),
-                    metric_type (metric) {}
+                    metric_type (metric),
+                    metric_arg(0) {}
 
     virtual ~Index ();
 
@@ -106,7 +119,7 @@ struct Index {
      *
      * @param xids if non-null, ids to store for the vectors (size n)
      */
-    virtual void add_with_ids (idx_t n, const float * x, const long *xids);
+    virtual void add_with_ids (idx_t n, const float * x, const idx_t *xids);
 
     /** query n vectors of dimension d to the index.
      *
@@ -144,9 +157,10 @@ struct Index {
     /// removes all elements from the database.
     virtual void reset() = 0;
 
-    /** removes IDs from the index. Not supported by all indexes
+    /** removes IDs from the index. Not supported by all
+     * indexes. Returns the number of elements removed.
      */
-    virtual long remove_ids (const IDSelector & sel);
+    virtual size_t remove_ids (const IDSelector & sel);
 
     /** Reconstruct a stored vector (or an approximation if lossy coding)
      *
@@ -155,7 +169,6 @@ struct Index {
      * @param recons      reconstucted vector (size d)
      */
     virtual void reconstruct (idx_t key, float * recons) const;
-
 
     /** Reconstruct vectors i0 to i0 + ni - 1
      *
@@ -192,7 +205,13 @@ struct Index {
     /** Display the actual class name and some more info */
     void display () const;
 
-
+    /** Get a DistanceComputer (defined in AuxIndexStructures) object
+     * for this kind of index.
+     *
+     * DistanceComputer is implemented for indexes that support random
+     * access of their vectors.
+     */
+    virtual DistanceComputer * get_distance_computer() const;
 
 };
 

--- a/Index.h
+++ b/Index.h
@@ -15,6 +15,7 @@
 #include <typeinfo>
 #include <string>
 #include <sstream>
+#include <stdint.h>
 
 #define FAISS_VERSION_MAJOR 1
 #define FAISS_VERSION_MINOR 5
@@ -119,7 +120,7 @@ struct Index {
      *
      * @param xids if non-null, ids to store for the vectors (size n)
      */
-    virtual void add_with_ids (idx_t n, const float * x, const idx_t *xids);
+    virtual void add_with_ids (idx_t n, const float * x, const int64_t *xids);
 
     /** query n vectors of dimension d to the index.
      *

--- a/Index.h
+++ b/Index.h
@@ -69,7 +69,7 @@ struct DistanceComputer;
  * database-to-database queries are not implemented.
  */
 struct Index {
-    using idx_t = long;    ///< all indices are this type
+    using idx_t = int64_t;  ///< all indices are this type
     using component_t = float;
     using distance_t = float;
 

--- a/Index.h
+++ b/Index.h
@@ -15,7 +15,6 @@
 #include <typeinfo>
 #include <string>
 #include <sstream>
-#include <stdint.h>
 
 #define FAISS_VERSION_MAJOR 1
 #define FAISS_VERSION_MINOR 5
@@ -120,7 +119,7 @@ struct Index {
      *
      * @param xids if non-null, ids to store for the vectors (size n)
      */
-    virtual void add_with_ids (idx_t n, const float * x, const int64_t *xids);
+    virtual void add_with_ids (idx_t n, const float * x, const idx_t *xids);
 
     /** query n vectors of dimension d to the index.
      *

--- a/IndexBinary.cpp
+++ b/IndexBinary.cpp
@@ -31,7 +31,7 @@ void IndexBinary::assign(idx_t n, const uint8_t *x, idx_t *labels, idx_t k) {
   search(n, x, k, distances, labels);
 }
 
-void IndexBinary::add_with_ids(idx_t, const uint8_t *, const long *) {
+void IndexBinary::add_with_ids(idx_t, const uint8_t *, const idx_t *) {
   FAISS_THROW_MSG("add_with_ids not implemented for this type of index");
 }
 

--- a/IndexBinary.cpp
+++ b/IndexBinary.cpp
@@ -35,9 +35,9 @@ void IndexBinary::add_with_ids(idx_t, const uint8_t *, const long *) {
   FAISS_THROW_MSG("add_with_ids not implemented for this type of index");
 }
 
-long IndexBinary::remove_ids(const IDSelector&) {
+size_t IndexBinary::remove_ids(const IDSelector&) {
   FAISS_THROW_MSG("remove_ids not implemented for this type of index");
-  return -1;
+  return 0;
 }
 
 void IndexBinary::reconstruct(idx_t, uint8_t *) const {

--- a/IndexBinary.h
+++ b/IndexBinary.h
@@ -83,7 +83,7 @@ struct IndexBinary {
    *
    * @param xids if non-null, ids to store for the vectors (size n)
    */
-  virtual void add_with_ids(idx_t n, const uint8_t *x, const long *xids);
+  virtual void add_with_ids(idx_t n, const uint8_t *x, const idx_t *xids);
 
   /** Query n vectors of dimension d to the index.
    *

--- a/IndexBinary.h
+++ b/IndexBinary.h
@@ -123,7 +123,7 @@ struct IndexBinary {
 
   /** Removes IDs from the index. Not supported by all indexes.
    */
-  virtual long remove_ids(const IDSelector& sel);
+  virtual size_t remove_ids(const IDSelector& sel);
 
   /** Reconstruct a stored vector.
    *

--- a/IndexBinaryFlat.cpp
+++ b/IndexBinaryFlat.cpp
@@ -55,7 +55,7 @@ void IndexBinaryFlat::search(idx_t n, const uint8_t *x, idx_t k,
   }
 }
 
-long IndexBinaryFlat::remove_ids(const IDSelector& sel) {
+size_t IndexBinaryFlat::remove_ids(const IDSelector& sel) {
   idx_t j = 0;
   for (idx_t i = 0; i < ntotal; i++) {
     if (sel.is_member(i)) {

--- a/IndexBinaryFlat.h
+++ b/IndexBinaryFlat.h
@@ -43,7 +43,7 @@ struct IndexBinaryFlat : IndexBinary {
   /** Remove some ids. Note that because of the indexing structure,
    * the semantics of this operation are different from the usual ones:
    * the new ids are shifted. */
-  long remove_ids(const IDSelector& sel) override;
+  size_t remove_ids(const IDSelector& sel) override;
 
   IndexBinaryFlat() {}
 };

--- a/IndexBinaryIVF.cpp
+++ b/IndexBinaryIVF.cpp
@@ -57,33 +57,33 @@ void IndexBinaryIVF::add(idx_t n, const uint8_t *x) {
   add_with_ids(n, x, nullptr);
 }
 
-void IndexBinaryIVF::add_with_ids(idx_t n, const uint8_t *x, const long *xids) {
+void IndexBinaryIVF::add_with_ids(idx_t n, const uint8_t *x, const idx_t *xids) {
   add_core(n, x, xids, nullptr);
 }
 
-void IndexBinaryIVF::add_core(idx_t n, const uint8_t *x, const long *xids,
-                              const long *precomputed_idx) {
+void IndexBinaryIVF::add_core(idx_t n, const uint8_t *x, const idx_t *xids,
+                              const idx_t *precomputed_idx) {
   FAISS_THROW_IF_NOT(is_trained);
   assert(invlists);
   FAISS_THROW_IF_NOT_MSG(!(maintain_direct_map && xids),
                          "cannot have direct map and add with ids");
 
-  const long * idx;
+  const idx_t * idx;
 
-  std::unique_ptr<long[]> scoped_idx;
+  std::unique_ptr<idx_t[]> scoped_idx;
 
   if (precomputed_idx) {
     idx = precomputed_idx;
   } else {
-    scoped_idx.reset(new long[n]);
+    scoped_idx.reset(new idx_t[n]);
     quantizer->assign(n, x, scoped_idx.get());
     idx = scoped_idx.get();
   }
 
   long n_add = 0;
   for (size_t i = 0; i < n; i++) {
-    long id = xids ? xids[i] : ntotal + i;
-    long list_no = idx[i];
+    idx_t id = xids ? xids[i] : ntotal + i;
+    idx_t list_no = idx[i];
 
     if (list_no < 0)
       continue;
@@ -112,7 +112,7 @@ void IndexBinaryIVF::make_direct_map(bool new_maintain_direct_map) {
       size_t list_size = invlists->list_size(key);
       const idx_t *idlist = invlists->get_ids(key);
 
-      for (long ofs = 0; ofs < list_size; ofs++) {
+      for (size_t ofs = 0; ofs < list_size; ofs++) {
         FAISS_THROW_IF_NOT_MSG(0 <= idlist[ofs] && idlist[ofs] < ntotal,
                                "direct map supported only for seuquential ids");
         direct_map[idlist[ofs]] = key << 32 | ofs;
@@ -144,20 +144,20 @@ void IndexBinaryIVF::search(idx_t n, const uint8_t *x, idx_t k,
 void IndexBinaryIVF::reconstruct(idx_t key, uint8_t *recons) const {
   FAISS_THROW_IF_NOT_MSG(direct_map.size() == ntotal,
                          "direct map is not initialized");
-  long list_no = direct_map[key] >> 32;
-  long offset = direct_map[key] & 0xffffffff;
+  idx_t list_no = direct_map[key] >> 32;
+  idx_t offset = direct_map[key] & 0xffffffff;
   reconstruct_from_offset(list_no, offset, recons);
 }
 
 void IndexBinaryIVF::reconstruct_n(idx_t i0, idx_t ni, uint8_t *recons) const {
   FAISS_THROW_IF_NOT(ni == 0 || (i0 >= 0 && i0 + ni <= ntotal));
 
-  for (long list_no = 0; list_no < nlist; list_no++) {
+  for (idx_t list_no = 0; list_no < nlist; list_no++) {
     size_t list_size = invlists->list_size(list_no);
     const Index::idx_t *idlist = invlists->get_ids(list_no);
 
-    for (long offset = 0; offset < list_size; offset++) {
-      long id = idlist[offset];
+    for (idx_t offset = 0; offset < list_size; offset++) {
+      idx_t id = idlist[offset];
       if (!(id >= i0 && id < i0 + ni)) {
         continue;
       }
@@ -171,7 +171,7 @@ void IndexBinaryIVF::reconstruct_n(idx_t i0, idx_t ni, uint8_t *recons) const {
 void IndexBinaryIVF::search_and_reconstruct(idx_t n, const uint8_t *x, idx_t k,
                                             int32_t *distances, idx_t *labels,
                                             uint8_t *recons) const {
-  std::unique_ptr<idx_t[]> idx(new long[n * nprobe]);
+  std::unique_ptr<idx_t[]> idx(new idx_t[n * nprobe]);
   std::unique_ptr<int32_t[]> coarse_dis(new int32_t[n * nprobe]);
 
   quantizer->search(n, x, nprobe, coarse_dis.get(), idx.get());
@@ -203,7 +203,7 @@ void IndexBinaryIVF::search_and_reconstruct(idx_t n, const uint8_t *x, idx_t k,
   }
 }
 
-void IndexBinaryIVF::reconstruct_from_offset(long list_no, long offset,
+void IndexBinaryIVF::reconstruct_from_offset(idx_t list_no, idx_t offset,
                                              uint8_t *recons) const {
   memcpy(recons, invlists->get_single_code(list_no, offset), code_size);
 }
@@ -218,11 +218,11 @@ size_t IndexBinaryIVF::remove_ids(const IDSelector& sel) {
   FAISS_THROW_IF_NOT_MSG(!maintain_direct_map,
                          "direct map remove not implemented");
 
-  std::vector<long> toremove(nlist);
+  std::vector<idx_t> toremove(nlist);
 
 #pragma omp parallel for
-  for (long i = 0; i < nlist; i++) {
-    long l0 = invlists->list_size (i), l = l0, j = 0;
+  for (idx_t i = 0; i < nlist; i++) {
+    idx_t l0 = invlists->list_size (i), l = l0, j = 0;
     const idx_t *idsi = invlists->get_ids(i);
     while (j < l) {
       if (sel.is_member(idsi[j])) {
@@ -238,8 +238,8 @@ size_t IndexBinaryIVF::remove_ids(const IDSelector& sel) {
     toremove[i] = l0 - l;
   }
   // this will not run well in parallel on ondisk because of possible shrinks
-  long nremove = 0;
-  for (long i = 0; i < nlist; i++) {
+  size_t nremove = 0;
+  for (idx_t i = 0; i < nlist; i++) {
     if (toremove[i] > 0) {
       nremove += toremove[i];
       invlists->resize(
@@ -357,7 +357,7 @@ struct IVFBinaryScannerL2: BinaryInvertedListScanner {
             uint32_t dis = hc.hamming (codes);
             if (dis < simi[0]) {
                 heap_pop<C> (k, simi, idxi);
-                long id = store_pairs ? (list_no << 32 | j) : ids[j];
+                idx_t id = store_pairs ? (list_no << 32 | j) : ids[j];
                 heap_push<C> (k, simi, idxi, dis, id);
                 nup++;
             }
@@ -429,9 +429,9 @@ void search_knn_hamming_heap(const IndexBinaryIVF& ivf,
             const uint8_t *xi = x + i * ivf.code_size;
             scanner->set_query(xi);
 
-            const long * keysi = keys + i * nprobe;
+            const idx_t * keysi = keys + i * nprobe;
             int32_t * simi = distances + k * i;
-            long * idxi = labels + k * i;
+            idx_t * idxi = labels + k * i;
 
             if (metric_type == METRIC_INNER_PRODUCT) {
                 heap_heapify<HeapForIP> (k, simi, idxi);
@@ -442,13 +442,13 @@ void search_knn_hamming_heap(const IndexBinaryIVF& ivf,
             size_t nscan = 0;
 
             for (size_t ik = 0; ik < nprobe; ik++) {
-                long key = keysi[ik];  /* select the list  */
+                idx_t key = keysi[ik];  /* select the list  */
                 if (key < 0) {
                     // not enough centroids for multiprobe
                     continue;
                 }
                 FAISS_THROW_IF_NOT_FMT
-                    (key < (long) ivf.nlist,
+                    (key < (idx_t) ivf.nlist,
                      "Invalid key=%ld  at ik=%ld nlist=%ld\n",
                      key, ik, ivf.nlist);
 
@@ -495,14 +495,14 @@ template<class HammingComputer, bool store_pairs>
 void search_knn_hamming_count(const IndexBinaryIVF& ivf,
                               size_t nx,
                               const uint8_t *x,
-                              const long *keys,
+                              const idx_t *keys,
                               int k,
                               int32_t *distances,
-                              long *labels,
+                              idx_t *labels,
                               const IVFSearchParameters *params) {
   const int nBuckets = ivf.d + 1;
   std::vector<int> all_counters(nx * nBuckets, 0);
-  std::unique_ptr<long[]> all_ids_per_dis(new long[nx * nBuckets * k]);
+  std::unique_ptr<idx_t[]> all_ids_per_dis(new idx_t[nx * nBuckets * k]);
 
   long nprobe = params ? params->nprobe : ivf.nprobe;
   long max_codes = params ? params->max_codes : ivf.max_codes;
@@ -522,19 +522,19 @@ void search_knn_hamming_count(const IndexBinaryIVF& ivf,
 
 #pragma omp parallel for reduction(+: nlistv, ndis)
   for (size_t i = 0; i < nx; i++) {
-    const long * keysi = keys + i * nprobe;
+    const idx_t * keysi = keys + i * nprobe;
     HCounterState<HammingComputer>& csi = cs[i];
 
     size_t nscan = 0;
 
     for (size_t ik = 0; ik < nprobe; ik++) {
-      long key = keysi[ik];  /* select the list  */
+      idx_t key = keysi[ik];  /* select the list  */
       if (key < 0) {
         // not enough centroids for multiprobe
         continue;
       }
       FAISS_THROW_IF_NOT_FMT (
-        key < (long) ivf.nlist,
+        key < (idx_t) ivf.nlist,
         "Invalid key=%ld  at ik=%ld nlist=%ld\n",
         key, ik, ivf.nlist);
 
@@ -549,7 +549,7 @@ void search_knn_hamming_count(const IndexBinaryIVF& ivf,
       for (size_t j = 0; j < list_size; j++) {
         const uint8_t * yj = list_vecs + ivf.code_size * j;
 
-        long id = store_pairs ? (key << 32 | j) : ids[j];
+        idx_t id = store_pairs ? (key << 32 | j) : ids[j];
         csi.update_counter(yj, id);
       }
       if (ids)
@@ -588,10 +588,10 @@ void search_knn_hamming_count_1 (
                         const IndexBinaryIVF& ivf,
                         size_t nx,
                         const uint8_t *x,
-                        const long *keys,
+                        const idx_t *keys,
                         int k,
                         int32_t *distances,
-                        long *labels,
+                        idx_t *labels,
                         const IVFSearchParameters *params) {
     switch (ivf.code_size) {
 #define HANDLE_CS(cs)                                                  \

--- a/IndexBinaryIVF.cpp
+++ b/IndexBinaryIVF.cpp
@@ -214,7 +214,7 @@ void IndexBinaryIVF::reset() {
   ntotal = 0;
 }
 
-long IndexBinaryIVF::remove_ids(const IDSelector& sel) {
+size_t IndexBinaryIVF::remove_ids(const IDSelector& sel) {
   FAISS_THROW_IF_NOT_MSG(!maintain_direct_map,
                          "direct map remove not implemented");
 

--- a/IndexBinaryIVF.h
+++ b/IndexBinaryIVF.h
@@ -151,8 +151,7 @@ struct IndexBinaryIVF : IndexBinary {
 
 
     /// Dataset manipulation functions
-
-    long remove_ids(const IDSelector& sel) override;
+    size_t remove_ids(const IDSelector& sel) override;
 
     /** moves the entries from another dataset to self. On output,
      * other is empty. add_id is added to all moved ids (for

--- a/IndexBinaryIVF.h
+++ b/IndexBinaryIVF.h
@@ -47,7 +47,7 @@ struct IndexBinaryIVF : IndexBinary {
 
     /// map for direct access to the elements. Enables reconstruct().
     bool maintain_direct_map;
-    std::vector<long> direct_map;
+    std::vector<idx_t> direct_map;
 
     IndexBinary *quantizer;   ///< quantizer that maps vectors to inverted lists
     size_t nlist;             ///< number of possible key values
@@ -75,11 +75,11 @@ struct IndexBinaryIVF : IndexBinary {
 
     void add(idx_t n, const uint8_t *x) override;
 
-    void add_with_ids(idx_t n, const uint8_t *x, const long *xids) override;
+    void add_with_ids(idx_t n, const uint8_t *x, const idx_t *xids) override;
 
     /// same as add_with_ids, with precomputed coarse quantizer
-    void add_core (idx_t n, const uint8_t * x, const long *xids,
-                   const long *precomputed_idx);
+    void add_core (idx_t n, const uint8_t * x, const idx_t *xids,
+                   const idx_t *precomputed_idx);
 
     /** Search a set of vectors, that are pre-quantized by the IVF
      *  quantizer. Fill in the corresponding heaps with the query
@@ -146,7 +146,7 @@ struct IndexBinaryIVF : IndexBinary {
      * the inv list offset is computed by search_preassigned() with
      * `store_pairs` set.
      */
-    virtual void reconstruct_from_offset(long list_no, long offset,
+    virtual void reconstruct_from_offset(idx_t list_no, idx_t offset,
                                          uint8_t* recons) const;
 
 

--- a/IndexFlat.h
+++ b/IndexFlat.h
@@ -61,9 +61,11 @@ struct IndexFlat: Index {
     /** remove some ids. NB that Because of the structure of the
      * indexing structre, the semantics of this operation are
      * different from the usual ones: the new ids are shifted */
-    long remove_ids(const IDSelector& sel) override;
+    size_t remove_ids(const IDSelector& sel) override;
 
     IndexFlat () {}
+
+    DistanceComputer * get_distance_computer() const override;
 };
 
 

--- a/IndexHNSW.cpp
+++ b/IndexHNSW.cpp
@@ -965,15 +965,15 @@ void IndexHNSW2Level::search (idx_t n, const float *x, idx_t k,
 
         int nprobe = index_ivfpq->nprobe;
 
-        long * coarse_assign = new long [n * nprobe];
-        ScopeDeleter<long> del (coarse_assign);
-        float * coarse_dis = new float [n * nprobe];
-        ScopeDeleter<float> del2 (coarse_dis);
+        std::unique_ptr<idx_t[]> coarse_assign(new idx_t[n * nprobe]);
+        std::unique_ptr<float[]> coarse_dis(new float[n * nprobe]);
 
-        index_ivfpq->quantizer->search (n, x, nprobe, coarse_dis, coarse_assign);
+        index_ivfpq->quantizer->search (n, x, nprobe, coarse_dis.get(),
+                                        coarse_assign.get());
 
-        index_ivfpq->search_preassigned (
-            n, x, k, coarse_assign, coarse_dis, distances, labels, false);
+        index_ivfpq->search_preassigned (n, x, k, coarse_assign.get(),
+                                         coarse_dis.get(), distances, labels,
+                                         false);
 
 #pragma omp parallel
         {

--- a/IndexHNSW.cpp
+++ b/IndexHNSW.cpp
@@ -123,7 +123,6 @@ void hnsw_add_vertices(IndexHNSW &index_hnsw,
         }
     }
 
-
     idx_t check_period = InterruptCallback::get_period_hint
         (max_level * index_hnsw.d * hnsw.efConstruction);
 
@@ -150,7 +149,8 @@ void hnsw_add_vertices(IndexHNSW &index_hnsw,
             {
                 VisitedTable vt (ntotal);
 
-                DistanceComputer *dis = index_hnsw.get_distance_computer();
+                DistanceComputer *dis =
+                    index_hnsw.storage->get_distance_computer();
                 ScopeDeleter1<DistanceComputer> del(dis);
                 int prev_display = verbose && omp_get_thread_num() == 0 ? 0 : -1;
                 size_t counter = 0;
@@ -174,11 +174,8 @@ void hnsw_add_vertices(IndexHNSW &index_hnsw,
                     }
 
                     if (counter % check_period == 0) {
-#pragma omp critical
-                        {
-                            if (InterruptCallback::is_interrupted ()) {
-                                interrupt = true;
-                            }
+                        if (InterruptCallback::is_interrupted ()) {
+                            interrupt = true;
                         }
                     }
                     counter++;
@@ -220,7 +217,7 @@ IndexHNSW::IndexHNSW(int d, int M):
 {}
 
 IndexHNSW::IndexHNSW(Index *storage, int M):
-    Index(storage->d, METRIC_L2),
+    Index(storage->d, storage->metric_type),
     hnsw(M),
     own_fields(false),
     storage(storage),
@@ -255,7 +252,7 @@ void IndexHNSW::search (idx_t n, const float *x, idx_t k,
 #pragma omp parallel reduction(+ : nreorder)
         {
             VisitedTable vt (ntotal);
-            DistanceComputer *dis = get_distance_computer();
+            DistanceComputer *dis = storage->get_distance_computer();
             ScopeDeleter1<DistanceComputer> del(dis);
 
 #pragma omp for
@@ -318,7 +315,7 @@ void IndexHNSW::shrink_level_0_neighbors(int new_size)
 {
 #pragma omp parallel
     {
-        DistanceComputer *dis = get_distance_computer();
+        DistanceComputer *dis = storage->get_distance_computer();
         ScopeDeleter1<DistanceComputer> del(dis);
 
 #pragma omp for
@@ -362,7 +359,7 @@ void IndexHNSW::search_level_0(
     storage_idx_t ntotal = hnsw.levels.size();
 #pragma omp parallel
     {
-        DistanceComputer *qdis = get_distance_computer();
+        DistanceComputer *qdis = storage->get_distance_computer();
         ScopeDeleter1<DistanceComputer> del(qdis);
 
         VisitedTable vt (ntotal);
@@ -431,7 +428,7 @@ void IndexHNSW::init_level_0_from_knngraph(
 
 #pragma omp parallel for
     for (idx_t i = 0; i < ntotal; i++) {
-        DistanceComputer *qdis = get_distance_computer();
+        DistanceComputer *qdis = storage->get_distance_computer();
         float vec[d];
         storage->reconstruct(i, vec);
         qdis->set_query(vec);
@@ -475,7 +472,7 @@ void IndexHNSW::init_level_0_from_entry_points(
     {
         VisitedTable vt (ntotal);
 
-        DistanceComputer *dis = get_distance_computer();
+        DistanceComputer *dis = storage->get_distance_computer();
         ScopeDeleter1<DistanceComputer> del(dis);
         float vec[storage->d];
 
@@ -513,7 +510,7 @@ void IndexHNSW::reorder_links()
         std::vector<float> distances (M);
         std::vector<size_t> order (M);
         std::vector<storage_idx_t> tmp (M);
-        DistanceComputer *dis = get_distance_computer();
+        DistanceComputer *dis = storage->get_distance_computer();
         ScopeDeleter1<DistanceComputer> del(dis);
 
 #pragma omp for
@@ -579,51 +576,6 @@ void IndexHNSW::link_singletons()
     }
 
 
-}
-
-
-namespace {
-
-
-// storage that explicitly reconstructs vectors before computing distances
-struct GenericDistanceComputer: DistanceComputer {
-    size_t d;
-    const Index & storage;
-    std::vector<float> buf;
-    const float *q;
-
-    GenericDistanceComputer(const Index & storage): storage(storage)
-    {
-        d = storage.d;
-        buf.resize(d * 2);
-    }
-
-    float operator () (idx_t i) override
-    {
-        storage.reconstruct(i, buf.data());
-        return fvec_L2sqr(q, buf.data(), d);
-    }
-
-    float symmetric_dis(idx_t i, idx_t j) override
-    {
-        storage.reconstruct(i, buf.data());
-        storage.reconstruct(j, buf.data() + d);
-        return fvec_L2sqr(buf.data() + d, buf.data(), d);
-    }
-
-    void set_query(const float *x) override {
-        q = x;
-    }
-
-
-};
-
-
-}  // namespace
-
-DistanceComputer * IndexHNSW::get_distance_computer () const
-{
-    return new GenericDistanceComputer (*storage);
 }
 
 
@@ -861,58 +813,10 @@ void ReconstructFromNeighbors::add_codes(size_t n, const float *x)
  **************************************************************/
 
 
-namespace {
-
-
-struct FlatL2Dis: DistanceComputer {
-    size_t d;
-    Index::idx_t nb;
-    const float *q;
-    const float *b;
-    size_t ndis;
-
-    float operator () (idx_t i) override
-    {
-        ndis++;
-        return (fvec_L2sqr(q, b + i * d, d));
-    }
-
-    float symmetric_dis(idx_t i, idx_t j) override
-    {
-        return (fvec_L2sqr(b + j * d, b + i * d, d));
-    }
-
-
-    FlatL2Dis(const IndexFlatL2 & storage, const float *q = nullptr):
-        q(q)
-    {
-        nb = storage.ntotal;
-        d = storage.d;
-        b = storage.xb.data();
-        ndis = 0;
-    }
-
-    void set_query(const float *x) override {
-        q = x;
-    }
-
-    ~FlatL2Dis() override {
-#pragma omp critical
-        {
-            hnsw_stats.ndis += ndis;
-        }
-    }
-};
-
-
-}  // namespace
-
-
 IndexHNSWFlat::IndexHNSWFlat()
 {
     is_trained = true;
 }
-
 
 IndexHNSWFlat::IndexHNSWFlat(int d, int M):
     IndexHNSW(new IndexFlatL2(d), M)
@@ -922,86 +826,9 @@ IndexHNSWFlat::IndexHNSWFlat(int d, int M):
 }
 
 
-DistanceComputer * IndexHNSWFlat::get_distance_computer () const
-{
-    return new FlatL2Dis (*dynamic_cast<IndexFlatL2*> (storage));
-}
-
-
-
-
 /**************************************************************
  * IndexHNSWPQ implementation
  **************************************************************/
-
-
-namespace {
-
-
-struct PQDis: DistanceComputer {
-    size_t d;
-    Index::idx_t nb;
-    const uint8_t *codes;
-    size_t code_size;
-    const ProductQuantizer & pq;
-    const float *sdc;
-    std::vector<float> precomputed_table;
-    size_t ndis;
-
-    float operator () (idx_t i) override
-    {
-        const uint8_t *code = codes + i * code_size;
-        const float *dt = precomputed_table.data();
-        float accu = 0;
-        for (int j = 0; j < pq.M; j++) {
-            accu += dt[*code++];
-            dt += 256;
-        }
-        ndis++;
-        return accu;
-    }
-
-    float symmetric_dis(idx_t i, idx_t j) override
-    {
-        const float * sdci = sdc;
-        float accu = 0;
-        const uint8_t *codei = codes + i * code_size;
-        const uint8_t *codej = codes + j * code_size;
-
-        for (int l = 0; l < pq.M; l++) {
-            accu += sdci[(*codei++) + (*codej++) * 256];
-            sdci += 256 * 256;
-        }
-        return accu;
-    }
-
-    PQDis(const IndexPQ& storage, const float* /*q*/ = nullptr)
-        : pq(storage.pq) {
-      precomputed_table.resize(pq.M * pq.ksub);
-      nb = storage.ntotal;
-      d = storage.d;
-      codes = storage.codes.data();
-      code_size = pq.code_size;
-      FAISS_ASSERT(pq.ksub == 256);
-      FAISS_ASSERT(pq.sdc_table.size() == pq.ksub * pq.ksub * pq.M);
-      sdc = pq.sdc_table.data();
-      ndis = 0;
-    }
-
-    void set_query(const float *x) override {
-        pq.compute_distance_table(x, precomputed_table.data());
-    }
-
-    ~PQDis() override {
-#pragma omp critical
-        {
-            hnsw_stats.ndis += ndis;
-        }
-    }
-};
-
-
-}  // namespace
 
 
 IndexHNSWPQ::IndexHNSWPQ() {}
@@ -1020,13 +847,6 @@ void IndexHNSWPQ::train(idx_t n, const float* x)
 }
 
 
-
-DistanceComputer * IndexHNSWPQ::get_distance_computer () const
-{
-    return new PQDis (*dynamic_cast<IndexPQ*> (storage));
-}
-
-
 /**************************************************************
  * IndexHNSWSQ implementation
  **************************************************************/
@@ -1041,19 +861,10 @@ IndexHNSWSQ::IndexHNSWSQ(int d, ScalarQuantizer::QuantizerType qtype, int M):
 
 IndexHNSWSQ::IndexHNSWSQ() {}
 
-DistanceComputer * IndexHNSWSQ::get_distance_computer () const
-{
-    return (dynamic_cast<const IndexScalarQuantizer*> (storage))->
-        get_distance_computer ();
-}
-
-
-
 
 /**************************************************************
  * IndexHNSW2Level implementation
  **************************************************************/
-
 
 
 IndexHNSW2Level::IndexHNSW2Level(Index *quantizer, size_t nlist, int m_pq, int M):
@@ -1064,178 +875,6 @@ IndexHNSW2Level::IndexHNSW2Level(Index *quantizer, size_t nlist, int m_pq, int M
 }
 
 IndexHNSW2Level::IndexHNSW2Level() {}
-
-
-namespace {
-
-
-struct Distance2Level: DistanceComputer {
-    size_t d;
-    const Index2Layer & storage;
-    std::vector<float> buf;
-    const float *q;
-
-    const float *pq_l1_tab, *pq_l2_tab;
-
-    Distance2Level(const Index2Layer & storage): storage(storage)
-    {
-        d = storage.d;
-        FAISS_ASSERT(storage.pq.dsub == 4);
-        pq_l2_tab = storage.pq.centroids.data();
-        buf.resize(2 * d);
-    }
-
-    float symmetric_dis(idx_t i, idx_t j) override
-    {
-        storage.reconstruct(i, buf.data());
-        storage.reconstruct(j, buf.data() + d);
-        return fvec_L2sqr(buf.data() + d, buf.data(), d);
-    }
-
-    void set_query(const float *x) override {
-        q = x;
-    }
-};
-
-
-// well optimized for xNN+PQNN
-struct DistanceXPQ4: Distance2Level {
-
-    int M, k;
-
-    DistanceXPQ4(const Index2Layer & storage):
-        Distance2Level (storage)
-    {
-        const IndexFlat *quantizer =
-            dynamic_cast<IndexFlat*> (storage.q1.quantizer);
-
-        FAISS_ASSERT(quantizer);
-        M = storage.pq.M;
-        pq_l1_tab = quantizer->xb.data();
-    }
-
-    float operator () (idx_t i) override
-    {
-#ifdef __SSE__
-        const uint8_t *code = storage.codes.data() + i * storage.code_size;
-        long key = 0;
-        memcpy (&key, code, storage.code_size_1);
-        code += storage.code_size_1;
-
-        // walking pointers
-        const float *qa = q;
-        const __m128 *l1_t = (const __m128 *)(pq_l1_tab + d * key);
-        const __m128 *pq_l2_t = (const __m128 *)pq_l2_tab;
-        __m128 accu = _mm_setzero_ps();
-
-        for (int m = 0; m < M; m++) {
-            __m128 qi = _mm_loadu_ps(qa);
-            __m128 recons = l1_t[m] + pq_l2_t[*code++];
-            __m128 diff = qi - recons;
-            accu += diff * diff;
-            pq_l2_t += 256;
-            qa += 4;
-        }
-
-        accu = _mm_hadd_ps (accu, accu);
-        accu = _mm_hadd_ps (accu, accu);
-        return  _mm_cvtss_f32 (accu);
-#else
-        FAISS_THROW_MSG("not implemented for non-x64 platforms");
-#endif
-    }
-
-};
-
-// well optimized for 2xNN+PQNN
-struct Distance2xXPQ4: Distance2Level {
-
-    int M_2, mi_nbits;
-
-    Distance2xXPQ4(const Index2Layer & storage):
-        Distance2Level (storage)
-    {
-        const MultiIndexQuantizer *mi =
-            dynamic_cast<MultiIndexQuantizer*> (storage.q1.quantizer);
-
-        FAISS_ASSERT(mi);
-        FAISS_ASSERT(storage.pq.M % 2 == 0);
-        M_2 = storage.pq.M / 2;
-        mi_nbits = mi->pq.nbits;
-        pq_l1_tab = mi->pq.centroids.data();
-    }
-
-    float operator () (idx_t i) override
-    {
-        const uint8_t *code = storage.codes.data() + i * storage.code_size;
-        long key01 = 0;
-        memcpy (&key01, code, storage.code_size_1);
-        code += storage.code_size_1;
-#ifdef __SSE__
-
-        // walking pointers
-        const float *qa = q;
-        const __m128 *pq_l1_t = (const __m128 *)pq_l1_tab;
-        const __m128 *pq_l2_t = (const __m128 *)pq_l2_tab;
-        __m128 accu = _mm_setzero_ps();
-
-        for (int mi_m = 0; mi_m < 2; mi_m++) {
-            long l1_idx = key01 & ((1L << mi_nbits) - 1);
-            const __m128 * pq_l1 = pq_l1_t + M_2 * l1_idx;
-
-            for (int m = 0; m < M_2; m++) {
-                __m128 qi = _mm_loadu_ps(qa);
-                __m128 recons = pq_l1[m] + pq_l2_t[*code++];
-                __m128 diff = qi - recons;
-                accu += diff * diff;
-                pq_l2_t += 256;
-                qa += 4;
-            }
-            pq_l1_t += M_2 << mi_nbits;
-            key01 >>= mi_nbits;
-        }
-        accu = _mm_hadd_ps (accu, accu);
-        accu = _mm_hadd_ps (accu, accu);
-        return  _mm_cvtss_f32 (accu);
-#else
-        FAISS_THROW_MSG("not implemented for non-x64 platforms");
-#endif
-    }
-
-};
-
-
-}  // namespace
-
-
-DistanceComputer * IndexHNSW2Level::get_distance_computer () const
-{
-    const Index2Layer *storage2l =
-        dynamic_cast<Index2Layer*>(storage);
-
-    if (storage2l) {
-#ifdef __SSE__
-
-        const MultiIndexQuantizer *mi =
-            dynamic_cast<MultiIndexQuantizer*> (storage2l->q1.quantizer);
-
-        if (mi && storage2l->pq.M % 2 == 0 && storage2l->pq.dsub == 4) {
-            return new Distance2xXPQ4(*storage2l);
-        }
-
-        const IndexFlat *fl =
-            dynamic_cast<IndexFlat*> (storage2l->q1.quantizer);
-
-        if (fl && storage2l->pq.dsub == 4) {
-            return new DistanceXPQ4(*storage2l);
-        }
-#endif
-    }
-
-    // IVFPQ and cases not handled above
-    return new GenericDistanceComputer (*storage);
-
-}
 
 
 namespace {
@@ -1339,7 +978,7 @@ void IndexHNSW2Level::search (idx_t n, const float *x, idx_t k,
 #pragma omp parallel
         {
             VisitedTable vt (ntotal);
-            DistanceComputer *dis = get_distance_computer();
+            DistanceComputer *dis = storage->get_distance_computer();
             ScopeDeleter1<DistanceComputer> del(dis);
 
             int candidates_size = hnsw.upper_beam;

--- a/IndexHNSW.h
+++ b/IndexHNSW.h
@@ -84,9 +84,6 @@ struct IndexHNSW : Index {
 
     ~IndexHNSW() override;
 
-    // get a DistanceComputer object for this kind of storage
-    virtual DistanceComputer *get_distance_computer() const = 0;
-
     void add(idx_t n, const float *x) override;
 
     /// Trains the storage if needed
@@ -129,7 +126,6 @@ struct IndexHNSW : Index {
 };
 
 
-
 /** Flat index topped with with a HNSW structure to access elements
  *  more efficiently.
  */
@@ -137,8 +133,6 @@ struct IndexHNSW : Index {
 struct IndexHNSWFlat : IndexHNSW {
     IndexHNSWFlat();
     IndexHNSWFlat(int d, int M);
-    DistanceComputer *
-      get_distance_computer() const override;
 };
 
 /** PQ index topped with with a HNSW structure to access elements
@@ -148,8 +142,6 @@ struct IndexHNSWPQ : IndexHNSW {
     IndexHNSWPQ();
     IndexHNSWPQ(int d, int pq_m, int M);
     void train(idx_t n, const float* x) override;
-    DistanceComputer *
-      get_distance_computer() const override;
 };
 
 /** SQ index topped with with a HNSW structure to access elements
@@ -158,8 +150,6 @@ struct IndexHNSWPQ : IndexHNSW {
 struct IndexHNSWSQ : IndexHNSW {
     IndexHNSWSQ();
     IndexHNSWSQ(int d, ScalarQuantizer::QuantizerType qtype, int M);
-    DistanceComputer *
-      get_distance_computer() const override;
 };
 
 /** 2-level code structure with fast random access
@@ -167,8 +157,7 @@ struct IndexHNSWSQ : IndexHNSW {
 struct IndexHNSW2Level : IndexHNSW {
     IndexHNSW2Level();
     IndexHNSW2Level(Index *quantizer, size_t nlist, int m_pq, int M);
-    DistanceComputer *
-      get_distance_computer() const override;
+
     void flip_to_ivf();
 
     /// entry point for search

--- a/IndexIVF.cpp
+++ b/IndexIVF.cpp
@@ -146,7 +146,7 @@ void IndexIVF::add (idx_t n, const float * x)
 }
 
 
-void IndexIVF::add_with_ids (idx_t n, const float * x, const long *xids)
+void IndexIVF::add_with_ids (idx_t n, const float * x, const idx_t *xids)
 {
     // do some blocking to avoid excessive allocs
     idx_t bs = 65536;

--- a/IndexIVF.cpp
+++ b/IndexIVF.cpp
@@ -638,8 +638,8 @@ void IndexIVF::search_and_reconstruct (idx_t n, const float *x, idx_t k,
 }
 
 void IndexIVF::reconstruct_from_offset(
-    idx_t /*list_no*/,
-    idx_t /*offset*/,
+    int64_t /*list_no*/,
+    int64_t /*offset*/,
     float* /*recons*/) const {
   FAISS_THROW_MSG ("reconstruct_from_offset not implemented");
 }

--- a/IndexIVF.h
+++ b/IndexIVF.h
@@ -223,7 +223,7 @@ struct IndexIVF: Index, Level1Quantizer {
 
     /// Dataset manipulation functions
 
-    idx_t remove_ids(const IDSelector& sel) override;
+    size_t remove_ids(const IDSelector& sel) override;
 
     /** check that the two indexes are compatible (ie, they are
      * trained in the same way and have the same

--- a/IndexIVF.h
+++ b/IndexIVF.h
@@ -12,7 +12,7 @@
 
 
 #include <vector>
-
+#include <stdint.h>
 
 #include "Index.h"
 #include "InvertedLists.h"
@@ -217,7 +217,7 @@ struct IndexIVF: Index, Level1Quantizer {
      * the inv list offset is computed by search_preassigned() with
      * `store_pairs` set.
      */
-    virtual void reconstruct_from_offset (idx_t list_no, idx_t offset,
+    virtual void reconstruct_from_offset (int64_t list_no, int64_t offset,
                                           float* recons) const;
 
 

--- a/IndexIVFFlat.cpp
+++ b/IndexIVFFlat.cpp
@@ -33,7 +33,7 @@ IndexIVFFlat::IndexIVFFlat (Index * quantizer,
 }
 
 
-void IndexIVFFlat::add_with_ids (idx_t n, const float * x, const int64_t *xids)
+void IndexIVFFlat::add_with_ids (idx_t n, const float * x, const idx_t *xids)
 {
     add_core (n, x, xids, nullptr);
 }

--- a/IndexIVFFlat.cpp
+++ b/IndexIVFFlat.cpp
@@ -33,34 +33,34 @@ IndexIVFFlat::IndexIVFFlat (Index * quantizer,
 }
 
 
-void IndexIVFFlat::add_with_ids (idx_t n, const float * x, const long *xids)
+void IndexIVFFlat::add_with_ids (idx_t n, const float * x, const int64_t *xids)
 {
     add_core (n, x, xids, nullptr);
 }
 
-void IndexIVFFlat::add_core (idx_t n, const float * x, const long *xids,
-                             const long *precomputed_idx)
+void IndexIVFFlat::add_core (idx_t n, const float * x, const int64_t *xids,
+                             const int64_t *precomputed_idx)
 
 {
     FAISS_THROW_IF_NOT (is_trained);
     assert (invlists);
     FAISS_THROW_IF_NOT_MSG (!(maintain_direct_map && xids),
                             "cannot have direct map and add with ids");
-    const long * idx;
-    ScopeDeleter<long> del;
+    const int64_t * idx;
+    ScopeDeleter<int64_t> del;
 
     if (precomputed_idx) {
         idx = precomputed_idx;
     } else {
-        long * idx0 = new long [n];
+        int64_t * idx0 = new int64_t [n];
         del.set (idx0);
         quantizer->assign (n, x, idx0);
         idx = idx0;
     }
-    long n_add = 0;
+    int64_t n_add = 0;
     for (size_t i = 0; i < n; i++) {
-        long id = xids ? xids[i] : ntotal + i;
-        long list_no = idx [i];
+        int64_t id = xids ? xids[i] : ntotal + i;
+        int64_t list_no = idx [i];
 
         if (list_no < 0)
             continue;
@@ -91,11 +91,13 @@ void IndexIVFFlat::encode_vectors(idx_t n, const float* x,
 namespace {
 
 
-template<MetricType metric, bool store_pairs, class C>
+template<MetricType metric, class C>
 struct IVFFlatScanner: InvertedListScanner {
-
     size_t d;
-    IVFFlatScanner(size_t d): d(d) {}
+    bool store_pairs;
+
+    IVFFlatScanner(size_t d, bool store_pairs):
+        d(d), store_pairs(store_pairs) {}
 
     const float *xi;
     void set_query (const float *query) override {
@@ -128,7 +130,7 @@ struct IVFFlatScanner: InvertedListScanner {
                 fvec_inner_product (xi, yj, d) : fvec_L2sqr (xi, yj, d);
             if (C::cmp (simi[0], dis)) {
                 heap_pop<C> (k, simi, idxi);
-                long id = store_pairs ? (list_no << 32 | j) : ids[j];
+                int64_t id = store_pairs ? (list_no << 32 | j) : ids[j];
                 heap_push<C> (k, simi, idxi, dis, id);
                 nup++;
             }
@@ -148,7 +150,7 @@ struct IVFFlatScanner: InvertedListScanner {
             float dis = metric == METRIC_INNER_PRODUCT ?
                 fvec_inner_product (xi, yj, d) : fvec_L2sqr (xi, yj, d);
             if (C::cmp (radius, dis)) {
-                long id = store_pairs ? (list_no << 32 | j) : ids[j];
+                int64_t id = store_pairs ? (list_no << 32 | j) : ids[j];
                 res.add (dis, id);
             }
         }
@@ -166,21 +168,13 @@ InvertedListScanner* IndexIVFFlat::get_InvertedListScanner
      (bool store_pairs) const
 {
     if (metric_type == METRIC_INNER_PRODUCT) {
-        if (store_pairs) {
-            return new IVFFlatScanner<
-                METRIC_INNER_PRODUCT, true, CMin<float, long> > (d);
-        } else {
-            return new IVFFlatScanner<
-                METRIC_INNER_PRODUCT, false, CMin<float, long> >(d);
-        }
+        return new IVFFlatScanner<
+            METRIC_INNER_PRODUCT, CMin<float, int64_t> > (d, store_pairs);
     } else if (metric_type == METRIC_L2) {
-        if (store_pairs) {
-            return new IVFFlatScanner<
-                METRIC_L2, true, CMax<float, long> > (d);
-        } else {
-            return new IVFFlatScanner<
-                METRIC_L2, false, CMax<float, long> >(d);
-        }
+        return new IVFFlatScanner<
+            METRIC_L2, CMax<float, int64_t> >(d, store_pairs);
+    } else {
+        FAISS_THROW_MSG("metric type not supported");
     }
     return nullptr;
 }
@@ -200,12 +194,12 @@ void IndexIVFFlat::update_vectors (int n, idx_t *new_ids, const float *x)
         FAISS_THROW_IF_NOT_MSG (0 <= id && id < ntotal,
                                 "id to update out of range");
         { // remove old one
-            long dm = direct_map[id];
-            long ofs = dm & 0xffffffff;
-            long il = dm >> 32;
+            int64_t dm = direct_map[id];
+            int64_t ofs = dm & 0xffffffff;
+            int64_t il = dm >> 32;
             size_t l = invlists->list_size (il);
             if (ofs != l - 1) { // move l - 1 to ofs
-                long id2 = invlists->get_single_id (il, l - 1);
+                int64_t id2 = invlists->get_single_id (il, l - 1);
                 direct_map[id2] = (il << 32) | ofs;
                 invlists->update_entry (il, ofs, id2,
                                         invlists->get_single_code (il, l - 1));
@@ -213,9 +207,9 @@ void IndexIVFFlat::update_vectors (int n, idx_t *new_ids, const float *x)
             invlists->resize (il, l - 1);
         }
         { // insert new one
-            long il = assign[i];
+            int64_t il = assign[i];
             size_t l = invlists->list_size (il);
-            long dm = (il << 32) | l;
+            int64_t dm = (il << 32) | l;
             direct_map[id] = dm;
             invlists->add_entry (il, id, (const uint8_t*)(x + i * d));
         }
@@ -223,7 +217,7 @@ void IndexIVFFlat::update_vectors (int n, idx_t *new_ids, const float *x)
 
 }
 
-void IndexIVFFlat::reconstruct_from_offset (long list_no, long offset,
+void IndexIVFFlat::reconstruct_from_offset (int64_t list_no, int64_t offset,
                                             float* recons) const
 {
     memcpy (recons, invlists->get_single_code (list_no, offset), code_size);
@@ -246,8 +240,8 @@ void IndexIVFFlatDedup::train(idx_t n, const float* x)
     float * x2 = new float [n * d];
     ScopeDeleter<float> del (x2);
 
-    long n2 = 0;
-    for (long i = 0; i < n; i++) {
+    int64_t n2 = 0;
+    for (int64_t i = 0; i < n; i++) {
         uint64_t hash = hash_bytes((uint8_t *)(x + i * d), code_size);
         if (map.count(hash) &&
             !memcmp (x2 + map[hash] * d, x + i * d, code_size)) {
@@ -268,7 +262,7 @@ void IndexIVFFlatDedup::train(idx_t n, const float* x)
 
 
 void IndexIVFFlatDedup::add_with_ids(
-           idx_t na, const float* x, const long* xids)
+           idx_t na, const float* x, const int64_t* xids)
 {
 
     FAISS_THROW_IF_NOT (is_trained);
@@ -276,15 +270,15 @@ void IndexIVFFlatDedup::add_with_ids(
     FAISS_THROW_IF_NOT_MSG (
            !maintain_direct_map,
            "IVFFlatDedup not implemented with direct_map");
-    long * idx = new long [na];
-    ScopeDeleter<long> del (idx);
+    int64_t * idx = new int64_t [na];
+    ScopeDeleter<int64_t> del (idx);
     quantizer->assign (na, x, idx);
 
-    long n_add = 0, n_dup = 0;
+    int64_t n_add = 0, n_dup = 0;
     // TODO make a omp loop with this
     for (size_t i = 0; i < na; i++) {
         idx_t id = xids ? xids[i] : ntotal + i;
-        long list_no = idx [i];
+        int64_t list_no = idx [i];
 
         if (list_no < 0) {
             continue;
@@ -294,9 +288,9 @@ void IndexIVFFlatDedup::add_with_ids(
         // search if there is already an entry with that id
         InvertedLists::ScopedCodes codes (invlists, list_no);
 
-        long n = invlists->list_size (list_no);
-        long offset = -1;
-        for (long o = 0; o < n; o++) {
+        int64_t n = invlists->list_size (list_no);
+        int64_t offset = -1;
+        for (int64_t o = 0; o < n; o++) {
             if (!memcmp (codes.get() + o * code_size,
                          xi, code_size)) {
                 offset = o;
@@ -341,10 +335,10 @@ void IndexIVFFlatDedup::search_preassigned (
     std::vector <idx_t> labels2 (k);
     std::vector <float> dis2 (k);
 
-    for (long i = 0; i < n; i++) {
+    for (int64_t i = 0; i < n; i++) {
         idx_t *labels1 = labels + i * k;
         float *dis1 = distances + i * k;
-        long j = 0;
+        int64_t j = 0;
         for (; j < k; j++) {
             if (instances.find (labels1[j]) != instances.end ()) {
                 // a duplicate: special handling
@@ -353,8 +347,8 @@ void IndexIVFFlatDedup::search_preassigned (
         }
         if (j < k) {
             // there are duplicates, special handling
-            long j0 = j;
-            long rp = j;
+            int64_t j0 = j;
+            int64_t rp = j;
             while (j < k) {
                 auto range = instances.equal_range (labels1[rp]);
                 float dis = dis1[rp];
@@ -378,7 +372,7 @@ void IndexIVFFlatDedup::search_preassigned (
 }
 
 
-long IndexIVFFlatDedup::remove_ids(const IDSelector& sel)
+size_t IndexIVFFlatDedup::remove_ids(const IDSelector& sel)
 {
     std::unordered_map<idx_t, idx_t> replace;
     std::vector<std::pair<idx_t, idx_t> > toadd;
@@ -412,11 +406,11 @@ long IndexIVFFlatDedup::remove_ids(const IDSelector& sel)
     FAISS_THROW_IF_NOT_MSG (!maintain_direct_map,
                     "direct map remove not implemented");
 
-    std::vector<long> toremove(nlist);
+    std::vector<int64_t> toremove(nlist);
 
 #pragma omp parallel for
-    for (long i = 0; i < nlist; i++) {
-        long l0 = invlists->list_size (i), l = l0, j = 0;
+    for (int64_t i = 0; i < nlist; i++) {
+        int64_t l0 = invlists->list_size (i), l = l0, j = 0;
         InvertedLists::ScopedIds idsi (invlists, i);
         while (j < l) {
             if (sel.is_member (idsi[j])) {
@@ -440,8 +434,8 @@ long IndexIVFFlatDedup::remove_ids(const IDSelector& sel)
         toremove[i] = l0 - l;
     }
     // this will not run well in parallel on ondisk because of possible shrinks
-    long nremove = 0;
-    for (long i = 0; i < nlist; i++) {
+    int64_t nremove = 0;
+    for (int64_t i = 0; i < nlist; i++) {
         if (toremove[i] > 0) {
             nremove += toremove[i];
             invlists->resize(
@@ -469,8 +463,7 @@ void IndexIVFFlatDedup::update_vectors (int , idx_t *, const float *)
 
 
 void IndexIVFFlatDedup::reconstruct_from_offset (
-         long , long ,
-         float* ) const
+         int64_t , int64_t , float* ) const
 {
     FAISS_THROW_MSG ("not implemented");
 }

--- a/IndexIVFFlat.cpp
+++ b/IndexIVFFlat.cpp
@@ -262,7 +262,7 @@ void IndexIVFFlatDedup::train(idx_t n, const float* x)
 
 
 void IndexIVFFlatDedup::add_with_ids(
-           idx_t na, const float* x, const int64_t* xids)
+           idx_t na, const float* x, const idx_t* xids)
 {
 
     FAISS_THROW_IF_NOT (is_trained);

--- a/IndexIVFFlat.h
+++ b/IndexIVFFlat.h
@@ -28,11 +28,11 @@ struct IndexIVFFlat: IndexIVF {
             MetricType = METRIC_L2);
 
     /// same as add_with_ids, with precomputed coarse quantizer
-    virtual void add_core (idx_t n, const float * x, const long *xids,
-                   const long *precomputed_idx);
+    virtual void add_core (idx_t n, const float * x, const int64_t *xids,
+                   const int64_t *precomputed_idx);
 
     /// implemented for all IndexIVF* classes
-    void add_with_ids(idx_t n, const float* x, const long* xids) override;
+    void add_with_ids(idx_t n, const float* x, const int64_t* xids) override;
 
     void encode_vectors(idx_t n, const float* x,
                         const idx_t *list_nos,
@@ -52,7 +52,7 @@ struct IndexIVFFlat: IndexIVF {
      */
     virtual void update_vectors (int nv, idx_t *idx, const float *v);
 
-    void reconstruct_from_offset (long list_no, long offset,
+    void reconstruct_from_offset (int64_t list_no, int64_t offset,
                                   float* recons) const override;
 
     IndexIVFFlat () {}
@@ -74,7 +74,7 @@ struct IndexIVFFlatDedup: IndexIVFFlat {
     void train(idx_t n, const float* x) override;
 
     /// implemented for all IndexIVF* classes
-    void add_with_ids(idx_t n, const float* x, const long* xids) override;
+    void add_with_ids(idx_t n, const float* x, const int64_t* xids) override;
 
     void search_preassigned (idx_t n, const float *x, idx_t k,
                              const idx_t *assign,
@@ -84,7 +84,7 @@ struct IndexIVFFlatDedup: IndexIVFFlat {
                              const IVFSearchParameters *params=nullptr
                              ) const override;
 
-    long remove_ids(const IDSelector& sel) override;
+    size_t remove_ids(const IDSelector& sel) override;
 
     /// not implemented
     void range_search(
@@ -98,7 +98,7 @@ struct IndexIVFFlatDedup: IndexIVFFlat {
 
 
     /// not implemented
-    void reconstruct_from_offset (long list_no, long offset,
+    void reconstruct_from_offset (int64_t list_no, int64_t offset,
                                   float* recons) const override;
 
     IndexIVFFlatDedup () {}

--- a/IndexIVFFlat.h
+++ b/IndexIVFFlat.h
@@ -75,7 +75,7 @@ struct IndexIVFFlatDedup: IndexIVFFlat {
     void train(idx_t n, const float* x) override;
 
     /// implemented for all IndexIVF* classes
-    void add_with_ids(idx_t n, const float* x, const int64_t* xids) override;
+    void add_with_ids(idx_t n, const float* x, const idx_t* xids) override;
 
     void search_preassigned (idx_t n, const float *x, idx_t k,
                              const idx_t *assign,

--- a/IndexIVFFlat.h
+++ b/IndexIVFFlat.h
@@ -33,7 +33,7 @@ struct IndexIVFFlat: IndexIVF {
                    const int64_t *precomputed_idx);
 
     /// implemented for all IndexIVF* classes
-    void add_with_ids(idx_t n, const float* x, const int64_t* xids) override;
+    void add_with_ids(idx_t n, const float* x, const idx_t* xids) override;
 
     void encode_vectors(idx_t n, const float* x,
                         const idx_t *list_nos,

--- a/IndexIVFFlat.h
+++ b/IndexIVFFlat.h
@@ -11,6 +11,7 @@
 #define FAISS_INDEX_IVF_FLAT_H
 
 #include <unordered_map>
+#include <stdint.h>
 
 #include "IndexIVF.h"
 

--- a/IndexIVFPQ.cpp
+++ b/IndexIVFPQ.cpp
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cassert>
+#include <stdint.h>
 
 #include <algorithm>
 

--- a/IndexIVFPQ.cpp
+++ b/IndexIVFPQ.cpp
@@ -13,6 +13,9 @@
 #include <cstdio>
 #include <cassert>
 #include <stdint.h>
+#ifdef __SSE__
+#include <immintrin.h>
+#endif
 
 #include <algorithm>
 

--- a/IndexIVFPQ.cpp
+++ b/IndexIVFPQ.cpp
@@ -310,7 +310,7 @@ void IndexIVFPQ::add_core_o (idx_t n, const float * x, const long *xids,
 }
 
 
-void IndexIVFPQ::reconstruct_from_offset (long list_no, long offset,
+void IndexIVFPQ::reconstruct_from_offset (int64_t list_no, int64_t offset,
                                           float* recons) const
 {
     const uint8_t* code = invlists->get_single_code (list_no, offset);
@@ -1227,7 +1227,7 @@ void IndexIVFPQR::train_residual (idx_t n, const float *x)
 }
 
 
-void IndexIVFPQR::add_with_ids (idx_t n, const float *x, const long *xids) {
+void IndexIVFPQR::add_with_ids (idx_t n, const float *x, const idx_t *xids) {
     add_core (n, x, xids, nullptr);
 }
 
@@ -1338,7 +1338,7 @@ void IndexIVFPQR::search_preassigned (idx_t n, const float *x, idx_t k,
     indexIVFPQ_stats.refine_cycles += TOC;
 }
 
-void IndexIVFPQR::reconstruct_from_offset (long list_no, long offset,
+void IndexIVFPQR::reconstruct_from_offset (int64_t list_no, int64_t offset,
                                            float* recons) const
 {
     IndexIVFPQ::reconstruct_from_offset (list_no, offset, recons);

--- a/IndexIVFPQ.cpp
+++ b/IndexIVFPQ.cpp
@@ -180,7 +180,7 @@ void IndexIVFPQ::decode_multiple (size_t n, const long *keys,
  * add                                                          */
 
 
-void IndexIVFPQ::add_with_ids (idx_t n, const float * x, const long *xids)
+void IndexIVFPQ::add_with_ids (idx_t n, const float * x, const idx_t *xids)
 {
     add_core_o (n, x, xids, nullptr);
 }

--- a/IndexIVFPQ.h
+++ b/IndexIVFPQ.h
@@ -166,7 +166,7 @@ struct IndexIVFPQR: IndexIVFPQ {
 
     void reset() override;
 
-    long remove_ids(const IDSelector& sel) override;
+    size_t remove_ids(const IDSelector& sel) override;
 
     /// trains the two product quantizers
     void train_residual(idx_t n, const float* x) override;
@@ -243,6 +243,8 @@ struct Index2Layer: Index {
     void reconstruct(idx_t key, float* recons) const override;
 
     void reset() override;
+
+    DistanceComputer * get_distance_computer() const override;
 
     /// transfer the flat codes to an IVFPQ index
     void transfer_to_IVFPQ(IndexIVFPQ & other) const;

--- a/IndexIVFPQ.h
+++ b/IndexIVFPQ.h
@@ -171,7 +171,7 @@ struct IndexIVFPQR: IndexIVFPQ {
     /// trains the two product quantizers
     void train_residual(idx_t n, const float* x) override;
 
-    void add_with_ids(idx_t n, const float* x, const long* xids) override;
+    void add_with_ids(idx_t n, const float* x, const idx_t* xids) override;
 
     /// same as add_with_ids, but optionally use the precomputed list ids
     void add_core (idx_t n, const float *x, const long *xids,

--- a/IndexIVFPQ.h
+++ b/IndexIVFPQ.h
@@ -73,8 +73,8 @@ struct IndexIVFPQ: IndexIVF {
     /// - output 2nd level residuals if residuals_2 != NULL
     /// - use precomputed list numbers if precomputed_idx != NULL
     void add_core_o (idx_t n, const float *x,
-                     const long *xids, float *residuals_2,
-                     const long *precomputed_idx = nullptr);
+                     const idx_t *xids, float *residuals_2,
+                     const idx_t *precomputed_idx = nullptr);
 
     /// trains the product quantizer
     void train_residual(idx_t n, const float* x) override;
@@ -99,7 +99,7 @@ struct IndexIVFPQ: IndexIVF {
     size_t find_duplicates (idx_t *ids, size_t *lims) const;
 
     // map a vector to a binary code knowning the index
-    void encode (long key, const float * x, uint8_t * code) const;
+    void encode (idx_t key, const float * x, uint8_t * code) const;
 
     /** Encode multiple vectors
      *
@@ -110,12 +110,12 @@ struct IndexIVFPQ: IndexIVF {
      * @param compute_keys  if false, assume keys are precomputed,
      *                      otherwise compute them
      */
-    void encode_multiple (size_t n, long *keys,
+    void encode_multiple (size_t n, idx_t *keys,
                           const float * x, uint8_t * codes,
                           bool compute_keys = false) const;
 
     /// inverse of encode_multiple
-    void decode_multiple (size_t n, const long *keys,
+    void decode_multiple (size_t n, const idx_t *keys,
                           const uint8_t * xcodes, float * x) const;
 
     InvertedListScanner *get_InvertedListScanner (bool store_pairs)
@@ -174,8 +174,8 @@ struct IndexIVFPQR: IndexIVFPQ {
     void add_with_ids(idx_t n, const float* x, const idx_t* xids) override;
 
     /// same as add_with_ids, but optionally use the precomputed list ids
-    void add_core (idx_t n, const float *x, const long *xids,
-                     const long *precomputed_idx = nullptr);
+    void add_core (idx_t n, const float *x, const idx_t *xids,
+                     const idx_t *precomputed_idx = nullptr);
 
     void reconstruct_from_offset (int64_t list_no, int64_t offset,
                                   float* recons) const override;

--- a/IndexIVFPQ.h
+++ b/IndexIVFPQ.h
@@ -62,7 +62,7 @@ struct IndexIVFPQ: IndexIVF {
             Index * quantizer, size_t d, size_t nlist,
             size_t M, size_t nbits_per_idx);
 
-    void add_with_ids(idx_t n, const float* x, const long* xids = nullptr)
+    void add_with_ids(idx_t n, const float* x, const idx_t* xids = nullptr)
         override;
 
     void encode_vectors(idx_t n, const float* x,
@@ -82,7 +82,7 @@ struct IndexIVFPQ: IndexIVF {
     /// same as train_residual, also output 2nd level residuals
     void train_residual_o (idx_t n, const float *x, float *residuals_2);
 
-    void reconstruct_from_offset (long list_no, long offset,
+    void reconstruct_from_offset (int64_t list_no, int64_t offset,
                                   float* recons) const override;
 
     /** Find exact duplicates in the dataset.
@@ -177,7 +177,7 @@ struct IndexIVFPQR: IndexIVFPQ {
     void add_core (idx_t n, const float *x, const long *xids,
                      const long *precomputed_idx = nullptr);
 
-    void reconstruct_from_offset (long list_no, long offset,
+    void reconstruct_from_offset (int64_t list_no, int64_t offset,
                                   float* recons) const override;
 
     void merge_from (IndexIVF &other, idx_t add_id) override;

--- a/IndexIVFSpectralHash.cpp
+++ b/IndexIVFSpectralHash.cpp
@@ -12,6 +12,7 @@
 
 #include <memory>
 #include <algorithm>
+#include <stdint.h>
 
 #include "hamming.h"
 #include "utils.h"

--- a/IndexIVFSpectralHash.cpp
+++ b/IndexIVFSpectralHash.cpp
@@ -175,7 +175,7 @@ void IndexIVFSpectralHash::encode_vectors(idx_t n, const float* x_in,
         // each thread takes care of a subset of lists
 #pragma omp for
         for (size_t i = 0; i < n; i++) {
-            long list_no = list_nos [i];
+            int64_t list_no = list_nos [i];
 
             if (list_no >= 0) {
                 const float *c;
@@ -266,7 +266,7 @@ struct IVFScanner: InvertedListScanner {
 
             if (dis < simi [0]) {
                 maxheap_pop (k, simi, idxi);
-                long id = store_pairs ? (list_no << 32 | j) : ids[j];
+                int64_t id = store_pairs ? (list_no << 32 | j) : ids[j];
                 maxheap_push (k, simi, idxi, dis, id);
                 nup++;
             }
@@ -284,7 +284,7 @@ struct IVFScanner: InvertedListScanner {
         for (size_t j = 0; j < list_size; j++) {
             float dis = hc.hamming (codes);
             if (dis < radius) {
-                long id = store_pairs ? (list_no << 32 | j) : ids[j];
+                int64_t id = store_pairs ? (list_no << 32 | j) : ids[j];
                 res.add (dis, id);
             }
             codes += code_size;

--- a/IndexPQ.cpp
+++ b/IndexPQ.cpp
@@ -82,7 +82,7 @@ void IndexPQ::add (idx_t n, const float *x)
 }
 
 
-long IndexPQ::remove_ids (const IDSelector & sel)
+size_t IndexPQ::remove_ids (const IDSelector & sel)
 {
     idx_t j = 0;
     for (idx_t i = 0; i < ntotal; i++) {
@@ -95,7 +95,7 @@ long IndexPQ::remove_ids (const IDSelector & sel)
             j++;
         }
     }
-    long nremove = ntotal - j;
+    size_t nremove = ntotal - j;
     if (nremove > 0) {
         ntotal = j;
         codes.resize (ntotal * pq.code_size);
@@ -127,9 +127,72 @@ void IndexPQ::reconstruct (idx_t key, float * recons) const
 }
 
 
+namespace {
 
 
+struct PQDis: DistanceComputer {
+    size_t d;
+    Index::idx_t nb;
+    const uint8_t *codes;
+    size_t code_size;
+    const ProductQuantizer & pq;
+    const float *sdc;
+    std::vector<float> precomputed_table;
+    size_t ndis;
 
+    float operator () (idx_t i) override
+    {
+        const uint8_t *code = codes + i * code_size;
+        const float *dt = precomputed_table.data();
+        float accu = 0;
+        for (int j = 0; j < pq.M; j++) {
+            accu += dt[*code++];
+            dt += 256;
+        }
+        ndis++;
+        return accu;
+    }
+
+    float symmetric_dis(idx_t i, idx_t j) override
+    {
+        const float * sdci = sdc;
+        float accu = 0;
+        const uint8_t *codei = codes + i * code_size;
+        const uint8_t *codej = codes + j * code_size;
+
+        for (int l = 0; l < pq.M; l++) {
+            accu += sdci[(*codei++) + (*codej++) * 256];
+            sdci += 256 * 256;
+        }
+        return accu;
+    }
+
+    explicit PQDis(const IndexPQ& storage, const float* /*q*/ = nullptr)
+        : pq(storage.pq) {
+        precomputed_table.resize(pq.M * pq.ksub);
+        nb = storage.ntotal;
+        d = storage.d;
+        codes = storage.codes.data();
+        code_size = pq.code_size;
+        FAISS_ASSERT(pq.ksub == 256);
+        FAISS_ASSERT(pq.sdc_table.size() == pq.ksub * pq.ksub * pq.M);
+        sdc = pq.sdc_table.data();
+        ndis = 0;
+    }
+
+    void set_query(const float *x) override {
+        pq.compute_distance_table(x, precomputed_table.data());
+    }
+};
+
+
+}  // namespace
+
+
+DistanceComputer * IndexPQ::get_distance_computer() const {
+    FAISS_THROW_IF_NOT(pq.nbits == 8);
+    return new PQDis(*this);
+}
 
 
 /*****************************************
@@ -237,7 +300,7 @@ template <class HammingComputer>
 static size_t polysemous_inner_loop (
         const IndexPQ & index,
         const float *dis_table_qi, const uint8_t *q_code,
-        size_t k, float *heap_dis, long *heap_ids)
+        size_t k, float *heap_dis, int64_t *heap_ids)
 {
 
     int M = index.pq.M;
@@ -252,7 +315,7 @@ static size_t polysemous_inner_loop (
 
     HammingComputer hc (q_code, code_size);
 
-    for (long bi = 0; bi < ntotal; bi++) {
+    for (int64_t bi = 0; bi < ntotal; bi++) {
         int hd = hc.hamming (b_code);
 
         if (hd < ht) {
@@ -309,7 +372,7 @@ void IndexPQ::search_core_polysemous (idx_t n, const float *x, idx_t k,
 
         const float * dis_table_qi = dis_tables + qi * pq.M * pq.ksub;
 
-        long * heap_ids = labels + qi * k;
+        int64_t * heap_ids = labels + qi * k;
         float *heap_dis = distances + qi * k;
         maxheap_heapify (k, heap_dis, heap_ids);
 
@@ -410,7 +473,7 @@ void IndexPQ::hamming_distance_table (idx_t n, const float *x,
 
 void IndexPQ::hamming_distance_histogram (idx_t n, const float *x,
                                           idx_t nb, const float *xb,
-                                          long *hist)
+                                          int64_t *hist)
 {
     FAISS_THROW_IF_NOT (metric_type == METRIC_L2);
     FAISS_THROW_IF_NOT (pq.code_size % 8 == 0);
@@ -438,7 +501,7 @@ void IndexPQ::hamming_distance_histogram (idx_t n, const float *x,
 
 #pragma omp parallel
     {
-        std::vector<long> histi (nbits + 1);
+        std::vector<int64_t> histi (nbits + 1);
         hamdis_t *distances = new hamdis_t [nb * bs];
         ScopeDeleter<hamdis_t> del (distances);
 #pragma omp for
@@ -701,10 +764,10 @@ struct MinSumK {
      * We use a heap to maintain a queue of sums, with the associated
      * terms involved in the sum.
      */
-    typedef CMin<T, long> HC;
+    typedef CMin<T, int64_t> HC;
     size_t heap_capacity, heap_size;
     T *bh_val;
-    long *bh_ids;
+    int64_t *bh_ids;
 
     std::vector <SSA> ssx;
 
@@ -721,10 +784,10 @@ struct MinSumK {
 
         // we'll do k steps, each step pushes at most M vals
         bh_val = new T[heap_capacity];
-        bh_ids = new long[heap_capacity];
+        bh_ids = new int64_t[heap_capacity];
 
         if (use_seen) {
-            long n_ids = weight(M);
+            int64_t n_ids = weight(M);
             seen.resize ((n_ids + 7) / 8);
         }
 
@@ -733,21 +796,21 @@ struct MinSumK {
 
     }
 
-    long weight (int i) {
+    int64_t weight (int i) {
         return 1 << (i * nbit);
     }
 
-    bool is_seen (long i) {
+    bool is_seen (int64_t i) {
         return (seen[i >> 3] >> (i & 7)) & 1;
     }
 
-    void mark_seen (long i) {
+    void mark_seen (int64_t i) {
         if (use_seen)
             seen [i >> 3] |= 1 << (i & 7);
     }
 
-    void run (const T *x, long ldx,
-              T * sums, long * terms) {
+    void run (const T *x, int64_t ldx,
+              T * sums, int64_t * terms) {
         heap_size = 0;
 
         for (int m = 0; m < M; m++) {
@@ -781,7 +844,7 @@ struct MinSumK {
             assert (heap_size > 0);
 
             T sum = sums[k] = bh_val[0];
-            long ti = terms[k] = bh_ids[0];
+            int64_t ti = terms[k] = bh_ids[0];
 
             if (use_seen) {
                 mark_seen (ti);
@@ -793,9 +856,9 @@ struct MinSumK {
             }
 
             // enqueue followers
-            long ii = ti;
+            int64_t ii = ti;
             for (int m = 0; m < M; m++) {
-                long n = ii & ((1L << nbit) - 1);
+                int64_t n = ii & ((1L << nbit) - 1);
                 ii >>= nbit;
                 if (n + 1 >= N) continue;
 
@@ -811,15 +874,15 @@ struct MinSumK {
 
         // convert indices by applying permutation
         for (int k = 0; k < K; k++) {
-            long ii = terms[k];
+            int64_t ii = terms[k];
             if (use_seen) {
                 // clear seen for reuse at next loop
                 seen[ii >> 3] = 0;
             }
-            long ti = 0;
+            int64_t ti = 0;
             for (int m = 0; m < M; m++) {
-                long n = ii & ((1L << nbit) - 1);
-                ti += long(ssx[m].get_ord(n)) << (nbit * m);
+                int64_t n = ii & ((1L << nbit) - 1);
+                ti += int64_t(ssx[m].get_ord(n)) << (nbit * m);
                 ii >>= nbit;
             }
             terms[k] = ti;
@@ -827,9 +890,9 @@ struct MinSumK {
     }
 
 
-    void enqueue_follower (long ti, int m, int n, T sum) {
+    void enqueue_follower (int64_t ti, int m, int n, T sum) {
         T next_sum = sum + ssx[m].get_diff(n + 1);
-        long next_ti = ti + weight(m);
+        int64_t next_ti = ti + weight(m);
         heap_push<HC> (++heap_size, bh_val, bh_ids, next_sum, next_ti);
     }
 
@@ -940,9 +1003,9 @@ void MultiIndexQuantizer::search (idx_t n, const float *x, idx_t k,
 void MultiIndexQuantizer::reconstruct (idx_t key, float * recons) const
 {
 
-    long jj = key;
+    int64_t jj = key;
     for (int m = 0; m < pq.M; m++) {
-        long n = jj & ((1L << pq.nbits) - 1);
+        int64_t n = jj & ((1L << pq.nbits) - 1);
         jj >>= pq.nbits;
         memcpy(recons, pq.get_centroids(m, n), sizeof(recons[0]) * pq.dsub);
         recons += pq.dsub;
@@ -1024,10 +1087,10 @@ void MultiIndexQuantizer2::search(
 
     if (n == 0) return;
 
-    int k2 = std::min(K, long(pq.ksub));
+    int k2 = std::min(K, int64_t(pq.ksub));
 
-    long M = pq.M;
-    long dsub = pq.dsub, ksub = pq.ksub;
+    int64_t M = pq.M;
+    int64_t dsub = pq.dsub, ksub = pq.ksub;
 
     // size (M, n, k2)
     std::vector<idx_t> sub_ids(n * M * k2);
@@ -1082,16 +1145,16 @@ void MultiIndexQuantizer2::search(
                 // remap ids
 
                 const idx_t *idmap0 = sub_ids.data() + i * k2;
-                long ld_idmap = k2 * n;
-                long mask1 = ksub - 1L;
+                int64_t ld_idmap = k2 * n;
+                int64_t mask1 = ksub - 1L;
 
                 for (int k = 0; k < K; k++) {
                     const idx_t *idmap = idmap0;
-                    long vin = li[k];
-                    long vout = 0;
+                    int64_t vin = li[k];
+                    int64_t vout = 0;
                     int bs = 0;
                     for (int m = 0; m < M; m++) {
-                        long s = vin & mask1;
+                        int64_t s = vin & mask1;
                         vin >>= pq.nbits;
                         vout |= idmap[s] << bs;
                         bs += pq.nbits;

--- a/IndexPQ.h
+++ b/IndexPQ.h
@@ -61,7 +61,9 @@ struct IndexPQ: Index {
 
     void reconstruct(idx_t key, float* recons) const override;
 
-    long remove_ids(const IDSelector& sel) override;
+    size_t remove_ids(const IDSelector& sel) override;
+
+    DistanceComputer * get_distance_computer() const override;
 
     /******************************************************
      * Polysemous codes implementation
@@ -100,7 +102,7 @@ struct IndexPQ: Index {
     /// @param dist_histogram (M * nbits + 1)
     void hamming_distance_histogram (idx_t n, const float *x,
                                      idx_t nb, const float *xb,
-                                     long *dist_histogram);
+                                     int64_t *dist_histogram);
 
     /** compute pairwise distances between queries and database
      *

--- a/IndexScalarQuantizer.cpp
+++ b/IndexScalarQuantizer.cpp
@@ -1800,7 +1800,7 @@ void IndexIVFScalarQuantizer::encode_vectors(idx_t n, const float* x,
 
 
 void IndexIVFScalarQuantizer::add_with_ids
-       (idx_t n, const float * x, const int64_t *xids)
+       (idx_t n, const float * x, const idx_t *xids)
 {
     FAISS_THROW_IF_NOT (is_trained);
     int64_t * idx = new int64_t [n];

--- a/IndexScalarQuantizer.cpp
+++ b/IndexScalarQuantizer.cpp
@@ -1300,6 +1300,7 @@ void ScalarQuantizer::decode (const uint8_t *codes, float *x, size_t n) const
 SQDistanceComputer *
 ScalarQuantizer::get_distance_computer (MetricType metric) const
 {
+    FAISS_THROW_IF_NOT(metric == METRIC_L2 || metric == METRIC_INNER_PRODUCT);
 #ifdef USE_AVX
     if (d % 8 == 0) {
         if (metric == METRIC_L2) {
@@ -1379,7 +1380,7 @@ struct IVFSQScannerIP: InvertedListScanner {
 
             if (accu > simi [0]) {
                 minheap_pop (k, simi, idxi);
-                long id = store_pairs ? (list_no << 32 | j) : ids[j];
+                int64_t id = store_pairs ? (list_no << 32 | j) : ids[j];
                 minheap_push (k, simi, idxi, accu, id);
                 nup++;
             }
@@ -1397,7 +1398,7 @@ struct IVFSQScannerIP: InvertedListScanner {
         for (size_t j = 0; j < list_size; j++) {
             float accu = accu0 + dc.query_to_code (codes);
             if (accu > radius) {
-                long id = store_pairs ? (list_no << 32 | j) : ids[j];
+                int64_t id = store_pairs ? (list_no << 32 | j) : ids[j];
                 res.add (accu, id);
             }
             codes += code_size;
@@ -1467,7 +1468,7 @@ struct IVFSQScannerL2: InvertedListScanner {
 
             if (dis < simi [0]) {
                 maxheap_pop (k, simi, idxi);
-                long id = store_pairs ? (list_no << 32 | j) : ids[j];
+                int64_t id = store_pairs ? (list_no << 32 | j) : ids[j];
                 maxheap_push (k, simi, idxi, dis, id);
                 nup++;
             }
@@ -1485,7 +1486,7 @@ struct IVFSQScannerL2: InvertedListScanner {
         for (size_t j = 0; j < list_size; j++) {
             float dis = dc.query_to_code (codes);
             if (dis < radius) {
-                long id = store_pairs ? (list_no << 32 | j) : ids[j];
+                int64_t id = store_pairs ? (list_no << 32 | j) : ids[j];
                 res.add (dis, id);
             }
             codes += code_size;
@@ -1503,9 +1504,11 @@ InvertedListScanner* sel2_InvertedListScanner
     if (DCClass::Sim::metric_type == METRIC_L2) {
         return new IVFSQScannerL2<DCClass>(sq->d, sq->trained, sq->code_size,
                                            quantizer, store_pairs, r);
-    } else {
+    } else if (DCClass::Sim::metric_type == METRIC_INNER_PRODUCT) {
         return new IVFSQScannerIP<DCClass>(sq->d, sq->trained, sq->code_size,
                                            store_pairs, r);
+    } else {
+        FAISS_THROW_MSG("unsupported metric type");
     }
 }
 
@@ -1574,9 +1577,11 @@ InvertedListScanner* sel0_InvertedListScanner
     if (mt == METRIC_L2) {
         return sel1_InvertedListScanner<SimilarityL2<SIMDWIDTH> >
             (sq, quantizer, store_pairs, by_residual);
-    } else {
+    } else if (mt == METRIC_INNER_PRODUCT) {
         return sel1_InvertedListScanner<SimilarityIP<SIMDWIDTH> >
             (sq, quantizer, store_pairs, by_residual);
+    } else {
+        FAISS_THROW_MSG("unsupported metric type");
     }
 }
 
@@ -1645,6 +1650,8 @@ void IndexScalarQuantizer::search(
         idx_t* labels) const
 {
     FAISS_THROW_IF_NOT (is_trained);
+    FAISS_THROW_IF_NOT (metric_type == METRIC_L2 ||
+                        metric_type == METRIC_INNER_PRODUCT);
 
 #pragma omp parallel
     {
@@ -1744,8 +1751,8 @@ void IndexIVFScalarQuantizer::train_residual (idx_t n, const float *x)
     ScopeDeleter<float> del_x (x_in == x ? nullptr : x);
 
     if (by_residual) {
-        long * idx = new long [n];
-        ScopeDeleter<long> del (idx);
+        int64_t * idx = new int64_t [n];
+        ScopeDeleter<int64_t> del (idx);
         quantizer->assign (n, x, idx);
         float *residuals = new float [n * d];
         ScopeDeleter<float> del2 (residuals);
@@ -1776,7 +1783,7 @@ void IndexIVFScalarQuantizer::encode_vectors(idx_t n, const float* x,
         // each thread takes care of a subset of lists
 #pragma omp for
         for (size_t i = 0; i < n; i++) {
-            long list_no = list_nos [i];
+            int64_t list_no = list_nos [i];
             if (list_no >= 0) {
                 const float *xi = x + i * d;
                 if (by_residual) {
@@ -1793,11 +1800,11 @@ void IndexIVFScalarQuantizer::encode_vectors(idx_t n, const float* x,
 
 
 void IndexIVFScalarQuantizer::add_with_ids
-       (idx_t n, const float * x, const long *xids)
+       (idx_t n, const float * x, const int64_t *xids)
 {
     FAISS_THROW_IF_NOT (is_trained);
-    long * idx = new long [n];
-    ScopeDeleter<long> del (idx);
+    int64_t * idx = new int64_t [n];
+    ScopeDeleter<int64_t> del (idx);
     quantizer->assign (n, x, idx);
     size_t nadd = 0;
     Quantizer *squant = select_quantizer (sq);
@@ -1812,9 +1819,9 @@ void IndexIVFScalarQuantizer::add_with_ids
 
         // each thread takes care of a subset of lists
         for (size_t i = 0; i < n; i++) {
-            long list_no = idx [i];
+            int64_t list_no = idx [i];
             if (list_no >= 0 && list_no % nt == rank) {
-                long id = xids ? xids[i] : ntotal + i;
+                int64_t id = xids ? xids[i] : ntotal + i;
 
                 const float * xi = x + i * d;
                 if (by_residual) {
@@ -1847,8 +1854,8 @@ InvertedListScanner* IndexIVFScalarQuantizer::get_InvertedListScanner
 }
 
 
-void IndexIVFScalarQuantizer::reconstruct_from_offset (long list_no,
-                                                       long offset,
+void IndexIVFScalarQuantizer::reconstruct_from_offset (int64_t list_no,
+                                                       int64_t offset,
                                                        float* recons) const
 {
     std::vector<float> centroid(d);

--- a/IndexScalarQuantizer.h
+++ b/IndexScalarQuantizer.h
@@ -154,7 +154,7 @@ struct IndexIVFScalarQuantizer: IndexIVF {
                         const idx_t *list_nos,
                         uint8_t * codes) const override;
 
-    void add_with_ids(idx_t n, const float* x, const int64_t* xids) override;
+    void add_with_ids(idx_t n, const float* x, const idx_t* xids) override;
 
     InvertedListScanner *get_InvertedListScanner (bool store_pairs)
         const override;

--- a/IndexScalarQuantizer.h
+++ b/IndexScalarQuantizer.h
@@ -127,7 +127,7 @@ struct IndexScalarQuantizer: Index {
 
     void reconstruct(idx_t key, float* recons) const override;
 
-    DistanceComputer *get_distance_computer () const;
+    DistanceComputer *get_distance_computer () const override;
 
 };
 
@@ -154,13 +154,13 @@ struct IndexIVFScalarQuantizer: IndexIVF {
                         const idx_t *list_nos,
                         uint8_t * codes) const override;
 
-    void add_with_ids(idx_t n, const float* x, const long* xids) override;
+    void add_with_ids(idx_t n, const float* x, const int64_t* xids) override;
 
     InvertedListScanner *get_InvertedListScanner (bool store_pairs)
         const override;
 
 
-    void reconstruct_from_offset (long list_no, long offset,
+    void reconstruct_from_offset (int64_t list_no, int64_t offset,
                                   float* recons) const override;
 
 };

--- a/MetaIndexes.cpp
+++ b/MetaIndexes.cpp
@@ -29,49 +29,60 @@ typedef Index::idx_t idx_t;
  * IndexIDMap implementation
  *******************************************************/
 
-IndexIDMap::IndexIDMap (Index *index):
+template <typename IndexT>
+IndexIDMapTemplate<IndexT>::IndexIDMapTemplate (IndexT *index):
     index (index),
     own_fields (false)
 {
     FAISS_THROW_IF_NOT_MSG (index->ntotal == 0, "index must be empty on input");
-    is_trained = index->is_trained;
-    metric_type = index->metric_type;
-    verbose = index->verbose;
-    d = index->d;
+    this->is_trained = index->is_trained;
+    this->metric_type = index->metric_type;
+    this->verbose = index->verbose;
+    this->d = index->d;
 }
 
-void IndexIDMap::add (idx_t, const float *)
+template <typename IndexT>
+void IndexIDMapTemplate<IndexT>::add
+    (idx_t, const typename IndexT::component_t *)
 {
     FAISS_THROW_MSG ("add does not make sense with IndexIDMap, "
                       "use add_with_ids");
 }
 
 
-void IndexIDMap::train (idx_t n, const float *x)
+template <typename IndexT>
+void IndexIDMapTemplate<IndexT>::train
+    (idx_t n, const typename IndexT::component_t *x)
 {
     index->train (n, x);
-    is_trained = index->is_trained;
+    this->is_trained = index->is_trained;
 }
 
-void IndexIDMap::reset ()
+template <typename IndexT>
+void IndexIDMapTemplate<IndexT>::reset ()
 {
     index->reset ();
     id_map.clear();
-    ntotal = 0;
+    this->ntotal = 0;
 }
 
 
-void IndexIDMap::add_with_ids (idx_t n, const float * x, const long *xids)
+template <typename IndexT>
+void IndexIDMapTemplate<IndexT>::add_with_ids
+    (idx_t n, const typename IndexT::component_t * x,
+     const typename IndexT::idx_t *xids)
 {
     index->add (n, x);
     for (idx_t i = 0; i < n; i++)
         id_map.push_back (xids[i]);
-    ntotal = index->ntotal;
+    this->ntotal = index->ntotal;
 }
 
 
-void IndexIDMap::search (idx_t n, const float *x, idx_t k,
-                              float *distances, idx_t *labels) const
+template <typename IndexT>
+void IndexIDMapTemplate<IndexT>::search
+    (idx_t n, const typename IndexT::component_t *x, idx_t k,
+     typename IndexT::distance_t *distances, typename IndexT::idx_t *labels) const
 {
     index->search (n, x, k, distances, labels);
     idx_t *li = labels;
@@ -82,8 +93,10 @@ void IndexIDMap::search (idx_t n, const float *x, idx_t k,
 }
 
 
-void IndexIDMap::range_search (idx_t n, const float *x, float radius,
-                   RangeSearchResult *result) const
+template <typename IndexT>
+void IndexIDMapTemplate<IndexT>::range_search
+    (typename IndexT::idx_t n, const typename IndexT::component_t *x,
+     typename IndexT::distance_t radius, RangeSearchResult *result) const
 {
   index->range_search(n, x, radius, result);
 #pragma omp parallel for
@@ -96,9 +109,9 @@ void IndexIDMap::range_search (idx_t n, const float *x, float radius,
 namespace {
 
 struct IDTranslatedSelector: IDSelector {
-    const std::vector <long> & id_map;
+    const std::vector <int64_t> & id_map;
     const IDSelector & sel;
-    IDTranslatedSelector (const std::vector <long> & id_map,
+    IDTranslatedSelector (const std::vector <int64_t> & id_map,
                           const IDSelector & sel):
         id_map (id_map), sel (sel)
     {}
@@ -109,14 +122,15 @@ struct IDTranslatedSelector: IDSelector {
 
 }
 
-long IndexIDMap::remove_ids (const IDSelector & sel)
+template <typename IndexT>
+size_t IndexIDMapTemplate<IndexT>::remove_ids (const IDSelector & sel)
 {
     // remove in sub-index first
     IDTranslatedSelector sel2 (id_map, sel);
-    long nremove = index->remove_ids (sel2);
+    size_t nremove = index->remove_ids (sel2);
 
-    long j = 0;
-    for (idx_t i = 0; i < ntotal; i++) {
+    int64_t j = 0;
+    for (idx_t i = 0; i < this->ntotal; i++) {
         if (sel.is_member (id_map[i])) {
             // remove
         } else {
@@ -125,60 +139,78 @@ long IndexIDMap::remove_ids (const IDSelector & sel)
         }
     }
     FAISS_ASSERT (j == index->ntotal);
-    ntotal = j;
-    id_map.resize(ntotal);
+    this->ntotal = j;
+    id_map.resize(this->ntotal);
     return nremove;
 }
 
-
-
-
-IndexIDMap::~IndexIDMap ()
+template <typename IndexT>
+IndexIDMapTemplate<IndexT>::~IndexIDMapTemplate ()
 {
     if (own_fields) delete index;
 }
+
+
 
 /*****************************************************
  * IndexIDMap2 implementation
  *******************************************************/
 
-IndexIDMap2::IndexIDMap2 (Index *index): IndexIDMap (index)
+template <typename IndexT>
+IndexIDMap2Template<IndexT>::IndexIDMap2Template (IndexT *index):
+    IndexIDMapTemplate<IndexT> (index)
 {}
 
-void IndexIDMap2::add_with_ids(idx_t n, const float* x, const long* xids)
+template <typename IndexT>
+void IndexIDMap2Template<IndexT>::add_with_ids
+    (idx_t n, const typename IndexT::component_t* x,
+     const typename IndexT::idx_t* xids)
 {
-    size_t prev_ntotal = ntotal;
-    IndexIDMap::add_with_ids (n, x, xids);
-    for (size_t i = prev_ntotal; i < ntotal; i++) {
-        rev_map [id_map [i]] = i;
+    size_t prev_ntotal = this->ntotal;
+    IndexIDMapTemplate<IndexT>::add_with_ids (n, x, xids);
+    for (size_t i = prev_ntotal; i < this->ntotal; i++) {
+        rev_map [this->id_map [i]] = i;
     }
 }
 
-void IndexIDMap2::construct_rev_map ()
+template <typename IndexT>
+void IndexIDMap2Template<IndexT>::construct_rev_map ()
 {
     rev_map.clear ();
-    for (size_t i = 0; i < ntotal; i++) {
-        rev_map [id_map [i]] = i;
+    for (size_t i = 0; i < this->ntotal; i++) {
+        rev_map [this->id_map [i]] = i;
     }
 }
 
 
-long IndexIDMap2::remove_ids(const IDSelector& sel)
+template <typename IndexT>
+size_t IndexIDMap2Template<IndexT>::remove_ids(const IDSelector& sel)
 {
     // This is quite inefficient
-    long nremove = IndexIDMap::remove_ids (sel);
+    size_t nremove = IndexIDMapTemplate<IndexT>::remove_ids (sel);
     construct_rev_map ();
     return nremove;
 }
 
-void IndexIDMap2::reconstruct (idx_t key, float * recons) const
+template <typename IndexT>
+void IndexIDMap2Template<IndexT>::reconstruct
+    (idx_t key, typename IndexT::component_t * recons) const
 {
     try {
-        index->reconstruct (rev_map.at (key), recons);
+        this->index->reconstruct (rev_map.at (key), recons);
     } catch (const std::out_of_range& e) {
         FAISS_THROW_FMT ("key %ld not found", key);
     }
 }
+
+
+// explicit template instantiations
+
+template struct IndexIDMapTemplate<Index>;
+template struct IndexIDMapTemplate<IndexBinary>;
+template struct IndexIDMap2Template<Index>;
+template struct IndexIDMap2Template<IndexBinary>;
+
 
 /*****************************************************
  * IndexSplitVectors implementation
@@ -230,7 +262,7 @@ void IndexSplitVectors::search (
     FAISS_THROW_IF_NOT_MSG (sum_d == d,
                       "not enough indexes compared to # dimensions");
 
-    long nshard = sub_indexes.size();
+    int64_t nshard = sub_indexes.size();
     float *all_distances = new float [nshard * k * n];
     idx_t *all_labels = new idx_t [nshard * k * n];
     ScopeDeleter<float> del (all_distances);
@@ -244,7 +276,7 @@ void IndexSplitVectors::search (
         if (index->verbose)
             printf ("begin query shard %d on %ld points\n", no, n);
         const Index * sub_index = index->sub_indexes[no];
-        long sub_d = sub_index->d, d = index->d;
+        int64_t sub_d = sub_index->d, d = index->d;
         idx_t ofs = 0;
         for (int i = 0; i < no; i++) ofs += index->sub_indexes[i]->d;
         float *sub_x = new float [sub_d * n];
@@ -276,12 +308,12 @@ void IndexSplitVectors::search (
         }
     }
 
-    long factor = 1;
+    int64_t factor = 1;
     for (int i = 0; i < nshard; i++) {
         if (i > 0) { // results of 0 are already in the table
             const float *distances_i = all_distances + i * k * n;
             const idx_t *labels_i = all_labels + i * k * n;
-            for (long j = 0; j < n; j++) {
+            for (int64_t j = 0; j < n; j++) {
                 if (labels[j] >= 0 && labels_i[j] >= 0) {
                     labels[j] += labels_i[j] * factor;
                     distances[j] += distances_i[j];

--- a/MetaIndexes.cpp
+++ b/MetaIndexes.cpp
@@ -10,6 +10,7 @@
 #include "MetaIndexes.h"
 
 #include <cstdio>
+#include <stdint.h>
 
 #include "FaissAssert.h"
 #include "Heap.h"

--- a/MetaIndexes.h
+++ b/MetaIndexes.h
@@ -19,66 +19,79 @@
 namespace faiss {
 
 /** Index that translates search results to ids */
-struct IndexIDMap : Index {
-    Index * index;            ///! the sub-index
+template <typename IndexT>
+struct IndexIDMapTemplate : IndexT {
+    using idx_t = typename IndexT::idx_t;
+    using component_t = typename IndexT::component_t;
+    using distance_t = typename IndexT::distance_t;
+
+    IndexT * index;           ///! the sub-index
     bool own_fields;          ///! whether pointers are deleted in destructo
-    std::vector<long> id_map;
+    std::vector<idx_t> id_map;
 
-    explicit IndexIDMap (Index *index);
+    explicit IndexIDMapTemplate (IndexT *index);
 
-    /// Same as add_core, but stores xids instead of sequential ids
     /// @param xids if non-null, ids to store for the vectors (size n)
-    void add_with_ids(idx_t n, const float* x, const long* xids) override;
+    void add_with_ids(idx_t n, const component_t* x, const idx_t* xids) override;
 
     /// this will fail. Use add_with_ids
-    void add(idx_t n, const float* x) override;
+    void add(idx_t n, const component_t* x) override;
 
     void search(
-        idx_t n,
-        const float* x,
-        idx_t k,
-        float* distances,
+        idx_t n, const component_t* x, idx_t k,
+        distance_t* distances,
         idx_t* labels) const override;
 
-    void train(idx_t n, const float* x) override;
+    void train(idx_t n, const component_t* x) override;
 
     void reset() override;
 
     /// remove ids adapted to IndexFlat
-    long remove_ids(const IDSelector& sel) override;
+    size_t remove_ids(const IDSelector& sel) override;
 
-    void range_search (idx_t n, const float *x, float radius,
+    void range_search (idx_t n, const component_t *x, distance_t radius,
                        RangeSearchResult *result) const override;
 
-    ~IndexIDMap() override;
-    IndexIDMap () {own_fields=false; index=nullptr; }
+    ~IndexIDMapTemplate () override;
+    IndexIDMapTemplate () {own_fields=false; index=nullptr; }
 };
 
+using IndexIDMap = IndexIDMapTemplate<Index>;
+using IndexBinaryIDMap = IndexIDMapTemplate<IndexBinary>;
+
+
 /** same as IndexIDMap but also provides an efficient reconstruction
-    implementation via a 2-way index */
-struct IndexIDMap2 : IndexIDMap {
+ *  implementation via a 2-way index */
+template <typename IndexT>
+struct IndexIDMap2Template : IndexIDMapTemplate<IndexT> {
+    using idx_t = typename IndexT::idx_t;
+    using component_t = typename IndexT::component_t;
+    using distance_t = typename IndexT::distance_t;
 
     std::unordered_map<idx_t, idx_t> rev_map;
 
-    explicit IndexIDMap2 (Index *index);
+    explicit IndexIDMap2Template (IndexT *index);
 
     /// make the rev_map from scratch
     void construct_rev_map ();
 
-    void add_with_ids(idx_t n, const float* x, const long* xids) override;
+    void add_with_ids(idx_t n, const component_t* x, const idx_t* xids) override;
 
-    long remove_ids(const IDSelector& sel) override;
+    size_t remove_ids(const IDSelector& sel) override;
 
-    void reconstruct (idx_t key, float * recons) const override;
+    void reconstruct (idx_t key, component_t * recons) const override;
 
-    ~IndexIDMap2() override {}
-    IndexIDMap2 () {}
+    ~IndexIDMap2Template() override {}
+    IndexIDMap2Template () {}
 };
+
+using IndexIDMap2 = IndexIDMap2Template<Index>;
+using IndexBinaryIDMap2 = IndexIDMap2Template<IndexBinary>;
+
 
 /** splits input vectors in segments and assigns each segment to a sub-index
  * used to distribute a MultiIndexQuantizer
  */
-
 struct IndexSplitVectors: Index {
     bool own_fields;
     bool threaded;

--- a/PolysemousTraining.cpp
+++ b/PolysemousTraining.cpp
@@ -12,6 +12,7 @@
 #include <cstdlib>
 #include <cmath>
 #include <cstring>
+#include <stdint.h>
 
 #include <algorithm>
 

--- a/ProductQuantizer.cpp
+++ b/ProductQuantizer.cpp
@@ -667,7 +667,7 @@ void ProductQuantizer::search (const float * __restrict x,
     std::unique_ptr<float[]> dis_tables(new float [nx * ksub * M]);
     compute_distance_tables (nx, x, dis_tables.get());
 
-    pq_knn_search_with_tables<CMax<float, idx_t>> (
+    pq_knn_search_with_tables<CMax<float, int64_t>> (
       *this, nbits, dis_tables.get(), codes, ncodes, res, init_finalize_heap);
 }
 
@@ -682,7 +682,7 @@ void ProductQuantizer::search_ip (const float * __restrict x,
     std::unique_ptr<float[]> dis_tables(new float [nx * ksub * M]);
     compute_inner_prod_tables (nx, x, dis_tables.get());
 
-    pq_knn_search_with_tables<CMin<float, idx_t> > (
+    pq_knn_search_with_tables<CMin<float, int64_t> > (
       *this, nbits, dis_tables.get(), codes, ncodes, res, init_finalize_heap);
 }
 

--- a/ProductQuantizer.cpp
+++ b/ProductQuantizer.cpp
@@ -46,7 +46,7 @@ void pq_estimators_from_tables_Mmul4 (int M, const CT * codes,
                                       size_t ksub,
                                       size_t k,
                                       float * heap_dis,
-                                      long * heap_ids)
+                                      int64_t * heap_ids)
 {
 
     for (size_t j = 0; j < ncodes; j++) {
@@ -77,7 +77,7 @@ void pq_estimators_from_tables_M4 (const CT * codes,
                                    size_t ksub,
                                    size_t k,
                                    float * heap_dis,
-                                   long * heap_ids)
+                                   int64_t * heap_ids)
 {
 
     for (size_t j = 0; j < ncodes; j++) {
@@ -103,7 +103,7 @@ static inline void pq_estimators_from_tables (const ProductQuantizer& pq,
                                               const float * dis_table,
                                               size_t k,
                                               float * heap_dis,
-                                              long * heap_ids)
+                                              int64_t * heap_ids)
 {
 
     if (pq.M == 4)  {
@@ -146,7 +146,7 @@ static inline void pq_estimators_from_tables_generic(const ProductQuantizer& pq,
                                                      const float *dis_table,
                                                      size_t k,
                                                      float *heap_dis,
-                                                     long *heap_ids)
+                                                     int64_t *heap_ids)
 {
   const size_t M = pq.M;
   const size_t ksub = pq.ksub;
@@ -619,7 +619,7 @@ static void pq_knn_search_with_tables (
         const float* dis_table = dis_tables + i * ksub * M;
 
         /* Compute distances and keep smallest values */
-        long * __restrict heap_ids = res->ids + i * k;
+        int64_t * __restrict heap_ids = res->ids + i * k;
         float * __restrict heap_dis = res->val + i * k;
 
         if (init_finalize_heap) {
@@ -667,7 +667,7 @@ void ProductQuantizer::search (const float * __restrict x,
     std::unique_ptr<float[]> dis_tables(new float [nx * ksub * M]);
     compute_distance_tables (nx, x, dis_tables.get());
 
-    pq_knn_search_with_tables<CMax<float, long>> (
+    pq_knn_search_with_tables<CMax<float, idx_t>> (
       *this, nbits, dis_tables.get(), codes, ncodes, res, init_finalize_heap);
 }
 
@@ -682,7 +682,7 @@ void ProductQuantizer::search_ip (const float * __restrict x,
     std::unique_ptr<float[]> dis_tables(new float [nx * ksub * M]);
     compute_inner_prod_tables (nx, x, dis_tables.get());
 
-    pq_knn_search_with_tables<CMin<float, long> > (
+    pq_knn_search_with_tables<CMin<float, idx_t> > (
       *this, nbits, dis_tables.get(), codes, ncodes, res, init_finalize_heap);
 }
 
@@ -731,7 +731,7 @@ void ProductQuantizer::search_sdc (const uint8_t * qcodes,
     for (size_t i = 0; i < nq; i++) {
 
         /* Compute distances and keep smallest values */
-        long * heap_ids = res->ids + i * k;
+        idx_t * heap_ids = res->ids + i * k;
         float *  heap_dis = res->val + i * k;
         const uint8_t * qcode = qcodes + i * code_size;
 

--- a/ProductQuantizer.h
+++ b/ProductQuantizer.h
@@ -34,7 +34,6 @@ struct ProductQuantizer {
     size_t ksub;           ///< number of centroids for each subquantizer
     bool verbose;          ///< verbose during training?
 
-
     /// initialization
     enum train_type_t {
         Train_default,

--- a/VectorTransform.cpp
+++ b/VectorTransform.cpp
@@ -1000,7 +1000,7 @@ void IndexPreTransform::add (idx_t n, const float *x)
 }
 
 void IndexPreTransform::add_with_ids (idx_t n, const float * x,
-                                      const long *xids)
+                                      const idx_t *xids)
 {
     FAISS_THROW_IF_NOT (is_trained);
     const float *xt = apply_chain (n, x);

--- a/VectorTransform.cpp
+++ b/VectorTransform.cpp
@@ -1037,8 +1037,8 @@ void IndexPreTransform::reset () {
     ntotal = 0;
 }
 
-long IndexPreTransform::remove_ids (const IDSelector & sel) {
-    long nremove = index->remove_ids (sel);
+size_t IndexPreTransform::remove_ids (const IDSelector & sel) {
+    size_t nremove = index->remove_ids (sel);
     ntotal = index->ntotal;
     return nremove;
 }

--- a/VectorTransform.h
+++ b/VectorTransform.h
@@ -288,13 +288,13 @@ struct IndexPreTransform: Index {
 
     void add(idx_t n, const float* x) override;
 
-    void add_with_ids(idx_t n, const float* x, const long* xids) override;
+    void add_with_ids(idx_t n, const float* x, const int64_t* xids) override;
 
     void reset() override;
 
     /** removes IDs from the index. Not supported by all indexes.
      */
-    long remove_ids(const IDSelector& sel) override;
+    size_t remove_ids(const IDSelector& sel) override;
 
     void search(
         idx_t n,

--- a/VectorTransform.h
+++ b/VectorTransform.h
@@ -15,6 +15,7 @@
  */
 
 #include <vector>
+#include <stdint.h>
 
 #include "Index.h"
 

--- a/VectorTransform.h
+++ b/VectorTransform.h
@@ -289,7 +289,7 @@ struct IndexPreTransform: Index {
 
     void add(idx_t n, const float* x) override;
 
-    void add_with_ids(idx_t n, const float* x, const int64_t* xids) override;
+    void add_with_ids(idx_t n, const float* x, const idx_t* xids) override;
 
     void reset() override;
 

--- a/benchs/bench_for_interrupt.py
+++ b/benchs/bench_for_interrupt.py
@@ -1,0 +1,155 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+#! /usr/bin/env python3
+
+from __future__ import print_function
+import numpy as np
+import faiss
+import time
+import os
+import argparse
+
+
+parser = argparse.ArgumentParser()
+
+def aa(*args, **kwargs):
+    group.add_argument(*args, **kwargs)
+
+group = parser.add_argument_group('dataset options')
+aa('--dim', type=int, default=64)
+aa('--nb', type=int, default=int(1e6))
+aa('--subset_len', type=int, default=int(1e5))
+aa('--key', default='IVF1000,Flat')
+aa('--nprobe', type=int, default=640)
+aa('--no_intcallback', default=False, action='store_true')
+aa('--twostage', default=False, action='store_true')
+aa('--nt', type=int, default=-1)
+
+
+args = parser.parse_args()
+print("args:", args)
+
+
+d = args.dim  # dimension
+nb = args.nb  # database size
+nq = 1000  # nb of queries
+nt = 100000
+subset_len = args.subset_len
+
+
+np.random.seed(1234)  # make reproducible
+xb = np.random.random((nb, d)).astype('float32')
+xq = np.random.random((nq, d)).astype('float32')
+xt = np.random.random((nt, d)).astype('float32')
+k = 100
+
+if args.no_intcallback:
+    faiss.InterruptCallback.clear_instance()
+
+if args.nt != -1:
+    faiss.omp_set_num_threads(args.nt)
+
+nprobe = args.nprobe
+key = args.key
+#key = 'IVF1000,Flat'
+# key = 'IVF1000,PQ64'
+# key = 'IVF100_HNSW32,PQ64'
+
+# faiss.omp_set_num_threads(1)
+
+pf = 'dim%d_' % d
+if d == 64:
+    pf = ''
+
+basename = '/tmp/base%s%s.index' % (pf, key)
+
+if os.path.exists(basename):
+    print('load', basename)
+    index_1 = faiss.read_index(basename)
+else:
+    print('train + write', basename)
+    index_1 = faiss.index_factory(d, key)
+    index_1.train(xt)
+    faiss.write_index(index_1, basename)
+
+print('add')
+index_1.add(xb)
+
+print('set nprobe=', nprobe)
+faiss.ParameterSpace().set_index_parameter(index_1, 'nprobe', nprobe)
+
+class ResultHeap:
+    """ Combine query results from a sliced dataset """
+
+    def __init__(self, nq, k):
+        " nq: number of query vectors, k: number of results per query "
+        self.I = np.zeros((nq, k), dtype='int64')
+        self.D = np.zeros((nq, k), dtype='float32')
+        self.nq, self.k = nq, k
+        heaps = faiss.float_maxheap_array_t()
+        heaps.k = k
+        heaps.nh = nq
+        heaps.val = faiss.swig_ptr(self.D)
+        heaps.ids = faiss.swig_ptr(self.I)
+        heaps.heapify()
+        self.heaps = heaps
+
+    def add_batch_result(self, D, I, i0):
+        assert D.shape == (self.nq, self.k)
+        assert I.shape == (self.nq, self.k)
+        I += i0
+        self.heaps.addn_with_ids(
+            self.k, faiss.swig_ptr(D),
+            faiss.swig_ptr(I), self.k)
+
+    def finalize(self):
+        self.heaps.reorder()
+
+stats = faiss.cvar.indexIVF_stats
+stats.reset()
+
+print('index size', index_1.ntotal,
+      'imbalance', index_1.invlists.imbalance_factor())
+start = time.time()
+Dref, Iref = index_1.search(xq, k)
+print('time of searching: %.3f s = %.3f + %.3f ms' % (
+    time.time() - start, stats.quantization_time, stats.search_time))
+
+indexes = {}
+if args.twostage:
+
+    for i in range(0, nb, subset_len):
+        index = faiss.read_index(basename)
+        faiss.ParameterSpace().set_index_parameter(index, 'nprobe', nprobe)
+        print("add %d:%d" %(i, i+subset_len))
+        index.add(xb[i:i + subset_len])
+        indexes[i] = index
+
+rh = ResultHeap(nq, k)
+sum_time = tq = ts = 0
+for i in range(0, nb, subset_len):
+    if not args.twostage:
+        index = faiss.read_index(basename)
+        faiss.ParameterSpace().set_index_parameter(index, 'nprobe', nprobe)
+        print("add %d:%d" %(i, i+subset_len))
+        index.add(xb[i:i + subset_len])
+    else:
+        index = indexes[i]
+
+    stats.reset()
+    start = time.time()
+    Di, Ii = index.search(xq, k)
+    sum_time = sum_time + time.time() - start
+    tq += stats.quantization_time
+    ts += stats.search_time
+    rh.add_batch_result(Di, Ii, i)
+
+print('time of searching separately: %.3f s = %.3f + %.3f ms' %
+      (sum_time, tq, ts))
+
+rh.finalize()
+
+print('diffs: %d / %d'  % ((Iref != rh.I).sum(), Iref.size))

--- a/benchs/bench_pairwise_distances.py
+++ b/benchs/bench_pairwise_distances.py
@@ -1,0 +1,36 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+#! /usr/bin/env python3
+
+"""small test script to benchmark the SIMD implementation of the
+distance computations for the additional metrics. Call eg. with L1 to
+get L1 distance computations.
+"""
+
+import faiss
+
+import sys
+import time
+
+d = 64
+nq = 4096
+nb = 16384
+
+print("sample")
+
+xq = faiss.randn((nq, d), 123)
+xb = faiss.randn((nb, d), 123)
+
+mt_name = "L2" if len(sys.argv) < 2 else sys.argv[1]
+
+mt = getattr(faiss, "METRIC_" + mt_name)
+
+print("distances")
+t0 = time.time()
+dis = faiss.pairwise_distances(xq, xb, mt)
+t1 = time.time()
+
+print("nq=%d nb=%d d=%d %s: %.3f s" % (nq, nb, d, mt_name, t1 - t0))

--- a/depend
+++ b/depend
@@ -1,37 +1,3 @@
-WorkerThread.o: WorkerThread.cpp WorkerThread.h FaissAssert.h \
- FaissException.h
-IndexFlat.o: IndexFlat.cpp IndexFlat.h Index.h utils.h Heap.h \
- FaissAssert.h FaissException.h AuxIndexStructures.h
-IndexBinaryFlat.o: IndexBinaryFlat.cpp IndexBinaryFlat.h IndexBinary.h \
- FaissAssert.h FaissException.h Index.h hamming.h Heap.h utils.h \
- AuxIndexStructures.h
-IndexIVFSpectralHash.o: IndexIVFSpectralHash.cpp IndexIVFSpectralHash.h \
- IndexIVF.h Index.h InvertedLists.h Clustering.h Heap.h hamming.h utils.h \
- FaissAssert.h FaissException.h AuxIndexStructures.h VectorTransform.h
-IndexLSH.o: IndexLSH.cpp IndexLSH.h Index.h VectorTransform.h utils.h \
- Heap.h hamming.h FaissAssert.h FaissException.h
-ProductQuantizer.o: ProductQuantizer.cpp ProductQuantizer.h Clustering.h \
- Index.h Heap.h FaissAssert.h FaissException.h VectorTransform.h \
- IndexFlat.h utils.h
-IndexShards.o: IndexShards.cpp IndexShards.h Index.h IndexBinary.h \
- FaissAssert.h FaissException.h ThreadedIndex.h WorkerThread.h \
- ThreadedIndex-inl.h Heap.h
-IndexBinaryIVF.o: IndexBinaryIVF.cpp IndexBinaryIVF.h IndexBinary.h \
- FaissAssert.h FaissException.h Index.h IndexIVF.h InvertedLists.h \
- Clustering.h Heap.h hamming.h utils.h AuxIndexStructures.h IndexFlat.h
-PolysemousTraining.o: PolysemousTraining.cpp PolysemousTraining.h \
- ProductQuantizer.h Clustering.h Index.h Heap.h utils.h hamming.h \
- FaissAssert.h FaissException.h
-Heap.o: Heap.cpp Heap.h
-IndexBinaryFromFloat.o: IndexBinaryFromFloat.cpp IndexBinaryFromFloat.h \
- IndexBinary.h FaissAssert.h FaissException.h Index.h utils.h Heap.h
-IndexIVFPQ.o: IndexIVFPQ.cpp IndexIVFPQ.h IndexIVF.h Index.h \
- InvertedLists.h Clustering.h Heap.h IndexPQ.h ProductQuantizer.h \
- PolysemousTraining.h utils.h IndexFlat.h hamming.h FaissAssert.h \
- FaissException.h AuxIndexStructures.h
-VectorTransform.o: VectorTransform.cpp VectorTransform.h Index.h utils.h \
- Heap.h FaissAssert.h FaissException.h IndexPQ.h ProductQuantizer.h \
- Clustering.h PolysemousTraining.h
 AutoTune.o: AutoTune.cpp AutoTune.h Index.h IndexBinary.h FaissAssert.h \
  FaissException.h utils.h Heap.h IndexFlat.h VectorTransform.h IndexLSH.h \
  IndexPQ.h ProductQuantizer.h Clustering.h PolysemousTraining.h \
@@ -39,53 +5,87 @@ AutoTune.o: AutoTune.cpp AutoTune.h Index.h IndexBinary.h FaissAssert.h \
  IndexShards.h ThreadedIndex.h WorkerThread.h ThreadedIndex-inl.h \
  IndexReplicas.h IndexScalarQuantizer.h IndexHNSW.h HNSW.h \
  IndexBinaryFlat.h IndexBinaryHNSW.h IndexBinaryIVF.h
-utils.o: utils.cpp utils.h Heap.h AuxIndexStructures.h Index.h \
- FaissAssert.h FaissException.h
-MetaIndexes.o: MetaIndexes.cpp MetaIndexes.h Index.h IndexShards.h \
- IndexBinary.h FaissAssert.h FaissException.h ThreadedIndex.h \
- WorkerThread.h ThreadedIndex-inl.h IndexReplicas.h Heap.h \
- AuxIndexStructures.h
 AuxIndexStructures.o: AuxIndexStructures.cpp AuxIndexStructures.h Index.h \
  FaissAssert.h FaissException.h
-InvertedLists.o: InvertedLists.cpp InvertedLists.h Index.h utils.h Heap.h \
- FaissAssert.h FaissException.h
+Clustering.o: Clustering.cpp Clustering.h Index.h AuxIndexStructures.h \
+ utils.h Heap.h FaissAssert.h FaissException.h IndexFlat.h
+FaissException.o: FaissException.cpp FaissException.h
+HNSW.o: HNSW.cpp HNSW.h Index.h FaissAssert.h FaissException.h utils.h \
+ Heap.h AuxIndexStructures.h
+Heap.o: Heap.cpp Heap.h
+IVFlib.o: IVFlib.cpp IVFlib.h IndexIVF.h Index.h InvertedLists.h \
+ Clustering.h Heap.h VectorTransform.h FaissAssert.h FaissException.h
+Index.o: Index.cpp AuxIndexStructures.h Index.h FaissAssert.h \
+ FaissException.h utils.h Heap.h
+IndexBinary.o: IndexBinary.cpp IndexBinary.h FaissAssert.h \
+ FaissException.h Index.h
+IndexBinaryFlat.o: IndexBinaryFlat.cpp IndexBinaryFlat.h IndexBinary.h \
+ FaissAssert.h FaissException.h Index.h hamming.h Heap.h utils.h \
+ AuxIndexStructures.h
+IndexBinaryFromFloat.o: IndexBinaryFromFloat.cpp IndexBinaryFromFloat.h \
+ IndexBinary.h FaissAssert.h FaissException.h Index.h utils.h Heap.h
 IndexBinaryHNSW.o: IndexBinaryHNSW.cpp IndexBinaryHNSW.h HNSW.h Index.h \
  FaissAssert.h FaissException.h utils.h Heap.h IndexBinaryFlat.h \
  IndexBinary.h hamming.h AuxIndexStructures.h
-OnDiskInvertedLists.o: OnDiskInvertedLists.cpp OnDiskInvertedLists.h \
- IndexIVF.h Index.h InvertedLists.h Clustering.h Heap.h FaissAssert.h \
- FaissException.h utils.h
+IndexBinaryIVF.o: IndexBinaryIVF.cpp IndexBinaryIVF.h IndexBinary.h \
+ FaissAssert.h FaissException.h Index.h IndexIVF.h InvertedLists.h \
+ Clustering.h Heap.h hamming.h utils.h AuxIndexStructures.h IndexFlat.h
+IndexFlat.o: IndexFlat.cpp IndexFlat.h Index.h utils.h Heap.h distances.h \
+ FaissAssert.h FaissException.h AuxIndexStructures.h
+IndexHNSW.o: IndexHNSW.cpp IndexHNSW.h HNSW.h Index.h FaissAssert.h \
+ FaissException.h utils.h Heap.h IndexFlat.h IndexPQ.h ProductQuantizer.h \
+ Clustering.h PolysemousTraining.h IndexScalarQuantizer.h IndexIVF.h \
+ InvertedLists.h IndexIVFPQ.h AuxIndexStructures.h
 IndexIVF.o: IndexIVF.cpp IndexIVF.h Index.h InvertedLists.h Clustering.h \
  Heap.h utils.h hamming.h FaissAssert.h FaissException.h IndexFlat.h \
  AuxIndexStructures.h
 IndexIVFFlat.o: IndexIVFFlat.cpp IndexIVFFlat.h IndexIVF.h Index.h \
  InvertedLists.h Clustering.h Heap.h utils.h FaissAssert.h \
  FaissException.h IndexFlat.h AuxIndexStructures.h
-FaissException.o: FaissException.cpp FaissException.h
-IndexBinary.o: IndexBinary.cpp IndexBinary.h FaissAssert.h \
- FaissException.h Index.h
-IndexScalarQuantizer.o: IndexScalarQuantizer.cpp IndexScalarQuantizer.h \
- IndexIVF.h Index.h InvertedLists.h Clustering.h Heap.h utils.h \
- FaissAssert.h FaissException.h AuxIndexStructures.h
+IndexIVFPQ.o: IndexIVFPQ.cpp IndexIVFPQ.h IndexIVF.h Index.h \
+ InvertedLists.h Clustering.h Heap.h IndexPQ.h ProductQuantizer.h \
+ PolysemousTraining.h utils.h IndexFlat.h hamming.h FaissAssert.h \
+ FaissException.h AuxIndexStructures.h
+IndexIVFSpectralHash.o: IndexIVFSpectralHash.cpp IndexIVFSpectralHash.h \
+ IndexIVF.h Index.h InvertedLists.h Clustering.h Heap.h hamming.h utils.h \
+ FaissAssert.h FaissException.h AuxIndexStructures.h VectorTransform.h
+IndexLSH.o: IndexLSH.cpp IndexLSH.h Index.h VectorTransform.h utils.h \
+ Heap.h hamming.h FaissAssert.h FaissException.h
 IndexPQ.o: IndexPQ.cpp IndexPQ.h Index.h ProductQuantizer.h Clustering.h \
  Heap.h PolysemousTraining.h FaissAssert.h FaissException.h \
  AuxIndexStructures.h hamming.h
-utils_simd.o: utils_simd.cpp utils.h Heap.h
-HNSW.o: HNSW.cpp HNSW.h Index.h FaissAssert.h FaissException.h utils.h \
- Heap.h AuxIndexStructures.h
-hamming.o: hamming.cpp hamming.h Heap.h FaissAssert.h FaissException.h
-Clustering.o: Clustering.cpp Clustering.h Index.h AuxIndexStructures.h \
- utils.h Heap.h FaissAssert.h FaissException.h IndexFlat.h
 IndexReplicas.o: IndexReplicas.cpp IndexReplicas.h Index.h IndexBinary.h \
  FaissAssert.h FaissException.h ThreadedIndex.h WorkerThread.h \
  ThreadedIndex-inl.h
-IVFlib.o: IVFlib.cpp IVFlib.h IndexIVF.h Index.h InvertedLists.h \
- Clustering.h Heap.h VectorTransform.h FaissAssert.h FaissException.h
-Index.o: Index.cpp IndexFlat.h Index.h FaissAssert.h FaissException.h
-IndexHNSW.o: IndexHNSW.cpp IndexHNSW.h HNSW.h Index.h FaissAssert.h \
- FaissException.h utils.h Heap.h IndexFlat.h IndexPQ.h ProductQuantizer.h \
- Clustering.h PolysemousTraining.h IndexScalarQuantizer.h IndexIVF.h \
- InvertedLists.h IndexIVFPQ.h AuxIndexStructures.h
+IndexScalarQuantizer.o: IndexScalarQuantizer.cpp IndexScalarQuantizer.h \
+ IndexIVF.h Index.h InvertedLists.h Clustering.h Heap.h utils.h \
+ FaissAssert.h FaissException.h AuxIndexStructures.h
+IndexShards.o: IndexShards.cpp IndexShards.h Index.h IndexBinary.h \
+ FaissAssert.h FaissException.h ThreadedIndex.h WorkerThread.h \
+ ThreadedIndex-inl.h Heap.h
+InvertedLists.o: InvertedLists.cpp InvertedLists.h Index.h utils.h Heap.h \
+ FaissAssert.h FaissException.h
+MetaIndexes.o: MetaIndexes.cpp MetaIndexes.h Index.h IndexShards.h \
+ IndexBinary.h FaissAssert.h FaissException.h ThreadedIndex.h \
+ WorkerThread.h ThreadedIndex-inl.h IndexReplicas.h Heap.h \
+ AuxIndexStructures.h
+OnDiskInvertedLists.o: OnDiskInvertedLists.cpp OnDiskInvertedLists.h \
+ IndexIVF.h Index.h InvertedLists.h Clustering.h Heap.h FaissAssert.h \
+ FaissException.h utils.h
+PolysemousTraining.o: PolysemousTraining.cpp PolysemousTraining.h \
+ ProductQuantizer.h Clustering.h Index.h Heap.h utils.h hamming.h \
+ FaissAssert.h FaissException.h
+ProductQuantizer.o: ProductQuantizer.cpp ProductQuantizer.h Clustering.h \
+ Index.h Heap.h FaissAssert.h FaissException.h VectorTransform.h \
+ IndexFlat.h utils.h
+VectorTransform.o: VectorTransform.cpp VectorTransform.h Index.h utils.h \
+ Heap.h FaissAssert.h FaissException.h IndexPQ.h ProductQuantizer.h \
+ Clustering.h PolysemousTraining.h
+WorkerThread.o: WorkerThread.cpp WorkerThread.h FaissAssert.h \
+ FaissException.h
+distances.o: distances.cpp distances.h Index.h Heap.h utils.h \
+ FaissAssert.h FaissException.h AuxIndexStructures.h
+hamming.o: hamming.cpp hamming.h Heap.h FaissAssert.h FaissException.h
 index_io.o: index_io.cpp index_io.h FaissAssert.h FaissException.h \
  AuxIndexStructures.h Index.h IndexFlat.h VectorTransform.h IndexLSH.h \
  IndexPQ.h ProductQuantizer.h Clustering.h Heap.h PolysemousTraining.h \
@@ -95,13 +95,9 @@ index_io.o: index_io.cpp index_io.h FaissAssert.h FaissException.h \
  IndexScalarQuantizer.h IndexHNSW.h HNSW.h utils.h OnDiskInvertedLists.h \
  IndexBinaryFlat.h IndexBinaryFromFloat.h IndexBinaryHNSW.h \
  IndexBinaryIVF.h
-StandardGpuResources.o: gpu/StandardGpuResources.cpp \
- gpu/StandardGpuResources.h gpu/GpuResources.h gpu/utils/DeviceMemory.h \
- gpu/utils/StackDeviceMemory.h gpu/utils/DeviceUtils.h \
- gpu/utils/../../FaissAssert.h gpu/utils/../../FaissException.h \
- gpu/utils/MemorySpace.h gpu/../FaissAssert.h
-GpuClonerOptions.o: gpu/GpuClonerOptions.cpp gpu/GpuClonerOptions.h \
- gpu/GpuIndicesOptions.h
+utils.o: utils.cpp utils.h Heap.h AuxIndexStructures.h Index.h \
+ FaissAssert.h FaissException.h
+utils_simd.o: utils_simd.cpp utils.h Heap.h
 GpuAutoTune.o: gpu/GpuAutoTune.cpp gpu/GpuAutoTune.h gpu/../Index.h \
  gpu/../AutoTune.h gpu/../Index.h gpu/../IndexBinary.h \
  gpu/../FaissAssert.h gpu/../FaissException.h gpu/GpuClonerOptions.h \
@@ -116,23 +112,41 @@ GpuAutoTune.o: gpu/GpuAutoTune.cpp gpu/GpuAutoTune.h gpu/../Index.h \
  gpu/GpuIndexFlat.h gpu/GpuIndexIVFFlat.h gpu/GpuIndexIVF.h \
  gpu/../Clustering.h gpu/GpuIndexIVFPQ.h gpu/utils/DeviceUtils.h \
  gpu/utils/../../FaissAssert.h
+GpuClonerOptions.o: gpu/GpuClonerOptions.cpp gpu/GpuClonerOptions.h \
+ gpu/GpuIndicesOptions.h
 GpuResources.o: gpu/GpuResources.cpp gpu/GpuResources.h \
  gpu/utils/DeviceMemory.h gpu/utils/DeviceUtils.h \
  gpu/utils/../../FaissAssert.h gpu/utils/../../FaissException.h
+StandardGpuResources.o: gpu/StandardGpuResources.cpp \
+ gpu/StandardGpuResources.h gpu/GpuResources.h gpu/utils/DeviceMemory.h \
+ gpu/utils/StackDeviceMemory.h gpu/utils/DeviceUtils.h \
+ gpu/utils/../../FaissAssert.h gpu/utils/../../FaissException.h \
+ gpu/utils/MemorySpace.h gpu/../FaissAssert.h
 RemapIndices.o: gpu/impl/RemapIndices.cpp gpu/impl/RemapIndices.h \
  gpu/impl/../../FaissAssert.h gpu/impl/../../FaissException.h
+DeviceMemory.o: gpu/utils/DeviceMemory.cpp gpu/utils/DeviceMemory.h \
+ gpu/utils/DeviceUtils.h gpu/utils/../../FaissAssert.h \
+ gpu/utils/../../FaissException.h
 MemorySpace.o: gpu/utils/MemorySpace.cpp gpu/utils/MemorySpace.h \
- gpu/utils/../../FaissAssert.h gpu/utils/../../FaissException.h
-Timer.o: gpu/utils/Timer.cpp gpu/utils/Timer.h gpu/utils/DeviceUtils.h \
  gpu/utils/../../FaissAssert.h gpu/utils/../../FaissException.h
 StackDeviceMemory.o: gpu/utils/StackDeviceMemory.cpp \
  gpu/utils/StackDeviceMemory.h gpu/utils/DeviceMemory.h \
  gpu/utils/DeviceUtils.h gpu/utils/../../FaissAssert.h \
  gpu/utils/../../FaissException.h gpu/utils/MemorySpace.h \
  gpu/utils/StaticUtils.h
-DeviceMemory.o: gpu/utils/DeviceMemory.cpp gpu/utils/DeviceMemory.h \
- gpu/utils/DeviceUtils.h gpu/utils/../../FaissAssert.h \
- gpu/utils/../../FaissException.h
+Timer.o: gpu/utils/Timer.cpp gpu/utils/Timer.h gpu/utils/DeviceUtils.h \
+ gpu/utils/../../FaissAssert.h gpu/utils/../../FaissException.h
+GpuDistance.o: gpu/GpuDistance.cu gpu/GpuDistance.h gpu/../Index.h \
+ gpu/../FaissAssert.h gpu/../FaissException.h gpu/GpuResources.h \
+ gpu/utils/DeviceMemory.h gpu/impl/Distance.cuh \
+ gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/Tensor.cuh \
+ gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
+ gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/DeviceUtils.h \
+ gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/MemorySpace.h \
+ gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/../utils/Float16.cuh \
+ gpu/utils/ConversionOperators.cuh gpu/utils/../../Index.h \
+ gpu/utils/CopyUtils.cuh gpu/utils/HostTensor.cuh \
+ gpu/utils/HostTensor-inl.cuh
 GpuIndex.o: gpu/GpuIndex.cu gpu/GpuIndex.h gpu/../Index.h \
  gpu/utils/MemorySpace.h gpu/../FaissAssert.h gpu/../FaissException.h \
  gpu/GpuResources.h gpu/utils/DeviceMemory.h gpu/utils/CopyUtils.cuh \
@@ -155,17 +169,6 @@ GpuIndexBinaryFlat.o: gpu/GpuIndexBinaryFlat.cu gpu/GpuIndexBinaryFlat.h \
  gpu/utils/ConversionOperators.cuh gpu/utils/../../Index.h \
  gpu/utils/Float16.cuh gpu/utils/CopyUtils.cuh gpu/utils/HostTensor.cuh \
  gpu/utils/HostTensor-inl.cuh
-GpuIndexIVF.o: gpu/GpuIndexIVF.cu gpu/GpuIndexIVF.h gpu/GpuIndex.h \
- gpu/../Index.h gpu/utils/MemorySpace.h gpu/GpuIndexFlat.h \
- gpu/GpuIndicesOptions.h gpu/../Clustering.h gpu/../Index.h \
- gpu/../FaissAssert.h gpu/../FaissException.h gpu/../IndexFlat.h \
- gpu/../IndexIVF.h gpu/../InvertedLists.h gpu/../Clustering.h \
- gpu/../Heap.h gpu/utils/DeviceUtils.h gpu/utils/../../FaissAssert.h \
- gpu/utils/Float16.cuh gpu/utils/../GpuResources.h \
- gpu/utils/../utils/DeviceMemory.h gpu/utils/DeviceTensor.cuh \
- gpu/utils/Tensor.cuh gpu/utils/Tensor-inl.cuh \
- gpu/utils/../GpuFaissAssert.h gpu/utils/../../FaissAssert.h \
- gpu/utils/DeviceTensor-inl.cuh
 GpuIndexFlat.o: gpu/GpuIndexFlat.cu gpu/GpuIndexFlat.h gpu/GpuIndex.h \
  gpu/../Index.h gpu/utils/MemorySpace.h gpu/../IndexFlat.h gpu/../Index.h \
  gpu/GpuResources.h gpu/utils/DeviceMemory.h gpu/impl/FlatIndex.cuh \
@@ -179,6 +182,17 @@ GpuIndexFlat.o: gpu/GpuIndexFlat.cu gpu/GpuIndexFlat.h gpu/GpuIndex.h \
  gpu/impl/../utils/Float16.cuh gpu/utils/ConversionOperators.cuh \
  gpu/utils/../../Index.h gpu/utils/CopyUtils.cuh gpu/utils/HostTensor.cuh \
  gpu/utils/HostTensor-inl.cuh
+GpuIndexIVF.o: gpu/GpuIndexIVF.cu gpu/GpuIndexIVF.h gpu/GpuIndex.h \
+ gpu/../Index.h gpu/utils/MemorySpace.h gpu/GpuIndexFlat.h \
+ gpu/GpuIndicesOptions.h gpu/../Clustering.h gpu/../Index.h \
+ gpu/../FaissAssert.h gpu/../FaissException.h gpu/../IndexFlat.h \
+ gpu/../IndexIVF.h gpu/../InvertedLists.h gpu/../Clustering.h \
+ gpu/../Heap.h gpu/utils/DeviceUtils.h gpu/utils/../../FaissAssert.h \
+ gpu/utils/Float16.cuh gpu/utils/../GpuResources.h \
+ gpu/utils/../utils/DeviceMemory.h gpu/utils/DeviceTensor.cuh \
+ gpu/utils/Tensor.cuh gpu/utils/Tensor-inl.cuh \
+ gpu/utils/../GpuFaissAssert.h gpu/utils/../../FaissAssert.h \
+ gpu/utils/DeviceTensor-inl.cuh
 GpuIndexIVFFlat.o: gpu/GpuIndexIVFFlat.cu gpu/GpuIndexIVFFlat.h \
  gpu/GpuIndexIVF.h gpu/GpuIndex.h gpu/../Index.h gpu/utils/MemorySpace.h \
  gpu/GpuIndexFlat.h gpu/GpuIndicesOptions.h gpu/../Clustering.h \
@@ -212,27 +226,41 @@ GpuIndexIVFPQ.o: gpu/GpuIndexIVFPQ.cu gpu/GpuIndexIVFPQ.h \
  gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/../utils/Float16.cuh \
  gpu/utils/CopyUtils.cuh gpu/utils/HostTensor.cuh \
  gpu/utils/HostTensor-inl.cuh
-GpuDistance.o: gpu/GpuDistance.cu gpu/GpuDistance.h gpu/../Index.h \
- gpu/../FaissAssert.h gpu/../FaissException.h gpu/GpuResources.h \
- gpu/utils/DeviceMemory.h gpu/impl/Distance.cuh \
+BinaryDistance.o: gpu/impl/BinaryDistance.cu \
  gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/Tensor.cuh \
  gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
- gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/DeviceUtils.h \
- gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/MemorySpace.h \
- gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/../utils/Float16.cuh \
- gpu/utils/ConversionOperators.cuh gpu/utils/../../Index.h \
- gpu/utils/CopyUtils.cuh gpu/utils/HostTensor.cuh \
- gpu/utils/HostTensor-inl.cuh
-InvertedListAppend.o: gpu/impl/InvertedListAppend.cu \
- gpu/impl/InvertedListAppend.cuh gpu/impl/../GpuIndicesOptions.h \
+ gpu/impl/../utils/../../FaissAssert.h \
+ gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
+ gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/DeviceMemory.h \
+ gpu/impl/../utils/MemorySpace.h gpu/impl/../utils/DeviceTensor-inl.cuh \
+ gpu/impl/../utils/DeviceDefs.cuh gpu/impl/../utils/Select.cuh \
+ gpu/impl/../utils/Comparators.cuh gpu/impl/../utils/Float16.cuh \
+ gpu/impl/../utils/../GpuResources.h \
+ gpu/impl/../utils/MergeNetworkBlock.cuh \
+ gpu/impl/../utils/MergeNetworkUtils.cuh gpu/impl/../utils/PtxUtils.cuh \
+ gpu/impl/../utils/StaticUtils.h gpu/impl/../utils/WarpShuffles.cuh \
+ gpu/impl/../utils/MergeNetworkWarp.cuh gpu/impl/../utils/Reductions.cuh \
+ gpu/impl/../utils/ReductionOperators.cuh gpu/impl/../utils/Limits.cuh \
+ gpu/impl/../utils/Pair.cuh gpu/impl/../utils/MathOperators.cuh
+BinaryFlatIndex.o: gpu/impl/BinaryFlatIndex.cu \
+ gpu/impl/BinaryFlatIndex.cuh gpu/impl/../utils/DeviceTensor.cuh \
  gpu/impl/../utils/Tensor.cuh gpu/impl/../utils/Tensor-inl.cuh \
  gpu/impl/../utils/../GpuFaissAssert.h \
  gpu/impl/../utils/../../FaissAssert.h \
  gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
- gpu/impl/../utils/../../FaissAssert.h gpu/impl/../../FaissAssert.h \
- gpu/impl/../utils/Float16.cuh gpu/impl/../utils/../GpuResources.h \
+ gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/DeviceMemory.h \
+ gpu/impl/../utils/MemorySpace.h gpu/impl/../utils/DeviceTensor-inl.cuh \
+ gpu/impl/../utils/DeviceVector.cuh gpu/impl/../utils/StaticUtils.h \
+ gpu/impl/BinaryDistance.cuh gpu/impl/../GpuResources.h
+BroadcastSum.o: gpu/impl/BroadcastSum.cu gpu/impl/../../FaissAssert.h \
+ gpu/impl/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
+ gpu/impl/../utils/../../FaissAssert.h \
+ gpu/impl/../utils/MathOperators.cuh gpu/impl/../utils/Float16.cuh \
+ gpu/impl/../utils/../GpuResources.h \
  gpu/impl/../utils/../utils/DeviceMemory.h \
- gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/MemorySpace.h \
+ gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/Tensor.cuh \
+ gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
+ gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/MemorySpace.h \
  gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/../utils/StaticUtils.h
 Distance.o: gpu/impl/Distance.cu gpu/impl/Distance.cuh \
  gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/Tensor.cuh \
@@ -254,6 +282,31 @@ Distance.o: gpu/impl/Distance.cu gpu/impl/Distance.cuh \
  gpu/impl/../utils/StaticUtils.h gpu/impl/../utils/MergeNetworkWarp.cuh \
  gpu/impl/../utils/Reductions.cuh \
  gpu/impl/../utils/ReductionOperators.cuh
+FlatIndex.o: gpu/impl/FlatIndex.cu gpu/impl/FlatIndex.cuh \
+ gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/Tensor.cuh \
+ gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
+ gpu/impl/../utils/../../FaissAssert.h \
+ gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
+ gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/DeviceMemory.h \
+ gpu/impl/../utils/MemorySpace.h gpu/impl/../utils/DeviceTensor-inl.cuh \
+ gpu/impl/../utils/DeviceVector.cuh gpu/impl/../utils/StaticUtils.h \
+ gpu/impl/../utils/Float16.cuh gpu/impl/../utils/../GpuResources.h \
+ gpu/impl/Distance.cuh gpu/impl/L2Norm.cuh \
+ gpu/impl/../utils/CopyUtils.cuh gpu/impl/../utils/HostTensor.cuh \
+ gpu/impl/../utils/HostTensor-inl.cuh gpu/impl/../utils/Transpose.cuh
+IVFBase.o: gpu/impl/IVFBase.cu gpu/impl/IVFBase.cuh \
+ gpu/impl/../GpuIndicesOptions.h gpu/impl/../utils/DeviceVector.cuh \
+ gpu/impl/../utils/../../FaissAssert.h \
+ gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
+ gpu/impl/../utils/MemorySpace.h gpu/impl/../utils/StaticUtils.h \
+ gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/Tensor.cuh \
+ gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
+ gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/DeviceMemory.h \
+ gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/../GpuResources.h \
+ gpu/impl/FlatIndex.cuh gpu/impl/../utils/Float16.cuh \
+ gpu/impl/InvertedListAppend.cuh gpu/impl/RemapIndices.h \
+ gpu/impl/../utils/DeviceDefs.cuh gpu/impl/../utils/HostTensor.cuh \
+ gpu/impl/../utils/HostTensor-inl.cuh
 IVFFlat.o: gpu/impl/IVFFlat.cu gpu/impl/IVFFlat.cuh gpu/impl/IVFBase.cuh \
  gpu/impl/../GpuIndicesOptions.h gpu/impl/../utils/DeviceVector.cuh \
  gpu/impl/../utils/../../FaissAssert.h \
@@ -285,128 +338,6 @@ IVFFlatScan.o: gpu/impl/IVFFlatScan.cu gpu/impl/IVFFlatScan.cuh \
  gpu/impl/../utils/ReductionOperators.cuh gpu/impl/../utils/Limits.cuh \
  gpu/impl/../utils/Pair.cuh gpu/impl/../utils/WarpShuffles.cuh \
  gpu/impl/../utils/StaticUtils.h
-BinaryDistance.o: gpu/impl/BinaryDistance.cu \
- gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/Tensor.cuh \
- gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
- gpu/impl/../utils/../../FaissAssert.h \
- gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
- gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/DeviceMemory.h \
- gpu/impl/../utils/MemorySpace.h gpu/impl/../utils/DeviceTensor-inl.cuh \
- gpu/impl/../utils/DeviceDefs.cuh gpu/impl/../utils/Select.cuh \
- gpu/impl/../utils/Comparators.cuh gpu/impl/../utils/Float16.cuh \
- gpu/impl/../utils/../GpuResources.h \
- gpu/impl/../utils/MergeNetworkBlock.cuh \
- gpu/impl/../utils/MergeNetworkUtils.cuh gpu/impl/../utils/PtxUtils.cuh \
- gpu/impl/../utils/StaticUtils.h gpu/impl/../utils/WarpShuffles.cuh \
- gpu/impl/../utils/MergeNetworkWarp.cuh gpu/impl/../utils/Reductions.cuh \
- gpu/impl/../utils/ReductionOperators.cuh gpu/impl/../utils/Limits.cuh \
- gpu/impl/../utils/Pair.cuh gpu/impl/../utils/MathOperators.cuh
-IVFUtilsSelect1.o: gpu/impl/IVFUtilsSelect1.cu gpu/impl/IVFUtils.cuh \
- gpu/impl/../GpuIndicesOptions.h gpu/impl/../utils/Tensor.cuh \
- gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
- gpu/impl/../utils/../../FaissAssert.h \
- gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
- gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/DeviceDefs.cuh \
- gpu/impl/../utils/Limits.cuh gpu/impl/../utils/Float16.cuh \
- gpu/impl/../utils/../GpuResources.h \
- gpu/impl/../utils/../utils/DeviceMemory.h \
- gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/MemorySpace.h \
- gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/../utils/Pair.cuh \
- gpu/impl/../utils/MathOperators.cuh gpu/impl/../utils/WarpShuffles.cuh \
- gpu/impl/../utils/Select.cuh gpu/impl/../utils/Comparators.cuh \
- gpu/impl/../utils/MergeNetworkBlock.cuh \
- gpu/impl/../utils/MergeNetworkUtils.cuh gpu/impl/../utils/PtxUtils.cuh \
- gpu/impl/../utils/StaticUtils.h gpu/impl/../utils/MergeNetworkWarp.cuh \
- gpu/impl/../utils/Reductions.cuh \
- gpu/impl/../utils/ReductionOperators.cuh
-BroadcastSum.o: gpu/impl/BroadcastSum.cu gpu/impl/../../FaissAssert.h \
- gpu/impl/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
- gpu/impl/../utils/../../FaissAssert.h \
- gpu/impl/../utils/MathOperators.cuh gpu/impl/../utils/Float16.cuh \
- gpu/impl/../utils/../GpuResources.h \
- gpu/impl/../utils/../utils/DeviceMemory.h \
- gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/Tensor.cuh \
- gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
- gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/MemorySpace.h \
- gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/../utils/StaticUtils.h
-PQScanMultiPassNoPrecomputed.o: gpu/impl/PQScanMultiPassNoPrecomputed.cu \
- gpu/impl/PQScanMultiPassNoPrecomputed.cuh \
- gpu/impl/../GpuIndicesOptions.h gpu/impl/../utils/Tensor.cuh \
- gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
- gpu/impl/../utils/../../FaissAssert.h \
- gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
- gpu/impl/../utils/../../FaissAssert.h gpu/impl/../GpuResources.h \
- gpu/impl/../utils/DeviceMemory.h gpu/impl/PQCodeDistances.cuh \
- gpu/impl/../utils/NoTypeTensor.cuh gpu/impl/PQCodeLoad.cuh \
- gpu/impl/../utils/PtxUtils.cuh gpu/impl/IVFUtils.cuh \
- gpu/impl/../utils/ConversionOperators.cuh \
- gpu/impl/../utils/../../Index.h gpu/impl/../utils/Float16.cuh \
- gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/MemorySpace.h \
- gpu/impl/../utils/DeviceTensor-inl.cuh \
- gpu/impl/../utils/LoadStoreOperators.cuh gpu/impl/../utils/StaticUtils.h \
- gpu/impl/../utils/HostTensor.cuh gpu/impl/../utils/HostTensor-inl.cuh
-VectorResidual.o: gpu/impl/VectorResidual.cu gpu/impl/VectorResidual.cuh \
- gpu/impl/../utils/Tensor.cuh gpu/impl/../utils/Tensor-inl.cuh \
- gpu/impl/../utils/../GpuFaissAssert.h \
- gpu/impl/../utils/../../FaissAssert.h \
- gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
- gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/Float16.cuh \
- gpu/impl/../utils/../GpuResources.h \
- gpu/impl/../utils/../utils/DeviceMemory.h \
- gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/MemorySpace.h \
- gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/../../FaissAssert.h \
- gpu/impl/../utils/ConversionOperators.cuh \
- gpu/impl/../utils/../../Index.h gpu/impl/../utils/StaticUtils.h
-L2Select.o: gpu/impl/L2Select.cu gpu/impl/L2Select.cuh \
- gpu/impl/../utils/Float16.cuh gpu/impl/../utils/../GpuResources.h \
- gpu/impl/../utils/../utils/DeviceMemory.h \
- gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/Tensor.cuh \
- gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
- gpu/impl/../utils/../../FaissAssert.h \
- gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
- gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/MemorySpace.h \
- gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/../../FaissAssert.h \
- gpu/impl/../utils/DeviceDefs.cuh gpu/impl/../utils/MathOperators.cuh \
- gpu/impl/../utils/Pair.cuh gpu/impl/../utils/WarpShuffles.cuh \
- gpu/impl/../utils/Reductions.cuh gpu/impl/../utils/PtxUtils.cuh \
- gpu/impl/../utils/ReductionOperators.cuh gpu/impl/../utils/Limits.cuh \
- gpu/impl/../utils/StaticUtils.h gpu/impl/../utils/Select.cuh \
- gpu/impl/../utils/Comparators.cuh \
- gpu/impl/../utils/MergeNetworkBlock.cuh \
- gpu/impl/../utils/MergeNetworkUtils.cuh \
- gpu/impl/../utils/MergeNetworkWarp.cuh
-L2Norm.o: gpu/impl/L2Norm.cu gpu/impl/L2Norm.cuh \
- gpu/impl/../utils/Float16.cuh gpu/impl/../utils/../GpuResources.h \
- gpu/impl/../utils/../utils/DeviceMemory.h \
- gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/Tensor.cuh \
- gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
- gpu/impl/../utils/../../FaissAssert.h \
- gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
- gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/MemorySpace.h \
- gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/../../FaissAssert.h \
- gpu/impl/../utils/ConversionOperators.cuh \
- gpu/impl/../utils/../../Index.h gpu/impl/../utils/DeviceDefs.cuh \
- gpu/impl/../utils/MathOperators.cuh gpu/impl/../utils/PtxUtils.cuh \
- gpu/impl/../utils/StaticUtils.h gpu/impl/../utils/Reductions.cuh \
- gpu/impl/../utils/ReductionOperators.cuh gpu/impl/../utils/Limits.cuh \
- gpu/impl/../utils/Pair.cuh gpu/impl/../utils/WarpShuffles.cuh
-BinaryFlatIndex.o: gpu/impl/BinaryFlatIndex.cu \
- gpu/impl/BinaryFlatIndex.cuh gpu/impl/../utils/DeviceTensor.cuh \
- gpu/impl/../utils/Tensor.cuh gpu/impl/../utils/Tensor-inl.cuh \
- gpu/impl/../utils/../GpuFaissAssert.h \
- gpu/impl/../utils/../../FaissAssert.h \
- gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
- gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/DeviceMemory.h \
- gpu/impl/../utils/MemorySpace.h gpu/impl/../utils/DeviceTensor-inl.cuh \
- gpu/impl/../utils/DeviceVector.cuh gpu/impl/../utils/StaticUtils.h \
- gpu/impl/BinaryDistance.cuh gpu/impl/../GpuResources.h
-IVFUtils.o: gpu/impl/IVFUtils.cu gpu/impl/IVFUtils.cuh \
- gpu/impl/../GpuIndicesOptions.h gpu/impl/../utils/Tensor.cuh \
- gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
- gpu/impl/../utils/../../FaissAssert.h \
- gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
- gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/StaticUtils.h \
- gpu/impl/../utils/ThrustAllocator.cuh gpu/impl/../utils/MemorySpace.h
 IVFPQ.o: gpu/impl/IVFPQ.cu gpu/impl/IVFPQ.cuh gpu/impl/IVFBase.cuh \
  gpu/impl/../GpuIndicesOptions.h gpu/impl/../utils/DeviceVector.cuh \
  gpu/impl/../utils/../../FaissAssert.h \
@@ -425,6 +356,31 @@ IVFPQ.o: gpu/impl/IVFPQ.cu gpu/impl/IVFPQ.cuh gpu/impl/IVFBase.cuh \
  gpu/impl/VectorResidual.cuh gpu/impl/../utils/DeviceDefs.cuh \
  gpu/impl/../utils/HostTensor.cuh gpu/impl/../utils/HostTensor-inl.cuh \
  gpu/impl/../utils/MatrixMult.cuh gpu/impl/../utils/Transpose.cuh
+IVFUtils.o: gpu/impl/IVFUtils.cu gpu/impl/IVFUtils.cuh \
+ gpu/impl/../GpuIndicesOptions.h gpu/impl/../utils/Tensor.cuh \
+ gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
+ gpu/impl/../utils/../../FaissAssert.h \
+ gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
+ gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/StaticUtils.h \
+ gpu/impl/../utils/ThrustAllocator.cuh gpu/impl/../utils/MemorySpace.h
+IVFUtilsSelect1.o: gpu/impl/IVFUtilsSelect1.cu gpu/impl/IVFUtils.cuh \
+ gpu/impl/../GpuIndicesOptions.h gpu/impl/../utils/Tensor.cuh \
+ gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
+ gpu/impl/../utils/../../FaissAssert.h \
+ gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
+ gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/DeviceDefs.cuh \
+ gpu/impl/../utils/Limits.cuh gpu/impl/../utils/Float16.cuh \
+ gpu/impl/../utils/../GpuResources.h \
+ gpu/impl/../utils/../utils/DeviceMemory.h \
+ gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/MemorySpace.h \
+ gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/../utils/Pair.cuh \
+ gpu/impl/../utils/MathOperators.cuh gpu/impl/../utils/WarpShuffles.cuh \
+ gpu/impl/../utils/Select.cuh gpu/impl/../utils/Comparators.cuh \
+ gpu/impl/../utils/MergeNetworkBlock.cuh \
+ gpu/impl/../utils/MergeNetworkUtils.cuh gpu/impl/../utils/PtxUtils.cuh \
+ gpu/impl/../utils/StaticUtils.h gpu/impl/../utils/MergeNetworkWarp.cuh \
+ gpu/impl/../utils/Reductions.cuh \
+ gpu/impl/../utils/ReductionOperators.cuh
 IVFUtilsSelect2.o: gpu/impl/IVFUtilsSelect2.cu gpu/impl/IVFUtils.cuh \
  gpu/impl/../GpuIndicesOptions.h gpu/impl/../utils/Tensor.cuh \
  gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
@@ -443,6 +399,80 @@ IVFUtilsSelect2.o: gpu/impl/IVFUtilsSelect2.cu gpu/impl/IVFUtils.cuh \
  gpu/impl/../utils/StaticUtils.h gpu/impl/../utils/MergeNetworkWarp.cuh \
  gpu/impl/../utils/Reductions.cuh \
  gpu/impl/../utils/ReductionOperators.cuh
+InvertedListAppend.o: gpu/impl/InvertedListAppend.cu \
+ gpu/impl/InvertedListAppend.cuh gpu/impl/../GpuIndicesOptions.h \
+ gpu/impl/../utils/Tensor.cuh gpu/impl/../utils/Tensor-inl.cuh \
+ gpu/impl/../utils/../GpuFaissAssert.h \
+ gpu/impl/../utils/../../FaissAssert.h \
+ gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
+ gpu/impl/../utils/../../FaissAssert.h gpu/impl/../../FaissAssert.h \
+ gpu/impl/../utils/Float16.cuh gpu/impl/../utils/../GpuResources.h \
+ gpu/impl/../utils/../utils/DeviceMemory.h \
+ gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/MemorySpace.h \
+ gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/../utils/StaticUtils.h
+L2Norm.o: gpu/impl/L2Norm.cu gpu/impl/L2Norm.cuh \
+ gpu/impl/../utils/Float16.cuh gpu/impl/../utils/../GpuResources.h \
+ gpu/impl/../utils/../utils/DeviceMemory.h \
+ gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/Tensor.cuh \
+ gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
+ gpu/impl/../utils/../../FaissAssert.h \
+ gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
+ gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/MemorySpace.h \
+ gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/../../FaissAssert.h \
+ gpu/impl/../utils/ConversionOperators.cuh \
+ gpu/impl/../utils/../../Index.h gpu/impl/../utils/DeviceDefs.cuh \
+ gpu/impl/../utils/MathOperators.cuh gpu/impl/../utils/PtxUtils.cuh \
+ gpu/impl/../utils/StaticUtils.h gpu/impl/../utils/Reductions.cuh \
+ gpu/impl/../utils/ReductionOperators.cuh gpu/impl/../utils/Limits.cuh \
+ gpu/impl/../utils/Pair.cuh gpu/impl/../utils/WarpShuffles.cuh
+L2Select.o: gpu/impl/L2Select.cu gpu/impl/L2Select.cuh \
+ gpu/impl/../utils/Float16.cuh gpu/impl/../utils/../GpuResources.h \
+ gpu/impl/../utils/../utils/DeviceMemory.h \
+ gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/Tensor.cuh \
+ gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
+ gpu/impl/../utils/../../FaissAssert.h \
+ gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
+ gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/MemorySpace.h \
+ gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/../../FaissAssert.h \
+ gpu/impl/../utils/DeviceDefs.cuh gpu/impl/../utils/MathOperators.cuh \
+ gpu/impl/../utils/Pair.cuh gpu/impl/../utils/WarpShuffles.cuh \
+ gpu/impl/../utils/Reductions.cuh gpu/impl/../utils/PtxUtils.cuh \
+ gpu/impl/../utils/ReductionOperators.cuh gpu/impl/../utils/Limits.cuh \
+ gpu/impl/../utils/StaticUtils.h gpu/impl/../utils/Select.cuh \
+ gpu/impl/../utils/Comparators.cuh \
+ gpu/impl/../utils/MergeNetworkBlock.cuh \
+ gpu/impl/../utils/MergeNetworkUtils.cuh \
+ gpu/impl/../utils/MergeNetworkWarp.cuh
+PQCodeDistances.o: gpu/impl/PQCodeDistances.cu \
+ gpu/impl/PQCodeDistances.cuh gpu/impl/../utils/Tensor.cuh \
+ gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
+ gpu/impl/../utils/../../FaissAssert.h \
+ gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
+ gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/NoTypeTensor.cuh \
+ gpu/impl/BroadcastSum.cuh gpu/impl/../utils/Float16.cuh \
+ gpu/impl/../utils/../GpuResources.h \
+ gpu/impl/../utils/../utils/DeviceMemory.h \
+ gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/MemorySpace.h \
+ gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/Distance.cuh \
+ gpu/impl/L2Norm.cuh gpu/impl/../utils/DeviceDefs.cuh \
+ gpu/impl/../utils/MatrixMult.cuh gpu/impl/../utils/PtxUtils.cuh \
+ gpu/impl/../utils/StaticUtils.h gpu/impl/../utils/Transpose.cuh
+PQScanMultiPassNoPrecomputed.o: gpu/impl/PQScanMultiPassNoPrecomputed.cu \
+ gpu/impl/PQScanMultiPassNoPrecomputed.cuh \
+ gpu/impl/../GpuIndicesOptions.h gpu/impl/../utils/Tensor.cuh \
+ gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
+ gpu/impl/../utils/../../FaissAssert.h \
+ gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
+ gpu/impl/../utils/../../FaissAssert.h gpu/impl/../GpuResources.h \
+ gpu/impl/../utils/DeviceMemory.h gpu/impl/PQCodeDistances.cuh \
+ gpu/impl/../utils/NoTypeTensor.cuh gpu/impl/PQCodeLoad.cuh \
+ gpu/impl/../utils/PtxUtils.cuh gpu/impl/IVFUtils.cuh \
+ gpu/impl/../utils/ConversionOperators.cuh \
+ gpu/impl/../utils/../../Index.h gpu/impl/../utils/Float16.cuh \
+ gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/MemorySpace.h \
+ gpu/impl/../utils/DeviceTensor-inl.cuh \
+ gpu/impl/../utils/LoadStoreOperators.cuh gpu/impl/../utils/StaticUtils.h \
+ gpu/impl/../utils/HostTensor.cuh gpu/impl/../utils/HostTensor-inl.cuh
 PQScanMultiPassPrecomputed.o: gpu/impl/PQScanMultiPassPrecomputed.cu \
  gpu/impl/PQScanMultiPassPrecomputed.cuh gpu/impl/../GpuIndicesOptions.h \
  gpu/impl/../utils/Tensor.cuh gpu/impl/../utils/Tensor-inl.cuh \
@@ -458,84 +488,18 @@ PQScanMultiPassPrecomputed.o: gpu/impl/PQScanMultiPassPrecomputed.cu \
  gpu/impl/../utils/DeviceTensor-inl.cuh \
  gpu/impl/../utils/LoadStoreOperators.cuh \
  gpu/impl/../utils/MathOperators.cuh gpu/impl/../utils/StaticUtils.h
-FlatIndex.o: gpu/impl/FlatIndex.cu gpu/impl/FlatIndex.cuh \
- gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/Tensor.cuh \
- gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
+VectorResidual.o: gpu/impl/VectorResidual.cu gpu/impl/VectorResidual.cuh \
+ gpu/impl/../utils/Tensor.cuh gpu/impl/../utils/Tensor-inl.cuh \
+ gpu/impl/../utils/../GpuFaissAssert.h \
  gpu/impl/../utils/../../FaissAssert.h \
  gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
- gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/DeviceMemory.h \
- gpu/impl/../utils/MemorySpace.h gpu/impl/../utils/DeviceTensor-inl.cuh \
- gpu/impl/../utils/DeviceVector.cuh gpu/impl/../utils/StaticUtils.h \
- gpu/impl/../utils/Float16.cuh gpu/impl/../utils/../GpuResources.h \
- gpu/impl/Distance.cuh gpu/impl/L2Norm.cuh \
- gpu/impl/../utils/CopyUtils.cuh gpu/impl/../utils/HostTensor.cuh \
- gpu/impl/../utils/HostTensor-inl.cuh gpu/impl/../utils/Transpose.cuh
-IVFBase.o: gpu/impl/IVFBase.cu gpu/impl/IVFBase.cuh \
- gpu/impl/../GpuIndicesOptions.h gpu/impl/../utils/DeviceVector.cuh \
- gpu/impl/../utils/../../FaissAssert.h \
- gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
- gpu/impl/../utils/MemorySpace.h gpu/impl/../utils/StaticUtils.h \
- gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/Tensor.cuh \
- gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
- gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/DeviceMemory.h \
- gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/../GpuResources.h \
- gpu/impl/FlatIndex.cuh gpu/impl/../utils/Float16.cuh \
- gpu/impl/InvertedListAppend.cuh gpu/impl/RemapIndices.h \
- gpu/impl/../utils/DeviceDefs.cuh gpu/impl/../utils/HostTensor.cuh \
- gpu/impl/../utils/HostTensor-inl.cuh
-PQCodeDistances.o: gpu/impl/PQCodeDistances.cu \
- gpu/impl/PQCodeDistances.cuh gpu/impl/../utils/Tensor.cuh \
- gpu/impl/../utils/Tensor-inl.cuh gpu/impl/../utils/../GpuFaissAssert.h \
- gpu/impl/../utils/../../FaissAssert.h \
- gpu/impl/../utils/../../FaissException.h gpu/impl/../utils/DeviceUtils.h \
- gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/NoTypeTensor.cuh \
- gpu/impl/BroadcastSum.cuh gpu/impl/../utils/Float16.cuh \
+ gpu/impl/../utils/../../FaissAssert.h gpu/impl/../utils/Float16.cuh \
  gpu/impl/../utils/../GpuResources.h \
  gpu/impl/../utils/../utils/DeviceMemory.h \
  gpu/impl/../utils/DeviceTensor.cuh gpu/impl/../utils/MemorySpace.h \
- gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/Distance.cuh \
- gpu/impl/L2Norm.cuh gpu/impl/../utils/DeviceDefs.cuh \
- gpu/impl/../utils/MatrixMult.cuh gpu/impl/../utils/PtxUtils.cuh \
- gpu/impl/../utils/StaticUtils.h gpu/impl/../utils/Transpose.cuh
-DeviceUtils.o: gpu/utils/DeviceUtils.cu gpu/utils/DeviceUtils.h \
- gpu/utils/../../FaissAssert.h gpu/utils/../../FaissException.h \
- gpu/utils/DeviceDefs.cuh
-Float16.o: gpu/utils/Float16.cu gpu/utils/Float16.cuh \
- gpu/utils/../GpuResources.h gpu/utils/../utils/DeviceMemory.h \
- gpu/utils/DeviceTensor.cuh gpu/utils/Tensor.cuh gpu/utils/Tensor-inl.cuh \
- gpu/utils/../GpuFaissAssert.h gpu/utils/../../FaissAssert.h \
- gpu/utils/../../FaissException.h gpu/utils/DeviceUtils.h \
- gpu/utils/../../FaissAssert.h gpu/utils/MemorySpace.h \
- gpu/utils/DeviceTensor-inl.cuh gpu/utils/nvidia/fp16_emu.cuh
-BlockSelectHalf.o: gpu/utils/BlockSelectHalf.cu \
- gpu/utils/blockselect/BlockSelectImpl.cuh \
- gpu/utils/blockselect/../BlockSelectKernel.cuh \
- gpu/utils/blockselect/../Float16.cuh \
- gpu/utils/blockselect/../../GpuResources.h \
- gpu/utils/blockselect/../../utils/DeviceMemory.h \
- gpu/utils/blockselect/../DeviceTensor.cuh \
- gpu/utils/blockselect/../Tensor.cuh \
- gpu/utils/blockselect/../Tensor-inl.cuh \
- gpu/utils/blockselect/../../GpuFaissAssert.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../../../FaissException.h \
- gpu/utils/blockselect/../DeviceUtils.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../MemorySpace.h \
- gpu/utils/blockselect/../DeviceTensor-inl.cuh \
- gpu/utils/blockselect/../Select.cuh \
- gpu/utils/blockselect/../Comparators.cuh \
- gpu/utils/blockselect/../DeviceDefs.cuh \
- gpu/utils/blockselect/../MergeNetworkBlock.cuh \
- gpu/utils/blockselect/../MergeNetworkUtils.cuh \
- gpu/utils/blockselect/../PtxUtils.cuh \
- gpu/utils/blockselect/../StaticUtils.h \
- gpu/utils/blockselect/../WarpShuffles.cuh \
- gpu/utils/blockselect/../MergeNetworkWarp.cuh \
- gpu/utils/blockselect/../Reductions.cuh \
- gpu/utils/blockselect/../ReductionOperators.cuh \
- gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
- gpu/utils/blockselect/../MathOperators.cuh
+ gpu/impl/../utils/DeviceTensor-inl.cuh gpu/impl/../../FaissAssert.h \
+ gpu/impl/../utils/ConversionOperators.cuh \
+ gpu/impl/../utils/../../Index.h gpu/impl/../utils/StaticUtils.h
 BlockSelectFloat.o: gpu/utils/BlockSelectFloat.cu \
  gpu/utils/blockselect/BlockSelectImpl.cuh \
  gpu/utils/blockselect/../BlockSelectKernel.cuh \
@@ -565,35 +529,45 @@ BlockSelectFloat.o: gpu/utils/BlockSelectFloat.cu \
  gpu/utils/blockselect/../ReductionOperators.cuh \
  gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
  gpu/utils/blockselect/../MathOperators.cuh
-WarpSelectHalf.o: gpu/utils/WarpSelectHalf.cu \
- gpu/utils/warpselect/WarpSelectImpl.cuh \
- gpu/utils/warpselect/../WarpSelectKernel.cuh \
- gpu/utils/warpselect/../Float16.cuh \
- gpu/utils/warpselect/../../GpuResources.h \
- gpu/utils/warpselect/../../utils/DeviceMemory.h \
- gpu/utils/warpselect/../DeviceTensor.cuh \
- gpu/utils/warpselect/../Tensor.cuh \
- gpu/utils/warpselect/../Tensor-inl.cuh \
- gpu/utils/warpselect/../../GpuFaissAssert.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../../../FaissException.h \
- gpu/utils/warpselect/../DeviceUtils.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../MemorySpace.h \
- gpu/utils/warpselect/../DeviceTensor-inl.cuh \
- gpu/utils/warpselect/../Select.cuh \
- gpu/utils/warpselect/../Comparators.cuh \
- gpu/utils/warpselect/../DeviceDefs.cuh \
- gpu/utils/warpselect/../MergeNetworkBlock.cuh \
- gpu/utils/warpselect/../MergeNetworkUtils.cuh \
- gpu/utils/warpselect/../PtxUtils.cuh \
- gpu/utils/warpselect/../StaticUtils.h \
- gpu/utils/warpselect/../WarpShuffles.cuh \
- gpu/utils/warpselect/../MergeNetworkWarp.cuh \
- gpu/utils/warpselect/../Reductions.cuh \
- gpu/utils/warpselect/../ReductionOperators.cuh \
- gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
- gpu/utils/warpselect/../MathOperators.cuh
+BlockSelectHalf.o: gpu/utils/BlockSelectHalf.cu \
+ gpu/utils/blockselect/BlockSelectImpl.cuh \
+ gpu/utils/blockselect/../BlockSelectKernel.cuh \
+ gpu/utils/blockselect/../Float16.cuh \
+ gpu/utils/blockselect/../../GpuResources.h \
+ gpu/utils/blockselect/../../utils/DeviceMemory.h \
+ gpu/utils/blockselect/../DeviceTensor.cuh \
+ gpu/utils/blockselect/../Tensor.cuh \
+ gpu/utils/blockselect/../Tensor-inl.cuh \
+ gpu/utils/blockselect/../../GpuFaissAssert.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../../../FaissException.h \
+ gpu/utils/blockselect/../DeviceUtils.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../MemorySpace.h \
+ gpu/utils/blockselect/../DeviceTensor-inl.cuh \
+ gpu/utils/blockselect/../Select.cuh \
+ gpu/utils/blockselect/../Comparators.cuh \
+ gpu/utils/blockselect/../DeviceDefs.cuh \
+ gpu/utils/blockselect/../MergeNetworkBlock.cuh \
+ gpu/utils/blockselect/../MergeNetworkUtils.cuh \
+ gpu/utils/blockselect/../PtxUtils.cuh \
+ gpu/utils/blockselect/../StaticUtils.h \
+ gpu/utils/blockselect/../WarpShuffles.cuh \
+ gpu/utils/blockselect/../MergeNetworkWarp.cuh \
+ gpu/utils/blockselect/../Reductions.cuh \
+ gpu/utils/blockselect/../ReductionOperators.cuh \
+ gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
+ gpu/utils/blockselect/../MathOperators.cuh
+DeviceUtils.o: gpu/utils/DeviceUtils.cu gpu/utils/DeviceUtils.h \
+ gpu/utils/../../FaissAssert.h gpu/utils/../../FaissException.h \
+ gpu/utils/DeviceDefs.cuh
+Float16.o: gpu/utils/Float16.cu gpu/utils/Float16.cuh \
+ gpu/utils/../GpuResources.h gpu/utils/../utils/DeviceMemory.h \
+ gpu/utils/DeviceTensor.cuh gpu/utils/Tensor.cuh gpu/utils/Tensor-inl.cuh \
+ gpu/utils/../GpuFaissAssert.h gpu/utils/../../FaissAssert.h \
+ gpu/utils/../../FaissException.h gpu/utils/DeviceUtils.h \
+ gpu/utils/../../FaissAssert.h gpu/utils/MemorySpace.h \
+ gpu/utils/DeviceTensor-inl.cuh gpu/utils/nvidia/fp16_emu.cuh
 MatrixMult.o: gpu/utils/MatrixMult.cu gpu/utils/MatrixMult.cuh \
  gpu/utils/Float16.cuh gpu/utils/../GpuResources.h \
  gpu/utils/../utils/DeviceMemory.h gpu/utils/DeviceTensor.cuh \
@@ -632,153 +606,37 @@ WarpSelectFloat.o: gpu/utils/WarpSelectFloat.cu \
  gpu/utils/warpselect/../ReductionOperators.cuh \
  gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
  gpu/utils/warpselect/../MathOperators.cuh
+WarpSelectHalf.o: gpu/utils/WarpSelectHalf.cu \
+ gpu/utils/warpselect/WarpSelectImpl.cuh \
+ gpu/utils/warpselect/../WarpSelectKernel.cuh \
+ gpu/utils/warpselect/../Float16.cuh \
+ gpu/utils/warpselect/../../GpuResources.h \
+ gpu/utils/warpselect/../../utils/DeviceMemory.h \
+ gpu/utils/warpselect/../DeviceTensor.cuh \
+ gpu/utils/warpselect/../Tensor.cuh \
+ gpu/utils/warpselect/../Tensor-inl.cuh \
+ gpu/utils/warpselect/../../GpuFaissAssert.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../../../FaissException.h \
+ gpu/utils/warpselect/../DeviceUtils.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../MemorySpace.h \
+ gpu/utils/warpselect/../DeviceTensor-inl.cuh \
+ gpu/utils/warpselect/../Select.cuh \
+ gpu/utils/warpselect/../Comparators.cuh \
+ gpu/utils/warpselect/../DeviceDefs.cuh \
+ gpu/utils/warpselect/../MergeNetworkBlock.cuh \
+ gpu/utils/warpselect/../MergeNetworkUtils.cuh \
+ gpu/utils/warpselect/../PtxUtils.cuh \
+ gpu/utils/warpselect/../StaticUtils.h \
+ gpu/utils/warpselect/../WarpShuffles.cuh \
+ gpu/utils/warpselect/../MergeNetworkWarp.cuh \
+ gpu/utils/warpselect/../Reductions.cuh \
+ gpu/utils/warpselect/../ReductionOperators.cuh \
+ gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
+ gpu/utils/warpselect/../MathOperators.cuh
 fp16_emu.o: gpu/utils/nvidia/fp16_emu.cu gpu/utils/nvidia/fp16_emu.cuh
-BlockSelectFloatT2048.o: gpu/utils/blockselect/BlockSelectFloatT2048.cu \
- gpu/utils/blockselect/BlockSelectImpl.cuh \
- gpu/utils/blockselect/../BlockSelectKernel.cuh \
- gpu/utils/blockselect/../Float16.cuh \
- gpu/utils/blockselect/../../GpuResources.h \
- gpu/utils/blockselect/../../utils/DeviceMemory.h \
- gpu/utils/blockselect/../DeviceTensor.cuh \
- gpu/utils/blockselect/../Tensor.cuh \
- gpu/utils/blockselect/../Tensor-inl.cuh \
- gpu/utils/blockselect/../../GpuFaissAssert.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../../../FaissException.h \
- gpu/utils/blockselect/../DeviceUtils.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../MemorySpace.h \
- gpu/utils/blockselect/../DeviceTensor-inl.cuh \
- gpu/utils/blockselect/../Select.cuh \
- gpu/utils/blockselect/../Comparators.cuh \
- gpu/utils/blockselect/../DeviceDefs.cuh \
- gpu/utils/blockselect/../MergeNetworkBlock.cuh \
- gpu/utils/blockselect/../MergeNetworkUtils.cuh \
- gpu/utils/blockselect/../PtxUtils.cuh \
- gpu/utils/blockselect/../StaticUtils.h \
- gpu/utils/blockselect/../WarpShuffles.cuh \
- gpu/utils/blockselect/../MergeNetworkWarp.cuh \
- gpu/utils/blockselect/../Reductions.cuh \
- gpu/utils/blockselect/../ReductionOperators.cuh \
- gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
- gpu/utils/blockselect/../MathOperators.cuh
-BlockSelectHalfF1024.o: gpu/utils/blockselect/BlockSelectHalfF1024.cu \
- gpu/utils/blockselect/BlockSelectImpl.cuh \
- gpu/utils/blockselect/../BlockSelectKernel.cuh \
- gpu/utils/blockselect/../Float16.cuh \
- gpu/utils/blockselect/../../GpuResources.h \
- gpu/utils/blockselect/../../utils/DeviceMemory.h \
- gpu/utils/blockselect/../DeviceTensor.cuh \
- gpu/utils/blockselect/../Tensor.cuh \
- gpu/utils/blockselect/../Tensor-inl.cuh \
- gpu/utils/blockselect/../../GpuFaissAssert.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../../../FaissException.h \
- gpu/utils/blockselect/../DeviceUtils.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../MemorySpace.h \
- gpu/utils/blockselect/../DeviceTensor-inl.cuh \
- gpu/utils/blockselect/../Select.cuh \
- gpu/utils/blockselect/../Comparators.cuh \
- gpu/utils/blockselect/../DeviceDefs.cuh \
- gpu/utils/blockselect/../MergeNetworkBlock.cuh \
- gpu/utils/blockselect/../MergeNetworkUtils.cuh \
- gpu/utils/blockselect/../PtxUtils.cuh \
- gpu/utils/blockselect/../StaticUtils.h \
- gpu/utils/blockselect/../WarpShuffles.cuh \
- gpu/utils/blockselect/../MergeNetworkWarp.cuh \
- gpu/utils/blockselect/../Reductions.cuh \
- gpu/utils/blockselect/../ReductionOperators.cuh \
- gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
- gpu/utils/blockselect/../MathOperators.cuh
-BlockSelectHalfT1024.o: gpu/utils/blockselect/BlockSelectHalfT1024.cu \
- gpu/utils/blockselect/BlockSelectImpl.cuh \
- gpu/utils/blockselect/../BlockSelectKernel.cuh \
- gpu/utils/blockselect/../Float16.cuh \
- gpu/utils/blockselect/../../GpuResources.h \
- gpu/utils/blockselect/../../utils/DeviceMemory.h \
- gpu/utils/blockselect/../DeviceTensor.cuh \
- gpu/utils/blockselect/../Tensor.cuh \
- gpu/utils/blockselect/../Tensor-inl.cuh \
- gpu/utils/blockselect/../../GpuFaissAssert.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../../../FaissException.h \
- gpu/utils/blockselect/../DeviceUtils.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../MemorySpace.h \
- gpu/utils/blockselect/../DeviceTensor-inl.cuh \
- gpu/utils/blockselect/../Select.cuh \
- gpu/utils/blockselect/../Comparators.cuh \
- gpu/utils/blockselect/../DeviceDefs.cuh \
- gpu/utils/blockselect/../MergeNetworkBlock.cuh \
- gpu/utils/blockselect/../MergeNetworkUtils.cuh \
- gpu/utils/blockselect/../PtxUtils.cuh \
- gpu/utils/blockselect/../StaticUtils.h \
- gpu/utils/blockselect/../WarpShuffles.cuh \
- gpu/utils/blockselect/../MergeNetworkWarp.cuh \
- gpu/utils/blockselect/../Reductions.cuh \
- gpu/utils/blockselect/../ReductionOperators.cuh \
- gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
- gpu/utils/blockselect/../MathOperators.cuh
-BlockSelectHalf256.o: gpu/utils/blockselect/BlockSelectHalf256.cu \
- gpu/utils/blockselect/BlockSelectImpl.cuh \
- gpu/utils/blockselect/../BlockSelectKernel.cuh \
- gpu/utils/blockselect/../Float16.cuh \
- gpu/utils/blockselect/../../GpuResources.h \
- gpu/utils/blockselect/../../utils/DeviceMemory.h \
- gpu/utils/blockselect/../DeviceTensor.cuh \
- gpu/utils/blockselect/../Tensor.cuh \
- gpu/utils/blockselect/../Tensor-inl.cuh \
- gpu/utils/blockselect/../../GpuFaissAssert.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../../../FaissException.h \
- gpu/utils/blockselect/../DeviceUtils.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../MemorySpace.h \
- gpu/utils/blockselect/../DeviceTensor-inl.cuh \
- gpu/utils/blockselect/../Select.cuh \
- gpu/utils/blockselect/../Comparators.cuh \
- gpu/utils/blockselect/../DeviceDefs.cuh \
- gpu/utils/blockselect/../MergeNetworkBlock.cuh \
- gpu/utils/blockselect/../MergeNetworkUtils.cuh \
- gpu/utils/blockselect/../PtxUtils.cuh \
- gpu/utils/blockselect/../StaticUtils.h \
- gpu/utils/blockselect/../WarpShuffles.cuh \
- gpu/utils/blockselect/../MergeNetworkWarp.cuh \
- gpu/utils/blockselect/../Reductions.cuh \
- gpu/utils/blockselect/../ReductionOperators.cuh \
- gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
- gpu/utils/blockselect/../MathOperators.cuh
-BlockSelectHalf128.o: gpu/utils/blockselect/BlockSelectHalf128.cu \
- gpu/utils/blockselect/BlockSelectImpl.cuh \
- gpu/utils/blockselect/../BlockSelectKernel.cuh \
- gpu/utils/blockselect/../Float16.cuh \
- gpu/utils/blockselect/../../GpuResources.h \
- gpu/utils/blockselect/../../utils/DeviceMemory.h \
- gpu/utils/blockselect/../DeviceTensor.cuh \
- gpu/utils/blockselect/../Tensor.cuh \
- gpu/utils/blockselect/../Tensor-inl.cuh \
- gpu/utils/blockselect/../../GpuFaissAssert.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../../../FaissException.h \
- gpu/utils/blockselect/../DeviceUtils.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../MemorySpace.h \
- gpu/utils/blockselect/../DeviceTensor-inl.cuh \
- gpu/utils/blockselect/../Select.cuh \
- gpu/utils/blockselect/../Comparators.cuh \
- gpu/utils/blockselect/../DeviceDefs.cuh \
- gpu/utils/blockselect/../MergeNetworkBlock.cuh \
- gpu/utils/blockselect/../MergeNetworkUtils.cuh \
- gpu/utils/blockselect/../PtxUtils.cuh \
- gpu/utils/blockselect/../StaticUtils.h \
- gpu/utils/blockselect/../WarpShuffles.cuh \
- gpu/utils/blockselect/../MergeNetworkWarp.cuh \
- gpu/utils/blockselect/../Reductions.cuh \
- gpu/utils/blockselect/../ReductionOperators.cuh \
- gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
- gpu/utils/blockselect/../MathOperators.cuh
-BlockSelectHalfT512.o: gpu/utils/blockselect/BlockSelectHalfT512.cu \
+BlockSelectFloat1.o: gpu/utils/blockselect/BlockSelectFloat1.cu \
  gpu/utils/blockselect/BlockSelectImpl.cuh \
  gpu/utils/blockselect/../BlockSelectKernel.cuh \
  gpu/utils/blockselect/../Float16.cuh \
@@ -836,210 +694,7 @@ BlockSelectFloat128.o: gpu/utils/blockselect/BlockSelectFloat128.cu \
  gpu/utils/blockselect/../ReductionOperators.cuh \
  gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
  gpu/utils/blockselect/../MathOperators.cuh
-BlockSelectHalf32.o: gpu/utils/blockselect/BlockSelectHalf32.cu \
- gpu/utils/blockselect/BlockSelectImpl.cuh \
- gpu/utils/blockselect/../BlockSelectKernel.cuh \
- gpu/utils/blockselect/../Float16.cuh \
- gpu/utils/blockselect/../../GpuResources.h \
- gpu/utils/blockselect/../../utils/DeviceMemory.h \
- gpu/utils/blockselect/../DeviceTensor.cuh \
- gpu/utils/blockselect/../Tensor.cuh \
- gpu/utils/blockselect/../Tensor-inl.cuh \
- gpu/utils/blockselect/../../GpuFaissAssert.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../../../FaissException.h \
- gpu/utils/blockselect/../DeviceUtils.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../MemorySpace.h \
- gpu/utils/blockselect/../DeviceTensor-inl.cuh \
- gpu/utils/blockselect/../Select.cuh \
- gpu/utils/blockselect/../Comparators.cuh \
- gpu/utils/blockselect/../DeviceDefs.cuh \
- gpu/utils/blockselect/../MergeNetworkBlock.cuh \
- gpu/utils/blockselect/../MergeNetworkUtils.cuh \
- gpu/utils/blockselect/../PtxUtils.cuh \
- gpu/utils/blockselect/../StaticUtils.h \
- gpu/utils/blockselect/../WarpShuffles.cuh \
- gpu/utils/blockselect/../MergeNetworkWarp.cuh \
- gpu/utils/blockselect/../Reductions.cuh \
- gpu/utils/blockselect/../ReductionOperators.cuh \
- gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
- gpu/utils/blockselect/../MathOperators.cuh
-BlockSelectFloatF1024.o: gpu/utils/blockselect/BlockSelectFloatF1024.cu \
- gpu/utils/blockselect/BlockSelectImpl.cuh \
- gpu/utils/blockselect/../BlockSelectKernel.cuh \
- gpu/utils/blockselect/../Float16.cuh \
- gpu/utils/blockselect/../../GpuResources.h \
- gpu/utils/blockselect/../../utils/DeviceMemory.h \
- gpu/utils/blockselect/../DeviceTensor.cuh \
- gpu/utils/blockselect/../Tensor.cuh \
- gpu/utils/blockselect/../Tensor-inl.cuh \
- gpu/utils/blockselect/../../GpuFaissAssert.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../../../FaissException.h \
- gpu/utils/blockselect/../DeviceUtils.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../MemorySpace.h \
- gpu/utils/blockselect/../DeviceTensor-inl.cuh \
- gpu/utils/blockselect/../Select.cuh \
- gpu/utils/blockselect/../Comparators.cuh \
- gpu/utils/blockselect/../DeviceDefs.cuh \
- gpu/utils/blockselect/../MergeNetworkBlock.cuh \
- gpu/utils/blockselect/../MergeNetworkUtils.cuh \
- gpu/utils/blockselect/../PtxUtils.cuh \
- gpu/utils/blockselect/../StaticUtils.h \
- gpu/utils/blockselect/../WarpShuffles.cuh \
- gpu/utils/blockselect/../MergeNetworkWarp.cuh \
- gpu/utils/blockselect/../Reductions.cuh \
- gpu/utils/blockselect/../ReductionOperators.cuh \
- gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
- gpu/utils/blockselect/../MathOperators.cuh
-BlockSelectHalfF512.o: gpu/utils/blockselect/BlockSelectHalfF512.cu \
- gpu/utils/blockselect/BlockSelectImpl.cuh \
- gpu/utils/blockselect/../BlockSelectKernel.cuh \
- gpu/utils/blockselect/../Float16.cuh \
- gpu/utils/blockselect/../../GpuResources.h \
- gpu/utils/blockselect/../../utils/DeviceMemory.h \
- gpu/utils/blockselect/../DeviceTensor.cuh \
- gpu/utils/blockselect/../Tensor.cuh \
- gpu/utils/blockselect/../Tensor-inl.cuh \
- gpu/utils/blockselect/../../GpuFaissAssert.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../../../FaissException.h \
- gpu/utils/blockselect/../DeviceUtils.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../MemorySpace.h \
- gpu/utils/blockselect/../DeviceTensor-inl.cuh \
- gpu/utils/blockselect/../Select.cuh \
- gpu/utils/blockselect/../Comparators.cuh \
- gpu/utils/blockselect/../DeviceDefs.cuh \
- gpu/utils/blockselect/../MergeNetworkBlock.cuh \
- gpu/utils/blockselect/../MergeNetworkUtils.cuh \
- gpu/utils/blockselect/../PtxUtils.cuh \
- gpu/utils/blockselect/../StaticUtils.h \
- gpu/utils/blockselect/../WarpShuffles.cuh \
- gpu/utils/blockselect/../MergeNetworkWarp.cuh \
- gpu/utils/blockselect/../Reductions.cuh \
- gpu/utils/blockselect/../ReductionOperators.cuh \
- gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
- gpu/utils/blockselect/../MathOperators.cuh
-BlockSelectHalfT2048.o: gpu/utils/blockselect/BlockSelectHalfT2048.cu \
- gpu/utils/blockselect/BlockSelectImpl.cuh \
- gpu/utils/blockselect/../BlockSelectKernel.cuh \
- gpu/utils/blockselect/../Float16.cuh \
- gpu/utils/blockselect/../../GpuResources.h \
- gpu/utils/blockselect/../../utils/DeviceMemory.h \
- gpu/utils/blockselect/../DeviceTensor.cuh \
- gpu/utils/blockselect/../Tensor.cuh \
- gpu/utils/blockselect/../Tensor-inl.cuh \
- gpu/utils/blockselect/../../GpuFaissAssert.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../../../FaissException.h \
- gpu/utils/blockselect/../DeviceUtils.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../MemorySpace.h \
- gpu/utils/blockselect/../DeviceTensor-inl.cuh \
- gpu/utils/blockselect/../Select.cuh \
- gpu/utils/blockselect/../Comparators.cuh \
- gpu/utils/blockselect/../DeviceDefs.cuh \
- gpu/utils/blockselect/../MergeNetworkBlock.cuh \
- gpu/utils/blockselect/../MergeNetworkUtils.cuh \
- gpu/utils/blockselect/../PtxUtils.cuh \
- gpu/utils/blockselect/../StaticUtils.h \
- gpu/utils/blockselect/../WarpShuffles.cuh \
- gpu/utils/blockselect/../MergeNetworkWarp.cuh \
- gpu/utils/blockselect/../Reductions.cuh \
- gpu/utils/blockselect/../ReductionOperators.cuh \
- gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
- gpu/utils/blockselect/../MathOperators.cuh
-BlockSelectHalf64.o: gpu/utils/blockselect/BlockSelectHalf64.cu \
- gpu/utils/blockselect/BlockSelectImpl.cuh \
- gpu/utils/blockselect/../BlockSelectKernel.cuh \
- gpu/utils/blockselect/../Float16.cuh \
- gpu/utils/blockselect/../../GpuResources.h \
- gpu/utils/blockselect/../../utils/DeviceMemory.h \
- gpu/utils/blockselect/../DeviceTensor.cuh \
- gpu/utils/blockselect/../Tensor.cuh \
- gpu/utils/blockselect/../Tensor-inl.cuh \
- gpu/utils/blockselect/../../GpuFaissAssert.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../../../FaissException.h \
- gpu/utils/blockselect/../DeviceUtils.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../MemorySpace.h \
- gpu/utils/blockselect/../DeviceTensor-inl.cuh \
- gpu/utils/blockselect/../Select.cuh \
- gpu/utils/blockselect/../Comparators.cuh \
- gpu/utils/blockselect/../DeviceDefs.cuh \
- gpu/utils/blockselect/../MergeNetworkBlock.cuh \
- gpu/utils/blockselect/../MergeNetworkUtils.cuh \
- gpu/utils/blockselect/../PtxUtils.cuh \
- gpu/utils/blockselect/../StaticUtils.h \
- gpu/utils/blockselect/../WarpShuffles.cuh \
- gpu/utils/blockselect/../MergeNetworkWarp.cuh \
- gpu/utils/blockselect/../Reductions.cuh \
- gpu/utils/blockselect/../ReductionOperators.cuh \
- gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
- gpu/utils/blockselect/../MathOperators.cuh
-BlockSelectFloatT512.o: gpu/utils/blockselect/BlockSelectFloatT512.cu \
- gpu/utils/blockselect/BlockSelectImpl.cuh \
- gpu/utils/blockselect/../BlockSelectKernel.cuh \
- gpu/utils/blockselect/../Float16.cuh \
- gpu/utils/blockselect/../../GpuResources.h \
- gpu/utils/blockselect/../../utils/DeviceMemory.h \
- gpu/utils/blockselect/../DeviceTensor.cuh \
- gpu/utils/blockselect/../Tensor.cuh \
- gpu/utils/blockselect/../Tensor-inl.cuh \
- gpu/utils/blockselect/../../GpuFaissAssert.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../../../FaissException.h \
- gpu/utils/blockselect/../DeviceUtils.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../MemorySpace.h \
- gpu/utils/blockselect/../DeviceTensor-inl.cuh \
- gpu/utils/blockselect/../Select.cuh \
- gpu/utils/blockselect/../Comparators.cuh \
- gpu/utils/blockselect/../DeviceDefs.cuh \
- gpu/utils/blockselect/../MergeNetworkBlock.cuh \
- gpu/utils/blockselect/../MergeNetworkUtils.cuh \
- gpu/utils/blockselect/../PtxUtils.cuh \
- gpu/utils/blockselect/../StaticUtils.h \
- gpu/utils/blockselect/../WarpShuffles.cuh \
- gpu/utils/blockselect/../MergeNetworkWarp.cuh \
- gpu/utils/blockselect/../Reductions.cuh \
- gpu/utils/blockselect/../ReductionOperators.cuh \
- gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
- gpu/utils/blockselect/../MathOperators.cuh
-BlockSelectFloatT1024.o: gpu/utils/blockselect/BlockSelectFloatT1024.cu \
- gpu/utils/blockselect/BlockSelectImpl.cuh \
- gpu/utils/blockselect/../BlockSelectKernel.cuh \
- gpu/utils/blockselect/../Float16.cuh \
- gpu/utils/blockselect/../../GpuResources.h \
- gpu/utils/blockselect/../../utils/DeviceMemory.h \
- gpu/utils/blockselect/../DeviceTensor.cuh \
- gpu/utils/blockselect/../Tensor.cuh \
- gpu/utils/blockselect/../Tensor-inl.cuh \
- gpu/utils/blockselect/../../GpuFaissAssert.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../../../FaissException.h \
- gpu/utils/blockselect/../DeviceUtils.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../MemorySpace.h \
- gpu/utils/blockselect/../DeviceTensor-inl.cuh \
- gpu/utils/blockselect/../Select.cuh \
- gpu/utils/blockselect/../Comparators.cuh \
- gpu/utils/blockselect/../DeviceDefs.cuh \
- gpu/utils/blockselect/../MergeNetworkBlock.cuh \
- gpu/utils/blockselect/../MergeNetworkUtils.cuh \
- gpu/utils/blockselect/../PtxUtils.cuh \
- gpu/utils/blockselect/../StaticUtils.h \
- gpu/utils/blockselect/../WarpShuffles.cuh \
- gpu/utils/blockselect/../MergeNetworkWarp.cuh \
- gpu/utils/blockselect/../Reductions.cuh \
- gpu/utils/blockselect/../ReductionOperators.cuh \
- gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
- gpu/utils/blockselect/../MathOperators.cuh
-BlockSelectFloatF512.o: gpu/utils/blockselect/BlockSelectFloatF512.cu \
+BlockSelectFloat256.o: gpu/utils/blockselect/BlockSelectFloat256.cu \
  gpu/utils/blockselect/BlockSelectImpl.cuh \
  gpu/utils/blockselect/../BlockSelectKernel.cuh \
  gpu/utils/blockselect/../Float16.cuh \
@@ -1097,64 +752,6 @@ BlockSelectFloat32.o: gpu/utils/blockselect/BlockSelectFloat32.cu \
  gpu/utils/blockselect/../ReductionOperators.cuh \
  gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
  gpu/utils/blockselect/../MathOperators.cuh
-BlockSelectFloat1.o: gpu/utils/blockselect/BlockSelectFloat1.cu \
- gpu/utils/blockselect/BlockSelectImpl.cuh \
- gpu/utils/blockselect/../BlockSelectKernel.cuh \
- gpu/utils/blockselect/../Float16.cuh \
- gpu/utils/blockselect/../../GpuResources.h \
- gpu/utils/blockselect/../../utils/DeviceMemory.h \
- gpu/utils/blockselect/../DeviceTensor.cuh \
- gpu/utils/blockselect/../Tensor.cuh \
- gpu/utils/blockselect/../Tensor-inl.cuh \
- gpu/utils/blockselect/../../GpuFaissAssert.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../../../FaissException.h \
- gpu/utils/blockselect/../DeviceUtils.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../MemorySpace.h \
- gpu/utils/blockselect/../DeviceTensor-inl.cuh \
- gpu/utils/blockselect/../Select.cuh \
- gpu/utils/blockselect/../Comparators.cuh \
- gpu/utils/blockselect/../DeviceDefs.cuh \
- gpu/utils/blockselect/../MergeNetworkBlock.cuh \
- gpu/utils/blockselect/../MergeNetworkUtils.cuh \
- gpu/utils/blockselect/../PtxUtils.cuh \
- gpu/utils/blockselect/../StaticUtils.h \
- gpu/utils/blockselect/../WarpShuffles.cuh \
- gpu/utils/blockselect/../MergeNetworkWarp.cuh \
- gpu/utils/blockselect/../Reductions.cuh \
- gpu/utils/blockselect/../ReductionOperators.cuh \
- gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
- gpu/utils/blockselect/../MathOperators.cuh
-BlockSelectHalf1.o: gpu/utils/blockselect/BlockSelectHalf1.cu \
- gpu/utils/blockselect/BlockSelectImpl.cuh \
- gpu/utils/blockselect/../BlockSelectKernel.cuh \
- gpu/utils/blockselect/../Float16.cuh \
- gpu/utils/blockselect/../../GpuResources.h \
- gpu/utils/blockselect/../../utils/DeviceMemory.h \
- gpu/utils/blockselect/../DeviceTensor.cuh \
- gpu/utils/blockselect/../Tensor.cuh \
- gpu/utils/blockselect/../Tensor-inl.cuh \
- gpu/utils/blockselect/../../GpuFaissAssert.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../../../FaissException.h \
- gpu/utils/blockselect/../DeviceUtils.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../MemorySpace.h \
- gpu/utils/blockselect/../DeviceTensor-inl.cuh \
- gpu/utils/blockselect/../Select.cuh \
- gpu/utils/blockselect/../Comparators.cuh \
- gpu/utils/blockselect/../DeviceDefs.cuh \
- gpu/utils/blockselect/../MergeNetworkBlock.cuh \
- gpu/utils/blockselect/../MergeNetworkUtils.cuh \
- gpu/utils/blockselect/../PtxUtils.cuh \
- gpu/utils/blockselect/../StaticUtils.h \
- gpu/utils/blockselect/../WarpShuffles.cuh \
- gpu/utils/blockselect/../MergeNetworkWarp.cuh \
- gpu/utils/blockselect/../Reductions.cuh \
- gpu/utils/blockselect/../ReductionOperators.cuh \
- gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
- gpu/utils/blockselect/../MathOperators.cuh
 BlockSelectFloat64.o: gpu/utils/blockselect/BlockSelectFloat64.cu \
  gpu/utils/blockselect/BlockSelectImpl.cuh \
  gpu/utils/blockselect/../BlockSelectKernel.cuh \
@@ -1184,36 +781,7 @@ BlockSelectFloat64.o: gpu/utils/blockselect/BlockSelectFloat64.cu \
  gpu/utils/blockselect/../ReductionOperators.cuh \
  gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
  gpu/utils/blockselect/../MathOperators.cuh
-BlockSelectHalfF2048.o: gpu/utils/blockselect/BlockSelectHalfF2048.cu \
- gpu/utils/blockselect/BlockSelectImpl.cuh \
- gpu/utils/blockselect/../BlockSelectKernel.cuh \
- gpu/utils/blockselect/../Float16.cuh \
- gpu/utils/blockselect/../../GpuResources.h \
- gpu/utils/blockselect/../../utils/DeviceMemory.h \
- gpu/utils/blockselect/../DeviceTensor.cuh \
- gpu/utils/blockselect/../Tensor.cuh \
- gpu/utils/blockselect/../Tensor-inl.cuh \
- gpu/utils/blockselect/../../GpuFaissAssert.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../../../FaissException.h \
- gpu/utils/blockselect/../DeviceUtils.h \
- gpu/utils/blockselect/../../../FaissAssert.h \
- gpu/utils/blockselect/../MemorySpace.h \
- gpu/utils/blockselect/../DeviceTensor-inl.cuh \
- gpu/utils/blockselect/../Select.cuh \
- gpu/utils/blockselect/../Comparators.cuh \
- gpu/utils/blockselect/../DeviceDefs.cuh \
- gpu/utils/blockselect/../MergeNetworkBlock.cuh \
- gpu/utils/blockselect/../MergeNetworkUtils.cuh \
- gpu/utils/blockselect/../PtxUtils.cuh \
- gpu/utils/blockselect/../StaticUtils.h \
- gpu/utils/blockselect/../WarpShuffles.cuh \
- gpu/utils/blockselect/../MergeNetworkWarp.cuh \
- gpu/utils/blockselect/../Reductions.cuh \
- gpu/utils/blockselect/../ReductionOperators.cuh \
- gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
- gpu/utils/blockselect/../MathOperators.cuh
-BlockSelectFloat256.o: gpu/utils/blockselect/BlockSelectFloat256.cu \
+BlockSelectFloatF1024.o: gpu/utils/blockselect/BlockSelectFloatF1024.cu \
  gpu/utils/blockselect/BlockSelectImpl.cuh \
  gpu/utils/blockselect/../BlockSelectKernel.cuh \
  gpu/utils/blockselect/../Float16.cuh \
@@ -1271,355 +839,442 @@ BlockSelectFloatF2048.o: gpu/utils/blockselect/BlockSelectFloatF2048.cu \
  gpu/utils/blockselect/../ReductionOperators.cuh \
  gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
  gpu/utils/blockselect/../MathOperators.cuh
-WarpSelectHalfF2048.o: gpu/utils/warpselect/WarpSelectHalfF2048.cu \
- gpu/utils/warpselect/WarpSelectImpl.cuh \
- gpu/utils/warpselect/../WarpSelectKernel.cuh \
- gpu/utils/warpselect/../Float16.cuh \
- gpu/utils/warpselect/../../GpuResources.h \
- gpu/utils/warpselect/../../utils/DeviceMemory.h \
- gpu/utils/warpselect/../DeviceTensor.cuh \
- gpu/utils/warpselect/../Tensor.cuh \
- gpu/utils/warpselect/../Tensor-inl.cuh \
- gpu/utils/warpselect/../../GpuFaissAssert.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../../../FaissException.h \
- gpu/utils/warpselect/../DeviceUtils.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../MemorySpace.h \
- gpu/utils/warpselect/../DeviceTensor-inl.cuh \
- gpu/utils/warpselect/../Select.cuh \
- gpu/utils/warpselect/../Comparators.cuh \
- gpu/utils/warpselect/../DeviceDefs.cuh \
- gpu/utils/warpselect/../MergeNetworkBlock.cuh \
- gpu/utils/warpselect/../MergeNetworkUtils.cuh \
- gpu/utils/warpselect/../PtxUtils.cuh \
- gpu/utils/warpselect/../StaticUtils.h \
- gpu/utils/warpselect/../WarpShuffles.cuh \
- gpu/utils/warpselect/../MergeNetworkWarp.cuh \
- gpu/utils/warpselect/../Reductions.cuh \
- gpu/utils/warpselect/../ReductionOperators.cuh \
- gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
- gpu/utils/warpselect/../MathOperators.cuh
-WarpSelectFloatF512.o: gpu/utils/warpselect/WarpSelectFloatF512.cu \
- gpu/utils/warpselect/WarpSelectImpl.cuh \
- gpu/utils/warpselect/../WarpSelectKernel.cuh \
- gpu/utils/warpselect/../Float16.cuh \
- gpu/utils/warpselect/../../GpuResources.h \
- gpu/utils/warpselect/../../utils/DeviceMemory.h \
- gpu/utils/warpselect/../DeviceTensor.cuh \
- gpu/utils/warpselect/../Tensor.cuh \
- gpu/utils/warpselect/../Tensor-inl.cuh \
- gpu/utils/warpselect/../../GpuFaissAssert.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../../../FaissException.h \
- gpu/utils/warpselect/../DeviceUtils.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../MemorySpace.h \
- gpu/utils/warpselect/../DeviceTensor-inl.cuh \
- gpu/utils/warpselect/../Select.cuh \
- gpu/utils/warpselect/../Comparators.cuh \
- gpu/utils/warpselect/../DeviceDefs.cuh \
- gpu/utils/warpselect/../MergeNetworkBlock.cuh \
- gpu/utils/warpselect/../MergeNetworkUtils.cuh \
- gpu/utils/warpselect/../PtxUtils.cuh \
- gpu/utils/warpselect/../StaticUtils.h \
- gpu/utils/warpselect/../WarpShuffles.cuh \
- gpu/utils/warpselect/../MergeNetworkWarp.cuh \
- gpu/utils/warpselect/../Reductions.cuh \
- gpu/utils/warpselect/../ReductionOperators.cuh \
- gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
- gpu/utils/warpselect/../MathOperators.cuh
-WarpSelectFloat32.o: gpu/utils/warpselect/WarpSelectFloat32.cu \
- gpu/utils/warpselect/WarpSelectImpl.cuh \
- gpu/utils/warpselect/../WarpSelectKernel.cuh \
- gpu/utils/warpselect/../Float16.cuh \
- gpu/utils/warpselect/../../GpuResources.h \
- gpu/utils/warpselect/../../utils/DeviceMemory.h \
- gpu/utils/warpselect/../DeviceTensor.cuh \
- gpu/utils/warpselect/../Tensor.cuh \
- gpu/utils/warpselect/../Tensor-inl.cuh \
- gpu/utils/warpselect/../../GpuFaissAssert.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../../../FaissException.h \
- gpu/utils/warpselect/../DeviceUtils.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../MemorySpace.h \
- gpu/utils/warpselect/../DeviceTensor-inl.cuh \
- gpu/utils/warpselect/../Select.cuh \
- gpu/utils/warpselect/../Comparators.cuh \
- gpu/utils/warpselect/../DeviceDefs.cuh \
- gpu/utils/warpselect/../MergeNetworkBlock.cuh \
- gpu/utils/warpselect/../MergeNetworkUtils.cuh \
- gpu/utils/warpselect/../PtxUtils.cuh \
- gpu/utils/warpselect/../StaticUtils.h \
- gpu/utils/warpselect/../WarpShuffles.cuh \
- gpu/utils/warpselect/../MergeNetworkWarp.cuh \
- gpu/utils/warpselect/../Reductions.cuh \
- gpu/utils/warpselect/../ReductionOperators.cuh \
- gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
- gpu/utils/warpselect/../MathOperators.cuh
+BlockSelectFloatF512.o: gpu/utils/blockselect/BlockSelectFloatF512.cu \
+ gpu/utils/blockselect/BlockSelectImpl.cuh \
+ gpu/utils/blockselect/../BlockSelectKernel.cuh \
+ gpu/utils/blockselect/../Float16.cuh \
+ gpu/utils/blockselect/../../GpuResources.h \
+ gpu/utils/blockselect/../../utils/DeviceMemory.h \
+ gpu/utils/blockselect/../DeviceTensor.cuh \
+ gpu/utils/blockselect/../Tensor.cuh \
+ gpu/utils/blockselect/../Tensor-inl.cuh \
+ gpu/utils/blockselect/../../GpuFaissAssert.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../../../FaissException.h \
+ gpu/utils/blockselect/../DeviceUtils.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../MemorySpace.h \
+ gpu/utils/blockselect/../DeviceTensor-inl.cuh \
+ gpu/utils/blockselect/../Select.cuh \
+ gpu/utils/blockselect/../Comparators.cuh \
+ gpu/utils/blockselect/../DeviceDefs.cuh \
+ gpu/utils/blockselect/../MergeNetworkBlock.cuh \
+ gpu/utils/blockselect/../MergeNetworkUtils.cuh \
+ gpu/utils/blockselect/../PtxUtils.cuh \
+ gpu/utils/blockselect/../StaticUtils.h \
+ gpu/utils/blockselect/../WarpShuffles.cuh \
+ gpu/utils/blockselect/../MergeNetworkWarp.cuh \
+ gpu/utils/blockselect/../Reductions.cuh \
+ gpu/utils/blockselect/../ReductionOperators.cuh \
+ gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
+ gpu/utils/blockselect/../MathOperators.cuh
+BlockSelectFloatT1024.o: gpu/utils/blockselect/BlockSelectFloatT1024.cu \
+ gpu/utils/blockselect/BlockSelectImpl.cuh \
+ gpu/utils/blockselect/../BlockSelectKernel.cuh \
+ gpu/utils/blockselect/../Float16.cuh \
+ gpu/utils/blockselect/../../GpuResources.h \
+ gpu/utils/blockselect/../../utils/DeviceMemory.h \
+ gpu/utils/blockselect/../DeviceTensor.cuh \
+ gpu/utils/blockselect/../Tensor.cuh \
+ gpu/utils/blockselect/../Tensor-inl.cuh \
+ gpu/utils/blockselect/../../GpuFaissAssert.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../../../FaissException.h \
+ gpu/utils/blockselect/../DeviceUtils.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../MemorySpace.h \
+ gpu/utils/blockselect/../DeviceTensor-inl.cuh \
+ gpu/utils/blockselect/../Select.cuh \
+ gpu/utils/blockselect/../Comparators.cuh \
+ gpu/utils/blockselect/../DeviceDefs.cuh \
+ gpu/utils/blockselect/../MergeNetworkBlock.cuh \
+ gpu/utils/blockselect/../MergeNetworkUtils.cuh \
+ gpu/utils/blockselect/../PtxUtils.cuh \
+ gpu/utils/blockselect/../StaticUtils.h \
+ gpu/utils/blockselect/../WarpShuffles.cuh \
+ gpu/utils/blockselect/../MergeNetworkWarp.cuh \
+ gpu/utils/blockselect/../Reductions.cuh \
+ gpu/utils/blockselect/../ReductionOperators.cuh \
+ gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
+ gpu/utils/blockselect/../MathOperators.cuh
+BlockSelectFloatT2048.o: gpu/utils/blockselect/BlockSelectFloatT2048.cu \
+ gpu/utils/blockselect/BlockSelectImpl.cuh \
+ gpu/utils/blockselect/../BlockSelectKernel.cuh \
+ gpu/utils/blockselect/../Float16.cuh \
+ gpu/utils/blockselect/../../GpuResources.h \
+ gpu/utils/blockselect/../../utils/DeviceMemory.h \
+ gpu/utils/blockselect/../DeviceTensor.cuh \
+ gpu/utils/blockselect/../Tensor.cuh \
+ gpu/utils/blockselect/../Tensor-inl.cuh \
+ gpu/utils/blockselect/../../GpuFaissAssert.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../../../FaissException.h \
+ gpu/utils/blockselect/../DeviceUtils.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../MemorySpace.h \
+ gpu/utils/blockselect/../DeviceTensor-inl.cuh \
+ gpu/utils/blockselect/../Select.cuh \
+ gpu/utils/blockselect/../Comparators.cuh \
+ gpu/utils/blockselect/../DeviceDefs.cuh \
+ gpu/utils/blockselect/../MergeNetworkBlock.cuh \
+ gpu/utils/blockselect/../MergeNetworkUtils.cuh \
+ gpu/utils/blockselect/../PtxUtils.cuh \
+ gpu/utils/blockselect/../StaticUtils.h \
+ gpu/utils/blockselect/../WarpShuffles.cuh \
+ gpu/utils/blockselect/../MergeNetworkWarp.cuh \
+ gpu/utils/blockselect/../Reductions.cuh \
+ gpu/utils/blockselect/../ReductionOperators.cuh \
+ gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
+ gpu/utils/blockselect/../MathOperators.cuh
+BlockSelectFloatT512.o: gpu/utils/blockselect/BlockSelectFloatT512.cu \
+ gpu/utils/blockselect/BlockSelectImpl.cuh \
+ gpu/utils/blockselect/../BlockSelectKernel.cuh \
+ gpu/utils/blockselect/../Float16.cuh \
+ gpu/utils/blockselect/../../GpuResources.h \
+ gpu/utils/blockselect/../../utils/DeviceMemory.h \
+ gpu/utils/blockselect/../DeviceTensor.cuh \
+ gpu/utils/blockselect/../Tensor.cuh \
+ gpu/utils/blockselect/../Tensor-inl.cuh \
+ gpu/utils/blockselect/../../GpuFaissAssert.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../../../FaissException.h \
+ gpu/utils/blockselect/../DeviceUtils.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../MemorySpace.h \
+ gpu/utils/blockselect/../DeviceTensor-inl.cuh \
+ gpu/utils/blockselect/../Select.cuh \
+ gpu/utils/blockselect/../Comparators.cuh \
+ gpu/utils/blockselect/../DeviceDefs.cuh \
+ gpu/utils/blockselect/../MergeNetworkBlock.cuh \
+ gpu/utils/blockselect/../MergeNetworkUtils.cuh \
+ gpu/utils/blockselect/../PtxUtils.cuh \
+ gpu/utils/blockselect/../StaticUtils.h \
+ gpu/utils/blockselect/../WarpShuffles.cuh \
+ gpu/utils/blockselect/../MergeNetworkWarp.cuh \
+ gpu/utils/blockselect/../Reductions.cuh \
+ gpu/utils/blockselect/../ReductionOperators.cuh \
+ gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
+ gpu/utils/blockselect/../MathOperators.cuh
+BlockSelectHalf1.o: gpu/utils/blockselect/BlockSelectHalf1.cu \
+ gpu/utils/blockselect/BlockSelectImpl.cuh \
+ gpu/utils/blockselect/../BlockSelectKernel.cuh \
+ gpu/utils/blockselect/../Float16.cuh \
+ gpu/utils/blockselect/../../GpuResources.h \
+ gpu/utils/blockselect/../../utils/DeviceMemory.h \
+ gpu/utils/blockselect/../DeviceTensor.cuh \
+ gpu/utils/blockselect/../Tensor.cuh \
+ gpu/utils/blockselect/../Tensor-inl.cuh \
+ gpu/utils/blockselect/../../GpuFaissAssert.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../../../FaissException.h \
+ gpu/utils/blockselect/../DeviceUtils.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../MemorySpace.h \
+ gpu/utils/blockselect/../DeviceTensor-inl.cuh \
+ gpu/utils/blockselect/../Select.cuh \
+ gpu/utils/blockselect/../Comparators.cuh \
+ gpu/utils/blockselect/../DeviceDefs.cuh \
+ gpu/utils/blockselect/../MergeNetworkBlock.cuh \
+ gpu/utils/blockselect/../MergeNetworkUtils.cuh \
+ gpu/utils/blockselect/../PtxUtils.cuh \
+ gpu/utils/blockselect/../StaticUtils.h \
+ gpu/utils/blockselect/../WarpShuffles.cuh \
+ gpu/utils/blockselect/../MergeNetworkWarp.cuh \
+ gpu/utils/blockselect/../Reductions.cuh \
+ gpu/utils/blockselect/../ReductionOperators.cuh \
+ gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
+ gpu/utils/blockselect/../MathOperators.cuh
+BlockSelectHalf128.o: gpu/utils/blockselect/BlockSelectHalf128.cu \
+ gpu/utils/blockselect/BlockSelectImpl.cuh \
+ gpu/utils/blockselect/../BlockSelectKernel.cuh \
+ gpu/utils/blockselect/../Float16.cuh \
+ gpu/utils/blockselect/../../GpuResources.h \
+ gpu/utils/blockselect/../../utils/DeviceMemory.h \
+ gpu/utils/blockselect/../DeviceTensor.cuh \
+ gpu/utils/blockselect/../Tensor.cuh \
+ gpu/utils/blockselect/../Tensor-inl.cuh \
+ gpu/utils/blockselect/../../GpuFaissAssert.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../../../FaissException.h \
+ gpu/utils/blockselect/../DeviceUtils.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../MemorySpace.h \
+ gpu/utils/blockselect/../DeviceTensor-inl.cuh \
+ gpu/utils/blockselect/../Select.cuh \
+ gpu/utils/blockselect/../Comparators.cuh \
+ gpu/utils/blockselect/../DeviceDefs.cuh \
+ gpu/utils/blockselect/../MergeNetworkBlock.cuh \
+ gpu/utils/blockselect/../MergeNetworkUtils.cuh \
+ gpu/utils/blockselect/../PtxUtils.cuh \
+ gpu/utils/blockselect/../StaticUtils.h \
+ gpu/utils/blockselect/../WarpShuffles.cuh \
+ gpu/utils/blockselect/../MergeNetworkWarp.cuh \
+ gpu/utils/blockselect/../Reductions.cuh \
+ gpu/utils/blockselect/../ReductionOperators.cuh \
+ gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
+ gpu/utils/blockselect/../MathOperators.cuh
+BlockSelectHalf256.o: gpu/utils/blockselect/BlockSelectHalf256.cu \
+ gpu/utils/blockselect/BlockSelectImpl.cuh \
+ gpu/utils/blockselect/../BlockSelectKernel.cuh \
+ gpu/utils/blockselect/../Float16.cuh \
+ gpu/utils/blockselect/../../GpuResources.h \
+ gpu/utils/blockselect/../../utils/DeviceMemory.h \
+ gpu/utils/blockselect/../DeviceTensor.cuh \
+ gpu/utils/blockselect/../Tensor.cuh \
+ gpu/utils/blockselect/../Tensor-inl.cuh \
+ gpu/utils/blockselect/../../GpuFaissAssert.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../../../FaissException.h \
+ gpu/utils/blockselect/../DeviceUtils.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../MemorySpace.h \
+ gpu/utils/blockselect/../DeviceTensor-inl.cuh \
+ gpu/utils/blockselect/../Select.cuh \
+ gpu/utils/blockselect/../Comparators.cuh \
+ gpu/utils/blockselect/../DeviceDefs.cuh \
+ gpu/utils/blockselect/../MergeNetworkBlock.cuh \
+ gpu/utils/blockselect/../MergeNetworkUtils.cuh \
+ gpu/utils/blockselect/../PtxUtils.cuh \
+ gpu/utils/blockselect/../StaticUtils.h \
+ gpu/utils/blockselect/../WarpShuffles.cuh \
+ gpu/utils/blockselect/../MergeNetworkWarp.cuh \
+ gpu/utils/blockselect/../Reductions.cuh \
+ gpu/utils/blockselect/../ReductionOperators.cuh \
+ gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
+ gpu/utils/blockselect/../MathOperators.cuh
+BlockSelectHalf32.o: gpu/utils/blockselect/BlockSelectHalf32.cu \
+ gpu/utils/blockselect/BlockSelectImpl.cuh \
+ gpu/utils/blockselect/../BlockSelectKernel.cuh \
+ gpu/utils/blockselect/../Float16.cuh \
+ gpu/utils/blockselect/../../GpuResources.h \
+ gpu/utils/blockselect/../../utils/DeviceMemory.h \
+ gpu/utils/blockselect/../DeviceTensor.cuh \
+ gpu/utils/blockselect/../Tensor.cuh \
+ gpu/utils/blockselect/../Tensor-inl.cuh \
+ gpu/utils/blockselect/../../GpuFaissAssert.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../../../FaissException.h \
+ gpu/utils/blockselect/../DeviceUtils.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../MemorySpace.h \
+ gpu/utils/blockselect/../DeviceTensor-inl.cuh \
+ gpu/utils/blockselect/../Select.cuh \
+ gpu/utils/blockselect/../Comparators.cuh \
+ gpu/utils/blockselect/../DeviceDefs.cuh \
+ gpu/utils/blockselect/../MergeNetworkBlock.cuh \
+ gpu/utils/blockselect/../MergeNetworkUtils.cuh \
+ gpu/utils/blockselect/../PtxUtils.cuh \
+ gpu/utils/blockselect/../StaticUtils.h \
+ gpu/utils/blockselect/../WarpShuffles.cuh \
+ gpu/utils/blockselect/../MergeNetworkWarp.cuh \
+ gpu/utils/blockselect/../Reductions.cuh \
+ gpu/utils/blockselect/../ReductionOperators.cuh \
+ gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
+ gpu/utils/blockselect/../MathOperators.cuh
+BlockSelectHalf64.o: gpu/utils/blockselect/BlockSelectHalf64.cu \
+ gpu/utils/blockselect/BlockSelectImpl.cuh \
+ gpu/utils/blockselect/../BlockSelectKernel.cuh \
+ gpu/utils/blockselect/../Float16.cuh \
+ gpu/utils/blockselect/../../GpuResources.h \
+ gpu/utils/blockselect/../../utils/DeviceMemory.h \
+ gpu/utils/blockselect/../DeviceTensor.cuh \
+ gpu/utils/blockselect/../Tensor.cuh \
+ gpu/utils/blockselect/../Tensor-inl.cuh \
+ gpu/utils/blockselect/../../GpuFaissAssert.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../../../FaissException.h \
+ gpu/utils/blockselect/../DeviceUtils.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../MemorySpace.h \
+ gpu/utils/blockselect/../DeviceTensor-inl.cuh \
+ gpu/utils/blockselect/../Select.cuh \
+ gpu/utils/blockselect/../Comparators.cuh \
+ gpu/utils/blockselect/../DeviceDefs.cuh \
+ gpu/utils/blockselect/../MergeNetworkBlock.cuh \
+ gpu/utils/blockselect/../MergeNetworkUtils.cuh \
+ gpu/utils/blockselect/../PtxUtils.cuh \
+ gpu/utils/blockselect/../StaticUtils.h \
+ gpu/utils/blockselect/../WarpShuffles.cuh \
+ gpu/utils/blockselect/../MergeNetworkWarp.cuh \
+ gpu/utils/blockselect/../Reductions.cuh \
+ gpu/utils/blockselect/../ReductionOperators.cuh \
+ gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
+ gpu/utils/blockselect/../MathOperators.cuh
+BlockSelectHalfF1024.o: gpu/utils/blockselect/BlockSelectHalfF1024.cu \
+ gpu/utils/blockselect/BlockSelectImpl.cuh \
+ gpu/utils/blockselect/../BlockSelectKernel.cuh \
+ gpu/utils/blockselect/../Float16.cuh \
+ gpu/utils/blockselect/../../GpuResources.h \
+ gpu/utils/blockselect/../../utils/DeviceMemory.h \
+ gpu/utils/blockselect/../DeviceTensor.cuh \
+ gpu/utils/blockselect/../Tensor.cuh \
+ gpu/utils/blockselect/../Tensor-inl.cuh \
+ gpu/utils/blockselect/../../GpuFaissAssert.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../../../FaissException.h \
+ gpu/utils/blockselect/../DeviceUtils.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../MemorySpace.h \
+ gpu/utils/blockselect/../DeviceTensor-inl.cuh \
+ gpu/utils/blockselect/../Select.cuh \
+ gpu/utils/blockselect/../Comparators.cuh \
+ gpu/utils/blockselect/../DeviceDefs.cuh \
+ gpu/utils/blockselect/../MergeNetworkBlock.cuh \
+ gpu/utils/blockselect/../MergeNetworkUtils.cuh \
+ gpu/utils/blockselect/../PtxUtils.cuh \
+ gpu/utils/blockselect/../StaticUtils.h \
+ gpu/utils/blockselect/../WarpShuffles.cuh \
+ gpu/utils/blockselect/../MergeNetworkWarp.cuh \
+ gpu/utils/blockselect/../Reductions.cuh \
+ gpu/utils/blockselect/../ReductionOperators.cuh \
+ gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
+ gpu/utils/blockselect/../MathOperators.cuh
+BlockSelectHalfF2048.o: gpu/utils/blockselect/BlockSelectHalfF2048.cu \
+ gpu/utils/blockselect/BlockSelectImpl.cuh \
+ gpu/utils/blockselect/../BlockSelectKernel.cuh \
+ gpu/utils/blockselect/../Float16.cuh \
+ gpu/utils/blockselect/../../GpuResources.h \
+ gpu/utils/blockselect/../../utils/DeviceMemory.h \
+ gpu/utils/blockselect/../DeviceTensor.cuh \
+ gpu/utils/blockselect/../Tensor.cuh \
+ gpu/utils/blockselect/../Tensor-inl.cuh \
+ gpu/utils/blockselect/../../GpuFaissAssert.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../../../FaissException.h \
+ gpu/utils/blockselect/../DeviceUtils.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../MemorySpace.h \
+ gpu/utils/blockselect/../DeviceTensor-inl.cuh \
+ gpu/utils/blockselect/../Select.cuh \
+ gpu/utils/blockselect/../Comparators.cuh \
+ gpu/utils/blockselect/../DeviceDefs.cuh \
+ gpu/utils/blockselect/../MergeNetworkBlock.cuh \
+ gpu/utils/blockselect/../MergeNetworkUtils.cuh \
+ gpu/utils/blockselect/../PtxUtils.cuh \
+ gpu/utils/blockselect/../StaticUtils.h \
+ gpu/utils/blockselect/../WarpShuffles.cuh \
+ gpu/utils/blockselect/../MergeNetworkWarp.cuh \
+ gpu/utils/blockselect/../Reductions.cuh \
+ gpu/utils/blockselect/../ReductionOperators.cuh \
+ gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
+ gpu/utils/blockselect/../MathOperators.cuh
+BlockSelectHalfF512.o: gpu/utils/blockselect/BlockSelectHalfF512.cu \
+ gpu/utils/blockselect/BlockSelectImpl.cuh \
+ gpu/utils/blockselect/../BlockSelectKernel.cuh \
+ gpu/utils/blockselect/../Float16.cuh \
+ gpu/utils/blockselect/../../GpuResources.h \
+ gpu/utils/blockselect/../../utils/DeviceMemory.h \
+ gpu/utils/blockselect/../DeviceTensor.cuh \
+ gpu/utils/blockselect/../Tensor.cuh \
+ gpu/utils/blockselect/../Tensor-inl.cuh \
+ gpu/utils/blockselect/../../GpuFaissAssert.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../../../FaissException.h \
+ gpu/utils/blockselect/../DeviceUtils.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../MemorySpace.h \
+ gpu/utils/blockselect/../DeviceTensor-inl.cuh \
+ gpu/utils/blockselect/../Select.cuh \
+ gpu/utils/blockselect/../Comparators.cuh \
+ gpu/utils/blockselect/../DeviceDefs.cuh \
+ gpu/utils/blockselect/../MergeNetworkBlock.cuh \
+ gpu/utils/blockselect/../MergeNetworkUtils.cuh \
+ gpu/utils/blockselect/../PtxUtils.cuh \
+ gpu/utils/blockselect/../StaticUtils.h \
+ gpu/utils/blockselect/../WarpShuffles.cuh \
+ gpu/utils/blockselect/../MergeNetworkWarp.cuh \
+ gpu/utils/blockselect/../Reductions.cuh \
+ gpu/utils/blockselect/../ReductionOperators.cuh \
+ gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
+ gpu/utils/blockselect/../MathOperators.cuh
+BlockSelectHalfT1024.o: gpu/utils/blockselect/BlockSelectHalfT1024.cu \
+ gpu/utils/blockselect/BlockSelectImpl.cuh \
+ gpu/utils/blockselect/../BlockSelectKernel.cuh \
+ gpu/utils/blockselect/../Float16.cuh \
+ gpu/utils/blockselect/../../GpuResources.h \
+ gpu/utils/blockselect/../../utils/DeviceMemory.h \
+ gpu/utils/blockselect/../DeviceTensor.cuh \
+ gpu/utils/blockselect/../Tensor.cuh \
+ gpu/utils/blockselect/../Tensor-inl.cuh \
+ gpu/utils/blockselect/../../GpuFaissAssert.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../../../FaissException.h \
+ gpu/utils/blockselect/../DeviceUtils.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../MemorySpace.h \
+ gpu/utils/blockselect/../DeviceTensor-inl.cuh \
+ gpu/utils/blockselect/../Select.cuh \
+ gpu/utils/blockselect/../Comparators.cuh \
+ gpu/utils/blockselect/../DeviceDefs.cuh \
+ gpu/utils/blockselect/../MergeNetworkBlock.cuh \
+ gpu/utils/blockselect/../MergeNetworkUtils.cuh \
+ gpu/utils/blockselect/../PtxUtils.cuh \
+ gpu/utils/blockselect/../StaticUtils.h \
+ gpu/utils/blockselect/../WarpShuffles.cuh \
+ gpu/utils/blockselect/../MergeNetworkWarp.cuh \
+ gpu/utils/blockselect/../Reductions.cuh \
+ gpu/utils/blockselect/../ReductionOperators.cuh \
+ gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
+ gpu/utils/blockselect/../MathOperators.cuh
+BlockSelectHalfT2048.o: gpu/utils/blockselect/BlockSelectHalfT2048.cu \
+ gpu/utils/blockselect/BlockSelectImpl.cuh \
+ gpu/utils/blockselect/../BlockSelectKernel.cuh \
+ gpu/utils/blockselect/../Float16.cuh \
+ gpu/utils/blockselect/../../GpuResources.h \
+ gpu/utils/blockselect/../../utils/DeviceMemory.h \
+ gpu/utils/blockselect/../DeviceTensor.cuh \
+ gpu/utils/blockselect/../Tensor.cuh \
+ gpu/utils/blockselect/../Tensor-inl.cuh \
+ gpu/utils/blockselect/../../GpuFaissAssert.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../../../FaissException.h \
+ gpu/utils/blockselect/../DeviceUtils.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../MemorySpace.h \
+ gpu/utils/blockselect/../DeviceTensor-inl.cuh \
+ gpu/utils/blockselect/../Select.cuh \
+ gpu/utils/blockselect/../Comparators.cuh \
+ gpu/utils/blockselect/../DeviceDefs.cuh \
+ gpu/utils/blockselect/../MergeNetworkBlock.cuh \
+ gpu/utils/blockselect/../MergeNetworkUtils.cuh \
+ gpu/utils/blockselect/../PtxUtils.cuh \
+ gpu/utils/blockselect/../StaticUtils.h \
+ gpu/utils/blockselect/../WarpShuffles.cuh \
+ gpu/utils/blockselect/../MergeNetworkWarp.cuh \
+ gpu/utils/blockselect/../Reductions.cuh \
+ gpu/utils/blockselect/../ReductionOperators.cuh \
+ gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
+ gpu/utils/blockselect/../MathOperators.cuh
+BlockSelectHalfT512.o: gpu/utils/blockselect/BlockSelectHalfT512.cu \
+ gpu/utils/blockselect/BlockSelectImpl.cuh \
+ gpu/utils/blockselect/../BlockSelectKernel.cuh \
+ gpu/utils/blockselect/../Float16.cuh \
+ gpu/utils/blockselect/../../GpuResources.h \
+ gpu/utils/blockselect/../../utils/DeviceMemory.h \
+ gpu/utils/blockselect/../DeviceTensor.cuh \
+ gpu/utils/blockselect/../Tensor.cuh \
+ gpu/utils/blockselect/../Tensor-inl.cuh \
+ gpu/utils/blockselect/../../GpuFaissAssert.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../../../FaissException.h \
+ gpu/utils/blockselect/../DeviceUtils.h \
+ gpu/utils/blockselect/../../../FaissAssert.h \
+ gpu/utils/blockselect/../MemorySpace.h \
+ gpu/utils/blockselect/../DeviceTensor-inl.cuh \
+ gpu/utils/blockselect/../Select.cuh \
+ gpu/utils/blockselect/../Comparators.cuh \
+ gpu/utils/blockselect/../DeviceDefs.cuh \
+ gpu/utils/blockselect/../MergeNetworkBlock.cuh \
+ gpu/utils/blockselect/../MergeNetworkUtils.cuh \
+ gpu/utils/blockselect/../PtxUtils.cuh \
+ gpu/utils/blockselect/../StaticUtils.h \
+ gpu/utils/blockselect/../WarpShuffles.cuh \
+ gpu/utils/blockselect/../MergeNetworkWarp.cuh \
+ gpu/utils/blockselect/../Reductions.cuh \
+ gpu/utils/blockselect/../ReductionOperators.cuh \
+ gpu/utils/blockselect/../Limits.cuh gpu/utils/blockselect/../Pair.cuh \
+ gpu/utils/blockselect/../MathOperators.cuh
 WarpSelectFloat1.o: gpu/utils/warpselect/WarpSelectFloat1.cu \
- gpu/utils/warpselect/WarpSelectImpl.cuh \
- gpu/utils/warpselect/../WarpSelectKernel.cuh \
- gpu/utils/warpselect/../Float16.cuh \
- gpu/utils/warpselect/../../GpuResources.h \
- gpu/utils/warpselect/../../utils/DeviceMemory.h \
- gpu/utils/warpselect/../DeviceTensor.cuh \
- gpu/utils/warpselect/../Tensor.cuh \
- gpu/utils/warpselect/../Tensor-inl.cuh \
- gpu/utils/warpselect/../../GpuFaissAssert.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../../../FaissException.h \
- gpu/utils/warpselect/../DeviceUtils.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../MemorySpace.h \
- gpu/utils/warpselect/../DeviceTensor-inl.cuh \
- gpu/utils/warpselect/../Select.cuh \
- gpu/utils/warpselect/../Comparators.cuh \
- gpu/utils/warpselect/../DeviceDefs.cuh \
- gpu/utils/warpselect/../MergeNetworkBlock.cuh \
- gpu/utils/warpselect/../MergeNetworkUtils.cuh \
- gpu/utils/warpselect/../PtxUtils.cuh \
- gpu/utils/warpselect/../StaticUtils.h \
- gpu/utils/warpselect/../WarpShuffles.cuh \
- gpu/utils/warpselect/../MergeNetworkWarp.cuh \
- gpu/utils/warpselect/../Reductions.cuh \
- gpu/utils/warpselect/../ReductionOperators.cuh \
- gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
- gpu/utils/warpselect/../MathOperators.cuh
-WarpSelectFloat64.o: gpu/utils/warpselect/WarpSelectFloat64.cu \
- gpu/utils/warpselect/WarpSelectImpl.cuh \
- gpu/utils/warpselect/../WarpSelectKernel.cuh \
- gpu/utils/warpselect/../Float16.cuh \
- gpu/utils/warpselect/../../GpuResources.h \
- gpu/utils/warpselect/../../utils/DeviceMemory.h \
- gpu/utils/warpselect/../DeviceTensor.cuh \
- gpu/utils/warpselect/../Tensor.cuh \
- gpu/utils/warpselect/../Tensor-inl.cuh \
- gpu/utils/warpselect/../../GpuFaissAssert.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../../../FaissException.h \
- gpu/utils/warpselect/../DeviceUtils.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../MemorySpace.h \
- gpu/utils/warpselect/../DeviceTensor-inl.cuh \
- gpu/utils/warpselect/../Select.cuh \
- gpu/utils/warpselect/../Comparators.cuh \
- gpu/utils/warpselect/../DeviceDefs.cuh \
- gpu/utils/warpselect/../MergeNetworkBlock.cuh \
- gpu/utils/warpselect/../MergeNetworkUtils.cuh \
- gpu/utils/warpselect/../PtxUtils.cuh \
- gpu/utils/warpselect/../StaticUtils.h \
- gpu/utils/warpselect/../WarpShuffles.cuh \
- gpu/utils/warpselect/../MergeNetworkWarp.cuh \
- gpu/utils/warpselect/../Reductions.cuh \
- gpu/utils/warpselect/../ReductionOperators.cuh \
- gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
- gpu/utils/warpselect/../MathOperators.cuh
-WarpSelectFloat256.o: gpu/utils/warpselect/WarpSelectFloat256.cu \
- gpu/utils/warpselect/WarpSelectImpl.cuh \
- gpu/utils/warpselect/../WarpSelectKernel.cuh \
- gpu/utils/warpselect/../Float16.cuh \
- gpu/utils/warpselect/../../GpuResources.h \
- gpu/utils/warpselect/../../utils/DeviceMemory.h \
- gpu/utils/warpselect/../DeviceTensor.cuh \
- gpu/utils/warpselect/../Tensor.cuh \
- gpu/utils/warpselect/../Tensor-inl.cuh \
- gpu/utils/warpselect/../../GpuFaissAssert.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../../../FaissException.h \
- gpu/utils/warpselect/../DeviceUtils.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../MemorySpace.h \
- gpu/utils/warpselect/../DeviceTensor-inl.cuh \
- gpu/utils/warpselect/../Select.cuh \
- gpu/utils/warpselect/../Comparators.cuh \
- gpu/utils/warpselect/../DeviceDefs.cuh \
- gpu/utils/warpselect/../MergeNetworkBlock.cuh \
- gpu/utils/warpselect/../MergeNetworkUtils.cuh \
- gpu/utils/warpselect/../PtxUtils.cuh \
- gpu/utils/warpselect/../StaticUtils.h \
- gpu/utils/warpselect/../WarpShuffles.cuh \
- gpu/utils/warpselect/../MergeNetworkWarp.cuh \
- gpu/utils/warpselect/../Reductions.cuh \
- gpu/utils/warpselect/../ReductionOperators.cuh \
- gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
- gpu/utils/warpselect/../MathOperators.cuh
-WarpSelectFloatF2048.o: gpu/utils/warpselect/WarpSelectFloatF2048.cu \
- gpu/utils/warpselect/WarpSelectImpl.cuh \
- gpu/utils/warpselect/../WarpSelectKernel.cuh \
- gpu/utils/warpselect/../Float16.cuh \
- gpu/utils/warpselect/../../GpuResources.h \
- gpu/utils/warpselect/../../utils/DeviceMemory.h \
- gpu/utils/warpselect/../DeviceTensor.cuh \
- gpu/utils/warpselect/../Tensor.cuh \
- gpu/utils/warpselect/../Tensor-inl.cuh \
- gpu/utils/warpselect/../../GpuFaissAssert.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../../../FaissException.h \
- gpu/utils/warpselect/../DeviceUtils.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../MemorySpace.h \
- gpu/utils/warpselect/../DeviceTensor-inl.cuh \
- gpu/utils/warpselect/../Select.cuh \
- gpu/utils/warpselect/../Comparators.cuh \
- gpu/utils/warpselect/../DeviceDefs.cuh \
- gpu/utils/warpselect/../MergeNetworkBlock.cuh \
- gpu/utils/warpselect/../MergeNetworkUtils.cuh \
- gpu/utils/warpselect/../PtxUtils.cuh \
- gpu/utils/warpselect/../StaticUtils.h \
- gpu/utils/warpselect/../WarpShuffles.cuh \
- gpu/utils/warpselect/../MergeNetworkWarp.cuh \
- gpu/utils/warpselect/../Reductions.cuh \
- gpu/utils/warpselect/../ReductionOperators.cuh \
- gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
- gpu/utils/warpselect/../MathOperators.cuh
-WarpSelectFloatT2048.o: gpu/utils/warpselect/WarpSelectFloatT2048.cu \
- gpu/utils/warpselect/WarpSelectImpl.cuh \
- gpu/utils/warpselect/../WarpSelectKernel.cuh \
- gpu/utils/warpselect/../Float16.cuh \
- gpu/utils/warpselect/../../GpuResources.h \
- gpu/utils/warpselect/../../utils/DeviceMemory.h \
- gpu/utils/warpselect/../DeviceTensor.cuh \
- gpu/utils/warpselect/../Tensor.cuh \
- gpu/utils/warpselect/../Tensor-inl.cuh \
- gpu/utils/warpselect/../../GpuFaissAssert.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../../../FaissException.h \
- gpu/utils/warpselect/../DeviceUtils.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../MemorySpace.h \
- gpu/utils/warpselect/../DeviceTensor-inl.cuh \
- gpu/utils/warpselect/../Select.cuh \
- gpu/utils/warpselect/../Comparators.cuh \
- gpu/utils/warpselect/../DeviceDefs.cuh \
- gpu/utils/warpselect/../MergeNetworkBlock.cuh \
- gpu/utils/warpselect/../MergeNetworkUtils.cuh \
- gpu/utils/warpselect/../PtxUtils.cuh \
- gpu/utils/warpselect/../StaticUtils.h \
- gpu/utils/warpselect/../WarpShuffles.cuh \
- gpu/utils/warpselect/../MergeNetworkWarp.cuh \
- gpu/utils/warpselect/../Reductions.cuh \
- gpu/utils/warpselect/../ReductionOperators.cuh \
- gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
- gpu/utils/warpselect/../MathOperators.cuh
-WarpSelectHalfF1024.o: gpu/utils/warpselect/WarpSelectHalfF1024.cu \
- gpu/utils/warpselect/WarpSelectImpl.cuh \
- gpu/utils/warpselect/../WarpSelectKernel.cuh \
- gpu/utils/warpselect/../Float16.cuh \
- gpu/utils/warpselect/../../GpuResources.h \
- gpu/utils/warpselect/../../utils/DeviceMemory.h \
- gpu/utils/warpselect/../DeviceTensor.cuh \
- gpu/utils/warpselect/../Tensor.cuh \
- gpu/utils/warpselect/../Tensor-inl.cuh \
- gpu/utils/warpselect/../../GpuFaissAssert.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../../../FaissException.h \
- gpu/utils/warpselect/../DeviceUtils.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../MemorySpace.h \
- gpu/utils/warpselect/../DeviceTensor-inl.cuh \
- gpu/utils/warpselect/../Select.cuh \
- gpu/utils/warpselect/../Comparators.cuh \
- gpu/utils/warpselect/../DeviceDefs.cuh \
- gpu/utils/warpselect/../MergeNetworkBlock.cuh \
- gpu/utils/warpselect/../MergeNetworkUtils.cuh \
- gpu/utils/warpselect/../PtxUtils.cuh \
- gpu/utils/warpselect/../StaticUtils.h \
- gpu/utils/warpselect/../WarpShuffles.cuh \
- gpu/utils/warpselect/../MergeNetworkWarp.cuh \
- gpu/utils/warpselect/../Reductions.cuh \
- gpu/utils/warpselect/../ReductionOperators.cuh \
- gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
- gpu/utils/warpselect/../MathOperators.cuh
-WarpSelectHalfT1024.o: gpu/utils/warpselect/WarpSelectHalfT1024.cu \
- gpu/utils/warpselect/WarpSelectImpl.cuh \
- gpu/utils/warpselect/../WarpSelectKernel.cuh \
- gpu/utils/warpselect/../Float16.cuh \
- gpu/utils/warpselect/../../GpuResources.h \
- gpu/utils/warpselect/../../utils/DeviceMemory.h \
- gpu/utils/warpselect/../DeviceTensor.cuh \
- gpu/utils/warpselect/../Tensor.cuh \
- gpu/utils/warpselect/../Tensor-inl.cuh \
- gpu/utils/warpselect/../../GpuFaissAssert.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../../../FaissException.h \
- gpu/utils/warpselect/../DeviceUtils.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../MemorySpace.h \
- gpu/utils/warpselect/../DeviceTensor-inl.cuh \
- gpu/utils/warpselect/../Select.cuh \
- gpu/utils/warpselect/../Comparators.cuh \
- gpu/utils/warpselect/../DeviceDefs.cuh \
- gpu/utils/warpselect/../MergeNetworkBlock.cuh \
- gpu/utils/warpselect/../MergeNetworkUtils.cuh \
- gpu/utils/warpselect/../PtxUtils.cuh \
- gpu/utils/warpselect/../StaticUtils.h \
- gpu/utils/warpselect/../WarpShuffles.cuh \
- gpu/utils/warpselect/../MergeNetworkWarp.cuh \
- gpu/utils/warpselect/../Reductions.cuh \
- gpu/utils/warpselect/../ReductionOperators.cuh \
- gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
- gpu/utils/warpselect/../MathOperators.cuh
-WarpSelectHalf256.o: gpu/utils/warpselect/WarpSelectHalf256.cu \
- gpu/utils/warpselect/WarpSelectImpl.cuh \
- gpu/utils/warpselect/../WarpSelectKernel.cuh \
- gpu/utils/warpselect/../Float16.cuh \
- gpu/utils/warpselect/../../GpuResources.h \
- gpu/utils/warpselect/../../utils/DeviceMemory.h \
- gpu/utils/warpselect/../DeviceTensor.cuh \
- gpu/utils/warpselect/../Tensor.cuh \
- gpu/utils/warpselect/../Tensor-inl.cuh \
- gpu/utils/warpselect/../../GpuFaissAssert.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../../../FaissException.h \
- gpu/utils/warpselect/../DeviceUtils.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../MemorySpace.h \
- gpu/utils/warpselect/../DeviceTensor-inl.cuh \
- gpu/utils/warpselect/../Select.cuh \
- gpu/utils/warpselect/../Comparators.cuh \
- gpu/utils/warpselect/../DeviceDefs.cuh \
- gpu/utils/warpselect/../MergeNetworkBlock.cuh \
- gpu/utils/warpselect/../MergeNetworkUtils.cuh \
- gpu/utils/warpselect/../PtxUtils.cuh \
- gpu/utils/warpselect/../StaticUtils.h \
- gpu/utils/warpselect/../WarpShuffles.cuh \
- gpu/utils/warpselect/../MergeNetworkWarp.cuh \
- gpu/utils/warpselect/../Reductions.cuh \
- gpu/utils/warpselect/../ReductionOperators.cuh \
- gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
- gpu/utils/warpselect/../MathOperators.cuh
-WarpSelectHalf128.o: gpu/utils/warpselect/WarpSelectHalf128.cu \
- gpu/utils/warpselect/WarpSelectImpl.cuh \
- gpu/utils/warpselect/../WarpSelectKernel.cuh \
- gpu/utils/warpselect/../Float16.cuh \
- gpu/utils/warpselect/../../GpuResources.h \
- gpu/utils/warpselect/../../utils/DeviceMemory.h \
- gpu/utils/warpselect/../DeviceTensor.cuh \
- gpu/utils/warpselect/../Tensor.cuh \
- gpu/utils/warpselect/../Tensor-inl.cuh \
- gpu/utils/warpselect/../../GpuFaissAssert.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../../../FaissException.h \
- gpu/utils/warpselect/../DeviceUtils.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../MemorySpace.h \
- gpu/utils/warpselect/../DeviceTensor-inl.cuh \
- gpu/utils/warpselect/../Select.cuh \
- gpu/utils/warpselect/../Comparators.cuh \
- gpu/utils/warpselect/../DeviceDefs.cuh \
- gpu/utils/warpselect/../MergeNetworkBlock.cuh \
- gpu/utils/warpselect/../MergeNetworkUtils.cuh \
- gpu/utils/warpselect/../PtxUtils.cuh \
- gpu/utils/warpselect/../StaticUtils.h \
- gpu/utils/warpselect/../WarpShuffles.cuh \
- gpu/utils/warpselect/../MergeNetworkWarp.cuh \
- gpu/utils/warpselect/../Reductions.cuh \
- gpu/utils/warpselect/../ReductionOperators.cuh \
- gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
- gpu/utils/warpselect/../MathOperators.cuh
-WarpSelectHalfT512.o: gpu/utils/warpselect/WarpSelectHalfT512.cu \
  gpu/utils/warpselect/WarpSelectImpl.cuh \
  gpu/utils/warpselect/../WarpSelectKernel.cuh \
  gpu/utils/warpselect/../Float16.cuh \
@@ -1677,7 +1332,65 @@ WarpSelectFloat128.o: gpu/utils/warpselect/WarpSelectFloat128.cu \
  gpu/utils/warpselect/../ReductionOperators.cuh \
  gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
  gpu/utils/warpselect/../MathOperators.cuh
-WarpSelectHalf32.o: gpu/utils/warpselect/WarpSelectHalf32.cu \
+WarpSelectFloat256.o: gpu/utils/warpselect/WarpSelectFloat256.cu \
+ gpu/utils/warpselect/WarpSelectImpl.cuh \
+ gpu/utils/warpselect/../WarpSelectKernel.cuh \
+ gpu/utils/warpselect/../Float16.cuh \
+ gpu/utils/warpselect/../../GpuResources.h \
+ gpu/utils/warpselect/../../utils/DeviceMemory.h \
+ gpu/utils/warpselect/../DeviceTensor.cuh \
+ gpu/utils/warpselect/../Tensor.cuh \
+ gpu/utils/warpselect/../Tensor-inl.cuh \
+ gpu/utils/warpselect/../../GpuFaissAssert.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../../../FaissException.h \
+ gpu/utils/warpselect/../DeviceUtils.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../MemorySpace.h \
+ gpu/utils/warpselect/../DeviceTensor-inl.cuh \
+ gpu/utils/warpselect/../Select.cuh \
+ gpu/utils/warpselect/../Comparators.cuh \
+ gpu/utils/warpselect/../DeviceDefs.cuh \
+ gpu/utils/warpselect/../MergeNetworkBlock.cuh \
+ gpu/utils/warpselect/../MergeNetworkUtils.cuh \
+ gpu/utils/warpselect/../PtxUtils.cuh \
+ gpu/utils/warpselect/../StaticUtils.h \
+ gpu/utils/warpselect/../WarpShuffles.cuh \
+ gpu/utils/warpselect/../MergeNetworkWarp.cuh \
+ gpu/utils/warpselect/../Reductions.cuh \
+ gpu/utils/warpselect/../ReductionOperators.cuh \
+ gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
+ gpu/utils/warpselect/../MathOperators.cuh
+WarpSelectFloat32.o: gpu/utils/warpselect/WarpSelectFloat32.cu \
+ gpu/utils/warpselect/WarpSelectImpl.cuh \
+ gpu/utils/warpselect/../WarpSelectKernel.cuh \
+ gpu/utils/warpselect/../Float16.cuh \
+ gpu/utils/warpselect/../../GpuResources.h \
+ gpu/utils/warpselect/../../utils/DeviceMemory.h \
+ gpu/utils/warpselect/../DeviceTensor.cuh \
+ gpu/utils/warpselect/../Tensor.cuh \
+ gpu/utils/warpselect/../Tensor-inl.cuh \
+ gpu/utils/warpselect/../../GpuFaissAssert.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../../../FaissException.h \
+ gpu/utils/warpselect/../DeviceUtils.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../MemorySpace.h \
+ gpu/utils/warpselect/../DeviceTensor-inl.cuh \
+ gpu/utils/warpselect/../Select.cuh \
+ gpu/utils/warpselect/../Comparators.cuh \
+ gpu/utils/warpselect/../DeviceDefs.cuh \
+ gpu/utils/warpselect/../MergeNetworkBlock.cuh \
+ gpu/utils/warpselect/../MergeNetworkUtils.cuh \
+ gpu/utils/warpselect/../PtxUtils.cuh \
+ gpu/utils/warpselect/../StaticUtils.h \
+ gpu/utils/warpselect/../WarpShuffles.cuh \
+ gpu/utils/warpselect/../MergeNetworkWarp.cuh \
+ gpu/utils/warpselect/../Reductions.cuh \
+ gpu/utils/warpselect/../ReductionOperators.cuh \
+ gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
+ gpu/utils/warpselect/../MathOperators.cuh
+WarpSelectFloat64.o: gpu/utils/warpselect/WarpSelectFloat64.cu \
  gpu/utils/warpselect/WarpSelectImpl.cuh \
  gpu/utils/warpselect/../WarpSelectKernel.cuh \
  gpu/utils/warpselect/../Float16.cuh \
@@ -1735,94 +1448,123 @@ WarpSelectFloatF1024.o: gpu/utils/warpselect/WarpSelectFloatF1024.cu \
  gpu/utils/warpselect/../ReductionOperators.cuh \
  gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
  gpu/utils/warpselect/../MathOperators.cuh
+WarpSelectFloatF2048.o: gpu/utils/warpselect/WarpSelectFloatF2048.cu \
+ gpu/utils/warpselect/WarpSelectImpl.cuh \
+ gpu/utils/warpselect/../WarpSelectKernel.cuh \
+ gpu/utils/warpselect/../Float16.cuh \
+ gpu/utils/warpselect/../../GpuResources.h \
+ gpu/utils/warpselect/../../utils/DeviceMemory.h \
+ gpu/utils/warpselect/../DeviceTensor.cuh \
+ gpu/utils/warpselect/../Tensor.cuh \
+ gpu/utils/warpselect/../Tensor-inl.cuh \
+ gpu/utils/warpselect/../../GpuFaissAssert.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../../../FaissException.h \
+ gpu/utils/warpselect/../DeviceUtils.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../MemorySpace.h \
+ gpu/utils/warpselect/../DeviceTensor-inl.cuh \
+ gpu/utils/warpselect/../Select.cuh \
+ gpu/utils/warpselect/../Comparators.cuh \
+ gpu/utils/warpselect/../DeviceDefs.cuh \
+ gpu/utils/warpselect/../MergeNetworkBlock.cuh \
+ gpu/utils/warpselect/../MergeNetworkUtils.cuh \
+ gpu/utils/warpselect/../PtxUtils.cuh \
+ gpu/utils/warpselect/../StaticUtils.h \
+ gpu/utils/warpselect/../WarpShuffles.cuh \
+ gpu/utils/warpselect/../MergeNetworkWarp.cuh \
+ gpu/utils/warpselect/../Reductions.cuh \
+ gpu/utils/warpselect/../ReductionOperators.cuh \
+ gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
+ gpu/utils/warpselect/../MathOperators.cuh
+WarpSelectFloatF512.o: gpu/utils/warpselect/WarpSelectFloatF512.cu \
+ gpu/utils/warpselect/WarpSelectImpl.cuh \
+ gpu/utils/warpselect/../WarpSelectKernel.cuh \
+ gpu/utils/warpselect/../Float16.cuh \
+ gpu/utils/warpselect/../../GpuResources.h \
+ gpu/utils/warpselect/../../utils/DeviceMemory.h \
+ gpu/utils/warpselect/../DeviceTensor.cuh \
+ gpu/utils/warpselect/../Tensor.cuh \
+ gpu/utils/warpselect/../Tensor-inl.cuh \
+ gpu/utils/warpselect/../../GpuFaissAssert.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../../../FaissException.h \
+ gpu/utils/warpselect/../DeviceUtils.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../MemorySpace.h \
+ gpu/utils/warpselect/../DeviceTensor-inl.cuh \
+ gpu/utils/warpselect/../Select.cuh \
+ gpu/utils/warpselect/../Comparators.cuh \
+ gpu/utils/warpselect/../DeviceDefs.cuh \
+ gpu/utils/warpselect/../MergeNetworkBlock.cuh \
+ gpu/utils/warpselect/../MergeNetworkUtils.cuh \
+ gpu/utils/warpselect/../PtxUtils.cuh \
+ gpu/utils/warpselect/../StaticUtils.h \
+ gpu/utils/warpselect/../WarpShuffles.cuh \
+ gpu/utils/warpselect/../MergeNetworkWarp.cuh \
+ gpu/utils/warpselect/../Reductions.cuh \
+ gpu/utils/warpselect/../ReductionOperators.cuh \
+ gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
+ gpu/utils/warpselect/../MathOperators.cuh
+WarpSelectFloatT1024.o: gpu/utils/warpselect/WarpSelectFloatT1024.cu \
+ gpu/utils/warpselect/WarpSelectImpl.cuh \
+ gpu/utils/warpselect/../WarpSelectKernel.cuh \
+ gpu/utils/warpselect/../Float16.cuh \
+ gpu/utils/warpselect/../../GpuResources.h \
+ gpu/utils/warpselect/../../utils/DeviceMemory.h \
+ gpu/utils/warpselect/../DeviceTensor.cuh \
+ gpu/utils/warpselect/../Tensor.cuh \
+ gpu/utils/warpselect/../Tensor-inl.cuh \
+ gpu/utils/warpselect/../../GpuFaissAssert.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../../../FaissException.h \
+ gpu/utils/warpselect/../DeviceUtils.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../MemorySpace.h \
+ gpu/utils/warpselect/../DeviceTensor-inl.cuh \
+ gpu/utils/warpselect/../Select.cuh \
+ gpu/utils/warpselect/../Comparators.cuh \
+ gpu/utils/warpselect/../DeviceDefs.cuh \
+ gpu/utils/warpselect/../MergeNetworkBlock.cuh \
+ gpu/utils/warpselect/../MergeNetworkUtils.cuh \
+ gpu/utils/warpselect/../PtxUtils.cuh \
+ gpu/utils/warpselect/../StaticUtils.h \
+ gpu/utils/warpselect/../WarpShuffles.cuh \
+ gpu/utils/warpselect/../MergeNetworkWarp.cuh \
+ gpu/utils/warpselect/../Reductions.cuh \
+ gpu/utils/warpselect/../ReductionOperators.cuh \
+ gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
+ gpu/utils/warpselect/../MathOperators.cuh
+WarpSelectFloatT2048.o: gpu/utils/warpselect/WarpSelectFloatT2048.cu \
+ gpu/utils/warpselect/WarpSelectImpl.cuh \
+ gpu/utils/warpselect/../WarpSelectKernel.cuh \
+ gpu/utils/warpselect/../Float16.cuh \
+ gpu/utils/warpselect/../../GpuResources.h \
+ gpu/utils/warpselect/../../utils/DeviceMemory.h \
+ gpu/utils/warpselect/../DeviceTensor.cuh \
+ gpu/utils/warpselect/../Tensor.cuh \
+ gpu/utils/warpselect/../Tensor-inl.cuh \
+ gpu/utils/warpselect/../../GpuFaissAssert.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../../../FaissException.h \
+ gpu/utils/warpselect/../DeviceUtils.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../MemorySpace.h \
+ gpu/utils/warpselect/../DeviceTensor-inl.cuh \
+ gpu/utils/warpselect/../Select.cuh \
+ gpu/utils/warpselect/../Comparators.cuh \
+ gpu/utils/warpselect/../DeviceDefs.cuh \
+ gpu/utils/warpselect/../MergeNetworkBlock.cuh \
+ gpu/utils/warpselect/../MergeNetworkUtils.cuh \
+ gpu/utils/warpselect/../PtxUtils.cuh \
+ gpu/utils/warpselect/../StaticUtils.h \
+ gpu/utils/warpselect/../WarpShuffles.cuh \
+ gpu/utils/warpselect/../MergeNetworkWarp.cuh \
+ gpu/utils/warpselect/../Reductions.cuh \
+ gpu/utils/warpselect/../ReductionOperators.cuh \
+ gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
+ gpu/utils/warpselect/../MathOperators.cuh
 WarpSelectFloatT512.o: gpu/utils/warpselect/WarpSelectFloatT512.cu \
- gpu/utils/warpselect/WarpSelectImpl.cuh \
- gpu/utils/warpselect/../WarpSelectKernel.cuh \
- gpu/utils/warpselect/../Float16.cuh \
- gpu/utils/warpselect/../../GpuResources.h \
- gpu/utils/warpselect/../../utils/DeviceMemory.h \
- gpu/utils/warpselect/../DeviceTensor.cuh \
- gpu/utils/warpselect/../Tensor.cuh \
- gpu/utils/warpselect/../Tensor-inl.cuh \
- gpu/utils/warpselect/../../GpuFaissAssert.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../../../FaissException.h \
- gpu/utils/warpselect/../DeviceUtils.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../MemorySpace.h \
- gpu/utils/warpselect/../DeviceTensor-inl.cuh \
- gpu/utils/warpselect/../Select.cuh \
- gpu/utils/warpselect/../Comparators.cuh \
- gpu/utils/warpselect/../DeviceDefs.cuh \
- gpu/utils/warpselect/../MergeNetworkBlock.cuh \
- gpu/utils/warpselect/../MergeNetworkUtils.cuh \
- gpu/utils/warpselect/../PtxUtils.cuh \
- gpu/utils/warpselect/../StaticUtils.h \
- gpu/utils/warpselect/../WarpShuffles.cuh \
- gpu/utils/warpselect/../MergeNetworkWarp.cuh \
- gpu/utils/warpselect/../Reductions.cuh \
- gpu/utils/warpselect/../ReductionOperators.cuh \
- gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
- gpu/utils/warpselect/../MathOperators.cuh
-WarpSelectHalfF512.o: gpu/utils/warpselect/WarpSelectHalfF512.cu \
- gpu/utils/warpselect/WarpSelectImpl.cuh \
- gpu/utils/warpselect/../WarpSelectKernel.cuh \
- gpu/utils/warpselect/../Float16.cuh \
- gpu/utils/warpselect/../../GpuResources.h \
- gpu/utils/warpselect/../../utils/DeviceMemory.h \
- gpu/utils/warpselect/../DeviceTensor.cuh \
- gpu/utils/warpselect/../Tensor.cuh \
- gpu/utils/warpselect/../Tensor-inl.cuh \
- gpu/utils/warpselect/../../GpuFaissAssert.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../../../FaissException.h \
- gpu/utils/warpselect/../DeviceUtils.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../MemorySpace.h \
- gpu/utils/warpselect/../DeviceTensor-inl.cuh \
- gpu/utils/warpselect/../Select.cuh \
- gpu/utils/warpselect/../Comparators.cuh \
- gpu/utils/warpselect/../DeviceDefs.cuh \
- gpu/utils/warpselect/../MergeNetworkBlock.cuh \
- gpu/utils/warpselect/../MergeNetworkUtils.cuh \
- gpu/utils/warpselect/../PtxUtils.cuh \
- gpu/utils/warpselect/../StaticUtils.h \
- gpu/utils/warpselect/../WarpShuffles.cuh \
- gpu/utils/warpselect/../MergeNetworkWarp.cuh \
- gpu/utils/warpselect/../Reductions.cuh \
- gpu/utils/warpselect/../ReductionOperators.cuh \
- gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
- gpu/utils/warpselect/../MathOperators.cuh
-WarpSelectHalfT2048.o: gpu/utils/warpselect/WarpSelectHalfT2048.cu \
- gpu/utils/warpselect/WarpSelectImpl.cuh \
- gpu/utils/warpselect/../WarpSelectKernel.cuh \
- gpu/utils/warpselect/../Float16.cuh \
- gpu/utils/warpselect/../../GpuResources.h \
- gpu/utils/warpselect/../../utils/DeviceMemory.h \
- gpu/utils/warpselect/../DeviceTensor.cuh \
- gpu/utils/warpselect/../Tensor.cuh \
- gpu/utils/warpselect/../Tensor-inl.cuh \
- gpu/utils/warpselect/../../GpuFaissAssert.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../../../FaissException.h \
- gpu/utils/warpselect/../DeviceUtils.h \
- gpu/utils/warpselect/../../../FaissAssert.h \
- gpu/utils/warpselect/../MemorySpace.h \
- gpu/utils/warpselect/../DeviceTensor-inl.cuh \
- gpu/utils/warpselect/../Select.cuh \
- gpu/utils/warpselect/../Comparators.cuh \
- gpu/utils/warpselect/../DeviceDefs.cuh \
- gpu/utils/warpselect/../MergeNetworkBlock.cuh \
- gpu/utils/warpselect/../MergeNetworkUtils.cuh \
- gpu/utils/warpselect/../PtxUtils.cuh \
- gpu/utils/warpselect/../StaticUtils.h \
- gpu/utils/warpselect/../WarpShuffles.cuh \
- gpu/utils/warpselect/../MergeNetworkWarp.cuh \
- gpu/utils/warpselect/../Reductions.cuh \
- gpu/utils/warpselect/../ReductionOperators.cuh \
- gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
- gpu/utils/warpselect/../MathOperators.cuh
-WarpSelectHalf64.o: gpu/utils/warpselect/WarpSelectHalf64.cu \
  gpu/utils/warpselect/WarpSelectImpl.cuh \
  gpu/utils/warpselect/../WarpSelectKernel.cuh \
  gpu/utils/warpselect/../Float16.cuh \
@@ -1880,7 +1622,268 @@ WarpSelectHalf1.o: gpu/utils/warpselect/WarpSelectHalf1.cu \
  gpu/utils/warpselect/../ReductionOperators.cuh \
  gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
  gpu/utils/warpselect/../MathOperators.cuh
-WarpSelectFloatT1024.o: gpu/utils/warpselect/WarpSelectFloatT1024.cu \
+WarpSelectHalf128.o: gpu/utils/warpselect/WarpSelectHalf128.cu \
+ gpu/utils/warpselect/WarpSelectImpl.cuh \
+ gpu/utils/warpselect/../WarpSelectKernel.cuh \
+ gpu/utils/warpselect/../Float16.cuh \
+ gpu/utils/warpselect/../../GpuResources.h \
+ gpu/utils/warpselect/../../utils/DeviceMemory.h \
+ gpu/utils/warpselect/../DeviceTensor.cuh \
+ gpu/utils/warpselect/../Tensor.cuh \
+ gpu/utils/warpselect/../Tensor-inl.cuh \
+ gpu/utils/warpselect/../../GpuFaissAssert.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../../../FaissException.h \
+ gpu/utils/warpselect/../DeviceUtils.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../MemorySpace.h \
+ gpu/utils/warpselect/../DeviceTensor-inl.cuh \
+ gpu/utils/warpselect/../Select.cuh \
+ gpu/utils/warpselect/../Comparators.cuh \
+ gpu/utils/warpselect/../DeviceDefs.cuh \
+ gpu/utils/warpselect/../MergeNetworkBlock.cuh \
+ gpu/utils/warpselect/../MergeNetworkUtils.cuh \
+ gpu/utils/warpselect/../PtxUtils.cuh \
+ gpu/utils/warpselect/../StaticUtils.h \
+ gpu/utils/warpselect/../WarpShuffles.cuh \
+ gpu/utils/warpselect/../MergeNetworkWarp.cuh \
+ gpu/utils/warpselect/../Reductions.cuh \
+ gpu/utils/warpselect/../ReductionOperators.cuh \
+ gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
+ gpu/utils/warpselect/../MathOperators.cuh
+WarpSelectHalf256.o: gpu/utils/warpselect/WarpSelectHalf256.cu \
+ gpu/utils/warpselect/WarpSelectImpl.cuh \
+ gpu/utils/warpselect/../WarpSelectKernel.cuh \
+ gpu/utils/warpselect/../Float16.cuh \
+ gpu/utils/warpselect/../../GpuResources.h \
+ gpu/utils/warpselect/../../utils/DeviceMemory.h \
+ gpu/utils/warpselect/../DeviceTensor.cuh \
+ gpu/utils/warpselect/../Tensor.cuh \
+ gpu/utils/warpselect/../Tensor-inl.cuh \
+ gpu/utils/warpselect/../../GpuFaissAssert.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../../../FaissException.h \
+ gpu/utils/warpselect/../DeviceUtils.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../MemorySpace.h \
+ gpu/utils/warpselect/../DeviceTensor-inl.cuh \
+ gpu/utils/warpselect/../Select.cuh \
+ gpu/utils/warpselect/../Comparators.cuh \
+ gpu/utils/warpselect/../DeviceDefs.cuh \
+ gpu/utils/warpselect/../MergeNetworkBlock.cuh \
+ gpu/utils/warpselect/../MergeNetworkUtils.cuh \
+ gpu/utils/warpselect/../PtxUtils.cuh \
+ gpu/utils/warpselect/../StaticUtils.h \
+ gpu/utils/warpselect/../WarpShuffles.cuh \
+ gpu/utils/warpselect/../MergeNetworkWarp.cuh \
+ gpu/utils/warpselect/../Reductions.cuh \
+ gpu/utils/warpselect/../ReductionOperators.cuh \
+ gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
+ gpu/utils/warpselect/../MathOperators.cuh
+WarpSelectHalf32.o: gpu/utils/warpselect/WarpSelectHalf32.cu \
+ gpu/utils/warpselect/WarpSelectImpl.cuh \
+ gpu/utils/warpselect/../WarpSelectKernel.cuh \
+ gpu/utils/warpselect/../Float16.cuh \
+ gpu/utils/warpselect/../../GpuResources.h \
+ gpu/utils/warpselect/../../utils/DeviceMemory.h \
+ gpu/utils/warpselect/../DeviceTensor.cuh \
+ gpu/utils/warpselect/../Tensor.cuh \
+ gpu/utils/warpselect/../Tensor-inl.cuh \
+ gpu/utils/warpselect/../../GpuFaissAssert.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../../../FaissException.h \
+ gpu/utils/warpselect/../DeviceUtils.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../MemorySpace.h \
+ gpu/utils/warpselect/../DeviceTensor-inl.cuh \
+ gpu/utils/warpselect/../Select.cuh \
+ gpu/utils/warpselect/../Comparators.cuh \
+ gpu/utils/warpselect/../DeviceDefs.cuh \
+ gpu/utils/warpselect/../MergeNetworkBlock.cuh \
+ gpu/utils/warpselect/../MergeNetworkUtils.cuh \
+ gpu/utils/warpselect/../PtxUtils.cuh \
+ gpu/utils/warpselect/../StaticUtils.h \
+ gpu/utils/warpselect/../WarpShuffles.cuh \
+ gpu/utils/warpselect/../MergeNetworkWarp.cuh \
+ gpu/utils/warpselect/../Reductions.cuh \
+ gpu/utils/warpselect/../ReductionOperators.cuh \
+ gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
+ gpu/utils/warpselect/../MathOperators.cuh
+WarpSelectHalf64.o: gpu/utils/warpselect/WarpSelectHalf64.cu \
+ gpu/utils/warpselect/WarpSelectImpl.cuh \
+ gpu/utils/warpselect/../WarpSelectKernel.cuh \
+ gpu/utils/warpselect/../Float16.cuh \
+ gpu/utils/warpselect/../../GpuResources.h \
+ gpu/utils/warpselect/../../utils/DeviceMemory.h \
+ gpu/utils/warpselect/../DeviceTensor.cuh \
+ gpu/utils/warpselect/../Tensor.cuh \
+ gpu/utils/warpselect/../Tensor-inl.cuh \
+ gpu/utils/warpselect/../../GpuFaissAssert.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../../../FaissException.h \
+ gpu/utils/warpselect/../DeviceUtils.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../MemorySpace.h \
+ gpu/utils/warpselect/../DeviceTensor-inl.cuh \
+ gpu/utils/warpselect/../Select.cuh \
+ gpu/utils/warpselect/../Comparators.cuh \
+ gpu/utils/warpselect/../DeviceDefs.cuh \
+ gpu/utils/warpselect/../MergeNetworkBlock.cuh \
+ gpu/utils/warpselect/../MergeNetworkUtils.cuh \
+ gpu/utils/warpselect/../PtxUtils.cuh \
+ gpu/utils/warpselect/../StaticUtils.h \
+ gpu/utils/warpselect/../WarpShuffles.cuh \
+ gpu/utils/warpselect/../MergeNetworkWarp.cuh \
+ gpu/utils/warpselect/../Reductions.cuh \
+ gpu/utils/warpselect/../ReductionOperators.cuh \
+ gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
+ gpu/utils/warpselect/../MathOperators.cuh
+WarpSelectHalfF1024.o: gpu/utils/warpselect/WarpSelectHalfF1024.cu \
+ gpu/utils/warpselect/WarpSelectImpl.cuh \
+ gpu/utils/warpselect/../WarpSelectKernel.cuh \
+ gpu/utils/warpselect/../Float16.cuh \
+ gpu/utils/warpselect/../../GpuResources.h \
+ gpu/utils/warpselect/../../utils/DeviceMemory.h \
+ gpu/utils/warpselect/../DeviceTensor.cuh \
+ gpu/utils/warpselect/../Tensor.cuh \
+ gpu/utils/warpselect/../Tensor-inl.cuh \
+ gpu/utils/warpselect/../../GpuFaissAssert.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../../../FaissException.h \
+ gpu/utils/warpselect/../DeviceUtils.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../MemorySpace.h \
+ gpu/utils/warpselect/../DeviceTensor-inl.cuh \
+ gpu/utils/warpselect/../Select.cuh \
+ gpu/utils/warpselect/../Comparators.cuh \
+ gpu/utils/warpselect/../DeviceDefs.cuh \
+ gpu/utils/warpselect/../MergeNetworkBlock.cuh \
+ gpu/utils/warpselect/../MergeNetworkUtils.cuh \
+ gpu/utils/warpselect/../PtxUtils.cuh \
+ gpu/utils/warpselect/../StaticUtils.h \
+ gpu/utils/warpselect/../WarpShuffles.cuh \
+ gpu/utils/warpselect/../MergeNetworkWarp.cuh \
+ gpu/utils/warpselect/../Reductions.cuh \
+ gpu/utils/warpselect/../ReductionOperators.cuh \
+ gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
+ gpu/utils/warpselect/../MathOperators.cuh
+WarpSelectHalfF2048.o: gpu/utils/warpselect/WarpSelectHalfF2048.cu \
+ gpu/utils/warpselect/WarpSelectImpl.cuh \
+ gpu/utils/warpselect/../WarpSelectKernel.cuh \
+ gpu/utils/warpselect/../Float16.cuh \
+ gpu/utils/warpselect/../../GpuResources.h \
+ gpu/utils/warpselect/../../utils/DeviceMemory.h \
+ gpu/utils/warpselect/../DeviceTensor.cuh \
+ gpu/utils/warpselect/../Tensor.cuh \
+ gpu/utils/warpselect/../Tensor-inl.cuh \
+ gpu/utils/warpselect/../../GpuFaissAssert.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../../../FaissException.h \
+ gpu/utils/warpselect/../DeviceUtils.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../MemorySpace.h \
+ gpu/utils/warpselect/../DeviceTensor-inl.cuh \
+ gpu/utils/warpselect/../Select.cuh \
+ gpu/utils/warpselect/../Comparators.cuh \
+ gpu/utils/warpselect/../DeviceDefs.cuh \
+ gpu/utils/warpselect/../MergeNetworkBlock.cuh \
+ gpu/utils/warpselect/../MergeNetworkUtils.cuh \
+ gpu/utils/warpselect/../PtxUtils.cuh \
+ gpu/utils/warpselect/../StaticUtils.h \
+ gpu/utils/warpselect/../WarpShuffles.cuh \
+ gpu/utils/warpselect/../MergeNetworkWarp.cuh \
+ gpu/utils/warpselect/../Reductions.cuh \
+ gpu/utils/warpselect/../ReductionOperators.cuh \
+ gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
+ gpu/utils/warpselect/../MathOperators.cuh
+WarpSelectHalfF512.o: gpu/utils/warpselect/WarpSelectHalfF512.cu \
+ gpu/utils/warpselect/WarpSelectImpl.cuh \
+ gpu/utils/warpselect/../WarpSelectKernel.cuh \
+ gpu/utils/warpselect/../Float16.cuh \
+ gpu/utils/warpselect/../../GpuResources.h \
+ gpu/utils/warpselect/../../utils/DeviceMemory.h \
+ gpu/utils/warpselect/../DeviceTensor.cuh \
+ gpu/utils/warpselect/../Tensor.cuh \
+ gpu/utils/warpselect/../Tensor-inl.cuh \
+ gpu/utils/warpselect/../../GpuFaissAssert.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../../../FaissException.h \
+ gpu/utils/warpselect/../DeviceUtils.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../MemorySpace.h \
+ gpu/utils/warpselect/../DeviceTensor-inl.cuh \
+ gpu/utils/warpselect/../Select.cuh \
+ gpu/utils/warpselect/../Comparators.cuh \
+ gpu/utils/warpselect/../DeviceDefs.cuh \
+ gpu/utils/warpselect/../MergeNetworkBlock.cuh \
+ gpu/utils/warpselect/../MergeNetworkUtils.cuh \
+ gpu/utils/warpselect/../PtxUtils.cuh \
+ gpu/utils/warpselect/../StaticUtils.h \
+ gpu/utils/warpselect/../WarpShuffles.cuh \
+ gpu/utils/warpselect/../MergeNetworkWarp.cuh \
+ gpu/utils/warpselect/../Reductions.cuh \
+ gpu/utils/warpselect/../ReductionOperators.cuh \
+ gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
+ gpu/utils/warpselect/../MathOperators.cuh
+WarpSelectHalfT1024.o: gpu/utils/warpselect/WarpSelectHalfT1024.cu \
+ gpu/utils/warpselect/WarpSelectImpl.cuh \
+ gpu/utils/warpselect/../WarpSelectKernel.cuh \
+ gpu/utils/warpselect/../Float16.cuh \
+ gpu/utils/warpselect/../../GpuResources.h \
+ gpu/utils/warpselect/../../utils/DeviceMemory.h \
+ gpu/utils/warpselect/../DeviceTensor.cuh \
+ gpu/utils/warpselect/../Tensor.cuh \
+ gpu/utils/warpselect/../Tensor-inl.cuh \
+ gpu/utils/warpselect/../../GpuFaissAssert.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../../../FaissException.h \
+ gpu/utils/warpselect/../DeviceUtils.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../MemorySpace.h \
+ gpu/utils/warpselect/../DeviceTensor-inl.cuh \
+ gpu/utils/warpselect/../Select.cuh \
+ gpu/utils/warpselect/../Comparators.cuh \
+ gpu/utils/warpselect/../DeviceDefs.cuh \
+ gpu/utils/warpselect/../MergeNetworkBlock.cuh \
+ gpu/utils/warpselect/../MergeNetworkUtils.cuh \
+ gpu/utils/warpselect/../PtxUtils.cuh \
+ gpu/utils/warpselect/../StaticUtils.h \
+ gpu/utils/warpselect/../WarpShuffles.cuh \
+ gpu/utils/warpselect/../MergeNetworkWarp.cuh \
+ gpu/utils/warpselect/../Reductions.cuh \
+ gpu/utils/warpselect/../ReductionOperators.cuh \
+ gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
+ gpu/utils/warpselect/../MathOperators.cuh
+WarpSelectHalfT2048.o: gpu/utils/warpselect/WarpSelectHalfT2048.cu \
+ gpu/utils/warpselect/WarpSelectImpl.cuh \
+ gpu/utils/warpselect/../WarpSelectKernel.cuh \
+ gpu/utils/warpselect/../Float16.cuh \
+ gpu/utils/warpselect/../../GpuResources.h \
+ gpu/utils/warpselect/../../utils/DeviceMemory.h \
+ gpu/utils/warpselect/../DeviceTensor.cuh \
+ gpu/utils/warpselect/../Tensor.cuh \
+ gpu/utils/warpselect/../Tensor-inl.cuh \
+ gpu/utils/warpselect/../../GpuFaissAssert.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../../../FaissException.h \
+ gpu/utils/warpselect/../DeviceUtils.h \
+ gpu/utils/warpselect/../../../FaissAssert.h \
+ gpu/utils/warpselect/../MemorySpace.h \
+ gpu/utils/warpselect/../DeviceTensor-inl.cuh \
+ gpu/utils/warpselect/../Select.cuh \
+ gpu/utils/warpselect/../Comparators.cuh \
+ gpu/utils/warpselect/../DeviceDefs.cuh \
+ gpu/utils/warpselect/../MergeNetworkBlock.cuh \
+ gpu/utils/warpselect/../MergeNetworkUtils.cuh \
+ gpu/utils/warpselect/../PtxUtils.cuh \
+ gpu/utils/warpselect/../StaticUtils.h \
+ gpu/utils/warpselect/../WarpShuffles.cuh \
+ gpu/utils/warpselect/../MergeNetworkWarp.cuh \
+ gpu/utils/warpselect/../Reductions.cuh \
+ gpu/utils/warpselect/../ReductionOperators.cuh \
+ gpu/utils/warpselect/../Limits.cuh gpu/utils/warpselect/../Pair.cuh \
+ gpu/utils/warpselect/../MathOperators.cuh
+WarpSelectHalfT512.o: gpu/utils/warpselect/WarpSelectHalfT512.cu \
  gpu/utils/warpselect/WarpSelectImpl.cuh \
  gpu/utils/warpselect/../WarpSelectKernel.cuh \
  gpu/utils/warpselect/../Float16.cuh \

--- a/distances.cpp
+++ b/distances.cpp
@@ -1,0 +1,336 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+#include "distances.h"
+
+#include <cmath>
+#include <omp.h>
+
+
+#include "utils.h"
+#include "FaissAssert.h"
+#include "AuxIndexStructures.h"
+
+namespace faiss {
+
+/***************************************************************************
+ * Distance functions (other than L2 and IP)
+ ***************************************************************************/
+
+struct VectorDistanceL2 {
+    size_t d;
+
+    float operator () (const float *x, const float *y) const {
+        return fvec_L2sqr (x, y, d);
+    }
+};
+
+struct VectorDistanceL1 {
+    size_t d;
+
+    float operator () (const float *x, const float *y) const {
+        return fvec_L1 (x, y, d);
+    }
+};
+
+struct VectorDistanceLinf {
+    size_t d;
+
+    float operator () (const float *x, const float *y) const {
+        return fvec_Linf (x, y, d);
+        /*
+        float vmax = 0;
+        for (size_t i = 0; i < d; i++) {
+            float diff = fabs (x[i] - y[i]);
+            if (diff > vmax) vmax = diff;
+        }
+        return vmax;*/
+    }
+};
+
+struct VectorDistanceLp {
+    size_t d;
+    const float p;
+
+    float operator () (const float *x, const float *y) const {
+        float accu = 0;
+        for (size_t i = 0; i < d; i++) {
+            float diff = fabs (x[i] - y[i]);
+            accu += powf (diff, p);
+        }
+        return accu;
+    }
+};
+
+struct VectorDistanceCanberra {
+    size_t d;
+
+    float operator () (const float *x, const float *y) const {
+        float accu = 0;
+        for (size_t i = 0; i < d; i++) {
+            float xi = x[i], yi = y[i];
+            accu += fabs (xi - yi) / (fabs(xi) + fabs(yi));
+        }
+        return accu;
+    }
+};
+
+struct VectorDistanceBrayCurtis {
+    size_t d;
+
+    float operator () (const float *x, const float *y) const {
+        float accu_num = 0, accu_den = 0;
+        for (size_t i = 0; i < d; i++) {
+            float xi = x[i], yi = y[i];
+            accu_num += fabs (xi - yi);
+            accu_den += fabs (xi + yi);
+        }
+        return accu_num / accu_den;
+    }
+};
+
+struct VectorDistanceJensenShannon {
+    size_t d;
+
+    float operator () (const float *x, const float *y) const {
+        float accu = 0;
+
+        for (size_t i = 0; i < d; i++) {
+            float xi = x[i], yi = y[i];
+            float mi = 0.5 * (xi + yi);
+            float kl1 = - xi * log(mi / xi);
+            float kl2 = - yi * log(mi / yi);
+            accu += kl1 + kl2;
+        }
+        return 0.5 * accu;
+    }
+};
+
+
+
+
+
+
+
+
+
+
+namespace {
+
+template<class VD>
+void pairwise_extra_distances_template (
+                     VD vd,
+                     int64_t nq, const float *xq,
+                     int64_t nb, const float *xb,
+                     float *dis,
+                     int64_t ldq, int64_t ldb, int64_t ldd)
+{
+
+#pragma omp parallel for if(nq > 10)
+    for (int64_t i = 0; i < nq; i++) {
+        const float *xqi = xq + i * ldq;
+        const float *xbj = xb;
+        float *disi = dis + ldd * i;
+
+        for (int64_t j = 0; j < nb; j++) {
+            disi[j] = vd (xqi, xbj);
+            xbj += ldb;
+        }
+    }
+}
+
+
+template<class VD>
+void knn_extra_metrics_template (
+        VD vd,
+        const float * x,
+        const float * y,
+        size_t nx, size_t ny,
+        float_maxheap_array_t * res)
+{
+    size_t k = res->k;
+    size_t d = vd.d;
+    size_t check_period = InterruptCallback::get_period_hint (ny * d);
+    check_period *= omp_get_max_threads();
+
+    for (size_t i0 = 0; i0 < nx; i0 += check_period) {
+        size_t i1 = std::min(i0 + check_period, nx);
+
+#pragma omp parallel for
+        for (size_t i = i0; i < i1; i++) {
+            const float * x_i = x + i * d;
+            const float * y_j = y;
+            size_t j;
+            float * simi = res->get_val(i);
+            long * idxi = res->get_ids (i);
+
+            maxheap_heapify (k, simi, idxi);
+            for (j = 0; j < ny; j++) {
+                float disij = vd (x_i, y_j);
+
+                if (disij < simi[0]) {
+                    maxheap_pop (k, simi, idxi);
+                    maxheap_push (k, simi, idxi, disij, j);
+                }
+                y_j += d;
+            }
+            maxheap_reorder (k, simi, idxi);
+        }
+        InterruptCallback::check ();
+    }
+
+}
+
+
+template<class VD>
+struct ExtraDistanceComputer : DistanceComputer {
+    VD vd;
+    Index::idx_t nb;
+    const float *q;
+    const float *b;
+
+    float operator () (idx_t i) override {
+        return vd (q, b + i * vd.d);
+    }
+
+    float symmetric_dis(idx_t i, idx_t j) override {
+        return vd (b + j * vd.d, b + i * vd.d);
+    }
+
+    ExtraDistanceComputer(const VD & vd, const float *xb,
+                          size_t nb, const float *q = nullptr)
+        : vd(vd), nb(nb), q(q), b(xb) {}
+
+    void set_query(const float *x) override {
+        q = x;
+    }
+};
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+} // anonymous namespace
+
+void pairwise_extra_distances (
+                     int64_t d,
+                     int64_t nq, const float *xq,
+                     int64_t nb, const float *xb,
+                     MetricType mt, float metric_arg,
+                     float *dis,
+                     int64_t ldq, int64_t ldb, int64_t ldd)
+{
+    if (nq == 0 || nb == 0) return;
+    if (ldq == -1) ldq = d;
+    if (ldb == -1) ldb = d;
+    if (ldd == -1) ldd = nb;
+
+    switch(mt) {
+#define HANDLE_VAR(kw)                                          \
+     case METRIC_ ## kw: {                                      \
+        VectorDistance ## kw vd({(size_t)d});                   \
+        pairwise_extra_distances_template (vd, nq, xq, nb, xb,  \
+                                           dis, ldq, ldb, ldd); \
+        break;                                                  \
+    }
+        HANDLE_VAR(L2);
+        HANDLE_VAR(L1);
+        HANDLE_VAR(Linf);
+        HANDLE_VAR(Canberra);
+        HANDLE_VAR(BrayCurtis);
+        HANDLE_VAR(JensenShannon);
+#undef HANDLE_VAR
+    case METRIC_Lp: {
+        VectorDistanceLp vd({(size_t)d, metric_arg});
+        pairwise_extra_distances_template (vd, nq, xq, nb, xb,
+                                           dis, ldq, ldb, ldd);
+        break;
+    }
+    default:
+        FAISS_THROW_MSG ("metric type not implemented");
+    }
+
+}
+
+void knn_extra_metrics (
+        const float * x,
+        const float * y,
+        size_t d, size_t nx, size_t ny,
+        MetricType mt, float metric_arg,
+        float_maxheap_array_t * res)
+{
+
+    switch(mt) {
+#define HANDLE_VAR(kw)                                          \
+     case METRIC_ ## kw: {                                      \
+        VectorDistance ## kw vd({(size_t)d});                   \
+        knn_extra_metrics_template (vd, x, y, nx, ny, res);     \
+        break;                                                  \
+    }
+        HANDLE_VAR(L2);
+        HANDLE_VAR(L1);
+        HANDLE_VAR(Linf);
+        HANDLE_VAR(Canberra);
+        HANDLE_VAR(BrayCurtis);
+        HANDLE_VAR(JensenShannon);
+#undef HANDLE_VAR
+    case METRIC_Lp: {
+        VectorDistanceLp vd({(size_t)d, metric_arg});
+        knn_extra_metrics_template (vd, x, y, nx, ny, res);
+        break;
+    }
+    default:
+        FAISS_THROW_MSG ("metric type not implemented");
+    }
+
+}
+
+DistanceComputer *get_extra_distance_computer (
+        size_t d,
+        MetricType mt, float metric_arg,
+        size_t nb, const float *xb)
+{
+
+    switch(mt) {
+#define HANDLE_VAR(kw)                                                  \
+     case METRIC_ ## kw: {                                              \
+        VectorDistance ## kw vd({(size_t)d});                           \
+        return new ExtraDistanceComputer<VectorDistance ## kw>(vd, xb, nb); \
+    }
+        HANDLE_VAR(L2);
+        HANDLE_VAR(L1);
+        HANDLE_VAR(Linf);
+        HANDLE_VAR(Canberra);
+        HANDLE_VAR(BrayCurtis);
+        HANDLE_VAR(JensenShannon);
+#undef HANDLE_VAR
+    case METRIC_Lp: {
+        VectorDistanceLp vd({(size_t)d, metric_arg});
+        return new ExtraDistanceComputer<VectorDistanceLp> (vd, xb, nb);
+        break;
+    }
+    default:
+        FAISS_THROW_MSG ("metric type not implemented");
+    }
+
+}
+
+
+} // namespace faiss

--- a/distances.cpp
+++ b/distances.cpp
@@ -168,7 +168,7 @@ void knn_extra_metrics_template (
             const float * y_j = y;
             size_t j;
             float * simi = res->get_val(i);
-            long * idxi = res->get_ids (i);
+            int64_t * idxi = res->get_ids (i);
 
             maxheap_heapify (k, simi, idxi);
             for (j = 0; j < ny; j++) {

--- a/distances.h
+++ b/distances.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+#ifndef FAISS_distances_h
+#define FAISS_distances_h
+
+/** In this file are the implementations of extra metrics beyond L2
+ *  and inner product */
+
+#include <stdint.h>
+
+#include "Index.h"
+
+#include "Heap.h"
+
+
+
+namespace faiss {
+
+
+void pairwise_extra_distances (
+                     int64_t d,
+                     int64_t nq, const float *xq,
+                     int64_t nb, const float *xb,
+                     MetricType mt, float metric_arg,
+                     float *dis,
+                     int64_t ldq = -1, int64_t ldb = -1, int64_t ldd = -1);
+
+
+void knn_extra_metrics (
+        const float * x,
+        const float * y,
+        size_t d, size_t nx, size_t ny,
+        MetricType mt, float metric_arg,
+        float_maxheap_array_t * res);
+
+
+/** get a DistanceComputer that refers to this type of distance and
+ *  indexes a flat array of size nb */
+DistanceComputer *get_extra_distance_computer (
+        size_t d,
+        MetricType mt, float metric_arg,
+        size_t nb, const float *xb);
+
+}
+
+
+#endif

--- a/gpu/test/TestGpuMemoryException.cpp
+++ b/gpu/test/TestGpuMemoryException.cpp
@@ -24,27 +24,33 @@ TEST(TestGpuMemoryException, AddException) {
   CUDA_VERIFY(cudaMemGetInfo(&devFree, &devTotal));
 
   // Figure out the dimensionality needed to get at least greater than devTotal
-  size_t dims = ((devTotal / sizeof(float)) / numBrokenAdd) + 1;
+  size_t brokenAddDims = ((devTotal / sizeof(float)) / numBrokenAdd) + 1;
+  size_t realAddDims = 128;
 
   faiss::gpu::StandardGpuResources res;
 
   faiss::gpu::GpuIndexFlatConfig config;
   config.device = faiss::gpu::randVal(0, faiss::gpu::getNumDevices() - 1);
 
-  faiss::gpu::GpuIndexFlatL2 gpuIndexL2(&res, (int) dims, config);
-  faiss::IndexFlatL2 cpuIndex((int) dims);
+  faiss::gpu::GpuIndexFlatL2
+    gpuIndexL2Broken(&res, (int) brokenAddDims, config);
+  faiss::gpu::GpuIndexFlatL2
+    gpuIndexL2(&res, (int) realAddDims, config);
+  faiss::IndexFlatL2
+    cpuIndex((int) realAddDims);
 
   // Should throw on attempting to allocate too much data
   {
     // allocate memory without initialization
-    auto vecs = std::unique_ptr<float[]>(new float[numBrokenAdd * dims]);
-    EXPECT_THROW(gpuIndexL2.add(numBrokenAdd, vecs.get()),
+    auto vecs =
+      std::unique_ptr<float[]>(new float[numBrokenAdd * brokenAddDims]);
+    EXPECT_THROW(gpuIndexL2Broken.add(numBrokenAdd, vecs.get()),
                  faiss::FaissException);
   }
 
   // Should be able to add a smaller set of data now
   {
-    auto vecs = faiss::gpu::randVecs(numRealAdd, dims);
+    auto vecs = faiss::gpu::randVecs(numRealAdd, realAddDims);
     EXPECT_NO_THROW(gpuIndexL2.add(numRealAdd, vecs.data()));
     cpuIndex.add(numRealAdd, vecs.data());
   }
@@ -52,17 +58,18 @@ TEST(TestGpuMemoryException, AddException) {
   // Should throw on attempting to allocate too much data
   {
     // allocate memory without initialization
-    auto vecs = std::unique_ptr<float[]>(new float[numBrokenAdd * dims]);
-    EXPECT_THROW(gpuIndexL2.add(numBrokenAdd, vecs.get()),
+    auto vecs =
+      std::unique_ptr<float[]>(new float[numBrokenAdd * brokenAddDims]);
+    EXPECT_THROW(gpuIndexL2Broken.add(numBrokenAdd, vecs.get()),
                  faiss::FaissException);
   }
 
   // Should be able to query results from what we had before
   {
     size_t numQuery = 10;
-    auto vecs = faiss::gpu::randVecs(numQuery, dims);
+    auto vecs = faiss::gpu::randVecs(numQuery, realAddDims);
     EXPECT_NO_THROW(compareIndices(vecs, cpuIndex, gpuIndexL2,
-                                   numQuery, dims, 50, "",
+                                   numQuery, realAddDims, 50, "",
                                    6e-3f, 0.1f, 0.015f));
   }
 }

--- a/hamming.cpp
+++ b/hamming.cpp
@@ -143,10 +143,10 @@ void hammings (
     size_t i, j;
     const size_t nwords = nbits / 64;
     for (i = 0; i < n1; i++) {
-      const uint64_t * __restrict bs1_ = bs1 + i * nwords;
-      hamdis_t * __restrict dis_ = dis + i * n2;
-      for (j = 0; j < n2; j++)
-        dis_[j] = hamming<nbits>(bs1_, bs2 + j * nwords);
+        const uint64_t * __restrict bs1_ = bs1 + i * nwords;
+        hamdis_t * __restrict dis_ = dis + i * n2;
+        for (j = 0; j < n2; j++)
+            dis_[j] = hamming<nbits>(bs1_, bs2 + j * nwords);
     }
 }
 
@@ -232,7 +232,7 @@ size_t match_hamming_thres (
         size_t n1,
         size_t n2,
         int ht,
-        long * idx,
+        int64_t * idx,
         hamdis_t * hams)
 {
     const size_t nwords = nbits / 64;
@@ -287,7 +287,7 @@ void hammings_knn_hc (
         const uint8_t * bs2_ = bs2 + j0 * bytes_per_code;
         hamdis_t dis;
         hamdis_t * __restrict bh_val_ = ha->val + i * k;
-        long * __restrict bh_ids_ = ha->ids + i * k;
+        int64_t * __restrict bh_ids_ = ha->ids + i * k;
         size_t j;
         for (j = j0; j < j1; j++, bs2_+= bytes_per_code) {
           dis = hc.hamming (bs2_);
@@ -312,11 +312,11 @@ void hammings_knn_mc (
         size_t nb,
         size_t k,
         int32_t *distances,
-        long *labels)
+        int64_t *labels)
 {
   const int nBuckets = bytes_per_code * 8 + 1;
   std::vector<int> all_counters(na * nBuckets, 0);
-  std::unique_ptr<long[]> all_ids_per_dis(new long[na * nBuckets * k]);
+  std::unique_ptr<int64_t[]> all_ids_per_dis(new int64_t[na * nBuckets * k]);
 
   std::vector<HCounterState<HammingComputer>> cs;
   for (size_t i = 0; i < na; ++i) {
@@ -386,7 +386,7 @@ void hammings_knn_hc_1 (
         hamdis_t dis;
         hamdis_t * bh_val_ = ha->val + i * k;
         hamdis_t bh_val_0 = bh_val_[0];
-        long * bh_ids_ = ha->ids + i * k;
+        int64_t * bh_ids_ = ha->ids + i * k;
         size_t j;
         for (j = 0; j < n2; j++, bs2_+= nwords) {
             dis = popcount64 (bs1_ ^ *bs2_);
@@ -434,7 +434,7 @@ void fvec2bitvec (const float * x, uint8_t * b, size_t d)
    Ensure that the ouptut b is byte-aligned (pad with 0s). */
 void fvecs2bitvecs (const float * x, uint8_t * b, size_t d, size_t n)
 {
-    const long ncodes = ((d + 7) / 8);
+    const int64_t ncodes = ((d + 7) / 8);
 #pragma omp parallel for
     for (size_t i = 0; i < n; i++)
         fvec2bitvec (x + i * d, b + i * ncodes, d);
@@ -560,7 +560,7 @@ void hammings_knn_mc(
     size_t k,
     size_t ncodes,
     int32_t *distances,
-    long *labels)
+    int64_t *labels)
 {
     switch (ncodes) {
     case 4:
@@ -669,7 +669,7 @@ size_t match_hamming_thres (
         size_t n2,
         hamdis_t ht,
         size_t ncodes,
-        long * idx,
+        int64_t * idx,
         hamdis_t * dis)
 {
     switch (ncodes) {
@@ -710,7 +710,7 @@ static void hamming_dis_inner_loop (
         size_t code_size,
         int k,
         hamdis_t * bh_val_,
-        long *     bh_ids_)
+        int64_t *     bh_ids_)
 {
 
     HammingComputer hc (ca, code_size);
@@ -745,7 +745,7 @@ void generalized_hammings_knn_hc (
         const uint8_t *cb = b;
 
         hamdis_t * bh_val_ = ha->val + i * k;
-        long *     bh_ids_ = ha->ids + i * k;
+        int64_t *     bh_ids_ = ha->ids + i * k;
 
         switch (code_size) {
         case 8:

--- a/hamming.h
+++ b/hamming.h
@@ -8,9 +8,10 @@
 // -*- c++ -*-
 
 /*
- * Hamming distances. The binary vector dimensionality should be a multiple
- * of 64, as the elementary operations operate on words. If you really need
- * other sizes, just pad with 0s (this is done by function fvecs2bitvecs).
+ * Hamming distances. The binary vector dimensionality should be a
+ * multiple of 8, as the elementary operations operate on bytes. If
+ * you need other sizes, just pad with 0s (this is done by function
+ * fvecs2bitvecs).
  *
  * User-defined type hamdis_t is used for distances because at this time
  * it is still uncler clear how we will need to balance
@@ -18,8 +19,6 @@
  * - memory usage
  * - cache-misses when dealing with large volumes of data (fewer bits is better)
  *
- * hamdis_t should optimally be compatibe with one of the Torch Storage
- * (Byte,Short,Long) and therefore should be signed for 2-bytes and 4-bytes.
  */
 
 #ifndef FAISS_hamming_h
@@ -31,8 +30,7 @@
 #include "Heap.h"
 
 
-/* The Hamming distance type should be exportable to Lua Tensor, which
-   excludes most unsigned type */
+/* The Hamming distance type */
 typedef int32_t hamdis_t;
 
 namespace faiss {
@@ -125,7 +123,7 @@ void hammings_knn_mc (
   size_t k,
   size_t ncodes,
   int32_t *distances,
-  long *labels);
+  int64_t *labels);
 
 /* Counting the number of matches or of cross-matches (without returning them)
    For use with function that assume pre-allocated memory */
@@ -147,7 +145,7 @@ size_t match_hamming_thres (
         size_t n2,
         hamdis_t ht,
         size_t ncodes,
-        long * idx,
+        int64_t * idx,
         hamdis_t * dis);
 
 /* Cross-matching in a set of vectors */
@@ -529,7 +527,7 @@ void generalized_hammings_knn_hc (
 template<class HammingComputer>
 struct HCounterState {
   int *counters;
-  long *ids_per_dis;
+  int64_t *ids_per_dis;
 
   HammingComputer hc;
   int thres;
@@ -537,7 +535,7 @@ struct HCounterState {
   int count_eq;
   int k;
 
- HCounterState(int *counters, long *ids_per_dis,
+ HCounterState(int *counters, int64_t *ids_per_dis,
                const uint8_t *x, int d, int k)
  : counters(counters),
         ids_per_dis(ids_per_dis),

--- a/makefile.inc.in
+++ b/makefile.inc.in
@@ -11,6 +11,7 @@ CPUFLAGS     = @ARCH_CPUFLAGS@
 LDFLAGS      = @OPENMP_CXXFLAGS@ @LDFLAGS@ @NVCC_LDFLAGS@
 LIBS         = @BLAS_LIBS@ @LAPACK_LIBS@ @LIBS@ @NVCC_LIBS@
 PYTHONCFLAGS = @PYTHON_CFLAGS@ -I@NUMPY_INCLUDE@
+SWIGFLAGS    = -DSWIGWORDSIZE64
 
 NVCC         = @NVCC@
 CUDA_ROOT    = @CUDA_PREFIX@
@@ -30,6 +31,7 @@ SHAREDFLAGS = -shared
 ifeq ($(OS),Darwin)
 	SHAREDEXT   = dylib
 	SHAREDFLAGS = -dynamiclib -undefined dynamic_lookup
+        SWIGFLAGS   =
 endif
 
 MKDIR_P      = @MKDIR_P@

--- a/python/Makefile
+++ b/python/Makefile
@@ -6,7 +6,7 @@
 -include ../makefile.inc
 
 ifneq ($(strip $(NVCC)),)
-	SWIGFLAGS = -DGPU_WRAPPER
+	SWIGFLAGS += -DGPU_WRAPPER
 endif
 
 all: build

--- a/python/faiss.py
+++ b/python/faiss.py
@@ -15,16 +15,7 @@ import pdb
 
 
 # we import * so that the symbol X can be accessed as faiss.X
-
-try:
-    from swigfaiss_gpu import *
-except ImportError as e:
-
-    if 'No module named' not in e.args[0]:
-        # swigfaiss_gpu is there but failed to load: Warn user about it.
-        sys.stderr.write("Failed to load GPU Faiss: %s\n" % e.args[0])
-        sys.stderr.write("Faiss falling back to CPU-only.\n")
-    from swigfaiss import *
+from swigfaiss import *
 
 __version__ = "%d.%d.%d" % (FAISS_VERSION_MAJOR,
                             FAISS_VERSION_MINOR,

--- a/python/faiss.py
+++ b/python/faiss.py
@@ -15,7 +15,16 @@ import pdb
 
 
 # we import * so that the symbol X can be accessed as faiss.X
-from .swigfaiss import *
+
+try:
+    from swigfaiss_gpu import *
+except ImportError as e:
+
+    if 'No module named' not in e.args[0]:
+        # swigfaiss_gpu is there but failed to load: Warn user about it.
+        sys.stderr.write("Failed to load GPU Faiss: %s\n" % e.args[0])
+        sys.stderr.write("Faiss falling back to CPU-only.\n")
+    from swigfaiss import *
 
 __version__ = "%d.%d.%d" % (FAISS_VERSION_MAJOR,
                             FAISS_VERSION_MINOR,
@@ -218,11 +227,20 @@ def handle_IndexBinary(the_class):
                       swig_ptr(labels))
         return distances, labels
 
+    def replacement_remove_ids(self, x):
+        if isinstance(x, IDSelector):
+            sel = x
+        else:
+            assert x.ndim == 1
+            sel = IDSelectorBatch(x.size, swig_ptr(x))
+        return self.remove_ids_c(sel)
+
     replace_method(the_class, 'add', replacement_add)
     replace_method(the_class, 'add_with_ids', replacement_add_with_ids)
     replace_method(the_class, 'train', replacement_train)
     replace_method(the_class, 'search', replacement_search)
     replace_method(the_class, 'reconstruct', replacement_reconstruct)
+    replace_method(the_class, 'remove_ids', replacement_remove_ids)
 
 
 def handle_VectorTransform(the_class):
@@ -375,11 +393,14 @@ add_ref_in_constructor(Level1Quantizer, 0)
 add_ref_in_constructor(IndexIVFScalarQuantizer, 0)
 add_ref_in_constructor(IndexIDMap, 0)
 add_ref_in_constructor(IndexIDMap2, 0)
+add_ref_in_constructor(IndexHNSW, 0)
 add_ref_in_method(IndexShards, 'add_shard', 0)
 add_ref_in_method(IndexBinaryShards, 'add_shard', 0)
 add_ref_in_constructor(IndexRefineFlat, 0)
 add_ref_in_constructor(IndexBinaryIVF, 0)
 add_ref_in_constructor(IndexBinaryFromFloat, 0)
+add_ref_in_constructor(IndexBinaryIDMap, 0)
+add_ref_in_constructor(IndexBinaryIDMap2, 0)
 
 add_ref_in_method(IndexReplicas, 'addIndex', 0)
 add_ref_in_method(IndexBinaryReplicas, 'addIndex', 0)
@@ -507,21 +528,45 @@ def kmax(array, k):
     return D, I
 
 
+def pairwise_distances(xq, xb, mt=METRIC_L2, metric_arg=0):
+    """compute the whole pairwise distance matrix between two sets of
+    vectors"""
+    nq, d = xq.shape
+    nb, d2 = xb.shape
+    assert d == d2
+    dis = np.empty((nq, nb), dtype='float32')
+    if mt == METRIC_L2:
+        pairwise_L2sqr(
+            d, nq, swig_ptr(xq),
+            nb, swig_ptr(xb),
+            swig_ptr(dis))
+    else:
+        pairwise_extra_distances(
+            d, nq, swig_ptr(xq),
+            nb, swig_ptr(xb),
+            mt, metric_arg,
+            swig_ptr(dis))
+    return dis
+
+
+
+
 def rand(n, seed=12345):
     res = np.empty(n, dtype='float32')
-    float_rand(swig_ptr(res), n, seed)
+    float_rand(swig_ptr(res), res.size, seed)
     return res
 
 
-def lrand(n, seed=12345):
+def randint(n, seed=12345):
     res = np.empty(n, dtype='int64')
-    long_rand(swig_ptr(res), n, seed)
+    int64_rand(swig_ptr(res), res.size, seed)
     return res
 
+lrand = randint
 
 def randn(n, seed=12345):
     res = np.empty(n, dtype='float32')
-    float_randn(swig_ptr(res), n, seed)
+    float_randn(swig_ptr(res), res.size, seed)
     return res
 
 
@@ -591,7 +636,7 @@ class Kmeans:
         centroids = vector_float_to_array(clus.centroids)
         self.centroids = centroids.reshape(self.k, d)
         self.obj = vector_float_to_array(clus.obj)
-        return self.obj[-1]
+        return self.obj[-1] if self.obj.size > 0 else 0.0
 
     def assign(self, x):
         assert self.centroids is not None, "should train before assigning"

--- a/python/swigfaiss.swig
+++ b/python/swigfaiss.swig
@@ -14,7 +14,11 @@
 // SWIGPYTHON: Python-specific code
 // GPU_WRAPPER: also compile interfaces for GPU.
 
+#ifdef GPU_WRAPPER
+%module swigfaiss_gpu;
+#else
 %module swigfaiss;
+#endif
 
 // fbode SWIG fails on warnings, so make them non fatal
 #pragma SWIG nowarn=321
@@ -27,6 +31,7 @@
 
 typedef unsigned long uint64_t;
 typedef uint64_t size_t;
+typedef long int64_t ;
 typedef int int32_t;
 typedef unsigned char uint8_t;
 
@@ -97,6 +102,7 @@ extern "C" {
 
 #include "IVFlib.h"
 #include "utils.h"
+#include "distances.h"
 #include "Heap.h"
 #include "AuxIndexStructures.h"
 #include "OnDiskInvertedLists.h"
@@ -109,7 +115,53 @@ extern "C" {
 
 
 
- %}
+%}
+
+/********************************************************
+ * GIL manipulation and exception handling
+ ********************************************************/
+
+#ifdef SWIGPYTHON
+// %catches(faiss::FaissException);
+
+
+// Python-specific: release GIL by default for all functions
+%exception {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+        $action
+    } catch(faiss::FaissException & e) {
+        PyEval_RestoreThread(_save);
+
+        if (PyErr_Occurred()) {
+            // some previous code already set the error type.
+        } else {
+            PyErr_SetString(PyExc_RuntimeError, e.what());
+        }
+        SWIG_fail;
+    } catch(std::bad_alloc & ba) {
+        PyEval_RestoreThread(_save);
+        PyErr_SetString(PyExc_MemoryError, "std::bad_alloc");
+        SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+}
+
+#endif
+
+#ifdef SWIGLUA
+
+%exception {
+    try {
+        $action
+    } catch(faiss::FaissException & e) {
+        SWIG_Lua_pushferrstring(L, "C++ exception: %s", e.what());       \
+        goto fail;
+    }
+}
+
+#endif
+
 
 /*******************************************************************
  * Types of vectors we want to manipulate at the scripting language
@@ -151,8 +203,6 @@ namespace std {
 %template(ByteVectorVector) std::vector<std::vector<unsigned char> >;
 %template(LongVectorVector) std::vector<std::vector<long> >;
 
-
-
 #ifdef GPU_WRAPPER
 %template(GpuResourcesVector) std::vector<faiss::gpu::GpuResources*>;
 #endif
@@ -162,48 +212,9 @@ namespace std {
 // produces an error on the Mac
 %ignore faiss::hamming;
 
-
 /*******************************************************************
  * Parse headers
  *******************************************************************/
-
-#ifdef SWIGPYTHON
-// %catches(faiss::FaissException);
-
-
-// Python-specific: release GIL by default for all functions
-%exception {
-    Py_BEGIN_ALLOW_THREADS
-    try {
-        $action
-    } catch(faiss::FaissException & e) {
-        PyEval_RestoreThread(_save);
-
-        if (PyErr_Occurred()) {
-            // some previous code already set the error type.
-        } else {
-            PyErr_SetString(PyExc_RuntimeError, e.what());
-        }
-        SWIG_fail;
-    }
-    Py_END_ALLOW_THREADS
-}
-
-#endif
-
-#ifdef SWIGLUA
-
-%exception {
-    try {
-        $action
-    } catch(faiss::FaissException & e) {
-        SWIG_Lua_pushferrstring(L, "C++ exception: %s", e.what());       \
-        goto fail;
-    }
-}
-
-#endif
-
 
 
 %ignore *::cmp;
@@ -262,6 +273,8 @@ int get_num_gpus()
 %include "Index.h"
 %include "Clustering.h"
 
+%include "distances.h"
+
 %ignore faiss::ProductQuantizer::get_centroids(size_t,size_t) const;
 
 %include "ProductQuantizer.h"
@@ -313,6 +326,10 @@ int get_num_gpus()
 
 
 %include "MetaIndexes.h"
+%template(IndexIDMap) faiss::IndexIDMapTemplate<faiss::Index>;
+%template(IndexBinaryIDMap) faiss::IndexIDMapTemplate<faiss::IndexBinary>;
+%template(IndexIDMap2) faiss::IndexIDMap2Template<faiss::Index>;
+%template(IndexBinaryIDMap2) faiss::IndexIDMap2Template<faiss::IndexBinary>;
 
 #ifdef GPU_WRAPPER
 
@@ -329,6 +346,15 @@ int get_num_gpus()
 %include "gpu/GpuIndexIVFFlat.h"
 %include "gpu/GpuIndexBinaryFlat.h"
 %include "gpu/GpuDistance.h"
+
+#ifdef SWIGLUA
+
+/// in Lua, swigfaiss_gpu is known as swigfaiss
+%luacode {
+local swigfaiss = swigfaiss_gpu
+}
+
+#endif
 
 
 #endif
@@ -478,7 +504,8 @@ struct AsyncIndexSearchC {
 
 // Subclasses should appear before their parent
 %typemap(out) faiss::Index * {
-    DOWNCAST ( IndexIDMap )
+    DOWNCAST2 ( IndexIDMap, IndexIDMapTemplateT_faiss__Index_t )
+    DOWNCAST2 ( IndexIDMap2, IndexIDMap2TemplateT_faiss__Index_t )
     DOWNCAST2 ( IndexShards, IndexShardsTemplateT_faiss__Index_t )
     DOWNCAST2 ( IndexReplicas, IndexReplicasTemplateT_faiss__Index_t )
     DOWNCAST ( IndexIVFPQR )
@@ -522,6 +549,8 @@ struct AsyncIndexSearchC {
 
 %typemap(out) faiss::IndexBinary * {
     DOWNCAST2 ( IndexBinaryReplicas, IndexReplicasTemplateT_faiss__IndexBinary_t )
+    DOWNCAST2 ( IndexBinaryIDMap, IndexIDMapTemplateT_faiss__IndexBinary_t )
+    DOWNCAST2 ( IndexBinaryIDMap2, IndexIDMap2TemplateT_faiss__IndexBinary_t )
     DOWNCAST ( IndexBinaryIVF )
     DOWNCAST ( IndexBinaryFlat )
     DOWNCAST ( IndexBinaryFromFloat )
@@ -837,6 +866,7 @@ int * cast_integer_to_int_ptr (long x) {
 %ignore faiss::IDSelectorBatch::bloom;
 
 %ignore faiss::InterruptCallback::instance;
+%ignore faiss::InterruptCallback::lock;
 %include "AuxIndexStructures.h"
 
 %{
@@ -884,10 +914,8 @@ struct MapLong2Long {
 %}
 
 %inline %{
-
     void wait() {
-        // in gdb
-        // set variable i = 1
+        // in gdb, use return to get out of this function
         for(int i = 0; i == 0; i += 0);
     }
  %}

--- a/python/swigfaiss.swig
+++ b/python/swigfaiss.swig
@@ -804,16 +804,16 @@ TYPE_CONVERSION (uint8_t, ByteTensor)
 
 // answer: the same as the C++ typedefs, but we still have to redefine them
 
-%template() faiss::CMin<float, long>;
-%template() faiss::CMin<int, long>;
-%template() faiss::CMax<float, long>;
-%template() faiss::CMax<int, long>;
+%template() faiss::CMin<float, int64_t>;
+%template() faiss::CMin<int, int64_t>;
+%template() faiss::CMax<float, int64_t>;
+%template() faiss::CMax<int, int64_t>;
 
-%template(float_minheap_array_t) faiss::HeapArray<faiss::CMin<float, long> >;
-%template(int_minheap_array_t) faiss::HeapArray<faiss::CMin<int, long> >;
+%template(float_minheap_array_t) faiss::HeapArray<faiss::CMin<float, int64_t> >;
+%template(int_minheap_array_t) faiss::HeapArray<faiss::CMin<int, int64_t> >;
 
-%template(float_maxheap_array_t) faiss::HeapArray<faiss::CMax<float, long> >;
-%template(int_maxheap_array_t) faiss::HeapArray<faiss::CMax<int, long> >;
+%template(float_maxheap_array_t) faiss::HeapArray<faiss::CMax<float, int64_t> >;
+%template(int_maxheap_array_t) faiss::HeapArray<faiss::CMax<int, int64_t> >;
 
 
 /*******************************************************************

--- a/python/swigfaiss.swig
+++ b/python/swigfaiss.swig
@@ -25,6 +25,7 @@
 #pragma SWIG nowarn=512
 
 %include <stdint.i>
+typedef int64_t size_t;
 
 #define __restrict
 
@@ -746,13 +747,8 @@ PyObject * rev_swig_ptr(ctype *src, size_t size);
 REV_SWIG_PTR(float, NPY_FLOAT32);
 REV_SWIG_PTR(int, NPY_INT32);
 REV_SWIG_PTR(unsigned char, NPY_UINT8);
-#ifdef SWIGWORDSIZE64
-REV_SWIG_PTR(long, NPY_INT64);
-REV_SWIG_PTR(unsigned long, NPY_UINT64);
-#else
-REV_SWIG_PTR(long long, NPY_INT64);
-REV_SWIG_PTR(unsigned long long, NPY_UINT64);
-#endif
+REV_SWIG_PTR(int64_t, NPY_INT64);
+REV_SWIG_PTR(uint64_t, NPY_UINT64);
 
 #endif
 
@@ -890,16 +886,16 @@ void ignore_SIGTTIN();
 // represents not found values as -1 like in the Index implementation
 
 struct MapLong2Long {
-    std::unordered_map<long, long> map;
+    std::unordered_map<int64_t, int64_t> map;
 
-    void add(size_t n, const long *keys, const long *vals) {
+    void add(size_t n, const int64_t *keys, const int64_t *vals) {
         map.reserve(map.size() + n);
         for (size_t i = 0; i < n; i++) {
             map[keys[i]] = vals[i];
         }
     }
 
-    long search(long key) {
+    long search(int64_t key) {
         if (map.count(key) == 0) {
             return -1;
         } else {
@@ -907,7 +903,7 @@ struct MapLong2Long {
         }
     }
 
-    void search_multiple(size_t n, const long *keys, long * vals) {
+    void search_multiple(size_t n, int64_t *keys, int64_t * vals) {
         for (size_t i = 0; i < n; i++) {
             vals[i] = search(keys[i]);
         }

--- a/python/swigfaiss.swig
+++ b/python/swigfaiss.swig
@@ -24,7 +24,7 @@
 #pragma SWIG nowarn=341
 #pragma SWIG nowarn=512
 
-#include <stdint.i>
+%include <stdint.i>
 
 #define __restrict
 
@@ -683,10 +683,18 @@ PyObject *swig_ptr (PyObject *a)
         return SWIG_NewPointerObj(data, SWIGTYPE_p_char, 0);
     }
     if(PyArray_TYPE(ao) == NPY_UINT64) {
+#ifdef SWIGWORDSIZE64
         return SWIG_NewPointerObj(data, SWIGTYPE_p_unsigned_long, 0);
+#else
+        return SWIG_NewPointerObj(data, SWIGTYPE_p_unsigned_long_long, 0);
+#endif
     }
     if(PyArray_TYPE(ao) == NPY_INT64) {
+#ifdef SWIGWORDSIZE64
         return SWIG_NewPointerObj(data, SWIGTYPE_p_long, 0);
+#else
+        return SWIG_NewPointerObj(data, SWIGTYPE_p_long_long, 0);
+#endif
     }
     PyErr_SetString(PyExc_ValueError, "did not recognize array type");
     return NULL;
@@ -738,9 +746,13 @@ PyObject * rev_swig_ptr(ctype *src, size_t size);
 REV_SWIG_PTR(float, NPY_FLOAT32);
 REV_SWIG_PTR(int, NPY_INT32);
 REV_SWIG_PTR(unsigned char, NPY_UINT8);
-REV_SWIG_PTR(unsigned long, NPY_UINT64);
+#ifdef SWIGWORDSIZE64
 REV_SWIG_PTR(long, NPY_INT64);
-
+REV_SWIG_PTR(unsigned long, NPY_UINT64);
+#else
+REV_SWIG_PTR(long long, NPY_INT64);
+REV_SWIG_PTR(unsigned long long, NPY_UINT64);
+#endif
 
 #endif
 

--- a/python/swigfaiss.swig
+++ b/python/swigfaiss.swig
@@ -28,12 +28,7 @@
 #pragma SWIG nowarn=341
 #pragma SWIG nowarn=512
 
-
-typedef unsigned long uint64_t;
-typedef uint64_t size_t;
-typedef long int64_t ;
-typedef int int32_t;
-typedef unsigned char uint8_t;
+#include <stdint.i>
 
 #define __restrict
 

--- a/python/swigfaiss.swig
+++ b/python/swigfaiss.swig
@@ -14,11 +14,7 @@
 // SWIGPYTHON: Python-specific code
 // GPU_WRAPPER: also compile interfaces for GPU.
 
-#ifdef GPU_WRAPPER
-%module swigfaiss_gpu;
-#else
 %module swigfaiss;
-#endif
 
 // fbode SWIG fails on warnings, so make them non fatal
 #pragma SWIG nowarn=321

--- a/tests/common.py
+++ b/tests/common.py
@@ -62,8 +62,11 @@ class Randu10kUnbalanced(Randu10k):
         rs = np.random.RandomState(123)
         weights = weights[rs.permutation(self.d)]
         self.xb *= weights
+        self.xb /= np.linalg.norm(self.xb, axis=1)[:, np.newaxis]
         self.xq *= weights
+        self.xq /= np.linalg.norm(self.xq, axis=1)[:, np.newaxis]
         self.xt *= weights
+        self.xt /= np.linalg.norm(self.xt, axis=1)[:, np.newaxis]
 
         dotprods = np.dot(self.xq, self.xb.T)
         self.gt = dotprods.argmax(1)

--- a/tests/test_build_blocks.py
+++ b/tests/test_build_blocks.py
@@ -74,6 +74,15 @@ class TestClustering(unittest.TestCase):
 
         self.assertGreater(obj1[-1], obj10[-1])
 
+    def test_1ptpercluster(self):
+        # https://github.com/facebookresearch/faiss/issues/842
+        X = np.random.randint(0, 1, (5, 10)).astype('float32')
+        k = 5
+        niter = 10
+        verbose = True
+        kmeans = faiss.Kmeans(X.shape[1], k, niter=niter, verbose=verbose)
+        kmeans.train(X)
+        l2_distances, I = kmeans.index.search(X, 1)
 
 
 class TestPCA(unittest.TestCase):
@@ -420,10 +429,6 @@ class TestScalarQuantizer(unittest.TestCase):
                     dis = ((y[i] - x2[I[i, j]]) ** 2).sum()
                     print(dis, D[i, j])
                     assert abs(D[i, j] - dis) / dis < 1e-5
-
-
-
-
 
 
 if __name__ == '__main__':

--- a/tests/test_extra_distances.py
+++ b/tests/test_extra_distances.py
@@ -1,0 +1,137 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+#! /usr/bin/env python2
+# noqa E741
+
+import numpy as np
+
+import faiss
+import unittest
+
+from common import get_dataset_2
+
+import scipy.spatial.distance
+
+
+class TestExtraDistances(unittest.TestCase):
+    """ check wrt. the scipy implementation """
+
+    def make_example(self):
+        rs = np.random.RandomState(123)
+        x = rs.rand(5, 32).astype('float32')
+        y = rs.rand(3, 32).astype('float32')
+        return x, y
+
+    def run_simple_dis_test(self, ref_func, metric_type):
+        xq, yb = self.make_example()
+        ref_dis = np.array([
+            [ref_func(x, y) for y in yb]
+            for x in xq
+        ])
+        new_dis = faiss.pairwise_distances(xq, yb, metric_type)
+        self.assertTrue(np.allclose(ref_dis, new_dis))
+
+    def test_L1(self):
+        self.run_simple_dis_test(scipy.spatial.distance.cityblock,
+                                 faiss.METRIC_L1)
+
+    def test_Linf(self):
+        self.run_simple_dis_test(scipy.spatial.distance.chebyshev,
+                                 faiss.METRIC_Linf)
+
+    def test_L2(self):
+        xq, yb = self.make_example()
+        ref_dis = np.array([
+            [scipy.spatial.distance.sqeuclidean(x, y) for y in yb]
+            for x in xq
+        ])
+        new_dis = faiss.pairwise_distances(xq, yb, faiss.METRIC_L2)
+        self.assertTrue(np.allclose(ref_dis, new_dis))
+
+        ref_dis = np.array([
+            [scipy.spatial.distance.euclidean(x, y) for y in yb]
+            for x in xq
+        ])
+        new_dis = np.sqrt(new_dis)        # post processing
+        self.assertTrue(np.allclose(ref_dis, new_dis))
+
+    def test_Lp(self):
+        p = 1.5
+        xq, yb = self.make_example()
+        ref_dis = np.array([
+            [scipy.spatial.distance.minkowski(x, y, p) for y in yb]
+            for x in xq
+        ])
+        new_dis = faiss.pairwise_distances(xq, yb, faiss.METRIC_Lp, p)
+        new_dis = new_dis ** (1 / p)     # post processing
+        self.assertTrue(np.allclose(ref_dis, new_dis))
+
+    def test_canberra(self):
+        self.run_simple_dis_test(scipy.spatial.distance.canberra,
+                                 faiss.METRIC_Canberra)
+
+    def test_braycurtis(self):
+        self.run_simple_dis_test(scipy.spatial.distance.braycurtis,
+                                 faiss.METRIC_BrayCurtis)
+
+    def xx_test_jensenshannon(self):
+        # this distance does not seem to be implemented in scipy
+        # vectors should probably be L1 normalized
+        self.run_simple_dis_test(scipy.spatial.distance.jensenshannon,
+                                 faiss.METRIC_JensenShannon)
+
+
+class TestKNN(unittest.TestCase):
+    """ test that the knn search gives the same as distance matrix + argmin """
+
+    def do_test_knn(self, mt):
+        d = 10
+        nb = 100
+        nq = 50
+        nt = 0
+        xt, xb, xq = get_dataset_2(d, nb, nt, nq)
+
+        index = faiss.IndexFlat(d, mt)
+        index.add(xb)
+
+        D, I = index.search(xq, 10)
+
+        dis = faiss.pairwise_distances(xq, xb, mt)
+        o = dis.argsort(axis=1)
+        assert np.all(I == o[:, :10])
+
+        for q in range(nq):
+            assert np.all(D[q] == dis[q, I[q]])
+
+    def test_L1(self):
+        self.do_test_knn(faiss.METRIC_L1)
+
+    def test_Linf(self):
+        self.do_test_knn(faiss.METRIC_Linf)
+
+
+class TestHNSW(unittest.TestCase):
+    """ since it has a distance computer, HNSW should work """
+
+    def test_hnsw(self):
+
+        d = 10
+        nb = 1000
+        nq = 100
+        nt = 0
+        xt, xb, xq = get_dataset_2(d, nb, nt, nq)
+
+        mt = faiss.METRIC_L1
+
+        index = faiss.IndexHNSW(faiss.IndexFlat(d, mt))
+        index.add(xb)
+
+        D, I = index.search(xq, 10)
+
+        dis = faiss.pairwise_distances(xq, xb, mt)
+
+        for q in range(nq):
+            assert np.all(D[q] == dis[q, I[q]])

--- a/tests/test_index_accuracy.py
+++ b/tests/test_index_accuracy.py
@@ -511,7 +511,8 @@ class OPQRelativeAccuracy(unittest.TestCase):
         print('e_opq=%s' % e_opq)
 
         # verify that OPQ better than PQ
-        assert(e_opq[10] > e_pq[10])
+        for r in 1, 10, 100:
+            assert(e_opq[r] > e_pq[r])
 
     def test_OIVFPQ(self):
         # Parameters inverted indexes
@@ -527,6 +528,7 @@ class OPQRelativeAccuracy(unittest.TestCase):
         res = ev.launch('IVFPQ', index)
         e_ivfpq = ev.evalres(res)
 
+        quantizer = faiss.IndexFlatL2(d)
         index_ivfpq = faiss.IndexIVFPQ(quantizer, d, ncentroids, M, 8)
         index_ivfpq.nprobe = 5
         opq_matrix = faiss.OPQMatrix(d, M)
@@ -536,9 +538,9 @@ class OPQRelativeAccuracy(unittest.TestCase):
         res = ev.launch('O+IVFPQ', index)
         e_oivfpq = ev.evalres(res)
 
-        # TODO(beauby): Fix and re-enable.
         # verify same on OIVFPQ
-        # assert(e_oivfpq[1] > e_ivfpq[1])
+        for r in 1, 10, 100:
+            assert(e_oivfpq[r] > e_ivfpq[r])
 
 
 class TestRoundoff(unittest.TestCase):

--- a/tests/test_index_accuracy.py
+++ b/tests/test_index_accuracy.py
@@ -540,7 +540,8 @@ class OPQRelativeAccuracy(unittest.TestCase):
 
         # verify same on OIVFPQ
         for r in 1, 10, 100:
-            assert(e_oivfpq[r] > e_ivfpq[r])
+            print(e_oivfpq[r], e_ivfpq[r])
+            assert(e_oivfpq[r] >= e_ivfpq[r])
 
 
 class TestRoundoff(unittest.TestCase):

--- a/tests/test_ivfpq_codec.cpp
+++ b/tests/test_ivfpq_codec.cpp
@@ -34,7 +34,7 @@ double eval_codec_error (long ncentroids, long m, const std::vector<float> &v)
 
     // encode and decode to compute reconstruction error
 
-    std::vector<long> keys (nb);
+    std::vector<faiss::Index::idx_t> keys (nb);
     std::vector<uint8_t> codes (nb * m);
     index.encode_multiple (nb, keys.data(), v.data(), codes.data(), true);
 

--- a/tests/test_meta_index.py
+++ b/tests/test_meta_index.py
@@ -42,8 +42,6 @@ class IDRemap(unittest.TestCase):
         index2.train(xt)
         index2.add_with_ids(xb, ids)
 
-        # false = do not add 1 to the returned ids (this is done by
-        # default to accommodate lua indexing)
         _D, I = index2.search(xq, k)
 
         assert np.all(I == nb - 1 - Iref)

--- a/tests/test_ondisk_ivf.cpp
+++ b/tests/test_ondisk_ivf.cpp
@@ -83,10 +83,10 @@ TEST(ONDISK, make_invlists) {
     int ntot = 0;
     for (int i = 0; i < nlist; i++) {
         int size = ivf.list_size(i);
-        const long *ids = ivf.get_ids (i);
+        const faiss::Index::idx_t *ids = ivf.get_ids (i);
         const uint8_t *codes = ivf.get_codes (i);
         for (int j = 0; j < size; j++) {
-            long id = ids[j];
+            faiss::Index::idx_t id = ids[j];
             const int * ar = (const int*)&codes[code_size * j];
             EXPECT_EQ (ar[0], id);
             EXPECT_EQ (ar[1], i);
@@ -204,10 +204,10 @@ TEST(ONDISK, make_invlists_threaded) {
     int ntot = 0;
     for (int i = 0; i < nlist; i++) {
         int size = ivf.list_size(i);
-        const long *ids = ivf.get_ids (i);
+        const faiss::Index::idx_t *ids = ivf.get_ids (i);
         const uint8_t *codes = ivf.get_codes (i);
         for (int j = 0; j < size; j++) {
-            long id = ids[j];
+            faiss::Index::idx_t id = ids[j];
             const int * ar = (const int*)&codes[code_size * j];
             EXPECT_EQ (ar[0], id);
             EXPECT_EQ (ar[1], i);

--- a/tests/test_oom_exception.py
+++ b/tests/test_oom_exception.py
@@ -5,6 +5,7 @@
 
 #! /usr/bin/env python2
 
+import sys
 import faiss
 import unittest
 import resource
@@ -12,6 +13,10 @@ import resource
 class TestOOMException(unittest.TestCase):
 
     def test_outrageous_alloc(self):
+        # Disable test on OSX.
+        if sys.platform == "darwin":
+            return
+
         # https://github.com/facebookresearch/faiss/issues/758
         soft_as, hard_as = resource.getrlimit(resource.RLIMIT_AS)
         # make sure that allocing more than 10G will fail

--- a/tests/test_oom_exception.py
+++ b/tests/test_oom_exception.py
@@ -1,0 +1,32 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+#! /usr/bin/env python2
+
+import faiss
+import unittest
+import resource
+
+class TestOOMException(unittest.TestCase):
+
+    def test_outrageous_alloc(self):
+        # https://github.com/facebookresearch/faiss/issues/758
+        soft_as, hard_as = resource.getrlimit(resource.RLIMIT_AS)
+        # make sure that allocing more than 10G will fail
+        resource.setrlimit(resource.RLIMIT_AS, (10 * 1024 * 1024, hard_as))
+        try:
+            x = faiss.IntVector()
+            try:
+                x.resize(10**11)   # 400 G of RAM
+            except MemoryError:
+                pass               # good, that's what we expect
+            else:
+                assert False, "should raise exception"
+        finally:
+            resource.setrlimit(resource.RLIMIT_AS, (soft_as, hard_as))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_sliding_ivf.cpp
+++ b/tests/test_sliding_ivf.cpp
@@ -90,7 +90,7 @@ void make_index_slices (const Index* trained_index,
         Index * index = sub_indexes.back().get();
 
         auto xb = make_data(nb * d);
-        std::vector<long> ids (nb);
+        std::vector<faiss::Index::idx_t> ids (nb);
         for (int j = 0; j < nb; j++) {
             ids[j] = lrand48();
         }

--- a/utils.cpp
+++ b/utils.cpp
@@ -1227,8 +1227,8 @@ size_t merge_result_table_with (size_t n, size_t k,
 
 
 
-size_t ranklist_intersection_size (size_t k1, const int64_t *v1,
-                                   size_t k2, const int64_t *v2_in)
+size_t ranklist_intersection_size (size_t k1, const Index::idx_t *v1,
+                                   size_t k2, const Index::idx_t *v2_in)
 {
     if (k2 > k1) return ranklist_intersection_size (k2, v2_in, k1, v1);
     int64_t *v2 = new int64_t [k2];

--- a/utils.cpp
+++ b/utils.cpp
@@ -1227,8 +1227,8 @@ size_t merge_result_table_with (size_t n, size_t k,
 
 
 
-size_t ranklist_intersection_size (size_t k1, const Index::idx_t *v1,
-                                   size_t k2, const Index::idx_t *v2_in)
+size_t ranklist_intersection_size (size_t k1, const int64_t *v1,
+                                   size_t k2, const int64_t *v2_in)
 {
     if (k2 > k1) return ranklist_intersection_size (k2, v2_in, k1, v1);
     int64_t *v2 = new int64_t [k2];

--- a/utils.h
+++ b/utils.h
@@ -20,7 +20,6 @@
 #include <random>
 #include <stdint.h>
 
-#include "Index.h"
 #include "Heap.h"
 
 
@@ -335,8 +334,8 @@ void ranklist_handle_ties (int k, int64_t *idx, const float *dis);
 /** count the number of comon elements between v1 and v2
  * algorithm = sorting + bissection to avoid double-counting duplicates
  */
-size_t ranklist_intersection_size (size_t k1, const Index::idx_t *v1,
-                                   size_t k2, const Index::idx_t *v2);
+size_t ranklist_intersection_size (size_t k1, const int64_t *v1,
+                                   size_t k2, const int64_t *v2);
 
 /** merge a result table into another one
  *

--- a/utils.h
+++ b/utils.h
@@ -20,6 +20,7 @@
 #include <random>
 #include <stdint.h>
 
+#include "Index.h"
 #include "Heap.h"
 
 
@@ -334,8 +335,8 @@ void ranklist_handle_ties (int k, int64_t *idx, const float *dis);
 /** count the number of comon elements between v1 and v2
  * algorithm = sorting + bissection to avoid double-counting duplicates
  */
-size_t ranklist_intersection_size (size_t k1, const int64_t *v1,
-                                   size_t k2, const int64_t *v2);
+size_t ranklist_intersection_size (size_t k1, const Index::idx_t *v1,
+                                   size_t k2, const Index::idx_t *v2);
 
 /** merge a result table into another one
  *

--- a/utils_simd.cpp
+++ b/utils_simd.cpp
@@ -89,6 +89,20 @@ float fvec_L1_ref (const float * x,
     return res;
 }
 
+float fvec_Linf_ref (const float * x,
+                     const float * y,
+                     size_t d)
+{
+  float res = 0;
+  for (size_t i = 0; i < d; i++) {
+    const float tmp = fabs(x[i] - y[i]);
+    if (tmp > res) {
+      res = tmp;
+    }
+  }
+  return res;
+}
+
 float fvec_inner_product_ref (const float * x,
                              const float * y,
                              size_t d)

--- a/utils_simd.cpp
+++ b/utils_simd.cpp
@@ -93,12 +93,10 @@ float fvec_Linf_ref (const float * x,
                      const float * y,
                      size_t d)
 {
+  size_t i;
   float res = 0;
-  for (size_t i = 0; i < d; i++) {
-    const float tmp = fabs(x[i] - y[i]);
-    if (tmp > res) {
-      res = tmp;
-    }
+  for (i = 0; i < d; i++) {
+    res = fmax(res, fabs(x[i] - y[i]));
   }
   return res;
 }

--- a/utils_simd.cpp
+++ b/utils_simd.cpp
@@ -62,7 +62,7 @@ namespace faiss {
  * Reference implementations
  */
 
-/* same without SSE */
+
 float fvec_L2sqr_ref (const float * x,
                      const float * y,
                      size_t d)
@@ -72,6 +72,19 @@ float fvec_L2sqr_ref (const float * x,
     for (i = 0; i < d; i++) {
         const float tmp = x[i] - y[i];
        res += tmp * tmp;
+    }
+    return res;
+}
+
+float fvec_L1_ref (const float * x,
+                   const float * y,
+                   size_t d)
+{
+    size_t i;
+    float res = 0;
+    for (i = 0; i < d; i++) {
+        const float tmp = x[i] - y[i];
+        res += fabs(tmp);
     }
     return res;
 }
@@ -385,9 +398,93 @@ float fvec_L2sqr (const float * x,
     return  _mm_cvtss_f32 (msum2);
 }
 
-#elif defined(__SSE__)
+float fvec_L1 (const float * x, const float * y, size_t d)
+{
+    __m256 msum1 = _mm256_setzero_ps();
+    __m256 signmask = __m256(_mm256_set1_epi32 (0x7fffffffUL));
 
-/* SSE-implementation of L2 distance */
+    while (d >= 8) {
+        __m256 mx = _mm256_loadu_ps (x); x += 8;
+        __m256 my = _mm256_loadu_ps (y); y += 8;
+        const __m256 a_m_b = mx - my;
+        msum1 += _mm256_and_ps(signmask, a_m_b);
+        d -= 8;
+    }
+
+    __m128 msum2 = _mm256_extractf128_ps(msum1, 1);
+    msum2 +=       _mm256_extractf128_ps(msum1, 0);
+    __m128 signmask2 = __m128(_mm_set1_epi32 (0x7fffffffUL));
+
+    if (d >= 4) {
+        __m128 mx = _mm_loadu_ps (x); x += 4;
+        __m128 my = _mm_loadu_ps (y); y += 4;
+        const __m128 a_m_b = mx - my;
+        msum2 += _mm_and_ps(signmask2, a_m_b);
+        d -= 4;
+    }
+
+    if (d > 0) {
+        __m128 mx = masked_read (d, x);
+        __m128 my = masked_read (d, y);
+        __m128 a_m_b = mx - my;
+        msum2 += _mm_and_ps(signmask2, a_m_b);
+    }
+
+    msum2 = _mm_hadd_ps (msum2, msum2);
+    msum2 = _mm_hadd_ps (msum2, msum2);
+    return  _mm_cvtss_f32 (msum2);
+}
+
+float fvec_Linf (const float * x, const float * y, size_t d)
+{
+    __m256 msum1 = _mm256_setzero_ps();
+    __m256 signmask = __m256(_mm256_set1_epi32 (0x7fffffffUL));
+
+    while (d >= 8) {
+        __m256 mx = _mm256_loadu_ps (x); x += 8;
+        __m256 my = _mm256_loadu_ps (y); y += 8;
+        const __m256 a_m_b = mx - my;
+        msum1 = _mm256_max_ps(msum1, _mm256_and_ps(signmask, a_m_b));
+        d -= 8;
+    }
+
+    __m128 msum2 = _mm256_extractf128_ps(msum1, 1);
+    msum2 = _mm_max_ps (msum2, _mm256_extractf128_ps(msum1, 0));
+    __m128 signmask2 = __m128(_mm_set1_epi32 (0x7fffffffUL));
+
+    if (d >= 4) {
+        __m128 mx = _mm_loadu_ps (x); x += 4;
+        __m128 my = _mm_loadu_ps (y); y += 4;
+        const __m128 a_m_b = mx - my;
+        msum2 = _mm_max_ps(msum2, _mm_and_ps(signmask2, a_m_b));
+        d -= 4;
+    }
+
+    if (d > 0) {
+        __m128 mx = masked_read (d, x);
+        __m128 my = masked_read (d, y);
+        __m128 a_m_b = mx - my;
+        msum2 = _mm_max_ps(msum2, _mm_and_ps(signmask2, a_m_b));
+    }
+
+    msum2 = _mm_max_ps(_mm_movehl_ps(msum2, msum2), msum2);
+    msum2 = _mm_max_ps(msum2, _mm_shuffle_ps (msum2, msum2, 1));
+    return  _mm_cvtss_f32 (msum2);
+}
+
+#elif defined(__SSE__) // But not AVX
+
+float fvec_L1 (const float * x, const float * y, size_t d)
+{
+    return fvec_L1_ref (x, y, d);
+}
+
+float fvec_Linf (const float * x, const float * y, size_t d)
+{
+    return fvec_Linf_ref (x, y, d);
+}
+
+
 float fvec_L2sqr (const float * x,
                  const float * y,
                  size_t d)
@@ -494,6 +591,16 @@ void fvec_L2sqr_ny (float * dis, const float * x,
     fvec_L2sqr_ny_ref (dis, x, y, d, ny);
 }
 
+float fvec_L1 (const float * x, const float * y, size_t d)
+{
+    return fvec_L1_ref (x, y, d);
+}
+
+float fvec_Linf (const float * x, const float * y, size_t d)
+{
+    return fvec_Linf_ref (x, y, d);
+}
+
 
 #else
 // scalar implementation
@@ -503,6 +610,16 @@ float fvec_L2sqr (const float * x,
                   size_t d)
 {
     return fvec_L2sqr_ref (x, y, d);
+}
+
+float fvec_L1 (const float * x, const float * y, size_t d)
+{
+    return fvec_L1_ref (x, y, d);
+}
+
+float fvec_Linf (const float * x, const float * y, size_t d)
+{
+    return fvec_Linf_ref (x, y, d);
 }
 
 float fvec_inner_product (const float * x,


### PR DESCRIPTION
## Changelog:

### Bugfixes:
- slow scanning of inverted lists (#836).

### Features:
- add basic support for 6 new metrics in CPU `IndexFlat` and `IndexHNSW` (#848);
- add support for `IndexIDMap`/`IndexIDMap2` with binary indexes (#780).

### Misc:
- throw python exception for OOM (#758);
- make `DistanceComputer` available for all random access indexes;
- gradually moving from `long` to `int64_t` for portability.