### PR TITLE
Fix gpu compilation with cuda 10.1 related to #751

### DIFF
--- a/gpu/utils/Tensor.cuh
+++ b/gpu/utils/Tensor.cuh
@@ -358,7 +358,7 @@ bool canUseIndexType() {
 
 template <typename IndexType, typename T, typename... U>
 bool canUseIndexType(const T& arg, const U&... args) {
-  return arg.template canUseIndexType<IndexType>() &&
+  return arg.template canUseIndexType() &&
     canUseIndexType(args...);
 }
 


### PR DESCRIPTION
#771 was not sufficient as the latest platform in my case.
I checked the compilation works with this PR.

```
$ make
...
impl/../utils/Tensor.cuh(362): error: type name is not allowed

impl/../utils/Tensor.cuh(362): error: expected an expression
```

## Platform
### OS
```
$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=18.04
DISTRIB_CODENAME=bionic
DISTRIB_DESCRIPTION="Ubuntu 18.04.2 LTS"
```

### g++
```
$ g++ --version
g++ (Ubuntu 8.3.0-6ubuntu1~18.04.1) 8.3.0
```

### cuda
```
$ nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2019 NVIDIA Corporation
Built on Fri_Feb__8_19:08:17_PST_2019
Cuda compilation tools, release 10.1, V10.1.105
```