### PR TITLE
[C API] June 2019 update

### DIFF
--- a/c_api/AuxIndexStructures_c.cpp
+++ b/c_api/AuxIndexStructures_c.cpp
@@ -89,7 +89,7 @@ int faiss_IDSelectorRange_new(FaissIDSelectorRange** p_sel, idx_t imin, idx_t im
 DEFINE_GETTER(IDSelectorBatch, int, nbits)
 DEFINE_GETTER(IDSelectorBatch, idx_t, mask)
 
-int faiss_IDSelectorBatch_new(FaissIDSelectorBatch** p_sel, long n, const idx_t* indices) {
+int faiss_IDSelectorBatch_new(FaissIDSelectorBatch** p_sel, size_t n, const idx_t* indices) {
     try {
         *p_sel = reinterpret_cast<FaissIDSelectorBatch*>(
             new IDSelectorBatch(n, indices)

--- a/c_api/AuxIndexStructures_c.h
+++ b/c_api/AuxIndexStructures_c.h
@@ -71,7 +71,7 @@ FAISS_DECLARE_CLASS(IDSelectorBatch)
 FAISS_DECLARE_GETTER(IDSelectorBatch, int, nbits)
 FAISS_DECLARE_GETTER(IDSelectorBatch, idx_t, mask)
 
-int faiss_IDSelectorBatch_new(FaissIDSelectorBatch** p_sel, long n, const idx_t* indices);
+int faiss_IDSelectorBatch_new(FaissIDSelectorBatch** p_sel, size_t n, const idx_t* indices);
 
 // Below are structures used only by Index implementations
 

--- a/c_api/IndexIVFFlat_c.cpp
+++ b/c_api/IndexIVFFlat_c.cpp
@@ -48,7 +48,7 @@ int faiss_IndexIVFFlat_new_with_metric(
 }
 
 int faiss_IndexIVFFlat_add_core(FaissIndexIVFFlat* index, idx_t n, 
-    const float * x, const long *xids, const long *precomputed_idx)
+    const float * x, const idx_t *xids, const int64_t *precomputed_idx)
 {
     try {
         reinterpret_cast<IndexIVFFlat*>(index)->add_core(n, x, xids, precomputed_idx);

--- a/c_api/IndexIVFFlat_c.h
+++ b/c_api/IndexIVFFlat_c.h
@@ -37,7 +37,7 @@ int faiss_IndexIVFFlat_new_with_metric(
     FaissMetricType metric);
 
 int faiss_IndexIVFFlat_add_core(FaissIndexIVFFlat* index, idx_t n, 
-    const float * x, const long *xids, const long *precomputed_idx);
+    const float * x, const idx_t *xids, const int64_t *precomputed_idx);
 
 /** Update a subset of vectors.
  *

--- a/c_api/IndexIVF_c.cpp
+++ b/c_api/IndexIVF_c.cpp
@@ -48,8 +48,8 @@ int faiss_IndexIVF_merge_from(
 }
 
 int faiss_IndexIVF_copy_subset_to(
-    const FaissIndexIVF* index, FaissIndexIVF* other, int subset_type, long a1,
-    long a2) {
+    const FaissIndexIVF* index, FaissIndexIVF* other, int subset_type, idx_t a1,
+    idx_t a2) {
     try {
         reinterpret_cast<const IndexIVF*>(index)->copy_subset_to(
             *reinterpret_cast<IndexIVF*>(other), subset_type, a1, a2);

--- a/c_api/IndexIVF_c.h
+++ b/c_api/IndexIVF_c.h
@@ -70,8 +70,8 @@ int faiss_IndexIVF_merge_from(
  *                      elements are left before and a2 elements are after
  */
 int faiss_IndexIVF_copy_subset_to(
-    const FaissIndexIVF* index, FaissIndexIVF* other, int subset_type, long a1,
-    long a2);
+    const FaissIndexIVF* index, FaissIndexIVF* other, int subset_type, idx_t a1,
+    idx_t a2);
 
 /** search a set of vectors, that are pre-quantized by the IVF
  *  quantizer. Fill in the corresponding heaps with the query

--- a/c_api/IndexIVF_c.h
+++ b/c_api/IndexIVF_c.h
@@ -127,36 +127,6 @@ inline void faiss_IndexIVFStats_init(FaissIndexIVFStats* stats) {
     faiss_IndexIVFStats_reset(stats);
 }
 
-/** Inverted file with stored vectors. Here the inverted file
- * pre-selects the vectors to be searched, but they are not otherwise
- * encoded, the code array just contains the raw float entries.
- */
-FAISS_DECLARE_CLASS(IndexIVFFlat)
-FAISS_DECLARE_DESTRUCTOR(IndexIVFFlat)
-
-int faiss_IndexIVFFlat_new(FaissIndexIVFFlat** p_index);
-
-int faiss_IndexIVFFlat_new_with(FaissIndexIVFFlat** p_index,
-    FaissIndex* quantizer, size_t d, size_t nlist);
-
-int faiss_IndexIVFFlat_new_with_metric(
-    FaissIndexIVFFlat** p_index, FaissIndex* quantizer, size_t d, size_t nlist,
-    FaissMetricType metric);
-
-int faiss_IndexIVFFlat_add_core(FaissIndexIVFFlat* index, idx_t n, 
-    const float * x, const long *xids, const long *precomputed_idx);
-
-/** Update a subset of vectors.
- *
- * The index must have a direct_map
- *
- * @param nv     nb of vectors to update
- * @param idx    vector indices to update, size nv
- * @param v      vectors of new values, size nv*d
- */
-int faiss_IndexIVFFlat_update_vectors(FaissIndexIVFFlat* index, int nv,
-    idx_t *idx, const float *v);
-
 #ifdef __cplusplus
 }
 #endif

--- a/c_api/Index_c.cpp
+++ b/c_api/Index_c.cpp
@@ -36,7 +36,7 @@ int faiss_Index_add(FaissIndex* index, idx_t n, const float* x) {
     } CATCH_AND_HANDLE
 }
 
-int faiss_Index_add_with_ids(FaissIndex* index, idx_t n, const float* x, const long* xids) {
+int faiss_Index_add_with_ids(FaissIndex* index, idx_t n, const float* x, const idx_t* xids) {
     try {
         reinterpret_cast<faiss::Index*>(index)->add_with_ids(n, x, xids);
     } CATCH_AND_HANDLE
@@ -69,10 +69,10 @@ int faiss_Index_reset(FaissIndex* index) {
     } CATCH_AND_HANDLE
 }
 
-int faiss_Index_remove_ids(FaissIndex* index, const FaissIDSelector* sel, long* n_removed) {
+int faiss_Index_remove_ids(FaissIndex* index, const FaissIDSelector* sel, size_t* n_removed) {
     try {
-        long n = reinterpret_cast<faiss::Index*>(index)->remove_ids(
-            *reinterpret_cast<const faiss::IDSelector*>(sel));
+        size_t n {reinterpret_cast<faiss::Index*>(index)->remove_ids(
+            *reinterpret_cast<const faiss::IDSelector*>(sel))};
         if (n_removed) {
             *n_removed = n;
         }

--- a/c_api/Index_c.h
+++ b/c_api/Index_c.h
@@ -72,7 +72,7 @@ int faiss_Index_add(FaissIndex* index, idx_t n, const float* x);
  * @param index  opaque pointer to index object
  * @param xids   if non-null, ids to store for the vectors (size n)
  */
-int faiss_Index_add_with_ids(FaissIndex* index, idx_t n, const float* x, const long* xids);
+int faiss_Index_add_with_ids(FaissIndex* index, idx_t n, const float* x, const idx_t* xids);
 
 /** query n vectors of dimension d to the index.
  *
@@ -119,7 +119,7 @@ int faiss_Index_reset(FaissIndex* index);
  * @param index       opaque pointer to index object
  * @param nremove     output for the number of IDs removed
  */
-int faiss_Index_remove_ids(FaissIndex* index, const FaissIDSelector* sel, long* n_removed);
+int faiss_Index_remove_ids(FaissIndex* index, const FaissIDSelector* sel, size_t* n_removed);
 
 /** Reconstruct a stored vector (or an approximation if lossy coding)
  *

--- a/c_api/Makefile
+++ b/c_api/Makefile
@@ -15,6 +15,7 @@ CLIBNAME=libfaiss_c
 LIBCOBJ=error_impl.o Index_c.o IndexFlat_c.o Clustering_c.o AutoTune_c.o \
 	AuxIndexStructures_c.o IndexIVF_c.o IndexIVFFlat_c.o IndexLSH_c.o \
 	index_io_c.o MetaIndexes_c.o IndexShards_c.o
+CFLAGS=-fPIC -m64 -Wno-sign-compare -g -O3 -Wall -Wextra
 
 # Build static and shared object files by default
 all: $(CLIBNAME).a $(CLIBNAME).$(SHAREDEXT)

--- a/c_api/Makefile
+++ b/c_api/Makefile
@@ -36,6 +36,9 @@ bin/example_c: example_c.c $(CLIBNAME).$(SHAREDEXT)
 clean:
 	rm -f $(CLIBNAME).a $(CLIBNAME).$(SHAREDEXT)* *.o bin/example_c
 
+%.o: %.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(CPUFLAGS) -c $< -o $@
+
 # Dependencies
 
 error_impl.o: CXXFLAGS += -I.. $(DEBUGFLAG)

--- a/c_api/MetaIndexes_c.cpp
+++ b/c_api/MetaIndexes_c.cpp
@@ -26,7 +26,7 @@ int faiss_IndexIDMap_new(FaissIndexIDMap** p_index, FaissIndex* index) {
     } CATCH_AND_HANDLE
 }
 
-void faiss_IndexIDMap_id_map(FaissIndexIDMap* index, long** p_id_map, size_t* p_size) {
+void faiss_IndexIDMap_id_map(FaissIndexIDMap* index, idx_t** p_id_map, size_t* p_size) {
     auto idx = reinterpret_cast<IndexIDMap*>(index);
     if (p_id_map)
         *p_id_map = idx->id_map.data();

--- a/c_api/MetaIndexes_c.h
+++ b/c_api/MetaIndexes_c.h
@@ -32,7 +32,7 @@ int faiss_IndexIDMap_new(FaissIndexIDMap** p_index, FaissIndex* index);
  * @param p_id_map    output, the pointer to the beginning of `id_map`.
  * @param p_size  output, the current length of `id_map`.
  */
-void faiss_IndexIDMap_id_map(FaissIndexIDMap* index, long** p_id_map, size_t* p_size);
+void faiss_IndexIDMap_id_map(FaissIndexIDMap* index, idx_t** p_id_map, size_t* p_size);
 
 /** same as IndexIDMap but also provides an efficient reconstruction
     implementation via a 2-way index */

--- a/c_api/example_c.c
+++ b/c_api/example_c.c
@@ -61,7 +61,7 @@ int main() {
     int k = 5;
 
     {       // sanity check: search 5 first vectors of xb
-        long *I = malloc(k * 5 * sizeof(long));
+        idx_t *I = malloc(k * 5 * sizeof(idx_t));
         float *D = malloc(k * 5 * sizeof(float));
         FAISS_TRY(faiss_Index_search(index, 5, xb, k, D, I));
         printf("I=\n");
@@ -73,7 +73,7 @@ int main() {
         free(D);
     }
     {       // search xq
-        long *I = malloc(k * nq * sizeof(long));
+        idx_t *I = malloc(k * nq * sizeof(idx_t));
         float *D = malloc(k * nq * sizeof(float));
         FAISS_TRY(faiss_Index_search(index, 5, xb, k, D, I));
         printf("I=\n");

--- a/c_api/faiss_c.h
+++ b/c_api/faiss_c.h
@@ -13,7 +13,12 @@
 #ifndef FAISS_C_H
 #define FAISS_C_H
 
-typedef long idx_t;    ///< all indices are this type
+#include <stdint.h>
+
+typedef int64_t faiss_idx_t;    ///< all indices are this type
+typedef faiss_idx_t idx_t;
+typedef float faiss_component_t;    ///< all vector components are this type
+typedef float faiss_distance_t;    ///< all distances between vectors are this type
 
 /// Declare an opaque type for a class type `clazz`.
 #define FAISS_DECLARE_CLASS(clazz) \

--- a/c_api/gpu/Makefile
+++ b/c_api/gpu/Makefile
@@ -15,6 +15,8 @@ CLIBNAME=libgpufaiss_c
 LIBGPUCOBJ=GpuAutoTune_c.o GpuClonerOptions_c.o GpuIndex_c.o GpuResources_c.o \
 	StandardGpuResources_c.o
 LIBCOBJ=../libfaiss_c.a
+CFLAGS=-fPIC -m64 -Wno-sign-compare -g -O3 -Wall -Wextra
+CUDACFLAGS=-I$(CUDA_ROOT)/include
 
 # Build shared object file by default
 all: $(CLIBNAME).$(SHAREDEXT)
@@ -34,7 +36,7 @@ $(CLIBNAME).$(SHAREDEXT): $(LIBCOBJ) $(LIBGPUCOBJ) ../../libfaiss.a ../../gpu/$(
 
 # Build GPU example
 bin/example_gpu_c: example_gpu_c.c $(CLIBNAME).$(SHAREDEXT)
-	$(CC) $(CFLAGS) $(CUDACFLAGS) -std=c99 -I. -I.. -o $@ example_gpu_c.c \
+	$(CC) $(CFLAGS) $(CUDACFLAGS) $(NVCCLIBS) -std=c99 -I. -I.. -o $@ example_gpu_c.c \
 	-L. -lgpufaiss_c 
 
 clean:

--- a/c_api/gpu/Makefile
+++ b/c_api/gpu/Makefile
@@ -40,6 +40,9 @@ bin/example_gpu_c: example_gpu_c.c $(CLIBNAME).$(SHAREDEXT)
 clean:
 	rm -f $(CLIBNAME).a $(CLIBNAME).$(SHAREDEXT)* *.o bin/example_gpu_c
 
+%.o: %.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(CPUFLAGS) -c $< -o $@
+
 # Dependencies
 
 GpuAutoTune_c.o: CXXFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)

--- a/c_api/gpu/example_gpu_c.c
+++ b/c_api/gpu/example_gpu_c.c
@@ -71,7 +71,7 @@ int main() {
     int k = 5;
 
     {       // sanity check: search 5 first vectors of xb
-        long *I = malloc(k * 5 * sizeof(long));
+        idx_t *I = malloc(k * 5 * sizeof(idx_t));
         float *D = malloc(k * 5 * sizeof(float));
         FAISS_TRY(faiss_Index_search(index, 5, xb, k, D, I));
         printf("I=\n");
@@ -83,7 +83,7 @@ int main() {
         free(D);
     }
     {       // search xq
-        long *I = malloc(k * nq * sizeof(long));
+        idx_t *I = malloc(k * nq * sizeof(idx_t));
         float *D = malloc(k * nq * sizeof(float));
         FAISS_TRY(faiss_Index_search(index, 5, xb, k, D, I));
         printf("I=\n");


### PR DESCRIPTION
This is a set of changes to adapt the C API to the latest major updates. Quick summary:

- Update Makefiles in c_api to include the relevant flags from makefile.inc
- Type changes: use `idx_t` or `size_t` where appropriate instead of `long`
- Remove a redundant declaration of `FaissIndexIVF`