### PR TITLE
Fix error messages on `make clean` in fresh repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,9 @@ uninstall:
 
 #############################
 # Dependencies
-
+ifdef CXXCPP
 -include depend
+endif
 
 depend: $(SRC) $(GPU_SRC)
 	for i in $^; do \


### PR DESCRIPTION
This PR is a fix for issue: https://github.com/facebookresearch/faiss/issues/787

Include the rule `depend` only when the relevant make variables are set.

To test run make clean on a fresh repository:
```sh
$ make clean
rm -f libfaiss.a libfaiss.
rm -f AutoTune.o AuxIndexStructures.o Clustering.o FaissException.o HNSW.o Heap.o IVFlib.o Index.o IndexBinary.o IndexBinaryFlat.o IndexBinaryFromFloat.o IndexBinaryHNSW.o IndexBinaryIVF.o IndexFlat.o IndexHNSW.o IndexIVF.o IndexIVFFlat.o IndexIVFPQ.o IndexIVFSpectralHash.o IndexLSH.o IndexPQ.o IndexReplicas.o IndexScalarQuantizer.o IndexShards.o InvertedLists.o MetaIndexes.o OnDiskInvertedLists.o PolysemousTraining.o ProductQuantizer.o VectorTransform.o WorkerThread.o distances.o hamming.o index_io.o utils.o utils_simd.o
```