### PR TITLE
Fix Dockerfile build and tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 sift1M
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,17 +13,24 @@ ENV LD_PRELOAD /usr/lib64/libgomp.so.1:/opt/intel/mkl/lib/intel64/libmkl_def.so:
 # Install necessary build tools
 RUN yum install -y gcc-c++ make swig3
 
-# Install necesary headers/libs
-RUN yum install -y python-devel numpy
+# Install Python and necesary headers/libs
+RUN yum -y install https://centos7.iuscommunity.org/ius-release.rpm && \
+    yum -y install python36u-devel python36u-pip && \
+    ln -sf /usr/bin/python3.6 /usr/bin/python && \
+    ln -sf /usr/bin/pip3.6 /usr/bin/pip && \
+    pip install -U pip numpy==1.17.0 scipy==1.3.1 && \
+    rm -rf /root/.cache/pip
 
 COPY . /opt/faiss
 
 WORKDIR /opt/faiss
 
-# --with-cuda=/usr/local/cuda-8.0 
-RUN ./configure --prefix=/usr --libdir=/usr/lib64 --without-cuda
+# --with-cuda=/usr/local/cuda-8.0
+RUN ./configure --prefix=/usr --libdir=/usr/lib64 --without-cuda PYTHONFLAGS="-I/usr/include/python3.6m/ -I/usr/lib64/python3.6/site-packages/numpy/core/include/"
 RUN make -j $(nproc)
 RUN make -C python
 RUN make test
 RUN make install
 RUN make -C demos demo_ivfpq_indexing && ./demos/demo_ivfpq_indexing
+
+ENV PYTHONPATH="$PYTHONPATH:/opt/faiss"

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN make test
 RUN make install
 RUN make -C demos demo_ivfpq_indexing && ./demos/demo_ivfpq_indexing
 
-ENV PYTHONPATH="$PYTHONPATH:/opt/faiss"
+ENV PYTHONPATH="$PYTHONPATH:/opt/faiss/python"

--- a/tests/test_build_blocks.py
+++ b/tests/test_build_blocks.py
@@ -325,7 +325,7 @@ class TestMatrixStats(unittest.TestCase):
         m = rs.rand(40, 20).astype('float32')
         m[5:10] = 0
         comments = faiss.MatrixStats(m).comments
-        print comments
+        print(comments)
         assert 'has 5 copies' in comments
         assert '5 null vectors' in comments
 
@@ -334,7 +334,7 @@ class TestMatrixStats(unittest.TestCase):
         m = rs.rand(40, 20).astype('float32')
         m[::2] = m[1::2]
         comments = faiss.MatrixStats(m).comments
-        print comments
+        print(comments)
         assert '20 vectors are distinct' in comments
 
     def test_dead_dims(self):
@@ -342,7 +342,7 @@ class TestMatrixStats(unittest.TestCase):
         m = rs.rand(40, 20).astype('float32')
         m[:, 5:10] = 0
         comments = faiss.MatrixStats(m).comments
-        print comments
+        print(comments)
         assert '5 dimensions are constant' in comments
 
     def test_rogue_means(self):
@@ -350,7 +350,7 @@ class TestMatrixStats(unittest.TestCase):
         m = rs.rand(40, 20).astype('float32')
         m[:, 5:10] += 12345
         comments = faiss.MatrixStats(m).comments
-        print comments
+        print(comments)
         assert '5 dimensions are too large wrt. their variance' in comments
 
     def test_normalized(self):
@@ -358,7 +358,7 @@ class TestMatrixStats(unittest.TestCase):
         m = rs.rand(40, 20).astype('float32')
         faiss.normalize_L2(m)
         comments = faiss.MatrixStats(m).comments
-        print comments
+        print(comments)
         assert 'vectors are normalized' in comments
 
 


### PR DESCRIPTION
Current [Dockerfile](https://github.com/facebookresearch/faiss/blob/master/Dockerfile) fails on tests building `nvidia-docker build -t faiss github.com/facebookresearch/faiss`:
```
test_shards (test_meta_index.Shards) ... ok
test_openmp (test_omp_threads_py.TestOpenMP) ... ok
test_outrageous_alloc (test_oom_exception.TestOOMException) ... ok
test_IDMap (test_referenced_objects.TestReferenced) ... ok
test_IndexIVF (test_referenced_objects.TestReferenced) ... WARNING clustering 100 points to 10 centroids: please provide at least 390 training points
ok
test_IndexIVF_2 (test_referenced_objects.TestReferenced) ... WARNING clustering 100 points to 10 centroids: please provide at least 390 training points
ok
test_IndexPreTransform (test_referenced_objects.TestReferenced) ... ok
test_IndexPreTransform_2 (test_referenced_objects.TestReferenced) ... ok
test_count_refs (test_referenced_objects.TestReferenced) ... ok
test_shards (test_referenced_objects.TestReferenced) ... ok
test_binary_ivf (test_referenced_objects.TestReferencedBinary) ... WARNING clustering 100 points to 10 centroids: please provide at least 390 training points
ok
test_wrap (test_referenced_objects.TestReferencedBinary) ... ok

======================================================================
ERROR: test_extra_distances (unittest.loader.ModuleImportFailure)
----------------------------------------------------------------------
ImportError: Failed to import test module: test_extra_distances
Traceback (most recent call last):
  File "/usr/lib64/python2.7/unittest/loader.py", line 252, in _find_tests
    module = self._get_module_from_name(name)
  File "/usr/lib64/python2.7/unittest/loader.py", line 230, in _get_module_from_name
    __import__(name)
  File "/opt/faiss/tests/test_extra_distances.py", line 16, in <module>
    import scipy.spatial.distance
ImportError: No module named scipy.spatial.distance


======================================================================
ERROR: test_OIVFPQ (test_index_accuracy.OPQRelativeAccuracy)
----------------------------------------------------------------------

...

Traceback (most recent call last):
  File "/opt/faiss/tests/test_index_accuracy.py", line 522, in test_OIVFPQ
    ev = Randu10kUnbalanced()
  File "/opt/faiss/tests/common.py", line 65, in __init__
    self.xb /= np.linalg.norm(self.xb, axis=1)[:, np.newaxis]
TypeError: norm() got an unexpected keyword argument 'axis'

======================================================================
ERROR: test_OPQ (test_index_accuracy.OPQRelativeAccuracy)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/faiss/tests/test_index_accuracy.py", line 493, in test_OPQ
    ev = Randu10kUnbalanced()
  File "/opt/faiss/tests/common.py", line 65, in __init__
    self.xb /= np.linalg.norm(self.xb, axis=1)[:, np.newaxis]
TypeError: norm() got an unexpected keyword argument 'axis'

----------------------------------------------------------------------
Ran 128 tests in 53.408s

FAILED (errors=3)
make: *** [test] Error 1
```


I replaced outdated Python and NumPy and fix `print` function in a test file.