### PR TITLE
Pass forward prefix option to python install target

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -30,7 +30,7 @@ build: _swigfaiss.so faiss.py
 	$(PYTHON) setup.py build
 
 install: build
-	$(PYTHON) setup.py install
+	$(PYTHON) setup.py install --prefix=$(prefix)
 
 clean:
 	rm -f swigfaiss*.cpp swigfaiss*.o swigfaiss*.py _swigfaiss*.so


### PR DESCRIPTION
The python Makefile install target did not include specifying the same install prefix that is given at configure time and used for the native library and headers. This can cause the python module to be installed into a different location than the libraries/headers when a custom install target is specified. Adding ``--prefix=$(prefix)`` tells the ``setup.py install`` to also install in the same root context as the library/headers.