### PR TITLE
update IndexIVF.cpp function reconstruct_n

### DIFF
--- a/IndexIVF.cpp
+++ b/IndexIVF.cpp
@@ -622,17 +622,16 @@ void IndexIVF::reconstruct_n (idx_t i0, idx_t ni, float* recons) const
 {
     FAISS_THROW_IF_NOT (ni == 0 || (i0 >= 0 && i0 + ni <= ntotal));
 
+    idx_t nc = 0;
     for (idx_t list_no = 0; list_no < nlist; list_no++) {
         size_t list_size = invlists->list_size (list_no);
-        ScopedIds idlist (invlists, list_no);
 
-        for (idx_t offset = 0; offset < list_size; offset++) {
-            idx_t id = idlist[offset];
-            if (!(id >= i0 && id < i0 + ni)) {
+        for (idx_t offset = 0; offset < list_size; offset++, nc++) {
+            if (!(nc >= i0 && nc < i0 + ni)) {
                 continue;
             }
-
-            float* reconstructed = recons + (id - i0) * d;
+            
+            float* reconstructed = recons + (nc - i0) * d;
             reconstruct_from_offset (list_no, offset, reconstructed);
         }
     }


### PR DESCRIPTION
When using the function index.add_with_ids(xb, xb_ids)，if xb_ids not series id, such as: 1,38,21,54;the return of reconstruct_n is error result; because ScopedIds is ids list, so code : idx_t id = idlist[offset]; if (!(id >= i0 && id < i0 + ni)) {...} is logical error

sorry, my English is so poor!!

here is my python test code:
```
import faiss                   # make faiss available
import numpy as np

d = 64                           # dimension
nb = 10000                      # database size
nq = 100                       # nb of queries
np.random.seed(1234)             # make reproducible
xb = np.random.random((nb, d)).astype('float32')
xb[:, 0] += np.arange(nb) / 1000.
xb_ids = nb*30 + np.arange(nb)*3
xq = np.random.random((nq, d)).astype('float32')
xq[:, 0] += np.arange(nq) / 1000.

nlist = 100
k = 4
quantizer = faiss.IndexFlatL2(d)  # the other index
index = faiss.IndexIVFFlat(quantizer, d, nlist)
assert not index.is_trained
index.train(xb)
assert index.is_trained

index.add_with_ids(xb, xb_ids)

i0 = 70
ni = 1000
#re_data = index.reconstruct_n(i0, ni)
#list_dis, list_nos, list_vectors = index.search_and_reconstruct(re_data, 1)
#D, I = index.search(re_data, 1)
#print(list_dis, list_nos[:,0], list_vectors[:,0])
#print((list_nos[:,0] == I[:,0]).all())
#print((re_data == list_vectors[:,0]).all())

def user_reconstruct_n(i0, ni):
    invlists = index.invlists
    if not (ni == 0 or (i0 >= 0 and i0 + ni <= index.ntotal)) :
        return [];

    recons = np.empty((ni, index.d), dtype=np.float32)
    nc = 0
    ri = 0
    for list_no in range(0, index.nlist):
        list_size = index.get_list_size(list_no)

        for li_id in range(0, list_size):
            if nc >= i0 and nc < i0 + ni :
                re_da = np.empty((1, index.d), dtype=np.float32)
                index.reconstruct_from_offset(list_no, li_id, faiss.swig_ptr(re_da))
                print("------")
                print(list_no, li_id)
                recons[ri] = re_da
                ri += 1
            nc +=1

    return recons

re_data = user_reconstruct_n(i0, ni)
list_dis, list_nos, list_vectors = index.search_and_reconstruct(re_data, 1)
D, I = index.search(re_data, 1)
print(list_dis, list_nos[:, 0], list_vectors[:, 0])
print(D[:, 0], I[:, 0])
print((list_nos[:,0] == I[:,0]).all())
print((re_data == list_vectors[:,0]).all())
```