### PR TITLE
Fix GPUSQ copyto bug

### DIFF
--- a/gpu/GpuIndexIVFScalarQuantizer.cu
+++ b/gpu/GpuIndexIVFScalarQuantizer.cu
@@ -139,6 +139,7 @@ GpuIndexIVFScalarQuantizer::copyTo(
 
   GpuIndexIVF::copyTo(index);
   index->sq = sq;
+  index->code_size = sq.code_size;
   index->by_residual = by_residual;
 
   InvertedLists* ivf = new ArrayInvertedLists(nlist, index->code_size);


### PR DESCRIPTION
In  gpu/GpuIndexIVFScalarQuantizer.cu copyTo function. Index->code_size isn't set. And the code_size will be used in creating new invertedlist, which will lead to error.

Solution:
code_size is stored in scalar_quantizer, just assign it to index->code_size.