### PR TITLE
Fix GpuIndexIVF::setNumProbes bug

### DIFF
--- a/gpu/GpuIndexIVFScalarQuantizer.cu
+++ b/gpu/GpuIndexIVFScalarQuantizer.cu
@@ -139,6 +139,7 @@ GpuIndexIVFScalarQuantizer::copyTo(
 
   GpuIndexIVF::copyTo(index);
   index->sq = sq;
+  index->code_size = sq.code_size;
   index->by_residual = by_residual;
 
   InvertedLists* ivf = new ArrayInvertedLists(nlist, index->code_size);


### PR DESCRIPTION
nprobe = nprobe; won't set object member: nprobe.