### PR TITLE
fix compilation error on clang 11

### DIFF
--- a/demos/demo_imi_pq.cpp
+++ b/demos/demo_imi_pq.cpp
@@ -121,7 +121,7 @@ int main ()
                 elapsed() - t0, nb);
 
         std::vector <float> database (nb * d);
-        std::vector <long> ids (nb);
+        std::vector <long long> ids (nb);
         for (size_t i = 0; i < nb; i++) {
             for (size_t j = 0; j < d; j++) {
                 database[i * d + j] = drand48();


### PR DESCRIPTION
this fixes the following compilation issue on macOS Darwin 19/clang 11

```make
demo_imi_pq.cpp:138:33: error: cannot initialize a parameter of type 'const faiss::Index::idx_t *' (aka 'const long long *') with an rvalue of type 'std::__1::vector<long,
      std::__1::allocator<long> >::value_type *' (aka 'long *')
```