### PR TITLE
Enable Tensor Core for cublasHgemm

### DIFF
--- a/gpu/utils/Float16.cu
+++ b/gpu/utils/Float16.cu
@@ -20,6 +20,11 @@ bool getDeviceSupportsFloat16Math(int device) {
           (prop.major == 5 && prop.minor >= 3));
 }
 
+bool getDeviceSupportsTensorCore(int device) {
+  const auto& prop = getDeviceProperties(device);
+  return (prop.major >=7);
+}
+
 __half hostFloat2Half(float a) {
 #if CUDA_VERSION >= 9000
   __half_raw raw;

--- a/gpu/utils/Float16.cuh
+++ b/gpu/utils/Float16.cuh
@@ -70,6 +70,9 @@ struct Half8 {
 /// Returns true if the given device supports native float16 math
 bool getDeviceSupportsFloat16Math(int device);
 
+/// Returns true if the given device supports Tensor Core
+bool getDeviceSupportsTensorCore(int device);
+
 __half hostFloat2Half(float v);
 
 } } // namespace

--- a/gpu/utils/MatrixMult.cu
+++ b/gpu/utils/MatrixMult.cu
@@ -62,6 +62,9 @@ struct CublasGemm<half> {
       half hAlpha = hostFloat2Half(fAlpha);
       half hBeta = hostFloat2Half(fBeta);
 
+      if (getDeviceSupportsTensorCore(getCurrentDevice())) {
+        cublasSetMathMode(handle, CUBLAS_TENSOR_OP_MATH);
+      }
       return cublasHgemm(handle, transa, transb, m, n, k,
                          &hAlpha, A, lda, B, ldb, &hBeta, C, ldc);
     }


### PR DESCRIPTION
This PR makes faiss can use Tensor Core to accelerate computation when useFloat16 and useFloat16Accumulator are set.

In my testing, FP16 computation on Tensor Core is 2.2 faster than FP32 computation.