### PR TITLE
[ C api ] Indexpretransform get underlying index 

### DIFF
--- a/c_api/IndexPreTransform_c.cpp
+++ b/c_api/IndexPreTransform_c.cpp
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#include "IndexPreTransform_c.h"
+#include "IndexPreTransform.h"
+#include "macros_impl.h"
+
+using faiss::Index;
+using faiss::IndexPreTransform;
+
+DEFINE_DESTRUCTOR(IndexPreTransform)
+DEFINE_INDEX_DOWNCAST(IndexPreTransform)
+
+DEFINE_GETTER_PERMISSIVE(IndexPreTransform, FaissIndex*, index)

--- a/c_api/IndexPreTransform_c.h
+++ b/c_api/IndexPreTransform_c.h
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c -*-
+
+#ifndef FAISS_INDEX_PRETRANSFORM_C_H
+#define FAISS_INDEX_PRETRANSFORM_C_H
+
+#include "faiss_c.h"
+#include "Index_c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+FAISS_DECLARE_CLASS(IndexPreTransform)
+FAISS_DECLARE_DESTRUCTOR(IndexPreTransform)
+FAISS_DECLARE_INDEX_DOWNCAST(IndexPreTransform)
+
+FAISS_DECLARE_GETTER(IndexPreTransform, FaissIndex*, index)
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif

--- a/c_api/Makefile
+++ b/c_api/Makefile
@@ -15,7 +15,7 @@ CLIBNAME=libfaiss_c
 LIBCOBJ=error_impl.o Index_c.o IndexFlat_c.o Clustering_c.o AutoTune_c.o \
 	impl/AuxIndexStructures_c.o IndexIVF_c.o IndexIVFFlat_c.o IndexLSH_c.o \
 	index_io_c.o MetaIndexes_c.o IndexShards_c.o index_factory_c.o \
-	clone_index_c.o
+	clone_index_c.o IndexPreTransform_c.o
 CFLAGS=-fPIC -m64 -Wno-sign-compare -g -O3 -Wall -Wextra
 
 # Build static and shared object files by default
@@ -84,3 +84,6 @@ impl/AuxIndexStructures_c.o: impl/AuxIndexStructures_c.cpp impl/AuxIndexStructur
 
 MetaIndexes_c.o: CXXFLAGS += -I.. -I ../impl $(DEBUGFLAG)
 MetaIndexes_c.o: MetaIndexes_c.cpp MetaIndexes_c.h ../MetaIndexes.h macros_impl.h
+
+IndexPreTransform_c.o: CXXFLAGS += -I.. -I ../impl $(DEBUGFLAG)
+IndexPreTransform_c.o: IndexPreTransform_c.cpp IndexPreTransform_c.h ../IndexPreTransform.h macros_impl.h


### PR DESCRIPTION
I work with a index built by factory `"PCAR4,IVF4050,SQ8"`

The feature relying this faiss index need to use the `faiss_Index_reconstruct` function.

`faiss_IndexIVF_make_direct_map` need to be called at first, against the underlying IVF casted index.

To retrieve the the IVF underlying casted index, `faiss_IndexIVF_cast` argument must be the underlying index of the pretransform index

### what already works in python

```python
import numpy as np
d = 12                           # dimension
nb = 100000                      # database size
nq = 10000                       # nb of queries
...
import faiss
conf = "PCAR4,IVF4050,SQ8"
index = faiss.index_factory(d, conf)
index.train(xb[:4050])
index.add(xb)

index_ivf = faiss.downcast_index(index.index)
print(index) #<faiss.swigfaiss_avx2.IndexPreTransform; proxy of <Swig Object of type 'faiss::IndexPreTransform *' at 0x7f344dc97d80> >
print(index.index) #<faiss.swigfaiss_avx2.Index; proxy of <Swig Object of type 'faiss::Index *' at 0x7f3442012d50> >
print(index_ivf) #<faiss.swigfaiss_avx2.IndexIVFScalarQuantizer; proxy of <Swig Object of type 'faiss::IndexIVFScalarQuantizer *' at 0x7f3442012d20> >

index_ivf.make_direct_map()

tester = 70
print(index.reconstruct(tester))
print(xb[tester])

faiss.ParameterSpace().set_index_parameter(index, 'nprobe', 1000)
_, I = index.search( np.array(index.reconstruct(tester)).reshape(1,d), 5)     # actual search
print(I[:5])  # rank 70 is retrieved 👍

```
everything is fine because I am able to get `index.index` 


### what I have to do in Go (Cgo)
```go
var faissIndex *C.FaissIndex

var castedIndexIVF *C.FaissIndexIVF
castedIndexIVF = C.faiss_IndexIVF_cast(faissIndex)
fmt.Printf("casted Index CLAZZ %T => %v\n", castedIndexIVF, castedIndexIVF)
 // casted to nil 😩

var castedPreTransform *C.FaissIndexPreTransform
castedPreTransform = C.faiss_IndexPreTransform_cast(faissIndex)
fmt.Printf("casted Index CLAZZ %T => %v\n", castedPreTransform, castedPreTransform) 
// First step 😉 ok
underIndex := C.faiss_IndexPreTransform_index(castedPreTransform)
fmt.Printf("castedPreTransform index %T => %v\n", underIndex, underIndex)
  // Second step 😜 ok

var castedIndexIVF *C.FaissIndexIVF
castedIndexIVF = C.faiss_IndexIVF_cast(underIndex)
fmt.Printf("underIndex casted Index CLAZZ %T => %v\n", castedIndexIVF, castedIndexIVF)
 // Yeah I got that  IndexIVF 😎
if ret := C.faiss_IndexIVF_make_direct_map(castedIndexIVF, 1); ret != 0 {
    return nil, fmt.Errorf("error status %d: %s", ret, C.GoString(C.faiss_get_last_error()))
// the direct map is done 👌
...
```