### PR TITLE
CI : job with allowed failure to build C api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ env:
 
 matrix:
   include:
-    - os: linux
+    - &base_job
+      os: linux
       compiler: gcc
       addons:
         apt:
@@ -17,6 +18,10 @@ matrix:
 #            - swig3.0
       env:
         - PYTHON_CFLAGS="-I/usr/include/python2.7"
+    - <<: *base_job
+      env:
+        - PYTHON_CFLAGS="-I/usr/include/python2.7"
+        - BUILD_C_API="true"
     - os: linux
       compiler: gcc
       addons:
@@ -86,6 +91,9 @@ matrix:
           update: true
       env:
         - MATRIX_EVAL="which gcc; export CC=/usr/local/bin/gcc CXX=/usr/local/bin/g++"
+    - env:
+        - PYTHON_CFLAGS="-I/usr/include/python2.7"
+        - BUILD_C_API="true"
 
 before_install:
   - eval "$MATRIX_EVAL"
@@ -98,6 +106,7 @@ install:
   - ./configure --without-cuda
   - make
   - make -C python
+  - ./.travis/install_c.sh
 
 script:
   - make test

--- a/.travis/install_c.sh
+++ b/.travis/install_c.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -x
+set -e
+
+if [ -n "${BUILD_C_API}" ]; then
+    cd c_api
+    make
+    cd ..
+fi


### PR DESCRIPTION
following of https://github.com/facebookresearch/faiss/issues/1139#issuecomment-598350870

I duplicated the first job, adding a env var to init C api compilation
I set this duplicated job as `allow_failures`

![image](https://user-images.githubusercontent.com/1442992/76645264-ee6efd00-6558-11ea-98d2-3ea87c26f29c.png)

***


## existing job
![image](https://user-images.githubusercontent.com/1442992/76645328-13fc0680-6559-11ea-908f-6362214625d6.png)

***



## new job with `allow_failures`
![image](https://user-images.githubusercontent.com/1442992/76645486-5f161980-6559-11ea-8af0-62c31466804b.png)

