### PR TITLE
Improve CPU architecture tolerance

### DIFF
--- a/python/faiss.py
+++ b/python/faiss.py
@@ -28,7 +28,7 @@ def instruction_set():
             return "default"
     elif platform.system() == "Linux":
         import numpy.distutils.cpuinfo
-        if "avx2" in numpy.distutils.cpuinfo.cpu.info[0]['flags']:
+        if "avx2" in numpy.distutils.cpuinfo.cpu.info[0].get('flags', ""):
             return "AVX2"
         else:
             return "default"


### PR DESCRIPTION
numpy's CPU info dictionary does not have a 'flags' field on some
CPU architectures (such as ppc64le). Tolerate absence of 'flags'
when checking for instruction set to allow faiss to continue in
non-AVX2 mode on those architectures.