### PR TITLE
Improve CPU architecture tolerance for CUDA build

### DIFF
--- a/makefile.inc.in
+++ b/makefile.inc.in
@@ -13,17 +13,23 @@ LIBS         = @BLAS_LIBS@ @LAPACK_LIBS@ @LIBS@ @NVCC_LIBS@
 PYTHONCFLAGS = @PYTHON_CFLAGS@ -I@NUMPY_INCLUDE@
 SWIGFLAGS    = -DSWIGWORDSIZE64
 
+OS = $(shell uname -s)
+
 NVCC         = @NVCC@
 CUDA_ROOT    = @CUDA_PREFIX@
 CUDA_ARCH    = @CUDA_ARCH@
-NVCCFLAGS    = -I $(CUDA_ROOT)/targets/x86_64-linux/include/ \
+
+CUDA_INCLUDES = -I $(CUDA_ROOT)/include/
+ifeq ($(OS),Linux)
+    CUDA_INCLUDES += -I $(CUDA_ROOT)/targets/$(shell uname -p)-linux/include/
+endif
+
+NVCCFLAGS    = $(CUDA_INCLUDES) \
 -Xcompiler -fPIC \
 -Xcudafe --diag_suppress=unrecognized_attribute \
 $(CUDA_ARCH) \
 -lineinfo \
 -ccbin $(CXX) -DFAISS_USE_FLOAT16
-
-OS = $(shell uname -s)
 
 SHAREDEXT   = so
 SHAREDFLAGS = -shared


### PR DESCRIPTION
Depending on the host architecture type and the CUDA install
packaging type (e.g. .deb, .rpm, .run), CUDA include files can
end up in a couple different locations. Expand the search for
CUDA headers to add top-level 'include/' directory in the CUDA
root. And (on linux) adjust the target-specific search location
to match the build machine architecture.