### PR TITLE
fix free parameterspace

### DIFF
--- a/c_api/AutoTune_c.h
+++ b/c_api/AutoTune_c.h
@@ -31,6 +31,8 @@ void faiss_ParameterRange_values(FaissParameterRange*, double**, size_t*);
  */
 FAISS_DECLARE_CLASS(ParameterSpace)
 
+FAISS_DECLARE_DESTRUCTOR(ParameterSpace)
+
 /// Parameter space default constructor
 int faiss_ParameterSpace_new(FaissParameterSpace** space);
 


### PR DESCRIPTION
ParameterSpace destructor implementation exists but declaration in header file is missing

https://github.com/facebookresearch/faiss/blob/v1.6.3/c_api/AutoTune_c.cpp#L37

it ends up in user code with error
```
faiss/writer/index.go:65:9: could not determine kind of name for C.faiss_ParameterSpace_free
```

the fix resolve this issue