### PR TITLE
Fix demo_ivfpq_indexing_gpu compilation error

### DIFF
--- a/gpu/test/demo_ivfpq_indexing_gpu.cpp
+++ b/gpu/test/demo_ivfpq_indexing_gpu.cpp
@@ -17,6 +17,7 @@
 
 #include <faiss/gpu/StandardGpuResources.h>
 #include <faiss/gpu/GpuIndexIVFPQ.h>
+#include <faiss/gpu/GpuCloner.h>
 
 #include <faiss/gpu/GpuAutoTune.h>
 #include <faiss/index_io.h>


### PR DESCRIPTION
Fix the following compilation error (fix #1191)
```c
demo_ivfpq_indexing_gpu.cpp:88:36: error: ‘index_gpu_to_cpu’ is not a member of ‘faiss::gpu’
         faiss::Index * cpu_index = faiss::gpu::index_gpu_to_cpu (&index);
```