### PR TITLE
python makefile should respect configured prefix

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -30,7 +30,7 @@ build: _swigfaiss.so faiss.py
 	$(PYTHON) setup.py build
 
 install: build
-	$(PYTHON) setup.py install
+	$(PYTHON) setup.py install --prefix=${prefix}
 
 clean:
 	rm -f swigfaiss*.cpp swigfaiss*.o swigfaiss*.py _swigfaiss*.so


### PR DESCRIPTION
Python bindings should be installed in the prefix provided by the config, since the user may want to customize the installation.