### PR TITLE
[C API] Fix GPU library build process

### DIFF
--- a/c_api/example_c.c
+++ b/c_api/example_c.c
@@ -13,6 +13,7 @@
 #include <time.h>
 
 #include "error_c.h"
+#include "index_factory_c.h"
 #include "index_io_c.h"
 #include "Index_c.h"
 #include "IndexFlat_c.h"

--- a/c_api/gpu/GpuAutoTune_c.cpp
+++ b/c_api/gpu/GpuAutoTune_c.cpp
@@ -12,8 +12,10 @@
 #include "GpuClonerOptions_c.h"
 #include "macros_impl.h"
 #include "Index.h"
-#include "gpu/GpuAutoTune.h"
-#include "gpu/GpuClonerOptions.h"
+#include <faiss/gpu/GpuCloner.h>
+#include <faiss/gpu/GpuResources.h>
+#include <faiss/gpu/GpuAutoTune.h>
+#include <faiss/gpu/GpuClonerOptions.h>
 #include <vector>
 
 using faiss::Index;

--- a/c_api/gpu/GpuClonerOptions_c.cpp
+++ b/c_api/gpu/GpuClonerOptions_c.cpp
@@ -9,7 +9,7 @@
 // -*- c++ -*-
 
 #include "GpuClonerOptions_c.h"
-#include "gpu/GpuClonerOptions.h"
+#include <faiss/gpu/GpuClonerOptions.h>
 #include "macros_impl.h"
 
 using faiss::gpu::IndicesOptions;

--- a/c_api/gpu/GpuIndex_c.cpp
+++ b/c_api/gpu/GpuIndex_c.cpp
@@ -8,7 +8,7 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
-#include "gpu/GpuIndex.h"
+#include <faiss/gpu/GpuIndex.h>
 #include "GpuIndex_c.h"
 #include "macros_impl.h"
 

--- a/c_api/gpu/GpuResources_c.cpp
+++ b/c_api/gpu/GpuResources_c.cpp
@@ -9,7 +9,7 @@
 // -*- c++ -*-
 
 #include "gpu/GpuResources_c.h"
-#include "gpu/GpuResources.h"
+#include <faiss/gpu/GpuResources.h>
 #include "macros_impl.h"
 
 using faiss::gpu::GpuResources;

--- a/c_api/gpu/Makefile
+++ b/c_api/gpu/Makefile
@@ -10,7 +10,7 @@
 include ../../makefile.inc
 DEBUGFLAG=-DNDEBUG # no debugging
 
-LIBNAME=libgpufaiss
+LIBNAME=libfaiss
 CLIBNAME=libgpufaiss_c
 LIBGPUCOBJ=GpuAutoTune_c.o GpuClonerOptions_c.o GpuIndex_c.o GpuResources_c.o \
 	StandardGpuResources_c.o
@@ -23,15 +23,15 @@ all: $(CLIBNAME).$(SHAREDEXT)
 
 # Build static object file containing the wrapper implementation only.
 # Consumers are required to link with the C++ standard library and remaining
-# portions of this library: libfaiss_c.a, libfaiss.a, libgpufaiss.a, and libstdc++.
-$(CLIBNAME).a: $(LIBGPUCOBJ) ../../gpu/$(LIBNAME).a
+# portions of this library: libfaiss_c.a, libfaiss.a, and libstdc++.
+$(CLIBNAME).a: $(LIBGPUCOBJ) ../../$(LIBNAME).a
 	ar r $@ $^
 
 # Build dynamic library
-$(CLIBNAME).$(SHAREDEXT): $(LIBCOBJ) $(LIBGPUCOBJ) ../../libfaiss.a ../../gpu/$(LIBNAME).a
+$(CLIBNAME).$(SHAREDEXT): $(LIBCOBJ) $(LIBGPUCOBJ) ../../libfaiss.a
 	$(CXX) $(LDFLAGS) $(SHAREDFLAGS) $(CUDACFLAGS) -o $@ \
 	-Wl,--whole-archive $(LIBCOBJ) ../../libfaiss.a \
-	-Wl,--no-whole-archive -static-libstdc++ $(LIBGPUCOBJ) $(LIBS) ../../gpu/$(LIBNAME).a \
+	-Wl,--no-whole-archive -static-libstdc++ $(LIBGPUCOBJ) $(LIBS) \
 	$(NVCCLDFLAGS) $(NVCCLIBS)
 
 # Build GPU example
@@ -47,17 +47,17 @@ clean:
 
 # Dependencies
 
-GpuAutoTune_c.o: CXXFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
-GpuAutoTune_c.o: GpuAutoTune_c.cpp GpuAutoTune_c.h ../../gpu/GpuAutoTune.h ../Index_c.h ../macros_impl.h
+GpuAutoTune_c.o: CXXFLAGS += -I.. -I../.. -I../../gpu -I../../impl $(CUDACFLAGS) $(DEBUGFLAG)
+GpuAutoTune_c.o: GpuAutoTune_c.cpp GpuAutoTune_c.h ../../gpu/GpuCloner.h ../../gpu/GpuAutoTune.h ../Index_c.h ../macros_impl.h
 
-GpuClonerOptions_c.o: CXXFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
+GpuClonerOptions_c.o: CXXFLAGS += -I.. -I../.. -I../../gpu -I../../impl $(CUDACFLAGS) $(DEBUGFLAG)
 GpuClonerOptions_c.o: GpuClonerOptions_c.cpp GpuClonerOptions_c.h GpuIndicesOptions_c.h ../../gpu/GpuClonerOptions.h ../macros_impl.h
 
-GpuIndex_c.o: CXXFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
+GpuIndex_c.o: CXXFLAGS += -I.. -I../.. -I../../gpu -I../../impl $(CUDACFLAGS) $(DEBUGFLAG)
 GpuIndex_c.o: GpuIndex_c.cpp GpuIndex_c.h ../../gpu/GpuIndex.h ../macros_impl.h
 
-GpuResources_c.o: CXXFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
+GpuResources_c.o: CXXFLAGS += -I.. -I../.. -I../../gpu -I../../impl $(CUDACFLAGS) $(DEBUGFLAG)
 GpuResources_c.o: GpuResources_c.cpp GpuResources_c.h ../../gpu/GpuResources.h ../macros_impl.h
 
-StandardGpuResources_c.o: CXXFLAGS += -I.. -I../.. $(CUDACFLAGS) $(DEBUGFLAG)
+StandardGpuResources_c.o: CXXFLAGS += -I.. -I../.. -I../../gpu -I../../impl $(CUDACFLAGS) $(DEBUGFLAG)
 StandardGpuResources_c.o: StandardGpuResources_c.cpp StandardGpuResources_c.h ../../gpu/StandardGpuResources.h ../macros_impl.h

--- a/c_api/gpu/StandardGpuResources_c.cpp
+++ b/c_api/gpu/StandardGpuResources_c.cpp
@@ -9,7 +9,7 @@
 // -*- c++ -*-
 
 #include "gpu/StandardGpuResources_c.h"
-#include "gpu/StandardGpuResources.h"
+#include <faiss/gpu/StandardGpuResources.h>
 #include "macros_impl.h"
 
 using faiss::gpu::StandardGpuResources;

--- a/c_api/gpu/example_gpu_c.c
+++ b/c_api/gpu/example_gpu_c.c
@@ -13,6 +13,7 @@
 #include <time.h>
 
 #include "error_c.h"
+#include "index_factory_c.h"
 #include "Index_c.h"
 #include "AutoTune_c.h"
 #include "GpuAutoTune_c.h"


### PR DESCRIPTION
The changes in the building process of Faiss v1.5.1 affected the C API building process, which currently still relies on separate libfaiss and libgpufaiss. This was probably overlooked due to the lack of CUDA in CI.

I would be interested in improving the makefiles for the C API eventually, but for now this PR will make building the full C library work again.