### PR TITLE
Add missing algorithm header.

### DIFF
--- a/faiss/IndexBinaryFromFloat.cpp
+++ b/faiss/IndexBinaryFromFloat.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/IndexBinaryFromFloat.h>
 
+#include <algorithm>
 #include <memory>
 #include <faiss/utils/utils.h>
 

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -12,6 +12,7 @@
 
 #include <omp.h>
 
+#include <algorithm>
 #include <cstdio>
 #include <memory>
 

--- a/faiss/impl/AuxIndexStructures.cpp
+++ b/faiss/impl/AuxIndexStructures.cpp
@@ -7,6 +7,7 @@
 
 // -*- c++ -*-
 
+#include <algorithm>
 #include <cstring>
 
 #include <faiss/impl/AuxIndexStructures.h>

--- a/faiss/impl/io.cpp
+++ b/faiss/impl/io.cpp
@@ -7,6 +7,7 @@
 
 // -*- c++ -*-
 
+#include <algorithm>
 #include <cstring>
 #include <cassert>
 

--- a/faiss/utils/distances.cpp
+++ b/faiss/utils/distances.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/utils/distances.h>
 
+#include <algorithm>
 #include <cstdio>
 #include <cassert>
 #include <cstring>

--- a/faiss/utils/extra_distances.cpp
+++ b/faiss/utils/extra_distances.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/utils/distances.h>
 
+#include <algorithm>
 #include <cmath>
 #include <omp.h>
 

--- a/faiss/utils/hamming.cpp
+++ b/faiss/utils/hamming.cpp
@@ -26,6 +26,7 @@
 
 #include <faiss/utils/hamming.h>
 
+#include <algorithm>
 #include <vector>
 #include <memory>
 #include <stdio.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1344 Avoid OpenMP 4.0 custom reduction.
* #1343 Fix unsigned OpenMP loop indices (disallowed in OpenMP 2).
* #1342 Fix long literals used as 64 bit.
* #1341 Replace finite() with std::isfinite().
* #1340 Replace bzero (deprecated in POSIX 2001) with memset.
* #1339 Fix division by zero.
* #1338 Fix format specifiers for size_t/idx_t.
* **#1337 Add missing algorithm header.**

Differential Revision: [D23234965](https://our.internmc.facebook.com/intern/diff/D23234965)