### PR TITLE
Fix format specifiers for size_t/idx_t.

### DIFF
--- a/faiss/AutoTune.cpp
+++ b/faiss/AutoTune.cpp
@@ -13,6 +13,7 @@
 
 #include <faiss/AutoTune.h>
 
+#include <cinttypes>
 #include <cmath>
 
 #include <faiss/impl/FaissAssert.h>
@@ -233,7 +234,7 @@ void OperatingPoints::display (bool only_optimal) const
 {
     const std::vector<OperatingPoint> &pts =
         only_optimal ? optimal_pts : all_pts;
-    printf("Tested %ld operating points, %ld ones are optimal:\n",
+    printf("Tested %zd operating points, %zd ones are optimal:\n",
            all_pts.size(), optimal_pts.size());
 
     for (int i = 0; i < pts.size(); i++) {
@@ -247,7 +248,7 @@ void OperatingPoints::display (bool only_optimal) const
                 }
             }
         }
-        printf ("cno=%ld key=%s perf=%.4f t=%.3f %s\n",
+        printf ("cno=%" PRId64 " key=%s perf=%.4f t=%.3f %s\n",
                 op.cno, op.key.c_str(), op.perf, op.t, star);
     }
 
@@ -566,7 +567,7 @@ void ParameterSpace::set_index_parameter (
 
 void ParameterSpace::display () const
 {
-    printf ("ParameterSpace, %ld parameters, %ld combinations:\n",
+    printf ("ParameterSpace, %zd parameters, %zd combinations:\n",
             parameter_ranges.size (), n_combinations ());
     for (int i = 0; i < parameter_ranges.size(); i++) {
         const ParameterRange & pr = parameter_ranges[i];
@@ -622,7 +623,7 @@ void ParameterSpace::explore (Index *index,
             bool keep = ops->add (perf, t_search, combination_name (cno), cno);
 
             if (verbose)
-                printf("  %ld/%ld: %s perf=%.3f t=%.3f s %s\n", cno, n_comb,
+                printf("  %zd/%zd: %s perf=%.3f t=%.3f s %s\n", cno, n_comb,
                        combination_name (cno).c_str(), perf, t_search,
                        keep ? "*" : "");
         }
@@ -646,7 +647,7 @@ void ParameterSpace::explore (Index *index,
         size_t cno = perm[xp];
 
         if (verbose)
-            printf("  %ld/%d: cno=%ld %s ", xp, n_exp, cno,
+            printf("  %zd/%d: cno=%zd %s ", xp, n_exp, cno,
                    combination_name (cno).c_str());
 
         {

--- a/faiss/Clustering.cpp
+++ b/faiss/Clustering.cpp
@@ -10,6 +10,7 @@
 #include <faiss/Clustering.h>
 #include <faiss/impl/AuxIndexStructures.h>
 
+#include <cinttypes>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
@@ -97,7 +98,7 @@ idx_t subsample_training_set(
 )
 {
     if (clus.verbose) {
-        printf("Sampling a subset of %ld / %ld for training\n",
+        printf("Sampling a subset of %zd / %" PRId64 " for training\n",
                clus.k * clus.max_points_per_centroid, nx);
     }
     std::vector<int> perm (nx);
@@ -269,8 +270,8 @@ void Clustering::train_encoded (idx_t nx, const uint8_t *x_in,
                                 const float *weights) {
 
     FAISS_THROW_IF_NOT_FMT (nx >= k,
-             "Number of training points (%ld) should be at least "
-             "as large as number of clusters (%ld)", nx, k);
+             "Number of training points (%" PRId64 ") should be at least "
+             "as large as number of clusters (%zd)", nx, k);
 
     FAISS_THROW_IF_NOT_FMT ((!codec || codec->d == d),
              "Codec dimension %d not the same as data dimension %d",
@@ -307,15 +308,15 @@ void Clustering::train_encoded (idx_t nx, const uint8_t *x_in,
         del3.reset (weights_new); weights = weights_new;
     } else if (nx < k * min_points_per_centroid) {
         fprintf (stderr,
-                 "WARNING clustering %ld points to %ld centroids: "
-                 "please provide at least %ld training points\n",
+                 "WARNING clustering %" PRId64 " points to %zd centroids: "
+                 "please provide at least %" PRId64 " training points\n",
                  nx, k, idx_t(k) * min_points_per_centroid);
     }
 
     if (nx == k) {
         // this is a corner case, just copy training set to clusters
         if (verbose) {
-            printf("Number of training points (%ld) same as number of "
+            printf("Number of training points (%" PRId64 ") same as number of "
                    "clusters, just copying\n", nx);
         }
         centroids.resize (d * k);
@@ -336,11 +337,11 @@ void Clustering::train_encoded (idx_t nx, const uint8_t *x_in,
 
 
     if (verbose) {
-        printf("Clustering %d points in %ldD to %ld clusters, "
+        printf("Clustering %" PRId64 " points in %zdD to %zd clusters, "
                "redo %d times, %d iterations\n",
-               int(nx), d, k, nredo, niter);
+               nx, d, k, nredo, niter);
         if (codec) {
-            printf("Input data encoded in %ld bytes per vector\n",
+            printf("Input data encoded in %zd bytes per vector\n",
                    codec->sa_code_size ());
         }
     }

--- a/faiss/Index2Layer.cpp
+++ b/faiss/Index2Layer.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/Index2Layer.h>
 
+#include <cinttypes>
 #include <cmath>
 #include <cstdio>
 #include <cassert>
@@ -77,7 +78,7 @@ Index2Layer::~Index2Layer ()
 void Index2Layer::train(idx_t n, const float* x)
 {
     if (verbose) {
-        printf ("training level-1 quantizer %ld vectors in %dD\n",
+        printf ("training level-1 quantizer %" PRId64 " vectors in %dD\n",
                 n, d);
     }
 
@@ -104,7 +105,7 @@ void Index2Layer::train(idx_t n, const float* x)
     }
 
     if (verbose)
-        printf ("training %zdx%zd product quantizer on %ld vectors in %dD\n",
+        printf ("training %zdx%zd product quantizer on %" PRId64 " vectors in %dD\n",
                 pq.M, pq.ksub, n, d);
     pq.verbose = verbose;
     pq.train (n, residuals.data());
@@ -119,7 +120,7 @@ void Index2Layer::add(idx_t n, const float* x)
         for (idx_t i0 = 0; i0 < n; i0 += bs) {
             idx_t i1 = std::min(i0 + bs, n);
             if (verbose) {
-                printf("Index2Layer::add: adding %ld:%ld / %ld\n",
+                printf("Index2Layer::add: adding %" PRId64 ":%" PRId64 " / %" PRId64 "\n",
                        i0, i1, n);
             }
             add (i1 - i0, x + i0 * d);

--- a/faiss/IndexBinary.cpp
+++ b/faiss/IndexBinary.cpp
@@ -10,6 +10,7 @@
 #include <faiss/IndexBinary.h>
 #include <faiss/impl/FaissAssert.h>
 
+#include <cinttypes>
 #include <cstring>
 
 namespace faiss {
@@ -70,7 +71,7 @@ void IndexBinary::search_and_reconstruct(idx_t n, const uint8_t *x, idx_t k,
 }
 
 void IndexBinary::display() const {
-  printf("Index: %s  -> %ld elements\n", typeid (*this).name(), ntotal);
+  printf("Index: %s  -> %" PRId64 " elements\n", typeid (*this).name(), ntotal);
 }
 
 

--- a/faiss/IndexBinaryHNSW.cpp
+++ b/faiss/IndexBinaryHNSW.cpp
@@ -52,7 +52,7 @@ void hnsw_add_vertices(IndexBinaryHNSW& index_hnsw,
   size_t ntotal = n0 + n;
   double t0 = getmillisecs();
   if (verbose) {
-    printf("hnsw_add_vertices: adding %ld elements on top of %ld "
+    printf("hnsw_add_vertices: adding %zd elements on top of %zd "
            "(preset_levels=%d)\n",
            n, n0, int(preset_levels));
   }

--- a/faiss/IndexBinaryHash.cpp
+++ b/faiss/IndexBinaryHash.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/IndexBinaryHash.h>
 
+#include <cinttypes>
 #include <cstdio>
 #include <memory>
 
@@ -271,10 +272,10 @@ size_t IndexBinaryHash::hashtable_size() const
 void IndexBinaryHash::display() const
 {
     for (auto it = invlists.begin(); it != invlists.end(); ++it) {
-        printf("%ld: [", it->first);
+        printf("%" PRId64 ": [", it->first);
         const std::vector<idx_t> & v = it->second.ids;
         for (auto x: v) {
-            printf("%ld ", 0 + x);
+            printf("%" PRId64 " ", x);
         }
         printf("]\n");
 

--- a/faiss/IndexBinaryIVF.cpp
+++ b/faiss/IndexBinaryIVF.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/IndexBinaryIVF.h>
 
+#include <cinttypes>
 #include <cstdio>
 #include <omp.h>
 
@@ -96,7 +97,7 @@ void IndexBinaryIVF::add_core(idx_t n, const uint8_t *x, const idx_t *xids,
     n_add++;
   }
   if (verbose) {
-    printf("IndexBinaryIVF::add_with_ids: added %ld / %ld vectors\n",
+    printf("IndexBinaryIVF::add_with_ids: added %ld / %" PRId64 " vectors\n",
            n_add, n);
   }
   ntotal += n_add;
@@ -221,7 +222,7 @@ void IndexBinaryIVF::train(idx_t n, const uint8_t *x) {
     }
   } else {
     if (verbose) {
-      printf("Training quantizer on %ld vectors in %dD\n", n, d);
+      printf("Training quantizer on %" PRId64 " vectors in %dD\n", n, d);
     }
 
     Clustering clus(d, nlist, cp);
@@ -406,7 +407,7 @@ void search_knn_hamming_heap(const IndexBinaryIVF& ivf,
                 }
                 FAISS_THROW_IF_NOT_FMT
                     (key < (idx_t) ivf.nlist,
-                     "Invalid key=%ld  at ik=%ld nlist=%ld\n",
+                     "Invalid key=%" PRId64 " at ik=%zd nlist=%zd\n",
                      key, ik, ivf.nlist);
 
                 scanner->set_list (key, coarse_dis[i * nprobe + ik]);
@@ -494,7 +495,7 @@ void search_knn_hamming_count(const IndexBinaryIVF& ivf,
       }
       FAISS_THROW_IF_NOT_FMT (
         key < (idx_t) ivf.nlist,
-        "Invalid key=%ld  at ik=%ld nlist=%ld\n",
+        "Invalid key=%" PRId64 " at ik=%zd nlist=%zd\n",
         key, ik, ivf.nlist);
 
       nlistv++;
@@ -668,7 +669,7 @@ void IndexBinaryIVF::range_search(
             if (key < 0) return;
             FAISS_THROW_IF_NOT_FMT (
                     key < (idx_t) nlist,
-                    "Invalid key=%ld  at ik=%ld nlist=%ld\n",
+                    "Invalid key=%" PRId64 " at ik=%zd nlist=%zd\n",
                     key, ik, nlist);
             const size_t list_size = invlists->list_size(key);
 

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -119,7 +119,7 @@ void hnsw_add_vertices(IndexHNSW &index_hnsw,
     size_t ntotal = n0 + n;
     double t0 = getmillisecs();
     if (verbose) {
-        printf("hnsw_add_vertices: adding %ld elements on top of %ld "
+        printf("hnsw_add_vertices: adding %zd elements on top of %zd "
                "(preset_levels=%d)\n",
                n, n0, int(preset_levels));
     }
@@ -628,7 +628,7 @@ void IndexHNSW::link_singletons()
         }
     }
 
-    printf("  Found %d / %ld singletons (%d appear in a level above)\n",
+    printf("  Found %d / %zd singletons (%d appear in a level above)\n",
            n_sing, ntotal, n_sing_l1);
 
     std::vector<float>recons(singletons.size() * d);

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -13,6 +13,7 @@
 #include <omp.h>
 
 #include <algorithm>
+#include <cinttypes>
 #include <cstdio>
 #include <memory>
 
@@ -73,7 +74,7 @@ void Level1Quantizer::train_q1 (size_t n, const float *x, bool verbose, MetricTy
                           "nlist not consistent with quantizer size");
     } else if (quantizer_trains_alone == 0) {
         if (verbose)
-            printf ("Training level-1 quantizer on %ld vectors in %ldD\n",
+            printf ("Training level-1 quantizer on %zd vectors in %zdD\n",
                     n, d);
 
         Clustering clus (d, nlist, cp);
@@ -88,7 +89,7 @@ void Level1Quantizer::train_q1 (size_t n, const float *x, bool verbose, MetricTy
     } else if (quantizer_trains_alone == 2) {
         if (verbose)
             printf (
-                "Training L2 quantizer on %ld vectors in %ldD%s\n",
+                "Training L2 quantizer on %zd vectors in %zdD%s\n",
                 n, d,
                 clustering_index ? "(user provided index)" : "");
         FAISS_THROW_IF_NOT (metric_type == METRIC_L2);
@@ -189,7 +190,7 @@ void IndexIVF::add_with_ids (idx_t n, const float * x, const idx_t *xids)
         for (idx_t i0 = 0; i0 < n; i0 += bs) {
             idx_t i1 = std::min (n, i0 + bs);
             if (verbose) {
-                printf("   IndexIVF::add_with_ids %ld:%ld\n", i0, i1);
+                printf("   IndexIVF::add_with_ids %" PRId64 ":%" PRId64 "\n", i0, i1);
             }
             add_with_ids (i1 - i0, x + i0 * d,
                           xids ? xids + i0 : nullptr);
@@ -239,7 +240,7 @@ void IndexIVF::add_with_ids (idx_t n, const float * x, const idx_t *xids)
 
 
     if (verbose) {
-        printf("    added %ld / %ld vectors (%ld -1s)\n", nadd, n, nminus1);
+        printf("    added %zd / %" PRId64 " vectors (%zd -1s)\n", nadd, n, nminus1);
     }
 
     ntotal += n;
@@ -360,7 +361,7 @@ void IndexIVF::search_preassigned (idx_t n, const float *x, idx_t k,
                 return (size_t)0;
             }
             FAISS_THROW_IF_NOT_FMT (key < (idx_t) nlist,
-                                    "Invalid key=%ld nlist=%ld\n",
+                                    "Invalid key=%" PRId64 " nlist=%zd\n",
                                     key, nlist);
 
             size_t list_size = invlists->list_size(key);
@@ -563,7 +564,7 @@ void IndexIVF::range_search_preassigned (
             if (key < 0) return;
             FAISS_THROW_IF_NOT_FMT (
                   key < (idx_t) nlist,
-                  "Invalid key=%ld  at ik=%ld nlist=%ld\n",
+                  "Invalid key=%" PRId64 " at ik=%zd nlist=%zd\n",
                   key, ik, nlist);
             const size_t list_size = invlists->list_size(key);
 

--- a/faiss/IndexIVFFlat.cpp
+++ b/faiss/IndexIVFFlat.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/IndexIVFFlat.h>
 
+#include <cinttypes>
 #include <cstdio>
 
 #include <faiss/IndexFlat.h>
@@ -75,7 +76,7 @@ void IndexIVFFlat::add_core (idx_t n, const float * x, const int64_t *xids,
     }
 
     if (verbose) {
-        printf("IndexIVFFlat::add_core: added %ld / %ld vectors\n",
+        printf("IndexIVFFlat::add_core: added %" PRId64 " / %" PRId64 " vectors\n",
                n_add, n);
     }
     ntotal += n;
@@ -247,8 +248,8 @@ void IndexIVFFlatDedup::train(idx_t n, const float* x)
         }
     }
     if (verbose) {
-        printf ("IndexIVFFlatDedup::train: train on %ld points after dedup "
-                "(was %ld points)\n", n2, n);
+        printf ("IndexIVFFlatDedup::train: train on %" PRId64 " points after dedup "
+                "(was %" PRId64 " points)\n", n2, n);
     }
     IndexIVFFlat::train (n2, x2);
 }
@@ -303,8 +304,8 @@ void IndexIVFFlatDedup::add_with_ids(
         n_add++;
     }
     if (verbose) {
-        printf("IndexIVFFlat::add_with_ids: added %ld / %ld vectors"
-               " (out of which %ld are duplicates)\n",
+        printf("IndexIVFFlat::add_with_ids: added %" PRId64 " / %" PRId64 " vectors"
+               " (out of which %" PRId64 " are duplicates)\n",
                n_add, na, n_dup);
     }
     ntotal += n_add;

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/IndexIVFPQ.h>
 
+#include <cinttypes>
 #include <cmath>
 #include <cstdio>
 #include <cassert>
@@ -91,7 +92,7 @@ void IndexIVFPQ::train_residual_o (idx_t n, const float *x, float *residuals_2)
         trainset = x;
     }
     if (verbose)
-        printf ("training %zdx%zd product quantizer on %ld vectors in %dD\n",
+        printf ("training %zdx%zd product quantizer on %" PRId64 " vectors in %dD\n",
                 pq.M, pq.ksub, n, d);
     pq.verbose = verbose;
     pq.train (n, trainset);
@@ -265,7 +266,7 @@ void IndexIVFPQ::add_core_o (idx_t n, const float * x, const idx_t *xids,
         for (idx_t i0 = 0; i0 < n; i0 += bs) {
             idx_t i1 = std::min(i0 + bs, n);
             if (verbose) {
-                printf("IndexIVFPQ::add_core_o: adding %ld:%ld / %ld\n",
+                printf("IndexIVFPQ::add_core_o: adding %" PRId64 ":%" PRId64 " / %" PRId64 "\n",
                        i0, i1, n);
             }
             add_core_o (i1 - i0, x + i0 * d,
@@ -341,7 +342,7 @@ void IndexIVFPQ::add_core_o (idx_t n, const float * x, const idx_t *xids,
     if(verbose) {
         char comment[100] = {0};
         if (n_ignore > 0)
-            snprintf (comment, 100, "(%ld vectors ignored)", n_ignore);
+            snprintf (comment, 100, "(%zd vectors ignored)", n_ignore);
         printf(" add_core times: %.3f %.3f %.3f %s\n",
                t1 - t0, t2 - t1, t3 - t2, comment);
     }
@@ -425,7 +426,7 @@ void IndexIVFPQ::precompute_table ()
                 if (verbose) {
                     printf(
                        "IndexIVFPQ::precompute_table: not precomputing table, "
-                       "it would be too big: %ld bytes (max %ld)\n",
+                       "it would be too big: %zd bytes (max %zd)\n",
                        table_size, precomputed_table_max_bytes);
                     use_precomputed_table = 0;
                 }

--- a/faiss/IndexIVFPQR.cpp
+++ b/faiss/IndexIVFPQR.cpp
@@ -9,6 +9,8 @@
 
 #include <faiss/IndexIVFPQR.h>
 
+#include <cinttypes>
+
 #include <faiss/utils/Heap.h>
 #include <faiss/utils/utils.h>
 #include <faiss/utils/distances.h>
@@ -59,7 +61,7 @@ void IndexIVFPQR::train_residual (idx_t n, const float *x)
     train_residual_o (n, x, residual_2);
 
     if (verbose)
-        printf ("training %zdx%zd 2nd level PQ quantizer on %ld %dD-vectors\n",
+        printf ("training %zdx%zd 2nd level PQ quantizer on %" PRId64 " %dD-vectors\n",
                 refine_pq.M, refine_pq.ksub, n, d);
 
     refine_pq.cp.max_points_per_centroid = 1000;

--- a/faiss/IndexPQ.cpp
+++ b/faiss/IndexPQ.cpp
@@ -9,7 +9,7 @@
 
 #include <faiss/IndexPQ.h>
 
-
+#include <cinttypes>
 #include <cstddef>
 #include <cstring>
 #include <cstdio>
@@ -59,7 +59,7 @@ void IndexPQ::train (idx_t n, const float *x)
         if (ntrain_perm > n / 4)
             ntrain_perm = n / 4;
         if (verbose) {
-            printf ("PQ training on %ld points, remains %ld points: "
+            printf ("PQ training on %" PRId64 " points, remains %" PRId64 " points: "
                     "training polysemous on %s\n",
                     n - ntrain_perm, ntrain_perm,
                     ntrain_perm == 0 ? "centroids" : "these");
@@ -523,7 +523,7 @@ void IndexPQ::hamming_distance_histogram (idx_t n, const float *x,
         ScopeDeleter<hamdis_t> del (distances);
 #pragma omp for
         for (size_t q0 = 0; q0 < n; q0 += bs) {
-            // printf ("dis stats: %ld/%ld\n", q0, n);
+            // printf ("dis stats: %zd/%zd\n", q0, n);
             size_t q1 = q0 + bs;
             if (q1 > n) q1 = n;
 
@@ -955,7 +955,7 @@ void MultiIndexQuantizer::search (idx_t n, const float *x, idx_t k,
         for (idx_t i0 = 0; i0 < n; i0 += bs) {
             idx_t i1 = std::min(i0 + bs, n);
             if (verbose) {
-                printf("MultiIndexQuantizer::search: %ld:%ld / %ld\n",
+                printf("MultiIndexQuantizer::search: %" PRId64 ":%" PRId64 " / %" PRId64 "\n",
                        i0, i1, n);
             }
             search (i1 - i0, x + i0 * d, k,

--- a/faiss/IndexReplicas.cpp
+++ b/faiss/IndexReplicas.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <cinttypes>
+
 #include <faiss/IndexReplicas.h>
 #include <faiss/impl/FaissAssert.h>
 
@@ -36,7 +38,7 @@ IndexReplicasTemplate<IndexT>::onAfterAddIndex(IndexT* index) {
     FAISS_THROW_IF_NOT_FMT(index->ntotal == existing->ntotal,
                            "IndexReplicas: newly added index does "
                            "not have same number of vectors as prior index; "
-                           "prior index has %ld vectors, new index has %ld",
+                           "prior index has %" PRId64 " vectors, new index has %" PRId64,
                            existing->ntotal, index->ntotal);
 
     FAISS_THROW_IF_NOT_MSG(index->is_trained == existing->is_trained,

--- a/faiss/IndexShards.cpp
+++ b/faiss/IndexShards.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/IndexShards.h>
 
+#include <cinttypes>
 #include <cstdio>
 #include <functional>
 
@@ -172,7 +173,7 @@ IndexShardsTemplate<IndexT>::train(idx_t n,
   auto fn =
     [n, x](int no, IndexT *index) {
       if (index->verbose) {
-        printf("begin train shard %d on %ld points\n", no, n);
+        printf("begin train shard %d on %" PRId64 " points\n", no, n);
       }
 
       index->train(n, x);
@@ -237,7 +238,7 @@ IndexShardsTemplate<IndexT>::add_with_ids(idx_t n,
       auto x0 = x + i0 * components_per_vec;
 
       if (index->verbose) {
-        printf ("begin add shard %d on %ld points\n", no, n);
+        printf ("begin add shard %d on %" PRId64 " points\n", no, n);
       }
 
       if (ids) {
@@ -247,7 +248,7 @@ IndexShardsTemplate<IndexT>::add_with_ids(idx_t n,
       }
 
       if (index->verbose) {
-        printf ("end add shard %d on %ld points\n", no, i1 - i0);
+        printf ("end add shard %d on %" PRId64 " points\n", no, i1 - i0);
       }
     };
 
@@ -273,7 +274,7 @@ IndexShardsTemplate<IndexT>::search(idx_t n,
   auto fn =
     [n, k, x, &all_distances, &all_labels](int no, const IndexT *index) {
       if (index->verbose) {
-        printf ("begin query shard %d on %ld points\n", no, n);
+        printf ("begin query shard %d on %" PRId64 " points\n", no, n);
       }
 
       index->search (n, x, k,

--- a/faiss/InvertedLists.cpp
+++ b/faiss/InvertedLists.cpp
@@ -274,7 +274,7 @@ const uint8_t * HStackInvertedLists::get_single_code (
         }
         offset -= sz;
     }
-    FAISS_THROW_FMT ("offset %ld unknown", offset);
+    FAISS_THROW_FMT ("offset %zd unknown", offset);
 }
 
 
@@ -309,7 +309,7 @@ Index::idx_t HStackInvertedLists::get_single_id (
         }
         offset -= sz;
     }
-    FAISS_THROW_FMT ("offset %ld unknown", offset);
+    FAISS_THROW_FMT ("offset %zd unknown", offset);
 }
 
 

--- a/faiss/MetaIndexes.cpp
+++ b/faiss/MetaIndexes.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/MetaIndexes.h>
 
+#include <cinttypes>
 #include <cstdio>
 #include <stdint.h>
 
@@ -199,7 +200,7 @@ void IndexIDMap2Template<IndexT>::reconstruct
     try {
         this->index->reconstruct (rev_map.at (key), recons);
     } catch (const std::out_of_range& e) {
-        FAISS_THROW_FMT ("key %ld not found", key);
+        FAISS_THROW_FMT ("key %" PRId64 " not found", key);
     }
 }
 
@@ -274,7 +275,7 @@ void IndexSplitVectors::search (
         float *distances1 = no == 0 ? distances : all_distances + no * k * n;
         idx_t *labels1 = no == 0 ? labels : all_labels + no * k * n;
         if (index->verbose)
-            printf ("begin query shard %d on %ld points\n", no, n);
+            printf ("begin query shard %d on %" PRId64 " points\n", no, n);
         const Index * sub_index = index->sub_indexes[no];
         int64_t sub_d = sub_index->d, d = index->d;
         idx_t ofs = 0;

--- a/faiss/OnDiskInvertedLists.cpp
+++ b/faiss/OnDiskInvertedLists.cpp
@@ -324,7 +324,7 @@ void OnDiskInvertedLists::update_totsize (size_t new_size)
     totsize = new_size;
 
     // create file
-    printf ("resizing %s to %ld bytes\n", filename.c_str(), totsize);
+    printf ("resizing %s to %zd bytes\n", filename.c_str(), totsize);
 
     int err = truncate (filename.c_str(), totsize);
 
@@ -644,7 +644,7 @@ size_t OnDiskInvertedLists::merge_from (const InvertedLists **ils, int n_il,
                 nmerged++;
                 double t1 = getmillisecs();
                 if (t1 - last_t > 500) {
-                    printf("merged %ld lists in %.3f s\r",
+                    printf("merged %zd lists in %.3f s\r",
                            nmerged, (t1 - t0) / 1000.0);
                     fflush(stdout);
                     last_t = t1;

--- a/faiss/VectorTransform.cpp
+++ b/faiss/VectorTransform.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/VectorTransform.h>
 
+#include <cinttypes>
 #include <cstdio>
 #include <cmath>
 #include <cstring>
@@ -867,7 +868,7 @@ void OPQMatrix::train (Index::idx_t n, const float *x)
 
     if (verbose) {
         printf ("OPQMatrix::train: training an OPQ rotation matrix "
-                "for M=%d from %ld vectors in %dD -> %dD\n",
+                "for M=%d from %" PRId64 " vectors in %dD -> %dD\n",
                 M, n, d_in, d_out);
     }
 
@@ -895,7 +896,7 @@ void OPQMatrix::train (Index::idx_t n, const float *x)
         A.resize (d * d);
         rotation = A.data();
         if (verbose)
-            printf("  OPQMatrix::train: making random %ld*%ld rotation\n",
+            printf("  OPQMatrix::train: making random %zd*%zd rotation\n",
                    d, d);
         float_randn (rotation, d * d, 1234);
         matrix_qr (d, d, rotation);

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -157,11 +157,11 @@ void HNSW::print_neighbor_stats(int level) const
     }
   }
   float normalizer = n_node;
-  printf("   nb of nodes at that level %ld\n", n_node);
-  printf("   neighbors per node: %.2f (%ld)\n",
+  printf("   nb of nodes at that level %zd\n", n_node);
+  printf("   neighbors per node: %.2f (%zd)\n",
          tot_neigh / normalizer, tot_neigh);
   printf("   nb of reciprocal neighbors: %.2f\n", tot_reciprocal / normalizer);
-  printf("   nb of neighbors that are also neighbor-of-neighbors: %.2f (%ld)\n",
+  printf("   nb of neighbors that are also neighbor-of-neighbors: %.2f (%zd)\n",
          tot_common / normalizer, tot_common);
 
 
@@ -181,7 +181,7 @@ void HNSW::fill_with_random_links(size_t n)
         elts.push_back(i);
       }
     }
-    printf ("linking %ld elements in level %d\n",
+    printf ("linking %zd elements in level %d\n",
             elts.size(), level);
 
     if (elts.size() == 1) continue;

--- a/faiss/impl/PolysemousTraining.cpp
+++ b/faiss/impl/PolysemousTraining.cpp
@@ -893,7 +893,7 @@ void PolysemousTraining::optimize_ranking (
         ScopeDeleter1<PermutationObjective> del (obj);
 
         if (verbose > 0) {
-            printf("   m=%d, nq=%ld, nb=%ld, intialize RankingScore "
+            printf("   m=%d, nq=%zd, nb=%zd, intialize RankingScore "
                    "in %.3f ms\n",
                    m, nq, nb, getmillisecs () - t0);
         }

--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -261,7 +261,7 @@ void ProductQuantizer::train (int n, const float * x)
             train_type == Train_hypercube_pca) {
             if (dsub < nbits) {
                 final_train_type = Train_default;
-                printf ("cannot train hypercube: nbits=%ld > log2(d=%ld)\n",
+                printf ("cannot train hypercube: nbits=%zd > log2(d=%zd)\n",
                         nbits, dsub);
             }
         }

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -843,7 +843,7 @@ void InvertedListsIOHook::add_callback(InvertedListsIOHook *cb)
 
 void InvertedListsIOHook::print_callbacks()
 {
-    printf("registered %ld InvertedListsIOHooks:\n",
+    printf("registered %zd InvertedListsIOHooks:\n",
           InvertedListsIOHook_table.size());
     for(const auto & cb: InvertedListsIOHook_table) {
         printf("%08x %s %s\n",

--- a/faiss/impl/io.cpp
+++ b/faiss/impl/io.cpp
@@ -229,7 +229,7 @@ BufferedIOWriter::~BufferedIOWriter()
 {
     size_t ofs = 0;
     while(ofs != b0) {
-        // printf("Destructor write %ld \n", b0 - ofs);
+        // printf("Destructor write %zd \n", b0 - ofs);
         size_t written = (*writer)(buffer.data() + ofs, 1, b0 - ofs);
         FAISS_THROW_IF_NOT(written > 0);
         ofs += written;

--- a/faiss/impl/io_macros.h
+++ b/faiss/impl/io_macros.h
@@ -19,7 +19,7 @@
 #define READANDCHECK(ptr, n) {                                  \
         size_t ret = (*f)(ptr, sizeof(*(ptr)), n);              \
         FAISS_THROW_IF_NOT_FMT(ret == (n),                      \
-            "read error in %s: %ld != %ld (%s)",                \
+            "read error in %s: %zd != %zd (%s)",                \
             f->name.c_str(), ret, size_t(n), strerror(errno));  \
     }
 
@@ -44,7 +44,7 @@
 #define WRITEANDCHECK(ptr, n) {                                 \
         size_t ret = (*f)(ptr, sizeof(*(ptr)), n);              \
         FAISS_THROW_IF_NOT_FMT(ret == (n),                      \
-            "write error in %s: %ld != %ld (%s)",               \
+            "write error in %s: %zd != %zd (%s)",               \
             f->name.c_str(), ret, size_t(n), strerror(errno));  \
     }
 

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -13,8 +13,8 @@
 
 #include <faiss/AutoTune.h>
 
+#include <cinttypes>
 #include <cmath>
-
 
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/utils.h>
@@ -140,11 +140,11 @@ Index *index_factory (int d, const char *description_in, MetricType metric)
 
         // coarse quantizers
         } else if (!coarse_quantizer &&
-                   sscanf (tok, "IVF%ld_HNSW%d", &ncentroids, &M) == 2) {
+                   sscanf (tok, "IVF%" PRId64 "_HNSW%d", &ncentroids, &M) == 2) {
             coarse_quantizer_1 = new IndexHNSWFlat (d, M);
 
         } else if (!coarse_quantizer &&
-                   sscanf (tok, "IVF%ld", &ncentroids) == 1) {
+                   sscanf (tok, "IVF%" PRId64, &ncentroids) == 1) {
             if (metric == METRIC_L2) {
                 coarse_quantizer_1 = new IndexFlatL2 (d);
             } else {
@@ -165,7 +165,7 @@ Index *index_factory (int d, const char *description_in, MetricType metric)
             use_2layer = true;
 
         } else if (!coarse_quantizer &&
-                   sscanf (tok, "Residual%ld", &ncentroids) == 1) {
+                   sscanf (tok, "Residual%" PRId64, &ncentroids) == 1) {
             coarse_quantizer_1 = new IndexFlatL2 (d);
             use_2layer = true;
 

--- a/faiss/utils/utils.cpp
+++ b/faiss/utils/utils.cpp
@@ -598,8 +598,8 @@ const float *fvecs_maybe_subsample (
 
     size_t n2 = nmax;
     if (verbose) {
-        printf ("  Input training set too big (max size is %ld), sampling "
-                "%ld / %ld vectors\n", nmax, n2, *n);
+        printf ("  Input training set too big (max size is %zd), sampling "
+                "%zd / %zd vectors\n", nmax, n2, *n);
     }
     std::vector<int> subset (*n);
     rand_perm (subset.data (), *n, seed);

--- a/tests/test_lowlevel_ivf.cpp
+++ b/tests/test_lowlevel_ivf.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
 
@@ -376,7 +377,7 @@ void test_lowlevel_access_binary (const char *index_key) {
 
         printf("new before reroder: [");
         for (int j = 0; j < k; j++)
-            printf("%ld,%d ", I[j], D[j]);
+            printf("%" PRId64 ",%d ", I[j], D[j]);
         printf("]\n");
 
         // re-order heap
@@ -384,10 +385,10 @@ void test_lowlevel_access_binary (const char *index_key) {
 
         printf("ref: [");
         for (int j = 0; j < k; j++)
-            printf("%ld,%d ", I_ref[j], D_ref[j]);
+            printf("%" PRId64 ",%d ", I_ref[j], D_ref[j]);
         printf("]\nnew: [");
         for (int j = 0; j < k; j++)
-            printf("%ld,%d ", I[j], D[j]);
+            printf("%" PRId64 ",%d ", I[j], D[j]);
         printf("]\n");
 
         // check that we have the same results as the reference search

--- a/tests/test_sliding_ivf.cpp
+++ b/tests/test_sliding_ivf.cpp
@@ -192,7 +192,7 @@ int test_sliding_invlists (const char *index_key) {
         // will be deleted by the index
         index_ivf->replace_invlists (ci, true);
 
-        printf ("   nb invlists = %ld\n", ils.size());
+        printf ("   nb invlists = %zd\n", ils.size());
 
         auto new_res = search_index (index.get(), xq.data());
 
@@ -208,7 +208,7 @@ int test_sliding_invlists (const char *index_key) {
             if (ref_res[j] != new_res[j])
                 ndiff++;
         }
-        printf("  nb differences: %ld / %ld\n",
+        printf("  nb differences: %zd / %zd\n",
                ndiff, ref_res.size());
         EXPECT_EQ (ref_res, new_res);
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1344 Avoid OpenMP 4.0 custom reduction.
* #1343 Fix unsigned OpenMP loop indices (disallowed in OpenMP 2).
* #1342 Fix long literals used as 64 bit.
* #1341 Replace finite() with std::isfinite().
* #1340 Replace bzero (deprecated in POSIX 2001) with memset.
* #1339 Fix division by zero.
* **#1338 Fix format specifiers for size_t/idx_t.**
* #1337 Add missing algorithm header.

Differential Revision: [D23234964](https://our.internmc.facebook.com/intern/diff/D23234964)