### PR TITLE
Fix division by zero.

### DIFF
--- a/faiss/MetaIndexes.cpp
+++ b/faiss/MetaIndexes.cpp
@@ -11,6 +11,7 @@
 
 #include <cinttypes>
 #include <cstdio>
+#include <limits>
 #include <stdint.h>
 
 #include <faiss/impl/FaissAssert.h>
@@ -320,7 +321,7 @@ void IndexSplitVectors::search (
                     distances[j] += distances_i[j];
                 } else {
                     labels[j] = -1;
-                    distances[j] = 0.0 / 0.0;
+                    distances[j] = std::numeric_limits<float>::quiet_NaN();
                 }
             }
         }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1344 Avoid OpenMP 4.0 custom reduction.
* #1343 Fix unsigned OpenMP loop indices (disallowed in OpenMP 2).
* #1342 Fix long literals used as 64 bit.
* #1341 Replace finite() with std::isfinite().
* #1340 Replace bzero (deprecated in POSIX 2001) with memset.
* **#1339 Fix division by zero.**
* #1338 Fix format specifiers for size_t/idx_t.
* #1337 Add missing algorithm header.

Differential Revision: [D23234966](https://our.internmc.facebook.com/intern/diff/D23234966)