### PR TITLE
Replace bzero (deprecated in POSIX 2001) with memset.

### DIFF
--- a/faiss/utils/hamming-inl.h
+++ b/faiss/utils/hamming-inl.h
@@ -11,7 +11,7 @@ namespace faiss {
 inline BitstringWriter::BitstringWriter(uint8_t *code, int code_size):
     code (code), code_size (code_size), i(0)
 {
-    bzero (code, code_size);
+    memset (code, 0, code_size);
 }
 
 inline void BitstringWriter::write(uint64_t x, int nbit) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1344 Avoid OpenMP 4.0 custom reduction.
* #1343 Fix unsigned OpenMP loop indices (disallowed in OpenMP 2).
* #1342 Fix long literals used as 64 bit.
* #1341 Replace finite() with std::isfinite().
* **#1340 Replace bzero (deprecated in POSIX 2001) with memset.**
* #1339 Fix division by zero.
* #1338 Fix format specifiers for size_t/idx_t.
* #1337 Add missing algorithm header.

Differential Revision: [D23234969](https://our.internmc.facebook.com/intern/diff/D23234969)