### PR TITLE
Replace finite() with std::isfinite().

### DIFF
--- a/faiss/Clustering.cpp
+++ b/faiss/Clustering.cpp
@@ -289,7 +289,7 @@ void Clustering::train_encoded (idx_t nx, const uint8_t *x_in,
         // reports.
         const float *x = reinterpret_cast<const float *>(x_in);
         for (size_t i = 0; i < nx * d; i++) {
-            FAISS_THROW_IF_NOT_MSG (finite (x[i]),
+            FAISS_THROW_IF_NOT_MSG (std::isfinite (x[i]),
                                     "input contains NaN's or Inf's");
         }
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1344 Avoid OpenMP 4.0 custom reduction.
* #1343 Fix unsigned OpenMP loop indices (disallowed in OpenMP 2).
* #1342 Fix long literals used as 64 bit.
* **#1341 Replace finite() with std::isfinite().**
* #1340 Replace bzero (deprecated in POSIX 2001) with memset.
* #1339 Fix division by zero.
* #1338 Fix format specifiers for size_t/idx_t.
* #1337 Add missing algorithm header.

Differential Revision: [D23234968](https://our.internmc.facebook.com/intern/diff/D23234968)