### PR TITLE
Fix long literals used as 64 bit.

### DIFF
--- a/faiss/impl/io_macros.h
+++ b/faiss/impl/io_macros.h
@@ -29,7 +29,7 @@
 #define READVECTOR(vec) {                       \
         long size;                            \
         READANDCHECK (&size, 1);                \
-        FAISS_THROW_IF_NOT (size >= 0 && size < (1L << 40));  \
+        FAISS_THROW_IF_NOT (size >= 0 && size < (1LL << 40));  \
         (vec).resize (size);                    \
         READANDCHECK ((vec).data (), size);     \
     }

--- a/faiss/impl/lattice_Zn.cpp
+++ b/faiss/impl/lattice_Zn.cpp
@@ -116,11 +116,11 @@ long repeats_encode_64 (
         for(;;) {
             // directly jump to next available slot.
             int i = __builtin_ctzl(tosee);
-            tosee &= ~(1UL << i) ;
+            tosee &= ~(1ULL << i) ;
             if (c[i] == r->val) {
                 code_comb += comb(rank, occ + 1);
                 occ++;
-                coded |= 1UL << i;
+                coded |= 1ULL << i;
                 if (occ == r->n) break;
             }
             rank++;
@@ -148,13 +148,13 @@ void repeats_decode_64(
         int occ = 0;
         int rank = nfree;
         int next_rank = decode_comb_1 (&code_comb, r->n, rank);
-        uint64_t tosee = ((1UL << dim) - 1) ^ decoded;
+        uint64_t tosee = ((1ULL << dim) - 1) ^ decoded;
         for(;;) {
             int i = 63 - __builtin_clzl(tosee);
-            tosee &= ~(1UL << i);
+            tosee &= ~(1ULL << i);
             rank--;
             if (rank == next_rank) {
-                decoded |= 1UL << i;
+                decoded |= 1ULL << i;
                 c[i] = r->val;
                 occ++;
                 if (occ == r->n) break;

--- a/faiss/utils/utils.cpp
+++ b/faiss/utils/utils.cpp
@@ -319,7 +319,7 @@ size_t ranklist_intersection_size (size_t k1, const int64_t *v1,
         }
         k2 = wp;
     }
-    const int64_t seen_flag = 1L << 60;
+    const int64_t seen_flag = 1LL << 60;
     size_t count = 0;
     for (size_t i = 0; i < k1; i++) {
         int64_t q = v1 [i];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1344 Avoid OpenMP 4.0 custom reduction.
* #1343 Fix unsigned OpenMP loop indices (disallowed in OpenMP 2).
* **#1342 Fix long literals used as 64 bit.**
* #1341 Replace finite() with std::isfinite().
* #1340 Replace bzero (deprecated in POSIX 2001) with memset.
* #1339 Fix division by zero.
* #1338 Fix format specifiers for size_t/idx_t.
* #1337 Add missing algorithm header.

Differential Revision: [D23234963](https://our.internmc.facebook.com/intern/diff/D23234963)