### PR TITLE
Fix unsigned OpenMP loop indices (disallowed in OpenMP 2).

### DIFF
--- a/faiss/AutoTune.cpp
+++ b/faiss/AutoTune.cpp
@@ -678,7 +678,7 @@ void ParameterSpace::explore (Index *index,
 
             if (thread_over_batches) {
 #pragma omp parallel for
-                for (size_t q0 = 0; q0 < nq; q0 += batchsize) {
+                for (idx_t q0 = 0; q0 < nq; q0 += batchsize) {
                     size_t q1 = q0 + batchsize;
                     if (q1 > nq) q1 = nq;
                     index->search (q1 - q0, xq + q0 * index->d,

--- a/faiss/AutoTune.cpp
+++ b/faiss/AutoTune.cpp
@@ -678,7 +678,7 @@ void ParameterSpace::explore (Index *index,
 
             if (thread_over_batches) {
 #pragma omp parallel for
-                for (idx_t q0 = 0; q0 < nq; q0 += batchsize) {
+                for (Index::idx_t q0 = 0; q0 < nq; q0 += batchsize) {
                     size_t q1 = q0 + batchsize;
                     if (q1 > nq) q1 = nq;
                     index->search (q1 - q0, xq + q0 * index->d,

--- a/faiss/Clustering.cpp
+++ b/faiss/Clustering.cpp
@@ -191,7 +191,7 @@ void compute_centroids (size_t d, size_t k, size_t n,
     }
 
 #pragma omp parallel for
-    for (size_t ci = 0; ci < k; ci++) {
+    for (idx_t ci = 0; ci < k; ci++) {
         if (hassign[ci] == 0) {
             continue;
         }

--- a/faiss/Index2Layer.cpp
+++ b/faiss/Index2Layer.cpp
@@ -417,13 +417,13 @@ void Index2Layer::sa_decode (idx_t n, const uint8_t *bytes, float *x) const
         std::vector<float> residual (d);
 
 #pragma omp for
-        for (size_t i = 0; i < n; i++) {
+        for (idx_t i = 0; i < n; i++) {
             const uint8_t *code = bytes + i * code_size;
             int64_t list_no = q1.decode_listno (code);
             float *xi = x + i * d;
             pq.decode (code + code_size_1, xi);
             q1.quantizer->reconstruct (list_no, residual.data());
-            for (size_t j = 0; j < d; j++) {
+            for (int j = 0; j < d; j++) {
                 xi[j] += residual[j];
             }
         }

--- a/faiss/IndexBinaryHash.cpp
+++ b/faiss/IndexBinaryHash.cpp
@@ -222,7 +222,7 @@ void IndexBinaryHash::range_search(idx_t n, const uint8_t *x, int radius,
         RangeSearchPartialResult pres (result);
 
 #pragma omp for
-        for (size_t i = 0; i < n; i++) { // loop queries
+        for (idx_t i = 0; i < n; i++) { // loop queries
             RangeQueryResult & qres = pres.new_result (i);
             RangeSearchResults res = {radius, qres};
             const uint8_t *q = x + i * code_size;
@@ -246,7 +246,7 @@ void IndexBinaryHash::search(idx_t n, const uint8_t *x, idx_t k,
     size_t nlist = 0, ndis = 0, n0 = 0;
 
 #pragma omp parallel for if(n > 100) reduction(+: nlist, ndis, n0)
-    for (size_t i = 0; i < n; i++) {
+    for (idx_t i = 0; i < n; i++) {
         int32_t * simi = distances + k * i;
         idx_t * idxi = labels + k * i;
 
@@ -437,7 +437,7 @@ void IndexBinaryMultiHash::range_search(idx_t n, const uint8_t *x, int radius,
         RangeSearchPartialResult pres (result);
 
 #pragma omp for
-        for (size_t i = 0; i < n; i++) { // loop queries
+        for (idx_t i = 0; i < n; i++) { // loop queries
             RangeQueryResult & qres = pres.new_result (i);
             RangeSearchResults res = {radius, qres};
             const uint8_t *q = x + i * code_size;
@@ -461,7 +461,7 @@ void IndexBinaryMultiHash::search(idx_t n, const uint8_t *x, idx_t k,
     size_t nlist = 0, ndis = 0, n0 = 0;
 
 #pragma omp parallel for if(n > 100) reduction(+: nlist, ndis, n0)
-    for (size_t i = 0; i < n; i++) {
+    for (idx_t i = 0; i < n; i++) {
         int32_t * simi = distances + k * i;
         idx_t * idxi = labels + k * i;
 

--- a/faiss/IndexBinaryIVF.cpp
+++ b/faiss/IndexBinaryIVF.cpp
@@ -383,7 +383,7 @@ void search_knn_hamming_heap(const IndexBinaryIVF& ivf,
             (ivf.get_InvertedListScanner (store_pairs));
 
 #pragma omp for
-        for (size_t i = 0; i < n; i++) {
+        for (idx_t i = 0; i < n; i++) {
             const uint8_t *xi = x + i * ivf.code_size;
             scanner->set_query(xi);
 
@@ -481,7 +481,7 @@ void search_knn_hamming_count(const IndexBinaryIVF& ivf,
   size_t nlistv = 0, ndis = 0;
 
 #pragma omp parallel for reduction(+: nlistv, ndis)
-  for (size_t i = 0; i < nx; i++) {
+  for (int64_t i = 0; i < nx; i++) {
     const idx_t * keysi = keys + i * nprobe;
     HCounterState<HammingComputer>& csi = cs[i];
 
@@ -686,7 +686,7 @@ void IndexBinaryIVF::range_search(
         };
 
 #pragma omp for
-        for (size_t i = 0; i < n; i++) {
+        for (idx_t i = 0; i < n; i++) {
             scanner->set_query (x + i * code_size);
 
             RangeQueryResult & qres = pres.new_result (i);

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -398,7 +398,7 @@ void IndexIVF::search_preassigned (idx_t n, const float *x, idx_t k,
         if (pmode == 0) {
 
 #pragma omp for
-            for (size_t i = 0; i < n; i++) {
+            for (idx_t i = 0; i < n; i++) {
 
                 if (interrupt) {
                     continue;
@@ -444,7 +444,7 @@ void IndexIVF::search_preassigned (idx_t n, const float *x, idx_t k,
                 init_result (local_dis.data(), local_idx.data());
 
 #pragma omp for schedule(dynamic)
-                for (size_t ik = 0; ik < nprobe; ik++) {
+                for (long ik = 0; ik < nprobe; ik++) {
                     ndis += scan_one_list
                         (keys [i * nprobe + ik],
                          coarse_dis[i * nprobe + ik],
@@ -474,12 +474,12 @@ void IndexIVF::search_preassigned (idx_t n, const float *x, idx_t k,
             std::vector <float> local_dis (k);
 
 #pragma omp single
-            for (size_t i = 0; i < n; i++) {
+            for (int64_t i = 0; i < n; i++) {
                 init_result (distances + i * k, labels + i * k);
             }
 
 #pragma omp for schedule(dynamic)
-            for (size_t ij = 0; ij < n * nprobe; ij++) {
+            for (int64_t ij = 0; ij < n * nprobe; ij++) {
                 size_t i = ij / nprobe;
                 size_t j = ij % nprobe;
 
@@ -495,7 +495,7 @@ void IndexIVF::search_preassigned (idx_t n, const float *x, idx_t k,
                 }
             }
 #pragma omp single
-            for (size_t i = 0; i < n; i++) {
+            for (int64_t i = 0; i < n; i++) {
                 reorder_result (distances + i * k, labels + i * k);
             }
         } else {
@@ -583,7 +583,7 @@ void IndexIVF::range_search_preassigned (
         if (parallel_mode == 0) {
 
 #pragma omp for
-            for (size_t i = 0; i < nx; i++) {
+            for (idx_t i = 0; i < nx; i++) {
                 scanner->set_query (x + i * d);
 
                 RangeQueryResult & qres = pres.new_result (i);
@@ -602,7 +602,7 @@ void IndexIVF::range_search_preassigned (
                 RangeQueryResult & qres = pres.new_result (i);
 
 #pragma omp for schedule(dynamic)
-                for (size_t ik = 0; ik < nprobe; ik++) {
+                for (int64_t ik = 0; ik < nprobe; ik++) {
                     scan_list_func (i, ik, qres);
                 }
             }
@@ -611,9 +611,9 @@ void IndexIVF::range_search_preassigned (
             RangeQueryResult *qres = nullptr;
 
 #pragma omp for schedule(dynamic)
-            for (size_t iik = 0; iik < nx * nprobe; iik++) {
-                size_t i = iik / nprobe;
-                size_t ik = iik % nprobe;
+            for (idx_t iik = 0; iik < nx * (idx_t)nprobe; iik++) {
+                idx_t i = iik / (idx_t)nprobe;
+                idx_t ik = iik % (idx_t)nprobe;
                 if (qres == nullptr || qres->qno != i) {
                     FAISS_ASSERT (!qres || i > qres->qno);
                     qres = &pres.new_result (i);

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -241,7 +241,7 @@ void IndexIVFPQ::sa_decode (idx_t n, const uint8_t *codes,
         std::vector<float> residual (d);
 
 #pragma omp for
-        for (size_t i = 0; i < n; i++) {
+        for (idx_t i = 0; i < n; i++) {
             const uint8_t *code = codes + i * (code_size + coarse_size);
             int64_t list_no = decode_listno (code);
             float *xi = x + i * d;

--- a/faiss/IndexIVFSpectralHash.cpp
+++ b/faiss/IndexIVFSpectralHash.cpp
@@ -178,7 +178,7 @@ void IndexIVFSpectralHash::encode_vectors(idx_t n, const float* x_in,
 
         // each thread takes care of a subset of lists
 #pragma omp for
-        for (size_t i = 0; i < n; i++) {
+        for (idx_t i = 0; i < n; i++) {
             int64_t list_no = list_nos [i];
 
             if (list_no >= 0) {

--- a/faiss/IndexPQ.cpp
+++ b/faiss/IndexPQ.cpp
@@ -522,7 +522,7 @@ void IndexPQ::hamming_distance_histogram (idx_t n, const float *x,
         hamdis_t *distances = new hamdis_t [nb * bs];
         ScopeDeleter<hamdis_t> del (distances);
 #pragma omp for
-        for (size_t q0 = 0; q0 < n; q0 += bs) {
+        for (idx_t q0 = 0; q0 < n; q0 += bs) {
             // printf ("dis stats: %zd/%zd\n", q0, n);
             size_t q1 = q0 + bs;
             if (q1 > n) q1 = n;

--- a/faiss/IndexScalarQuantizer.cpp
+++ b/faiss/IndexScalarQuantizer.cpp
@@ -77,7 +77,7 @@ void IndexScalarQuantizer::search(
         ScopeDeleter1<InvertedListScanner> del(scanner);
 
 #pragma omp for
-        for (size_t i = 0; i < n; i++) {
+        for (idx_t i = 0; i < n; i++) {
             float * D = distances + k * i;
             idx_t * I = labels + k * i;
             // re-order heap
@@ -197,7 +197,7 @@ void IndexIVFScalarQuantizer::encode_vectors(idx_t n, const float* x,
         std::vector<float> residual (d);
 
 #pragma omp for
-        for (size_t i = 0; i < n; i++) {
+        for (idx_t i = 0; i < n; i++) {
             int64_t list_no = list_nos [i];
             if (list_no >= 0) {
                 const float *xi = x + i * d;
@@ -227,7 +227,7 @@ void IndexIVFScalarQuantizer::sa_decode (idx_t n, const uint8_t *codes,
         std::vector<float> residual (d);
 
 #pragma omp for
-        for (size_t i = 0; i < n; i++) {
+        for (idx_t i = 0; i < n; i++) {
             const uint8_t *code = codes + i * (code_size + coarse_size);
             int64_t list_no = decode_listno (code);
             float *xi = x + i * d;

--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -496,7 +496,7 @@ void ProductQuantizer::compute_codes (const float * x,
     if (dsub < 16) { // simple direct computation
 
 #pragma omp parallel for
-        for (size_t i = 0; i < n; i++)
+        for (int64_t i = 0; i < n; i++)
             compute_code (x + i * d, codes + i * code_size);
 
     } else { // worthwile to use BLAS
@@ -505,7 +505,7 @@ void ProductQuantizer::compute_codes (const float * x,
         compute_distance_tables (n, x, dis_tables);
 
 #pragma omp parallel for
-        for (size_t i = 0; i < n; i++) {
+        for (int64_t i = 0; i < n; i++) {
             uint8_t * code = codes + i * code_size;
             const float * tab = dis_tables + i * ksub * M;
             compute_code_from_distance_table (tab, code);
@@ -552,7 +552,7 @@ void ProductQuantizer::compute_distance_tables (
     if (dsub < 16) {
 
 #pragma omp parallel for
-        for (size_t i = 0; i < nx; i++) {
+        for (int64_t i = 0; i < nx; i++) {
             compute_distance_table (x + i * d, dis_tables + i * ksub * M);
         }
 
@@ -577,7 +577,7 @@ void ProductQuantizer::compute_inner_prod_tables (
     if (dsub < 16) {
 
 #pragma omp parallel for
-        for (size_t i = 0; i < nx; i++) {
+        for (int64_t i = 0; i < nx; i++) {
             compute_inner_prod_table (x + i * d, dis_tables + i * ksub * M);
         }
 
@@ -614,7 +614,7 @@ static void pq_knn_search_with_tables (
 
 
 #pragma omp parallel for
-    for (size_t i = 0; i < nx; i++) {
+    for (int64_t i = 0; i < nx; i++) {
         /* query preparation for asymmetric search: compute look-up tables */
         const float* dis_table = dis_tables + i * ksub * M;
 
@@ -728,7 +728,7 @@ void ProductQuantizer::search_sdc (const uint8_t * qcodes,
 
 
 #pragma omp parallel for
-    for (size_t i = 0; i < nq; i++) {
+    for (int64_t i = 0; i < nq; i++) {
 
         /* Compute distances and keep smallest values */
         idx_t * heap_ids = res->ids + i * k;

--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -728,7 +728,7 @@ void train_NonUniform(RangeStat rs, float rs_arg,
         }
         std::vector<float> trained_d(2);
 #pragma omp parallel for
-        for (size_t j = 0; j < d; j++) {
+        for (int j = 0; j < d; j++) {
             train_Uniform(rs, rs_arg,
                           n, k, xt.data() + j * n,
                           trained_d);
@@ -1322,7 +1322,7 @@ void ScalarQuantizer::compute_codes (const float * x,
 
     memset (codes, 0, code_size * n);
 #pragma omp parallel for
-    for (size_t i = 0; i < n; i++)
+    for (int64_t i = 0; i < n; i++)
         squant->encode_vector (x + i * d, codes + i * code_size);
 }
 
@@ -1331,7 +1331,7 @@ void ScalarQuantizer::decode (const uint8_t *codes, float *x, size_t n) const
     std::unique_ptr<Quantizer> squant(select_quantizer ());
 
 #pragma omp parallel for
-    for (size_t i = 0; i < n; i++)
+    for (int64_t i = 0; i < n; i++)
         squant->decode_vector (codes + i * code_size, x + i * d);
 }
 

--- a/faiss/utils/Heap.cpp
+++ b/faiss/utils/Heap.cpp
@@ -19,7 +19,7 @@ template <typename C>
 void HeapArray<C>::heapify ()
 {
 #pragma omp parallel for
-    for (size_t j = 0; j < nh; j++)
+    for (int64_t j = 0; j < nh; j++)
         heap_heapify<C> (k, val + j * k, ids + j * k);
 }
 
@@ -27,7 +27,7 @@ template <typename C>
 void HeapArray<C>::reorder ()
 {
 #pragma omp parallel for
-    for (size_t j = 0; j < nh; j++)
+    for (int64_t j = 0; j < nh; j++)
         heap_reorder<C> (k, val + j * k, ids + j * k);
 }
 
@@ -38,7 +38,7 @@ void HeapArray<C>::addn (size_t nj, const T *vin, TI j0,
     if (ni == -1) ni = nh;
     assert (i0 >= 0 && i0 + ni <= nh);
 #pragma omp parallel for
-    for (size_t i = i0; i < i0 + ni; i++) {
+    for (int64_t i = i0; i < i0 + ni; i++) {
         T * __restrict simi = get_val(i);
         TI * __restrict idxi = get_ids (i);
         const T *ip_line = vin + (i - i0) * nj;
@@ -65,7 +65,7 @@ void HeapArray<C>::addn_with_ids (
     if (ni == -1) ni = nh;
     assert (i0 >= 0 && i0 + ni <= nh);
 #pragma omp parallel for
-    for (size_t i = i0; i < i0 + ni; i++) {
+    for (int64_t i = i0; i < i0 + ni; i++) {
         T * __restrict simi = get_val(i);
         TI * __restrict idxi = get_ids (i);
         const T *ip_line = vin + (i - i0) * nj;
@@ -87,7 +87,7 @@ void HeapArray<C>::per_line_extrema (
                    TI * out_ids) const
 {
 #pragma omp parallel for
-    for (size_t j = 0; j < nh; j++) {
+    for (int64_t j = 0; j < nh; j++) {
         int64_t imin = -1;
         typename C::T xval = C::Crev::neutral ();
         const typename C::T * x_ = val + j * k;

--- a/faiss/utils/distances.cpp
+++ b/faiss/utils/distances.cpp
@@ -94,7 +94,7 @@ void fvec_norms_L2 (float * __restrict nr,
 {
 
 #pragma omp parallel for
-    for (size_t i = 0; i < nx; i++) {
+    for (int64_t i = 0; i < nx; i++) {
         nr[i] = sqrtf (fvec_norm_L2sqr (x + i * d, d));
     }
 }
@@ -104,7 +104,7 @@ void fvec_norms_L2sqr (float * __restrict nr,
                        size_t d, size_t nx)
 {
 #pragma omp parallel for
-    for (size_t i = 0; i < nx; i++)
+    for (int64_t i = 0; i < nx; i++)
         nr[i] = fvec_norm_L2sqr (x + i * d, d);
 }
 
@@ -113,7 +113,7 @@ void fvec_norms_L2sqr (float * __restrict nr,
 void fvec_renorm_L2 (size_t d, size_t nx, float * __restrict x)
 {
 #pragma omp parallel for
-    for (size_t i = 0; i < nx; i++) {
+    for (int64_t i = 0; i < nx; i++) {
         float * __restrict xi = x + i * d;
 
         float nr = fvec_norm_L2sqr (xi, d);
@@ -159,7 +159,7 @@ static void knn_inner_product_sse (const float * x,
         size_t i1 = std::min(i0 + check_period, nx);
 
 #pragma omp parallel for
-        for (size_t i = i0; i < i1; i++) {
+        for (int64_t i = i0; i < i1; i++) {
             const float * x_i = x + i * d;
             const float * y_j = y;
 
@@ -199,7 +199,7 @@ static void knn_L2sqr_sse (
         size_t i1 = std::min(i0 + check_period, nx);
 
 #pragma omp parallel for
-        for (size_t i = i0; i < i1; i++) {
+        for (int64_t i = i0; i < i1; i++) {
             const float * x_i = x + i * d;
             const float * y_j = y;
             size_t j;
@@ -313,7 +313,7 @@ static void knn_L2sqr_blas (const float * x,
 
             /* collect minima */
 #pragma omp parallel for
-            for (size_t i = i0; i < i1; i++) {
+            for (int64_t i = i0; i < i1; i++) {
                 float * __restrict simi = res->get_val(i);
                 int64_t * __restrict idxi = res->get_ids (i);
                 const float *ip_line = ip_block + (i - i0) * (j1 - j0);
@@ -421,7 +421,7 @@ void fvec_inner_products_by_idx (float * __restrict ip,
                                  size_t d, size_t nx, size_t ny)
 {
 #pragma omp parallel for
-    for (size_t j = 0; j < nx; j++) {
+    for (int64_t j = 0; j < nx; j++) {
         const int64_t * __restrict idsj = ids + j * ny;
         const float * xj = x + j * d;
         float * __restrict ipj = ip + j * ny;
@@ -444,7 +444,7 @@ void fvec_L2sqr_by_idx (float * __restrict dis,
                         size_t d, size_t nx, size_t ny)
 {
 #pragma omp parallel for
-    for (size_t j = 0; j < nx; j++) {
+    for (int64_t j = 0; j < nx; j++) {
         const int64_t * __restrict idsj = ids + j * ny;
         const float * xj = x + j * d;
         float * __restrict disj = dis + j * ny;
@@ -463,7 +463,7 @@ void pairwise_indexed_L2sqr (
         float *dis)
 {
 #pragma omp parallel for
-    for (size_t j = 0; j < n; j++) {
+    for (int64_t j = 0; j < n; j++) {
         if (ix[j] >= 0 && iy[j] >= 0) {
             dis[j] = fvec_L2sqr (x + d * ix[j], y + d * iy[j], d);
         }
@@ -477,7 +477,7 @@ void pairwise_indexed_inner_product (
         float *dis)
 {
 #pragma omp parallel for
-    for (size_t j = 0; j < n; j++) {
+    for (int64_t j = 0; j < n; j++) {
         if (ix[j] >= 0 && iy[j] >= 0) {
             dis[j] = fvec_inner_product (x + d * ix[j], y + d * iy[j], d);
         }
@@ -496,7 +496,7 @@ void knn_inner_products_by_idx (const float * x,
     size_t k = res->k;
 
 #pragma omp parallel for
-    for (size_t i = 0; i < nx; i++) {
+    for (int64_t i = 0; i < nx; i++) {
         const float * x_ = x + i * d;
         const int64_t * idsi = ids + i * ny;
         size_t j;
@@ -527,7 +527,7 @@ void knn_L2sqr_by_idx (const float * x,
     size_t k = res->k;
 
 #pragma omp parallel for
-    for (size_t i = 0; i < nx; i++) {
+    for (int64_t i = 0; i < nx; i++) {
         const float * x_ = x + i * d;
         const int64_t * __restrict idsi = ids + i * ny;
         float * __restrict simi = res->get_val(i);
@@ -650,7 +650,7 @@ static void range_search_sse (const float * x,
         RangeSearchPartialResult pres (res);
 
 #pragma omp for
-        for (size_t i = 0; i < nx; i++) {
+        for (int64_t i = 0; i < nx; i++) {
             const float * x_ = x + i * d;
             const float * y_ = y;
             size_t j;

--- a/faiss/utils/extra_distances.cpp
+++ b/faiss/utils/extra_distances.cpp
@@ -164,7 +164,7 @@ void knn_extra_metrics_template (
         size_t i1 = std::min(i0 + check_period, nx);
 
 #pragma omp parallel for
-        for (size_t i = i0; i < i1; i++) {
+        for (int64_t i = i0; i < i1; i++) {
             const float * x_i = x + i * d;
             const float * y_j = y;
             size_t j;

--- a/faiss/utils/hamming.cpp
+++ b/faiss/utils/hamming.cpp
@@ -281,7 +281,7 @@ void hammings_knn_hc (
     for (size_t j0 = 0; j0 < n2; j0 += block_size) {
       const size_t j1 = std::min(j0 + block_size, n2);
 #pragma omp parallel for
-      for (size_t i = 0; i < ha->nh; i++) {
+      for (int64_t i = 0; i < ha->nh; i++) {
         HammingComputer hc (bs1 + i * bytes_per_code, bytes_per_code);
 
         const uint8_t * bs2_ = bs2 + j0 * bytes_per_code;
@@ -333,7 +333,7 @@ void hammings_knn_mc (
   for (size_t j0 = 0; j0 < nb; j0 += block_size) {
     const size_t j1 = std::min(j0 + block_size, nb);
 #pragma omp parallel for
-    for (size_t i = 0; i < na; ++i) {
+    for (int64_t i = 0; i < na; ++i) {
       for (size_t j = j0; j < j1; ++j) {
         cs[i].update_counter(b + j * bytes_per_code, j);
       }
@@ -380,7 +380,7 @@ void hammings_knn_hc_1 (
     }
 
 #pragma omp parallel for
-    for (size_t i = 0; i < ha->nh; i++) {
+    for (int64_t i = 0; i < ha->nh; i++) {
         const uint64_t bs1_ = bs1 [i];
         const uint64_t * bs2_ = bs2;
         hamdis_t dis;
@@ -436,7 +436,7 @@ void fvecs2bitvecs (const float * x, uint8_t * b, size_t d, size_t n)
 {
     const int64_t ncodes = ((d + 7) / 8);
 #pragma omp parallel for if(n > 100000)
-    for (size_t i = 0; i < n; i++)
+    for (int64_t i = 0; i < n; i++)
         fvec2bitvec (x + i * d, b + i * ncodes, d);
 }
 
@@ -450,7 +450,7 @@ void bitvecs2fvecs (
 
     const int64_t ncodes = ((d + 7) / 8);
 #pragma omp parallel for if(n > 100000)
-    for (size_t i = 0; i < n; i++) {
+    for (int64_t i = 0; i < n; i++) {
         binary_to_real (d, b + i * ncodes, x + i * d);
     }
 }
@@ -498,7 +498,7 @@ void bitvec_shuffle (size_t n, size_t da, size_t db,
     size_t ldb = (db + 7) / 8;
 
 #pragma omp parallel for if(n > 10000)
-    for (size_t i = 0; i < n; i++) {
+    for (int64_t i = 0; i < n; i++) {
         const uint8_t *ai = a + i * lda;
         uint8_t *bi = b + i * ldb;
         memset (bi, 0, ldb);
@@ -654,7 +654,7 @@ void hamming_range_search_template (
         RangeSearchPartialResult pres (res);
 
 #pragma omp for
-        for (size_t i = 0; i < na; i++) {
+        for (int64_t i = 0; i < na; i++) {
              HammingComputer hc (a + i * code_size, code_size);
             const uint8_t * yi = b;
             RangeQueryResult & qres = pres.new_result (i);

--- a/faiss/utils/random.cpp
+++ b/faiss/utils/random.cpp
@@ -61,7 +61,7 @@ void float_rand (float * x, size_t n, int64_t seed)
     int a0 = rng0.rand_int (), b0 = rng0.rand_int ();
 
 #pragma omp parallel for
-    for (size_t j = 0; j < nblock; j++) {
+    for (int64_t j = 0; j < nblock; j++) {
 
         RandomGenerator rng (a0 + j * b0);
 
@@ -83,7 +83,7 @@ void float_randn (float * x, size_t n, int64_t seed)
     int a0 = rng0.rand_int (), b0 = rng0.rand_int ();
 
 #pragma omp parallel for
-    for (size_t j = 0; j < nblock; j++) {
+    for (int64_t j = 0; j < nblock; j++) {
         RandomGenerator rng (a0 + j * b0);
 
         double a = 0, b = 0, s = 0;
@@ -120,7 +120,7 @@ void int64_rand (int64_t * x, size_t n, int64_t seed)
     int a0 = rng0.rand_int (), b0 = rng0.rand_int ();
 
 #pragma omp parallel for
-    for (size_t j = 0; j < nblock; j++) {
+    for (int64_t j = 0; j < nblock; j++) {
 
         RandomGenerator rng (a0 + j * b0);
 
@@ -140,7 +140,7 @@ void int64_rand_max (int64_t * x, size_t n, uint64_t max, int64_t seed)
     int a0 = rng0.rand_int (), b0 = rng0.rand_int ();
 
 #pragma omp parallel for
-    for (size_t j = 0; j < nblock; j++) {
+    for (int64_t j = 0; j < nblock; j++) {
 
         RandomGenerator rng (a0 + j * b0);
 
@@ -176,7 +176,7 @@ void byte_rand (uint8_t * x, size_t n, int64_t seed)
     int a0 = rng0.rand_int (), b0 = rng0.rand_int ();
 
 #pragma omp parallel for
-    for (size_t j = 0; j < nblock; j++) {
+    for (int64_t j = 0; j < nblock; j++) {
 
         RandomGenerator rng (a0 + j * b0);
 

--- a/faiss/utils/utils.cpp
+++ b/faiss/utils/utils.cpp
@@ -184,7 +184,7 @@ void inner_product_to_L2sqr (float * __restrict dis,
 {
 
 #pragma omp parallel for
-    for (size_t j = 0 ; j < n1 ; j++) {
+    for (int64_t j = 0 ; j < n1 ; j++) {
         float * disj = dis + j * n2;
         for (size_t i = 0 ; i < n2 ; i++)
             disj[i] = nr1[j] + nr2[i] - 2 * disj[i];
@@ -251,7 +251,7 @@ size_t merge_result_table_with (size_t n, size_t k,
         std::vector<float> tmpD (k);
 
 #pragma omp for
-        for (size_t i = 0; i < n; i++) {
+        for (int64_t i = 0; i < n; i++) {
             int64_t *lI0 = I0 + i * k;
             float *lD0 = D0 + i * k;
             const int64_t *lI1 = I1 + i * k;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1344 Avoid OpenMP 4.0 custom reduction.
* **#1343 Fix unsigned OpenMP loop indices (disallowed in OpenMP 2).**
* #1342 Fix long literals used as 64 bit.
* #1341 Replace finite() with std::isfinite().
* #1340 Replace bzero (deprecated in POSIX 2001) with memset.
* #1339 Fix division by zero.
* #1338 Fix format specifiers for size_t/idx_t.
* #1337 Add missing algorithm header.

Differential Revision: [D23234967](https://our.internmc.facebook.com/intern/diff/D23234967)