### PR TITLE
Avoid OpenMP 4.0 custom reduction.

### DIFF
--- a/faiss/impl/HNSW.h
+++ b/faiss/impl/HNSW.h
@@ -257,9 +257,8 @@ struct HNSWStats {
   size_t ndis;
   size_t nreorder;
 
-  HNSWStats() {
-    reset();
-  }
+  HNSWStats(size_t n1 = 0, size_t n2 = 0, size_t n3 = 0, size_t ndis = 0, size_t nreorder = 0)
+    : n1(n1), n2(n2), n3(n3), ndis(ndis), nreorder(nreorder) {}
 
   void reset() {
     n1 = n2 = n3 = 0;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#1344 Avoid OpenMP 4.0 custom reduction.**
* #1343 Fix unsigned OpenMP loop indices (disallowed in OpenMP 2).
* #1342 Fix long literals used as 64 bit.
* #1341 Replace finite() with std::isfinite().
* #1340 Replace bzero (deprecated in POSIX 2001) with memset.
* #1339 Fix division by zero.
* #1338 Fix format specifiers for size_t/idx_t.
* #1337 Add missing algorithm header.

Differential Revision: [D23234970](https://our.internmc.facebook.com/intern/diff/D23234970)