### PR TITLE
Fix unclosed thread pool.

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -10,7 +10,6 @@ import tempfile
 import os
 import io
 import sys
-import warnings
 from multiprocessing.dummy import Pool as ThreadPool
 
 from common import get_dataset, get_dataset_2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1354 Make OOMException test Linux-only.
* #1353 Avoid leaking file descriptors in python tests.
* #1352 Fix long used as uint64_t in lattice_Zn.
* **#1351 Fix unclosed thread pool.**

Differential Revision: [D23292458](https://our.internmc.facebook.com/intern/diff/D23292458)