### PR TITLE
Avoid leaking file descriptors in python tests.

### DIFF
--- a/tests/test_binary_io.py
+++ b/tests/test_binary_io.py
@@ -37,7 +37,8 @@ class TestBinaryFlat(unittest.TestCase):
         index.add(self.xb)
         D, I = index.search(self.xq, 3)
 
-        _, tmpnam = tempfile.mkstemp()
+        fd, tmpnam = tempfile.mkstemp()
+        os.close(fd)
         try:
             faiss.write_index_binary(index, tmpnam)
 
@@ -74,8 +75,8 @@ class TestBinaryIVF(unittest.TestCase):
         index.add(self.xb)
         D, I = index.search(self.xq, 3)
 
-        _, tmpnam = tempfile.mkstemp()
-
+        fd, tmpnam = tempfile.mkstemp()
+        os.close(fd)
         try:
             faiss.write_index_binary(index, tmpnam)
 
@@ -107,7 +108,8 @@ class TestObjectOwnership(unittest.TestCase):
         index = faiss.IndexBinaryFlat(d)
         index.add(self.xb)
 
-        _, tmpnam = tempfile.mkstemp()
+        fd, tmpnam = tempfile.mkstemp()
+        os.close(fd)
         try:
             faiss.write_index_binary(index, tmpnam)
 
@@ -137,8 +139,8 @@ class TestBinaryFromFloat(unittest.TestCase):
         index.add(self.xb)
         D, I = index.search(self.xq, 3)
 
-        _, tmpnam = tempfile.mkstemp()
-
+        fd, tmpnam = tempfile.mkstemp()
+        os.close(fd)
         try:
             faiss.write_index_binary(index, tmpnam)
 
@@ -171,8 +173,8 @@ class TestBinaryHNSW(unittest.TestCase):
         index.add(self.xb)
         D, I = index.search(self.xq, 3)
 
-        _, tmpnam = tempfile.mkstemp()
-
+        fd, tmpnam = tempfile.mkstemp()
+        os.close(fd)
         try:
             faiss.write_index_binary(index, tmpnam)
 
@@ -197,8 +199,8 @@ class TestBinaryHNSW(unittest.TestCase):
         index.add(self.xb)
         D, I = index.search(self.xq, 3)
 
-        _, tmpnam = tempfile.mkstemp()
-
+        fd, tmpnam = tempfile.mkstemp()
+        os.close(fd)
         try:
             faiss.write_index_binary(index, tmpnam)
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -445,7 +445,8 @@ class TestHNSW(unittest.TestCase):
         self.io_and_retest(index, Dhnsw, Ihnsw)
 
     def io_and_retest(self, index, Dhnsw, Ihnsw):
-        _, tmpfile = tempfile.mkstemp()
+        fd, tmpfile = tempfile.mkstemp()
+        os.close(fd)
         try:
             faiss.write_index(index, tmpfile)
             index2 = faiss.read_index(tmpfile)

--- a/tests/test_index_composite.py
+++ b/tests/test_index_composite.py
@@ -130,7 +130,8 @@ class TestRemove(unittest.TestCase):
             assert False, 'should have raised an exception'
 
         # while we are there, let's test I/O as well...
-        _, tmpnam = tempfile.mkstemp()
+        fd, tmpnam = tempfile.mkstemp()
+        os.close(fd)
         try:
             faiss.write_index_binary(index, tmpnam)
             index = faiss.read_index_binary(tmpnam)
@@ -409,7 +410,8 @@ class TestIVFFlatDedup(unittest.TestCase):
             assert ref == new
 
         # test I/O
-        _, tmpfile = tempfile.mkstemp()
+        fd, tmpfile = tempfile.mkstemp()
+        os.close(fd)
         try:
             faiss.write_index(index_new, tmpfile)
             index_st = faiss.read_index(tmpfile)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1354 Make OOMException test Linux-only.
* **#1353 Avoid leaking file descriptors in python tests.**
* #1352 Fix long used as uint64_t in lattice_Zn.
* #1351 Fix unclosed thread pool.

Differential Revision: [D23292456](https://our.internmc.facebook.com/intern/diff/D23292456)