### PR TITLE
Make OOMException test Linux-only.

### DIFF
--- a/tests/test_oom_exception.py
+++ b/tests/test_oom_exception.py
@@ -6,14 +6,13 @@
 import sys
 import faiss
 import unittest
-import resource
+import platform
 
 class TestOOMException(unittest.TestCase):
-
+    @unittest.skipIf(platform.system() != 'Linux',
+                     'Test is Linux only.')
     def test_outrageous_alloc(self):
-        # Disable test on OSX.
-        if sys.platform == "darwin":
-            return
+        import resource
 
         # https://github.com/facebookresearch/faiss/issues/758
         soft_as, hard_as = resource.getrlimit(resource.RLIMIT_AS)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#1354 Make OOMException test Linux-only.**
* #1353 Avoid leaking file descriptors in python tests.
* #1352 Fix long used as uint64_t in lattice_Zn.
* #1351 Fix unclosed thread pool.

Differential Revision: [D23292455](https://our.internmc.facebook.com/intern/diff/D23292455)