### PR TITLE
Remove extraneous unix header include.

### DIFF
--- a/faiss/IndexBinaryHNSW.cpp
+++ b/faiss/IndexBinaryHNSW.cpp
@@ -23,7 +23,6 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <stdint.h>
 
 #include <faiss/utils/random.h>

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -22,7 +22,6 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <stdint.h>
 
 #ifdef __SSE__

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -15,7 +15,6 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/io.h>

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -15,7 +15,6 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/io.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1362 Fix leaking fd in test_io.
* #1361 Fix format specifier in python_callbacks.
* #1360 Make Faiss work with 32bit python.
* #1359 Move definition of inner_product_to_L2sqr() to distances.cpp.
* #1358 Fix VectorDistance initialization.
* **#1356 Remove extraneous unix header include.**

Differential Revision: [D23312000](https://our.internmc.facebook.com/intern/diff/D23312000)