### PR TITLE
Fix std::vector used as array.

### DIFF
--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -336,7 +336,7 @@ void compute_code(const ProductQuantizer& pq, const float *x, uint8_t *code) {
     uint64_t idxm = 0;
     const float * xsub = x + m * pq.dsub;
 
-    fvec_L2sqr_ny(distances, xsub, pq.get_centroids(m, 0), pq.dsub, pq.ksub);
+    fvec_L2sqr_ny(distances.data(), xsub, pq.get_centroids(m, 0), pq.dsub, pq.ksub);
 
     /* Find best centroid */
     for (size_t i = 0; i < pq.ksub; i++) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1362 Fix leaking fd in test_io.
* #1361 Fix format specifier in python_callbacks.
* #1360 Make Faiss work with 32bit python.
* #1359 Move definition of inner_product_to_L2sqr() to distances.cpp.
* #1358 Fix VectorDistance initialization.
* **#1357 Fix std::vector used as array.**
* #1356 Remove extraneous unix header include.

Differential Revision: [D23312004](https://our.internmc.facebook.com/intern/diff/D23312004)