### PR TITLE
Move definition of inner_product_to_L2sqr() to distances.cpp.

### DIFF
--- a/faiss/utils/distances.cpp
+++ b/faiss/utils/distances.cpp
@@ -761,5 +761,19 @@ void pairwise_L2sqr (int64_t d,
 
 }
 
+void inner_product_to_L2sqr(float* __restrict dis,
+    const float* nr1,
+    const float* nr2,
+    size_t n1, size_t n2)
+{
+
+#pragma omp parallel for
+    for (int64_t j = 0; j < n1; j++) {
+        float* disj = dis + j * n2;
+        for (size_t i = 0; i < n2; i++)
+            disj[i] = nr1[j] + nr2[i] - 2 * disj[i];
+    }
+}
+
 
 } // namespace faiss

--- a/faiss/utils/utils.cpp
+++ b/faiss/utils/utils.cpp
@@ -173,25 +173,6 @@ void reflection_ref (const float * u, float * x, size_t n, size_t d, size_t nu)
  * Some matrix manipulation functions
  ***************************************************************************/
 
-
-/* This function exists because the Torch counterpart is extremly slow
-   (not multi-threaded + unexpected overhead even in single thread).
-   It is here to implement the usual property |x-y|^2=|x|^2+|y|^2-2<x|y>  */
-void inner_product_to_L2sqr (float * __restrict dis,
-                             const float * nr1,
-                             const float * nr2,
-                             size_t n1, size_t n2)
-{
-
-#pragma omp parallel for
-    for (int64_t j = 0 ; j < n1 ; j++) {
-        float * disj = dis + j * n2;
-        for (size_t i = 0 ; i < n2 ; i++)
-            disj[i] = nr1[j] + nr2[i] - 2 * disj[i];
-    }
-}
-
-
 void matrix_qr (int m, int n, float *a)
 {
     FAISS_THROW_IF_NOT (m >= n);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1362 Fix leaking fd in test_io.
* #1361 Fix format specifier in python_callbacks.
* #1360 Make Faiss work with 32bit python.
* **#1359 Move definition of inner_product_to_L2sqr() to distances.cpp.**
* #1358 Fix VectorDistance initialization.
* #1356 Remove extraneous unix header include.

The declaration is in distances.h, which utils.cpp does not include,
confusing the linker on Windows.

Differential Revision: [D23311999](https://our.internmc.facebook.com/intern/diff/D23311999)