### PR TITLE
Make Faiss work with 32bit python.

### DIFF
--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -83,6 +83,7 @@ def handle_Quantizer(the_class):
     def replacement_decode(self, codes):
         n, cs = codes.shape
         assert cs == self.code_size
+        codes = np.ascontiguousarray(codes, np.uint8)
         x = np.empty((n, self.d), dtype='float32')
         self.decode_c(swig_ptr(codes), swig_ptr(x), n)
         return x
@@ -108,6 +109,7 @@ def handle_Index(the_class):
         n, d = x.shape
         assert d == self.d
         assert ids.shape == (n, ), 'not same nb of vectors as ids'
+        ids = np.ascontiguousarray(ids, dtype=np.int64)
         self.add_with_ids_c(n, swig_ptr(x), swig_ptr(ids))
 
     def replacement_assign(self, x, k):
@@ -151,6 +153,7 @@ def handle_Index(the_class):
         else:
             assert x.ndim == 1
             index_ivf = try_extract_index_ivf (self)
+            x = np.ascontiguousarray(x, dtype=np.int64)
             if index_ivf and index_ivf.direct_map.type == DirectMap.Hashtable:
                 sel = IDSelectorArray(x.size, swig_ptr(x))
             else:
@@ -170,6 +173,7 @@ def handle_Index(the_class):
     def replacement_update_vectors(self, keys, x):
         n = keys.size
         assert keys.shape == (n, )
+        keys = np.ascontiguousarray(keys, dtype=np.int64)
         assert x.shape == (n, self.d)
         self.update_vectors_c(n, swig_ptr(keys), swig_ptr(x))
 
@@ -227,6 +231,7 @@ def handle_IndexBinary(the_class):
         n, d = x.shape
         assert d * 8 == self.d
         assert ids.shape == (n, ), 'not same nb of vectors as ids'
+        ids = np.ascontiguousarray(ids, dtype=np.int64)
         self.add_with_ids_c(n, swig_ptr(x), swig_ptr(ids))
 
     def replacement_train(self, x):
@@ -267,6 +272,7 @@ def handle_IndexBinary(the_class):
             sel = x
         else:
             assert x.ndim == 1
+            x = np.ascontiguousarray(x, dtype=np.int64)
             sel = IDSelectorBatch(x.size, swig_ptr(x))
         return self.remove_ids_c(sel)
 
@@ -651,10 +657,13 @@ def normalize_L2(x):
 def replacement_map_add(self, keys, vals):
     n, = keys.shape
     assert (n,) == keys.shape
+    keys = np.ascontiguousarray(keys, dtype=np.int64)
+    vals = np.ascontiguousarray(vals, dtype=np.int64)
     self.add_c(n, swig_ptr(keys), swig_ptr(vals))
 
 def replacement_map_search_multiple(self, keys):
     n, = keys.shape
+    keys = np.ascontiguousarray(keys, dtype=np.int64)
     vals = np.empty(n, dtype='int64')
     self.search_multiple_c(n, swig_ptr(keys), swig_ptr(vals))
     return vals

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -601,7 +601,7 @@ class TestReconsHash(unittest.TestCase):
             self.assertTrue(np.all(recons == ref_recons[i]))
 
         # remove
-        toremove = np.ascontiguousarray(ids[0:200:3])
+        toremove = np.ascontiguousarray(ids[0:200:3], dtype=np.int64)
 
         sel = faiss.IDSelectorArray(50, faiss.swig_ptr(toremove[:50]))
 

--- a/tests/test_meta_index.py
+++ b/tests/test_meta_index.py
@@ -217,7 +217,7 @@ class Merge(unittest.TestCase):
         print('ref search ntotal=%d' % index.ntotal)
         Dref, Iref = index.search(xq, k)
 
-        toremove = np.zeros(nq * k, dtype=int)
+        toremove = np.zeros(nq * k, dtype=np.int64)
         nr = 0
         for i in range(nq):
             for j in range(k):

--- a/tests/test_standalone_codec.py
+++ b/tests/test_standalone_codec.py
@@ -250,7 +250,7 @@ class LatticeTest(unittest.TestCase):
         codec = faiss.ZnSphereCodecAlt(dim, r2)
         rs = np.random.RandomState(123)
         n = 100
-        codes = rs.randint(codec.nv, size=n).astype('uint64')
+        codes = rs.randint(codec.nv, size=n, dtype=np.uint64)
         x = np.empty((n, dim), dtype='float32')
         codec.decode_multi(n, swig_ptr(codes), swig_ptr(x))
         codes2 = np.empty(n, dtype='uint64')
@@ -286,7 +286,7 @@ class TestBitstring(unittest.TestCase):
                 nbit = int(1 + 62 * rs.rand() ** 4)
                 if sz + nbit > nbyte * 8:
                     break
-                x = rs.randint(1 << nbit)
+                x = int(rs.randint(1 << nbit, dtype=np.uint64))
                 bw.write(x, nbit)
                 ctrl.append((nbit, x))
                 sz += nbit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1362 Fix leaking fd in test_io.
* #1361 Fix format specifier in python_callbacks.
* **#1360 Make Faiss work with 32bit python.**
* #1359 Move definition of inner_product_to_L2sqr() to distances.cpp.
* #1358 Fix VectorDistance initialization.
* #1356 Remove extraneous unix header include.

On 32bit python, numpy arrays of integers get converted to int32_t
pointers instead of int64_t pointers.

Differential Revision: [D23312002](https://our.internmc.facebook.com/intern/diff/D23312002)