### PR TITLE
Fix format specifier in python_callbacks.

### DIFF
--- a/faiss/python/python_callbacks.cpp
+++ b/faiss/python/python_callbacks.cpp
@@ -95,7 +95,7 @@ size_t PyCallbackIOReader::operator()(void *ptrv, size_t size, size_t nitems)
         nb += sz;
         if (sz > rs) {
             Py_DECREF(result);
-            FAISS_THROW_FMT("read callback returned %ld bytes (asked %ld)",
+            FAISS_THROW_FMT("read callback returned %zd bytes (asked %zd)",
                             sz, rs);
         }
         memcpy(ptr, PyBytes_AsString(result), sz);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1362 Fix leaking fd in test_io.
* **#1361 Fix format specifier in python_callbacks.**
* #1360 Make Faiss work with 32bit python.
* #1359 Move definition of inner_product_to_L2sqr() to distances.cpp.
* #1358 Fix VectorDistance initialization.
* #1356 Remove extraneous unix header include.

Differential Revision: [D23312001](https://our.internmc.facebook.com/intern/diff/D23312001)