### PR TITLE
Fix leaking fd in test_io.

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -22,7 +22,8 @@ class TestIOVariants(unittest.TestCase):
         x = np.random.uniform(size=(n, d)).astype('float32')
         index = faiss.IndexFlatL2(d)
         index.add(x)
-        _, fname = tempfile.mkstemp()
+        fd, fname = tempfile.mkstemp()
+        os.close(fd)
         try:
             faiss.write_index(index, fname)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#1362 Fix leaking fd in test_io.**
* #1361 Fix format specifier in python_callbacks.
* #1360 Make Faiss work with 32bit python.
* #1359 Move definition of inner_product_to_L2sqr() to distances.cpp.
* #1358 Fix VectorDistance initialization.
* #1356 Remove extraneous unix header include.

Differential Revision: [D23311998](https://our.internmc.facebook.com/intern/diff/D23311998)