### PR TITLE
Disable contrib tests for python2.

### DIFF
--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -1,10 +1,16 @@
 import faiss
 import unittest
 import numpy as np
+import platform
 
 from common import get_dataset_2
-from faiss.contrib.exhaustive_search import knn_ground_truth
+try:
+    from faiss.contrib.exhaustive_search import knn_ground_truth
+except:
+    pass  # Submodule import broken in python 2.
 
+@unittest.skipIf(platform.python_version_tuple()[0] < '3', \
+                 'Submodule import broken in python 2.')
 class TestComputeGT(unittest.TestCase):
 
     def test_compute_GT(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1377 Windows CI + conda packaging.
* #1376 Fix dynamic size arrays.
* #1375 Add __PRETTY_FUNCTION__ polyfill.
* #1374 Avoid building OnDiskInvertedLists on Windows.
* #1373 Export static/extern globals.
* #1372 Fix target export for Windows.
* #1371 Fix guard clause on get_mem_usage_kb().
* #1370 Fix swig build on Windows.
* #1369 Windows implementation of getmillisecs().
* #1368 Add __builtin_ctzll/__builtin_clzll polyfills.
* #1367 Add __builtin_popcountl polyfill.
* #1366 Add strtok_r polyfill.
* #1365 Fix setup.py for Windows.
* **#1364 Disable contrib tests for python2.**
* #1363 Update conda packaging.

Differential Revision: [D23314732](https://our.internmc.facebook.com/intern/diff/D23314732)