### PR TITLE
Fix setup.py for Windows.

### DIFF
--- a/faiss/python/setup.py
+++ b/faiss/python/setup.py
@@ -2,13 +2,7 @@ from __future__ import print_function
 from setuptools import setup, find_packages
 import os
 import shutil
-
-here = os.path.abspath(os.path.dirname(__file__))
-
-check_fpath = os.path.join("_swigfaiss.so")
-if not os.path.exists(check_fpath):
-    print("Could not find {}".format(check_fpath))
-    print("Have you run `make` and `make -C python`?")
+import platform
 
 # make the faiss python package dir
 shutil.rmtree("faiss", ignore_errors=True)
@@ -17,12 +11,16 @@ shutil.copytree("contrib", "faiss/contrib")
 shutil.copyfile("__init__.py", "faiss/__init__.py")
 shutil.copyfile("loader.py", "faiss/loader.py")
 shutil.copyfile("swigfaiss.py", "faiss/swigfaiss.py")
-shutil.copyfile("_swigfaiss.so", "faiss/_swigfaiss.so")
-try:
-    shutil.copyfile("swigfaiss_avx2.py", "faiss/swigfaiss_avx2.py")
-    shutil.copyfile("_swigfaiss_avx2.so", "faiss/_swigfaiss_avx2.so")
-except:
-    pass
+if platform.system() == 'Windows':
+    shutil.copyfile("Release/_swigfaiss.pyd", "faiss/_swigfaiss.pyd")
+
+else:
+    shutil.copyfile("_swigfaiss.so", "faiss/_swigfaiss.so")
+    try:
+        shutil.copyfile("swigfaiss_avx2.py", "faiss/swigfaiss_avx2.py")
+        shutil.copyfile("_swigfaiss_avx2.so", "faiss/_swigfaiss_avx2.so")
+    except:
+        pass
 
 long_description="""
 Faiss is a library for efficient similarity search and clustering of dense
@@ -46,7 +44,7 @@ setup(
     install_requires=['numpy'],
     packages=['faiss', 'faiss.contrib'],
     package_data={
-        'faiss': ['*.so'],
+        'faiss': ['*.so', '*.pyd'],
     },
 
 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1377 Windows CI + conda packaging.
* #1376 Fix dynamic size arrays.
* #1375 Add __PRETTY_FUNCTION__ polyfill.
* #1374 Avoid building OnDiskInvertedLists on Windows.
* #1373 Export static/extern globals.
* #1372 Fix target export for Windows.
* #1371 Fix guard clause on get_mem_usage_kb().
* #1370 Fix swig build on Windows.
* #1369 Windows implementation of getmillisecs().
* #1368 Add __builtin_ctzll/__builtin_clzll polyfills.
* #1367 Add __builtin_popcountl polyfill.
* #1366 Add strtok_r polyfill.
* **#1365 Fix setup.py for Windows.**
* #1364 Disable contrib tests for python2.
* #1363 Update conda packaging.

Differential Revision: [D23314737](https://our.internmc.facebook.com/intern/diff/D23314737)