### PR TITLE
Add __builtin_ctzll/__builtin_clzll polyfills.

### DIFF
--- a/faiss/IndexBinaryHash.cpp
+++ b/faiss/IndexBinaryHash.cpp
@@ -19,6 +19,15 @@
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>
 
+#ifdef _MSC_VER
+#include <intrin.h>
+
+static inline int __builtin_ctzll(uint64_t x) {
+    unsigned long ret;
+    _BitScanForward64(&ret, x);
+    return (int)ret;
+}
+#endif // _MSC_VER
 
 namespace faiss {
 

--- a/faiss/impl/lattice_Zn.cpp
+++ b/faiss/impl/lattice_Zn.cpp
@@ -21,6 +21,22 @@
 
 #include <faiss/utils/distances.h>
 
+#ifdef _MSC_VER
+
+#include <intrin.h>
+
+static inline int __builtin_ctzll(uint64_t x) {
+    unsigned long ret;
+    _BitScanForward64(&ret, x);
+    return (int)ret;
+}
+
+static inline int __builtin_clzll(uint64_t x) {
+    return (int)__lzcnt64(x);
+}
+
+#endif // _MSC_VER
+
 namespace faiss {
 
 /********************************************
@@ -115,7 +131,7 @@ uint64_t repeats_encode_64 (
         uint64_t tosee = ~coded;
         for(;;) {
             // directly jump to next available slot.
-            int i = __builtin_ctzl(tosee);
+            int i = __builtin_ctzll(tosee);
             tosee &= ~(uint64_t{1} << i) ;
             if (c[i] == r->val) {
                 code_comb += comb(rank, occ + 1);
@@ -150,7 +166,7 @@ void repeats_decode_64(
         int next_rank = decode_comb_1 (&code_comb, r->n, rank);
         uint64_t tosee = ((uint64_t{1} << dim) - 1) ^ decoded;
         for(;;) {
-            int i = 63 - __builtin_clzl(tosee);
+            int i = 63 - __builtin_clzll(tosee);
             tosee &= ~(uint64_t{1} << i);
             rank--;
             if (rank == next_rank) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1377 Windows CI + conda packaging.
* #1376 Fix dynamic size arrays.
* #1375 Add __PRETTY_FUNCTION__ polyfill.
* #1374 Avoid building OnDiskInvertedLists on Windows.
* #1373 Export static/extern globals.
* #1372 Fix target export for Windows.
* #1371 Fix guard clause on get_mem_usage_kb().
* #1370 Fix swig build on Windows.
* #1369 Windows implementation of getmillisecs().
* **#1368 Add __builtin_ctzll/__builtin_clzll polyfills.**
* #1367 Add __builtin_popcountl polyfill.
* #1366 Add strtok_r polyfill.
* #1365 Fix setup.py for Windows.
* #1364 Disable contrib tests for python2.
* #1363 Update conda packaging.

Differential Revision: [D23314730](https://our.internmc.facebook.com/intern/diff/D23314730)