### PR TITLE
Windows implementation of getmillisecs().

### DIFF
--- a/faiss/utils/utils.cpp
+++ b/faiss/utils/utils.cpp
@@ -14,9 +14,16 @@
 #include <cstring>
 #include <cmath>
 
-#include <sys/time.h>
 #include <sys/types.h>
+
+#ifdef _MSC_VER
+#define NOMINMAX
+#include <windows.h>
+#undef NOMINMAX
+#else
+#include <sys/time.h>
 #include <unistd.h>
+#endif // !_MSC_VER
 
 #include <omp.h>
 
@@ -65,11 +72,22 @@ int sgemv_(const char *trans, FINTEGER *m, FINTEGER *n, float *alpha,
 
 namespace faiss {
 
+#ifdef _MSC_VER
+double getmillisecs() {
+    LARGE_INTEGER ts;
+    LARGE_INTEGER freq;
+    QueryPerformanceFrequency(&freq);
+    QueryPerformanceCounter(&ts);
+
+    return (ts.QuadPart * 1e3) / freq.QuadPart;
+}
+#else // _MSC_VER
 double getmillisecs () {
     struct timeval tv;
     gettimeofday (&tv, nullptr);
     return tv.tv_sec * 1e3 + tv.tv_usec * 1e-3;
 }
+#endif // _MSC_VER
 
 uint64_t get_cycles () {
 #ifdef  __x86_64__


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1377 Windows CI + conda packaging.
* #1376 Fix dynamic size arrays.
* #1375 Add __PRETTY_FUNCTION__ polyfill.
* #1374 Avoid building OnDiskInvertedLists on Windows.
* #1373 Export static/extern globals.
* #1372 Fix target export for Windows.
* #1371 Fix guard clause on get_mem_usage_kb().
* #1370 Fix swig build on Windows.
* **#1369 Windows implementation of getmillisecs().**
* #1368 Add __builtin_ctzll/__builtin_clzll polyfills.
* #1367 Add __builtin_popcountl polyfill.
* #1366 Add strtok_r polyfill.
* #1365 Fix setup.py for Windows.
* #1364 Disable contrib tests for python2.
* #1363 Update conda packaging.

Differential Revision: [D23314738](https://our.internmc.facebook.com/intern/diff/D23314738)