### PR TITLE
Fix swig build on Windows.

### DIFF
--- a/faiss/python/CMakeLists.txt
+++ b/faiss/python/CMakeLists.txt
@@ -24,9 +24,15 @@ set_source_files_properties(swigfaiss.swig PROPERTIES
   USE_TARGET_INCLUDE_DIRECTORIES TRUE
 )
 
-if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT WIN32)
   set_source_files_properties(swigfaiss.swig PROPERTIES
     SWIG_FLAGS -DSWIGWORDSIZE64
+  )
+endif()
+
+if(WIN32)
+  set_source_files_properties(swigfaiss.swig PROPERTIES
+    SWIG_FLAGS -DSWIGWIN
   )
 endif()
 
@@ -36,8 +42,10 @@ swig_add_library(swigfaiss
   SOURCES swigfaiss.swig
 )
 
-# NOTE: Python does not recognize the dylib extension.
-set_target_properties(swigfaiss PROPERTIES SUFFIX .so)
+if(NOT WIN32)
+  # NOTE: Python does not recognize the dylib extension.
+  set_target_properties(swigfaiss PROPERTIES SUFFIX .so)
+endif()
 
 if(FAISS_ENABLE_GPU)
   find_package(CUDAToolkit REQUIRED)

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -975,17 +975,6 @@ int * cast_integer_to_int_ptr (long x) {
 %ignore faiss::InterruptCallback::lock;
 %include  <faiss/impl/AuxIndexStructures.h>
 
-%{
-// may be useful for lua code launched in background from shell
-
-#include <signal.h>
-void ignore_SIGTTIN() {
-    signal(SIGTTIN, SIG_IGN);
-}
-%}
-
-void ignore_SIGTTIN();
-
 
 %inline %{
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1377 Windows CI + conda packaging.
* #1376 Fix dynamic size arrays.
* #1375 Add __PRETTY_FUNCTION__ polyfill.
* #1374 Avoid building OnDiskInvertedLists on Windows.
* #1373 Export static/extern globals.
* #1372 Fix target export for Windows.
* #1371 Fix guard clause on get_mem_usage_kb().
* **#1370 Fix swig build on Windows.**
* #1369 Windows implementation of getmillisecs().
* #1368 Add __builtin_ctzll/__builtin_clzll polyfills.
* #1367 Add __builtin_popcountl polyfill.
* #1366 Add strtok_r polyfill.
* #1365 Fix setup.py for Windows.
* #1364 Disable contrib tests for python2.
* #1363 Update conda packaging.

Differential Revision: [D23314739](https://our.internmc.facebook.com/intern/diff/D23314739)