### PR TITLE
Fix guard clause on get_mem_usage_kb().

### DIFF
--- a/faiss/utils/utils.cpp
+++ b/faiss/utils/utils.cpp
@@ -121,11 +121,11 @@ size_t get_mem_usage_kb ()
     return sz;
 }
 
-#elif __APPLE__
+#else
 
 size_t get_mem_usage_kb ()
 {
-    fprintf(stderr, "WARN: get_mem_usage_kb not implemented on the mac\n");
+    fprintf(stderr, "WARN: get_mem_usage_kb not implemented on current architecture\n");
     return 0;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1377 Windows CI + conda packaging.
* #1376 Fix dynamic size arrays.
* #1375 Add __PRETTY_FUNCTION__ polyfill.
* #1374 Avoid building OnDiskInvertedLists on Windows.
* #1373 Export static/extern globals.
* #1372 Fix target export for Windows.
* **#1371 Fix guard clause on get_mem_usage_kb().**
* #1370 Fix swig build on Windows.
* #1369 Windows implementation of getmillisecs().
* #1368 Add __builtin_ctzll/__builtin_clzll polyfills.
* #1367 Add __builtin_popcountl polyfill.
* #1366 Add strtok_r polyfill.
* #1365 Fix setup.py for Windows.
* #1364 Disable contrib tests for python2.
* #1363 Update conda packaging.

Differential Revision: [D23314741](https://our.internmc.facebook.com/intern/diff/D23314741)