### PR TITLE
Fix target export for Windows.

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -129,9 +129,10 @@ endif()
 target_include_directories(faiss PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
 
-# NOTE: This is needed for building faiss as a static library that will then be
-# linked into a shared library.
-set_property(TARGET faiss PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_target_properties(faiss PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+  WINDOWS_EXPORT_ALL_SYMBOLS ON
+)
 
 target_compile_definitions(faiss PRIVATE FINTEGER=int)
 
@@ -151,6 +152,9 @@ endif()
 
 install(TARGETS faiss
   EXPORT faiss-targets
+  RUNTIME DESTINATION bin
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
   INCLUDES DESTINATION include
 )
 foreach(header ${FAISS_HEADERS})


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1377 Windows CI + conda packaging.
* #1376 Fix dynamic size arrays.
* #1375 Add __PRETTY_FUNCTION__ polyfill.
* #1374 Avoid building OnDiskInvertedLists on Windows.
* #1373 Export static/extern globals.
* **#1372 Fix target export for Windows.**
* #1371 Fix guard clause on get_mem_usage_kb().
* #1370 Fix swig build on Windows.
* #1369 Windows implementation of getmillisecs().
* #1368 Add __builtin_ctzll/__builtin_clzll polyfills.
* #1367 Add __builtin_popcountl polyfill.
* #1366 Add strtok_r polyfill.
* #1365 Fix setup.py for Windows.
* #1364 Disable contrib tests for python2.
* #1363 Update conda packaging.

Differential Revision: [D23314733](https://our.internmc.facebook.com/intern/diff/D23314733)