### PR TITLE
Export static/extern globals.

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -107,6 +107,7 @@ set(FAISS_HEADERS
   impl/io.h
   impl/io_macros.h
   impl/lattice_Zn.h
+  impl/macros.h
   utils/Heap.h
   utils/WorkerThread.h
   utils/distances.h
@@ -133,6 +134,10 @@ set_target_properties(faiss PROPERTIES
   POSITION_INDEPENDENT_CODE ON
   WINDOWS_EXPORT_ALL_SYMBOLS ON
 )
+
+if(WIN32)
+  target_compile_definitions(faiss PRIVATE FAISS_MAIN_LIB)
+endif()
 
 target_compile_definitions(faiss PRIVATE FINTEGER=int)
 

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -107,7 +107,7 @@ set(FAISS_HEADERS
   impl/io.h
   impl/io_macros.h
   impl/lattice_Zn.h
-  impl/macros.h
+  impl/platform_macros.h
   utils/Heap.h
   utils/WorkerThread.h
   utils/distances.h

--- a/faiss/IndexBinaryHash.h
+++ b/faiss/IndexBinaryHash.h
@@ -17,6 +17,7 @@
 
 #include <faiss/IndexBinary.h>
 #include <faiss/IndexBinaryFlat.h>
+#include <faiss/impl/macros.h>
 #include <faiss/utils/Heap.h>
 
 
@@ -71,7 +72,7 @@ struct IndexBinaryHashStats {
     void reset ();
 };
 
-extern IndexBinaryHashStats indexBinaryHash_stats;
+FAISS_API extern IndexBinaryHashStats indexBinaryHash_stats;
 
 
 /** just uses the b first bits as a hash value */

--- a/faiss/IndexBinaryHash.h
+++ b/faiss/IndexBinaryHash.h
@@ -17,7 +17,7 @@
 
 #include <faiss/IndexBinary.h>
 #include <faiss/IndexBinaryFlat.h>
-#include <faiss/impl/macros.h>
+#include <faiss/impl/platform_macros.h>
 #include <faiss/utils/Heap.h>
 
 

--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -19,6 +19,7 @@
 #include <faiss/InvertedLists.h>
 #include <faiss/DirectMap.h>
 #include <faiss/Clustering.h>
+#include <faiss/impl/macros.h>
 #include <faiss/utils/Heap.h>
 
 
@@ -364,7 +365,7 @@ struct IndexIVFStats {
 };
 
 // global var that collects them all
-extern IndexIVFStats indexIVF_stats;
+FAISS_API extern IndexIVFStats indexIVF_stats;
 
 
 } // namespace faiss

--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -19,7 +19,7 @@
 #include <faiss/InvertedLists.h>
 #include <faiss/DirectMap.h>
 #include <faiss/Clustering.h>
-#include <faiss/impl/macros.h>
+#include <faiss/impl/platform_macros.h>
 #include <faiss/utils/Heap.h>
 
 

--- a/faiss/IndexIVFPQ.h
+++ b/faiss/IndexIVFPQ.h
@@ -15,6 +15,7 @@
 
 #include <faiss/IndexIVF.h>
 #include <faiss/IndexPQ.h>
+#include <faiss/impl/macros.h>
 
 
 namespace faiss {
@@ -30,7 +31,7 @@ struct IVFPQSearchParameters: IVFSearchParameters {
 /** Inverted file with Product Quantizer encoding. Each residual
  * vector is encoded as a product quantizer code.
  */
-struct IndexIVFPQ: IndexIVF {
+struct FAISS_API IndexIVFPQ: IndexIVF {
     bool by_residual;              ///< Encode residual or plain vector?
 
     ProductQuantizer pq;           ///< produces the codes
@@ -150,7 +151,7 @@ struct IndexIVFPQStats {
 };
 
 // global var that collects them all
-extern IndexIVFPQStats indexIVFPQ_stats;
+FAISS_API extern IndexIVFPQStats indexIVFPQ_stats;
 
 
 

--- a/faiss/IndexIVFPQ.h
+++ b/faiss/IndexIVFPQ.h
@@ -15,7 +15,7 @@
 
 #include <faiss/IndexIVF.h>
 #include <faiss/IndexPQ.h>
-#include <faiss/impl/macros.h>
+#include <faiss/impl/platform_macros.h>
 
 
 namespace faiss {

--- a/faiss/IndexPQ.h
+++ b/faiss/IndexPQ.h
@@ -17,6 +17,8 @@
 #include <faiss/Index.h>
 #include <faiss/impl/ProductQuantizer.h>
 #include <faiss/impl/PolysemousTraining.h>
+#include <faiss/impl/macros.h>
+
 
 namespace faiss {
 
@@ -138,7 +140,7 @@ struct IndexPQStats {
     void reset ();
 };
 
-extern IndexPQStats indexPQ_stats;
+FAISS_API extern IndexPQStats indexPQ_stats;
 
 
 

--- a/faiss/IndexPQ.h
+++ b/faiss/IndexPQ.h
@@ -17,7 +17,7 @@
 #include <faiss/Index.h>
 #include <faiss/impl/ProductQuantizer.h>
 #include <faiss/impl/PolysemousTraining.h>
-#include <faiss/impl/macros.h>
+#include <faiss/impl/platform_macros.h>
 
 
 namespace faiss {

--- a/faiss/impl/AuxIndexStructures.h
+++ b/faiss/impl/AuxIndexStructures.h
@@ -21,6 +21,8 @@
 #include <mutex>
 
 #include <faiss/Index.h>
+#include <faiss/impl/macros.h>
+
 
 namespace faiss {
 
@@ -218,7 +220,7 @@ struct DistanceComputer {
  * Interrupt callback
  ***********************************************************/
 
-struct InterruptCallback {
+struct FAISS_API InterruptCallback {
     virtual bool want_interrupt () = 0;
     virtual ~InterruptCallback() {}
 

--- a/faiss/impl/AuxIndexStructures.h
+++ b/faiss/impl/AuxIndexStructures.h
@@ -21,7 +21,7 @@
 #include <mutex>
 
 #include <faiss/Index.h>
-#include <faiss/impl/macros.h>
+#include <faiss/impl/platform_macros.h>
 
 
 namespace faiss {

--- a/faiss/impl/HNSW.h
+++ b/faiss/impl/HNSW.h
@@ -19,6 +19,7 @@
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/random.h>
 #include <faiss/utils/Heap.h>
+#include <faiss/impl/macros.h>
 
 
 namespace faiss {
@@ -276,7 +277,7 @@ struct HNSWStats {
 };
 
 // global var that collects them all
-extern HNSWStats hnsw_stats;
+FAISS_API extern HNSWStats hnsw_stats;
 
 
 }  // namespace faiss

--- a/faiss/impl/HNSW.h
+++ b/faiss/impl/HNSW.h
@@ -19,7 +19,7 @@
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/random.h>
 #include <faiss/utils/Heap.h>
-#include <faiss/impl/macros.h>
+#include <faiss/impl/platform_macros.h>
 
 
 namespace faiss {

--- a/faiss/impl/macros.h
+++ b/faiss/impl/macros.h
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef _MSC_VER
+#ifdef FAISS_MAIN_LIB
+#define FAISS_API __declspec(dllexport)
+#else // _MSC_VER
+#define FAISS_API __declspec(dllimport)
+#endif // FAISS_MAIN_LIB
+#else
+#define FAISS_API
+#endif // _MSC_VER

--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -10,7 +10,7 @@
 #ifdef _MSC_VER
 #ifdef FAISS_MAIN_LIB
 #define FAISS_API __declspec(dllexport)
-#else // _MSC_VER
+#else // _FAISS_MAIN_LIB
 #define FAISS_API __declspec(dllimport)
 #endif // FAISS_MAIN_LIB
 #else

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -16,6 +16,14 @@
 
 %module swigfaiss;
 
+// NOTE: While parsing the headers to generate the interface, SWIG does not know
+// about `_MSC_VER`.
+// TODO: Remove the need for this hack.
+#ifdef SWIGWIN
+#define _MSC_VER
+%include <windows.i>
+#endif // SWIGWIN
+
 // fbode SWIG fails on warnings, so make them non fatal
 #pragma SWIG nowarn=321
 #pragma SWIG nowarn=403
@@ -230,6 +238,7 @@ namespace std {
  * Parse headers
  *******************************************************************/
 
+%include <faiss/impl/macros.h>
 
 %ignore *::cmp;
 

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -238,7 +238,7 @@ namespace std {
  * Parse headers
  *******************************************************************/
 
-%include <faiss/impl/macros.h>
+%include <faiss/impl/platform_macros.h>
 
 %ignore *::cmp;
 

--- a/faiss/utils/distances.h
+++ b/faiss/utils/distances.h
@@ -15,6 +15,7 @@
 #include <stdint.h>
 
 #include <faiss/utils/Heap.h>
+#include <faiss/impl/macros.h>
 
 
 namespace faiss {
@@ -153,7 +154,7 @@ void pairwise_indexed_inner_product (
  ***************************************************************************/
 
 // threshold on nx above which we switch to BLAS to compute distances
-extern int distance_compute_blas_threshold;
+FAISS_API extern int distance_compute_blas_threshold;
 
 /** Return the k nearest neighors of each of the nx vectors x among the ny
  *  vector y, w.r.t to max inner product

--- a/faiss/utils/distances.h
+++ b/faiss/utils/distances.h
@@ -15,7 +15,7 @@
 #include <stdint.h>
 
 #include <faiss/utils/Heap.h>
-#include <faiss/impl/macros.h>
+#include <faiss/impl/platform_macros.h>
 
 
 namespace faiss {

--- a/faiss/utils/hamming.h
+++ b/faiss/utils/hamming.h
@@ -32,6 +32,7 @@
 #define __builtin_popcountl __popcnt64
 #endif // _MSC_VER
 
+#include <faiss/impl/macros.h>
 #include <faiss/utils/Heap.h>
 
 
@@ -114,7 +115,7 @@ struct BitstringReader {
 
 
 
-extern size_t hamming_batch_size;
+FAISS_API extern size_t hamming_batch_size;
 
 inline int popcount64(uint64_t x) {
     return __builtin_popcountl(x);

--- a/faiss/utils/hamming.h
+++ b/faiss/utils/hamming.h
@@ -32,7 +32,7 @@
 #define __builtin_popcountl __popcnt64
 #endif // _MSC_VER
 
-#include <faiss/impl/macros.h>
+#include <faiss/impl/platform_macros.h>
 #include <faiss/utils/Heap.h>
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1377 Windows CI + conda packaging.
* #1376 Fix dynamic size arrays.
* #1375 Add __PRETTY_FUNCTION__ polyfill.
* #1374 Avoid building OnDiskInvertedLists on Windows.
* **#1373 Export static/extern globals.**
* #1372 Fix target export for Windows.
* #1371 Fix guard clause on get_mem_usage_kb().
* #1370 Fix swig build on Windows.
* #1369 Windows implementation of getmillisecs().
* #1368 Add __builtin_ctzll/__builtin_clzll polyfills.
* #1367 Add __builtin_popcountl polyfill.
* #1366 Add strtok_r polyfill.
* #1365 Fix setup.py for Windows.
* #1364 Disable contrib tests for python2.
* #1363 Update conda packaging.

Differential Revision: [D23314736](https://our.internmc.facebook.com/intern/diff/D23314736)