### PR TITLE
Add __PRETTY_FUNCTION__ polyfill.

### DIFF
--- a/faiss/impl/FaissAssert.h
+++ b/faiss/impl/FaissAssert.h
@@ -11,6 +11,7 @@
 #define FAISS_ASSERT_INCLUDED
 
 #include <faiss/impl/FaissException.h>
+#include <faiss/impl/macros.h>
 #include <cstdlib>
 #include <cstdio>
 #include <string>

--- a/faiss/impl/macros.h
+++ b/faiss/impl/macros.h
@@ -8,11 +8,17 @@
 #pragma once
 
 #ifdef _MSC_VER
+
 #ifdef FAISS_MAIN_LIB
 #define FAISS_API __declspec(dllexport)
 #else // _MSC_VER
 #define FAISS_API __declspec(dllimport)
 #endif // FAISS_MAIN_LIB
+
+#define __PRETTY_FUNCTION__ __FUNCSIG__
+
 #else
+
 #define FAISS_API
+
 #endif // _MSC_VER


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1377 Windows CI + conda packaging.
* #1376 Fix dynamic size arrays.
* **#1375 Add __PRETTY_FUNCTION__ polyfill.**
* #1374 Avoid building OnDiskInvertedLists on Windows.
* #1373 Export static/extern globals.
* #1372 Fix target export for Windows.
* #1371 Fix guard clause on get_mem_usage_kb().
* #1370 Fix swig build on Windows.
* #1369 Windows implementation of getmillisecs().
* #1368 Add __builtin_ctzll/__builtin_clzll polyfills.
* #1367 Add __builtin_popcountl polyfill.
* #1366 Add strtok_r polyfill.
* #1365 Fix setup.py for Windows.
* #1364 Disable contrib tests for python2.
* #1363 Update conda packaging.

Differential Revision: [D23314740](https://our.internmc.facebook.com/intern/diff/D23314740)