### PR TITLE
Fix dynamic size arrays.

### DIFF
--- a/faiss/AutoTune.cpp
+++ b/faiss/AutoTune.cpp
@@ -438,11 +438,10 @@ void ParameterSpace::set_index_parameters (Index *index, size_t cno) const
 void ParameterSpace::set_index_parameters (
      Index *index, const char *description_in) const
 {
-    char description[strlen(description_in) + 1];
+    std::string description(description_in);
     char *ptr;
-    memcpy (description, description_in, strlen(description_in) + 1);
 
-    for (char *tok = strtok_r (description, " ,", &ptr);
+    for (char *tok = strtok_r (&description[0], " ,", &ptr);
          tok;
          tok = strtok_r (nullptr, " ,", &ptr)) {
         char name[100];

--- a/faiss/Index2Layer.cpp
+++ b/faiss/Index2Layer.cpp
@@ -173,14 +173,14 @@ void Index2Layer::search(
 
 void Index2Layer::reconstruct_n(idx_t i0, idx_t ni, float* recons) const
 {
-    float recons1[d];
+    std::vector<float> recons1(d);
     FAISS_THROW_IF_NOT (i0 >= 0 && i0 + ni <= ntotal);
     const uint8_t *rp = &codes[i0 * code_size];
 
     for (idx_t i = 0; i < ni; i++) {
         idx_t key = 0;
         memcpy (&key, rp, code_size_1);
-        q1.quantizer->reconstruct (key, recons1);
+        q1.quantizer->reconstruct (key, recons1.data());
         rp += code_size_1;
         pq.decode (rp, recons);
         for (idx_t j = 0; j < d; j++) {

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -507,9 +507,9 @@ void IndexHNSW::init_level_0_from_knngraph(
 #pragma omp parallel for
     for (idx_t i = 0; i < ntotal; i++) {
         DistanceComputer *qdis = storage_distance_computer(storage);
-        float vec[d];
-        storage->reconstruct(i, vec);
-        qdis->set_query(vec);
+        std::vector<float> vec(d);
+        storage->reconstruct(i, vec.data());
+        qdis->set_query(vec.data());
 
         std::priority_queue<NodeDistFarther> initial_list;
 
@@ -552,14 +552,14 @@ void IndexHNSW::init_level_0_from_entry_points(
 
         DistanceComputer *dis = storage_distance_computer(storage);
         ScopeDeleter1<DistanceComputer> del(dis);
-        float vec[storage->d];
+        std::vector<float> vec(storage->d);
 
 #pragma omp  for schedule(dynamic)
         for (int i = 0; i < n; i++) {
             storage_idx_t pt_id = points[i];
             storage_idx_t nearest = nearests[i];
-            storage->reconstruct (pt_id, vec);
-            dis->set_query (vec);
+            storage->reconstruct (pt_id, vec.data());
+            dis->set_query (vec.data());
 
             hnsw.add_links_starting_from(*dis, pt_id,
                                          nearest, (*dis)(nearest),
@@ -740,7 +740,7 @@ void ReconstructFromNeighbors::reconstruct(storage_idx_t i, float *x, float *tmp
                 x[l] += w * tmp[l];
         }
     } else {
-        const float *betas[nsq];
+        std::vector<const float *> betas(nsq);
         {
             const float *b = codebook.data();
             const uint8_t *c = &codes[i * code_size];

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -141,9 +141,9 @@ void IndexIVFPQ::train_residual_o (idx_t n, const float *x, float *residuals_2)
 void IndexIVFPQ::encode (idx_t key, const float * x, uint8_t * code) const
 {
     if (by_residual) {
-        float residual_vec[d];
-        quantizer->compute_residual (x, residual_vec, key);
-        pq.compute_code (residual_vec, code);
+        std::vector<float> residual_vec(d);
+        quantizer->compute_residual (x, residual_vec.data(), key);
+        pq.compute_code (residual_vec.data(), code);
     }
     else pq.compute_code (x, code);
 }

--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -329,14 +329,14 @@ void ProductQuantizer::train (int n, const float * x)
 
 template<class PQEncoder>
 void compute_code(const ProductQuantizer& pq, const float *x, uint8_t *code) {
-  float distances [pq.ksub];
+  std::vector<float> distances(pq.ksub);
   PQEncoder encoder(code, pq.nbits);
   for (size_t m = 0; m < pq.M; m++) {
     float mindis = 1e20;
     uint64_t idxm = 0;
     const float * xsub = x + m * pq.dsub;
 
-    fvec_L2sqr_ny(distances, xsub, pq.get_centroids(m, 0), pq.dsub, pq.ksub);
+    fvec_L2sqr_ny(distances.data(), xsub, pq.get_centroids(m, 0), pq.dsub, pq.ksub);
 
     /* Find best centroid */
     for (size_t i = 0; i < pq.ksub; i++) {

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -82,15 +82,14 @@ Index *index_factory (int d, const char *description_in, MetricType metric)
 
     ScopeDeleter1<Index> del_coarse_quantizer, del_index;
 
-    char description[strlen(description_in) + 1];
+    std::string description(description_in);
     char *ptr;
-    memcpy (description, description_in, strlen(description_in) + 1);
 
     int64_t ncentroids = -1;
     bool use_2layer = false;
     int hnsw_M = -1;
 
-    for (char *tok = strtok_r (description, " ,", &ptr);
+    for (char *tok = strtok_r (&description[0], " ,", &ptr);
          tok;
          tok = strtok_r (nullptr, " ,", &ptr)) {
         int d_out, opq_M, nbit, M, M2, pq_m, ncent, r2;

--- a/faiss/utils/utils.cpp
+++ b/faiss/utils/utils.cpp
@@ -435,7 +435,7 @@ namespace {
         }
 
         // compute sub-ranges for each thread
-        SegmentS s1s[nt], s2s[nt], sws[nt];
+        std::vector<SegmentS> s1s(nt), s2s(nt), sws(nt);
         s2s[0].i0 = s2.i0;
         s2s[nt - 1].i1 = s2.i1;
 
@@ -528,7 +528,7 @@ void fvec_argsort_parallel (size_t n, const float *vals,
 
     ArgsortComparator comp = {vals};
 
-    SegmentS segs[nt];
+    std::vector<SegmentS> segs(nt);
 
     // independent sorts
 #pragma omp parallel for


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1377 Windows CI + conda packaging.
* **#1376 Fix dynamic size arrays.**
* #1375 Add __PRETTY_FUNCTION__ polyfill.
* #1374 Avoid building OnDiskInvertedLists on Windows.
* #1373 Export static/extern globals.
* #1372 Fix target export for Windows.
* #1371 Fix guard clause on get_mem_usage_kb().
* #1370 Fix swig build on Windows.
* #1369 Windows implementation of getmillisecs().
* #1368 Add __builtin_ctzll/__builtin_clzll polyfills.
* #1367 Add __builtin_popcountl polyfill.
* #1366 Add strtok_r polyfill.
* #1365 Fix setup.py for Windows.
* #1364 Disable contrib tests for python2.
* #1363 Update conda packaging.

Differential Revision: [D23314734](https://our.internmc.facebook.com/intern/diff/D23314734)