### PR TITLE
Windows CI + conda packaging.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  win: circleci/windows@2.4.0
+
 jobs:
   build_linux:
     docker:
@@ -103,9 +106,23 @@ jobs:
           environment:
             OMP_NUM_THREADS: 10
 
+  build_windows:
+    executor:
+      name: win/default
+      shell: bash.exe
+    steps:
+      - checkout
+      - run:
+          name: Build/test
+          command: |
+            conda install conda-build
+            cd conda
+            conda build faiss --python 3.7
+
 workflows:
   version: 2
   build:
     jobs:
       - build_linux
       - build_osx
+      - build_windows

--- a/conda/conda_build_config.yaml
+++ b/conda/conda_build_config.yaml
@@ -1,7 +1,7 @@
 CONDA_BUILD_SYSROOT:
   - /opt/MacOSX10.9.sdk        # [osx]
 python:
-  - 2.7
+  - 2.7  # [not win]
   - 3.6
   - 3.7
   - 3.8

--- a/conda/faiss/build-lib.bat
+++ b/conda/faiss/build-lib.bat
@@ -1,0 +1,23 @@
+:: Copyright (c) Facebook, Inc. and its affiliates.
+::
+:: This source code is licensed under the MIT license found in the
+:: LICENSE file in the root directory of this source tree.
+
+:: Build libfaiss.so.
+cmake -B _build ^
+      -T v141 ^
+      -A x64 ^
+      -G "Visual Studio 16 2019" ^
+      -DBUILD_SHARED_LIBS=ON ^
+      -DBUILD_TESTING=OFF ^
+      -DFAISS_ENABLE_GPU=OFF ^
+      -DFAISS_ENABLE_PYTHON=OFF ^
+      -DBLA_VENDOR=Intel10_64_dyn ^
+      .
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+cmake --build _build --config Release -j %CPU_COUNT%
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+cmake --install _build --config Release --prefix %PREFIX%
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/conda/faiss/build-pkg.bat
+++ b/conda/faiss/build-pkg.bat
@@ -1,0 +1,23 @@
+:: Copyright (c) Facebook, Inc. and its affiliates.
+::
+:: This source code is licensed under the MIT license found in the
+:: LICENSE file in the root directory of this source tree.
+
+:: Build vanilla version (no avx).
+cmake -B _build_python_%PY_VER% ^
+      -T v141 ^
+      -A x64 ^
+      -G "Visual Studio 16 2019" ^
+      -DFAISS_ENABLE_GPU=OFF ^
+      -DPython_EXECUTABLE=%PYTHON% ^
+      faiss/python
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+cmake --build _build_python_%PY_VER% --config Release -j %CPU_COUNT%
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+
+:: Build actual python module.
+cd _build_python_%PY_VER%/
+%PYTHON% setup.py install --single-version-externally-managed --record=record.txt --prefix=%PREFIX%
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/conda/faiss/meta.yaml
+++ b/conda/faiss/meta.yaml
@@ -25,7 +25,8 @@ source:
 
 outputs:
   - name: libfaiss
-    script: build-lib.sh
+    script: build-lib.sh   # [not win]
+    script: build-lib.bat  # [win]
     build:
       string: "h{{ PKG_HASH }}_{{ number }}_cpu"
       run_exports:
@@ -33,10 +34,11 @@ outputs:
     requirements:
       build:
         - {{ compiler('cxx') }}
-        - llvm-openmp  # [osx]
-        - cmake-local
+        - llvm-openmp   # [osx]
+        - cmake >=3.17  # [win]
+        - cmake-local   # [not win]
       host:
-        - mkl >=2018
+        - mkl-devel >=2018
         - blas =*=mkl
       run:
         - mkl >=2018
@@ -49,14 +51,16 @@ outputs:
         - conda inspect objects -p $PREFIX $PKG_NAME   # [osx]
 
   - name: faiss-cpu
-    script: build-pkg.sh
+    script: build-pkg.sh   # [not win]
+    script: build-pkg.bat  # [win]
     build:
       string: "py{{ PY_VER }}_h{{ PKG_HASH }}_{{ number }}_cpu"
     requirements:
       build:
         - {{ compiler('cxx') }}
         - swig
-        - cmake-local
+        - cmake >=3.17  # [win]
+        - cmake-local   # [not win]
       host:
         - python {{ python }}
         - numpy 1.11.*
@@ -77,6 +81,8 @@ outputs:
   - name: cmake-local
     version: 3.17
     script: install-cmake.sh
+    build:
+      skip: True  # [win]
     requirements:
       build:
         - {{ compiler('cxx') }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#1377 Windows CI + conda packaging.**
* #1376 Fix dynamic size arrays.
* #1375 Add __PRETTY_FUNCTION__ polyfill.
* #1374 Avoid building OnDiskInvertedLists on Windows.
* #1373 Export static/extern globals.
* #1372 Fix target export for Windows.
* #1371 Fix guard clause on get_mem_usage_kb().
* #1370 Fix swig build on Windows.
* #1369 Windows implementation of getmillisecs().
* #1368 Add __builtin_ctzll/__builtin_clzll polyfills.
* #1367 Add __builtin_popcountl polyfill.
* #1366 Add strtok_r polyfill.
* #1365 Fix setup.py for Windows.
* #1364 Disable contrib tests for python2.
* #1363 Update conda packaging.

Differential Revision: [D23314728](https://our.internmc.facebook.com/intern/diff/D23314728)