### PR TITLE
Add IVF statistics info for search_with_parameters

### DIFF
--- a/faiss/IVFlib.cpp
+++ b/faiss/IVFlib.cpp
@@ -335,8 +335,11 @@ void search_with_parameters (const Index *index,
     const IndexIVF *index_ivf = dynamic_cast<const IndexIVF *>(index);
     FAISS_THROW_IF_NOT (index_ivf);
 
+    double t0 = getmillisecs();
     index_ivf->quantizer->search(n, x, params->nprobe,
                                  Dq.data(), Iq.data());
+    double t1 = getmillisecs();
+    indexIVF_stats.quantization_time += t1 - t0;
 
     if (nb_dis_ptr) {
         size_t nb_dis = 0;
@@ -352,6 +355,8 @@ void search_with_parameters (const Index *index,
     index_ivf->search_preassigned(n, x, k, Iq.data(), Dq.data(),
                                   distances, labels,
                                   false, params);
+    double t2 = getmillisecs();
+    indexIVF_stats.search_time += t2 - t1;
 }
 
 

--- a/faiss/IVFlib.cpp
+++ b/faiss/IVFlib.cpp
@@ -14,7 +14,7 @@
 #include <faiss/IndexPreTransform.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/MetaIndexes.h>
-
+#include <faiss/utils/utils.h>
 
 
 namespace faiss { namespace ivflib {


### PR DESCRIPTION
Signed-off-by: JinHai-CN <hai.jin@zilliz.com>

No, IVF completed statistics information when we use search_with_parameters in IVFlib.cpp to search the vector.