### PR TITLE
Replace lower() numeric_limits

### DIFF
--- a/faiss/utils/Heap.h
+++ b/faiss/utils/Heap.h
@@ -57,10 +57,8 @@ struct CMin {
     inline static bool cmp (T a, T b) {
         return a < b;
     }
-    // value that will be popped first -> must be smaller than all others
-    // for int types this is not strictly the smallest val (-max - 1)
     inline static T neutral () {
-        return -std::numeric_limits<T>::max();
+        return std::numeric_limits<T>::lowest();
     }
 };
 


### PR DESCRIPTION
Summary: in C++03 there was no way to get the min value that is portable between int and float types (for float min returns the lowests strictly positive value). For C++11 this is lowest, so let's use it in the heap funcs.

Differential Revision: D23622612

