### PR TITLE
Cleanup flag/data propagation for IndexShards and IndexReplicas

### DIFF
--- a/c_api/IndexShards_c.cpp
+++ b/c_api/IndexShards_c.cpp
@@ -32,12 +32,6 @@ int faiss_IndexShards_add_shard(FaissIndexShards* index, FaissIndex* shard) {
     } CATCH_AND_HANDLE
 }
 
-int faiss_IndexShards_sync_with_shard_indexes(FaissIndexShards* index) {
-    try {
-        reinterpret_cast<IndexShards*>(index)->sync_with_shard_indexes();
-    } CATCH_AND_HANDLE
-}
-
 FaissIndex* faiss_IndexShards_at(FaissIndexShards* index, int i) {
     auto shard = reinterpret_cast<IndexShards*>(index)->at(i);
     return reinterpret_cast<FaissIndex*>(shard);

--- a/c_api/IndexShards_c.h
+++ b/c_api/IndexShards_c.h
@@ -31,9 +31,6 @@ int faiss_IndexShards_new_with_options(FaissIndexShards** p_index, idx_t d, int 
 
 int faiss_IndexShards_add_shard(FaissIndexShards* index, FaissIndex* shard);
 
-/// update metric_type and ntotal
-int faiss_IndexShards_sync_with_shard_indexes(FaissIndexShards* index);
-
 FaissIndex* faiss_IndexShards_at(FaissIndexShards* index, int i);
 
 #ifdef __cplusplus

--- a/faiss/IndexReplicas.h
+++ b/faiss/IndexReplicas.h
@@ -65,9 +65,15 @@ class IndexReplicasTemplate : public ThreadedIndex<IndexT> {
   /// reconstructs from the first index
   void reconstruct(idx_t, component_t *v) const override;
 
+  /// Synchronize the top-level index (IndexShards) with data in the sub-indices
+  void syncWithSubIndexes();
+
  protected:
   /// Called just after an index is added
   void onAfterAddIndex(IndexT* index) override;
+
+  /// Called just after an index is removed
+  void onAfterRemoveIndex(IndexT* index) override;
 };
 
 using IndexReplicas = IndexReplicasTemplate<Index>;

--- a/faiss/IndexShards.h
+++ b/faiss/IndexShards.h
@@ -79,11 +79,10 @@ struct IndexShardsTemplate : public ThreadedIndex<IndexT> {
 
   void train(idx_t n, const component_t* x) override;
 
-  // update metric_type and ntotal. Call if you changes something in
-  // the shard indexes.
-  void sync_with_shard_indexes();
-
   bool successive_ids;
+
+  /// Synchronize the top-level index (IndexShards) with data in the sub-indices
+  void syncWithSubIndexes();
 
  protected:
   /// Called just after an index is added

--- a/tests/test_merge.cpp
+++ b/tests/test_merge.cpp
@@ -114,7 +114,7 @@ int compare_merged (faiss::IndexShards *index_shards, bool shift_ids,
                    shift_ids);
         }
 
-        index_shards->sync_with_shard_indexes();
+        index_shards->syncWithSubIndexes();
     } else {
         std::vector<const faiss::InvertedLists *> lists;
         faiss::IndexIVF *index0 = nullptr;


### PR DESCRIPTION
Summary:
This diff fixes https://github.com/facebookresearch/faiss/issues/1412

There were various inconsistencies in how the shard and replica wrappers updated their internal state as the sub-indices were updated. This makes the two container classes work in the same way with similar synchronization functionality.

Reviewed By: beauby

Differential Revision: D23974186

