### PR TITLE
Test GPU ground-truth computation

### DIFF
--- a/faiss/gpu/test/test_contrib.py
+++ b/faiss/gpu/test/test_contrib.py
@@ -1,0 +1,30 @@
+import faiss
+import unittest
+import numpy as np
+
+from faiss.contrib import datasets
+from faiss.contrib.exhaustive_search import knn_ground_truth
+
+from common import get_dataset_2
+
+
+class TestComputeGT(unittest.TestCase):
+
+    def test_compute_GT(self):
+        d = 64
+        xt, xb, xq = get_dataset_2(d, 0, 10000, 100)
+
+        index = faiss.IndexFlatL2(d)
+        index.add(xb)
+        Dref, Iref = index.search(xq, 10)
+
+        # iterator function on the matrix
+
+        def matrix_iterator(xb, bs):
+            for i0 in range(0, xb.shape[0], bs):
+                yield xb[i0:i0 + bs]
+
+        Dnew, Inew = knn_ground_truth(xq, matrix_iterator(xb, 1000), 10)
+
+        np.testing.assert_array_equal(Iref, Inew)
+        np.testing.assert_almost_equal(Dref, Dnew, decimal=4)

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -32,7 +32,8 @@ class TestComputeGT(unittest.TestCase):
         Dnew, Inew = knn_ground_truth(xq, matrix_iterator(xb, 1000), 10)
 
         np.testing.assert_array_equal(Iref, Inew)
-        np.testing.assert_almost_equal(Dref, Dnew, decimal=5)
+        # decimal = 4 required when run on GPU
+        np.testing.assert_almost_equal(Dref, Dnew, decimal=4)
 
 
 class TestDatasets(unittest.TestCase):


### PR DESCRIPTION
Summary: The contrib function knn_ground_truth does not provide exactly the same resutls on GPU and CPU (but relative accuracy is still 1e-7). This diff relaxes the constraint on CPU and added test on GPU.

Differential Revision: D24012199

