### PR TITLE
GPU brute-force kNN can take int32 indices

### DIFF
--- a/faiss/gpu/GpuDistance.h
+++ b/faiss/gpu/GpuDistance.h
@@ -20,6 +20,12 @@ enum class DistanceDataType {
   F16,
 };
 
+// Scalar type of the indices data
+enum class IndicesDataType {
+  I64 = 1,
+  I32,
+};
+
 /// Arguments to brute-force GPU k-nearest neighbor searching
 struct GpuDistanceParams {
   GpuDistanceParams()
@@ -38,6 +44,7 @@ struct GpuDistanceParams {
         numQueries(0),
         outDistances(nullptr),
         ignoreOutDistances(false),
+        outIndicesType(IndicesDataType::I64),
         outIndices(nullptr) {
   }
 
@@ -101,7 +108,8 @@ struct GpuDistanceParams {
 
   // A region of memory size numQueries x k, with k
   // innermost (row major)
-  faiss::Index::idx_t* outIndices;
+  IndicesDataType outIndicesType;
+  void* outIndices;
 };
 
 /// A wrapper for gpu/impl/Distance.cuh to expose direct brute-force k-nearest

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -653,6 +653,9 @@ PyObject *swig_ptr (PyObject *a)
     if(PyArray_TYPE(ao) == NPY_FLOAT64) {
         return SWIG_NewPointerObj(data, SWIGTYPE_p_double, 0);
     }
+    if(PyArray_TYPE(ao) == NPY_FLOAT16) {
+        return SWIG_NewPointerObj(data, SWIGTYPE_p_unsigned_short, 0);
+    }
     if(PyArray_TYPE(ao) == NPY_UINT8) {
         return SWIG_NewPointerObj(data, SWIGTYPE_p_unsigned_char, 0);
     }


### PR DESCRIPTION
Summary:
As requested in https://github.com/facebookresearch/faiss/issues/1304, `bfKnn` can now produce int32 indices for output.

The native kernels themselves for brute-force kNN only operate on int32 indices in any case, so this is faster.

Also added a SWIG definition for float16 numpy arrays. As there is not a native half type, the reverse definition is undefined, so this is only really used for taking float16 data (e.g., from numpy) as input when in Python.

Differential Revision: D24152296

