### PR TITLE
Mark ~BufferedIOWriter() noexcept(false)

### DIFF
--- a/faiss/impl/io.h
+++ b/faiss/impl/io.h
@@ -50,7 +50,7 @@ struct IOWriter {
     // return a file number that can be memory-mapped
     virtual int fileno ();
 
-    virtual ~IOWriter() {}
+    virtual ~IOWriter() noexcept(false) {}
 };
 
 
@@ -139,7 +139,7 @@ struct BufferedIOWriter: IOWriter {
     size_t operator()(const void *ptr, size_t size, size_t nitems) override;
 
     // flushes
-    ~BufferedIOWriter();
+    ~BufferedIOWriter() override;
 };
 
 /// cast a 4-character string to a uint32_t that can be written and read easily


### PR DESCRIPTION
Summary: In C++11, destructors default to `noexcept(true)`. This destructor can throw (through `FAISS_THROW_IF_NOT()`), so marking it accordingly.

Differential Revision: D24253879

