### PR TITLE
Fix CMake build on GPU.

### DIFF
--- a/faiss/gpu/CMakeLists.txt
+++ b/faiss/gpu/CMakeLists.txt
@@ -151,7 +151,6 @@ set(FAISS_GPU_HEADERS
   utils/MergeNetworkUtils.cuh
   utils/MergeNetworkWarp.cuh
   utils/NoTypeTensor.cuh
-  utils/nvidia/fp16_emu.cuh
   utils/Pair.cuh
   utils/PtxUtils.cuh
   utils/ReductionOperators.cuh


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1477 Add docker image for CUDA 10.1.
* #1476 Update conda package for faiss-gpu.
* **#1475 Fix CMake build on GPU.**

