### PR TITLE
CMake: use GNUInstallDirs instead of hardcoded paths.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ project(faiss
   DESCRIPTION "A library for efficient similarity search and clustering of dense vectors."
   HOMEPAGE_URL "https://github.com/facebookresearch/faiss"
   LANGUAGES CXX)
+include(GNUInstallDirs)
 
 set(CMAKE_CXX_STANDARD 11)
 

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -164,15 +164,15 @@ endif()
 
 install(TARGETS faiss
   EXPORT faiss-targets
-  RUNTIME DESTINATION bin
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  INCLUDES DESTINATION include
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 foreach(header ${FAISS_HEADERS})
   get_filename_component(dir ${header} DIRECTORY )
   install(FILES ${header}
-    DESTINATION include/faiss/${dir}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/faiss/${dir}
   )
 endforeach()
 
@@ -189,9 +189,9 @@ configure_file(${PROJECT_SOURCE_DIR}/cmake/faiss-config.cmake.in
 )
 install(FILES ${PROJECT_BINARY_DIR}/cmake/faiss-config.cmake
   ${PROJECT_BINARY_DIR}/cmake/faiss-config-version.cmake
-  DESTINATION share/faiss
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/faiss
 )
 
 install(EXPORT faiss-targets
-  DESTINATION share/faiss
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/faiss
 )

--- a/faiss/gpu/CMakeLists.txt
+++ b/faiss/gpu/CMakeLists.txt
@@ -170,7 +170,7 @@ set(FAISS_GPU_HEADERS
 foreach(header ${FAISS_GPU_HEADERS})
   get_filename_component(dir ${header} DIRECTORY )
   install(FILES ${header}
-    DESTINATION include/faiss/gpu/${dir}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/faiss/gpu/${dir}
   )
 endforeach()
 


### PR DESCRIPTION
Upstreamed from Debian packaging: https://salsa.debian.org/deeplearning-team/faiss