### PR TITLE
Fix SWIG dependencies in CMake.

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -140,6 +140,9 @@ set(FAISS_HEADERS
   utils/utils.h
 )
 
+# Export FAISS_HEADERS variable to parent scope.
+set(FAISS_HEADERS ${FAISS_HEADERS} PARENT_SCOPE)
+
 if(NOT WIN32)
   target_sources(faiss PRIVATE invlists/OnDiskInvertedLists.cpp)
   list(APPEND FAISS_HEADERS invlists/OnDiskInvertedLists.h)

--- a/faiss/gpu/CMakeLists.txt
+++ b/faiss/gpu/CMakeLists.txt
@@ -177,6 +177,10 @@ set(FAISS_GPU_HEADERS
   utils/warpselect/WarpSelectImpl.cuh
   utils/WarpShuffles.cuh
 )
+
+# Export FAISS_HEADERS variable to parent scope.
+set(FAISS_GPU_HEADERS ${FAISS_GPU_HEADERS} PARENT_SCOPE)
+
 foreach(header ${FAISS_GPU_HEADERS})
   get_filename_component(dir ${header} DIRECTORY )
   install(FILES ${header}

--- a/faiss/python/CMakeLists.txt
+++ b/faiss/python/CMakeLists.txt
@@ -42,6 +42,19 @@ if(FAISS_ENABLE_GPU)
   )
 endif()
 
+if(TARGET faiss)
+  # Manually add headers as extra dependencies of swigfaiss.
+  set(SWIG_MODULE_swigfaiss_EXTRA_DEPS)
+  foreach(h ${FAISS_HEADERS})
+    list(APPEND SWIG_MODULE_swigfaiss_EXTRA_DEPS "${PROJECT_SOURCE_DIR}/../${h}")
+  endforeach()
+  foreach(h ${FAISS_GPU_HEADERS})
+    list(APPEND SWIG_MODULE_swigfaiss_EXTRA_DEPS "${PROJECT_SOURCE_DIR}/../gpu/${h}")
+  endforeach()
+else()
+  find_package(faiss REQUIRED)
+endif()
+
 swig_add_library(swigfaiss
   TYPE SHARED
   LANGUAGE python
@@ -56,10 +69,6 @@ endif()
 if(FAISS_ENABLE_GPU)
   find_package(CUDAToolkit REQUIRED)
   target_link_libraries(swigfaiss PRIVATE CUDA::cudart)
-endif()
-
-if(NOT TARGET faiss)
-  find_package(faiss REQUIRED)
 endif()
 
 find_package(OpenMP REQUIRED)


### PR DESCRIPTION
CMake's SWIG module does not track dependencies to header files by
default, and they have to be stated manually.