### PR TITLE
Replace tempnam with mkstemp in tests.

### DIFF
--- a/tests/test_merge.cpp
+++ b/tests/test_merge.cpp
@@ -9,6 +9,8 @@
 #include <cstdlib>
 #include <random>
 
+#include <unistd.h>
+
 #include <gtest/gtest.h>
 
 #include <faiss/IndexIVFFlat.h>
@@ -27,13 +29,12 @@ struct Tempfilename {
 
     static pthread_mutex_t mutex;
 
-    std::string filename;
+    std::string filename = "faiss_tmp_XXXXXX";
 
-    Tempfilename (const char *prefix = nullptr) {
+    Tempfilename () {
         pthread_mutex_lock (&mutex);
-        char *cfname = tempnam (nullptr, prefix);
-        filename = cfname;
-        free(cfname);
+        int fd = mkstemp (&filename[0]);
+        close(fd);
         pthread_mutex_unlock (&mutex);
     }
 

--- a/tests/test_ondisk_ivf.cpp
+++ b/tests/test_ondisk_ivf.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <random>
 
+#include <unistd.h>
 #include <omp.h>
 
 #include <unordered_map>
@@ -29,13 +30,12 @@ struct Tempfilename {
 
     static pthread_mutex_t mutex;
 
-    std::string filename;
+    std::string filename = "faiss_tmp_XXXXXX";
 
-    Tempfilename (const char *prefix = nullptr) {
+    Tempfilename () {
         pthread_mutex_lock (&mutex);
-        char *cfname = tempnam (nullptr, prefix);
-        filename = cfname;
-        free(cfname);
+        int fd = mkstemp (&filename[0]);
+        close(fd);
         pthread_mutex_unlock (&mutex);
     }
 


### PR DESCRIPTION
This avoids triggering the following warnings:
```
tests/test_ondisk_ivf.cpp:36:24: warning: 'tempnam' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of tempnam(3), it is highly recommended that you use mkstemp(3) instead. [-Wdeprecated-declarations]
        char *cfname = tempnam (nullptr, prefix);
                       ^
tests/test_merge.cpp:34:24: warning: 'tempnam' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of tempnam(3), it is highly recommended that you use mkstemp(3) instead. [-Wdeprecated-declarations]
        char *cfname = tempnam (nullptr, prefix);
```