### PR TITLE
make AVX2-detection platform-independent

### DIFF
--- a/faiss/python/loader.py
+++ b/faiss/python/loader.py
@@ -11,42 +11,42 @@ import logging
 
 def instruction_set():
     """
-    Returns a dictionary for supported instruction sets, see
+    Returns the set of supported CPU features, see
     https://github.com/numpy/numpy/blob/master/numpy/core/src/common/npy_cpu_features.h
-    for the list of features that this dictionary contains per architecture.
+    for the list of features that this set may contain per architecture.
 
     Example:
     >>> instruction_set()  # for x86
-    {"SSE2": True, "AVX2": False, ...}
+    {"SSE2", "AVX2", ...}
     >>> instruction_set()  # for PPC
-    {"VSX": True, "VSX2": False, ...}
+    {"VSX", "VSX2", ...}
     >>> instruction_set()  # for ARM
-    {"NEON": True, "ASIMD": False, ...}
+    {"NEON", "ASIMD", ...}
     """
     import numpy
     if LooseVersion(numpy.__version__) >= "1.19":
         # use private API as next-best thing until numpy/numpy#18058 is solved
         from numpy.core._multiarray_umath import __cpu_features__
-        return __cpu_features__
+        # __cpu_features__ is a dictionary with CPU features
+        # as keys, and True / False as values
+        supported = {k for k, v in __cpu_features__.items() if v}
+        return supported
 
     # platform-dependent legacy fallback before numpy 1.19, no windows
     if platform.system() == "Darwin":
         if subprocess.check_output(["/usr/sbin/sysctl", "hw.optional.avx2_0"])[-1] == '1':
-            return {"AVX2": True}
+            return {"AVX2"}
     elif platform.system() == "Linux":
         import numpy.distutils.cpuinfo
         if "avx2" in numpy.distutils.cpuinfo.cpu.info[0].get('flags', ""):
-            return {"AVX2": True}
-    return {"AVX2": False}
+            return {"AVX2"}
+    return set()
 
 
 logger = logging.getLogger(__name__)
 
 try:
-    instr_set = instruction_set()
-    # dict-values of instr_set are True or False, but do not have
-    # uniform keys across arches -> use fallback value of False
-    has_AVX2 = instr_set.get("AVX2", False)
+    has_AVX2 = "AVX2" in instruction_set()
     if has_AVX2:
         logger.info("Loading faiss with AVX2 support.")
         from .swigfaiss_avx2 import *

--- a/faiss/python/loader.py
+++ b/faiss/python/loader.py
@@ -3,30 +3,39 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from distutils.version import LooseVersion
 import platform
 import subprocess
 import logging
 
 
-def instruction_set():
+def supports_AVX2():
+    import numpy
+    if LooseVersion(numpy.__version__) >= "1.19":
+        # use private API as next-best thing until numpy/numpy#18058 is solved
+        from numpy.core._multiarray_umath import __cpu_features__
+        return __cpu_features__["AVX2"]
+
+    # platform-dependent fallback before numpy 1.19, no windows
     if platform.system() == "Darwin":
         if subprocess.check_output(["/usr/sbin/sysctl", "hw.optional.avx2_0"])[-1] == '1':
-            return "AVX2"
+            return True
         else:
-            return "default"
+            return False
     elif platform.system() == "Linux":
         import numpy.distutils.cpuinfo
         if "avx2" in numpy.distutils.cpuinfo.cpu.info[0].get('flags', ""):
-            return "AVX2"
+            return True
         else:
-            return "default"
+            return False
+    return False
 
 
 logger = logging.getLogger(__name__)
 
 try:
-    instr_set = instruction_set()
-    if instr_set == "AVX2":
+    has_AVX2 = supports_AVX2()
+    if has_AVX2:
         logger.info("Loading faiss with AVX2 support.")
         from .swigfaiss_avx2 import *
     else:

--- a/faiss/python/loader.py
+++ b/faiss/python/loader.py
@@ -33,14 +33,10 @@ def instruction_set():
     if platform.system() == "Darwin":
         if subprocess.check_output(["/usr/sbin/sysctl", "hw.optional.avx2_0"])[-1] == '1':
             return {"AVX2": True}
-        else:
-            return {"AVX2": False}
     elif platform.system() == "Linux":
         import numpy.distutils.cpuinfo
         if "avx2" in numpy.distutils.cpuinfo.cpu.info[0].get('flags', ""):
             return {"AVX2": True}
-        else:
-            return {"AVX2": False}
     return {"AVX2": False}
 
 

--- a/faiss/python/loader.py
+++ b/faiss/python/loader.py
@@ -9,18 +9,18 @@ import subprocess
 import logging
 
 
-def instruction_set():
+def supported_instruction_sets():
     """
     Returns the set of supported CPU features, see
     https://github.com/numpy/numpy/blob/master/numpy/core/src/common/npy_cpu_features.h
     for the list of features that this set may contain per architecture.
 
     Example:
-    >>> instruction_set()  # for x86
+    >>> supported_instruction_sets()  # for x86
     {"SSE2", "AVX2", ...}
-    >>> instruction_set()  # for PPC
+    >>> supported_instruction_sets()  # for PPC
     {"VSX", "VSX2", ...}
-    >>> instruction_set()  # for ARM
+    >>> supported_instruction_sets()  # for ARM
     {"NEON", "ASIMD", ...}
     """
     import numpy
@@ -46,7 +46,7 @@ def instruction_set():
 logger = logging.getLogger(__name__)
 
 try:
-    has_AVX2 = "AVX2" in instruction_set()
+    has_AVX2 = "AVX2" in supported_instruction_sets()
     if has_AVX2:
         logger.info("Loading faiss with AVX2 support.")
         from .swigfaiss_avx2 import *

--- a/faiss/python/loader.py
+++ b/faiss/python/loader.py
@@ -43,7 +43,10 @@ def instruction_set():
 logger = logging.getLogger(__name__)
 
 try:
-    has_AVX2 = instruction_set()["AVX2"]  # dict-values of instruction_set() are True or False
+    instr_set = instruction_set()
+    # dict-values of instr_set are True or False, but do not have
+    # uniform keys across arches -> use fallback value of False
+    has_AVX2 = instr_set.get("AVX2", False)
     if has_AVX2:
         logger.info("Loading faiss with AVX2 support.")
         from .swigfaiss_avx2 import *


### PR DESCRIPTION
In the context of https://github.com/conda-forge/faiss-split-feedstock/issues/23, I discussed with some of the conda-folks how we should support AVX2 (and potentially other builds) for faiss. In the meantime, we'd like to follow the model that faiss itself is using (i.e. build with AVX2 and without and then load the corresponding library at runtime depending on CPU capabilities).

Since windows support for this is missing (and the other stuff is also non-portable in `loader.py`), I chased down `numpy.distutils.cpuinfo`, which is pretty outdated, and opened: https://github.com/numpy/numpy/issues/18058

While the [private API](https://github.com/numpy/numpy/issues/18058#issuecomment-749852711) is obviously something that _could_ change at any time, I still think it's better than platform-dependent shenanigans.

Opening this here to ideally upstream this right away, rather than carrying patches in the conda-forge feedstock.

TODO:
* [ ] adapt conda recipe for windows in this repo to also build avx2 version