### PR TITLE
Increase no-output timeout for Linux GPU nightlies build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,7 @@ jobs:
               faiss \
               conda build faiss-gpu --variants '{ "cudatoolkit": "<<parameters.cuda>>" }' \
                 --user pytorch --label <<parameters.label>>
+          no_output_timeout: 20m
 
   deploy_osx:
     parameters:


### PR DESCRIPTION
Since #1566, the build for GPU seems to take significantly longer, causing GPU nightly builds to timeout.