### PR TITLE
Fix refine implementation

### DIFF
--- a/benchs/bench_all_ivf/cmp_with_scann.py
+++ b/benchs/bench_all_ivf/cmp_with_scann.py
@@ -270,6 +270,8 @@ def faiss_eval_search(
           "by residual=", index.by_residual)
 
     print("adding a refine index")
+    flat_index = faiss.IndexFlat(index.d, index.metric_type)
+    flat_index.add(xb)
     index_refine = faiss.IndexRefineFlat(index, faiss.swig_ptr(xb))
 
     print("set single thread")

--- a/benchs/bench_all_ivf/cmp_with_scann.py
+++ b/benchs/bench_all_ivf/cmp_with_scann.py
@@ -270,8 +270,6 @@ def faiss_eval_search(
           "by residual=", index.by_residual)
 
     print("adding a refine index")
-    flat_index = faiss.IndexFlat(index.d, index.metric_type)
-    flat_index.add(xb)
     index_refine = faiss.IndexRefineFlat(index, faiss.swig_ptr(xb))
 
     print("set single thread")

--- a/faiss/IndexRefine.cpp
+++ b/faiss/IndexRefine.cpp
@@ -29,10 +29,12 @@ IndexRefine::IndexRefine (Index *base_index, Index *refine_index):
     refine_index (refine_index)
 {
     own_fields = own_refine_index = false;
-    FAISS_THROW_IF_NOT (base_index->d == refine_index->d);
-    FAISS_THROW_IF_NOT (base_index->metric_type == refine_index->metric_type);
-    is_trained = base_index->is_trained && refine_index->is_trained;
-    FAISS_THROW_IF_NOT (base_index->ntotal == refine_index->ntotal);
+    if (refine_index != nullptr) {
+        FAISS_THROW_IF_NOT (base_index->d == refine_index->d);
+        FAISS_THROW_IF_NOT (base_index->metric_type == refine_index->metric_type);
+        is_trained = base_index->is_trained && refine_index->is_trained;
+        FAISS_THROW_IF_NOT (base_index->ntotal == refine_index->ntotal);
+    } // other case is useful only to construct an IndexRefineFlat
     ntotal = base_index->ntotal;
 }
 
@@ -183,12 +185,13 @@ IndexRefineFlat::IndexRefineFlat (Index *base_index):
 
 
 IndexRefineFlat::IndexRefineFlat (Index *base_index, const float *xb):
-    IndexRefine (base_index, new IndexFlat(base_index->d, base_index->metric_type))
+    IndexRefine (base_index, nullptr)
 {
     is_trained = base_index->is_trained;
+    refine_index = new IndexFlat(base_index->d, base_index->metric_type);
     own_refine_index = true;
     refine_index->add (base_index->ntotal, xb);
-    ntotal = base_index->ntotal;
+
 }
 
 IndexRefineFlat::IndexRefineFlat():


### PR DESCRIPTION
The IndexRefineFlat with pre-populated indexes could not be used because of the order of construction of the parent class. This diff fixes is. This addresses #1604.