### PR TITLE
[c_api] Add GPU device utility functions

### DIFF
--- a/c_api/gpu/DeviceUtils_c.cpp
+++ b/c_api/gpu/DeviceUtils_c.cpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c++ -*-
+
+#include "DeviceUtils_c.h"
+#include "macros_impl.h"
+#include <faiss/gpu/utils/DeviceUtils.h>
+
+/// Returns the number of available GPU devices
+int faiss_get_num_gpus(int* p_output) {
+    try {
+        int output = faiss::gpu::getNumDevices();
+        *p_output = output;
+    } CATCH_AND_HANDLE
+}
+
+/// Starts the CUDA profiler (exposed via SWIG)
+int faiss_gpu_profiler_start() {
+    try {
+        faiss::gpu::profilerStart();
+    } CATCH_AND_HANDLE
+}
+
+/// Stops the CUDA profiler (exposed via SWIG)
+int faiss_gpu_profiler_stop() {
+    try {
+        faiss::gpu::profilerStop();
+    } CATCH_AND_HANDLE
+}
+
+/// Synchronizes the CPU against all devices (equivalent to
+/// cudaDeviceSynchronize for each device)
+int faiss_gpu_sync_all_devices() {
+    try {
+        faiss::gpu::synchronizeAllDevices();
+    } CATCH_AND_HANDLE
+}

--- a/c_api/gpu/DeviceUtils_c.h
+++ b/c_api/gpu/DeviceUtils_c.h
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Copyright 2004-present Facebook. All Rights Reserved.
+// -*- c -*-
+
+#ifndef FAISS_DEVICE_UTILS_C_H
+#define FAISS_DEVICE_UTILS_C_H
+
+#include <cuda_runtime_api.h>
+#include <cublas.h>
+#include "faiss_c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Returns the number of available GPU devices
+int faiss_get_num_gpus(int* p_output);
+
+/// Starts the CUDA profiler (exposed via SWIG)
+int faiss_gpu_profiler_start();
+
+/// Stops the CUDA profiler (exposed via SWIG)
+int faiss_gpu_profiler_stop();
+
+/// Synchronizes the CPU against all devices (equivalent to
+/// cudaDeviceSynchronize for each device)
+int faiss_gpu_sync_all_devices();
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/c_api/gpu/Makefile
+++ b/c_api/gpu/Makefile
@@ -13,7 +13,7 @@ DEBUGFLAG=-DNDEBUG # no debugging
 LIBNAME=libfaiss
 CLIBNAME=libgpufaiss_c
 LIBGPUCOBJ=GpuAutoTune_c.o GpuClonerOptions_c.o GpuIndex_c.o GpuResources_c.o \
-	StandardGpuResources_c.o
+	StandardGpuResources_c.o DeviceUtils_c.o
 LIBCOBJ=../libfaiss_c.a
 CFLAGS=-fPIC -m64 -Wno-sign-compare -g -O3 -Wall -Wextra
 CUDACFLAGS=-I$(CUDA_ROOT)/include
@@ -61,3 +61,6 @@ GpuResources_c.o: GpuResources_c.cpp GpuResources_c.h ../../gpu/GpuResources.h .
 
 StandardGpuResources_c.o: CXXFLAGS += -I.. -I../.. -I../../gpu -I../../impl $(CUDACFLAGS) $(DEBUGFLAG)
 StandardGpuResources_c.o: StandardGpuResources_c.cpp StandardGpuResources_c.h ../../gpu/StandardGpuResources.h ../macros_impl.h
+
+DeviceUtils_c.o: CXXFLAGS += -I.. -I../.. -I../../gpu -I../../impl $(CUDACFLAGS) $(DEBUGFLAG)
+DeviceUtils_c.o: DeviceUtils_c.cpp DeviceUtils_c.h ../../gpu/utils/DeviceUtils.h ../macros_impl.h

--- a/c_api/gpu/example_gpu_c.c
+++ b/c_api/gpu/example_gpu_c.c
@@ -18,6 +18,7 @@
 #include "AutoTune_c.h"
 #include "GpuAutoTune_c.h"
 #include "StandardGpuResources_c.h"
+#include "DeviceUtils_c.h"
 
 #define FAISS_TRY(C)                                       \
     {                                                      \
@@ -34,6 +35,11 @@ double drand() {
 int main() {
     time_t seed = time(NULL);
     srand(seed);
+
+    int gpus = -1;
+    FAISS_TRY(faiss_get_num_gpus(&gpus));
+    printf("%d GPU devices are available\n", gpus);
+
     printf("Generating some data...\n");
     int d = 128;                           // dimension
     int nb = 100000;                       // database size


### PR DESCRIPTION
This adds some more functions to the C API, under a new DeviceUtils_c.h module. Resolves #1414.

- `faiss_get_num_gpus`
- `faiss_gpu_profiler_start`
- `faiss_gpu_profiler_stop`
- `faiss_gpu_sync_all_devices`

The only minor issue right now is that building this requires basing it against an older version of Faiss until the building system is updated to use CMake (#1390). I have provided a separate branch with the same contribution which is based against a version that works and builds OK: [`imp/c_api/add_gpu_device_utils`](https://github.com/Enet4/faiss/tree/imp/c_api/add_gpu_device_utils)