### PR TITLE
Add NNDescent to faiss

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -13,6 +13,9 @@ target_link_libraries(demo_imi_pq PRIVATE faiss)
 add_executable(demo_ivfpq_indexing EXCLUDE_FROM_ALL demo_ivfpq_indexing.cpp)
 target_link_libraries(demo_ivfpq_indexing PRIVATE faiss)
 
+add_executable(demo_nndescent EXCLUDE_FROM_ALL demo_nndescent.cpp)
+target_link_libraries(demo_nndescent PRIVATE faiss)
+
 add_executable(demo_sift1M EXCLUDE_FROM_ALL demo_sift1M.cpp)
 target_link_libraries(demo_sift1M PRIVATE faiss)
 

--- a/demos/demo_nndescent.cpp
+++ b/demos/demo_nndescent.cpp
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <chrono>
+#include <random>
+
+#include <faiss/IndexFlat.h>
+#include <faiss/IndexNNDescent.h>
+
+using namespace std::chrono;
+
+int main(void) {
+  // dimension of the vectors to index
+  int d = 64;
+  int K = 64;
+
+  // size of the database we plan to index
+  size_t nb = 10000;
+
+  std::mt19937 rng(12345);
+
+  // make the index object and train it
+  faiss::IndexNNDescentFlat index(d, K, faiss::METRIC_L2);
+  index.nndescent.S = 10;
+  index.nndescent.R = 32;
+  index.nndescent.L = K;
+  index.nndescent.iter = 10;
+  index.verbose = true;
+
+  // generate labels by IndexFlat
+  faiss::IndexFlat bruteforce(d, faiss::METRIC_L2);
+
+  std::vector<float> database(nb * d);
+  for (size_t i = 0; i < nb * d; i++) {
+    database[i] = rng() % 1024;
+  }
+
+  { // populating the database
+    index.add(nb, database.data());
+    bruteforce.add(nb, database.data());
+  }
+
+  size_t nq = 1000;
+
+  { // searching the database
+    printf("Searching ...\n");
+    index.nndescent.search_L = 50;
+
+    std::vector<float> queries(nq * d);
+    for (size_t i = 0; i < nq * d; i++) {
+      queries[i] = rng() % 1024;
+    }
+
+    int k = 5;
+    std::vector<faiss::IndexNNDescent::idx_t> nns(k * nq);
+    std::vector<faiss::IndexFlat::idx_t> gt_nns(k * nq);
+    std::vector<float> dis(k * nq);
+
+    auto start = high_resolution_clock::now();
+    index.search(nq, queries.data(), k, dis.data(), nns.data());
+    auto end = high_resolution_clock::now();
+
+    // find exact kNNs by brute force search
+    bruteforce.search(nq, queries.data(), k, dis.data(), gt_nns.data());
+
+    int recalls = 0;
+    for (size_t i = 0; i < nq; ++i) {
+      for (int n = 0; n < k; n++) {
+        for (int m = 0; m < k; m++) {
+          if (nns[i * k + n] == gt_nns[i * k + m]) {
+            recalls += 1;
+          }
+        }
+      }
+    }
+    float recall = 1.0f * recalls / (k * nq);
+    auto t = duration_cast<microseconds>(end - start).count();
+    int qps = nq * 1.0f * 1000 * 1000 / t;
+
+    printf("Recall@%d: %f, QPS: %d\n", k, recall, qps);
+  }
+}

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(faiss
   IndexPQFastScan.cpp
   IndexIVFSpectralHash.cpp
   IndexLSH.cpp
+  IndexNNDescent.cpp
   IndexLattice.cpp
   IndexPQ.cpp
   IndexPreTransform.cpp
@@ -51,6 +52,7 @@ add_library(faiss
   impl/pq4_fast_scan_search_qbs.cpp
   impl/io.cpp
   impl/lattice_Zn.cpp
+  impl/NNDescent.cpp
   invlists/DirectMap.cpp
   invlists/InvertedLists.cpp
   invlists/BlockInvertedLists.cpp
@@ -90,6 +92,7 @@ set(FAISS_HEADERS
   IndexIVFSpectralHash.h
   IndexLSH.h
   IndexLattice.h
+  IndexNNDescent.h
   IndexPQ.h
   IndexPreTransform.h
   IndexReplicas.h
@@ -116,6 +119,7 @@ set(FAISS_HEADERS
   impl/io.h
   impl/io_macros.h
   impl/lattice_Zn.h
+  impl/NNDescent.h
   impl/pq4_fast_scan.h
   impl/simd_result_handlers.h
   impl/platform_macros.h

--- a/faiss/IndexNNDescent.cpp
+++ b/faiss/IndexNNDescent.cpp
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+#include <faiss/IndexNNDescent.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <omp.h>
+
+#include <queue>
+#include <unordered_set>
+
+#ifdef __SSE__
+#endif
+
+#include <faiss/IndexFlat.h>
+#include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/utils/Heap.h>
+#include <faiss/utils/distances.h>
+#include <faiss/utils/random.h>
+
+extern "C" {
+
+/* declare BLAS functions, see http://www.netlib.org/clapack/cblas/ */
+
+int sgemm_(const char *transa, const char *transb, FINTEGER *m, FINTEGER *n,
+           FINTEGER *k, const float *alpha, const float *a, FINTEGER *lda,
+           const float *b, FINTEGER *ldb, float *beta, float *c, FINTEGER *ldc);
+}
+
+namespace faiss {
+
+using idx_t = Index::idx_t;
+using storage_idx_t = NNDescent::storage_idx_t;
+
+/**************************************************************
+ * add / search blocks of descriptors
+ **************************************************************/
+
+namespace {
+
+/* Wrap the distance computer into one that negates the
+   distances. This makes supporting INNER_PRODUCE search easier */
+
+struct NegativeDistanceComputer : DistanceComputer {
+
+  /// owned by this
+  DistanceComputer *basedis;
+
+  explicit NegativeDistanceComputer(DistanceComputer *basedis)
+      : basedis(basedis) {}
+
+  void set_query(const float *x) override { basedis->set_query(x); }
+
+  /// compute distance of vector i to current query
+  float operator()(idx_t i) override { return -(*basedis)(i); }
+
+  /// compute distance between two stored vectors
+  float symmetric_dis(idx_t i, idx_t j) override {
+    return -basedis->symmetric_dis(i, j);
+  }
+
+  virtual ~NegativeDistanceComputer() { delete basedis; }
+};
+
+DistanceComputer *storage_distance_computer(const Index *storage) {
+  if (storage->metric_type == METRIC_INNER_PRODUCT) {
+    return new NegativeDistanceComputer(storage->get_distance_computer());
+  } else {
+    return storage->get_distance_computer();
+  }
+}
+
+} // namespace
+
+/**************************************************************
+ * IndexNNDescent implementation
+ **************************************************************/
+
+IndexNNDescent::IndexNNDescent(int d, int K, MetricType metric)
+    : Index(d, metric), nndescent(d, K), own_fields(false), storage(nullptr) {}
+
+IndexNNDescent::IndexNNDescent(Index *storage, int K)
+    : Index(storage->d, storage->metric_type), nndescent(storage->d, K),
+      own_fields(false), storage(storage) {}
+
+IndexNNDescent::~IndexNNDescent() {
+  if (own_fields) {
+    delete storage;
+  }
+}
+
+void IndexNNDescent::train(idx_t n, const float *x) {
+  FAISS_THROW_IF_NOT_MSG(storage, "Please use IndexNNDescentFlat (or variants) "
+                                  "instead of IndexNNDescent directly");
+  // nndescent structure does not require training
+  storage->train(n, x);
+  is_trained = true;
+}
+
+void IndexNNDescent::search(idx_t n, const float *x, idx_t k, float *distances,
+                            idx_t *labels) const
+
+{
+  FAISS_THROW_IF_NOT_MSG(storage, "Please use IndexNNDescentFlat (or variants) "
+                                  "instead of IndexNNDescent directly");
+  if (verbose) {
+    printf("Parameters: k=%ld, search_L=%d\n", k, nndescent.search_L);
+  }
+
+  idx_t check_period =
+      InterruptCallback::get_period_hint(d * nndescent.search_L);
+
+  for (idx_t i0 = 0; i0 < n; i0 += check_period) {
+    idx_t i1 = std::min(i0 + check_period, n);
+
+#pragma omp parallel
+    {
+      VisitedTable vt(ntotal);
+
+      DistanceComputer *dis = storage_distance_computer(storage);
+      ScopeDeleter1<DistanceComputer> del(dis);
+
+#pragma omp for
+      for (idx_t i = i0; i < i1; i++) {
+        idx_t *idxi = labels + i * k;
+        float *simi = distances + i * k;
+        dis->set_query(x + i * d);
+
+        maxheap_heapify(k, simi, idxi);
+        nndescent.search(*dis, k, idxi, simi, vt);
+        maxheap_reorder(k, simi, idxi);
+      }
+    }
+    InterruptCallback::check();
+  }
+
+  if (metric_type == METRIC_INNER_PRODUCT) {
+    // we need to revert the negated distances
+    for (size_t i = 0; i < k * n; i++) {
+      distances[i] = -distances[i];
+    }
+  }
+}
+
+void IndexNNDescent::add(idx_t n, const float *x) {
+  FAISS_THROW_IF_NOT_MSG(storage, "Please use IndexNNDescentFlat (or variants) "
+                                  "instead of IndexNNDescent directly");
+  FAISS_THROW_IF_NOT(is_trained);
+
+  if (ntotal != 0) {
+    fprintf(stderr, "WARNING NNDescent doest not support dynamic insertions,"
+                    "mutiple insertions would lead to re-building the index");
+  }
+
+  storage->add(n, x);
+  ntotal = storage->ntotal;
+
+  DistanceComputer *dis = storage_distance_computer(storage);
+  ScopeDeleter1<DistanceComputer> del(dis);
+  nndescent.build(*dis, ntotal, verbose);
+}
+
+void IndexNNDescent::reset() {
+  nndescent.reset();
+  storage->reset();
+  ntotal = 0;
+}
+
+void IndexNNDescent::reconstruct(idx_t key, float *recons) const {
+  storage->reconstruct(key, recons);
+}
+
+/**************************************************************
+ * IndexNNDescentFlat implementation
+ **************************************************************/
+
+IndexNNDescentFlat::IndexNNDescentFlat() { is_trained = true; }
+
+IndexNNDescentFlat::IndexNNDescentFlat(int d, int M, MetricType metric)
+    : IndexNNDescent(new IndexFlat(d, metric), M) {
+  own_fields = true;
+  is_trained = true;
+}
+
+} // namespace faiss

--- a/faiss/IndexNNDescent.h
+++ b/faiss/IndexNNDescent.h
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+#pragma once
+
+#include <vector>
+
+#include <faiss/IndexFlat.h>
+#include <faiss/impl/NNDescent.h>
+#include <faiss/utils/utils.h>
+
+namespace faiss {
+
+/** The NNDescent index is a normal random-access index with an NNDescent
+ * link structure built on top */
+
+struct IndexNNDescent : Index {
+
+  // internal storage of vectors (32 bits)
+  using storage_idx_t = NNDescent::storage_idx_t;
+
+  /// Faiss results are 64-bit
+  using idx_t = Index::idx_t;
+
+  // the link strcuture
+  NNDescent nndescent;
+
+  // the sequential storage
+  bool own_fields;
+  Index *storage;
+
+  explicit IndexNNDescent(int d = 0, int K = 32, MetricType metric = METRIC_L2);
+  explicit IndexNNDescent(Index *storage, int K = 32);
+
+  ~IndexNNDescent() override;
+
+  void add(idx_t n, const float *x) override;
+
+  /// Trains the storage if needed
+  void train(idx_t n, const float *x) override;
+
+  /// entry point for search
+  void search(idx_t n, const float *x, idx_t k, float *distances,
+              idx_t *labels) const override;
+
+  void reconstruct(idx_t key, float *recons) const override;
+
+  void reset() override;
+};
+
+/** Flat index topped with with a NNDescent structure to access elements
+ *  more efficiently.
+ */
+
+struct IndexNNDescentFlat : IndexNNDescent {
+  IndexNNDescentFlat();
+  IndexNNDescentFlat(int d, int K, MetricType metric = METRIC_L2);
+};
+
+} // namespace faiss

--- a/faiss/impl/AuxIndexStructures.h
+++ b/faiss/impl/AuxIndexStructures.h
@@ -15,6 +15,7 @@
 
 #include <stdint.h>
 
+#include <cstring>
 #include <vector>
 #include <unordered_set>
 #include <memory>
@@ -251,6 +252,30 @@ struct FAISS_API InterruptCallback {
 
 };
 
+
+/// set implementation optimized for fast access.
+struct VisitedTable {
+  std::vector<uint8_t> visited;
+  int visno;
+
+  explicit VisitedTable(int size) : visited(size), visno(1) {}
+
+  /// set flag #no to true
+  void set(int no) { visited[no] = visno; }
+
+  /// get flag #no
+  bool get(int no) const { return visited[no] == visno; }
+
+  /// reset all flags to false
+  void advance() {
+    visno++;
+    if (visno == 250) {
+      // 250 rather than 255 because sometimes we use visno and visno+1
+      memset(visited.data(), 0, sizeof(visited[0]) * visited.size());
+      visno = 1;
+    }
+  }
+};
 
 
 }; // namespace faiss

--- a/faiss/impl/HNSW.h
+++ b/faiss/impl/HNSW.h
@@ -219,40 +219,6 @@ struct HNSW {
 };
 
 
-/**************************************************************
- * Auxiliary structures
- **************************************************************/
-
-/// set implementation optimized for fast access.
-struct VisitedTable {
-  std::vector<uint8_t> visited;
-  int visno;
-
-  explicit VisitedTable(int size)
-    : visited(size), visno(1) {}
-
-  /// set flog #no to true
-  void set(int no) {
-    visited[no] = visno;
-  }
-
-  /// get flag #no
-  bool get(int no) const {
-    return visited[no] == visno;
-  }
-
-  /// reset all flags to false
-  void advance() {
-    visno++;
-    if (visno == 250) {
-      // 250 rather than 255 because sometimes we use visno and visno+1
-      memset(visited.data(), 0, sizeof(visited[0]) * visited.size());
-      visno = 1;
-    }
-  }
-};
-
-
 struct HNSWStats {
   size_t n1, n2, n3;
   size_t ndis;

--- a/faiss/impl/NNDescent.cpp
+++ b/faiss/impl/NNDescent.cpp
@@ -223,7 +223,7 @@ void NNDescent::nndescent(DistanceComputer &qdis, bool verbose) {
 
     if (verbose) {
       float recall = eval_recall(eval_points, acc_eval_set);
-      std::cout << "iter: " << it << " recall: " << recall << std::endl;
+      printf("Iter: %d, recall@%d: %lf\n", it, K, recall);
     }
   }
 }
@@ -323,7 +323,9 @@ void NNDescent::build(DistanceComputer &qdis, const int n, bool verbose) {
   std::vector<Nhood>().swap(graph);
   has_built = true;
 
-  std::cout << "Added " << ntotal << " points into index" << std::endl;
+  if (verbose) {
+    printf("Addes %d points into the index\n", ntotal);
+  }
 }
 
 void NNDescent::search(DistanceComputer &qdis, const int topk, idx_t *indices,

--- a/faiss/impl/NNDescent.cpp
+++ b/faiss/impl/NNDescent.cpp
@@ -1,0 +1,363 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+#include <faiss/impl/NNDescent.h>
+
+#include <iostream>
+#include <mutex>
+#include <string>
+
+#include <faiss/impl/AuxIndexStructures.h>
+
+namespace faiss {
+
+constexpr int NUM_EVAL_POINTS = 100;
+inline int insert_into_pool(Neighbor *addr, int size, Neighbor nn);
+
+NNDescent::NNDescent(const int d, const int K) : d(d), K(K), rng(2021) {
+
+  ntotal = 0;
+  has_built = false;
+  S = 10;
+  R = 100;
+  L = K;
+  iter = 10;
+  search_L = 0;
+}
+
+NNDescent::~NNDescent() {}
+
+void NNDescent::join(DistanceComputer &qdis) {
+#pragma omp parallel for default(shared) schedule(dynamic, 100)
+  for (int n = 0; n < ntotal; n++) {
+    graph[n].join([&](int i, int j) {
+      if (i != j) {
+        float dist = qdis.symmetric_dis(i, j);
+        graph[i].insert(j, dist);
+        graph[j].insert(i, dist);
+      }
+    });
+  }
+}
+
+void NNDescent::update() {
+#pragma omp parallel for
+  for (int i = 0; i < ntotal; i++) {
+    std::vector<int>().swap(graph[i].nn_new);
+    std::vector<int>().swap(graph[i].nn_old);
+  }
+
+#pragma omp parallel for
+  for (int n = 0; n < ntotal; ++n) {
+    auto &nn = graph[n];
+    std::sort(nn.pool.begin(), nn.pool.end());
+    if (nn.pool.size() > L)
+      nn.pool.resize(L);
+    nn.pool.reserve(L);
+    int maxl = std::min(nn.M + S, (int)nn.pool.size());
+    int c = 0;
+    int l = 0;
+
+    while ((l < maxl) && (c < S)) {
+      if (nn.pool[l].flag)
+        ++c;
+      ++l;
+    }
+    nn.M = l;
+  }
+#pragma omp parallel for
+  for (int n = 0; n < ntotal; ++n) {
+    auto &nnhd = graph[n];
+    auto &nn_new = nnhd.nn_new;
+    auto &nn_old = nnhd.nn_old;
+    for (int l = 0; l < nnhd.M; ++l) {
+      auto &nn = nnhd.pool[l];
+      auto &nhood_o = graph[nn.id]; // nn on the other side of the edge
+
+      if (nn.flag) {
+        nn_new.push_back(nn.id);
+        if (nn.distance > nhood_o.pool.back().distance) {
+          LockGuard guard(nhood_o.lock);
+          if (nhood_o.rnn_new.size() < R)
+            nhood_o.rnn_new.push_back(n);
+          else {
+            int pos = rand() % R;
+            nhood_o.rnn_new[pos] = n;
+          }
+        }
+        nn.flag = false;
+      } else {
+        nn_old.push_back(nn.id);
+        if (nn.distance > nhood_o.pool.back().distance) {
+          LockGuard guard(nhood_o.lock);
+          if (nhood_o.rnn_old.size() < R)
+            nhood_o.rnn_old.push_back(n);
+          else {
+            int pos = rand() % R;
+            nhood_o.rnn_old[pos] = n;
+          }
+        }
+      }
+    }
+    std::make_heap(nnhd.pool.begin(), nnhd.pool.end());
+  }
+#pragma omp parallel for
+  for (int i = 0; i < ntotal; ++i) {
+    auto &nn_new = graph[i].nn_new;
+    auto &nn_old = graph[i].nn_old;
+    auto &rnn_new = graph[i].rnn_new;
+    auto &rnn_old = graph[i].rnn_old;
+    if (R && rnn_new.size() > R) {
+      std::random_shuffle(rnn_new.begin(), rnn_new.end());
+      rnn_new.resize(R);
+    }
+    nn_new.insert(nn_new.end(), rnn_new.begin(), rnn_new.end());
+    if (R && rnn_old.size() > R) {
+      std::random_shuffle(rnn_old.begin(), rnn_old.end());
+      rnn_old.resize(R);
+    }
+    nn_old.insert(nn_old.end(), rnn_old.begin(), rnn_old.end());
+    if (nn_old.size() > R * 2) {
+      nn_old.resize(R * 2);
+      nn_old.reserve(R * 2);
+    }
+    std::vector<int>().swap(graph[i].rnn_new);
+    std::vector<int>().swap(graph[i].rnn_old);
+  }
+}
+
+void NNDescent::nndescent(DistanceComputer &qdis, bool verbose) {
+  int num_eval_points = std::min(NUM_EVAL_POINTS, ntotal);
+  std::vector<int> eval_points(num_eval_points);
+  std::vector<std::vector<int>> acc_eval_set(num_eval_points);
+  gen_random(rng, &eval_points[0], eval_points.size(), ntotal);
+  generate_eval_set(qdis, eval_points, acc_eval_set, ntotal);
+  for (int it = 0; it < iter; it++) {
+    join(qdis);
+    update();
+
+    if (verbose) {
+      float recall = eval_recall(eval_points, acc_eval_set);
+      std::cout << "iter: " << it << " recall: " << recall << std::endl;
+    }
+  }
+}
+
+void NNDescent::generate_eval_set(DistanceComputer &qdis, std::vector<int> &c,
+                                  std::vector<std::vector<int>> &v, int N) {
+#pragma omp parallel for
+  for (int i = 0; i < c.size(); i++) {
+    std::vector<Neighbor> tmp;
+    for (int j = 0; j < N; j++) {
+      float dist = qdis.symmetric_dis(c[i], j);
+      tmp.push_back(Neighbor(j, dist, true));
+    }
+
+    std::partial_sort(tmp.begin(), tmp.begin() + K, tmp.end());
+    for (int j = 0; j < K; j++) {
+      v[i].push_back(tmp[j].id);
+    }
+  }
+}
+
+float NNDescent::eval_recall(std::vector<int> &eval_points,
+                             std::vector<std::vector<int>> &acc_eval_set) {
+  float mean_acc = 0.0f;
+  for (size_t i = 0; i < eval_points.size(); i++) {
+    float acc = 0;
+    auto &g = graph[eval_points[i]].pool;
+    auto &v = acc_eval_set[i];
+    for (size_t j = 0; j < g.size(); j++) {
+      for (size_t k = 0; k < v.size(); k++) {
+        if (g[j].id == v[k]) {
+          acc++;
+          break;
+        }
+      }
+    }
+    mean_acc += acc / v.size();
+  }
+  return mean_acc / eval_points.size();
+}
+
+void NNDescent::init_graph(DistanceComputer &qdis) {
+
+  graph.reserve(ntotal);
+  for (int i = 0; i < ntotal; i++) {
+    graph.push_back(Nhood(L, S, rng, (int)ntotal));
+  }
+#pragma omp parallel for
+  for (int i = 0; i < ntotal; i++) {
+    std::vector<int> tmp(S);
+
+    gen_random(rng, tmp.data(), S, ntotal);
+
+    for (int j = 0; j < S; j++) {
+      int id = tmp[j];
+      if (id == i)
+        continue;
+      float dist = qdis.symmetric_dis(i, id);
+
+      graph[i].pool.push_back(Neighbor(id, dist, true));
+    }
+    std::make_heap(graph[i].pool.begin(), graph[i].pool.end());
+    graph[i].pool.reserve(L);
+  }
+}
+
+void NNDescent::build(DistanceComputer &qdis, const int n, bool verbose) {
+  FAISS_THROW_IF_NOT_MSG(L >= K, "L should be >= K in NNDescent.build");
+
+  if (verbose) {
+    printf("Parameters: K=%d, S=%d, R=%d, L=%d, iter=%d\n", K, S, R, L, iter);
+  }
+
+  ntotal = n;
+  init_graph(qdis);
+  nndescent(qdis, verbose);
+
+  final_graph.resize(ntotal * K);
+
+  for (int i = 0; i < ntotal; i++) {
+    // std::vector<int> tmp;
+    std::sort(graph[i].pool.begin(), graph[i].pool.end());
+    for (int j = 0; j < K; j++) {
+      // tmp.push_back(graph[i].pool[j].id);
+      FAISS_ASSERT(graph[i].pool[j].id < ntotal);
+      final_graph[i * K + j] = graph[i].pool[j].id;
+    }
+
+    std::vector<Neighbor>().swap(graph[i].pool);
+    std::vector<int>().swap(graph[i].nn_new);
+    std::vector<int>().swap(graph[i].nn_old);
+    std::vector<int>().swap(graph[i].rnn_new);
+    std::vector<int>().swap(graph[i].rnn_new);
+  }
+  std::vector<Nhood>().swap(graph);
+  has_built = true;
+
+  std::cout << "Added " << ntotal << " points into index" << std::endl;
+}
+
+void NNDescent::search(DistanceComputer &qdis, const int topk, idx_t *indices,
+                       float *dists, VisitedTable &vt) const {
+
+  FAISS_THROW_IF_NOT_MSG(has_built, "The index is not build yet.");
+  FAISS_THROW_IF_NOT_MSG(search_L >= topk,
+                         "search_L should be >= k in NNDescent.search");
+
+  std::vector<Neighbor> retset(search_L + 1);
+  std::vector<int> init_ids(search_L);
+  gen_random(rng, init_ids.data(), search_L, ntotal);
+
+  for (int i = 0; i < search_L; i++) {
+    int id = init_ids[i];
+    float dist = qdis(id);
+    retset[i] = Neighbor(id, dist, true);
+  }
+
+  std::sort(retset.begin(), retset.begin() + search_L);
+  int k = 0;
+  while (k < search_L) {
+    int nk = search_L;
+
+    if (retset[k].flag) {
+      retset[k].flag = false;
+      int n = retset[k].id;
+
+      for (int m = 0; m < K; ++m) {
+        int id = final_graph[n * K + m];
+        if (vt.get(id))
+          continue;
+
+        vt.set(id);
+        float dist = qdis(id);
+        if (dist >= retset[search_L - 1].distance)
+          continue;
+
+        Neighbor nn(id, dist, true);
+        int r = insert_into_pool(retset.data(), search_L, nn);
+
+        if (r < nk)
+          nk = r;
+      }
+      // lock to here
+    }
+    if (nk <= k)
+      k = nk;
+    else
+      ++k;
+  }
+  for (size_t i = 0; i < topk; i++) {
+    indices[i] = retset[i].id;
+    dists[i] = retset[i].distance;
+  }
+
+  vt.advance();
+}
+
+void NNDescent::reset() {
+  has_built = false;
+  ntotal = 0;
+  std::vector<int>().swap(final_graph);
+}
+
+void gen_random(std::mt19937 &rng, int *addr, const int size, const int N) {
+  for (int i = 0; i < size; ++i) {
+    addr[i] = rng() % (N - size);
+  }
+  std::sort(addr, addr + size);
+  for (int i = 1; i < size; ++i) {
+    if (addr[i] <= addr[i - 1]) {
+      addr[i] = addr[i - 1] + 1;
+    }
+  }
+  int off = rng() % N;
+  for (int i = 0; i < size; ++i) {
+    addr[i] = (addr[i] + off) % N;
+  }
+}
+
+inline int insert_into_pool(Neighbor *addr, int size, Neighbor nn) {
+  // find the location to insert
+  int left = 0, right = size - 1;
+  if (addr[left].distance > nn.distance) {
+    memmove((char *)&addr[left + 1], &addr[left], size * sizeof(Neighbor));
+    addr[left] = nn;
+    return left;
+  }
+  if (addr[right].distance < nn.distance) {
+    addr[size] = nn;
+    return size;
+  }
+  while (left < right - 1) {
+    int mid = (left + right) / 2;
+    if (addr[mid].distance > nn.distance)
+      right = mid;
+    else
+      left = mid;
+  }
+  // check equal ID
+
+  while (left > 0) {
+    if (addr[left].distance < nn.distance)
+      break;
+    if (addr[left].id == nn.id)
+      return size + 1;
+    left--;
+  }
+  if (addr[left].id == nn.id || addr[right].id == nn.id)
+    return size + 1;
+  memmove((char *)&addr[right + 1], &addr[right],
+          (size - right) * sizeof(Neighbor));
+  addr[right] = nn;
+  return right;
+}
+
+} // namespace faiss

--- a/faiss/impl/NNDescent.h
+++ b/faiss/impl/NNDescent.h
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+#pragma once
+
+#include <algorithm>
+#include <mutex>
+#include <queue>
+#include <random>
+#include <unordered_set>
+#include <vector>
+
+#include <omp.h>
+
+#include <faiss/Index.h>
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/platform_macros.h>
+#include <faiss/utils/Heap.h>
+#include <faiss/utils/random.h>
+
+namespace faiss {
+
+/** Implementation of NNDescent which is one of the most popular
+ *  KNN graph building algorithms
+ *
+ * Efficient K-Nearest Neighbor Graph Construction for Generic
+ * Similarity Measures
+ *
+ *  Dong, Wei, Charikar Moses, and Kai Li, WWW 2011
+ *
+ * This implmentation is heavily influenced by the efanna
+ * implementation by Cong Fu
+ * (https://github.com/ZJULearning/efanna_graph)
+ *
+ * The NNDescent object stores only the neighbor link structure,
+ * see IndexNNDescent.h for the full index object.
+ */
+
+struct VisitedTable;
+struct Neighbor;
+struct Nhood;
+struct DistanceComputer;
+
+typedef std::lock_guard<std::mutex> LockGuard;
+
+struct NNDescent {
+
+  using storage_idx_t = int;
+  using idx_t = Index::idx_t;
+
+  using KNNGraph = std::vector<Nhood>;
+
+  explicit NNDescent(const int d, const int K);
+
+  ~NNDescent();
+
+  void build(DistanceComputer &qdis, const int n, bool verbose);
+
+  void search(DistanceComputer &qdis, const int topk, idx_t *indices,
+              float *dists, VisitedTable &vt) const;
+
+  void reset();
+
+  void init_graph(DistanceComputer &qdis);
+
+  void nndescent(DistanceComputer &qdis, bool verbose);
+
+  void join(DistanceComputer &qdis);
+
+  void update();
+
+  void generate_eval_set(DistanceComputer &qdis, std::vector<int> &c,
+                         std::vector<std::vector<int>> &v, int N);
+
+  float eval_recall(std::vector<int> &ctrl_points,
+                    std::vector<std::vector<int>> &acc_eval_set);
+
+  bool has_built;
+
+  int K;
+  int S, R, L, iter;
+  int search_L;
+
+  // dimensions
+  int d;
+
+  int ntotal;
+
+  mutable std::mt19937 rng;
+
+  KNNGraph graph;
+  std::vector<int> final_graph;
+};
+
+void gen_random(std::mt19937 &rng, int *addr, const int size, const int N);
+
+
+struct Neighbor {
+  int id;
+  float distance;
+  bool flag;
+
+  Neighbor() = default;
+  Neighbor(int id, float distance, bool f)
+      : id(id), distance(distance), flag(f) {}
+
+  inline bool operator<(const Neighbor &other) const {
+    return distance < other.distance;
+  }
+};
+
+struct Nhood {
+  std::mutex lock;
+  std::vector<Neighbor> pool;
+  int M;
+
+  std::vector<int> nn_old;
+  std::vector<int> nn_new;
+  std::vector<int> rnn_old;
+  std::vector<int> rnn_new;
+
+  Nhood() {}
+
+  Nhood(int l, int s, std::mt19937 &rng, int N) {
+    M = s;
+    nn_new.resize(s * 2);
+    gen_random(rng, &nn_new[0], (int)nn_new.size(), N);
+    nn_new.reserve(s * 2);
+    pool.reserve(l);
+  }
+
+  Nhood& operator=(const Nhood &other) {
+    M = other.M;
+    std::copy(other.nn_new.begin(), other.nn_new.end(),
+              std::back_inserter(nn_new));
+    nn_new.reserve(other.nn_new.capacity());
+    pool.reserve(other.pool.capacity());
+  }
+
+  Nhood(const Nhood &other) {
+    M = other.M;
+    std::copy(other.nn_new.begin(), other.nn_new.end(),
+              std::back_inserter(nn_new));
+    nn_new.reserve(other.nn_new.capacity());
+    pool.reserve(other.pool.capacity());
+  }
+
+  void insert(int id, float dist) {
+    LockGuard guard(lock);
+    if (dist > pool.front().distance)
+      return;
+    for (int i = 0; i < pool.size(); i++) {
+      if (id == pool[i].id)
+        return;
+    }
+    if (pool.size() < pool.capacity()) {
+      pool.push_back(Neighbor(id, dist, true));
+      std::push_heap(pool.begin(), pool.end());
+    } else {
+      std::pop_heap(pool.begin(), pool.end());
+      pool[pool.size() - 1] = Neighbor(id, dist, true);
+      std::push_heap(pool.begin(), pool.end());
+    }
+  }
+
+  template <typename C> void join(C callback) const {
+    for (int const i : nn_new) {
+      for (int const j : nn_new) {
+        if (i < j) {
+          callback(i, j);
+        }
+      }
+      for (int j : nn_old) {
+        callback(i, j);
+      }
+    }
+  }
+};
+
+} // namespace faiss

--- a/faiss/impl/NNDescent.h
+++ b/faiss/impl/NNDescent.h
@@ -64,8 +64,8 @@ struct Neighbor {
 
 struct Nhood {
   std::mutex lock;
-  std::vector<Neighbor> pool; // candidate pool
-  int M;                      // number of new nodes to be operated
+  std::vector<Neighbor> pool; // candidate pool (a max heap)
+  int M;                      // number of new neighbors to be operated
 
   std::vector<int> nn_old;  // old neighbors
   std::vector<int> nn_new;  // new neighbors
@@ -114,7 +114,7 @@ struct NNDescent {
   /// Perform local join on each node
   void join(DistanceComputer &qdis);
 
-  /// Combine forward and reverse links
+  /// Sample new neighbors for each node to peform local join later
   void update();
 
   /// Sample a small number of points to evaluate the quality of KNNG built

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -401,7 +401,7 @@ void gpu_sync_all_devices()
 %include  <faiss/impl/HNSW.h>
 %include  <faiss/IndexHNSW.h>
 
-%ignore faiss::Nhood::lock;
+%ignore faiss::nndescent::Nhood::lock;
 %include  <faiss/impl/NNDescent.h>
 %include  <faiss/IndexNNDescent.h>
 

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -87,6 +87,10 @@ typedef uint64_t size_t;
 #include <faiss/IndexReplicas.h>
 #include <faiss/impl/HNSW.h>
 #include <faiss/IndexHNSW.h>
+
+#include <faiss/impl/NNDescent.h>
+#include <faiss/IndexNNDescent.h>
+
 #include <faiss/MetaIndexes.h>
 #include <faiss/IndexRefine.h>
 
@@ -396,6 +400,11 @@ void gpu_sync_all_devices()
 %include  <faiss/IndexIVFSpectralHash.h>
 %include  <faiss/impl/HNSW.h>
 %include  <faiss/IndexHNSW.h>
+
+%ignore faiss::Nhood::lock;
+%include  <faiss/impl/NNDescent.h>
+%include  <faiss/IndexNNDescent.h>
+
 %include  <faiss/IndexIVFFlat.h>
 
 #ifndef SWIGWIN
@@ -542,6 +551,7 @@ void gpu_sync_all_devices()
     DOWNCAST ( IndexHNSWPQ )
     DOWNCAST ( IndexHNSWSQ )
     DOWNCAST ( IndexHNSW2Level )
+    DOWNCAST ( IndexNNDescentFlat )
     DOWNCAST ( Index2Layer )
 #ifdef GPU_WRAPPER
     DOWNCAST_GPU ( GpuIndexIVFPQ )

--- a/faiss/utils/AlignedTable.h
+++ b/faiss/utils/AlignedTable.h
@@ -58,7 +58,7 @@ struct AlignedTableTightAlloc {
             new_ptr = nullptr;
         }
         numel = n;
-        free(ptr);
+        posix_memalign_free(ptr);
         ptr = new_ptr;
     }
 

--- a/tests/test_build_blocks.py
+++ b/tests/test_build_blocks.py
@@ -665,12 +665,14 @@ class TestNNDescentKNNG(unittest.TestCase):
 
         index.add(xb)
         graph = index.nndescent.final_graph
+        graph = faiss.vector_to_array(graph)
+        graph = graph.reshape(nb, K)
 
         recalls = 0
         for i in range(nb):
             for j in range(K):
                 for k in range(K):
-                    if graph.at(i * K + j) == knn[i, k]:
+                    if graph[i, j] == knn[i, k]:
                         recalls += 1
                         break
         recall = 1.0 * recalls / (nb * K)

--- a/tests/test_build_blocks.py
+++ b/tests/test_build_blocks.py
@@ -637,5 +637,46 @@ class TestSWIGWrap(unittest.TestCase):
         faiss.vector_to_array(idx.id_map)
 
 
+class TestNNDescentKNNG(unittest.TestCase):
+
+    def test_knng_L2(self):
+        self.subtest(32, 10, faiss.METRIC_L2)
+
+    def test_knng_IP(self):
+        self.subtest(32, 10, faiss.METRIC_INNER_PRODUCT)
+
+    def subtest(self, d, K, metric):
+        metric_names = {faiss.METRIC_L1: 'L1',
+                        faiss.METRIC_L2: 'L2',
+                        faiss.METRIC_INNER_PRODUCT: 'IP'}
+
+        nb = 1000
+        _, xb, _ = get_dataset_2(d, 0, nb, 0)
+
+        _, knn = faiss.knn(xb, xb, K + 1, metric)
+        knn = knn[:, 1:]
+
+        index = faiss.IndexNNDescentFlat(d, K, metric)
+        index.nndescent.S = 10
+        index.nndescent.R = 32
+        index.nndescent.L = K + 20
+        index.nndescent.iter = 5
+        index.verbose = True
+
+        index.add(xb)
+        graph = index.nndescent.final_graph
+
+        recalls = 0
+        for i in range(nb):
+            for j in range(K):
+                for k in range(K):
+                    if graph.at(i * K + j) == knn[i, k]:
+                        recalls += 1
+                        break
+        recall = 1.0 * recalls / (nb * K)
+        print('Metric: {}, knng accuracy: {}'.format(metric_names[metric], recall))
+        assert recall > 0.99
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As discussed in https://github.com/facebookresearch/faiss/issues/685, I'm going to add an NSG index to faiss. This PR which adds an NNDescent index is the first step as I commented [here ](https://github.com/facebookresearch/faiss/issues/685#issuecomment-760608431).

**Changes:**
1. Add an `IndexNNDescent` and an `IndexNNDescentFlat` which allow users to construct a KNN graph on a million scale dataset using CPU and search NN on it. The implementation part is put under `faiss/impl`.
2. Add compilation entries to `CMakeLists.txt` for C++ and `swigfaiss.swig` for Python. `IndexNNDescentFlat` could be directly called by users in C++ and Python.
3. `VisitedTable` struct in `HNSW.h` is moved into `AuxIndexStructures.h`.
3. Add a demo `demo_nndescent.cpp` to demonstrate the effectiveness.

**TODO**
1. Support index factor.
2. Implement `IndexNNDescentPQ` and `IndexNNDescentSQ`
3. More comments in the code.