### PR TITLE
Add missing headers in faiss/[gpu/]CMakeLists.txt

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -110,6 +110,7 @@ set(FAISS_HEADERS
   impl/PolysemousTraining.h
   impl/ProductQuantizer-inl.h
   impl/ProductQuantizer.h
+  impl/ResultHandler.h
   impl/ScalarQuantizer.h
   impl/ThreadedIndex-inl.h
   impl/ThreadedIndex.h

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -21,18 +21,18 @@ add_library(faiss
   IndexIVF.cpp
   IndexIVFFlat.cpp
   IndexIVFPQ.cpp
-  IndexIVFPQR.cpp
   IndexIVFPQFastScan.cpp
-  IndexPQFastScan.cpp
+  IndexIVFPQR.cpp
   IndexIVFSpectralHash.cpp
   IndexLSH.cpp
   IndexLattice.cpp
   IndexPQ.cpp
+  IndexPQFastScan.cpp
   IndexPreTransform.cpp
+  IndexRefine.cpp
   IndexReplicas.cpp
   IndexScalarQuantizer.cpp
   IndexShards.cpp
-  IndexRefine.cpp
   MatrixStats.cpp
   MetaIndexes.cpp
   VectorTransform.cpp
@@ -46,14 +46,14 @@ add_library(faiss
   impl/ScalarQuantizer.cpp
   impl/index_read.cpp
   impl/index_write.cpp
+  impl/io.cpp
+  impl/lattice_Zn.cpp
   impl/pq4_fast_scan.cpp
   impl/pq4_fast_scan_search_1.cpp
   impl/pq4_fast_scan_search_qbs.cpp
-  impl/io.cpp
-  impl/lattice_Zn.cpp
+  invlists/BlockInvertedLists.cpp
   invlists/DirectMap.cpp
   invlists/InvertedLists.cpp
-  invlists/BlockInvertedLists.cpp
   invlists/InvertedListsIOHook.cpp
   utils/Heap.cpp
   utils/WorkerThread.cpp
@@ -84,18 +84,18 @@ set(FAISS_HEADERS
   IndexIVF.h
   IndexIVFFlat.h
   IndexIVFPQ.h
-  IndexIVFPQR.h
   IndexIVFPQFastScan.h
-  IndexPQFastScan.h
+  IndexIVFPQR.h
   IndexIVFSpectralHash.h
   IndexLSH.h
   IndexLattice.h
   IndexPQ.h
+  IndexPQFastScan.h
   IndexPreTransform.h
+  IndexRefine.h
   IndexReplicas.h
   IndexScalarQuantizer.h
   IndexShards.h
-  IndexRefine.h
   MatrixStats.h
   MetaIndexes.h
   MetricType.h
@@ -116,15 +116,15 @@ set(FAISS_HEADERS
   impl/io.h
   impl/io_macros.h
   impl/lattice_Zn.h
+  impl/platform_macros.h
   impl/pq4_fast_scan.h
   impl/simd_result_handlers.h
-  impl/platform_macros.h
-  invlists/InvertedLists.h
   invlists/BlockInvertedLists.h
   invlists/DirectMap.h
+  invlists/InvertedLists.h
   invlists/InvertedListsIOHook.h
-  utils/Heap.h
   utils/AlignedTable.h
+  utils/Heap.h
   utils/WorkerThread.h
   utils/distances.h
   utils/extra_distances.h
@@ -135,8 +135,8 @@ set(FAISS_HEADERS
   utils/quantize_lut.h
   utils/random.h
   utils/simdlib.h
-  utils/simdlib_emulated.h
   utils/simdlib_avx2.h
+  utils/simdlib_emulated.h
   utils/utils.h
 )
 

--- a/faiss/gpu/CMakeLists.txt
+++ b/faiss/gpu/CMakeLists.txt
@@ -127,8 +127,10 @@ set(FAISS_GPU_HEADERS
   impl/IVFBase.cuh
   impl/IVFFlat.cuh
   impl/IVFFlatScan.cuh
+  impl/IVFInterleaved.cuh
   impl/IVFPQ.cuh
   impl/IVFUtils.cuh
+  impl/InterleavedCodes.h
   impl/L2Norm.cuh
   impl/L2Select.cuh
   impl/PQCodeDistances-inl.cuh
@@ -172,6 +174,7 @@ set(FAISS_GPU_HEADERS
   utils/ThrustAllocator.cuh
   utils/Timer.h
   utils/Transpose.cuh
+  utils/WarpPackedBits.cuh
   utils/WarpSelectKernel.cuh
   utils/WarpShuffles.cuh
   utils/blockselect/BlockSelectImpl.cuh

--- a/faiss/gpu/CMakeLists.txt
+++ b/faiss/gpu/CMakeLists.txt
@@ -23,7 +23,6 @@ target_sources(faiss PRIVATE
   impl/BroadcastSum.cu
   impl/Distance.cu
   impl/FlatIndex.cu
-  impl/InterleavedCodes.cpp
   impl/IVFAppend.cu
   impl/IVFBase.cu
   impl/IVFFlat.cu
@@ -33,6 +32,7 @@ target_sources(faiss PRIVATE
   impl/IVFUtils.cu
   impl/IVFUtilsSelect1.cu
   impl/IVFUtilsSelect2.cu
+  impl/InterleavedCodes.cpp
   impl/L2Norm.cu
   impl/L2Select.cu
   impl/PQScanMultiPassPrecomputed.cu
@@ -105,11 +105,11 @@ set(FAISS_GPU_HEADERS
   GpuClonerOptions.h
   GpuDistance.h
   GpuFaissAssert.h
+  GpuIndex.h
   GpuIndexBinaryFlat.h
   GpuIndexFlat.h
-  GpuIndex.h
-  GpuIndexIVFFlat.h
   GpuIndexIVF.h
+  GpuIndexIVFFlat.h
   GpuIndexIVFPQ.h
   GpuIndexIVFScalarQuantizer.h
   GpuIndicesOptions.h
@@ -131,32 +131,31 @@ set(FAISS_GPU_HEADERS
   impl/IVFUtils.cuh
   impl/L2Norm.cuh
   impl/L2Select.cuh
-  impl/PQCodeDistances.cuh
   impl/PQCodeDistances-inl.cuh
+  impl/PQCodeDistances.cuh
   impl/PQCodeLoad.cuh
-  impl/PQScanMultiPassNoPrecomputed.cuh
   impl/PQScanMultiPassNoPrecomputed-inl.cuh
+  impl/PQScanMultiPassNoPrecomputed.cuh
   impl/PQScanMultiPassPrecomputed.cuh
   impl/RemapIndices.h
   impl/VectorResidual.cuh
-  utils/blockselect/BlockSelectImpl.cuh
   utils/BlockSelectKernel.cuh
   utils/Comparators.cuh
   utils/ConversionOperators.cuh
   utils/CopyUtils.cuh
   utils/DeviceDefs.cuh
-  utils/DeviceTensor.cuh
   utils/DeviceTensor-inl.cuh
+  utils/DeviceTensor.cuh
   utils/DeviceUtils.h
   utils/DeviceVector.cuh
   utils/Float16.cuh
-  utils/HostTensor.cuh
   utils/HostTensor-inl.cuh
+  utils/HostTensor.cuh
   utils/Limits.cuh
   utils/LoadStoreOperators.cuh
   utils/MathOperators.cuh
-  utils/MatrixMult.cuh
   utils/MatrixMult-inl.cuh
+  utils/MatrixMult.cuh
   utils/MergeNetworkBlock.cuh
   utils/MergeNetworkUtils.cuh
   utils/MergeNetworkWarp.cuh
@@ -168,14 +167,15 @@ set(FAISS_GPU_HEADERS
   utils/Select.cuh
   utils/StackDeviceMemory.h
   utils/StaticUtils.h
-  utils/Tensor.cuh
   utils/Tensor-inl.cuh
+  utils/Tensor.cuh
   utils/ThrustAllocator.cuh
   utils/Timer.h
   utils/Transpose.cuh
   utils/WarpSelectKernel.cuh
-  utils/warpselect/WarpSelectImpl.cuh
   utils/WarpShuffles.cuh
+  utils/blockselect/BlockSelectImpl.cuh
+  utils/warpselect/WarpSelectImpl.cuh
 )
 
 # Export FAISS_HEADERS variable to parent scope.

--- a/faiss/gpu/CMakeLists.txt
+++ b/faiss/gpu/CMakeLists.txt
@@ -54,49 +54,49 @@ target_sources(faiss PRIVATE
   utils/WarpSelectFloat.cu
   utils/WarpSelectHalf.cu
   utils/blockselect/BlockSelectFloat1.cu
-  utils/blockselect/BlockSelectFloat128.cu
-  utils/blockselect/BlockSelectFloat256.cu
   utils/blockselect/BlockSelectFloat32.cu
   utils/blockselect/BlockSelectFloat64.cu
+  utils/blockselect/BlockSelectFloat128.cu
+  utils/blockselect/BlockSelectFloat256.cu
+  utils/blockselect/BlockSelectFloatF512.cu
   utils/blockselect/BlockSelectFloatF1024.cu
   utils/blockselect/BlockSelectFloatF2048.cu
-  utils/blockselect/BlockSelectFloatF512.cu
+  utils/blockselect/BlockSelectFloatT512.cu
   utils/blockselect/BlockSelectFloatT1024.cu
   utils/blockselect/BlockSelectFloatT2048.cu
-  utils/blockselect/BlockSelectFloatT512.cu
   utils/blockselect/BlockSelectHalf1.cu
-  utils/blockselect/BlockSelectHalf128.cu
-  utils/blockselect/BlockSelectHalf256.cu
   utils/blockselect/BlockSelectHalf32.cu
   utils/blockselect/BlockSelectHalf64.cu
+  utils/blockselect/BlockSelectHalf128.cu
+  utils/blockselect/BlockSelectHalf256.cu
+  utils/blockselect/BlockSelectHalfF512.cu
   utils/blockselect/BlockSelectHalfF1024.cu
   utils/blockselect/BlockSelectHalfF2048.cu
-  utils/blockselect/BlockSelectHalfF512.cu
+  utils/blockselect/BlockSelectHalfT512.cu
   utils/blockselect/BlockSelectHalfT1024.cu
   utils/blockselect/BlockSelectHalfT2048.cu
-  utils/blockselect/BlockSelectHalfT512.cu
   utils/warpselect/WarpSelectFloat1.cu
-  utils/warpselect/WarpSelectFloat128.cu
-  utils/warpselect/WarpSelectFloat256.cu
   utils/warpselect/WarpSelectFloat32.cu
   utils/warpselect/WarpSelectFloat64.cu
+  utils/warpselect/WarpSelectFloat128.cu
+  utils/warpselect/WarpSelectFloat256.cu
+  utils/warpselect/WarpSelectFloatF512.cu
   utils/warpselect/WarpSelectFloatF1024.cu
   utils/warpselect/WarpSelectFloatF2048.cu
-  utils/warpselect/WarpSelectFloatF512.cu
+  utils/warpselect/WarpSelectFloatT512.cu
   utils/warpselect/WarpSelectFloatT1024.cu
   utils/warpselect/WarpSelectFloatT2048.cu
-  utils/warpselect/WarpSelectFloatT512.cu
   utils/warpselect/WarpSelectHalf1.cu
-  utils/warpselect/WarpSelectHalf128.cu
-  utils/warpselect/WarpSelectHalf256.cu
   utils/warpselect/WarpSelectHalf32.cu
   utils/warpselect/WarpSelectHalf64.cu
+  utils/warpselect/WarpSelectHalf128.cu
+  utils/warpselect/WarpSelectHalf256.cu
+  utils/warpselect/WarpSelectHalfF512.cu
   utils/warpselect/WarpSelectHalfF1024.cu
   utils/warpselect/WarpSelectHalfF2048.cu
-  utils/warpselect/WarpSelectHalfF512.cu
+  utils/warpselect/WarpSelectHalfT512.cu
   utils/warpselect/WarpSelectHalfT1024.cu
   utils/warpselect/WarpSelectHalfT2048.cu
-  utils/warpselect/WarpSelectHalfT512.cu
 )
 
 set(FAISS_GPU_HEADERS


### PR DESCRIPTION
While preparing https://github.com/conda-forge/faiss-split-feedstock/pull/26, I grepped for the expected headers based on the files in the repo, à la: 
```
>ls faiss/invlists/ | grep -E "h$"
BlockInvertedLists.h
DirectMap.h
InvertedLists.h
InvertedListsIOHook.h
OnDiskInvertedLists.h
```

Doing so uncovered that there were some headers missing (apparently) in `CMakeLists.txt`, namely:
```
faiss/impl/ResultHandler.h
faiss/gpu/impl/IVFInterleaved.cuh
faiss/gpu/impl/InterleavedCodes.h
faiss/gpu/utils/WarpPackedBits.cuh
```

It's possible that they were left out intentionally, but I didn't see something that would make me think so e.g. in [`ResultHandler.h`](https://github.com/facebookresearch/faiss/blob/master/faiss/impl/ResultHandler.h).

While I was at it, I decided to order the filenames consistently (alphabetically, except for the increasing bit-sizes for blockselect/warpselect, as is already the case for `impl/scan/IVFInterleaved<x>.cu`), but of course, those commits could easily be dropped.

By reviewing the commits separately, it should be clear (for the first two) from the equal number of deletions/insertions (and the simple diff) that this is just a reshuffle. The only additions are in the last commit.
