### PR TITLE
Handle the situation where nprobe > nlist in IndexIVF

### DIFF
--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -277,7 +277,7 @@ void IndexIVF::set_direct_map_type (DirectMap::Type type)
 void IndexIVF::search (idx_t n, const float *x, idx_t k,
                          float *distances, idx_t *labels) const
 {
-    size_t nprobe = std::min(nlist, this->nprobe);
+    const size_t nprobe = std::min(nlist, this->nprobe);
 
     // search function for a subset of queries
     auto sub_search_func = [this, k, nprobe]
@@ -351,10 +351,10 @@ void IndexIVF::search_preassigned (idx_t n, const float *x, idx_t k,
                                    const IVFSearchParameters *params,
                                    IndexIVFStats *ivf_stats) const
 {
-    long nprobe = params ? params->nprobe : this->nprobe;
-    nprobe = std::min((long)nlist, nprobe);
+    idx_t nprobe = params ? params->nprobe : this->nprobe;
+    nprobe = std::min((idx_t)nlist, nprobe);
 
-    long max_codes = params ? params->max_codes : this->max_codes;
+    idx_t max_codes = params ? params->max_codes : this->max_codes;
 
     size_t nlistv = 0, ndis = 0, nheap = 0;
 
@@ -487,7 +487,7 @@ void IndexIVF::search_preassigned (idx_t n, const float *x, idx_t k,
 
                 init_result (simi, idxi);
 
-                long nscan = 0;
+                idx_t nscan = 0;
 
                 // loop over probes
                 for (size_t ik = 0; ik < nprobe; ik++) {
@@ -520,7 +520,7 @@ void IndexIVF::search_preassigned (idx_t n, const float *x, idx_t k,
                 init_result (local_dis.data(), local_idx.data());
 
 #pragma omp for schedule(dynamic)
-                for (long ik = 0; ik < nprobe; ik++) {
+                for (idx_t ik = 0; ik < nprobe; ik++) {
                     ndis += scan_one_list
                         (keys [i * nprobe + ik],
                          coarse_dis[i * nprobe + ik],
@@ -603,6 +603,7 @@ void IndexIVF::search_preassigned (idx_t n, const float *x, idx_t k,
 void IndexIVF::range_search (idx_t nx, const float *x, float radius,
                              RangeSearchResult *result) const
 {
+    const size_t nprobe = std::min(nlist, this->nprobe);
     std::unique_ptr<idx_t[]> keys (new idx_t[nx * nprobe]);
     std::unique_ptr<float []> coarse_dis (new float[nx * nprobe]);
 
@@ -627,8 +628,9 @@ void IndexIVF::range_search_preassigned (
          const IVFSearchParameters *params,
          IndexIVFStats *stats) const
 {
-    long nprobe = params ? params->nprobe : this->nprobe;
-    long max_codes = params ? params->max_codes : this->max_codes;
+    idx_t nprobe = params ? params->nprobe : this->nprobe;
+    nprobe = std::min((idx_t)nlist, nprobe);
+    idx_t max_codes = params ? params->max_codes : this->max_codes;
 
     size_t nlistv = 0, ndis = 0;
 
@@ -815,6 +817,7 @@ void IndexIVF::search_and_reconstruct (idx_t n, const float *x, idx_t k,
                                        float *distances, idx_t *labels,
                                        float *recons) const
 {
+    const size_t nprobe = std::min(nlist, this->nprobe);
     idx_t * idx = new idx_t [n * nprobe];
     ScopeDeleter<idx_t> del (idx);
     float * coarse_dis = new float [n * nprobe];

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -277,10 +277,10 @@ void IndexIVF::set_direct_map_type (DirectMap::Type type)
 void IndexIVF::search (idx_t n, const float *x, idx_t k,
                          float *distances, idx_t *labels) const
 {
-
+    size_t nprobe = std::min(nlist, this->nprobe);
 
     // search function for a subset of queries
-    auto sub_search_func = [this, k]
+    auto sub_search_func = [this, k, nprobe]
             (idx_t n, const float *x, float *distances, idx_t *labels,
              IndexIVFStats *ivf_stats) {
 
@@ -352,6 +352,8 @@ void IndexIVF::search_preassigned (idx_t n, const float *x, idx_t k,
                                    IndexIVFStats *ivf_stats) const
 {
     long nprobe = params ? params->nprobe : this->nprobe;
+    nprobe = std::min((long)nlist, nprobe);
+
     long max_codes = params ? params->max_codes : this->max_codes;
 
     size_t nlistv = 0, ndis = 0, nheap = 0;

--- a/faiss/IndexPQ.cpp
+++ b/faiss/IndexPQ.cpp
@@ -776,11 +776,11 @@ struct SemiSortedArray {
  * occasionally several t's are returned.
  *
  * @param x       size M * n, values to add up
- * @parms k       nb of results to retrieve
+ * @param k       nb of results to retrieve
  * @param M       nb of terms
  * @param n       nb of distinct values
  * @param sums    output, size k, sorted
- * @prarm terms   output, size k, with encoding as above
+ * @param terms   output, size k, with encoding as above
  *
  ******************************************/
 template <typename T, class SSA, bool use_seen>

--- a/tests/test_ivflib.py
+++ b/tests/test_ivflib.py
@@ -161,6 +161,7 @@ class TestSmallData(unittest.TestCase):
         rs = np.random.RandomState(123)
         xt = rs.rand(100, d).astype('float32')
         xb = rs.rand(1000, d).astype('float32')
+
         index.train(xt)
         index.add(xb)
         index.nprobe = 2048

--- a/tests/test_ivflib.py
+++ b/tests/test_ivflib.py
@@ -31,7 +31,8 @@ def search_single_scan(index, xq, k, bs=128):
         index = faiss.downcast_index(index.index)
 
     # coarse assignment
-    coarse_dis, assign = index.quantizer.search(xq, index.nprobe)
+    nprobe = min(index.nprobe, index.nlist)
+    coarse_dis, assign = index.quantizer.search(xq, nprobe)
     nlist = index.nlist
     assign_buckets = assign // bs
     nq = len(xq)
@@ -146,3 +147,26 @@ class TestSearchWithParameters(unittest.TestCase):
         np.testing.assert_array_equal(Dnew, Dref)
 
         self.assertEqual(stats2["ndis"], ref_ndis)
+
+
+class TestSmallData(unittest.TestCase):
+    """Test in case of nprobe > nlist"""
+
+    def test_small_data(self):
+        d = 20
+        index = faiss.index_factory(d, 'IMI2x4,Flat')
+
+        rs = np.random.RandomState(123)
+        xt = rs.rand(100, d).astype('float32')
+        xb = rs.rand(1000, d).astype('float32')
+        index.train(xt)
+        index.add(xb)
+        index.nprobe = 2048
+        k = 5
+        xq = rs.rand(10, d).astype('float32')
+
+        ref_D, ref_I = index.search(xq, k)
+        D, I = search_single_scan(index, xq, k, bs=10)
+
+        assert np.all(D == ref_D)
+        assert np.all(I == ref_I)

--- a/tests/test_ivflib.py
+++ b/tests/test_ivflib.py
@@ -154,6 +154,7 @@ class TestSmallData(unittest.TestCase):
 
     def test_small_data(self):
         d = 20
+        # nlist = (2^4)^2 = 256
         index = faiss.index_factory(d, 'IMI2x4,Flat')
 
         rs = np.random.RandomState(123)
@@ -166,7 +167,7 @@ class TestSmallData(unittest.TestCase):
         xq = rs.rand(10, d).astype('float32')
 
         ref_D, ref_I = index.search(xq, k)
-        D, I = search_single_scan(index, xq, k, bs=10)
+        D, I = faiss.knn(xq, xb, k)
 
         assert np.all(D == ref_D)
         assert np.all(I == ref_I)


### PR DESCRIPTION
## Description

Fix the bug mentioned in https://github.com/facebookresearch/faiss/issues/1010. When `nprobe` is greater than `nlist` in `IndexIVF`, the program will crash because the index will ask the quantizer to return more centroids than it owns.

## Changes:
1. Set `nprobe` as `nlist` if it is greater than `nlist` during searching.
2. Add one test to detect this bug.
3. Fix typo in `IndexPQ.cpp`.