### PR TITLE
add msvc-compatible AVX2 switch in CMakeLists.txt

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -153,6 +153,9 @@ if(FAISS_OPT_LEVEL STREQUAL "avx2")
     target_compile_options(faiss PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-mavx2 -mfma -mf16c -mpopcnt>)
   else()
     # MSVC enables FMA with /arch:AVX2; no separate flags for F16C, POPCNT
+    # Ref. FMA (under /arch:AVX2): https://docs.microsoft.com/en-us/cpp/build/reference/arch-x64
+    # Ref. F16C (2nd paragraph): https://walbourn.github.io/directxmath-avx2/
+    # Ref. POPCNT: https://docs.microsoft.com/en-us/cpp/intrinsics/popcnt16-popcnt-popcnt64
     target_compile_options(faiss PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/arch:AVX2>)
   endif()
   set_target_properties(faiss PROPERTIES OUTPUT_NAME "faiss_avx2")

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -149,7 +149,12 @@ if(NOT WIN32)
 endif()
 
 if(FAISS_OPT_LEVEL STREQUAL "avx2")
-  target_compile_options(faiss PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-mavx2 -mfma -mf16c -mpopcnt>)
+  if(NOT WIN32)
+    target_compile_options(faiss PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-mavx2 -mfma -mf16c -mpopcnt>)
+  else()
+    # MSVC enables FMA with /arch:AVX2; no separate flags for F16C, POPCNT
+    target_compile_options(faiss PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/arch:AVX2>)
+  endif()
   set_target_properties(faiss PROPERTIES OUTPUT_NAME "faiss_avx2")
 elseif(FAISS_OPT_LEVEL STREQUAL "sse4")
   target_compile_options(faiss PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-msse4 -mpopcnt>)


### PR DESCRIPTION
Upstreaming patches from https://github.com/conda-forge/faiss-split-feedstock/pull/27, follow-up (sorta) to #1600.

Not sure if there are more CMake-native tricks to use here, but given that the flags don't have
an equivalent on the MSVC side, I think this approach is reasonable.

Without this patch, we would get:
```
cl : Command line warning D9002: ignoring unknown option '-mavx2'
cl : Command line warning D9002: ignoring unknown option '-mfma'
cl : Command line warning D9002: ignoring unknown option '-mf16c'
cl : Command line warning D9002: ignoring unknown option '-mpopcnt'
```