### PR TITLE
log success messages and errors in loader.py

### DIFF
--- a/faiss/python/loader.py
+++ b/faiss/python/loader.py
@@ -45,16 +45,19 @@ def supported_instruction_sets():
 
 logger = logging.getLogger(__name__)
 
-try:
-    has_AVX2 = "AVX2" in supported_instruction_sets()
-    if has_AVX2:
+has_AVX2 = "AVX2" in supported_instruction_sets()
+if has_AVX2:
+    try:
         logger.info("Loading faiss with AVX2 support.")
         from .swigfaiss_avx2 import *
-    else:
-        logger.info("Loading faiss.")
-        from .swigfaiss import *
+        logger.info("Successfully loaded faiss with AVX2 support.")
+    except ImportError as e:
+        logger.info(f"Could not load library with AVX2 support due to:\n{e!r}")
+        # reset so that we load without AVX2 below
+        has_AVX2 = False
 
-except ImportError:
+if not has_AVX2:
     # we import * so that the symbol X can be accessed as faiss.X
     logger.info("Loading faiss.")
     from .swigfaiss import *
+    logger.info("Successfully loaded faiss.")


### PR DESCRIPTION
This patch is to provide log information in case of failing to load the AVX2-enabled lib,
and also to log the successful loading of the libraries.

Otherwise, the programmatic detection of which library was loaded also needs to take
into account which other log statements were executed, if the original import failed due to an exception,
cf. the tests in https://github.com/conda-forge/faiss-split-feedstock/pull/27

Finally, this reduces the number of import statements by one - one non-AVX2 fallback is enough.

Related to #1600, #1680, #1681, #1682.