### PR TITLE
Make faiss compatible with Clang 11

### DIFF
--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -755,7 +755,7 @@ void IndexIVF::range_search_preassigned(
                 idx_t i = iik / (idx_t)nprobe;
                 idx_t ik = iik % (idx_t)nprobe;
                 if (qres == nullptr || qres->qno != i) {
-                    FAISS_ASSERT(!qres || i > qres->qno);
+                    // FAISS_ASSERT(!qres || i > qres->qno);
                     qres = &pres.new_result(i);
                     scanner->set_query(x + i * d);
                 }

--- a/tests/test_index_accuracy.py
+++ b/tests/test_index_accuracy.py
@@ -723,7 +723,7 @@ class TestRefine(unittest.TestCase):
         # the original recall@100
         recall2 = (I2 == Iref[:, :1]).sum()
         # print("recalls", recall1, recall2)
-        self.assertEquals(recall1, recall2)
+        self.assertEqual(recall1, recall2)
 
     def test_IP(self):
         self.do_test(faiss.METRIC_INNER_PRODUCT)


### PR DESCRIPTION
Fixes #1696, removing a failing assertion that appeared in https://github.com/conda-forge/faiss-split-feedstock/pull/33
(and previously https://github.com/conda-forge/faiss-split-feedstock/pull/17) at the suggestion of @mdouze.

Also fixes a deprecation warning in the test suite.