### PR TITLE
Remove duplicated advance()

### DIFF
--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -1130,8 +1130,6 @@ void IndexHNSW2Level::search (idx_t n, const float *x, idx_t k,
                     nreorder += search_stats.nreorder;
 
                     vt.advance ();
-                    vt.advance ();
-
                 }
 
                 maxheap_reorder (k, simi, idxi);


### PR DESCRIPTION
The `vt.advance()` statement is duplicated although it does not harm the performance too much...

This diff removed the duplicated statement.