### PR TITLE
Remove warnings in format printing

### DIFF
--- a/faiss/IndexBinaryIVF.cpp
+++ b/faiss/IndexBinaryIVF.cpp
@@ -100,8 +100,8 @@ void IndexBinaryIVF::add_core(
         n_add++;
     }
     if (verbose) {
-        printf("IndexBinaryIVF::add_with_ids: added %ld / %" PRId64
-               " vectors\n",
+        printf("IndexBinaryIVF::add_with_ids: added "
+               "%" PRId64 " / %" PRId64 " vectors\n",
                n_add,
                n);
     }

--- a/faiss/IndexIVFPQFastScan.cpp
+++ b/faiss/IndexIVFPQFastScan.cpp
@@ -150,10 +150,11 @@ void IndexIVFPQFastScan::train_residual(idx_t n, const float* x_in) {
     }
 
     if (verbose) {
-        printf("training %zdx%zd product quantizer on %zd vectors in %dD\n",
+        printf("training %zdx%zd product quantizer on "
+               "%" PRId64 " vectors in %dD\n",
                pq.M,
                pq.ksub,
-               long(n),
+               n,
                d);
     }
     pq.verbose = verbose;


### PR DESCRIPTION
This diff fixed some warnings in [Windows building](https://app.circleci.com/pipelines/github/facebookresearch/faiss/1267/workflows/d3147265-becc-4a9b-9ab4-854ec13b89d8/jobs/3976). 

The warnings are caused by the incompatibility between `int64_t` and `%ld`.
