### PR TITLE
Fix swig vs. AVX2

### DIFF
--- a/conda/faiss-gpu/build-pkg.sh
+++ b/conda/faiss-gpu/build-pkg.sh
@@ -10,6 +10,7 @@ set -e
 # Build avx2 version.
 cmake -B _build_python_${PY_VER}_avx2 \
       -Dfaiss_ROOT=_libfaiss_avx2_stage/ \
+      -DFAISS_OPT_LEVEL=avx2 \
       -DFAISS_ENABLE_GPU=ON \
       -DCMAKE_BUILD_TYPE=Release \
       -DPython_EXECUTABLE=$PYTHON \
@@ -31,6 +32,6 @@ cmake --build _build_python_${PY_VER} -j $CPU_COUNT
 
 # Build actual python module.
 cp _build_python_${PY_VER}_avx2/swigfaiss.py _build_python_${PY_VER}/swigfaiss_avx2.py
-cp _build_python_${PY_VER}_avx2/_swigfaiss.so _build_python_${PY_VER}/_swigfaiss_avx2.so
+cp _build_python_${PY_VER}_avx2/_swigfaiss_avx2.so _build_python_${PY_VER}/_swigfaiss_avx2.so
 cd _build_python_${PY_VER}/
 $PYTHON setup.py install --single-version-externally-managed --record=record.txt --prefix=$PREFIX

--- a/conda/faiss/build-pkg.sh
+++ b/conda/faiss/build-pkg.sh
@@ -10,6 +10,7 @@ set -e
 # Build avx2 version.
 cmake -B _build_python_${PY_VER}_avx2 \
       -Dfaiss_ROOT=_libfaiss_avx2_stage/ \
+      -DFAISS_OPT_LEVEL=avx2 \
       -DFAISS_ENABLE_GPU=OFF \
       -DCMAKE_BUILD_TYPE=Release \
       -DPython_EXECUTABLE=$PYTHON \
@@ -31,6 +32,6 @@ cmake --build _build_python_${PY_VER} -j $CPU_COUNT
 
 # Build actual python module.
 cp _build_python_${PY_VER}_avx2/swigfaiss.py _build_python_${PY_VER}/swigfaiss_avx2.py
-cp _build_python_${PY_VER}_avx2/_swigfaiss.so _build_python_${PY_VER}/_swigfaiss_avx2.so
+cp _build_python_${PY_VER}_avx2/_swigfaiss_avx2.so _build_python_${PY_VER}/_swigfaiss_avx2.so
 cd _build_python_${PY_VER}/
 $PYTHON setup.py install --single-version-externally-managed --record=record.txt --prefix=$PREFIX

--- a/faiss/python/CMakeLists.txt
+++ b/faiss/python/CMakeLists.txt
@@ -61,6 +61,10 @@ swig_add_library(swigfaiss
   SOURCES swigfaiss.swig
 )
 
+if(FAISS_OPT_LEVEL STREQUAL "avx2")
+  set_target_properties(swigfaiss PROPERTIES OUTPUT_NAME "swigfaiss_avx2")
+endif()
+
 if(NOT WIN32)
   # NOTE: Python does not recognize the dylib extension.
   set_target_properties(swigfaiss PROPERTIES SUFFIX .so)


### PR DESCRIPTION
Towards #1711. There's still a test [error](https://github.com/facebookresearch/faiss/issues/1711#issuecomment-787509873) that won't be picked up unless an AVX2-specific CI run is added.