### PR TITLE
do not overload __builtin_ctz for win + cuda>=11

### DIFF
--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -38,11 +38,14 @@ inline int __builtin_ctzll(uint64_t x) {
     return (int)ret;
 }
 
+// cudatoolkit provides __builtin_ctz for NVCC >= 11.0
+#if ! defined(__CUDACC__) || __CUDACC_VER_MAJOR__ < 11
 inline int __builtin_ctz(unsigned long x) {
     unsigned long ret;
     _BitScanForward(&ret, x);
     return (int)ret;
 }
+#endif
 
 inline int __builtin_clzll(uint64_t x) {
     return (int)__lzcnt64(x);


### PR DESCRIPTION
Apparently, this is now being supplied by CUDA libs. Without this patch, CUDA builds
on 11.1 & 11.2 give the following kind of warnings:
```
Compiling CUDA source file ..\..\faiss\gpu\GpuIndex.cu...
[...]/faiss/impl/platform_macros.h(42): warning : declaration overloads built-in function "__builtin_ctz"   
[...]/faiss/impl/platform_macros.h(42): warning : declaration overloads built-in function "__builtin_ctz"
[...]/faiss/impl/platform_macros.h(42): warning : declaration overloads built-in function "__builtin_ctz"
```