### PR TITLE
fix warning about deprecate assertEquals

### DIFF
--- a/tests/test_index_accuracy.py
+++ b/tests/test_index_accuracy.py
@@ -778,7 +778,7 @@ class TestRefine(unittest.TestCase):
         # the original recall@100
         recall2 = (I2 == Iref[:, :1]).sum()
         # print("recalls", recall1, recall2)
-        self.assertEquals(recall1, recall2)
+        self.assertEqual(recall1, recall2)
 
     def test_IP(self):
         self.do_test(faiss.METRIC_INNER_PRODUCT)


### PR DESCRIPTION
There's an annoying warning on every test run that I'd like to fix
```
=============================== warnings summary ===============================
tests/test_index_accuracy.py::TestRefine::test_IP
tests/test_index_accuracy.py::TestRefine::test_L2
  $SRC_DIR/tests/test_index_accuracy.py:726: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(recall1, recall2)
```

I've tried sneaking this into #1704 & #1717 already, but the first needs more time and
in the second, @beauby asked me to keep this separate, so here's a new PR. :)