### PR TITLE
Combine AVX with non-AVX in Python setup

### DIFF
--- a/conda/faiss-gpu/build-pkg.sh
+++ b/conda/faiss-gpu/build-pkg.sh
@@ -31,7 +31,7 @@ cmake --build _build_python_${PY_VER} -j $CPU_COUNT
 
 
 # Build actual python module.
-cp _build_python_${PY_VER}_avx2/swigfaiss.py _build_python_${PY_VER}/swigfaiss_avx2.py
-cp _build_python_${PY_VER}_avx2/_swigfaiss_avx2.so _build_python_${PY_VER}/_swigfaiss_avx2.so
+cp _build_python_${PY_VER}_avx2/swigfaiss.py _build_python_${PY_VER}/swigfaiss.py
+cp _build_python_${PY_VER}_avx2/_swigfaiss.so _build_python_${PY_VER}/_swigfaiss.so
 cd _build_python_${PY_VER}/
 $PYTHON setup.py install --single-version-externally-managed --record=record.txt --prefix=$PREFIX

--- a/conda/faiss/build-pkg.sh
+++ b/conda/faiss/build-pkg.sh
@@ -31,7 +31,7 @@ cmake --build _build_python_${PY_VER} -j $CPU_COUNT
 
 
 # Build actual python module.
-cp _build_python_${PY_VER}_avx2/swigfaiss.py _build_python_${PY_VER}/swigfaiss_avx2.py
-cp _build_python_${PY_VER}_avx2/_swigfaiss_avx2.so _build_python_${PY_VER}/_swigfaiss_avx2.so
+cp _build_python_${PY_VER}_avx2/swigfaiss.py _build_python_${PY_VER}/swigfaiss.py
+cp _build_python_${PY_VER}_avx2/_swigfaiss.so _build_python_${PY_VER}/_swigfaiss.so
 cd _build_python_${PY_VER}/
 $PYTHON setup.py install --single-version-externally-managed --record=record.txt --prefix=$PREFIX

--- a/faiss/python/CMakeLists.txt
+++ b/faiss/python/CMakeLists.txt
@@ -80,6 +80,7 @@ target_link_libraries(swigfaiss PRIVATE
   OpenMP::OpenMP_CXX
 )
 
+
 # Hack so that python_callbacks.h can be included as
 # `#include <faiss/python/python_callbacks.h>`.
 target_include_directories(swigfaiss PRIVATE ${PROJECT_SOURCE_DIR}/../../)

--- a/faiss/python/CMakeLists.txt
+++ b/faiss/python/CMakeLists.txt
@@ -61,10 +61,6 @@ swig_add_library(swigfaiss
   SOURCES swigfaiss.swig
 )
 
-if(FAISS_OPT_LEVEL STREQUAL "avx2")
-  set_target_properties(swigfaiss PROPERTIES OUTPUT_NAME "swigfaiss_avx2")
-endif()
-
 if(NOT WIN32)
   # NOTE: Python does not recognize the dylib extension.
   set_target_properties(swigfaiss PROPERTIES SUFFIX .so)

--- a/faiss/python/loader.py
+++ b/faiss/python/loader.py
@@ -9,55 +9,9 @@ import subprocess
 import logging
 
 
-def supported_instruction_sets():
-    """
-    Returns the set of supported CPU features, see
-    https://github.com/numpy/numpy/blob/master/numpy/core/src/common/npy_cpu_features.h
-    for the list of features that this set may contain per architecture.
-
-    Example:
-    >>> supported_instruction_sets()  # for x86
-    {"SSE2", "AVX2", ...}
-    >>> supported_instruction_sets()  # for PPC
-    {"VSX", "VSX2", ...}
-    >>> supported_instruction_sets()  # for ARM
-    {"NEON", "ASIMD", ...}
-    """
-    import numpy
-    if LooseVersion(numpy.__version__) >= "1.19":
-        # use private API as next-best thing until numpy/numpy#18058 is solved
-        from numpy.core._multiarray_umath import __cpu_features__
-        # __cpu_features__ is a dictionary with CPU features
-        # as keys, and True / False as values
-        supported = {k for k, v in __cpu_features__.items() if v}
-        return supported
-
-    # platform-dependent legacy fallback before numpy 1.19, no windows
-    if platform.system() == "Darwin":
-        if subprocess.check_output(["/usr/sbin/sysctl", "hw.optional.avx2_0"])[-1] == '1':
-            return {"AVX2"}
-    elif platform.system() == "Linux":
-        import numpy.distutils.cpuinfo
-        if "avx2" in numpy.distutils.cpuinfo.cpu.info[0].get('flags', ""):
-            return {"AVX2"}
-    return set()
-
-
 logger = logging.getLogger(__name__)
 
-has_AVX2 = "AVX2" in supported_instruction_sets()
-if has_AVX2:
-    try:
-        logger.info("Loading faiss with AVX2 support.")
-        from .swigfaiss_avx2 import *
-        logger.info("Successfully loaded faiss with AVX2 support.")
-    except ImportError as e:
-        logger.info(f"Could not load library with AVX2 support due to:\n{e!r}")
-        # reset so that we load without AVX2 below
-        has_AVX2 = False
-
-if not has_AVX2:
-    # we import * so that the symbol X can be accessed as faiss.X
-    logger.info("Loading faiss.")
-    from .swigfaiss import *
-    logger.info("Successfully loaded faiss.")
+# we import * so that the symbol X can be accessed as faiss.X
+logger.info("Loading faiss.")
+from .swigfaiss import *
+logger.info("Successfully loaded faiss.")

--- a/faiss/python/setup.py
+++ b/faiss/python/setup.py
@@ -19,14 +19,9 @@ shutil.copyfile("swigfaiss.py", "faiss/swigfaiss.py")
 
 ext = ".pyd" if platform.system() == 'Windows' else ".so"
 prefix = "Release/" * (platform.system() == 'Windows')
-shutil.copyfile(f"{prefix}_swigfaiss{ext}", f"faiss/_swigfaiss{ext}")
 
-try:
-    shutil.copyfile("swigfaiss_avx2.py", "faiss/swigfaiss_avx2.py")
-    shutil.copyfile(f"{prefix}_swigfaiss_avx2{ext}", f"faiss/_swigfaiss_avx2{ext}")
-except Exception as e:
-    print(f"Could not move swigfaiss_avx2.py / {prefix}_swigfaiss_avx2{ext} due to:\n{e!r}")
-    pass
+faiss_lib = "{}_swigfaiss{}".format(prefix, ext)
+shutil.copyfile(faiss_lib, "faiss/_swigfaiss{}".format(ext))
 
 long_description="""
 Faiss is a library for efficient similarity search and clustering of dense


### PR DESCRIPTION
This diff fixed https://github.com/facebookresearch/faiss/issues/1743.
The python setup script is a little bit too complicated now. In my view, it is not necessary to separate AVX and non-AVX in the building.
