### PR TITLE
Fix the include header for PRId64

### DIFF
--- a/faiss/IndexIVFPQFastScan.cpp
+++ b/faiss/IndexIVFPQFastScan.cpp
@@ -7,7 +7,7 @@
 
 #include <faiss/IndexIVFPQFastScan.h>
 
-#include <inttypes.h>
+#include <cinttypes>
 #include <cassert>
 #include <cstdio>
 

--- a/faiss/IndexIVFPQFastScan.cpp
+++ b/faiss/IndexIVFPQFastScan.cpp
@@ -7,8 +7,8 @@
 
 #include <faiss/IndexIVFPQFastScan.h>
 
-#include <cinttypes>
 #include <cassert>
+#include <cinttypes>
 #include <cstdio>
 
 #include <omp.h>


### PR DESCRIPTION
This diff fixed the error in [Linux nightlies
](https://app.circleci.com/pipelines/github/facebookresearch/faiss/1325/workflows/e3c09d68-9fbe-4215-a3df-f901a1a5c08e/jobs/4245)