### PR TITLE
Fix building with -DFAISS_OPT_LEVEL=avx2

### DIFF
--- a/faiss/python/setup.py
+++ b/faiss/python/setup.py
@@ -29,7 +29,7 @@ found_swigfaiss_general = os.path.exists(swigfaiss_general_lib)
 found_swigfaiss_avx2 = os.path.exists(swigfaiss_avx2_lib)
 
 assert (found_swigfaiss_general or found_swigfaiss_avx2), \
-        f"Could not find {swigfaiss_general_lib} and " \
+        f"Could not find {swigfaiss_general_lib} or " \
         f"{swigfaiss_avx2_lib}. Faiss may not be compiled yet."
 
 if found_swigfaiss_general:

--- a/faiss/python/setup.py
+++ b/faiss/python/setup.py
@@ -16,8 +16,6 @@ shutil.copytree("contrib", "faiss/contrib")
 shutil.copyfile("__init__.py", "faiss/__init__.py")
 shutil.copyfile("loader.py", "faiss/loader.py")
 shutil.copyfile("swigfaiss.py", "faiss/swigfaiss.py")
-if os.path.exists("swigfaiss_avx2.py"):
-    shutil.copyfile("swigfaiss_avx2.py", "faiss/swigfaiss_avx2.py")
 
 ext = ".pyd" if platform.system() == 'Windows' else ".so"
 prefix = "Release/" * (platform.system() == 'Windows')

--- a/faiss/python/setup.py
+++ b/faiss/python/setup.py
@@ -21,7 +21,6 @@ if os.path.exists("swigfaiss_avx2.py"):
 
 ext = ".pyd" if platform.system() == 'Windows' else ".so"
 prefix = "Release/" * (platform.system() == 'Windows')
-
 faiss_exists = os.path.exists(f"{prefix}_swigfaiss{ext}")
 faiss_avx2_exists = os.path.exists(f"{prefix}_swigfaiss_avx2{ext}")
 assert(faiss_exists or faiss_avx2_exists)

--- a/faiss/python/setup.py
+++ b/faiss/python/setup.py
@@ -21,17 +21,24 @@ if os.path.exists("swigfaiss_avx2.py"):
 
 ext = ".pyd" if platform.system() == 'Windows' else ".so"
 prefix = "Release/" * (platform.system() == 'Windows')
-faiss_exists = os.path.exists(f"{prefix}_swigfaiss{ext}")
-faiss_avx2_exists = os.path.exists(f"{prefix}_swigfaiss_avx2{ext}")
-assert(faiss_exists or faiss_avx2_exists)
 
-if faiss_exists:
-    print("Found swigfaiss")
-    shutil.copyfile(f"{prefix}_swigfaiss{ext}", f"faiss/_swigfaiss{ext}")
+swigfaiss_general_lib = f"{prefix}_swigfaiss{ext}"
+swigfaiss_avx2_lib = f"{prefix}_swigfaiss_avx2{ext}"
 
-if faiss_avx2_exists:
-    print("Found swigfaiss_avx2")
-    shutil.copyfile(f"{prefix}_swigfaiss_avx2{ext}", f"faiss/_swigfaiss_avx2{ext}")
+found_swigfaiss_general = os.path.exists(swigfaiss_general_lib)
+found_swigfaiss_avx2 = os.path.exists(swigfaiss_avx2_lib)
+
+assert (found_swigfaiss_general or found_swigfaiss_avx2), \
+        f"Could not find {swigfaiss_general_lib} and " \
+        f"{swigfaiss_avx2_lib}. Faiss may not be compiled yet."
+
+if found_swigfaiss_general:
+    print(f"Copying {swigfaiss_general_lib}")
+    shutil.copyfile(swigfaiss_general_lib, f"faiss/_swigfaiss{ext}")
+
+if found_swigfaiss_avx2:
+    print(f"Copying {swigfaiss_avx2_lib}")
+    shutil.copyfile(swigfaiss_avx2_lib, f"faiss/_swigfaiss_avx2{ext}")
 
 long_description="""
 Faiss is a library for efficient similarity search and clustering of dense

--- a/faiss/python/setup.py
+++ b/faiss/python/setup.py
@@ -16,17 +16,23 @@ shutil.copytree("contrib", "faiss/contrib")
 shutil.copyfile("__init__.py", "faiss/__init__.py")
 shutil.copyfile("loader.py", "faiss/loader.py")
 shutil.copyfile("swigfaiss.py", "faiss/swigfaiss.py")
+if os.path.exists("swigfaiss_avx2.py"):
+    shutil.copyfile("swigfaiss_avx2.py", "faiss/swigfaiss_avx2.py")
 
 ext = ".pyd" if platform.system() == 'Windows' else ".so"
 prefix = "Release/" * (platform.system() == 'Windows')
-shutil.copyfile(f"{prefix}_swigfaiss{ext}", f"faiss/_swigfaiss{ext}")
 
-try:
-    shutil.copyfile("swigfaiss_avx2.py", "faiss/swigfaiss_avx2.py")
+faiss_exists = os.path.exists(f"{prefix}_swigfaiss{ext}")
+faiss_avx2_exists = os.path.exists(f"{prefix}_swigfaiss_avx2{ext}")
+assert(faiss_exists or faiss_avx2_exists)
+
+if faiss_exists:
+    print("Found swigfaiss")
+    shutil.copyfile(f"{prefix}_swigfaiss{ext}", f"faiss/_swigfaiss{ext}")
+
+if faiss_avx2_exists:
+    print("Found swigfaiss_avx2")
     shutil.copyfile(f"{prefix}_swigfaiss_avx2{ext}", f"faiss/_swigfaiss_avx2{ext}")
-except Exception as e:
-    print(f"Could not move swigfaiss_avx2.py / {prefix}_swigfaiss_avx2{ext} due to:\n{e!r}")
-    pass
 
 long_description="""
 Faiss is a library for efficient similarity search and clustering of dense

--- a/faiss/python/setup.py
+++ b/faiss/python/setup.py
@@ -22,19 +22,19 @@ if os.path.exists("swigfaiss_avx2.py"):
 ext = ".pyd" if platform.system() == 'Windows' else ".so"
 prefix = "Release/" * (platform.system() == 'Windows')
 
-swigfaiss_general_lib = f"{prefix}_swigfaiss{ext}"
+swigfaiss_generic_lib = f"{prefix}_swigfaiss{ext}"
 swigfaiss_avx2_lib = f"{prefix}_swigfaiss_avx2{ext}"
 
-found_swigfaiss_general = os.path.exists(swigfaiss_general_lib)
+found_swigfaiss_generic = os.path.exists(swigfaiss_generic_lib)
 found_swigfaiss_avx2 = os.path.exists(swigfaiss_avx2_lib)
 
-assert (found_swigfaiss_general or found_swigfaiss_avx2), \
-        f"Could not find {swigfaiss_general_lib} or " \
+assert (found_swigfaiss_generic or found_swigfaiss_avx2), \
+        f"Could not find {swigfaiss_generic_lib} or " \
         f"{swigfaiss_avx2_lib}. Faiss may not be compiled yet."
 
-if found_swigfaiss_general:
-    print(f"Copying {swigfaiss_general_lib}")
-    shutil.copyfile(swigfaiss_general_lib, f"faiss/_swigfaiss{ext}")
+if found_swigfaiss_generic:
+    print(f"Copying {swigfaiss_generic_lib}")
+    shutil.copyfile(swigfaiss_generic_lib, f"faiss/_swigfaiss{ext}")
 
 if found_swigfaiss_avx2:
     print(f"Copying {swigfaiss_avx2_lib}")


### PR DESCRIPTION
As stated in https://github.com/facebookresearch/faiss/issues/1743, `_swigfaiss.so` will not exist if compiled with `-DFAISS_OPT_LEVEL=avx2`. This diff added a conditional statement before copying it.