### PR TITLE
Fix compile errors in NSG

### DIFF
--- a/faiss/IndexNNDescent.cpp
+++ b/faiss/IndexNNDescent.cpp
@@ -9,8 +9,9 @@
 
 #include <faiss/IndexNNDescent.h>
 
-#include <inttypes.h>
 #include <omp.h>
+
+#include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
 

--- a/faiss/IndexNSG.cpp
+++ b/faiss/IndexNSG.cpp
@@ -9,9 +9,9 @@
 
 #include <faiss/IndexNSG.h>
 
-#include <inttypes.h>
 #include <omp.h>
 
+#include <cinttypes>
 #include <memory>
 
 #include <faiss/IndexFlat.h>

--- a/faiss/impl/NSG.cpp
+++ b/faiss/impl/NSG.cpp
@@ -137,7 +137,6 @@ inline int insert_into_pool(Neighbor* addr, int K, Neighbor nn) {
     return right;
 }
 
-
 NSG::NSG(int R) : R(R), rng(0x0903) {
     L = R + 32;
     C = R + 100;

--- a/faiss/impl/NSG.cpp
+++ b/faiss/impl/NSG.cpp
@@ -22,6 +22,9 @@ namespace nsg {
 
 namespace {
 
+// It needs to be smaller than 0
+constexpr int EMPTY_ID = -1;
+
 /* Wrap the distance computer into one that negates the
    distances. This makes supporting INNER_PRODUCE search easier */
 
@@ -134,7 +137,6 @@ inline int insert_into_pool(Neighbor* addr, int K, Neighbor nn) {
     return right;
 }
 
-const int NSG::EMPTY_ID = -1;
 
 NSG::NSG(int R) : R(R), rng(0x0903) {
     L = R + 32;

--- a/faiss/impl/NSG.h
+++ b/faiss/impl/NSG.h
@@ -98,9 +98,6 @@ struct NSG {
     /// Faiss results are 64-bit
     using idx_t = Index::idx_t;
 
-    /// It needs to be smaller than 0
-    static const int EMPTY_ID;
-
     int ntotal; ///< nb of nodes
 
     /// construction-time parameters

--- a/faiss/impl/PolysemousTraining.cpp
+++ b/faiss/impl/PolysemousTraining.cpp
@@ -975,6 +975,9 @@ size_t PolysemousTraining::memory_usage_per_thread(
         case OT_Ranking_weighted_diff:
             return n * n * n * sizeof(float);
     }
+
+    FAISS_THROW_MSG("Invalid optmization type");
+    return 0;
 }
 
 } // namespace faiss


### PR DESCRIPTION
## Description

This PR fixed following two compile errors in NSG and one warning in PolysemousTraining:

In [Linux(conda)](https://app.circleci.com/pipelines/github/facebookresearch/faiss/1369/workflows/701ac434-3ad7-48b8-bd5b-a41fed7716a2/jobs/4512) building:
```
/opt/conda/conda-bld/faiss-pkg_1615417553875/work/faiss/IndexNSG.cpp:279:25: error: expected ')' before 'PRId64'
                 "has %" PRId64 " invalid entries\n",
                         ^~~~~~
```

In [Windows](https://app.circleci.com/pipelines/github/facebookresearch/faiss/1369/workflows/701ac434-3ad7-48b8-bd5b-a41fed7716a2/jobs/4514) building:
```
swigfaissPYTHON_wrap.obj : error LNK2019: unresolved external symbol "public: static int const faiss::NSG::EMPTY_ID" (?EMPTY_ID@NSG@faiss@@2HB) referenced in function Swig_var_NSG_EMPTY_ID_get [C:\tools\miniconda3\conda-bld\faiss-pkg_1615417741685\work\_build_python_3.7\swigfaiss.vcxproj]
```

In [Linux(AVX2)](https://app.circleci.com/pipelines/github/facebookresearch/faiss/1376/workflows/7ed0ebd1-9dec-48c8-b6ba-75efe5e80eec/jobs/4546) building:
```
/home/circleci/project/faiss/impl/PolysemousTraining.cpp:978:1: warning: control reaches end of non-void function [-Wreturn-type]
  978 | }
      | ^
```

## Changed
1. Replaced all `inttypes.h` by `cinttypes`.
2. Removed the constant static member in NSG.
3. Return a default value in `PolysemousTraining::memory_usage_per_thread`.