### PR TITLE
Support NSG in the index factory

### DIFF
--- a/faiss/IndexNSG.cpp
+++ b/faiss/IndexNSG.cpp
@@ -51,7 +51,7 @@ IndexNSG::IndexNSG(Index* storage, int R)
           storage(storage),
           is_built(false),
           GK(64),
-          build_type(0) {
+          build_type(1) {
     nndescent_S = 10;
     nndescent_R = 100;
     nndescent_L = GK + 50;

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -75,15 +75,28 @@ class TestFactory(unittest.TestCase):
 
     def test_factory_NSG(self):
         index = faiss.index_factory(12, "NSG64")
-        assert index.storage.sa_code_size() == 12 * 4 and index.nsg.R == 64
+        assert isinstance(index, faiss.IndexNSGFlat)
+        assert index.nsg.R == 64
+
         index = faiss.index_factory(12, "NSG64", faiss.METRIC_INNER_PRODUCT)
-        assert index.storage.sa_code_size() == 12 * 4 and index.nsg.R == 64
+        assert isinstance(index, faiss.IndexNSGFlat)
+        assert index.nsg.R == 64
         assert index.metric_type == faiss.METRIC_INNER_PRODUCT
+
         index = faiss.index_factory(12, "NSG64,Flat")
-        assert index.storage.sa_code_size() == 12 * 4 and index.nsg.R == 64
+        assert isinstance(index, faiss.IndexNSGFlat)
+        assert index.nsg.R == 64
+
         index = faiss.index_factory(12, "IVF65536_NSG64,Flat")
         index_nsg = faiss.downcast_index(index.quantizer)
+        assert isinstance(index, faiss.IndexIVFFlat)
         assert index.nlist == 65536 and index_nsg.nsg.R == 64
+
+        index = faiss.index_factory(12, "IVF65536_NSG64,PQ2x8")
+        index_nsg = faiss.downcast_index(index.quantizer)
+        assert isinstance(index, faiss.IndexIVFPQ)
+        assert index.nlist == 65536 and index_nsg.nsg.R == 64
+        assert index.pq.M == 2 and index.pq.nbits == 8
 
     def test_factory_fast_scan(self):
         index = faiss.index_factory(56, "PQ28x4fs")

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -73,6 +73,18 @@ class TestFactory(unittest.TestCase):
         indexpq = faiss.downcast_index(index.storage)
         assert not indexpq.do_polysemous_training
 
+    def test_factory_NSG(self):
+        index = faiss.index_factory(12, "NSG64")
+        assert index.storage.sa_code_size() == 12 * 4 and index.nsg.R == 64
+        index = faiss.index_factory(12, "NSG64", faiss.METRIC_INNER_PRODUCT)
+        assert index.storage.sa_code_size() == 12 * 4 and index.nsg.R == 64
+        assert index.metric_type == faiss.METRIC_INNER_PRODUCT
+        index = faiss.index_factory(12, "NSG64,Flat")
+        assert index.storage.sa_code_size() == 12 * 4 and index.nsg.R == 64
+        index = faiss.index_factory(12, "IVF65536_NSG64,Flat")
+        index_nsg = faiss.downcast_index(index.quantizer)
+        assert index.nlist == 65536 and index_nsg.nsg.R == 64
+
     def test_factory_fast_scan(self):
         index = faiss.index_factory(56, "PQ28x4fs")
         self.assertEqual(index.bbs, 32)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -90,11 +90,13 @@ class TestFactory(unittest.TestCase):
         index = faiss.index_factory(12, "IVF65536_NSG64,Flat")
         index_nsg = faiss.downcast_index(index.quantizer)
         assert isinstance(index, faiss.IndexIVFFlat)
+        assert isinstance(index_nsg, faiss.IndexNSGFlat)
         assert index.nlist == 65536 and index_nsg.nsg.R == 64
 
         index = faiss.index_factory(12, "IVF65536_NSG64,PQ2x8")
         index_nsg = faiss.downcast_index(index.quantizer)
         assert isinstance(index, faiss.IndexIVFPQ)
+        assert isinstance(index_nsg, faiss.IndexNSGFlat)
         assert index.nlist == 65536 and index_nsg.nsg.R == 64
         assert index.pq.M == 2 and index.pq.nbits == 8
 


### PR DESCRIPTION
## Description
This PR added NSG into the index factory. Here are the supported index strings:
1. `NSG{0}` or `NSG{0},Flat`: Create an IndexNSGFlat with `R = {0}`.
2. `IVF{0}_NSG{1},{2}`: Create an IndexIVF using NSG as a coarse quantizer where `ncentroids = {0}`, `R = {1}` and `{2}` is the second level quantizer.

These two types of indexes may be the most useful ones. Other composite indexes could be supported in the future.