### PR TITLE
Use BLAS to compute sdc table

### DIFF
--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -717,14 +717,16 @@ void ProductQuantizer::compute_sdc_table() {
     sdc_table.resize(M * ksub * ksub);
 
     if (dsub < 4) {
-#pragma omp parallel for collapse(2)
-        for (int m = 0; m < M; m++) {
-            for (int k = 0; k < ksub; k++) {
-                const float* cents = centroids.data() + m * ksub * dsub;
-                const float* centi = cents + k * dsub;
-                float* dis_tab = sdc_table.data() + m * ksub * ksub;
-                fvec_L2sqr_ny(dis_tab + k * ksub, centi, cents, dsub, ksub);
-            }
+#pragma omp parallel for
+        for (int mk = 0; mk < M * ksub; mk++) {
+            // allow omp to schedule in a more fine-grained way
+            // `collapse` is not supported in OpenMP 2.x
+            int m = mk / ksub;
+            int k = mk % ksub;
+            const float* cents = centroids.data() + m * ksub * dsub;
+            const float* centi = cents + k * dsub;
+            float* dis_tab = sdc_table.data() + m * ksub * ksub;
+            fvec_L2sqr_ny(dis_tab + k * ksub, centi, cents, dsub, ksub);
         }
     } else {
         // NOTE: it would disable the omp loop in pairwise_L2sqr

--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -716,51 +716,25 @@ static float sqr(float x) {
 void ProductQuantizer::compute_sdc_table() {
     sdc_table.resize(M * ksub * ksub);
 
-    if (dsub < 8) {
-#pragma omp parallel for
-        for (int mk = 0; mk < M * ksub; mk++) {
-            int m = mk / ksub;
-            int k = mk % ksub;
-            const float* cents = centroids.data() + m * ksub * dsub;
-            const float* centi = cents + k * dsub;
-            float* dis_tab = sdc_table.data() + m * ksub * ksub;
-            fvec_L2sqr_ny(dis_tab + k * ksub, centi, cents, dsub, ksub);
+    if (dsub < 4) {
+#pragma omp parallel for collapse(2)
+        for (int m = 0; m < M; m++) {
+            for (int k = 0; k < ksub; k++) {
+                const float* cents = centroids.data() + m * ksub * dsub;
+                const float* centi = cents + k * dsub;
+                float* dis_tab = sdc_table.data() + m * ksub * ksub;
+                fvec_L2sqr_ny(dis_tab + k * ksub, centi, cents, dsub, ksub);
+            }
         }
     } else {
-        std::unique_ptr<float[]> inner_product(new float[M * ksub * ksub]);
+        // NOTE: it would disable the omp loop in pairwise_L2sqr
+        // but still accelerate especially when M >= 4
 #pragma omp parallel for
         for (int m = 0; m < M; m++) {
             const float* cents = centroids.data() + m * ksub * dsub;
-            float* ip = inner_product.get() + m * ksub * ksub;
             float* dis_tab = sdc_table.data() + m * ksub * ksub;
-            float one = 1.0f;
-            float zero = 0.0f;
-            FINTEGER ncodes = ksub, ndims = dsub;
-
-            // compute X * X^T
-            // blas assumes matrices are column major
-            sgemm_("Transposed",
-                   "Not Transposed",
-                   &ncodes,
-                   &ncodes,
-                   &ndims,
-                   &one,
-                   cents,
-                   &ndims,
-                   cents,
-                   &ndims,
-                   &zero,
-                   ip,
-                   &ncodes);
-
-            // (x - y)^2 = x^2 + y^2 - 2xy
-            for (int i = 0; i < ksub; i++) {
-                for (int j = 0; j < ksub; j++) {
-                    float xx_yy = ip[i * ksub + i] + ip[j * ksub + j];
-                    float xy = ip[i * ksub + j];
-                    dis_tab[i * ksub + j] = xx_yy - 2 * xy;
-                }
-            }
+            pairwise_L2sqr(
+                    dsub, ksub, cents, ksub, cents, dis_tab, dsub, dsub, ksub);
         }
     }
 }

--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -746,8 +746,8 @@ void ProductQuantizer::compute_sdc_table() {
         for (int i = 0; i < ksub; i++) {
             for (int j = 0; j < ksub; j++) {
                 float xx_yy = ip[i * ksub + i] + ip[j * ksub + j];
-                float xy = 2 * ip[i * ksub + j];
-                dis_tab[i * ksub + j] = xx_yy - xy;
+                float xy = ip[i * ksub + j];
+                dis_tab[i * ksub + j] = xx_yy - 2 * xy;
             }
         }
     }

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -978,8 +978,8 @@ class TestValidIndexParams(unittest.TestCase):
         k = 10
         D, nns = index.search(xq, k)
 
-        self.assertEquals(D.shape[0], nq)
-        self.assertEquals(D.shape[1], k)
+        self.assertEqual(D.shape[0], nq)
+        self.assertEqual(D.shape[1], k)
 
     def test_IndexFlat(self):
         d = 32
@@ -1000,5 +1000,5 @@ class TestValidIndexParams(unittest.TestCase):
         k = 5
         D, I = index.search(xq, k)
 
-        self.assertEquals(D.shape[0], nq)
-        self.assertEquals(D.shape[1], k)
+        self.assertEqual(D.shape[0], nq)
+        self.assertEqual(D.shape[1], k)

--- a/tests/test_product_quantizer.py
+++ b/tests/test_product_quantizer.py
@@ -122,7 +122,20 @@ class TestPQTables(unittest.TestCase):
         else:
             assert False
 
+        # compute sdc tables in numpy
+        ref_sdc_tab = np.zeros((M, pq.ksub, pq.ksub), "float32")
+        for sq in range(M):
+            centsq = centroids[sq, :, :]
+            cent1 = centsq.reshape(pq.ksub, 1, dsub)
+            cent2 = centsq.reshape(1, pq.ksub, dsub)
+            ref_sdc_tab[sq] = ((cent1 - cent2) ** 2).sum(2)
+
+        pq.compute_sdc_table()
+        new_sdc_tab = faiss.vector_to_array(pq.sdc_table)
+        new_sdc_tab = new_sdc_tab.reshape(M, pq.ksub, pq.ksub)
+
         np.testing.assert_array_almost_equal(ref_tab, new_tab, decimal=5)
+        np.testing.assert_array_almost_equal(ref_sdc_tab, new_sdc_tab, decimal=5)
 
     def test_dsub2(self):
         self.do_test(16, 2)

--- a/tests/test_product_quantizer.py
+++ b/tests/test_product_quantizer.py
@@ -123,12 +123,9 @@ class TestPQTables(unittest.TestCase):
             assert False
 
         # compute sdc tables in numpy
-        ref_sdc_tab = np.zeros((M, pq.ksub, pq.ksub), "float32")
-        for sq in range(M):
-            centsq = centroids[sq, :, :]
-            cent1 = centsq.reshape(pq.ksub, 1, dsub)
-            cent2 = centsq.reshape(1, pq.ksub, dsub)
-            ref_sdc_tab[sq] = ((cent1 - cent2) ** 2).sum(2)
+        cent1 = np.expand_dims(centroids, axis=2)  # [M, ksub, 1, dsub]
+        cent2 = np.expand_dims(centroids, axis=1)  # [M, 1, ksub, dsub]
+        ref_sdc_tab = ((cent1 - cent2) ** 2).sum(3)
 
         pq.compute_sdc_table()
         new_sdc_tab = faiss.vector_to_array(pq.sdc_table)


### PR DESCRIPTION
This PR used BLAS to compute sdc table in ProductQuantizer.

Here is the time of computing sdc tables:

```
nbits=8, d=128 (this commit)
M: 2, sdc: 0.0001361370086669922s
M: 4, sdc: 8.273124694824219e-05s
M: 8, sdc: 7.867813110351562e-05s
M: 16, sdc: 0.0001227855682373047s
M: 32, sdc: 0.0001697540283203125s
M: 64, sdc: 0.0007395744323730469s
```

```
nbits=8, d=128 (master)
M: 2,  sdc: 0.0055773258209228516s
M: 4,  sdc: 0.005366802215576172s
M: 8,  sdc: 0.0050809383392333984s
M: 16, sdc: 0.005639791488647461s
M: 32, sdc: 0.006036281585693359s
M: 64, sdc: 0.009720802307128906s
```

