### PR TITLE
Improve IndexPQFastScan and IndexIVFPQFastScan performance for aarch64 devices

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -148,6 +148,7 @@ set(FAISS_HEADERS
   utils/simdlib.h
   utils/simdlib_avx2.h
   utils/simdlib_emulated.h
+  utils/simdlib_neon.h
   utils/utils.h
 )
 

--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -534,7 +534,7 @@ void ProductQuantizer::compute_distance_tables(
         size_t nx,
         const float* x,
         float* dis_tables) const {
-#ifdef __AVX2__
+#if defined(__AVX2__) || defined(__aarch64__)
     if (dsub == 2 && nbits < 8) { // interesting for a narrow range of settings
         compute_PQ_dis_tables_dsub2(
                 d, ksub, centroids.data(), nx, x, false, dis_tables);
@@ -568,7 +568,7 @@ void ProductQuantizer::compute_inner_prod_tables(
         size_t nx,
         const float* x,
         float* dis_tables) const {
-#ifdef __AVX2__
+#if defined(__AVX2__) || defined(__aarch64__)
     if (dsub == 2 && nbits < 8) {
         compute_PQ_dis_tables_dsub2(
                 d, ksub, centroids.data(), nx, x, true, dis_tables);

--- a/faiss/utils/distances_simd.cpp
+++ b/faiss/utils/distances_simd.cpp
@@ -845,28 +845,6 @@ int fvec_madd_and_argmin(
 
 namespace {
 
-// get even float32's of a and b, interleaved
-simd8float32 geteven(simd8float32 a, simd8float32 b) {
-    return simd8float32(
-            _mm256_shuffle_ps(a.f, b.f, 0 << 0 | 2 << 2 | 0 << 4 | 2 << 6));
-}
-
-// get odd float32's of a and b, interleaved
-simd8float32 getodd(simd8float32 a, simd8float32 b) {
-    return simd8float32(
-            _mm256_shuffle_ps(a.f, b.f, 1 << 0 | 3 << 2 | 1 << 4 | 3 << 6));
-}
-
-// 3 cycles
-// if the lanes are a = [a0 a1] and b = [b0 b1], return [a0 b0]
-simd8float32 getlow128(simd8float32 a, simd8float32 b) {
-    return simd8float32(_mm256_permute2f128_ps(a.f, b.f, 0 | 2 << 4));
-}
-
-simd8float32 gethigh128(simd8float32 a, simd8float32 b) {
-    return simd8float32(_mm256_permute2f128_ps(a.f, b.f, 1 | 3 << 4));
-}
-
 /// compute the IP for dsub = 2 for 8 centroids and 4 sub-vectors at a time
 template <bool is_inner_product>
 void pq2_8cents_table(

--- a/faiss/utils/distances_simd.cpp
+++ b/faiss/utils/distances_simd.cpp
@@ -841,8 +841,6 @@ int fvec_madd_and_argmin(
  * PQ tables computations
  ***************************************************************************/
 
-#ifdef __AVX2__
-
 namespace {
 
 /// compute the IP for dsub = 2 for 8 centroids and 4 sub-vectors at a time
@@ -956,20 +954,5 @@ void compute_PQ_dis_tables_dsub2(
         }
     }
 }
-
-#else
-
-void compute_PQ_dis_tables_dsub2(
-        size_t d,
-        size_t ksub,
-        const float* all_centroids,
-        size_t nx,
-        const float* x,
-        bool is_inner_product,
-        float* dis_tables) {
-    FAISS_THROW_MSG("only implemented for AVX2");
-}
-
-#endif
 
 } // namespace faiss

--- a/faiss/utils/simdlib.h
+++ b/faiss/utils/simdlib.h
@@ -18,6 +18,10 @@
 
 #include <faiss/utils/simdlib_avx2.h>
 
+#elif defined(__aarch64__)
+
+#include <faiss/utils/simdlib_neon.h>
+
 #else
 
 // emulated = all operations are implemented as scalars

--- a/faiss/utils/simdlib_avx2.h
+++ b/faiss/utils/simdlib_avx2.h
@@ -435,4 +435,30 @@ inline simd8float32 fmadd(simd8float32 a, simd8float32 b, simd8float32 c) {
     return simd8float32(_mm256_fmadd_ps(a.f, b.f, c.f));
 }
 
+namespace {
+
+// get even float32's of a and b, interleaved
+simd8float32 geteven(simd8float32 a, simd8float32 b) {
+    return simd8float32(
+            _mm256_shuffle_ps(a.f, b.f, 0 << 0 | 2 << 2 | 0 << 4 | 2 << 6));
+}
+
+// get odd float32's of a and b, interleaved
+simd8float32 getodd(simd8float32 a, simd8float32 b) {
+    return simd8float32(
+            _mm256_shuffle_ps(a.f, b.f, 1 << 0 | 3 << 2 | 1 << 4 | 3 << 6));
+}
+
+// 3 cycles
+// if the lanes are a = [a0 a1] and b = [b0 b1], return [a0 b0]
+simd8float32 getlow128(simd8float32 a, simd8float32 b) {
+    return simd8float32(_mm256_permute2f128_ps(a.f, b.f, 0 | 2 << 4));
+}
+
+simd8float32 gethigh128(simd8float32 a, simd8float32 b) {
+    return simd8float32(_mm256_permute2f128_ps(a.f, b.f, 1 | 3 << 4));
+}
+
+} // namespace
+
 } // namespace faiss

--- a/faiss/utils/simdlib_emulated.h
+++ b/faiss/utils/simdlib_emulated.h
@@ -560,4 +560,76 @@ inline simd8float32 fmadd(simd8float32 a, simd8float32 b, simd8float32 c) {
     return res;
 }
 
+namespace {
+
+// get even float32's of a and b, interleaved
+simd8float32 geteven(const simd8float32& a, const simd8float32& b) {
+    simd8float32 c;
+
+    c.f32[0] = a.f32[0];
+    c.f32[1] = a.f32[2];
+    c.f32[2] = b.f32[0];
+    c.f32[3] = b.f32[2];
+
+    c.f32[4] = a.f32[4];
+    c.f32[5] = a.f32[6];
+    c.f32[6] = b.f32[4];
+    c.f32[7] = b.f32[6];
+
+    return c;
+}
+
+// get odd float32's of a and b, interleaved
+simd8float32 getodd(const simd8float32& a, const simd8float32& b) {
+    simd8float32 c;
+
+    c.f32[0] = a.f32[1];
+    c.f32[1] = a.f32[3];
+    c.f32[2] = b.f32[1];
+    c.f32[3] = b.f32[3];
+
+    c.f32[4] = a.f32[5];
+    c.f32[5] = a.f32[7];
+    c.f32[6] = b.f32[5];
+    c.f32[7] = b.f32[7];
+
+    return c;
+}
+
+// 3 cycles
+// if the lanes are a = [a0 a1] and b = [b0 b1], return [a0 b0]
+simd8float32 getlow128(const simd8float32& a, const simd8float32& b) {
+    simd8float32 c;
+
+    c.f32[0] = a.f32[0];
+    c.f32[1] = a.f32[1];
+    c.f32[2] = a.f32[2];
+    c.f32[3] = a.f32[3];
+
+    c.f32[4] = b.f32[0];
+    c.f32[5] = b.f32[1];
+    c.f32[6] = b.f32[2];
+    c.f32[7] = b.f32[3];
+
+    return c;
+}
+
+simd8float32 gethigh128(const simd8float32& a, const simd8float32& b) {
+    simd8float32 c;
+
+    c.f32[0] = a.f32[4];
+    c.f32[1] = a.f32[5];
+    c.f32[2] = a.f32[6];
+    c.f32[3] = a.f32[7];
+
+    c.f32[4] = b.f32[4];
+    c.f32[5] = b.f32[5];
+    c.f32[6] = b.f32[6];
+    c.f32[7] = b.f32[7];
+
+    return c;
+}
+
+} // namespace
+
 } // namespace faiss

--- a/faiss/utils/simdlib_neon.h
+++ b/faiss/utils/simdlib_neon.h
@@ -1,0 +1,563 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <string>
+
+namespace faiss {
+
+struct simd256bit {
+    union {
+        uint8_t u8[32];
+        uint16_t u16[16];
+        uint32_t u32[8];
+        float f32[8];
+    };
+
+    simd256bit() {}
+
+    explicit simd256bit(const void* x) {
+        memcpy(u8, x, 32);
+    }
+
+    void clear() {
+        memset(u8, 0, 32);
+    }
+
+    void storeu(void* ptr) const {
+        memcpy(ptr, u8, 32);
+    }
+
+    void loadu(const void* ptr) {
+        memcpy(u8, ptr, 32);
+    }
+
+    void store(void* ptr) const {
+        storeu(ptr);
+    }
+
+    void bin(char bits[257]) const {
+        const char* bytes = (char*)this->u8;
+        for (int i = 0; i < 256; i++) {
+            bits[i] = '0' + ((bytes[i / 8] >> (i % 8)) & 1);
+        }
+        bits[256] = 0;
+    }
+
+    std::string bin() const {
+        char bits[257];
+        bin(bits);
+        return std::string(bits);
+    }
+};
+
+/// vector of 16 elements in uint16
+struct simd16uint16 : simd256bit {
+    simd16uint16() {}
+
+    explicit simd16uint16(int x) {
+        set1(x);
+    }
+
+    explicit simd16uint16(uint16_t x) {
+        set1(x);
+    }
+
+    explicit simd16uint16(simd256bit x) : simd256bit(x) {}
+
+    explicit simd16uint16(const uint16_t* x) : simd256bit((const void*)x) {}
+
+    std::string elements_to_string(const char* fmt) const {
+        char res[1000], *ptr = res;
+        for (int i = 0; i < 16; i++) {
+            ptr += sprintf(ptr, fmt, u16[i]);
+        }
+        // strip last ,
+        ptr[-1] = 0;
+        return std::string(res);
+    }
+
+    std::string hex() const {
+        return elements_to_string("%02x,");
+    }
+
+    std::string dec() const {
+        return elements_to_string("%3d,");
+    }
+
+    static simd16uint16 unary_func(
+            simd16uint16 a,
+            std::function<uint16_t(uint16_t)> f) {
+        simd16uint16 c;
+        for (int j = 0; j < 16; j++) {
+            c.u16[j] = f(a.u16[j]);
+        }
+        return c;
+    }
+
+    static simd16uint16 binary_func(
+            simd16uint16 a,
+            simd16uint16 b,
+            std::function<uint16_t(uint16_t, uint16_t)> f) {
+        simd16uint16 c;
+        for (int j = 0; j < 16; j++) {
+            c.u16[j] = f(a.u16[j], b.u16[j]);
+        }
+        return c;
+    }
+
+    void set1(uint16_t x) {
+        for (int i = 0; i < 16; i++) {
+            u16[i] = x;
+        }
+    }
+
+    // shift must be known at compile time
+    simd16uint16 operator>>(const int shift) const {
+        return unary_func(*this, [shift](uint16_t a) { return a >> shift; });
+    }
+
+    // shift must be known at compile time
+    simd16uint16 operator<<(const int shift) const {
+        return unary_func(*this, [shift](uint16_t a) { return a << shift; });
+    }
+
+    simd16uint16 operator+=(simd16uint16 other) {
+        *this = *this + other;
+        return *this;
+    }
+
+    simd16uint16 operator-=(simd16uint16 other) {
+        *this = *this - other;
+        return *this;
+    }
+
+    simd16uint16 operator+(simd16uint16 other) const {
+        return binary_func(
+                *this, other, [](uint16_t a, uint16_t b) { return a + b; });
+    }
+
+    simd16uint16 operator-(simd16uint16 other) const {
+        return binary_func(
+                *this, other, [](uint16_t a, uint16_t b) { return a - b; });
+    }
+
+    simd16uint16 operator&(simd256bit other) const {
+        return binary_func(
+                *this, simd16uint16(other), [](uint16_t a, uint16_t b) {
+                    return a & b;
+                });
+    }
+
+    simd16uint16 operator|(simd256bit other) const {
+        return binary_func(
+                *this, simd16uint16(other), [](uint16_t a, uint16_t b) {
+                    return a | b;
+                });
+    }
+
+    // returns binary masks
+    simd16uint16 operator==(simd16uint16 other) const {
+        return binary_func(*this, other, [](uint16_t a, uint16_t b) {
+            return a == b ? 0xffff : 0;
+        });
+    }
+
+    simd16uint16 operator~() const {
+        return unary_func(*this, [](uint16_t a) { return ~a; });
+    }
+
+    // get scalar at index 0
+    uint16_t get_scalar_0() const {
+        return u16[0];
+    }
+
+    // mask of elements where this >= thresh
+    // 2 bit per component: 16 * 2 = 32 bit
+    uint32_t ge_mask(simd16uint16 thresh) const {
+        uint32_t gem = 0;
+        for (int j = 0; j < 16; j++) {
+            if (u16[j] >= thresh.u16[j]) {
+                gem |= 3 << (j * 2);
+            }
+        }
+        return gem;
+    }
+
+    uint32_t le_mask(simd16uint16 thresh) const {
+        return thresh.ge_mask(*this);
+    }
+
+    uint32_t gt_mask(simd16uint16 thresh) const {
+        return ~le_mask(thresh);
+    }
+
+    bool all_gt(simd16uint16 thresh) const {
+        return le_mask(thresh) == 0;
+    }
+
+    // for debugging only
+    uint16_t operator[](int i) const {
+        return u16[i];
+    }
+
+    void accu_min(simd16uint16 incoming) {
+        for (int j = 0; j < 16; j++) {
+            if (incoming.u16[j] < u16[j]) {
+                u16[j] = incoming.u16[j];
+            }
+        }
+    }
+
+    void accu_max(simd16uint16 incoming) {
+        for (int j = 0; j < 16; j++) {
+            if (incoming.u16[j] > u16[j]) {
+                u16[j] = incoming.u16[j];
+            }
+        }
+    }
+};
+
+// not really a std::min because it returns an elementwise min
+inline simd16uint16 min(simd16uint16 av, simd16uint16 bv) {
+    return simd16uint16::binary_func(
+            av, bv, [](uint16_t a, uint16_t b) { return std::min(a, b); });
+}
+
+inline simd16uint16 max(simd16uint16 av, simd16uint16 bv) {
+    return simd16uint16::binary_func(
+            av, bv, [](uint16_t a, uint16_t b) { return std::max(a, b); });
+}
+
+// decompose in 128-lanes: a = (a0, a1), b = (b0, b1)
+// return (a0 + a1, b0 + b1)
+// TODO find a better name
+inline simd16uint16 combine2x2(simd16uint16 a, simd16uint16 b) {
+    simd16uint16 c;
+    for (int j = 0; j < 8; j++) {
+        c.u16[j] = a.u16[j] + a.u16[j + 8];
+        c.u16[j + 8] = b.u16[j] + b.u16[j + 8];
+    }
+    return c;
+}
+
+// compare d0 and d1 to thr, return 32 bits corresponding to the concatenation
+// of d0 and d1 with thr
+inline uint32_t cmp_ge32(simd16uint16 d0, simd16uint16 d1, simd16uint16 thr) {
+    uint32_t gem = 0;
+    for (int j = 0; j < 16; j++) {
+        if (d0.u16[j] >= thr.u16[j]) {
+            gem |= 1 << j;
+        }
+        if (d1.u16[j] >= thr.u16[j]) {
+            gem |= 1 << (j + 16);
+        }
+    }
+    return gem;
+}
+
+inline uint32_t cmp_le32(simd16uint16 d0, simd16uint16 d1, simd16uint16 thr) {
+    uint32_t gem = 0;
+    for (int j = 0; j < 16; j++) {
+        if (d0.u16[j] <= thr.u16[j]) {
+            gem |= 1 << j;
+        }
+        if (d1.u16[j] <= thr.u16[j]) {
+            gem |= 1 << (j + 16);
+        }
+    }
+    return gem;
+}
+
+// vector of 32 unsigned 8-bit integers
+struct simd32uint8 : simd256bit {
+    simd32uint8() {}
+
+    explicit simd32uint8(int x) {
+        set1(x);
+    }
+
+    explicit simd32uint8(uint8_t x) {
+        set1(x);
+    }
+
+    explicit simd32uint8(simd256bit x) : simd256bit(x) {}
+
+    explicit simd32uint8(const uint8_t* x) : simd256bit((const void*)x) {}
+
+    std::string elements_to_string(const char* fmt) const {
+        char res[1000], *ptr = res;
+        for (int i = 0; i < 32; i++) {
+            ptr += sprintf(ptr, fmt, u8[i]);
+        }
+        // strip last ,
+        ptr[-1] = 0;
+        return std::string(res);
+    }
+
+    std::string hex() const {
+        return elements_to_string("%02x,");
+    }
+
+    std::string dec() const {
+        return elements_to_string("%3d,");
+    }
+
+    void set1(uint8_t x) {
+        for (int j = 0; j < 32; j++) {
+            u8[j] = x;
+        }
+    }
+
+    static simd32uint8 binary_func(
+            simd32uint8 a,
+            simd32uint8 b,
+            std::function<uint8_t(uint8_t, uint8_t)> f) {
+        simd32uint8 c;
+        for (int j = 0; j < 32; j++) {
+            c.u8[j] = f(a.u8[j], b.u8[j]);
+        }
+        return c;
+    }
+
+    simd32uint8 operator&(simd256bit other) const {
+        return binary_func(*this, simd32uint8(other), [](uint8_t a, uint8_t b) {
+            return a & b;
+        });
+    }
+
+    simd32uint8 operator+(simd32uint8 other) const {
+        return binary_func(
+                *this, other, [](uint8_t a, uint8_t b) { return a + b; });
+    }
+
+    // The very important operation that everything relies on
+    simd32uint8 lookup_2_lanes(simd32uint8 idx) const {
+        simd32uint8 c;
+        for (int j = 0; j < 32; j++) {
+            if (idx.u8[j] & 0x80) {
+                c.u8[j] = 0;
+            } else {
+                uint8_t i = idx.u8[j] & 15;
+                if (j < 16) {
+                    c.u8[j] = u8[i];
+                } else {
+                    c.u8[j] = u8[16 + i];
+                }
+            }
+        }
+        return c;
+    }
+
+    // extract + 0-extend lane
+    // this operation is slow (3 cycles)
+
+    simd32uint8 operator+=(simd32uint8 other) {
+        *this = *this + other;
+        return *this;
+    }
+
+    // for debugging only
+    uint8_t operator[](int i) const {
+        return u8[i];
+    }
+};
+
+// convert with saturation
+// careful: this does not cross lanes, so the order is weird
+inline simd32uint8 uint16_to_uint8_saturate(simd16uint16 a, simd16uint16 b) {
+    simd32uint8 c;
+
+    auto saturate_16_to_8 = [](uint16_t x) { return x >= 256 ? 0xff : x; };
+
+    for (int i = 0; i < 8; i++) {
+        c.u8[i] = saturate_16_to_8(a.u16[i]);
+        c.u8[8 + i] = saturate_16_to_8(b.u16[i]);
+        c.u8[16 + i] = saturate_16_to_8(a.u16[8 + i]);
+        c.u8[24 + i] = saturate_16_to_8(b.u16[8 + i]);
+    }
+    return c;
+}
+
+/// get most significant bit of each byte
+inline uint32_t get_MSBs(simd32uint8 a) {
+    uint32_t res = 0;
+    for (int i = 0; i < 32; i++) {
+        if (a.u8[i] & 0x80) {
+            res |= 1 << i;
+        }
+    }
+    return res;
+}
+
+/// use MSB of each byte of mask to select a byte between a and b
+inline simd32uint8 blendv(simd32uint8 a, simd32uint8 b, simd32uint8 mask) {
+    simd32uint8 c;
+    for (int i = 0; i < 32; i++) {
+        if (mask.u8[i] & 0x80) {
+            c.u8[i] = b.u8[i];
+        } else {
+            c.u8[i] = a.u8[i];
+        }
+    }
+    return c;
+}
+
+/// vector of 8 unsigned 32-bit integers
+struct simd8uint32 : simd256bit {
+    simd8uint32() {}
+
+    explicit simd8uint32(uint32_t x) {
+        set1(x);
+    }
+
+    explicit simd8uint32(simd256bit x) : simd256bit(x) {}
+
+    explicit simd8uint32(const uint8_t* x) : simd256bit((const void*)x) {}
+
+    std::string elements_to_string(const char* fmt) const {
+        char res[1000], *ptr = res;
+        for (int i = 0; i < 8; i++) {
+            ptr += sprintf(ptr, fmt, u32[i]);
+        }
+        // strip last ,
+        ptr[-1] = 0;
+        return std::string(res);
+    }
+
+    std::string hex() const {
+        return elements_to_string("%08x,");
+    }
+
+    std::string dec() const {
+        return elements_to_string("%10d,");
+    }
+
+    void set1(uint32_t x) {
+        for (int i = 0; i < 8; i++) {
+            u32[i] = x;
+        }
+    }
+};
+
+struct simd8float32 : simd256bit {
+    simd8float32() {}
+
+    explicit simd8float32(simd256bit x) : simd256bit(x) {}
+
+    explicit simd8float32(float x) {
+        set1(x);
+    }
+
+    explicit simd8float32(const float* x) {
+        loadu((void*)x);
+    }
+
+    void set1(float x) {
+        for (int i = 0; i < 8; i++) {
+            f32[i] = x;
+        }
+    }
+
+    static simd8float32 binary_func(
+            simd8float32 a,
+            simd8float32 b,
+            std::function<float(float, float)> f) {
+        simd8float32 c;
+        for (int j = 0; j < 8; j++) {
+            c.f32[j] = f(a.f32[j], b.f32[j]);
+        }
+        return c;
+    }
+
+    simd8float32 operator*(simd8float32 other) const {
+        return binary_func(
+                *this, other, [](float a, float b) { return a * b; });
+    }
+
+    simd8float32 operator+(simd8float32 other) const {
+        return binary_func(
+                *this, other, [](float a, float b) { return a + b; });
+    }
+
+    simd8float32 operator-(simd8float32 other) const {
+        return binary_func(
+                *this, other, [](float a, float b) { return a - b; });
+    }
+
+    std::string tostring() const {
+        char res[1000], *ptr = res;
+        for (int i = 0; i < 8; i++) {
+            ptr += sprintf(ptr, "%g,", f32[i]);
+        }
+        // strip last ,
+        ptr[-1] = 0;
+        return std::string(res);
+    }
+};
+
+// hadd does not cross lanes
+inline simd8float32 hadd(simd8float32 a, simd8float32 b) {
+    simd8float32 c;
+    c.f32[0] = a.f32[0] + a.f32[1];
+    c.f32[1] = a.f32[2] + a.f32[3];
+    c.f32[2] = b.f32[0] + b.f32[1];
+    c.f32[3] = b.f32[2] + b.f32[3];
+
+    c.f32[4] = a.f32[4] + a.f32[5];
+    c.f32[5] = a.f32[6] + a.f32[7];
+    c.f32[6] = b.f32[4] + b.f32[5];
+    c.f32[7] = b.f32[6] + b.f32[7];
+
+    return c;
+}
+
+inline simd8float32 unpacklo(simd8float32 a, simd8float32 b) {
+    simd8float32 c;
+    c.f32[0] = a.f32[0];
+    c.f32[1] = b.f32[0];
+    c.f32[2] = a.f32[1];
+    c.f32[3] = b.f32[1];
+
+    c.f32[4] = a.f32[4];
+    c.f32[5] = b.f32[4];
+    c.f32[6] = a.f32[5];
+    c.f32[7] = b.f32[5];
+
+    return c;
+}
+
+inline simd8float32 unpackhi(simd8float32 a, simd8float32 b) {
+    simd8float32 c;
+    c.f32[0] = a.f32[2];
+    c.f32[1] = b.f32[2];
+    c.f32[2] = a.f32[3];
+    c.f32[3] = b.f32[3];
+
+    c.f32[4] = a.f32[6];
+    c.f32[5] = b.f32[6];
+    c.f32[6] = a.f32[7];
+    c.f32[7] = b.f32[7];
+
+    return c;
+}
+
+// compute a * b + c
+inline simd8float32 fmadd(simd8float32 a, simd8float32 b, simd8float32 c) {
+    simd8float32 res;
+    for (int i = 0; i < 8; i++) {
+        res.f32[i] = a.f32[i] * b.f32[i] + c.f32[i];
+    }
+    return res;
+}
+
+} // namespace faiss

--- a/faiss/utils/simdlib_neon.h
+++ b/faiss/utils/simdlib_neon.h
@@ -7,83 +7,235 @@
 
 #pragma once
 
+// TODO: Support big endian (currently supporting only little endian)
+
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <functional>
 #include <string>
+#include <type_traits>
+
+#include <arm_neon.h>
 
 namespace faiss {
 
-struct simd256bit {
-    union {
-        uint8_t u8[32];
-        uint16_t u16[16];
-        uint32_t u32[8];
-        float f32[8];
-    };
+namespace detail {
 
-    simd256bit() {}
+namespace simdlib {
 
-    explicit simd256bit(const void* x) {
-        memcpy(u8, x, 32);
+static inline uint8x16x2_t reinterpret_u8(const uint8x16x2_t& v) {
+    return v;
+}
+
+static inline uint8x16x2_t reinterpret_u8(const uint16x8x2_t& v) {
+    return {vreinterpretq_u8_u16(v.val[0]), vreinterpretq_u8_u16(v.val[1])};
+}
+
+static inline uint8x16x2_t reinterpret_u8(const uint32x4x2_t& v) {
+    return {vreinterpretq_u8_u32(v.val[0]), vreinterpretq_u8_u32(v.val[1])};
+}
+
+static inline uint8x16x2_t reinterpret_u8(const float32x4x2_t& v) {
+    return {vreinterpretq_u8_f32(v.val[0]), vreinterpretq_u8_f32(v.val[1])};
+}
+
+static inline uint16x8x2_t reinterpret_u16(const uint8x16x2_t& v) {
+    return {vreinterpretq_u16_u8(v.val[0]), vreinterpretq_u16_u8(v.val[1])};
+}
+
+static inline uint16x8x2_t reinterpret_u16(const uint16x8x2_t& v) {
+    return v;
+}
+
+static inline uint16x8x2_t reinterpret_u16(const uint32x4x2_t& v) {
+    return {vreinterpretq_u16_u32(v.val[0]), vreinterpretq_u16_u32(v.val[1])};
+}
+
+static inline uint16x8x2_t reinterpret_u16(const float32x4x2_t& v) {
+    return {vreinterpretq_u16_f32(v.val[0]), vreinterpretq_u16_f32(v.val[1])};
+}
+
+static inline uint32x4x2_t reinterpret_u32(const uint8x16x2_t& v) {
+    return {vreinterpretq_u32_u8(v.val[0]), vreinterpretq_u32_u8(v.val[1])};
+}
+
+static inline uint32x4x2_t reinterpret_u32(const uint16x8x2_t& v) {
+    return {vreinterpretq_u32_u16(v.val[0]), vreinterpretq_u32_u16(v.val[1])};
+}
+
+static inline uint32x4x2_t reinterpret_u32(const uint32x4x2_t& v) {
+    return v;
+}
+
+static inline uint32x4x2_t reinterpret_u32(const float32x4x2_t& v) {
+    return {vreinterpretq_u32_f32(v.val[0]), vreinterpretq_u32_f32(v.val[1])};
+}
+
+static inline float32x4x2_t reinterpret_f32(const uint8x16x2_t& v) {
+    return {vreinterpretq_f32_u8(v.val[0]), vreinterpretq_f32_u8(v.val[1])};
+}
+
+static inline float32x4x2_t reinterpret_f32(const uint16x8x2_t& v) {
+    return {vreinterpretq_f32_u16(v.val[0]), vreinterpretq_f32_u16(v.val[1])};
+}
+
+static inline float32x4x2_t reinterpret_f32(const uint32x4x2_t& v) {
+    return {vreinterpretq_f32_u32(v.val[0]), vreinterpretq_f32_u32(v.val[1])};
+}
+
+static inline float32x4x2_t reinterpret_f32(const float32x4x2_t& v) {
+    return v;
+}
+
+template <
+        typename T,
+        typename U = decltype(reinterpret_u8(std::declval<T>().data))>
+struct is_simd256bit : std::is_same<U, uint8x16x2_t> {};
+
+static inline void bin(const char (&bytes)[32], char bits[257]) {
+    for (int i = 0; i < 256; ++i) {
+        bits[i] = '0' + ((bytes[i / 8] >> (i % 8)) & 1);
     }
+    bits[256] = 0;
+}
+
+template <typename T, size_t N, typename S>
+static inline void bin(const S& simd, char bits[257]) {
+    static_assert(
+            std::is_same<void (S::*)(T*) const, decltype(&S::store)>::value,
+            "invalid T");
+    T ds[N];
+    simd.store(ds);
+    char bytes[32];
+    std::memcpy(bytes, ds, sizeof(char) * 32);
+    bin(bytes, bits);
+}
+
+template <typename S>
+static inline std::string bin(const S& simd) {
+    char bits[257];
+    simd.bin(bits);
+    return std::string(bits);
+}
+
+template <typename D, typename F, typename T>
+static inline void set1(D& d, F&& f, T t) {
+    const auto v = f(t);
+    d.val[0] = v;
+    d.val[1] = v;
+}
+
+template <typename T, size_t N, typename S>
+static inline std::string elements_to_string(const char* fmt, const S& simd) {
+    static_assert(
+            std::is_same<void (S::*)(T*) const, decltype(&S::store)>::value,
+            "invalid T");
+    T bytes[N];
+    simd.store(bytes);
+    char res[1000], *ptr = res;
+    for (size_t i = 0; i < N; ++i) {
+        ptr += sprintf(ptr, fmt, bytes[i]);
+    }
+    // strip last ,
+    ptr[-1] = 0;
+    return std::string(res);
+}
+
+template <typename T, typename F>
+static inline T unary_func(const T& a, F&& f) {
+    T t;
+    t.val[0] = f(a.val[0]);
+    t.val[1] = f(a.val[1]);
+    return t;
+}
+
+template <typename T, typename F>
+static inline T binary_func(const T& a, const T& b, F&& f) {
+    T t;
+    t.val[0] = f(a.val[0], b.val[0]);
+    t.val[1] = f(a.val[1], b.val[1]);
+    return t;
+}
+
+static inline uint16_t vmovmask_u8(const uint8x16_t& v) {
+    uint8_t d[16];
+    const auto v2 = vreinterpretq_u16_u8(vshrq_n_u8(v, 7));
+    const auto v3 = vreinterpretq_u32_u16(vsraq_n_u16(v2, v2, 7));
+    const auto v4 = vreinterpretq_u64_u32(vsraq_n_u32(v3, v3, 14));
+    vst1q_u8(d, vreinterpretq_u8_u64(vsraq_n_u64(v4, v4, 28)));
+    return d[0] | static_cast<uint16_t>(d[8]) << 8u;
+}
+
+template <uint16x8_t (*F)(uint16x8_t, uint16x8_t)>
+static inline uint32_t cmp_xe32(
+        const uint16x8x2_t& d0,
+        const uint16x8x2_t& d1,
+        const uint16x8x2_t& thr) {
+    const auto d0_thr = detail::simdlib::binary_func(d0, thr, F);
+    const auto d1_thr = detail::simdlib::binary_func(d1, thr, F);
+    const auto d0_mask = vmovmask_u8(
+            vmovn_high_u16(vmovn_u16(d0_thr.val[0]), d0_thr.val[1]));
+    const auto d1_mask = vmovmask_u8(
+            vmovn_high_u16(vmovn_u16(d1_thr.val[0]), d1_thr.val[1]));
+    return d0_mask | static_cast<uint32_t>(d1_mask) << 16;
+}
+
+} // namespace simdlib
+
+} // namespace detail
+
+/// vector of 16 elements in uint16
+struct simd16uint16 {
+    uint16x8x2_t data;
+
+    simd16uint16() = default;
+
+    explicit simd16uint16(int x) : data{vdupq_n_u16(x), vdupq_n_u16(x)} {}
+
+    explicit simd16uint16(uint16_t x) : data{vdupq_n_u16(x), vdupq_n_u16(x)} {}
+
+    explicit simd16uint16(const uint16x8x2_t& v) : data{v} {}
+
+    template <
+            typename T,
+            typename std::enable_if<
+                    detail::simdlib::is_simd256bit<T>::value,
+                    std::nullptr_t>::type = nullptr>
+    explicit simd16uint16(const T& x)
+            : data{detail::simdlib::reinterpret_u16(x.data)} {}
+
+    explicit simd16uint16(const uint16_t* x)
+            : data{vld1q_u16(x), vld1q_u16(x + 8)} {}
 
     void clear() {
-        memset(u8, 0, 32);
+        detail::simdlib::set1(data, &vdupq_n_u16, static_cast<uint16_t>(0));
     }
 
-    void storeu(void* ptr) const {
-        memcpy(ptr, u8, 32);
+    void storeu(uint16_t* ptr) const {
+        vst1q_u16(ptr, data.val[0]);
+        vst1q_u16(ptr + 8, data.val[1]);
     }
 
-    void loadu(const void* ptr) {
-        memcpy(u8, ptr, 32);
+    void loadu(const uint16_t* ptr) {
+        data.val[0] = vld1q_u16(ptr);
+        data.val[1] = vld1q_u16(ptr + 8);
     }
 
-    void store(void* ptr) const {
+    void store(uint16_t* ptr) const {
         storeu(ptr);
     }
 
     void bin(char bits[257]) const {
-        const char* bytes = (char*)this->u8;
-        for (int i = 0; i < 256; i++) {
-            bits[i] = '0' + ((bytes[i / 8] >> (i % 8)) & 1);
-        }
-        bits[256] = 0;
+        detail::simdlib::bin<uint16_t, 16u>(*this, bits);
     }
 
     std::string bin() const {
-        char bits[257];
-        bin(bits);
-        return std::string(bits);
+        return detail::simdlib::bin(*this);
     }
-};
-
-/// vector of 16 elements in uint16
-struct simd16uint16 : simd256bit {
-    simd16uint16() {}
-
-    explicit simd16uint16(int x) {
-        set1(x);
-    }
-
-    explicit simd16uint16(uint16_t x) {
-        set1(x);
-    }
-
-    explicit simd16uint16(simd256bit x) : simd256bit(x) {}
-
-    explicit simd16uint16(const uint16_t* x) : simd256bit((const void*)x) {}
 
     std::string elements_to_string(const char* fmt) const {
-        char res[1000], *ptr = res;
-        for (int i = 0; i < 16; i++) {
-            ptr += sprintf(ptr, fmt, u16[i]);
-        }
-        // strip last ,
-        ptr[-1] = 0;
-        return std::string(res);
+        return detail::simdlib::elements_to_string<uint16_t, 16u>(fmt, *this);
     }
 
     std::string hex() const {
@@ -94,214 +246,216 @@ struct simd16uint16 : simd256bit {
         return elements_to_string("%3d,");
     }
 
-    static simd16uint16 unary_func(
-            simd16uint16 a,
-            std::function<uint16_t(uint16_t)> f) {
-        simd16uint16 c;
-        for (int j = 0; j < 16; j++) {
-            c.u16[j] = f(a.u16[j]);
-        }
-        return c;
-    }
-
-    static simd16uint16 binary_func(
-            simd16uint16 a,
-            simd16uint16 b,
-            std::function<uint16_t(uint16_t, uint16_t)> f) {
-        simd16uint16 c;
-        for (int j = 0; j < 16; j++) {
-            c.u16[j] = f(a.u16[j], b.u16[j]);
-        }
-        return c;
-    }
-
     void set1(uint16_t x) {
-        for (int i = 0; i < 16; i++) {
-            u16[i] = x;
-        }
+        detail::simdlib::set1(data, &vdupq_n_u16, x);
     }
 
     // shift must be known at compile time
     simd16uint16 operator>>(const int shift) const {
-        return unary_func(*this, [shift](uint16_t a) { return a >> shift; });
+        return simd16uint16{detail::simdlib::unary_func(
+                data, [shift](uint16x8_t a) { return vshrq_n_u16(a, shift); })};
     }
 
     // shift must be known at compile time
     simd16uint16 operator<<(const int shift) const {
-        return unary_func(*this, [shift](uint16_t a) { return a << shift; });
+        return simd16uint16{detail::simdlib::unary_func(
+                data, [shift](uint16x8_t a) { return vshlq_n_u16(a, shift); })};
     }
 
-    simd16uint16 operator+=(simd16uint16 other) {
+    simd16uint16 operator+=(const simd16uint16& other) {
         *this = *this + other;
         return *this;
     }
 
-    simd16uint16 operator-=(simd16uint16 other) {
+    simd16uint16 operator-=(const simd16uint16& other) {
         *this = *this - other;
         return *this;
     }
 
-    simd16uint16 operator+(simd16uint16 other) const {
-        return binary_func(
-                *this, other, [](uint16_t a, uint16_t b) { return a + b; });
+    simd16uint16 operator+(const simd16uint16& other) const {
+        return simd16uint16{
+                detail::simdlib::binary_func(data, other.data, &vaddq_u16)};
     }
 
-    simd16uint16 operator-(simd16uint16 other) const {
-        return binary_func(
-                *this, other, [](uint16_t a, uint16_t b) { return a - b; });
+    simd16uint16 operator-(const simd16uint16& other) const {
+        return simd16uint16{
+                detail::simdlib::binary_func(data, other.data, &vsubq_u16)};
     }
 
-    simd16uint16 operator&(simd256bit other) const {
-        return binary_func(
-                *this, simd16uint16(other), [](uint16_t a, uint16_t b) {
-                    return a & b;
-                });
+    template <
+            typename T,
+            typename std::enable_if<
+                    detail::simdlib::is_simd256bit<T>::value,
+                    std::nullptr_t>::type = nullptr>
+    simd16uint16 operator&(const T& other) const {
+        return simd16uint16{detail::simdlib::binary_func(
+                data,
+                detail::simdlib::reinterpret_u16(other.data),
+                &vandq_u16)};
     }
 
-    simd16uint16 operator|(simd256bit other) const {
-        return binary_func(
-                *this, simd16uint16(other), [](uint16_t a, uint16_t b) {
-                    return a | b;
-                });
+    template <
+            typename T,
+            typename std::enable_if<
+                    detail::simdlib::is_simd256bit<T>::value,
+                    std::nullptr_t>::type = nullptr>
+    simd16uint16 operator|(const T& other) const {
+        return simd16uint16{detail::simdlib::binary_func(
+                data,
+                detail::simdlib::reinterpret_u16(other.data),
+                &vorrq_u16)};
     }
 
     // returns binary masks
-    simd16uint16 operator==(simd16uint16 other) const {
-        return binary_func(*this, other, [](uint16_t a, uint16_t b) {
-            return a == b ? 0xffff : 0;
-        });
+    simd16uint16 operator==(const simd16uint16& other) const {
+        return simd16uint16{
+                detail::simdlib::binary_func(data, other.data, &vceqq_u16)};
     }
 
     simd16uint16 operator~() const {
-        return unary_func(*this, [](uint16_t a) { return ~a; });
+        return simd16uint16{detail::simdlib::unary_func(data, &vmvnq_u16)};
     }
 
     // get scalar at index 0
     uint16_t get_scalar_0() const {
-        return u16[0];
+        return vgetq_lane_u16(data.val[0], 0);
     }
 
     // mask of elements where this >= thresh
     // 2 bit per component: 16 * 2 = 32 bit
-    uint32_t ge_mask(simd16uint16 thresh) const {
-        uint32_t gem = 0;
-        for (int j = 0; j < 16; j++) {
-            if (u16[j] >= thresh.u16[j]) {
-                gem |= 3 << (j * 2);
-            }
-        }
-        return gem;
+    uint32_t ge_mask(const simd16uint16& thresh) const {
+        const auto input =
+                detail::simdlib::binary_func(data, thresh.data, &vcgeq_u16);
+        const auto vmovmask_u16 = [](uint16x8_t v) -> uint16_t {
+            uint16_t d[8];
+            const auto v2 = vreinterpretq_u32_u16(vshrq_n_u16(v, 14));
+            const auto v3 = vreinterpretq_u64_u32(vsraq_n_u32(v2, v2, 14));
+            vst1q_u16(d, vreinterpretq_u16_u64(vsraq_n_u64(v3, v3, 28)));
+            return d[0] | d[4] << 8u;
+        };
+        return static_cast<uint32_t>(vmovmask_u16(input.val[1])) << 16u |
+                vmovmask_u16(input.val[0]);
     }
 
-    uint32_t le_mask(simd16uint16 thresh) const {
+    uint32_t le_mask(const simd16uint16& thresh) const {
         return thresh.ge_mask(*this);
     }
 
-    uint32_t gt_mask(simd16uint16 thresh) const {
+    uint32_t gt_mask(const simd16uint16& thresh) const {
         return ~le_mask(thresh);
     }
 
-    bool all_gt(simd16uint16 thresh) const {
+    bool all_gt(const simd16uint16& thresh) const {
         return le_mask(thresh) == 0;
     }
 
     // for debugging only
     uint16_t operator[](int i) const {
-        return u16[i];
+        uint16_t tab[8];
+        const bool high = i >= 8;
+        vst1q_u16(tab, data.val[high]);
+        return tab[i - high * 8];
     }
 
-    void accu_min(simd16uint16 incoming) {
-        for (int j = 0; j < 16; j++) {
-            if (incoming.u16[j] < u16[j]) {
-                u16[j] = incoming.u16[j];
-            }
-        }
+    void accu_min(const simd16uint16& incoming) {
+        data = detail::simdlib::binary_func(incoming.data, data, &vminq_u16);
     }
 
-    void accu_max(simd16uint16 incoming) {
-        for (int j = 0; j < 16; j++) {
-            if (incoming.u16[j] > u16[j]) {
-                u16[j] = incoming.u16[j];
-            }
-        }
+    void accu_max(const simd16uint16& incoming) {
+        data = detail::simdlib::binary_func(incoming.data, data, &vmaxq_u16);
     }
 };
 
 // not really a std::min because it returns an elementwise min
-inline simd16uint16 min(simd16uint16 av, simd16uint16 bv) {
-    return simd16uint16::binary_func(
-            av, bv, [](uint16_t a, uint16_t b) { return std::min(a, b); });
+inline simd16uint16 min(const simd16uint16& av, const simd16uint16& bv) {
+    return simd16uint16{
+            detail::simdlib::binary_func(av.data, bv.data, &vminq_u16)};
 }
 
-inline simd16uint16 max(simd16uint16 av, simd16uint16 bv) {
-    return simd16uint16::binary_func(
-            av, bv, [](uint16_t a, uint16_t b) { return std::max(a, b); });
+inline simd16uint16 max(const simd16uint16& av, const simd16uint16& bv) {
+    return simd16uint16{
+            detail::simdlib::binary_func(av.data, bv.data, &vmaxq_u16)};
 }
 
 // decompose in 128-lanes: a = (a0, a1), b = (b0, b1)
 // return (a0 + a1, b0 + b1)
 // TODO find a better name
-inline simd16uint16 combine2x2(simd16uint16 a, simd16uint16 b) {
-    simd16uint16 c;
-    for (int j = 0; j < 8; j++) {
-        c.u16[j] = a.u16[j] + a.u16[j + 8];
-        c.u16[j + 8] = b.u16[j] + b.u16[j + 8];
-    }
-    return c;
+inline simd16uint16 combine2x2(const simd16uint16& a, const simd16uint16& b) {
+    return simd16uint16{uint16x8x2_t{
+            vaddq_u16(a.data.val[0], a.data.val[1]),
+            vaddq_u16(b.data.val[0], b.data.val[1])}};
 }
 
 // compare d0 and d1 to thr, return 32 bits corresponding to the concatenation
 // of d0 and d1 with thr
-inline uint32_t cmp_ge32(simd16uint16 d0, simd16uint16 d1, simd16uint16 thr) {
-    uint32_t gem = 0;
-    for (int j = 0; j < 16; j++) {
-        if (d0.u16[j] >= thr.u16[j]) {
-            gem |= 1 << j;
-        }
-        if (d1.u16[j] >= thr.u16[j]) {
-            gem |= 1 << (j + 16);
-        }
-    }
-    return gem;
+inline uint32_t cmp_ge32(
+        const simd16uint16& d0,
+        const simd16uint16& d1,
+        const simd16uint16& thr) {
+    return detail::simdlib::cmp_xe32<&vcgeq_u16>(d0.data, d1.data, thr.data);
 }
 
-inline uint32_t cmp_le32(simd16uint16 d0, simd16uint16 d1, simd16uint16 thr) {
-    uint32_t gem = 0;
-    for (int j = 0; j < 16; j++) {
-        if (d0.u16[j] <= thr.u16[j]) {
-            gem |= 1 << j;
-        }
-        if (d1.u16[j] <= thr.u16[j]) {
-            gem |= 1 << (j + 16);
-        }
-    }
-    return gem;
+inline uint32_t cmp_le32(
+        const simd16uint16& d0,
+        const simd16uint16& d1,
+        const simd16uint16& thr) {
+    return detail::simdlib::cmp_xe32<&vcleq_u16>(d0.data, d1.data, thr.data);
 }
 
 // vector of 32 unsigned 8-bit integers
-struct simd32uint8 : simd256bit {
-    simd32uint8() {}
+struct simd32uint8 {
+    uint8x16x2_t data;
 
-    explicit simd32uint8(int x) {
-        set1(x);
+    simd32uint8() = default;
+
+    explicit simd32uint8(int x) : data{vdupq_n_u8(x), vdupq_n_u8(x)} {}
+
+    explicit simd32uint8(uint8_t x) : data{vdupq_n_u8(x), vdupq_n_u8(x)} {}
+
+    explicit simd32uint8(const uint8x16x2_t& v) : data{v} {}
+
+    template <
+            typename T,
+            typename std::enable_if<
+                    detail::simdlib::is_simd256bit<T>::value,
+                    std::nullptr_t>::type = nullptr>
+    explicit simd32uint8(const T& x)
+            : data{detail::simdlib::reinterpret_u8(x.data)} {}
+
+    explicit simd32uint8(const uint8_t* x)
+            : data{vld1q_u8(x), vld1q_u8(x + 16)} {}
+
+    void clear() {
+        detail::simdlib::set1(data, &vdupq_n_u8, static_cast<uint8_t>(0));
     }
 
-    explicit simd32uint8(uint8_t x) {
-        set1(x);
+    void storeu(uint8_t* ptr) const {
+        vst1q_u8(ptr, data.val[0]);
+        vst1q_u8(ptr + 16, data.val[1]);
     }
 
-    explicit simd32uint8(simd256bit x) : simd256bit(x) {}
+    void loadu(const uint8_t* ptr) {
+        data.val[0] = vld1q_u8(ptr);
+        data.val[1] = vld1q_u8(ptr + 16);
+    }
 
-    explicit simd32uint8(const uint8_t* x) : simd256bit((const void*)x) {}
+    void store(uint8_t* ptr) const {
+        storeu(ptr);
+    }
+
+    void bin(char bits[257]) const {
+        uint8_t bytes[32];
+        store(bytes);
+        detail::simdlib::bin(
+                const_cast<const char(&)[32]>(reinterpret_cast<char(&)[32]>(bytes)), bits);
+    }
+
+    std::string bin() const {
+        return detail::simdlib::bin(*this);
+    }
 
     std::string elements_to_string(const char* fmt) const {
-        char res[1000], *ptr = res;
-        for (int i = 0; i < 32; i++) {
-            ptr += sprintf(ptr, fmt, u8[i]);
-        }
-        // strip last ,
-        ptr[-1] = 0;
-        return std::string(res);
+        return detail::simdlib::elements_to_string<uint8_t, 32u>(fmt, *this);
     }
 
     std::string hex() const {
@@ -313,125 +467,123 @@ struct simd32uint8 : simd256bit {
     }
 
     void set1(uint8_t x) {
-        for (int j = 0; j < 32; j++) {
-            u8[j] = x;
-        }
+        detail::simdlib::set1(data, &vdupq_n_u8, x);
     }
 
-    static simd32uint8 binary_func(
-            simd32uint8 a,
-            simd32uint8 b,
-            std::function<uint8_t(uint8_t, uint8_t)> f) {
-        simd32uint8 c;
-        for (int j = 0; j < 32; j++) {
-            c.u8[j] = f(a.u8[j], b.u8[j]);
-        }
-        return c;
+    template <
+            typename T,
+            typename std::enable_if<
+                    detail::simdlib::is_simd256bit<T>::value,
+                    std::nullptr_t>::type = nullptr>
+    simd32uint8 operator&(const T& other) const {
+        return simd32uint8{detail::simdlib::binary_func(
+                data, detail::simdlib::reinterpret_u8(other.data), &vandq_u8)};
     }
 
-    simd32uint8 operator&(simd256bit other) const {
-        return binary_func(*this, simd32uint8(other), [](uint8_t a, uint8_t b) {
-            return a & b;
-        });
-    }
-
-    simd32uint8 operator+(simd32uint8 other) const {
-        return binary_func(
-                *this, other, [](uint8_t a, uint8_t b) { return a + b; });
+    simd32uint8 operator+(const simd32uint8& other) const {
+        return simd32uint8{
+                detail::simdlib::binary_func(data, other.data, &vaddq_u8)};
     }
 
     // The very important operation that everything relies on
-    simd32uint8 lookup_2_lanes(simd32uint8 idx) const {
-        simd32uint8 c;
-        for (int j = 0; j < 32; j++) {
-            if (idx.u8[j] & 0x80) {
-                c.u8[j] = 0;
-            } else {
-                uint8_t i = idx.u8[j] & 15;
-                if (j < 16) {
-                    c.u8[j] = u8[i];
-                } else {
-                    c.u8[j] = u8[16 + i];
-                }
-            }
-        }
-        return c;
+    simd32uint8 lookup_2_lanes(const simd32uint8& idx) const {
+        return simd32uint8{
+                detail::simdlib::binary_func(data, idx.data, &vqtbl1q_u8)};
     }
 
-    // extract + 0-extend lane
-    // this operation is slow (3 cycles)
-
-    simd32uint8 operator+=(simd32uint8 other) {
+    simd32uint8 operator+=(const simd32uint8& other) {
         *this = *this + other;
         return *this;
     }
 
     // for debugging only
     uint8_t operator[](int i) const {
-        return u8[i];
+        uint8_t tab[16];
+        const bool high = i >= 16;
+        vst1q_u8(tab, data.val[high]);
+        return tab[i - high * 16];
     }
 };
 
 // convert with saturation
 // careful: this does not cross lanes, so the order is weird
-inline simd32uint8 uint16_to_uint8_saturate(simd16uint16 a, simd16uint16 b) {
-    simd32uint8 c;
-
-    auto saturate_16_to_8 = [](uint16_t x) { return x >= 256 ? 0xff : x; };
-
-    for (int i = 0; i < 8; i++) {
-        c.u8[i] = saturate_16_to_8(a.u16[i]);
-        c.u8[8 + i] = saturate_16_to_8(b.u16[i]);
-        c.u8[16 + i] = saturate_16_to_8(a.u16[8 + i]);
-        c.u8[24 + i] = saturate_16_to_8(b.u16[8 + i]);
-    }
-    return c;
+inline simd32uint8 uint16_to_uint8_saturate(
+        const simd16uint16& a,
+        const simd16uint16& b) {
+    return simd32uint8{uint8x16x2_t{
+            vqmovn_high_u16(vqmovn_u16(a.data.val[0]), b.data.val[0]),
+            vqmovn_high_u16(vqmovn_u16(a.data.val[1]), b.data.val[1])}};
 }
 
 /// get most significant bit of each byte
-inline uint32_t get_MSBs(simd32uint8 a) {
-    uint32_t res = 0;
-    for (int i = 0; i < 32; i++) {
-        if (a.u8[i] & 0x80) {
-            res |= 1 << i;
-        }
-    }
-    return res;
+inline uint32_t get_MSBs(const simd32uint8& a) {
+    using detail::simdlib::vmovmask_u8;
+    return vmovmask_u8(a.data.val[0]) |
+            static_cast<uint32_t>(vmovmask_u8(a.data.val[1])) << 16u;
 }
 
 /// use MSB of each byte of mask to select a byte between a and b
-inline simd32uint8 blendv(simd32uint8 a, simd32uint8 b, simd32uint8 mask) {
-    simd32uint8 c;
-    for (int i = 0; i < 32; i++) {
-        if (mask.u8[i] & 0x80) {
-            c.u8[i] = b.u8[i];
-        } else {
-            c.u8[i] = a.u8[i];
-        }
-    }
-    return c;
+inline simd32uint8 blendv(
+        const simd32uint8& a,
+        const simd32uint8& b,
+        const simd32uint8& mask) {
+    const auto msb = vdupq_n_u8(0x80);
+    const uint8x16x2_t msb_mask = {
+            vtstq_u8(mask.data.val[0], msb), vtstq_u8(mask.data.val[1], msb)};
+    const uint8x16x2_t selected = {
+            vbslq_u8(msb_mask.val[0], a.data.val[0], b.data.val[0]),
+            vbslq_u8(msb_mask.val[1], a.data.val[1], b.data.val[1])};
+    return simd32uint8{selected};
 }
 
 /// vector of 8 unsigned 32-bit integers
-struct simd8uint32 : simd256bit {
-    simd8uint32() {}
+struct simd8uint32 {
+    uint32x4x2_t data;
 
-    explicit simd8uint32(uint32_t x) {
-        set1(x);
+    simd8uint32() = default;
+
+    explicit simd8uint32(uint32_t x) : data{vdupq_n_u32(x), vdupq_n_u32(x)} {}
+
+    explicit simd8uint32(const uint32x4x2_t& v) : data{v} {}
+
+    template <
+            typename T,
+            typename std::enable_if<
+                    detail::simdlib::is_simd256bit<T>::value,
+                    std::nullptr_t>::type = nullptr>
+    explicit simd8uint32(const T& x)
+            : data{detail::simdlib::reinterpret_u32(x.data)} {}
+
+    explicit simd8uint32(const uint8_t* x) : simd8uint32(simd32uint8(x)) {}
+
+    void clear() {
+        detail::simdlib::set1(data, &vdupq_n_u32, static_cast<uint32_t>(0));
     }
 
-    explicit simd8uint32(simd256bit x) : simd256bit(x) {}
+    void storeu(uint32_t* ptr) const {
+        vst1q_u32(ptr, data.val[0]);
+        vst1q_u32(ptr + 4, data.val[1]);
+    }
 
-    explicit simd8uint32(const uint8_t* x) : simd256bit((const void*)x) {}
+    void loadu(const uint32_t* ptr) {
+        data.val[0] = vld1q_u32(ptr);
+        data.val[1] = vld1q_u32(ptr + 4);
+    }
+
+    void store(uint32_t* ptr) const {
+        storeu(ptr);
+    }
+
+    void bin(char bits[257]) const {
+        detail::simdlib::bin<uint32_t, 8u>(*this, bits);
+    }
+
+    std::string bin() const {
+        return detail::simdlib::bin(*this);
+    }
 
     std::string elements_to_string(const char* fmt) const {
-        char res[1000], *ptr = res;
-        for (int i = 0; i < 8; i++) {
-            ptr += sprintf(ptr, fmt, u32[i]);
-        }
-        // strip last ,
-        ptr[-1] = 0;
-        return std::string(res);
+        return detail::simdlib::elements_to_string<uint32_t, 8u>(fmt, *this);
     }
 
     std::string hex() const {
@@ -443,121 +595,100 @@ struct simd8uint32 : simd256bit {
     }
 
     void set1(uint32_t x) {
-        for (int i = 0; i < 8; i++) {
-            u32[i] = x;
-        }
+        detail::simdlib::set1(data, &vdupq_n_u32, x);
     }
 };
 
-struct simd8float32 : simd256bit {
-    simd8float32() {}
+struct simd8float32 {
+    float32x4x2_t data;
 
-    explicit simd8float32(simd256bit x) : simd256bit(x) {}
+    simd8float32() = default;
 
-    explicit simd8float32(float x) {
-        set1(x);
+    explicit simd8float32(float x) : data{vdupq_n_f32(x), vdupq_n_f32(x)} {}
+
+    explicit simd8float32(const float32x4x2_t& v) : data{v} {}
+
+    template <
+            typename T,
+            typename std::enable_if<
+                    detail::simdlib::is_simd256bit<T>::value,
+                    std::nullptr_t>::type = nullptr>
+    explicit simd8float32(const T& x)
+            : data{detail::simdlib::reinterpret_f32(x.data)} {}
+
+    explicit simd8float32(const float* x)
+            : data{vld1q_f32(x), vld1q_f32(x + 4)} {}
+
+    void clear() {
+        detail::simdlib::set1(data, &vdupq_n_f32, 0.f);
     }
 
-    explicit simd8float32(const float* x) {
-        loadu((void*)x);
+    void storeu(float* ptr) const {
+        vst1q_f32(ptr, data.val[0]);
+        vst1q_f32(ptr + 4, data.val[1]);
     }
 
-    void set1(float x) {
-        for (int i = 0; i < 8; i++) {
-            f32[i] = x;
-        }
+    void loadu(const float* ptr) {
+        data.val[0] = vld1q_f32(ptr);
+        data.val[1] = vld1q_f32(ptr + 4);
     }
 
-    static simd8float32 binary_func(
-            simd8float32 a,
-            simd8float32 b,
-            std::function<float(float, float)> f) {
-        simd8float32 c;
-        for (int j = 0; j < 8; j++) {
-            c.f32[j] = f(a.f32[j], b.f32[j]);
-        }
-        return c;
+    void store(float* ptr) const {
+        storeu(ptr);
     }
 
-    simd8float32 operator*(simd8float32 other) const {
-        return binary_func(
-                *this, other, [](float a, float b) { return a * b; });
+    void bin(char bits[257]) const {
+        detail::simdlib::bin<float, 8u>(*this, bits);
     }
 
-    simd8float32 operator+(simd8float32 other) const {
-        return binary_func(
-                *this, other, [](float a, float b) { return a + b; });
+    std::string bin() const {
+        return detail::simdlib::bin(*this);
     }
 
-    simd8float32 operator-(simd8float32 other) const {
-        return binary_func(
-                *this, other, [](float a, float b) { return a - b; });
+    simd8float32 operator*(const simd8float32& other) const {
+        return simd8float32{
+                detail::simdlib::binary_func(data, other.data, &vmulq_f32)};
+    }
+
+    simd8float32 operator+(const simd8float32& other) const {
+        return simd8float32{
+                detail::simdlib::binary_func(data, other.data, &vaddq_f32)};
+    }
+
+    simd8float32 operator-(const simd8float32& other) const {
+        return simd8float32{
+                detail::simdlib::binary_func(data, other.data, &vsubq_f32)};
     }
 
     std::string tostring() const {
-        char res[1000], *ptr = res;
-        for (int i = 0; i < 8; i++) {
-            ptr += sprintf(ptr, "%g,", f32[i]);
-        }
-        // strip last ,
-        ptr[-1] = 0;
-        return std::string(res);
+        return detail::simdlib::elements_to_string<float, 8u>("%g,", *this);
     }
 };
 
 // hadd does not cross lanes
-inline simd8float32 hadd(simd8float32 a, simd8float32 b) {
-    simd8float32 c;
-    c.f32[0] = a.f32[0] + a.f32[1];
-    c.f32[1] = a.f32[2] + a.f32[3];
-    c.f32[2] = b.f32[0] + b.f32[1];
-    c.f32[3] = b.f32[2] + b.f32[3];
-
-    c.f32[4] = a.f32[4] + a.f32[5];
-    c.f32[5] = a.f32[6] + a.f32[7];
-    c.f32[6] = b.f32[4] + b.f32[5];
-    c.f32[7] = b.f32[6] + b.f32[7];
-
-    return c;
+inline simd8float32 hadd(const simd8float32& a, const simd8float32& b) {
+    return simd8float32{
+            detail::simdlib::binary_func(a.data, b.data, &vpaddq_f32)};
 }
 
-inline simd8float32 unpacklo(simd8float32 a, simd8float32 b) {
-    simd8float32 c;
-    c.f32[0] = a.f32[0];
-    c.f32[1] = b.f32[0];
-    c.f32[2] = a.f32[1];
-    c.f32[3] = b.f32[1];
-
-    c.f32[4] = a.f32[4];
-    c.f32[5] = b.f32[4];
-    c.f32[6] = a.f32[5];
-    c.f32[7] = b.f32[5];
-
-    return c;
+inline simd8float32 unpacklo(const simd8float32& a, const simd8float32& b) {
+    return simd8float32{
+            detail::simdlib::binary_func(a.data, b.data, &vzip1q_f32)};
 }
 
-inline simd8float32 unpackhi(simd8float32 a, simd8float32 b) {
-    simd8float32 c;
-    c.f32[0] = a.f32[2];
-    c.f32[1] = b.f32[2];
-    c.f32[2] = a.f32[3];
-    c.f32[3] = b.f32[3];
-
-    c.f32[4] = a.f32[6];
-    c.f32[5] = b.f32[6];
-    c.f32[6] = a.f32[7];
-    c.f32[7] = b.f32[7];
-
-    return c;
+inline simd8float32 unpackhi(const simd8float32& a, const simd8float32& b) {
+    return simd8float32{
+            detail::simdlib::binary_func(a.data, b.data, &vzip2q_f32)};
 }
 
 // compute a * b + c
-inline simd8float32 fmadd(simd8float32 a, simd8float32 b, simd8float32 c) {
-    simd8float32 res;
-    for (int i = 0; i < 8; i++) {
-        res.f32[i] = a.f32[i] * b.f32[i] + c.f32[i];
-    }
-    return res;
+inline simd8float32 fmadd(
+        const simd8float32& a,
+        const simd8float32& b,
+        const simd8float32& c) {
+    return simd8float32{float32x4x2_t{
+            vfmaq_f32(c.data.val[0], a.data.val[0], b.data.val[0]),
+            vfmaq_f32(c.data.val[1], a.data.val[1], b.data.val[1])}};
 }
 
 } // namespace faiss

--- a/faiss/utils/simdlib_neon.h
+++ b/faiss/utils/simdlib_neon.h
@@ -691,4 +691,32 @@ inline simd8float32 fmadd(
             vfmaq_f32(c.data.val[1], a.data.val[1], b.data.val[1])}};
 }
 
+namespace {
+
+// get even float32's of a and b, interleaved
+simd8float32 geteven(const simd8float32& a, const simd8float32& b) {
+    return simd8float32{float32x4x2_t{
+            vuzp1q_f32(a.data.val[0], b.data.val[0]),
+            vuzp1q_f32(a.data.val[1], b.data.val[1])}};
+}
+
+// get odd float32's of a and b, interleaved
+simd8float32 getodd(const simd8float32& a, const simd8float32& b) {
+    return simd8float32{float32x4x2_t{
+            vuzp2q_f32(a.data.val[0], b.data.val[0]),
+            vuzp2q_f32(a.data.val[1], b.data.val[1])}};
+}
+
+// 3 cycles
+// if the lanes are a = [a0 a1] and b = [b0 b1], return [a0 b0]
+simd8float32 getlow128(const simd8float32& a, const simd8float32& b) {
+    return simd8float32{float32x4x2_t{a.data.val[0], b.data.val[0]}};
+}
+
+simd8float32 gethigh128(const simd8float32& a, const simd8float32& b) {
+    return simd8float32{float32x4x2_t{a.data.val[1], b.data.val[1]}};
+}
+
+} // namespace
+
 } // namespace faiss

--- a/faiss/utils/simdlib_neon.h
+++ b/faiss/utils/simdlib_neon.h
@@ -447,7 +447,9 @@ struct simd32uint8 {
         uint8_t bytes[32];
         store(bytes);
         detail::simdlib::bin(
-                const_cast<const char(&)[32]>(reinterpret_cast<char(&)[32]>(bytes)), bits);
+                const_cast<const char(&)[32]>(
+                        reinterpret_cast<char(&)[32]>(bytes)),
+                bits);
     }
 
     std::string bin() const {


### PR DESCRIPTION
related: #1812 

This PR improves the performance of `IndexPQFastScan` and `IndexIVFPQFastScan` on aarch64 devices, e.g., 60x faster on an AWS Arm instance with the SIFT1M dataset.
The contents of this PR are below:

- Add `simdlib_neon.h`
    - `simdlib_neon.h` has `simdlib` compatible API, and they are implemented with Arm NEON intrinsics.
    - `simdlib.h` includes `simdlib_neon.h` if `__aarch64__` is defined.
- Move `geteven` , `getodd` , `getlow128` , and `gethigh128` from `distances_simd.cpp` to `simdlib_avx2.h` .
- Port `geteven` , `getodd` , `getlow128` , and `gethigh128` for non-AVX2 environments.
    - These codes are implemented with AVX2 intrinsics, so they have prevented to implement `compute_PQ_dis_tables_dsub2` for non-AVX2 environments.
    - Now `simdlib_avx2.h` , `simdlib_emulated.h` , and `simdlib_neon.h` all have those functions.
- Enable `compute_PQ_dis_tables_dsub2` on aarch64
    - Above change makes `compute_PQ_dis_tables_dsub2` independent from `geteven` and so on.
    - `compute_PQ_dis_tables_dsub2` implemented with `simdlib_neon.h` is little faster than current implementation, so enabling that.
        - In contrast, `compute_PQ_dis_tables_dsub2` implemented with `simdlib_emulated.h` is slower than current implementation, so we have not enabled it in our PR.