### PR TITLE
Update OSX version in CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
 
   build_osx:
     macos:
-      xcode: 11.6.0
+      xcode: 12.4.0
     environment:
       OMP_NUM_THREADS: 10
     steps:
@@ -231,7 +231,7 @@ jobs:
         type: string
         default: main
     macos:
-      xcode: 11.6.0
+      xcode: 12.4.0
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This should fix the HomeBrew failures we see.