### PR TITLE
Remove redundant c_api headers while installing

### DIFF
--- a/c_api/CMakeLists.txt
+++ b/c_api/CMakeLists.txt
@@ -31,11 +31,21 @@ set(FAISS_C_SRC
 add_library(faiss_c ${FAISS_C_SRC})
 target_link_libraries(faiss_c PRIVATE faiss)
 
-install(DIRECTORY ${PROJECT_SOURCE_DIR}
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/faiss
-        FILES_MATCHING
-        PATTERN "*.h"
-        PATTERN "gpu" EXCLUDE)
+function(faiss_install_headers headers p)
+  foreach(h ${headers})
+    get_filename_component(f ${h} DIRECTORY)
+    install(FILES ${h}
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/faiss/${p}/${f}
+    )
+  endforeach()
+endfunction()
+
+file(GLOB FAISS_C_API_HEADERS
+     RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+     "*.h"
+     "impl/*.h")
+
+faiss_install_headers("${FAISS_C_API_HEADERS}" c_api)
 
 add_executable(example_c EXCLUDE_FROM_ALL example_c.c)
 target_link_libraries(example_c PRIVATE faiss_c)

--- a/c_api/CMakeLists.txt
+++ b/c_api/CMakeLists.txt
@@ -30,12 +30,12 @@ set(FAISS_C_SRC
 )
 add_library(faiss_c ${FAISS_C_SRC})
 target_link_libraries(faiss_c PRIVATE faiss)
+
 install(DIRECTORY ${PROJECT_SOURCE_DIR}
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/faiss/c_api/
-        FILES_MATCHING PATTERN "*.h")
-install(DIRECTORY ${PROJECT_SOURCE_DIR}
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/faiss/c_api/impl/
-        FILES_MATCHING PATTERN "*.h")
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/faiss
+        FILES_MATCHING
+        PATTERN "*.h"
+        PATTERN "gpu" EXCLUDE)
 
 add_executable(example_c EXCLUDE_FROM_ALL example_c.c)
 target_link_libraries(example_c PRIVATE faiss_c)

--- a/c_api/gpu/CMakeLists.txt
+++ b/c_api/gpu/CMakeLists.txt
@@ -11,9 +11,9 @@ target_sources(faiss_c PRIVATE
   GpuResources_c.cpp
   StandardGpuResources_c.cpp
 )
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/faiss/c_api
-        FILES_MATCHING PATTERN "*.h")
+
+file(GLOB FAISS_C_API_GPU_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.h")
+faiss_install_headers("${FAISS_C_API_GPU_HEADERS}" c_api/gpu)
 
 find_package(CUDAToolkit REQUIRED)
 target_link_libraries(faiss_c PUBLIC CUDA::cudart CUDA::cublas)

--- a/c_api/gpu/CMakeLists.txt
+++ b/c_api/gpu/CMakeLists.txt
@@ -12,7 +12,7 @@ target_sources(faiss_c PRIVATE
   StandardGpuResources_c.cpp
 )
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/faiss/c_api/gpu/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/faiss/c_api
         FILES_MATCHING PATTERN "*.h")
 
 find_package(CUDAToolkit REQUIRED)


### PR DESCRIPTION
This diff is related to
#1722

File structure with `-DFAISS_ENABLE_GPU=OFF`
```
/usr/local/include/faiss/c_api
├── AutoTune_c.h
├── clone_index_c.h
├── Clustering_c.h
├── error_c.h
├── error_impl.h
├── faiss_c.h
├── impl
│   └── AuxIndexStructures_c.h
├── Index_c.h
├── index_factory_c.h
├── IndexFlat_c.h
├── index_io_c.h
├── IndexIVF_c.h
├── IndexIVFFlat_c.h
├── IndexLSH_c.h
├── IndexPreTransform_c.h
├── IndexScalarQuantizer_c.h
├── IndexShards_c.h
├── macros_impl.h
├── MetaIndexes_c.h
└── VectorTransform_c.h
```

File structure with `-DFAISS_ENABLE_GPU=ON`
```
/usr/local/include/faiss/c_api
├── AutoTune_c.h
├── clone_index_c.h
├── Clustering_c.h
├── error_c.h
├── error_impl.h
├── faiss_c.h
├── gpu
│   ├── DeviceUtils_c.h
│   ├── GpuAutoTune_c.h
│   ├── GpuClonerOptions_c.h
│   ├── GpuIndex_c.h
│   ├── GpuIndicesOptions_c.h
│   ├── GpuResources_c.h
│   ├── macros_impl.h
│   └── StandardGpuResources_c.h
├── impl
│   └── AuxIndexStructures_c.h
├── Index_c.h
├── index_factory_c.h
├── IndexFlat_c.h
├── index_io_c.h
├── IndexIVF_c.h
├── IndexIVFFlat_c.h
├── IndexLSH_c.h
├── IndexPreTransform_c.h
├── IndexScalarQuantizer_c.h
├── IndexShards_c.h
├── macros_impl.h
├── MetaIndexes_c.h
└── VectorTransform_c.h
```

