### PR TITLE
Fix CMakeLists for Residual quantizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ at the moment.
 - Serializing the indexes with the python pickle module
 - Support for the NNDescent k-NN graph building method
 - Support for the NSG graph indexing method
-- Begin support for residual quantizers
+- Residual quantizers: support as codec and unoptimized search
 
 ### Changed
 - The order of xb an xq was different between `faiss.knn` and `faiss.knn_gpu`.

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -33,6 +33,7 @@ set(FAISS_SRC
   IndexPreTransform.cpp
   IndexRefine.cpp
   IndexReplicas.cpp
+  IndexResidual.cpp
   IndexScalarQuantizer.cpp
   IndexShards.cpp
   MatrixStats.cpp

--- a/faiss/IndexResidual.cpp
+++ b/faiss/IndexResidual.cpp
@@ -104,7 +104,7 @@ void search_with_decompress(
     using SingleResultHandler = typename ResultHandler::SingleResultHandler;
 
 #pragma omp parallel for
-    for (size_t q = 0; q < res.nq; q++) {
+    for (int64_t q = 0; q < res.nq; q++) {
         SingleResultHandler resi(res);
         resi.begin(q);
         std::vector<float> tmp(ir.d);
@@ -191,7 +191,7 @@ void ResidualCoarseQuantizer::train(idx_t n, const float* x) {
     ntotal = (idx_t)1 << rq.tot_bits;
 }
 
-void ResidualCoarseQuantizer::add(idx_t, const float* ) {
+void ResidualCoarseQuantizer::add(idx_t, const float*) {
     FAISS_THROW_MSG("not applicable");
 }
 


### PR DESCRIPTION
Summary: Forgot to add the IndexResidual to the CMakeLists.txt

Differential Revision: D28024663

