### PR TITLE
Fix test failure in OSX with OpenMP called from multiple threads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,9 @@ jobs:
       OMP_NUM_THREADS: 10
     steps:
       - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "ea:af:e4:cc:96:1b:87:11:e2:88:88:80:8d:b4:cc:5c"
       - run:
           name: Install Homebrew packages
           command: |

--- a/faiss/IndexIVFPQR.h
+++ b/faiss/IndexIVFPQR.h
@@ -46,7 +46,7 @@ struct IndexIVFPQR : IndexIVFPQ {
             idx_t n,
             const float* x,
             const idx_t* xids,
-            const idx_t* precomputed_idx = nullptr);
+            const idx_t* precomputed_idx) override;
 
     void reconstruct_from_offset(int64_t list_no, int64_t offset, float* recons)
             const override;

--- a/tests/test_index_binary.py
+++ b/tests/test_index_binary.py
@@ -6,6 +6,7 @@
 """this is a basic test script for simple indices work"""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import sys
 import numpy as np
 import unittest
 import faiss

--- a/tests/test_index_binary.py
+++ b/tests/test_index_binary.py
@@ -351,6 +351,13 @@ class TestReplicasAndShards(unittest.TestCase):
 
         Dref, Iref = index_ref.search(xq, 10)
 
+        # there is a OpenMP bug in this configuration, so disable threading 
+        if sys.platform == "darwin" and "Clang 12" in sys.version: 
+            nthreads = faiss.omp_get_max_threads()
+            faiss.omp_set_num_threads(1)
+        else: 
+            nthreads = None
+        
         nrep = 5
         index = faiss.IndexBinaryReplicas()
         for _i in range(nrep):
@@ -371,6 +378,9 @@ class TestReplicasAndShards(unittest.TestCase):
         index2.add(xb)
         D2, I2 = index2.search(xq, 10)
 
+        if nthreads is not None: 
+            faiss.omp_set_num_threads(nthreads)
+        
         self.assertTrue((Dref == D2).all())
         self.assertTrue((Iref == I2).all())
 

--- a/tests/test_meta_index.py
+++ b/tests/test_meta_index.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 # translation of test_meta_index.lua
 
+import sys
 import numpy as np
 import faiss
 import unittest

--- a/tests/test_meta_index.py
+++ b/tests/test_meta_index.py
@@ -86,6 +86,13 @@ class Shards(unittest.TestCase):
         _Dref, Iref = ref_index.search(xq, k)
         print(Iref[:5, :6])
 
+        # there is a OpenMP bug in this configuration, so disable threading 
+        if sys.platform == "darwin" and "Clang 12" in sys.version: 
+            nthreads = faiss.omp_get_max_threads()
+            faiss.omp_set_num_threads(1)
+        else: 
+            nthreads = None
+        
         shard_index = faiss.IndexShards(d)
         shard_index_2 = faiss.IndexShards(d, True, False)
 
@@ -130,7 +137,9 @@ class Shards(unittest.TestCase):
 
             print('%d / %d differences' % (ndiff, nq * k))
             assert(ndiff < nq * k / 1000.)
-
+            
+        if nthreads is not None: 
+            faiss.omp_set_num_threads(nthreads)
 
 class Merge(unittest.TestCase):
 


### PR DESCRIPTION
Need to add an ssh key to the circleci to be able to debug

For my own ref, how to connect to the job: 
```
[matthijs@matthijs-mbp /Users/matthijs/Desktop/faiss_github/circleci_keys] ssh -p 54782 38.39.188.110 -i id_ed25519
```