### PR TITLE
IndexRefineFlat always owns refine index

### DIFF
--- a/c_api/IndexFlat_c.cpp
+++ b/c_api/IndexFlat_c.cpp
@@ -122,9 +122,6 @@ DEFINE_DESTRUCTOR(IndexRefineFlat)
 DEFINE_GETTER(IndexRefineFlat, int, own_fields)
 DEFINE_SETTER(IndexRefineFlat, int, own_fields)
 
-DEFINE_GETTER(IndexRefineFlat, int, own_refine_index)
-DEFINE_SETTER(IndexRefineFlat, int, own_refine_index)
-
 DEFINE_GETTER(IndexRefineFlat, float, k_factor)
 DEFINE_SETTER(IndexRefineFlat, float, k_factor)
 

--- a/c_api/IndexFlat_c.h
+++ b/c_api/IndexFlat_c.h
@@ -96,8 +96,6 @@ FAISS_DECLARE_DESTRUCTOR(IndexRefineFlat)
 
 FAISS_DECLARE_GETTER_SETTER(IndexRefineFlat, int, own_fields)
 
-FAISS_DECLARE_GETTER_SETTER(IndexRefineFlat, int, own_refine_index)
-
 /// factor between k requested in search and the k requested from
 /// the base_index (should be >= 1)
 FAISS_DECLARE_GETTER_SETTER(IndexRefineFlat, float, k_factor)


### PR DESCRIPTION
If own_refine_index = false
it's a memory leak

`IndexRefineFlat` always owns refine index
https://github.com/facebookresearch/faiss/blob/master/faiss/IndexRefine.cpp#L172
https://github.com/facebookresearch/faiss/blob/master/faiss/IndexRefine.cpp#L183