### PR TITLE
Fix Conda CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,9 +93,8 @@ jobs:
           name: Conda build
           command: |
             conda install -y -q conda-build
-            conda install -c pytorch pytorch
             cd conda
-            conda build faiss --python 3.7
+            conda build faiss --python 3.7 -c pytorch
 
   build_osx:
     macos:
@@ -158,9 +157,8 @@ jobs:
           name: Build/test
           command: |
             conda install conda-build
-            conda install -c pytorch pytorch
             cd conda
-            conda build faiss --python 3.7
+            conda build faiss --python 3.7 -c pytorch
 
   build_linux_gpu:
     machine:

--- a/conda/faiss/meta.yaml
+++ b/conda/faiss/meta.yaml
@@ -65,7 +65,7 @@ outputs:
         - make  # [not win]
       host:
         - python {{ python }}
-        - numpy >=1.11.*
+        - numpy 1.11.*
         - {{ pin_subpackage('libfaiss', exact=True) }}
       run:
         - python {{ python }}

--- a/conda/faiss/meta.yaml
+++ b/conda/faiss/meta.yaml
@@ -65,7 +65,7 @@ outputs:
         - make  # [not win]
       host:
         - python {{ python }}
-        - numpy 1.11.*
+        - numpy >=1.11.*
         - {{ pin_subpackage('libfaiss', exact=True) }}
       run:
         - python {{ python }}

--- a/conda/faiss/meta.yaml
+++ b/conda/faiss/meta.yaml
@@ -40,7 +40,7 @@ outputs:
       host:
         - mkl =2018
       run:
-        - mkl >=2018
+        - mkl >=2018,<2021
     test:
       commands:
         - test -f $PREFIX/lib/libfaiss$SHLIB_EXT       # [not win]


### PR DESCRIPTION
Currently CI jobs using conda are failed due to conflict packages.
This PR fixes this.

- use newer `numpy` to build `faiss-cpu`
- install `pytorch` when testing `faiss-cpu`
    - to find correct `pytorch` package, `pytorch` channel is set at `conda build`