### PR TITLE
Suppress -Wpedantic

### DIFF
--- a/faiss/IndexIVFSpectralHash.h
+++ b/faiss/IndexIVFSpectralHash.h
@@ -68,6 +68,6 @@ struct IndexIVFSpectralHash : IndexIVF {
     ~IndexIVFSpectralHash() override;
 };
 
-}; // namespace faiss
+} // namespace faiss
 
 #endif

--- a/faiss/impl/AuxIndexStructures.h
+++ b/faiss/impl/AuxIndexStructures.h
@@ -271,6 +271,6 @@ struct VisitedTable {
     }
 };
 
-}; // namespace faiss
+} // namespace faiss
 
 #endif

--- a/faiss/impl/lattice_Zn.h
+++ b/faiss/impl/lattice_Zn.h
@@ -183,6 +183,6 @@ struct ZnSphereCodecAlt : ZnSphereCodec {
     void decode(uint64_t code, float* c) const override;
 };
 
-}; // namespace faiss
+} // namespace faiss
 
 #endif


### PR DESCRIPTION
Current `faiss` contains some codes which will be warned by compilers when we will add some compile options like `-Wall -Wextra` .
IMHO, warning codes in `.cpp` and `.cu` doesn't need to be fixed if the policy of this project allows warning.
However, I think that it is better to fix the codes in `.h` and `.cuh` , which are also referenced by `faiss` users.

Currently it makes a error to `#include` some faiss headers like `#include<faiss/IndexHNSW.h>` when we compile the codes with `-pedantic-errors` .
This PR fix this problem.
In this PR, for the reasons above, we fixed `-Wpedantic` codes only in `.h` .

This PR doesn't change `faiss` behavior.