### PR TITLE
Add missing includes for std::min/std::max.

### DIFF
--- a/faiss/IndexResidual.cpp
+++ b/faiss/IndexResidual.cpp
@@ -8,6 +8,7 @@
 #include <faiss/IndexResidual.h>
 #include "faiss/utils/utils.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 

--- a/faiss/gpu/GpuIndex.cu
+++ b/faiss/gpu/GpuIndex.cu
@@ -11,6 +11,8 @@
 #include <faiss/gpu/utils/StaticUtils.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/gpu/utils/CopyUtils.cuh>
+
+#include <algorithm>
 #include <limits>
 #include <memory>
 

--- a/faiss/gpu/impl/DistanceUtils.cuh
+++ b/faiss/gpu/impl/DistanceUtils.cuh
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include <faiss/gpu/utils/Tensor.cuh>
 
 //

--- a/faiss/gpu/impl/IVFAppend.cu
+++ b/faiss/gpu/impl/IVFAppend.cu
@@ -16,6 +16,8 @@
 #include <faiss/gpu/utils/WarpPackedBits.cuh>
 #include <faiss/gpu/utils/WarpShuffles.cuh>
 
+#include <algorithm>
+
 namespace faiss {
 namespace gpu {
 

--- a/faiss/gpu/impl/IVFFlatScan.cu
+++ b/faiss/gpu/impl/IVFFlatScan.cu
@@ -20,6 +20,8 @@
 #include <faiss/gpu/utils/PtxUtils.cuh>
 #include <faiss/gpu/utils/Reductions.cuh>
 
+#include <algorithm>
+
 namespace faiss {
 namespace gpu {
 

--- a/faiss/gpu/impl/IVFUtils.cu
+++ b/faiss/gpu/impl/IVFUtils.cu
@@ -13,6 +13,8 @@
 #include <faiss/gpu/utils/Tensor.cuh>
 #include <faiss/gpu/utils/ThrustAllocator.cuh>
 
+#include <algorithm>
+
 namespace faiss {
 namespace gpu {
 

--- a/faiss/gpu/impl/L2Norm.cu
+++ b/faiss/gpu/impl/L2Norm.cu
@@ -16,6 +16,8 @@
 #include <faiss/gpu/utils/PtxUtils.cuh>
 #include <faiss/gpu/utils/Reductions.cuh>
 
+#include <algorithm>
+
 namespace faiss {
 namespace gpu {
 

--- a/faiss/gpu/impl/PQScanMultiPassPrecomputed.cu
+++ b/faiss/gpu/impl/PQScanMultiPassPrecomputed.cu
@@ -17,6 +17,8 @@
 #include <faiss/gpu/utils/LoadStoreOperators.cuh>
 #include <faiss/gpu/utils/MathOperators.cuh>
 #include <faiss/gpu/utils/WarpPackedBits.cuh>
+
+#include <algorithm>
 #include <limits>
 
 namespace faiss {

--- a/faiss/gpu/impl/VectorResidual.cu
+++ b/faiss/gpu/impl/VectorResidual.cu
@@ -13,6 +13,8 @@
 #include <faiss/gpu/utils/ConversionOperators.cuh>
 #include <faiss/gpu/utils/Tensor.cuh>
 
+#include <algorithm>
+
 namespace faiss {
 namespace gpu {
 


### PR DESCRIPTION
Closes #1876.