### PR TITLE
Add CUDA compute capability 8.6 for CUDA 11 packages.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,7 +324,7 @@ workflows:
       - deploy_linux_gpu:
           name: Linux GPU packages (CUDA 11.0)
           cuda: "11.0"
-          cuda_archs: "35;52;60;61;70;72;75;80"
+          cuda_archs: "60;61;70;72;75;80;86"
           filters:
             tags:
               only: /^v.*/
@@ -370,7 +370,7 @@ workflows:
       - deploy_linux_gpu:
           name: Linux GPU nightlies (CUDA 11.0)
           cuda: "11.0"
-          cuda_archs: "35;52;60;61;70;72;75;80"
+          cuda_archs: "60;61;70;72;75;80;86"
           label: nightly
       - deploy_windows:
           name: Windows nightlies


### PR DESCRIPTION
Also remove support for deprecated compute capabilities 3.5 and 5.2 in
CUDA 11.