### PR TITLE
Fix GPU nighties test

### DIFF
--- a/conda/faiss-gpu/meta.yaml
+++ b/conda/faiss-gpu/meta.yaml
@@ -76,6 +76,7 @@ outputs:
         - pytorch
       commands:
         - python -m unittest discover tests/
+        - cp tests/common_faiss_tests.py faiss/gpu/test
         - python -m unittest discover faiss/gpu/test/
         - sh test_cpu_dispatch.sh  # [linux]
       files:


### PR DESCRIPTION
This should fix the GPU nighties. 

The rationale for the cp is that there is a shared file between the CPU and GPU tests. 

Ideally, this file should probably moved to contrib at some point.