### PR TITLE
Add LocalSearchQuantizer (#1862)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project DOES NOT adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 at the moment.
 
+We try to indicate most contributions here with the contributor names who are not part of
+the Facebook Faiss team.  Feel free to add entries here if you submit a PR.
+
 ## [Unreleased]
 ### Added
 - Support for building C bindings through the `FAISS_ENABLE_C_API` CMake option.
 - Serializing the indexes with the python pickle module
-- Support for the NNDescent k-NN graph building method
-- Support for the NSG graph indexing method
+- Support for the NNDescent k-NN graph building method (by @KinglittleQ)
+- Support for the NSG graph indexing method (by @KinglittleQ)
 - Residual quantizers: support as codec and unoptimized search
+- Support for 4-bit PQ implementation for ARM (by @vorj, @n-miyamoto-fixstars, @LWisteria, and @matsui528)
+- Implementation of Local Search Quantization (by @KinglittleQ)
 
 ### Changed
 - The order of xb an xq was different between `faiss.knn` and `faiss.knn_gpu`.
 Also the metric argument was called distance_type.
 - The typed vectors (LongVector, LongLongVector, etc.) of the SWIG interface have
-been deprecated. They have been replaced with Int32Vector, Int64Vector, etc.
+been deprecated. They have been replaced with Int32Vector, Int64Vector, etc. (by h-vetinari)
 
 ### Fixed
 - Fixed a bug causing kNN search functions for IndexBinaryHash and

--- a/benchs/bench_quantizer.py
+++ b/benchs/bench_quantizer.py
@@ -1,0 +1,64 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+import faiss
+import time
+
+try:
+    from faiss.contrib.datasets_fb import DatasetSIFT1M
+except ImportError:
+    from faiss.contrib.datasets import DatasetSIFT1M
+
+
+def eval_codec(q, xb):
+    t0 = time.time()
+    codes = q.compute_codes(xb)
+    t1 = time.time()
+    decoded = q.decode(codes)
+    return ((xb - decoded) ** 2).sum() / xb.shape[0], t1 - t0
+
+
+def eval_quantizer(q, xb, xt, name):
+    t0 = time.time()
+    q.train(xt)
+    t1 = time.time()
+    train_t = t1 - t0
+    err, encode_t = eval_codec(q, xb)
+    print(f'===== {name}:')
+    print(f'\tmean square error = {err}')
+    print(f'\ttraining time: {train_t} s')
+    print(f'\tencoding time: {encode_t} s')
+
+
+todo = sys.argv[1:]
+ds = DatasetSIFT1M()
+
+xq = ds.get_queries()
+xb = ds.get_database()
+gt = ds.get_groundtruth()
+xt = ds.get_train()
+
+nb, d = xb.shape
+nq, d = xq.shape
+nt, d = xt.shape
+
+M = 8
+nbits = 8
+
+if 'lsq' in todo:
+    lsq = faiss.LocalSearchQuantizer(d, M, nbits)
+    lsq.log_level = 2  # show detailed training progress
+    eval_quantizer(lsq, xb, xt, 'lsq')
+
+if 'pq' in todo:
+    pq = faiss.ProductQuantizer(d, M, nbits)
+    eval_quantizer(pq, xb, xt, 'pq')
+
+if 'rq' in todo:
+    rq = faiss.ResidualQuantizer(d, M, nbits)
+    rq.train_type = faiss.ResidualQuantizer.Train_default
+    rq.verbose = True
+    eval_quantizer(rq, xb, xt, 'rq')

--- a/contrib/datasets.py
+++ b/contrib/datasets.py
@@ -122,7 +122,8 @@ for dataset_basedir in (
     if os.path.exists(dataset_basedir):
         break
 else:
-    dataset_basedir = None
+    # users can link their data directory to `./data`
+    dataset_basedir = 'data/'
 
 
 class DatasetSIFT1M(Dataset):

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -47,7 +47,9 @@ set(FAISS_SRC
   impl/NSG.cpp
   impl/PolysemousTraining.cpp
   impl/ProductQuantizer.cpp
+  impl/AdditiveQuantizer.cpp
   impl/ResidualQuantizer.cpp
+  impl/LocalSearchQuantizer.cpp
   impl/ScalarQuantizer.cpp
   impl/index_read.cpp
   impl/index_write.cpp
@@ -121,6 +123,9 @@ set(FAISS_HEADERS
   impl/PolysemousTraining.h
   impl/ProductQuantizer-inl.h
   impl/ProductQuantizer.h
+  impl/AdditiveQuantizer.h
+  impl/ResidualQuantizer.h
+  impl/LocalSearchQuantizer.h
   impl/ResultHandler.h
   impl/ScalarQuantizer.h
   impl/ThreadedIndex-inl.h

--- a/faiss/IndexResidual.cpp
+++ b/faiss/IndexResidual.cpp
@@ -262,7 +262,7 @@ void ResidualCoarseQuantizer::reconstruct(idx_t key, float* recons) const {
         int nbits = rq.nbits[m];
         idx_t l = key & ((idx_t(1) << nbits) - 1);
         key = key >> nbits;
-        const float* c = rq.centroids.data() + d * (rq.centroid_offsets[m] + l);
+        const float* c = rq.codebooks.data() + d * (rq.codebook_offsets[m] + l);
         if (m == 0) {
             memcpy(recons, c, sizeof(*c) * d);
         } else {

--- a/faiss/impl/AdditiveQuantizer.cpp
+++ b/faiss/impl/AdditiveQuantizer.cpp
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+#include <faiss/impl/AdditiveQuantizer.h>
+#include <faiss/impl/FaissAssert.h>
+
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <random>
+
+#include <algorithm>
+
+#include <faiss/utils/distances.h>
+#include <faiss/utils/hamming.h> // BitstringWriter
+#include <faiss/utils/utils.h>
+
+namespace {
+
+// c and a and b can overlap
+void fvec_add(size_t d, const float* a, const float* b, float* c) {
+    for (size_t i = 0; i < d; i++) {
+        c[i] = a[i] + b[i];
+    }
+}
+
+} // namespace
+
+namespace faiss {
+
+void AdditiveQuantizer::set_derived_values() {
+    tot_bits = 0;
+    is_byte_aligned = true;
+    codebook_offsets.resize(M + 1, 0);
+    for (int i = 0; i < M; i++) {
+        int nbit = nbits[i];
+        size_t k = 1 << nbit;
+        codebook_offsets[i + 1] = codebook_offsets[i] + k;
+        tot_bits += nbit;
+        if (nbit % 8 != 0) {
+            is_byte_aligned = false;
+        }
+    }
+    // convert bits to bytes
+    code_size = (tot_bits + 7) / 8;
+}
+
+void AdditiveQuantizer::pack_codes(
+        size_t n,
+        const int32_t* codes,
+        uint8_t* packed_codes,
+        int64_t ld_codes) const {
+    if (ld_codes == -1) {
+        ld_codes = M;
+    }
+#pragma omp parallel for if (n > 1000)
+    for (int64_t i = 0; i < n; i++) {
+        const int32_t* codes1 = codes + i * ld_codes;
+        BitstringWriter bsw(packed_codes + i * code_size, code_size);
+        for (int m = 0; m < M; m++) {
+            bsw.write(codes1[m], nbits[m]);
+        }
+    }
+}
+
+void AdditiveQuantizer::decode(const uint8_t* code, float* x, size_t n) const {
+    FAISS_THROW_IF_NOT_MSG(
+            is_trained, "The additive quantizer is not trained yet.");
+
+    // standard additive quantizer decoding
+#pragma omp parallel for if (n > 1000)
+    for (int64_t i = 0; i < n; i++) {
+        BitstringReader bsr(code + i * code_size, code_size);
+        float* xi = x + i * d;
+        for (int m = 0; m < M; m++) {
+            int idx = bsr.read(nbits[m]);
+            const float* c = codebooks.data() + d * (codebook_offsets[m] + idx);
+            if (m == 0) {
+                memcpy(xi, c, sizeof(*x) * d);
+            } else {
+                fvec_add(d, xi, c, xi);
+            }
+        }
+    }
+}
+
+AdditiveQuantizer::~AdditiveQuantizer() {}
+
+} // namespace faiss

--- a/faiss/impl/AdditiveQuantizer.h
+++ b/faiss/impl/AdditiveQuantizer.h
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace faiss {
+
+/** Abstract structure for additive quantizers
+ *
+ * Different from the product quantizer in which the decoded vector is the
+ * concatenation of M sub-vectors, additive quantizers sum M sub-vectors
+ * to get the decoded vector.
+ */
+struct AdditiveQuantizer {
+    size_t d;                     ///< size of the input vectors
+    size_t M;                     ///< number of codebooks
+    std::vector<size_t> nbits;    ///< bits for each step
+    std::vector<float> codebooks; ///< codebooks
+
+    // derived values
+    std::vector<size_t> codebook_offsets;
+    size_t code_size; ///< code size in bytes
+    size_t tot_bits;  ///< total number of bits
+    bool is_byte_aligned;
+
+    bool verbose;    ///< verbose during training?
+    bool is_trained; ///< is trained or not
+
+    ///< compute derived values when d, M and nbits have been set
+    void set_derived_values();
+
+    ///< Train the additive quantizer
+    virtual void train(size_t n, const float* x) = 0;
+
+    /** Encode a set of vectors
+     *
+     * @param x      vectors to encode, size n * d
+     * @param codes  output codes, size n * code_size
+     */
+    virtual void compute_codes(const float* x, uint8_t* codes, size_t n)
+            const = 0;
+
+    /** pack a series of code to bit-compact format
+     *
+     * @param codes  codes to be packed, size n * code_size
+     * @param packed_codes output bit-compact codes
+     * @param ld_codes  leading dimension of codes
+     */
+    void pack_codes(
+            size_t n,
+            const int32_t* codes,
+            uint8_t* packed_codes,
+            int64_t ld_codes = -1) const;
+
+    /** Decode a set of vectors
+     *
+     * @param codes  codes to decode, size n * code_size
+     * @param x      output vectors, size n * d
+     */
+    void decode(const uint8_t* codes, float* x, size_t n) const;
+
+    virtual ~AdditiveQuantizer();
+};
+
+}; // namespace faiss

--- a/faiss/impl/HNSW.h
+++ b/faiss/impl/HNSW.h
@@ -31,7 +31,7 @@ namespace faiss {
  *
  *  Yu. A. Malkov, D. A. Yashunin, arXiv 2017
  *
- * This implmentation is heavily influenced by the NMSlib
+ * This implementation is heavily influenced by the NMSlib
  * implementation by Yury Malkov and Leonid Boystov
  * (https://github.com/searchivarius/nmslib)
  *

--- a/faiss/impl/LocalSearchQuantizer.cpp
+++ b/faiss/impl/LocalSearchQuantizer.cpp
@@ -1,0 +1,672 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/LocalSearchQuantizer.h>
+
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <random>
+
+#include <algorithm>
+
+#include <faiss/utils/distances.h>
+#include <faiss/utils/hamming.h> // BitstringWriter
+#include <faiss/utils/utils.h>
+
+extern "C" {
+// LU decomoposition of a general matrix
+void sgetrf_(
+        FINTEGER* m,
+        FINTEGER* n,
+        float* a,
+        FINTEGER* lda,
+        FINTEGER* ipiv,
+        FINTEGER* info);
+
+// generate inverse of a matrix given its LU decomposition
+void sgetri_(
+        FINTEGER* n,
+        float* a,
+        FINTEGER* lda,
+        FINTEGER* ipiv,
+        float* work,
+        FINTEGER* lwork,
+        FINTEGER* info);
+
+// solves a system of linear equations
+void sgetrs_(
+        const char* trans,
+        FINTEGER* n,
+        FINTEGER* nrhs,
+        float* A,
+        FINTEGER* lda,
+        FINTEGER* ipiv,
+        float* b,
+        FINTEGER* ldb,
+        FINTEGER* info);
+
+// general matrix multiplication
+int sgemm_(
+        const char* transa,
+        const char* transb,
+        FINTEGER* m,
+        FINTEGER* n,
+        FINTEGER* k,
+        const float* alpha,
+        const float* a,
+        FINTEGER* lda,
+        const float* b,
+        FINTEGER* ldb,
+        float* beta,
+        float* c,
+        FINTEGER* ldc);
+}
+
+namespace {
+
+// c and a and b can overlap
+void fvec_add(size_t d, const float* a, const float* b, float* c) {
+    for (size_t i = 0; i < d; i++) {
+        c[i] = a[i] + b[i];
+    }
+}
+
+void fmat_inverse(float* a, int n) {
+    int info;
+    int lwork = n * n;
+    std::vector<int> ipiv(n);
+    std::vector<float> workspace(lwork);
+
+    sgetrf_(&n, &n, a, &n, ipiv.data(), &info);
+    FAISS_THROW_IF_NOT(info == 0);
+    sgetri_(&n, a, &n, ipiv.data(), workspace.data(), &lwork, &info);
+    FAISS_THROW_IF_NOT(info == 0);
+}
+
+void random_int32(
+        std::vector<int32_t>& x,
+        int32_t min,
+        int32_t max,
+        std::mt19937& gen) {
+    std::uniform_int_distribution<int32_t> distrib(min, max);
+    for (size_t i = 0; i < x.size(); i++) {
+        x[i] = distrib(gen);
+    }
+}
+
+} // anonymous namespace
+
+namespace faiss {
+
+LSQTimer lsq_timer;
+
+LocalSearchQuantizer::LocalSearchQuantizer(size_t d, size_t M, size_t nbits) {
+    FAISS_THROW_IF_NOT((M * nbits) % 8 == 0);
+
+    this->d = d;
+    this->M = M;
+    this->nbits = std::vector<size_t>(M, nbits);
+
+    // set derived values
+    set_derived_values();
+
+    is_trained = false;
+    verbose = false;
+
+    K = (1 << nbits);
+
+    train_iters = 25;
+    train_ils_iters = 8;
+    icm_iters = 4;
+
+    encode_ils_iters = 16;
+
+    p = 0.5f;
+    lambd = 1e-2f;
+
+    chunk_size = 10000;
+    nperts = 4;
+
+    random_seed = 0x12345;
+    std::srand(random_seed);
+}
+
+void LocalSearchQuantizer::train(size_t n, const float* x) {
+    FAISS_THROW_IF_NOT(K == (1 << nbits[0]));
+    FAISS_THROW_IF_NOT(nperts <= M);
+
+    lsq_timer.reset();
+    if (verbose) {
+        lsq_timer.start("train");
+        printf("Training LSQ, with %zd subcodes on %zd %zdD vectors\n",
+               M,
+               n,
+               d);
+    }
+
+    // allocate memory for codebooks, size [M, K, d]
+    codebooks.resize(M * K * d);
+
+    // randomly intialize codes
+    std::mt19937 gen(random_seed);
+    std::vector<int32_t> codes(n * M); // [n, M]
+    random_int32(codes, 0, K - 1, gen);
+
+    // compute standard derivations of each dimension
+    std::vector<float> stddev(d, 0);
+
+#pragma omp parallel for
+    for (int64_t i = 0; i < d; i++) {
+        float mean = 0;
+        for (size_t j = 0; j < n; j++) {
+            mean += x[j * d + i];
+        }
+        mean = mean / n;
+
+        float sum = 0;
+        for (size_t j = 0; j < n; j++) {
+            float xi = x[j * d + i] - mean;
+            sum += xi * xi;
+        }
+        stddev[i] = sqrtf(sum / n);
+    }
+
+    if (verbose) {
+        float obj = evaluate(codes.data(), x, n);
+        printf("Before training: obj = %lf\n", obj);
+    }
+
+    for (size_t i = 0; i < train_iters; i++) {
+        // 1. update codebooks given x and codes
+        // 2. add perturbation to codebooks (SR-D)
+        // 3. refine codes given x and codebooks using icm
+
+        // update codebooks
+        update_codebooks(x, codes.data(), n);
+
+        if (verbose) {
+            float obj = evaluate(codes.data(), x, n);
+            printf("iter %zd:\n", i);
+            printf("\tafter updating codebooks: obj = %lf\n", obj);
+        }
+
+        // SR-D: perturb codebooks
+        float T = pow((1.0f - (i + 1.0f) / train_iters), p);
+        perturb_codebooks(T, stddev, gen);
+
+        if (verbose) {
+            float obj = evaluate(codes.data(), x, n);
+            printf("\tafter perturbing codebooks: obj = %lf\n", obj);
+        }
+
+        // refine codes
+        icm_encode(x, codes.data(), n, train_ils_iters, gen);
+
+        if (verbose) {
+            float obj = evaluate(codes.data(), x, n);
+            printf("\tafter updating codes: obj = %lf\n", obj);
+        }
+    }
+
+    if (verbose) {
+        lsq_timer.end("train");
+        float obj = evaluate(codes.data(), x, n);
+        printf("After training: obj = %lf\n", obj);
+
+        printf("Time statistic:\n");
+        for (const auto& it : lsq_timer.duration) {
+            printf("\t%s time: %lf s\n", it.first.data(), it.second);
+        }
+    }
+
+    is_trained = true;
+}
+
+void LocalSearchQuantizer::perturb_codebooks(
+        float T,
+        const std::vector<float>& stddev,
+        std::mt19937& gen) {
+    lsq_timer.start("perturb_codebooks");
+
+    std::vector<std::normal_distribution<float>> distribs;
+    for (size_t i = 0; i < d; i++) {
+        distribs.emplace_back(0.0f, stddev[i]);
+    }
+
+    for (size_t m = 0; m < M; m++) {
+        for (size_t k = 0; k < K; k++) {
+            for (size_t i = 0; i < d; i++) {
+                codebooks[m * K * d + k * d + i] += T * distribs[i](gen) / M;
+            }
+        }
+    }
+
+    lsq_timer.end("perturb_codebooks");
+}
+
+void LocalSearchQuantizer::compute_codes(
+        const float* x,
+        uint8_t* codes_out,
+        size_t n) const {
+    FAISS_THROW_IF_NOT_MSG(is_trained, "LSQ is not trained yet.");
+    if (verbose) {
+        lsq_timer.reset();
+        printf("Encoding %zd vectors...\n", n);
+        lsq_timer.start("encode");
+    }
+
+    std::vector<int32_t> codes(n * M);
+    std::mt19937 gen(random_seed);
+    random_int32(codes, 0, K - 1, gen);
+
+    icm_encode(x, codes.data(), n, encode_ils_iters, gen);
+    pack_codes(n, codes.data(), codes_out);
+
+    if (verbose) {
+        lsq_timer.end("encode");
+        double t = lsq_timer.get("encode");
+        printf("Time to encode %zd vectors: %lf s\n", n, t);
+    }
+}
+
+/** update codebooks given x and codes
+ *
+ * Let B denote the sparse matrix of codes, size [n, M * K].
+ * Let C denote the codebooks, size [M * K, d].
+ * Let X denote the training vectors, size [n, d]
+ *
+ * objective function:
+ *     L = (X - BC)^2
+ *
+ * To minimize L, we have:
+ *     C = (B'B)^(-1)B'X
+ * where ' denote transposed
+ *
+ * Add a regularization term to make B'B inversible:
+ *     C = (B'B + lambd * I)^(-1)B'X
+ */
+void LocalSearchQuantizer::update_codebooks(
+        const float* x,
+        const int32_t* codes,
+        size_t n) {
+    lsq_timer.start("update_codebooks");
+
+    // allocate memory
+    // bb = B'B, bx = BX
+    std::vector<float> bb(M * K * M * K, 0.0f); // [M * K, M * K]
+    std::vector<float> bx(M * K * d, 0.0f);     // [M * K, d]
+
+    // compute B'B
+    for (size_t i = 0; i < n; i++) {
+        for (size_t m = 0; m < M; m++) {
+            int32_t code1 = codes[i * M + m];
+            int32_t idx1 = m * K + code1;
+            bb[idx1 * M * K + idx1] += 1;
+
+            for (size_t m2 = m + 1; m2 < M; m2++) {
+                int32_t code2 = codes[i * M + m2];
+                int32_t idx2 = m2 * K + code2;
+                bb[idx1 * M * K + idx2] += 1;
+                bb[idx2 * M * K + idx1] += 1;
+            }
+        }
+    }
+
+    // add a regularization term to B'B
+    for (int64_t i = 0; i < M * K; i++) {
+        bb[i * (M * K) + i] += lambd;
+    }
+
+    // compute (B'B)^(-1)
+    fmat_inverse(bb.data(), M * K); // [M*K, M*K]
+
+    // compute BX
+    for (size_t i = 0; i < n; i++) {
+        for (size_t m = 0; m < M; m++) {
+            int32_t code = codes[i * M + m];
+            float* data = bx.data() + (m * K + code) * d;
+            fvec_add(d, data, x + i * d, data);
+        }
+    }
+
+    // compute C = (B'B)^(-1) @ BX
+    //
+    // NOTE: LAPACK use column major order
+    // out = alpha * op(A) * op(B) + beta * C
+    FINTEGER nrows_A = d;
+    FINTEGER ncols_A = M * K;
+
+    FINTEGER nrows_B = M * K;
+    FINTEGER ncols_B = M * K;
+
+    float alpha = 1.0f;
+    float beta = 0.0f;
+    sgemm_("Not Transposed",
+           "Not Transposed",
+           &nrows_A, // nrows of op(A)
+           &ncols_B, // ncols of op(B)
+           &ncols_A, // ncols of op(A)
+           &alpha,
+           bx.data(),
+           &nrows_A, // nrows of A
+           bb.data(),
+           &nrows_B, // nrows of B
+           &beta,
+           codebooks.data(),
+           &nrows_A); // nrows of output
+
+    lsq_timer.end("update_codebooks");
+}
+
+/** encode using iterative conditional mode
+ *
+ * iterative conditional mode:
+ *     For every subcode ci (i = 1, ..., M) of a vector, we fix the other
+ *     subcodes cj (j != i) and then find the optimal value of ci such
+ *     that minimizing the objective function.
+
+ * objective function:
+ *     L = (X - \sum cj)^2, j = 1, ..., M
+ *     L = X^2 - 2X * \sum cj + (\sum cj)^2
+ *
+ * X^2 is negligable since it is the same for all possible value
+ * k of the m-th subcode.
+ *
+ * 2X * \sum cj is the unary term
+ * (\sum cj)^2 is the binary term
+ * These two terms can be precomputed and store in a look up table.
+ */
+void LocalSearchQuantizer::icm_encode(
+        const float* x,
+        int32_t* codes,
+        size_t n,
+        size_t ils_iters,
+        std::mt19937& gen) const {
+    lsq_timer.start("icm_encode");
+
+    std::vector<float> binaries(M * M * K * K); // [M, M, K, K]
+    compute_binary_terms(binaries.data());
+
+    const size_t n_chunks = (n + chunk_size - 1) / chunk_size;
+    for (size_t i = 0; i < n_chunks; i++) {
+        size_t ni = std::min(chunk_size, n - i * chunk_size);
+
+        if (verbose) {
+            printf("\r\ticm encoding %zd/%zd ...", i * chunk_size + ni, n);
+            fflush(stdout);
+            if (i == n_chunks - 1 || i == 0) {
+                printf("\n");
+            }
+        }
+
+        const float* xi = x + i * chunk_size * d;
+        int32_t* codesi = codes + i * chunk_size * M;
+        icm_encode_partial(i, xi, codesi, ni, binaries.data(), ils_iters, gen);
+    }
+
+    lsq_timer.end("icm_encode");
+}
+
+void LocalSearchQuantizer::icm_encode_partial(
+        size_t index,
+        const float* x,
+        int32_t* codes,
+        size_t n,
+        const float* binaries,
+        size_t ils_iters,
+        std::mt19937& gen) const {
+    std::vector<float> unaries(n * M * K); // [n, M, K]
+    compute_unary_terms(x, unaries.data(), n);
+
+    std::vector<int32_t> best_codes;
+    best_codes.assign(codes, codes + n * M);
+
+    std::vector<float> best_objs(n, 0.0f);
+    evaluate(codes, x, n, best_objs.data());
+
+    FAISS_THROW_IF_NOT(nperts <= M);
+    for (size_t iter1 = 0; iter1 < ils_iters; iter1++) {
+        // add perturbation to codes
+        perturb_codes(codes, n, gen);
+
+        for (size_t iter2 = 0; iter2 < icm_iters; iter2++) {
+            icm_encode_step(unaries.data(), binaries, codes, n);
+        }
+
+        std::vector<float> icm_objs(n, 0.0f);
+        evaluate(codes, x, n, icm_objs.data());
+        size_t n_betters = 0;
+        float mean_obj = 0.0f;
+
+        // select the best code for every vector xi
+#pragma omp parallel for reduction(+ : n_betters, mean_obj)
+        for (int64_t i = 0; i < n; i++) {
+            if (icm_objs[i] < best_objs[i]) {
+                best_objs[i] = icm_objs[i];
+                memcpy(best_codes.data() + i * M,
+                       codes + i * M,
+                       sizeof(int32_t) * M);
+                n_betters += 1;
+            }
+            mean_obj += best_objs[i];
+        }
+        mean_obj /= n;
+
+        memcpy(codes, best_codes.data(), sizeof(int32_t) * n * M);
+
+        if (verbose && index == 0) {
+            printf("\tils_iter %zd: obj = %lf, n_betters/n = %zd/%zd\n",
+                   iter1,
+                   mean_obj,
+                   n_betters,
+                   n);
+        }
+    } // loop ils_iters
+}
+
+void LocalSearchQuantizer::icm_encode_step(
+        const float* unaries,
+        const float* binaries,
+        int32_t* codes,
+        size_t n) const {
+    // condition on the m-th subcode
+    for (size_t m = 0; m < M; m++) {
+        std::vector<float> objs(n * K);
+#pragma omp parallel for
+        for (int64_t i = 0; i < n; i++) {
+            auto u = unaries + i * (M * K) + m * K;
+            memcpy(objs.data() + i * K, u, sizeof(float) * K);
+        }
+
+        // compute objective function by adding unary
+        // and binary terms together
+        for (size_t other_m = 0; other_m < M; other_m++) {
+            if (other_m == m) {
+                continue;
+            }
+
+#pragma omp parallel for
+            for (int64_t i = 0; i < n; i++) {
+                for (int32_t code = 0; code < K; code++) {
+                    int32_t code2 = codes[i * M + other_m];
+                    size_t binary_idx =
+                            m * M * K * K + other_m * K * K + code * K + code2;
+                    // binaries[m, other_m, code, code2]
+                    objs[i * K + code] += binaries[binary_idx];
+                }
+            }
+        }
+
+        // find the optimal value of the m-th subcode
+#pragma omp parallel for
+        for (int64_t i = 0; i < n; i++) {
+            float best_obj = HUGE_VALF;
+            int32_t best_code = 0;
+            for (size_t code = 0; code < K; code++) {
+                float obj = objs[i * K + code];
+                if (obj < best_obj) {
+                    best_obj = obj;
+                    best_code = code;
+                }
+            }
+            codes[i * M + m] = best_code;
+        }
+
+    } // loop M
+}
+
+void LocalSearchQuantizer::perturb_codes(
+        int32_t* codes,
+        size_t n,
+        std::mt19937& gen) const {
+    lsq_timer.start("perturb_codes");
+
+    std::uniform_int_distribution<size_t> m_distrib(0, M - 1);
+    std::uniform_int_distribution<int32_t> k_distrib(0, K - 1);
+
+    for (size_t i = 0; i < n; i++) {
+        for (size_t j = 0; j < nperts; j++) {
+            size_t m = m_distrib(gen);
+            codes[i * M + m] = k_distrib(gen);
+        }
+    }
+
+    lsq_timer.end("perturb_codes");
+}
+
+void LocalSearchQuantizer::compute_binary_terms(float* binaries) const {
+    lsq_timer.start("compute_binary_terms");
+
+#pragma omp parallel for
+    for (int64_t m12 = 0; m12 < M * M; m12++) {
+        size_t m1 = m12 / M;
+        size_t m2 = m12 % M;
+
+        for (size_t code1 = 0; code1 < K; code1++) {
+            for (size_t code2 = 0; code2 < K; code2++) {
+                const float* c1 = codebooks.data() + m1 * K * d + code1 * d;
+                const float* c2 = codebooks.data() + m2 * K * d + code2 * d;
+                float ip = fvec_inner_product(c1, c2, d);
+                // binaries[m1, m2, code1, code2] = ip * 2
+                binaries[m1 * M * K * K + m2 * K * K + code1 * K + code2] =
+                        ip * 2;
+            }
+        }
+    }
+
+    lsq_timer.end("compute_binary_terms");
+}
+
+void LocalSearchQuantizer::compute_unary_terms(
+        const float* x,
+        float* unaries,
+        size_t n) const {
+    lsq_timer.start("compute_unary_terms");
+
+    // compute x * codebooks^T
+    //
+    // NOTE: LAPACK use column major order
+    // out = alpha * op(A) * op(B) + beta * C
+    FINTEGER nrows_A = M * K;
+    FINTEGER ncols_A = d;
+
+    FINTEGER nrows_B = d;
+    FINTEGER ncols_B = n;
+
+    float alpha = -2.0f;
+    float beta = 0.0f;
+    sgemm_("Transposed",
+           "Not Transposed",
+           &nrows_A, // nrows of op(A)
+           &ncols_B, // ncols of op(B)
+           &ncols_A, // ncols of op(A)
+           &alpha,
+           codebooks.data(),
+           &ncols_A, // nrows of A
+           x,
+           &nrows_B, // nrows of B
+           &beta,
+           unaries,
+           &nrows_A); // nrows of output
+
+    std::vector<float> norms(M * K);
+    fvec_norms_L2sqr(norms.data(), codebooks.data(), d, M * K);
+
+#pragma omp parallel for
+    for (int64_t i = 0; i < n; i++) {
+        float* u = unaries + i * (M * K);
+        fvec_add(M * K, u, norms.data(), u);
+    }
+
+    lsq_timer.end("compute_unary_terms");
+}
+
+float LocalSearchQuantizer::evaluate(
+        const int32_t* codes,
+        const float* x,
+        size_t n,
+        float* objs) const {
+    lsq_timer.start("evaluate");
+
+    // decode
+    std::vector<float> decoded_x(n * d, 0.0f);
+    float obj = 0.0f;
+
+#pragma omp parallel for reduction(+ : obj)
+    for (int64_t i = 0; i < n; i++) {
+        const auto code = codes + i * M;
+        const auto decoded_i = decoded_x.data() + i * d;
+        for (size_t m = 0; m < M; m++) {
+            // c = codebooks[m, code[m]]
+            const auto c = codebooks.data() + m * K * d + code[m] * d;
+            fvec_add(d, decoded_i, c, decoded_i);
+        }
+
+        float err = fvec_L2sqr(x + i * d, decoded_i, d);
+        obj += err;
+
+        if (objs) {
+            objs[i] = err;
+        }
+    }
+
+    lsq_timer.end("evaluate");
+
+    obj = obj / n;
+    return obj;
+}
+
+double LSQTimer::get(const std::string& name) {
+    return duration[name];
+}
+
+void LSQTimer::start(const std::string& name) {
+    FAISS_THROW_IF_NOT_MSG(!started[name], " timer is already running");
+    started[name] = true;
+    t0[name] = getmillisecs();
+}
+
+void LSQTimer::end(const std::string& name) {
+    FAISS_THROW_IF_NOT_MSG(started[name], " timer is not running");
+    double t1 = getmillisecs();
+    double sec = (t1 - t0[name]) / 1000;
+    duration[name] += sec;
+    started[name] = false;
+}
+
+void LSQTimer::reset() {
+    duration.clear();
+    t0.clear();
+    started.clear();
+}
+
+} // namespace faiss

--- a/faiss/impl/LocalSearchQuantizer.h
+++ b/faiss/impl/LocalSearchQuantizer.h
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <faiss/impl/AdditiveQuantizer.h>
+#include <faiss/utils/utils.h>
+
+namespace faiss {
+
+/** Implementation of LSQ/LSQ++ described in the following two papers:
+ *
+ * Revisiting additive quantization
+ * Julieta Martinez, et al. ECCV 2016
+ *
+ * LSQ++: Lower running time and higher recall in multi-codebook quantization
+ * Julieta Martinez, et al. ECCV 2018
+ *
+ * This implementation is mostly translated from the Julia implementations
+ * by Julieta Martinez:
+ * (https://github.com/una-dinosauria/local-search-quantization,
+ *  https://github.com/una-dinosauria/Rayuela.jl)
+ *
+ * The trained codes are stored in `codebooks` which is called
+ * `centroids` in PQ and RQ.
+ */
+
+struct LocalSearchQuantizer : AdditiveQuantizer {
+    size_t K; ///< number of codes per codebook
+
+    size_t train_iters; ///< number of iterations in training
+
+    size_t encode_ils_iters; ///< iterations of local search in encoding
+    size_t train_ils_iters;  ///< iterations of local search in training
+    size_t icm_iters;        ///< number of iterations in icm
+
+    float p;     ///< temperature factor
+    float lambd; ///< regularization factor
+
+    size_t chunk_size; ///< nb of vectors to encode at a time
+
+    int random_seed; ///< seed for random generator
+    size_t nperts;   ///< number of perturbation in each code
+
+    LocalSearchQuantizer(
+            size_t d,      /* dimensionality of the input vectors */
+            size_t M,      /* number of subquantizers */
+            size_t nbits); /* number of bit per subvector index */
+
+    // Train the local search quantizer
+    void train(size_t n, const float* x) override;
+
+    /** Encode a set of vectors
+     *
+     * @param x      vectors to encode, size n * d
+     * @param codes  output codes, size n * code_size
+     */
+    void compute_codes(const float* x, uint8_t* codes, size_t n) const override;
+
+    /** Update codebooks given encodings
+     *
+     * @param x      training vectors, size n * d
+     * @param codes  encoded training vectors, size n * M
+     */
+    void update_codebooks(const float* x, const int32_t* codes, size_t n);
+
+    /** Encode vectors given codebooks using iterative conditional mode (icm).
+     *
+     * @param x      vectors to encode, size n * d
+     * @param codes  output codes, size n * M
+     * @param ils_iters number of iterations of iterative local search
+     */
+    void icm_encode(
+            const float* x,
+            int32_t* codes,
+            size_t n,
+            size_t ils_iters,
+            std::mt19937& gen) const;
+
+    void icm_encode_partial(
+            size_t index,
+            const float* x,
+            int32_t* codes,
+            size_t n,
+            const float* binaries,
+            size_t ils_iters,
+            std::mt19937& gen) const;
+
+    void icm_encode_step(
+            const float* unaries,
+            const float* binaries,
+            int32_t* codes,
+            size_t n) const;
+
+    /** Add some perturbation to codebooks
+     *
+     * @param T         temperature of simulated annealing
+     * @param stddev    standard derivations of each dimension in training data
+     */
+    void perturb_codebooks(
+            float T,
+            const std::vector<float>& stddev,
+            std::mt19937& gen);
+
+    /** Add some perturbation to codes
+     *
+     * @param codes codes to be perturbed, size n * M
+     */
+    void perturb_codes(int32_t* codes, size_t n, std::mt19937& gen) const;
+
+    /** Compute binary terms
+     *
+     * @param binaries binary terms, size M * M * K * K
+     */
+    void compute_binary_terms(float* binaries) const;
+
+    /** Compute unary terms
+     *
+     * @param x       vectors to encode, size n * d
+     * @param unaries unary terms, size n * M * K
+     */
+    void compute_unary_terms(const float* x, float* unaries, size_t n) const;
+
+    /** Helper function to compute reconstruction error
+     *
+     * @param x     vectors to encode, size n * d
+     * @param codes encoded codes, size n * M
+     * @param objs  if it is not null, store reconstruction
+                    error of each vector into it, size n
+     */
+    float evaluate(
+            const int32_t* codes,
+            const float* x,
+            size_t n,
+            float* objs = nullptr) const;
+};
+
+/** A helper struct to count consuming time during training.
+ *  It is NOT thread-safe.
+ */
+struct LSQTimer {
+    std::unordered_map<std::string, double> duration;
+    std::unordered_map<std::string, double> t0;
+    std::unordered_map<std::string, bool> started;
+
+    LSQTimer() {
+        reset();
+    }
+
+    double get(const std::string& name);
+
+    void start(const std::string& name);
+
+    void end(const std::string& name);
+
+    void reset();
+};
+
+FAISS_API extern LSQTimer lsq_timer; ///< timer to count consuming time
+
+} // namespace faiss

--- a/faiss/impl/NSG.h
+++ b/faiss/impl/NSG.h
@@ -31,7 +31,7 @@ namespace faiss {
  *
  *  Cong Fu, Chao Xiang, Changxu Wang, Deng Cai, VLDB 2019
  *
- * This implmentation is heavily influenced by the NSG
+ * This implementation is heavily influenced by the NSG
  * implementation by ZJULearning Group
  * (https://github.com/zjulearning/nsg)
  *

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -244,9 +244,10 @@ static void read_ResidualQuantizer(ResidualQuantizer* rq, IOReader* f) {
     READ1(rq->M);
     READVECTOR(rq->nbits);
     rq->set_derived_values();
+    READ1(rq->is_trained);
     READ1(rq->train_type);
     READ1(rq->max_beam_size);
-    READVECTOR(rq->centroids);
+    READVECTOR(rq->codebooks);
 }
 
 static void read_ScalarQuantizer(ScalarQuantizer* ivsc, IOReader* f) {

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -162,9 +162,10 @@ void write_ResidualQuantizer(const ResidualQuantizer* rq, IOWriter* f) {
     WRITE1(rq->d);
     WRITE1(rq->M);
     WRITEVECTOR(rq->nbits);
+    WRITE1(rq->is_trained);
     WRITE1(rq->train_type);
     WRITE1(rq->max_beam_size);
-    WRITEVECTOR(rq->centroids);
+    WRITEVECTOR(rq->codebooks);
 }
 
 static void write_ScalarQuantizer(const ScalarQuantizer* ivsc, IOWriter* f) {

--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -158,6 +158,7 @@ def handle_Quantizer(the_class):
 handle_Quantizer(ProductQuantizer)
 handle_Quantizer(ScalarQuantizer)
 handle_Quantizer(ResidualQuantizer)
+handle_Quantizer(LocalSearchQuantizer)
 
 
 def handle_NSG(the_class):

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -119,7 +119,9 @@ typedef uint64_t size_t;
 #include <faiss/utils/AlignedTable.h>
 #include <faiss/utils/partitioning.h>
 #include <faiss/impl/AuxIndexStructures.h>
-#include  <faiss/impl/ResidualQuantizer.h>
+#include <faiss/impl/AdditiveQuantizer.h>
+#include <faiss/impl/ResidualQuantizer.h>
+#include <faiss/impl/LocalSearchQuantizer.h>
 
 #include <faiss/invlists/BlockInvertedLists.h>
 
@@ -375,7 +377,9 @@ void gpu_sync_all_devices()
 %ignore faiss::ProductQuantizer::get_centroids(size_t,size_t) const;
 
 %include  <faiss/impl/ProductQuantizer.h>
+%include  <faiss/impl/AdditiveQuantizer.h>
 %include  <faiss/impl/ResidualQuantizer.h>
+%include  <faiss/impl/LocalSearchQuantizer.h>
 
 %include  <faiss/VectorTransform.h>
 %include  <faiss/IndexPreTransform.h>

--- a/tests/test_lsq.py
+++ b/tests/test_lsq.py
@@ -1,0 +1,310 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Tests for the implementation of Local Search Quantizer
+"""
+
+import numpy as np
+
+import faiss
+import unittest
+
+from faiss.contrib import datasets
+
+
+def construct_sparse_matrix(codes, K):
+    n, M = codes.shape
+    B = np.zeros((n, M * K), dtype=np.float32)
+    for i in range(n):
+        for j in range(M):
+            code = codes[i, j]
+            B[i, j * K + code] = 1
+    return B
+
+
+def update_codebooks_ref(x, codes, K, lambd):
+    n, d = x.shape
+    M = codes.shape[1]
+
+    B = construct_sparse_matrix(codes, K)
+    reg = np.identity(M * K) * float(lambd)
+    reg = reg.astype(np.float32)
+
+    # C = (B'B + lambd * I)^(-1)B'X
+    bb = np.linalg.inv(B.T @ B + reg)
+    C = bb @ B.T @ x
+    C = C.reshape(M, K, d)
+
+    return C
+
+
+def compute_binary_terms_ref(codebooks):
+    M, K, d = codebooks.shape
+
+    codebooks_t = np.swapaxes(codebooks, 1, 2)  # [M, d, K]
+    binaries = 2 * codebooks.dot(codebooks_t)   # [M, K, M, K]
+    binaries = np.swapaxes(binaries, 1, 2)      # [M, M, K, K]
+
+    return binaries
+
+
+def compute_unary_terms_ref(codebooks, x):
+    codebooks_t = np.swapaxes(codebooks, 1, 2)  # [M, d, K]
+    unaries = -2 * x.dot(codebooks_t)  # [n, M, K]
+
+    code_norms = np.sum(codebooks * codebooks, axis=2)  # [M, K]
+    unaries += code_norms
+
+    return unaries
+
+
+def icm_encode_step_ref(unaries, binaries, codes):
+    n, M, K = unaries.shape
+
+    for m in range(M):
+        objs = unaries[:, m].copy()  # [n, K]
+
+        for m2 in range(M):  # pair, m2 != m
+            if m2 == m:
+                continue
+
+            for i in range(n):
+                for code in range(K):
+                    code2 = codes[i, m2]
+                    objs[i, code] += binaries[m, m2, code, code2]
+
+        codes[:, m] = np.argmin(objs, axis=1)
+
+    return codes
+
+
+def decode_ref(x, codebooks, codes):
+    n, d = x.shape
+    _, M = codes.shape
+    decoded_x = np.zeros((n, d), dtype=np.float32)
+    for i in range(n):
+        for m in range(M):
+            decoded_x[i] += codebooks[m, codes[i, m]]
+
+    return decoded_x
+
+
+def icm_encode_ref(x, codebooks, codes):
+    n, d = x.shape
+    M, K, d = codebooks.shape
+
+    codes = codes.copy()
+    for m in range(M):
+        objs = np.zeros((n, K), dtype=np.float32)  # [n, K]
+        for code in range(K):
+            new_codes = codes.copy()
+            new_codes[:, m] = code
+
+            # decode x
+            decoded_x = decode_ref(x, codebooks, new_codes)
+            objs[:, code] = np.sum((x - decoded_x) ** 2, axis=1)
+
+        codes[:, m] = np.argmin(objs, axis=1)
+
+    return codes
+
+
+class TestComponents(unittest.TestCase):
+
+    def test_decode(self):
+        """Test LSQ decode"""
+        d = 16
+        n = 500
+        M = 4
+        nbits = 6
+        K = (1 << nbits)
+
+        rs = np.random.RandomState(123)
+        x = rs.rand(n, d).astype(np.float32)
+        codes = rs.randint(0, K, (n, M)).astype(np.int32)
+        lsq = faiss.LocalSearchQuantizer(d, M, nbits)
+        lsq.train(x)
+
+        # decode x
+        pack_codes = np.zeros((n, lsq.code_size)).astype(np.uint8)
+        decoded_x = np.zeros((n, d)).astype(np.float32)
+        lsq.pack_codes(n, faiss.swig_ptr(codes), faiss.swig_ptr(pack_codes))
+        lsq.decode_c(faiss.swig_ptr(pack_codes), faiss.swig_ptr(decoded_x), n)
+
+        # decode in Python
+        codebooks = faiss.vector_float_to_array(lsq.codebooks)
+        codebooks = codebooks.reshape(M, K, d).copy()
+        decoded_x_ref = decode_ref(x, codebooks, codes)
+
+        np.testing.assert_allclose(decoded_x, decoded_x_ref, rtol=1e-6)
+
+    def test_update_codebooks(self):
+        """Test codebooks updatation."""
+        d = 16
+        n = 500
+        M = 4
+        nbits = 6
+        K = (1 << nbits)
+
+        # set a larger value to make the updating process more stable
+        lambd = 1e-2
+
+        rs = np.random.RandomState(123)
+        x = rs.rand(n, d).astype(np.float32)
+        codes = rs.randint(0, K, (n, M)).astype(np.int32)
+
+        lsq = faiss.LocalSearchQuantizer(d, M, nbits)
+        lsq.lambd = lambd
+        lsq.train(x)  # just for allocating memory for codebooks
+
+        codebooks = faiss.vector_float_to_array(lsq.codebooks)
+        codebooks = codebooks.reshape(M, K, d).copy()
+
+        lsq.update_codebooks(faiss.swig_ptr(x), faiss.swig_ptr(codes), n)
+        new_codebooks = faiss.vector_float_to_array(lsq.codebooks)
+        new_codebooks = new_codebooks.reshape(M, K, d).copy()
+
+        ref_codebooks = update_codebooks_ref(x, codes, K, lambd)
+
+        np.testing.assert_allclose(new_codebooks, ref_codebooks, atol=1e-3)
+
+    def test_compute_binary_terms(self):
+        d = 16
+        n = 500
+        M = 4
+        nbits = 6
+        K = (1 << nbits)
+
+        rs = np.random.RandomState(123)
+        x = rs.rand(n, d).astype(np.float32)
+        binaries = np.zeros((M, M, K, K)).astype(np.float32)
+
+        lsq = faiss.LocalSearchQuantizer(d, M, nbits)
+        lsq.train(x)  # just for allocating memory for codebooks
+
+        lsq.compute_binary_terms(faiss.swig_ptr(binaries))
+
+        codebooks = faiss.vector_float_to_array(lsq.codebooks)
+        codebooks = codebooks.reshape(M, K, d).copy()
+        ref_binaries = compute_binary_terms_ref(codebooks)
+
+        np.testing.assert_allclose(binaries, ref_binaries, atol=1e-4)
+
+    def test_compute_unary_terms(self):
+        d = 16
+        n = 500
+        M = 4
+        nbits = 6
+        K = (1 << nbits)
+
+        rs = np.random.RandomState(123)
+        x = rs.rand(n, d).astype(np.float32)
+        unaries = np.zeros((n, M, K)).astype(np.float32)
+
+        lsq = faiss.LocalSearchQuantizer(d, M, nbits)
+        lsq.train(x)  # just for allocating memory for codebooks
+
+        lsq.compute_unary_terms(faiss.swig_ptr(x), faiss.swig_ptr(unaries), n)
+
+        codebooks = faiss.vector_float_to_array(lsq.codebooks)
+        codebooks = codebooks.reshape(M, K, d).copy()
+        ref_unaries = compute_unary_terms_ref(codebooks, x)
+
+        np.testing.assert_allclose(unaries, ref_unaries, atol=1e-4)
+
+    def test_icm_encode_step(self):
+        d = 16
+        n = 500
+        M = 4
+        nbits = 6
+        K = (1 << nbits)
+
+        rs = np.random.RandomState(123)
+
+        # randomly generate codes, binary terms and unary terms
+        codes = rs.randint(0, K, (n, M)).astype(np.int32)
+        new_codes = codes.copy()
+        unaries = rs.rand(n, M, K).astype(np.float32)
+        binaries = rs.rand(M, M, K, K).astype(np.float32)
+
+        # do icm encoding given binary and unary terms
+        lsq = faiss.LocalSearchQuantizer(d, M, nbits)
+        lsq.icm_encode_step(
+            faiss.swig_ptr(unaries),
+            faiss.swig_ptr(binaries),
+            faiss.swig_ptr(new_codes), n)
+
+        # do icm encoding given binary and unary terms in Python
+        ref_codes = icm_encode_step_ref(unaries, binaries, codes)
+        np.testing.assert_array_equal(new_codes, ref_codes)
+
+    def test_icm_encode(self):
+        d = 16
+        n = 500
+        M = 4
+        nbits = 4
+        K = (1 << nbits)
+
+        rs = np.random.RandomState(123)
+        x = rs.rand(n, d).astype(np.float32)
+
+        lsq = faiss.LocalSearchQuantizer(d, M, nbits)
+        lsq.train(x)  # just for allocating memory for codebooks
+
+        # compute binary terms
+        binaries = np.zeros((M, M, K, K)).astype(np.float32)
+        lsq.compute_binary_terms(faiss.swig_ptr(binaries))
+
+        # compute unary terms
+        unaries = np.zeros((n, M, K)).astype(np.float32)
+        lsq.compute_unary_terms(faiss.swig_ptr(x), faiss.swig_ptr(unaries), n)
+
+        # randomly generate codes
+        codes = rs.randint(0, K, (n, M)).astype(np.int32)
+        new_codes = codes.copy()
+
+        # do icm encoding given binary and unary terms
+        lsq.icm_encode_step(
+            faiss.swig_ptr(unaries),
+            faiss.swig_ptr(binaries),
+            faiss.swig_ptr(new_codes), n)
+
+        # do icm encoding without pre-computed unary and bianry terms in Python
+        codebooks = faiss.vector_float_to_array(lsq.codebooks)
+        codebooks = codebooks.reshape(M, K, d).copy()
+        ref_codes = icm_encode_ref(x, codebooks, codes)
+
+        np.testing.assert_array_equal(new_codes, ref_codes)
+
+
+def eval_codec(q, xb):
+    codes = q.compute_codes(xb)
+    decoded = q.decode(codes)
+    return ((xb - decoded) ** 2).sum()
+
+
+class TestLocalSearchQuantizer(unittest.TestCase):
+
+    def test_training(self):
+        """check that the error is in the same ballpark as PQ."""
+        ds = datasets.SyntheticDataset(32, 3000, 3000, 0)
+
+        xt = ds.get_train()
+        xb = ds.get_database()
+
+        M = 4
+        nbits = 4
+
+        lsq = faiss.LocalSearchQuantizer(ds.d, M, nbits)
+        lsq.train(xt)
+        err_lsq = eval_codec(lsq, xb)
+
+        pq = faiss.ProductQuantizer(ds.d, M, nbits)
+        pq.train(xt)
+        err_pq = eval_codec(pq, xb)
+
+        print(err_lsq, err_pq)
+        self.assertLess(err_lsq, err_pq)


### PR DESCRIPTION
Summary:
This PR implemented LSQ/LSQ++, a vector quantization technique described in the following two papers:

1. Revisiting additive quantization
2. LSQ++: Lower running time and higher recall in multi-codebook quantization

Here is a benchmark running on SIFT1M for 64 bits encoding:
```
===== lsq:
        mean square error = 17335.390208
        training time: 312.729779958725 s
        encoding time: 244.6277096271515 s
===== pq:
        mean square error = 23743.004672
        training time: 1.1610801219940186 s
        encoding time: 2.636141061782837 s
===== rq:
        mean square error = 20999.737344
        training time: 31.813055515289307 s
        encoding time: 307.51959800720215 s
```

Changes:

1. Add LocalSearchQuantizer object
2. Fix an out of memory bug in ResidualQuantizer
3. Add a benchmark for evaluating quantizers
4. Add tests for LocalSearchQuantizer

Pull Request resolved: https://github.com/facebookresearch/faiss/pull/1862

Test Plan:
```
buck test //faiss/tests/:test_lsq

buck run mode/opt //faiss/benchs/:bench_quantizer -- lsq pq rq
```

Reviewed By: beauby

Differential Revision: D28376369

Pulled By: mdouze

