### PR TITLE
Conda for aarch64-linux

### DIFF
--- a/conda/Dockerfile.cpu.aarch64
+++ b/conda/Dockerfile.cpu.aarch64
@@ -1,0 +1,19 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+FROM nvidia/cuda:10.2-devel-ubuntu18.04
+
+RUN apt-get update && apt-get install -y wget git
+
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+        bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda3
+ENV PATH="/root/miniconda3/condabin:${PATH}"
+
+RUN conda install conda-build
+
+COPY ./ faiss
+WORKDIR /faiss/conda
+
+RUN conda build faiss --no-anaconda-upload -c pytorch

--- a/conda/Dockerfile.cpu.aarch64
+++ b/conda/Dockerfile.cpu.aarch64
@@ -3,17 +3,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-FROM nvidia/cuda:10.2-devel-ubuntu18.04
+FROM condaforge/miniforge3
 
 RUN apt-get update && apt-get install -y wget git
-
-RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-        bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda3
-ENV PATH="/root/miniconda3/condabin:${PATH}"
 
 RUN conda install conda-build
 
 COPY ./ faiss
 WORKDIR /faiss/conda
 
-RUN conda build faiss --no-anaconda-upload -c pytorch
+RUN conda build faiss-aarch64 --no-anaconda-upload -c pytorch

--- a/conda/faiss-aarch64/build-lib.sh
+++ b/conda/faiss-aarch64/build-lib.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+
+
+# Build libfaiss.so/libfaiss_avx2.so.
+cmake -B _build \
+      -DBUILD_SHARED_LIBS=ON \
+      -DBUILD_TESTING=OFF \
+      -DFAISS_OPT_LEVEL=avx2 \
+      -DFAISS_ENABLE_GPU=OFF \
+      -DFAISS_ENABLE_PYTHON=OFF \
+      -DBLA_VENDOR=Intel10_64lp \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DCMAKE_BUILD_TYPE=Release .
+
+make -C _build -j $CPU_COUNT faiss faiss_avx2
+
+cmake --install _build --prefix $PREFIX
+cmake --install _build --prefix _libfaiss_stage/

--- a/conda/faiss-aarch64/build-lib.sh
+++ b/conda/faiss-aarch64/build-lib.sh
@@ -13,7 +13,6 @@ cmake -B _build \
       -DBUILD_TESTING=OFF \
       -DFAISS_ENABLE_GPU=OFF \
       -DFAISS_ENABLE_PYTHON=OFF \
-      -DBLA_VENDOR=Intel10_64lp \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DCMAKE_BUILD_TYPE=Release .
 

--- a/conda/faiss-aarch64/build-lib.sh
+++ b/conda/faiss-aarch64/build-lib.sh
@@ -7,18 +7,17 @@
 set -e
 
 
-# Build libfaiss.so/libfaiss_avx2.so.
+# Build libfaiss.so.
 cmake -B _build \
       -DBUILD_SHARED_LIBS=ON \
       -DBUILD_TESTING=OFF \
-      -DFAISS_OPT_LEVEL=avx2 \
       -DFAISS_ENABLE_GPU=OFF \
       -DFAISS_ENABLE_PYTHON=OFF \
       -DBLA_VENDOR=Intel10_64lp \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DCMAKE_BUILD_TYPE=Release .
 
-make -C _build -j $CPU_COUNT faiss faiss_avx2
+make -C _build -j $CPU_COUNT faiss
 
 cmake --install _build --prefix $PREFIX
 cmake --install _build --prefix _libfaiss_stage/

--- a/conda/faiss-aarch64/build-pkg.sh
+++ b/conda/faiss-aarch64/build-pkg.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+
+
+# Build swigfaiss.so/swigfaiss_avx2.so.
+cmake -B _build_python_${PY_VER} \
+      -Dfaiss_ROOT=_libfaiss_stage/ \
+      -DFAISS_OPT_LEVEL=avx2 \
+      -DFAISS_ENABLE_GPU=OFF \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DPython_EXECUTABLE=$PYTHON \
+      faiss/python
+
+make -C _build_python_${PY_VER} -j $CPU_COUNT swigfaiss swigfaiss_avx2
+
+# Build actual python module.
+cd _build_python_${PY_VER}/
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt --prefix=$PREFIX

--- a/conda/faiss-aarch64/build-pkg.sh
+++ b/conda/faiss-aarch64/build-pkg.sh
@@ -7,16 +7,15 @@
 set -e
 
 
-# Build swigfaiss.so/swigfaiss_avx2.so.
+# Build swigfaiss.so.
 cmake -B _build_python_${PY_VER} \
       -Dfaiss_ROOT=_libfaiss_stage/ \
-      -DFAISS_OPT_LEVEL=avx2 \
       -DFAISS_ENABLE_GPU=OFF \
       -DCMAKE_BUILD_TYPE=Release \
       -DPython_EXECUTABLE=$PYTHON \
       faiss/python
 
-make -C _build_python_${PY_VER} -j $CPU_COUNT swigfaiss swigfaiss_avx2
+make -C _build_python_${PY_VER} -j $CPU_COUNT swigfaiss
 
 # Build actual python module.
 cd _build_python_${PY_VER}/

--- a/conda/faiss-aarch64/install-cmake.sh
+++ b/conda/faiss-aarch64/install-cmake.sh
@@ -1,0 +1,10 @@
+#!/bin/sh#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+
+wget -O - https://github.com/Kitware/CMake/releases/download/v3.17.1/cmake-3.17.1-Linux-x86_64.tar.gz | tar xzf -
+cp -R cmake-3.17.1-Linux-x86_64/* $PREFIX

--- a/conda/faiss-aarch64/install-cmake.sh
+++ b/conda/faiss-aarch64/install-cmake.sh
@@ -6,5 +6,5 @@
 
 set -e
 
-wget -O - https://github.com/Kitware/CMake/releases/download/v3.17.1/cmake-3.17.1-Linux-x86_64.tar.gz | tar xzf -
-cp -R cmake-3.17.1-Linux-x86_64/* $PREFIX
+wget -O - https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2-linux-aarch64.tar.gz | tar xzf -
+cp -R cmake-3.20.2-linux-aarch64/* $PREFIX

--- a/conda/faiss-aarch64/meta.yaml
+++ b/conda/faiss-aarch64/meta.yaml
@@ -61,6 +61,7 @@ outputs:
       host:
         - python {{ python }}
         - numpy =1.11
+        - openblas =*=openmp*
         - {{ pin_subpackage('libfaiss', exact=True) }}
       run:
         - python {{ python }}

--- a/conda/faiss-aarch64/meta.yaml
+++ b/conda/faiss-aarch64/meta.yaml
@@ -38,9 +38,9 @@ outputs:
         - cmake >=3.17
         - make  # [not win]
       host:
-        - mkl =2018
+        - openblas =*=openmp*
       run:
-        - mkl >=2018
+        - openblas =*=openmp*
     test:
       commands:
         - test -f $PREFIX/lib/libfaiss$SHLIB_EXT       # [not win]

--- a/conda/faiss-aarch64/meta.yaml
+++ b/conda/faiss-aarch64/meta.yaml
@@ -44,7 +44,6 @@ outputs:
     test:
       commands:
         - test -f $PREFIX/lib/libfaiss$SHLIB_EXT       # [not win]
-        - test -f $PREFIX/lib/libfaiss_avx2$SHLIB_EXT  # [not win]
         - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
         - conda inspect objects -p $PREFIX $PKG_NAME   # [osx]
 

--- a/conda/faiss-aarch64/meta.yaml
+++ b/conda/faiss-aarch64/meta.yaml
@@ -26,7 +26,7 @@ source:
 outputs:
   - name: libfaiss
     script: build-lib.sh   # [not win]
-    script: build-lib.bat  # [win]
+#    script: build-lib.bat  # [win]
     build:
       string: "h{{ PKG_HASH }}_{{ number }}_cpu"
       run_exports:
@@ -49,7 +49,7 @@ outputs:
 
   - name: faiss-cpu
     script: build-pkg.sh   # [not win]
-    script: build-pkg.bat  # [win]
+#    script: build-pkg.bat  # [win]
     build:
       string: "py{{ PY_VER }}_h{{ PKG_HASH }}_{{ number }}_cpu"
     requirements:

--- a/conda/faiss-aarch64/meta.yaml
+++ b/conda/faiss-aarch64/meta.yaml
@@ -70,10 +70,8 @@ outputs:
       requires:
         - numpy
         - scipy
-        - pytorch
       commands:
         - python -X faulthandler -m unittest discover -v -s tests -p "test_*"
-        - python -X faulthandler -m unittest discover -v -s tests -p "torch_*"
         - sh test_cpu_dispatch.sh  # [linux]
       files:
         - test_cpu_dispatch.sh  # [linux]

--- a/conda/faiss-aarch64/meta.yaml
+++ b/conda/faiss-aarch64/meta.yaml
@@ -34,7 +34,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('cxx') }}
-        - llvm-openmp  # [osx]
+#        - llvm-openmp  # [osx]
         - cmake >=3.17
         - make  # [not win]
       host:
@@ -45,7 +45,7 @@ outputs:
       commands:
         - test -f $PREFIX/lib/libfaiss$SHLIB_EXT       # [not win]
         - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
-        - conda inspect objects -p $PREFIX $PKG_NAME   # [osx]
+#        - conda inspect objects -p $PREFIX $PKG_NAME   # [osx]
 
   - name: faiss-cpu
     script: build-pkg.sh   # [not win]

--- a/conda/faiss-aarch64/meta.yaml
+++ b/conda/faiss-aarch64/meta.yaml
@@ -1,0 +1,82 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+{% set version = environ.get('GIT_DESCRIBE_TAG').lstrip('v') %}
+{% set number = GIT_DESCRIBE_NUMBER %}
+
+package:
+  name: faiss-pkg
+  version: {{ version }}
+
+build:
+  number: {{ number }}
+
+about:
+  home: https://github.com/facebookresearch/faiss
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: A library for efficient similarity search and clustering of dense vectors.
+
+source:
+  git_url: ../../
+
+outputs:
+  - name: libfaiss
+    script: build-lib.sh   # [not win]
+    script: build-lib.bat  # [win]
+    build:
+      string: "h{{ PKG_HASH }}_{{ number }}_cpu"
+      run_exports:
+        - {{ pin_compatible('libfaiss', exact=True) }}
+    requirements:
+      build:
+        - {{ compiler('cxx') }}
+        - llvm-openmp  # [osx]
+        - cmake >=3.17
+        - make  # [not win]
+      host:
+        - mkl =2018
+      run:
+        - mkl >=2018
+    test:
+      commands:
+        - test -f $PREFIX/lib/libfaiss$SHLIB_EXT       # [not win]
+        - test -f $PREFIX/lib/libfaiss_avx2$SHLIB_EXT  # [not win]
+        - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+        - conda inspect objects -p $PREFIX $PKG_NAME   # [osx]
+
+  - name: faiss-cpu
+    script: build-pkg.sh   # [not win]
+    script: build-pkg.bat  # [win]
+    build:
+      string: "py{{ PY_VER }}_h{{ PKG_HASH }}_{{ number }}_cpu"
+    requirements:
+      build:
+        - {{ compiler('cxx') }}
+        - swig
+        - cmake >=3.17
+        - make  # [not win]
+      host:
+        - python {{ python }}
+        - numpy =1.11
+        - {{ pin_subpackage('libfaiss', exact=True) }}
+      run:
+        - python {{ python }}
+        - numpy >=1.11,<2
+        - {{ pin_subpackage('libfaiss', exact=True) }}
+    test:
+      requires:
+        - numpy
+        - scipy
+        - pytorch
+      commands:
+        - python -X faulthandler -m unittest discover -v -s tests -p "test_*"
+        - python -X faulthandler -m unittest discover -v -s tests -p "torch_*"
+        - sh test_cpu_dispatch.sh  # [linux]
+      files:
+        - test_cpu_dispatch.sh  # [linux]
+      source_files:
+        - tests/

--- a/conda/faiss-aarch64/meta.yaml
+++ b/conda/faiss-aarch64/meta.yaml
@@ -60,12 +60,12 @@ outputs:
         - make  # [not win]
       host:
         - python {{ python }}
-        - numpy =1.11
+        - numpy =1.16.5
         - openblas =*=openmp*
         - {{ pin_subpackage('libfaiss', exact=True) }}
       run:
         - python {{ python }}
-        - numpy >=1.11,<2
+        - numpy >=1.16.5,<2
         - {{ pin_subpackage('libfaiss', exact=True) }}
     test:
       requires:

--- a/conda/faiss-aarch64/test_cpu_dispatch.sh
+++ b/conda/faiss-aarch64/test_cpu_dispatch.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+
+FAISS_DISABLE_CPU_FEATURES=AVX2 LD_DEBUG=libs python -c "import faiss" 2>&1 | grep libfaiss.so
+LD_DEBUG=libs python -c "import faiss" 2>&1 | grep libfaiss_avx2.so

--- a/conda/faiss-aarch64/test_cpu_dispatch.sh
+++ b/conda/faiss-aarch64/test_cpu_dispatch.sh
@@ -7,4 +7,3 @@
 set -e
 
 FAISS_DISABLE_CPU_FEATURES=AVX2 LD_DEBUG=libs python -c "import faiss" 2>&1 | grep libfaiss.so
-LD_DEBUG=libs python -c "import faiss" 2>&1 | grep libfaiss_avx2.so


### PR DESCRIPTION
This PR adds conda recipe for `aarch64-linux` .

- This PR just adds conda recipe and Dockerfile, no CI jobs.
    - It needs to create a Docker image for aarch64 like `beauby/faiss-circleci:cpu`, but this PR doesn't.
- This PR doesn't add conda recipe for Windows/macOS, because we have no envs to check the behavior for them.

```console
$ uname -a
Linux ubuntu 5.4.0-1034-raspi #37-Ubuntu SMP PREEMPT Mon Apr 12 23:14:49 UTC 2021 aarch64 aarch64 aarch64 GNU/Linux
$ pwd
/path/to/faiss
$ which conda
/path/to/miniforge3/bin/conda
$ conda create -y -n py37 python=3.7
$ conda activate py37
$ which python3
/path/to/miniforge3/envs/py37/bin/python3
$ python3 --version
Python 3.7.10
$ conda install -y numpy blas
$ conda install -y scipy --no-deps  # prevent to install pypy as dependency
$
$ docker build -t faiss-conda-linux-aarch64 -f conda/Dockerfile.cpu.aarch64 .
$ CONTAINER_ID=$(docker create faiss-conda-linux-aarch64)
$ docker cp ${CONTAINER_ID}:/opt/conda/conda-bld/linux-aarch64 .
$ docker rm ${CONTAINER_ID}
$ conda install linux-aarch64/libfaiss-1.7.0-*_cpu.tar.bz2
$ conda install linux-aarch64/faiss-cpu-1.7.0-py3.7*_cpu.tar.bz2
$ python3
>>> import faiss
>>> faiss.__version__
'1.7.0'
```

### FAQ

- Q. Why has CMake been updated the version from v3.17.1 to v3.20.2?
    - A. Because [there is no pre-built binary release for linux-aarch64 on v3.17.1](https://github.com/Kitware/CMake/releases/tag/v3.17.1) (v3.20.2 is newest one at today).
- Q. Why have tests for `pytorch` been omitted?
    - A. Because [there is no `pytorch` conda package for linux-aarch64](https://anaconda.org/pytorch/pytorch).
- Q. Why is the numpy version specified to be `=1.16.5` instead of `=1.11` ?
    - A. Because [there is no `numpy=1.11` conda package for Python 3.8 at `conda-forge` channel](https://anaconda.org/conda-forge/numpy/files?page=18).
        - [The oldest `numpy` conda package for Python 3.8 at `conda-forge` channel is `1.16.5`](https://anaconda.org/conda-forge/numpy/files?page=10) as I confirmed.
            - Additionaly, now [all packages on `conda-forge` uses numpy `1.17` ](https://github.com/facebookresearch/faiss/pull/1894#issuecomment-843421783), so it seems that this setting will be conflicted with some other packages in the near future.
        - The solutions in order to specify `numpy=1.11` are below:
            1. Giving up on packaging for Python 3.8 on aarch64
                - I don't know how to do that without editing `faiss/conda/conda_build_config.yaml` , but the file is also referred by conda for x86, so if the file will be edited, `faiss` conda packages for Python3.8 on x86 also disabled. I think that this is not good choice.
            1. Providing `numpy=1.11` package for Python 3.8 on aarch64 at `pytorch` channel
            1. Contributing to [`numpy-feedstock`](https://github.com/conda-forge/numpy-feedstock) for adding `numpy-1.11-py3.8*` into `conda-forge` channel.
- Q. Why you use miniforge? There is miniconda for linux-aarch64
    - A. Whoops, I didn't know that...
        - However, there is no `numpy` for Python 3.6 on [`pkgs/main/linux-aarch64`](https://repo.anaconda.com/pkgs/main/linux-aarch64), so anyway `faiss/conda/conda_build_config.yaml` is needed to edit as removing Python 3.6 when using miniconda for linux-aarch64, or it is needed to provide `numpy` for Python 3.6 of linux-aarch64 at `pytorch` channel, etc.