### PR TITLE
Small build fixes for 1.7.1

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -106,6 +106,7 @@ set(FAISS_HEADERS
   IndexPreTransform.h
   IndexRefine.h
   IndexReplicas.h
+  IndexResidual.h
   IndexScalarQuantizer.h
   IndexShards.h
   MatrixStats.h
@@ -115,17 +116,18 @@ set(FAISS_HEADERS
   clone_index.h
   index_factory.h
   index_io.h
+  impl/AdditiveQuantizer.h
   impl/AuxIndexStructures.h
   impl/FaissAssert.h
   impl/FaissException.h
   impl/HNSW.h
+  impl/LocalSearchQuantizer.h
+  impl/NNDescent.h
   impl/NSG.h
   impl/PolysemousTraining.h
   impl/ProductQuantizer-inl.h
   impl/ProductQuantizer.h
-  impl/AdditiveQuantizer.h
   impl/ResidualQuantizer.h
-  impl/LocalSearchQuantizer.h
   impl/ResultHandler.h
   impl/ScalarQuantizer.h
   impl/ThreadedIndex-inl.h
@@ -133,7 +135,6 @@ set(FAISS_HEADERS
   impl/io.h
   impl/io_macros.h
   impl/lattice_Zn.h
-  impl/NNDescent.h
   impl/platform_macros.h
   impl/pq4_fast_scan.h
   impl/simd_result_handlers.h
@@ -145,6 +146,7 @@ set(FAISS_HEADERS
   utils/Heap.h
   utils/WorkerThread.h
   utils/distances.h
+  utils/extra_distances-inl.h
   utils/extra_distances.h
   utils/hamming-inl.h
   utils/hamming.h

--- a/faiss/gpu/CMakeLists.txt
+++ b/faiss/gpu/CMakeLists.txt
@@ -117,6 +117,7 @@ set(FAISS_GPU_HEADERS
   impl/PQScanMultiPassPrecomputed.cuh
   impl/RemapIndices.h
   impl/VectorResidual.cuh
+  impl/scan/IVFInterleavedImpl.cuh
   utils/BlockSelectKernel.cuh
   utils/Comparators.cuh
   utils/ConversionOperators.cuh

--- a/faiss/utils/distances_simd.cpp
+++ b/faiss/utils/distances_simd.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/utils/distances.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <cstdio>


### PR DESCRIPTION
Some small fixes from https://github.com/conda-forge/faiss-split-feedstock/pull/46; some missing (and unsorted) headers like in #1666, and a missing `<algorithm>` include like in  #1895