### PR TITLE
Auto tune lambd for LSQ

### DIFF
--- a/benchs/bench_quantizer.py
+++ b/benchs/bench_quantizer.py
@@ -50,7 +50,7 @@ nbits = 8
 
 if 'lsq' in todo:
     lsq = faiss.LocalSearchQuantizer(d, M, nbits)
-    lsq.log_level = 2  # show detailed training progress
+    lsq.verbose = True
     eval_quantizer(lsq, xb, xt, 'lsq')
 
 if 'pq' in todo:

--- a/faiss/impl/LocalSearchQuantizer.h
+++ b/faiss/impl/LocalSearchQuantizer.h
@@ -45,8 +45,10 @@ struct LocalSearchQuantizer : AdditiveQuantizer {
     size_t train_ils_iters;  ///< iterations of local search in training
     size_t icm_iters;        ///< number of iterations in icm
 
-    float p;     ///< temperature factor
-    float lambd; ///< regularization factor
+    float p;                ///< temperature factor
+    float lambd;            ///< regularization factor
+    float lambd_multiplier; ///< lambd multiplier
+    float max_lambd;        ///< max lambd
 
     size_t chunk_size; ///< nb of vectors to encode at a time
 

--- a/tests/test_lsq.py
+++ b/tests/test_lsq.py
@@ -308,3 +308,28 @@ class TestLocalSearchQuantizer(unittest.TestCase):
 
         print(err_lsq, err_pq)
         self.assertLess(err_lsq, err_pq)
+
+    def test_autotune_lambd(self):
+        ds = datasets.SyntheticDataset(4, 10000, 1000, 0)
+
+        xt = ds.get_train()
+        xb = ds.get_database()
+
+        M = 8
+        nbits = 2
+
+        lsq = faiss.LocalSearchQuantizer(ds.d, M, nbits)
+        lsq.lambd = 0.0001
+        lsq.train(xt)
+        err1 = eval_codec(lsq, xb)
+        print(lsq.lambd)
+
+        lsq = faiss.LocalSearchQuantizer(ds.d, M, nbits)
+        lsq.lambd = 0.0001
+        lsq.max_lambd = 0  # do not tune lambd
+        lsq.train(xt)
+        err2 = eval_codec(lsq, xb)
+        print(lsq.lambd)
+
+        print(err1, err2)
+        self.assertLess(err1, err2)

--- a/tests/test_lsq.py
+++ b/tests/test_lsq.py
@@ -319,13 +319,13 @@ class TestLocalSearchQuantizer(unittest.TestCase):
         nbits = 2
 
         lsq = faiss.LocalSearchQuantizer(ds.d, M, nbits)
-        lsq.lambd = 0.0001
+        lsq.lambd = 0.0005
         lsq.train(xt)
         err1 = eval_codec(lsq, xb)
         print(lsq.lambd)
 
         lsq = faiss.LocalSearchQuantizer(ds.d, M, nbits)
-        lsq.lambd = 0.0001
+        lsq.lambd = 0.0005
         lsq.max_lambd = 0  # do not tune lambd
         lsq.train(xt)
         err2 = eval_codec(lsq, xb)


### PR DESCRIPTION
`lambd` in LSQ is a sensitive parameter that may lead to an inferior result if it was too small.

This diff fixed it by enlarging `lambd` if the objective did not converge. 

It would not slow down the training process since updating codebooks is quite fast.