### PR TITLE
Update codebooks with double type

### DIFF
--- a/benchs/bench_quantizer.py
+++ b/benchs/bench_quantizer.py
@@ -50,7 +50,7 @@ nbits = 8
 
 if 'lsq' in todo:
     lsq = faiss.LocalSearchQuantizer(d, M, nbits)
-    lsq.log_level = 2  # show detailed training progress
+    lsq.verbose = True
     eval_quantizer(lsq, xb, xt, 'lsq')
 
 if 'pq' in todo:

--- a/faiss/impl/LocalSearchQuantizer.h
+++ b/faiss/impl/LocalSearchQuantizer.h
@@ -53,6 +53,8 @@ struct LocalSearchQuantizer : AdditiveQuantizer {
     int random_seed; ///< seed for random generator
     size_t nperts;   ///< number of perturbation in each code
 
+    bool update_codebooks_with_double = true;
+
     LocalSearchQuantizer(
             size_t d,      /* dimensionality of the input vectors */
             size_t M,      /* number of subquantizers */

--- a/tests/test_lsq.py
+++ b/tests/test_lsq.py
@@ -171,6 +171,30 @@ class TestComponents(unittest.TestCase):
 
         np.testing.assert_allclose(new_codebooks, ref_codebooks, atol=1e-3)
 
+    def test_update_codebooks_with_double(self):
+        """If the data is not zero-centering, it would be much accurate to
+        use double-precision floating-point numbers."""
+        ds = datasets.SyntheticDataset(16, 1000, 1000, 0)
+
+        xt = ds.get_train() + 1000
+        xb = ds.get_database() + 1000
+
+        M = 4
+        nbits = 4
+
+        lsq = faiss.LocalSearchQuantizer(ds.d, M, nbits)
+        lsq.train(xt)
+        err_double = eval_codec(lsq, xb)
+
+        lsq = faiss.LocalSearchQuantizer(ds.d, M, nbits)
+        lsq.update_codebooks_with_double = False
+        lsq.train(xt)
+        err_float = eval_codec(lsq, xb)
+
+        # 6533.377 vs 25457.99
+        print(err_double, err_float)
+        self.assertLess(err_double, err_float)
+
     def test_compute_binary_terms(self):
         d = 16
         n = 500

--- a/tests/test_lsq.py
+++ b/tests/test_lsq.py
@@ -172,7 +172,7 @@ class TestComponents(unittest.TestCase):
         np.testing.assert_allclose(new_codebooks, ref_codebooks, atol=1e-3)
 
     def test_update_codebooks_with_double(self):
-        """If the data is not zero-centering, it would be much accurate to
+        """If the data is not zero-centering, it would be more accurate to
         use double-precision floating-point numbers."""
         ds = datasets.SyntheticDataset(16, 1000, 1000, 0)
 


### PR DESCRIPTION
## Description

The process of updating the codebook in LSQ may be unstable if the data is not zero-centering. This diff fixed it by using `double` instead of `float` during codebook updating. This would not affect the performance since the update process is quite fast.

Users could switch back to `float` mode by setting `update_codebooks_with_double = False`

## Changes

1. Support `double` during codebook updating. 
2. Add a unit test.
3. Add `__init__.py` under `contrib/` to avoid warnings.