### PR TITLE
Include ResidualCoarseQuantizer in clone_index

### DIFF
--- a/faiss/clone_index.cpp
+++ b/faiss/clone_index.cpp
@@ -83,6 +83,7 @@ Index* Cloner::clone_Index(const Index* index) {
     TRYCLONE(IndexResidual, index)
     TRYCLONE(IndexScalarQuantizer, index)
     TRYCLONE(MultiIndexQuantizer, index)
+    TRYCLONE(ResidualCoarseQuantizer, index)
     if (const IndexIVF* ivf = dynamic_cast<const IndexIVF*>(index)) {
         IndexIVF* res = clone_IndexIVF(ivf);
         if (ivf->invlists == nullptr) {


### PR DESCRIPTION
Summary: Add clone_index support to ResidualCoarseQuantizer to enable GPU training. Similar to D28614996

Reviewed By: mdouze

Differential Revision: D29605169

