### PR TITLE
Possible fix for the GPU transpose utility

### DIFF
--- a/faiss/gpu/utils/Transpose.cuh
+++ b/faiss/gpu/utils/Transpose.cuh
@@ -95,8 +95,8 @@ template <typename T, typename IndexT>
 __global__ void transposeOuter(const T* in,
                                T* out,
                                IndexT t1, IndexT t2, IndexT i1) {
-  IndexT gt1 = blockIdx.y;
-  IndexT gt2 = blockIdx.x;
+  IndexT gt1 = blockIdx.x;
+  IndexT gt2 = blockIdx.y;
 
   in += i1 * (gt1 * t2 + gt2);
   out += i1 * (gt2 * t1 + gt1);
@@ -157,7 +157,7 @@ void runTransposeAny(Tensor<T, Dim, true>& in,
       innerSize *= in.getSize(i);
     }
 
-    auto grid = dim3(in.getSize(1), in.getSize(0));
+    auto grid = dim3(in.getSize(0), in.getSize(1));
     int block = (innerSize < maxThreads) ? innerSize : maxThreads;
 
     if (totalSize <= (size_t) std::numeric_limits<int>::max()) {


### PR DESCRIPTION
I identified a bug in the GPU transpose utility and could create an attempt to fix it. The bug is visible when using the GPU approximate nearest neighbors method `IVFPQ` and is reproducible with the following code (requires `cuML`) :
```
import cupy as cp
from cuml.neighbors import NearestNeighbors

n_dims = 2
n_neighbors = 10
n_samples = 65_536
n_unknown = 10_000

index = cp.random.random((n_samples, n_dims))
query = cp.random.random((n_unknown, n_dims))

knn_model = NearestNeighbors(n_neighbors=n_neighbors,  algorithm='ivfpq')
knn_model.fit(index)
nearest_neighbors = knn_model.kneighbors(query)
```
This code throws the following error:
`Faiss assertion 'err__ == cudaSuccess' failed in void faiss::gpu::runTransposeAny(faiss::gpu::Tensor<OtherT, OtherDim, true, int, faiss::gpu::traits::DefaultPtrTraits>&, int, int, faiss::gpu::Tensor<OtherT, OtherDim, true, int, faiss::gpu::traits::DefaultPtrTraits>&, cudaStream_t) [with T = float; int Dim = 3; cudaStream_t = CUstream_st*] at <...>/faiss/faiss/gpu/utils/Transpose.cuh:207; details: CUDA error 9 invalid configuration argument
Aborted (core dumped)`

The problem appears when the number of samples in the index is above 65535. The issue seems to stem from the fact that in preparation of the launch of the `transposeOuter` CUDA kernel, the y dimension of the grid of thread blocks is parametrized with the number of rows/samples. Indeed, this causes a problem as the maximum y-, or z-dimension of a grid of thread blocks is 65535 (see [CUDA compute compatibility technical specifications](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications)). In my understanding, this is what throws a `CUDA error 9 invalid configuration argument` during the launch of the CUDA kernel that follows.

Here is the part of the code that is concerned by the problem:
https://github.com/facebookresearch/faiss/blob/7c2d2388a492d65fdda934c7e74ae87acaeed066/faiss/gpu/utils/Transpose.cuh#L160-L175

Tagging issues:
https://github.com/rapidsai/cuml/issues/4020
https://github.com/facebookresearch/faiss/issues/1771
https://github.com/facebookresearch/faiss/issues/1835