### PR TITLE
fix centroids_norms storage for ResidualCoarseQuantizer

### DIFF
--- a/faiss/IndexAdditiveQuantizer.cpp
+++ b/faiss/IndexAdditiveQuantizer.cpp
@@ -310,7 +310,7 @@ ResidualCoarseQuantizer::ResidualCoarseQuantizer(
         MetricType metric)
         : ResidualCoarseQuantizer(d, std::vector<size_t>(M, nbits), metric) {}
 
-ResidualCoarseQuantizer::ResidualCoarseQuantizer(): beam_factor(4.0) {}
+ResidualCoarseQuantizer::ResidualCoarseQuantizer(): ResidualCoarseQuantizer(0, 0, 0) {}
 
 
 
@@ -319,8 +319,13 @@ void ResidualCoarseQuantizer::set_beam_factor(float new_beam_factor) {
     if (new_beam_factor > 0) {
         FAISS_THROW_IF_NOT(new_beam_factor >= 1.0);
         return;
+    } else if (metric_type == METRIC_L2 && ntotal != centroid_norms.size()) {
+        if (verbose) {
+            printf("AdditiveCoarseQuantizer::train: computing centroid norms for %ld centroids\n", ntotal);
+        }
+        centroid_norms.resize(ntotal);
+        aq->compute_centroid_norms(centroid_norms.data());
     }
-
 }
 
 void ResidualCoarseQuantizer::search(

--- a/tests/test_residual_quantizer.py
+++ b/tests/test_residual_quantizer.py
@@ -497,6 +497,13 @@ class TestIVFResidualCoarseQuantizer(unittest.TestCase):
         np.testing.assert_array_almost_equal(Dref, Dnew, decimal=5)
         np.testing.assert_array_equal(Iref, Inew)
 
+        # check i/o
+        CDref, CIref = quantizer.search(ds.get_queries(), 10)
+        quantizer2 = faiss.deserialize_index(faiss.serialize_index(quantizer))
+        quantizer2.search(ds.get_queries(), 10)
+        CDnew, CInew = quantizer2.search(ds.get_queries(), 10)
+        np.testing.assert_array_almost_equal(CDref, CDnew, decimal=5)
+        np.testing.assert_array_equal(CIref, CInew)
 
 ###########################################################
 # Test search with LUTs


### PR DESCRIPTION
Summary: The centroids norms table was not reconstructed correctly after being stored in RCQ.

Reviewed By: Sugoshnr

Differential Revision: D30484389

