### PR TITLE
Change default branch references from master to main.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,7 +426,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - deploy_linux:
           name: Linux nightlies

--- a/.github/workflows/update-doxygen.yml
+++ b/.github/workflows/update-doxygen.yml
@@ -2,7 +2,7 @@ name: update-doxygen
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - 'faiss/**'
 jobs:
@@ -35,6 +35,6 @@ jobs:
           git add xml cpp_api
           if [ -n "$(git status --porcelain)" ]
           then
-            git commit -m "Update API docs ($(git rev-parse --short master))."
+            git commit -m "Update API docs ($(git rev-parse --short main))."
             git push origin gh-pages
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,9 @@ Tensor Core operations (mixed-precision arithmetic) are enabled on supported
 hardware when operating with float16 data.
 - Support k-means clustering with encoded vectors. This makes it possible to
 train on larger datasets without decompressing them in RAM, and is especially
-useful for binary datasets (see https://github.com/facebookresearch/faiss/blob/master/tests/test_build_blocks.py#L92).
+useful for binary datasets (see https://github.com/facebookresearch/faiss/blob/main/tests/test_build_blocks.py#L92).
 - Support weighted k-means. Weights can be associated to each training point
-(see https://github.com/facebookresearch/faiss/blob/master/tests/test_build_blocks.py).
+(see https://github.com/facebookresearch/faiss/blob/main/tests/test_build_blocks.py).
 - Serialize callback in python, to write to pipes or sockets (see
 https://github.com/facebookresearch/faiss/wiki/Index-IO,-cloning-and-hyper-parameter-tuning).
 - Reconstruct arbitrary ids from IndexIVF + efficient remove of a small number
@@ -63,12 +63,12 @@ of ids. This avoids 2 inefficiencies: O(ntotal) removal of vectors and
 IndexIDMap2 on top of indexIVF. Documentation here:
 https://github.com/facebookresearch/faiss/wiki/Special-operations-on-indexes.
 - Support inner product as a metric in IndexHNSW (see
-https://github.com/facebookresearch/faiss/blob/master/tests/test_index.py#L490).
+https://github.com/facebookresearch/faiss/blob/main/tests/test_index.py#L490).
 - Support PQ of sizes other than 8 bit in IndexIVFPQ.
 - Demo on how to perform searches sequentially on an IVF index. This is useful
 for an OnDisk index with a very large batch of queries. In that case, it is
 worthwhile to scan the index sequentially (see
-https://github.com/facebookresearch/faiss/blob/master/tests/test_ivflib.py#L62).
+https://github.com/facebookresearch/faiss/blob/main/tests/test_ivflib.py#L62).
 - Range search support for most binary indexes.
 - Support for hashing-based binary indexes (see
 https://github.com/facebookresearch/faiss/wiki/Binary-indexes).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Contributing to Faiss
 
 We want to make contributing to this project as easy and transparent as
-possible. 
+possible.
 
 ## Our Development Process
 
-We mainly develop Faiss within Facebook. Sometimes, we will sync the 
-github version of Faiss with the internal state. 
+We mainly develop Faiss within Facebook. Sometimes, we will sync the
+github version of Faiss with the internal state.
 
 ## Pull Requests
 
@@ -14,14 +14,14 @@ We welcome pull requests that add significant value to Faiss. If you plan to do
 a major development and contribute it back to Faiss, please contact us first before
 putting too much effort into it.
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.
 5. Make sure your code lints.
 6. If you haven't already, complete the Contributor License Agreement ("CLA").
 
-There is a Facebook internal test suite for Faiss, and we need to run 
+There is a Facebook internal test suite for Faiss, and we need to run
 all changes to Faiss through it.
 
 ## Contributor License Agreement ("CLA")
@@ -40,7 +40,7 @@ Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
 disclosure of security bugs. In those cases, please go through the process
 outlined on that page and do not file a public issue.
 
-## Coding Style  
+## Coding Style
 
 * 4 or 2 spaces for indentation in C++ (no tabs)
 * 80 character line length (both for C++ and Python)
@@ -50,4 +50,3 @@ outlined on that page and do not file a public issue.
 
 By contributing to Faiss, you agree that your contributions will be licensed
 under the LICENSE file in the root directory of this source tree.
-

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -175,7 +175,7 @@ $ PYTHONPATH="$(ls -d ./build/faiss/python/build/lib*/)" pytest tests/test_*.py
 ### Basic example
 
 A basic usage example is available in
-[`demos/demo_ivfpq_indexing.cpp`](https://github.com/facebookresearch/faiss/blob/master/demos/demo_ivfpq_indexing.cpp).
+[`demos/demo_ivfpq_indexing.cpp`](https://github.com/facebookresearch/faiss/blob/main/demos/demo_ivfpq_indexing.cpp).
 
 It creates a small index, stores it and performs some searches. A normal runtime
 is around 20s. With a fast machine and Intel MKL's BLAS it runs in 2.5s.

--- a/contrib/datasets.py
+++ b/contrib/datasets.py
@@ -202,7 +202,7 @@ class DatasetBigANN(Dataset):
 class DatasetDeep1B(Dataset):
     """
     See
-    https://github.com/facebookresearch/faiss/tree/master/benchs#getting-deep1b
+    https://github.com/facebookresearch/faiss/tree/main/benchs#getting-deep1b
     on how to get the data
     """
 


### PR DESCRIPTION
This is required for the renaming of the default branch from `master` to `main`, in accordance with the new Facebook OSS guidelines.