### PR TITLE
MOD: add some cpp feature, like distance/norm/inner prod computations

### DIFF
--- a/c_api/utils/distances_c.cpp
+++ b/c_api/utils/distances_c.cpp
@@ -10,6 +10,54 @@
 
 #include "distances_c.h"
 #include <faiss/utils/distances.h>
+#include <cstdio>
+
+void faiss_pairwise_L2sqr(
+        int64_t d,
+        int64_t nq,
+        const float* xq,
+        int64_t nb,
+        const float* xb,
+        float* dis,
+        int64_t ldq,
+        int64_t ldb,
+        int64_t ldd) {
+    faiss::pairwise_L2sqr(d, nq, xq, nb, xb, dis, ldq, ldb, ldd);
+}
+
+void faiss_fvec_inner_products_ny(
+        float* ip,
+        const float* x,
+        const float* y,
+        size_t d,
+        size_t ny) {
+    faiss::fvec_inner_products_ny(ip, x, y, d, ny);
+}
+
+void faiss_fvec_L2sqr_ny(
+        float* dis,
+        const float* x,
+        const float* y,
+        size_t d,
+        size_t ny) {
+    faiss::fvec_L2sqr_ny(dis, x, y, d, ny);
+}
+
+float faiss_fvec_norm_L2sqr(const float* x, size_t d) {
+    return faiss::fvec_norm_L2sqr(x, d);
+}
+
+void faiss_fvec_norms_L2(float* norms, const float* x, size_t d, size_t nx) {
+    faiss::fvec_norms_L2(norms, x, d, nx);
+}
+
+void faiss_fvec_norms_L2sqr(float* norms, const float* x, size_t d, size_t nx) {
+    faiss::fvec_norms_L2sqr(norms, x, d, nx);
+}
+
+void faiss_fvec_renorm_L2(size_t d, size_t nx, float* x) {
+    faiss::fvec_renorm_L2(d, nx, x);
+}
 
 void faiss_set_distance_compute_blas_threshold(int value) {
     faiss::distance_compute_blas_threshold = value;

--- a/c_api/utils/distances_c.h
+++ b/c_api/utils/distances_c.h
@@ -11,9 +11,55 @@
 #ifndef FAISS_DISTANCES_C_H
 #define FAISS_DISTANCES_C_H
 
+#include <stdlib.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/*********************************************************
+ * Optimized distance/norm/inner prod computations
+ *********************************************************/
+
+/// Compute pairwise distances between sets of vectors
+void faiss_pairwise_L2sqr(
+        int64_t d,
+        int64_t nq,
+        const float* xq,
+        int64_t nb,
+        const float* xb,
+        float* dis,
+        int64_t ldq = -1,
+        int64_t ldb = -1,
+        int64_t ldd = -1);
+
+/// compute the inner product between nx vectors x and one y
+void faiss_fvec_inner_products_ny(
+        float* ip, /* output inner product */
+        const float* x,
+        const float* y,
+        size_t d,
+        size_t ny);
+
+/// compute ny square L2 distance between x and a set of contiguous y vectors
+void faiss_fvec_L2sqr_ny(
+        float* dis,
+        const float* x,
+        const float* y,
+        size_t d,
+        size_t ny);
+
+/// squared norm of a vector
+float faiss_fvec_norm_L2sqr(const float* x, size_t d);
+
+/// compute the L2 norms for a set of vectors
+void faiss_fvec_norms_L2(float* norms, const float* x, size_t d, size_t nx);
+
+/// same as fvec_norms_L2, but computes squared norms
+void faiss_fvec_norms_L2sqr(float* norms, const float* x, size_t d, size_t nx);
+
+/// L2-renormalize a set of vector. Nothing done if the vector is 0-normed
+void faiss_fvec_renorm_L2(size_t d, size_t nx, float* x);
 
 /// Setter of threshold value on nx above which we switch to BLAS to compute
 /// distances


### PR DESCRIPTION
I want to invoke norm  computations by using CGO, but I find some functions which have been implemented in cpp are not exported in c api, so I commit the PR to solve the problem.