### PR TITLE
Reduce mem usage  + improve performance for sequential search imlementation

### DIFF
--- a/faiss/utils/distances.cpp
+++ b/faiss/utils/distances.cpp
@@ -105,8 +105,9 @@ void exhaustive_inner_product_seq(
         size_t ny,
         ResultHandler& res) {
     using SingleResultHandler = typename ResultHandler::SingleResultHandler;
+    int nt = std::min(int(nx), omp_get_max_threads());
 
-#pragma omp parallel
+#pragma omp parallel num_threads(nt)
     {
         SingleResultHandler resi(res);
 #pragma omp for
@@ -135,8 +136,9 @@ void exhaustive_L2sqr_seq(
         size_t ny,
         ResultHandler& res) {
     using SingleResultHandler = typename ResultHandler::SingleResultHandler;
+    int nt = std::min(int(nx), omp_get_max_threads());
 
-#pragma omp parallel
+#pragma omp parallel num_threads(nt)
     {
         SingleResultHandler resi(res);
 #pragma omp for

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(FAISS_TEST_SRC
   test_sliding_ivf.cpp
   test_threaded_index.cpp
   test_transfer_invlists.cpp
+  test_mem_leak.cpp
 )
 
 add_executable(faiss_test ${FAISS_TEST_SRC})

--- a/tests/test_mem_leak.cpp
+++ b/tests/test_mem_leak.cpp
@@ -1,0 +1,49 @@
+#include <faiss/utils/utils.h>
+#include <faiss/utils/random.h>
+#include <faiss/IndexIVFFlat.h>
+#include <faiss/IndexFlat.h>
+
+#include <gtest/gtest.h>
+
+
+using namespace faiss;
+
+
+TEST(MEM_LEAK, ivfflat) {
+
+    size_t num_tfidf_faiss_cells = 20;
+    size_t max_tfidf_features = 500;
+
+    IndexFlatIP quantizer(max_tfidf_features);
+    IndexIVFFlat tfidf_faiss_index(
+        &quantizer, max_tfidf_features, num_tfidf_faiss_cells);
+
+    std::vector<float> dense_matrix(5000 * max_tfidf_features);
+    float_rand(dense_matrix.data(), dense_matrix.size(), 123);
+
+    tfidf_faiss_index.train(5000, dense_matrix.data());
+    tfidf_faiss_index.add(5000, dense_matrix.data());
+
+    std::vector<float> ent_substr_tfidfs_list(10000 * max_tfidf_features);
+    float_rand(ent_substr_tfidfs_list.data(), ent_substr_tfidfs_list.size(), 1234);
+
+
+
+    size_t m0 = get_mem_usage_kb();
+    for(int i = 0; i < 100000; i++) {
+        std::vector<Index::idx_t> I(10);
+        std::vector<float> D(10);
+
+        tfidf_faiss_index.search(
+            1, ent_substr_tfidfs_list.data() + i * max_tfidf_features, 10,
+            D.data(), I.data());
+        if(i%100 == 0) {
+            printf("%d: %ld kB %.2f bytes/it\r", i, get_mem_usage_kb(),
+                (get_mem_usage_kb() - m0) * 1024.0 / (i + 1));
+            fflush(stdout);
+        }
+    }
+
+    EXPECT_GE(50, (get_mem_usage_kb() - m0) * 1024.0 / 100000);
+
+}

--- a/tests/test_mem_leak.cpp
+++ b/tests/test_mem_leak.cpp
@@ -35,7 +35,7 @@ TEST(MEM_LEAK, ivfflat) {
         std::vector<float> D(10);
 
         tfidf_faiss_index.search(
-            1, ent_substr_tfidfs_list.data() + i * max_tfidf_features, 10,
+            1, ent_substr_tfidfs_list.data() + (i % 10000) * max_tfidf_features, 10,
             D.data(), I.data());
         if(i%100 == 0) {
             printf("%d: %ld kB %.2f bytes/it\r", i, get_mem_usage_kb(),


### PR DESCRIPTION
Following up on issue #2054 it seems that this code crashes Faiss (instead of just leaking memory). 
This PR is just to run it in CI to see if this is because I did not compile Faiss properly. 