### PR TITLE
Fix unorder bug in NSG

### DIFF
--- a/faiss/IndexNNDescent.cpp
+++ b/faiss/IndexNNDescent.cpp
@@ -167,9 +167,7 @@ void IndexNNDescent::search(
                 float* simi = distances + i * k;
                 dis->set_query(x + i * d);
 
-                maxheap_heapify(k, simi, idxi);
                 nndescent.search(*dis, k, idxi, simi, vt);
-                maxheap_reorder(k, simi, idxi);
             }
         }
         InterruptCallback::check();

--- a/faiss/IndexNSG.cpp
+++ b/faiss/IndexNSG.cpp
@@ -104,9 +104,7 @@ void IndexNSG::search(
                 float* simi = distances + i * k;
                 dis->set_query(x + i * d);
 
-                maxheap_heapify(k, simi, idxi);
                 nsg.search(*dis, k, idxi, simi, vt);
-                maxheap_reorder(k, simi, idxi);
 
                 vt.advance();
             }

--- a/faiss/impl/NSG.cpp
+++ b/faiss/impl/NSG.cpp
@@ -161,9 +161,6 @@ void NSG::search(
     search_on_graph<false>(
             *final_graph, dis, vt, enterpoint, pool_size, retset, tmp);
 
-    std::partial_sort(
-            retset.begin(), retset.begin() + k, retset.begin() + pool_size);
-
     for (size_t i = 0; i < k; i++) {
         I[i] = retset[i].id;
         D[i] = retset[i].distance;

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -757,6 +757,23 @@ class TestNSG(unittest.TestCase):
         self.assertGreaterEqual(recalls, 475)
         self.subtest_connectivity(index, self.xb.shape[0])
 
+    def test_order(self):
+        """make sure that output results are sorted"""
+        d = self.xq.shape[1]
+        index = faiss.IndexNSGFlat(d, 32)
+
+        index.train(self.xb)
+        index.add(self.xb)
+
+        k = 10
+        nq = self.xq.shape[0]
+        D, _ = index.search(self.xq, k)
+        
+        indices = np.argsort(D, axis=1)
+        gt = np.arange(0, k)[np.newaxis, :]  # [1, k]
+        gt = np.repeat(gt, nq, axis=0)  # [nq, k]
+        assert np.array_equal(indices, gt)
+
 
 class TestDistancesPositive(unittest.TestCase):
 


### PR DESCRIPTION
The results returned by `NSG::search` are already sorted. Calling `maxheap_reorder` will make the results unorder.

Fixed https://github.com/facebookresearch/faiss/issues/2081.