### PR TITLE
Speedup write_InvertedLists

### DIFF
--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -227,6 +227,7 @@ void write_InvertedLists(const InvertedLists* ils, IOWriter* f) {
             uint32_t list_type = fourcc("full");
             WRITE1(list_type);
             std::vector<size_t> sizes;
+            sizes.reserve(ails->nlist);
             for (size_t i = 0; i < ails->nlist; i++) {
                 sizes.push_back(ails->ids[i].size());
             }


### PR DESCRIPTION
Use reserve() before push_back() to avoid memory multiple reallocation, it will improve write_InvertedLists's performance.