### PR TITLE
Changing default python install direction

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,7 +137,7 @@ it is recommended to set the `-j` option to a fixed value (such as `-j4`).
 
 ``` shell
 $ make -C build -j swigfaiss
-$ (cd build/faiss/python && python setup.py install)
+$ (cd build/faiss/python && python -m pip install .)
 ```
 
 The first command builds the python bindings for Faiss, while the second one


### PR DESCRIPTION
The current use of python setup has issues, see #866. This is a one-line change using pip fixes the problem on Ubuntu, but I've not tested this on windows or alternative distros of linux. I am merely making a PR to gauge interest and hopefully change these directions to better reflect the actual python install process.