### PR TITLE
IndexFlatCodes: a single parent for all flat codecs

### DIFF
--- a/c_api/IndexFlat_c.cpp
+++ b/c_api/IndexFlat_c.cpp
@@ -47,10 +47,10 @@ int faiss_IndexFlat_new_with(
 }
 
 void faiss_IndexFlat_xb(FaissIndexFlat* index, float** p_xb, size_t* p_size) {
-    auto& xb = reinterpret_cast<IndexFlat*>(index)->xb;
-    *p_xb = xb.data();
+    IndexFlat* indexf = reinterpret_cast<IndexFlat*>(index);
+    *p_xb = indexf->get_xb();
     if (p_size) {
-        *p_size = xb.size();
+        *p_size = indexf->codes.size() / sizeof(float);
     }
 }
 

--- a/c_api/IndexLSH_c.cpp
+++ b/c_api/IndexLSH_c.cpp
@@ -19,7 +19,7 @@ DEFINE_DESTRUCTOR(IndexLSH)
 DEFINE_INDEX_DOWNCAST(IndexLSH)
 
 DEFINE_GETTER(IndexLSH, int, nbits)
-DEFINE_GETTER(IndexLSH, int, bytes_per_vec)
+DEFINE_GETTER(IndexLSH, int, code_size)
 DEFINE_GETTER_PERMISSIVE(IndexLSH, int, rotate_data)
 DEFINE_GETTER_PERMISSIVE(IndexLSH, int, train_thresholds)
 

--- a/c_api/IndexLSH_c.h
+++ b/c_api/IndexLSH_c.h
@@ -25,7 +25,7 @@ FAISS_DECLARE_DESTRUCTOR(IndexLSH)
 FAISS_DECLARE_INDEX_DOWNCAST(IndexLSH)
 
 FAISS_DECLARE_GETTER(IndexLSH, int, nbits)
-FAISS_DECLARE_GETTER(IndexLSH, int, bytes_per_vec)
+FAISS_DECLARE_GETTER(IndexLSH, int, code_size)
 FAISS_DECLARE_GETTER(IndexLSH, int, rotate_data)
 FAISS_DECLARE_GETTER(IndexLSH, int, train_thresholds)
 

--- a/contrib/inspect_tools.py
+++ b/contrib/inspect_tools.py
@@ -6,6 +6,7 @@
 import numpy as np
 import faiss
 
+
 def get_invlist(invlists, l):
     """ returns the inverted lists content as a pair of (list_ids, list_codes).
     The codes are reshaped to a proper size
@@ -75,3 +76,9 @@ def get_additive_quantizer_codebooks(aq):
         codebooks[co[i]:co[i + 1]]
         for i in range(aq.M)
     ]
+
+
+def get_flat_data(index):
+    """ copy and return the data matrix in an IndexFlat """
+    xb = faiss.vector_to_array(index.codes).view("float32")
+    return xb.reshape(index.ntotal, index.d)

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -18,6 +18,7 @@ set(FAISS_SRC
   IndexBinaryHash.cpp
   IndexBinaryIVF.cpp
   IndexFlat.cpp
+  IndexFlatCodes.cpp
   IndexHNSW.cpp
   IndexIVF.cpp
   IndexIVFAdditiveQuantizer.cpp
@@ -93,6 +94,7 @@ set(FAISS_HEADERS
   IndexBinaryHash.h
   IndexBinaryIVF.h
   IndexFlat.h
+  IndexFlatCodes.h
   IndexHNSW.h
   IndexIVF.h
   IndexIVFAdditiveQuantizer.h

--- a/faiss/IndexAdditiveQuantizer.cpp
+++ b/faiss/IndexAdditiveQuantizer.cpp
@@ -32,18 +32,11 @@ IndexAdditiveQuantizer::IndexAdditiveQuantizer(
             idx_t d,
             AdditiveQuantizer* aq,
             MetricType metric):
-        Index(d, metric), aq(aq)
+        IndexFlatCodes(aq->code_size, d, metric), aq(aq)
 {
     FAISS_THROW_IF_NOT(metric == METRIC_INNER_PRODUCT || metric == METRIC_L2);
 }
 
-
-void IndexAdditiveQuantizer::add(idx_t n, const float* x) {
-    FAISS_THROW_IF_NOT(is_trained);
-    codes.resize((n + ntotal) * aq->code_size);
-    aq->compute_codes(x, &codes[ntotal * aq->code_size], n);
-    ntotal += n;
-}
 
 namespace {
 
@@ -161,15 +154,6 @@ void IndexAdditiveQuantizer::search(
         }
 
     }
-}
-
-void IndexAdditiveQuantizer::reset() {
-    codes.clear();
-    ntotal = 0;
-}
-
-size_t IndexAdditiveQuantizer::sa_code_size() const {
-    return code_size;
 }
 
 void IndexAdditiveQuantizer::sa_encode(idx_t n, const float* x, uint8_t* bytes) const {

--- a/faiss/IndexAdditiveQuantizer.h
+++ b/faiss/IndexAdditiveQuantizer.h
@@ -13,7 +13,7 @@
 #include <cstdint>
 #include <vector>
 
-#include <faiss/Index.h>
+#include <faiss/IndexFlatCodes.h>
 #include <faiss/impl/LocalSearchQuantizer.h>
 #include <faiss/impl/ResidualQuantizer.h>
 #include <faiss/impl/platform_macros.h>
@@ -21,7 +21,7 @@
 namespace faiss {
 
 /// Abstract class for additive quantizers. The search functions are in common.
-struct IndexAdditiveQuantizer : Index {
+struct IndexAdditiveQuantizer : IndexFlatCodes {
     // the quantizer, this points to the relevant field in the inheriting
     // classes
     AdditiveQuantizer* aq;
@@ -32,12 +32,6 @@ struct IndexAdditiveQuantizer : Index {
             AdditiveQuantizer* aq = nullptr,
             MetricType metric = METRIC_L2);
 
-    /// size of residual quantizer codes + norms
-    size_t code_size;
-
-    /// Codes. Size ntotal * rq.code_size
-    std::vector<uint8_t> codes;
-
     void search(
             idx_t n,
             const float* x,
@@ -45,13 +39,7 @@ struct IndexAdditiveQuantizer : Index {
             float* distances,
             idx_t* labels) const override;
 
-    void reset() override;
-
-    void add(idx_t n, const float* x) override;
-
     /* The standalone codec interface */
-    size_t sa_code_size() const override;
-
     void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override;
 
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;

--- a/faiss/IndexFlat.h
+++ b/faiss/IndexFlat.h
@@ -12,20 +12,13 @@
 
 #include <vector>
 
-#include <faiss/Index.h>
+#include <faiss/IndexFlatCodes.h>
 
 namespace faiss {
 
 /** Index that stores the full vectors and performs exhaustive search */
-struct IndexFlat : Index {
-    /// database vectors, size ntotal * d
-    std::vector<float> xb;
-
+struct IndexFlat : IndexFlatCodes {
     explicit IndexFlat(idx_t d, MetricType metric = METRIC_L2);
-
-    void add(idx_t n, const float* x) override;
-
-    void reset() override;
 
     void search(
             idx_t n,
@@ -57,18 +50,19 @@ struct IndexFlat : Index {
             float* distances,
             const idx_t* labels) const;
 
-    /** remove some ids. NB that Because of the structure of the
-     * indexing structure, the semantics of this operation are
-     * different from the usual ones: the new ids are shifted */
-    size_t remove_ids(const IDSelector& sel) override;
+    // get pointer to the floating point data
+    float* get_xb() {
+        return (float*)codes.data();
+    }
+    const float* get_xb() const {
+        return (const float*)codes.data();
+    }
 
     IndexFlat() {}
 
     DistanceComputer* get_distance_computer() const override;
 
     /* The stanadlone codec interface (just memcopies in this case) */
-    size_t sa_code_size() const override;
-
     void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override;
 
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;

--- a/faiss/IndexFlatCodes.cpp
+++ b/faiss/IndexFlatCodes.cpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <faiss/IndexFlatCodes.h>
+
+#include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/FaissAssert.h>
+
+namespace faiss {
+
+IndexFlatCodes::IndexFlatCodes(size_t code_size, idx_t d, MetricType metric)
+        : Index(d, metric), code_size(code_size) {}
+
+IndexFlatCodes::IndexFlatCodes() : code_size(0) {}
+
+void IndexFlatCodes::add(idx_t n, const float* x) {
+    FAISS_THROW_IF_NOT(is_trained);
+    codes.resize((ntotal + n) * code_size);
+    sa_encode(n, x, &codes[ntotal * code_size]);
+    ntotal += n;
+}
+
+void IndexFlatCodes::reset() {
+    codes.clear();
+    ntotal = 0;
+}
+
+size_t IndexFlatCodes::sa_code_size() const {
+    return code_size;
+}
+
+size_t IndexFlatCodes::remove_ids(const IDSelector& sel) {
+    idx_t j = 0;
+    for (idx_t i = 0; i < ntotal; i++) {
+        if (sel.is_member(i)) {
+            // should be removed
+        } else {
+            if (i > j) {
+                memmove(&codes[code_size * j],
+                        &codes[code_size * i],
+                        code_size);
+            }
+            j++;
+        }
+    }
+    size_t nremove = ntotal - j;
+    if (nremove > 0) {
+        ntotal = j;
+        codes.resize(ntotal * code_size);
+    }
+    return nremove;
+}
+
+void IndexFlatCodes::reconstruct_n(idx_t i0, idx_t ni, float* recons) const {
+    FAISS_THROW_IF_NOT(ni == 0 || (i0 >= 0 && i0 + ni <= ntotal));
+    sa_decode(ni, codes.data() + i0 * code_size, recons);
+}
+
+void IndexFlatCodes::reconstruct(idx_t key, float* recons) const {
+    reconstruct_n(key, 1, recons);
+}
+
+} // namespace faiss

--- a/faiss/IndexFlatCodes.h
+++ b/faiss/IndexFlatCodes.h
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+#pragma once
+
+#include <faiss/Index.h>
+#include <vector>
+
+namespace faiss {
+
+/** Index that encodes all vectors as fixed-size codes (size code_size). Storage
+ * is in the codes vector */
+struct IndexFlatCodes : Index {
+    size_t code_size;
+
+    /// encoded dataset, size ntotal * code_size
+    std::vector<uint8_t> codes;
+
+    IndexFlatCodes();
+
+    IndexFlatCodes(size_t code_size, idx_t d, MetricType metric = METRIC_L2);
+
+    /// default add uses sa_encode
+    void add(idx_t n, const float* x) override;
+
+    void reset() override;
+
+    /// reconstruction using the codec interface
+    void reconstruct_n(idx_t i0, idx_t ni, float* recons) const override;
+
+    void reconstruct(idx_t key, float* recons) const override;
+
+    size_t sa_code_size() const override;
+
+    /** remove some ids. NB that Because of the structure of the
+     * indexing structure, the semantics of this operation are
+     * different from the usual ones: the new ids are shifted */
+    size_t remove_ids(const IDSelector& sel) override;
+};
+
+} // namespace faiss

--- a/faiss/IndexLSH.h
+++ b/faiss/IndexLSH.h
@@ -12,26 +12,20 @@
 
 #include <vector>
 
-#include <faiss/Index.h>
+#include <faiss/IndexFlatCodes.h>
 #include <faiss/VectorTransform.h>
 
 namespace faiss {
 
 /** The sign of each vector component is put in a binary signature */
-struct IndexLSH : Index {
-    typedef unsigned char uint8_t;
-
+struct IndexLSH : IndexFlatCodes {
     int nbits;             ///< nb of bits per vector
-    int bytes_per_vec;     ///< nb of 8-bits per encoded vector
     bool rotate_data;      ///< whether to apply a random rotation to input
     bool train_thresholds; ///< whether we train thresholds or use 0
 
     RandomRotationMatrix rrot; ///< optional random rotation
 
     std::vector<float> thresholds; ///< thresholds to compare with
-
-    /// encoded dataset
-    std::vector<uint8_t> codes;
 
     IndexLSH(
             idx_t d,
@@ -50,8 +44,6 @@ struct IndexLSH : Index {
 
     void train(idx_t n, const float* x) override;
 
-    void add(idx_t n, const float* x) override;
-
     void search(
             idx_t n,
             const float* x,
@@ -59,7 +51,6 @@ struct IndexLSH : Index {
             float* distances,
             idx_t* labels) const override;
 
-    void reset() override;
 
     /// transfer the thresholds to a pre-processing stage (and unset
     /// train_thresholds)
@@ -72,9 +63,6 @@ struct IndexLSH : Index {
     /* standalone codec interface.
      *
      * The vectors are decoded to +/- 1 (not 0, 1) */
-
-    size_t sa_code_size() const override;
-
     void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override;
 
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;

--- a/faiss/IndexPQ.h
+++ b/faiss/IndexPQ.h
@@ -12,7 +12,7 @@
 
 #include <vector>
 
-#include <faiss/Index.h>
+#include <faiss/IndexFlatCodes.h>
 #include <faiss/impl/PolysemousTraining.h>
 #include <faiss/impl/ProductQuantizer.h>
 #include <faiss/impl/platform_macros.h>
@@ -21,12 +21,9 @@ namespace faiss {
 
 /** Index based on a product quantizer. Stored vectors are
  * approximated by PQ codes. */
-struct IndexPQ : Index {
+struct IndexPQ : IndexFlatCodes {
     /// The product quantizer used to encode the vectors
     ProductQuantizer pq;
-
-    /// Codes. Size ntotal * pq.code_size
-    std::vector<uint8_t> codes;
 
     /** Constructor.
      *
@@ -43,8 +40,6 @@ struct IndexPQ : Index {
 
     void train(idx_t n, const float* x) override;
 
-    void add(idx_t n, const float* x) override;
-
     void search(
             idx_t n,
             const float* x,
@@ -52,17 +47,7 @@ struct IndexPQ : Index {
             float* distances,
             idx_t* labels) const override;
 
-    void reset() override;
-
-    void reconstruct_n(idx_t i0, idx_t ni, float* recons) const override;
-
-    void reconstruct(idx_t key, float* recons) const override;
-
-    size_t remove_ids(const IDSelector& sel) override;
-
     /* The standalone codec interface */
-    size_t sa_code_size() const override;
-
     void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override;
 
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;

--- a/faiss/IndexScalarQuantizer.h
+++ b/faiss/IndexScalarQuantizer.h
@@ -13,6 +13,7 @@
 #include <stdint.h>
 #include <vector>
 
+#include <faiss/IndexFlatCodes.h>
 #include <faiss/IndexIVF.h>
 #include <faiss/impl/ScalarQuantizer.h>
 
@@ -24,14 +25,9 @@ namespace faiss {
  * (default).
  */
 
-struct IndexScalarQuantizer : Index {
+struct IndexScalarQuantizer : IndexFlatCodes {
     /// Used to encode the vectors
     ScalarQuantizer sq;
-
-    /// Codes. Size ntotal * pq.code_size
-    std::vector<uint8_t> codes;
-
-    size_t code_size;
 
     /** Constructor.
      *
@@ -48,8 +44,6 @@ struct IndexScalarQuantizer : Index {
 
     void train(idx_t n, const float* x) override;
 
-    void add(idx_t n, const float* x) override;
-
     void search(
             idx_t n,
             const float* x,
@@ -57,17 +51,9 @@ struct IndexScalarQuantizer : Index {
             float* distances,
             idx_t* labels) const override;
 
-    void reset() override;
-
-    void reconstruct_n(idx_t i0, idx_t ni, float* recons) const override;
-
-    void reconstruct(idx_t key, float* recons) const override;
-
     DistanceComputer* get_distance_computer() const override;
 
     /* standalone codec interface */
-    size_t sa_code_size() const override;
-
     void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override;
 
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;

--- a/faiss/gpu/GpuCloner.cpp
+++ b/faiss/gpu/GpuCloner.cpp
@@ -40,7 +40,7 @@ void ToCPUCloner::merge_index(Index* dst, Index* src, bool successive_ids) {
         auto ifl2 = dynamic_cast<const IndexFlat*>(src);
         FAISS_ASSERT(ifl2);
         FAISS_ASSERT(successive_ids);
-        ifl->add(ifl2->ntotal, ifl2->xb.data());
+        ifl->add(ifl2->ntotal, ifl2->get_xb());
     } else if (auto ifl = dynamic_cast<IndexIVFFlat*>(dst)) {
         auto ifl2 = dynamic_cast<IndexIVFFlat*>(src);
         FAISS_ASSERT(ifl2);
@@ -329,7 +329,7 @@ Index* ToGpuClonerMultiple::clone_Index_to_shards(const Index* index) {
             if (index->ntotal > 0) {
                 long i0 = index->ntotal * i / n;
                 long i1 = index->ntotal * (i + 1) / n;
-                shards[i]->add(i1 - i0, index_flat->xb.data() + i0 * index->d);
+                shards[i]->add(i1 - i0, index_flat->get_xb() + i0 * index->d);
             }
         }
     }

--- a/faiss/impl/AdditiveQuantizer.cpp
+++ b/faiss/impl/AdditiveQuantizer.cpp
@@ -137,7 +137,7 @@ uint32_t AdditiveQuantizer::encode_qcint(float x) const {
 }
 
 float AdditiveQuantizer::decode_qcint(uint32_t c) const {
-    return qnorm.xb[c];
+    return qnorm.get_xb()[c];
 }
 
 void AdditiveQuantizer::pack_codes(

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -171,7 +171,7 @@ static void write_AdditiveQuantizer(const AdditiveQuantizer* aq, IOWriter* f) {
     WRITE1(aq->norm_max);
     if (aq->search_type == AdditiveQuantizer::ST_norm_cqint8 ||
         aq->search_type == AdditiveQuantizer::ST_norm_cqint4) {
-        WRITEVECTOR(aq->qnorm.xb);
+        WRITEXBVECTOR(aq->qnorm.codes);
     }
 }
 
@@ -345,7 +345,7 @@ void write_index(const Index* idx, IOWriter* f) {
                                                                  : "IxFl");
         WRITE1(h);
         write_index_header(idx, f);
-        WRITEVECTOR(idxf->xb);
+        WRITEXBVECTOR(idxf->codes);
     } else if (const IndexLSH* idxl = dynamic_cast<const IndexLSH*>(idx)) {
         uint32_t h = fourcc("IxHe");
         WRITE1(h);
@@ -354,7 +354,8 @@ void write_index(const Index* idx, IOWriter* f) {
         WRITE1(idxl->rotate_data);
         WRITE1(idxl->train_thresholds);
         WRITEVECTOR(idxl->thresholds);
-        WRITE1(idxl->bytes_per_vec);
+        int code_size_i = idxl->code_size;
+        WRITE1(code_size_i);
         write_VectorTransform(&idxl->rrot, f);
         WRITEVECTOR(idxl->codes);
     } else if (const IndexPQ* idxp = dynamic_cast<const IndexPQ*>(idx)) {

--- a/faiss/impl/io.cpp
+++ b/faiss/impl/io.cpp
@@ -240,7 +240,7 @@ uint32_t fourcc(const std::string& sx) {
 
 void fourcc_inv(uint32_t x, char str[5]) {
     *(uint32_t*)str = x;
-    str[5] = 0;
+    str[4] = 0;
 }
 
 std::string fourcc_inv(uint32_t x) {

--- a/faiss/impl/io_macros.h
+++ b/faiss/impl/io_macros.h
@@ -66,3 +66,23 @@
         WRITEANDCHECK(&size, 1);           \
         WRITEANDCHECK((vec).data(), size); \
     }
+
+// read/write xb vector for backwards compatibility of IndexFlat
+
+#define WRITEXBVECTOR(vec)                         \
+    {                                              \
+        FAISS_THROW_IF_NOT((vec).size() % 4 == 0); \
+        size_t size = (vec).size() / 4;            \
+        WRITEANDCHECK(&size, 1);                   \
+        WRITEANDCHECK((vec).data(), size * 4);     \
+    }
+
+#define READXBVECTOR(vec)                                            \
+    {                                                                \
+        size_t size;                                                 \
+        READANDCHECK(&size, 1);                                      \
+        FAISS_THROW_IF_NOT(size >= 0 && size < (uint64_t{1} << 40)); \
+        size *= 4;                                                   \
+        (vec).resize(size);                                          \
+        READANDCHECK((vec).data(), size);                            \
+    }

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -374,6 +374,7 @@ void gpu_sync_all_devices()
 
 %newobject *::get_distance_computer() const;
 %include  <faiss/Index.h>
+%include  <faiss/IndexFlatCodes.h>
 %include  <faiss/IndexFlat.h>
 %include  <faiss/Clustering.h>
 

--- a/tests/test_build_blocks.py
+++ b/tests/test_build_blocks.py
@@ -75,7 +75,7 @@ class TestRevSwigPtr(unittest.TestCase):
             i * 10 + np.array([1, 2, 3, 4], dtype='float32')
             for i in range(5)])
         index.add(xb0)
-        xb = faiss.rev_swig_ptr(index.xb.data(), 4 * 5).reshape(5, 4)
+        xb = faiss.rev_swig_ptr(index.get_xb(), 4 * 5).reshape(5, 4)
         self.assertEqual(np.abs(xb0 - xb).sum(), 0)
 
 

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -174,7 +174,6 @@ class TestExhaustiveSearch(unittest.TestCase):
         )
 
 
-
 class TestInspect(unittest.TestCase):
 
     def test_LinearTransform(self):
@@ -193,6 +192,14 @@ class TestInspect(unittest.TestCase):
         # verify
         ynew = x @ A.T + b
         np.testing.assert_array_almost_equal(yref, ynew)
+
+    def test_IndexFlat(self):
+        xb = np.random.rand(13, 20).astype('float32')
+        index = faiss.IndexFlatL2(20)
+        index.add(xb)
+        np.testing.assert_array_equal(
+            xb, inspect_tools.get_flat_data(index)
+        )
 
 
 class TestRangeEval(unittest.TestCase):

--- a/tests/test_index_accuracy.py
+++ b/tests/test_index_accuracy.py
@@ -192,7 +192,8 @@ class TestSQFlavors(unittest.TestCase):
         nlist = index.nlist
         quantizer = faiss.downcast_index(index.quantizer)
         quantizer2 = faiss.IndexFlat(d2, index.metric_type)
-        centroids = faiss.vector_to_array(quantizer.xb).reshape(nlist, d)
+        centroids = faiss.vector_to_array(quantizer.codes)
+        centroids = centroids.view("float32").reshape(nlist, d)
         centroids2 = self.add2columns(centroids)
         quantizer2.add(centroids2)
         index2 = faiss.IndexIVFScalarQuantizer(

--- a/tests/test_index_composite.py
+++ b/tests/test_index_composite.py
@@ -77,7 +77,8 @@ class TestRemove(unittest.TestCase):
         xb[:, 0] = np.arange(10, dtype='int64') + 1000
         index.add(xb)
         index.remove_ids(np.arange(5, dtype='int64') * 2)
-        xb2 = faiss.vector_float_to_array(index.xb).reshape(5, 5)
+        xb2 = faiss.vector_float_to_array(index.codes)
+        xb2 = xb2.view("float32").reshape(5, 5)
         assert np.all(xb2[:, 0] == xb[np.arange(5) * 2 + 1, 0])
 
     def test_remove_id_map(self):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -13,8 +13,6 @@ import sys
 import pickle
 from multiprocessing.dummy import Pool as ThreadPool
 
-from common_faiss_tests import get_dataset, get_dataset_2
-
 
 class TestIOVariants(unittest.TestCase):
 
@@ -77,9 +75,10 @@ class TestCallbacks(unittest.TestCase):
         index2 = faiss.deserialize_index(np.frombuffer(buf, dtype='uint8'))
 
         self.assertEqual(index.d, index2.d)
-        self.assertTrue(np.all(
-            faiss.vector_to_array(index.xb) == faiss.vector_to_array(index2.xb)
-        ))
+        np.testing.assert_array_equal(
+            faiss.vector_to_array(index.codes),
+            faiss.vector_to_array(index2.codes)
+        )
 
         # This is not a callable function: shoudl raise an exception
         writer = faiss.PyCallbackIOWriter("blabla")
@@ -132,8 +131,8 @@ class TestCallbacks(unittest.TestCase):
 
             self.assertEqual(index.d, index2.d)
             np.testing.assert_array_equal(
-                faiss.vector_to_array(index.xb),
-                faiss.vector_to_array(index2.xb)
+                faiss.vector_to_array(index.codes),
+                faiss.vector_to_array(index2.codes)
             )
 
             # This is not a callable function: should raise an exception
@@ -178,8 +177,8 @@ class TestCallbacks(unittest.TestCase):
 
             self.assertEqual(index.d, index2.d)
             np.testing.assert_array_equal(
-                faiss.vector_to_array(index.xb),
-                faiss.vector_to_array(index2.xb)
+                faiss.vector_to_array(index.codes),
+                faiss.vector_to_array(index2.codes)
             )
 
         finally:


### PR DESCRIPTION
Summary:
This diff adds the class IndexFlatCodes that becomes the parent of all "flat" encodings.
IndexPQ
IndexFlat
IndexAdditiveQuantizer
IndexScalarQuantizer
IndexLSH
Index2Layer

The other changes are:
- for IndexFlat, there is no vector<float> with the data anymore. It is replaced with a `get_xb()` function. This broke quite a few external codes, that this diff also attempts to fix.
- I/O functions needed to be adapted. This is done without changing the I/O format for any index.
- added a small contrib function to get the data from the IndexFlat
- the functionality has been made uniform, for example remove_ids and add are now in the parent class.

Eventually, we may support generic storage for flat indexes, similar to `InvertedLists`, eg to memmap the data, but this will again require a big change.

Differential Revision: D32646769

