### PR TITLE
Faiss GPU: fix gpu 0 usage if gpu 0 is not used (GitHub issue 2178)

### DIFF
--- a/faiss/gpu/StandardGpuResources.cpp
+++ b/faiss/gpu/StandardGpuResources.cpp
@@ -268,6 +268,9 @@ void StandardGpuResourcesImpl::initializeForDevice(int device) {
         return;
     }
 
+    FAISS_ASSERT(device < getNumDevices());
+    DeviceScope scope(device);
+
     // If this is the first device that we're initializing, create our
     // pinned memory allocation
     if (defaultStreams_.empty() && pinnedMemSize_ > 0) {
@@ -284,9 +287,6 @@ void StandardGpuResourcesImpl::initializeForDevice(int device) {
 
         pinnedMemAllocSize_ = pinnedMemSize_;
     }
-
-    FAISS_ASSERT(device < getNumDevices());
-    DeviceScope scope(device);
 
     // Make sure that device properties for all devices are cached
     auto& prop = getDeviceProperties(device);


### PR DESCRIPTION
Summary:
This diff fixes the issue in https://github.com/facebookresearch/faiss/issues/2178

namely that cudaHostAlloc does seem to perform some GPU initialization on the current device that is active.

Differential Revision: D33480473

