### PR TITLE
SWIG wrapper for InvertedListScanner

### DIFF
--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -401,8 +401,6 @@ void gpu_sync_all_devices()
 %ignore BlockInvertedListsIOHook;
 %include  <faiss/invlists/BlockInvertedLists.h>
 %include  <faiss/invlists/DirectMap.h>
-%ignore InvertedListScanner;
-%ignore BinaryInvertedListScanner;
 %include  <faiss/IndexIVF.h>
 // NOTE(hoss): SWIG (wrongly) believes the overloaded const version shadows the
 //   non-const one.


### PR DESCRIPTION
As discussed in #2072, here is a PR to use InvertedListScanner with Python. It might be slower but it gives access to this features in Python for those who want to avoid C++.