### PR TITLE
Break distance ties in `heap_replace_top()` by ID

### DIFF
--- a/faiss/utils/ordered_key_value.h
+++ b/faiss/utils/ordered_key_value.h
@@ -46,6 +46,11 @@ struct CMin {
     inline static bool cmp(T a, T b) {
         return a < b;
     }
+    // Similar to cmp(), but also breaks ties
+    // by comparing the second pair of arguments.
+    inline static bool cmp2(T a1, T b1, TI a2, TI b2) {
+        return (a1 < b1) || ((a1 == b1) && (a2 < b2));
+    }
     inline static T neutral() {
         return std::numeric_limits<T>::lowest();
     }
@@ -63,6 +68,11 @@ struct CMax {
     typedef CMin<T_, TI_> Crev;
     inline static bool cmp(T a, T b) {
         return a > b;
+    }
+    // Similar to cmp(), but also breaks ties
+    // by comparing the second pair of arguments.
+    inline static bool cmp2(T a1, T b1, TI a2, TI b2) {
+        return (a1 > b1) || ((a1 == b1) && (a2 > b2));
     }
     inline static T neutral() {
         return std::numeric_limits<T>::max();

--- a/tests/test_fast_scan.py
+++ b/tests/test_fast_scan.py
@@ -112,7 +112,7 @@ class TestRounding(unittest.TestCase):
             recalls[rank] = (Iref[:, :1] == I4[:, :rank]).sum() / nq
 
         min_r1 = 0.98 if metric == faiss.METRIC_INNER_PRODUCT else 0.99
-        self.assertGreater(recalls[1], min_r1)
+        self.assertGreaterEqual(recalls[1], min_r1)
         self.assertGreater(recalls[10], 0.995)
         # check accuracy of distances
         # err3 = ((D3 - D2) ** 2).sum()
@@ -423,7 +423,7 @@ class TestAdd(unittest.TestCase):
 
         recall_at_1 = (Iref[:, 0] == Inew[:, 0]).sum() / nq
 
-        self.assertGreater(recall_at_1, 0.99)
+        self.assertGreaterEqual(recall_at_1, 0.99)
 
         data = faiss.serialize_index(index2)
         index3 = faiss.deserialize_index(data)

--- a/tests/test_fast_scan_ivf.py
+++ b/tests/test_fast_scan_ivf.py
@@ -436,15 +436,15 @@ class TestTraining(unittest.TestCase):
         m3 = three_metrics(Dref, Iref, Dnew, Inew)
         #   print((by_residual, metric, d), ":", m3)
         ref_m3_tab = {
-            (True, 1, 32) : (0.995, 1.0, 9.91),
-            (True, 0, 32) : (0.99, 1.0, 9.91),
-            (True, 1, 30) : (0.99, 1.0, 9.885),
-            (False, 1, 32) : (0.99, 1.0, 9.875),
-            (False, 0, 32) : (0.99, 1.0, 9.92),
-            (False, 1, 30) : (1.0, 1.0, 9.895)
+            (True, 1, 32): (0.995, 1.0, 9.91),
+            (True, 0, 32): (0.99, 1.0, 9.91),
+            (True, 1, 30): (0.989, 1.0, 9.885),
+            (False, 1, 32): (0.99, 1.0, 9.875),
+            (False, 0, 32): (0.99, 1.0, 9.92),
+            (False, 1, 30): (1.0, 1.0, 9.895)
         }
         ref_m3 = ref_m3_tab[(by_residual, metric, d)]
-        self.assertGreater(m3[0], ref_m3[0] * 0.99)
+        self.assertGreaterEqual(m3[0], ref_m3[0] * 0.99)
         self.assertGreater(m3[1], ref_m3[1] * 0.99)
         self.assertGreater(m3[2], ref_m3[2] * 0.99)
 

--- a/tests/test_residual_quantizer.py
+++ b/tests/test_residual_quantizer.py
@@ -735,7 +735,7 @@ class TestIndexResidualQuantizerSearch(unittest.TestCase):
                 self.assertLess((Iref != I2).sum(), Iref.size * 0.05)
             else:
                 inter_2 = faiss.eval_intersection(I2, gt)
-                self.assertGreater(inter_ref, inter_2)
+                self.assertGreaterEqual(inter_ref, inter_2)
                 # print(st, inter_ref, inter_2)
 
 


### PR DESCRIPTION
Summary: This changeset makes the `heap_replace_top()` function of the FAISS heap implementation break distance ties by the element's ID, according to the heap's min/max property.

Reviewed By: mdouze

Differential Revision: D34669542

