### PR TITLE
Generalize DistanceComputer for flat indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ the Facebook Faiss team.  Feel free to add entries here if you submit a PR.
 ## [Unreleased]
 
 - Added sparse k-means routines and moved the generic kmeans to contrib
+- Added FlatDistanceComputer for all FlatCodes indexes
 
 ## [1.7.2] - 2021-12-15
 ### Added

--- a/c_api/impl/AuxIndexStructures_c.cpp
+++ b/c_api/impl/AuxIndexStructures_c.cpp
@@ -10,6 +10,7 @@
 
 #include "AuxIndexStructures_c.h"
 #include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/DistanceComputer.h>
 #include <iostream>
 #include "../macros_impl.h"
 

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -131,6 +131,7 @@ set(FAISS_HEADERS
   index_io.h
   impl/AdditiveQuantizer.h
   impl/AuxIndexStructures.h
+  impl/DistanceComputer.h
   impl/FaissAssert.h
   impl/FaissException.h
   impl/HNSW.h

--- a/faiss/Index.cpp
+++ b/faiss/Index.cpp
@@ -10,6 +10,7 @@
 #include <faiss/Index.h>
 
 #include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/DistanceComputer.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/distances.h>
 

--- a/faiss/Index.h
+++ b/faiss/Index.h
@@ -38,7 +38,8 @@
 
 namespace faiss {
 
-/// Forward declarations see AuxIndexStructures.h
+/// Forward declarations see impl/AuxIndexStructures.h and
+/// impl/DistanceComputer.h
 struct IDSelector;
 struct RangeSearchResult;
 struct DistanceComputer;

--- a/faiss/IndexAdditiveQuantizer.cpp
+++ b/faiss/IndexAdditiveQuantizer.cpp
@@ -40,6 +40,90 @@ IndexAdditiveQuantizer::IndexAdditiveQuantizer(
 
 namespace {
 
+/************************************************************
+ * DistanceComputer implementation
+ ************************************************************/
+
+template <class VectorDistance>
+struct AQDistanceComputerDecompress: FlatCodesDistanceComputer {
+    std::vector<float> tmp;
+    const AdditiveQuantizer & aq;
+    VectorDistance vd;
+    size_t d;
+
+    AQDistanceComputerDecompress(const IndexAdditiveQuantizer &iaq, VectorDistance vd):
+        FlatCodesDistanceComputer(iaq.codes.data(), iaq.code_size),
+        tmp(iaq.d * 2),
+        aq(*iaq.aq),
+        vd(vd),
+        d(iaq.d)
+        {}
+
+    const float *q;
+    void set_query(const float* x) final {
+        q = x;
+    }
+
+    float symmetric_dis(idx_t i, idx_t j) final {
+        aq.decode(codes + i * d, tmp.data(), 1);
+        aq.decode(codes + j * d, tmp.data() + d, 1);
+        return vd(tmp.data(), tmp.data() + d);
+    }
+
+    float distance_to_code(const uint8_t *code) final {
+        aq.decode(code, tmp.data(), 1);
+        return vd(q, tmp.data());
+    }
+
+    virtual ~AQDistanceComputerDecompress() {}
+};
+
+
+template<bool is_IP, AdditiveQuantizer::Search_type_t st>
+struct AQDistanceComputerLUT: FlatCodesDistanceComputer {
+    std::vector<float> LUT;
+    const AdditiveQuantizer & aq;
+    size_t d;
+
+    explicit AQDistanceComputerLUT(const IndexAdditiveQuantizer &iaq):
+        FlatCodesDistanceComputer(iaq.codes.data(), iaq.code_size),
+        LUT(iaq.aq->total_codebook_size + iaq.d * 2),
+        aq(*iaq.aq),
+        d(iaq.d)
+        {}
+
+    float bias;
+    void set_query(const float* x) final {
+        // this is quite sub-optimal for multiple queries
+        aq.compute_LUT(1, x, LUT.data());
+        if (is_IP) {
+            bias = 0;
+        } else {
+            bias = fvec_norm_L2sqr(x, d);
+        }
+    }
+
+    float symmetric_dis(idx_t i, idx_t j) final {
+        float *tmp = LUT.data();
+        aq.decode(codes + i * d, tmp, 1);
+        aq.decode(codes + j * d, tmp + d, 1);
+        return fvec_L2sqr(tmp, tmp + d, d);
+    }
+
+    float distance_to_code(const uint8_t *code) final {
+        return bias + aq.compute_1_distance_LUT<is_IP, st>(code, LUT.data());
+    }
+
+    virtual ~AQDistanceComputerLUT() {}
+};
+
+
+
+/************************************************************
+ * scanning implementation for search
+ ************************************************************/
+
+
 template <class VectorDistance, class ResultHandler>
 void search_with_decompress(
         const IndexAdditiveQuantizer& ir,
@@ -111,12 +195,58 @@ void search_with_LUT(
 
 } // anonymous namespace
 
+
+FlatCodesDistanceComputer * IndexAdditiveQuantizer::get_FlatCodesDistanceComputer() const {
+
+    if (aq->search_type == AdditiveQuantizer::ST_decompress) {
+        if (metric_type == METRIC_L2) {
+            using VD = VectorDistance<METRIC_L2>;
+            VD vd = {size_t(d), metric_arg};
+            return new AQDistanceComputerDecompress<VD>(*this, vd);
+        } else if (metric_type == METRIC_INNER_PRODUCT) {
+            using VD = VectorDistance<METRIC_INNER_PRODUCT>;
+            VD vd = {size_t(d), metric_arg};
+            return new AQDistanceComputerDecompress<VD>(*this, vd);
+        } else {
+            FAISS_THROW_MSG("unsupported metric");
+        }
+    } else {
+        if (metric_type == METRIC_INNER_PRODUCT) {
+            return new AQDistanceComputerLUT<true, AdditiveQuantizer::ST_LUT_nonorm>(*this);
+        } else {
+            switch(aq->search_type) {
+#define DISPATCH(st) \
+            case AdditiveQuantizer::st: \
+                return new AQDistanceComputerLUT<false, AdditiveQuantizer::st> (*this);\
+                break;
+            DISPATCH(ST_norm_float)
+            DISPATCH(ST_LUT_nonorm)
+            DISPATCH(ST_norm_qint8)
+            DISPATCH(ST_norm_qint4)
+            DISPATCH(ST_norm_cqint4)
+            case AdditiveQuantizer::ST_norm_cqint8:
+            case AdditiveQuantizer::ST_norm_lsq2x4:
+            case AdditiveQuantizer::ST_norm_rq2x4:
+                return new AQDistanceComputerLUT<false, AdditiveQuantizer::ST_norm_cqint8> (*this);\
+                break;
+#undef DISPATCH
+            default:
+                FAISS_THROW_FMT("search type %d not supported", aq->search_type);
+            }
+        }
+    }
+}
+
+
+
+
 void IndexAdditiveQuantizer::search(
         idx_t n,
         const float* x,
         idx_t k,
         float* distances,
         idx_t* labels) const {
+
     if (aq->search_type == AdditiveQuantizer::ST_decompress) {
         if (metric_type == METRIC_L2) {
             using VD = VectorDistance<METRIC_L2>;
@@ -135,22 +265,23 @@ void IndexAdditiveQuantizer::search(
             search_with_LUT<true, AdditiveQuantizer::ST_LUT_nonorm> (*this, x, rh);
         } else {
             HeapResultHandler<CMax<float, idx_t> > rh(n, distances, labels, k);
-
-            if (aq->search_type == AdditiveQuantizer::ST_norm_float) {
-                search_with_LUT<false, AdditiveQuantizer::ST_norm_float> (*this, x, rh);
-            } else if (aq->search_type == AdditiveQuantizer::ST_LUT_nonorm) {
-                search_with_LUT<false, AdditiveQuantizer::ST_norm_float> (*this, x, rh);
-            } else if (aq->search_type == AdditiveQuantizer::ST_norm_qint8) {
-                search_with_LUT<false, AdditiveQuantizer::ST_norm_qint8> (*this, x, rh);
-            } else if (aq->search_type == AdditiveQuantizer::ST_norm_qint4) {
-                search_with_LUT<false, AdditiveQuantizer::ST_norm_qint4> (*this, x, rh);
-            } else if (aq->search_type == AdditiveQuantizer::ST_norm_cqint8 ||
-                    aq->search_type == AdditiveQuantizer::ST_norm_lsq2x4 ||
-                    aq->search_type == AdditiveQuantizer::ST_norm_rq2x4) {
+            switch(aq->search_type) {
+#define DISPATCH(st) \
+            case AdditiveQuantizer::st: \
+                search_with_LUT<false, AdditiveQuantizer::st> (*this, x, rh);\
+                break;
+            DISPATCH(ST_norm_float)
+            DISPATCH(ST_LUT_nonorm)
+            DISPATCH(ST_norm_qint8)
+            DISPATCH(ST_norm_qint4)
+            DISPATCH(ST_norm_cqint4)
+            case AdditiveQuantizer::ST_norm_cqint8:
+            case AdditiveQuantizer::ST_norm_lsq2x4:
+            case AdditiveQuantizer::ST_norm_rq2x4:
                 search_with_LUT<false, AdditiveQuantizer::ST_norm_cqint8> (*this, x, rh);
-            } else if (aq->search_type == AdditiveQuantizer::ST_norm_cqint4) {
-                search_with_LUT<false, AdditiveQuantizer::ST_norm_cqint4> (*this, x, rh);
-            } else {
+                break;
+#undef DISPATCH
+            default:
                 FAISS_THROW_FMT("search type %d not supported", aq->search_type);
             }
         }

--- a/faiss/IndexAdditiveQuantizer.h
+++ b/faiss/IndexAdditiveQuantizer.h
@@ -43,6 +43,8 @@ struct IndexAdditiveQuantizer : IndexFlatCodes {
     void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override;
 
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
+
+    FlatCodesDistanceComputer* get_FlatCodesDistanceComputer() const override;
 };
 
 /** Index based on a residual quantizer. Stored vectors are

--- a/faiss/IndexBinaryHNSW.cpp
+++ b/faiss/IndexBinaryHNSW.cpp
@@ -26,6 +26,7 @@
 
 #include <faiss/IndexBinaryFlat.h>
 #include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/DistanceComputer.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/Heap.h>
 #include <faiss/utils/hamming.h>

--- a/faiss/IndexFlat.h
+++ b/faiss/IndexFlat.h
@@ -60,7 +60,7 @@ struct IndexFlat : IndexFlatCodes {
 
     IndexFlat() {}
 
-    DistanceComputer* get_distance_computer() const override;
+    FlatCodesDistanceComputer* get_FlatCodesDistanceComputer() const override;
 
     /* The stanadlone codec interface (just memcopies in this case) */
     void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override;

--- a/faiss/IndexFlatCodes.cpp
+++ b/faiss/IndexFlatCodes.cpp
@@ -8,6 +8,7 @@
 #include <faiss/IndexFlatCodes.h>
 
 #include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/DistanceComputer.h>
 #include <faiss/impl/FaissAssert.h>
 
 namespace faiss {
@@ -62,6 +63,11 @@ void IndexFlatCodes::reconstruct_n(idx_t i0, idx_t ni, float* recons) const {
 
 void IndexFlatCodes::reconstruct(idx_t key, float* recons) const {
     reconstruct_n(key, 1, recons);
+}
+
+FlatCodesDistanceComputer* IndexFlatCodes::get_FlatCodesDistanceComputer()
+        const {
+    FAISS_THROW_MSG("not implemented");
 }
 
 } // namespace faiss

--- a/faiss/IndexFlatCodes.h
+++ b/faiss/IndexFlatCodes.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <faiss/Index.h>
+#include <faiss/impl/DistanceComputer.h>
 #include <vector>
 
 namespace faiss {
@@ -42,6 +43,13 @@ struct IndexFlatCodes : Index {
      * indexing structure, the semantics of this operation are
      * different from the usual ones: the new ids are shifted */
     size_t remove_ids(const IDSelector& sel) override;
+
+    /** a FlatCodesDistanceComputer offers a distance_to_code method */
+    virtual FlatCodesDistanceComputer* get_FlatCodesDistanceComputer() const;
+
+    DistanceComputer* get_distance_computer() const override {
+        return get_FlatCodesDistanceComputer();
+    }
 };
 
 } // namespace faiss

--- a/faiss/IndexIVFAdditiveQuantizer.cpp
+++ b/faiss/IndexIVFAdditiveQuantizer.cpp
@@ -5,9 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// quiet the noise
-// XXclang-format off
-
 #include <faiss/IndexIVFAdditiveQuantizer.h>
 
 #include <algorithm>

--- a/faiss/IndexPQ.h
+++ b/faiss/IndexPQ.h
@@ -52,7 +52,7 @@ struct IndexPQ : IndexFlatCodes {
 
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
 
-    DistanceComputer* get_distance_computer() const override;
+    FlatCodesDistanceComputer* get_FlatCodesDistanceComputer() const override;
 
     /******************************************************
      * Polysemous codes implementation

--- a/faiss/IndexPreTransform.cpp
+++ b/faiss/IndexPreTransform.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 
 #include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/DistanceComputer.h>
 #include <faiss/impl/FaissAssert.h>
 
 namespace faiss {

--- a/faiss/IndexScalarQuantizer.cpp
+++ b/faiss/IndexScalarQuantizer.cpp
@@ -85,7 +85,8 @@ void IndexScalarQuantizer::search(
     }
 }
 
-DistanceComputer* IndexScalarQuantizer::get_distance_computer() const {
+FlatCodesDistanceComputer* IndexScalarQuantizer::get_FlatCodesDistanceComputer()
+        const {
     ScalarQuantizer::SQDistanceComputer* dc =
             sq.get_distance_computer(metric_type);
     dc->code_size = sq.code_size;

--- a/faiss/IndexScalarQuantizer.h
+++ b/faiss/IndexScalarQuantizer.h
@@ -20,11 +20,8 @@
 namespace faiss {
 
 /**
- * The uniform quantizer has a range [vmin, vmax]. The range can be
- * the same for all dimensions (uniform) or specific per dimension
- * (default).
+ * Flat index built on a scalar quantizer.
  */
-
 struct IndexScalarQuantizer : IndexFlatCodes {
     /// Used to encode the vectors
     ScalarQuantizer sq;
@@ -51,7 +48,7 @@ struct IndexScalarQuantizer : IndexFlatCodes {
             float* distances,
             idx_t* labels) const override;
 
-    DistanceComputer* get_distance_computer() const override;
+    FlatCodesDistanceComputer* get_FlatCodesDistanceComputer() const override;
 
     /* standalone codec interface */
     void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override;

--- a/faiss/impl/AdditiveQuantizer.h
+++ b/faiss/impl/AdditiveQuantizer.h
@@ -30,7 +30,8 @@ struct AdditiveQuantizer {
     // derived values
     std::vector<uint64_t> codebook_offsets;
     size_t code_size;           ///< code size in bytes
-    size_t tot_bits;            ///< total number of bits
+    size_t tot_bits;            ///< total number of bits (indexes + norms)
+    size_t norm_bits;           ///< bits allocated for the norms
     size_t total_codebook_size; ///< size of the codebook in vectors
     bool only_8bit;             ///< are all nbits = 8 (use faster decoder)
 
@@ -41,11 +42,15 @@ struct AdditiveQuantizer {
     std::vector<float> norm_tabs; ///< store norms of codebook entries for 4-bit
                                   ///< fastscan search
 
+    /// encode a norm into norm_bits bits
+    uint64_t encode_norm(float norm) const;
+
     uint32_t encode_qcint(
             float x) const; ///< encode norm by non-uniform scalar quantization
 
     float decode_qcint(uint32_t c)
             const; ///< decode norm by non-uniform scalar quantization
+
 
     /// Encodes how search is performed and how vectors are encoded
     enum Search_type_t {

--- a/faiss/impl/AuxIndexStructures.h
+++ b/faiss/impl/AuxIndexStructures.h
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// -*- c++ -*-
-
 // Auxiliary index structures, that are used in indexes but that can
 // be forward-declared
 
@@ -184,30 +182,6 @@ struct RangeSearchPartialResult : BufferList {
     static void merge(
             std::vector<RangeSearchPartialResult*>& partial_results,
             bool do_delete = true);
-};
-
-/***********************************************************
- * The distance computer maintains a current query and computes
- * distances to elements in an index that supports random access.
- *
- * The DistanceComputer is not intended to be thread-safe (eg. because
- * it maintains counters) so the distance functions are not const,
- * instantiate one from each thread if needed.
- ***********************************************************/
-struct DistanceComputer {
-    using idx_t = Index::idx_t;
-
-    /// called before computing distances. Pointer x should remain valid
-    /// while operator () is called
-    virtual void set_query(const float* x) = 0;
-
-    /// compute distance of vector i to current query
-    virtual float operator()(idx_t i) = 0;
-
-    /// compute distance between two stored vectors
-    virtual float symmetric_dis(idx_t i, idx_t j) = 0;
-
-    virtual ~DistanceComputer() {}
 };
 
 /***********************************************************

--- a/faiss/impl/DistanceComputer.h
+++ b/faiss/impl/DistanceComputer.h
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <faiss/Index.h>
+
+namespace faiss {
+
+/***********************************************************
+ * The distance computer maintains a current query and computes
+ * distances to elements in an index that supports random access.
+ *
+ * The DistanceComputer is not intended to be thread-safe (eg. because
+ * it maintains counters) so the distance functions are not const,
+ * instantiate one from each thread if needed.
+ *
+ * Note that the equivalent for IVF indexes is the InvertedListScanner,
+ * that has additional methods to handle the inverted list context.
+ ***********************************************************/
+struct DistanceComputer {
+    using idx_t = Index::idx_t;
+
+    /// called before computing distances. Pointer x should remain valid
+    /// while operator () is called
+    virtual void set_query(const float* x) = 0;
+
+    /// compute distance of vector i to current query
+    virtual float operator()(idx_t i) = 0;
+
+    /// compute distance between two stored vectors
+    virtual float symmetric_dis(idx_t i, idx_t j) = 0;
+
+    virtual ~DistanceComputer() {}
+};
+
+/*************************************************************
+ * Specialized version of the DistanceComputer when we know that codes are
+ * laid out in a flat index.
+ */
+struct FlatCodesDistanceComputer : DistanceComputer {
+    const uint8_t* codes;
+    size_t code_size;
+
+    FlatCodesDistanceComputer(const uint8_t* codes, size_t code_size)
+            : codes(codes), code_size(code_size) {}
+
+    FlatCodesDistanceComputer() : codes(nullptr), code_size(0) {}
+
+    float operator()(idx_t i) final {
+        return distance_to_code(codes + i * code_size);
+    }
+
+    /// compute distance of current query to an encoded vector
+    virtual float distance_to_code(const uint8_t* code) = 0;
+
+    virtual ~FlatCodesDistanceComputer() {}
+};
+
+} // namespace faiss

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -12,6 +12,7 @@
 #include <string>
 
 #include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/DistanceComputer.h>
 
 namespace faiss {
 

--- a/faiss/impl/NNDescent.cpp
+++ b/faiss/impl/NNDescent.cpp
@@ -13,6 +13,7 @@
 #include <string>
 
 #include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/DistanceComputer.h>
 
 namespace faiss {
 

--- a/faiss/impl/NSG.cpp
+++ b/faiss/impl/NSG.cpp
@@ -14,7 +14,7 @@
 #include <mutex>
 #include <stack>
 
-#include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/DistanceComputer.h>
 
 namespace faiss {
 

--- a/faiss/impl/ResidualQuantizer.h
+++ b/faiss/impl/ResidualQuantizer.h
@@ -28,7 +28,7 @@ struct ResidualQuantizer : AdditiveQuantizer {
     //  Was enum but that does not work so well with bitmasks
     using train_type_t = int;
 
-    /// Or of the Train_* flags below
+    /// Binary or of the Train_* flags below
     train_type_t train_type;
 
     /// regular k-means (minimal amount of computation)
@@ -47,7 +47,7 @@ struct ResidualQuantizer : AdditiveQuantizer {
      *  first element of the beam (faster but less accurate) */
     static const int Train_top_beam = 1024;
 
-    /** set this bit to not autmatically compute the codebook tables
+    /** set this bit to *not* autmatically compute the codebook tables
      * after training */
     static const int Skip_codebook_tables = 2048;
 
@@ -82,6 +82,9 @@ struct ResidualQuantizer : AdditiveQuantizer {
 
     /// Train the residual quantizer
     void train(size_t n, const float* x) override;
+
+    /// Copy the M codebook levels from other, starting from skip_M
+    void initialize_from(const ResidualQuantizer& other, int skip_M = 0);
 
     /** Encode the vectors and compute codebook that minimizes the quantization
      * error on these codes

--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -911,11 +911,6 @@ struct DCTemplate<Quantizer, Similarity, 1> : SQDistanceComputer {
         q = x;
     }
 
-    /// compute distance of vector i to current query
-    float operator()(idx_t i) final {
-        return query_to_code(codes + i * code_size);
-    }
-
     float symmetric_dis(idx_t i, idx_t j) override {
         return compute_code_distance(
                 codes + i * code_size, codes + j * code_size);
@@ -961,11 +956,6 @@ struct DCTemplate<Quantizer, Similarity, 8> : SQDistanceComputer {
 
     void set_query(const float* x) final {
         q = x;
-    }
-
-    /// compute distance of vector i to current query
-    float operator()(idx_t i) final {
-        return query_to_code(codes + i * code_size);
     }
 
     float symmetric_dis(idx_t i, idx_t j) override {
@@ -1019,11 +1009,6 @@ struct DistanceComputerByte<Similarity, 1> : SQDistanceComputer {
     int compute_distance(const float* x, const uint8_t* code) {
         set_query(x);
         return compute_code_distance(tmp.data(), code);
-    }
-
-    /// compute distance of vector i to current query
-    float operator()(idx_t i) final {
-        return query_to_code(codes + i * code_size);
     }
 
     float symmetric_dis(idx_t i, idx_t j) override {
@@ -1087,11 +1072,6 @@ struct DistanceComputerByte<Similarity, 8> : SQDistanceComputer {
     int compute_distance(const float* x, const uint8_t* code) {
         set_query(x);
         return compute_code_distance(tmp.data(), code);
-    }
-
-    /// compute distance of vector i to current query
-    float operator()(idx_t i) final {
-        return query_to_code(codes + i * code_size);
     }
 
     float symmetric_dis(idx_t i, idx_t j) override {

--- a/faiss/impl/ScalarQuantizer.h
+++ b/faiss/impl/ScalarQuantizer.h
@@ -11,6 +11,7 @@
 
 #include <faiss/IndexIVF.h>
 #include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/DistanceComputer.h>
 
 namespace faiss {
 
@@ -105,14 +106,16 @@ struct ScalarQuantizer {
 
     Quantizer* select_quantizer() const;
 
-    struct SQDistanceComputer : DistanceComputer {
+    struct SQDistanceComputer : FlatCodesDistanceComputer {
         const float* q;
-        const uint8_t* codes;
-        size_t code_size;
 
-        SQDistanceComputer() : q(nullptr), codes(nullptr), code_size(0) {}
+        SQDistanceComputer() : q(nullptr) {}
 
         virtual float query_to_code(const uint8_t* code) const = 0;
+
+        float distance_to_code(const uint8_t* code) final {
+            return query_to_code(code);
+        }
     };
 
     SQDistanceComputer* get_distance_computer(

--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -1287,6 +1287,12 @@ def randn(n, seed=12345):
     float_randn(swig_ptr(res), res.size, seed)
     return res
 
+rand_smooth_vectors_c = rand_smooth_vectors
+
+def rand_smooth_vectors(n, d, seed=1234):
+    res = np.empty((n, d), dtype='float32')
+    rand_smooth_vectors_c(n, d, swig_ptr(res), seed)
+    return res
 
 def eval_intersection(I1, I2):
     """ size of intersection between each line of two result tables"""
@@ -1429,24 +1435,14 @@ def knn(xq, xb, k, metric=METRIC_L2):
     D = np.empty((nq, k), dtype='float32')
 
     if metric == METRIC_L2:
-        heaps = float_maxheap_array_t()
-        heaps.k = k
-        heaps.nh = nq
-        heaps.val = swig_ptr(D)
-        heaps.ids = swig_ptr(I)
         knn_L2sqr(
             swig_ptr(xq), swig_ptr(xb),
-            d, nq, nb, heaps
+            d, nq, nb, k, swig_ptr(D), swig_ptr(I)
         )
     elif metric == METRIC_INNER_PRODUCT:
-        heaps = float_minheap_array_t()
-        heaps.k = k
-        heaps.nh = nq
-        heaps.val = swig_ptr(D)
-        heaps.ids = swig_ptr(I)
         knn_inner_product(
             swig_ptr(xq), swig_ptr(xb),
-            d, nq, nb, heaps
+            d, nq, nb, k, swig_ptr(D), swig_ptr(I)
         )
     else:
         raise NotImplementedError("only L2 and INNER_PRODUCT are supported")

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -126,6 +126,7 @@ typedef uint64_t size_t;
 #include <faiss/utils/AlignedTable.h>
 #include <faiss/utils/partitioning.h>
 #include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/DistanceComputer.h>
 #include <faiss/impl/AdditiveQuantizer.h>
 #include <faiss/impl/ResidualQuantizer.h>
 #include <faiss/impl/LocalSearchQuantizer.h>
@@ -378,6 +379,10 @@ void gpu_sync_all_devices()
 
 %newobject *::get_distance_computer() const;
 %include  <faiss/Index.h>
+
+%include <faiss/impl/DistanceComputer.h>
+
+%newobject *::get_FlatCodesDistanceComputer() const;
 %include  <faiss/IndexFlatCodes.h>
 %include  <faiss/IndexFlat.h>
 %include  <faiss/Clustering.h>
@@ -484,7 +489,8 @@ void gpu_sync_all_devices()
 %ignore faiss::InterruptCallback::instance;
 %ignore faiss::InterruptCallback::lock;
 
-%include  <faiss/impl/AuxIndexStructures.h>
+%include <faiss/impl/AuxIndexStructures.h>
+
 
 
 #ifdef GPU_WRAPPER

--- a/faiss/utils/distances.cpp
+++ b/faiss/utils/distances.cpp
@@ -333,6 +333,19 @@ void knn_inner_product(
     }
 }
 
+void knn_inner_product(
+        const float* x,
+        const float* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        size_t k,
+        float* distances,
+        int64_t* indexes) {
+    float_minheap_array_t heaps = {nx, k, indexes, distances};
+    knn_inner_product(x, y, d, nx, ny, &heaps);
+}
+
 void knn_L2sqr(
         const float* x,
         const float* y,
@@ -359,6 +372,20 @@ void knn_L2sqr(
             exhaustive_L2sqr_blas(x, y, d, nx, ny, res, y_norm2);
         }
     }
+}
+
+void knn_L2sqr(
+        const float* x,
+        const float* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        size_t k,
+        float* distances,
+        int64_t* indexes,
+        const float* y_norm2) {
+    float_maxheap_array_t heaps = {nx, k, indexes, distances};
+    knn_L2sqr(x, y, d, nx, ny, &heaps, y_norm2);
 }
 
 /***************************************************************************

--- a/faiss/utils/distances.h
+++ b/faiss/utils/distances.h
@@ -198,11 +198,11 @@ FAISS_API extern int distance_compute_blas_database_bs;
 FAISS_API extern int distance_compute_min_k_reservoir;
 
 /** Return the k nearest neighors of each of the nx vectors x among the ny
- *  vector y, w.r.t to max inner product
+ *  vector y, w.r.t to max inner product.
  *
  * @param x    query vectors, size nx * d
  * @param y    database vectors, size ny * d
- * @param res  result array, which also provides k. Sorted on output
+ * @param res  result heap structure, which also provides k. Sorted on output
  */
 void knn_inner_product(
         const float* x,
@@ -212,8 +212,30 @@ void knn_inner_product(
         size_t ny,
         float_minheap_array_t* res);
 
-/** Same as knn_inner_product, for the L2 distance
- *  @param y_norm2    norms for the y vectors (nullptr or size ny)
+/**  Return the k nearest neighors of each of the nx vectors x among the ny
+ *  vector y, for the inner product metric.
+ *
+ * @param x    query vectors, size nx * d
+ * @param y    database vectors, size ny * d
+ * @param distances  output distances, size nq * k
+ * @param indexes    output vector ids, size nq * k
+ */
+void knn_inner_product(
+        const float* x,
+        const float* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        size_t k,
+        float* distances,
+        int64_t* indexes);
+
+/** Return the k nearest neighors of each of the nx vectors x among the ny
+ *  vector y, for the L2 distance
+ * @param x    query vectors, size nx * d
+ * @param y    database vectors, size ny * d
+ * @param res  result heap strcture, which also provides k. Sorted on output
+ * @param y_norm2    (optional) norms for the y vectors (nullptr or size ny)
  */
 void knn_L2sqr(
         const float* x,
@@ -222,6 +244,26 @@ void knn_L2sqr(
         size_t nx,
         size_t ny,
         float_maxheap_array_t* res,
+        const float* y_norm2 = nullptr);
+
+/**  Return the k nearest neighors of each of the nx vectors x among the ny
+ *  vector y, for the L2 distance
+ *
+ * @param x    query vectors, size nx * d
+ * @param y    database vectors, size ny * d
+ * @param distances  output distances, size nq * k
+ * @param indexes    output vector ids, size nq * k
+ * @param y_norm2    (optional) norms for the y vectors (nullptr or size ny)
+ */
+void knn_L2sqr(
+        const float* x,
+        const float* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        size_t k,
+        float* distances,
+        int64_t* indexes,
         const float* y_norm2 = nullptr);
 
 /* Find the nearest neighbors for nx queries in a set of ny vectors

--- a/faiss/utils/extra_distances.h
+++ b/faiss/utils/extra_distances.h
@@ -18,6 +18,8 @@
 
 namespace faiss {
 
+struct FlatCodesDistanceComputer;
+
 void pairwise_extra_distances(
         int64_t d,
         int64_t nq,
@@ -43,7 +45,7 @@ void knn_extra_metrics(
 
 /** get a DistanceComputer that refers to this type of distance and
  *  indexes a flat array of size nb */
-DistanceComputer* get_extra_distance_computer(
+FlatCodesDistanceComputer* get_extra_distance_computer(
         size_t d,
         MetricType mt,
         float metric_arg,

--- a/faiss/utils/random.h
+++ b/faiss/utils/random.h
@@ -54,4 +54,9 @@ void int64_rand_max(int64_t* x, size_t n, uint64_t max, int64_t seed);
 /* random permutation */
 void rand_perm(int* perm, size_t n, int64_t seed);
 
+/* Random set of vectors with intrinsic dimensionality 10 that is harder to
+ * index than a subspace of dim 10 but easier than uniform data in dimension d
+ * */
+void rand_smooth_vectors(size_t n, size_t d, float* x, int64_t seed);
+
 } // namespace faiss

--- a/tests/test_build_blocks.py
+++ b/tests/test_build_blocks.py
@@ -325,6 +325,7 @@ class TestScalarQuantizer(unittest.TestCase):
                     # print(dis, D[i, j])
                     assert abs(D[i, j] - dis) / dis < 1e-5
 
+
 class TestRandom(unittest.TestCase):
 
     def test_rand(self):
@@ -339,6 +340,24 @@ class TestRandom(unittest.TestCase):
         c = np.bincount(x, minlength=100)
         print(c)
         assert c.max() - c.min() < 50 * 2
+
+    def test_rand_vector(self):
+        """ test if the smooth_vectors function is reasonably compressible with
+        a small PQ """
+        x = faiss.rand_smooth_vectors(1300, 32)
+        xt = x[:1000]
+        xb = x[1000:1200]
+        xq = x[1200:]
+        _, gt = faiss.knn(xq, xb, 10)
+        index = faiss.IndexPQ(32, 4, 4)
+        index.train(xt)
+        index.add(xb)
+        D, I = index.search(xq, 10)
+        ninter = faiss.eval_intersection(I, gt)
+        # 445 for SyntheticDataset
+        self.assertGreater(ninter, 420)
+        self.assertLess(ninter, 460)
+
 
 
 class TestPairwiseDis(unittest.TestCase):


### PR DESCRIPTION
Summary:
The `DistanceComputer` object is derived from an Index (obtained with `get_distance_computer()`). It maintains a current query and quickly computes distances from that query to any item in the database. This is useful, eg. for the IndexHNSW and IndexNSG that rely on query-to-point comparisons in the datasets.

This diff introduces the `FlatCodesDistanceComputer`, that inherits from `DistanceComputer` for Flat indexes. In addition to the distance-to-item function, it adds a `distance_to_code` that computes the distance from any code to the current query, even if it is not stored in the index.

This is implemented for all FlatCode indexes (IndexFlat, IndexPQ, IndexScalarQuantizer and IndexAdditiveQuantizer).

In the process, the two classes were extracted to their own header file `impl/DistanceComputer.h`

Differential Revision: D34863609

