### PR TITLE
Fix GPU IVF serialization bug; fix stream issues

### DIFF
--- a/faiss/gpu/CMakeLists.txt
+++ b/faiss/gpu/CMakeLists.txt
@@ -152,7 +152,7 @@ set(FAISS_GPU_HEADERS
   utils/StaticUtils.h
   utils/Tensor-inl.cuh
   utils/Tensor.cuh
-  utils/ThrustAllocator.cuh
+  utils/ThrustUtils.cuh
   utils/Timer.h
   utils/Transpose.cuh
   utils/WarpPackedBits.cuh

--- a/faiss/gpu/impl/IVFAppend.cu
+++ b/faiss/gpu/impl/IVFAppend.cu
@@ -49,9 +49,9 @@ void runUpdateListPointers(
         Tensor<int, 1, true>& newListLength,
         Tensor<void*, 1, true>& newCodePointers,
         Tensor<void*, 1, true>& newIndexPointers,
-        thrust::device_vector<int>& listLengths,
-        thrust::device_vector<void*>& listCodes,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<int>& listLengths,
+        DeviceVector<void*>& listCodes,
+        DeviceVector<void*>& listIndices,
         cudaStream_t stream) {
     int numThreads = std::min(listIds.getSize(0), getMaxThreadsCurrentDevice());
     int numBlocks = utils::divUp(listIds.getSize(0), numThreads);
@@ -64,9 +64,9 @@ void runUpdateListPointers(
             newListLength,
             newCodePointers,
             newIndexPointers,
-            listLengths.data().get(),
-            listCodes.data().get(),
-            listIndices.data().get());
+            listLengths.data(),
+            listCodes.data(),
+            listIndices.data());
 
     CUDA_TEST_ERROR();
 }
@@ -107,7 +107,7 @@ void runIVFIndicesAppend(
         Tensor<int, 1, true>& listOffset,
         Tensor<Index::idx_t, 1, true>& indices,
         IndicesOptions opt,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<void*>& listIndices,
         cudaStream_t stream) {
     FAISS_ASSERT(
             opt == INDICES_CPU || opt == INDICES_IVF || opt == INDICES_32_BIT ||
@@ -119,7 +119,7 @@ void runIVFIndicesAppend(
         int blocks = utils::divUp(num, threads);
 
         ivfIndicesAppend<<<blocks, threads, 0, stream>>>(
-                listIds, listOffset, indices, opt, listIndices.data().get());
+                listIds, listOffset, indices, opt, listIndices.data());
 
         CUDA_TEST_ERROR();
     }
@@ -192,18 +192,18 @@ void runIVFFlatAppend(
         Tensor<int, 1, true>& listOffset,
         Tensor<float, 2, true>& vecs,
         GpuScalarQuantizer* scalarQ,
-        thrust::device_vector<void*>& listData,
+        DeviceVector<void*>& listData,
         cudaStream_t stream) {
     int dim = vecs.getSize(1);
     int maxThreads = getMaxThreadsCurrentDevice();
 
     // Each block will handle appending a single vector
-#define RUN_APPEND                                                        \
-    do {                                                                  \
-        dim3 grid(vecs.getSize(0));                                       \
-        dim3 block(std::min(dim / codec.kDimPerIter, maxThreads));        \
-        ivfFlatAppend<<<grid, block, 0, stream>>>(                        \
-                listIds, listOffset, vecs, listData.data().get(), codec); \
+#define RUN_APPEND                                                  \
+    do {                                                            \
+        dim3 grid(vecs.getSize(0));                                 \
+        dim3 block(std::min(dim / codec.kDimPerIter, maxThreads));  \
+        ivfFlatAppend<<<grid, block, 0, stream>>>(                  \
+                listIds, listOffset, vecs, listData.data(), codec); \
     } while (0)
 
     if (!scalarQ) {
@@ -295,13 +295,13 @@ void runIVFPQAppend(
         Tensor<int, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
         Tensor<uint8_t, 2, true>& encodings,
-        thrust::device_vector<void*>& listCodes,
+        DeviceVector<void*>& listCodes,
         cudaStream_t stream) {
     int threads = std::min(listIds.getSize(0), getMaxThreadsCurrentDevice());
     int blocks = utils::divUp(listIds.getSize(0), threads);
 
     ivfpqAppend<<<threads, blocks, 0, stream>>>(
-            listIds, listOffset, encodings, listCodes.data().get());
+            listIds, listOffset, encodings, listCodes.data());
 
     CUDA_TEST_ERROR();
 }
@@ -456,7 +456,7 @@ void runIVFFlatInterleavedAppend(
         Tensor<int, 1, true>& uniqueListStartOffset,
         Tensor<float, 2, true>& vecs,
         GpuScalarQuantizer* scalarQ,
-        thrust::device_vector<void*>& listData,
+        DeviceVector<void*>& listData,
         GpuResources* res,
         cudaStream_t stream) {
     int dim = vecs.getSize(1);
@@ -472,7 +472,7 @@ void runIVFFlatInterleavedAppend(
                         vectorsByUniqueList,        \
                         uniqueListStartOffset,      \
                         DATA,                       \
-                        listData.data().get());     \
+                        listData.data());           \
     } while (0)
 
     if (!scalarQ) {
@@ -590,7 +590,7 @@ void runIVFPQInterleavedAppend(
         Tensor<int, 1, true>& uniqueListStartOffset,
         int bitsPerCode,
         Tensor<uint8_t, 2, true>& encodings,
-        thrust::device_vector<void*>& listCodes,
+        DeviceVector<void*>& listCodes,
         cudaStream_t stream) {
     // limitation for now
     FAISS_ASSERT(bitsPerCode <= 8);
@@ -607,7 +607,7 @@ void runIVFPQInterleavedAppend(
                         vectorsByUniqueList,        \
                         uniqueListStartOffset,      \
                         encodings,                  \
-                        listCodes.data().get());    \
+                        listCodes.data());          \
     } while (0)
 
     switch (bitsPerCode) {

--- a/faiss/gpu/impl/IVFAppend.cuh
+++ b/faiss/gpu/impl/IVFAppend.cuh
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <faiss/gpu/GpuIndicesOptions.h>
-#include <thrust/device_vector.h>
 #include <faiss/gpu/impl/GpuScalarQuantizer.cuh>
+#include <faiss/gpu/utils/DeviceVector.cuh>
 #include <faiss/gpu/utils/Tensor.cuh>
 
 namespace faiss {
@@ -21,7 +21,7 @@ void runIVFIndicesAppend(
         Tensor<int, 1, true>& listOffset,
         Tensor<Index::idx_t, 1, true>& indices,
         IndicesOptions opt,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<void*>& listIndices,
         cudaStream_t stream);
 
 /// Update device-side list pointers in a batch
@@ -30,9 +30,9 @@ void runUpdateListPointers(
         Tensor<int, 1, true>& newListLength,
         Tensor<void*, 1, true>& newCodePointers,
         Tensor<void*, 1, true>& newIndexPointers,
-        thrust::device_vector<int>& listLengths,
-        thrust::device_vector<void*>& listCodes,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<int>& listLengths,
+        DeviceVector<void*>& listCodes,
+        DeviceVector<void*>& listIndices,
         cudaStream_t stream);
 
 /// Append PQ codes to IVF lists (non-interleaved format)
@@ -40,7 +40,7 @@ void runIVFPQAppend(
         Tensor<int, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
         Tensor<uint8_t, 2, true>& encodings,
-        thrust::device_vector<void*>& listCodes,
+        DeviceVector<void*>& listCodes,
         cudaStream_t stream);
 
 /// Append PQ codes to IVF lists (interleaved format)
@@ -53,7 +53,7 @@ void runIVFPQInterleavedAppend(
         Tensor<int, 1, true>& uniqueListStartOffset,
         int bitsPerCode,
         Tensor<uint8_t, 2, true>& encodings,
-        thrust::device_vector<void*>& listCodes,
+        DeviceVector<void*>& listCodes,
         cudaStream_t stream);
 
 /// Append SQ codes to IVF lists (non-interleaved, old format)
@@ -62,7 +62,7 @@ void runIVFFlatAppend(
         Tensor<int, 1, true>& listOffset,
         Tensor<float, 2, true>& vecs,
         GpuScalarQuantizer* scalarQ,
-        thrust::device_vector<void*>& listData,
+        DeviceVector<void*>& listData,
         cudaStream_t stream);
 
 /// Append SQ codes to IVF lists (interleaved)
@@ -75,7 +75,7 @@ void runIVFFlatInterleavedAppend(
         Tensor<int, 1, true>& uniqueListStartOffset,
         Tensor<float, 2, true>& vecs,
         GpuScalarQuantizer* scalarQ,
-        thrust::device_vector<void*>& listData,
+        DeviceVector<void*>& listData,
         GpuResources* res,
         cudaStream_t stream);
 

--- a/faiss/gpu/impl/IVFBase.cuh
+++ b/faiss/gpu/impl/IVFBase.cuh
@@ -10,7 +10,6 @@
 #include <faiss/Index.h>
 #include <faiss/MetricType.h>
 #include <faiss/gpu/GpuIndicesOptions.h>
-#include <thrust/device_vector.h>
 #include <faiss/gpu/utils/DeviceTensor.cuh>
 #include <faiss/gpu/utils/DeviceVector.cuh>
 #include <memory>
@@ -178,15 +177,15 @@ class IVFBase {
 
     /// Device representation of all inverted list data
     /// id -> data
-    thrust::device_vector<void*> deviceListDataPointers_;
+    DeviceVector<void*> deviceListDataPointers_;
 
     /// Device representation of all inverted list index pointers
     /// id -> data
-    thrust::device_vector<void*> deviceListIndexPointers_;
+    DeviceVector<void*> deviceListIndexPointers_;
 
     /// Device representation of all inverted list lengths
     /// id -> length in number of vectors
-    thrust::device_vector<int> deviceListLengths_;
+    DeviceVector<int> deviceListLengths_;
 
     /// Maximum list length seen
     int maxListLength_;

--- a/faiss/gpu/impl/IVFFlatScan.cu
+++ b/faiss/gpu/impl/IVFFlatScan.cu
@@ -186,10 +186,10 @@ void runIVFFlatScanTile(
         GpuResources* res,
         Tensor<float, 2, true>& queries,
         Tensor<int, 2, true>& listIds,
-        thrust::device_vector<void*>& listData,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<void*>& listData,
+        DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
-        thrust::device_vector<int>& listLengths,
+        DeviceVector<int>& listLengths,
         Tensor<char, 1, true>& thrustMem,
         Tensor<int, 2, true>& prefixSumOffsets,
         Tensor<float, 1, true>& allDistances,
@@ -237,8 +237,8 @@ void runIVFFlatScanTile(
                 useResidual,                                          \
                 residualBase,                                         \
                 listIds,                                              \
-                listData.data().get(),                                \
-                listLengths.data().get(),                             \
+                listData.data(),                                      \
+                listLengths.data(),                                   \
                 codec,                                                \
                 metric,                                               \
                 prefixSumOffsets,                                     \
@@ -342,10 +342,10 @@ void runIVFFlatScanTile(
 void runIVFFlatScan(
         Tensor<float, 2, true>& queries,
         Tensor<int, 2, true>& listIds,
-        thrust::device_vector<void*>& listData,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<void*>& listData,
+        DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
-        thrust::device_vector<int>& listLengths,
+        DeviceVector<int>& listLengths,
         int maxListLength,
         int k,
         faiss::MetricType metric,

--- a/faiss/gpu/impl/IVFFlatScan.cuh
+++ b/faiss/gpu/impl/IVFFlatScan.cuh
@@ -9,8 +9,8 @@
 
 #include <faiss/MetricType.h>
 #include <faiss/gpu/GpuIndicesOptions.h>
-#include <thrust/device_vector.h>
 #include <faiss/gpu/impl/GpuScalarQuantizer.cuh>
+#include <faiss/gpu/utils/DeviceVector.cuh>
 #include <faiss/gpu/utils/Tensor.cuh>
 
 namespace faiss {
@@ -21,10 +21,10 @@ class GpuResources;
 void runIVFFlatScan(
         Tensor<float, 2, true>& queries,
         Tensor<int, 2, true>& listIds,
-        thrust::device_vector<void*>& listData,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<void*>& listData,
+        DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
-        thrust::device_vector<int>& listLengths,
+        DeviceVector<int>& listLengths,
         int maxListLength,
         int k,
         faiss::MetricType metric,

--- a/faiss/gpu/impl/IVFInterleaved.cu
+++ b/faiss/gpu/impl/IVFInterleaved.cu
@@ -125,7 +125,7 @@ void runIVFInterleavedScan2(
         Tensor<int, 3, true>& indicesIn,
         Tensor<int, 2, true>& listIds,
         int k,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
         bool dir,
         Tensor<float, 2, true>& distanceOut,
@@ -138,7 +138,7 @@ void runIVFInterleavedScan2(
                     indicesIn,                               \
                     listIds,                                 \
                     k,                                       \
-                    listIndices.data().get(),                \
+                    listIndices.data(),                      \
                     indicesOptions,                          \
                     dir,                                     \
                     distanceOut,                             \
@@ -169,10 +169,10 @@ void runIVFInterleavedScan2(
 void runIVFInterleavedScan(
         Tensor<float, 2, true>& queries,
         Tensor<int, 2, true>& listIds,
-        thrust::device_vector<void*>& listData,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<void*>& listData,
+        DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
-        thrust::device_vector<int>& listLengths,
+        DeviceVector<int>& listLengths,
         int k,
         faiss::MetricType metric,
         bool useResidual,

--- a/faiss/gpu/impl/IVFInterleaved.cuh
+++ b/faiss/gpu/impl/IVFInterleaved.cuh
@@ -12,13 +12,13 @@
 #include <faiss/gpu/GpuResources.h>
 #include <faiss/gpu/utils/DeviceUtils.h>
 #include <faiss/gpu/utils/StaticUtils.h>
-#include <thrust/device_vector.h>
 #include <faiss/gpu/impl/DistanceUtils.cuh>
 #include <faiss/gpu/impl/GpuScalarQuantizer.cuh>
 #include <faiss/gpu/utils/Comparators.cuh>
 #include <faiss/gpu/utils/ConversionOperators.cuh>
 #include <faiss/gpu/utils/DeviceDefs.cuh>
 #include <faiss/gpu/utils/DeviceTensor.cuh>
+#include <faiss/gpu/utils/DeviceVector.cuh>
 #include <faiss/gpu/utils/Float16.cuh>
 #include <faiss/gpu/utils/MathOperators.cuh>
 #include <faiss/gpu/utils/PtxUtils.cuh>
@@ -227,8 +227,8 @@ __global__ void ivfInterleavedScan(
                     queries,                                                   \
                     residualBase,                                              \
                     listIds,                                                   \
-                    listData.data().get(),                                     \
-                    listLengths.data().get(),                                  \
+                    listData.data(),                                           \
+                    listLengths.data(),                                        \
                     codec,                                                     \
                     metric,                                                    \
                     k,                                                         \
@@ -245,8 +245,8 @@ __global__ void ivfInterleavedScan(
                     queries,                                                   \
                     residualBase,                                              \
                     listIds,                                                   \
-                    listData.data().get(),                                     \
-                    listLengths.data().get(),                                  \
+                    listData.data(),                                           \
+                    listLengths.data(),                                        \
                     codec,                                                     \
                     metric,                                                    \
                     k,                                                         \
@@ -410,10 +410,10 @@ __global__ void ivfInterleavedScan(
 void runIVFInterleavedScan(
         Tensor<float, 2, true>& queries,
         Tensor<int, 2, true>& listIds,
-        thrust::device_vector<void*>& listData,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<void*>& listData,
+        DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
-        thrust::device_vector<int>& listLengths,
+        DeviceVector<int>& listLengths,
         int k,
         faiss::MetricType metric,
         bool useResidual,
@@ -432,7 +432,7 @@ void runIVFInterleavedScan2(
         Tensor<int, 3, true>& indicesIn,
         Tensor<int, 2, true>& listIds,
         int k,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
         bool dir,
         Tensor<float, 2, true>& distanceOut,

--- a/faiss/gpu/impl/IVFUtils.cuh
+++ b/faiss/gpu/impl/IVFUtils.cuh
@@ -9,7 +9,7 @@
 
 #include <faiss/Index.h>
 #include <faiss/gpu/GpuIndicesOptions.h>
-#include <thrust/device_vector.h>
+#include <faiss/gpu/utils/DeviceVector.cuh>
 #include <faiss/gpu/utils/Tensor.cuh>
 
 // A collection of utility functions for IVFPQ and IVFFlat, for
@@ -24,7 +24,7 @@ class GpuResources;
 void runCalcListOffsets(
         GpuResources* res,
         Tensor<int, 2, true>& topQueryToCentroid,
-        thrust::device_vector<int>& listLengths,
+        DeviceVector<int>& listLengths,
         Tensor<int, 2, true>& prefixSumOffsets,
         Tensor<char, 1, true>& thrustMem,
         cudaStream_t stream);
@@ -45,7 +45,7 @@ void runPass1SelectLists(
 void runPass2SelectLists(
         Tensor<float, 2, true>& heapDistances,
         Tensor<int, 2, true>& heapIndices,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
         Tensor<int, 2, true>& prefixSumOffsets,
         Tensor<int, 2, true>& topQueryToCentroid,

--- a/faiss/gpu/impl/IVFUtilsSelect2.cu
+++ b/faiss/gpu/impl/IVFUtilsSelect2.cu
@@ -152,7 +152,7 @@ __global__ void pass2SelectLists(
 void runPass2SelectLists(
         Tensor<float, 2, true>& heapDistances,
         Tensor<int, 2, true>& heapIndices,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
         Tensor<int, 2, true>& prefixSumOffsets,
         Tensor<int, 2, true>& topQueryToCentroid,
@@ -169,7 +169,7 @@ void runPass2SelectLists(
                 <<<grid, BLOCK, 0, stream>>>(                  \
                         heapDistances,                         \
                         heapIndices,                           \
-                        listIndices.data().get(),              \
+                        listIndices.data(),                    \
                         prefixSumOffsets,                      \
                         topQueryToCentroid,                    \
                         k,                                     \

--- a/faiss/gpu/impl/PQScanMultiPassNoPrecomputed-inl.cuh
+++ b/faiss/gpu/impl/PQScanMultiPassNoPrecomputed-inl.cuh
@@ -284,10 +284,10 @@ void runMultiPassTile(
         int bitsPerSubQuantizer,
         int numSubQuantizers,
         int numSubQuantizerCodes,
-        thrust::device_vector<void*>& listCodes,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<void*>& listCodes,
+        DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
-        thrust::device_vector<int>& listLengths,
+        DeviceVector<int>& listLengths,
         Tensor<char, 1, true>& thrustMem,
         Tensor<int, 2, true>& prefixSumOffsets,
         Tensor<float, 1, true>& allDistances,
@@ -345,8 +345,8 @@ void runMultiPassTile(
                         pqCentroidsInnermostCode,              \
                         coarseIndices,                         \
                         codeDistancesT,                        \
-                        listCodes.data().get(),                \
-                        listLengths.data().get(),              \
+                        listCodes.data(),                      \
+                        listLengths.data(),                    \
                         prefixSumOffsets,                      \
                         allDistances);                         \
     } while (0)
@@ -416,8 +416,8 @@ void runMultiPassTile(
                         pqCentroidsInnermostCode,                       \
                         coarseIndices,                                  \
                         codeDistancesT,                                 \
-                        listCodes.data().get(),                         \
-                        listLengths.data().get(),                       \
+                        listCodes.data(),                               \
+                        listLengths.data(),                             \
                         prefixSumOffsets,                               \
                         allDistances);                                  \
     } while (0)
@@ -533,10 +533,10 @@ void runPQScanMultiPassNoPrecomputed(
         int bitsPerSubQuantizer,
         int numSubQuantizers,
         int numSubQuantizerCodes,
-        thrust::device_vector<void*>& listCodes,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<void*>& listCodes,
+        DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
-        thrust::device_vector<int>& listLengths,
+        DeviceVector<int>& listLengths,
         int maxListLength,
         int k,
         faiss::MetricType metric,

--- a/faiss/gpu/impl/PQScanMultiPassNoPrecomputed.cuh
+++ b/faiss/gpu/impl/PQScanMultiPassNoPrecomputed.cuh
@@ -10,7 +10,7 @@
 #include <faiss/Index.h>
 #include <faiss/MetricType.h>
 #include <faiss/gpu/GpuIndicesOptions.h>
-#include <thrust/device_vector.h>
+#include <faiss/gpu/utils/DeviceVector.cuh>
 #include <faiss/gpu/utils/Tensor.cuh>
 
 namespace faiss {
@@ -31,10 +31,10 @@ void runPQScanMultiPassNoPrecomputed(
         int bitsPerSubQuantizer,
         int numSubQuantizers,
         int numSubQuantizerCodes,
-        thrust::device_vector<void*>& listCodes,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<void*>& listCodes,
+        DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
-        thrust::device_vector<int>& listLengths,
+        DeviceVector<int>& listLengths,
         int maxListLength,
         int k,
         faiss::MetricType metric,

--- a/faiss/gpu/impl/PQScanMultiPassPrecomputed.cu
+++ b/faiss/gpu/impl/PQScanMultiPassPrecomputed.cu
@@ -316,10 +316,10 @@ void runMultiPassTile(
         int bitsPerSubQuantizer,
         int numSubQuantizers,
         int numSubQuantizerCodes,
-        thrust::device_vector<void*>& listCodes,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<void*>& listCodes,
+        DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
-        thrust::device_vector<int>& listLengths,
+        DeviceVector<int>& listLengths,
         Tensor<char, 1, true>& thrustMem,
         Tensor<int, 2, true>& prefixSumOffsets,
         Tensor<float, 1, true>& allDistances,
@@ -356,8 +356,8 @@ void runMultiPassTile(
                         precompTerm2T,                                    \
                         precompTerm3T,                                    \
                         topQueryToCentroid,                               \
-                        listCodes.data().get(),                           \
-                        listLengths.data().get(),                         \
+                        listCodes.data(),                                 \
+                        listLengths.data(),                               \
                         prefixSumOffsets,                                 \
                         allDistances);                                    \
     } while (0)
@@ -432,8 +432,8 @@ void runMultiPassTile(
                         precompTerm2T,                                \
                         precompTerm3T,                                \
                         topQueryToCentroid,                           \
-                        listCodes.data().get(),                       \
-                        listLengths.data().get(),                     \
+                        listCodes.data(),                             \
+                        listLengths.data(),                           \
                         prefixSumOffsets,                             \
                         allDistances);                                \
     } while (0)
@@ -553,10 +553,10 @@ void runPQScanMultiPassPrecomputed(
         int bitsPerSubQuantizer,
         int numSubQuantizers,
         int numSubQuantizerCodes,
-        thrust::device_vector<void*>& listCodes,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<void*>& listCodes,
+        DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
-        thrust::device_vector<int>& listLengths,
+        DeviceVector<int>& listLengths,
         int maxListLength,
         int k,
         // output

--- a/faiss/gpu/impl/PQScanMultiPassPrecomputed.cuh
+++ b/faiss/gpu/impl/PQScanMultiPassPrecomputed.cuh
@@ -9,7 +9,7 @@
 
 #include <faiss/Index.h>
 #include <faiss/gpu/GpuIndicesOptions.h>
-#include <thrust/device_vector.h>
+#include <faiss/gpu/utils/DeviceVector.cuh>
 #include <faiss/gpu/utils/NoTypeTensor.cuh>
 #include <faiss/gpu/utils/Tensor.cuh>
 
@@ -29,10 +29,10 @@ void runPQScanMultiPassPrecomputed(
         int bitsPerSubQuantizer,
         int numSubQuantizers,
         int numSubQuantizerCodes,
-        thrust::device_vector<void*>& listCodes,
-        thrust::device_vector<void*>& listIndices,
+        DeviceVector<void*>& listCodes,
+        DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
-        thrust::device_vector<int>& listLengths,
+        DeviceVector<int>& listLengths,
         int maxListLength,
         int k,
         // output

--- a/faiss/gpu/impl/scan/IVFInterleavedImpl.cuh
+++ b/faiss/gpu/impl/scan/IVFInterleavedImpl.cuh
@@ -9,16 +9,17 @@
 
 #include <faiss/gpu/impl/IVFInterleaved.cuh>
 #include <faiss/gpu/utils/DeviceDefs.cuh>
+#include <faiss/gpu/utils/DeviceVector.cuh>
 
 #define IVF_INTERLEAVED_IMPL(THREADS, WARP_Q, THREAD_Q) \
                                                         \
     void ivfInterleavedScanImpl_##WARP_Q##_(            \
             Tensor<float, 2, true>& queries,            \
             Tensor<int, 2, true>& listIds,              \
-            thrust::device_vector<void*>& listData,     \
-            thrust::device_vector<void*>& listIndices,  \
+            DeviceVector<void*>& listData,              \
+            DeviceVector<void*>& listIndices,           \
             IndicesOptions indicesOptions,              \
-            thrust::device_vector<int>& listLengths,    \
+            DeviceVector<int>& listLengths,             \
             int k,                                      \
             faiss::MetricType metric,                   \
             bool useResidual,                           \
@@ -39,10 +40,10 @@
     void ivfInterleavedScanImpl_##WARP_Q##_(           \
             Tensor<float, 2, true>& queries,           \
             Tensor<int, 2, true>& listIds,             \
-            thrust::device_vector<void*>& listData,    \
-            thrust::device_vector<void*>& listIndices, \
+            DeviceVector<void*>& listData,             \
+            DeviceVector<void*>& listIndices,          \
             IndicesOptions indicesOptions,             \
-            thrust::device_vector<int>& listLengths,   \
+            DeviceVector<int>& listLengths,            \
             int k,                                     \
             faiss::MetricType metric,                  \
             bool useResidual,                          \

--- a/faiss/gpu/test/test_gpu_index_serialize.py
+++ b/faiss/gpu/test/test_gpu_index_serialize.py
@@ -1,0 +1,78 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+import time
+import unittest
+import numpy as np
+import faiss
+import tempfile
+import os
+
+def make_t(num, d):
+    rs = np.random.RandomState(123)
+    return rs.rand(num, d).astype('float32')
+
+class TestGpuSerialize(unittest.TestCase):
+    def test_serialize(self):
+        res = faiss.StandardGpuResources()
+
+        d = 32
+        k = 10
+        train = make_t(10000, d)
+        add = make_t(10000, d)
+        query = make_t(10, d)
+
+        # Construct various GPU index types
+        indexes = []
+
+        # Flat
+        indexes.append(faiss.GpuIndexFlatL2(res, d))
+
+        # IVF
+        nlist = 5
+
+        # IVFFlat
+        indexes.append(faiss.GpuIndexIVFFlat(res, d, nlist, faiss.METRIC_L2))
+
+        # IVFSQ
+        indexes.append(faiss.GpuIndexIVFScalarQuantizer(res, d, nlist, faiss.ScalarQuantizer.QT_fp16))
+
+        # IVFPQ
+        indexes.append(faiss.GpuIndexIVFPQ(res, d, nlist, 4, 8, faiss.METRIC_L2))
+
+        for index in indexes:
+            index.train(train)
+            index.add(add)
+
+            orig_d, orig_i = index.search(query, k)
+
+            # Write index to file and read it back in again
+            fd, fname = tempfile.mkstemp()
+            os.close(fd)
+
+            cpu_index = None
+
+            try:
+                faiss.write_index(faiss.index_gpu_to_cpu(index), fname)
+                try:
+                    cpu_index = faiss.read_index(fname)
+                except RuntimeError as e:
+                    if fname not in str(e):
+                        raise
+            finally:
+                if os.path.exists(fname):
+                    os.unlink(fname)
+
+            assert cpu_index is not None
+            gpu_index_restore = faiss.index_cpu_to_gpu(res, 0, cpu_index)
+
+            restore_d, restore_i = gpu_index_restore.search(query, k)
+
+            self.assertTrue(np.array_equal(orig_d, restore_d))
+            self.assertTrue(np.array_equal(orig_i, restore_i))
+
+            # Make sure the index is in a state where we can add to it without error
+            gpu_index_restore.add(query)

--- a/faiss/gpu/utils/ThrustUtils.cuh
+++ b/faiss/gpu/utils/ThrustUtils.cuh
@@ -9,17 +9,18 @@
 
 #include <cuda.h>
 #include <faiss/gpu/GpuResources.h>
+#include <thrust/device_vector.h>
 #include <unordered_set>
 
 namespace faiss {
 namespace gpu {
 
 /// Allocator for Thrust that comes out of a specified memory space
-class GpuResourcesThrustAllocator {
+class ThrustAllocator {
    public:
     typedef char value_type;
 
-    inline GpuResourcesThrustAllocator(
+    inline ThrustAllocator(
             GpuResources* res,
             cudaStream_t stream,
             void* mem,
@@ -30,7 +31,7 @@ class GpuResourcesThrustAllocator {
               cur_((char*)mem),
               end_((char*)mem + size) {}
 
-    inline ~GpuResourcesThrustAllocator() {
+    inline ~ThrustAllocator() {
         // In the case of an exception being thrown, we may not have called
         // deallocate on all of our sub-allocations. Free them here
         for (auto p : mallocAllocs_) {


### PR DESCRIPTION
Summary:
GPU IVF indices could not be properly deserialized or copied from CPU then added to after the fact, this resulted in the following C++ assertion:

```
Faiss assertion 'indices->numVecs == oldNumVecs' failed in int faiss::gpu::IVFBase::addVectors(faiss::gpu::Tensor<float, 2, true>&, faiss::gpu::Tensor<long int, 1, true>&) at faiss/gpu/impl/IVFBase.cu:581
```

as the count of vectors present was not updated properly everywhere, as discovered internally by vtantia.

This diff fixes this issue by properly updating the count, as well as cleaning up stream usage in the IVF code. The problem is that the code was previously using `thrust::device_vector` which does not have a means to control on which stream copies or other work is performed. This is fixed by replacing all usage of `thrust::device_vector` with our own `DeviceVector` which was already used to store IVF data but not metadata. `DeviceVector` provides sufficient control over the proper CUDA stream usage.

Differential Revision: D34886859

