### PR TITLE
Fix reconstruct bug when by_residual is false

### DIFF
--- a/faiss/IndexScalarQuantizer.cpp
+++ b/faiss/IndexScalarQuantizer.cpp
@@ -251,13 +251,18 @@ void IndexIVFScalarQuantizer::reconstruct_from_offset(
         int64_t list_no,
         int64_t offset,
         float* recons) const {
-    std::vector<float> centroid(d);
-    quantizer->reconstruct(list_no, centroid.data());
-
     const uint8_t* code = invlists->get_single_code(list_no, offset);
-    sq.decode(code, recons, 1);
-    for (int i = 0; i < d; ++i) {
-        recons[i] += centroid[i];
+
+    if (by_residual) {
+        std::vector<float> centroid(d);
+        quantizer->reconstruct(list_no, centroid.data());
+
+        sq.decode(code, recons, 1);
+        for (int i = 0; i < d; ++i) {
+            recons[i] += centroid[i];
+        }
+    } else {
+        sq.decode(code, recons, 1);
     }
 }
 


### PR DESCRIPTION
When I reconstruct with by_residual turned off, the distance was greatly increased. 
This is because the reconstruct_from_offset function did not check if the by_residual option was off. 
I fix this bug with simple if statement.
(like this https://github.com/facebookresearch/faiss/blob/main/faiss/IndexIVFPQ.cpp#L365)