### PR TITLE
add batched parallel mode for IVFFLAT

### DIFF
--- a/benchs/bench_ivfflat_pmode.py
+++ b/benchs/bench_ivfflat_pmode.py
@@ -1,0 +1,45 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import print_function
+import faiss
+import time
+from datasets import load_sift1M
+
+def evaluate(index, xq, gt, k):
+    nq = xq.shape[0]
+    t0 = time.time()
+    D, I = index.search(xq, k)  # noqa: E741
+    t1 = time.time()
+    recalls = {}
+    i = 1
+    while i <= k:
+        recalls[i] = (I[:, :i] == gt[:nq, :1]).sum() / float(nq)
+        i *= 10
+
+    return (t1 - t0) * 1000.0 / nq, recalls
+
+xb, xq, xt, gt = load_sift1M()
+nq, d = xq.shape
+
+k = 50
+
+quantizer = faiss.IndexFlat(d)
+index = faiss.IndexIVFFlat(quantizer, d, 1024)
+index.train(xt)
+index.add(xb)
+
+for pmode in 0,4:
+    print("pmode = ",pmode)
+    for nprobe in 16,32,64:
+        for nq in 100,1000,10000:
+            try:
+                index.parallel_mode = pmode
+                index.nprobe = nprobe
+                sub_xq = xq[:nq]
+                t, r = evaluate(index, sub_xq, gt, k)
+                print("\tnprobe=%d,nq=%d; %7.3f ms per query, R@1 %.4f" % (nprobe, nq, t, r[1]))
+            except Exception as e:
+                print(e)

--- a/benchs/bench_ivfflat_pmode.py
+++ b/benchs/bench_ivfflat_pmode.py
@@ -8,6 +8,7 @@ import faiss
 import time
 from datasets import load_sift1M
 
+
 def evaluate(index, xq, gt, k):
     nq = xq.shape[0]
     t0 = time.time()
@@ -21,6 +22,7 @@ def evaluate(index, xq, gt, k):
 
     return (t1 - t0) * 1000.0 / nq, recalls
 
+
 xb, xq, xt, gt = load_sift1M()
 nq, d = xq.shape
 
@@ -31,10 +33,10 @@ index = faiss.IndexIVFFlat(quantizer, d, 1024)
 index.train(xt)
 index.add(xb)
 
-for pmode in 0,4:
-    print("pmode = ",pmode)
-    for nprobe in 16,32,64:
-        for nq in 100,1000,10000:
+for pmode in 0, 4:
+    print("pmode = ", pmode)
+    for nprobe in 16, 32, 64:
+        for nq in 100, 1000, 10000:
             try:
                 index.parallel_mode = pmode
                 index.nprobe = nprobe

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -324,7 +324,6 @@ void IndexIVF::search(
 
         double t1 = getmillisecs();
         invlists->prefetch_lists(idx.get(), n * nprobe);
-
         search_preassigned(
                 n,
                 x,
@@ -409,6 +408,7 @@ void IndexIVF::search_preassigned(
     bool interrupt = false;
     std::mutex exception_mutex;
     std::string exception_string;
+    std::vector<std::vector<idx_t>> keys_by_list;
 
     int pmode = this->parallel_mode & ~PARALLEL_MODE_NO_HEAP_INIT;
     bool do_heap_init = !(this->parallel_mode & PARALLEL_MODE_NO_HEAP_INIT);
@@ -500,9 +500,13 @@ void IndexIVF::search_preassigned(
                     sids.reset(new InvertedLists::ScopedIds(invlists, key));
                     ids = sids->get();
                 }
-
-                nheap += scanner->scan_codes(
-                        list_size, scodes.get(), ids, simi, idxi, k);
+                if (pmode == 4) {
+                    nheap += scanner->scan_codes_batched(
+                            list_size, scodes.get(), ids, simi, idxi, k);
+                } else {
+                    nheap += scanner->scan_codes(
+                            list_size, scodes.get(), ids, simi, idxi, k);
+                }
 
             } catch (const std::exception& e) {
                 std::lock_guard<std::mutex> lock(exception_mutex);
@@ -623,6 +627,53 @@ void IndexIVF::search_preassigned(
             }
 #pragma omp single
             for (int64_t i = 0; i < n; i++) {
+                reorder_result(distances + i * k, labels + i * k);
+            }
+        } else if (pmode == 4) {
+            /// for this parallelization method, we parallelize over every
+            /// existing list, group together all the queries affiliated, and
+            /// scan all the queries of this list in one go.
+#pragma omp single
+            {
+                keys_by_list.resize(nlist);
+                for (idx_t i = 0; i < nlist; i++) {
+                    keys_by_list[i].reserve(nprobe * n / nlist);
+                }
+                for (idx_t il = 0; il < n; il++) {
+                    for (idx_t ikey = 0; ikey < nprobe; ikey++) {
+                        keys_by_list[keys[il * nprobe + ikey]].emplace_back(il);
+                    }
+                }
+                if (metric_type == METRIC_INNER_PRODUCT) {
+                    heap_heapify<HeapForIP>(k * n, distances, labels);
+                } else {
+                    heap_heapify<HeapForL2>(k * n, distances, labels);
+                }
+            }
+#pragma omp for schedule(dynamic)
+            for (idx_t il = 0; il < invlists->nlist; il++) {
+                std::vector<idx_t>& my_list = keys_by_list[il];
+                idx_t num_of_x = my_list.size();
+                if (num_of_x > 0) {
+                    std::vector<idx_t> local_idx(k * num_of_x);
+                    std::vector<float> local_dis(k * num_of_x);
+                    scanner->set_query_batched(x, my_list);
+                    ndis += scan_one_list(
+                            il, 0, local_dis.data(), local_idx.data());
+#pragma omp critical
+                    for (idx_t one_x = 0; one_x < num_of_x; one_x++) {
+                        float* simi = distances + my_list[one_x] * k;
+                        idx_t* idxi = labels + my_list[one_x] * k;
+                        add_local_results(
+                                local_dis.data() + one_x * k,
+                                local_idx.data() + one_x * k,
+                                simi,
+                                idxi);
+                    }
+                }
+            }
+#pragma omp for schedule(dynamic)
+            for (idx_t i = 0; i < n; i++) {
                 reorder_result(distances + i * k, labels + i * k);
             }
         } else {
@@ -1112,6 +1163,12 @@ IndexIVFStats indexIVF_stats;
  * InvertedListScanner
  *************************************************************************/
 
+void InvertedListScanner::set_query_batched(
+        const float* query_base,
+        std::vector<idx_t>& queries) {
+    FAISS_THROW_MSG("set_query_batched not implemented");
+}
+
 size_t InvertedListScanner::scan_codes(
         size_t list_size,
         const uint8_t* codes,
@@ -1143,6 +1200,17 @@ size_t InvertedListScanner::scan_codes(
         }
     }
     return nup;
+}
+
+size_t InvertedListScanner::scan_codes_batched(
+        size_t n,
+        const uint8_t* codes,
+        const idx_t* ids,
+        float* distances,
+        idx_t* labels,
+        size_t k) const {
+    FAISS_THROW_MSG("scan_codes_batched not implemented");
+    return 0;
 }
 
 void InvertedListScanner::scan_codes_range(

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -442,6 +442,16 @@ void IndexIVF::search_preassigned(
             }
         };
 
+        auto init_result_n = [&](float* simi, idx_t* idxi, size_t n) {
+            if (!do_heap_init)
+                return;
+            if (metric_type == METRIC_INNER_PRODUCT) {
+                heap_heapify<HeapForIP>(k * n, simi, idxi);
+            } else {
+                heap_heapify<HeapForL2>(k * n, simi, idxi);
+            }
+        };
+
         auto add_local_results = [&](const float* local_dis,
                                      const idx_t* local_idx,
                                      float* simi,
@@ -644,11 +654,7 @@ void IndexIVF::search_preassigned(
                         keys_by_list[keys[il * nprobe + ikey]].emplace_back(il);
                     }
                 }
-                if (metric_type == METRIC_INNER_PRODUCT) {
-                    heap_heapify<HeapForIP>(k * n, distances, labels);
-                } else {
-                    heap_heapify<HeapForL2>(k * n, distances, labels);
-                }
+                init_result_n(distances, labels, n);
             }
 #pragma omp for schedule(dynamic)
             for (idx_t il = 0; il < invlists->nlist; il++) {
@@ -657,6 +663,8 @@ void IndexIVF::search_preassigned(
                 if (num_of_x > 0) {
                     std::vector<idx_t> local_idx(k * num_of_x);
                     std::vector<float> local_dis(k * num_of_x);
+                    init_result_n(local_dis.data(), local_idx.data(), num_of_x);
+
                     scanner->set_query_batched(x, my_list);
                     ndis += scan_one_list(
                             il, 0, local_dis.data(), local_idx.data());

--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -108,6 +108,7 @@ struct IndexIVF : Index, Level1Quantizer {
      * 1: parallelize over inverted lists
      * 2: parallelize over both
      * 3: split over queries with a finer granularity
+     * 4: split over inverted lists with batched query
      *
      * PARALLEL_MODE_NO_HEAP_INIT: binary or with the previous to
      * prevent the heap to be initialized and finalized
@@ -371,6 +372,11 @@ struct InvertedListScanner {
     /// from now on we handle this query.
     virtual void set_query(const float* query_vector) = 0;
 
+    /// we'll handle a list of queries.
+    virtual void set_query_batched(
+            const float* query_base,
+            std::vector<idx_t>& queries);
+
     /// following codes come from this inverted list
     virtual void set_list(idx_t list_no, float coarse_dis) = 0;
 
@@ -390,6 +396,16 @@ struct InvertedListScanner {
      * @return number of heap updates performed
      */
     virtual size_t scan_codes(
+            size_t n,
+            const uint8_t* codes,
+            const idx_t* ids,
+            float* distances,
+            idx_t* labels,
+            size_t k) const;
+
+    /// same as scan_codes, but we scan a list of queries.
+
+    virtual size_t scan_codes_batched(
             size_t n,
             const uint8_t* codes,
             const idx_t* ids,

--- a/faiss/IndexIVFFlat.cpp
+++ b/faiss/IndexIVFFlat.cpp
@@ -118,9 +118,19 @@ void IndexIVFFlat::sa_decode(idx_t n, const uint8_t* bytes, float* x) const {
 
 namespace {
 
+template <class T>
+void update_res_ids(T* t, const size_t n, const Index::idx_t* ids) {
+    Index::idx_t* start = t->get_ids(0);
+    for (size_t i = 0; i < n; i++) {
+        start[i] = ids[start[i]];
+    }
+}
+
 template <MetricType metric, class C>
 struct IVFFlatScanner : InvertedListScanner {
     size_t d;
+    size_t nx;
+    bool store_new_xi = false;
 
     IVFFlatScanner(size_t d, bool store_pairs) : d(d) {
         this->store_pairs = store_pairs;
@@ -129,6 +139,22 @@ struct IVFFlatScanner : InvertedListScanner {
     const float* xi;
     void set_query(const float* query) override {
         this->xi = query;
+    }
+
+    void set_query_batched(const float* query_base, std::vector<idx_t>& queries)
+            override {
+        if (!queries.empty()) {
+            float* new_xi = new float[queries.size() * d];
+            size_t float_size = sizeof(new_xi[0]);
+            for (idx_t i = 0; i < queries.size(); i++) {
+                memcpy(new_xi + i * d,
+                       query_base + queries[i] * d,
+                       d * float_size);
+            }
+            this->xi = new_xi;
+            nx = queries.size();
+            store_new_xi = true;
+        }
     }
 
     void set_list(idx_t list_no, float /* coarse_dis */) override {
@@ -166,6 +192,26 @@ struct IVFFlatScanner : InvertedListScanner {
         return nup;
     }
 
+    size_t scan_codes_batched(
+            size_t list_size,
+            const uint8_t* codes,
+            const idx_t* ids,
+            float* simi,
+            idx_t* idxi,
+            size_t k) const override {
+        const float* list_vecs = (const float*)codes;
+        if (metric == METRIC_INNER_PRODUCT) {
+            float_minheap_array_t res = {nx, size_t(k), idxi, simi};
+            knn_inner_product(xi, list_vecs, d, nx, list_size, &res);
+            update_res_ids<float_minheap_array_t>(&res, nx * k, ids);
+        } else {
+            float_maxheap_array_t res = {nx, size_t(k), idxi, simi};
+            knn_L2sqr(xi, list_vecs, d, nx, list_size, &res);
+            update_res_ids<float_maxheap_array_t>(&res, nx * k, ids);
+        }
+        return 0;
+    }
+
     void scan_codes_range(
             size_t list_size,
             const uint8_t* codes,
@@ -182,6 +228,12 @@ struct IVFFlatScanner : InvertedListScanner {
                 int64_t id = store_pairs ? lo_build(list_no, j) : ids[j];
                 res.add(dis, id);
             }
+        }
+    }
+
+    ~IVFFlatScanner() override {
+        if (store_new_xi) {
+            delete[] xi;
         }
     }
 };

--- a/faiss/IndexIVFFlat.cpp
+++ b/faiss/IndexIVFFlat.cpp
@@ -139,7 +139,7 @@ struct IVFFlatScanner : InvertedListScanner {
         this->store_pairs = store_pairs;
     }
 
-    const float* xi;
+    const float* xi = NULL;
     void set_query(const float* query) override {
         this->xi = query;
     }
@@ -154,6 +154,7 @@ struct IVFFlatScanner : InvertedListScanner {
                        query_base + queries[i] * d,
                        d * float_size);
             }
+            delete[] xi;
             this->xi = new_xi;
             nx = queries.size();
             store_new_xi = true;

--- a/faiss/IndexIVFFlat.cpp
+++ b/faiss/IndexIVFFlat.cpp
@@ -118,11 +118,14 @@ void IndexIVFFlat::sa_decode(idx_t n, const uint8_t* bytes, float* x) const {
 
 namespace {
 
+/// update heap array's id with the given id list,
+/// input heap should not contain previous results.
 template <class T>
 void update_res_ids(T* t, const size_t n, const Index::idx_t* ids) {
     Index::idx_t* start = t->get_ids(0);
     for (size_t i = 0; i < n; i++) {
-        start[i] = ids[start[i]];
+        if (start[i] >= 0)
+            start[i] = ids[start[i]];
     }
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(FAISS_TEST_SRC
   test_threaded_index.cpp
   test_transfer_invlists.cpp
   test_mem_leak.cpp
+  test_ivfflat_pmode.cpp
 )
 
 add_executable(faiss_test ${FAISS_TEST_SRC})

--- a/tests/test_ivfflat_pmode.cpp
+++ b/tests/test_ivfflat_pmode.cpp
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <random>
+
+#include <gtest/gtest.h>
+
+#include <faiss/IndexFlat.h>
+#include <faiss/IndexIVFFlat.h>
+#include <faiss/index_io.h>
+
+TEST(IVFFlat_pmode, accuracy) {
+    // dimension of the vectors to index
+    int d = 64;
+
+    // size of the database we plan to index
+    size_t nb = 2000;
+
+    // make a set of nt training vectors in the unit cube
+    // (could be the database)
+    size_t nt = 2000;
+
+    // make the index object and train it
+    faiss::IndexFlatL2 coarse_quantizer(d);
+
+    // a reasonable number of cetroids to index nb vectors
+    int ncentroids = 50;
+
+    faiss::IndexIVFFlat index(&coarse_quantizer, d, ncentroids);
+
+    // index that gives the ground-truth
+    faiss::IndexFlatL2 index_gt(d);
+
+    std::mt19937 rng;
+    std::uniform_real_distribution<> distrib;
+
+    { // training
+
+        std::vector<float> trainvecs(nt * d);
+        for (size_t i = 0; i < nt * d; i++) {
+            trainvecs[i] = distrib(rng);
+        }
+        index.verbose = true;
+        index.train(nt, trainvecs.data());
+    }
+
+    { // populating the database
+
+        std::vector<float> database(nb * d);
+        for (size_t i = 0; i < nb * d; i++) {
+            database[i] = distrib(rng);
+        }
+
+        index.add(nb, database.data());
+        index_gt.add(nb, database.data());
+    }
+
+    int nq = 200;
+    int n_ok;
+
+    { // searching the database
+
+        std::vector<float> queries(nq * d);
+        for (size_t i = 0; i < nq * d; i++) {
+            queries[i] = distrib(rng);
+        }
+
+        std::vector<faiss::Index::idx_t> gt_nns(nq);
+        std::vector<float> gt_dis(nq);
+
+        index_gt.search(nq, queries.data(), 1, gt_dis.data(), gt_nns.data());
+
+        for (int i = 0; i <= 4; i++) {
+            index.nprobe = 10;
+            index.parallel_mode = i;
+            int k = 5;
+            std::vector<faiss::Index::idx_t> nns(k * nq);
+            std::vector<float> dis(k * nq);
+
+            index.search(nq, queries.data(), k, dis.data(), nns.data());
+
+            n_ok = 0;
+            for (int q = 0; q < nq; q++) {
+                for (int i = 0; i < k; i++)
+                    if (nns[q * k + i] == gt_nns[q])
+                        n_ok++;
+            }
+            EXPECT_GT(n_ok, nq * 0.5);
+        }
+    }
+}


### PR DESCRIPTION
This PR follows #2306.
In short, it adds a new parallel mode to IVFFLAT that works well for computation-intensive queries.
To use, simply set parallel_mode=4.
