### PR TITLE
Fix failures surfaced by platform010 migration

### DIFF
--- a/faiss/IndexFlatCodes.cpp
+++ b/faiss/IndexFlatCodes.cpp
@@ -20,6 +20,9 @@ IndexFlatCodes::IndexFlatCodes() : code_size(0) {}
 
 void IndexFlatCodes::add(idx_t n, const float* x) {
     FAISS_THROW_IF_NOT(is_trained);
+    if (n == 0) {
+        return;
+    }
     codes.resize((ntotal + n) * code_size);
     sa_encode(n, x, codes.data() + (ntotal * code_size));
     ntotal += n;

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -202,7 +202,10 @@ void hnsw_add_vertices(
                         verbose && omp_get_thread_num() == 0 ? 0 : -1;
                 size_t counter = 0;
 
-#pragma omp for schedule(dynamic)
+                // here we should do schedule(dynamic) but this segfaults for
+                // some versions of LLVM. The performance impact should not be
+                // too large when (i1 - i0) / num_threads >> 1
+#pragma omp for schedule(static)
                 for (int i = i0; i < i1; i++) {
                     storage_idx_t pt_id = order[i];
                     dis->set_query(x + (pt_id - n0) * d);
@@ -219,7 +222,6 @@ void hnsw_add_vertices(
                         printf("  %d / %d\r", i - i0, i1 - i0);
                         fflush(stdout);
                     }
-
                     if (counter % check_period == 0) {
                         if (InterruptCallback::is_interrupted()) {
                             interrupt = true;

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -774,7 +774,6 @@ void IndexIVF::range_search_preassigned(
                 }
             }
         } else if (parallel_mode == 2) {
-            std::vector<RangeQueryResult*> all_qres(nx);
             RangeQueryResult* qres = nullptr;
 
 #pragma omp for schedule(dynamic)
@@ -782,7 +781,6 @@ void IndexIVF::range_search_preassigned(
                 idx_t i = iik / (idx_t)nprobe;
                 idx_t ik = iik % (idx_t)nprobe;
                 if (qres == nullptr || qres->qno != i) {
-                    FAISS_ASSERT(!qres || i > qres->qno);
                     qres = &pres.new_result(i);
                     scanner->set_query(x + i * d);
                 }


### PR DESCRIPTION
Summary:
Checks are a bit stricted in platform010, so fix new CI errors here.
The errors corrected fall in 3 classes:

- `&vector[vector.size()]` now fails because `operator []` checks for array bounds even if only the address is maniuplated

- `omp schedule(dynamic)` does not run the loop in the correct order.

- several threads calling omp loop seems to cause errors in the distributed Faiss code

Reviewed By: beauby

Differential Revision: D35895550

