### PR TITLE
expose certain buffer sizes

### DIFF
--- a/faiss/Index2Layer.cpp
+++ b/faiss/Index2Layer.cpp
@@ -282,10 +282,13 @@ DistanceComputer* Index2Layer::get_distance_computer() const {
 
 /* The standalone codec interface */
 
+// block size used in Index2Layer::sa_encode
+int index2layer_sa_encode_bs = 32768;
+
 void Index2Layer::sa_encode(idx_t n, const float* x, uint8_t* bytes) const {
     FAISS_THROW_IF_NOT(is_trained);
 
-    idx_t bs = 32768;
+    idx_t bs = index2layer_sa_encode_bs;
     if (n > bs) {
         for (idx_t i0 = 0; i0 < n; i0 += bs) {
             idx_t i1 = std::min(i0 + bs, n);

--- a/faiss/Index2Layer.h
+++ b/faiss/Index2Layer.h
@@ -14,6 +14,7 @@
 #include <faiss/IndexFlatCodes.h>
 #include <faiss/IndexIVF.h>
 #include <faiss/IndexPQ.h>
+#include <faiss/impl/platform_macros.h>
 
 namespace faiss {
 
@@ -67,5 +68,8 @@ struct Index2Layer : IndexFlatCodes {
     void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override;
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
 };
+
+// block size used in Index2Layer::sa_encode
+FAISS_API extern int index2layer_sa_encode_bs;
 
 } // namespace faiss

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -260,13 +260,16 @@ void IndexIVFPQ::sa_decode(idx_t n, const uint8_t* codes, float* x) const {
     }
 }
 
+// block size used in IndexIVFPQ::add_core_o
+int index_ivfpq_add_core_o_bs = 32768;
+
 void IndexIVFPQ::add_core_o(
         idx_t n,
         const float* x,
         const idx_t* xids,
         float* residuals_2,
         const idx_t* precomputed_idx) {
-    idx_t bs = 32768;
+    idx_t bs = index_ivfpq_add_core_o_bs;
     if (n > bs) {
         for (idx_t i0 = 0; i0 < n; i0 += bs) {
             idx_t i1 = std::min(i0 + bs, n);

--- a/faiss/IndexIVFPQ.h
+++ b/faiss/IndexIVFPQ.h
@@ -142,6 +142,9 @@ struct IndexIVFPQ : IndexIVF {
     IndexIVFPQ();
 };
 
+// block size used in IndexIVFPQ::add_core_o
+FAISS_API extern int index_ivfpq_add_core_o_bs;
+
 /** Pre-compute distance tables for IVFPQ with by-residual and METRIC_L2
  *
  * @param use_precomputed_table (I/O)

--- a/faiss/IndexPQ.cpp
+++ b/faiss/IndexPQ.cpp
@@ -862,6 +862,9 @@ void MultiIndexQuantizer::train(idx_t n, const float* x) {
         ntotal *= pq.ksub;
 }
 
+// block size used in MultiIndexQuantizer::search
+int multi_index_quantizer_search_bs = 32768;
+
 void MultiIndexQuantizer::search(
         idx_t n,
         const float* x,
@@ -874,7 +877,7 @@ void MultiIndexQuantizer::search(
     FAISS_THROW_IF_NOT(k > 0);
 
     // the allocation just below can be severe...
-    idx_t bs = 32768;
+    idx_t bs = multi_index_quantizer_search_bs;
     if (n > bs) {
         for (idx_t i0 = 0; i0 < n; i0 += bs) {
             idx_t i1 = std::min(i0 + bs, n);

--- a/faiss/IndexPQ.h
+++ b/faiss/IndexPQ.h
@@ -153,6 +153,9 @@ struct MultiIndexQuantizer : Index {
     void reconstruct(idx_t key, float* recons) const override;
 };
 
+// block size used in MultiIndexQuantizer::search
+FAISS_API extern int multi_index_quantizer_search_bs;
+
 /** MultiIndexQuantizer where the PQ assignmnet is performed by sub-indexes
  */
 struct MultiIndexQuantizer2 : MultiIndexQuantizer {

--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -495,10 +495,13 @@ void ProductQuantizer::compute_codes_with_assign_index(
     }
 }
 
+// block size used in ProductQuantizer::compute_codes
+int product_quantizer_compute_codes_bs = 256 * 1024;
+
 void ProductQuantizer::compute_codes(const float* x, uint8_t* codes, size_t n)
         const {
     // process by blocks to avoid using too much RAM
-    size_t bs = 256 * 1024;
+    size_t bs = product_quantizer_compute_codes_bs;
     if (n > bs) {
         for (size_t i0 = 0; i0 < n; i0 += bs) {
             size_t i1 = std::min(i0 + bs, n);

--- a/faiss/impl/ProductQuantizer.h
+++ b/faiss/impl/ProductQuantizer.h
@@ -16,6 +16,7 @@
 
 #include <faiss/Clustering.h>
 #include <faiss/impl/Quantizer.h>
+#include <faiss/impl/platform_macros.h>
 #include <faiss/utils/Heap.h>
 
 namespace faiss {
@@ -165,6 +166,9 @@ struct ProductQuantizer : Quantizer {
             float_maxheap_array_t* res,
             bool init_finalize_heap = true) const;
 };
+
+// block size used in ProductQuantizer::compute_codes
+FAISS_API extern int product_quantizer_compute_codes_bs;
 
 /*************************************************
  * Objects to encode / decode strings of bits


### PR DESCRIPTION
Summary:
Expose buffer sizes for:
* MultiIndexQuantizer::search
* IndexIVFPQ::add_core_o
* Index2Layer::sa_encode
* ProductQuantizer::compute_codes

Differential Revision: D36248391

