### PR TITLE
fix IndexFastScan verbose output

### DIFF
--- a/faiss/IndexFastScan.cpp
+++ b/faiss/IndexFastScan.cpp
@@ -72,7 +72,7 @@ void IndexFastScan::add(idx_t n, const float* x) {
         for (idx_t i0 = 0; i0 < n; i0 += bs) {
             idx_t i1 = std::min(n, i0 + bs);
             if (verbose) {
-                printf("IndexFastScan::add %zd/%zd", size_t(i1), size_t(n));
+                printf("IndexFastScan::add %zd/%zd\n", size_t(i1), size_t(n));
             }
             add(i1 - i0, x + i0 * d);
         }

--- a/faiss/IndexIVFFastScan.cpp
+++ b/faiss/IndexIVFFastScan.cpp
@@ -97,7 +97,7 @@ void IndexIVFFastScan::add_with_ids(
                 }
                 size_t mem = get_mem_usage_kb() / (1 << 10);
 
-                printf("IndexIVFFastScan::add_with_ids %zd/%zd, time %.2f/%.2f, RSS %zdMB",
+                printf("IndexIVFFastScan::add_with_ids %zd/%zd, time %.2f/%.2f, RSS %zdMB\n",
                        size_t(i1),
                        size_t(n),
                        elapsed_time,


### PR DESCRIPTION
When using IndexFastScan and IndexIVFFastScan to build database with verbose=True, the progress output is garbled because of lack of \n.

For example:
```python
import faiss
import numpy as np

d = 64
M = 32
nbits = 4
db = np.random.rand(300000, d).astype(np.float32)
index = faiss.IndexPQFastScan(d, M, nbits)
index.train(db)
index.verbose = True
index.add(db)
```
outputs:
```
IndexFastScan::add 65536/300000IndexFastScan::add 131072/300000IndexFastScan::add 196608/300000IndexFastScan::add 262144/300000IndexFastScan::add 300000/300000%
```

This pull request can fix this problem.