### PR TITLE
add batch reconstruction function

### DIFF
--- a/faiss/Index.h
+++ b/faiss/Index.h
@@ -158,6 +158,16 @@ struct Index {
      */
     virtual void reconstruct(idx_t key, float* recons) const;
 
+    /** Reconstruct several stored vectors (or an approximation if lossy coding)
+     *
+     * this function may not be defined for some indexes
+     * @param n        number of vectors to reconstruct
+     * @param keys        ids of the vectors to reconstruct (size n)
+     * @param recons      reconstucted vector (size n * d)
+     */
+    virtual void reconstruct_batch(idx_t n, const idx_t* keys, float* recons)
+            const;
+
     /** Reconstruct vectors i0 to i0 + ni - 1
      *
      * this function may not be defined for some indexes

--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -437,8 +437,7 @@ def handle_Index(the_class):
 
         Returns
         -------
-        x : array_like
-            Reconstructed vector, size `self.d`, `dtype`=float32
+        x : array_like reconstructed vector, size `self.d`, `dtype`=float32
         """
         if x is None:
             x = np.empty(self.d, dtype=np.float32)
@@ -446,6 +445,30 @@ def handle_Index(the_class):
             assert x.shape == (self.d, )
 
         self.reconstruct_c(key, swig_ptr(x))
+        return x
+
+    def replacement_reconstruct_batch(self, key, x=None):
+        """Approximate reconstruction of several vectors from the index.
+
+        Parameters
+        ----------
+        key : array of ints
+            Ids of the vectors to reconstruct
+        x : array_like, optional
+            pre-allocated array to store the results
+
+        Returns
+        -------
+        x : array_like
+            reconstrcuted vectors, size `len(key), self.d`
+        """
+        key = np.ascontiguousarray(key, dtype='int64')
+        n, = key.shape
+        if x is None:
+            x = np.empty((n, self.d), dtype=np.float32)
+        else:
+            assert x.shape == (n, self.d)
+        self.reconstruct_batch_c(n, swig_ptr(key), swig_ptr(x))
         return x
 
     def replacement_reconstruct_n(self, n0, ni, x=None):
@@ -564,6 +587,7 @@ def handle_Index(the_class):
     replace_method(the_class, 'search', replacement_search)
     replace_method(the_class, 'remove_ids', replacement_remove_ids)
     replace_method(the_class, 'reconstruct', replacement_reconstruct)
+    replace_method(the_class, 'reconstruct_batch', replacement_reconstruct_batch)
     replace_method(the_class, 'reconstruct_n', replacement_reconstruct_n)
     replace_method(the_class, 'range_search', replacement_range_search)
     replace_method(the_class, 'update_vectors', replacement_update_vectors,

--- a/tests/test_build_blocks.py
+++ b/tests/test_build_blocks.py
@@ -573,3 +573,27 @@ class TestResultHeap(unittest.TestCase):
 
         np.testing.assert_equal(all_rh[1].D, all_rh[3].D)
         np.testing.assert_equal(all_rh[1].I, all_rh[3].I)
+
+
+class TestReconstructBatch(unittest.TestCase):
+
+    def test_indexflat(self):
+        index = faiss.IndexFlatL2(32)
+        x = faiss.randn((100, 32), 1234)
+        index.add(x)
+
+        subset = [4, 7, 45]
+        np.testing.assert_equal(x[subset], index.reconstruct_batch(subset))
+
+    def test_exception(self):
+        index = faiss.index_factory(32, "IVF2,Flat")
+        x = faiss.randn((100, 32), 1234)
+        index.train(x)
+        index.add(x)
+
+        # make sure it raises an exception even if it enters the openmp for
+        subset = np.zeros(1200, dtype=int)
+        self.assertRaises(
+            RuntimeError,
+            lambda : index.reconstruct_batch(subset),
+        )

--- a/tests/test_merge.cpp
+++ b/tests/test_merge.cpp
@@ -26,7 +26,7 @@ namespace {
 struct Tempfilename {
     static pthread_mutex_t mutex;
 
-    std::string filename = "faiss_tmp_XXXXXX";
+    std::string filename = "/tmp/faiss_tmp_XXXXXX";
 
     Tempfilename() {
         pthread_mutex_lock(&mutex);

--- a/tests/test_ondisk_ivf.cpp
+++ b/tests/test_ondisk_ivf.cpp
@@ -28,7 +28,7 @@ namespace {
 struct Tempfilename {
     static pthread_mutex_t mutex;
 
-    std::string filename = "faiss_tmp_XXXXXX";
+    std::string filename = "/tmp/faiss_tmp_XXXXXX";
 
     Tempfilename() {
         pthread_mutex_lock(&mutex);


### PR DESCRIPTION
Summary:
As requested in https://github.com/facebookresearch/faiss/issues/1163
add `reconstruct_batch` that calls `reconstruct` in a C++ for loop.

Differential Revision: D37717342

