### PR TITLE
Fix test_cppcontrib_sa_decode.cpp

### DIFF
--- a/faiss/cppcontrib/SaDecodeKernels-avx2-inl.h
+++ b/faiss/cppcontrib/SaDecodeKernels-avx2-inl.h
@@ -122,36 +122,44 @@ inline __m256 elementaryBlock8x1bAccum(
 }
 
 // reduces the number of read operations from RAM
-template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CPOS>
-struct Uint8Reader {
+template <
+        intptr_t DIM,
+        intptr_t CODE_SIZE,
+        intptr_t CPOS,
+        bool = DIM / CODE_SIZE <= 3>
+struct Uint8ReaderImpl {
     static intptr_t get(const uint8_t* const __restrict codes) {
-        constexpr intptr_t nCodeWords = DIM / CODE_SIZE;
-        if constexpr (nCodeWords <= 3) {
-            // Read 1 byte (movzx).
-            return codes[CPOS];
-        } else {
-            // Read using 4-bytes.
-            // Reading using 8-byte takes too many registers somewhy.
-            const uint32_t* __restrict codes32 =
-                    reinterpret_cast<const uint32_t*>(codes);
+        // Read 1 byte (movzx).
+        return codes[CPOS];
+    }
+};
+template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CPOS>
+struct Uint8ReaderImpl<DIM, CODE_SIZE, CPOS, false> {
+    static intptr_t get(const uint8_t* const __restrict codes) {
+        // Read using 4-bytes.
+        // Reading using 8-byte takes too many registers somewhy.
+        const uint32_t* __restrict codes32 =
+                reinterpret_cast<const uint32_t*>(codes);
 
-            constexpr intptr_t ELEMENT_TO_READ = CPOS / 4;
-            constexpr intptr_t SUB_ELEMENT = CPOS % 4;
-            const uint32_t code32 = codes32[ELEMENT_TO_READ];
+        constexpr intptr_t ELEMENT_TO_READ = CPOS / 4;
+        constexpr intptr_t SUB_ELEMENT = CPOS % 4;
+        const uint32_t code32 = codes32[ELEMENT_TO_READ];
 
-            switch (SUB_ELEMENT) {
-                case 0:
-                    return (code32 & 0x000000FF);
-                case 1:
-                    return (code32 & 0x0000FF00) >> 8;
-                case 2:
-                    return (code32 & 0x00FF0000) >> 16;
-                case 3:
-                    return (code32) >> 24;
-            }
+        switch (SUB_ELEMENT) {
+            case 0:
+                return (code32 & 0x000000FF);
+            case 1:
+                return (code32 & 0x0000FF00) >> 8;
+            case 2:
+                return (code32 & 0x00FF0000) >> 16;
+            case 3:
+                return (code32) >> 24;
         }
     }
 };
+
+template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CPOS>
+using Uint8Reader = Uint8ReaderImpl<DIM, CODE_SIZE, CPOS>;
 
 // The following code uses template-based for-loop unrolling,
 //   because the compiler does not do that on its own as needed.
@@ -174,8 +182,34 @@ struct Uint8Reader {
 
 // Suitable for IVF256,PQ[1]x8
 // Suitable for Residual[1]x8,PQ[2]x8
-template <intptr_t DIM, intptr_t COARSE_SIZE, intptr_t FINE_SIZE, intptr_t CPOS>
-struct Index2LevelDecoderImpl {
+template <
+        intptr_t DIM,
+        intptr_t COARSE_SIZE,
+        intptr_t FINE_SIZE,
+        intptr_t CPOS,
+        bool FINE_SIZE_EQ_4 = FINE_SIZE == 4,
+        bool QPOS_LEFT_GE_8 = (FINE_SIZE - CPOS % FINE_SIZE >= 8),
+        bool QPOS_LEFT_GE_4 = (FINE_SIZE - CPOS % FINE_SIZE >= 4),
+        bool DIM_EQ_CPOS = DIM == CPOS>
+struct Index2LevelDecoderImpl;
+
+template <
+        intptr_t DIM,
+        intptr_t COARSE_SIZE,
+        intptr_t CPOS,
+        bool QPOS_LEFT_GE_8,
+        bool QPOS_LEFT_GE_4>
+struct Index2LevelDecoderImpl<
+        DIM,
+        COARSE_SIZE,
+        4,
+        CPOS,
+        true,
+        QPOS_LEFT_GE_8,
+        QPOS_LEFT_GE_4,
+        false> {
+    static constexpr intptr_t FINE_SIZE = 4;
+
     static constexpr intptr_t coarseCentroidIdx = CPOS / COARSE_SIZE;
     static constexpr intptr_t coarseCentroidOffset = CPOS % COARSE_SIZE;
     static constexpr intptr_t fineCentroidIdx = CPOS / FINE_SIZE;
@@ -195,70 +229,28 @@ struct Index2LevelDecoderImpl {
         // fine quantizer
         const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
 
-        if constexpr (FINE_SIZE == 4) {
-            // clang-format off
+        // clang-format off
 
-            // process chunks, 4 float
-            // but 8 floats per loop
+        // process chunks, 4 float
+        // but 8 floats per loop
 
-            const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-            const intptr_t fineCode0a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine0);
-            const intptr_t fineCode0b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine0);
+        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine0);
+        const intptr_t fineCode0b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine0);
 
-            const __m256 storeValue = elementaryBlock4x2b(
-                  pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-                  pqFineCentroids0 + ((fineCentroidIdx + 0) * 256 + fineCode0a) * FINE_SIZE + fineCentroidOffset,
-                  pqFineCentroids0 + ((fineCentroidIdx + 1) * 256 + fineCode0b) * FINE_SIZE + fineCentroidOffset);
+        const __m256 storeValue = elementaryBlock4x2b(
+              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 0) * 256 + fineCode0a) * FINE_SIZE + fineCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 1) * 256 + fineCode0b) * FINE_SIZE + fineCentroidOffset);
 
-            _mm256_storeu_ps(outputStore + CPOS, storeValue);
+        _mm256_storeu_ps(outputStore + CPOS, storeValue);
 
-            // next
-            Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::store(
-                  pqCoarseCentroids0, pqFineCentroids0, code0,
-                  outputStore);
+        // next
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::store(
+              pqCoarseCentroids0, pqFineCentroids0, code0,
+              outputStore);
 
-            // clang-format on
-        } else if constexpr (QPOS_LEFT >= 8) {
-            // clang-format off
-
-            // process chunks, 8 float
-
-            const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-            const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
-
-            const __m256 storeValue = elementaryBlock8x1b(
-                  pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-                  pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset);
-
-            _mm256_storeu_ps(outputStore + CPOS, storeValue);
-
-            // next
-            Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::store(
-                  pqCoarseCentroids0, pqFineCentroids0, code0,
-                  outputStore);
-
-            // clang-format on
-        } else if constexpr (QPOS_LEFT >= 4) {
-            // clang-format off
-
-            // process chunks, 4 float
-
-            const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-            const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
-
-            const __m128 storeValue = elementaryBlock4x1b(
-                  pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-                  pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset);
-
-            _mm_storeu_ps(outputStore + CPOS, storeValue);
-
-            // next
-            Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 4>::store(
-                  pqCoarseCentroids0, pqFineCentroids0, code0,
-                  outputStore);
-
-            // clang-format on
-        }
+        // clang-format on
     }
 
     // process 1 sample
@@ -274,82 +266,32 @@ struct Index2LevelDecoderImpl {
         // fine quantizer
         const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
 
-        if constexpr (FINE_SIZE == 4) {
-            // clang-format off
+        // clang-format off
 
-            // process chunks, 4 float
-            // but 8 floats per loop
+        // process chunks, 4 float
+        // but 8 floats per loop
 
-            const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-            const intptr_t fineCode0a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine0);
-            const intptr_t fineCode0b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine0);
+        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine0);
+        const intptr_t fineCode0b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine0);
 
-            __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
+        __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
 
-            existingValue = elementaryBlock4x2bAccum(
-                  pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-                  pqFineCentroids0 + ((fineCentroidIdx + 0) * 256 + fineCode0a) * FINE_SIZE + fineCentroidOffset,
-                  pqFineCentroids0 + ((fineCentroidIdx + 1) * 256 + fineCode0b) * FINE_SIZE + fineCentroidOffset,
-                  weight0,
-                  existingValue);
+        existingValue = elementaryBlock4x2bAccum(
+              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 0) * 256 + fineCode0a) * FINE_SIZE + fineCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 1) * 256 + fineCode0b) * FINE_SIZE + fineCentroidOffset,
+              weight0,
+              existingValue);
 
-            _mm256_storeu_ps(outputAccum + CPOS, existingValue);
+        _mm256_storeu_ps(outputAccum + CPOS, existingValue);
 
-            // next
-            Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
-                  pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
-                  outputAccum);
+        // next
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
+              pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
+              outputAccum);
 
-            // clang-format on
-        } else if constexpr (QPOS_LEFT >= 8) {
-            // clang-format off
-
-            // process chunks, 8 float
-
-            const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-            const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
-
-            __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
-
-            existingValue = elementaryBlock8x1bAccum(
-                  pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-                  pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
-                  weight0,
-                  existingValue);
-
-            _mm256_storeu_ps(outputAccum + CPOS, existingValue);
-
-            // next
-            Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
-                  pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
-                  outputAccum);
-
-            // clang-format on
-        } else if constexpr (QPOS_LEFT >= 4) {
-            // clang-format off
-
-            // process chunks, 4 float
-
-            const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-            const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
-
-            __m128 existingValue = _mm_loadu_ps(outputAccum + CPOS);
-
-            existingValue = elementaryBlock4x1bAccum(
-                  pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-                  pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
-                  weight0,
-                  existingValue);
-
-            _mm_storeu_ps(outputAccum + CPOS, existingValue);
-
-            // next
-            Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 4>::accum(
-                  pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
-                  outputAccum);
-
-            // clang-format on
-        }
+        // clang-format on
     }
 
     // process 2 samples
@@ -371,119 +313,349 @@ struct Index2LevelDecoderImpl {
         const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
         const uint8_t* const __restrict fine1 = code1 + (DIM / COARSE_SIZE);
 
-        if constexpr (FINE_SIZE == 4) {
-            // clang-format off
+        // clang-format off
 
-            // process chunks, 4 float
-            // but 8 floats per loop
+        // process chunks, 4 float
+        // but 8 floats per loop
 
-            const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-            const intptr_t fineCode0a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine0);
-            const intptr_t fineCode0b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine0);
-            const intptr_t coarseCode1 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse1);
-            const intptr_t fineCode1a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine1);
-            const intptr_t fineCode1b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine1);
+        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine0);
+        const intptr_t fineCode0b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine0);
+        const intptr_t coarseCode1 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse1);
+        const intptr_t fineCode1a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine1);
+        const intptr_t fineCode1b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine1);
 
-            __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
+        __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
 
-            existingValue = elementaryBlock4x2bAccum(
-                  pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-                  pqFineCentroids0 + ((fineCentroidIdx + 0) * 256 + fineCode0a) * FINE_SIZE + fineCentroidOffset,
-                  pqFineCentroids0 + ((fineCentroidIdx + 1) * 256 + fineCode0b) * FINE_SIZE + fineCentroidOffset,
-                  weight0,
-                  existingValue);
+        existingValue = elementaryBlock4x2bAccum(
+              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 0) * 256 + fineCode0a) * FINE_SIZE + fineCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 1) * 256 + fineCode0b) * FINE_SIZE + fineCentroidOffset,
+              weight0,
+              existingValue);
 
-            existingValue = elementaryBlock4x2bAccum(
-                  pqCoarseCentroids1 + (coarseCentroidIdx * 256 + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
-                  pqFineCentroids1 + ((fineCentroidIdx + 0) * 256 + fineCode1a) * FINE_SIZE + fineCentroidOffset,
-                  pqFineCentroids1 + ((fineCentroidIdx + 1) * 256 + fineCode1b) * FINE_SIZE + fineCentroidOffset,
-                  weight1,
-                  existingValue);
+        existingValue = elementaryBlock4x2bAccum(
+              pqCoarseCentroids1 + (coarseCentroidIdx * 256 + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids1 + ((fineCentroidIdx + 0) * 256 + fineCode1a) * FINE_SIZE + fineCentroidOffset,
+              pqFineCentroids1 + ((fineCentroidIdx + 1) * 256 + fineCode1b) * FINE_SIZE + fineCentroidOffset,
+              weight1,
+              existingValue);
 
-            _mm256_storeu_ps(outputAccum + CPOS, existingValue);
+        _mm256_storeu_ps(outputAccum + CPOS, existingValue);
 
-            // next
-            Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
-                  pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
-                  pqCoarseCentroids1, pqFineCentroids1, code1, weight1,
-                  outputAccum);
+        // next
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
+              pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
+              pqCoarseCentroids1, pqFineCentroids1, code1, weight1,
+              outputAccum);
 
-            // clang-format on
-        } else if constexpr (QPOS_LEFT >= 8) {
-            // clang-format off
+        // clang-format on
+    }
+};
 
-            // process chunks, 8 float
+template <intptr_t DIM, intptr_t COARSE_SIZE, intptr_t FINE_SIZE, intptr_t CPOS>
+struct Index2LevelDecoderImpl<
+        DIM,
+        COARSE_SIZE,
+        FINE_SIZE,
+        CPOS,
+        false,
+        true,
+        true,
+        false> {
+    static constexpr intptr_t coarseCentroidIdx = CPOS / COARSE_SIZE;
+    static constexpr intptr_t coarseCentroidOffset = CPOS % COARSE_SIZE;
+    static constexpr intptr_t fineCentroidIdx = CPOS / FINE_SIZE;
+    static constexpr intptr_t fineCentroidOffset = CPOS % FINE_SIZE;
 
-            const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-            const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
-            const intptr_t coarseCode1 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse1);
-            const intptr_t fineCode1 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine1);
+    static constexpr intptr_t QPOS_LEFT = FINE_SIZE - fineCentroidOffset;
 
-            __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
+    // process 1 sample
+    static void store(
+            const float* const __restrict pqCoarseCentroids0,
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            float* const __restrict outputStore) {
+        // coarse quantizer
+        const uint8_t* const __restrict coarse0 = code0;
 
-            existingValue = elementaryBlock8x1bAccum(
-                  pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-                  pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
-                  weight0,
-                  existingValue);
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
 
-            existingValue = elementaryBlock8x1bAccum(
-                  pqCoarseCentroids1 + (coarseCentroidIdx * 256 + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
-                  pqFineCentroids1 + (fineCentroidIdx * 256 + fineCode1) * FINE_SIZE + fineCentroidOffset,
-                  weight1,
-                  existingValue);
+        // clang-format off
 
-            _mm256_storeu_ps(outputAccum + CPOS, existingValue);
+        // process chunks, 8 float
 
-            // next
-            Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
-                  pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
-                  pqCoarseCentroids1, pqFineCentroids1, code1, weight1,
-                  outputAccum);
+        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
 
-            // clang-format on
-        } else if constexpr (QPOS_LEFT >= 4) {
-            // clang-format off
+        const __m256 storeValue = elementaryBlock8x1b(
+              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset);
 
-            // process chunks, 4 float
+        _mm256_storeu_ps(outputStore + CPOS, storeValue);
 
-            const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-            const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
-            const intptr_t coarseCode1 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse1);
-            const intptr_t fineCode1 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine1);
+        // next
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::store(
+              pqCoarseCentroids0, pqFineCentroids0, code0,
+              outputStore);
 
-            __m128 existingValue = _mm_loadu_ps(outputAccum + CPOS);
+        // clang-format on
+    }
 
-            existingValue = elementaryBlock4x1bAccum(
-                  pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-                  pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
-                  weight0,
-                  existingValue);
+    // process 1 sample
+    static void accum(
+            const float* const __restrict pqCoarseCentroids0,
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            float* const __restrict outputAccum) {
+        // coarse quantizer
+        const uint8_t* const __restrict coarse0 = code0;
 
-            existingValue = elementaryBlock4x1bAccum(
-                  pqCoarseCentroids1 + (coarseCentroidIdx * 256 + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
-                  pqFineCentroids1 + (fineCentroidIdx * 256 + fineCode1) * FINE_SIZE + fineCentroidOffset,
-                  weight1,
-                  existingValue);
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
 
-            _mm_storeu_ps(outputAccum + CPOS, existingValue);
+        // clang-format off
 
-            // next
-            Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 4>::accum(
-                  pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
-                  pqCoarseCentroids1, pqFineCentroids1, code1, weight1,
-                  outputAccum);
+        // process chunks, 8 float
 
-            // clang-format on
-        }
+        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
+
+        __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
+
+        existingValue = elementaryBlock8x1bAccum(
+              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
+              weight0,
+              existingValue);
+
+        _mm256_storeu_ps(outputAccum + CPOS, existingValue);
+
+        // next
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
+              pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
+              outputAccum);
+
+        // clang-format on
+    }
+
+    // process 2 samples
+    static void accum(
+            const float* const __restrict pqCoarseCentroids0,
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            const float* const __restrict pqCoarseCentroids1,
+            const float* const __restrict pqFineCentroids1,
+            const uint8_t* const __restrict code1,
+            const float weight1,
+            float* const __restrict outputAccum) {
+        // coarse quantizer
+        const uint8_t* const __restrict coarse0 = code0;
+        const uint8_t* const __restrict coarse1 = code1;
+
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine1 = code1 + (DIM / COARSE_SIZE);
+
+        // clang-format off
+
+        // process chunks, 8 float
+
+        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode1 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse1);
+        const intptr_t fineCode1 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine1);
+
+        __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
+
+        existingValue = elementaryBlock8x1bAccum(
+              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
+              weight0,
+              existingValue);
+
+        existingValue = elementaryBlock8x1bAccum(
+              pqCoarseCentroids1 + (coarseCentroidIdx * 256 + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids1 + (fineCentroidIdx * 256 + fineCode1) * FINE_SIZE + fineCentroidOffset,
+              weight1,
+              existingValue);
+
+        _mm256_storeu_ps(outputAccum + CPOS, existingValue);
+
+        // next
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
+              pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
+              pqCoarseCentroids1, pqFineCentroids1, code1, weight1,
+              outputAccum);
+
+        // clang-format on
+    }
+};
+
+template <intptr_t DIM, intptr_t COARSE_SIZE, intptr_t FINE_SIZE, intptr_t CPOS>
+struct Index2LevelDecoderImpl<
+        DIM,
+        COARSE_SIZE,
+        FINE_SIZE,
+        CPOS,
+        false,
+        false,
+        true,
+        false> {
+    static constexpr intptr_t coarseCentroidIdx = CPOS / COARSE_SIZE;
+    static constexpr intptr_t coarseCentroidOffset = CPOS % COARSE_SIZE;
+    static constexpr intptr_t fineCentroidIdx = CPOS / FINE_SIZE;
+    static constexpr intptr_t fineCentroidOffset = CPOS % FINE_SIZE;
+
+    static constexpr intptr_t QPOS_LEFT = FINE_SIZE - fineCentroidOffset;
+
+    // process 1 sample
+    static void store(
+            const float* const __restrict pqCoarseCentroids0,
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            float* const __restrict outputStore) {
+        // coarse quantizer
+        const uint8_t* const __restrict coarse0 = code0;
+
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+
+        // clang-format off
+
+        // process chunks, 4 float
+
+        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
+
+        const __m128 storeValue = elementaryBlock4x1b(
+              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset);
+
+        _mm_storeu_ps(outputStore + CPOS, storeValue);
+
+        // next
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 4>::store(
+              pqCoarseCentroids0, pqFineCentroids0, code0,
+              outputStore);
+
+        // clang-format on
+    }
+
+    // process 1 sample
+    static void accum(
+            const float* const __restrict pqCoarseCentroids0,
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            float* const __restrict outputAccum) {
+        // coarse quantizer
+        const uint8_t* const __restrict coarse0 = code0;
+
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+
+        // clang-format off
+
+        // process chunks, 4 float
+
+        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
+
+        __m128 existingValue = _mm_loadu_ps(outputAccum + CPOS);
+
+        existingValue = elementaryBlock4x1bAccum(
+              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
+              weight0,
+              existingValue);
+
+        _mm_storeu_ps(outputAccum + CPOS, existingValue);
+
+        // next
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 4>::accum(
+              pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
+              outputAccum);
+
+        // clang-format on
+    }
+
+    // process 2 samples
+    static void accum(
+            const float* const __restrict pqCoarseCentroids0,
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            const float* const __restrict pqCoarseCentroids1,
+            const float* const __restrict pqFineCentroids1,
+            const uint8_t* const __restrict code1,
+            const float weight1,
+            float* const __restrict outputAccum) {
+        // coarse quantizer
+        const uint8_t* const __restrict coarse0 = code0;
+        const uint8_t* const __restrict coarse1 = code1;
+
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine1 = code1 + (DIM / COARSE_SIZE);
+
+        // clang-format off
+
+        // process chunks, 4 float
+
+        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode1 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse1);
+        const intptr_t fineCode1 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine1);
+
+        __m128 existingValue = _mm_loadu_ps(outputAccum + CPOS);
+
+        existingValue = elementaryBlock4x1bAccum(
+              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
+              weight0,
+              existingValue);
+
+        existingValue = elementaryBlock4x1bAccum(
+              pqCoarseCentroids1 + (coarseCentroidIdx * 256 + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids1 + (fineCentroidIdx * 256 + fineCode1) * FINE_SIZE + fineCentroidOffset,
+              weight1,
+              existingValue);
+
+        _mm_storeu_ps(outputAccum + CPOS, existingValue);
+
+        // next
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 4>::accum(
+              pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
+              pqCoarseCentroids1, pqFineCentroids1, code1, weight1,
+              outputAccum);
+
+        // clang-format on
     }
 };
 
 // Suitable for IVF256,PQ[1]x8
 // Suitable for Residual[1]x8,PQ[2]x8
 // This partial specialization is expected to do nothing.
-template <intptr_t DIM, intptr_t COARSE_SIZE, intptr_t FINE_SIZE>
-struct Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, DIM> {
+template <
+        intptr_t DIM,
+        intptr_t COARSE_SIZE,
+        intptr_t FINE_SIZE,
+        bool FINE_SIZE_EQ_4,
+        bool QPOS_LEFT_GE_8,
+        bool QPOS_LEFT_GE_4>
+struct Index2LevelDecoderImpl<
+        DIM,
+        COARSE_SIZE,
+        FINE_SIZE,
+        DIM,
+        FINE_SIZE_EQ_4,
+        QPOS_LEFT_GE_8,
+        QPOS_LEFT_GE_4,
+        true> {
     // clang-format off
 
     // process 1 sample

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,11 @@ set(FAISS_TEST_SRC
 add_executable(faiss_test ${FAISS_TEST_SRC})
 
 if(FAISS_OPT_LEVEL STREQUAL "avx2")
+  if(NOT WIN32)
+    target_compile_options(faiss_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-mavx2 -mfma>)
+  else()
+    target_compile_options(faiss_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/arch:AVX2>)
+  endif()
   target_link_libraries(faiss_test PRIVATE faiss_avx2)
 else()
   target_link_libraries(faiss_test PRIVATE faiss)

--- a/tests/test_cppcontrib_sa_decode.cpp
+++ b/tests/test_cppcontrib_sa_decode.cpp
@@ -201,7 +201,9 @@ std::vector<float> generate(const size_t n, const size_t d) {
 template <typename T>
 void test(const uint64_t n, const uint64_t d, const std::string& description) {
     auto data = generate(n, d);
-    auto [index, encodedData] = trainDataset(data, n, d, description);
+    std::shared_ptr<faiss::Index> index;
+    std::vector<uint8_t> encodedData;
+    std::tie(index, encodedData) = trainDataset(data, n, d, description);
 
     verify<T>(n, d, index, encodedData);
 }


### PR DESCRIPTION
This PR contains below changes:

- Conform C++11
    - [`faiss` is written in C++11](https://github.com/facebookresearch/faiss/blob/main/CONTRIBUTING.md#coding-style), but [`faiss/cppcontrib/SaDecodeKernels-avx2-inl.h`](https://github.com/facebookresearch/faiss/blob/442d9f4a2d43e2ada6423e8e4e3414131dea849d/faiss/cppcontrib/SaDecodeKernels-avx2-inl.h) and [the test](https://github.com/facebookresearch/faiss/blob/442d9f4a2d43e2ada6423e8e4e3414131dea849d/tests/test_cppcontrib_sa_decode.cpp) use some C++17 features. This PR rewrites these codes to make them independent to C++17.
- Enable AVX2 on `faiss_test`
    - Currently `faiss_test` is compiled without `-mavx2` even if `-DFAISS_OPT_LEVEL=avx2` , so **`tests/test_cppcontrib_sa_decode.cpp` hasn't checked `faiss/cppcontrib/SaDecodeKernels-avx2-inl.h` at all** . This PR adds `-mavx2` to `faiss_test` if `-DFAISS_OPT_LEVEL=avx2` , so now `tests/test_cppcontrib_sa_decode.cpp` confirms `faiss/cppcontrib/SaDecodeKernels-avx2-inl.h` if `-DFAISS_OPT_LEVEL=avx2` , and does `faiss/cppcontrib/SaDecodeKernels-inl.h` if not `-DFAISS_OPT_LEVEL=avx2` .