### PR TITLE
Remove an Outdated Description in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -101,8 +101,8 @@ Several options can be passed to CMake, among which:
   - `-DCMAKE_BUILD_TYPE=Release` in order to enable generic compiler
   optimization options (enables `-O3` on gcc for instance),
   - `-DFAISS_OPT_LEVEL=avx2` in order to enable the required compiler flags to
-  generate code using optimized SIMD instructions (possible values are `generic`,
-  `sse4`, and `avx2`, by increasing order of optimization),
+  generate code using optimized SIMD instructions (possible values are `generic`
+  and `avx2`, by increasing order of optimization),
 - BLAS-related options:
   - `-DBLA_VENDOR=Intel10_64_dyn -DMKL_LIBRARIES=/path/to/mkl/libs` to use the
   Intel MKL BLAS implementation, which is significantly faster than OpenBLAS


### PR DESCRIPTION
According to [`CMakeLists.txt`](https://github.com/facebookresearch/faiss/blob/442d9f4a2d43e2ada6423e8e4e3414131dea849d/CMakeLists.txt#L20), current `faiss` doesn't recognize `sse4` as `FAISS_OPT_LEVEL` .
I've read `CMakeLists.txt`s and confirmed that (current `faiss` treats `sse4` as same as `generic`), so this PR removes the description of this outdated option from `INSTALL.md` .

This PR contains only document update, so this doesn't affect the software behavior.