### PR TITLE
Fix potential memory leak in `InvertedLists` default implementation

### DIFF
--- a/faiss/invlists/InvertedLists.cpp
+++ b/faiss/invlists/InvertedLists.cpp
@@ -28,7 +28,10 @@ InvertedLists::~InvertedLists() {}
 InvertedLists::idx_t InvertedLists::get_single_id(size_t list_no, size_t offset)
         const {
     assert(offset < list_size(list_no));
-    return get_ids(list_no)[offset];
+    const idx_t* ids = get_ids(list_no);
+    idx_t id = ids[offset];
+    release_ids(list_no, ids);
+    return id;
 }
 
 void InvertedLists::release_codes(size_t, const uint8_t*) const {}


### PR DESCRIPTION
According to `InvertedLists` API conventions, pointers returned from `get_ids` must be released by `release_ids`, which is violated by `get_single_id`. Note that all subclasses of `InvertedLists` which overwrite `release_ids` also overwrite `get_single_id`, the code change has no actual runtime impact with respect to existing code. However, if someone wants to implement his or her `InvertedLists` subclass and chooses not to overwrite `get_single_id`, this code change will help him or her to avoid potential memory leak.