### PR TITLE
Additional C++ templates for fast sa_decode

### DIFF
--- a/faiss/cppcontrib/SaDecodeKernels-avx2-inl.h
+++ b/faiss/cppcontrib/SaDecodeKernels-avx2-inl.h
@@ -7,6 +7,9 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <faiss/cppcontrib/detail/CoarseBitType.h>
+#include <faiss/cppcontrib/detail/UintReader.h>
+
 namespace faiss {
 namespace cppcontrib {
 
@@ -121,46 +124,6 @@ inline __m256 elementaryBlock8x1bAccum(
     return _mm256_fmadd_ps(combinedValue, weightAvx2, existingValue);
 }
 
-// reduces the number of read operations from RAM
-template <
-        intptr_t DIM,
-        intptr_t CODE_SIZE,
-        intptr_t CPOS,
-        bool = DIM / CODE_SIZE <= 3>
-struct Uint8ReaderImpl {
-    static intptr_t get(const uint8_t* const __restrict codes) {
-        // Read 1 byte (movzx).
-        return codes[CPOS];
-    }
-};
-template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CPOS>
-struct Uint8ReaderImpl<DIM, CODE_SIZE, CPOS, false> {
-    static intptr_t get(const uint8_t* const __restrict codes) {
-        // Read using 4-bytes.
-        // Reading using 8-byte takes too many registers somewhy.
-        const uint32_t* __restrict codes32 =
-                reinterpret_cast<const uint32_t*>(codes);
-
-        constexpr intptr_t ELEMENT_TO_READ = CPOS / 4;
-        constexpr intptr_t SUB_ELEMENT = CPOS % 4;
-        const uint32_t code32 = codes32[ELEMENT_TO_READ];
-
-        switch (SUB_ELEMENT) {
-            case 0:
-                return (code32 & 0x000000FF);
-            case 1:
-                return (code32 & 0x0000FF00) >> 8;
-            case 2:
-                return (code32 & 0x00FF0000) >> 16;
-            case 3:
-                return (code32) >> 24;
-        }
-    }
-};
-
-template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CPOS>
-using Uint8Reader = Uint8ReaderImpl<DIM, CODE_SIZE, CPOS>;
-
 // The following code uses template-based for-loop unrolling,
 //   because the compiler does not do that on its own as needed.
 // The idea is the following:
@@ -180,12 +143,11 @@ using Uint8Reader = Uint8ReaderImpl<DIM, CODE_SIZE, CPOS>;
 //   Initiate the loop:
 //     Foo<0, MAX>::bar();
 
-// Suitable for IVF256,PQ[1]x8
-// Suitable for Residual[1]x8,PQ[2]x8
 template <
         intptr_t DIM,
         intptr_t COARSE_SIZE,
         intptr_t FINE_SIZE,
+        intptr_t COARSE_BITS,
         intptr_t CPOS,
         bool FINE_SIZE_EQ_4 = FINE_SIZE == 4,
         bool QPOS_LEFT_GE_8 = (FINE_SIZE - CPOS % FINE_SIZE >= 8),
@@ -196,6 +158,7 @@ struct Index2LevelDecoderImpl;
 template <
         intptr_t DIM,
         intptr_t COARSE_SIZE,
+        intptr_t COARSE_BITS,
         intptr_t CPOS,
         bool QPOS_LEFT_GE_8,
         bool QPOS_LEFT_GE_4>
@@ -203,6 +166,7 @@ struct Index2LevelDecoderImpl<
         DIM,
         COARSE_SIZE,
         4,
+        COARSE_BITS,
         CPOS,
         true,
         QPOS_LEFT_GE_8,
@@ -217,6 +181,11 @@ struct Index2LevelDecoderImpl<
 
     static constexpr intptr_t QPOS_LEFT = FINE_SIZE - fineCentroidOffset;
 
+    // coarse quantizer storage
+    using coarse_storage_type =
+            typename detail::CoarseBitType<COARSE_BITS>::bit_type;
+    static constexpr intptr_t COARSE_TABLE_BYTES = (1 << COARSE_BITS);
+
     // process 1 sample
     static void store(
             const float* const __restrict pqCoarseCentroids0,
@@ -227,26 +196,27 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 =
+                code0 + (DIM / COARSE_SIZE) * sizeof(coarse_storage_type);
 
         // clang-format off
 
         // process chunks, 4 float
         // but 8 floats per loop
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine0);
-        const intptr_t fineCode0b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0a = detail::UintReader<DIM, FINE_SIZE, 8, fineCentroidIdx + 0>::get(fine0);
+        const intptr_t fineCode0b = detail::UintReader<DIM, FINE_SIZE, 8, fineCentroidIdx + 1>::get(fine0);
 
         const __m256 storeValue = elementaryBlock4x2b(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
               pqFineCentroids0 + ((fineCentroidIdx + 0) * 256 + fineCode0a) * FINE_SIZE + fineCentroidOffset,
               pqFineCentroids0 + ((fineCentroidIdx + 1) * 256 + fineCode0b) * FINE_SIZE + fineCentroidOffset);
 
         _mm256_storeu_ps(outputStore + CPOS, storeValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::store(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, CPOS + 8>::store(
               pqCoarseCentroids0, pqFineCentroids0, code0,
               outputStore);
 
@@ -264,21 +234,22 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 =
+                code0 + (DIM / COARSE_SIZE) * sizeof(coarse_storage_type);
 
         // clang-format off
 
         // process chunks, 4 float
         // but 8 floats per loop
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine0);
-        const intptr_t fineCode0b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0a = detail::UintReader<DIM, FINE_SIZE, 8, fineCentroidIdx + 0>::get(fine0);
+        const intptr_t fineCode0b = detail::UintReader<DIM, FINE_SIZE, 8, fineCentroidIdx + 1>::get(fine0);
 
         __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock4x2bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
               pqFineCentroids0 + ((fineCentroidIdx + 0) * 256 + fineCode0a) * FINE_SIZE + fineCentroidOffset,
               pqFineCentroids0 + ((fineCentroidIdx + 1) * 256 + fineCode0b) * FINE_SIZE + fineCentroidOffset,
               weight0,
@@ -287,7 +258,7 @@ struct Index2LevelDecoderImpl<
         _mm256_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, CPOS + 8>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               outputAccum);
 
@@ -310,32 +281,34 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse1 = code1;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
-        const uint8_t* const __restrict fine1 = code1 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 =
+                code0 + (DIM / COARSE_SIZE) * sizeof(coarse_storage_type);
+        const uint8_t* const __restrict fine1 =
+                code1 + (DIM / COARSE_SIZE) * sizeof(coarse_storage_type);
 
         // clang-format off
 
         // process chunks, 4 float
         // but 8 floats per loop
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine0);
-        const intptr_t fineCode0b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine0);
-        const intptr_t coarseCode1 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse1);
-        const intptr_t fineCode1a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine1);
-        const intptr_t fineCode1b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine1);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0a = detail::UintReader<DIM, FINE_SIZE, 8, fineCentroidIdx + 0>::get(fine0);
+        const intptr_t fineCode0b = detail::UintReader<DIM, FINE_SIZE, 8, fineCentroidIdx + 1>::get(fine0);
+        const intptr_t coarseCode1 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse1);
+        const intptr_t fineCode1a = detail::UintReader<DIM, FINE_SIZE, 8, fineCentroidIdx + 0>::get(fine1);
+        const intptr_t fineCode1b = detail::UintReader<DIM, FINE_SIZE, 8, fineCentroidIdx + 1>::get(fine1);
 
         __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock4x2bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
               pqFineCentroids0 + ((fineCentroidIdx + 0) * 256 + fineCode0a) * FINE_SIZE + fineCentroidOffset,
               pqFineCentroids0 + ((fineCentroidIdx + 1) * 256 + fineCode0b) * FINE_SIZE + fineCentroidOffset,
               weight0,
               existingValue);
 
         existingValue = elementaryBlock4x2bAccum(
-              pqCoarseCentroids1 + (coarseCentroidIdx * 256 + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
+              pqCoarseCentroids1 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
               pqFineCentroids1 + ((fineCentroidIdx + 0) * 256 + fineCode1a) * FINE_SIZE + fineCentroidOffset,
               pqFineCentroids1 + ((fineCentroidIdx + 1) * 256 + fineCode1b) * FINE_SIZE + fineCentroidOffset,
               weight1,
@@ -344,7 +317,7 @@ struct Index2LevelDecoderImpl<
         _mm256_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, CPOS + 8>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               pqCoarseCentroids1, pqFineCentroids1, code1, weight1,
               outputAccum);
@@ -353,11 +326,17 @@ struct Index2LevelDecoderImpl<
     }
 };
 
-template <intptr_t DIM, intptr_t COARSE_SIZE, intptr_t FINE_SIZE, intptr_t CPOS>
+template <
+        intptr_t DIM,
+        intptr_t COARSE_SIZE,
+        intptr_t FINE_SIZE,
+        intptr_t COARSE_BITS,
+        intptr_t CPOS>
 struct Index2LevelDecoderImpl<
         DIM,
         COARSE_SIZE,
         FINE_SIZE,
+        COARSE_BITS,
         CPOS,
         false,
         true,
@@ -370,6 +349,11 @@ struct Index2LevelDecoderImpl<
 
     static constexpr intptr_t QPOS_LEFT = FINE_SIZE - fineCentroidOffset;
 
+    // coarse quantizer storage
+    using coarse_storage_type =
+            typename detail::CoarseBitType<COARSE_BITS>::bit_type;
+    static constexpr intptr_t COARSE_TABLE_BYTES = (1 << COARSE_BITS);
+
     // process 1 sample
     static void store(
             const float* const __restrict pqCoarseCentroids0,
@@ -380,23 +364,24 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 =
+                code0 + (DIM / COARSE_SIZE) * sizeof(coarse_storage_type);
 
         // clang-format off
 
         // process chunks, 8 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, 8, fineCentroidIdx>::get(fine0);
 
         const __m256 storeValue = elementaryBlock8x1b(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
               pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset);
 
         _mm256_storeu_ps(outputStore + CPOS, storeValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::store(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, CPOS + 8>::store(
               pqCoarseCentroids0, pqFineCentroids0, code0,
               outputStore);
 
@@ -414,19 +399,20 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 =
+                code0 + (DIM / COARSE_SIZE) * sizeof(coarse_storage_type);
 
         // clang-format off
 
         // process chunks, 8 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, 8, fineCentroidIdx>::get(fine0);
 
         __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock8x1bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
               pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
               weight0,
               existingValue);
@@ -434,7 +420,7 @@ struct Index2LevelDecoderImpl<
         _mm256_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, CPOS + 8>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               outputAccum);
 
@@ -457,28 +443,30 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse1 = code1;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
-        const uint8_t* const __restrict fine1 = code1 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 =
+                code0 + (DIM / COARSE_SIZE) * sizeof(coarse_storage_type);
+        const uint8_t* const __restrict fine1 =
+                code1 + (DIM / COARSE_SIZE) * sizeof(coarse_storage_type);
 
         // clang-format off
 
         // process chunks, 8 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
-        const intptr_t coarseCode1 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse1);
-        const intptr_t fineCode1 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine1);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, 8, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode1 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse1);
+        const intptr_t fineCode1 = detail::UintReader<DIM, FINE_SIZE, 8, fineCentroidIdx>::get(fine1);
 
         __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock8x1bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
               pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
               weight0,
               existingValue);
 
         existingValue = elementaryBlock8x1bAccum(
-              pqCoarseCentroids1 + (coarseCentroidIdx * 256 + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
+              pqCoarseCentroids1 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
               pqFineCentroids1 + (fineCentroidIdx * 256 + fineCode1) * FINE_SIZE + fineCentroidOffset,
               weight1,
               existingValue);
@@ -486,7 +474,7 @@ struct Index2LevelDecoderImpl<
         _mm256_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, CPOS + 8>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               pqCoarseCentroids1, pqFineCentroids1, code1, weight1,
               outputAccum);
@@ -495,11 +483,17 @@ struct Index2LevelDecoderImpl<
     }
 };
 
-template <intptr_t DIM, intptr_t COARSE_SIZE, intptr_t FINE_SIZE, intptr_t CPOS>
+template <
+        intptr_t DIM,
+        intptr_t COARSE_SIZE,
+        intptr_t FINE_SIZE,
+        intptr_t COARSE_BITS,
+        intptr_t CPOS>
 struct Index2LevelDecoderImpl<
         DIM,
         COARSE_SIZE,
         FINE_SIZE,
+        COARSE_BITS,
         CPOS,
         false,
         false,
@@ -512,6 +506,11 @@ struct Index2LevelDecoderImpl<
 
     static constexpr intptr_t QPOS_LEFT = FINE_SIZE - fineCentroidOffset;
 
+    // coarse quantizer storage
+    using coarse_storage_type =
+            typename detail::CoarseBitType<COARSE_BITS>::bit_type;
+    static constexpr intptr_t COARSE_TABLE_BYTES = (1 << COARSE_BITS);
+
     // process 1 sample
     static void store(
             const float* const __restrict pqCoarseCentroids0,
@@ -522,23 +521,24 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 =
+                code0 + (DIM / COARSE_SIZE) * sizeof(coarse_storage_type);
 
         // clang-format off
 
         // process chunks, 4 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, 8, fineCentroidIdx>::get(fine0);
 
         const __m128 storeValue = elementaryBlock4x1b(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
               pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset);
 
         _mm_storeu_ps(outputStore + CPOS, storeValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 4>::store(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, CPOS + 4>::store(
               pqCoarseCentroids0, pqFineCentroids0, code0,
               outputStore);
 
@@ -556,19 +556,20 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 =
+                code0 + (DIM / COARSE_SIZE) * sizeof(coarse_storage_type);
 
         // clang-format off
 
         // process chunks, 4 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, 8,fineCentroidIdx>::get(fine0);
 
         __m128 existingValue = _mm_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock4x1bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
               pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
               weight0,
               existingValue);
@@ -576,7 +577,7 @@ struct Index2LevelDecoderImpl<
         _mm_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 4>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, CPOS + 4>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               outputAccum);
 
@@ -599,28 +600,30 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse1 = code1;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
-        const uint8_t* const __restrict fine1 = code1 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 =
+                code0 + (DIM / COARSE_SIZE) * sizeof(coarse_storage_type);
+        const uint8_t* const __restrict fine1 =
+                code1 + (DIM / COARSE_SIZE) * sizeof(coarse_storage_type);
 
         // clang-format off
 
         // process chunks, 4 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
-        const intptr_t coarseCode1 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse1);
-        const intptr_t fineCode1 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine1);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, 8, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode1 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse1);
+        const intptr_t fineCode1 = detail::UintReader<DIM, FINE_SIZE, 8, fineCentroidIdx>::get(fine1);
 
         __m128 existingValue = _mm_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock4x1bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
               pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
               weight0,
               existingValue);
 
         existingValue = elementaryBlock4x1bAccum(
-              pqCoarseCentroids1 + (coarseCentroidIdx * 256 + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
+              pqCoarseCentroids1 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
               pqFineCentroids1 + (fineCentroidIdx * 256 + fineCode1) * FINE_SIZE + fineCentroidOffset,
               weight1,
               existingValue);
@@ -628,7 +631,7 @@ struct Index2LevelDecoderImpl<
         _mm_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 4>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, CPOS + 4>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               pqCoarseCentroids1, pqFineCentroids1, code1, weight1,
               outputAccum);
@@ -637,13 +640,12 @@ struct Index2LevelDecoderImpl<
     }
 };
 
-// Suitable for IVF256,PQ[1]x8
-// Suitable for Residual[1]x8,PQ[2]x8
 // This partial specialization is expected to do nothing.
 template <
         intptr_t DIM,
         intptr_t COARSE_SIZE,
         intptr_t FINE_SIZE,
+        intptr_t COARSE_BITS,
         bool FINE_SIZE_EQ_4,
         bool QPOS_LEFT_GE_8,
         bool QPOS_LEFT_GE_4>
@@ -651,6 +653,7 @@ struct Index2LevelDecoderImpl<
         DIM,
         COARSE_SIZE,
         FINE_SIZE,
+        COARSE_BITS,
         DIM,
         FINE_SIZE_EQ_4,
         QPOS_LEFT_GE_8,
@@ -691,7 +694,13 @@ struct Index2LevelDecoderImpl<
 
 // Suitable for IVF256,PQ[1]x8
 // Suitable for Residual[1]x8,PQ[2]x8
-template <intptr_t DIM, intptr_t COARSE_SIZE, intptr_t FINE_SIZE>
+// Suitable for IVF[9-16 bit],PQ[1]x8 (such as IVF1024,PQ16np)
+// Suitable for Residual1x[9-16 bit],PQ[1]x8 (such as Residual1x9,PQ8)
+template <
+        intptr_t DIM,
+        intptr_t COARSE_SIZE,
+        intptr_t FINE_SIZE,
+        intptr_t COARSE_BITS = 8>
 struct Index2LevelDecoder {
     // Process 1 sample.
     static void store(
@@ -699,8 +708,8 @@ struct Index2LevelDecoder {
             const float* const __restrict pqFineCentroids,
             const uint8_t* const __restrict code,
             float* const __restrict outputStore) {
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, 0>::store(
-                pqCoarseCentroids, pqFineCentroids, code, outputStore);
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, 0>::
+                store(pqCoarseCentroids, pqFineCentroids, code, outputStore);
     }
 
     // Process 1 sample.
@@ -711,8 +720,12 @@ struct Index2LevelDecoder {
             const uint8_t* const __restrict code,
             const float weight,
             float* const __restrict outputAccum) {
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, 0>::accum(
-                pqCoarseCentroids, pqFineCentroids, code, weight, outputAccum);
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, 0>::
+                accum(pqCoarseCentroids,
+                      pqFineCentroids,
+                      code,
+                      weight,
+                      outputAccum);
     }
 
     // process 2 samples
@@ -728,16 +741,16 @@ struct Index2LevelDecoder {
             const uint8_t* const __restrict code1,
             const float weight1,
             float* const __restrict outputAccum) {
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, 0>::accum(
-                pqCoarseCentroids0,
-                pqFineCentroids0,
-                code0,
-                weight0,
-                pqCoarseCentroids1,
-                pqFineCentroids1,
-                code1,
-                weight1,
-                outputAccum);
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, 0>::
+                accum(pqCoarseCentroids0,
+                      pqFineCentroids0,
+                      code0,
+                      weight0,
+                      pqCoarseCentroids1,
+                      pqFineCentroids1,
+                      code1,
+                      weight1,
+                      outputAccum);
     }
 };
 

--- a/faiss/cppcontrib/SaDecodeKernels-inl.h
+++ b/faiss/cppcontrib/SaDecodeKernels-inl.h
@@ -5,13 +5,26 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <faiss/cppcontrib/detail/CoarseBitType.h>
+
 namespace faiss {
 namespace cppcontrib {
 
 // Suitable for IVF256,PQ[1]x8
 // Suitable for Residual[1]x8,PQ[2]x8
-template <intptr_t DIM, intptr_t COARSE_SIZE, intptr_t FINE_SIZE>
+// Suitable for IVF[9-16 bit],PQ[1]x8 (such as IVF1024,PQ16np)
+// Suitable for Residual1x[9-16 bit],PQ[1]x8 (such as Residual1x9,PQ8)
+template <
+        intptr_t DIM,
+        intptr_t COARSE_SIZE,
+        intptr_t FINE_SIZE,
+        intptr_t COARSE_BITS = 8>
 struct Index2LevelDecoder {
+    // coarse quantizer storage
+    using coarse_storage_type =
+            typename detail::CoarseBitType<COARSE_BITS>::bit_type;
+    static constexpr intptr_t COARSE_TABLE_BYTES = (1 << COARSE_BITS);
+
     // Process 1 sample.
     // Performs outputStore = decoded(code)
     static void store(
@@ -20,10 +33,12 @@ struct Index2LevelDecoder {
             const uint8_t* const __restrict code,
             float* const __restrict outputStore) {
         // coarse quantizer
-        const uint8_t* const __restrict coarse = code;
+        const coarse_storage_type* const __restrict coarse =
+                reinterpret_cast<const coarse_storage_type*>(code);
 
         // fine quantizer
-        const uint8_t* const __restrict fine = code + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine =
+                code + (DIM / COARSE_SIZE) * sizeof(coarse_storage_type);
 
 #pragma unroll
         for (intptr_t i = 0; i < DIM; i++) {
@@ -36,7 +51,8 @@ struct Index2LevelDecoder {
             const intptr_t fineCode = fine[fineCentroidIdx];
 
             const float* const __restrict coarsePtr = pqCoarseCentroids +
-                    (coarseCentroidIdx * 256 + coarseCode) * COARSE_SIZE +
+                    (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode) *
+                            COARSE_SIZE +
                     coarseCentroidOffset;
             const float* const __restrict finePtr = pqFineCentroids +
                     (fineCentroidIdx * 256 + fineCode) * FINE_SIZE +
@@ -55,10 +71,12 @@ struct Index2LevelDecoder {
             const float weight,
             float* const __restrict outputAccum) {
         // coarse quantizer
-        const uint8_t* const __restrict coarse = code;
+        const coarse_storage_type* const __restrict coarse =
+                reinterpret_cast<const coarse_storage_type*>(code);
 
         // fine quantizer
-        const uint8_t* const __restrict fine = code + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine =
+                code + (DIM / COARSE_SIZE) * sizeof(coarse_storage_type);
 
 #pragma unroll
         for (intptr_t i = 0; i < DIM; i++) {
@@ -71,7 +89,8 @@ struct Index2LevelDecoder {
             const intptr_t fineCode = fine[fineCentroidIdx];
 
             const float* const __restrict coarsePtr = pqCoarseCentroids +
-                    (coarseCentroidIdx * 256 + coarseCode) * COARSE_SIZE +
+                    (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode) *
+                            COARSE_SIZE +
                     coarseCentroidOffset;
             const float* const __restrict finePtr = pqFineCentroids +
                     (fineCentroidIdx * 256 + fineCode) * FINE_SIZE +
@@ -95,12 +114,16 @@ struct Index2LevelDecoder {
             const float weight1,
             float* const __restrict outputAccum) {
         // coarse quantizer
-        const uint8_t* const __restrict coarse0 = code0;
-        const uint8_t* const __restrict coarse1 = code1;
+        const coarse_storage_type* const __restrict coarse0 =
+                reinterpret_cast<const coarse_storage_type*>(code0);
+        const coarse_storage_type* const __restrict coarse1 =
+                reinterpret_cast<const coarse_storage_type*>(code1);
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
-        const uint8_t* const __restrict fine1 = code1 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 =
+                code0 + (DIM / COARSE_SIZE) * sizeof(coarse_storage_type);
+        const uint8_t* const __restrict fine1 =
+                code1 + (DIM / COARSE_SIZE) * sizeof(coarse_storage_type);
 
 #pragma unroll
         for (intptr_t i = 0; i < DIM; i++) {
@@ -115,13 +138,15 @@ struct Index2LevelDecoder {
             const intptr_t fineCode1 = fine1[fineCentroidIdx];
 
             const float* const __restrict coarsePtr0 = pqCoarseCentroids0 +
-                    (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE +
+                    (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) *
+                            COARSE_SIZE +
                     coarseCentroidOffset;
             const float* const __restrict finePtr0 = pqFineCentroids0 +
                     (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE +
                     fineCentroidOffset;
             const float* const __restrict coarsePtr1 = pqCoarseCentroids1 +
-                    (coarseCentroidIdx * 256 + coarseCode1) * COARSE_SIZE +
+                    (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode1) *
+                            COARSE_SIZE +
                     coarseCentroidOffset;
             const float* const __restrict finePtr1 = pqFineCentroids1 +
                     (fineCentroidIdx * 256 + fineCode1) * FINE_SIZE +

--- a/faiss/cppcontrib/SaDecodeKernels.h
+++ b/faiss/cppcontrib/SaDecodeKernels.h
@@ -6,21 +6,34 @@
 //   function for the following index families:
 //   * IVF256,PQ[1]x8np
 //   * Residual[1]x8,PQ[2]x8
+//   * IVF[9-16 bit],PQ[1]x8 (such as IVF1024,PQ16np)
+//   * Residual1x[9-16 bit],PQ[1]x8 (such as Residual1x9,PQ8)
 //
 // The goal was to achieve the maximum performance, so the template version it
 // is. The provided index families share the same code for sa_decode.
 // The front-end code looks the following:
 //   {
-//     template <intptr_t DIM, intptr_t COARSE_SIZE, intptr_t FINE_SIZE>
+//     template <
+//        intptr_t DIM,
+//        intptr_t COARSE_SIZE,
+//        intptr_t FINE_SIZE,
+//        intptr_t COARSE_BITS = 8>
 //     struct Index2LevelDecoder { /*...*/ };
 //   }
 // * DIM is the dimensionality of data
 // * COARSE_SIZE is the dimensionality of the coarse quantizer (IVF, Residual)
 // * FINE_SIZE is the dimensionality of the ProductQuantizer dsq
+// * COARSE_BITS is the number of bits that are needed to represent a coarse
+//   quantizer code.
 // For example, "IVF256,PQ8np" for 160-dim data translates into
-//   Index2LevelDecoder<160,160,20>
+//   Index2LevelDecoder<160,160,20,8>
 // For example, "Residual4x8,PQ16" for 256-dim data translates into
-//   Index2LevelDecoder<256,64,16>
+//   Index2LevelDecoder<256,64,1,8>
+// For example, "IVF1024,PQ16np" for 256-dim data translates into
+//   Index2LevelDecoder<256,256,16,16>
+//
+// Additional supported COARSE_BITS values may be added later.
+// FINE_BITS might be added later.
 //
 // Unlike the general purpose version in faiss::Index::sa_decode(),
 //   this version provides the following functions:

--- a/faiss/cppcontrib/detail/CoarseBitType.h
+++ b/faiss/cppcontrib/detail/CoarseBitType.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+namespace faiss {
+namespace cppcontrib {
+namespace detail {
+
+template <int COARSE_BITS>
+struct CoarseBitType {};
+
+template <>
+struct CoarseBitType<8> {
+    using bit_type = uint8_t;
+};
+
+template <>
+struct CoarseBitType<16> {
+    using bit_type = uint16_t;
+};
+
+} // namespace detail
+} // namespace cppcontrib
+} // namespace faiss

--- a/faiss/cppcontrib/detail/UintReader.h
+++ b/faiss/cppcontrib/detail/UintReader.h
@@ -1,0 +1,110 @@
+#pragma once
+
+namespace faiss {
+namespace cppcontrib {
+namespace detail {
+
+namespace {
+
+template <
+        intptr_t DIM,
+        intptr_t CODE_SIZE,
+        intptr_t CPOS,
+        bool = DIM / CODE_SIZE <= 3>
+struct Uint8ReaderImpl {
+    static intptr_t get(const uint8_t* const __restrict codes) {
+        // Read 1 byte (movzx).
+        return codes[CPOS];
+    }
+};
+template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CPOS>
+struct Uint8ReaderImpl<DIM, CODE_SIZE, CPOS, false> {
+    static intptr_t get(const uint8_t* const __restrict codes) {
+        // Read using 4-bytes.
+        // Reading using 8-byte takes too many registers somewhy.
+        const uint32_t* __restrict codes32 =
+                reinterpret_cast<const uint32_t*>(codes);
+
+        constexpr intptr_t ELEMENT_TO_READ = CPOS / 4;
+        constexpr intptr_t SUB_ELEMENT = CPOS % 4;
+        const uint32_t code32 = codes32[ELEMENT_TO_READ];
+
+        switch (SUB_ELEMENT) {
+            case 0:
+                return (code32 & 0x000000FF);
+            case 1:
+                return (code32 & 0x0000FF00) >> 8;
+            case 2:
+                return (code32 & 0x00FF0000) >> 16;
+            case 3:
+                return (code32) >> 24;
+        }
+    }
+};
+
+template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CPOS>
+using Uint8Reader = Uint8ReaderImpl<DIM, CODE_SIZE, CPOS>;
+
+// reduces the number of read operations from RAM
+template <
+        intptr_t DIM,
+        intptr_t CODE_SIZE,
+        intptr_t CPOS,
+        bool = DIM / CODE_SIZE <= 1>
+struct Uint16ReaderImpl {
+    static intptr_t get(const uint8_t* const __restrict codes) {
+        // Read 2 bytes.
+        const uint16_t* const __restrict codesFp16 =
+                reinterpret_cast<const uint16_t*>(codes);
+        return codesFp16[CPOS];
+    }
+};
+template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CPOS>
+struct Uint16ReaderImpl<DIM, CODE_SIZE, CPOS, false> {
+    static intptr_t get(const uint8_t* const __restrict codes) {
+        // Read using 4-bytes.
+        // Reading using 8-byte takes too many registers somewhy.
+        const uint32_t* __restrict codes32 =
+                reinterpret_cast<const uint32_t*>(codes);
+
+        constexpr intptr_t ELEMENT_TO_READ = CPOS / 2;
+        constexpr intptr_t SUB_ELEMENT = CPOS % 2;
+        const uint32_t code32 = codes32[ELEMENT_TO_READ];
+
+        switch (SUB_ELEMENT) {
+            case 0:
+                return (code32 & 0x0000FFFF);
+            case 1:
+                return code32 >> 16;
+        }
+    }
+};
+
+template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CPOS>
+using Uint16Reader = Uint16ReaderImpl<DIM, CODE_SIZE, CPOS>;
+
+//
+template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CODE_BITS, intptr_t CPOS>
+struct UintReaderImplType {};
+
+template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CPOS>
+struct UintReaderImplType<DIM, CODE_SIZE, 8, CPOS> {
+    using reader_type = Uint8Reader<DIM, CODE_SIZE, CPOS>;
+};
+
+template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CPOS>
+struct UintReaderImplType<DIM, CODE_SIZE, 16, CPOS> {
+    using reader_type = Uint16Reader<DIM, CODE_SIZE, CPOS>;
+};
+
+} // namespace
+
+// reduces the number of read operations from RAM
+template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CODE_BITS, intptr_t CPOS>
+using UintReader =
+        typename UintReaderImplType<DIM, CODE_SIZE, CODE_BITS, CPOS>::
+                reader_type;
+
+} // namespace detail
+} // namespace cppcontrib
+} // namespace faiss

--- a/tests/test_cppcontrib_sa_decode.cpp
+++ b/tests/test_cppcontrib_sa_decode.cpp
@@ -156,11 +156,18 @@ void verify(
         ASSERT_FLOAT_EQ(outputFaiss[j], outputContrib1s[j]);
     }
 
-    // test contrib::accum, 2 samples per iteration
+    // test contrib::accum, 2 samples per iteration.
     rng.seed(123);
 
     std::vector<float> outputContrib2s(d, 0);
     for (size_t i = 0; i < n; i += 2) {
+        // populate outputContribs with some existing data
+        for (size_t j = 0; j < d; j++) {
+            outputContrib1s[j] = (j + 1) * (j + 1);
+            outputContrib2s[j] = (j + 1) * (j + 1);
+        }
+
+        // do a single step, 2 samples per step
         const float weight0 = u(rng);
         const float weight1 = u(rng);
 
@@ -174,11 +181,25 @@ void verify(
                 encodedData.data() + (i + 1) * codeSize,
                 weight1,
                 outputContrib2s.data());
-    }
 
-    // verify
-    for (size_t j = 0; j < d; j++) {
-        ASSERT_NEAR(outputFaiss[j], outputContrib2s[j], 1e-2);
+        // do two steps, 1 sample per step
+        T::accum(
+                pqCoarseCentroidsQ,
+                pqFineCentroidsQ,
+                encodedData.data() + (i + 0) * codeSize,
+                weight0,
+                outputContrib1s.data());
+        T::accum(
+                pqCoarseCentroidsQ,
+                pqFineCentroidsQ,
+                encodedData.data() + (i + 1) * codeSize,
+                weight1,
+                outputContrib1s.data());
+
+        // compare
+        for (size_t j = 0; j < d; j++) {
+            ASSERT_FLOAT_EQ(outputContrib1s[j], outputContrib2s[j]);
+        }
     }
 }
 
@@ -334,4 +355,15 @@ TEST(TEST_CPPCONTRIB_SA_DECODE, D64_Residual4x8_PQ8) {
 TEST(TEST_CPPCONTRIB_SA_DECODE, D64_Residual4x8_PQ4) {
     using T = faiss::cppcontrib::Index2LevelDecoder<64, 16, 16>;
     test<T>(NSAMPLES, 64, "Residual4x8,PQ4");
+}
+
+//
+TEST(TEST_CPPCONTRIB_SA_DECODE, D256_IVF1024_PQ16) {
+    using T = faiss::cppcontrib::Index2LevelDecoder<256, 256, 16, 16>;
+    test<T>(NSAMPLES, 256, "IVF1024,PQ16np");
+}
+
+TEST(TEST_CPPCONTRIB_SA_DECODE, D64_Residual1x9_PQ8) {
+    using T = faiss::cppcontrib::Index2LevelDecoder<64, 64, 8, 16>;
+    test<T>(NSAMPLES, 64, "Residual1x9,PQ8");
 }


### PR DESCRIPTION
Summary:
Add support for
* IVF[9-16 bit],PQ[1]x8 (such as IVF1024,PQ16np)
* Residual1x[9-16 bit],PQ[1]x8 (such as Residual1x9,PQ8)

Differential Revision: D38718716

