### PR TITLE
IndexRowwiseMinMax

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -40,6 +40,7 @@ set(FAISS_SRC
   IndexPreTransform.cpp
   IndexRefine.cpp
   IndexReplicas.cpp
+  IndexRowwiseMinMax.cpp
   IndexScalarQuantizer.cpp
   IndexShards.cpp
   MatrixStats.cpp
@@ -121,6 +122,7 @@ set(FAISS_HEADERS
   IndexPreTransform.h
   IndexRefine.h
   IndexReplicas.h
+  IndexRowwiseMinMax.h
   IndexScalarQuantizer.h
   IndexShards.h
   MatrixStats.h

--- a/faiss/IndexRowwiseMinMax.cpp
+++ b/faiss/IndexRowwiseMinMax.cpp
@@ -1,0 +1,428 @@
+#include <faiss/IndexRowwiseMinMax.h>
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/utils/fp16.h>
+
+namespace faiss {
+
+namespace {
+
+using idx_t = faiss::Index::idx_t;
+
+struct StorageMinMaxFP16 {
+    uint16_t scaler;
+    uint16_t minv;
+
+    inline void from_floats(const float float_scaler, const float float_minv) {
+        scaler = encode_fp16(float_scaler);
+        minv = encode_fp16(float_minv);
+    }
+
+    inline void to_floats(float& float_scaler, float& float_minv) const {
+        float_scaler = decode_fp16(scaler);
+        float_minv = decode_fp16(minv);
+    }
+};
+
+struct StorageMinMaxFP32 {
+    float scaler;
+    float minv;
+
+    inline void from_floats(const float float_scaler, const float float_minv) {
+        scaler = float_scaler;
+        minv = float_minv;
+    }
+
+    inline void to_floats(float& float_scaler, float& float_minv) const {
+        float_scaler = scaler;
+        float_minv = minv;
+    }
+};
+
+template <typename StorageMinMaxT>
+void sa_encode_impl(
+        const IndexRowwiseMinMaxBase* const index,
+        const idx_t n_input,
+        const float* x_input,
+        uint8_t* bytes_output) {
+    // process chunks
+    const size_t chunk_size = rowwise_minmax_sa_encode_bs;
+
+    // useful variables
+    const Index* const sub_index = index->index;
+    const int d = index->d;
+
+    // the code size of the subindex
+    const size_t old_code_size = sub_index->sa_code_size();
+    // the code size of the index
+    const size_t new_code_size = index->sa_code_size();
+
+    // allocate tmp buffers
+    std::vector<float> tmp(chunk_size * d);
+    std::vector<StorageMinMaxT> minmax(chunk_size);
+
+    // all the elements to process
+    size_t n_left = n_input;
+
+    const float* __restrict x = x_input;
+    uint8_t* __restrict bytes = bytes_output;
+
+    while (n_left > 0) {
+        // current portion to be processed
+        const idx_t n = std::min(n_left, chunk_size);
+
+        // allocate a temporary buffer and do the rescale
+        for (idx_t i = 0; i < n; i++) {
+            // compute min & max values
+            float minv = std::numeric_limits<float>::max();
+            float maxv = std::numeric_limits<float>::lowest();
+
+            const float* const vec_in = x + i * d;
+            for (idx_t j = 0; j < d; j++) {
+                minv = std::min(minv, vec_in[j]);
+                maxv = std::max(maxv, vec_in[j]);
+            }
+
+            // save the coefficients
+            const float scaler = maxv - minv;
+            minmax[i].from_floats(scaler, minv);
+
+            // and load them back, because the coefficients might
+            // be modified.
+            float actual_scaler = 0;
+            float actual_minv = 0;
+            minmax[i].to_floats(actual_scaler, actual_minv);
+
+            float* const vec_out = tmp.data() + i * d;
+            if (actual_scaler == 0) {
+                for (idx_t j = 0; j < d; j++) {
+                    vec_out[j] = 0;
+                }
+            } else {
+                float inv_actual_scaler = 1.0f / actual_scaler;
+                for (idx_t j = 0; j < d; j++) {
+                    vec_out[j] = (vec_in[j] - actual_minv) * inv_actual_scaler;
+                }
+            }
+        }
+
+        // do the coding
+        sub_index->sa_encode(n, tmp.data(), bytes);
+
+        // rearrange
+        for (idx_t i = n; (i--) > 0;) {
+            // move a single index
+            std::memmove(
+                    bytes + i * new_code_size + (new_code_size - old_code_size),
+                    bytes + i * old_code_size,
+                    old_code_size);
+
+            // save min & max values
+            StorageMinMaxT* fpv = reinterpret_cast<StorageMinMaxT*>(
+                    bytes + i * new_code_size);
+            *fpv = minmax[i];
+        }
+
+        // next chunk
+        x += n * d;
+        bytes += n * new_code_size;
+
+        n_left -= n;
+    }
+}
+
+template <typename StorageMinMaxT>
+void sa_decode_impl(
+        const IndexRowwiseMinMaxBase* const index,
+        const idx_t n_input,
+        const uint8_t* bytes_input,
+        float* x_output) {
+    // process chunks
+    const size_t chunk_size = rowwise_minmax_sa_decode_bs;
+
+    // useful variables
+    const Index* const sub_index = index->index;
+    const int d = index->d;
+
+    // the code size of the subindex
+    const size_t old_code_size = sub_index->sa_code_size();
+    // the code size of the index
+    const size_t new_code_size = index->sa_code_size();
+
+    // allocate tmp buffers
+    std::vector<uint8_t> tmp(chunk_size * old_code_size);
+    std::vector<StorageMinMaxFP16> minmax(chunk_size);
+
+    // all the elements to process
+    size_t n_left = n_input;
+
+    const uint8_t* __restrict bytes = bytes_input;
+    float* __restrict x = x_output;
+
+    while (n_left > 0) {
+        // current portion to be processed
+        const idx_t n = std::min(n_left, chunk_size);
+
+        // rearrange
+        for (idx_t i = 0; i < n; i++) {
+            std::memcpy(
+                    tmp.data() + i * old_code_size,
+                    bytes + i * new_code_size + (new_code_size - old_code_size),
+                    old_code_size);
+        }
+
+        // decode
+        sub_index->sa_decode(n, tmp.data(), x);
+
+        // scale back
+        for (idx_t i = 0; i < n; i++) {
+            const uint8_t* const vec_in = bytes + i * new_code_size;
+            StorageMinMaxT fpv =
+                    *(reinterpret_cast<const StorageMinMaxT*>(vec_in));
+
+            float scaler = 0;
+            float minv = 0;
+            fpv.to_floats(scaler, minv);
+
+            float* const __restrict vec = x + d * i;
+
+            for (idx_t j = 0; j < d; j++) {
+                vec[j] = vec[j] * scaler + minv;
+            }
+        }
+
+        // next chunk
+        bytes += n * new_code_size;
+        x += n * d;
+
+        n_left -= n;
+    }
+}
+
+//
+template <typename StorageMinMaxT>
+void train_inplace_impl(
+        IndexRowwiseMinMaxBase* const index,
+        idx_t n,
+        float* x) {
+    // useful variables
+    Index* const sub_index = index->index;
+    const int d = index->d;
+
+    // save normalizing coefficients
+    std::vector<StorageMinMaxT> minmax(n);
+
+    // normalize
+#pragma omp for
+    for (idx_t i = 0; i < n; i++) {
+        // compute min & max values
+        float minv = std::numeric_limits<float>::max();
+        float maxv = std::numeric_limits<float>::lowest();
+
+        float* const vec = x + i * d;
+        for (idx_t j = 0; j < d; j++) {
+            minv = std::min(minv, vec[j]);
+            maxv = std::max(maxv, vec[j]);
+        }
+
+        // save the coefficients
+        const float scaler = maxv - minv;
+        minmax[i].from_floats(scaler, minv);
+
+        // and load them back, because the coefficients might
+        // be modified.
+        float actual_scaler = 0;
+        float actual_minv = 0;
+        minmax[i].to_floats(actual_scaler, actual_minv);
+
+        if (actual_scaler == 0) {
+            for (idx_t j = 0; j < d; j++) {
+                vec[j] = 0;
+            }
+        } else {
+            float inv_actual_scaler = 1.0f / actual_scaler;
+            for (idx_t j = 0; j < d; j++) {
+                vec[j] = (vec[j] - actual_minv) * inv_actual_scaler;
+            }
+        }
+    }
+
+    // train the subindex
+    sub_index->train(n, x);
+
+    // rescale data back
+    for (idx_t i = 0; i < n; i++) {
+        float scaler = 0;
+        float minv = 0;
+        minmax[i].to_floats(scaler, minv);
+
+        float* const vec = x + i * d;
+
+        for (idx_t j = 0; j < d; j++) {
+            vec[j] = vec[j] * scaler + minv;
+        }
+    }
+}
+
+//
+template <typename StorageMinMaxT>
+void train_impl(IndexRowwiseMinMaxBase* const index, idx_t n, const float* x) {
+    // the default training that creates a copy of the input data
+
+    // useful variables
+    Index* const sub_index = index->index;
+    const int d = index->d;
+
+    // temp buffer
+    std::vector<float> tmp(n * d);
+
+#pragma omp for
+    for (idx_t i = 0; i < n; i++) {
+        // compute min & max values
+        float minv = std::numeric_limits<float>::max();
+        float maxv = std::numeric_limits<float>::lowest();
+
+        const float* const __restrict vec_in = x + i * d;
+        for (idx_t j = 0; j < d; j++) {
+            minv = std::min(minv, vec_in[j]);
+            maxv = std::max(maxv, vec_in[j]);
+        }
+
+        const float scaler = maxv - minv;
+
+        // save the coefficients
+        StorageMinMaxT storage;
+        storage.from_floats(scaler, minv);
+
+        // and load them back, because the coefficients might
+        // be modified.
+        float actual_scaler = 0;
+        float actual_minv = 0;
+        storage.to_floats(actual_scaler, actual_minv);
+
+        float* const __restrict vec_out = tmp.data() + i * d;
+        if (actual_scaler == 0) {
+            for (idx_t j = 0; j < d; j++) {
+                vec_out[j] = 0;
+            }
+        } else {
+            float inv_actual_scaler = 1.0f / actual_scaler;
+            for (idx_t j = 0; j < d; j++) {
+                vec_out[j] = (vec_in[j] - actual_minv) * inv_actual_scaler;
+            }
+        }
+    }
+
+    sub_index->train(n, tmp.data());
+}
+
+} // namespace
+
+// block size for performing sa_encode and sa_decode
+int rowwise_minmax_sa_encode_bs = 16384;
+int rowwise_minmax_sa_decode_bs = 16384;
+
+/*********************************************************
+ * IndexRowwiseMinMaxBase implementation
+ ********************************************************/
+
+IndexRowwiseMinMaxBase::IndexRowwiseMinMaxBase(Index* index)
+        : Index(index->d, index->metric_type),
+          index{index},
+          own_fields{false} {}
+
+IndexRowwiseMinMaxBase::IndexRowwiseMinMaxBase()
+        : index{nullptr}, own_fields{false} {}
+
+void IndexRowwiseMinMaxBase::add(idx_t n, const float* x) {
+    FAISS_THROW_MSG("add not implemented for this type of index");
+}
+
+void IndexRowwiseMinMaxBase::search(
+        idx_t n,
+        const float* x,
+        idx_t k,
+        float* distances,
+        idx_t* labels) const {
+    FAISS_THROW_MSG("search not implemented for this type of index");
+}
+
+void IndexRowwiseMinMaxBase::reset() {
+    FAISS_THROW_MSG("reset not implemented for this type of index");
+}
+
+/*********************************************************
+ * IndexRowwiseMinMaxFP16 implementation
+ ********************************************************/
+
+IndexRowwiseMinMaxFP16::IndexRowwiseMinMaxFP16(Index* index)
+        : IndexRowwiseMinMaxBase(index) {}
+
+IndexRowwiseMinMaxFP16::IndexRowwiseMinMaxFP16() : IndexRowwiseMinMaxBase() {}
+
+size_t IndexRowwiseMinMaxFP16::sa_code_size() const {
+    return index->sa_code_size() + 2 * sizeof(uint16_t);
+}
+
+void IndexRowwiseMinMaxFP16::sa_encode(
+        idx_t n_input,
+        const float* x_input,
+        uint8_t* bytes_output) const {
+    sa_encode_impl<StorageMinMaxFP16>(this, n_input, x_input, bytes_output);
+}
+
+void IndexRowwiseMinMaxFP16::sa_decode(
+        idx_t n_input,
+        const uint8_t* bytes_input,
+        float* x_output) const {
+    sa_decode_impl<StorageMinMaxFP16>(this, n_input, bytes_input, x_output);
+}
+
+void IndexRowwiseMinMaxFP16::train(idx_t n, const float* x) {
+    train_impl<StorageMinMaxFP16>(this, n, x);
+}
+
+void IndexRowwiseMinMaxFP16::train_inplace(idx_t n, float* x) {
+    train_inplace_impl<StorageMinMaxFP16>(this, n, x);
+}
+
+/*********************************************************
+ * IndexRowwiseMinMax implementation
+ ********************************************************/
+
+IndexRowwiseMinMax::IndexRowwiseMinMax(Index* index)
+        : IndexRowwiseMinMaxBase(index) {}
+
+IndexRowwiseMinMax::IndexRowwiseMinMax() : IndexRowwiseMinMaxBase() {}
+
+size_t IndexRowwiseMinMax::sa_code_size() const {
+    return index->sa_code_size() + 2 * sizeof(float);
+}
+
+void IndexRowwiseMinMax::sa_encode(
+        idx_t n_input,
+        const float* x_input,
+        uint8_t* bytes_output) const {
+    sa_encode_impl<StorageMinMaxFP32>(this, n_input, x_input, bytes_output);
+}
+
+void IndexRowwiseMinMax::sa_decode(
+        idx_t n_input,
+        const uint8_t* bytes_input,
+        float* x_output) const {
+    sa_decode_impl<StorageMinMaxFP32>(this, n_input, bytes_input, x_output);
+}
+
+void IndexRowwiseMinMax::train(idx_t n, const float* x) {
+    train_impl<StorageMinMaxFP32>(this, n, x);
+}
+
+void IndexRowwiseMinMax::train_inplace(idx_t n, float* x) {
+    train_inplace_impl<StorageMinMaxFP32>(this, n, x);
+}
+
+} // namespace faiss

--- a/faiss/IndexRowwiseMinMax.h
+++ b/faiss/IndexRowwiseMinMax.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <faiss/Index.h>
+#include <faiss/impl/platform_macros.h>
+
+namespace faiss {
+
+/// Index wrapper that performs rowwise normalization to [0,1], preserving
+/// the coefficients. This is a vector codec index only.
+///
+/// Basically, this index performs a rowwise scaling to [0,1] of every row
+/// in an input dataset before calling subindex::train() and
+/// subindex::sa_encode(). sa_encode() call stores the scaling coefficients
+///  (scaler and minv) in the very beginning of every output code. The format:
+///     [scaler][minv][subindex::sa_encode() output]
+/// The de-scaling in sa_decode() is done using:
+///     output_rescaled = scaler * output + minv
+///
+/// An additional ::train_inplace() function is provided in order to do
+/// an inplace scaling before calling subindex::train() and, thus, avoiding
+/// the cloning of the input dataset, but modifying the input dataset because
+/// of the scaling and the scaling back. It is up to user to call
+/// this function instead of ::train()
+///
+/// Derived classes provide different data types for scaling coefficients.
+/// Currently, versions with fp16 and fp32 scaling coefficients are available.
+/// * fp16 version adds 4 extra bytes per encoded vector
+/// * fp32 version adds 8 extra bytes per encoded vector
+
+/// Provides base functions for rowwise normalizing indices.
+struct IndexRowwiseMinMaxBase : Index {
+    /// sub-index
+    Index* index;
+
+    /// whether the subindex needs to be freed in the destructor.
+    bool own_fields;
+
+    explicit IndexRowwiseMinMaxBase(Index* index);
+
+    IndexRowwiseMinMaxBase();
+
+    void add(idx_t n, const float* x) override;
+    void search(
+            idx_t n,
+            const float* x,
+            idx_t k,
+            float* distances,
+            idx_t* labels) const override;
+    void reset() override;
+
+    virtual void train_inplace(idx_t n, float* x) = 0;
+};
+
+/// Stores scaling coefficients as fp16 values.
+struct IndexRowwiseMinMaxFP16 : IndexRowwiseMinMaxBase {
+    explicit IndexRowwiseMinMaxFP16(Index* index);
+
+    IndexRowwiseMinMaxFP16();
+
+    void train(idx_t n, const float* x) override;
+    void train_inplace(idx_t n, float* x) override;
+
+    size_t sa_code_size() const override;
+    void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override;
+    void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
+};
+
+/// Stores scaling coefficients as fp32 values.
+struct IndexRowwiseMinMax : IndexRowwiseMinMaxBase {
+    explicit IndexRowwiseMinMax(Index* index);
+
+    IndexRowwiseMinMax();
+
+    void train(idx_t n, const float* x) override;
+    void train_inplace(idx_t n, float* x) override;
+
+    size_t sa_code_size() const override;
+    void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override;
+    void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
+};
+
+/// block size for performing sa_encode and sa_decode
+FAISS_API extern int rowwise_minmax_sa_encode_bs;
+FAISS_API extern int rowwise_minmax_sa_decode_bs;
+
+} // namespace faiss

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -44,6 +44,7 @@
 #include <faiss/IndexPQFastScan.h>
 #include <faiss/IndexPreTransform.h>
 #include <faiss/IndexRefine.h>
+#include <faiss/IndexRowwiseMinMax.h>
 #include <faiss/IndexScalarQuantizer.h>
 #include <faiss/MetaIndexes.h>
 #include <faiss/VectorTransform.h>
@@ -976,6 +977,22 @@ Index* read_index(IOReader* f, int io_flags) {
         ivpq->code_size = pq.code_size;
 
         idx = ivpq;
+    } else if (h == fourcc("IRMf")) {
+        IndexRowwiseMinMax* imm = new IndexRowwiseMinMax();
+        read_index_header(imm, f);
+
+        imm->index = read_index(f, io_flags);
+        imm->own_fields = true;
+
+        idx = imm;
+    } else if (h == fourcc("IRMh")) {
+        IndexRowwiseMinMaxFP16* imm = new IndexRowwiseMinMaxFP16();
+        read_index_header(imm, f);
+
+        imm->index = read_index(f, io_flags);
+        imm->own_fields = true;
+
+        idx = imm;
     } else {
         FAISS_THROW_FMT(
                 "Index type 0x%08x (\"%s\") not recognized",

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -45,6 +45,7 @@
 #include <faiss/IndexPQFastScan.h>
 #include <faiss/IndexPreTransform.h>
 #include <faiss/IndexRefine.h>
+#include <faiss/IndexRowwiseMinMax.h>
 #include <faiss/IndexScalarQuantizer.h>
 #include <faiss/MetaIndexes.h>
 #include <faiss/VectorTransform.h>
@@ -774,6 +775,22 @@ void write_index(const Index* idx, IOWriter* f) {
         WRITE1(ivpq->qbs2);
         write_ProductQuantizer(&ivpq->pq, f);
         write_InvertedLists(ivpq->invlists, f);
+    } else if (
+            const IndexRowwiseMinMax* imm =
+                    dynamic_cast<const IndexRowwiseMinMax*>(idx)) {
+        // IndexRowwiseMinmaxFloat
+        uint32_t h = fourcc("IRMf");
+        WRITE1(h);
+        write_index_header(imm, f);
+        write_index(imm->index, f);
+    } else if (
+            const IndexRowwiseMinMaxFP16* imm =
+                    dynamic_cast<const IndexRowwiseMinMaxFP16*>(idx)) {
+        // IndexRowwiseMinmaxHalf
+        uint32_t h = fourcc("IRMh");
+        WRITE1(h);
+        write_index_header(imm, f);
+        write_index(imm->index, f);
     } else {
         FAISS_THROW_MSG("don't know how to serialize this type of index");
     }

--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -777,6 +777,27 @@ def handle_IOReader(the_class):
 
 handle_IOReader(IOReader)
 
+def handle_IndexRowwiseMinMax(the_class):
+    def replacement_train_inplace(self, x):
+        """Trains the index on a representative set of vectors inplace.
+        The index must be trained before vectors can be added to it.
+
+        This call WILL change the values in the input array, because
+        of two scaling proceduces being performed inplace.
+
+        Parameters
+        ----------
+        x : array_like
+            Query vectors, shape (n, d) where d is appropriate for the index.
+            `dtype` must be float32.
+        """
+        n, d = x.shape
+        assert d == self.d
+        x = np.ascontiguousarray(x, dtype='float32')
+        self.train_inplace_c(n, swig_ptr(x))
+
+    replace_method(the_class, 'train_inplace', replacement_train_inplace)
+
 this_module = sys.modules[__name__]
 
 
@@ -805,6 +826,10 @@ for symbol in dir(this_module):
 
         if issubclass(the_class, Quantizer):
             handle_Quantizer(the_class)
+
+        if issubclass(the_class, IndexRowwiseMinMax) or \
+            issubclass(the_class, IndexRowwiseMinMaxFP16):
+            handle_IndexRowwiseMinMax(the_class)
 
 
 ###########################################
@@ -910,6 +935,8 @@ add_ref_in_constructor(IndexIVFLocalSearchQuantizerFastScan, 0)
 add_ref_in_constructor(Index2Layer, 0)
 add_ref_in_constructor(Level1Quantizer, 0)
 add_ref_in_constructor(IndexIVFScalarQuantizer, 0)
+add_ref_in_constructor(IndexRowwiseMinMax, 0)
+add_ref_in_constructor(IndexRowwiseMinMaxFP16, 0)
 add_ref_in_constructor(IndexIDMap, 0)
 add_ref_in_constructor(IndexIDMap2, 0)
 add_ref_in_constructor(IndexHNSW, 0)

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -105,6 +105,8 @@ typedef uint64_t size_t;
 #include <faiss/MetaIndexes.h>
 #include <faiss/IndexRefine.h>
 
+#include <faiss/IndexRowwiseMinMax.h>
+
 #include <faiss/impl/FaissAssert.h>
 
 #include <faiss/IndexBinaryFlat.h>
@@ -484,6 +486,7 @@ void gpu_sync_all_devices()
 %template(IndexIDMap2) faiss::IndexIDMap2Template<faiss::Index>;
 %template(IndexBinaryIDMap2) faiss::IndexIDMap2Template<faiss::IndexBinary>;
 
+%include  <faiss/IndexRowwiseMinMax.h>
 
 
 %ignore faiss::BufferList::Buffer;
@@ -611,6 +614,8 @@ void gpu_sync_all_devices()
     DOWNCAST ( IndexNSGPQ )
     DOWNCAST ( IndexNSGSQ )
     DOWNCAST ( Index2Layer )
+    DOWNCAST ( IndexRowwiseMinMax )
+    DOWNCAST ( IndexRowwiseMinMaxFP16 )
 #ifdef GPU_WRAPPER
     DOWNCAST_GPU ( GpuIndexIVFPQ )
     DOWNCAST_GPU ( GpuIndexIVFFlat )

--- a/tests/test_rowwise_minmax.py
+++ b/tests/test_rowwise_minmax.py
@@ -1,0 +1,56 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import numpy as np
+
+import faiss
+import unittest
+
+from common_faiss_tests import get_dataset_2
+
+
+class TestIndexRowwiseMinmax(unittest.TestCase):
+    def compare_train_vs_train_inplace(self, factory_key):
+        d = 96
+        nb = 1000
+        nq = 0
+        nt = 2000
+
+        xt, x, _ = get_dataset_2(d, nt, nb, nq)
+
+        assert x.size > 0
+
+        codec = faiss.index_factory(d, factory_key)
+
+        # use the regular .train()
+        codec.train(xt)
+        codes_train = codec.sa_encode(x)
+
+        decoded = codec.sa_decode(codes_train)
+
+        # use .train_inplace()
+        xt_cloned = np.copy(xt)
+        codec.train_inplace(xt_cloned)
+        codes_train_inplace = codec.sa_encode(x)
+
+        # compare .train and .train_inplace codes
+        n_diff = (codes_train != codes_train_inplace).sum()
+        self.assertEqual(n_diff, 0)
+
+        # make sure that the array used for .train_inplace got affected
+        n_diff_xt = (xt_cloned != xt).sum()
+        self.assertNotEqual(n_diff_xt, 0)
+
+        # make sure that the reconstruction error is not crazy
+        reconstruction_err = ((x - decoded) ** 2).sum()
+        print(reconstruction_err)
+
+        self.assertLess(reconstruction_err, 0.6)
+
+    def test_fp32(self) -> None:
+        self.compare_train_vs_train_inplace("MinMax,SQ8")
+
+    def test_fp16(self) -> None:
+        self.compare_train_vs_train_inplace("MinMaxFP16,SQ8")


### PR DESCRIPTION
Summary:
Index wrapper that performs rowwise normalization to [0,1], preserving the coefficients. This is a vector codec index only.

Basically, this index performs a rowwise scaling to [0,1] of every row in an input dataset before calling subindex::train() and subindex::sa_encode(). sa_encode() call stores the scaling coefficients (scaler and minv) in the very beginning of every output code. The format:
    [scaler][minv][subindex::sa_encode() output]
The de-scaling in sa_decode() is done using:
    output_rescaled = scaler * output + minv

An additional ::train_inplace() function is provided in order to do an inplace scaling before calling subindex::train() and, thus, avoiding the cloning of the input dataset, but modifying the input dataset because of the scaling and the scaling back.

Derived classes provide different data types for scaling coefficients. Currently, versions with fp16 and fp32 scaling coefficients are available.
* fp16 version adds 4 extra bytes per encoded vector
* fp32 version adds 8 extra bytes per encoded vector

Reviewed By: mdouze

Differential Revision: D38581012

