### PR TITLE
Fix F16C handling in fp16.h and fp16-inl.h

### DIFF
--- a/faiss/utils/fp16-inl.h
+++ b/faiss/utils/fp16-inl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 
 namespace faiss {

--- a/faiss/utils/fp16.h
+++ b/faiss/utils/fp16.h
@@ -2,7 +2,9 @@
 
 #include <cstdint>
 
-#if defined(__SSE__) && defined(USE_F16C)
+#include <faiss/impl/platform_macros.h>
+
+#if defined(__F16C__)
 #include <faiss/utils/fp16-fp16c.h>
 #else
 #include <faiss/utils/fp16-inl.h>


### PR DESCRIPTION
Summary: Upgrade the handling of fp16 conversion function on MSVC.

Differential Revision: D39175875

