### PR TITLE
Update macOS CI Image Tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
 
   build_osx:
     macos:
-      xcode: 12.4.0
+      xcode: 12.5.1
     environment:
       OMP_NUM_THREADS: 10
     steps:


### PR DESCRIPTION
It seems that [`xcode:12.4.0` has been retired from CircleCI](https://circleci.com/docs/en/using-macos#supported-xcode-versions), so this PR updates the image version and fixes stopping the pipeline at the spin-up stage.

This PR changes only `.circleci/config.yml` , and doesn't affect the software behavior.