### PR TITLE
Additional C++ templates for fast sa_decode: more codecs for Index2LevelDecoder

### DIFF
--- a/faiss/cppcontrib/detail/CoarseBitType.h
+++ b/faiss/cppcontrib/detail/CoarseBitType.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+namespace faiss {
+namespace cppcontrib {
+namespace detail {
+
+template <int COARSE_BITS>
+struct CoarseBitType {};
+
+template <>
+struct CoarseBitType<8> {
+    using bit_type = uint8_t;
+};
+
+template <>
+struct CoarseBitType<16> {
+    using bit_type = uint16_t;
+};
+
+} // namespace detail
+} // namespace cppcontrib
+} // namespace faiss

--- a/faiss/cppcontrib/detail/UintReader.h
+++ b/faiss/cppcontrib/detail/UintReader.h
@@ -1,0 +1,195 @@
+#pragma once
+
+#include <cstdint>
+
+namespace faiss {
+namespace cppcontrib {
+namespace detail {
+
+namespace {
+
+template <intptr_t N_ELEMENTS, intptr_t CPOS>
+struct Uint8Reader {
+    static_assert(CPOS < N_ELEMENTS, "CPOS should be less than N_ELEMENTS");
+
+    static intptr_t get(const uint8_t* const __restrict codes) {
+        // Read using 4-bytes, if possible.
+        // Reading using 8-byte takes too many registers somewhy.
+
+        constexpr intptr_t ELEMENT_TO_READ = CPOS / 4;
+        constexpr intptr_t SUB_ELEMENT = CPOS % 4;
+
+        switch (SUB_ELEMENT) {
+            case 0: {
+                if (N_ELEMENTS > CPOS + 3) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 4);
+                    return (code32 & 0x000000FF);
+                } else {
+                    return codes[CPOS];
+                }
+            }
+            case 1: {
+                if (N_ELEMENTS > CPOS + 2) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 4);
+                    return (code32 & 0x0000FF00) >> 8;
+                } else {
+                    return codes[CPOS];
+                }
+            }
+            case 2: {
+                if (N_ELEMENTS > CPOS + 1) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 4);
+                    return (code32 & 0x00FF0000) >> 16;
+                } else {
+                    return codes[CPOS];
+                }
+            }
+            case 3: {
+                if (N_ELEMENTS > CPOS) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 4);
+                    return (code32) >> 24;
+                } else {
+                    return codes[CPOS];
+                }
+            }
+        }
+    }
+};
+
+// reduces the number of read operations from RAM
+///////////////////////////////////////////////
+// 76543210 76543210 76543210 76543210 76543210
+// 00000000 00
+//            111111 1111
+//                       2222 222222
+//                                  33 33333333
+template <intptr_t N_ELEMENTS, intptr_t CPOS>
+struct Uint10Reader {
+    static_assert(CPOS < N_ELEMENTS, "CPOS should be less than N_ELEMENTS");
+
+    static intptr_t get(const uint8_t* const __restrict codes) {
+        // Read using 4-bytes or 2-bytes.
+
+        constexpr intptr_t ELEMENT_TO_READ = CPOS / 4;
+        constexpr intptr_t SUB_ELEMENT = CPOS % 4;
+
+        switch (SUB_ELEMENT) {
+            case 0: {
+                if (N_ELEMENTS > CPOS + 2) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 5);
+                    return (code32 & 0b0000001111111111);
+                } else {
+                    const uint16_t code16 = *reinterpret_cast<const uint16_t*>(
+                            codes + ELEMENT_TO_READ * 5 + 0);
+                    return (code16 & 0b0000001111111111);
+                }
+            }
+            case 1: {
+                if (N_ELEMENTS > CPOS + 1) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 5);
+                    return (code32 & 0b000011111111110000000000) >> 10;
+                } else {
+                    const uint16_t code16 = *reinterpret_cast<const uint16_t*>(
+                            codes + ELEMENT_TO_READ * 5 + 1);
+                    return (code16 & 0b0000111111111100) >> 2;
+                }
+            }
+            case 2: {
+                if (N_ELEMENTS > CPOS) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 5);
+                    return (code32 & 0b00111111111100000000000000000000) >> 20;
+                } else {
+                    const uint16_t code16 = *reinterpret_cast<const uint16_t*>(
+                            codes + ELEMENT_TO_READ * 5 + 2);
+                    return (code16 & 0b0011111111110000) >> 4;
+                }
+            }
+            case 3: {
+                const uint16_t code16 = *reinterpret_cast<const uint16_t*>(
+                        codes + ELEMENT_TO_READ * 5 + 3);
+                return (code16 & 0b1111111111000000) >> 6;
+            }
+        }
+    }
+};
+
+// reduces the number of read operations from RAM
+template <intptr_t N_ELEMENTS, intptr_t CPOS>
+struct Uint16Reader {
+    static_assert(CPOS < N_ELEMENTS, "CPOS should be less than N_ELEMENTS");
+
+    static intptr_t get(const uint8_t* const __restrict codes) {
+        // Read using 4-bytes or 2-bytes.
+        // Reading using 8-byte takes too many registers somewhy.
+
+        constexpr intptr_t ELEMENT_TO_READ = CPOS / 2;
+        constexpr intptr_t SUB_ELEMENT = CPOS % 2;
+
+        switch (SUB_ELEMENT) {
+            case 0: {
+                if (N_ELEMENTS > CPOS + 1) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 4);
+                    return (code32 & 0x0000FFFF);
+                } else {
+                    const uint16_t* const __restrict codesFp16 =
+                            reinterpret_cast<const uint16_t*>(codes);
+                    return codesFp16[CPOS];
+                }
+            }
+            case 1: {
+                if (N_ELEMENTS > CPOS) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 4);
+                    return code32 >> 16;
+                } else {
+                    const uint16_t* const __restrict codesFp16 =
+                            reinterpret_cast<const uint16_t*>(codes);
+                    return codesFp16[CPOS];
+                }
+            }
+        }
+    }
+};
+
+//
+template <intptr_t N_ELEMENTS, intptr_t CODE_BITS, intptr_t CPOS>
+struct UintReaderImplType {};
+
+template <intptr_t N_ELEMENTS, intptr_t CPOS>
+struct UintReaderImplType<N_ELEMENTS, 8, CPOS> {
+    using reader_type = Uint8Reader<N_ELEMENTS, CPOS>;
+};
+
+template <intptr_t N_ELEMENTS, intptr_t CPOS>
+struct UintReaderImplType<N_ELEMENTS, 10, CPOS> {
+    using reader_type = Uint10Reader<N_ELEMENTS, CPOS>;
+};
+
+template <intptr_t N_ELEMENTS, intptr_t CPOS>
+struct UintReaderImplType<N_ELEMENTS, 16, CPOS> {
+    using reader_type = Uint16Reader<N_ELEMENTS, CPOS>;
+};
+
+} // namespace
+
+// reduces the number of read operations from RAM
+template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CODE_BITS, intptr_t CPOS>
+using UintReader =
+        typename UintReaderImplType<DIM / CODE_SIZE, CODE_BITS, CPOS>::
+                reader_type;
+
+template <intptr_t N_ELEMENTS, intptr_t CODE_BITS, intptr_t CPOS>
+using UintReaderRaw =
+        typename UintReaderImplType<N_ELEMENTS, CODE_BITS, CPOS>::reader_type;
+
+} // namespace detail
+} // namespace cppcontrib
+} // namespace faiss

--- a/faiss/cppcontrib/sa_decode/Level2-avx2-inl.h
+++ b/faiss/cppcontrib/sa_decode/Level2-avx2-inl.h
@@ -7,8 +7,14 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <faiss/cppcontrib/detail/UintReader.h>
+
 namespace faiss {
 namespace cppcontrib {
+
+////////////////////////////////////////////////////////////////////////////////////
+/// Index2LevelDecoder
+////////////////////////////////////////////////////////////////////////////////////
 
 namespace {
 
@@ -121,46 +127,6 @@ inline __m256 elementaryBlock8x1bAccum(
     return _mm256_fmadd_ps(combinedValue, weightAvx2, existingValue);
 }
 
-// reduces the number of read operations from RAM
-template <
-        intptr_t DIM,
-        intptr_t CODE_SIZE,
-        intptr_t CPOS,
-        bool = DIM / CODE_SIZE <= 3>
-struct Uint8ReaderImpl {
-    static intptr_t get(const uint8_t* const __restrict codes) {
-        // Read 1 byte (movzx).
-        return codes[CPOS];
-    }
-};
-template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CPOS>
-struct Uint8ReaderImpl<DIM, CODE_SIZE, CPOS, false> {
-    static intptr_t get(const uint8_t* const __restrict codes) {
-        // Read using 4-bytes.
-        // Reading using 8-byte takes too many registers somewhy.
-        const uint32_t* __restrict codes32 =
-                reinterpret_cast<const uint32_t*>(codes);
-
-        constexpr intptr_t ELEMENT_TO_READ = CPOS / 4;
-        constexpr intptr_t SUB_ELEMENT = CPOS % 4;
-        const uint32_t code32 = codes32[ELEMENT_TO_READ];
-
-        switch (SUB_ELEMENT) {
-            case 0:
-                return (code32 & 0x000000FF);
-            case 1:
-                return (code32 & 0x0000FF00) >> 8;
-            case 2:
-                return (code32 & 0x00FF0000) >> 16;
-            case 3:
-                return (code32) >> 24;
-        }
-    }
-};
-
-template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CPOS>
-using Uint8Reader = Uint8ReaderImpl<DIM, CODE_SIZE, CPOS>;
-
 // The following code uses template-based for-loop unrolling,
 //   because the compiler does not do that on its own as needed.
 // The idea is the following:
@@ -180,12 +146,12 @@ using Uint8Reader = Uint8ReaderImpl<DIM, CODE_SIZE, CPOS>;
 //   Initiate the loop:
 //     Foo<0, MAX>::bar();
 
-// Suitable for IVF256,PQ[1]x8
-// Suitable for Residual[1]x8,PQ[2]x8
 template <
         intptr_t DIM,
         intptr_t COARSE_SIZE,
         intptr_t FINE_SIZE,
+        intptr_t COARSE_BITS,
+        intptr_t FINE_BITS,
         intptr_t CPOS,
         bool FINE_SIZE_EQ_4 = FINE_SIZE == 4,
         bool QPOS_LEFT_GE_8 = (FINE_SIZE - CPOS % FINE_SIZE >= 8),
@@ -196,6 +162,8 @@ struct Index2LevelDecoderImpl;
 template <
         intptr_t DIM,
         intptr_t COARSE_SIZE,
+        intptr_t COARSE_BITS,
+        intptr_t FINE_BITS,
         intptr_t CPOS,
         bool QPOS_LEFT_GE_8,
         bool QPOS_LEFT_GE_4>
@@ -203,6 +171,8 @@ struct Index2LevelDecoderImpl<
         DIM,
         COARSE_SIZE,
         4,
+        COARSE_BITS,
+        FINE_BITS,
         CPOS,
         true,
         QPOS_LEFT_GE_8,
@@ -217,6 +187,19 @@ struct Index2LevelDecoderImpl<
 
     static constexpr intptr_t QPOS_LEFT = FINE_SIZE - fineCentroidOffset;
 
+    // coarse quantizer storage
+    static constexpr intptr_t COARSE_TABLE_BYTES = (1 << COARSE_BITS);
+
+    // coarse quantizer bytes start from 0
+    // fine quantizer bytes start from N_COARSE_ELEMENTS_BYTES
+    static constexpr intptr_t N_COARSE_ELEMENTS = DIM / COARSE_SIZE;
+    static constexpr intptr_t N_COARSE_ELEMENTS_BITS =
+            N_COARSE_ELEMENTS * COARSE_BITS;
+    static constexpr intptr_t N_COARSE_ELEMENTS_BYTES =
+            (N_COARSE_ELEMENTS_BITS + 7) / 8;
+
+    static constexpr intptr_t FINE_TABLE_BYTES = (1 << FINE_BITS);
+
     // process 1 sample
     static void store(
             const float* const __restrict pqCoarseCentroids0,
@@ -227,26 +210,26 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 4 float
         // but 8 floats per loop
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine0);
-        const intptr_t fineCode0b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0a = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 0>::get(fine0);
+        const intptr_t fineCode0b = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 1>::get(fine0);
 
         const __m256 storeValue = elementaryBlock4x2b(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + ((fineCentroidIdx + 0) * 256 + fineCode0a) * FINE_SIZE + fineCentroidOffset,
-              pqFineCentroids0 + ((fineCentroidIdx + 1) * 256 + fineCode0b) * FINE_SIZE + fineCentroidOffset);
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 0) * FINE_TABLE_BYTES + fineCode0a) * FINE_SIZE + fineCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 1) * FINE_TABLE_BYTES + fineCode0b) * FINE_SIZE + fineCentroidOffset);
 
         _mm256_storeu_ps(outputStore + CPOS, storeValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::store(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 8>::store(
               pqCoarseCentroids0, pqFineCentroids0, code0,
               outputStore);
 
@@ -264,30 +247,30 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 4 float
         // but 8 floats per loop
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine0);
-        const intptr_t fineCode0b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0a = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 0>::get(fine0);
+        const intptr_t fineCode0b = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 1>::get(fine0);
 
         __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock4x2bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + ((fineCentroidIdx + 0) * 256 + fineCode0a) * FINE_SIZE + fineCentroidOffset,
-              pqFineCentroids0 + ((fineCentroidIdx + 1) * 256 + fineCode0b) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 0) * FINE_TABLE_BYTES + fineCode0a) * FINE_SIZE + fineCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 1) * FINE_TABLE_BYTES + fineCode0b) * FINE_SIZE + fineCentroidOffset,
               weight0,
               existingValue);
 
         _mm256_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 8>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               outputAccum);
 
@@ -310,41 +293,41 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse1 = code1;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
-        const uint8_t* const __restrict fine1 = code1 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
+        const uint8_t* const __restrict fine1 = code1 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 4 float
         // but 8 floats per loop
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine0);
-        const intptr_t fineCode0b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine0);
-        const intptr_t coarseCode1 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse1);
-        const intptr_t fineCode1a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine1);
-        const intptr_t fineCode1b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine1);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0a = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 0>::get(fine0);
+        const intptr_t fineCode0b = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 1>::get(fine0);
+        const intptr_t coarseCode1 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse1);
+        const intptr_t fineCode1a = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 0>::get(fine1);
+        const intptr_t fineCode1b = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 1>::get(fine1);
 
         __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock4x2bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + ((fineCentroidIdx + 0) * 256 + fineCode0a) * FINE_SIZE + fineCentroidOffset,
-              pqFineCentroids0 + ((fineCentroidIdx + 1) * 256 + fineCode0b) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 0) * FINE_TABLE_BYTES + fineCode0a) * FINE_SIZE + fineCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 1) * FINE_TABLE_BYTES + fineCode0b) * FINE_SIZE + fineCentroidOffset,
               weight0,
               existingValue);
 
         existingValue = elementaryBlock4x2bAccum(
-              pqCoarseCentroids1 + (coarseCentroidIdx * 256 + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids1 + ((fineCentroidIdx + 0) * 256 + fineCode1a) * FINE_SIZE + fineCentroidOffset,
-              pqFineCentroids1 + ((fineCentroidIdx + 1) * 256 + fineCode1b) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids1 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids1 + ((fineCentroidIdx + 0) * FINE_TABLE_BYTES + fineCode1a) * FINE_SIZE + fineCentroidOffset,
+              pqFineCentroids1 + ((fineCentroidIdx + 1) * FINE_TABLE_BYTES + fineCode1b) * FINE_SIZE + fineCentroidOffset,
               weight1,
               existingValue);
 
         _mm256_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 8>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               pqCoarseCentroids1, pqFineCentroids1, code1, weight1,
               outputAccum);
@@ -353,11 +336,19 @@ struct Index2LevelDecoderImpl<
     }
 };
 
-template <intptr_t DIM, intptr_t COARSE_SIZE, intptr_t FINE_SIZE, intptr_t CPOS>
+template <
+        intptr_t DIM,
+        intptr_t COARSE_SIZE,
+        intptr_t FINE_SIZE,
+        intptr_t COARSE_BITS,
+        intptr_t FINE_BITS,
+        intptr_t CPOS>
 struct Index2LevelDecoderImpl<
         DIM,
         COARSE_SIZE,
         FINE_SIZE,
+        COARSE_BITS,
+        FINE_BITS,
         CPOS,
         false,
         true,
@@ -370,6 +361,19 @@ struct Index2LevelDecoderImpl<
 
     static constexpr intptr_t QPOS_LEFT = FINE_SIZE - fineCentroidOffset;
 
+    // coarse quantizer storage
+    static constexpr intptr_t COARSE_TABLE_BYTES = (1 << COARSE_BITS);
+
+    // coarse quantizer bytes start from 0
+    // fine quantizer bytes start from N_COARSE_ELEMENTS_BYTES
+    static constexpr intptr_t N_COARSE_ELEMENTS = DIM / COARSE_SIZE;
+    static constexpr intptr_t N_COARSE_ELEMENTS_BITS =
+            N_COARSE_ELEMENTS * COARSE_BITS;
+    static constexpr intptr_t N_COARSE_ELEMENTS_BYTES =
+            (N_COARSE_ELEMENTS_BITS + 7) / 8;
+
+    static constexpr intptr_t FINE_TABLE_BYTES = (1 << FINE_BITS);
+
     // process 1 sample
     static void store(
             const float* const __restrict pqCoarseCentroids0,
@@ -380,23 +384,23 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 8 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine0);
 
         const __m256 storeValue = elementaryBlock8x1b(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset);
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset);
 
         _mm256_storeu_ps(outputStore + CPOS, storeValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::store(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 8>::store(
               pqCoarseCentroids0, pqFineCentroids0, code0,
               outputStore);
 
@@ -414,27 +418,27 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 8 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine0);
 
         __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock8x1bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset,
               weight0,
               existingValue);
 
         _mm256_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 8>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               outputAccum);
 
@@ -457,36 +461,36 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse1 = code1;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
-        const uint8_t* const __restrict fine1 = code1 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
+        const uint8_t* const __restrict fine1 = code1 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 8 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
-        const intptr_t coarseCode1 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse1);
-        const intptr_t fineCode1 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine1);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode1 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse1);
+        const intptr_t fineCode1 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine1);
 
         __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock8x1bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset,
               weight0,
               existingValue);
 
         existingValue = elementaryBlock8x1bAccum(
-              pqCoarseCentroids1 + (coarseCentroidIdx * 256 + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids1 + (fineCentroidIdx * 256 + fineCode1) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids1 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids1 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode1) * FINE_SIZE + fineCentroidOffset,
               weight1,
               existingValue);
 
         _mm256_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 8>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               pqCoarseCentroids1, pqFineCentroids1, code1, weight1,
               outputAccum);
@@ -495,11 +499,19 @@ struct Index2LevelDecoderImpl<
     }
 };
 
-template <intptr_t DIM, intptr_t COARSE_SIZE, intptr_t FINE_SIZE, intptr_t CPOS>
+template <
+        intptr_t DIM,
+        intptr_t COARSE_SIZE,
+        intptr_t FINE_SIZE,
+        intptr_t COARSE_BITS,
+        intptr_t FINE_BITS,
+        intptr_t CPOS>
 struct Index2LevelDecoderImpl<
         DIM,
         COARSE_SIZE,
         FINE_SIZE,
+        COARSE_BITS,
+        FINE_BITS,
         CPOS,
         false,
         false,
@@ -512,6 +524,19 @@ struct Index2LevelDecoderImpl<
 
     static constexpr intptr_t QPOS_LEFT = FINE_SIZE - fineCentroidOffset;
 
+    // coarse quantizer storage
+    static constexpr intptr_t COARSE_TABLE_BYTES = (1 << COARSE_BITS);
+
+    // coarse quantizer bytes start from 0
+    // fine quantizer bytes start from N_COARSE_ELEMENTS_BYTES
+    static constexpr intptr_t N_COARSE_ELEMENTS = DIM / COARSE_SIZE;
+    static constexpr intptr_t N_COARSE_ELEMENTS_BITS =
+            N_COARSE_ELEMENTS * COARSE_BITS;
+    static constexpr intptr_t N_COARSE_ELEMENTS_BYTES =
+            (N_COARSE_ELEMENTS_BITS + 7) / 8;
+
+    static constexpr intptr_t FINE_TABLE_BYTES = (1 << FINE_BITS);
+
     // process 1 sample
     static void store(
             const float* const __restrict pqCoarseCentroids0,
@@ -522,23 +547,23 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 4 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine0);
 
         const __m128 storeValue = elementaryBlock4x1b(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset);
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset);
 
         _mm_storeu_ps(outputStore + CPOS, storeValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 4>::store(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 4>::store(
               pqCoarseCentroids0, pqFineCentroids0, code0,
               outputStore);
 
@@ -556,27 +581,27 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 4 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS,fineCentroidIdx>::get(fine0);
 
         __m128 existingValue = _mm_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock4x1bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset,
               weight0,
               existingValue);
 
         _mm_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 4>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 4>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               outputAccum);
 
@@ -599,36 +624,36 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse1 = code1;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
-        const uint8_t* const __restrict fine1 = code1 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
+        const uint8_t* const __restrict fine1 = code1 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 4 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
-        const intptr_t coarseCode1 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse1);
-        const intptr_t fineCode1 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine1);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode1 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse1);
+        const intptr_t fineCode1 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine1);
 
         __m128 existingValue = _mm_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock4x1bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset,
               weight0,
               existingValue);
 
         existingValue = elementaryBlock4x1bAccum(
-              pqCoarseCentroids1 + (coarseCentroidIdx * 256 + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids1 + (fineCentroidIdx * 256 + fineCode1) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids1 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids1 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode1) * FINE_SIZE + fineCentroidOffset,
               weight1,
               existingValue);
 
         _mm_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 4>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 4>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               pqCoarseCentroids1, pqFineCentroids1, code1, weight1,
               outputAccum);
@@ -637,13 +662,13 @@ struct Index2LevelDecoderImpl<
     }
 };
 
-// Suitable for IVF256,PQ[1]x8
-// Suitable for Residual[1]x8,PQ[2]x8
 // This partial specialization is expected to do nothing.
 template <
         intptr_t DIM,
         intptr_t COARSE_SIZE,
         intptr_t FINE_SIZE,
+        intptr_t COARSE_BITS,
+        intptr_t FINE_BITS,
         bool FINE_SIZE_EQ_4,
         bool QPOS_LEFT_GE_8,
         bool QPOS_LEFT_GE_4>
@@ -651,6 +676,8 @@ struct Index2LevelDecoderImpl<
         DIM,
         COARSE_SIZE,
         FINE_SIZE,
+        COARSE_BITS,
+        FINE_BITS,
         DIM,
         FINE_SIZE_EQ_4,
         QPOS_LEFT_GE_8,
@@ -691,16 +718,36 @@ struct Index2LevelDecoderImpl<
 
 // Suitable for IVF256,PQ[1]x8
 // Suitable for Residual[1]x8,PQ[2]x8
-template <intptr_t DIM, intptr_t COARSE_SIZE, intptr_t FINE_SIZE>
+// Suitable for IVF[9-16 bit],PQ[1]x8 (such as IVF1024,PQ16np)
+// Suitable for Residual[1]x[9-16 bit],PQ[2]x[3] (such as Residual2x9,PQ8)
+template <
+        intptr_t DIM,
+        intptr_t COARSE_SIZE,
+        intptr_t FINE_SIZE,
+        intptr_t COARSE_BITS = 8,
+        intptr_t FINE_BITS = 8>
 struct Index2LevelDecoder {
+    static_assert(
+            COARSE_BITS == 8 || COARSE_BITS == 10 || COARSE_BITS == 16,
+            "Only 8, 10 or 16 bits are currently supported for COARSE_BITS");
+    static_assert(
+            FINE_BITS == 8 || FINE_BITS == 10 || FINE_BITS == 16,
+            "Only 8, 10 or 16 bits are currently supported for FINE_BITS");
+
     // Process 1 sample.
     static void store(
             const float* const __restrict pqCoarseCentroids,
             const float* const __restrict pqFineCentroids,
             const uint8_t* const __restrict code,
             float* const __restrict outputStore) {
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, 0>::store(
-                pqCoarseCentroids, pqFineCentroids, code, outputStore);
+        Index2LevelDecoderImpl<
+                DIM,
+                COARSE_SIZE,
+                FINE_SIZE,
+                COARSE_BITS,
+                FINE_BITS,
+                0>::
+                store(pqCoarseCentroids, pqFineCentroids, code, outputStore);
     }
 
     // Process 1 sample.
@@ -711,8 +758,18 @@ struct Index2LevelDecoder {
             const uint8_t* const __restrict code,
             const float weight,
             float* const __restrict outputAccum) {
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, 0>::accum(
-                pqCoarseCentroids, pqFineCentroids, code, weight, outputAccum);
+        Index2LevelDecoderImpl<
+                DIM,
+                COARSE_SIZE,
+                FINE_SIZE,
+                COARSE_BITS,
+                FINE_BITS,
+                0>::
+                accum(pqCoarseCentroids,
+                      pqFineCentroids,
+                      code,
+                      weight,
+                      outputAccum);
     }
 
     // process 2 samples
@@ -728,16 +785,22 @@ struct Index2LevelDecoder {
             const uint8_t* const __restrict code1,
             const float weight1,
             float* const __restrict outputAccum) {
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, 0>::accum(
-                pqCoarseCentroids0,
-                pqFineCentroids0,
-                code0,
-                weight0,
-                pqCoarseCentroids1,
-                pqFineCentroids1,
-                code1,
-                weight1,
-                outputAccum);
+        Index2LevelDecoderImpl<
+                DIM,
+                COARSE_SIZE,
+                FINE_SIZE,
+                COARSE_BITS,
+                FINE_BITS,
+                0>::
+                accum(pqCoarseCentroids0,
+                      pqFineCentroids0,
+                      code0,
+                      weight0,
+                      pqCoarseCentroids1,
+                      pqFineCentroids1,
+                      code1,
+                      weight1,
+                      outputAccum);
     }
 };
 

--- a/tests/test_cppcontrib_uintreader.cpp
+++ b/tests/test_cppcontrib_uintreader.cpp
@@ -1,0 +1,103 @@
+// This test was designed to be run using valgrind or ASAN to test the
+// correctness of memory accesses.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+
+#include <faiss/utils/hamming.h>
+
+#include <faiss/cppcontrib/detail/UintReader.h>
+
+template <intptr_t N_ELEMENTS, intptr_t CODE_BITS, intptr_t CPOS>
+struct TestLoop {
+    static void test(
+            const uint8_t* const container,
+            faiss::BitstringReader& br) {
+        // validate
+        const intptr_t uintreader_data = faiss::cppcontrib::detail::
+                UintReaderRaw<N_ELEMENTS, CODE_BITS, CPOS>::get(container);
+        const intptr_t bitstringreader_data = br.read(CODE_BITS);
+
+        ASSERT_EQ(uintreader_data, bitstringreader_data)
+                << "Mismatch between BitstringReader (" << bitstringreader_data
+                << ") and UintReader (" << uintreader_data
+                << ") for N_ELEMENTS=" << N_ELEMENTS
+                << ", CODE_BITS=" << CODE_BITS << ", CPOS=" << CPOS;
+
+        //
+        TestLoop<N_ELEMENTS, CODE_BITS, CPOS + 1>::test(container, br);
+    }
+};
+
+template <intptr_t N_ELEMENTS, intptr_t CODE_BITS>
+struct TestLoop<N_ELEMENTS, CODE_BITS, N_ELEMENTS> {
+    static void test(
+            const uint8_t* const container,
+            faiss::BitstringReader& br) {}
+};
+
+template <intptr_t N_ELEMENTS, intptr_t CODE_BITS>
+void TestUintReader() {
+    constexpr intptr_t CODE_BYTES = (CODE_BITS * N_ELEMENTS + 7) / 8;
+
+    std::default_random_engine rng;
+    std::uniform_int_distribution<uint64_t> u(0, 1 << CODE_BITS);
+
+    // do several attempts
+    for (size_t attempt = 0; attempt < 10; attempt++) {
+        // allocate a buffer. This way, not std::vector
+        std::unique_ptr<uint8_t[]> container(new uint8_t[CODE_BYTES]);
+        // make it empty
+        for (size_t i = 0; i < CODE_BYTES; i++) {
+            container.get()[i] = 0;
+        }
+
+        // populate it
+        faiss::BitstringWriter bw(container.get(), CODE_BYTES);
+        for (size_t i = 0; i < N_ELEMENTS; i++) {
+            bw.write(u(rng), CODE_BITS);
+        }
+
+        // read it back and verify against bitreader
+        faiss::BitstringReader br(container.get(), CODE_BYTES);
+
+        TestLoop<N_ELEMENTS, CODE_BITS, 0>::test(container.get(), br);
+    }
+}
+
+template <intptr_t CODE_BITS>
+void TestUintReaderBits() {
+    TestUintReader<1, CODE_BITS>();
+    TestUintReader<2, CODE_BITS>();
+    TestUintReader<3, CODE_BITS>();
+    TestUintReader<4, CODE_BITS>();
+    TestUintReader<5, CODE_BITS>();
+    TestUintReader<6, CODE_BITS>();
+    TestUintReader<7, CODE_BITS>();
+    TestUintReader<8, CODE_BITS>();
+    TestUintReader<9, CODE_BITS>();
+    TestUintReader<10, CODE_BITS>();
+    TestUintReader<11, CODE_BITS>();
+    TestUintReader<12, CODE_BITS>();
+    TestUintReader<13, CODE_BITS>();
+    TestUintReader<14, CODE_BITS>();
+    TestUintReader<15, CODE_BITS>();
+    TestUintReader<16, CODE_BITS>();
+    TestUintReader<17, CODE_BITS>();
+}
+
+TEST(TEST_CPPCONTRIB_UINTREADER, Test8bit) {
+    TestUintReaderBits<8>();
+}
+
+TEST(TEST_CPPCONTRIB_UINTREADER, Test10bit) {
+    TestUintReaderBits<10>();
+}
+
+TEST(TEST_CPPCONTRIB_UINTREADER, Test16bit) {
+    TestUintReaderBits<16>();
+}


### PR DESCRIPTION
Summary:
Add support for
* IVF[9-16 bit],PQ[1]x8 (such as IVF1024,PQ16np)
* Residual1x[9-16 bit],PQ[1]x8 (such as Residual1x9,PQ8)

Additionally, AVX2 and ARM versions support
* Residual[1]x8,PQ[2]x10
* Residual[1]x8,PQ[2]x16
* Residual1x[9-16 bit],PQ[1]x10 (such as Residual1x9,PQ16x10)
* Residual1x[9-16 bit],PQ[1]x16 (such as Residual1x9,PQ16x16)
* Residual[1]x10,PQ[2]x10
* Residual[1]x10,PQ[2]x16
* Residual[1]x16,PQ[2]x10
* Residual[1]x16,PQ[2]x16

IVF[9-16 bit],PQ[1]x10 and IVF[9-16 bit],PQ[1]x16 (such as IVF1024,PQ16x10np) are supported as well, but Faiss does not allow to train such Indices as this time.

Differential Revision: D39176424

