### PR TITLE
Additional C++ templates for fast sa_decode: add IndexPQDecoder

### DIFF
--- a/faiss/cppcontrib/SaDecodeKernels.h
+++ b/faiss/cppcontrib/SaDecodeKernels.h
@@ -6,13 +6,24 @@
 //   function for the following index families:
 //   * IVF256,PQ[1]x8np
 //   * Residual[1]x8,PQ[2]x8
-//   * IVF[9-16 bit],PQ[1]x8 (such as IVF1024,PQ16np)
+//   * IVF[2^9-2^16 bit],PQ[1]x8 (such as IVF1024,PQ16np)
 //   * Residual1x[9-16 bit],PQ[1]x8 (such as Residual1x9,PQ8)
+//   * PQ[1]x8
 // Additionally, AVX2 and ARM versions support
 //   * Residual[1]x8,PQ[2]x10
 //   * Residual[1]x8,PQ[2]x16
+//   * Residual[1]x10,PQ[2]x10
+//   * Residual[1]x10,PQ[2]x16
+//   * Residual[1]x16,PQ[2]x10
+//   * Residual[1]x16,PQ[2]x16
 //   * Residual1x[9-16 bit],PQ[1]x10 (such as Residual1x9,PQ16x10)
+//   * * (use with COARSE_BITS=16)
 //   * Residual1x[9-16 bit],PQ[1]x16 (such as Residual1x9,PQ16x16)
+//   * * (use with COARSE_BITS=16)
+//   * PQ[1]x10
+//   * PQ[1]x16
+// Unfortunately, currently Faiss does not support something like
+//   IVF256,PQ16x10np
 //
 // The goal was to achieve the maximum performance, so the template version it
 // is. The provided index families share the same code for sa_decode.
@@ -25,7 +36,8 @@
 //        intptr_t DIM,
 //        intptr_t COARSE_SIZE,
 //        intptr_t FINE_SIZE,
-//        intptr_t COARSE_BITS = 8>
+//        intptr_t COARSE_BITS = 8
+//        intptr_t FINE_BITS = 8>
 //     struct Index2LevelDecoder { /*...*/ };
 //   }
 // * DIM is the dimensionality of data
@@ -33,18 +45,40 @@
 // * FINE_SIZE is the dimensionality of the ProductQuantizer dsq
 // * COARSE_BITS is the number of bits that are needed to represent a coarse
 //   quantizer code.
+// * FINE_BITS is the number of bits that are needed to represent a fine
+//   quantizer code.
 // For example, "IVF256,PQ8np" for 160-dim data translates into
 //   Index2LevelDecoder<160,160,20,8>
 // For example, "Residual4x8,PQ16" for 256-dim data translates into
 //   Index2LevelDecoder<256,64,1,8>
 // For example, "IVF1024,PQ16np" for 256-dim data translates into
-//   Index2LevelDecoder<256,256,16,16>
+//   Index2LevelDecoder<256,256,16,10>. But as there are only 1 coarse code
+//   element, Index2LevelDecoder<256,256,16,16> can be used as a faster
+//   decoder.
+// For example, "Residual4x10,PQ16x10np" for 256-dim data translates into
+//   Index2LevelDecoder<256,64,16,10,10>
 //
-// Additional supported COARSE_BITS values may be added later.
-// FINE_BITS might be added later.
+// Additional supported values for COARSE_BITS and FINE_BITS may be added later.
+//
+// Second one:
+//   {
+//     template <
+//        intptr_t DIM,
+//        intptr_t FINE_SIZE,
+//        intptr_t FINE_BITS = 8>
+//     struct IndexPQDecoder { /*...*/ };
+//   }
+// * DIM is the dimensionality of data
+// * FINE_SIZE is the dimensionality of the ProductQuantizer dsq
+// * FINE_BITS is the number of bits that are needed to represent a fine
+//   quantizer code.
+// For example, "PQ8np" for 160-dim data translates into
+//   IndexPQDecoder<160,20>
 //
 // Unlike the general purpose version in faiss::Index::sa_decode(),
-//   this version provides the following functions:
+//   this version provides the following functions (please note that
+//   pqCoarseCentroids params are not available for IndexPQDecoder,
+//   but the functionality is the same as for Index2LevelDecoder):
 // * ::store, which is similar to sa_decode(1, input, output),
 //   The method signature is the following:
 //   {
@@ -101,8 +135,11 @@
 
 #ifdef __AVX2__
 #include <faiss/cppcontrib/sa_decode/Level2-avx2-inl.h>
+#include <faiss/cppcontrib/sa_decode/PQ-avx2-inl.h>
 #elif defined(__ARM_NEON)
 #include <faiss/cppcontrib/sa_decode/Level2-neon-inl.h>
+#include <faiss/cppcontrib/sa_decode/PQ-neon-inl.h>
 #else
 #include <faiss/cppcontrib/sa_decode/Level2-inl.h>
+#include <faiss/cppcontrib/sa_decode/PQ-inl.h>
 #endif

--- a/faiss/cppcontrib/detail/CoarseBitType.h
+++ b/faiss/cppcontrib/detail/CoarseBitType.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+namespace faiss {
+namespace cppcontrib {
+namespace detail {
+
+template <int COARSE_BITS>
+struct CoarseBitType {};
+
+template <>
+struct CoarseBitType<8> {
+    using bit_type = uint8_t;
+};
+
+template <>
+struct CoarseBitType<16> {
+    using bit_type = uint16_t;
+};
+
+} // namespace detail
+} // namespace cppcontrib
+} // namespace faiss

--- a/faiss/cppcontrib/detail/UintReader.h
+++ b/faiss/cppcontrib/detail/UintReader.h
@@ -1,0 +1,195 @@
+#pragma once
+
+#include <cstdint>
+
+namespace faiss {
+namespace cppcontrib {
+namespace detail {
+
+namespace {
+
+template <intptr_t N_ELEMENTS, intptr_t CPOS>
+struct Uint8Reader {
+    static_assert(CPOS < N_ELEMENTS, "CPOS should be less than N_ELEMENTS");
+
+    static intptr_t get(const uint8_t* const __restrict codes) {
+        // Read using 4-bytes, if possible.
+        // Reading using 8-byte takes too many registers somewhy.
+
+        constexpr intptr_t ELEMENT_TO_READ = CPOS / 4;
+        constexpr intptr_t SUB_ELEMENT = CPOS % 4;
+
+        switch (SUB_ELEMENT) {
+            case 0: {
+                if (N_ELEMENTS > CPOS + 3) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 4);
+                    return (code32 & 0x000000FF);
+                } else {
+                    return codes[CPOS];
+                }
+            }
+            case 1: {
+                if (N_ELEMENTS > CPOS + 2) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 4);
+                    return (code32 & 0x0000FF00) >> 8;
+                } else {
+                    return codes[CPOS];
+                }
+            }
+            case 2: {
+                if (N_ELEMENTS > CPOS + 1) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 4);
+                    return (code32 & 0x00FF0000) >> 16;
+                } else {
+                    return codes[CPOS];
+                }
+            }
+            case 3: {
+                if (N_ELEMENTS > CPOS) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 4);
+                    return (code32) >> 24;
+                } else {
+                    return codes[CPOS];
+                }
+            }
+        }
+    }
+};
+
+// reduces the number of read operations from RAM
+///////////////////////////////////////////////
+// 76543210 76543210 76543210 76543210 76543210
+// 00000000 00
+//            111111 1111
+//                       2222 222222
+//                                  33 33333333
+template <intptr_t N_ELEMENTS, intptr_t CPOS>
+struct Uint10Reader {
+    static_assert(CPOS < N_ELEMENTS, "CPOS should be less than N_ELEMENTS");
+
+    static intptr_t get(const uint8_t* const __restrict codes) {
+        // Read using 4-bytes or 2-bytes.
+
+        constexpr intptr_t ELEMENT_TO_READ = CPOS / 4;
+        constexpr intptr_t SUB_ELEMENT = CPOS % 4;
+
+        switch (SUB_ELEMENT) {
+            case 0: {
+                if (N_ELEMENTS > CPOS + 2) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 5);
+                    return (code32 & 0b0000001111111111);
+                } else {
+                    const uint16_t code16 = *reinterpret_cast<const uint16_t*>(
+                            codes + ELEMENT_TO_READ * 5 + 0);
+                    return (code16 & 0b0000001111111111);
+                }
+            }
+            case 1: {
+                if (N_ELEMENTS > CPOS + 1) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 5);
+                    return (code32 & 0b000011111111110000000000) >> 10;
+                } else {
+                    const uint16_t code16 = *reinterpret_cast<const uint16_t*>(
+                            codes + ELEMENT_TO_READ * 5 + 1);
+                    return (code16 & 0b0000111111111100) >> 2;
+                }
+            }
+            case 2: {
+                if (N_ELEMENTS > CPOS) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 5);
+                    return (code32 & 0b00111111111100000000000000000000) >> 20;
+                } else {
+                    const uint16_t code16 = *reinterpret_cast<const uint16_t*>(
+                            codes + ELEMENT_TO_READ * 5 + 2);
+                    return (code16 & 0b0011111111110000) >> 4;
+                }
+            }
+            case 3: {
+                const uint16_t code16 = *reinterpret_cast<const uint16_t*>(
+                        codes + ELEMENT_TO_READ * 5 + 3);
+                return (code16 & 0b1111111111000000) >> 6;
+            }
+        }
+    }
+};
+
+// reduces the number of read operations from RAM
+template <intptr_t N_ELEMENTS, intptr_t CPOS>
+struct Uint16Reader {
+    static_assert(CPOS < N_ELEMENTS, "CPOS should be less than N_ELEMENTS");
+
+    static intptr_t get(const uint8_t* const __restrict codes) {
+        // Read using 4-bytes or 2-bytes.
+        // Reading using 8-byte takes too many registers somewhy.
+
+        constexpr intptr_t ELEMENT_TO_READ = CPOS / 2;
+        constexpr intptr_t SUB_ELEMENT = CPOS % 2;
+
+        switch (SUB_ELEMENT) {
+            case 0: {
+                if (N_ELEMENTS > CPOS + 1) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 4);
+                    return (code32 & 0x0000FFFF);
+                } else {
+                    const uint16_t* const __restrict codesFp16 =
+                            reinterpret_cast<const uint16_t*>(codes);
+                    return codesFp16[CPOS];
+                }
+            }
+            case 1: {
+                if (N_ELEMENTS > CPOS) {
+                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                            codes + ELEMENT_TO_READ * 4);
+                    return code32 >> 16;
+                } else {
+                    const uint16_t* const __restrict codesFp16 =
+                            reinterpret_cast<const uint16_t*>(codes);
+                    return codesFp16[CPOS];
+                }
+            }
+        }
+    }
+};
+
+//
+template <intptr_t N_ELEMENTS, intptr_t CODE_BITS, intptr_t CPOS>
+struct UintReaderImplType {};
+
+template <intptr_t N_ELEMENTS, intptr_t CPOS>
+struct UintReaderImplType<N_ELEMENTS, 8, CPOS> {
+    using reader_type = Uint8Reader<N_ELEMENTS, CPOS>;
+};
+
+template <intptr_t N_ELEMENTS, intptr_t CPOS>
+struct UintReaderImplType<N_ELEMENTS, 10, CPOS> {
+    using reader_type = Uint10Reader<N_ELEMENTS, CPOS>;
+};
+
+template <intptr_t N_ELEMENTS, intptr_t CPOS>
+struct UintReaderImplType<N_ELEMENTS, 16, CPOS> {
+    using reader_type = Uint16Reader<N_ELEMENTS, CPOS>;
+};
+
+} // namespace
+
+// reduces the number of read operations from RAM
+template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CODE_BITS, intptr_t CPOS>
+using UintReader =
+        typename UintReaderImplType<DIM / CODE_SIZE, CODE_BITS, CPOS>::
+                reader_type;
+
+template <intptr_t N_ELEMENTS, intptr_t CODE_BITS, intptr_t CPOS>
+using UintReaderRaw =
+        typename UintReaderImplType<N_ELEMENTS, CODE_BITS, CPOS>::reader_type;
+
+} // namespace detail
+} // namespace cppcontrib
+} // namespace faiss

--- a/faiss/cppcontrib/sa_decode/Level2-avx2-inl.h
+++ b/faiss/cppcontrib/sa_decode/Level2-avx2-inl.h
@@ -7,8 +7,14 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <faiss/cppcontrib/detail/UintReader.h>
+
 namespace faiss {
 namespace cppcontrib {
+
+////////////////////////////////////////////////////////////////////////////////////
+/// Index2LevelDecoder
+////////////////////////////////////////////////////////////////////////////////////
 
 namespace {
 
@@ -121,46 +127,6 @@ inline __m256 elementaryBlock8x1bAccum(
     return _mm256_fmadd_ps(combinedValue, weightAvx2, existingValue);
 }
 
-// reduces the number of read operations from RAM
-template <
-        intptr_t DIM,
-        intptr_t CODE_SIZE,
-        intptr_t CPOS,
-        bool = DIM / CODE_SIZE <= 3>
-struct Uint8ReaderImpl {
-    static intptr_t get(const uint8_t* const __restrict codes) {
-        // Read 1 byte (movzx).
-        return codes[CPOS];
-    }
-};
-template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CPOS>
-struct Uint8ReaderImpl<DIM, CODE_SIZE, CPOS, false> {
-    static intptr_t get(const uint8_t* const __restrict codes) {
-        // Read using 4-bytes.
-        // Reading using 8-byte takes too many registers somewhy.
-        const uint32_t* __restrict codes32 =
-                reinterpret_cast<const uint32_t*>(codes);
-
-        constexpr intptr_t ELEMENT_TO_READ = CPOS / 4;
-        constexpr intptr_t SUB_ELEMENT = CPOS % 4;
-        const uint32_t code32 = codes32[ELEMENT_TO_READ];
-
-        switch (SUB_ELEMENT) {
-            case 0:
-                return (code32 & 0x000000FF);
-            case 1:
-                return (code32 & 0x0000FF00) >> 8;
-            case 2:
-                return (code32 & 0x00FF0000) >> 16;
-            case 3:
-                return (code32) >> 24;
-        }
-    }
-};
-
-template <intptr_t DIM, intptr_t CODE_SIZE, intptr_t CPOS>
-using Uint8Reader = Uint8ReaderImpl<DIM, CODE_SIZE, CPOS>;
-
 // The following code uses template-based for-loop unrolling,
 //   because the compiler does not do that on its own as needed.
 // The idea is the following:
@@ -180,12 +146,12 @@ using Uint8Reader = Uint8ReaderImpl<DIM, CODE_SIZE, CPOS>;
 //   Initiate the loop:
 //     Foo<0, MAX>::bar();
 
-// Suitable for IVF256,PQ[1]x8
-// Suitable for Residual[1]x8,PQ[2]x8
 template <
         intptr_t DIM,
         intptr_t COARSE_SIZE,
         intptr_t FINE_SIZE,
+        intptr_t COARSE_BITS,
+        intptr_t FINE_BITS,
         intptr_t CPOS,
         bool FINE_SIZE_EQ_4 = FINE_SIZE == 4,
         bool QPOS_LEFT_GE_8 = (FINE_SIZE - CPOS % FINE_SIZE >= 8),
@@ -196,6 +162,8 @@ struct Index2LevelDecoderImpl;
 template <
         intptr_t DIM,
         intptr_t COARSE_SIZE,
+        intptr_t COARSE_BITS,
+        intptr_t FINE_BITS,
         intptr_t CPOS,
         bool QPOS_LEFT_GE_8,
         bool QPOS_LEFT_GE_4>
@@ -203,6 +171,8 @@ struct Index2LevelDecoderImpl<
         DIM,
         COARSE_SIZE,
         4,
+        COARSE_BITS,
+        FINE_BITS,
         CPOS,
         true,
         QPOS_LEFT_GE_8,
@@ -217,6 +187,19 @@ struct Index2LevelDecoderImpl<
 
     static constexpr intptr_t QPOS_LEFT = FINE_SIZE - fineCentroidOffset;
 
+    // coarse quantizer storage
+    static constexpr intptr_t COARSE_TABLE_BYTES = (1 << COARSE_BITS);
+
+    // coarse quantizer bytes start from 0
+    // fine quantizer bytes start from N_COARSE_ELEMENTS_BYTES
+    static constexpr intptr_t N_COARSE_ELEMENTS = DIM / COARSE_SIZE;
+    static constexpr intptr_t N_COARSE_ELEMENTS_BITS =
+            N_COARSE_ELEMENTS * COARSE_BITS;
+    static constexpr intptr_t N_COARSE_ELEMENTS_BYTES =
+            (N_COARSE_ELEMENTS_BITS + 7) / 8;
+
+    static constexpr intptr_t FINE_TABLE_BYTES = (1 << FINE_BITS);
+
     // process 1 sample
     static void store(
             const float* const __restrict pqCoarseCentroids0,
@@ -227,26 +210,26 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 4 float
         // but 8 floats per loop
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine0);
-        const intptr_t fineCode0b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0a = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 0>::get(fine0);
+        const intptr_t fineCode0b = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 1>::get(fine0);
 
         const __m256 storeValue = elementaryBlock4x2b(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + ((fineCentroidIdx + 0) * 256 + fineCode0a) * FINE_SIZE + fineCentroidOffset,
-              pqFineCentroids0 + ((fineCentroidIdx + 1) * 256 + fineCode0b) * FINE_SIZE + fineCentroidOffset);
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 0) * FINE_TABLE_BYTES + fineCode0a) * FINE_SIZE + fineCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 1) * FINE_TABLE_BYTES + fineCode0b) * FINE_SIZE + fineCentroidOffset);
 
         _mm256_storeu_ps(outputStore + CPOS, storeValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::store(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 8>::store(
               pqCoarseCentroids0, pqFineCentroids0, code0,
               outputStore);
 
@@ -264,30 +247,30 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 4 float
         // but 8 floats per loop
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine0);
-        const intptr_t fineCode0b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0a = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 0>::get(fine0);
+        const intptr_t fineCode0b = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 1>::get(fine0);
 
         __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock4x2bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + ((fineCentroidIdx + 0) * 256 + fineCode0a) * FINE_SIZE + fineCentroidOffset,
-              pqFineCentroids0 + ((fineCentroidIdx + 1) * 256 + fineCode0b) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 0) * FINE_TABLE_BYTES + fineCode0a) * FINE_SIZE + fineCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 1) * FINE_TABLE_BYTES + fineCode0b) * FINE_SIZE + fineCentroidOffset,
               weight0,
               existingValue);
 
         _mm256_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 8>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               outputAccum);
 
@@ -310,41 +293,41 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse1 = code1;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
-        const uint8_t* const __restrict fine1 = code1 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
+        const uint8_t* const __restrict fine1 = code1 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 4 float
         // but 8 floats per loop
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine0);
-        const intptr_t fineCode0b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine0);
-        const intptr_t coarseCode1 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse1);
-        const intptr_t fineCode1a = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 0>::get(fine1);
-        const intptr_t fineCode1b = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx + 1>::get(fine1);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0a = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 0>::get(fine0);
+        const intptr_t fineCode0b = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 1>::get(fine0);
+        const intptr_t coarseCode1 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse1);
+        const intptr_t fineCode1a = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 0>::get(fine1);
+        const intptr_t fineCode1b = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 1>::get(fine1);
 
         __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock4x2bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + ((fineCentroidIdx + 0) * 256 + fineCode0a) * FINE_SIZE + fineCentroidOffset,
-              pqFineCentroids0 + ((fineCentroidIdx + 1) * 256 + fineCode0b) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 0) * FINE_TABLE_BYTES + fineCode0a) * FINE_SIZE + fineCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 1) * FINE_TABLE_BYTES + fineCode0b) * FINE_SIZE + fineCentroidOffset,
               weight0,
               existingValue);
 
         existingValue = elementaryBlock4x2bAccum(
-              pqCoarseCentroids1 + (coarseCentroidIdx * 256 + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids1 + ((fineCentroidIdx + 0) * 256 + fineCode1a) * FINE_SIZE + fineCentroidOffset,
-              pqFineCentroids1 + ((fineCentroidIdx + 1) * 256 + fineCode1b) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids1 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids1 + ((fineCentroidIdx + 0) * FINE_TABLE_BYTES + fineCode1a) * FINE_SIZE + fineCentroidOffset,
+              pqFineCentroids1 + ((fineCentroidIdx + 1) * FINE_TABLE_BYTES + fineCode1b) * FINE_SIZE + fineCentroidOffset,
               weight1,
               existingValue);
 
         _mm256_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 8>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               pqCoarseCentroids1, pqFineCentroids1, code1, weight1,
               outputAccum);
@@ -353,11 +336,19 @@ struct Index2LevelDecoderImpl<
     }
 };
 
-template <intptr_t DIM, intptr_t COARSE_SIZE, intptr_t FINE_SIZE, intptr_t CPOS>
+template <
+        intptr_t DIM,
+        intptr_t COARSE_SIZE,
+        intptr_t FINE_SIZE,
+        intptr_t COARSE_BITS,
+        intptr_t FINE_BITS,
+        intptr_t CPOS>
 struct Index2LevelDecoderImpl<
         DIM,
         COARSE_SIZE,
         FINE_SIZE,
+        COARSE_BITS,
+        FINE_BITS,
         CPOS,
         false,
         true,
@@ -370,6 +361,19 @@ struct Index2LevelDecoderImpl<
 
     static constexpr intptr_t QPOS_LEFT = FINE_SIZE - fineCentroidOffset;
 
+    // coarse quantizer storage
+    static constexpr intptr_t COARSE_TABLE_BYTES = (1 << COARSE_BITS);
+
+    // coarse quantizer bytes start from 0
+    // fine quantizer bytes start from N_COARSE_ELEMENTS_BYTES
+    static constexpr intptr_t N_COARSE_ELEMENTS = DIM / COARSE_SIZE;
+    static constexpr intptr_t N_COARSE_ELEMENTS_BITS =
+            N_COARSE_ELEMENTS * COARSE_BITS;
+    static constexpr intptr_t N_COARSE_ELEMENTS_BYTES =
+            (N_COARSE_ELEMENTS_BITS + 7) / 8;
+
+    static constexpr intptr_t FINE_TABLE_BYTES = (1 << FINE_BITS);
+
     // process 1 sample
     static void store(
             const float* const __restrict pqCoarseCentroids0,
@@ -380,23 +384,23 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 8 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine0);
 
         const __m256 storeValue = elementaryBlock8x1b(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset);
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset);
 
         _mm256_storeu_ps(outputStore + CPOS, storeValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::store(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 8>::store(
               pqCoarseCentroids0, pqFineCentroids0, code0,
               outputStore);
 
@@ -414,27 +418,27 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 8 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine0);
 
         __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock8x1bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset,
               weight0,
               existingValue);
 
         _mm256_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 8>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               outputAccum);
 
@@ -457,36 +461,36 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse1 = code1;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
-        const uint8_t* const __restrict fine1 = code1 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
+        const uint8_t* const __restrict fine1 = code1 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 8 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
-        const intptr_t coarseCode1 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse1);
-        const intptr_t fineCode1 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine1);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode1 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse1);
+        const intptr_t fineCode1 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine1);
 
         __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock8x1bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset,
               weight0,
               existingValue);
 
         existingValue = elementaryBlock8x1bAccum(
-              pqCoarseCentroids1 + (coarseCentroidIdx * 256 + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids1 + (fineCentroidIdx * 256 + fineCode1) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids1 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids1 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode1) * FINE_SIZE + fineCentroidOffset,
               weight1,
               existingValue);
 
         _mm256_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 8>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 8>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               pqCoarseCentroids1, pqFineCentroids1, code1, weight1,
               outputAccum);
@@ -495,11 +499,19 @@ struct Index2LevelDecoderImpl<
     }
 };
 
-template <intptr_t DIM, intptr_t COARSE_SIZE, intptr_t FINE_SIZE, intptr_t CPOS>
+template <
+        intptr_t DIM,
+        intptr_t COARSE_SIZE,
+        intptr_t FINE_SIZE,
+        intptr_t COARSE_BITS,
+        intptr_t FINE_BITS,
+        intptr_t CPOS>
 struct Index2LevelDecoderImpl<
         DIM,
         COARSE_SIZE,
         FINE_SIZE,
+        COARSE_BITS,
+        FINE_BITS,
         CPOS,
         false,
         false,
@@ -512,6 +524,19 @@ struct Index2LevelDecoderImpl<
 
     static constexpr intptr_t QPOS_LEFT = FINE_SIZE - fineCentroidOffset;
 
+    // coarse quantizer storage
+    static constexpr intptr_t COARSE_TABLE_BYTES = (1 << COARSE_BITS);
+
+    // coarse quantizer bytes start from 0
+    // fine quantizer bytes start from N_COARSE_ELEMENTS_BYTES
+    static constexpr intptr_t N_COARSE_ELEMENTS = DIM / COARSE_SIZE;
+    static constexpr intptr_t N_COARSE_ELEMENTS_BITS =
+            N_COARSE_ELEMENTS * COARSE_BITS;
+    static constexpr intptr_t N_COARSE_ELEMENTS_BYTES =
+            (N_COARSE_ELEMENTS_BITS + 7) / 8;
+
+    static constexpr intptr_t FINE_TABLE_BYTES = (1 << FINE_BITS);
+
     // process 1 sample
     static void store(
             const float* const __restrict pqCoarseCentroids0,
@@ -522,23 +547,23 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 4 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine0);
 
         const __m128 storeValue = elementaryBlock4x1b(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset);
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset);
 
         _mm_storeu_ps(outputStore + CPOS, storeValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 4>::store(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 4>::store(
               pqCoarseCentroids0, pqFineCentroids0, code0,
               outputStore);
 
@@ -556,27 +581,27 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse0 = code0;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 4 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS,fineCentroidIdx>::get(fine0);
 
         __m128 existingValue = _mm_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock4x1bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset,
               weight0,
               existingValue);
 
         _mm_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 4>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 4>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               outputAccum);
 
@@ -599,36 +624,36 @@ struct Index2LevelDecoderImpl<
         const uint8_t* const __restrict coarse1 = code1;
 
         // fine quantizer
-        const uint8_t* const __restrict fine0 = code0 + (DIM / COARSE_SIZE);
-        const uint8_t* const __restrict fine1 = code1 + (DIM / COARSE_SIZE);
+        const uint8_t* const __restrict fine0 = code0 + N_COARSE_ELEMENTS_BYTES;
+        const uint8_t* const __restrict fine1 = code1 + N_COARSE_ELEMENTS_BYTES;
 
         // clang-format off
 
         // process chunks, 4 float
 
-        const intptr_t coarseCode0 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse0);
-        const intptr_t fineCode0 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine0);
-        const intptr_t coarseCode1 = Uint8Reader<DIM, COARSE_SIZE, coarseCentroidIdx>::get(coarse1);
-        const intptr_t fineCode1 = Uint8Reader<DIM, FINE_SIZE, fineCentroidIdx>::get(fine1);
+        const intptr_t coarseCode0 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse0);
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine0);
+        const intptr_t coarseCode1 = detail::UintReader<DIM, COARSE_SIZE, COARSE_BITS, coarseCentroidIdx>::get(coarse1);
+        const intptr_t fineCode1 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine1);
 
         __m128 existingValue = _mm_loadu_ps(outputAccum + CPOS);
 
         existingValue = elementaryBlock4x1bAccum(
-              pqCoarseCentroids0 + (coarseCentroidIdx * 256 + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids0 + (fineCentroidIdx * 256 + fineCode0) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids0 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset,
               weight0,
               existingValue);
 
         existingValue = elementaryBlock4x1bAccum(
-              pqCoarseCentroids1 + (coarseCentroidIdx * 256 + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
-              pqFineCentroids1 + (fineCentroidIdx * 256 + fineCode1) * FINE_SIZE + fineCentroidOffset,
+              pqCoarseCentroids1 + (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode1) * COARSE_SIZE + coarseCentroidOffset,
+              pqFineCentroids1 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode1) * FINE_SIZE + fineCentroidOffset,
               weight1,
               existingValue);
 
         _mm_storeu_ps(outputAccum + CPOS, existingValue);
 
         // next
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, CPOS + 4>::accum(
+        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, COARSE_BITS, FINE_BITS, CPOS + 4>::accum(
               pqCoarseCentroids0, pqFineCentroids0, code0, weight0,
               pqCoarseCentroids1, pqFineCentroids1, code1, weight1,
               outputAccum);
@@ -637,13 +662,13 @@ struct Index2LevelDecoderImpl<
     }
 };
 
-// Suitable for IVF256,PQ[1]x8
-// Suitable for Residual[1]x8,PQ[2]x8
 // This partial specialization is expected to do nothing.
 template <
         intptr_t DIM,
         intptr_t COARSE_SIZE,
         intptr_t FINE_SIZE,
+        intptr_t COARSE_BITS,
+        intptr_t FINE_BITS,
         bool FINE_SIZE_EQ_4,
         bool QPOS_LEFT_GE_8,
         bool QPOS_LEFT_GE_4>
@@ -651,6 +676,8 @@ struct Index2LevelDecoderImpl<
         DIM,
         COARSE_SIZE,
         FINE_SIZE,
+        COARSE_BITS,
+        FINE_BITS,
         DIM,
         FINE_SIZE_EQ_4,
         QPOS_LEFT_GE_8,
@@ -691,16 +718,36 @@ struct Index2LevelDecoderImpl<
 
 // Suitable for IVF256,PQ[1]x8
 // Suitable for Residual[1]x8,PQ[2]x8
-template <intptr_t DIM, intptr_t COARSE_SIZE, intptr_t FINE_SIZE>
+// Suitable for IVF[9-16 bit],PQ[1]x8 (such as IVF1024,PQ16np)
+// Suitable for Residual[1]x[9-16 bit],PQ[2]x[3] (such as Residual2x9,PQ8)
+template <
+        intptr_t DIM,
+        intptr_t COARSE_SIZE,
+        intptr_t FINE_SIZE,
+        intptr_t COARSE_BITS = 8,
+        intptr_t FINE_BITS = 8>
 struct Index2LevelDecoder {
+    static_assert(
+            COARSE_BITS == 8 || COARSE_BITS == 10 || COARSE_BITS == 16,
+            "Only 8, 10 or 16 bits are currently supported for COARSE_BITS");
+    static_assert(
+            FINE_BITS == 8 || FINE_BITS == 10 || FINE_BITS == 16,
+            "Only 8, 10 or 16 bits are currently supported for FINE_BITS");
+
     // Process 1 sample.
     static void store(
             const float* const __restrict pqCoarseCentroids,
             const float* const __restrict pqFineCentroids,
             const uint8_t* const __restrict code,
             float* const __restrict outputStore) {
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, 0>::store(
-                pqCoarseCentroids, pqFineCentroids, code, outputStore);
+        Index2LevelDecoderImpl<
+                DIM,
+                COARSE_SIZE,
+                FINE_SIZE,
+                COARSE_BITS,
+                FINE_BITS,
+                0>::
+                store(pqCoarseCentroids, pqFineCentroids, code, outputStore);
     }
 
     // Process 1 sample.
@@ -711,8 +758,18 @@ struct Index2LevelDecoder {
             const uint8_t* const __restrict code,
             const float weight,
             float* const __restrict outputAccum) {
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, 0>::accum(
-                pqCoarseCentroids, pqFineCentroids, code, weight, outputAccum);
+        Index2LevelDecoderImpl<
+                DIM,
+                COARSE_SIZE,
+                FINE_SIZE,
+                COARSE_BITS,
+                FINE_BITS,
+                0>::
+                accum(pqCoarseCentroids,
+                      pqFineCentroids,
+                      code,
+                      weight,
+                      outputAccum);
     }
 
     // process 2 samples
@@ -728,16 +785,22 @@ struct Index2LevelDecoder {
             const uint8_t* const __restrict code1,
             const float weight1,
             float* const __restrict outputAccum) {
-        Index2LevelDecoderImpl<DIM, COARSE_SIZE, FINE_SIZE, 0>::accum(
-                pqCoarseCentroids0,
-                pqFineCentroids0,
-                code0,
-                weight0,
-                pqCoarseCentroids1,
-                pqFineCentroids1,
-                code1,
-                weight1,
-                outputAccum);
+        Index2LevelDecoderImpl<
+                DIM,
+                COARSE_SIZE,
+                FINE_SIZE,
+                COARSE_BITS,
+                FINE_BITS,
+                0>::
+                accum(pqCoarseCentroids0,
+                      pqFineCentroids0,
+                      code0,
+                      weight0,
+                      pqCoarseCentroids1,
+                      pqFineCentroids1,
+                      code1,
+                      weight1,
+                      outputAccum);
     }
 };
 

--- a/faiss/cppcontrib/sa_decode/PQ-avx2-inl.h
+++ b/faiss/cppcontrib/sa_decode/PQ-avx2-inl.h
@@ -1,0 +1,613 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <immintrin.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include <faiss/cppcontrib/detail/UintReader.h>
+
+namespace faiss {
+namespace cppcontrib {
+
+////////////////////////////////////////////////////////////////////////////////////
+/// IndexPQDecoder
+////////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+// Despite the following functions are somewhat redundant, I'd like to keep the
+// overall basic blocks similar to ones from Index2LevelDecoder.
+// A compiler will optimize away the redundant code.
+
+// Processes 4 float values.
+// Returns {
+//   [0..3] = *fine[0..3];
+// }
+inline __m128 elementaryBlock4x1b(const float* const __restrict fine) {
+    // load fine
+    const __m128 fineValue = _mm_loadu_ps(fine);
+    return fineValue;
+}
+
+// Processes 4 float values.
+// Returns {
+//   [0..3] = existingValue[0..3] + weight * (*fine[0..3]);
+// }
+inline __m128 elementaryBlock4x1bAccum(
+        const float* const __restrict fine,
+        const float weight,
+        const __m128 existingValue) {
+    const __m128 fineValue = elementaryBlock4x1b(fine);
+
+    // this operation is expected to be optimized by a compiler
+    const __m128 weightAvx = _mm_set1_ps(weight);
+    // do fma
+    return _mm_fmadd_ps(fineValue, weightAvx, existingValue);
+}
+
+// Processes 8 float values.
+// Returns {
+//   [0..3] = *fine0[0..3];
+//   [4..7] = *fine1[0..3];
+// }
+inline __m256 elementaryBlock4x2b(
+        const float* const __restrict fine0,
+        const float* const __restrict fine1) {
+    // load fine
+    const __m128 fineValue0 = _mm_loadu_ps(fine0);
+    const __m128 fineValue1 = _mm_loadu_ps(fine1);
+
+    // combine two 4b into a single 8b
+    const __m256 combinedFineValue = _mm256_set_m128(fineValue1, fineValue0);
+    return combinedFineValue;
+}
+
+// Processes 8 float values.
+// Returns {
+//   [0..3] = existingValue[0..3] + weight * (*fine0[0..3]);
+//   [4..7] = existingValue[4..7] + weight * (*fine1[0..3]);
+// }
+inline __m256 elementaryBlock4x2bAccum(
+        const float* const __restrict fine0,
+        const float* const __restrict fine1,
+        const float weight,
+        const __m256 existingValue) {
+    const __m256 fineValue = elementaryBlock4x2b(fine0, fine1);
+
+    // this operation is expected to be optimized by a compiler
+    const __m256 weightAvx2 = _mm256_set1_ps(weight);
+    // do fma
+    return _mm256_fmadd_ps(fineValue, weightAvx2, existingValue);
+}
+
+// Processes 8 float values.
+// Returns {
+//   [0..7] = *fine[0..7];
+// }
+inline __m256 elementaryBlock8x1b(const float* const __restrict fine) {
+    // load fine
+    const __m256 fineValue = _mm256_loadu_ps(fine);
+    return fineValue;
+}
+
+// Processes 8 float values.
+// Returns {
+//   [0..7] = existingValue[0..7] + weight * (*fine[0..7]);
+// }
+inline __m256 elementaryBlock8x1bAccum(
+        const float* const __restrict fine,
+        const float weight,
+        const __m256 existingValue) {
+    const __m256 fineValue = elementaryBlock8x1b(fine);
+
+    // this operation is expected to be optimized by a compiler
+    const __m256 weightAvx2 = _mm256_set1_ps(weight);
+    // do fma
+    return _mm256_fmadd_ps(fineValue, weightAvx2, existingValue);
+}
+
+// The following code uses template-based for-loop unrolling,
+//   because the compiler does not do that on its own as needed.
+// The idea is the following:
+//   template<int I, int MAX>
+//   struct Foo {
+//     static void bar() {
+//       doSomething(I);
+//       Foo<I + 1, MAX>::bar();
+//     }
+//   };
+//
+//   template<int MAX>
+//   struct Foo<MAX, MAX> {
+//     static void bar() {}
+//   };
+//
+//   Initiate the loop:
+//     Foo<0, MAX>::bar();
+
+template <
+        intptr_t DIM,
+        intptr_t FINE_SIZE,
+        intptr_t FINE_BITS,
+        intptr_t CPOS,
+        bool FINE_SIZE_EQ_4 = FINE_SIZE == 4,
+        bool QPOS_LEFT_GE_8 = (FINE_SIZE - CPOS % FINE_SIZE >= 8),
+        bool QPOS_LEFT_GE_4 = (FINE_SIZE - CPOS % FINE_SIZE >= 4),
+        bool DIM_EQ_CPOS = DIM == CPOS>
+struct IndexPQDecoderImpl;
+
+template <
+        intptr_t DIM,
+        intptr_t FINE_BITS,
+        intptr_t CPOS,
+        bool QPOS_LEFT_GE_8,
+        bool QPOS_LEFT_GE_4>
+struct IndexPQDecoderImpl<
+        DIM,
+        4,
+        FINE_BITS,
+        CPOS,
+        true,
+        QPOS_LEFT_GE_8,
+        QPOS_LEFT_GE_4,
+        false> {
+    static constexpr intptr_t FINE_SIZE = 4;
+
+    static constexpr intptr_t fineCentroidIdx = CPOS / FINE_SIZE;
+    static constexpr intptr_t fineCentroidOffset = CPOS % FINE_SIZE;
+
+    static constexpr intptr_t QPOS_LEFT = FINE_SIZE - fineCentroidOffset;
+
+    static constexpr intptr_t FINE_TABLE_BYTES = (1 << FINE_BITS);
+
+    // process 1 sample
+    static void store(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            float* const __restrict outputStore) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+
+        // clang-format off
+
+        // process chunks, 4 float
+        // but 8 floats per loop
+
+        const intptr_t fineCode0a = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 0>::get(fine0);
+        const intptr_t fineCode0b = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 1>::get(fine0);
+
+        const __m256 storeValue = elementaryBlock4x2b(
+              pqFineCentroids0 + ((fineCentroidIdx + 0) * FINE_TABLE_BYTES + fineCode0a) * FINE_SIZE + fineCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 1) * FINE_TABLE_BYTES + fineCode0b) * FINE_SIZE + fineCentroidOffset);
+
+        _mm256_storeu_ps(outputStore + CPOS, storeValue);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 8>::store(
+              pqFineCentroids0, code0, outputStore);
+
+        // clang-format on
+    }
+
+    // process 1 sample
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            float* const __restrict outputAccum) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+
+        // clang-format off
+
+        // process chunks, 4 float
+        // but 8 floats per loop
+
+        const intptr_t fineCode0a = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 0>::get(fine0);
+        const intptr_t fineCode0b = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 1>::get(fine0);
+
+        __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
+
+        existingValue = elementaryBlock4x2bAccum(
+              pqFineCentroids0 + ((fineCentroidIdx + 0) * FINE_TABLE_BYTES + fineCode0a) * FINE_SIZE + fineCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 1) * FINE_TABLE_BYTES + fineCode0b) * FINE_SIZE + fineCentroidOffset,
+              weight0,
+              existingValue);
+
+        _mm256_storeu_ps(outputAccum + CPOS, existingValue);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 8>::accum(
+              pqFineCentroids0, code0, weight0, outputAccum);
+
+        // clang-format on
+    }
+
+    // process 2 samples
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            const float* const __restrict pqFineCentroids1,
+            const uint8_t* const __restrict code1,
+            const float weight1,
+            float* const __restrict outputAccum) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+        const uint8_t* const __restrict fine1 = code1;
+
+        // clang-format off
+
+        // process chunks, 4 float
+        // but 8 floats per loop
+
+        const intptr_t fineCode0a = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 0>::get(fine0);
+        const intptr_t fineCode0b = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 1>::get(fine0);
+        const intptr_t fineCode1a = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 0>::get(fine1);
+        const intptr_t fineCode1b = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 1>::get(fine1);
+
+        __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
+
+        existingValue = elementaryBlock4x2bAccum(
+              pqFineCentroids0 + ((fineCentroidIdx + 0) * FINE_TABLE_BYTES + fineCode0a) * FINE_SIZE + fineCentroidOffset,
+              pqFineCentroids0 + ((fineCentroidIdx + 1) * FINE_TABLE_BYTES + fineCode0b) * FINE_SIZE + fineCentroidOffset,
+              weight0,
+              existingValue);
+
+        existingValue = elementaryBlock4x2bAccum(
+              pqFineCentroids1 + ((fineCentroidIdx + 0) * FINE_TABLE_BYTES + fineCode1a) * FINE_SIZE + fineCentroidOffset,
+              pqFineCentroids1 + ((fineCentroidIdx + 1) * FINE_TABLE_BYTES + fineCode1b) * FINE_SIZE + fineCentroidOffset,
+              weight1,
+              existingValue);
+
+        _mm256_storeu_ps(outputAccum + CPOS, existingValue);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 8>::accum(
+              pqFineCentroids0, code0, weight0,
+              pqFineCentroids1, code1, weight1,
+              outputAccum);
+
+        // clang-format on
+    }
+};
+
+template <intptr_t DIM, intptr_t FINE_SIZE, intptr_t FINE_BITS, intptr_t CPOS>
+struct IndexPQDecoderImpl<
+        DIM,
+        FINE_SIZE,
+        FINE_BITS,
+        CPOS,
+        false,
+        true,
+        true,
+        false> {
+    static constexpr intptr_t fineCentroidIdx = CPOS / FINE_SIZE;
+    static constexpr intptr_t fineCentroidOffset = CPOS % FINE_SIZE;
+
+    static constexpr intptr_t QPOS_LEFT = FINE_SIZE - fineCentroidOffset;
+
+    static constexpr intptr_t FINE_TABLE_BYTES = (1 << FINE_BITS);
+
+    // process 1 sample
+    static void store(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            float* const __restrict outputStore) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+
+        // clang-format off
+
+        // process chunks, 8 float
+
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine0);
+
+        const __m256 storeValue = elementaryBlock8x1b(
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset);
+
+        _mm256_storeu_ps(outputStore + CPOS, storeValue);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 8>::store(
+              pqFineCentroids0, code0, outputStore);
+
+        // clang-format on
+    }
+
+    // process 1 sample
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            float* const __restrict outputAccum) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+
+        // clang-format off
+
+        // process chunks, 8 float
+
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine0);
+
+        __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
+
+        existingValue = elementaryBlock8x1bAccum(
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset,
+              weight0,
+              existingValue);
+
+        _mm256_storeu_ps(outputAccum + CPOS, existingValue);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 8>::accum(
+              pqFineCentroids0, code0, weight0, outputAccum);
+
+        // clang-format on
+    }
+
+    // process 2 samples
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            const float* const __restrict pqFineCentroids1,
+            const uint8_t* const __restrict code1,
+            const float weight1,
+            float* const __restrict outputAccum) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+        const uint8_t* const __restrict fine1 = code1;
+
+        // clang-format off
+
+        // process chunks, 8 float
+
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine0);
+        const intptr_t fineCode1 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine1);
+
+        __m256 existingValue = _mm256_loadu_ps(outputAccum + CPOS);
+
+        existingValue = elementaryBlock8x1bAccum(
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset,
+              weight0,
+              existingValue);
+
+        existingValue = elementaryBlock8x1bAccum(
+              pqFineCentroids1 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode1) * FINE_SIZE + fineCentroidOffset,
+              weight1,
+              existingValue);
+
+        _mm256_storeu_ps(outputAccum + CPOS, existingValue);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 8>::accum(
+              pqFineCentroids0, code0, weight0,
+              pqFineCentroids1, code1, weight1,
+              outputAccum);
+
+        // clang-format on
+    }
+};
+
+template <intptr_t DIM, intptr_t FINE_SIZE, intptr_t FINE_BITS, intptr_t CPOS>
+struct IndexPQDecoderImpl<
+        DIM,
+        FINE_SIZE,
+        FINE_BITS,
+        CPOS,
+        false,
+        false,
+        true,
+        false> {
+    static constexpr intptr_t fineCentroidIdx = CPOS / FINE_SIZE;
+    static constexpr intptr_t fineCentroidOffset = CPOS % FINE_SIZE;
+
+    static constexpr intptr_t QPOS_LEFT = FINE_SIZE - fineCentroidOffset;
+
+    static constexpr intptr_t FINE_TABLE_BYTES = (1 << FINE_BITS);
+
+    // process 1 sample
+    static void store(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            float* const __restrict outputStore) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+
+        // clang-format off
+
+        // process chunks, 4 float
+
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine0);
+
+        const __m128 storeValue = elementaryBlock4x1b(
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset);
+
+        _mm_storeu_ps(outputStore + CPOS, storeValue);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 4>::store(
+              pqFineCentroids0, code0, outputStore);
+
+        // clang-format on
+    }
+
+    // process 1 sample
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            float* const __restrict outputAccum) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+
+        // clang-format off
+
+        // process chunks, 4 float
+
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine0);
+
+        __m128 existingValue = _mm_loadu_ps(outputAccum + CPOS);
+
+        existingValue = elementaryBlock4x1bAccum(
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset,
+              weight0,
+              existingValue);
+
+        _mm_storeu_ps(outputAccum + CPOS, existingValue);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 4>::accum(
+              pqFineCentroids0, code0, weight0, outputAccum);
+
+        // clang-format on
+    }
+
+    // process 2 samples
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            const float* const __restrict pqFineCentroids1,
+            const uint8_t* const __restrict code1,
+            const float weight1,
+            float* const __restrict outputAccum) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+        const uint8_t* const __restrict fine1 = code1;
+
+        // clang-format off
+
+        // process chunks, 4 float
+
+        const intptr_t fineCode0 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine0);
+        const intptr_t fineCode1 = detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::get(fine1);
+
+        __m128 existingValue = _mm_loadu_ps(outputAccum + CPOS);
+
+        existingValue = elementaryBlock4x1bAccum(
+              pqFineCentroids0 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE + fineCentroidOffset,
+              weight0,
+              existingValue);
+
+        existingValue = elementaryBlock4x1bAccum(
+              pqFineCentroids1 + (fineCentroidIdx * FINE_TABLE_BYTES + fineCode1) * FINE_SIZE + fineCentroidOffset,
+              weight1,
+              existingValue);
+
+        _mm_storeu_ps(outputAccum + CPOS, existingValue);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 4>::accum(
+              pqFineCentroids0, code0, weight0,
+              pqFineCentroids1, code1, weight1,
+              outputAccum);
+
+        // clang-format on
+    }
+};
+
+// This partial specialization is expected to do nothing.
+template <
+        intptr_t DIM,
+        intptr_t FINE_SIZE,
+        intptr_t FINE_BITS,
+        bool FINE_SIZE_EQ_4,
+        bool QPOS_LEFT_GE_8,
+        bool QPOS_LEFT_GE_4>
+struct IndexPQDecoderImpl<
+        DIM,
+        FINE_SIZE,
+        FINE_BITS,
+        DIM,
+        FINE_SIZE_EQ_4,
+        QPOS_LEFT_GE_8,
+        QPOS_LEFT_GE_4,
+        true> {
+    // clang-format off
+
+    // process 1 sample
+    static void store(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            float* const __restrict outputStore) {}
+
+    // process 1 sample
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            float* const __restrict outputAccum) {}
+
+    // process 2 samples
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            const float* const __restrict pqFineCentroids1,
+            const uint8_t* const __restrict code1,
+            const float weight1,
+            float* const __restrict outputAccum) {}
+
+    // clang-format on
+};
+
+} // namespace
+
+// Suitable for PQ[1]x8
+// Suitable for PQ[1]x10
+// Suitable for PQ[1]x16
+template <intptr_t DIM, intptr_t FINE_SIZE, intptr_t FINE_BITS = 8>
+struct IndexPQDecoder {
+    static_assert(
+            FINE_BITS == 8 || FINE_BITS == 10 || FINE_BITS == 16,
+            "Only 8, 10 or 16 bits are currently supported for FINE_BITS");
+
+    // Process 1 sample.
+    static void store(
+            const float* const __restrict pqFineCentroids,
+            const uint8_t* const __restrict code,
+            float* const __restrict outputStore) {
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, 0>::store(
+                pqFineCentroids, code, outputStore);
+    }
+
+    // Process 1 sample.
+    // Performs outputAccum += weight * decoded(code)
+    static void accum(
+            const float* const __restrict pqFineCentroids,
+            const uint8_t* const __restrict code,
+            const float weight,
+            float* const __restrict outputAccum) {
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, 0>::accum(
+                pqFineCentroids, code, weight, outputAccum);
+    }
+
+    // process 2 samples
+    // Performs outputAccum += weight0 * decoded(code0) + weight1 *
+    //   decoded(code1)
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            const float* const __restrict pqFineCentroids1,
+            const uint8_t* const __restrict code1,
+            const float weight1,
+            float* const __restrict outputAccum) {
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, 0>::accum(
+                pqFineCentroids0,
+                code0,
+                weight0,
+                pqFineCentroids1,
+                code1,
+                weight1,
+                outputAccum);
+    }
+};
+
+} // namespace cppcontrib
+} // namespace faiss

--- a/faiss/cppcontrib/sa_decode/PQ-neon-inl.h
+++ b/faiss/cppcontrib/sa_decode/PQ-neon-inl.h
@@ -1,0 +1,687 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <arm_neon.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include <faiss/cppcontrib/detail/UintReader.h>
+
+namespace faiss {
+namespace cppcontrib {
+
+////////////////////////////////////////////////////////////////////////////////////
+/// IndexPQDecoder
+////////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+// Despite the following functions are somewhat redundant, I'd like to keep the
+// overall basic blocks similar to ones from Index2LevelDecoder.
+// A compiler will optimize away the redundant code.
+
+// Processes 4 float values.
+// Returns {
+//   [0..3] = *fine[0..3];
+// }
+inline float32x4_t elementaryBlock4x1b(const float* const __restrict fine) {
+    // load fine
+    const auto fineValue = vld1q_f32(fine);
+    return fineValue;
+}
+
+// Processes 4 float values.
+// Returns {
+//   [0..3] = existingValue[0..3] + weight * (*fine[0..3]);
+// }
+inline float32x4_t elementaryBlock4x1bAccum(
+        const float* const __restrict fine,
+        const float weight,
+        const float32x4_t existingValue) {
+    const auto fineValue = elementaryBlock4x1b(fine);
+
+    // this operation is expected to be optimized by a compiler
+    const auto weightNeon = vdupq_n_f32(weight);
+    // do fma
+    return vfmaq_f32(existingValue, weightNeon, fineValue);
+}
+
+// Processes 8 float values.
+// Returns {
+//   [0..3] = *fine0[0..3];
+//   [4..7] = *fine1[0..3];
+// }
+inline float32x4x2_t elementaryBlock4x2b(
+        const float* const __restrict fine0,
+        const float* const __restrict fine1) {
+    // load fine
+    const auto fineValue0 = vld1q_f32(fine0);
+    const auto fineValue1 = vld1q_f32(fine1);
+
+    return {fineValue0, fineValue1};
+}
+
+// Processes 8 float values.
+// Returns {
+//   [0..3] = existingValue[0..3] + weight * (*fine0[0..3]);
+//   [4..7] = existingValue[4..7] + weight * (*fine1[0..3]);
+// }
+inline float32x4x2_t elementaryBlock4x2bAccum(
+        const float* const __restrict fine0,
+        const float* const __restrict fine1,
+        const float weight,
+        const float32x4x2_t existingValue) {
+    const auto fineValue = elementaryBlock4x2b(fine0, fine1);
+
+    // this operation is expected to be optimized by a compiler
+    const auto weightNeon = vdupq_n_f32(weight);
+    // do fma
+    const auto result0 =
+            vfmaq_f32(existingValue.val[0], weightNeon, fineValue.val[0]);
+    const auto result1 =
+            vfmaq_f32(existingValue.val[1], weightNeon, fineValue.val[1]);
+    return {result0, result1};
+}
+
+// Processes 8 float values.
+// Returns {
+//   [0..7] = *fine[0..7];
+// }
+inline float32x4x2_t elementaryBlock8x1b(const float* const __restrict fine) {
+    // load fine
+    const auto fineValue0 = vld1q_f32(fine);
+    const auto fineValue1 = vld1q_f32(fine + 4);
+    return {fineValue0, fineValue1};
+}
+
+// Processes 8 float values.
+// Returns {
+//   [0..7] = existingValue[0..7] + weight * (*fine[0..7]);
+// }
+inline float32x4x2_t elementaryBlock8x1bAccum(
+        const float* const __restrict fine,
+        const float weight,
+        const float32x4x2_t existingValue) {
+    const auto fineValue = elementaryBlock8x1b(fine);
+
+    // this operation is expected to be optimized by a compiler
+    const auto weightNeon = vdupq_n_f32(weight);
+    // do fma
+    const auto result0 =
+            vfmaq_f32(existingValue.val[0], weightNeon, fineValue.val[0]);
+    const auto result1 =
+            vfmaq_f32(existingValue.val[1], weightNeon, fineValue.val[1]);
+    return {result0, result1};
+}
+
+// The following code uses template-based for-loop unrolling,
+//   because the compiler does not do that on its own as needed.
+// The idea is the following:
+//   template<int I, int MAX>
+//   struct Foo {
+//     static void bar() {
+//       doSomething(I);
+//       Foo<I + 1, MAX>::bar();
+//     }
+//   };
+//
+//   template<int MAX>
+//   struct Foo<MAX, MAX> {
+//     static void bar() {}
+//   };
+//
+//   Initiate the loop:
+//     Foo<0, MAX>::bar();
+
+template <
+        intptr_t DIM,
+        intptr_t FINE_SIZE,
+        intptr_t FINE_BITS,
+        intptr_t CPOS,
+        bool FINE_SIZE_EQ_4 = FINE_SIZE == 4,
+        bool QPOS_LEFT_GE_8 = (FINE_SIZE - CPOS % FINE_SIZE >= 8),
+        bool QPOS_LEFT_GE_4 = (FINE_SIZE - CPOS % FINE_SIZE >= 4),
+        bool DIM_EQ_CPOS = DIM == CPOS>
+struct IndexPQDecoderImpl;
+
+template <
+        intptr_t DIM,
+        intptr_t CPOS,
+        intptr_t FINE_BITS,
+        bool QPOS_LEFT_GE_8,
+        bool QPOS_LEFT_GE_4>
+struct IndexPQDecoderImpl<
+        DIM,
+        4,
+        FINE_BITS,
+        CPOS,
+        true,
+        QPOS_LEFT_GE_8,
+        QPOS_LEFT_GE_4,
+        false> {
+    static constexpr intptr_t FINE_SIZE = 4;
+
+    static constexpr intptr_t fineCentroidIdx = CPOS / FINE_SIZE;
+    static constexpr intptr_t fineCentroidOffset = CPOS % FINE_SIZE;
+
+    static constexpr intptr_t QPOS_LEFT = FINE_SIZE - fineCentroidOffset;
+
+    static constexpr intptr_t FINE_TABLE_BYTES = (1 << FINE_BITS);
+
+    // process 1 sample
+    static void store(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            float* const __restrict outputStore) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+
+        // process chunks, 4 float
+        // but 8 floats per loop
+
+        const intptr_t fineCode0a = detail::
+                UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 0>::get(
+                        fine0);
+        const intptr_t fineCode0b = detail::
+                UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 1>::get(
+                        fine0);
+
+        const auto storeValue = elementaryBlock4x2b(
+                pqFineCentroids0 +
+                        ((fineCentroidIdx + 0) * FINE_TABLE_BYTES +
+                         fineCode0a) *
+                                FINE_SIZE +
+                        fineCentroidOffset,
+                pqFineCentroids0 +
+                        ((fineCentroidIdx + 1) * FINE_TABLE_BYTES +
+                         fineCode0b) *
+                                FINE_SIZE +
+                        fineCentroidOffset);
+
+        vst1q_f32(outputStore + CPOS, storeValue.val[0]);
+        vst1q_f32(outputStore + CPOS + 4, storeValue.val[1]);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 8>::store(
+                pqFineCentroids0, code0, outputStore);
+    }
+
+    // process 1 sample
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            float* const __restrict outputAccum) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+
+        // process chunks, 4 float
+        // but 8 floats per loop
+
+        const intptr_t fineCode0a = detail::
+                UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 0>::get(
+                        fine0);
+        const intptr_t fineCode0b = detail::
+                UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 1>::get(
+                        fine0);
+
+        auto existingValue0 = vld1q_f32(outputAccum + CPOS);
+        auto existingValue1 = vld1q_f32(outputAccum + CPOS + 4);
+
+        auto existingValue = elementaryBlock4x2bAccum(
+                pqFineCentroids0 +
+                        ((fineCentroidIdx + 0) * FINE_TABLE_BYTES +
+                         fineCode0a) *
+                                FINE_SIZE +
+                        fineCentroidOffset,
+                pqFineCentroids0 +
+                        ((fineCentroidIdx + 1) * FINE_TABLE_BYTES +
+                         fineCode0b) *
+                                FINE_SIZE +
+                        fineCentroidOffset,
+                weight0,
+                {existingValue0, existingValue1});
+
+        vst1q_f32(outputAccum + CPOS, existingValue.val[0]);
+        vst1q_f32(outputAccum + CPOS + 4, existingValue.val[1]);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 8>::accum(
+                pqFineCentroids0, code0, weight0, outputAccum);
+    }
+
+    // process 2 samples
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            const float* const __restrict pqFineCentroids1,
+            const uint8_t* const __restrict code1,
+            const float weight1,
+            float* const __restrict outputAccum) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+        const uint8_t* const __restrict fine1 = code1;
+
+        // process chunks, 4 float
+        // but 8 floats per loop
+
+        const intptr_t fineCode0a = detail::
+                UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 0>::get(
+                        fine0);
+        const intptr_t fineCode0b = detail::
+                UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 1>::get(
+                        fine0);
+        const intptr_t fineCode1a = detail::
+                UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 0>::get(
+                        fine1);
+        const intptr_t fineCode1b = detail::
+                UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx + 1>::get(
+                        fine1);
+
+        auto existingValue0 = vld1q_f32(outputAccum + CPOS);
+        auto existingValue1 = vld1q_f32(outputAccum + CPOS + 4);
+
+        auto existingValue = elementaryBlock4x2bAccum(
+                pqFineCentroids0 +
+                        ((fineCentroidIdx + 0) * FINE_TABLE_BYTES +
+                         fineCode0a) *
+                                FINE_SIZE +
+                        fineCentroidOffset,
+                pqFineCentroids0 +
+                        ((fineCentroidIdx + 1) * FINE_TABLE_BYTES +
+                         fineCode0b) *
+                                FINE_SIZE +
+                        fineCentroidOffset,
+                weight0,
+                {existingValue0, existingValue1});
+
+        existingValue = elementaryBlock4x2bAccum(
+                pqFineCentroids1 +
+                        ((fineCentroidIdx + 0) * FINE_TABLE_BYTES +
+                         fineCode1a) *
+                                FINE_SIZE +
+                        fineCentroidOffset,
+                pqFineCentroids1 +
+                        ((fineCentroidIdx + 1) * FINE_TABLE_BYTES +
+                         fineCode1b) *
+                                FINE_SIZE +
+                        fineCentroidOffset,
+                weight1,
+                existingValue);
+
+        vst1q_f32(outputAccum + CPOS, existingValue.val[0]);
+        vst1q_f32(outputAccum + CPOS + 4, existingValue.val[1]);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 8>::accum(
+                pqFineCentroids0,
+                code0,
+                weight0,
+                pqFineCentroids1,
+                code1,
+                weight1,
+                outputAccum);
+    }
+};
+
+template <intptr_t DIM, intptr_t FINE_SIZE, intptr_t FINE_BITS, intptr_t CPOS>
+struct IndexPQDecoderImpl<
+        DIM,
+        FINE_SIZE,
+        FINE_BITS,
+        CPOS,
+        false,
+        true,
+        true,
+        false> {
+    static constexpr intptr_t fineCentroidIdx = CPOS / FINE_SIZE;
+    static constexpr intptr_t fineCentroidOffset = CPOS % FINE_SIZE;
+
+    static constexpr intptr_t QPOS_LEFT = FINE_SIZE - fineCentroidOffset;
+
+    static constexpr intptr_t FINE_TABLE_BYTES = (1 << FINE_BITS);
+
+    // process 1 sample
+    static void store(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            float* const __restrict outputStore) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+
+        // process chunks, 8 float
+
+        const intptr_t fineCode0 =
+                detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::
+                        get(fine0);
+
+        const auto storeValue = elementaryBlock8x1b(
+                pqFineCentroids0 +
+                (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE +
+                fineCentroidOffset);
+
+        vst1q_f32(outputStore + CPOS, storeValue.val[0]);
+        vst1q_f32(outputStore + CPOS + 4, storeValue.val[1]);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 8>::store(
+                pqFineCentroids0, code0, outputStore);
+    }
+
+    // process 1 sample
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            float* const __restrict outputAccum) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+
+        // process chunks, 8 float
+
+        const intptr_t fineCode0 =
+                detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::
+                        get(fine0);
+
+        const auto existingValue0 = vld1q_f32(outputAccum + CPOS);
+        const auto existingValue1 = vld1q_f32(outputAccum + CPOS + 4);
+
+        const auto existingValue = elementaryBlock8x1bAccum(
+                pqFineCentroids0 +
+                        (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) *
+                                FINE_SIZE +
+                        fineCentroidOffset,
+                weight0,
+                {existingValue0, existingValue1});
+
+        vst1q_f32(outputAccum + CPOS, existingValue.val[0]);
+        vst1q_f32(outputAccum + CPOS + 4, existingValue.val[1]);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 8>::accum(
+                pqFineCentroids0, code0, weight0, outputAccum);
+    }
+
+    // process 2 samples
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            const float* const __restrict pqFineCentroids1,
+            const uint8_t* const __restrict code1,
+            const float weight1,
+            float* const __restrict outputAccum) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+        const uint8_t* const __restrict fine1 = code1;
+
+        // process chunks, 8 float
+
+        const intptr_t fineCode0 =
+                detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::
+                        get(fine0);
+        const intptr_t fineCode1 =
+                detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::
+                        get(fine1);
+
+        const auto existingValue0 = vld1q_f32(outputAccum + CPOS);
+        const auto existingValue1 = vld1q_f32(outputAccum + CPOS + 4);
+
+        auto existingValue = elementaryBlock8x1bAccum(
+                pqFineCentroids0 +
+                        (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) *
+                                FINE_SIZE +
+                        fineCentroidOffset,
+                weight0,
+                {existingValue0, existingValue1});
+
+        existingValue = elementaryBlock8x1bAccum(
+                pqFineCentroids1 +
+                        (fineCentroidIdx * FINE_TABLE_BYTES + fineCode1) *
+                                FINE_SIZE +
+                        fineCentroidOffset,
+                weight1,
+                existingValue);
+
+        vst1q_f32(outputAccum + CPOS, existingValue.val[0]);
+        vst1q_f32(outputAccum + CPOS + 4, existingValue.val[1]);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 8>::accum(
+                pqFineCentroids0,
+                code0,
+                weight0,
+                pqFineCentroids1,
+                code1,
+                weight1,
+                outputAccum);
+    }
+};
+
+template <intptr_t DIM, intptr_t FINE_SIZE, intptr_t FINE_BITS, intptr_t CPOS>
+struct IndexPQDecoderImpl<
+        DIM,
+        FINE_SIZE,
+        FINE_BITS,
+        CPOS,
+        false,
+        false,
+        true,
+        false> {
+    static constexpr intptr_t fineCentroidIdx = CPOS / FINE_SIZE;
+    static constexpr intptr_t fineCentroidOffset = CPOS % FINE_SIZE;
+
+    static constexpr intptr_t QPOS_LEFT = FINE_SIZE - fineCentroidOffset;
+
+    static constexpr intptr_t FINE_TABLE_BYTES = (1 << FINE_BITS);
+
+    // process 1 sample
+    static void store(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            float* const __restrict outputStore) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+
+        // process chunks, 4 float
+
+        const intptr_t fineCode0 =
+                detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::
+                        get(fine0);
+
+        const auto storeValue = elementaryBlock4x1b(
+                pqFineCentroids0 +
+                (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) * FINE_SIZE +
+                fineCentroidOffset);
+
+        vst1q_f32(outputStore + CPOS, storeValue);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 4>::store(
+                pqFineCentroids0, code0, outputStore);
+    }
+
+    // process 1 sample
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            float* const __restrict outputAccum) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+
+        // process chunks, 4 float
+
+        const intptr_t fineCode0 =
+                detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::
+                        get(fine0);
+
+        auto existingValue = vld1q_f32(outputAccum + CPOS);
+
+        existingValue = elementaryBlock4x1bAccum(
+                pqFineCentroids0 +
+                        (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) *
+                                FINE_SIZE +
+                        fineCentroidOffset,
+                weight0,
+                existingValue);
+
+        vst1q_f32(outputAccum + CPOS, existingValue);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 4>::accum(
+                pqFineCentroids0, code0, weight0, outputAccum);
+    }
+
+    // process 2 samples
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            const float* const __restrict pqFineCentroids1,
+            const uint8_t* const __restrict code1,
+            const float weight1,
+            float* const __restrict outputAccum) {
+        // fine quantizer
+        const uint8_t* const __restrict fine0 = code0;
+        const uint8_t* const __restrict fine1 = code1;
+
+        // process chunks, 4 float
+
+        const intptr_t fineCode0 =
+                detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::
+                        get(fine0);
+        const intptr_t fineCode1 =
+                detail::UintReader<DIM, FINE_SIZE, FINE_BITS, fineCentroidIdx>::
+                        get(fine1);
+
+        auto existingValue = vld1q_f32(outputAccum + CPOS);
+
+        existingValue = elementaryBlock4x1bAccum(
+                pqFineCentroids0 +
+                        (fineCentroidIdx * FINE_TABLE_BYTES + fineCode0) *
+                                FINE_SIZE +
+                        fineCentroidOffset,
+                weight0,
+                existingValue);
+
+        existingValue = elementaryBlock4x1bAccum(
+                pqFineCentroids1 +
+                        (fineCentroidIdx * FINE_TABLE_BYTES + fineCode1) *
+                                FINE_SIZE +
+                        fineCentroidOffset,
+                weight1,
+                existingValue);
+
+        vst1q_f32(outputAccum + CPOS, existingValue);
+
+        // next
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, CPOS + 4>::accum(
+                pqFineCentroids0,
+                code0,
+                weight0,
+                pqFineCentroids1,
+                code1,
+                weight1,
+                outputAccum);
+    }
+};
+
+// This partial specialization is expected to do nothing.
+template <
+        intptr_t DIM,
+        intptr_t FINE_SIZE,
+        intptr_t FINE_BITS,
+        bool FINE_SIZE_EQ_4,
+        bool QPOS_LEFT_GE_8,
+        bool QPOS_LEFT_GE_4>
+struct IndexPQDecoderImpl<
+        DIM,
+        FINE_SIZE,
+        FINE_BITS,
+        DIM,
+        FINE_SIZE_EQ_4,
+        QPOS_LEFT_GE_8,
+        QPOS_LEFT_GE_4,
+        true> {
+    // process 1 sample
+    static void store(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            float* const __restrict outputStore) {}
+
+    // process 1 sample
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            float* const __restrict outputAccum) {}
+
+    // process 2 samples
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            const float* const __restrict pqFineCentroids1,
+            const uint8_t* const __restrict code1,
+            const float weight1,
+            float* const __restrict outputAccum) {}
+};
+} // namespace
+
+// Suitable for PQ[1]x8
+// Suitable for PQ[1]x10
+// Suitable for PQ[1]x16
+template <intptr_t DIM, intptr_t FINE_SIZE, intptr_t FINE_BITS = 8>
+struct IndexPQDecoder {
+    static_assert(
+            FINE_BITS == 8 || FINE_BITS == 10 || FINE_BITS == 16,
+            "Only 8, 10 or 16 bits are currently supported for FINE_BITS");
+
+    // Process 1 sample.
+    static void store(
+            const float* const __restrict pqFineCentroids,
+            const uint8_t* const __restrict code,
+            float* const __restrict outputStore) {
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, 0>::store(
+                pqFineCentroids, code, outputStore);
+    }
+
+    // Process 1 sample.
+    // Performs outputAccum += weight * decoded(code)
+    static void accum(
+            const float* const __restrict pqFineCentroids,
+            const uint8_t* const __restrict code,
+            const float weight,
+            float* const __restrict outputAccum) {
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, 0>::accum(
+                pqFineCentroids, code, weight, outputAccum);
+    }
+
+    // process 2 samples
+    // Performs outputAccum += weight0 * decoded(code0) + weight1 *
+    // decoded(code1)
+    static void accum(
+            const float* const __restrict pqFineCentroids0,
+            const uint8_t* const __restrict code0,
+            const float weight0,
+            const float* const __restrict pqFineCentroids1,
+            const uint8_t* const __restrict code1,
+            const float weight1,
+            float* const __restrict outputAccum) {
+        IndexPQDecoderImpl<DIM, FINE_SIZE, FINE_BITS, 0>::accum(
+                pqFineCentroids0,
+                code0,
+                weight0,
+                pqFineCentroids1,
+                code1,
+                weight1,
+                outputAccum);
+    }
+};
+
+} // namespace cppcontrib
+} // namespace faiss

--- a/tests/test_cppcontrib_sa_decode.cpp
+++ b/tests/test_cppcontrib_sa_decode.cpp
@@ -203,6 +203,109 @@ void verifyIndex2LevelDecoder(
     }
 }
 
+template <typename T>
+void verifyIndexPQDecoder(
+        const uint64_t n,
+        const uint64_t d,
+        const std::shared_ptr<faiss::Index>& index,
+        const std::vector<uint8_t>& encodedData) {
+    //
+    faiss::IndexPQ* const indexQ = dynamic_cast<faiss::IndexPQ*>(index.get());
+    const float* const pqFineCentroidsQ = indexQ->pq.centroids.data();
+
+    //
+    const size_t codeSize = index->sa_code_size();
+
+    //
+    std::default_random_engine rng(123);
+    std::uniform_real_distribution<float> u(0, 1);
+
+    // test general purpose version vs contrib::store
+    std::vector<float> outputFaiss(d, 0);
+    std::vector<float> tmpFaiss(d, 0);
+    std::vector<float> tmpContrib(d, 0);
+    for (size_t i = 0; i < n; i++) {
+        // compute using faiss
+        index->sa_decode(1, encodedData.data() + i * codeSize, tmpFaiss.data());
+
+        // compute using contrib
+        T::store(
+                pqFineCentroidsQ,
+                encodedData.data() + i * codeSize,
+                tmpContrib.data());
+
+        // compare
+        for (size_t j = 0; j < d; j++)
+            ASSERT_FLOAT_EQ(tmpFaiss[j], tmpContrib[j]);
+
+        // save for the further comparison
+        const float weight = u(rng);
+        for (size_t j = 0; j < d; j++)
+            outputFaiss[j] += weight * tmpFaiss[j];
+    }
+
+    // test contrib::accum, 1 sample per iteration
+    rng.seed(123);
+
+    std::vector<float> outputContrib1s(d, 0);
+    for (size_t i = 0; i < n; i++) {
+        const float weight0 = u(rng);
+
+        T::accum(
+                pqFineCentroidsQ,
+                encodedData.data() + (i + 0) * codeSize,
+                weight0,
+                outputContrib1s.data());
+    }
+
+    // verify
+    for (size_t j = 0; j < d; j++) {
+        ASSERT_FLOAT_EQ(outputFaiss[j], outputContrib1s[j]);
+    }
+
+    // test contrib::accum, 2 samples per iteration.
+    rng.seed(123);
+
+    std::vector<float> outputContrib2s(d, 0);
+    for (size_t i = 0; i < n; i += 2) {
+        // populate outputContribs with some existing data
+        for (size_t j = 0; j < d; j++) {
+            outputContrib1s[j] = (j + 1) * (j + 1);
+            outputContrib2s[j] = (j + 1) * (j + 1);
+        }
+
+        // do a single step, 2 samples per step
+        const float weight0 = u(rng);
+        const float weight1 = u(rng);
+
+        T::accum(
+                pqFineCentroidsQ,
+                encodedData.data() + (i + 0) * codeSize,
+                weight0,
+                pqFineCentroidsQ,
+                encodedData.data() + (i + 1) * codeSize,
+                weight1,
+                outputContrib2s.data());
+
+        // do two steps, 1 sample per step
+        T::accum(
+                pqFineCentroidsQ,
+                encodedData.data() + (i + 0) * codeSize,
+                weight0,
+                outputContrib1s.data());
+        T::accum(
+                pqFineCentroidsQ,
+                encodedData.data() + (i + 1) * codeSize,
+                weight1,
+                outputContrib1s.data());
+
+        // compare
+        for (size_t j = 0; j < d; j++) {
+            ASSERT_FLOAT_EQ(outputContrib1s[j], outputContrib2s[j]);
+        }
+    }
+}
+
 std::vector<float> generate(const size_t n, const size_t d) {
     std::vector<float> data(n * d);
 
@@ -230,6 +333,19 @@ void testIndex2LevelDecoder(
     std::tie(index, encodedData) = trainDataset(data, n, d, description);
 
     verifyIndex2LevelDecoder<T>(n, d, index, encodedData);
+}
+
+template <typename T>
+void testIndexPQDecoder(
+        const uint64_t n,
+        const uint64_t d,
+        const std::string& description) {
+    auto data = generate(n, d);
+    std::shared_ptr<faiss::Index> index;
+    std::vector<uint8_t> encodedData;
+    std::tie(index, encodedData) = trainDataset(data, n, d, description);
+
+    verifyIndexPQDecoder<T>(n, d, index, encodedData);
 }
 
 constexpr size_t NSAMPLES = 4096;
@@ -362,17 +478,43 @@ TEST(TEST_CPPCONTRIB_SA_DECODE, D64_Residual4x8_PQ4) {
 
 //
 TEST(TEST_CPPCONTRIB_SA_DECODE, D256_IVF1024_PQ16) {
+    // It is acceptable to use COARSE_BITS=16 in this case,
+    // because there's only one coarse quantizer element.
     using T = faiss::cppcontrib::Index2LevelDecoder<256, 256, 16, 16>;
     testIndex2LevelDecoder<T>(NSAMPLES, 256, "IVF1024,PQ16np");
 }
 
 TEST(TEST_CPPCONTRIB_SA_DECODE, D64_Residual1x9_PQ8) {
+    // It is acceptable to use COARSE_BITS=16 in this case,
+    // because there's only one coarse quantizer element.
+    // It won't work for "Residual2x9,PQ8".
     using T = faiss::cppcontrib::Index2LevelDecoder<64, 64, 8, 16>;
     testIndex2LevelDecoder<T>(NSAMPLES, 64, "Residual1x9,PQ8");
 }
 
+//
+TEST(TEST_CPPCONTRIB_SA_DECODE, D256_PQ16) {
+    using T = faiss::cppcontrib::IndexPQDecoder<256, 16>;
+    testIndexPQDecoder<T>(NSAMPLES, 256, "PQ16np");
+}
+
+//
+TEST(TEST_CPPCONTRIB_SA_DECODE, D160_PQ20) {
+    using T = faiss::cppcontrib::IndexPQDecoder<160, 8>;
+    testIndexPQDecoder<T>(NSAMPLES, 160, "PQ20np");
+}
+
 // implemented for AVX2 and ARM so far
 #if defined(__AVX2__) || defined(__ARM_NEON)
+TEST(TEST_CPPCONTRIB_SA_DECODE, D256_PQ16x10) {
+    using T = faiss::cppcontrib::IndexPQDecoder<256, 16, 10>;
+    testIndexPQDecoder<T>(NSAMPLES, 256, "PQ16x10np");
+}
+
+TEST(TEST_CPPCONTRIB_SA_DECODE, D160_PQ20x10) {
+    using T = faiss::cppcontrib::IndexPQDecoder<160, 8, 10>;
+    testIndexPQDecoder<T>(NSAMPLES, 160, "PQ20x10np");
+}
 
 TEST(TEST_CPPCONTRIB_SA_DECODE, D160_Residual4x8_PQ8x10) {
     using T = faiss::cppcontrib::Index2LevelDecoder<160, 40, 20, 8, 10>;
@@ -380,8 +522,16 @@ TEST(TEST_CPPCONTRIB_SA_DECODE, D160_Residual4x8_PQ8x10) {
 }
 
 TEST(TEST_CPPCONTRIB_SA_DECODE, D256_Residual1x9_PQ16x10) {
+    // It is acceptable to use COARSE_BITS=16 in this case,
+    // because there's only one coarse quantizer element.
+    // It won't work for "Residual2x9,PQ16x10".
     using T = faiss::cppcontrib::Index2LevelDecoder<256, 256, 16, 16, 10>;
     testIndex2LevelDecoder<T>(NSAMPLES, 256, "Residual1x9,PQ16x10");
+}
+
+TEST(TEST_CPPCONTRIB_SA_DECODE, D256_Residual4x10_PQ16x10) {
+    using T = faiss::cppcontrib::Index2LevelDecoder<256, 64, 16, 10, 10>;
+    testIndex2LevelDecoder<T>(NSAMPLES, 256, "Residual4x10,PQ16x10");
 }
 
 #endif

--- a/tests/test_cppcontrib_uintreader.cpp
+++ b/tests/test_cppcontrib_uintreader.cpp
@@ -1,0 +1,103 @@
+// This test was designed to be run using valgrind or ASAN to test the
+// correctness of memory accesses.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+
+#include <faiss/utils/hamming.h>
+
+#include <faiss/cppcontrib/detail/UintReader.h>
+
+template <intptr_t N_ELEMENTS, intptr_t CODE_BITS, intptr_t CPOS>
+struct TestLoop {
+    static void test(
+            const uint8_t* const container,
+            faiss::BitstringReader& br) {
+        // validate
+        const intptr_t uintreader_data = faiss::cppcontrib::detail::
+                UintReaderRaw<N_ELEMENTS, CODE_BITS, CPOS>::get(container);
+        const intptr_t bitstringreader_data = br.read(CODE_BITS);
+
+        ASSERT_EQ(uintreader_data, bitstringreader_data)
+                << "Mismatch between BitstringReader (" << bitstringreader_data
+                << ") and UintReader (" << uintreader_data
+                << ") for N_ELEMENTS=" << N_ELEMENTS
+                << ", CODE_BITS=" << CODE_BITS << ", CPOS=" << CPOS;
+
+        //
+        TestLoop<N_ELEMENTS, CODE_BITS, CPOS + 1>::test(container, br);
+    }
+};
+
+template <intptr_t N_ELEMENTS, intptr_t CODE_BITS>
+struct TestLoop<N_ELEMENTS, CODE_BITS, N_ELEMENTS> {
+    static void test(
+            const uint8_t* const container,
+            faiss::BitstringReader& br) {}
+};
+
+template <intptr_t N_ELEMENTS, intptr_t CODE_BITS>
+void TestUintReader() {
+    constexpr intptr_t CODE_BYTES = (CODE_BITS * N_ELEMENTS + 7) / 8;
+
+    std::default_random_engine rng;
+    std::uniform_int_distribution<uint64_t> u(0, 1 << CODE_BITS);
+
+    // do several attempts
+    for (size_t attempt = 0; attempt < 10; attempt++) {
+        // allocate a buffer. This way, not std::vector
+        std::unique_ptr<uint8_t[]> container(new uint8_t[CODE_BYTES]);
+        // make it empty
+        for (size_t i = 0; i < CODE_BYTES; i++) {
+            container.get()[i] = 0;
+        }
+
+        // populate it
+        faiss::BitstringWriter bw(container.get(), CODE_BYTES);
+        for (size_t i = 0; i < N_ELEMENTS; i++) {
+            bw.write(u(rng), CODE_BITS);
+        }
+
+        // read it back and verify against bitreader
+        faiss::BitstringReader br(container.get(), CODE_BYTES);
+
+        TestLoop<N_ELEMENTS, CODE_BITS, 0>::test(container.get(), br);
+    }
+}
+
+template <intptr_t CODE_BITS>
+void TestUintReaderBits() {
+    TestUintReader<1, CODE_BITS>();
+    TestUintReader<2, CODE_BITS>();
+    TestUintReader<3, CODE_BITS>();
+    TestUintReader<4, CODE_BITS>();
+    TestUintReader<5, CODE_BITS>();
+    TestUintReader<6, CODE_BITS>();
+    TestUintReader<7, CODE_BITS>();
+    TestUintReader<8, CODE_BITS>();
+    TestUintReader<9, CODE_BITS>();
+    TestUintReader<10, CODE_BITS>();
+    TestUintReader<11, CODE_BITS>();
+    TestUintReader<12, CODE_BITS>();
+    TestUintReader<13, CODE_BITS>();
+    TestUintReader<14, CODE_BITS>();
+    TestUintReader<15, CODE_BITS>();
+    TestUintReader<16, CODE_BITS>();
+    TestUintReader<17, CODE_BITS>();
+}
+
+TEST(TEST_CPPCONTRIB_UINTREADER, Test8bit) {
+    TestUintReaderBits<8>();
+}
+
+TEST(TEST_CPPCONTRIB_UINTREADER, Test10bit) {
+    TestUintReaderBits<10>();
+}
+
+TEST(TEST_CPPCONTRIB_UINTREADER, Test16bit) {
+    TestUintReaderBits<16>();
+}


### PR DESCRIPTION
Summary:
Add IndexPQDecoder. The following codecs are supported:
* PQ[1]x8

Additionally, AVX2 and ARM versions support the following codecs:
* PQ[1]x10
* PQ[1]x16

Differential Revision: D39176423

