### PR TITLE
Fix simdlib

### DIFF
--- a/faiss/IndexIVFFastScan.cpp
+++ b/faiss/IndexIVFFastScan.cpp
@@ -26,7 +26,6 @@
 #include <faiss/utils/distances.h>
 #include <faiss/utils/hamming.h>
 #include <faiss/utils/quantize_lut.h>
-#include <faiss/utils/simdlib.h>
 #include <faiss/utils/utils.h>
 
 namespace faiss {

--- a/faiss/impl/ResidualQuantizer.cpp
+++ b/faiss/impl/ResidualQuantizer.cpp
@@ -21,7 +21,6 @@
 #include <faiss/utils/Heap.h>
 #include <faiss/utils/distances.h>
 #include <faiss/utils/hamming.h>
-#include <faiss/utils/simdlib.h>
 #include <faiss/utils/utils.h>
 
 extern "C" {

--- a/faiss/utils/simdlib_emulated.h
+++ b/faiss/utils/simdlib_emulated.h
@@ -438,7 +438,7 @@ struct simd8uint32 : simd256bit {
 
     explicit simd8uint32(const simd256bit& x) : simd256bit(x) {}
 
-    explicit simd8uint32(const uint8_t* x) : simd256bit((const void*)x) {}
+    explicit simd8uint32(const uint32_t* x) : simd256bit((const void*)x) {}
 
     std::string elements_to_string(const char* fmt) const {
         char res[1000], *ptr = res;

--- a/faiss/utils/simdlib_neon.h
+++ b/faiss/utils/simdlib_neon.h
@@ -646,8 +646,8 @@ inline simd32uint8 blendv(
     const uint8x16x2_t msb_mask = {
             vtstq_u8(mask.data.val[0], msb), vtstq_u8(mask.data.val[1], msb)};
     const uint8x16x2_t selected = {
-            vbslq_u8(msb_mask.val[0], a.data.val[0], b.data.val[0]),
-            vbslq_u8(msb_mask.val[1], a.data.val[1], b.data.val[1])};
+            vbslq_u8(msb_mask.val[0], b.data.val[0], a.data.val[0]),
+            vbslq_u8(msb_mask.val[1], b.data.val[1], a.data.val[1])};
     return simd32uint8{selected};
 }
 


### PR DESCRIPTION
- fix type of an argument of the `simd8uint32` constructor on `simdlib_emulated`
- fix `blendv` on aarch64, which returns completely inverted results
- remove unused `#include <faiss/utils/simdlib.h>`