### PR TITLE
T131797380 add read/write_VectorTransform to puplic API

### DIFF
--- a/faiss/index_io.h
+++ b/faiss/index_io.h
@@ -63,7 +63,10 @@ IndexBinary* read_index_binary(FILE* f, int io_flags = 0);
 IndexBinary* read_index_binary(IOReader* reader, int io_flags = 0);
 
 void write_VectorTransform(const VectorTransform* vt, const char* fname);
+void write_VectorTransform(const VectorTransform* vt, IOWriter* f);
+
 VectorTransform* read_VectorTransform(const char* fname);
+VectorTransform* read_VectorTransform(IOReader* f);
 
 ProductQuantizer* read_ProductQuantizer(const char* fname);
 ProductQuantizer* read_ProductQuantizer(IOReader* reader);

--- a/tests/test_io_vector_transform.py
+++ b/tests/test_io_vector_transform.py
@@ -1,0 +1,66 @@
+import os
+import tempfile
+import unittest
+
+import numpy as np
+import faiss
+
+
+class Test_IO_VectorTransform(unittest.TestCase):
+    """
+    test write_VectorTransform using IOWriter Pointer
+    and read_VectorTransform using file name
+    """
+    def test_write_vector_transform(self):
+        d, n = 32, 1000
+        x = np.random.uniform(size=(n, d)).astype('float32')
+        quantizer = faiss.IndexFlatL2(d)
+        index = faiss.IndexIVFSpectralHash(quantizer, d, n, 8, 1.0)
+        index.train(x)
+        index.add(x)
+        fd, fname = tempfile.mkstemp()
+        os.close(fd)
+        try:
+
+            writer = faiss.FileIOWriter(fname)
+            faiss.write_VectorTransform(index.vt, writer)
+            del writer
+
+            vt = faiss.read_VectorTransform(fname)
+
+            assert vt.d_in == index.vt.d_in
+            assert vt.d_out == index.vt.d_out
+            assert vt.is_trained
+
+        finally:
+            if os.path.exists(fname):
+                os.unlink(fname)
+
+    """
+    test write_VectorTransform using file name
+    and read_VectorTransform using IOWriter Pointer
+    """
+    def test_read_vector_transform(self):
+        d, n = 32, 1000
+        x = np.random.uniform(size=(n, d)).astype('float32')
+        quantizer = faiss.IndexFlatL2(d)
+        index = faiss.IndexIVFSpectralHash(quantizer, d, n, 8, 1.0)
+        index.train(x)
+        index.add(x)
+        fd, fname = tempfile.mkstemp()
+        os.close(fd)
+        try:
+
+            faiss.write_VectorTransform(index.vt, fname)
+
+            reader = faiss.FileIOReader(fname)
+            vt = faiss.read_VectorTransform(reader)
+            del reader
+
+            assert vt.d_in == index.vt.d_in
+            assert vt.d_out == index.vt.d_out
+            assert vt.is_trained
+
+        finally:
+            if os.path.exists(fname):
+                os.unlink(fname)


### PR DESCRIPTION
adds write_VectorTransform (const VectorTransform *vt, IOWriter *f) and read_VectorTransform (IOREAD *f) to public API 
Solves [issue 1645](https://github.com/facebookresearch/faiss/issues/1645)
adds required tests

Test plan:
cd build
make -j
cd faiss/python && python setup.py build
cd ../../..
PYTHONPATH="$(ls -d ./build/faiss/python/build/lib*/)" pytest tests/test_io_vector_transform.py