### PR TITLE
T132029385 modify merge_into to merge all index types

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -8,6 +8,7 @@ set(FAISS_SRC
   AutoTune.cpp
   Clustering.cpp
   IVFlib.cpp
+  merge.cpp
   Index.cpp
   Index2Layer.cpp
   IndexAdditiveQuantizer.cpp
@@ -90,6 +91,7 @@ set(FAISS_HEADERS
   AutoTune.h
   Clustering.h
   IVFlib.h
+  merge.h
   Index.h
   Index2Layer.h
   IndexAdditiveQuantizer.h

--- a/faiss/IVFlib.h
+++ b/faiss/IVFlib.h
@@ -25,10 +25,6 @@ struct ResidualQuantizer;
 
 namespace ivflib {
 
-/** check if two indexes have the same parameters and are trained in
- * the same way, otherwise throw. */
-void check_compatible_for_merge(const Index* index1, const Index* index2);
-
 /** get an IndexIVF from an index. The index may be an IndexIVF or
  * some wrapper class that encloses an IndexIVF
  *
@@ -40,13 +36,6 @@ IndexIVF* extract_index_ivf(Index* index);
 /// same as above but returns nullptr instead of throwing on failure
 const IndexIVF* try_extract_index_ivf(const Index* index);
 IndexIVF* try_extract_index_ivf(Index* index);
-
-/** Merge index1 into index0. Works on IndexIVF's and IndexIVF's
- *  embedded in a IndexPreTransform. On output, the index1 is empty.
- *
- * @param shift_ids: translate the ids from index1 to index0->prev_ntotal
- */
-void merge_into(Index* index0, Index* index1, bool shift_ids);
 
 typedef Index::idx_t idx_t;
 

--- a/faiss/merge.cpp
+++ b/faiss/merge.cpp
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <faiss/merge.h>
+
+#include <faiss/IndexPreTransform.h>
+#include <faiss/MetaIndexes.h>
+
+namespace faiss {
+namespace merge {
+void check_compatible_for_merge(const Index* index0, const Index* index1) {
+    const faiss::IndexPreTransform* pt0 =
+            dynamic_cast<const faiss::IndexPreTransform*>(index0);
+
+    if (pt0) {
+        const faiss::IndexPreTransform* pt1 =
+                dynamic_cast<const faiss::IndexPreTransform*>(index1);
+        FAISS_THROW_IF_NOT_MSG(pt1, "both indexes should be pretransforms");
+
+        FAISS_THROW_IF_NOT(pt0->chain.size() == pt1->chain.size());
+        for (int i = 0; i < pt0->chain.size(); i++) {
+            FAISS_THROW_IF_NOT(typeid(pt0->chain[i]) == typeid(pt1->chain[i]));
+        }
+
+        index0 = pt0->index;
+        index1 = pt1->index;
+    }
+    FAISS_THROW_IF_NOT(typeid(index0) == typeid(index1));
+    FAISS_THROW_IF_NOT(
+            index0->d == index1->d &&
+            index0->metric_type == index1->metric_type);
+
+    index0->check_compatible_for_merge(*index1);
+}
+
+const Index* try_extract_index(const Index* index) {
+    if (auto* pt = dynamic_cast<const IndexPreTransform*>(index)) {
+        index = pt->index;
+    }
+
+    if (auto* idmap = dynamic_cast<const IndexIDMap*>(index)) {
+        index = idmap->index;
+    }
+    if (auto* idmap = dynamic_cast<const IndexIDMap2*>(index)) {
+        index = idmap->index;
+    }
+
+    return index;
+}
+
+Index* try_extract_index(Index* index) {
+    return const_cast<Index*>(try_extract_index((const Index*)(index)));
+}
+
+const Index* extract_index(const Index* index) {
+    const Index* baseIndex = try_extract_index(index);
+    FAISS_THROW_IF_NOT(baseIndex);
+    return baseIndex;
+}
+
+Index* extract_index(Index* index) {
+    return const_cast<Index*>(extract_index((const Index*)(index)));
+}
+
+void merge_into(faiss::Index* index0, faiss::Index* index1, bool shift_ids) {
+    check_compatible_for_merge(index0, index1);
+
+    Index* baseIndex0 = extract_index(index0);
+    Index* baseIndex1 = extract_index(index1);
+
+    baseIndex0->merge_from(*baseIndex1, shift_ids ? baseIndex0->ntotal : 0);
+
+    // useful for IndexPreTransform
+    index0->ntotal = baseIndex0->ntotal;
+    index1->ntotal = baseIndex1->ntotal;
+}
+} // namespace merge
+} // namespace faiss

--- a/faiss/merge.h
+++ b/faiss/merge.h
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <faiss/Index.h>
+
+namespace faiss {
+namespace merge {
+/** check if two indexes have the same parameters and are trained in
+ * the same way, otherwise throw. */
+void check_compatible_for_merge(const Index* index1, const Index* index2);
+
+/** get a base Index from an index. The index may be the required Index or
+ * some wrapper class that encloses an Index
+ *
+ * throws an exception if this is not the case.
+ */
+
+const Index* extract_index(const Index* index);
+Index* extract_index(Index* index);
+
+/// same as above but returns nullptr instead of throwing on failure
+
+const Index* try_extract_index(const Index* index);
+Index* try_extract_index(Index* index);
+
+/** Merge index1 into index0. Works on all Index Types that implement merge_from
+ * or embedded in a IndexPreTransform / IndexIDMap / IndexIDMap2. On output,
+ * the index1 is empty.
+ *
+ * @param shift_ids: translate the ids from index1 to index0->prev_ntotal
+ */
+void merge_into(Index* index0, Index* index1, bool shift_ids = false);
+} // namespace merge
+} // namespace faiss

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -120,6 +120,7 @@ typedef uint64_t size_t;
 #include <faiss/clone_index.h>
 
 #include <faiss/IVFlib.h>
+#include <faiss/merge.h>
 #include <faiss/utils/utils.h>
 #include <faiss/utils/distances.h>
 #include <faiss/utils/extra_distances.h>
@@ -422,6 +423,9 @@ void gpu_sync_all_devices()
 %warnfilter(509) extract_index_ivf;
 %warnfilter(509) try_extract_index_ivf;
 %include  <faiss/IVFlib.h>
+%warnfilter(509) extract_index;
+%warnfilter(509) try_extract_index;
+%include  <faiss/merge.h>
 %include  <faiss/impl/ScalarQuantizer.h>
 %include  <faiss/IndexScalarQuantizer.h>
 %include  <faiss/IndexIVFSpectralHash.h>

--- a/tests/test_ivflib.py
+++ b/tests/test_ivflib.py
@@ -12,8 +12,8 @@ import numpy as np
 class TestIVFlib(unittest.TestCase):
 
     def test_methods_exported(self):
-        methods = ['check_compatible_for_merge', 'extract_index_ivf',
-                   'merge_into', 'search_centroid',
+        methods = ['extract_index_ivf',
+                   'search_centroid',
                    'search_and_return_centroids', 'get_invlist_range',
                    'set_invlist_range', 'search_with_parameters']
 


### PR DESCRIPTION
Make merge_into support all types of Index as it implements merge_from and check_compatible_for_merge
this is part 2 of 2 of this task to solve [issue 2472](https://github.com/facebookresearch/faiss/issues/2472) 

test plan:
cd build
make -j
make test
cd faiss/python && python setup.py build
cd ../../..
PYTHONPATH="$(ls -d ./build/faiss/python/build/lib*/)" pytest tests/test_*.py