### PR TITLE
add remove and merge features for IndexFastScan

### DIFF
--- a/faiss/IndexFastScan.cpp
+++ b/faiss/IndexFastScan.cpp
@@ -13,8 +13,8 @@
 
 #include <omp.h>
 
-#include <faiss/impl/IDSelector.h>
 #include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/IDSelector.h>
 #include <faiss/impl/LookupTableScaler.h>
 #include <faiss/impl/ResultHandler.h>
 #include <faiss/utils/distances.h>
@@ -105,8 +105,9 @@ size_t IndexFastScan::remove_ids(const IDSelector& sel) {
             // should be removed
         } else {
             if (i > j) {
-                for (int sq = 0; sq < M; sq++){
-                    uint8_t code = pq4_get_packed_element(codes.data(), bbs, M, i, sq);
+                for (int sq = 0; sq < M; sq++) {
+                    uint8_t code =
+                            pq4_get_packed_element(codes.data(), bbs, M, i, sq);
                     pq4_set_packed_element(codes.data(), code, bbs, M, j, sq);
                 }
             }
@@ -141,9 +142,10 @@ void IndexFastScan::merge_from(Index& otherIndex, idx_t add_id) {
     IndexFastScan* other = static_cast<IndexFastScan*>(&otherIndex);
     ntotal2 = roundup(ntotal + other->ntotal, bbs);
     codes.resize(ntotal2 * M2 / 2);
-    for (int i = 0; i < other->ntotal; i++){
-        for (int sq = 0; sq < M; sq++){
-            uint8_t code = pq4_get_packed_element(other->codes.data(), bbs, M, i, sq);
+    for (int i = 0; i < other->ntotal; i++) {
+        for (int sq = 0; sq < M; sq++) {
+            uint8_t code =
+                    pq4_get_packed_element(other->codes.data(), bbs, M, i, sq);
             pq4_set_packed_element(codes.data(), code, bbs, M, ntotal + i, sq);
         }
     }

--- a/faiss/IndexFastScan.h
+++ b/faiss/IndexFastScan.h
@@ -16,6 +16,7 @@ namespace faiss {
  *
  * The codes are not stored sequentially but grouped in blocks of size bbs.
  * This makes it possible to compute distances quickly with SIMD instructions.
+ * The trailing codes (padding codes that are added to complete the last code) are garbage.
  *
  * Implementations:
  * 12: blocked loop with internal loop on Q with qbs
@@ -123,6 +124,7 @@ struct IndexFastScan : Index {
             const Scaler& scaler) const;
 
     void reconstruct(idx_t key, float* recons) const override;
+    size_t remove_ids(const IDSelector& sel) override;
 };
 
 struct FastScanStats {

--- a/faiss/IndexFastScan.h
+++ b/faiss/IndexFastScan.h
@@ -16,7 +16,8 @@ namespace faiss {
  *
  * The codes are not stored sequentially but grouped in blocks of size bbs.
  * This makes it possible to compute distances quickly with SIMD instructions.
- * The trailing codes (padding codes that are added to complete the last code) are garbage.
+ * The trailing codes (padding codes that are added to complete the last code)
+ * are garbage.
  *
  * Implementations:
  * 12: blocked loop with internal loop on Q with qbs

--- a/faiss/IndexFastScan.h
+++ b/faiss/IndexFastScan.h
@@ -125,6 +125,8 @@ struct IndexFastScan : Index {
 
     void reconstruct(idx_t key, float* recons) const override;
     size_t remove_ids(const IDSelector& sel) override;
+    void merge_from(Index& otherIndex, idx_t add_id = 0) override;
+    void check_compatible_for_merge(const Index& otherIndex) const override;
 };
 
 struct FastScanStats {

--- a/faiss/impl/pq4_fast_scan.cpp
+++ b/faiss/impl/pq4_fast_scan.cpp
@@ -155,6 +155,42 @@ uint8_t pq4_get_packed_element(
     }
 }
 
+void pq4_set_packed_element(
+        uint8_t* data,
+        uint8_t code,
+        size_t bbs,
+        size_t nsq,
+        size_t vector_id,
+        size_t sq) {
+    // move to correct bbs-sized block
+    // number of blocks * block size
+    data += (vector_id / bbs) * ((nsq / 2) * bbs);
+
+    // get the vector_id inside the block
+    vector_id = vector_id % bbs;
+    bool shift = vector_id > 15;
+    vector_id = vector_id & 15;
+
+    // get the address of the vector in sq
+    size_t address;
+    if (vector_id < 8) {
+        address = vector_id << 1;
+    } else {
+        address = ((vector_id - 8) << 1) + 1;
+    }
+    if (sq & 1) {
+        address += 16;
+    }
+    address = (sq >> 1) * bbs + address;
+    uint8_t temp = data[address];
+    if (shift) {
+        temp = (code << 4) | (temp & 15);
+    } else {
+        temp = code | (temp & ~15);
+    }
+    data[address] = temp;
+}
+
 /***************************************************************
  * Packing functions for Look-Up Tables (LUT)
  ***************************************************************/

--- a/faiss/impl/pq4_fast_scan.cpp
+++ b/faiss/impl/pq4_fast_scan.cpp
@@ -122,13 +122,7 @@ void pq4_pack_codes_range(
     }
 }
 
-uint8_t get_address(
-        const uint8_t* data,
-        size_t& bbs,
-        size_t& nsq,
-        size_t& vector_id,
-        size_t& sq,
-        bool& shift) {
+uint8_t get_address(size_t bbs, size_t vector_id, size_t sq, bool& shift) {
     // get the vector_id inside the block
     vector_id = vector_id % bbs;
     shift = vector_id > 15;
@@ -157,7 +151,7 @@ uint8_t pq4_get_packed_element(
     // number of blocks * block size
     data += (vector_id / bbs) * (((nsq + 1) / 2) * bbs);
     bool shift;
-    size_t address = get_address(data, bbs, nsq, vector_id, sq, shift);
+    size_t address = get_address(bbs, vector_id, sq, shift);
     if (shift) {
         return data[address] >> 4;
     } else {
@@ -176,7 +170,7 @@ void pq4_set_packed_element(
     // number of blocks * block size
     data += (vector_id / bbs) * (((nsq + 1) / 2) * bbs);
     bool shift;
-    size_t address = get_address(data, bbs, nsq, vector_id, sq, shift);
+    size_t address = get_address(bbs, vector_id, sq, shift);
     if (shift) {
         data[address] = (code << 4) | (data[address] & 15);
     } else {

--- a/faiss/impl/pq4_fast_scan.cpp
+++ b/faiss/impl/pq4_fast_scan.cpp
@@ -122,7 +122,16 @@ void pq4_pack_codes_range(
     }
 }
 
-uint8_t get_address(size_t bbs, size_t vector_id, size_t sq, bool& shift) {
+namespace {
+
+// get the specific address of the vector inside a block
+// shift is used for determine the if the saved in bits 0..3 (false) or
+// bits 4..7 (true)
+uint8_t get_vector_specific_address(
+        size_t bbs,
+        size_t vector_id,
+        size_t sq,
+        bool& shift) {
     // get the vector_id inside the block
     vector_id = vector_id % bbs;
     shift = vector_id > 15;
@@ -141,6 +150,8 @@ uint8_t get_address(size_t bbs, size_t vector_id, size_t sq, bool& shift) {
     return (sq >> 1) * bbs + address;
 }
 
+} // anonymous namespace
+
 uint8_t pq4_get_packed_element(
         const uint8_t* data,
         size_t bbs,
@@ -151,7 +162,7 @@ uint8_t pq4_get_packed_element(
     // number of blocks * block size
     data += (vector_id / bbs) * (((nsq + 1) / 2) * bbs);
     bool shift;
-    size_t address = get_address(bbs, vector_id, sq, shift);
+    size_t address = get_vector_specific_address(bbs, vector_id, sq, shift);
     if (shift) {
         return data[address] >> 4;
     } else {
@@ -170,7 +181,7 @@ void pq4_set_packed_element(
     // number of blocks * block size
     data += (vector_id / bbs) * (((nsq + 1) / 2) * bbs);
     bool shift;
-    size_t address = get_address(bbs, vector_id, sq, shift);
+    size_t address = get_vector_specific_address(bbs, vector_id, sq, shift);
     if (shift) {
         data[address] = (code << 4) | (data[address] & 15);
     } else {

--- a/faiss/impl/pq4_fast_scan.h
+++ b/faiss/impl/pq4_fast_scan.h
@@ -61,14 +61,14 @@ void pq4_pack_codes_range(
 
 /** get a single element from a packed codes table
  *
- * @param i        vector id
+ * @param vector_id        vector id
  * @param sq       subquantizer (< nsq)
  */
 uint8_t pq4_get_packed_element(
         const uint8_t* data,
         size_t bbs,
         size_t nsq,
-        size_t i,
+        size_t vector_id,
         size_t sq);
 
 /** Pack Look-up table for consumption by the kernel.

--- a/faiss/impl/pq4_fast_scan.h
+++ b/faiss/impl/pq4_fast_scan.h
@@ -71,6 +71,19 @@ uint8_t pq4_get_packed_element(
         size_t vector_id,
         size_t sq);
 
+/** set a single element "code" into a packed codes table
+ *
+ * @param vector_id       vector id
+ * @param sq       subquantizer (< nsq)
+ */
+void pq4_set_packed_element(
+        uint8_t* data,
+        uint8_t code,
+        size_t bbs,
+        size_t nsq,
+        size_t vector_id,
+        size_t sq);
+
 /** Pack Look-up table for consumption by the kernel.
  *
  * @param nq      number of queries

--- a/tests/test_index_composite.py
+++ b/tests/test_index_composite.py
@@ -28,8 +28,10 @@ class TestRemoveFastScan(unittest.TestCase):
         index.remove_ids(np.array(removed))
         for i in range(ntotal):
             if i in removed:
+                # should throw RuntimeError as this vector should be removed
                 try:
                     after = index.reconstruct(i)
+                    assert False
                 except RuntimeError:
                     pass
             else:
@@ -41,11 +43,10 @@ class TestRemoveFastScan(unittest.TestCase):
         self.do_test(993, [992])
 
     # test remove element from every address 0 -> 31
+    # [0, 32 + 1, 2 * 32 + 2, ....]
+    # [0,   33  ,     66    , 99, 132, .....]
     def test_remove_every_address(self):
-        temp = np.arange(32).tolist()
-        removed = []
-        for i in range(32):
-            removed.append(i * 32 + temp[i])
+        removed = (33 * np.arange(32)).tolist()
         self.do_test(1100, removed)
 
     # test remove range of vectors and leave ntotal divisible by 32

--- a/tests/test_pq_encoding.cpp
+++ b/tests/test_pq_encoding.cpp
@@ -103,21 +103,43 @@ TEST(PQEncoder16, encode) {
     }
 }
 
-TEST(PQFastScan, set_paacked_element) {
+TEST(PQFastScan, set_packed_element) {
     int d = 20, ntotal = 1000, M = 5, nbits = 4;
     const std::vector<float> ds = random_vector_float(ntotal * d);
     faiss::IndexPQFastScan index(d, M, nbits);
     index.train(ntotal, ds.data());
     index.add(ntotal, ds.data());
+
     for (int i = 0; i < 10; i++) {
-        int vector_id = rand() % ntotal, sq = rand() % M;
-        uint8_t before = faiss::pq4_get_packed_element(
-                index.codes.data(), index.bbs, M, vector_id, sq);
-        uint8_t code = ((before + 3) % 16);
-        faiss::pq4_set_packed_element(
-                index.codes.data(), code, index.bbs, M, vector_id, sq);
-        uint8_t after = faiss::pq4_get_packed_element(
-                index.codes.data(), index.bbs, M, vector_id, sq);
-        EXPECT_EQ(((before + 3) % 16), after);
+        int vector_id = rand() % ntotal;
+        std::vector<uint8_t> old(ntotal * M);
+        std::vector<uint8_t> code(M);
+        for (int i = 0; i < ntotal; i++) {
+            for (int sq = 0; sq < M; sq++) {
+                old[i * M + sq] = faiss::pq4_get_packed_element(
+                        index.codes.data(), index.bbs, M, i, sq);
+            }
+        }
+        for (int sq = 0; sq < M; sq++) {
+            faiss::pq4_set_packed_element(
+                    index.codes.data(),
+                    ((old[vector_id * M + sq] + 3) % 16),
+                    index.bbs,
+                    M,
+                    vector_id,
+                    sq);
+        }
+        for (int i = 0; i < ntotal; i++) {
+            for (int sq = 0; sq < M; sq++) {
+                uint8_t newcode = faiss::pq4_get_packed_element(
+                        index.codes.data(), index.bbs, M, i, sq);
+                uint8_t oldcode = old[i * M + sq];
+                if (i == vector_id) {
+                    EXPECT_EQ(newcode, (oldcode + 3) % 16);
+                } else {
+                    EXPECT_EQ(newcode, oldcode);
+                }
+            }
+        }
     }
 }

--- a/tests/test_pq_encoding.cpp
+++ b/tests/test_pq_encoding.cpp
@@ -110,7 +110,7 @@ TEST(PQFastScan, set_packed_element) {
     index.train(ntotal, ds.data());
     index.add(ntotal, ds.data());
 
-    for (int i = 0; i < 10; i++) {
+    for (int j = 0; j < 10; j++) {
         int vector_id = rand() % ntotal;
         std::vector<uint8_t> old(ntotal * M);
         std::vector<uint8_t> code(M);


### PR DESCRIPTION
* Modify pq4_get_paked_element to make it not depend on an auxiliary table 
* Create pq4_set_packed_element which sets a single element in codes in packed format
(These methods would be used in merge and remove for IndexFastScan
get method is also used in FastScan indices for reconstruction)
* Add remove feature for IndexFastScan
* Add merge feature for indexFast Scan

test plan:
cd build && make -j
make test
cd faiss/python && python setup.py build && cd ../../..
PYTHONPATH="$(ls -d ./build/faiss/python/build/lib*/)" pytest tests/test_*.py