### PR TITLE
add pq4_set_packed_element that used in IndexPQFastScan

### DIFF
--- a/faiss/impl/pq4_fast_scan.cpp
+++ b/faiss/impl/pq4_fast_scan.cpp
@@ -149,6 +149,42 @@ uint8_t pq4_get_packed_element(
     }
 }
 
+void pq4_set_packed_element(
+        uint8_t* data,
+        uint8_t* code,
+        size_t bbs,
+        size_t nsq,
+        size_t vector_id,
+        size_t sq) {
+    // move to correct bbs-sized block
+    // number of blocks * block size
+    data += (vector_id / bbs) * ((nsq / 2) * bbs);
+
+    // get the vector_id inside the block
+    vector_id = vector_id % bbs;
+    bool shift = vector_id > 15;
+    vector_id = vector_id & 15;
+
+    // get the address of the vector in sq
+    size_t address;
+    if (vector_id < 8) {
+        address = vector_id << 1;
+    } else {
+        address = ((vector_id - 8) << 1) + 1;
+    }
+    if (sq & 1) {
+        address += 16;
+    }
+    address = (sq >> 1) * bbs + address;
+    uint8_t temp = data[address];
+    if (shift) {
+        temp = (*code << 4) | (temp & 15);
+    } else {
+        temp = *code | (temp & ~15);
+    }
+    data[address] = temp;
+}
+
 /***************************************************************
  * Packing functions for Look-Up Tables (LUT)
  ***************************************************************/

--- a/faiss/impl/pq4_fast_scan.h
+++ b/faiss/impl/pq4_fast_scan.h
@@ -71,6 +71,19 @@ uint8_t pq4_get_packed_element(
         size_t i,
         size_t sq);
 
+/** set a single element "code" into a packed codes table
+ *
+ * @param vector_id       vector id
+ * @param sq       subquantizer (< nsq)
+ */
+void pq4_set_packed_element(
+        uint8_t* data,
+        uint8_t* code,
+        size_t bbs,
+        size_t nsq,
+        size_t vector_id,
+        size_t sq);
+
 /** Pack Look-up table for consumption by the kernel.
  *
  * @param nq      number of queries

--- a/tests/test_pq_encoding.cpp
+++ b/tests/test_pq_encoding.cpp
@@ -11,12 +11,23 @@
 
 #include <gtest/gtest.h>
 
+#include <faiss/IndexPQFastScan.h>
 #include <faiss/impl/ProductQuantizer.h>
+#include <faiss/impl/pq4_fast_scan.h>
 
 namespace {
 
 const std::vector<uint64_t> random_vector(size_t s) {
     std::vector<uint64_t> v(s, 0);
+    for (size_t i = 0; i < s; ++i) {
+        v[i] = rand();
+    }
+
+    return v;
+}
+
+const std::vector<float> random_vector_float(size_t s) {
+    std::vector<float> v(s, 0);
     for (size_t i = 0; i < s; ++i) {
         v[i] = rand();
     }
@@ -89,5 +100,24 @@ TEST(PQEncoder16, encode) {
     for (int i = 0; i < nsubcodes; ++i) {
         uint64_t v = decoder.decode();
         EXPECT_EQ(values[i] & mask, v);
+    }
+}
+
+TEST(PQFastScan, set_paacked_element) {
+    int d = 20, ntotal = 1000, M = 5, nbits = 4;
+    const std::vector<float> ds = random_vector_float(ntotal * d);
+    faiss::IndexPQFastScan index(d, M, nbits);
+    index.train(ntotal, ds.data());
+    index.add(ntotal, ds.data());
+    for (int i = 0; i < 10; i++) {
+        int vector_id = rand() % ntotal, sq = rand() % M;
+        uint8_t before = faiss::pq4_get_packed_element(
+                index.codes.data(), index.bbs, M, vector_id, sq);
+        uint8_t code = ((before + 3) % 16);
+        faiss::pq4_set_packed_element(
+                index.codes.data(), &code, index.bbs, M, vector_id, sq);
+        uint8_t after = faiss::pq4_get_packed_element(
+                index.codes.data(), index.bbs, M, vector_id, sq);
+        EXPECT_EQ(((before + 3) % 16), after);
     }
 }


### PR DESCRIPTION
this method would be used in merge and remove for IndexPQFastScan
it sets a single element in codes in packed format

test plan:
cd build
make -j
make test ARGS="-R '^PQFastScan'"

