### PR TITLE
fix windows compilation

### DIFF
--- a/faiss/python/CMakeLists.txt
+++ b/faiss/python/CMakeLists.txt
@@ -88,8 +88,8 @@ if(NOT WIN32)
   set_target_properties(swigfaiss_avx2 PROPERTIES SUFFIX .so)
 else()
   # we need bigobj for the swig wrapper
-  add_compile_options(/bigobj)
-  add_link_options(/bigobj)
+  target_compile_options(swigfaiss PRIVATE /bigobj)
+  target_compile_options(swigfaiss_avx2 PRIVATE /bigobj)
 endif()
 
 if(FAISS_ENABLE_GPU)

--- a/tests/test_search_params.py
+++ b/tests/test_search_params.py
@@ -27,7 +27,7 @@ class TestSelector(unittest.TestCase):
 
         # reference result
         rs = np.random.RandomState(123)
-        subset = rs.choice(ds.nb, 50, replace=False)
+        subset = rs.choice(ds.nb, 50, replace=False).astype("int64")
         # add_with_ids not supported for all index types
         # index.add_with_ids(ds.get_database()[subset], subset)
         index.add(ds.get_database()[subset])
@@ -97,7 +97,7 @@ class TestSelector(unittest.TestCase):
 
         # reference result
         rs = np.random.RandomState(123)
-        subset = rs.choice(ds.nb, 50, replace=False)
+        subset = rs.choice(ds.nb, 50, replace=False).astype("int64")
         sel = faiss.IDSelectorBatch(
             len(subset),
             faiss.swig_ptr(subset)


### PR DESCRIPTION
Summary: the SearchParameters made the swig wrapper too long. This diff attempts to work around.

Differential Revision: D39998713

