### PR TITLE
[WIP] Add GpuIndexIVFAQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ the Facebook Faiss team.  Feel free to add entries here if you submit a PR.
 - Added FlatDistanceComputer for all FlatCodes indexes
 - Support for fast accumulation of 4-bit LSQ and RQ
 - Added product additive quantization
+- Added GpuIndexIVFAQ
 
 ## [1.7.2] - 2021-12-15
 ### Added


### PR DESCRIPTION
This PR is going to add GpuIndexIVFAQ into Faiss.

Nothing is implemented now. If anyone is working on it, please tell me and I will close this.

@mdouze @wickedfoo 
