### PR TITLE
GPU IVF indices now allow arbitrary quantizer instances + search_preassigned

### DIFF
--- a/faiss/gpu/CMakeLists.txt
+++ b/faiss/gpu/CMakeLists.txt
@@ -24,6 +24,7 @@ set(FAISS_GPU_SRC
   impl/BroadcastSum.cu
   impl/Distance.cu
   impl/FlatIndex.cu
+  impl/IndexUtils.cu
   impl/IVFAppend.cu
   impl/IVFBase.cu
   impl/IVFFlat.cu
@@ -102,6 +103,7 @@ set(FAISS_GPU_HEADERS
   impl/FlatIndex.cuh
   impl/GeneralDistance.cuh
   impl/GpuScalarQuantizer.cuh
+  impl/IndexUtils.h
   impl/IVFAppend.cuh
   impl/IVFBase.cuh
   impl/IVFFlat.cuh

--- a/faiss/gpu/GpuAutoTune.cpp
+++ b/faiss/gpu/GpuAutoTune.cpp
@@ -16,6 +16,7 @@
 #include <faiss/gpu/GpuIndexIVFFlat.h>
 #include <faiss/gpu/GpuIndexIVFPQ.h>
 #include <faiss/gpu/GpuIndexIVFScalarQuantizer.h>
+#include <faiss/gpu/impl/IndexUtils.h>
 #include <faiss/gpu/utils/DeviceUtils.h>
 #include <faiss/impl/FaissAssert.h>
 

--- a/faiss/gpu/GpuCloner.cpp
+++ b/faiss/gpu/GpuCloner.cpp
@@ -121,7 +121,6 @@ Index* ToGpuCloner::clone_Index(const Index* index) {
         GpuIndexFlatConfig config;
         config.device = device;
         config.useFloat16 = useFloat16;
-        config.storeTransposed = storeTransposed;
         return new GpuIndexFlat(provider, ifl, config);
     } else if (
             dynamic_cast<const IndexScalarQuantizer*>(index) &&
@@ -147,7 +146,6 @@ Index* ToGpuCloner::clone_Index(const Index* index) {
         config.device = device;
         config.indicesOptions = indicesOptions;
         config.flatConfig.useFloat16 = useFloat16CoarseQuantizer;
-        config.flatConfig.storeTransposed = storeTransposed;
 
         GpuIndexIVFFlat* res = new GpuIndexIVFFlat(
                 provider, ifl->d, ifl->nlist, ifl->metric_type, config);
@@ -164,7 +162,6 @@ Index* ToGpuCloner::clone_Index(const Index* index) {
         config.device = device;
         config.indicesOptions = indicesOptions;
         config.flatConfig.useFloat16 = useFloat16CoarseQuantizer;
-        config.flatConfig.storeTransposed = storeTransposed;
 
         GpuIndexIVFScalarQuantizer* res = new GpuIndexIVFScalarQuantizer(
                 provider,
@@ -195,7 +192,6 @@ Index* ToGpuCloner::clone_Index(const Index* index) {
         config.device = device;
         config.indicesOptions = indicesOptions;
         config.flatConfig.useFloat16 = useFloat16CoarseQuantizer;
-        config.flatConfig.storeTransposed = storeTransposed;
         config.useFloat16LookupTables = useFloat16;
         config.usePrecomputedTables = usePrecomputed;
 

--- a/faiss/gpu/GpuIndex.cu
+++ b/faiss/gpu/GpuIndex.cu
@@ -5,8 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <faiss/IndexFlat.h>
+#include <faiss/IndexIVFFlat.h>
+#include <faiss/IndexIVFPQ.h>
+#include <faiss/IndexScalarQuantizer.h>
 #include <faiss/gpu/GpuIndex.h>
 #include <faiss/gpu/GpuResources.h>
+#include <faiss/gpu/impl/IndexUtils.h>
 #include <faiss/gpu/utils/DeviceUtils.h>
 #include <faiss/gpu/utils/StaticUtils.h>
 #include <faiss/impl/FaissAssert.h>
@@ -104,13 +109,10 @@ void GpuIndex::add_with_ids(
         Index::idx_t n,
         const float* x,
         const Index::idx_t* ids) {
+    DeviceScope scope(config_.device);
     FAISS_THROW_IF_NOT_MSG(this->is_trained, "Index not trained");
 
-    // For now, only support <= max int results
-    FAISS_THROW_IF_NOT_FMT(
-            n <= (Index::idx_t)std::numeric_limits<int>::max(),
-            "GPU index only supports up to %d indices",
-            std::numeric_limits<int>::max());
+    validateNumVectors(n);
 
     if (n == 0) {
         // nothing to add
@@ -128,7 +130,6 @@ void GpuIndex::add_with_ids(
         }
     }
 
-    DeviceScope scope(config_.device);
     addPaged_((int)n, x, ids ? ids : generatedIds.data());
 }
 
@@ -195,22 +196,12 @@ void GpuIndex::assign(
         const float* x,
         Index::idx_t* labels,
         Index::idx_t k) const {
+    DeviceScope scope(config_.device);
     FAISS_THROW_IF_NOT_MSG(this->is_trained, "Index not trained");
 
-    // For now, only support <= max int results
-    FAISS_THROW_IF_NOT_FMT(
-            n <= (Index::idx_t)std::numeric_limits<int>::max(),
-            "GPU index only supports up to %d indices",
-            std::numeric_limits<int>::max());
+    validateNumVectors(n);
+    validateKSelect(k);
 
-    // Maximum k-selection supported is based on the CUDA SDK
-    FAISS_THROW_IF_NOT_FMT(
-            k <= (Index::idx_t)getMaxKSelection(),
-            "GPU index only supports k <= %d (requested %d)",
-            getMaxKSelection(),
-            (int)k); // select limitation
-
-    DeviceScope scope(config_.device);
     auto stream = resources_->getDefaultStream(config_.device);
 
     // We need to create a throw-away buffer for distances, which we don't use
@@ -231,29 +222,17 @@ void GpuIndex::search(
         float* distances,
         Index::idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT(k > 0);
-    FAISS_THROW_IF_NOT_MSG(!params, "params not implemented");
+    DeviceScope scope(config_.device);
     FAISS_THROW_IF_NOT_MSG(this->is_trained, "Index not trained");
 
-    // For now, only support <= max int results
-    FAISS_THROW_IF_NOT_FMT(
-            n <= (Index::idx_t)std::numeric_limits<int>::max(),
-            "GPU index only supports up to %d indices",
-            std::numeric_limits<int>::max());
-
-    // Maximum k-selection supported is based on the CUDA SDK
-    FAISS_THROW_IF_NOT_FMT(
-            k <= (Index::idx_t)getMaxKSelection(),
-            "GPU index only supports k <= %d (requested %d)",
-            getMaxKSelection(),
-            (int)k); // select limitation
+    validateNumVectors(n);
+    validateKSelect(k);
 
     if (n == 0 || k == 0) {
         // nothing to search
         return;
     }
 
-    DeviceScope scope(config_.device);
     auto stream = resources_->getDefaultStream(config_.device);
 
     // We guarantee that the searchImpl_ will be called with device-resident
@@ -287,13 +266,14 @@ void GpuIndex::search(
         size_t dataSize = (size_t)n * this->d * sizeof(float);
 
         if (dataSize >= minPagedSize_) {
-            searchFromCpuPaged_(n, x, k, outDistances.data(), outLabels.data());
+            searchFromCpuPaged_(
+                    n, x, k, outDistances.data(), outLabels.data(), params);
             usePaged = true;
         }
     }
 
     if (!usePaged) {
-        searchNonPaged_(n, x, k, outDistances.data(), outLabels.data());
+        searchNonPaged_(n, x, k, outDistances.data(), outLabels.data(), params);
     }
 
     // Copy back if necessary
@@ -301,12 +281,25 @@ void GpuIndex::search(
     fromDevice<Index::idx_t, 2>(outLabels, labels, stream);
 }
 
+void GpuIndex::search_and_reconstruct(
+        idx_t n,
+        const float* x,
+        idx_t k,
+        float* distances,
+        idx_t* labels,
+        float* recons,
+        const SearchParameters* params) const {
+    search(n, x, k, distances, labels, params);
+    reconstruct_batch(n, labels, recons);
+}
+
 void GpuIndex::searchNonPaged_(
         int n,
         const float* x,
         int k,
         float* outDistancesData,
-        Index::idx_t* outIndicesData) const {
+        Index::idx_t* outIndicesData,
+        const SearchParameters* params) const {
     auto stream = resources_->getDefaultStream(config_.device);
 
     // Make sure arguments are on the device we desire; use temporary
@@ -318,7 +311,7 @@ void GpuIndex::searchNonPaged_(
             stream,
             {n, (int)this->d});
 
-    searchImpl_(n, vecs.data(), k, outDistancesData, outIndicesData);
+    searchImpl_(n, vecs.data(), k, outDistancesData, outIndicesData, params);
 }
 
 void GpuIndex::searchFromCpuPaged_(
@@ -326,7 +319,8 @@ void GpuIndex::searchFromCpuPaged_(
         const float* x,
         int k,
         float* outDistancesData,
-        Index::idx_t* outIndicesData) const {
+        Index::idx_t* outIndicesData,
+        const SearchParameters* params) const {
     Tensor<float, 2, true> outDistances(outDistancesData, {n, k});
     Tensor<Index::idx_t, 2, true> outIndices(outIndicesData, {n, k});
 
@@ -351,7 +345,8 @@ void GpuIndex::searchFromCpuPaged_(
                     x + (size_t)cur * this->d,
                     k,
                     outDistancesSlice.data(),
-                    outIndicesSlice.data());
+                    outIndicesSlice.data(),
+                    params);
         }
 
         return;
@@ -466,7 +461,8 @@ void GpuIndex::searchFromCpuPaged_(
                     bufGpus[cur3BufIndex]->data(),
                     k,
                     outDistancesSlice.data(),
-                    outIndicesSlice.data());
+                    outIndicesSlice.data(),
+                    params);
 
             // Create completion event
             eventGpuExecuteDone[cur3BufIndex].reset(
@@ -517,6 +513,31 @@ void GpuIndex::compute_residual_n(
 
 std::shared_ptr<GpuResources> GpuIndex::getResources() {
     return resources_;
+}
+
+GpuIndex* tryCastGpuIndex(faiss::Index* index) {
+    return dynamic_cast<GpuIndex*>(index);
+}
+
+bool isGpuIndex(faiss::Index* index) {
+    return tryCastGpuIndex(index) != nullptr;
+}
+
+bool isGpuIndexImplemented(faiss::Index* index) {
+#define CHECK_INDEX(TYPE)                 \
+    do {                                  \
+        if (dynamic_cast<TYPE*>(index)) { \
+            return true;                  \
+        }                                 \
+    } while (false)
+
+    CHECK_INDEX(faiss::IndexFlat);
+    // FIXME: do we want recursive checking of the IVF quantizer?
+    CHECK_INDEX(faiss::IndexIVFFlat);
+    CHECK_INDEX(faiss::IndexIVFPQ);
+    CHECK_INDEX(faiss::IndexIVFScalarQuantizer);
+
+    return false;
 }
 
 } // namespace gpu

--- a/faiss/gpu/GpuIndexFlat.h
+++ b/faiss/gpu/GpuIndexFlat.h
@@ -24,17 +24,14 @@ namespace gpu {
 class FlatIndex;
 
 struct GpuIndexFlatConfig : public GpuIndexConfig {
-    inline GpuIndexFlatConfig() : useFloat16(false), storeTransposed(false) {}
+    inline GpuIndexFlatConfig() : useFloat16(false) {}
 
     /// Whether or not data is stored as float16
     bool useFloat16;
 
-    /// Whether or not data is stored (transparently) in a transposed
-    /// layout, enabling use of the NN GEMM call, which is ~10% faster.
-    /// This will improve the speed of the flat index, but will
-    /// substantially slow down any add() calls made, as all data must
-    /// be transposed, and will increase storage requirements (we store
-    /// data in both transposed and non-transposed layouts).
+    /// Deprecated: no longer used
+    /// Previously used to indicate whether internal storage of vectors is
+    /// transposed
     bool storeTransposed;
 };
 
@@ -98,6 +95,10 @@ class GpuIndexFlat : public GpuIndex {
     void reconstruct_n(Index::idx_t i0, Index::idx_t num, float* out)
             const override;
 
+    /// Batch reconstruction method
+    void reconstruct_batch(Index::idx_t n, const Index::idx_t* keys, float* out)
+            const override;
+
     /// Compute residual
     void compute_residual(const float* x, float* residual, Index::idx_t key)
             const override;
@@ -128,7 +129,8 @@ class GpuIndexFlat : public GpuIndex {
             const float* x,
             int k,
             float* distances,
-            Index::idx_t* labels) const override;
+            Index::idx_t* labels,
+            const SearchParameters* params) const override;
 
    protected:
     /// Our configuration options

--- a/faiss/gpu/GpuIndexIVF.cu
+++ b/faiss/gpu/GpuIndexIVF.cu
@@ -7,11 +7,14 @@
 
 #include <faiss/IndexFlat.h>
 #include <faiss/IndexIVF.h>
+#include <faiss/gpu/GpuCloner.h>
 #include <faiss/gpu/GpuIndexFlat.h>
 #include <faiss/gpu/GpuIndexIVF.h>
+#include <faiss/gpu/impl/IndexUtils.h>
 #include <faiss/gpu/utils/DeviceUtils.h>
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/gpu/utils/Float16.cuh>
+#include <faiss/gpu/impl/IVFBase.cuh>
+#include <faiss/gpu/utils/CopyUtils.cuh>
 
 namespace faiss {
 namespace gpu {
@@ -27,33 +30,71 @@ GpuIndexIVF::GpuIndexIVF(
           nlist(nlistIn),
           nprobe(1),
           quantizer(nullptr),
+          own_fields(false),
           ivfConfig_(config) {
+    // Only IP and L2 are supported for now
+    if (!(metric_type == faiss::METRIC_L2 ||
+          metric_type == faiss::METRIC_INNER_PRODUCT)) {
+        FAISS_THROW_FMT("unsupported metric type %d", (int)metric_type);
+    }
+
     init_();
+}
+
+GpuIndexIVF::GpuIndexIVF(
+        GpuResourcesProvider* provider,
+        Index* coarseQuantizer,
+        int dims,
+        faiss::MetricType metric,
+        float metricArg,
+        int nlistIn,
+        GpuIndexIVFConfig config)
+        : GpuIndex(provider->getResources(), dims, metric, metricArg, config),
+          nlist(nlistIn),
+          nprobe(1),
+          quantizer(coarseQuantizer),
+          ivfConfig_(config) {
+    FAISS_THROW_IF_NOT_MSG(
+            quantizer, "expecting a coarse quantizer object; none provided");
+
+    // We are passed an external quantizer object that we do not own
+    own_fields = false;
 
     // Only IP and L2 are supported for now
     if (!(metric_type == faiss::METRIC_L2 ||
           metric_type == faiss::METRIC_INNER_PRODUCT)) {
         FAISS_THROW_FMT("unsupported metric type %d", (int)metric_type);
     }
+
+    init_();
 }
 
 void GpuIndexIVF::init_() {
     FAISS_THROW_IF_NOT_MSG(nlist > 0, "nlist must be > 0");
 
     // Spherical by default if the metric is inner_product
+    // (copying IndexIVF.cpp)
     if (metric_type == faiss::METRIC_INNER_PRODUCT) {
         cp.spherical = true;
     }
 
     // here we set a low # iterations because this is typically used
     // for large clusterings
+    // (copying IndexIVF.cpp's Level1Quantizer
     cp.niter = 10;
     cp.verbose = verbose;
 
-    if (!quantizer) {
-        // Construct an empty quantizer
+    if (quantizer) {
+        // The passed in quantizer may be either a CPU or GPU index
+        // Same work as IndexIVF's constructor
+        is_trained = quantizer->is_trained && quantizer->ntotal == nlist;
+    } else {
+        // we have not yet been trained
+        is_trained = false;
+
+        // Construct a GPU empty flat quantizer as our coarse quantizer
         GpuIndexFlatConfig config = ivfConfig_.flatConfig;
-        // FIXME: inherit our same device
+        // inherit our same device
         config.device = config_.device;
 
         if (metric_type == faiss::METRIC_L2) {
@@ -64,15 +105,52 @@ void GpuIndexIVF::init_() {
             // unknown metric type
             FAISS_THROW_FMT("unsupported metric type %d", (int)metric_type);
         }
+
+        // we instantiated the coarse quantizer here, so we destroy it as well
+        own_fields = true;
     }
+
+    verifyIVFSettings_();
 }
 
 GpuIndexIVF::~GpuIndexIVF() {
-    delete quantizer;
+    if (own_fields) {
+        delete quantizer;
+    }
 }
 
-GpuIndexFlat* GpuIndexIVF::getQuantizer() {
-    return quantizer;
+void GpuIndexIVF::verifyIVFSettings_() const {
+    // We should always have a quantizer instance
+    FAISS_THROW_IF_NOT(quantizer);
+    FAISS_THROW_IF_NOT(d == quantizer->d);
+
+    if (is_trained) {
+        FAISS_THROW_IF_NOT(quantizer->is_trained);
+
+        // IVF quantizer should correspond to our set of lists
+        FAISS_THROW_IF_NOT_FMT(
+                quantizer->ntotal == nlist,
+                "IVF nlist count (%d) does not match trained coarse quantizer size (%zu)",
+                nlist,
+                quantizer->ntotal);
+    } else {
+        // The coarse quantizer may or may not be trained, but if we are
+        // trained, then the coarse quantizer must also be trained (the check
+        // above)
+        FAISS_THROW_IF_NOT(ntotal == 0);
+    }
+
+    // If the quantizer is a GPU index, then it must be resident on the same
+    // device as us
+    auto gpuQuantizer = tryCastGpuIndex(quantizer);
+    if (gpuQuantizer && gpuQuantizer->getDevice() != getDevice()) {
+        FAISS_THROW_FMT(
+                "GpuIndexIVF: not allowed to instantiate a GPU IVF "
+                "index that is resident on a different GPU (%d) "
+                "than its GPU coarse quantizer (%d)",
+                getDevice(),
+                gpuQuantizer->getDevice());
+    }
 }
 
 void GpuIndexIVF::copyFrom(const faiss::IndexIVF* index) {
@@ -96,47 +174,44 @@ void GpuIndexIVF::copyFrom(const faiss::IndexIVF* index) {
 
     // The metric type may have changed as well, so we might have to
     // change our quantizer
-    delete quantizer;
+    if (own_fields) {
+        delete quantizer;
+    }
     quantizer = nullptr;
 
-    // Construct an empty quantizer
-    GpuIndexFlatConfig config = ivfConfig_.flatConfig;
-    // FIXME: inherit our same device
-    config.device = config_.device;
+    // IVF index that we are copying from must have a coarse quantizer
+    FAISS_THROW_IF_NOT(index->quantizer);
 
-    if (index->metric_type == faiss::METRIC_L2) {
-        // FIXME: 2 different float16 options?
-        quantizer = new GpuIndexFlatL2(resources_, this->d, config);
-    } else if (index->metric_type == faiss::METRIC_INNER_PRODUCT) {
-        // FIXME: 2 different float16 options?
-        quantizer = new GpuIndexFlatIP(resources_, this->d, config);
+    if (!isGpuIndex(index->quantizer)) {
+        // The coarse quantizer used in the IndexIVF is non-GPU.
+        // If it is something that we support on the GPU, we wish to copy it
+        // over to the GPU, on the same device that we are on.
+        GpuResourcesProviderFromInstance pfi(getResources());
+
+        GpuClonerOptions options;
+        auto cloner = ToGpuCloner(&pfi, getDevice(), options);
+
+        quantizer = cloner.clone_Index(index->quantizer);
+        own_fields = true;
     } else {
-        // unknown metric type
-        FAISS_ASSERT(false);
+        // Otherwise, this is a GPU coarse quantizer index instance found in a
+        // CPU instance. It is unclear what we should do here, but for now we'll
+        // flag this as an error (we're expecting a pure CPU index)
+        FAISS_THROW_MSG(
+                "GpuIndexIVF::copyFrom: copying a CPU IVF index to GPU "
+                "that already contains a GPU coarse (level 1) quantizer "
+                "is not currently supported");
     }
 
-    if (!index->is_trained) {
-        // copied in GpuIndex::copyFrom
-        FAISS_ASSERT(!is_trained && ntotal == 0);
-        return;
-    }
+    // Validate equality
+    FAISS_ASSERT(is_trained == index->is_trained);
+    FAISS_ASSERT(ntotal == index->ntotal);
+    FAISS_ASSERT(nlist == index->nlist);
+    FAISS_ASSERT(quantizer->is_trained == index->quantizer->is_trained);
+    FAISS_ASSERT(quantizer->ntotal == index->quantizer->ntotal);
 
-    // copied in GpuIndex::copyFrom
-    // ntotal can exceed max int, but the number of vectors per inverted
-    // list cannot exceed this. We check this in the subclasses.
-    FAISS_ASSERT(is_trained && (ntotal == index->ntotal));
-
-    // Since we're trained, the quantizer must have data
-    FAISS_ASSERT(index->quantizer->ntotal > 0);
-
-    // Right now, we can only handle IndexFlat or derived classes
-    auto qFlat = dynamic_cast<faiss::IndexFlat*>(index->quantizer);
-    FAISS_THROW_IF_NOT_MSG(
-            qFlat,
-            "Only IndexFlat is supported for the coarse quantizer "
-            "for copying from an IndexIVF into a GpuIndexIVF");
-
-    quantizer->copyFrom(qFlat);
+    // Validate IVF/quantizer settings
+    verifyIVFSettings_();
 }
 
 void GpuIndexIVF::copyTo(faiss::IndexIVF* index) const {
@@ -153,30 +228,23 @@ void GpuIndexIVF::copyTo(faiss::IndexIVF* index) const {
     index->nlist = nlist;
     index->nprobe = nprobe;
 
-    // Construct and copy the appropriate quantizer
-    faiss::IndexFlat* q = nullptr;
-
-    if (this->metric_type == faiss::METRIC_L2) {
-        q = new faiss::IndexFlatL2(this->d);
-
-    } else if (this->metric_type == faiss::METRIC_INNER_PRODUCT) {
-        q = new faiss::IndexFlatIP(this->d);
-
-    } else {
-        // we should have one of the above metrics
-        FAISS_ASSERT(false);
-    }
-
     FAISS_ASSERT(quantizer);
-    quantizer->copyTo(q);
-
     if (index->own_fields) {
         delete index->quantizer;
+        index->quantizer = nullptr;
     }
 
-    index->quantizer = q;
-    index->quantizer_trains_alone = 0;
+    index->quantizer = index_gpu_to_cpu(quantizer);
+    FAISS_THROW_IF_NOT(index->quantizer);
+
+    // Validate consistency between the coarse quantizer and the index
+    FAISS_ASSERT(
+            index->quantizer->is_trained == quantizer->is_trained &&
+            index->quantizer->is_trained == is_trained);
+    FAISS_ASSERT(index->quantizer->ntotal == quantizer->ntotal);
+
     index->own_fields = true;
+    index->quantizer_trains_alone = 0;
     index->cp = this->cp;
     index->make_direct_map(false);
 }
@@ -198,12 +266,177 @@ int GpuIndexIVF::getNumProbes() const {
     return nprobe;
 }
 
+int GpuIndexIVF::getListLength(int listId) const {
+    DeviceScope scope(config_.device);
+    FAISS_ASSERT(baseIndex_);
+
+    return baseIndex_->getListLength(listId);
+}
+
+std::vector<uint8_t> GpuIndexIVF::getListVectorData(int listId, bool gpuFormat)
+        const {
+    DeviceScope scope(config_.device);
+    FAISS_ASSERT(baseIndex_);
+
+    return baseIndex_->getListVectorData(listId, gpuFormat);
+}
+
+std::vector<Index::idx_t> GpuIndexIVF::getListIndices(int listId) const {
+    DeviceScope scope(config_.device);
+    FAISS_ASSERT(baseIndex_);
+
+    return baseIndex_->getListIndices(listId);
+}
+
+void GpuIndexIVF::addImpl_(int n, const float* x, const Index::idx_t* xids) {
+    // Device is already set in GpuIndex::add
+    FAISS_ASSERT(baseIndex_);
+    FAISS_ASSERT(n > 0);
+
+    // Data is already resident on the GPU
+    Tensor<float, 2, true> data(const_cast<float*>(x), {n, (int)this->d});
+    Tensor<Index::idx_t, 1, true> labels(const_cast<Index::idx_t*>(xids), {n});
+
+    // Not all vectors may be able to be added (some may contain NaNs etc)
+    baseIndex_->addVectors(quantizer, data, labels);
+
+    // but keep the ntotal based on the total number of vectors that we
+    // attempted to add
+    ntotal += n;
+}
+
+void GpuIndexIVF::searchImpl_(
+        int n,
+        const float* x,
+        int k,
+        float* distances,
+        Index::idx_t* labels,
+        const SearchParameters* params) const {
+    // Device was already set in GpuIndex::search
+    Index::idx_t use_nprobe = nprobe;
+    if (params) {
+        auto ivfParams = dynamic_cast<const SearchParametersIVF*>(params);
+        if (ivfParams) {
+            use_nprobe = ivfParams->nprobe;
+
+            FAISS_THROW_IF_NOT_FMT(
+                    ivfParams->max_codes == 0,
+                    "GPU IVF index does not currently support "
+                    "SearchParametersIVF::max_codes (passed %zu, must be 0)",
+                    ivfParams->max_codes);
+        }
+    }
+
+    validateNProbe(use_nprobe);
+
+    // This was previously checked
+    FAISS_ASSERT(is_trained && baseIndex_);
+    FAISS_ASSERT(n > 0);
+
+    // Data is already resident on the GPU
+    Tensor<float, 2, true> queries(const_cast<float*>(x), {n, (int)this->d});
+    Tensor<float, 2, true> outDistances(distances, {n, k});
+    Tensor<Index::idx_t, 2, true> outLabels(
+            const_cast<Index::idx_t*>(labels), {n, k});
+
+    baseIndex_->search(
+            quantizer, queries, use_nprobe, k, outDistances, outLabels);
+}
+
+void GpuIndexIVF::search_preassigned(
+        idx_t n,
+        const float* x,
+        idx_t k,
+        const idx_t* assign,
+        const float* centroid_dis,
+        float* distances,
+        idx_t* labels,
+        bool store_pairs,
+        const IVFSearchParameters* params) const {
+    DeviceScope scope(config_.device);
+    auto stream = resources_->getDefaultStream(config_.device);
+
+    FAISS_THROW_IF_NOT_MSG(
+            !store_pairs,
+            "GpuIndexIVF::search_preassigned does not "
+            "currently support store_pairs");
+    FAISS_THROW_IF_NOT_MSG(this->is_trained, "GpuIndexIVF not trained");
+    FAISS_ASSERT(baseIndex_);
+
+    validateNumVectors(n);
+    validateKSelect(k);
+
+    if (n == 0 || k == 0) {
+        // nothing to search
+        return;
+    }
+
+    idx_t use_nprobe = params ? params->nprobe : this->nprobe;
+    validateNProbe(use_nprobe);
+
+    if (params) {
+        FAISS_THROW_IF_NOT_FMT(
+                params->max_codes == 0,
+                "GPU IVF index does not currently support "
+                "SearchParametersIVF::max_codes (passed %zu, must be 0)",
+                params->max_codes);
+    }
+
+    // Ensure that all data/output buffers are resident on our desired device
+    auto vecsDevice = toDeviceTemporary<float, 2>(
+            resources_.get(),
+            config_.device,
+            const_cast<float*>(x),
+            stream,
+            {(int)n, (int)d});
+
+    auto distanceDevice = toDeviceTemporary<float, 2>(
+            resources_.get(),
+            config_.device,
+            const_cast<float*>(centroid_dis),
+            stream,
+            {(int)n, (int)use_nprobe});
+
+    auto assignDevice = toDeviceTemporary<Index::idx_t, 2>(
+            resources_.get(),
+            config_.device,
+            const_cast<Index::idx_t*>(assign),
+            stream,
+            {(int)n, (int)use_nprobe});
+
+    auto outDistancesDevice = toDeviceTemporary<float, 2>(
+            resources_.get(),
+            config_.device,
+            distances,
+            stream,
+            {(int)n, (int)k});
+
+    auto outIndicesDevice = toDeviceTemporary<Index::idx_t, 2>(
+            resources_.get(), config_.device, labels, stream, {(int)n, (int)k});
+
+    baseIndex_->searchPreassigned(
+            quantizer,
+            vecsDevice,
+            distanceDevice,
+            assignDevice,
+            k,
+            outDistancesDevice,
+            outIndicesDevice,
+            store_pairs);
+
+    // If the output was not already on the GPU, copy it back
+    fromDevice<float, 2>(outDistancesDevice, distances, stream);
+    fromDevice<Index::idx_t, 2>(outIndicesDevice, labels, stream);
+}
+
 bool GpuIndexIVF::addImplRequiresIDs_() const {
     // All IVF indices have storage for IDs
     return true;
 }
 
 void GpuIndexIVF::trainQuantizer_(Index::idx_t n, const float* x) {
+    DeviceScope scope(config_.device);
+
     if (n == 0) {
         // nothing to do
         return;
@@ -220,8 +453,6 @@ void GpuIndexIVF::trainQuantizer_(Index::idx_t n, const float* x) {
     if (this->verbose) {
         printf("Training IVF quantizer on %ld vectors in %dD\n", n, d);
     }
-
-    DeviceScope scope(config_.device);
 
     // leverage the CPU-side k-means code, which works for the GPU
     // flat index as well

--- a/faiss/gpu/GpuIndexIVFFlat.cu
+++ b/faiss/gpu/GpuIndexIVFFlat.cu
@@ -45,19 +45,55 @@ GpuIndexIVFFlat::GpuIndexIVFFlat(
         : GpuIndexIVF(provider, dims, metric, 0, nlist, config),
           ivfFlatConfig_(config),
           reserveMemoryVecs_(0) {
-    // faiss::Index params
-    this->is_trained = false;
-
     // We haven't trained ourselves, so don't construct the IVFFlat
     // index yet
+}
+
+GpuIndexIVFFlat::GpuIndexIVFFlat(
+        GpuResourcesProvider* provider,
+        Index* coarseQuantizer,
+        int dims,
+        int nlist,
+        faiss::MetricType metric,
+        GpuIndexIVFFlatConfig config)
+        : GpuIndexIVF(
+                  provider,
+                  coarseQuantizer,
+                  dims,
+                  metric,
+                  0,
+                  nlist,
+                  config),
+          ivfFlatConfig_(config),
+          reserveMemoryVecs_(0) {
+    // We could have been passed an already trained coarse quantizer. There is
+    // no other quantizer that we need to train, so this is sufficient
+    if (this->is_trained) {
+        FAISS_ASSERT(this->quantizer);
+
+        index_.reset(new IVFFlat(
+                resources_.get(),
+                this->d,
+                this->nlist,
+                this->metric_type,
+                this->metric_arg,
+                false,   // no residual
+                nullptr, // no scalar quantizer
+                ivfFlatConfig_.interleavedLayout,
+                ivfFlatConfig_.indicesOptions,
+                config_.memorySpace));
+        baseIndex_ = std::static_pointer_cast<IVFBase, IVFFlat>(index_);
+        updateQuantizer();
+    }
 }
 
 GpuIndexIVFFlat::~GpuIndexIVFFlat() {}
 
 void GpuIndexIVFFlat::reserveMemory(size_t numVecs) {
+    DeviceScope scope(config_.device);
+
     reserveMemoryVecs_ = numVecs;
     if (index_) {
-        DeviceScope scope(config_.device);
         index_->reserveMemory(numVecs);
     }
 }
@@ -65,24 +101,27 @@ void GpuIndexIVFFlat::reserveMemory(size_t numVecs) {
 void GpuIndexIVFFlat::copyFrom(const faiss::IndexIVFFlat* index) {
     DeviceScope scope(config_.device);
 
+    // This will copy GpuIndexIVF data such as the coarse quantizer
     GpuIndexIVF::copyFrom(index);
 
     // Clear out our old data
     index_.reset();
+    baseIndex_.reset();
 
     // The other index might not be trained
     if (!index->is_trained) {
-        FAISS_ASSERT(!is_trained);
+        FAISS_ASSERT(!this->is_trained);
         return;
     }
 
     // Otherwise, we can populate ourselves from the other index
-    FAISS_ASSERT(is_trained);
+    FAISS_ASSERT(this->is_trained);
 
     // Copy our lists as well
     index_.reset(new IVFFlat(
             resources_.get(),
-            quantizer->getGpuData(),
+            this->d,
+            this->nlist,
             index->metric_type,
             index->metric_arg,
             false,   // no residual
@@ -90,6 +129,8 @@ void GpuIndexIVFFlat::copyFrom(const faiss::IndexIVFFlat* index) {
             ivfFlatConfig_.interleavedLayout,
             ivfFlatConfig_.indicesOptions,
             config_.memorySpace));
+    baseIndex_ = std::static_pointer_cast<IVFBase, IVFFlat>(index_);
+    updateQuantizer();
 
     // Copy all of the IVF data
     index_->copyInvertedListsFrom(index->invlists);
@@ -117,9 +158,9 @@ void GpuIndexIVFFlat::copyTo(faiss::IndexIVFFlat* index) const {
 }
 
 size_t GpuIndexIVFFlat::reclaimMemory() {
-    if (index_) {
-        DeviceScope scope(config_.device);
+    DeviceScope scope(config_.device);
 
+    if (index_) {
         return index_->reclaimMemory();
     }
 
@@ -127,9 +168,9 @@ size_t GpuIndexIVFFlat::reclaimMemory() {
 }
 
 void GpuIndexIVFFlat::reset() {
-    if (index_) {
-        DeviceScope scope(config_.device);
+    DeviceScope scope(config_.device);
 
+    if (index_) {
         index_->reset();
         this->ntotal = 0;
     } else {
@@ -137,18 +178,29 @@ void GpuIndexIVFFlat::reset() {
     }
 }
 
+void GpuIndexIVFFlat::updateQuantizer() {
+    FAISS_THROW_IF_NOT_MSG(
+            quantizer, "Calling updateQuantizer without a quantizer instance");
+
+    // Only need to do something if we are already initialized
+    if (index_) {
+        index_->updateQuantizer(quantizer);
+    }
+}
+
 void GpuIndexIVFFlat::train(Index::idx_t n, const float* x) {
+    DeviceScope scope(config_.device);
+
     // For now, only support <= max int results
     FAISS_THROW_IF_NOT_FMT(
             n <= (Index::idx_t)std::numeric_limits<int>::max(),
             "GPU index only supports up to %d indices",
             std::numeric_limits<int>::max());
 
-    DeviceScope scope(config_.device);
+    // just in case someone changed our quantizer
+    verifyIVFSettings_();
 
     if (this->is_trained) {
-        FAISS_ASSERT(quantizer->is_trained);
-        FAISS_ASSERT(quantizer->ntotal == nlist);
         FAISS_ASSERT(index_);
         return;
     }
@@ -168,7 +220,8 @@ void GpuIndexIVFFlat::train(Index::idx_t n, const float* x) {
     // The quantizer is now trained; construct the IVF index
     index_.reset(new IVFFlat(
             resources_.get(),
-            quantizer->getGpuData(),
+            this->d,
+            this->nlist,
             this->metric_type,
             this->metric_arg,
             false,   // no residual
@@ -176,75 +229,14 @@ void GpuIndexIVFFlat::train(Index::idx_t n, const float* x) {
             ivfFlatConfig_.interleavedLayout,
             ivfFlatConfig_.indicesOptions,
             config_.memorySpace));
+    baseIndex_ = std::static_pointer_cast<IVFBase, IVFFlat>(index_);
+    updateQuantizer();
 
     if (reserveMemoryVecs_) {
         index_->reserveMemory(reserveMemoryVecs_);
     }
 
     this->is_trained = true;
-}
-
-int GpuIndexIVFFlat::getListLength(int listId) const {
-    FAISS_ASSERT(index_);
-    DeviceScope scope(config_.device);
-
-    return index_->getListLength(listId);
-}
-
-std::vector<uint8_t> GpuIndexIVFFlat::getListVectorData(
-        int listId,
-        bool gpuFormat) const {
-    FAISS_ASSERT(index_);
-    DeviceScope scope(config_.device);
-
-    return index_->getListVectorData(listId, gpuFormat);
-}
-
-std::vector<Index::idx_t> GpuIndexIVFFlat::getListIndices(int listId) const {
-    FAISS_ASSERT(index_);
-    DeviceScope scope(config_.device);
-
-    return index_->getListIndices(listId);
-}
-
-void GpuIndexIVFFlat::addImpl_(
-        int n,
-        const float* x,
-        const Index::idx_t* xids) {
-    // Device is already set in GpuIndex::add
-    FAISS_ASSERT(index_);
-    FAISS_ASSERT(n > 0);
-
-    // Data is already resident on the GPU
-    Tensor<float, 2, true> data(const_cast<float*>(x), {n, (int)this->d});
-    Tensor<Index::idx_t, 1, true> labels(const_cast<Index::idx_t*>(xids), {n});
-
-    // Not all vectors may be able to be added (some may contain NaNs etc)
-    index_->addVectors(data, labels);
-
-    // but keep the ntotal based on the total number of vectors that we
-    // attempted to add
-    ntotal += n;
-}
-
-void GpuIndexIVFFlat::searchImpl_(
-        int n,
-        const float* x,
-        int k,
-        float* distances,
-        Index::idx_t* labels) const {
-    // Device is already set in GpuIndex::search
-    FAISS_ASSERT(index_);
-    FAISS_ASSERT(n > 0);
-    FAISS_THROW_IF_NOT(nprobe > 0 && nprobe <= nlist);
-
-    // Data is already resident on the GPU
-    Tensor<float, 2, true> queries(const_cast<float*>(x), {n, (int)this->d});
-    Tensor<float, 2, true> outDistances(distances, {n, k});
-    Tensor<Index::idx_t, 2, true> outLabels(
-            const_cast<Index::idx_t*>(labels), {n, k});
-
-    index_->query(queries, nprobe, k, outDistances, outLabels);
 }
 
 } // namespace gpu

--- a/faiss/gpu/GpuIndexIVFFlat.h
+++ b/faiss/gpu/GpuIndexIVFFlat.h
@@ -40,12 +40,22 @@ class GpuIndexIVFFlat : public GpuIndexIVF {
             GpuIndexIVFFlatConfig config = GpuIndexIVFFlatConfig());
 
     /// Constructs a new instance with an empty flat quantizer; the user
-    /// provides the number of lists desired.
+    /// provides the number of IVF lists desired.
     GpuIndexIVFFlat(
             GpuResourcesProvider* provider,
             int dims,
             int nlist,
-            faiss::MetricType metric,
+            faiss::MetricType metric = faiss::METRIC_L2,
+            GpuIndexIVFFlatConfig config = GpuIndexIVFFlatConfig());
+
+    /// Constructs a new instance with a provided CPU or GPU coarse quantizer;
+    /// the user provides the number of IVF lists desired.
+    GpuIndexIVFFlat(
+            GpuResourcesProvider* provider,
+            Index* coarseQuantizer,
+            int dims,
+            int nlist,
+            faiss::MetricType metric = faiss::METRIC_L2,
             GpuIndexIVFFlatConfig config = GpuIndexIVFFlatConfig());
 
     ~GpuIndexIVFFlat() override;
@@ -69,36 +79,13 @@ class GpuIndexIVFFlat : public GpuIndexIVF {
     /// information
     void reset() override;
 
+    /// Should be called if the user ever changes the state of the IVF coarse
+    /// quantizer manually (e.g., substitutes a new instance or changes vectors
+    /// in the coarse quantizer outside the scope of training)
+    void updateQuantizer() override;
+
     /// Trains the coarse quantizer based on the given vector data
     void train(Index::idx_t n, const float* x) override;
-
-    /// Returns the number of vectors present in a particular inverted list
-    int getListLength(int listId) const override;
-
-    /// Return the encoded vector data contained in a particular inverted list,
-    /// for debugging purposes.
-    /// If gpuFormat is true, the data is returned as it is encoded in the
-    /// GPU-side representation.
-    /// Otherwise, it is converted to the CPU format.
-    /// compliant format, while the native GPU format may differ.
-    std::vector<uint8_t> getListVectorData(int listId, bool gpuFormat = false)
-            const override;
-
-    /// Return the vector indices contained in a particular inverted list, for
-    /// debugging purposes.
-    std::vector<Index::idx_t> getListIndices(int listId) const override;
-
-   protected:
-    /// Called from GpuIndex for add/add_with_ids
-    void addImpl_(int n, const float* x, const Index::idx_t* ids) override;
-
-    /// Called from GpuIndex for search
-    void searchImpl_(
-            int n,
-            const float* x,
-            int k,
-            float* distances,
-            Index::idx_t* labels) const override;
 
    protected:
     /// Our configuration options
@@ -107,8 +94,8 @@ class GpuIndexIVFFlat : public GpuIndexIVF {
     /// Desired inverted list memory reservation
     size_t reserveMemoryVecs_;
 
-    /// Instance that we own; contains the inverted list
-    std::unique_ptr<IVFFlat> index_;
+    /// Instance that we own; contains the inverted lists
+    std::shared_ptr<IVFFlat> index_;
 };
 
 } // namespace gpu

--- a/faiss/gpu/GpuIndexIVFPQ.h
+++ b/faiss/gpu/GpuIndexIVFPQ.h
@@ -63,14 +63,27 @@ class GpuIndexIVFPQ : public GpuIndexIVF {
             const faiss::IndexIVFPQ* index,
             GpuIndexIVFPQConfig config = GpuIndexIVFPQConfig());
 
-    /// Construct an empty index
+    /// Constructs a new instance with an empty flat quantizer; the user
+    /// provides the number of IVF lists desired.
     GpuIndexIVFPQ(
             GpuResourcesProvider* provider,
             int dims,
             int nlist,
             int subQuantizers,
             int bitsPerCode,
-            faiss::MetricType metric,
+            faiss::MetricType metric = faiss::METRIC_L2,
+            GpuIndexIVFPQConfig config = GpuIndexIVFPQConfig());
+
+    /// Constructs a new instance with a provided CPU or GPU coarse quantizer;
+    /// the user provides the number of IVF lists desired.
+    GpuIndexIVFPQ(
+            GpuResourcesProvider* provider,
+            Index* coarseQuantizer,
+            int dims,
+            int nlist,
+            int subQuantizers,
+            int bitsPerCode,
+            faiss::MetricType metric = faiss::METRIC_L2,
             GpuIndexIVFPQConfig config = GpuIndexIVFPQConfig());
 
     ~GpuIndexIVFPQ() override;
@@ -112,24 +125,13 @@ class GpuIndexIVFPQ : public GpuIndexIVF {
     /// product centroid information
     void reset() override;
 
+    /// Should be called if the user ever changes the state of the IVF coarse
+    /// quantizer manually (e.g., substitutes a new instance or changes vectors
+    /// in the coarse quantizer outside the scope of training)
+    void updateQuantizer() override;
+
     /// Trains the coarse and product quantizer based on the given vector data
     void train(Index::idx_t n, const float* x) override;
-
-    /// Returns the number of vectors present in a particular inverted list
-    int getListLength(int listId) const override;
-
-    /// Return the encoded vector data contained in a particular inverted list,
-    /// for debugging purposes.
-    /// If gpuFormat is true, the data is returned as it is encoded in the
-    /// GPU-side representation.
-    /// Otherwise, it is converted to the CPU format.
-    /// compliant format, while the native GPU format may differ.
-    std::vector<uint8_t> getListVectorData(int listId, bool gpuFormat = false)
-            const override;
-
-    /// Return the vector indices contained in a particular inverted list, for
-    /// debugging purposes.
-    std::vector<Index::idx_t> getListIndices(int listId) const override;
 
    public:
     /// Like the CPU version, we expose a publically-visible ProductQuantizer
@@ -137,19 +139,8 @@ class GpuIndexIVFPQ : public GpuIndexIVF {
     ProductQuantizer pq;
 
    protected:
-    /// Called from GpuIndex for add/add_with_ids
-    void addImpl_(int n, const float* x, const Index::idx_t* ids) override;
-
-    /// Called from GpuIndex for search
-    void searchImpl_(
-            int n,
-            const float* x,
-            int k,
-            float* distances,
-            Index::idx_t* labels) const override;
-
     /// Throws errors if configuration settings are improper
-    void verifySettings_() const;
+    void verifyPQSettings_() const;
 
     /// Trains the PQ quantizer based on the given vector data
     void trainResidualQuantizer_(Index::idx_t n, const float* x);
@@ -172,7 +163,7 @@ class GpuIndexIVFPQ : public GpuIndexIVF {
 
     /// The product quantizer instance that we own; contains the
     /// inverted lists
-    std::unique_ptr<IVFPQ> index_;
+    std::shared_ptr<IVFPQ> index_;
 };
 
 } // namespace gpu

--- a/faiss/gpu/GpuIndexIVFScalarQuantizer.cu
+++ b/faiss/gpu/GpuIndexIVFScalarQuantizer.cu
@@ -32,10 +32,8 @@ GpuIndexIVFScalarQuantizer::GpuIndexIVFScalarQuantizer(
           by_residual(index->by_residual),
           ivfSQConfig_(config),
           reserveMemoryVecs_(0) {
+    // This will perform SQ settings verification as well
     copyFrom(index);
-
-    FAISS_THROW_IF_NOT_MSG(
-            isSQSupported(sq.qtype), "Unsupported QuantizerType on GPU");
 }
 
 GpuIndexIVFScalarQuantizer::GpuIndexIVFScalarQuantizer(
@@ -51,21 +49,52 @@ GpuIndexIVFScalarQuantizer::GpuIndexIVFScalarQuantizer(
           by_residual(encodeResidual),
           ivfSQConfig_(config),
           reserveMemoryVecs_(0) {
-    // faiss::Index params
-    this->is_trained = false;
-
     // We haven't trained ourselves, so don't construct the IVFFlat
     // index yet
-    FAISS_THROW_IF_NOT_MSG(
-            isSQSupported(sq.qtype), "Unsupported QuantizerType on GPU");
+    verifySQSettings_();
+}
+
+GpuIndexIVFScalarQuantizer::GpuIndexIVFScalarQuantizer(
+        GpuResourcesProvider* provider,
+        Index* coarseQuantizer,
+        int dims,
+        int nlist,
+        faiss::ScalarQuantizer::QuantizerType qtype,
+        faiss::MetricType metric,
+        bool encodeResidual,
+        GpuIndexIVFScalarQuantizerConfig config)
+        : GpuIndexIVF(
+                  provider,
+                  coarseQuantizer,
+                  dims,
+                  metric,
+                  0,
+                  nlist,
+                  config),
+          sq(dims, qtype),
+          by_residual(encodeResidual),
+          ivfSQConfig_(config),
+          reserveMemoryVecs_(0) {
+    // While we were passed an existing coarse quantizer instance (possibly
+    // trained or not), we have not yet trained our scalar quantizer, so we
+    // can't construct our index_ instance yet
+    this->is_trained = false;
+
+    verifySQSettings_();
 }
 
 GpuIndexIVFScalarQuantizer::~GpuIndexIVFScalarQuantizer() {}
 
+void GpuIndexIVFScalarQuantizer::verifySQSettings_() const {
+    FAISS_THROW_IF_NOT_MSG(
+            isSQSupported(sq.qtype), "Unsupported scalar QuantizerType on GPU");
+}
+
 void GpuIndexIVFScalarQuantizer::reserveMemory(size_t numVecs) {
+    DeviceScope scope(config_.device);
+
     reserveMemoryVecs_ = numVecs;
     if (index_) {
-        DeviceScope scope(config_.device);
         index_->reserveMemory(numVecs);
     }
 }
@@ -76,6 +105,7 @@ void GpuIndexIVFScalarQuantizer::copyFrom(
 
     // Clear out our old data
     index_.reset();
+    baseIndex_.reset();
 
     // Copy what we need from the CPU index
     GpuIndexIVF::copyFrom(index);
@@ -94,7 +124,8 @@ void GpuIndexIVFScalarQuantizer::copyFrom(
     // Copy our lists as well
     index_.reset(new IVFFlat(
             resources_.get(),
-            quantizer->getGpuData(),
+            this->d,
+            this->nlist,
             index->metric_type,
             index->metric_arg,
             by_residual,
@@ -102,9 +133,13 @@ void GpuIndexIVFScalarQuantizer::copyFrom(
             ivfSQConfig_.interleavedLayout,
             ivfSQConfig_.indicesOptions,
             config_.memorySpace));
+    baseIndex_ = std::static_pointer_cast<IVFBase, IVFFlat>(index_);
+    updateQuantizer();
 
     // Copy all of the IVF data
     index_->copyInvertedListsFrom(index->invlists);
+
+    verifySQSettings_();
 }
 
 void GpuIndexIVFScalarQuantizer::copyTo(
@@ -132,48 +167,34 @@ void GpuIndexIVFScalarQuantizer::copyTo(
 }
 
 size_t GpuIndexIVFScalarQuantizer::reclaimMemory() {
-    if (index_) {
-        DeviceScope scope(config_.device);
+    DeviceScope scope(config_.device);
 
+    if (index_) {
         return index_->reclaimMemory();
     }
 
     return 0;
 }
 
-void GpuIndexIVFScalarQuantizer::reset() {
-    if (index_) {
-        DeviceScope scope(config_.device);
+void GpuIndexIVFScalarQuantizer::updateQuantizer() {
+    FAISS_THROW_IF_NOT_MSG(
+            quantizer, "Calling updateQuantizer without a quantizer instance");
 
+    // Only need to do something if we are already initialized
+    if (index_) {
+        index_->updateQuantizer(quantizer);
+    }
+}
+
+void GpuIndexIVFScalarQuantizer::reset() {
+    DeviceScope scope(config_.device);
+
+    if (index_) {
         index_->reset();
         this->ntotal = 0;
     } else {
         FAISS_ASSERT(this->ntotal == 0);
     }
-}
-
-int GpuIndexIVFScalarQuantizer::getListLength(int listId) const {
-    FAISS_ASSERT(index_);
-    DeviceScope scope(config_.device);
-
-    return index_->getListLength(listId);
-}
-
-std::vector<uint8_t> GpuIndexIVFScalarQuantizer::getListVectorData(
-        int listId,
-        bool gpuFormat) const {
-    FAISS_ASSERT(index_);
-    DeviceScope scope(config_.device);
-
-    return index_->getListVectorData(listId, gpuFormat);
-}
-
-std::vector<Index::idx_t> GpuIndexIVFScalarQuantizer::getListIndices(
-        int listId) const {
-    FAISS_ASSERT(index_);
-    DeviceScope scope(config_.device);
-
-    return index_->getListIndices(listId);
 }
 
 void GpuIndexIVFScalarQuantizer::trainResiduals_(
@@ -184,17 +205,19 @@ void GpuIndexIVFScalarQuantizer::trainResiduals_(
 }
 
 void GpuIndexIVFScalarQuantizer::train(Index::idx_t n, const float* x) {
+    DeviceScope scope(config_.device);
+
     // For now, only support <= max int results
     FAISS_THROW_IF_NOT_FMT(
             n <= (Index::idx_t)std::numeric_limits<int>::max(),
             "GPU index only supports up to %d indices",
             std::numeric_limits<int>::max());
 
-    DeviceScope scope(config_.device);
+    // just in case someone changed us
+    verifySQSettings_();
+    verifyIVFSettings_();
 
     if (this->is_trained) {
-        FAISS_ASSERT(quantizer->is_trained);
-        FAISS_ASSERT(quantizer->ntotal == nlist);
         FAISS_ASSERT(index_);
         return;
     }
@@ -215,7 +238,8 @@ void GpuIndexIVFScalarQuantizer::train(Index::idx_t n, const float* x) {
     // The quantizer is now trained; construct the IVF index
     index_.reset(new IVFFlat(
             resources_.get(),
-            quantizer->getGpuData(),
+            this->d,
+            this->nlist,
             this->metric_type,
             this->metric_arg,
             by_residual,
@@ -223,52 +247,14 @@ void GpuIndexIVFScalarQuantizer::train(Index::idx_t n, const float* x) {
             ivfSQConfig_.interleavedLayout,
             ivfSQConfig_.indicesOptions,
             config_.memorySpace));
+    baseIndex_ = std::static_pointer_cast<IVFBase, IVFFlat>(index_);
+    updateQuantizer();
 
     if (reserveMemoryVecs_) {
         index_->reserveMemory(reserveMemoryVecs_);
     }
 
     this->is_trained = true;
-}
-
-void GpuIndexIVFScalarQuantizer::addImpl_(
-        int n,
-        const float* x,
-        const Index::idx_t* xids) {
-    // Device is already set in GpuIndex::add
-    FAISS_ASSERT(index_);
-    FAISS_ASSERT(n > 0);
-
-    // Data is already resident on the GPU
-    Tensor<float, 2, true> data(const_cast<float*>(x), {n, (int)this->d});
-    Tensor<Index::idx_t, 1, true> labels(const_cast<Index::idx_t*>(xids), {n});
-
-    // Not all vectors may be able to be added (some may contain NaNs etc)
-    index_->addVectors(data, labels);
-
-    // but keep the ntotal based on the total number of vectors that we
-    // attempted to add
-    ntotal += n;
-}
-
-void GpuIndexIVFScalarQuantizer::searchImpl_(
-        int n,
-        const float* x,
-        int k,
-        float* distances,
-        Index::idx_t* labels) const {
-    // Device is already set in GpuIndex::search
-    FAISS_ASSERT(index_);
-    FAISS_ASSERT(n > 0);
-    FAISS_THROW_IF_NOT(nprobe > 0 && nprobe <= nlist);
-
-    // Data is already resident on the GPU
-    Tensor<float, 2, true> queries(const_cast<float*>(x), {n, (int)this->d});
-    Tensor<float, 2, true> outDistances(distances, {n, k});
-    Tensor<Index::idx_t, 2, true> outLabels(
-            const_cast<Index::idx_t*>(labels), {n, k});
-
-    index_->query(queries, nprobe, k, outDistances, outLabels);
 }
 
 } // namespace gpu

--- a/faiss/gpu/GpuResources.cpp
+++ b/faiss/gpu/GpuResources.cpp
@@ -184,5 +184,19 @@ size_t GpuResources::getTempMemoryAvailableCurrentDevice() const {
 
 GpuResourcesProvider::~GpuResourcesProvider() {}
 
+//
+// GpuResourcesProviderFromResourceInstance
+//
+
+GpuResourcesProviderFromInstance::GpuResourcesProviderFromInstance(
+        std::shared_ptr<GpuResources> p)
+        : res_(p) {}
+
+GpuResourcesProviderFromInstance::~GpuResourcesProviderFromInstance() {}
+
+std::shared_ptr<GpuResources> GpuResourcesProviderFromInstance::getResources() {
+    return res_;
+}
+
 } // namespace gpu
 } // namespace faiss

--- a/faiss/gpu/GpuResources.h
+++ b/faiss/gpu/GpuResources.h
@@ -250,13 +250,27 @@ class GpuResources {
     cudaStream_t getAsyncCopyStreamCurrentDevice();
 };
 
-/// Interface for a provider of a shared resources object
+/// Interface for a provider of a shared resources object. This is to avoid
+/// interfacing std::shared_ptr to Python
 class GpuResourcesProvider {
    public:
     virtual ~GpuResourcesProvider();
 
     /// Returns the shared resources object
     virtual std::shared_ptr<GpuResources> getResources() = 0;
+};
+
+/// A simple wrapper for a GpuResources object to make a GpuResourcesProvider
+/// out of it again
+class GpuResourcesProviderFromInstance : public GpuResourcesProvider {
+   public:
+    explicit GpuResourcesProviderFromInstance(std::shared_ptr<GpuResources> p);
+    ~GpuResourcesProviderFromInstance() override;
+
+    std::shared_ptr<GpuResources> getResources() override;
+
+   private:
+    std::shared_ptr<GpuResources> res_;
 };
 
 } // namespace gpu

--- a/faiss/gpu/impl/IVFAppend.cu
+++ b/faiss/gpu/impl/IVFAppend.cu
@@ -27,7 +27,7 @@ namespace gpu {
 
 // Updates the device-size array of list start pointers for codes and indices
 __global__ void runUpdateListPointers(
-        Tensor<int, 1, true> listIds,
+        Tensor<Index::idx_t, 1, true> listIds,
         Tensor<int, 1, true> newListLength,
         Tensor<void*, 1, true> newCodePointers,
         Tensor<void*, 1, true> newIndexPointers,
@@ -37,7 +37,7 @@ __global__ void runUpdateListPointers(
     int i = blockIdx.x * blockDim.x + threadIdx.x;
 
     if (i < listIds.getSize(0)) {
-        int listId = listIds[i];
+        Index::idx_t listId = listIds[i];
         listLengths[listId] = newListLength[i];
         listCodes[listId] = newCodePointers[i];
         listIndices[listId] = newIndexPointers[i];
@@ -45,7 +45,7 @@ __global__ void runUpdateListPointers(
 }
 
 void runUpdateListPointers(
-        Tensor<int, 1, true>& listIds,
+        Tensor<Index::idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& newListLength,
         Tensor<void*, 1, true>& newCodePointers,
         Tensor<void*, 1, true>& newIndexPointers,
@@ -73,7 +73,7 @@ void runUpdateListPointers(
 
 // Appends new indices for vectors being added to the IVF indices lists
 __global__ void ivfIndicesAppend(
-        Tensor<int, 1, true> listIds,
+        Tensor<Index::idx_t, 1, true> listIds,
         Tensor<int, 1, true> listOffset,
         Tensor<Index::idx_t, 1, true> indices,
         IndicesOptions opt,
@@ -84,7 +84,7 @@ __global__ void ivfIndicesAppend(
         return;
     }
 
-    int listId = listIds[vec];
+    Index::idx_t listId = listIds[vec];
     int offset = listOffset[vec];
 
     // Add vector could be invalid (contains NaNs etc)
@@ -92,7 +92,7 @@ __global__ void ivfIndicesAppend(
         return;
     }
 
-    auto index = indices[vec];
+    Index::idx_t index = indices[vec];
 
     if (opt == INDICES_32_BIT) {
         // FIXME: there could be overflow here, but where should we check this?
@@ -103,7 +103,7 @@ __global__ void ivfIndicesAppend(
 }
 
 void runIVFIndicesAppend(
-        Tensor<int, 1, true>& listIds,
+        Tensor<Index::idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
         Tensor<Index::idx_t, 1, true>& indices,
         IndicesOptions opt,
@@ -131,14 +131,14 @@ void runIVFIndicesAppend(
 
 template <typename Codec>
 __global__ void ivfFlatAppend(
-        Tensor<int, 1, true> listIds,
+        Tensor<Index::idx_t, 1, true> listIds,
         Tensor<int, 1, true> listOffset,
         Tensor<float, 2, true> vecs,
         void** listData,
         Codec codec) {
     int vec = blockIdx.x;
 
-    int listId = listIds[vec];
+    Index::idx_t listId = listIds[vec];
     int offset = listOffset[vec];
 
     // Add vector could be invalid (contains NaNs etc)
@@ -188,7 +188,7 @@ __global__ void ivfFlatAppend(
 }
 
 void runIVFFlatAppend(
-        Tensor<int, 1, true>& listIds,
+        Tensor<Index::idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
         Tensor<float, 2, true>& vecs,
         GpuScalarQuantizer* scalarQ,
@@ -261,7 +261,7 @@ void runIVFFlatAppend(
 }
 
 __global__ void ivfpqAppend(
-        Tensor<int, 1, true> listIds,
+        Tensor<Index::idx_t, 1, true> listIds,
         Tensor<int, 1, true> listOffset,
         Tensor<uint8_t, 2, true> encodings,
         void** listCodes) {
@@ -271,7 +271,7 @@ __global__ void ivfpqAppend(
         return;
     }
 
-    int listId = listIds[encodingToAdd];
+    Index::idx_t listId = listIds[encodingToAdd];
     int vectorNumInList = listOffset[encodingToAdd];
 
     // Add vector could be invalid (contains NaNs etc)
@@ -292,7 +292,7 @@ __global__ void ivfpqAppend(
 }
 
 void runIVFPQAppend(
-        Tensor<int, 1, true>& listIds,
+        Tensor<Index::idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
         Tensor<uint8_t, 2, true>& encodings,
         DeviceVector<void*>& listCodes,
@@ -344,7 +344,7 @@ template <typename EncodeT, int EncodeBits>
 __global__ void ivfInterleavedAppend(
         // the IDs (offset in listData) of the unique lists
         // being added to
-        Tensor<int, 1, true> uniqueLists,
+        Tensor<Index::idx_t, 1, true> uniqueLists,
         // For each of the list IDs in uniqueLists, the start
         // offset in vectorsByUniqueList for the vectors that
         // we are adding to that list
@@ -369,7 +369,7 @@ __global__ void ivfInterleavedAppend(
     int warpsPerBlock = blockDim.x / kWarpSize;
 
     // Each block is dedicated to a separate list
-    int listId = uniqueLists[blockIdx.x];
+    Index::idx_t listId = uniqueLists[blockIdx.x];
 
     // The vecs we add to the list are at indices [vBUL[vecIdStart],
     // vBUL[vecIdEnd])
@@ -448,9 +448,9 @@ __global__ void ivfInterleavedAppend(
 }
 
 void runIVFFlatInterleavedAppend(
-        Tensor<int, 1, true>& listIds,
+        Tensor<Index::idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
-        Tensor<int, 1, true>& uniqueLists,
+        Tensor<Index::idx_t, 1, true>& uniqueLists,
         Tensor<int, 1, true>& vectorsByUniqueList,
         Tensor<int, 1, true>& uniqueListVectorStart,
         Tensor<int, 1, true>& uniqueListStartOffset,
@@ -582,9 +582,9 @@ void runIVFFlatInterleavedAppend(
 }
 
 void runIVFPQInterleavedAppend(
-        Tensor<int, 1, true>& listIds,
+        Tensor<Index::idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
-        Tensor<int, 1, true>& uniqueLists,
+        Tensor<Index::idx_t, 1, true>& uniqueLists,
         Tensor<int, 1, true>& vectorsByUniqueList,
         Tensor<int, 1, true>& uniqueListVectorStart,
         Tensor<int, 1, true>& uniqueListStartOffset,

--- a/faiss/gpu/impl/IVFAppend.cuh
+++ b/faiss/gpu/impl/IVFAppend.cuh
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <faiss/Index.h>
 #include <faiss/gpu/GpuIndicesOptions.h>
 #include <faiss/gpu/impl/GpuScalarQuantizer.cuh>
 #include <faiss/gpu/utils/DeviceVector.cuh>
@@ -17,7 +18,7 @@ namespace gpu {
 
 /// Append user indices to IVF lists
 void runIVFIndicesAppend(
-        Tensor<int, 1, true>& listIds,
+        Tensor<Index::idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
         Tensor<Index::idx_t, 1, true>& indices,
         IndicesOptions opt,
@@ -26,7 +27,7 @@ void runIVFIndicesAppend(
 
 /// Update device-side list pointers in a batch
 void runUpdateListPointers(
-        Tensor<int, 1, true>& listIds,
+        Tensor<Index::idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& newListLength,
         Tensor<void*, 1, true>& newCodePointers,
         Tensor<void*, 1, true>& newIndexPointers,
@@ -37,7 +38,7 @@ void runUpdateListPointers(
 
 /// Append PQ codes to IVF lists (non-interleaved format)
 void runIVFPQAppend(
-        Tensor<int, 1, true>& listIds,
+        Tensor<Index::idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
         Tensor<uint8_t, 2, true>& encodings,
         DeviceVector<void*>& listCodes,
@@ -45,9 +46,9 @@ void runIVFPQAppend(
 
 /// Append PQ codes to IVF lists (interleaved format)
 void runIVFPQInterleavedAppend(
-        Tensor<int, 1, true>& listIds,
+        Tensor<Index::idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
-        Tensor<int, 1, true>& uniqueLists,
+        Tensor<Index::idx_t, 1, true>& uniqueLists,
         Tensor<int, 1, true>& vectorsByUniqueList,
         Tensor<int, 1, true>& uniqueListVectorStart,
         Tensor<int, 1, true>& uniqueListStartOffset,
@@ -58,7 +59,7 @@ void runIVFPQInterleavedAppend(
 
 /// Append SQ codes to IVF lists (non-interleaved, old format)
 void runIVFFlatAppend(
-        Tensor<int, 1, true>& listIds,
+        Tensor<Index::idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
         Tensor<float, 2, true>& vecs,
         GpuScalarQuantizer* scalarQ,
@@ -67,9 +68,9 @@ void runIVFFlatAppend(
 
 /// Append SQ codes to IVF lists (interleaved)
 void runIVFFlatInterleavedAppend(
-        Tensor<int, 1, true>& listIds,
+        Tensor<Index::idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
-        Tensor<int, 1, true>& uniqueLists,
+        Tensor<Index::idx_t, 1, true>& uniqueLists,
         Tensor<int, 1, true>& vectorsByUniqueList,
         Tensor<int, 1, true>& uniqueListVectorStart,
         Tensor<int, 1, true>& uniqueListStartOffset,

--- a/faiss/gpu/impl/IVFBase.cu
+++ b/faiss/gpu/impl/IVFBase.cu
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <faiss/gpu/GpuIndex.h>
+#include <faiss/gpu/GpuIndexFlat.h>
 #include <faiss/gpu/GpuResources.h>
 #include <faiss/gpu/impl/RemapIndices.h>
 #include <faiss/gpu/utils/DeviceUtils.h>
@@ -28,18 +30,20 @@ IVFBase::DeviceIVFList::DeviceIVFList(GpuResources* res, const AllocInfo& info)
 
 IVFBase::IVFBase(
         GpuResources* resources,
+        int dim,
+        int nlist,
         faiss::MetricType metric,
         float metricArg,
-        FlatIndex* quantizer,
+        bool useResidual,
         bool interleavedLayout,
         IndicesOptions indicesOptions,
         MemorySpace space)
         : resources_(resources),
           metric_(metric),
           metricArg_(metricArg),
-          quantizer_(quantizer),
-          dim_(quantizer->getDim()),
-          numLists_(quantizer->getSize()),
+          dim_(dim),
+          numLists_(nlist),
+          useResidual_(useResidual),
           interleavedLayout_(interleavedLayout),
           indicesOptions_(indicesOptions),
           space_(space),
@@ -172,7 +176,7 @@ size_t IVFBase::reclaimMemory_(bool exact) {
 }
 
 void IVFBase::updateDeviceListInfo_(cudaStream_t stream) {
-    std::vector<int> listIds(deviceListData_.size());
+    std::vector<Index::idx_t> listIds(deviceListData_.size());
     for (int i = 0; i < deviceListData_.size(); ++i) {
         listIds[i] = i;
     }
@@ -181,9 +185,9 @@ void IVFBase::updateDeviceListInfo_(cudaStream_t stream) {
 }
 
 void IVFBase::updateDeviceListInfo_(
-        const std::vector<int>& listIds,
+        const std::vector<Index::idx_t>& listIds,
         cudaStream_t stream) {
-    HostTensor<int, 1, true> hostListsToUpdate({(int)listIds.size()});
+    HostTensor<Index::idx_t, 1, true> hostListsToUpdate({(int)listIds.size()});
     HostTensor<int, 1, true> hostNewListLength({(int)listIds.size()});
     HostTensor<void*, 1, true> hostNewDataPointers({(int)listIds.size()});
     HostTensor<void*, 1, true> hostNewIndexPointers({(int)listIds.size()});
@@ -200,7 +204,7 @@ void IVFBase::updateDeviceListInfo_(
     }
 
     // Copy the above update sets to the GPU
-    DeviceTensor<int, 1, true> listsToUpdate(
+    DeviceTensor<Index::idx_t, 1, true> listsToUpdate(
             resources_,
             makeTempAlloc(AllocType::Other, stream),
             hostListsToUpdate);
@@ -453,7 +457,133 @@ void IVFBase::addIndicesFromCpu_(
             listId, (void*)listIndices->data.data(), stream);
 }
 
+void IVFBase::updateQuantizer(Index* quantizer) {
+    FAISS_THROW_IF_NOT(quantizer->is_trained);
+
+    // Must match our basic IVF parameters
+    FAISS_THROW_IF_NOT(quantizer->d == getDim());
+    FAISS_THROW_IF_NOT(quantizer->ntotal == getNumLists());
+
+    auto stream = resources_->getDefaultStreamCurrentDevice();
+
+    // If the index instance is a GpuIndexFlat, then we can use direct access to
+    // the centroids within.
+    auto gpuQ = dynamic_cast<GpuIndexFlat*>(quantizer);
+    if (gpuQ) {
+        auto gpuData = gpuQ->getGpuData();
+        auto ref32 = gpuData->getVectorsFloat32Ref();
+
+        // Create a DeviceTensor that merely references, doesn't own the data
+        auto refOnly = DeviceTensor<float, 2, true>(
+                ref32.data(), {ref32.getSize(0), ref32.getSize(1)});
+
+        ivfCentroids_ = std::move(refOnly);
+    } else {
+        // Otherwise, we need to reconstruct all vectors from the index and copy
+        // them to the GPU, in order to have access as needed for residual
+        // computation
+        auto vecs = std::vector<float>(getNumLists() * getDim());
+        quantizer->reconstruct_n(0, quantizer->ntotal, vecs.data());
+
+        // Copy to a new DeviceTensor; this will own the data
+        DeviceTensor<float, 2, true> centroids(
+                resources_,
+                makeSpaceAlloc(AllocType::FlatData, space_, stream),
+                {(int)quantizer->ntotal, (int)quantizer->d});
+        centroids.copyFrom(vecs, stream);
+
+        ivfCentroids_ = std::move(centroids);
+    }
+}
+
+void IVFBase::searchCoarseQuantizer_(
+        Index* coarseQuantizer,
+        int nprobe,
+        // Guaranteed to be on device
+        Tensor<float, 2, true>& vecs,
+        Tensor<float, 2, true>& distances,
+        Tensor<Index::idx_t, 2, true>& indices,
+        Tensor<float, 3, true>* residuals,
+        Tensor<float, 3, true>* centroids) {
+    auto stream = resources_->getDefaultStreamCurrentDevice();
+
+    // The provided IVF quantizer may be CPU or GPU resident.
+    // If GPU resident, we can simply call it passing the above output device
+    // pointers.
+    auto gpuQuantizer = tryCastGpuIndex(coarseQuantizer);
+    if (gpuQuantizer) {
+        // We can pass device pointers directly
+        gpuQuantizer->search(
+                vecs.getSize(0),
+                vecs.data(),
+                nprobe,
+                distances.data(),
+                indices.data());
+
+        if (residuals) {
+            gpuQuantizer->compute_residual_n(
+                    vecs.getSize(0) * nprobe,
+                    vecs.data(),
+                    residuals->data(),
+                    indices.data());
+        }
+
+        if (centroids) {
+            gpuQuantizer->reconstruct_batch(
+                    vecs.getSize(0) * nprobe,
+                    indices.data(),
+                    centroids->data());
+        }
+    } else {
+        // temporary host storage for querying a CPU index
+        auto cpuVecs = toHost<float, 2>(
+                vecs.data(), stream, {vecs.getSize(0), vecs.getSize(1)});
+        auto cpuDistances = std::vector<float>(vecs.getSize(0) * nprobe);
+        auto cpuIndices = std::vector<Index::idx_t>(vecs.getSize(0) * nprobe);
+
+        coarseQuantizer->search(
+                vecs.getSize(0),
+                cpuVecs.data(),
+                nprobe,
+                cpuDistances.data(),
+                cpuIndices.data());
+
+        distances.copyFrom(cpuDistances, stream);
+
+        // Did we also want to return IVF cell residuals for the query vectors?
+        if (residuals) {
+            // we need space for the residuals as well
+            auto cpuResiduals =
+                    std::vector<float>(vecs.getSize(0) * nprobe * dim_);
+
+            coarseQuantizer->compute_residual_n(
+                    vecs.getSize(0) * nprobe,
+                    cpuVecs.data(),
+                    cpuResiduals.data(),
+                    cpuIndices.data());
+
+            residuals->copyFrom(cpuResiduals, stream);
+        }
+
+        // Did we also want to return the IVF cell centroids themselves?
+        if (centroids) {
+            auto cpuCentroids =
+                    std::vector<float>(vecs.getSize(0) * nprobe * dim_);
+
+            coarseQuantizer->reconstruct_batch(
+                    vecs.getSize(0) * nprobe,
+                    cpuIndices.data(),
+                    cpuCentroids.data());
+
+            centroids->copyFrom(cpuCentroids, stream);
+        }
+
+        indices.copyFrom(cpuIndices, stream);
+    }
+}
+
 int IVFBase::addVectors(
+        Index* coarseQuantizer,
         Tensor<float, 2, true>& vecs,
         Tensor<Index::idx_t, 1, true>& indices) {
     FAISS_ASSERT(vecs.getSize(0) == indices.getSize(0));
@@ -462,46 +592,59 @@ int IVFBase::addVectors(
     auto stream = resources_->getDefaultStreamCurrentDevice();
 
     // Determine which IVF lists we need to append to
-
-    // We don't actually need this
-    DeviceTensor<float, 2, true> listDistance(
-            resources_,
-            makeTempAlloc(AllocType::Other, stream),
-            {vecs.getSize(0), 1});
-    // We use this
-    DeviceTensor<int, 2, true> listIds2d(
+    // We report distances from the shared query function, but we don't need
+    // them
+    DeviceTensor<float, 2, true> unusedIVFDistances(
             resources_,
             makeTempAlloc(AllocType::Other, stream),
             {vecs.getSize(0), 1});
 
-    quantizer_->query(
-            vecs, 1, metric_, metricArg_, listDistance, listIds2d, false);
+    // We do need the closest IVF cell IDs though
+    DeviceTensor<Index::idx_t, 2, true> ivfIndices(
+            resources_,
+            makeTempAlloc(AllocType::Other, stream),
+            {vecs.getSize(0), 1});
+
+    // Calculate residuals for these vectors, if needed
+    DeviceTensor<float, 3, true> residuals(
+            resources_,
+            makeTempAlloc(AllocType::Other, stream),
+            {vecs.getSize(0), 1, dim_});
+
+    searchCoarseQuantizer_(
+            coarseQuantizer,
+            1, // nprobe
+            vecs,
+            unusedIVFDistances,
+            ivfIndices,
+            useResidual_ ? &residuals : nullptr,
+            nullptr);
 
     // Copy the lists that we wish to append to back to the CPU
     // FIXME: really this can be into pinned memory and a true async
     // copy on a different stream; we can start the copy early, but it's
     // tiny
-    auto listIdsHost = listIds2d.copyToVector(stream);
+    auto ivfIndicesHost = ivfIndices.copyToVector(stream);
 
     // Now we add the encoded vectors to the individual lists
     // First, make sure that there is space available for adding the new
     // encoded vectors and indices
 
     // list id -> vectors being added
-    std::unordered_map<int, std::vector<int>> listToVectorIds;
+    std::unordered_map<Index::idx_t, std::vector<int>> listToVectorIds;
 
     // vector id -> which list it is being appended to
-    std::vector<int> vectorIdToList(vecs.getSize(0));
+    std::vector<Index::idx_t> vectorIdToList(vecs.getSize(0));
 
     // vector id -> offset in list
     // (we already have vector id -> list id in listIds)
-    std::vector<int> listOffsetHost(listIdsHost.size());
+    std::vector<int> listOffsetHost(ivfIndicesHost.size());
 
     // Number of valid vectors that we actually add; we return this
     int numAdded = 0;
 
-    for (int i = 0; i < listIdsHost.size(); ++i) {
-        int listId = listIdsHost[i];
+    for (int i = 0; i < ivfIndicesHost.size(); ++i) {
+        auto listId = ivfIndicesHost[i];
 
         // Add vector could be invalid (contains NaNs etc)
         if (listId < 0) {
@@ -534,7 +677,7 @@ int IVFBase::addVectors(
     }
 
     // unique lists being added to
-    std::vector<int> uniqueLists;
+    std::vector<Index::idx_t> uniqueLists;
 
     for (auto& vecs : listToVectorIds) {
         uniqueLists.push_back(vecs.first);
@@ -635,7 +778,7 @@ int IVFBase::addVectors(
         HostTensor<Index::idx_t, 1, true> hostIndices(indices, stream);
 
         for (int i = 0; i < hostIndices.getSize(0); ++i) {
-            int listId = listIdsHost[i];
+            Index::idx_t listId = ivfIndicesHost[i];
 
             // Add vector could be invalid (contains NaNs etc)
             if (listId < 0) {
@@ -654,7 +797,8 @@ int IVFBase::addVectors(
     }
 
     // Copy the offsets to the GPU
-    auto listIdsDevice = listIds2d.downcastOuter<1>();
+    auto ivfIndices1dDevice = ivfIndices.downcastOuter<1>();
+    auto residuals2dDevice = residuals.downcastOuter<2>();
     auto listOffsetDevice =
             toDeviceTemporary(resources_, listOffsetHost, stream);
     auto uniqueListsDevice = toDeviceTemporary(resources_, uniqueLists, stream);
@@ -668,12 +812,13 @@ int IVFBase::addVectors(
     // Actually encode and append the vectors
     appendVectors_(
             vecs,
+            residuals2dDevice,
             indices,
             uniqueListsDevice,
             vectorsByUniqueListDevice,
             uniqueListVectorStartDevice,
             uniqueListStartOffsetDevice,
-            listIdsDevice,
+            ivfIndices1dDevice,
             listOffsetDevice,
             stream);
 

--- a/faiss/gpu/impl/IVFBase.cuh
+++ b/faiss/gpu/impl/IVFBase.cuh
@@ -29,11 +29,12 @@ class FlatIndex;
 class IVFBase {
    public:
     IVFBase(GpuResources* resources,
+            int dim,
+            int nlist,
             faiss::MetricType metric,
             float metricArg,
-            /// We do not own this reference
-            FlatIndex* quantizer,
             bool interleavedLayout,
+            bool useResidual,
             IndicesOptions indicesOptions,
             MemorySpace space);
 
@@ -72,13 +73,40 @@ class IVFBase {
     /// Copy all inverted lists from ourselves to a CPU representation
     void copyInvertedListsTo(InvertedLists* ivf);
 
+    /// Update our coarse quantizer with this quantizer instance; may be a CPU
+    /// or GPU quantizer
+    void updateQuantizer(Index* quantizer);
+
     /// Classify and encode/add vectors to our IVF lists.
     /// The input data must be on our current device.
     /// Returns the number of vectors successfully added. Vectors may
     /// not be able to be added because they contain NaNs.
     int addVectors(
+            Index* coarseQuantizer,
             Tensor<float, 2, true>& vecs,
             Tensor<Index::idx_t, 1, true>& indices);
+
+    /// Find the approximate k nearest neigbors for `queries` against
+    /// our database
+    virtual void search(
+            Index* coarseQuantizer,
+            Tensor<float, 2, true>& queries,
+            int nprobe,
+            int k,
+            Tensor<float, 2, true>& outDistances,
+            Tensor<Index::idx_t, 2, true>& outIndices) = 0;
+
+    /// Performs search when we are already given the IVF cells to look at
+    /// (GpuIndexIVF::search_preassigned implementation)
+    virtual void searchPreassigned(
+            Index* coarseQuantizer,
+            Tensor<float, 2, true>& vecs,
+            Tensor<float, 2, true>& ivfDistances,
+            Tensor<Index::idx_t, 2, true>& ivfAssignments,
+            int k,
+            Tensor<float, 2, true>& outDistances,
+            Tensor<Index::idx_t, 2, true>& outIndices,
+            bool storePairs) = 0;
 
    protected:
     /// Adds a set of codes and indices to a list, with the representation
@@ -90,6 +118,29 @@ class IVFBase {
             // resident on the host
             const Index::idx_t* indices,
             size_t numVecs);
+
+    /// Performs search in a CPU or GPU coarse quantizer for IVF cells,
+    /// returning residuals as well if necessary
+    void searchCoarseQuantizer_(
+            Index* coarseQuantizer,
+            int nprobe,
+            // guaranteed resident on device
+            Tensor<float, 2, true>& vecs,
+            // Output: the distances to the closest nprobe IVF cell centroids
+            // for the query vectors
+            // size (#vecs, nprobe)
+            Tensor<float, 2, true>& distances,
+            // Output: the closest nprobe IVF cells the query vectors lie in
+            // size (#vecs, nprobe)
+            Tensor<Index::idx_t, 2, true>& indices,
+            // optionally compute the residual relative to the IVF cell centroid
+            // if passed
+            // size (#vecs, nprobe, dim)
+            Tensor<float, 3, true>* residuals,
+            // optionally return the IVF cell centroids to which the input
+            // vectors were assigned
+            // size (#vecs, nprobe, dim)
+            Tensor<float, 3, true>* centroids);
 
     /// Returns the number of bytes in which an IVF list containing numVecs
     /// vectors is encoded on the device. Note that due to padding this is not
@@ -111,12 +162,13 @@ class IVFBase {
     /// Append vectors to our on-device lists
     virtual void appendVectors_(
             Tensor<float, 2, true>& vecs,
+            Tensor<float, 2, true>& ivfCentroidResiduals,
             Tensor<Index::idx_t, 1, true>& indices,
-            Tensor<int, 1, true>& uniqueLists,
+            Tensor<Index::idx_t, 1, true>& uniqueLists,
             Tensor<int, 1, true>& vectorsByUniqueList,
             Tensor<int, 1, true>& uniqueListVectorStart,
             Tensor<int, 1, true>& uniqueListStartOffset,
-            Tensor<int, 1, true>& listIds,
+            Tensor<Index::idx_t, 1, true>& listIds,
             Tensor<int, 1, true>& listOffset,
             cudaStream_t stream) = 0;
 
@@ -130,7 +182,7 @@ class IVFBase {
     /// For a set of list IDs, update device-side list pointer and size
     /// information
     void updateDeviceListInfo_(
-            const std::vector<int>& listIds,
+            const std::vector<Index::idx_t>& listIds,
             cudaStream_t stream);
 
     /// Shared function to copy indices from CPU to GPU
@@ -149,14 +201,17 @@ class IVFBase {
     /// Metric arg
     float metricArg_;
 
-    /// Quantizer object
-    FlatIndex* quantizer_;
-
     /// Expected dimensionality of the vectors
     const int dim_;
 
     /// Number of inverted lists we maintain
     const int numLists_;
+
+    /// Do we need to also compute residuals when processing vectors?
+    bool useResidual_;
+
+    /// Coarse quantizer centroids available on GPU
+    DeviceTensor<float, 2, true> ivfCentroids_;
 
     /// Whether or not our index uses an interleaved by 32 layout:
     /// The default memory layout is [vector][PQ/SQ component]:

--- a/faiss/gpu/impl/IVFFlatScan.cu
+++ b/faiss/gpu/impl/IVFFlatScan.cu
@@ -137,7 +137,7 @@ __global__ void ivfFlatScan(
         Tensor<float, 2, true> queries,
         bool useResidual,
         Tensor<float, 3, true> residualBase,
-        Tensor<int, 2, true> listIds,
+        Tensor<Index::idx_t, 2, true> listIds,
         void** allListData,
         int* listLengths,
         Codec codec,
@@ -153,7 +153,7 @@ __global__ void ivfFlatScan(
     // We ensure that before the array (at offset -1), there is a 0 value
     int outBase = *(prefixSumOffsets[queryId][probeId].data() - 1);
 
-    auto listId = listIds[queryId][probeId];
+    Index::idx_t listId = listIds[queryId][probeId];
     // Safety guard in case NaNs in input cause no list ID to be generated
     if (listId == -1) {
         return;
@@ -185,7 +185,7 @@ __global__ void ivfFlatScan(
 void runIVFFlatScanTile(
         GpuResources* res,
         Tensor<float, 2, true>& queries,
-        Tensor<int, 2, true>& listIds,
+        Tensor<Index::idx_t, 2, true>& listIds,
         DeviceVector<void*>& listData,
         DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
@@ -341,7 +341,7 @@ void runIVFFlatScanTile(
 
 void runIVFFlatScan(
         Tensor<float, 2, true>& queries,
-        Tensor<int, 2, true>& listIds,
+        Tensor<Index::idx_t, 2, true>& listIds,
         DeviceVector<void*>& listData,
         DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,

--- a/faiss/gpu/impl/IVFFlatScan.cuh
+++ b/faiss/gpu/impl/IVFFlatScan.cuh
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <faiss/Index.h>
 #include <faiss/MetricType.h>
 #include <faiss/gpu/GpuIndicesOptions.h>
 #include <faiss/gpu/impl/GpuScalarQuantizer.cuh>
@@ -20,7 +21,7 @@ class GpuResources;
 
 void runIVFFlatScan(
         Tensor<float, 2, true>& queries,
-        Tensor<int, 2, true>& listIds,
+        Tensor<Index::idx_t, 2, true>& listIds,
         DeviceVector<void*>& listData,
         DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,

--- a/faiss/gpu/impl/IVFInterleaved.cu
+++ b/faiss/gpu/impl/IVFInterleaved.cu
@@ -19,7 +19,7 @@ template <int ThreadsPerBlock, int NumWarpQ, int NumThreadQ>
 __global__ void ivfInterleavedScan2(
         Tensor<float, 3, true> distanceIn,
         Tensor<int, 3, true> indicesIn,
-        Tensor<int, 2, true> listIds,
+        Tensor<Index::idx_t, 2, true> listIds,
         int k,
         void** listIndices,
         IndicesOptions opt,
@@ -66,7 +66,7 @@ __global__ void ivfInterleavedScan2(
         uint32_t curK = i % k;
         uint32_t index = (curProbe << 16) | (curK & (uint32_t)0xffff);
 
-        int listId = listIds[queryId][curProbe];
+        Index::idx_t listId = listIds[queryId][curProbe];
         if (listId != -1) {
             // Adjust the value we are selecting based on the sorting order
             heap.addThreadQ(distanceBase[i] * adj, index);
@@ -81,7 +81,7 @@ __global__ void ivfInterleavedScan2(
         uint32_t curK = i % k;
         uint32_t index = (curProbe << 16) | (curK & (uint32_t)0xffff);
 
-        int listId = listIds[queryId][curProbe];
+        Index::idx_t listId = listIds[queryId][curProbe];
         if (listId != -1) {
             heap.addThreadQ(distanceBase[i] * adj, index);
         }
@@ -104,7 +104,7 @@ __global__ void ivfInterleavedScan2(
             uint32_t curProbe = packedIndex >> 16;
             uint32_t curK = packedIndex & 0xffff;
 
-            int listId = listIds[queryId][curProbe];
+            Index::idx_t listId = listIds[queryId][curProbe];
             int listOffset = indicesIn[queryId][curProbe][curK];
 
             if (opt == INDICES_32_BIT) {
@@ -112,7 +112,7 @@ __global__ void ivfInterleavedScan2(
             } else if (opt == INDICES_64_BIT) {
                 index = ((Index::idx_t*)listIndices[listId])[listOffset];
             } else {
-                index = ((Index::idx_t)listId << 32 | (Index::idx_t)listOffset);
+                index = (listId << 32 | (Index::idx_t)listOffset);
             }
         }
 
@@ -123,7 +123,7 @@ __global__ void ivfInterleavedScan2(
 void runIVFInterleavedScan2(
         Tensor<float, 3, true>& distanceIn,
         Tensor<int, 3, true>& indicesIn,
-        Tensor<int, 2, true>& listIds,
+        Tensor<Index::idx_t, 2, true>& listIds,
         int k,
         DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
@@ -168,7 +168,7 @@ void runIVFInterleavedScan2(
 
 void runIVFInterleavedScan(
         Tensor<float, 2, true>& queries,
-        Tensor<int, 2, true>& listIds,
+        Tensor<Index::idx_t, 2, true>& listIds,
         DeviceVector<void*>& listData,
         DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,

--- a/faiss/gpu/impl/IVFInterleaved.cuh
+++ b/faiss/gpu/impl/IVFInterleaved.cuh
@@ -40,7 +40,7 @@ template <
 __global__ void ivfInterleavedScan(
         Tensor<float, 2, true> queries,
         Tensor<float, 3, true> residualBase,
-        Tensor<int, 2, true> listIds,
+        Tensor<Index::idx_t, 2, true> listIds,
         void** allListData,
         int* listLengths,
         Codec codec,
@@ -55,7 +55,7 @@ __global__ void ivfInterleavedScan(
 
     int queryId = blockIdx.y;
     int probeId = blockIdx.x;
-    int listId = listIds[queryId][probeId];
+    Index::idx_t listId = listIds[queryId][probeId];
 
     // Safety guard in case NaNs in input cause no list ID to be generated, or
     // we have more nprobe than nlist
@@ -409,7 +409,7 @@ __global__ void ivfInterleavedScan(
 // with all implementations
 void runIVFInterleavedScan(
         Tensor<float, 2, true>& queries,
-        Tensor<int, 2, true>& listIds,
+        Tensor<Index::idx_t, 2, true>& listIds,
         DeviceVector<void*>& listData,
         DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
@@ -430,7 +430,7 @@ void runIVFInterleavedScan(
 void runIVFInterleavedScan2(
         Tensor<float, 3, true>& distanceIn,
         Tensor<int, 3, true>& indicesIn,
-        Tensor<int, 2, true>& listIds,
+        Tensor<Index::idx_t, 2, true>& listIds,
         int k,
         DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,

--- a/faiss/gpu/impl/IVFUtils.cuh
+++ b/faiss/gpu/impl/IVFUtils.cuh
@@ -23,7 +23,7 @@ class GpuResources;
 /// intermediate results for all (query, probe) pair
 void runCalcListOffsets(
         GpuResources* res,
-        Tensor<int, 2, true>& topQueryToCentroid,
+        Tensor<Index::idx_t, 2, true>& ivfListIds,
         DeviceVector<int>& listLengths,
         Tensor<int, 2, true>& prefixSumOffsets,
         Tensor<char, 1, true>& thrustMem,
@@ -48,7 +48,7 @@ void runPass2SelectLists(
         DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
         Tensor<int, 2, true>& prefixSumOffsets,
-        Tensor<int, 2, true>& topQueryToCentroid,
+        Tensor<Index::idx_t, 2, true>& ivfListIds,
         int k,
         bool chooseLargest,
         Tensor<float, 2, true>& outDistances,

--- a/faiss/gpu/impl/IndexUtils.cu
+++ b/faiss/gpu/impl/IndexUtils.cu
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <faiss/gpu/impl/IndexUtils.h>
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/gpu/utils/DeviceDefs.cuh>
+#include <limits>
+
+namespace faiss {
+namespace gpu {
+
+/// A collection of various utility functions for index implementation
+
+/// Returns the maximum k-selection value supported based on the CUDA SDK that
+/// we were compiled with. .cu files can use DeviceDefs.cuh, but this is for
+/// non-CUDA files
+int getMaxKSelection() {
+    return GPU_MAX_SELECTION_K;
+}
+
+void validateKSelect(Index::idx_t k) {
+    FAISS_THROW_IF_NOT_FMT(
+            k > 0 && k < (Index::idx_t)getMaxKSelection(),
+            "GPU index only supports min/max-K selection up to %d (requested %zu)",
+            getMaxKSelection(),
+            k);
+}
+
+void validateNProbe(Index::idx_t nprobe) {
+    FAISS_THROW_IF_NOT_FMT(
+            nprobe > 0 && nprobe < (Index::idx_t)getMaxKSelection(),
+            "GPU IVF index only supports nprobe selection up to %d (requested %zu)",
+            getMaxKSelection(),
+            nprobe);
+}
+
+void validateNumVectors(Index::idx_t n) {
+    FAISS_THROW_IF_NOT_FMT(
+            n <= (Index::idx_t)std::numeric_limits<int>::max(),
+            "GPU index only supports up to %d indices (requested %zu)",
+            std::numeric_limits<int>::max(),
+            n);
+}
+
+} // namespace gpu
+} // namespace faiss

--- a/faiss/gpu/impl/IndexUtils.h
+++ b/faiss/gpu/impl/IndexUtils.h
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <faiss/Index.h>
+
+namespace faiss {
+namespace gpu {
+
+/// A collection of various utility functions for index implementation
+
+/// Returns the maximum k-selection value supported based on the CUDA SDK that
+/// we were compiled with. .cu files can use DeviceDefs.cuh, but this is for
+/// non-CUDA files
+int getMaxKSelection();
+
+// Validate the k parameter for search
+void validateKSelect(Index::idx_t k);
+
+// Validate the nprobe parameter for search
+void validateNProbe(Index::idx_t nprobe);
+
+/// Validate the n (number of vectors) parameter for add, search, reconstruct
+void validateNumVectors(Index::idx_t n);
+
+} // namespace gpu
+} // namespace faiss

--- a/faiss/gpu/impl/PQCodeDistances.cuh
+++ b/faiss/gpu/impl/PQCodeDistances.cuh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cublas_v2.h>
+#include <faiss/Index.h>
 #include <faiss/gpu/utils/NoTypeTensor.cuh>
 #include <faiss/gpu/utils/Tensor.cuh>
 
@@ -27,7 +28,7 @@ void runPQCodeDistances(
         Tensor<float, 2, true>& queries,
         Tensor<CentroidT, 2, true>& coarseCentroids,
         Tensor<float, 2, true>& coarseDistances,
-        Tensor<int, 2, true>& coarseIndices,
+        Tensor<Index::idx_t, 2, true>& coarseIndices,
         NoTypeTensor<4, true>& outCodeDistances,
         bool useMMImplementation,
         bool l2Distance,

--- a/faiss/gpu/impl/PQScanMultiPassNoPrecomputed-inl.cuh
+++ b/faiss/gpu/impl/PQScanMultiPassNoPrecomputed-inl.cuh
@@ -28,7 +28,7 @@ template <typename EncodeT, int EncodeBits, typename CodeDistanceT>
 __global__ void pqScanInterleaved(
         Tensor<float, 2, true> queries,
         Tensor<float, 3, true> pqCentroids,
-        Tensor<int, 2, true> topQueryToCentroid,
+        Tensor<Index::idx_t, 2, true> ivfListIds,
         Tensor<CodeDistanceT, 4, true> codeDistances,
         void** listCodes,
         int* listLengths,
@@ -38,7 +38,7 @@ __global__ void pqScanInterleaved(
     auto queryId = blockIdx.y;
     auto probeId = blockIdx.x;
 
-    auto listId = topQueryToCentroid[queryId][probeId];
+    Index::idx_t listId = ivfListIds[queryId][probeId];
     // Safety guard in case NaNs in input cause no list ID to be generated
     if (listId == -1) {
         return;
@@ -174,7 +174,7 @@ template <int NumSubQuantizers, typename LookupT, typename LookupVecT>
 __global__ void pqScanNoPrecomputedMultiPass(
         Tensor<float, 2, true> queries,
         Tensor<float, 3, true> pqCentroids,
-        Tensor<int, 2, true> topQueryToCentroid,
+        Tensor<Index::idx_t, 2, true> ivfListIds,
         Tensor<LookupT, 4, true> codeDistances,
         void** listCodes,
         int* listLengths,
@@ -195,7 +195,7 @@ __global__ void pqScanNoPrecomputedMultiPass(
     int outBase = *(prefixSumOffsets[queryId][probeId].data() - 1);
     float* distanceOut = distance[outBase].data();
 
-    auto listId = topQueryToCentroid[queryId][probeId];
+    Index::idx_t listId = ivfListIds[queryId][probeId];
     // Safety guard in case NaNs in input cause no list ID to be generated
     if (listId == -1) {
         return;
@@ -277,7 +277,7 @@ void runMultiPassTile(
         Tensor<float, 3, true>& pqCentroidsInnermostCode,
         NoTypeTensor<4, true>& codeDistances,
         Tensor<float, 2, true>& coarseDistances,
-        Tensor<int, 2, true>& coarseIndices,
+        Tensor<Index::idx_t, 2, true>& coarseIndices,
         bool useFloat16Lookup,
         bool useMMCodeDistance,
         bool interleavedCodeLayout,
@@ -526,7 +526,7 @@ void runPQScanMultiPassNoPrecomputed(
         Tensor<CentroidT, 2, true>& centroids,
         Tensor<float, 3, true>& pqCentroidsInnermostCode,
         Tensor<float, 2, true>& coarseDistances,
-        Tensor<int, 2, true>& coarseIndices,
+        Tensor<Index::idx_t, 2, true>& coarseIndices,
         bool useFloat16Lookup,
         bool useMMCodeDistance,
         bool interleavedCodeLayout,

--- a/faiss/gpu/impl/PQScanMultiPassNoPrecomputed.cuh
+++ b/faiss/gpu/impl/PQScanMultiPassNoPrecomputed.cuh
@@ -24,7 +24,7 @@ void runPQScanMultiPassNoPrecomputed(
         Tensor<CentroidT, 2, true>& centroids,
         Tensor<float, 3, true>& pqCentroidsInnermostCode,
         Tensor<float, 2, true>& coarseDistances,
-        Tensor<int, 2, true>& coarseIndices,
+        Tensor<Index::idx_t, 2, true>& coarseIndices,
         bool useFloat16Lookup,
         bool useMMCodeDistance,
         bool interleavedCodeLayout,

--- a/faiss/gpu/impl/PQScanMultiPassPrecomputed.cu
+++ b/faiss/gpu/impl/PQScanMultiPassPrecomputed.cu
@@ -35,7 +35,7 @@ __global__ void pqScanPrecomputedInterleaved(
         Tensor<CodeDistanceT, 3, true> precompTerm2,
         // (query id)(sub q)(code id)
         Tensor<CodeDistanceT, 3, true> precompTerm3,
-        Tensor<int, 2, true> topQueryToCentroid,
+        Tensor<Index::idx_t, 2, true> ivfListIds,
         void** listCodes,
         int* listLengths,
         Tensor<int, 2, true> prefixSumOffsets,
@@ -44,7 +44,7 @@ __global__ void pqScanPrecomputedInterleaved(
     auto queryId = blockIdx.y;
     auto probeId = blockIdx.x;
 
-    auto listId = topQueryToCentroid[queryId][probeId];
+    Index::idx_t listId = ivfListIds[queryId][probeId];
     // Safety guard in case NaNs in input cause no list ID to be generated
     if (listId == -1) {
         return;
@@ -206,7 +206,7 @@ __global__ void pqScanPrecomputedMultiPass(
         Tensor<float, 2, true> precompTerm1,
         Tensor<LookupT, 3, true> precompTerm2,
         Tensor<LookupT, 3, true> precompTerm3,
-        Tensor<int, 2, true> topQueryToCentroid,
+        Tensor<Index::idx_t, 2, true> ivfListIds,
         void** listCodes,
         int* listLengths,
         Tensor<int, 2, true> prefixSumOffsets,
@@ -227,7 +227,7 @@ __global__ void pqScanPrecomputedMultiPass(
     int outBase = *(prefixSumOffsets[queryId][probeId].data() - 1);
     float* distanceOut = distance[outBase].data();
 
-    auto listId = topQueryToCentroid[queryId][probeId];
+    Index::idx_t listId = ivfListIds[queryId][probeId];
     // Safety guard in case NaNs in input cause no list ID to be generated
     if (listId == -1) {
         return;
@@ -310,7 +310,7 @@ void runMultiPassTile(
         Tensor<float, 2, true>& precompTerm1,
         NoTypeTensor<3, true>& precompTerm2,
         NoTypeTensor<3, true>& precompTerm3,
-        Tensor<int, 2, true>& topQueryToCentroid,
+        Tensor<Index::idx_t, 2, true>& ivfListIds,
         bool useFloat16Lookup,
         bool interleavedCodeLayout,
         int bitsPerSubQuantizer,
@@ -332,19 +332,13 @@ void runMultiPassTile(
     // Calculate offset lengths, so we know where to write out
     // intermediate results
     runCalcListOffsets(
-            res,
-            topQueryToCentroid,
-            listLengths,
-            prefixSumOffsets,
-            thrustMem,
-            stream);
+            res, ivfListIds, listLengths, prefixSumOffsets, thrustMem, stream);
 
     // The vector interleaved layout implementation
     if (interleavedCodeLayout) {
         auto kThreadsPerBlock = 256;
 
-        auto grid = dim3(
-                topQueryToCentroid.getSize(1), topQueryToCentroid.getSize(0));
+        auto grid = dim3(ivfListIds.getSize(1), ivfListIds.getSize(0));
         auto block = dim3(kThreadsPerBlock);
 
 #define RUN_INTERLEAVED(BITS_PER_CODE, CODE_DIST_T)                       \
@@ -355,7 +349,7 @@ void runMultiPassTile(
                         precompTerm1,                                     \
                         precompTerm2T,                                    \
                         precompTerm3T,                                    \
-                        topQueryToCentroid,                               \
+                        ivfListIds,                                       \
                         listCodes.data(),                                 \
                         listLengths.data(),                               \
                         prefixSumOffsets,                                 \
@@ -410,8 +404,7 @@ void runMultiPassTile(
         // index) values for all intermediate results
         auto kThreadsPerBlock = 256;
 
-        auto grid = dim3(
-                topQueryToCentroid.getSize(1), topQueryToCentroid.getSize(0));
+        auto grid = dim3(ivfListIds.getSize(1), ivfListIds.getSize(0));
         auto block = dim3(kThreadsPerBlock);
 
         // pq precomputed terms (2 + 3)
@@ -431,7 +424,7 @@ void runMultiPassTile(
                         precompTerm1,                                 \
                         precompTerm2T,                                \
                         precompTerm3T,                                \
-                        topQueryToCentroid,                           \
+                        ivfListIds,                                   \
                         listCodes.data(),                             \
                         listLengths.data(),                           \
                         prefixSumOffsets,                             \
@@ -512,7 +505,7 @@ void runMultiPassTile(
     runPass1SelectLists(
             prefixSumOffsets,
             allDistances,
-            topQueryToCentroid.getSize(1),
+            ivfListIds.getSize(1),
             k,
             false, // L2 distance chooses smallest
             heapDistances,
@@ -529,7 +522,7 @@ void runMultiPassTile(
             listIndices,
             indicesOptions,
             prefixSumOffsets,
-            topQueryToCentroid,
+            ivfListIds,
             k,
             false, // L2 distance chooses smallest
             outDistances,
@@ -547,7 +540,7 @@ void runPQScanMultiPassPrecomputed(
         NoTypeTensor<3, true>& precompTerm2,
         // (query id)(sub q)(code id)
         NoTypeTensor<3, true>& precompTerm3,
-        Tensor<int, 2, true>& topQueryToCentroid,
+        Tensor<Index::idx_t, 2, true>& ivfListIds,
         bool useFloat16Lookup,
         bool interleavedCodeLayout,
         int bitsPerSubQuantizer,
@@ -568,7 +561,7 @@ void runPQScanMultiPassPrecomputed(
     constexpr int kMaxQueryTileSize = 128;
     constexpr int kThrustMemSize = 16384;
 
-    int nprobe = topQueryToCentroid.getSize(1);
+    int nprobe = ivfListIds.getSize(1);
 
     auto stream = res->getDefaultStreamCurrentDevice();
 
@@ -684,7 +677,7 @@ void runPQScanMultiPassPrecomputed(
                         0, numQueriesInTile);
 
         auto coarseIndicesView =
-                topQueryToCentroid.narrowOutermost(query, numQueriesInTile);
+                ivfListIds.narrowOutermost(query, numQueriesInTile);
         auto queryView = queries.narrowOutermost(query, numQueriesInTile);
         auto term1View = precompTerm1.narrowOutermost(query, numQueriesInTile);
         auto term3View = precompTerm3.narrowOutermost(query, numQueriesInTile);

--- a/faiss/gpu/impl/PQScanMultiPassPrecomputed.cuh
+++ b/faiss/gpu/impl/PQScanMultiPassPrecomputed.cuh
@@ -23,7 +23,7 @@ void runPQScanMultiPassPrecomputed(
         Tensor<float, 2, true>& precompTerm1,
         NoTypeTensor<3, true>& precompTerm2,
         NoTypeTensor<3, true>& precompTerm3,
-        Tensor<int, 2, true>& topQueryToCentroid,
+        Tensor<Index::idx_t, 2, true>& ivfListIds,
         bool useFloat16Lookup,
         bool interleavedCodeLayout,
         int bitsPerSubQuantizer,

--- a/faiss/gpu/impl/VectorResidual.cu
+++ b/faiss/gpu/impl/VectorResidual.cu
@@ -18,16 +18,16 @@
 namespace faiss {
 namespace gpu {
 
-template <typename CentroidT, bool LargeDim>
+template <typename IndexT, typename CentroidT, bool LargeDim>
 __global__ void calcResidual(
         Tensor<float, 2, true> vecs,
         Tensor<CentroidT, 2, true> centroids,
-        Tensor<int, 1, true> vecToCentroid,
+        Tensor<IndexT, 1, true> vecToCentroid,
         Tensor<float, 2, true> residuals) {
     auto vec = vecs[blockIdx.x];
     auto residual = residuals[blockIdx.x];
+    IndexT centroidId = vecToCentroid[blockIdx.x];
 
-    int centroidId = vecToCentroid[blockIdx.x];
     // Vector could be invalid (containing NaNs), so -1 was the
     // classified centroid
     if (centroidId == -1) {
@@ -54,27 +54,11 @@ __global__ void calcResidual(
     }
 }
 
-template <typename T>
-__global__ void gatherReconstruct(
-        Tensor<int, 1, true> listIds,
-        Tensor<T, 2, true> vecs,
-        Tensor<float, 2, true> out) {
-    auto id = listIds[blockIdx.x];
-    auto vec = vecs[id];
-    auto outVec = out[blockIdx.x];
-
-    Convert<T, float> conv;
-
-    for (int i = threadIdx.x; i < vecs.getSize(1); i += blockDim.x) {
-        outVec[i] = id == -1 ? 0.0f : conv(vec[i]);
-    }
-}
-
-template <typename CentroidT>
+template <typename IndexT, typename CentroidT>
 void calcResidual(
         Tensor<float, 2, true>& vecs,
         Tensor<CentroidT, 2, true>& centroids,
-        Tensor<int, 1, true>& vecToCentroid,
+        Tensor<IndexT, 1, true>& vecToCentroid,
         Tensor<float, 2, true>& residuals,
         cudaStream_t stream) {
     FAISS_ASSERT(vecs.getSize(1) == centroids.getSize(1));
@@ -89,31 +73,12 @@ void calcResidual(
     dim3 block(std::min(vecs.getSize(1), maxThreads));
 
     if (largeDim) {
-        calcResidual<CentroidT, true><<<grid, block, 0, stream>>>(
+        calcResidual<IndexT, CentroidT, true><<<grid, block, 0, stream>>>(
                 vecs, centroids, vecToCentroid, residuals);
     } else {
-        calcResidual<CentroidT, false><<<grid, block, 0, stream>>>(
+        calcResidual<IndexT, CentroidT, false><<<grid, block, 0, stream>>>(
                 vecs, centroids, vecToCentroid, residuals);
     }
-
-    CUDA_TEST_ERROR();
-}
-
-template <typename T>
-void gatherReconstruct(
-        Tensor<int, 1, true>& listIds,
-        Tensor<T, 2, true>& vecs,
-        Tensor<float, 2, true>& out,
-        cudaStream_t stream) {
-    FAISS_ASSERT(listIds.getSize(0) == out.getSize(0));
-    FAISS_ASSERT(vecs.getSize(1) == out.getSize(1));
-
-    dim3 grid(listIds.getSize(0));
-
-    int maxThreads = getMaxThreadsCurrentDevice();
-    dim3 block(std::min(vecs.getSize(1), maxThreads));
-
-    gatherReconstruct<T><<<grid, block, 0, stream>>>(listIds, vecs, out);
 
     CUDA_TEST_ERROR();
 }
@@ -121,35 +86,72 @@ void gatherReconstruct(
 void runCalcResidual(
         Tensor<float, 2, true>& vecs,
         Tensor<float, 2, true>& centroids,
-        Tensor<int, 1, true>& vecToCentroid,
+        Tensor<Index::idx_t, 1, true>& vecToCentroid,
         Tensor<float, 2, true>& residuals,
         cudaStream_t stream) {
-    calcResidual<float>(vecs, centroids, vecToCentroid, residuals, stream);
+    calcResidual<Index::idx_t, float>(
+            vecs, centroids, vecToCentroid, residuals, stream);
 }
 
 void runCalcResidual(
         Tensor<float, 2, true>& vecs,
         Tensor<half, 2, true>& centroids,
-        Tensor<int, 1, true>& vecToCentroid,
+        Tensor<Index::idx_t, 1, true>& vecToCentroid,
         Tensor<float, 2, true>& residuals,
         cudaStream_t stream) {
-    calcResidual<half>(vecs, centroids, vecToCentroid, residuals, stream);
+    calcResidual<Index::idx_t, half>(
+            vecs, centroids, vecToCentroid, residuals, stream);
+}
+
+template <typename IndexT, typename T>
+__global__ void gatherReconstruct(
+        Tensor<IndexT, 1, true> ids,
+        Tensor<T, 2, true> vecs,
+        Tensor<float, 2, true> out) {
+    IndexT id = ids[blockIdx.x];
+    auto vec = vecs[id];
+    auto outVec = out[blockIdx.x];
+
+    Convert<T, float> conv;
+
+    for (int i = threadIdx.x; i < vecs.getSize(1); i += blockDim.x) {
+        outVec[i] = id == IndexT(-1) ? 0.0f : conv(vec[i]);
+    }
+}
+
+template <typename IndexT, typename T>
+void gatherReconstruct(
+        Tensor<IndexT, 1, true>& ids,
+        Tensor<T, 2, true>& vecs,
+        Tensor<float, 2, true>& out,
+        cudaStream_t stream) {
+    FAISS_ASSERT(ids.getSize(0) == out.getSize(0));
+    FAISS_ASSERT(vecs.getSize(1) == out.getSize(1));
+
+    dim3 grid(ids.getSize(0));
+
+    int maxThreads = getMaxThreadsCurrentDevice();
+    dim3 block(std::min(vecs.getSize(1), maxThreads));
+
+    gatherReconstruct<IndexT, T><<<grid, block, 0, stream>>>(ids, vecs, out);
+
+    CUDA_TEST_ERROR();
 }
 
 void runReconstruct(
-        Tensor<int, 1, true>& listIds,
+        Tensor<Index::idx_t, 1, true>& ids,
         Tensor<float, 2, true>& vecs,
         Tensor<float, 2, true>& out,
         cudaStream_t stream) {
-    gatherReconstruct<float>(listIds, vecs, out, stream);
+    gatherReconstruct<Index::idx_t, float>(ids, vecs, out, stream);
 }
 
 void runReconstruct(
-        Tensor<int, 1, true>& listIds,
+        Tensor<Index::idx_t, 1, true>& ids,
         Tensor<half, 2, true>& vecs,
         Tensor<float, 2, true>& out,
         cudaStream_t stream) {
-    gatherReconstruct<half>(listIds, vecs, out, stream);
+    gatherReconstruct<Index::idx_t, half>(ids, vecs, out, stream);
 }
 
 } // namespace gpu

--- a/faiss/gpu/impl/VectorResidual.cuh
+++ b/faiss/gpu/impl/VectorResidual.cuh
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <faiss/Index.h>
 #include <faiss/gpu/utils/Tensor.cuh>
 
 namespace faiss {
@@ -16,26 +17,26 @@ namespace gpu {
 void runCalcResidual(
         Tensor<float, 2, true>& vecs,
         Tensor<float, 2, true>& centroids,
-        Tensor<int, 1, true>& vecToCentroid,
+        Tensor<Index::idx_t, 1, true>& vecToCentroid,
         Tensor<float, 2, true>& residuals,
         cudaStream_t stream);
 
 void runCalcResidual(
         Tensor<float, 2, true>& vecs,
         Tensor<half, 2, true>& centroids,
-        Tensor<int, 1, true>& vecToCentroid,
+        Tensor<Index::idx_t, 1, true>& vecToCentroid,
         Tensor<float, 2, true>& residuals,
         cudaStream_t stream);
 
 // Gather vectors
 void runReconstruct(
-        Tensor<int, 1, true>& listIds,
+        Tensor<Index::idx_t, 1, true>& listIds,
         Tensor<float, 2, true>& vecs,
         Tensor<float, 2, true>& out,
         cudaStream_t stream);
 
 void runReconstruct(
-        Tensor<int, 1, true>& listIds,
+        Tensor<Index::idx_t, 1, true>& listIds,
         Tensor<half, 2, true>& vecs,
         Tensor<float, 2, true>& out,
         cudaStream_t stream);

--- a/faiss/gpu/impl/scan/IVFInterleavedImpl.cuh
+++ b/faiss/gpu/impl/scan/IVFInterleavedImpl.cuh
@@ -15,7 +15,7 @@
                                                         \
     void ivfInterleavedScanImpl_##WARP_Q##_(            \
             Tensor<float, 2, true>& queries,            \
-            Tensor<int, 2, true>& listIds,              \
+            Tensor<Index::idx_t, 2, true>& listIds,     \
             DeviceVector<void*>& listData,              \
             DeviceVector<void*>& listIndices,           \
             IndicesOptions indicesOptions,              \
@@ -39,7 +39,7 @@
                                                        \
     void ivfInterleavedScanImpl_##WARP_Q##_(           \
             Tensor<float, 2, true>& queries,           \
-            Tensor<int, 2, true>& listIds,             \
+            Tensor<Index::idx_t, 2, true>& listIds,    \
             DeviceVector<void*>& listData,             \
             DeviceVector<void*>& listIndices,          \
             IndicesOptions indicesOptions,             \

--- a/faiss/gpu/test/TestGpuIndexBinaryFlat.cpp
+++ b/faiss/gpu/test/TestGpuIndexBinaryFlat.cpp
@@ -8,6 +8,7 @@
 #include <faiss/IndexBinaryFlat.h>
 #include <faiss/gpu/GpuIndexBinaryFlat.h>
 #include <faiss/gpu/StandardGpuResources.h>
+#include <faiss/gpu/impl/IndexUtils.h>
 #include <faiss/gpu/test/TestUtils.h>
 #include <faiss/gpu/utils/DeviceUtils.h>
 #include <faiss/utils/utils.h>

--- a/faiss/gpu/utils/DeviceUtils.cu
+++ b/faiss/gpu/utils/DeviceUtils.cu
@@ -149,12 +149,6 @@ bool getTensorCoreSupportCurrentDevice() {
     return getTensorCoreSupport(getCurrentDevice());
 }
 
-int getMaxKSelection() {
-    // Don't use the device at the moment, just base this based on the CUDA SDK
-    // that we were compiled with
-    return GPU_MAX_SELECTION_K;
-}
-
 DeviceScope::DeviceScope(int device) {
     if (device >= 0) {
         int curDevice = getCurrentDevice();

--- a/faiss/gpu/utils/DeviceUtils.h
+++ b/faiss/gpu/utils/DeviceUtils.h
@@ -70,11 +70,6 @@ bool getTensorCoreSupport(int device);
 /// Equivalent to getTensorCoreSupport(getCurrentDevice())
 bool getTensorCoreSupportCurrentDevice();
 
-/// Returns the maximum k-selection value supported based on the CUDA SDK that
-/// we were compiled with. .cu files can use DeviceDefs.cuh, but this is for
-/// non-CUDA files
-int getMaxKSelection();
-
 /// RAII object to set the current device, and restore the previous
 /// device upon destruction
 class DeviceScope {


### PR DESCRIPTION
Summary:
From the beginning, the CPU IVF index design allowed rather arbitrary index instances to be used as the coarse (level 1) quantizer. On the GPU, IVF indices automatically constructed a FlatIndex (internal object that a GpuIndexFlat wraps) to be the coarse quantizer, and did not allow substituting anything else.

This diff allows for the GPU to function like the CPU IndexIVF classes, namely that there is a `quantizer` instance that can be arbitrarily substituted assuming that the coarse quantizer has the same number of vectors as the IVF nlist. Also, we now support any CPU or GPU index as the coarse quantizer for a GpuIndexIVF.

We detect internally if the IVF quantizer instance is a GPU index instance, in which case we can avoid d2h/h2d data copies as needed and pass device data directly to the plugged GPU coarse quantizer. If the plugged coarse quantizer is a CPU instance, then proper d2h/h2d copies for data are inserted as needed.

As some GPU IVF indices operate on the residual with respect to the coarse quantizer, it is necessary that the IVF index has access to the coarse centroids, even if the index is a CPU index. When a CPU index is used as a coarse quantizer, a reconstruction and copy of all of the coarse centroids to the GPU is performed. If the user changes the quantizer instance, or otherwise modifies the quantizer, in order for the GPU IVF index to recognize this change, a function `GpuIndexIVF::updateQuantizer()` must be called to update this cached state. If the coarse quantizer instance is a `GpuIndexFlat` then no separate cached copy is made as we can have direct access to the `FlatIndex` centroid storage.

Additionally, the `IndexIVF::search_preassigned` interface has been added to all GPU IVF instances via `GpuIndexIVF`. Conversion as needed from CPU arrays to GPU is done based on the address space of the passed inputs.

Other additional changes:
- Removed the `storeTransposed` functionality of `GpuIndexFlat`, as specified by `GpuIndexFlatConfig::storeTransposed`. This was a feature added back in 2016 to potentially accelerate coarse quantizer lookups by avoiding a transposition during matrix multiplication. This feature was not much used, and was an internal implementation detail, and supporting it with the new pluggable functionality wasn't worth it, so this transposition functionality was removed from the code but the parameter in `GpuIndexFlatConfig` still remained.

- This change also required updating index handling code to be `Index::idx_t` (64 bit) based instead of 32 bit in many instances, as any CPU and non-flat index GPU instances will be reporting IVF cells via `Index::idx_t`. 32 bit indices were used in much of the original Faiss due to the poor performance of 64 bit integers versus 32 bit integers.

- Refactored and deleted some redundant code between the `GPUIndexIVF` subclasses (`GpuIndexIVFFlat`, `GpuIndexIVFPQ`, `GpuIndexIVFScalarQuantizer`) for `search` and `search_preassigned`. This is now done by adding an interface to the IVFBase class which contains GPU-specific state (and is a CUDA file/header so is hidden behind an opaque pointer) and virtual functions to provide dispatch to the IVFFlat (which also implements IVFSQ) or IVFPQ classes in gpu/impl.

- Some of the `GpuIndexIVF` subclasses didn't have a default metric parameter (`METRIC_L2`), unlike the CPU versions. Added this default parameter to the header.

- Updated the check for the passed-in coarse quantizer in `GpuIndexIVF` to more closely correspond to the CPU version. Previously it was throwing an error if the coarse quantizer had ntotal not equal to nlist.

- Moved code that sets the proper GPU device (`DeviceScope` etc) to the very top of the functions that need it. It is critical that this is called, and nice to be able to visually verify that it is being set in these functions. Some functions buried it deep within (though not after the code that actually needed that scope to be set).

Differential Revision: D37777979

