### PR TITLE
Use packaging.version to fix deprecation warning

### DIFF
--- a/conda/faiss-gpu/meta.yaml
+++ b/conda/faiss-gpu/meta.yaml
@@ -66,16 +66,19 @@ outputs:
       host:
         - python {{ python }}
         - numpy =1.11
+        - packaging
         - {{ pin_subpackage('libfaiss', exact=True) }}
       run:
         - python {{ python }}
         - numpy >=1.11,<2
+        - packaging
         - {{ pin_subpackage('libfaiss', exact=True) }}
     test:
       requires:
         - numpy
         - scipy
         - pytorch
+        - packaging
       commands:
         - python -m unittest discover tests/
         - cp tests/common_faiss_tests.py faiss/gpu/test

--- a/conda/faiss/meta.yaml
+++ b/conda/faiss/meta.yaml
@@ -64,10 +64,12 @@ outputs:
       host:
         - python {{ python }}
         - numpy =1.11
+        - packaging
         - {{ pin_subpackage('libfaiss', exact=True) }}
       run:
         - python {{ python }}
         - numpy >=1.11,<2
+        - packaging
         - {{ pin_subpackage('libfaiss', exact=True) }}
     test:
       requires:
@@ -75,6 +77,7 @@ outputs:
         - scipy
         - pytorch  # [not osx]
         - pytorch <1.12.0  # [osx]
+        - packaging
       commands:
         - python -X faulthandler -m unittest discover -v -s tests -p "test_*"
         - python -X faulthandler -m unittest discover -v -s tests -p "torch_*"

--- a/faiss/python/loader.py
+++ b/faiss/python/loader.py
@@ -25,7 +25,7 @@ def supported_instruction_sets():
     {"NEON", "ASIMD", ...}
     """
     import numpy
-    if version.Version(numpy.__version__) >= "1.19":
+    if version.Version(numpy.__version__) >= version.Version("1.19"):
         # use private API as next-best thing until numpy/numpy#18058 is solved
         from numpy.core._multiarray_umath import __cpu_features__
         # __cpu_features__ is a dictionary with CPU features

--- a/faiss/python/loader.py
+++ b/faiss/python/loader.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from distutils.version import LooseVersion
+from packaging import version
 import platform
 import subprocess
 import logging
@@ -25,7 +25,7 @@ def supported_instruction_sets():
     {"NEON", "ASIMD", ...}
     """
     import numpy
-    if LooseVersion(numpy.__version__) >= "1.19":
+    if version.Version(numpy.__version__) >= "1.19":
         # use private API as next-best thing until numpy/numpy#18058 is solved
         from numpy.core._multiarray_umath import __cpu_features__
         # __cpu_features__ is a dictionary with CPU features

--- a/faiss/python/setup.py
+++ b/faiss/python/setup.py
@@ -62,7 +62,7 @@ setup(
     license='MIT',
     keywords='search nearest neighbors',
 
-    install_requires=['numpy'],
+    install_requires=['numpy', 'packaging'],
     packages=['faiss', 'faiss.contrib'],
     package_data={
         'faiss': ['*.so', '*.pyd'],


### PR DESCRIPTION
This PR fixes the following warning that was raised by `loader.py`

```
DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
```