### PR TITLE
Speedup IndexRowwiseMinMax::sa_decode()

### DIFF
--- a/faiss/IndexRowwiseMinMax.cpp
+++ b/faiss/IndexRowwiseMinMax.cpp
@@ -154,8 +154,10 @@ void sa_decode_impl(
     const size_t new_code_size = index->sa_code_size();
 
     // allocate tmp buffers
-    std::vector<uint8_t> tmp(chunk_size * old_code_size);
-    std::vector<StorageMinMaxFP16> minmax(chunk_size);
+    std::vector<uint8_t> tmp(
+            (chunk_size < n_input ? chunk_size : n_input) * old_code_size);
+    std::vector<StorageMinMaxFP16> minmax(
+            (chunk_size < n_input ? chunk_size : n_input));
 
     // all the elements to process
     size_t n_left = n_input;


### PR DESCRIPTION
Summary: Allocated temporary buffers are of the correct sizes.

Differential Revision: D40439826

