### PR TITLE
bumping gtest to 1.12.1

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 
 include(FetchContent)
 FetchContent_Declare(googletest
-  URL "https://github.com/google/googletest/archive/release-1.10.0.tar.gz")
+  URL "https://github.com/google/googletest/archive/release-1.12.1.tar.gz")
 set(BUILD_GMOCK CACHE BOOL OFF)
 set(INSTALL_GTEST CACHE BOOL OFF)
 FetchContent_MakeAvailable(googletest)


### PR DESCRIPTION
Summary:
Due to https://github.com/google/googletest/issues/3219 gtest doesn't compile with gcc 11 - Ubuntu 22.04 has GCC 11.2 currently.

The fix was https://github.com/google/googletest/pull/3024 so I'm bumping gtest to latest.

Differential Revision: D40512746

