### PR TITLE
add clone for IndexRefine + tests

### DIFF
--- a/faiss/clone_index.cpp
+++ b/faiss/clone_index.cpp
@@ -16,18 +16,24 @@
 
 #include <faiss/Index2Layer.h>
 #include <faiss/IndexAdditiveQuantizer.h>
+#include <faiss/IndexAdditiveQuantizerFastScan.h>
 #include <faiss/IndexFlat.h>
 #include <faiss/IndexHNSW.h>
 #include <faiss/IndexIVF.h>
+#include <faiss/IndexIVFAdditiveQuantizerFastScan.h>
 #include <faiss/IndexIVFFlat.h>
 #include <faiss/IndexIVFPQ.h>
+#include <faiss/IndexIVFPQFastScan.h>
 #include <faiss/IndexIVFPQR.h>
 #include <faiss/IndexIVFSpectralHash.h>
 #include <faiss/IndexLSH.h>
 #include <faiss/IndexLattice.h>
 #include <faiss/IndexNSG.h>
 #include <faiss/IndexPQ.h>
+#include <faiss/IndexPQFastScan.h>
 #include <faiss/IndexPreTransform.h>
+#include <faiss/IndexRefine.h>
+#include <faiss/IndexRowwiseMinMax.h>
 #include <faiss/IndexScalarQuantizer.h>
 #include <faiss/MetaIndexes.h>
 #include <faiss/VectorTransform.h>
@@ -36,6 +42,8 @@
 #include <faiss/impl/ProductQuantizer.h>
 #include <faiss/impl/ResidualQuantizer.h>
 #include <faiss/impl/ScalarQuantizer.h>
+
+#include <faiss/invlists/BlockInvertedLists.h>
 
 namespace faiss {
 
@@ -71,24 +79,175 @@ VectorTransform* Cloner::clone_VectorTransform(const VectorTransform* vt) {
 IndexIVF* Cloner::clone_IndexIVF(const IndexIVF* ivf) {
     TRYCLONE(IndexIVFPQR, ivf)
     TRYCLONE(IndexIVFPQ, ivf)
+
+    TRYCLONE(IndexIVFLocalSearchQuantizer, ivf)
+    TRYCLONE(IndexIVFProductLocalSearchQuantizer, ivf)
+    TRYCLONE(IndexIVFProductResidualQuantizer, ivf)
+    TRYCLONE(IndexIVFResidualQuantizer, ivf)
+
+    TRYCLONE(IndexIVFLocalSearchQuantizerFastScan, ivf)
+    TRYCLONE(IndexIVFProductLocalSearchQuantizerFastScan, ivf)
+    TRYCLONE(IndexIVFProductResidualQuantizerFastScan, ivf)
+    TRYCLONE(IndexIVFResidualQuantizerFastScan, ivf)
+    TRYCLONE(IndexIVFPQFastScan, ivf)
+
+    TRYCLONE(IndexIVFFlatDedup, ivf)
     TRYCLONE(IndexIVFFlat, ivf)
+
+    TRYCLONE(IndexIVFSpectralHash, ivf)
+
     TRYCLONE(IndexIVFScalarQuantizer, ivf) {
         FAISS_THROW_MSG("clone not supported for this type of IndexIVF");
     }
     return nullptr;
 }
 
+IndexRefine* clone_IndexRefine(const IndexRefine* ir) {
+    TRYCLONE(IndexRefineFlat, ir)
+    TRYCLONE(IndexRefine, ir) {
+        FAISS_THROW_MSG("clone not supported for this type of IndexRefine");
+    }
+}
+
+IndexIDMap* clone_IndexIDMap(const IndexIDMap* im) {
+    TRYCLONE(IndexIDMap2, im)
+    TRYCLONE(IndexIDMap, im) {
+        FAISS_THROW_MSG("clone not supported for this type of IndexIDMap");
+    }
+}
+
+IndexHNSW* clone_IndexHNSW(const IndexHNSW* ihnsw) {
+    TRYCLONE(IndexHNSW2Level, ihnsw)
+    TRYCLONE(IndexHNSWFlat, ihnsw)
+    TRYCLONE(IndexHNSWPQ, ihnsw)
+    TRYCLONE(IndexHNSWSQ, ihnsw)
+    TRYCLONE(IndexHNSW, ihnsw) {
+        FAISS_THROW_MSG("clone not supported for this type of IndexHNSW");
+    }
+}
+
+IndexNNDescent* clone_IndexNNDescent(const IndexNNDescent* innd) {
+    TRYCLONE(IndexNNDescentFlat, innd)
+    TRYCLONE(IndexNNDescent, innd) {
+        FAISS_THROW_MSG("clone not supported for this type of IndexNNDescent");
+    }
+}
+
+IndexNSG* clone_IndexNSG(const IndexNSG* insg) {
+    TRYCLONE(IndexNSGFlat, insg)
+    TRYCLONE(IndexNSGPQ, insg)
+    TRYCLONE(IndexNSGSQ, insg)
+    TRYCLONE(IndexNSG, insg) {
+        FAISS_THROW_MSG("clone not supported for this type of IndexNNDescent");
+    }
+}
+
+IndexRowwiseMinMaxBase* clone_IndexRowwiseMinMax(
+        const IndexRowwiseMinMaxBase* irmmb) {
+    TRYCLONE(IndexRowwiseMinMaxFP16, irmmb)
+    TRYCLONE(IndexRowwiseMinMax, irmmb) {
+        FAISS_THROW_MSG(
+                "clone not supported for this type of IndexRowwiseMinMax");
+    }
+}
+
+#define TRYCAST(classname) classname* res = dynamic_cast<classname*>(index)
+
+void reset_AdditiveQuantizerIndex(Index* index) {
+    auto clone_ProductQuantizers =
+            [](std::vector<AdditiveQuantizer*>& quantizers) {
+                for (auto& q : quantizers) {
+                    q = dynamic_cast<AdditiveQuantizer*>(clone_Quantizer(q));
+                }
+            };
+    if (TRYCAST(IndexIVFLocalSearchQuantizerFastScan)) {
+        res->aq = &res->lsq;
+    } else if (TRYCAST(IndexIVFResidualQuantizerFastScan)) {
+        res->aq = &res->rq;
+    } else if (TRYCAST(IndexIVFProductLocalSearchQuantizerFastScan)) {
+        res->aq = &res->plsq;
+        clone_ProductQuantizers(res->plsq.quantizers);
+    } else if (TRYCAST(IndexIVFProductResidualQuantizerFastScan)) {
+        res->aq = &res->prq;
+        clone_ProductQuantizers(res->prq.quantizers);
+    } else if (TRYCAST(IndexIVFLocalSearchQuantizer)) {
+        res->aq = &res->lsq;
+    } else if (TRYCAST(IndexIVFResidualQuantizer)) {
+        res->aq = &res->rq;
+    } else if (TRYCAST(IndexIVFProductLocalSearchQuantizer)) {
+        res->aq = &res->plsq;
+        clone_ProductQuantizers(res->plsq.quantizers);
+    } else if (TRYCAST(IndexIVFProductResidualQuantizer)) {
+        res->aq = &res->prq;
+        clone_ProductQuantizers(res->prq.quantizers);
+    } else if (TRYCAST(IndexLocalSearchQuantizerFastScan)) {
+        res->aq = &res->lsq;
+    } else if (TRYCAST(IndexResidualQuantizerFastScan)) {
+        res->aq = &res->rq;
+    } else if (TRYCAST(IndexProductLocalSearchQuantizerFastScan)) {
+        res->aq = &res->plsq;
+        clone_ProductQuantizers(res->plsq.quantizers);
+    } else if (TRYCAST(IndexProductResidualQuantizerFastScan)) {
+        res->aq = &res->prq;
+        clone_ProductQuantizers(res->prq.quantizers);
+    } else if (TRYCAST(IndexLocalSearchQuantizer)) {
+        res->aq = &res->lsq;
+    } else if (TRYCAST(IndexResidualQuantizer)) {
+        res->aq = &res->rq;
+    } else if (TRYCAST(IndexProductLocalSearchQuantizer)) {
+        res->aq = &res->plsq;
+        clone_ProductQuantizers(res->plsq.quantizers);
+    } else if (TRYCAST(IndexProductResidualQuantizer)) {
+        res->aq = &res->prq;
+        clone_ProductQuantizers(res->prq.quantizers);
+    } else if (TRYCAST(LocalSearchCoarseQuantizer)) {
+        res->aq = &res->lsq;
+    } else if (TRYCAST(ResidualCoarseQuantizer)) {
+        res->aq = &res->rq;
+    } else {
+        FAISS_THROW_MSG(
+                "clone not supported for this type of additive quantizer index");
+    }
+}
+
+Index* clone_AdditiveQuantizerIndex(const Index* index) {
+    // IndexAdditiveQuantizer
+    TRYCLONE(IndexResidualQuantizer, index)
+    TRYCLONE(IndexProductResidualQuantizer, index)
+    TRYCLONE(IndexLocalSearchQuantizer, index)
+    TRYCLONE(IndexProductLocalSearchQuantizer, index)
+
+    // IndexFastScan
+    TRYCLONE(IndexResidualQuantizerFastScan, index)
+    TRYCLONE(IndexLocalSearchQuantizerFastScan, index)
+    TRYCLONE(IndexProductResidualQuantizerFastScan, index)
+    TRYCLONE(IndexProductLocalSearchQuantizerFastScan, index)
+
+    // AdditiveCoarseQuantizer
+    TRYCLONE(ResidualCoarseQuantizer, index)
+    TRYCLONE(LocalSearchCoarseQuantizer, index) {
+        FAISS_THROW_MSG(
+                "clone not supported for this type of additive quantizer index");
+    }
+}
+
 Index* Cloner::clone_Index(const Index* index) {
     TRYCLONE(IndexPQ, index)
     TRYCLONE(IndexLSH, index)
+
+    // IndexFlat
+    TRYCLONE(IndexFlat1D, index)
     TRYCLONE(IndexFlatL2, index)
     TRYCLONE(IndexFlatIP, index)
     TRYCLONE(IndexFlat, index)
+
     TRYCLONE(IndexLattice, index)
-    TRYCLONE(IndexResidualQuantizer, index)
+
+    TRYCLONE(IndexPQFastScan, index)
+
     TRYCLONE(IndexScalarQuantizer, index)
     TRYCLONE(MultiIndexQuantizer, index)
-    TRYCLONE(ResidualCoarseQuantizer, index)
+
     if (const IndexIVF* ivf = dynamic_cast<const IndexIVF*>(index)) {
         IndexIVF* res = clone_IndexIVF(ivf);
         if (ivf->invlists == nullptr) {
@@ -98,12 +257,22 @@ Index* Cloner::clone_Index(const Index* index) {
                         ivf->invlists)) {
             res->invlists = new ArrayInvertedLists(*ails);
             res->own_invlists = true;
+        } else if (
+                auto* bils = dynamic_cast<const BlockInvertedLists*>(
+                        ivf->invlists)) {
+            res->invlists = new BlockInvertedLists(*bils);
+            res->own_invlists = true;
         } else {
             FAISS_THROW_MSG(
                     "clone not supported for this type of inverted lists");
         }
         res->own_fields = true;
         res->quantizer = clone_Index(ivf->quantizer);
+
+        if (dynamic_cast<const IndexIVFAdditiveQuantizerFastScan*>(res) ||
+            dynamic_cast<const IndexIVFAdditiveQuantizer*>(res)) {
+            reset_AdditiveQuantizerIndex(res);
+        }
         return res;
     } else if (
             const IndexPreTransform* ipt =
@@ -122,19 +291,17 @@ Index* Cloner::clone_Index(const Index* index) {
         return res;
     } else if (
             const IndexIDMap* idmap = dynamic_cast<const IndexIDMap*>(index)) {
-        const IndexIDMap2* idmap2 = dynamic_cast<const IndexIDMap2*>(index);
-        IndexIDMap* res =
-                idmap2 ? new IndexIDMap2(*idmap2) : new IndexIDMap(*idmap);
+        IndexIDMap* res = clone_IndexIDMap(idmap);
         res->own_fields = true;
         res->index = clone_Index(idmap->index);
         return res;
     } else if (const IndexHNSW* ihnsw = dynamic_cast<const IndexHNSW*>(index)) {
-        IndexHNSW* res = new IndexHNSW(*ihnsw);
+        IndexHNSW* res = clone_IndexHNSW(ihnsw);
         res->own_fields = true;
         res->storage = clone_Index(ihnsw->storage);
         return res;
     } else if (const IndexNSG* insg = dynamic_cast<const IndexNSG*>(index)) {
-        IndexNSG* res = new IndexNSG(*insg);
+        IndexNSG* res = clone_IndexNSG(insg);
 
         // copy the dynamic allocated graph
         auto& new_graph = res->nsg.final_graph;
@@ -147,7 +314,7 @@ Index* Cloner::clone_Index(const Index* index) {
     } else if (
             const IndexNNDescent* innd =
                     dynamic_cast<const IndexNNDescent*>(index)) {
-        IndexNNDescent* res = new IndexNNDescent(*innd);
+        IndexNNDescent* res = clone_IndexNNDescent(innd);
         res->own_fields = true;
         res->storage = clone_Index(innd->storage);
         return res;
@@ -156,6 +323,29 @@ Index* Cloner::clone_Index(const Index* index) {
         Index2Layer* res = new Index2Layer(*i2l);
         res->q1.own_fields = true;
         res->q1.quantizer = clone_Index(i2l->q1.quantizer);
+        return res;
+    } else if (
+            const IndexRefine* ir = dynamic_cast<const IndexRefine*>(index)) {
+        IndexRefine* res = clone_IndexRefine(ir);
+        res->own_fields = true;
+        res->base_index = clone_Index(ir->base_index);
+        if (ir->refine_index != nullptr) {
+            res->own_refine_index = true;
+            res->refine_index = clone_Index(ir->refine_index);
+        }
+        return res;
+    } else if (
+            const IndexRowwiseMinMaxBase* irmmb =
+                    dynamic_cast<const IndexRowwiseMinMaxBase*>(index)) {
+        IndexRowwiseMinMaxBase* res = clone_IndexRowwiseMinMax(irmmb);
+        res->own_fields = true;
+        res->index = clone_Index(irmmb->index);
+    } else if (
+            dynamic_cast<const IndexAdditiveQuantizerFastScan*>(index) ||
+            dynamic_cast<const IndexAdditiveQuantizer*>(index) ||
+            dynamic_cast<const AdditiveCoarseQuantizer*>(index)) {
+        Index* res = clone_AdditiveQuantizerIndex(index);
+        reset_AdditiveQuantizerIndex(res);
         return res;
     } else {
         FAISS_THROW_MSG("clone not supported for this type of Index");

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -665,19 +665,19 @@ std::unique_ptr<Index> index_factory_sub(
         re_match(description, "(.+),Refine\\((.+)\\)", sm)) {
         std::unique_ptr<Index> filter_index =
                 index_factory_sub(d, sm[1].str(), metric);
-        std::unique_ptr<Index> refine_index;
 
+        IndexRefine* index_rf = nullptr;
         if (sm.size() == 3) { // Refine
-            refine_index = index_factory_sub(d, sm[2].str(), metric);
+            std::unique_ptr<Index> refine_index =
+                    index_factory_sub(d, sm[2].str(), metric);
+            index_rf = new IndexRefine(
+                    filter_index.release(), refine_index.release());
+            index_rf->own_refine_index = true;
         } else { // RFlat
-            refine_index.reset(new IndexFlat(d, metric));
+            index_rf = new IndexRefineFlat(filter_index.release(), nullptr);
         }
-        IndexRefine* index_rf =
-                new IndexRefine(filter_index.get(), refine_index.get());
+        FAISS_ASSERT(index_rf != nullptr);
         index_rf->own_fields = true;
-        filter_index.release();
-        refine_index.release();
-        index_rf->own_refine_index = true;
         return std::unique_ptr<Index>(index_rf);
     }
 

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -1,0 +1,88 @@
+# (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import faiss
+import numpy as np
+
+from faiss.contrib import datasets
+
+faiss.omp_set_num_threads(4)
+
+
+class TestClone(unittest.TestCase):
+    """
+    Test clone_index for various index combinations.
+    """
+
+    def do_test_clone(self, factory, with_ids=False):
+        """
+        Verify that cloning works for a given index type
+        """
+        d = 32
+        ds = datasets.SyntheticDataset(d, 1000, 2000, 10)
+        index1 = faiss.index_factory(d, factory)
+        index1.train(ds.get_train())
+        if with_ids:
+            index1.add_with_ids(ds.get_database(),
+                                np.arange(ds.nb).astype("int64"))
+        else:
+            index1.add(ds.get_database())
+        k = 5
+        Dref1, Iref1 = index1.search(ds.get_queries(), k)
+
+        index2 = faiss.clone_index(index1)
+        self.assertEqual(type(index1), type(index2))
+        index1 = None
+
+        Dref2, Iref2 = index2.search(ds.get_queries(), k)
+        np.testing.assert_array_equal(Dref1, Dref2)
+        np.testing.assert_array_equal(Iref1, Iref2)
+
+    def test_RFlat(self):
+        self.do_test_clone("SQ4,RFlat")
+
+    def test_Refine(self):
+        self.do_test_clone("SQ4,Refine(SQ8)")
+
+    def test_IVF(self):
+        self.do_test_clone("IVF16,Flat")
+
+    def test_PCA(self):
+        self.do_test_clone("PCA8,Flat")
+
+    def test_IDMap(self):
+        self.do_test_clone("IVF16,Flat,IDMap", with_ids=True)
+
+    def test_IDMap2(self):
+        self.do_test_clone("IVF16,Flat,IDMap2", with_ids=True)
+
+    def test_NSGPQ(self):
+        self.do_test_clone("NSG32,Flat")
+
+    def test_IVFAdditiveQuantizer(self):
+        self.do_test_clone("IVF16,LSQ5x6_Nqint8")
+        self.do_test_clone("IVF16,RQ5x6_Nqint8")
+        self.do_test_clone("IVF16,PLSQ4x3x5_Nqint8")
+        self.do_test_clone("IVF16,PRQ4x3x5_Nqint8")
+
+    def test_IVFAdditiveQuantizerFastScan(self):
+        self.do_test_clone("IVF16,LSQ3x4fs_32_Nlsq2x4")
+        self.do_test_clone("IVF16,RQ3x4fs_32_Nlsq2x4")
+        self.do_test_clone("IVF16,PLSQ2x3x4fs_Nlsq2x4")
+        self.do_test_clone("IVF16,PRQ2x3x4fs_Nrq2x4")
+
+    def test_AdditiveQuantizer(self):
+        self.do_test_clone("LSQ5x6_Nqint8")
+        self.do_test_clone("RQ5x6_Nqint8")
+        self.do_test_clone("PLSQ4x3x5_Nqint8")
+        self.do_test_clone("PRQ4x3x5_Nqint8")
+
+    def test_AdditiveQuantizerFastScan(self):
+        self.do_test_clone("LSQ3x4fs_32_Nlsq2x4")
+        self.do_test_clone("RQ3x4fs_32_Nlsq2x4")
+        self.do_test_clone("PLSQ2x3x4fs_Nlsq2x4")
+        self.do_test_clone("PRQ2x3x4fs_Nrq2x4")


### PR DESCRIPTION
Summary:
Adding `clone_index()` for `IndexRefine` and `IndexRefineFlat`

https://github.com/facebookresearch/faiss/issues/2517

Note the change in `index_factory.cpp`, `RFlat` now constructs an `IndexRefineFlat`.

Differential Revision: D40511409

