### PR TITLE
Allow us to force include the avx files on aarch64

### DIFF
--- a/faiss/cppcontrib/sa_decode/Level2-avx2-inl.h
+++ b/faiss/cppcontrib/sa_decode/Level2-avx2-inl.h
@@ -1,6 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
-
-#pragma once
+#ifndef LEVEL2_AVX2_INL_H
+#define LEVEL2_AVX2_INL_H
 
 #include <immintrin.h>
 
@@ -2055,3 +2055,4 @@ struct Index2LevelDecoder {
 
 } // namespace cppcontrib
 } // namespace faiss
+#endif // LEVEL2_AVX2_INL_H

--- a/faiss/cppcontrib/sa_decode/Level2-inl.h
+++ b/faiss/cppcontrib/sa_decode/Level2-inl.h
@@ -1,6 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
-
-#pragma once
+#ifndef LEVEL2_INL_H
+#define LEVEL2_INL_H
 
 #include <cstddef>
 #include <cstdint>
@@ -405,3 +405,4 @@ struct Index2LevelDecoder {
 
 } // namespace cppcontrib
 } // namespace faiss
+#endif // LEVEL2_INL_H

--- a/faiss/cppcontrib/sa_decode/Level2-neon-inl.h
+++ b/faiss/cppcontrib/sa_decode/Level2-neon-inl.h
@@ -1,6 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
-
-#pragma once
+#ifndef LEVEL2_NEON_INL_H
+#define LEVEL2_NEON_INL_H
 
 #include <arm_neon.h>
 
@@ -2144,3 +2144,4 @@ struct Index2LevelDecoder {
 
 } // namespace cppcontrib
 } // namespace faiss
+#endif // LEVEL2_NEON_INL_H

--- a/faiss/cppcontrib/sa_decode/PQ-avx2-inl.h
+++ b/faiss/cppcontrib/sa_decode/PQ-avx2-inl.h
@@ -1,6 +1,7 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-#pragma once
+#ifndef PQ_AVX2_INL_H
+#define PQ_AVX2_INL_H
 
 #include <immintrin.h>
 
@@ -1614,3 +1615,4 @@ struct IndexPQDecoder {
 
 } // namespace cppcontrib
 } // namespace faiss
+#endif // PQ_AVX2_INL_H

--- a/faiss/cppcontrib/sa_decode/PQ-inl.h
+++ b/faiss/cppcontrib/sa_decode/PQ-inl.h
@@ -1,6 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
-
-#pragma once
+#ifndef PQ_INL_H
+#define PQ_INL_H
 
 #include <cstddef>
 #include <cstdint>
@@ -248,3 +248,4 @@ struct IndexPQDecoder {
 
 } // namespace cppcontrib
 } // namespace faiss
+#endif // PQ_INL_H

--- a/faiss/cppcontrib/sa_decode/PQ-neon-inl.h
+++ b/faiss/cppcontrib/sa_decode/PQ-neon-inl.h
@@ -1,6 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
-
-#pragma once
+#ifndef PQ_NEON_INL_H
+#define PQ_NEON_INL_H
 
 #include <arm_neon.h>
 
@@ -1449,3 +1449,4 @@ struct IndexPQDecoder {
 
 } // namespace cppcontrib
 } // namespace faiss
+#endif // PQ_NEON_INL_H


### PR DESCRIPTION
Summary: Don't use #pragma once for the include headers.

Reviewed By: rahulg

Differential Revision: D40544318

