### PR TITLE
GpuIndex::search_and_reconstruct, GpuFlatIndex::reserve fixes

### DIFF
--- a/faiss/gpu/GpuIndex.cu
+++ b/faiss/gpu/GpuIndex.cu
@@ -290,7 +290,7 @@ void GpuIndex::search_and_reconstruct(
         float* recons,
         const SearchParameters* params) const {
     search(n, x, k, distances, labels, params);
-    reconstruct_batch(n, labels, recons);
+    reconstruct_batch(n * k, labels, recons);
 }
 
 void GpuIndex::searchNonPaged_(

--- a/faiss/gpu/impl/FlatIndex.cu
+++ b/faiss/gpu/impl/FlatIndex.cu
@@ -65,6 +65,18 @@ void FlatIndex::reserve(size_t numVecs, cudaStream_t stream) {
     } else {
         rawData32_.reserve(numVecs * dim_ * sizeof(float), stream);
     }
+
+    // The above may have caused a reallocation, we need to update the vector
+    // types
+    if (useFloat16_) {
+        DeviceTensor<half, 2, true> vectors16(
+                (half*)rawData16_.data(), {num_, dim_});
+        vectorsHalf_ = std::move(vectors16);
+    } else {
+        DeviceTensor<float, 2, true> vectors32(
+                (float*)rawData32_.data(), {num_, dim_});
+        vectors_ = std::move(vectors32);
+    }
 }
 
 Tensor<float, 2, true>& FlatIndex::getVectorsFloat32Ref() {

--- a/faiss/gpu/utils/DeviceUtils.cu
+++ b/faiss/gpu/utils/DeviceUtils.cu
@@ -149,6 +149,26 @@ bool getTensorCoreSupportCurrentDevice() {
     return getTensorCoreSupport(getCurrentDevice());
 }
 
+size_t getFreeMemory(int device) {
+    DeviceScope scope(device);
+
+    size_t free = 0;
+    size_t total = 0;
+
+    CUDA_VERIFY(cudaMemGetInfo(&free, &total));
+
+    return free;
+}
+
+size_t getFreeMemoryCurrentDevice() {
+    size_t free = 0;
+    size_t total = 0;
+
+    CUDA_VERIFY(cudaMemGetInfo(&free, &total));
+
+    return free;
+}
+
 DeviceScope::DeviceScope(int device) {
     if (device >= 0) {
         int curDevice = getCurrentDevice();

--- a/faiss/gpu/utils/DeviceUtils.h
+++ b/faiss/gpu/utils/DeviceUtils.h
@@ -70,6 +70,12 @@ bool getTensorCoreSupport(int device);
 /// Equivalent to getTensorCoreSupport(getCurrentDevice())
 bool getTensorCoreSupportCurrentDevice();
 
+/// Returns the amount of currently available memory on the given device
+size_t getFreeMemory(int device);
+
+/// Equivalent to getFreeMemory(getCurrentDevice())
+size_t getFreeMemoryCurrentDevice();
+
 /// RAII object to set the current device, and restore the previous
 /// device upon destruction
 class DeviceScope {


### PR DESCRIPTION
Summary:
This diff contains two fixes:

-`GpuIndex::search_and_reconstruct` was implemented in D37777979 (the default `faiss::Index` implementation never worked on GPU if given GPU input data), but the number of vectors passed to reconstruct was wrong in that diff. This fixes that, and includes a test for `search_and_reconstruct` as well.

-`GpuFlatIndex::reserve` only worked properly if you were calling `add` afterwards. If not, then this would potentially leave the index in a bad state. This bug has existed since 2016 in GPU Faiss.

Also implemented a test for a massive `GpuIndexFlat` index (more than 4 GB of data). Proper implementation of large (>2 GB) indexes via 64 bit indexing arithmetic will be done in a followup diff which touches most of the GPU code.

Differential Revision: D40765397

