### PR TITLE
fix for conda inspect failure

### DIFF
--- a/conda/faiss-gpu/meta.yaml
+++ b/conda/faiss-gpu/meta.yaml
@@ -47,6 +47,8 @@ outputs:
         - mkl >=2018,<2021  # [win]
         - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
     test:
+      requires:
+        - conda-build
       commands:
         - test -f $PREFIX/lib/libfaiss.so              # [linux]
         - test -f $PREFIX/lib/libfaiss.dylib           # [osx]

--- a/conda/faiss/meta.yaml
+++ b/conda/faiss/meta.yaml
@@ -44,6 +44,8 @@ outputs:
         - mkl >=2018  # [not win]
         - mkl >=2018,<2021  # [win]
     test:
+      requires:
+        - conda-build
       commands:
         - test -f $PREFIX/lib/libfaiss$SHLIB_EXT       # [not win]
         - test -f $PREFIX/lib/libfaiss_avx2$SHLIB_EXT  # [not win]


### PR DESCRIPTION
Summary: The `conda inspect` commands in the `test` section fail without `conda-build` in the `test` environment.

Differential Revision: D40793051

