### PR TITLE
Faiss GPU IVF large query batch fix

### DIFF
--- a/faiss/gpu/impl/BroadcastSum.cu
+++ b/faiss/gpu/impl/BroadcastSum.cu
@@ -244,16 +244,20 @@ void runSumAlongColumns(
         auto inputV = input.template castResize<TVec>();
         auto outputV = output.template castResize<TVec>();
 
-        auto grid = dim3(
-                utils::divUp(outputV.getSize(0), kRowsPerBlock),
-                utils::divUp(outputV.getSize(1), threadsPerBlock * kColLoad));
+        auto rowTiles = utils::divUp(outputV.getSize(0), kRowsPerBlock);
+        auto colTiles =
+                utils::divUp(outputV.getSize(1), threadsPerBlock * kColLoad);
+        FAISS_ASSERT(colTiles <= getMaxGridCurrentDevice().y);
+        auto grid = dim3(rowTiles, colTiles);
 
         sumAlongColumns<TVec, kRowsPerBlock, kRowUnroll, kColLoad>
                 <<<grid, block, 0, stream>>>(inputV, outputV);
     } else {
-        auto grid = dim3(
-                utils::divUp(output.getSize(0), kRowsPerBlock),
-                utils::divUp(output.getSize(1), threadsPerBlock * kColLoad));
+        auto rowTiles = utils::divUp(output.getSize(0), kRowsPerBlock);
+        auto colTiles =
+                utils::divUp(output.getSize(1), threadsPerBlock * kColLoad);
+        FAISS_ASSERT(colTiles <= getMaxGridCurrentDevice().y);
+        auto grid = dim3(rowTiles, colTiles);
 
         sumAlongColumns<T, kRowsPerBlock, kRowUnroll, kColLoad>
                 <<<grid, block, 0, stream>>>(input, output);
@@ -295,16 +299,20 @@ void runAssignAlongColumns(
         auto inputV = input.template castResize<TVec>();
         auto outputV = output.template castResize<TVec>();
 
-        auto grid = dim3(
-                utils::divUp(outputV.getSize(0), kRowsPerBlock),
-                utils::divUp(outputV.getSize(1), threadsPerBlock * kColLoad));
+        auto rowTiles = utils::divUp(outputV.getSize(0), kRowsPerBlock);
+        auto colTiles =
+                utils::divUp(outputV.getSize(1), threadsPerBlock * kColLoad);
+        FAISS_ASSERT(colTiles <= getMaxGridCurrentDevice().y);
+        auto grid = dim3(rowTiles, colTiles);
 
         assignAlongColumns<TVec, kRowsPerBlock, kRowUnroll, kColLoad>
                 <<<grid, block, 0, stream>>>(inputV, outputV);
     } else {
-        auto grid = dim3(
-                utils::divUp(output.getSize(0), kRowsPerBlock),
-                utils::divUp(output.getSize(1), threadsPerBlock * kColLoad));
+        auto rowTiles = utils::divUp(output.getSize(0), kRowsPerBlock);
+        auto colTiles =
+                utils::divUp(output.getSize(1), threadsPerBlock * kColLoad);
+        FAISS_ASSERT(colTiles <= getMaxGridCurrentDevice().y);
+        auto grid = dim3(rowTiles, colTiles);
 
         assignAlongColumns<T, kRowsPerBlock, kRowUnroll, kColLoad>
                 <<<grid, block, 0, stream>>>(input, output);

--- a/faiss/gpu/impl/DistanceUtils.cuh
+++ b/faiss/gpu/impl/DistanceUtils.cuh
@@ -273,8 +273,10 @@ __global__ void incrementIndex(
         Tensor<T, 2, true> indices,
         int k,
         int increment) {
-    for (int i = threadIdx.x; i < k; i += blockDim.x) {
-        indices[blockIdx.y][blockIdx.x * k + i] += blockIdx.x * increment;
+    for (int i = blockIdx.y; i < indices.getSize(0); i += gridDim.y) {
+        for (int j = threadIdx.x; j < k; j += blockDim.x) {
+            indices[i][blockIdx.x * k + j] += blockIdx.x * increment;
+        }
     }
 }
 

--- a/faiss/gpu/impl/GeneralDistance.cuh
+++ b/faiss/gpu/impl/GeneralDistance.cuh
@@ -244,6 +244,7 @@ void runGeneralDistanceKernel(
     dim3 grid(
             utils::divUp(vecs.getSize(0), kWarpSize),
             utils::divUp(query.getSize(0), kWarpSize));
+    FAISS_ASSERT(grid.y <= getMaxGridCurrentDevice().y);
     dim3 block(kWarpSize, kWarpSize);
 
     generalDistance<<<grid, block, 0, stream>>>(query, vecs, op, out);

--- a/faiss/gpu/impl/IVFFlatScan.cu
+++ b/faiss/gpu/impl/IVFFlatScan.cu
@@ -358,7 +358,7 @@ void runIVFFlatScan(
         Tensor<Index::idx_t, 2, true>& outIndices,
         GpuResources* res) {
     constexpr int kMinQueryTileSize = 8;
-    constexpr int kMaxQueryTileSize = 128;
+    constexpr int kMaxQueryTileSize = 65536; // used as blockIdx.y dimension
     constexpr int kThrustMemSize = 16384;
 
     int nprobe = listIds.getSize(1);

--- a/faiss/gpu/impl/PQCodeDistances-inl.cuh
+++ b/faiss/gpu/impl/PQCodeDistances-inl.cuh
@@ -327,6 +327,7 @@ void runPQResidualVector(
         Tensor<float, 4, true>& residual,
         bool l2Residual,
         cudaStream_t stream) {
+    // blockDim.y is limited by nprobe
     auto grid = dim3(coarseIndices.getSize(0), coarseIndices.getSize(1));
     auto block =
             dim3(std::min(queries.getSize(1), getMaxThreadsCurrentDevice()));
@@ -380,6 +381,7 @@ void runPQDistanceIPCorrection(
         Tensor<T, 4, true>& codeDistances,
         Tensor<T, 2, true>& coarseDistances,
         cudaStream_t stream) {
+    // blockDim.y is limited by nprobe
     auto grid = dim3(coarseDistances.getSize(1), coarseDistances.getSize(0));
     auto block = 512;
 

--- a/faiss/gpu/impl/PQScanMultiPassNoPrecomputed-inl.cuh
+++ b/faiss/gpu/impl/PQScanMultiPassNoPrecomputed-inl.cuh
@@ -546,7 +546,7 @@ void runPQScanMultiPassNoPrecomputed(
         Tensor<Index::idx_t, 2, true>& outIndices,
         GpuResources* res) {
     constexpr int kMinQueryTileSize = 8;
-    constexpr int kMaxQueryTileSize = 128;
+    constexpr int kMaxQueryTileSize = 65536; // typical max gridDim.y
     constexpr int kThrustMemSize = 16384;
 
     int nprobe = coarseIndices.getSize(1);

--- a/faiss/gpu/impl/PQScanMultiPassPrecomputed.cu
+++ b/faiss/gpu/impl/PQScanMultiPassPrecomputed.cu
@@ -558,7 +558,7 @@ void runPQScanMultiPassPrecomputed(
         Tensor<Index::idx_t, 2, true>& outIndices,
         GpuResources* res) {
     constexpr int kMinQueryTileSize = 8;
-    constexpr int kMaxQueryTileSize = 128;
+    constexpr int kMaxQueryTileSize = 65536; // typical max gridDim.y
     constexpr int kThrustMemSize = 16384;
 
     int nprobe = ivfListIds.getSize(1);

--- a/faiss/gpu/test/TestGpuIndexIVFFlat.cpp
+++ b/faiss/gpu/test/TestGpuIndexIVFFlat.cpp
@@ -64,13 +64,10 @@ struct Options {
 };
 
 void queryTest(
+        Options opt,
         faiss::MetricType metricType,
-        bool useFloat16CoarseQuantizer,
-        int dimOverride = -1) {
+        bool useFloat16CoarseQuantizer) {
     for (int tries = 0; tries < 2; ++tries) {
-        Options opt;
-        opt.dim = dimOverride != -1 ? dimOverride : opt.dim;
-
         std::vector<float> trainVecs =
                 faiss::gpu::randVecs(opt.numTrain, opt.dim);
         std::vector<float> addVecs = faiss::gpu::randVecs(opt.numAdd, opt.dim);
@@ -288,21 +285,28 @@ TEST(TestGpuIndexIVFFlat, Float16_32_Add_IP) {
 //
 
 TEST(TestGpuIndexIVFFlat, Float32_Query_L2) {
-    queryTest(faiss::METRIC_L2, false);
+    queryTest(Options(), faiss::METRIC_L2, false);
 }
 
 TEST(TestGpuIndexIVFFlat, Float32_Query_IP) {
-    queryTest(faiss::METRIC_INNER_PRODUCT, false);
+    queryTest(Options(), faiss::METRIC_INNER_PRODUCT, false);
+}
+
+TEST(TestGpuIndexIVFFlat, LargeBatch) {
+    Options opt;
+    opt.dim = 3;
+    opt.numQuery = 100000;
+    queryTest(opt, faiss::METRIC_L2, false);
 }
 
 // float16 coarse quantizer
 
 TEST(TestGpuIndexIVFFlat, Float16_32_Query_L2) {
-    queryTest(faiss::METRIC_L2, true);
+    queryTest(Options(), faiss::METRIC_L2, true);
 }
 
 TEST(TestGpuIndexIVFFlat, Float16_32_Query_IP) {
-    queryTest(faiss::METRIC_INNER_PRODUCT, true);
+    queryTest(Options(), faiss::METRIC_INNER_PRODUCT, true);
 }
 
 //
@@ -311,19 +315,27 @@ TEST(TestGpuIndexIVFFlat, Float16_32_Query_IP) {
 //
 
 TEST(TestGpuIndexIVFFlat, Float32_Query_L2_64) {
-    queryTest(faiss::METRIC_L2, false, 64);
+    Options opt;
+    opt.dim = 64;
+    queryTest(opt, faiss::METRIC_L2, false);
 }
 
 TEST(TestGpuIndexIVFFlat, Float32_Query_IP_64) {
-    queryTest(faiss::METRIC_INNER_PRODUCT, false, 64);
+    Options opt;
+    opt.dim = 64;
+    queryTest(opt, faiss::METRIC_INNER_PRODUCT, false);
 }
 
 TEST(TestGpuIndexIVFFlat, Float32_Query_L2_128) {
-    queryTest(faiss::METRIC_L2, false, 128);
+    Options opt;
+    opt.dim = 128;
+    queryTest(opt, faiss::METRIC_L2, false);
 }
 
 TEST(TestGpuIndexIVFFlat, Float32_Query_IP_128) {
-    queryTest(faiss::METRIC_INNER_PRODUCT, false, 128);
+    Options opt;
+    opt.dim = 128;
+    queryTest(opt, faiss::METRIC_INNER_PRODUCT, false);
 }
 
 //

--- a/faiss/gpu/utils/DeviceUtils.cu
+++ b/faiss/gpu/utils/DeviceUtils.cu
@@ -86,6 +86,16 @@ int getMaxThreadsCurrentDevice() {
     return getMaxThreads(getCurrentDevice());
 }
 
+dim3 getMaxGrid(int device) {
+    auto& prop = getDeviceProperties(device);
+
+    return dim3(prop.maxGridSize[0], prop.maxGridSize[1], prop.maxGridSize[2]);
+}
+
+dim3 getMaxGridCurrentDevice() {
+    return getMaxGrid(getCurrentDevice());
+}
+
 size_t getMaxSharedMemPerBlock(int device) {
     return getDeviceProperties(device).sharedMemPerBlock;
 }

--- a/faiss/gpu/utils/DeviceUtils.h
+++ b/faiss/gpu/utils/DeviceUtils.h
@@ -47,6 +47,12 @@ int getMaxThreads(int device);
 /// Equivalent to getMaxThreads(getCurrentDevice())
 int getMaxThreadsCurrentDevice();
 
+/// Returns the maximum grid size for the given GPU device
+dim3 getMaxGrid(int device);
+
+/// Equivalent to getMaxGrid(getCurrentDevice())
+dim3 getMaxGridCurrentDevice();
+
 /// Returns the maximum smem available for the given GPU device
 size_t getMaxSharedMemPerBlock(int device);
 


### PR DESCRIPTION
Summary:
This is a fix to https://github.com/facebookresearch/faiss/issues/2561

namely, GpuIndexIVFFlat didn't work for query batch sizes larger than 65536, due to that being the maximum grid Y dimension.

This code fixes the IVFFlat code to instead perform a grid loop over the queries as needed for >65536, and in other cases which are not currently violated by large batch queries but we're simply passing in some array size as a grid Y parameter, I added asserts to catch this for the future.

Added two tests for IVFPQ and IVFFlat for the large batch case. The IVFPQ large batch test passed before, but IVFFlat reproduced the same issue as seen in GH issue 2561.

Differential Revision: D41184878

