### PR TITLE
Put idx_t in the faiss namespace

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,6 +31,17 @@ $ conda install -c pytorch/label/nightly faiss-cpu
 $ conda install -c pytorch/label/nightly faiss-gpu
 ```
 
+A combination of versions that works with Pytorch (as of 2022-11-23):
+```
+conda create -n faiss_1.7.3 python=3.8
+conda activate faiss_1.7.3
+conda install pytorch==1.11.0 cudatoolkit=11.3 -c pytorch
+conda install numpy
+conda install -c pytorch faiss-gpu=1.7.3 cudatoolkit=11.3
+conda install -c conda-forge notebook
+conda install -y matplotlib
+```
+
 ## Installing from conda-forge
 
 Faiss is also being packaged by [conda-forge](https://conda-forge.org/), the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Faiss
 
-Faiss is a library for efficient similarity search and clustering of dense vectors. It contains algorithms that search in sets of vectors of any size, up to ones that possibly do not fit in RAM. It also contains supporting code for evaluation and parameter tuning. Faiss is written in C++ with complete wrappers for Python/numpy. Some of the most useful algorithms are implemented on the GPU. It is developed primarily at [Facebook AI Research](https://ai.facebook.com/).
+Faiss is a library for efficient similarity search and clustering of dense vectors. It contains algorithms that search in sets of vectors of any size, up to ones that possibly do not fit in RAM. It also contains supporting code for evaluation and parameter tuning. Faiss is written in C++ with complete wrappers for Python/numpy. Some of the most useful algorithms are implemented on the GPU. It is developed primarily at Meta's [Fundamental AI Research](https://ai.facebook.com/) group.
 
 ## News
 
@@ -48,6 +48,7 @@ The main authors of Faiss are:
 - [Jeff Johnson](https://github.com/wickedfoo) implemented all of the GPU Faiss
 - [Lucas Hosseini](https://github.com/beauby) implemented the binary indexes and the build system
 - [Chengqi Deng](https://github.com/KinglittleQ) implemented NSG, NNdescent and much of the additive quantization code.
+- [Alexandr Guzhva](https://github.com/alexanderguzhva) many optimizations: SIMD, memory allocation and layout, fast decoding kernels for vector codecs, etc.
 
 ## Reference
 

--- a/benchs/bench_gpu_1bn.py
+++ b/benchs/bench_gpu_1bn.py
@@ -13,7 +13,7 @@ import sys
 import faiss
 import re
 
-from multiprocessing.dummy import Pool as ThreadPool
+from multiprocessing.pool import ThreadPool
 from datasets import ivecs_read
 
 ####################################################################

--- a/benchs/bench_ivf_selector.cpp
+++ b/benchs/bench_ivf_selector.cpp
@@ -25,7 +25,7 @@
  */
 
 int main() {
-    using idx_t = faiss::Index::idx_t;
+    using idx_t = faiss::idx_t;
     int d = 64;
     size_t nb = 1024 * 1024;
     size_t nq = 512 * 16;

--- a/benchs/bench_polysemous_1bn.py
+++ b/benchs/bench_polysemous_1bn.py
@@ -9,7 +9,7 @@ import time
 import numpy as np
 import re
 import faiss
-from multiprocessing.dummy import Pool as ThreadPool
+from multiprocessing.pool import ThreadPool
 from datasets import ivecs_read
 
 

--- a/benchs/distributed_ondisk/distributed_kmeans.py
+++ b/benchs/distributed_ondisk/distributed_kmeans.py
@@ -17,7 +17,7 @@ import numpy as np
 
 import faiss
 
-from multiprocessing.dummy import Pool as ThreadPool
+from multiprocessing.pool import ThreadPool
 from faiss.contrib import rpc
 from faiss.contrib.datasets import SyntheticDataset
 from faiss.contrib.vecs_io import bvecs_mmap, fvecs_mmap

--- a/benchs/distributed_ondisk/make_index_vslice.py
+++ b/benchs/distributed_ondisk/make_index_vslice.py
@@ -8,7 +8,7 @@ import time
 import numpy as np
 import faiss
 import argparse
-from multiprocessing.dummy import Pool as ThreadPool
+from multiprocessing.pool import ThreadPool
 
 def ivecs_mmap(fname):
     a = np.memmap(fname, dtype='int32', mode='r')

--- a/benchs/distributed_ondisk/merge_to_ondisk.py
+++ b/benchs/distributed_ondisk/merge_to_ondisk.py
@@ -6,7 +6,7 @@
 import os
 import faiss
 import argparse
-from multiprocessing.dummy import Pool as ThreadPool
+from multiprocessing.pool import ThreadPool
 
 if __name__ == '__main__':
 

--- a/benchs/distributed_ondisk/search_server.py
+++ b/benchs/distributed_ondisk/search_server.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
 # Client implementation
 ############################################################
 
-from multiprocessing.dummy import Pool as ThreadPool
+from multiprocessing.pool import ThreadPool
 import faiss
 import numpy as np
 

--- a/benchs/link_and_code/bench_link_and_code.py
+++ b/benchs/link_and_code/bench_link_and_code.py
@@ -8,10 +8,7 @@ import os
 import sys
 import time
 import numpy as np
-import re
 import faiss
-from multiprocessing.dummy import Pool as ThreadPool
-import pdb
 import argparse
 import datasets
 from datasets import sanitize

--- a/contrib/client_server.py
+++ b/contrib/client_server.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from multiprocessing.dummy import Pool as ThreadPool
+from multiprocessing.pool import ThreadPool
 import faiss
 from typing import List, Tuple
 

--- a/contrib/evaluation.py
+++ b/contrib/evaluation.py
@@ -6,7 +6,7 @@
 import numpy as np
 import unittest
 
-from multiprocessing.dummy import Pool as ThreadPool
+from multiprocessing.pool import ThreadPool
 
 ###############################################################
 # Simple functions to evaluate knn results

--- a/demos/demo_imi_flat.cpp
+++ b/demos/demo_imi_flat.cpp
@@ -132,7 +132,7 @@ int main() {
                k,
                nq);
 
-        std::vector<faiss::Index::idx_t> nns(k * nq);
+        std::vector<faiss::idx_t> nns(k * nq);
         std::vector<float> dis(k * nq);
 
         index.search(nq, queries.data(), k, dis.data(), nns.data());

--- a/demos/demo_imi_pq.cpp
+++ b/demos/demo_imi_pq.cpp
@@ -126,7 +126,7 @@ int main() {
                nb);
 
         std::vector<float> database(nb * d);
-        std::vector<faiss::Index::idx_t> ids(nb);
+        std::vector<faiss::idx_t> ids(nb);
         for (size_t i = 0; i < nb; i++) {
             for (size_t j = 0; j < d; j++) {
                 database[i * d + j] = distrib(rng);
@@ -169,7 +169,7 @@ int main() {
     // - given a vector float *x, finding which k centroids are
     //   closest to it (ie to find the nearest neighbors) can be done with
     //
-    //   faiss::Index::idx_t *centroid_ids = new faiss::Index::idx_t[k];
+    //   faiss::idx_t *centroid_ids = new faiss::idx_t[k];
     //   float *distances = new float[k];
     //   index.quantizer->search (1, x, k, dis, centroids_ids);
     //
@@ -184,7 +184,7 @@ int main() {
                k,
                nq);
 
-        std::vector<faiss::Index::idx_t> nns(k * nq);
+        std::vector<faiss::idx_t> nns(k * nq);
         std::vector<float> dis(k * nq);
 
         index.search(nq, queries.data(), k, dis.data(), nns.data());

--- a/demos/demo_ivfpq_indexing.cpp
+++ b/demos/demo_ivfpq_indexing.cpp
@@ -118,7 +118,7 @@ int main() {
                k,
                nq);
 
-        std::vector<faiss::Index::idx_t> nns(k * nq);
+        std::vector<faiss::idx_t> nns(k * nq);
         std::vector<float> dis(k * nq);
 
         index.search(nq, queries.data(), k, dis.data(), nns.data());

--- a/demos/demo_nndescent.cpp
+++ b/demos/demo_nndescent.cpp
@@ -58,8 +58,8 @@ int main(void) {
         }
 
         int k = 5;
-        std::vector<faiss::IndexNNDescent::idx_t> nns(k * nq);
-        std::vector<faiss::IndexFlat::idx_t> gt_nns(k * nq);
+        std::vector<faiss::idx_t> nns(k * nq);
+        std::vector<faiss::idx_t> gt_nns(k * nq);
         std::vector<float> dis(k * nq);
 
         auto start = high_resolution_clock::now();

--- a/demos/demo_residual_quantizer.cpp
+++ b/demos/demo_residual_quantizer.cpp
@@ -24,7 +24,7 @@ int main() {
     /******************************************
      * Generate a test dataset
      ******************************************/
-    using idx_t = faiss::Index::idx_t;
+    using idx_t = faiss::idx_t;
     size_t d = 128;
     size_t nt = 10000;
     size_t nb = 10000;

--- a/demos/demo_sift1M.cpp
+++ b/demos/demo_sift1M.cpp
@@ -141,7 +141,7 @@ int main() {
     }
 
     size_t k;                // nb of results per query in the GT
-    faiss::Index::idx_t* gt; // nq * k matrix of ground-truth nearest-neighbors
+    faiss::idx_t* gt; // nq * k matrix of ground-truth nearest-neighbors
 
     {
         printf("[%.3f s] Loading ground truth for %ld queries\n",
@@ -153,7 +153,7 @@ int main() {
         int* gt_int = ivecs_read("sift1M/sift_groundtruth.ivecs", &k, &nq2);
         assert(nq2 == nq || !"incorrect nb of ground truth entries");
 
-        gt = new faiss::Index::idx_t[k * nq];
+        gt = new faiss::idx_t[k * nq];
         for (int i = 0; i < k * nq; i++) {
             gt[i] = gt_int[i];
         }
@@ -219,7 +219,7 @@ int main() {
                nq);
 
         // output buffers
-        faiss::Index::idx_t* I = new faiss::Index::idx_t[nq * k];
+        faiss::idx_t* I = new faiss::idx_t[nq * k];
         float* D = new float[nq * k];
 
         index->search(nq, xq, k, D, I);

--- a/demos/demo_weighted_kmeans.cpp
+++ b/demos/demo_weighted_kmeans.cpp
@@ -155,7 +155,7 @@ int main(int argc, char** argv) {
                 faiss::IndexFlatL2 cent_index(d);
                 cent_index.add(nc, centroids.data());
                 std::vector<float> dis(n);
-                std::vector<faiss::Index::idx_t> idx(n);
+                std::vector<faiss::idx_t> idx(n);
 
                 cent_index.search(
                         nc * 2, ccent.data(), 1, dis.data(), idx.data());

--- a/faiss/AutoTune.cpp
+++ b/faiss/AutoTune.cpp
@@ -608,7 +608,7 @@ void ParameterSpace::explore(
     if (n_experiments == 0) {
         for (size_t cno = 0; cno < n_comb; cno++) {
             set_index_parameters(index, cno);
-            std::vector<Index::idx_t> I(nq * crit.nnn);
+            std::vector<idx_t> I(nq * crit.nnn);
             std::vector<float> D(nq * crit.nnn);
 
             double t0 = getmillisecs();
@@ -677,7 +677,7 @@ void ParameterSpace::explore(
         }
 
         set_index_parameters(index, cno);
-        std::vector<Index::idx_t> I(nq * crit.nnn);
+        std::vector<idx_t> I(nq * crit.nnn);
         std::vector<float> D(nq * crit.nnn);
 
         double t0 = getmillisecs();
@@ -688,7 +688,7 @@ void ParameterSpace::explore(
         do {
             if (thread_over_batches) {
 #pragma omp parallel for
-                for (Index::idx_t q0 = 0; q0 < nq; q0 += batchsize) {
+                for (idx_t q0 = 0; q0 < nq; q0 += batchsize) {
                     size_t q1 = q0 + batchsize;
                     if (q1 > nq)
                         q1 = nq;

--- a/faiss/AutoTune.h
+++ b/faiss/AutoTune.h
@@ -24,7 +24,7 @@ namespace faiss {
  * higher is better.
  */
 struct AutoTuneCriterion {
-    typedef Index::idx_t idx_t;
+    
     idx_t nq;     ///< nb of queries this criterion is evaluated on
     idx_t nnn;    ///< nb of NNs that the query should request
     idx_t gt_nnn; ///< nb of GT NNs required to evaluate criterion

--- a/faiss/Clustering.cpp
+++ b/faiss/Clustering.cpp
@@ -88,8 +88,6 @@ void Clustering::train(
 
 namespace {
 
-using idx_t = Clustering::idx_t;
-
 idx_t subsample_training_set(
         const Clustering& clus,
         idx_t nx,
@@ -624,7 +622,7 @@ ProgressiveDimClustering::ProgressiveDimClustering(
 
 namespace {
 
-using idx_t = Index::idx_t;
+
 
 void copy_columns(idx_t n, idx_t d1, const float* src, idx_t d2, float* dest) {
     idx_t d = std::min(d1, d2);

--- a/faiss/Clustering.h
+++ b/faiss/Clustering.h
@@ -61,7 +61,6 @@ struct ClusteringIterationStats {
  *
  */
 struct Clustering : ClusteringParameters {
-    typedef Index::idx_t idx_t;
     size_t d; ///< dimension of the vectors
     size_t k; ///< nb of centroids
 
@@ -154,7 +153,7 @@ struct ProgressiveDimIndexFactory {
  * https://arxiv.org/abs/1509.05195
  */
 struct ProgressiveDimClustering : ProgressiveDimClusteringParameters {
-    using idx_t = Index::idx_t;
+    
     size_t d; ///< dimension of the vectors
     size_t k; ///< nb of centroids
 

--- a/faiss/IVFlib.h
+++ b/faiss/IVFlib.h
@@ -48,7 +48,7 @@ IndexIVF* try_extract_index_ivf(Index* index);
  */
 void merge_into(Index* index0, Index* index1, bool shift_ids);
 
-typedef Index::idx_t idx_t;
+
 
 /* Returns the cluster the embeddings belong to.
  *

--- a/faiss/Index.h
+++ b/faiss/Index.h
@@ -62,7 +62,6 @@ struct SearchParameters {
  * although the internal representation may vary.
  */
 struct Index {
-    using idx_t = int64_t; ///< all indices are this type
     using component_t = float;
     using distance_t = float;
 
@@ -278,6 +277,7 @@ struct Index {
      * trained in the same way and have the same
      * parameters). Otherwise throw. */
     virtual void check_compatible_for_merge(const Index& otherIndex) const;
+
 };
 
 } // namespace faiss

--- a/faiss/IndexBinary.h
+++ b/faiss/IndexBinary.h
@@ -32,7 +32,6 @@ struct RangeSearchResult;
  * vectors.
  */
 struct IndexBinary {
-    using idx_t = Index::idx_t; ///< all indices are this type
     using component_t = uint8_t;
     using distance_t = int32_t;
 

--- a/faiss/IndexBinaryHash.cpp
+++ b/faiss/IndexBinaryHash.cpp
@@ -108,7 +108,7 @@ struct FlipEnumerator {
     }
 };
 
-using idx_t = Index::idx_t;
+
 
 struct RangeSearchResults {
     int radius;
@@ -353,7 +353,7 @@ template <class HammingComputer, class SearchResults>
 static void verify_shortlist(
         const IndexBinaryFlat& index,
         const uint8_t* q,
-        const std::unordered_set<Index::idx_t>& shortlist,
+        const std::unordered_set<idx_t>& shortlist,
         SearchResults& res) {
     size_t code_size = index.code_size;
     size_t nlist = 0, ndis = 0, n0 = 0;

--- a/faiss/IndexBinaryIVF.cpp
+++ b/faiss/IndexBinaryIVF.cpp
@@ -158,7 +158,7 @@ void IndexBinaryIVF::reconstruct_n(idx_t i0, idx_t ni, uint8_t* recons) const {
 
     for (idx_t list_no = 0; list_no < nlist; list_no++) {
         size_t list_size = invlists->list_size(list_no);
-        const Index::idx_t* idlist = invlists->get_ids(list_no);
+        const idx_t* idlist = invlists->get_ids(list_no);
 
         for (idx_t offset = 0; offset < list_size; offset++) {
             idx_t id = idlist[offset];
@@ -320,7 +320,7 @@ void IndexBinaryIVF::replace_invlists(InvertedLists* il, bool own) {
 
 namespace {
 
-using idx_t = Index::idx_t;
+
 
 template <class HammingComputer>
 struct IVFBinaryScannerL2 : BinaryInvertedListScanner {
@@ -448,7 +448,7 @@ void search_knn_hamming_heap(
                 size_t list_size = ivf.invlists->list_size(key);
                 InvertedLists::ScopedCodes scodes(ivf.invlists, key);
                 std::unique_ptr<InvertedLists::ScopedIds> sids;
-                const Index::idx_t* ids = nullptr;
+                const idx_t* ids = nullptr;
 
                 if (!store_pairs) {
                     sids.reset(new InvertedLists::ScopedIds(ivf.invlists, key));
@@ -533,7 +533,7 @@ void search_knn_hamming_count(
             size_t list_size = ivf.invlists->list_size(key);
             InvertedLists::ScopedCodes scodes(ivf.invlists, key);
             const uint8_t* list_vecs = scodes.get();
-            const Index::idx_t* ids =
+            const idx_t* ids =
                     store_pairs ? nullptr : ivf.invlists->get_ids(key);
 
             for (size_t j = 0; j < list_size; j++) {

--- a/faiss/IndexBinaryIVF.h
+++ b/faiss/IndexBinaryIVF.h
@@ -209,7 +209,7 @@ struct IndexBinaryIVF : IndexBinary {
 };
 
 struct BinaryInvertedListScanner {
-    using idx_t = Index::idx_t;
+    
 
     /// from now on we handle this query.
     virtual void set_query(const uint8_t* query_vector) = 0;

--- a/faiss/IndexFlat.cpp
+++ b/faiss/IndexFlat.cpp
@@ -90,7 +90,7 @@ namespace {
 
 struct FlatL2Dis : FlatCodesDistanceComputer {
     size_t d;
-    Index::idx_t nb;
+    idx_t nb;
     const float* q;
     const float* b;
     size_t ndis;
@@ -121,7 +121,7 @@ struct FlatL2Dis : FlatCodesDistanceComputer {
 
 struct FlatIPDis : FlatCodesDistanceComputer {
     size_t d;
-    Index::idx_t nb;
+    idx_t nb;
     const float* q;
     const float* b;
     size_t ndis;

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -58,7 +58,7 @@ int sgemm_(
 
 namespace faiss {
 
-using idx_t = Index::idx_t;
+
 using MinimaxHeap = HNSW::MinimaxHeap;
 using storage_idx_t = HNSW::storage_idx_t;
 using NodeDistFarther = HNSW::NodeDistFarther;

--- a/faiss/IndexHNSW.h
+++ b/faiss/IndexHNSW.h
@@ -22,7 +22,7 @@ namespace faiss {
 struct IndexHNSW;
 
 struct ReconstructFromNeighbors {
-    typedef Index::idx_t idx_t;
+    
     typedef HNSW::storage_idx_t storage_idx_t;
 
     const IndexHNSW& index;

--- a/faiss/IndexIDMap.cpp
+++ b/faiss/IndexIDMap.cpp
@@ -64,7 +64,7 @@ template <typename IndexT>
 void IndexIDMapTemplate<IndexT>::add_with_ids(
         idx_t n,
         const typename IndexT::component_t* x,
-        const typename IndexT::idx_t* xids) {
+        const idx_t* xids) {
     index->add(n, x);
     for (idx_t i = 0; i < n; i++)
         id_map.push_back(xids[i]);
@@ -77,7 +77,7 @@ void IndexIDMapTemplate<IndexT>::search(
         const typename IndexT::component_t* x,
         idx_t k,
         typename IndexT::distance_t* distances,
-        typename IndexT::idx_t* labels,
+        idx_t* labels,
         const SearchParameters* params) const {
     FAISS_THROW_IF_NOT_MSG(
             !params, "search params not supported for this index");
@@ -91,7 +91,7 @@ void IndexIDMapTemplate<IndexT>::search(
 
 template <typename IndexT>
 void IndexIDMapTemplate<IndexT>::range_search(
-        typename IndexT::idx_t n,
+        idx_t n,
         const typename IndexT::component_t* x,
         typename IndexT::distance_t radius,
         RangeSearchResult* result,
@@ -182,7 +182,7 @@ template <typename IndexT>
 void IndexIDMap2Template<IndexT>::add_with_ids(
         idx_t n,
         const typename IndexT::component_t* x,
-        const typename IndexT::idx_t* xids) {
+        const idx_t* xids) {
     size_t prev_ntotal = this->ntotal;
     IndexIDMapTemplate<IndexT>::add_with_ids(n, x, xids);
     for (size_t i = prev_ntotal; i < this->ntotal; i++) {

--- a/faiss/IndexIDMap.h
+++ b/faiss/IndexIDMap.h
@@ -18,7 +18,6 @@ namespace faiss {
 /** Index that translates search results to ids */
 template <typename IndexT>
 struct IndexIDMapTemplate : IndexT {
-    using idx_t = typename IndexT::idx_t;
     using component_t = typename IndexT::component_t;
     using distance_t = typename IndexT::distance_t;
 
@@ -74,7 +73,6 @@ using IndexBinaryIDMap = IndexIDMapTemplate<IndexBinary>;
  *  implementation via a 2-way index */
 template <typename IndexT>
 struct IndexIDMap2Template : IndexIDMapTemplate<IndexT> {
-    using idx_t = typename IndexT::idx_t;
     using component_t = typename IndexT::component_t;
     using distance_t = typename IndexT::distance_t;
 

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -131,7 +131,7 @@ size_t Level1Quantizer::coarse_code_size() const {
     return nbyte;
 }
 
-void Level1Quantizer::encode_listno(Index::idx_t list_no, uint8_t* code) const {
+void Level1Quantizer::encode_listno(idx_t list_no, uint8_t* code) const {
     // little endian
     size_t nl = nlist - 1;
     while (nl > 0) {
@@ -141,7 +141,7 @@ void Level1Quantizer::encode_listno(Index::idx_t list_no, uint8_t* code) const {
     }
 }
 
-Index::idx_t Level1Quantizer::decode_listno(const uint8_t* code) const {
+idx_t Level1Quantizer::decode_listno(const uint8_t* code) const {
     size_t nl = nlist - 1;
     int64_t list_no = 0;
     int nbit = 0;
@@ -522,7 +522,7 @@ void IndexIVF::search_preassigned(
                 const uint8_t* codes = scodes.get();
 
                 std::unique_ptr<InvertedLists::ScopedIds> sids;
-                const Index::idx_t* ids = nullptr;
+                const idx_t* ids = nullptr;
 
                 if (!store_pairs) {
                     sids.reset(new InvertedLists::ScopedIds(invlists, key));

--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -54,8 +54,8 @@ struct Level1Quantizer {
 
     /// compute the number of bytes required to store list ids
     size_t coarse_code_size() const;
-    void encode_listno(Index::idx_t list_no, uint8_t* code) const;
-    Index::idx_t decode_listno(const uint8_t* code) const;
+    void encode_listno(idx_t list_no, uint8_t* code) const;
+    idx_t decode_listno(const uint8_t* code) const;
 
     Level1Quantizer(Index* quantizer, size_t nlist);
 
@@ -366,7 +366,7 @@ struct RangeQueryResult;
  * distance_to_code and scan_codes can be called in multiple
  * threads */
 struct InvertedListScanner {
-    using idx_t = Index::idx_t;
+    
 
     idx_t list_no = -1;    ///< remember current list
     bool keep_max = false; ///< keep maximum instead of minimum

--- a/faiss/IndexIVFAdditiveQuantizer.cpp
+++ b/faiss/IndexIVFAdditiveQuantizer.cpp
@@ -51,7 +51,7 @@ void IndexIVFAdditiveQuantizer::train_residual(idx_t n, const float* x) {
     ScopeDeleter<float> del_x(x_in == x ? nullptr : x);
 
     if (by_residual) {
-        std::vector<Index::idx_t> idx(n);
+        std::vector<idx_t> idx(n);
         quantizer->assign(n, x, idx.data());
 
         std::vector<float> residuals(n * d);

--- a/faiss/IndexIVFFastScan.cpp
+++ b/faiss/IndexIVFFastScan.cpp
@@ -229,7 +229,7 @@ void estimators_from_tables_generic(
     }
 }
 
-using idx_t = Index::idx_t;
+
 using namespace quantize_lut;
 
 } // anonymous namespace

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -197,9 +197,9 @@ void IndexIVFPQ::add_core(
 
 static float* compute_residuals(
         const Index* quantizer,
-        Index::idx_t n,
+        idx_t n,
         const float* x,
-        const Index::idx_t* list_nos) {
+        const idx_t* list_nos) {
     size_t d = quantizer->d;
     float* residuals = new float[n * d];
     // TODO: parallelize?
@@ -520,7 +520,7 @@ void IndexIVFPQ::precompute_table() {
 
 namespace {
 
-using idx_t = Index::idx_t;
+
 
 #define TIC t0 = get_cycles()
 #define TOC get_cycles() - t0
@@ -622,7 +622,7 @@ struct QueryTables {
      *****************************************************/
 
     // fields specific to list
-    Index::idx_t key;
+    idx_t key;
     float coarse_dis;
     std::vector<uint8_t> q_code;
 
@@ -1170,7 +1170,7 @@ struct IVFPQScannerT : QueryTables {
  * use_sel: store or ignore the IDSelector
  */
 template <MetricType METRIC_TYPE, class C, class PQDecoder, bool use_sel>
-struct IVFPQScanner : IVFPQScannerT<Index::idx_t, METRIC_TYPE, PQDecoder>,
+struct IVFPQScanner : IVFPQScannerT<idx_t, METRIC_TYPE, PQDecoder>,
                       InvertedListScanner {
     int precompute_mode;
     const IDSelector* sel;
@@ -1180,7 +1180,7 @@ struct IVFPQScanner : IVFPQScannerT<Index::idx_t, METRIC_TYPE, PQDecoder>,
             bool store_pairs,
             int precompute_mode,
             const IDSelector* sel)
-            : IVFPQScannerT<Index::idx_t, METRIC_TYPE, PQDecoder>(
+            : IVFPQScannerT<idx_t, METRIC_TYPE, PQDecoder>(
                       ivfpq,
                       nullptr),
               precompute_mode(precompute_mode),

--- a/faiss/IndexIVFSpectralHash.cpp
+++ b/faiss/IndexIVFSpectralHash.cpp
@@ -213,7 +213,7 @@ struct IVFScanner : InvertedListScanner {
     std::vector<uint8_t> qcode;
     HammingComputer hc;
 
-    using idx_t = Index::idx_t;
+    
 
     IVFScanner(const IndexIVFSpectralHash* index, bool store_pairs)
             : index(index),

--- a/faiss/IndexNNDescent.cpp
+++ b/faiss/IndexNNDescent.cpp
@@ -50,7 +50,7 @@ int sgemm_(
 
 namespace faiss {
 
-using idx_t = Index::idx_t;
+
 using storage_idx_t = NNDescent::storage_idx_t;
 
 /**************************************************************

--- a/faiss/IndexNNDescent.h
+++ b/faiss/IndexNNDescent.h
@@ -25,7 +25,7 @@ struct IndexNNDescent : Index {
     using storage_idx_t = NNDescent::storage_idx_t;
 
     /// Faiss results are 64-bit
-    using idx_t = Index::idx_t;
+    
 
     // the link strcuture
     NNDescent nndescent;

--- a/faiss/IndexNSG.cpp
+++ b/faiss/IndexNSG.cpp
@@ -23,7 +23,7 @@
 
 namespace faiss {
 
-using idx_t = Index::idx_t;
+
 using namespace nsg;
 
 /**************************************************************

--- a/faiss/IndexPQ.cpp
+++ b/faiss/IndexPQ.cpp
@@ -74,7 +74,7 @@ template <class PQDecoder>
 struct PQDistanceComputer : FlatCodesDistanceComputer {
     size_t d;
     MetricType metric;
-    Index::idx_t nb;
+    idx_t nb;
     const ProductQuantizer& pq;
     const float* sdc;
     std::vector<float> precomputed_table;

--- a/faiss/IndexRefine.cpp
+++ b/faiss/IndexRefine.cpp
@@ -62,7 +62,7 @@ void IndexRefine::reset() {
 
 namespace {
 
-typedef faiss::Index::idx_t idx_t;
+typedef faiss::idx_t idx_t;
 
 template <class C>
 static void reorder_2_heaps(

--- a/faiss/IndexReplicas.cpp
+++ b/faiss/IndexReplicas.cpp
@@ -123,14 +123,13 @@ void IndexReplicasTemplate<IndexT>::search(
     size_t componentsPerVec = sizeof(component_t) == 1 ? (dim + 7) / 8 : dim;
 
     // Partition the query by the number of indices we have
-    faiss::Index::idx_t queriesPerIndex =
-            (faiss::Index::idx_t)(n + this->count() - 1) /
-            (faiss::Index::idx_t)this->count();
+    faiss::idx_t queriesPerIndex =
+            (faiss::idx_t)(n + this->count() - 1) / (faiss::idx_t)this->count();
     FAISS_ASSERT(n / queriesPerIndex <= this->count());
 
     auto fn = [queriesPerIndex, componentsPerVec, n, x, k, distances, labels](
                       int i, const IndexT* index) {
-        faiss::Index::idx_t base = (faiss::Index::idx_t)i * queriesPerIndex;
+        faiss::idx_t base = (faiss::idx_t)i * queriesPerIndex;
 
         if (base < n) {
             auto numForIndex = std::min(queriesPerIndex, n - base);

--- a/faiss/IndexReplicas.h
+++ b/faiss/IndexReplicas.h
@@ -20,7 +20,6 @@ namespace faiss {
 template <typename IndexT>
 class IndexReplicasTemplate : public ThreadedIndex<IndexT> {
    public:
-    using idx_t = typename IndexT::idx_t;
     using component_t = typename IndexT::component_t;
     using distance_t = typename IndexT::distance_t;
 

--- a/faiss/IndexRowwiseMinMax.cpp
+++ b/faiss/IndexRowwiseMinMax.cpp
@@ -11,7 +11,7 @@ namespace faiss {
 
 namespace {
 
-using idx_t = faiss::Index::idx_t;
+using idx_t = faiss::idx_t;
 
 struct StorageMinMaxFP16 {
     uint16_t scaler;

--- a/faiss/IndexShards.cpp
+++ b/faiss/IndexShards.cpp
@@ -22,7 +22,7 @@ namespace faiss {
 // subroutines
 namespace {
 
-typedef Index::idx_t idx_t;
+
 
 // add translation to all valid labels
 void translate_labels(long n, idx_t* labels, long translation) {

--- a/faiss/IndexShards.h
+++ b/faiss/IndexShards.h
@@ -18,7 +18,6 @@ namespace faiss {
  */
 template <typename IndexT>
 struct IndexShardsTemplate : public ThreadedIndex<IndexT> {
-    using idx_t = typename IndexT::idx_t;
     using component_t = typename IndexT::component_t;
     using distance_t = typename IndexT::distance_t;
 

--- a/faiss/MetricType.h
+++ b/faiss/MetricType.h
@@ -10,6 +10,8 @@
 #ifndef FAISS_METRIC_TYPE_H
 #define FAISS_METRIC_TYPE_H
 
+#include <faiss/impl/platform_macros.h>
+
 namespace faiss {
 
 /// The metric space for vector comparison for Faiss indices and algorithms.
@@ -30,6 +32,9 @@ enum MetricType {
     METRIC_BrayCurtis,
     METRIC_JensenShannon,
 };
+
+/// all vector indices are this type
+using idx_t = int64_t;
 
 } // namespace faiss
 

--- a/faiss/VectorTransform.cpp
+++ b/faiss/VectorTransform.cpp
@@ -135,7 +135,7 @@ int dgesvd_(
  * VectorTransform
  *********************************************/
 
-float* VectorTransform::apply(Index::idx_t n, const float* x) const {
+float* VectorTransform::apply(idx_t n, const float* x) const {
     float* xt = new float[n * d_out];
     apply_noalloc(n, x, xt);
     return xt;
@@ -166,7 +166,7 @@ LinearTransform::LinearTransform(int d_in, int d_out, bool have_bias)
     is_trained = false; // will be trained when A and b are initialized
 }
 
-void LinearTransform::apply_noalloc(Index::idx_t n, const float* x, float* xt)
+void LinearTransform::apply_noalloc(idx_t n, const float* x, float* xt)
         const {
     FAISS_THROW_IF_NOT_MSG(is_trained, "Transformation not trained yet");
 
@@ -348,7 +348,7 @@ void RandomRotationMatrix::init(int seed) {
     is_trained = true;
 }
 
-void RandomRotationMatrix::train(Index::idx_t /*n*/, const float* /*x*/) {
+void RandomRotationMatrix::train(idx_t /*n*/, const float* /*x*/) {
     // initialize with some arbitrary seed
     init(12345);
 }
@@ -442,7 +442,7 @@ void eig(size_t d_in, double* cov, double* eigenvalues, int verbose) {
 
 } // namespace
 
-void PCAMatrix::train(Index::idx_t n, const float* x) {
+void PCAMatrix::train(idx_t n, const float* x) {
     const float* x_in = x;
 
     x = fvecs_maybe_subsample(
@@ -733,7 +733,7 @@ ITQMatrix::ITQMatrix(int d)
         : LinearTransform(d, d, false), max_iter(50), seed(123) {}
 
 /** translated from fbcode/deeplearning/catalyzer/catalyzer/quantizers.py */
-void ITQMatrix::train(Index::idx_t n, const float* xf) {
+void ITQMatrix::train(idx_t n, const float* xf) {
     size_t d = d_in;
     std::vector<double> rotation(d * d);
 
@@ -957,7 +957,7 @@ void ITQTransform::train(idx_t n, const float* x) {
     is_trained = true;
 }
 
-void ITQTransform::apply_noalloc(Index::idx_t n, const float* x, float* xt)
+void ITQTransform::apply_noalloc(idx_t n, const float* x, float* xt)
         const {
     FAISS_THROW_IF_NOT_MSG(is_trained, "Transformation not trained yet");
 
@@ -1003,7 +1003,7 @@ OPQMatrix::OPQMatrix(int d, int M, int d2)
     pq = nullptr;
 }
 
-void OPQMatrix::train(Index::idx_t n, const float* x) {
+void OPQMatrix::train(idx_t n, const float* x) {
     const float* x_in = x;
 
     x = fvecs_maybe_subsample(d_in, (size_t*)&n, max_train_points, x, verbose);
@@ -1261,7 +1261,7 @@ CenteringTransform::CenteringTransform(int d) : VectorTransform(d, d) {
     is_trained = false;
 }
 
-void CenteringTransform::train(Index::idx_t n, const float* x) {
+void CenteringTransform::train(idx_t n, const float* x) {
     FAISS_THROW_IF_NOT_MSG(n > 0, "need at least one training vector");
     mean.resize(d_in, 0);
     for (idx_t i = 0; i < n; i++) {

--- a/faiss/VectorTransform.h
+++ b/faiss/VectorTransform.h
@@ -23,7 +23,7 @@ namespace faiss {
 
 /** Any transformation applied on a set of vectors */
 struct VectorTransform {
-    typedef Index::idx_t idx_t;
+    
 
     int d_in;  ///! input dimension
     int d_out; ///! output dimension

--- a/faiss/gpu/GpuCloner.cpp
+++ b/faiss/gpu/GpuCloner.cpp
@@ -116,7 +116,7 @@ ToGpuCloner::ToGpuCloner(
         : GpuClonerOptions(options), provider(prov), device(device) {}
 
 Index* ToGpuCloner::clone_Index(const Index* index) {
-    using idx_t = Index::idx_t;
+    
     if (auto ifl = dynamic_cast<const IndexFlat*>(index)) {
         GpuIndexFlatConfig config;
         config.device = device;

--- a/faiss/gpu/GpuDistance.cu
+++ b/faiss/gpu/GpuDistance.cu
@@ -137,20 +137,20 @@ void bfKnnConvert(GpuResourcesProvider* prov, const GpuDistanceParams& args) {
                 args.ignoreOutDistances);
 
         // Convert and copy int indices out
-        auto tOutIndices = toDeviceTemporary<Index::idx_t, 2>(
+        auto tOutIndices = toDeviceTemporary<idx_t, 2>(
                 res,
                 device,
-                (Index::idx_t*)args.outIndices,
+                (idx_t*)args.outIndices,
                 stream,
                 {args.numQueries, args.k});
 
         // Convert int to idx_t
-        convertTensor<int, Index::idx_t, 2>(
+        convertTensor<int, idx_t, 2>(
                 stream, tOutIntIndices, tOutIndices);
 
         // Copy back if necessary
-        fromDevice<Index::idx_t, 2>(
-                tOutIndices, (Index::idx_t*)args.outIndices, stream);
+        fromDevice<idx_t, 2>(
+                tOutIndices, (idx_t*)args.outIndices, stream);
 
     } else if (args.outIndicesType == IndicesDataType::I32) {
         // We can use the brute-force API directly, as it takes i32 indices
@@ -229,7 +229,7 @@ void bruteForceKnn(
         float* outDistances,
         // A region of memory size numQueries x k, with k
         // innermost
-        Index::idx_t* outIndices) {
+        idx_t* outIndices) {
     std::cerr << "bruteForceKnn is deprecated; call bfKnn instead" << std::endl;
 
     GpuDistanceParams args;

--- a/faiss/gpu/GpuDistance.h
+++ b/faiss/gpu/GpuDistance.h
@@ -163,7 +163,7 @@ void bruteForceKnn(
         float* outDistances,
         // A region of memory size numQueries x k, with k
         // innermost (row major)
-        Index::idx_t* outIndices);
+        idx_t* outIndices);
 
 } // namespace gpu
 } // namespace faiss

--- a/faiss/gpu/GpuIndex.cu
+++ b/faiss/gpu/GpuIndex.cu
@@ -100,15 +100,15 @@ size_t GpuIndex::getMinPagingSize() const {
     return minPagedSize_;
 }
 
-void GpuIndex::add(Index::idx_t n, const float* x) {
+void GpuIndex::add(idx_t n, const float* x) {
     // Pass to add_with_ids
     add_with_ids(n, x, nullptr);
 }
 
 void GpuIndex::add_with_ids(
-        Index::idx_t n,
+        idx_t n,
         const float* x,
-        const Index::idx_t* ids) {
+        const idx_t* ids) {
     DeviceScope scope(config_.device);
     FAISS_THROW_IF_NOT_MSG(this->is_trained, "Index not trained");
 
@@ -119,13 +119,13 @@ void GpuIndex::add_with_ids(
         return;
     }
 
-    std::vector<Index::idx_t> generatedIds;
+    std::vector<idx_t> generatedIds;
 
     // Generate IDs if we need them
     if (!ids && addImplRequiresIDs_()) {
-        generatedIds = std::vector<Index::idx_t>(n);
+        generatedIds = std::vector<idx_t>(n);
 
-        for (Index::idx_t i = 0; i < n; ++i) {
+        for (idx_t i = 0; i < n; ++i) {
             generatedIds[i] = this->ntotal + i;
         }
     }
@@ -133,7 +133,7 @@ void GpuIndex::add_with_ids(
     addPaged_((int)n, x, ids ? ids : generatedIds.data());
 }
 
-void GpuIndex::addPaged_(int n, const float* x, const Index::idx_t* ids) {
+void GpuIndex::addPaged_(int n, const float* x, const idx_t* ids) {
     if (n > 0) {
         size_t totalSize = (size_t)n * this->d * sizeof(float);
 
@@ -162,7 +162,7 @@ void GpuIndex::addPaged_(int n, const float* x, const Index::idx_t* ids) {
     }
 }
 
-void GpuIndex::addPage_(int n, const float* x, const Index::idx_t* ids) {
+void GpuIndex::addPage_(int n, const float* x, const idx_t* ids) {
     // At this point, `x` can be resident on CPU or GPU, and `ids` may be
     // resident on CPU, GPU or may be null.
     //
@@ -178,10 +178,10 @@ void GpuIndex::addPage_(int n, const float* x, const Index::idx_t* ids) {
             {n, this->d});
 
     if (ids) {
-        auto indices = toDeviceTemporary<Index::idx_t, 1>(
+        auto indices = toDeviceTemporary<idx_t, 1>(
                 resources_.get(),
                 config_.device,
-                const_cast<Index::idx_t*>(ids),
+                const_cast<idx_t*>(ids),
                 stream,
                 {n});
 
@@ -192,10 +192,10 @@ void GpuIndex::addPage_(int n, const float* x, const Index::idx_t* ids) {
 }
 
 void GpuIndex::assign(
-        Index::idx_t n,
+        idx_t n,
         const float* x,
-        Index::idx_t* labels,
-        Index::idx_t k) const {
+        idx_t* labels,
+        idx_t k) const {
     DeviceScope scope(config_.device);
     FAISS_THROW_IF_NOT_MSG(this->is_trained, "Index not trained");
 
@@ -216,11 +216,11 @@ void GpuIndex::assign(
 }
 
 void GpuIndex::search(
-        Index::idx_t n,
+        idx_t n,
         const float* x,
-        Index::idx_t k,
+        idx_t k,
         float* distances,
-        Index::idx_t* labels,
+        idx_t* labels,
         const SearchParameters* params) const {
     DeviceScope scope(config_.device);
     FAISS_THROW_IF_NOT_MSG(this->is_trained, "Index not trained");
@@ -251,7 +251,7 @@ void GpuIndex::search(
             stream,
             {(int)n, (int)k});
 
-    auto outLabels = toDeviceTemporary<Index::idx_t, 2>(
+    auto outLabels = toDeviceTemporary<idx_t, 2>(
             resources_.get(), config_.device, labels, stream, {(int)n, (int)k});
 
     bool usePaged = false;
@@ -278,7 +278,7 @@ void GpuIndex::search(
 
     // Copy back if necessary
     fromDevice<float, 2>(outDistances, distances, stream);
-    fromDevice<Index::idx_t, 2>(outLabels, labels, stream);
+    fromDevice<idx_t, 2>(outLabels, labels, stream);
 }
 
 void GpuIndex::search_and_reconstruct(
@@ -298,7 +298,7 @@ void GpuIndex::searchNonPaged_(
         const float* x,
         int k,
         float* outDistancesData,
-        Index::idx_t* outIndicesData,
+        idx_t* outIndicesData,
         const SearchParameters* params) const {
     auto stream = resources_->getDefaultStream(config_.device);
 
@@ -319,10 +319,10 @@ void GpuIndex::searchFromCpuPaged_(
         const float* x,
         int k,
         float* outDistancesData,
-        Index::idx_t* outIndicesData,
+        idx_t* outIndicesData,
         const SearchParameters* params) const {
     Tensor<float, 2, true> outDistances(outDistancesData, {n, k});
-    Tensor<Index::idx_t, 2, true> outIndices(outIndicesData, {n, k});
+    Tensor<idx_t, 2, true> outIndices(outIndicesData, {n, k});
 
     // Is pinned memory available?
     auto pinnedAlloc = resources_->getPinnedMemory();
@@ -498,15 +498,15 @@ void GpuIndex::searchFromCpuPaged_(
 void GpuIndex::compute_residual(
         const float* x,
         float* residual,
-        Index::idx_t key) const {
+        idx_t key) const {
     FAISS_THROW_MSG("compute_residual not implemented for this type of index");
 }
 
 void GpuIndex::compute_residual_n(
-        Index::idx_t n,
+        idx_t n,
         const float* xs,
         float* residuals,
-        const Index::idx_t* keys) const {
+        const idx_t* keys) const {
     FAISS_THROW_MSG(
             "compute_residual_n not implemented for this type of index");
 }

--- a/faiss/gpu/GpuIndex.h
+++ b/faiss/gpu/GpuIndex.h
@@ -51,30 +51,30 @@ class GpuIndex : public faiss::Index {
     /// `x` can be resident on the CPU or any GPU; copies are performed
     /// as needed
     /// Handles paged adds if the add set is too large; calls addInternal_
-    void add(Index::idx_t, const float* x) override;
+    void add(idx_t, const float* x) override;
 
     /// `x` and `ids` can be resident on the CPU or any GPU; copies are
     /// performed as needed
     /// Handles paged adds if the add set is too large; calls addInternal_
-    void add_with_ids(Index::idx_t n, const float* x, const Index::idx_t* ids)
+    void add_with_ids(idx_t n, const float* x, const idx_t* ids)
             override;
 
     /// `x` and `labels` can be resident on the CPU or any GPU; copies are
     /// performed as needed
     void assign(
-            Index::idx_t n,
+            idx_t n,
             const float* x,
-            Index::idx_t* labels,
-            Index::idx_t k = 1) const override;
+            idx_t* labels,
+            idx_t k = 1) const override;
 
     /// `x`, `distances` and `labels` can be resident on the CPU or any
     /// GPU; copies are performed as needed
     void search(
-            Index::idx_t n,
+            idx_t n,
             const float* x,
-            Index::idx_t k,
+            idx_t k,
             float* distances,
-            Index::idx_t* labels,
+            idx_t* labels,
             const SearchParameters* params = nullptr) const override;
 
     /// `x`, `distances` and `labels` and `recons` can be resident on the CPU or
@@ -90,16 +90,16 @@ class GpuIndex : public faiss::Index {
 
     /// Overridden to force GPU indices to provide their own GPU-friendly
     /// implementation
-    void compute_residual(const float* x, float* residual, Index::idx_t key)
+    void compute_residual(const float* x, float* residual, idx_t key)
             const override;
 
     /// Overridden to force GPU indices to provide their own GPU-friendly
     /// implementation
     void compute_residual_n(
-            Index::idx_t n,
+            idx_t n,
             const float* xs,
             float* residuals,
-            const Index::idx_t* keys) const override;
+            const idx_t* keys) const override;
 
    protected:
     /// Copy what we need from the CPU equivalent
@@ -114,7 +114,7 @@ class GpuIndex : public faiss::Index {
 
     /// Overridden to actually perform the add
     /// All data is guaranteed to be resident on our device
-    virtual void addImpl_(int n, const float* x, const Index::idx_t* ids) = 0;
+    virtual void addImpl_(int n, const float* x, const idx_t* ids) = 0;
 
     /// Overridden to actually perform the search
     /// All data is guaranteed to be resident on our device
@@ -123,16 +123,16 @@ class GpuIndex : public faiss::Index {
             const float* x,
             int k,
             float* distances,
-            Index::idx_t* labels,
+            idx_t* labels,
             const SearchParameters* params) const = 0;
 
    private:
     /// Handles paged adds if the add set is too large, passes to
     /// addImpl_ to actually perform the add for the current page
-    void addPaged_(int n, const float* x, const Index::idx_t* ids);
+    void addPaged_(int n, const float* x, const idx_t* ids);
 
     /// Calls addImpl_ for a single page of GPU-resident data
-    void addPage_(int n, const float* x, const Index::idx_t* ids);
+    void addPage_(int n, const float* x, const idx_t* ids);
 
     /// Calls searchImpl_ for a single page of GPU-resident data
     void searchNonPaged_(
@@ -140,7 +140,7 @@ class GpuIndex : public faiss::Index {
             const float* x,
             int k,
             float* outDistancesData,
-            Index::idx_t* outIndicesData,
+            idx_t* outIndicesData,
             const SearchParameters* params) const;
 
     /// Calls searchImpl_ for a single page of GPU-resident data,
@@ -150,7 +150,7 @@ class GpuIndex : public faiss::Index {
             const float* x,
             int k,
             float* outDistancesData,
-            Index::idx_t* outIndicesData,
+            idx_t* outIndicesData,
             const SearchParameters* params) const;
 
    protected:

--- a/faiss/gpu/GpuIndexBinaryFlat.cu
+++ b/faiss/gpu/GpuIndexBinaryFlat.cu
@@ -78,7 +78,7 @@ void GpuIndexBinaryFlat::copyFrom(const faiss::IndexBinaryFlat* index) {
 
     // GPU code has 32 bit indices
     FAISS_THROW_IF_NOT_FMT(
-            index->ntotal <= (Index::idx_t)std::numeric_limits<int>::max(),
+            index->ntotal <= (idx_t)std::numeric_limits<int>::max(),
             "GPU index only supports up to %zu indices; "
             "attempting to copy CPU index with %zu parameters",
             (size_t)std::numeric_limits<int>::max(),
@@ -117,7 +117,7 @@ void GpuIndexBinaryFlat::copyTo(faiss::IndexBinaryFlat* index) const {
     }
 }
 
-void GpuIndexBinaryFlat::add(faiss::IndexBinary::idx_t n, const uint8_t* x) {
+void GpuIndexBinaryFlat::add(faiss::idx_t n, const uint8_t* x) {
     DeviceScope scope(binaryFlatConfig_.device);
 
     validateNumVectors(n);
@@ -129,7 +129,7 @@ void GpuIndexBinaryFlat::add(faiss::IndexBinary::idx_t n, const uint8_t* x) {
     // Due to GPU indexing in int32, we can't store more than this
     // number of vectors on a GPU
     FAISS_THROW_IF_NOT_FMT(
-            this->ntotal + n <= (Index::idx_t)std::numeric_limits<int>::max(),
+            this->ntotal + n <= (idx_t)std::numeric_limits<int>::max(),
             "GPU index only supports up to %zu indices",
             (size_t)std::numeric_limits<int>::max());
 
@@ -149,11 +149,11 @@ void GpuIndexBinaryFlat::reset() {
 }
 
 void GpuIndexBinaryFlat::search(
-        faiss::IndexBinary::idx_t n,
+        faiss::idx_t n,
         const uint8_t* x,
-        faiss::IndexBinary::idx_t k,
+        faiss::idx_t k,
         int32_t* distances,
-        faiss::IndexBinary::idx_t* labels,
+        faiss::idx_t* labels,
         const SearchParameters* params) const {
     DeviceScope scope(binaryFlatConfig_.device);
     auto stream = resources_->getDefaultStream(binaryFlatConfig_.device);
@@ -209,7 +209,7 @@ void GpuIndexBinaryFlat::search(
     }
 
     // Convert and copy int indices out
-    auto outIndices = toDeviceTemporary<Index::idx_t, 2>(
+    auto outIndices = toDeviceTemporary<idx_t, 2>(
             resources_.get(),
             binaryFlatConfig_.device,
             labels,
@@ -217,11 +217,11 @@ void GpuIndexBinaryFlat::search(
             {(int)n, (int)k});
 
     // Convert int to idx_t
-    convertTensor<int, Index::idx_t, 2>(stream, outIntIndices, outIndices);
+    convertTensor<int, idx_t, 2>(stream, outIntIndices, outIndices);
 
     // Copy back if necessary
     fromDevice<int32_t, 2>(outDistances, distances, stream);
-    fromDevice<Index::idx_t, 2>(outIndices, labels, stream);
+    fromDevice<idx_t, 2>(outIndices, labels, stream);
 }
 
 void GpuIndexBinaryFlat::searchNonPaged_(
@@ -278,7 +278,7 @@ void GpuIndexBinaryFlat::searchFromCpuPaged_(
 }
 
 void GpuIndexBinaryFlat::reconstruct(
-        faiss::IndexBinary::idx_t key,
+        faiss::idx_t key,
         uint8_t* out) const {
     DeviceScope scope(binaryFlatConfig_.device);
 

--- a/faiss/gpu/GpuIndexBinaryFlat.h
+++ b/faiss/gpu/GpuIndexBinaryFlat.h
@@ -53,19 +53,19 @@ class GpuIndexBinaryFlat : public IndexBinary {
     /// in the index instance
     void copyTo(faiss::IndexBinaryFlat* index) const;
 
-    void add(faiss::IndexBinary::idx_t n, const uint8_t* x) override;
+    void add(faiss::idx_t n, const uint8_t* x) override;
 
     void reset() override;
 
     void search(
-            faiss::IndexBinary::idx_t n,
+            faiss::idx_t n,
             const uint8_t* x,
-            faiss::IndexBinary::idx_t k,
+            faiss::idx_t k,
             int32_t* distances,
-            faiss::IndexBinary::idx_t* labels,
+            faiss::idx_t* labels,
             const faiss::SearchParameters* params = nullptr) const override;
 
-    void reconstruct(faiss::IndexBinary::idx_t key, uint8_t* recons)
+    void reconstruct(faiss::idx_t key, uint8_t* recons)
             const override;
 
    protected:

--- a/faiss/gpu/GpuIndexFlat.cu
+++ b/faiss/gpu/GpuIndexFlat.cu
@@ -102,7 +102,7 @@ void GpuIndexFlat::copyFrom(const faiss::IndexFlat* index) {
 
     // GPU code has 32 bit indices
     FAISS_THROW_IF_NOT_FMT(
-            index->ntotal <= (Index::idx_t)std::numeric_limits<int>::max(),
+            index->ntotal <= (idx_t)std::numeric_limits<int>::max(),
             "GPU index only supports up to %zu indices; "
             "attempting to copy CPU index with %zu parameters",
             (size_t)std::numeric_limits<int>::max(),
@@ -153,11 +153,11 @@ void GpuIndexFlat::reset() {
     this->ntotal = 0;
 }
 
-void GpuIndexFlat::train(Index::idx_t n, const float* x) {
+void GpuIndexFlat::train(idx_t n, const float* x) {
     // nothing to do
 }
 
-void GpuIndexFlat::add(Index::idx_t n, const float* x) {
+void GpuIndexFlat::add(idx_t n, const float* x) {
     DeviceScope scope(config_.device);
 
     FAISS_THROW_IF_NOT_MSG(this->is_trained, "Index not trained");
@@ -186,7 +186,7 @@ bool GpuIndexFlat::addImplRequiresIDs_() const {
     return false;
 }
 
-void GpuIndexFlat::addImpl_(int n, const float* x, const Index::idx_t* ids) {
+void GpuIndexFlat::addImpl_(int n, const float* x, const idx_t* ids) {
     // current device already set
     // n already validated
     FAISS_ASSERT(data_);
@@ -198,7 +198,7 @@ void GpuIndexFlat::addImpl_(int n, const float* x, const Index::idx_t* ids) {
     // Due to GPU indexing in int32, we can't store more than this
     // number of vectors on a GPU
     FAISS_THROW_IF_NOT_FMT(
-            this->ntotal + n <= (Index::idx_t)std::numeric_limits<int>::max(),
+            this->ntotal + n <= (idx_t)std::numeric_limits<int>::max(),
             "GPU index only supports up to %zu indices",
             (size_t)std::numeric_limits<int>::max());
 
@@ -211,7 +211,7 @@ void GpuIndexFlat::searchImpl_(
         const float* x,
         int k,
         float* distances,
-        Index::idx_t* labels,
+        idx_t* labels,
         const SearchParameters* params) const {
     // current device already set
     // n/k already validated
@@ -220,7 +220,7 @@ void GpuIndexFlat::searchImpl_(
     // Input and output data are already resident on the GPU
     Tensor<float, 2, true> queries(const_cast<float*>(x), {n, (int)this->d});
     Tensor<float, 2, true> outDistances(distances, {n, k});
-    Tensor<Index::idx_t, 2, true> outLabels(labels, {n, k});
+    Tensor<idx_t, 2, true> outLabels(labels, {n, k});
 
     // FlatIndex only supports int indices
     DeviceTensor<int, 2, true> outIntLabels(
@@ -236,10 +236,10 @@ void GpuIndexFlat::searchImpl_(
             true);
 
     // Convert int to idx_t
-    convertTensor<int, Index::idx_t, 2>(stream, outIntLabels, outLabels);
+    convertTensor<int, idx_t, 2>(stream, outIntLabels, outLabels);
 }
 
-void GpuIndexFlat::reconstruct(Index::idx_t key, float* out) const {
+void GpuIndexFlat::reconstruct(idx_t key, float* out) const {
     DeviceScope scope(config_.device);
 
     FAISS_THROW_IF_NOT_FMT(
@@ -262,7 +262,7 @@ void GpuIndexFlat::reconstruct(Index::idx_t key, float* out) const {
     fromDevice(vec.data(), out, this->d, stream);
 }
 
-void GpuIndexFlat::reconstruct_n(Index::idx_t i0, Index::idx_t n, float* out)
+void GpuIndexFlat::reconstruct_n(idx_t i0, idx_t n, float* out)
         const {
     DeviceScope scope(config_.device);
 
@@ -284,10 +284,10 @@ void GpuIndexFlat::reconstruct_n(Index::idx_t i0, Index::idx_t n, float* out)
             i0 + n - 1,
             this->ntotal);
     FAISS_THROW_IF_NOT_FMT(
-            n <= (Index::idx_t)std::numeric_limits<int>::max(),
+            n <= (idx_t)std::numeric_limits<int>::max(),
             "number of vectors requested (%zu) must be less than %zu",
             n,
-            (Index::idx_t)std::numeric_limits<int>::max());
+            (idx_t)std::numeric_limits<int>::max());
     auto stream = resources_->getDefaultStream(config_.device);
 
     auto outDevice = toDeviceTemporary<float, 2>(
@@ -304,8 +304,8 @@ void GpuIndexFlat::reconstruct_n(Index::idx_t i0, Index::idx_t n, float* out)
 }
 
 void GpuIndexFlat::reconstruct_batch(
-        Index::idx_t n,
-        const Index::idx_t* keys,
+        idx_t n,
+        const idx_t* keys,
         float* out) const {
     DeviceScope scope(config_.device);
     auto stream = resources_->getDefaultStream(config_.device);
@@ -317,10 +317,10 @@ void GpuIndexFlat::reconstruct_batch(
 
     validateNumVectors(n);
 
-    auto keysDevice = toDeviceTemporary<faiss::Index::idx_t, 1>(
+    auto keysDevice = toDeviceTemporary<faiss::idx_t, 1>(
             resources_.get(),
             config_.device,
-            const_cast<Index::idx_t*>(keys),
+            const_cast<idx_t*>(keys),
             stream,
             {(int)n});
 
@@ -341,15 +341,15 @@ void GpuIndexFlat::reconstruct_batch(
 void GpuIndexFlat::compute_residual(
         const float* x,
         float* residual,
-        Index::idx_t key) const {
+        idx_t key) const {
     compute_residual_n(1, x, residual, &key);
 }
 
 void GpuIndexFlat::compute_residual_n(
-        Index::idx_t n,
+        idx_t n,
         const float* xs,
         float* residuals,
-        const Index::idx_t* keys) const {
+        const idx_t* keys) const {
     DeviceScope scope(config_.device);
     auto stream = resources_->getDefaultStream(config_.device);
 
@@ -366,10 +366,10 @@ void GpuIndexFlat::compute_residual_n(
             const_cast<float*>(xs),
             stream,
             {(int)n, (int)this->d});
-    auto idsDevice = toDeviceTemporary<Index::idx_t, 1>(
+    auto idsDevice = toDeviceTemporary<idx_t, 1>(
             resources_.get(),
             config_.device,
-            const_cast<Index::idx_t*>(keys),
+            const_cast<idx_t*>(keys),
             stream,
             {(int)n});
     auto residualDevice = toDeviceTemporary<float, 2>(

--- a/faiss/gpu/GpuIndexFlat.h
+++ b/faiss/gpu/GpuIndexFlat.h
@@ -82,33 +82,33 @@ class GpuIndexFlat : public GpuIndex {
     void reset() override;
 
     /// This index is not trained, so this does nothing
-    void train(Index::idx_t n, const float* x) override;
+    void train(idx_t n, const float* x) override;
 
     /// Overrides to avoid excessive copies
-    void add(Index::idx_t, const float* x) override;
+    void add(idx_t, const float* x) override;
 
     /// Reconstruction methods; prefer the batch reconstruct as it will
     /// be more efficient
-    void reconstruct(Index::idx_t key, float* out) const override;
+    void reconstruct(idx_t key, float* out) const override;
 
     /// Batch reconstruction method
-    void reconstruct_n(Index::idx_t i0, Index::idx_t num, float* out)
+    void reconstruct_n(idx_t i0, idx_t num, float* out)
             const override;
 
     /// Batch reconstruction method
-    void reconstruct_batch(Index::idx_t n, const Index::idx_t* keys, float* out)
+    void reconstruct_batch(idx_t n, const idx_t* keys, float* out)
             const override;
 
     /// Compute residual
-    void compute_residual(const float* x, float* residual, Index::idx_t key)
+    void compute_residual(const float* x, float* residual, idx_t key)
             const override;
 
     /// Compute residual (batch mode)
     void compute_residual_n(
-            Index::idx_t n,
+            idx_t n,
             const float* xs,
             float* residuals,
-            const Index::idx_t* keys) const override;
+            const idx_t* keys) const override;
 
     /// For internal access
     inline FlatIndex* getGpuData() {
@@ -121,7 +121,7 @@ class GpuIndexFlat : public GpuIndex {
     bool addImplRequiresIDs_() const override;
 
     /// Called from GpuIndex for add
-    void addImpl_(int n, const float* x, const Index::idx_t* ids) override;
+    void addImpl_(int n, const float* x, const idx_t* ids) override;
 
     /// Called from GpuIndex for search
     void searchImpl_(
@@ -129,7 +129,7 @@ class GpuIndexFlat : public GpuIndex {
             const float* x,
             int k,
             float* distances,
-            Index::idx_t* labels,
+            idx_t* labels,
             const SearchParameters* params) const override;
 
    protected:

--- a/faiss/gpu/GpuIndexIVF.cu
+++ b/faiss/gpu/GpuIndexIVF.cu
@@ -160,7 +160,7 @@ void GpuIndexIVF::copyFrom(const faiss::IndexIVF* index) {
 
     FAISS_ASSERT(index->nlist > 0);
     FAISS_THROW_IF_NOT_FMT(
-            index->nlist <= (Index::idx_t)std::numeric_limits<int>::max(),
+            index->nlist <= (idx_t)std::numeric_limits<int>::max(),
             "GPU index only supports %zu inverted lists",
             (size_t)std::numeric_limits<int>::max());
     nlist = index->nlist;
@@ -281,21 +281,21 @@ std::vector<uint8_t> GpuIndexIVF::getListVectorData(int listId, bool gpuFormat)
     return baseIndex_->getListVectorData(listId, gpuFormat);
 }
 
-std::vector<Index::idx_t> GpuIndexIVF::getListIndices(int listId) const {
+std::vector<idx_t> GpuIndexIVF::getListIndices(int listId) const {
     DeviceScope scope(config_.device);
     FAISS_ASSERT(baseIndex_);
 
     return baseIndex_->getListIndices(listId);
 }
 
-void GpuIndexIVF::addImpl_(int n, const float* x, const Index::idx_t* xids) {
+void GpuIndexIVF::addImpl_(int n, const float* x, const idx_t* xids) {
     // Device is already set in GpuIndex::add
     FAISS_ASSERT(baseIndex_);
     FAISS_ASSERT(n > 0);
 
     // Data is already resident on the GPU
     Tensor<float, 2, true> data(const_cast<float*>(x), {n, (int)this->d});
-    Tensor<Index::idx_t, 1, true> labels(const_cast<Index::idx_t*>(xids), {n});
+    Tensor<idx_t, 1, true> labels(const_cast<idx_t*>(xids), {n});
 
     // Not all vectors may be able to be added (some may contain NaNs etc)
     baseIndex_->addVectors(quantizer, data, labels);
@@ -310,10 +310,10 @@ void GpuIndexIVF::searchImpl_(
         const float* x,
         int k,
         float* distances,
-        Index::idx_t* labels,
+        idx_t* labels,
         const SearchParameters* params) const {
     // Device was already set in GpuIndex::search
-    Index::idx_t use_nprobe = nprobe;
+    idx_t use_nprobe = nprobe;
     if (params) {
         auto ivfParams = dynamic_cast<const SearchParametersIVF*>(params);
         if (ivfParams) {
@@ -341,8 +341,8 @@ void GpuIndexIVF::searchImpl_(
     // Data is already resident on the GPU
     Tensor<float, 2, true> queries(const_cast<float*>(x), {n, (int)this->d});
     Tensor<float, 2, true> outDistances(distances, {n, k});
-    Tensor<Index::idx_t, 2, true> outLabels(
-            const_cast<Index::idx_t*>(labels), {n, k});
+    Tensor<idx_t, 2, true> outLabels(
+            const_cast<idx_t*>(labels), {n, k});
 
     baseIndex_->search(
             quantizer, queries, use_nprobe, k, outDistances, outLabels);
@@ -402,10 +402,10 @@ void GpuIndexIVF::search_preassigned(
             stream,
             {(int)n, (int)use_nprobe});
 
-    auto assignDevice = toDeviceTemporary<Index::idx_t, 2>(
+    auto assignDevice = toDeviceTemporary<idx_t, 2>(
             resources_.get(),
             config_.device,
-            const_cast<Index::idx_t*>(assign),
+            const_cast<idx_t*>(assign),
             stream,
             {(int)n, (int)use_nprobe});
 
@@ -416,7 +416,7 @@ void GpuIndexIVF::search_preassigned(
             stream,
             {(int)n, (int)k});
 
-    auto outIndicesDevice = toDeviceTemporary<Index::idx_t, 2>(
+    auto outIndicesDevice = toDeviceTemporary<idx_t, 2>(
             resources_.get(), config_.device, labels, stream, {(int)n, (int)k});
 
     baseIndex_->searchPreassigned(
@@ -431,7 +431,7 @@ void GpuIndexIVF::search_preassigned(
 
     // If the output was not already on the GPU, copy it back
     fromDevice<float, 2>(outDistancesDevice, distances, stream);
-    fromDevice<Index::idx_t, 2>(outIndicesDevice, labels, stream);
+    fromDevice<idx_t, 2>(outIndicesDevice, labels, stream);
 }
 
 bool GpuIndexIVF::addImplRequiresIDs_() const {
@@ -439,7 +439,7 @@ bool GpuIndexIVF::addImplRequiresIDs_() const {
     return true;
 }
 
-void GpuIndexIVF::trainQuantizer_(Index::idx_t n, const float* x) {
+void GpuIndexIVF::trainQuantizer_(idx_t n, const float* x) {
     DeviceScope scope(config_.device);
 
     if (n == 0) {

--- a/faiss/gpu/GpuIndexIVF.h
+++ b/faiss/gpu/GpuIndexIVF.h
@@ -91,7 +91,7 @@ class GpuIndexIVF : public GpuIndex {
 
     /// Return the vector indices contained in a particular inverted list, for
     /// debugging purposes.
-    std::vector<Index::idx_t> getListIndices(int listId) const;
+    std::vector<idx_t> getListIndices(int listId) const;
 
     /// Sets the number of list probes per query
     void setNumProbes(int nprobe);
@@ -128,10 +128,10 @@ class GpuIndexIVF : public GpuIndex {
    protected:
     void verifyIVFSettings_() const;
     bool addImplRequiresIDs_() const override;
-    void trainQuantizer_(Index::idx_t n, const float* x);
+    void trainQuantizer_(idx_t n, const float* x);
 
     /// Called from GpuIndex for add/add_with_ids
-    void addImpl_(int n, const float* x, const Index::idx_t* ids) override;
+    void addImpl_(int n, const float* x, const idx_t* ids) override;
 
     /// Called from GpuIndex for search
     void searchImpl_(
@@ -139,7 +139,7 @@ class GpuIndexIVF : public GpuIndex {
             const float* x,
             int k,
             float* distances,
-            Index::idx_t* labels,
+            idx_t* labels,
             const SearchParameters* params) const override;
 
    public:

--- a/faiss/gpu/GpuIndexIVFFlat.cu
+++ b/faiss/gpu/GpuIndexIVFFlat.cu
@@ -188,12 +188,12 @@ void GpuIndexIVFFlat::updateQuantizer() {
     }
 }
 
-void GpuIndexIVFFlat::train(Index::idx_t n, const float* x) {
+void GpuIndexIVFFlat::train(idx_t n, const float* x) {
     DeviceScope scope(config_.device);
 
     // For now, only support <= max int results
     FAISS_THROW_IF_NOT_FMT(
-            n <= (Index::idx_t)std::numeric_limits<int>::max(),
+            n <= (idx_t)std::numeric_limits<int>::max(),
             "GPU index only supports up to %d indices",
             std::numeric_limits<int>::max());
 

--- a/faiss/gpu/GpuIndexIVFFlat.h
+++ b/faiss/gpu/GpuIndexIVFFlat.h
@@ -85,7 +85,7 @@ class GpuIndexIVFFlat : public GpuIndexIVF {
     void updateQuantizer() override;
 
     /// Trains the coarse quantizer based on the given vector data
-    void train(Index::idx_t n, const float* x) override;
+    void train(idx_t n, const float* x) override;
 
    protected:
     /// Our configuration options

--- a/faiss/gpu/GpuIndexIVFPQ.cu
+++ b/faiss/gpu/GpuIndexIVFPQ.cu
@@ -270,7 +270,7 @@ void GpuIndexIVFPQ::updateQuantizer() {
     }
 }
 
-void GpuIndexIVFPQ::trainResidualQuantizer_(Index::idx_t n, const float* x) {
+void GpuIndexIVFPQ::trainResidualQuantizer_(idx_t n, const float* x) {
     // Code largely copied from faiss::IndexIVFPQ
     auto x_in = x;
 
@@ -288,7 +288,7 @@ void GpuIndexIVFPQ::trainResidualQuantizer_(Index::idx_t n, const float* x) {
         printf("computing residuals\n");
     }
 
-    std::vector<Index::idx_t> assign(n);
+    std::vector<idx_t> assign(n);
     quantizer->assign(n, x, assign.data());
 
     std::vector<float> residuals(n * d);
@@ -347,12 +347,12 @@ void GpuIndexIVFPQ::trainResidualQuantizer_(Index::idx_t n, const float* x) {
     index_->setPrecomputedCodes(quantizer, usePrecomputedTables_);
 }
 
-void GpuIndexIVFPQ::train(Index::idx_t n, const float* x) {
+void GpuIndexIVFPQ::train(idx_t n, const float* x) {
     DeviceScope scope(config_.device);
 
     // For now, only support <= max int results
     FAISS_THROW_IF_NOT_FMT(
-            n <= (Index::idx_t)std::numeric_limits<int>::max(),
+            n <= (idx_t)std::numeric_limits<int>::max(),
             "GPU index only supports up to %d indices",
             std::numeric_limits<int>::max());
 

--- a/faiss/gpu/GpuIndexIVFPQ.h
+++ b/faiss/gpu/GpuIndexIVFPQ.h
@@ -131,7 +131,7 @@ class GpuIndexIVFPQ : public GpuIndexIVF {
     void updateQuantizer() override;
 
     /// Trains the coarse and product quantizer based on the given vector data
-    void train(Index::idx_t n, const float* x) override;
+    void train(idx_t n, const float* x) override;
 
    public:
     /// Like the CPU version, we expose a publically-visible ProductQuantizer
@@ -143,7 +143,7 @@ class GpuIndexIVFPQ : public GpuIndexIVF {
     void verifyPQSettings_() const;
 
     /// Trains the PQ quantizer based on the given vector data
-    void trainResidualQuantizer_(Index::idx_t n, const float* x);
+    void trainResidualQuantizer_(idx_t n, const float* x);
 
    protected:
     /// Our configuration options that we were initialized with

--- a/faiss/gpu/GpuIndexIVFScalarQuantizer.cu
+++ b/faiss/gpu/GpuIndexIVFScalarQuantizer.cu
@@ -198,18 +198,18 @@ void GpuIndexIVFScalarQuantizer::reset() {
 }
 
 void GpuIndexIVFScalarQuantizer::trainResiduals_(
-        Index::idx_t n,
+        idx_t n,
         const float* x) {
     // The input is already guaranteed to be on the CPU
     sq.train_residual(n, x, quantizer, by_residual, verbose);
 }
 
-void GpuIndexIVFScalarQuantizer::train(Index::idx_t n, const float* x) {
+void GpuIndexIVFScalarQuantizer::train(idx_t n, const float* x) {
     DeviceScope scope(config_.device);
 
     // For now, only support <= max int results
     FAISS_THROW_IF_NOT_FMT(
-            n <= (Index::idx_t)std::numeric_limits<int>::max(),
+            n <= (idx_t)std::numeric_limits<int>::max(),
             "GPU index only supports up to %d indices",
             std::numeric_limits<int>::max());
 

--- a/faiss/gpu/GpuIndexIVFScalarQuantizer.h
+++ b/faiss/gpu/GpuIndexIVFScalarQuantizer.h
@@ -89,14 +89,14 @@ class GpuIndexIVFScalarQuantizer : public GpuIndexIVF {
     void updateQuantizer() override;
 
     /// Trains the coarse and scalar quantizer based on the given vector data
-    void train(Index::idx_t n, const float* x) override;
+    void train(idx_t n, const float* x) override;
 
    protected:
     /// Validates index SQ parameters
     void verifySQSettings_() const;
 
     /// Called from train to handle SQ residual training
-    void trainResiduals_(Index::idx_t n, const float* x);
+    void trainResiduals_(idx_t n, const float* x);
 
    public:
     /// Exposed like the CPU version

--- a/faiss/gpu/impl/FlatIndex.cu
+++ b/faiss/gpu/impl/FlatIndex.cu
@@ -163,7 +163,7 @@ void FlatIndex::query(
 
 void FlatIndex::computeResidual(
         Tensor<float, 2, true>& vecs,
-        Tensor<Index::idx_t, 1, true>& ids,
+        Tensor<idx_t, 1, true>& ids,
         Tensor<float, 2, true>& residuals) {
     if (useFloat16_) {
         runCalcResidual(
@@ -183,8 +183,8 @@ void FlatIndex::computeResidual(
 }
 
 void FlatIndex::reconstruct(
-        Index::idx_t start,
-        Index::idx_t num,
+        idx_t start,
+        idx_t num,
         Tensor<float, 2, true>& vecs) {
     auto stream = resources_->getDefaultStreamCurrentDevice();
 
@@ -199,7 +199,7 @@ void FlatIndex::reconstruct(
 }
 
 void FlatIndex::reconstruct(
-        Tensor<Index::idx_t, 1, true>& ids,
+        Tensor<idx_t, 1, true>& ids,
         Tensor<float, 2, true>& vecs) {
     auto stream = resources_->getDefaultStreamCurrentDevice();
 

--- a/faiss/gpu/impl/FlatIndex.cuh
+++ b/faiss/gpu/impl/FlatIndex.cuh
@@ -65,18 +65,18 @@ class FlatIndex {
     /// Compute residual for set of vectors
     void computeResidual(
             Tensor<float, 2, true>& vecs,
-            Tensor<Index::idx_t, 1, true>& ids,
+            Tensor<idx_t, 1, true>& ids,
             Tensor<float, 2, true>& residuals);
 
     /// Gather vectors given the set of IDs
     void reconstruct(
-            Tensor<Index::idx_t, 1, true>& ids,
+            Tensor<idx_t, 1, true>& ids,
             Tensor<float, 2, true>& vecs);
 
     /// Gather vectors given a range of IDs
     void reconstruct(
-            Index::idx_t start,
-            Index::idx_t num,
+            idx_t start,
+            idx_t num,
             Tensor<float, 2, true>& vecs);
 
     /// Add vectors to ourselves; the pointer passed can be on the host

--- a/faiss/gpu/impl/IVFAppend.cuh
+++ b/faiss/gpu/impl/IVFAppend.cuh
@@ -18,16 +18,16 @@ namespace gpu {
 
 /// Append user indices to IVF lists
 void runIVFIndicesAppend(
-        Tensor<Index::idx_t, 1, true>& listIds,
+        Tensor<idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
-        Tensor<Index::idx_t, 1, true>& indices,
+        Tensor<idx_t, 1, true>& indices,
         IndicesOptions opt,
         DeviceVector<void*>& listIndices,
         cudaStream_t stream);
 
 /// Update device-side list pointers in a batch
 void runUpdateListPointers(
-        Tensor<Index::idx_t, 1, true>& listIds,
+        Tensor<idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& newListLength,
         Tensor<void*, 1, true>& newCodePointers,
         Tensor<void*, 1, true>& newIndexPointers,
@@ -38,7 +38,7 @@ void runUpdateListPointers(
 
 /// Append PQ codes to IVF lists (non-interleaved format)
 void runIVFPQAppend(
-        Tensor<Index::idx_t, 1, true>& listIds,
+        Tensor<idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
         Tensor<uint8_t, 2, true>& encodings,
         DeviceVector<void*>& listCodes,
@@ -46,9 +46,9 @@ void runIVFPQAppend(
 
 /// Append PQ codes to IVF lists (interleaved format)
 void runIVFPQInterleavedAppend(
-        Tensor<Index::idx_t, 1, true>& listIds,
+        Tensor<idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
-        Tensor<Index::idx_t, 1, true>& uniqueLists,
+        Tensor<idx_t, 1, true>& uniqueLists,
         Tensor<int, 1, true>& vectorsByUniqueList,
         Tensor<int, 1, true>& uniqueListVectorStart,
         Tensor<int, 1, true>& uniqueListStartOffset,
@@ -59,7 +59,7 @@ void runIVFPQInterleavedAppend(
 
 /// Append SQ codes to IVF lists (non-interleaved, old format)
 void runIVFFlatAppend(
-        Tensor<Index::idx_t, 1, true>& listIds,
+        Tensor<idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
         Tensor<float, 2, true>& vecs,
         GpuScalarQuantizer* scalarQ,
@@ -68,9 +68,9 @@ void runIVFFlatAppend(
 
 /// Append SQ codes to IVF lists (interleaved)
 void runIVFFlatInterleavedAppend(
-        Tensor<Index::idx_t, 1, true>& listIds,
+        Tensor<idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
-        Tensor<Index::idx_t, 1, true>& uniqueLists,
+        Tensor<idx_t, 1, true>& uniqueLists,
         Tensor<int, 1, true>& vectorsByUniqueList,
         Tensor<int, 1, true>& uniqueListVectorStart,
         Tensor<int, 1, true>& uniqueListStartOffset,

--- a/faiss/gpu/impl/IVFBase.cu
+++ b/faiss/gpu/impl/IVFBase.cu
@@ -93,7 +93,7 @@ void IVFBase::reserveMemory(size_t numVecs) {
         // Reserve for index lists as well
         size_t bytesPerIndexList = vecsPerList *
                 (indicesOptions_ == INDICES_32_BIT ? sizeof(int)
-                                                   : sizeof(Index::idx_t));
+                                                   : sizeof(idx_t));
 
         for (auto& list : deviceListIndices_) {
             list->data.reserve(bytesPerIndexList, stream);
@@ -125,7 +125,7 @@ void IVFBase::reset() {
         deviceListIndices_.emplace_back(std::unique_ptr<DeviceIVFList>(
                 new DeviceIVFList(resources_, info)));
 
-        listOffsetToUserIndex_.emplace_back(std::vector<Index::idx_t>());
+        listOffsetToUserIndex_.emplace_back(std::vector<idx_t>());
     }
 
     deviceListDataPointers_.resize(numLists_, stream);
@@ -176,7 +176,7 @@ size_t IVFBase::reclaimMemory_(bool exact) {
 }
 
 void IVFBase::updateDeviceListInfo_(cudaStream_t stream) {
-    std::vector<Index::idx_t> listIds(deviceListData_.size());
+    std::vector<idx_t> listIds(deviceListData_.size());
     for (int i = 0; i < deviceListData_.size(); ++i) {
         listIds[i] = i;
     }
@@ -185,9 +185,9 @@ void IVFBase::updateDeviceListInfo_(cudaStream_t stream) {
 }
 
 void IVFBase::updateDeviceListInfo_(
-        const std::vector<Index::idx_t>& listIds,
+        const std::vector<idx_t>& listIds,
         cudaStream_t stream) {
-    HostTensor<Index::idx_t, 1, true> hostListsToUpdate({(int)listIds.size()});
+    HostTensor<idx_t, 1, true> hostListsToUpdate({(int)listIds.size()});
     HostTensor<int, 1, true> hostNewListLength({(int)listIds.size()});
     HostTensor<void*, 1, true> hostNewDataPointers({(int)listIds.size()});
     HostTensor<void*, 1, true> hostNewIndexPointers({(int)listIds.size()});
@@ -204,7 +204,7 @@ void IVFBase::updateDeviceListInfo_(
     }
 
     // Copy the above update sets to the GPU
-    DeviceTensor<Index::idx_t, 1, true> listsToUpdate(
+    DeviceTensor<idx_t, 1, true> listsToUpdate(
             resources_,
             makeTempAlloc(AllocType::Other, stream),
             hostListsToUpdate);
@@ -250,7 +250,7 @@ int IVFBase::getListLength(int listId) const {
     return deviceListData_[listId]->numVecs;
 }
 
-std::vector<Index::idx_t> IVFBase::getListIndices(int listId) const {
+std::vector<idx_t> IVFBase::getListIndices(int listId) const {
     FAISS_THROW_IF_NOT_FMT(
             listId < numLists_,
             "IVF list %d is out of bounds (%d lists total)",
@@ -267,9 +267,9 @@ std::vector<Index::idx_t> IVFBase::getListIndices(int listId) const {
 
         auto intInd = deviceListIndices_[listId]->data.copyToHost<int>(stream);
 
-        std::vector<Index::idx_t> out(intInd.size());
+        std::vector<idx_t> out(intInd.size());
         for (size_t i = 0; i < intInd.size(); ++i) {
-            out[i] = (Index::idx_t)intInd[i];
+            out[i] = (idx_t)intInd[i];
         }
 
         return out;
@@ -277,7 +277,7 @@ std::vector<Index::idx_t> IVFBase::getListIndices(int listId) const {
         // The data is stored as int64 on the GPU
         FAISS_ASSERT(listId < deviceListIndices_.size());
 
-        return deviceListIndices_[listId]->data.copyToHost<Index::idx_t>(
+        return deviceListIndices_[listId]->data.copyToHost<idx_t>(
                 stream);
     } else if (indicesOptions_ == INDICES_CPU) {
         // The data is not stored on the GPU
@@ -294,7 +294,7 @@ std::vector<Index::idx_t> IVFBase::getListIndices(int listId) const {
     } else {
         // unhandled indices type (includes INDICES_IVF)
         FAISS_ASSERT(false);
-        return std::vector<Index::idx_t>();
+        return std::vector<idx_t>();
     }
 }
 
@@ -353,7 +353,7 @@ void IVFBase::copyInvertedListsTo(InvertedLists* ivf) {
 void IVFBase::addEncodedVectorsToList_(
         int listId,
         const void* codes,
-        const Index::idx_t* indices,
+        const idx_t* indices,
         size_t numVecs) {
     auto stream = resources_->getDefaultStreamCurrentDevice();
 
@@ -403,7 +403,7 @@ void IVFBase::addEncodedVectorsToList_(
 
 void IVFBase::addIndicesFromCpu_(
         int listId,
-        const Index::idx_t* indices,
+        const idx_t* indices,
         size_t numVecs) {
     auto stream = resources_->getDefaultStreamCurrentDevice();
 
@@ -417,7 +417,7 @@ void IVFBase::addIndicesFromCpu_(
         std::vector<int> indices32(numVecs);
         for (size_t i = 0; i < numVecs; ++i) {
             auto ind = indices[i];
-            FAISS_ASSERT(ind <= (Index::idx_t)std::numeric_limits<int>::max());
+            FAISS_ASSERT(ind <= (idx_t)std::numeric_limits<int>::max());
             indices32[i] = (int)ind;
         }
 
@@ -435,7 +435,7 @@ void IVFBase::addIndicesFromCpu_(
     } else if (indicesOptions_ == INDICES_64_BIT) {
         listIndices->data.append(
                 (uint8_t*)indices,
-                numVecs * sizeof(Index::idx_t),
+                numVecs * sizeof(idx_t),
                 stream,
                 true /* exact reserved size */);
 
@@ -519,7 +519,7 @@ void IVFBase::searchCoarseQuantizer_(
         // Guaranteed to be on device
         Tensor<float, 2, true>& vecs,
         Tensor<float, 2, true>& distances,
-        Tensor<Index::idx_t, 2, true>& indices,
+        Tensor<idx_t, 2, true>& indices,
         Tensor<float, 3, true>* residuals,
         Tensor<float, 3, true>* centroids) {
     auto stream = resources_->getDefaultStreamCurrentDevice();
@@ -556,7 +556,7 @@ void IVFBase::searchCoarseQuantizer_(
         auto cpuVecs = toHost<float, 2>(
                 vecs.data(), stream, {vecs.getSize(0), vecs.getSize(1)});
         auto cpuDistances = std::vector<float>(vecs.getSize(0) * nprobe);
-        auto cpuIndices = std::vector<Index::idx_t>(vecs.getSize(0) * nprobe);
+        auto cpuIndices = std::vector<idx_t>(vecs.getSize(0) * nprobe);
 
         coarseQuantizer->search(
                 vecs.getSize(0),
@@ -602,7 +602,7 @@ void IVFBase::searchCoarseQuantizer_(
 int IVFBase::addVectors(
         Index* coarseQuantizer,
         Tensor<float, 2, true>& vecs,
-        Tensor<Index::idx_t, 1, true>& indices) {
+        Tensor<idx_t, 1, true>& indices) {
     FAISS_ASSERT(vecs.getSize(0) == indices.getSize(0));
     FAISS_ASSERT(vecs.getSize(1) == dim_);
 
@@ -617,7 +617,7 @@ int IVFBase::addVectors(
             {vecs.getSize(0), 1});
 
     // We do need the closest IVF cell IDs though
-    DeviceTensor<Index::idx_t, 2, true> ivfIndices(
+    DeviceTensor<idx_t, 2, true> ivfIndices(
             resources_,
             makeTempAlloc(AllocType::Other, stream),
             {vecs.getSize(0), 1});
@@ -648,10 +648,10 @@ int IVFBase::addVectors(
     // encoded vectors and indices
 
     // list id -> vectors being added
-    std::unordered_map<Index::idx_t, std::vector<int>> listToVectorIds;
+    std::unordered_map<idx_t, std::vector<int>> listToVectorIds;
 
     // vector id -> which list it is being appended to
-    std::vector<Index::idx_t> vectorIdToList(vecs.getSize(0));
+    std::vector<idx_t> vectorIdToList(vecs.getSize(0));
 
     // vector id -> offset in list
     // (we already have vector id -> list id in listIds)
@@ -694,7 +694,7 @@ int IVFBase::addVectors(
     }
 
     // unique lists being added to
-    std::vector<Index::idx_t> uniqueLists;
+    std::vector<idx_t> uniqueLists;
 
     for (auto& vecs : listToVectorIds) {
         uniqueLists.push_back(vecs.first);
@@ -759,7 +759,7 @@ int IVFBase::addVectors(
                 (indicesOptions_ == INDICES_64_BIT)) {
                 size_t indexSize = (indicesOptions_ == INDICES_32_BIT)
                         ? sizeof(int)
-                        : sizeof(Index::idx_t);
+                        : sizeof(idx_t);
 
                 indices->data.resize(
                         indices->data.size() + numVecsToAdd * indexSize,
@@ -792,10 +792,10 @@ int IVFBase::addVectors(
     // map. We already resized our map above.
     if (indicesOptions_ == INDICES_CPU) {
         // We need to maintain the indices on the CPU side
-        HostTensor<Index::idx_t, 1, true> hostIndices(indices, stream);
+        HostTensor<idx_t, 1, true> hostIndices(indices, stream);
 
         for (int i = 0; i < hostIndices.getSize(0); ++i) {
-            Index::idx_t listId = ivfIndicesHost[i];
+            idx_t listId = ivfIndicesHost[i];
 
             // Add vector could be invalid (contains NaNs etc)
             if (listId < 0) {

--- a/faiss/gpu/impl/IVFBase.cuh
+++ b/faiss/gpu/impl/IVFBase.cuh
@@ -62,7 +62,7 @@ class IVFBase {
     int getListLength(int listId) const;
 
     /// Return the list indices of a particular list back to the CPU
-    std::vector<Index::idx_t> getListIndices(int listId) const;
+    std::vector<idx_t> getListIndices(int listId) const;
 
     /// Return the encoded vectors of a particular list back to the CPU
     std::vector<uint8_t> getListVectorData(int listId, bool gpuFormat) const;
@@ -84,7 +84,7 @@ class IVFBase {
     int addVectors(
             Index* coarseQuantizer,
             Tensor<float, 2, true>& vecs,
-            Tensor<Index::idx_t, 1, true>& indices);
+            Tensor<idx_t, 1, true>& indices);
 
     /// Find the approximate k nearest neigbors for `queries` against
     /// our database
@@ -94,7 +94,7 @@ class IVFBase {
             int nprobe,
             int k,
             Tensor<float, 2, true>& outDistances,
-            Tensor<Index::idx_t, 2, true>& outIndices) = 0;
+            Tensor<idx_t, 2, true>& outIndices) = 0;
 
     /// Performs search when we are already given the IVF cells to look at
     /// (GpuIndexIVF::search_preassigned implementation)
@@ -102,10 +102,10 @@ class IVFBase {
             Index* coarseQuantizer,
             Tensor<float, 2, true>& vecs,
             Tensor<float, 2, true>& ivfDistances,
-            Tensor<Index::idx_t, 2, true>& ivfAssignments,
+            Tensor<idx_t, 2, true>& ivfAssignments,
             int k,
             Tensor<float, 2, true>& outDistances,
-            Tensor<Index::idx_t, 2, true>& outIndices,
+            Tensor<idx_t, 2, true>& outIndices,
             bool storePairs) = 0;
 
    protected:
@@ -116,7 +116,7 @@ class IVFBase {
             // resident on the host
             const void* codes,
             // resident on the host
-            const Index::idx_t* indices,
+            const idx_t* indices,
             size_t numVecs);
 
     /// Performs search in a CPU or GPU coarse quantizer for IVF cells,
@@ -132,7 +132,7 @@ class IVFBase {
             Tensor<float, 2, true>& distances,
             // Output: the closest nprobe IVF cells the query vectors lie in
             // size (#vecs, nprobe)
-            Tensor<Index::idx_t, 2, true>& indices,
+            Tensor<idx_t, 2, true>& indices,
             // optionally compute the residual relative to the IVF cell centroid
             // if passed
             // size (#vecs, nprobe, dim)
@@ -163,12 +163,12 @@ class IVFBase {
     virtual void appendVectors_(
             Tensor<float, 2, true>& vecs,
             Tensor<float, 2, true>& ivfCentroidResiduals,
-            Tensor<Index::idx_t, 1, true>& indices,
-            Tensor<Index::idx_t, 1, true>& uniqueLists,
+            Tensor<idx_t, 1, true>& indices,
+            Tensor<idx_t, 1, true>& uniqueLists,
             Tensor<int, 1, true>& vectorsByUniqueList,
             Tensor<int, 1, true>& uniqueListVectorStart,
             Tensor<int, 1, true>& uniqueListStartOffset,
-            Tensor<Index::idx_t, 1, true>& listIds,
+            Tensor<idx_t, 1, true>& listIds,
             Tensor<int, 1, true>& listOffset,
             cudaStream_t stream) = 0;
 
@@ -182,13 +182,13 @@ class IVFBase {
     /// For a set of list IDs, update device-side list pointer and size
     /// information
     void updateDeviceListInfo_(
-            const std::vector<Index::idx_t>& listIds,
+            const std::vector<idx_t>& listIds,
             cudaStream_t stream);
 
     /// Shared function to copy indices from CPU to GPU
     void addIndicesFromCpu_(
             int listId,
-            const Index::idx_t* indices,
+            const idx_t* indices,
             size_t numVecs);
 
    protected:
@@ -266,7 +266,7 @@ class IVFBase {
     /// If we are storing indices on the CPU (indicesOptions_ is
     /// INDICES_CPU), then this maintains a CPU-side map of what
     /// (inverted list id, offset) maps to which user index
-    std::vector<std::vector<Index::idx_t>> listOffsetToUserIndex_;
+    std::vector<std::vector<idx_t>> listOffsetToUserIndex_;
 };
 
 } // namespace gpu

--- a/faiss/gpu/impl/IVFFlat.cu
+++ b/faiss/gpu/impl/IVFFlat.cu
@@ -115,12 +115,12 @@ std::vector<uint8_t> IVFFlat::translateCodesFromGpu_(
 void IVFFlat::appendVectors_(
         Tensor<float, 2, true>& vecs,
         Tensor<float, 2, true>& ivfCentroidResiduals,
-        Tensor<Index::idx_t, 1, true>& indices,
-        Tensor<Index::idx_t, 1, true>& uniqueLists,
+        Tensor<idx_t, 1, true>& indices,
+        Tensor<idx_t, 1, true>& uniqueLists,
         Tensor<int, 1, true>& vectorsByUniqueList,
         Tensor<int, 1, true>& uniqueListVectorStart,
         Tensor<int, 1, true>& uniqueListStartOffset,
-        Tensor<Index::idx_t, 1, true>& listIds,
+        Tensor<idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
         cudaStream_t stream) {
     //
@@ -167,7 +167,7 @@ void IVFFlat::search(
         int nprobe,
         int k,
         Tensor<float, 2, true>& outDistances,
-        Tensor<Index::idx_t, 2, true>& outIndices) {
+        Tensor<idx_t, 2, true>& outIndices) {
     auto stream = resources_->getDefaultStreamCurrentDevice();
 
     // These are caught at a higher level
@@ -185,7 +185,7 @@ void IVFFlat::search(
             resources_,
             makeTempAlloc(AllocType::Other, stream),
             {queries.getSize(0), nprobe});
-    DeviceTensor<Index::idx_t, 2, true> coarseIndices(
+    DeviceTensor<idx_t, 2, true> coarseIndices(
             resources_,
             makeTempAlloc(AllocType::Other, stream),
             {queries.getSize(0), nprobe});
@@ -223,10 +223,10 @@ void IVFFlat::searchPreassigned(
         Index* coarseQuantizer,
         Tensor<float, 2, true>& vecs,
         Tensor<float, 2, true>& ivfDistances,
-        Tensor<Index::idx_t, 2, true>& ivfAssignments,
+        Tensor<idx_t, 2, true>& ivfAssignments,
         int k,
         Tensor<float, 2, true>& outDistances,
-        Tensor<Index::idx_t, 2, true>& outIndices,
+        Tensor<idx_t, 2, true>& outIndices,
         bool storePairs) {
     FAISS_ASSERT(ivfDistances.getSize(0) == vecs.getSize(0));
     FAISS_ASSERT(ivfAssignments.getSize(0) == vecs.getSize(0));
@@ -286,11 +286,11 @@ void IVFFlat::searchPreassigned(
 void IVFFlat::searchImpl_(
         Tensor<float, 2, true>& queries,
         Tensor<float, 2, true>& coarseDistances,
-        Tensor<Index::idx_t, 2, true>& coarseIndices,
+        Tensor<idx_t, 2, true>& coarseIndices,
         Tensor<float, 3, true>& ivfCentroids,
         int k,
         Tensor<float, 2, true>& outDistances,
-        Tensor<Index::idx_t, 2, true>& outIndices,
+        Tensor<idx_t, 2, true>& outIndices,
         bool storePairs) {
     FAISS_ASSERT(storePairs == false);
 
@@ -336,7 +336,7 @@ void IVFFlat::searchImpl_(
     // FIXME: we might ultimately be calling this function with inputs
     // from the CPU, these are unnecessary copies
     if (indicesOptions_ == INDICES_CPU) {
-        HostTensor<Index::idx_t, 2, true> hostOutIndices(outIndices, stream);
+        HostTensor<idx_t, 2, true> hostOutIndices(outIndices, stream);
 
         ivfOffsetToUserIndex(
                 hostOutIndices.data(),

--- a/faiss/gpu/impl/IVFFlat.cuh
+++ b/faiss/gpu/impl/IVFFlat.cuh
@@ -37,7 +37,7 @@ class IVFFlat : public IVFBase {
             int nprobe,
             int k,
             Tensor<float, 2, true>& outDistances,
-            Tensor<Index::idx_t, 2, true>& outIndices) override;
+            Tensor<idx_t, 2, true>& outIndices) override;
 
     /// Performs search when we are already given the IVF cells to look at
     /// (GpuIndexIVF::search_preassigned implementation)
@@ -45,10 +45,10 @@ class IVFFlat : public IVFBase {
             Index* coarseQuantizer,
             Tensor<float, 2, true>& vecs,
             Tensor<float, 2, true>& ivfDistances,
-            Tensor<Index::idx_t, 2, true>& ivfAssignments,
+            Tensor<idx_t, 2, true>& ivfAssignments,
             int k,
             Tensor<float, 2, true>& outDistances,
-            Tensor<Index::idx_t, 2, true>& outIndices,
+            Tensor<idx_t, 2, true>& outIndices,
             bool storePairs) override;
 
    protected:
@@ -73,12 +73,12 @@ class IVFFlat : public IVFBase {
     void appendVectors_(
             Tensor<float, 2, true>& vecs,
             Tensor<float, 2, true>& ivfCentroidResiduals,
-            Tensor<Index::idx_t, 1, true>& indices,
-            Tensor<Index::idx_t, 1, true>& uniqueLists,
+            Tensor<idx_t, 1, true>& indices,
+            Tensor<idx_t, 1, true>& uniqueLists,
             Tensor<int, 1, true>& vectorsByUniqueList,
             Tensor<int, 1, true>& uniqueListVectorStart,
             Tensor<int, 1, true>& uniqueListStartOffset,
-            Tensor<Index::idx_t, 1, true>& listIds,
+            Tensor<idx_t, 1, true>& listIds,
             Tensor<int, 1, true>& listOffset,
             cudaStream_t stream) override;
 
@@ -87,11 +87,11 @@ class IVFFlat : public IVFBase {
     void searchImpl_(
             Tensor<float, 2, true>& queries,
             Tensor<float, 2, true>& coarseDistances,
-            Tensor<Index::idx_t, 2, true>& coarseIndices,
+            Tensor<idx_t, 2, true>& coarseIndices,
             Tensor<float, 3, true>& ivfCentroids,
             int k,
             Tensor<float, 2, true>& outDistances,
-            Tensor<Index::idx_t, 2, true>& outIndices,
+            Tensor<idx_t, 2, true>& outIndices,
             bool storePairs);
 
    protected:

--- a/faiss/gpu/impl/IVFFlatScan.cu
+++ b/faiss/gpu/impl/IVFFlatScan.cu
@@ -137,7 +137,7 @@ __global__ void ivfFlatScan(
         Tensor<float, 2, true> queries,
         bool useResidual,
         Tensor<float, 3, true> residualBase,
-        Tensor<Index::idx_t, 2, true> listIds,
+        Tensor<idx_t, 2, true> listIds,
         void** allListData,
         int* listLengths,
         Codec codec,
@@ -153,7 +153,7 @@ __global__ void ivfFlatScan(
     // We ensure that before the array (at offset -1), there is a 0 value
     int outBase = *(prefixSumOffsets[queryId][probeId].data() - 1);
 
-    Index::idx_t listId = listIds[queryId][probeId];
+    idx_t listId = listIds[queryId][probeId];
     // Safety guard in case NaNs in input cause no list ID to be generated
     if (listId == -1) {
         return;
@@ -185,7 +185,7 @@ __global__ void ivfFlatScan(
 void runIVFFlatScanTile(
         GpuResources* res,
         Tensor<float, 2, true>& queries,
-        Tensor<Index::idx_t, 2, true>& listIds,
+        Tensor<idx_t, 2, true>& listIds,
         DeviceVector<void*>& listData,
         DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
@@ -201,7 +201,7 @@ void runIVFFlatScanTile(
         Tensor<float, 3, true>& residualBase,
         GpuScalarQuantizer* scalarQ,
         Tensor<float, 2, true>& outDistances,
-        Tensor<Index::idx_t, 2, true>& outIndices,
+        Tensor<idx_t, 2, true>& outIndices,
         cudaStream_t stream) {
     int dim = queries.getSize(1);
 
@@ -341,7 +341,7 @@ void runIVFFlatScanTile(
 
 void runIVFFlatScan(
         Tensor<float, 2, true>& queries,
-        Tensor<Index::idx_t, 2, true>& listIds,
+        Tensor<idx_t, 2, true>& listIds,
         DeviceVector<void*>& listData,
         DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
@@ -355,7 +355,7 @@ void runIVFFlatScan(
         // output
         Tensor<float, 2, true>& outDistances,
         // output
-        Tensor<Index::idx_t, 2, true>& outIndices,
+        Tensor<idx_t, 2, true>& outIndices,
         GpuResources* res) {
     constexpr int kMinQueryTileSize = 8;
     constexpr int kMaxQueryTileSize = 65536; // used as blockIdx.y dimension

--- a/faiss/gpu/impl/IVFFlatScan.cuh
+++ b/faiss/gpu/impl/IVFFlatScan.cuh
@@ -21,7 +21,7 @@ class GpuResources;
 
 void runIVFFlatScan(
         Tensor<float, 2, true>& queries,
-        Tensor<Index::idx_t, 2, true>& listIds,
+        Tensor<idx_t, 2, true>& listIds,
         DeviceVector<void*>& listData,
         DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
@@ -35,7 +35,7 @@ void runIVFFlatScan(
         // output
         Tensor<float, 2, true>& outDistances,
         // output
-        Tensor<Index::idx_t, 2, true>& outIndices,
+        Tensor<idx_t, 2, true>& outIndices,
         GpuResources* res);
 
 } // namespace gpu

--- a/faiss/gpu/impl/IVFInterleaved.cuh
+++ b/faiss/gpu/impl/IVFInterleaved.cuh
@@ -40,7 +40,7 @@ template <
 __global__ void ivfInterleavedScan(
         Tensor<float, 2, true> queries,
         Tensor<float, 3, true> residualBase,
-        Tensor<Index::idx_t, 2, true> listIds,
+        Tensor<idx_t, 2, true> listIds,
         void** allListData,
         int* listLengths,
         Codec codec,
@@ -56,7 +56,7 @@ __global__ void ivfInterleavedScan(
     for (int queryId = blockIdx.y; queryId < queries.getSize(0);
          queryId += gridDim.y) {
         int probeId = blockIdx.x;
-        Index::idx_t listId = listIds[queryId][probeId];
+        idx_t listId = listIds[queryId][probeId];
 
         // Safety guard in case NaNs in input cause no list ID to be generated,
         // or we have more nprobe than nlist
@@ -412,7 +412,7 @@ __global__ void ivfInterleavedScan(
 // with all implementations
 void runIVFInterleavedScan(
         Tensor<float, 2, true>& queries,
-        Tensor<Index::idx_t, 2, true>& listIds,
+        Tensor<idx_t, 2, true>& listIds,
         DeviceVector<void*>& listData,
         DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
@@ -425,7 +425,7 @@ void runIVFInterleavedScan(
         // output
         Tensor<float, 2, true>& outDistances,
         // output
-        Tensor<Index::idx_t, 2, true>& outIndices,
+        Tensor<idx_t, 2, true>& outIndices,
         GpuResources* res);
 
 // Second pass of IVF list scanning to perform final k-selection and look up the
@@ -433,13 +433,13 @@ void runIVFInterleavedScan(
 void runIVFInterleavedScan2(
         Tensor<float, 3, true>& distanceIn,
         Tensor<int, 3, true>& indicesIn,
-        Tensor<Index::idx_t, 2, true>& listIds,
+        Tensor<idx_t, 2, true>& listIds,
         int k,
         DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
         bool dir,
         Tensor<float, 2, true>& distanceOut,
-        Tensor<Index::idx_t, 2, true>& indicesOut,
+        Tensor<idx_t, 2, true>& indicesOut,
         cudaStream_t stream);
 
 } // namespace gpu

--- a/faiss/gpu/impl/IVFPQ.cu
+++ b/faiss/gpu/impl/IVFPQ.cu
@@ -129,12 +129,12 @@ Tensor<float, 3, true> IVFPQ::getPQCentroids() {
 void IVFPQ::appendVectors_(
         Tensor<float, 2, true>& vecs,
         Tensor<float, 2, true>& ivfCentroidResiduals,
-        Tensor<Index::idx_t, 1, true>& indices,
-        Tensor<Index::idx_t, 1, true>& uniqueLists,
+        Tensor<idx_t, 1, true>& indices,
+        Tensor<idx_t, 1, true>& uniqueLists,
         Tensor<int, 1, true>& vectorsByUniqueList,
         Tensor<int, 1, true>& uniqueListVectorStart,
         Tensor<int, 1, true>& uniqueListStartOffset,
-        Tensor<Index::idx_t, 1, true>& listIds,
+        Tensor<idx_t, 1, true>& listIds,
         Tensor<int, 1, true>& listOffset,
         cudaStream_t stream) {
     //
@@ -492,7 +492,7 @@ void IVFPQ::search(
         int nprobe,
         int k,
         Tensor<float, 2, true>& outDistances,
-        Tensor<Index::idx_t, 2, true>& outIndices) {
+        Tensor<idx_t, 2, true>& outIndices) {
     // These are caught at a higher level
     FAISS_ASSERT(nprobe <= GPU_MAX_SELECTION_K);
     FAISS_ASSERT(k <= GPU_MAX_SELECTION_K);
@@ -509,7 +509,7 @@ void IVFPQ::search(
             resources_,
             makeTempAlloc(AllocType::Other, stream),
             {queries.getSize(0), nprobe});
-    DeviceTensor<Index::idx_t, 2, true> coarseIndices(
+    DeviceTensor<idx_t, 2, true> coarseIndices(
             resources_,
             makeTempAlloc(AllocType::Other, stream),
             {queries.getSize(0), nprobe});
@@ -537,10 +537,10 @@ void IVFPQ::searchPreassigned(
         Index* coarseQuantizer,
         Tensor<float, 2, true>& vecs,
         Tensor<float, 2, true>& ivfDistances,
-        Tensor<Index::idx_t, 2, true>& ivfAssignments,
+        Tensor<idx_t, 2, true>& ivfAssignments,
         int k,
         Tensor<float, 2, true>& outDistances,
-        Tensor<Index::idx_t, 2, true>& outIndices,
+        Tensor<idx_t, 2, true>& outIndices,
         bool storePairs) {
     FAISS_ASSERT(ivfDistances.getSize(0) == vecs.getSize(0));
     FAISS_ASSERT(ivfAssignments.getSize(0) == vecs.getSize(0));
@@ -565,10 +565,10 @@ void IVFPQ::searchPreassigned(
 void IVFPQ::searchImpl_(
         Tensor<float, 2, true>& queries,
         Tensor<float, 2, true>& coarseDistances,
-        Tensor<Index::idx_t, 2, true>& coarseIndices,
+        Tensor<idx_t, 2, true>& coarseIndices,
         int k,
         Tensor<float, 2, true>& outDistances,
-        Tensor<Index::idx_t, 2, true>& outIndices,
+        Tensor<idx_t, 2, true>& outIndices,
         bool storePairs) {
     FAISS_ASSERT(storePairs == false);
 
@@ -599,7 +599,7 @@ void IVFPQ::searchImpl_(
     // FIXME: we might ultimately be calling this function with inputs
     // from the CPU, these are unnecessary copies
     if (indicesOptions_ == INDICES_CPU) {
-        HostTensor<Index::idx_t, 2, true> hostOutIndices(outIndices, stream);
+        HostTensor<idx_t, 2, true> hostOutIndices(outIndices, stream);
 
         ivfOffsetToUserIndex(
                 hostOutIndices.data(),
@@ -617,10 +617,10 @@ void IVFPQ::searchImpl_(
 void IVFPQ::runPQPrecomputedCodes_(
         Tensor<float, 2, true>& queries,
         Tensor<float, 2, true>& coarseDistances,
-        Tensor<Index::idx_t, 2, true>& coarseIndices,
+        Tensor<idx_t, 2, true>& coarseIndices,
         int k,
         Tensor<float, 2, true>& outDistances,
-        Tensor<Index::idx_t, 2, true>& outIndices) {
+        Tensor<idx_t, 2, true>& outIndices) {
     FAISS_ASSERT(metric_ == MetricType::METRIC_L2);
 
     auto stream = resources_->getDefaultStreamCurrentDevice();
@@ -705,10 +705,10 @@ void IVFPQ::runPQPrecomputedCodes_(
 void IVFPQ::runPQNoPrecomputedCodes_(
         Tensor<float, 2, true>& queries,
         Tensor<float, 2, true>& coarseDistances,
-        Tensor<Index::idx_t, 2, true>& coarseIndices,
+        Tensor<idx_t, 2, true>& coarseIndices,
         int k,
         Tensor<float, 2, true>& outDistances,
-        Tensor<Index::idx_t, 2, true>& outIndices) {
+        Tensor<idx_t, 2, true>& outIndices) {
     runPQScanMultiPassNoPrecomputed(
             queries,
             ivfCentroids_,

--- a/faiss/gpu/impl/IVFPQ.cuh
+++ b/faiss/gpu/impl/IVFPQ.cuh
@@ -53,7 +53,7 @@ class IVFPQ : public IVFBase {
             int nprobe,
             int k,
             Tensor<float, 2, true>& outDistances,
-            Tensor<Index::idx_t, 2, true>& outIndices) override;
+            Tensor<idx_t, 2, true>& outIndices) override;
 
     /// Performs search when we are already given the IVF cells to look at
     /// (GpuIndexIVF::search_preassigned implementation)
@@ -61,10 +61,10 @@ class IVFPQ : public IVFBase {
             Index* coarseQuantizer,
             Tensor<float, 2, true>& vecs,
             Tensor<float, 2, true>& ivfDistances,
-            Tensor<Index::idx_t, 2, true>& ivfAssignments,
+            Tensor<idx_t, 2, true>& ivfAssignments,
             int k,
             Tensor<float, 2, true>& outDistances,
-            Tensor<Index::idx_t, 2, true>& outIndices,
+            Tensor<idx_t, 2, true>& outIndices,
             bool storePairs) override;
 
    protected:
@@ -86,12 +86,12 @@ class IVFPQ : public IVFBase {
     void appendVectors_(
             Tensor<float, 2, true>& vecs,
             Tensor<float, 2, true>& ivfCentroidResiduals,
-            Tensor<Index::idx_t, 1, true>& indices,
-            Tensor<Index::idx_t, 1, true>& uniqueLists,
+            Tensor<idx_t, 1, true>& indices,
+            Tensor<idx_t, 1, true>& uniqueLists,
             Tensor<int, 1, true>& vectorsByUniqueList,
             Tensor<int, 1, true>& uniqueListVectorStart,
             Tensor<int, 1, true>& uniqueListStartOffset,
-            Tensor<Index::idx_t, 1, true>& listIds,
+            Tensor<idx_t, 1, true>& listIds,
             Tensor<int, 1, true>& listOffset,
             cudaStream_t stream) override;
 
@@ -100,10 +100,10 @@ class IVFPQ : public IVFBase {
     void searchImpl_(
             Tensor<float, 2, true>& queries,
             Tensor<float, 2, true>& coarseDistances,
-            Tensor<Index::idx_t, 2, true>& coarseIndices,
+            Tensor<idx_t, 2, true>& coarseIndices,
             int k,
             Tensor<float, 2, true>& outDistances,
-            Tensor<Index::idx_t, 2, true>& outIndices,
+            Tensor<idx_t, 2, true>& outIndices,
             bool storePairs);
 
     /// Sets the current product quantizer centroids; the data can be
@@ -120,19 +120,19 @@ class IVFPQ : public IVFBase {
     void runPQPrecomputedCodes_(
             Tensor<float, 2, true>& queries,
             Tensor<float, 2, true>& coarseDistances,
-            Tensor<Index::idx_t, 2, true>& coarseIndices,
+            Tensor<idx_t, 2, true>& coarseIndices,
             int k,
             Tensor<float, 2, true>& outDistances,
-            Tensor<Index::idx_t, 2, true>& outIndices);
+            Tensor<idx_t, 2, true>& outIndices);
 
     /// Runs kernels for scanning inverted lists without precomputed codes
     void runPQNoPrecomputedCodes_(
             Tensor<float, 2, true>& queries,
             Tensor<float, 2, true>& coarseDistances,
-            Tensor<Index::idx_t, 2, true>& coarseIndices,
+            Tensor<idx_t, 2, true>& coarseIndices,
             int k,
             Tensor<float, 2, true>& outDistances,
-            Tensor<Index::idx_t, 2, true>& outIndices);
+            Tensor<idx_t, 2, true>& outIndices);
 
    private:
     /// Number of sub-quantizers per vector

--- a/faiss/gpu/impl/IVFUtils.cu
+++ b/faiss/gpu/impl/IVFUtils.cu
@@ -21,7 +21,7 @@ namespace gpu {
 // Calculates the total number of intermediate distances to consider
 // for all queries
 __global__ void getResultLengths(
-        Tensor<Index::idx_t, 2, true> ivfListIds,
+        Tensor<idx_t, 2, true> ivfListIds,
         int* listLengths,
         int totalSize,
         Tensor<int, 2, true> length) {
@@ -34,7 +34,7 @@ __global__ void getResultLengths(
     int queryId = linearThreadId / nprobe;
     int listId = linearThreadId % nprobe;
 
-    Index::idx_t centroidId = ivfListIds[queryId][listId];
+    idx_t centroidId = ivfListIds[queryId][listId];
 
     // Safety guard in case NaNs in input cause no list ID to be generated
     length[queryId][listId] = (centroidId != -1) ? listLengths[centroidId] : 0;
@@ -42,7 +42,7 @@ __global__ void getResultLengths(
 
 void runCalcListOffsets(
         GpuResources* res,
-        Tensor<Index::idx_t, 2, true>& ivfListIds,
+        Tensor<idx_t, 2, true>& ivfListIds,
         DeviceVector<int>& listLengths,
         Tensor<int, 2, true>& prefixSumOffsets,
         Tensor<char, 1, true>& thrustMem,

--- a/faiss/gpu/impl/IVFUtils.cuh
+++ b/faiss/gpu/impl/IVFUtils.cuh
@@ -23,7 +23,7 @@ class GpuResources;
 /// intermediate results for all (query, probe) pair
 void runCalcListOffsets(
         GpuResources* res,
-        Tensor<Index::idx_t, 2, true>& ivfListIds,
+        Tensor<idx_t, 2, true>& ivfListIds,
         DeviceVector<int>& listLengths,
         Tensor<int, 2, true>& prefixSumOffsets,
         Tensor<char, 1, true>& thrustMem,
@@ -48,11 +48,11 @@ void runPass2SelectLists(
         DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
         Tensor<int, 2, true>& prefixSumOffsets,
-        Tensor<Index::idx_t, 2, true>& ivfListIds,
+        Tensor<idx_t, 2, true>& ivfListIds,
         int k,
         bool chooseLargest,
         Tensor<float, 2, true>& outDistances,
-        Tensor<Index::idx_t, 2, true>& outIndices,
+        Tensor<idx_t, 2, true>& outIndices,
         cudaStream_t stream);
 
 } // namespace gpu

--- a/faiss/gpu/impl/IVFUtilsSelect2.cu
+++ b/faiss/gpu/impl/IVFUtilsSelect2.cu
@@ -55,11 +55,11 @@ __global__ void pass2SelectLists(
         Tensor<int, 2, true> heapIndices,
         void** listIndices,
         Tensor<int, 2, true> prefixSumOffsets,
-        Tensor<Index::idx_t, 2, true> ivfListIds,
+        Tensor<idx_t, 2, true> ivfListIds,
         int k,
         IndicesOptions opt,
         Tensor<float, 2, true> outDistances,
-        Tensor<Index::idx_t, 2, true> outIndices) {
+        Tensor<idx_t, 2, true> outIndices) {
     constexpr int kNumWarps = ThreadsPerBlock / kWarpSize;
 
     __shared__ float smemK[kNumWarps * NumWarpQ];
@@ -110,7 +110,7 @@ __global__ void pass2SelectLists(
         // is the very last step and it is happening a small number of
         // times (#queries x k).
         int v = smemV[i];
-        Index::idx_t index = -1;
+        idx_t index = -1;
 
         if (v != -1) {
             // `offset` is the offset of the intermediate result, as
@@ -127,7 +127,7 @@ __global__ void pass2SelectLists(
 
             // This is then the probe for the query; we can find the actual
             // list ID from this
-            Index::idx_t listId = ivfListIds[queryId][probe];
+            idx_t listId = ivfListIds[queryId][probe];
 
             // Now, we need to know the offset within the list
             // We ensure that before the array (at offset -1), there is a 0
@@ -137,11 +137,11 @@ __global__ void pass2SelectLists(
 
             // This gives us our final index
             if (opt == INDICES_32_BIT) {
-                index = (Index::idx_t)((int*)listIndices[listId])[listOffset];
+                index = (idx_t)((int*)listIndices[listId])[listOffset];
             } else if (opt == INDICES_64_BIT) {
-                index = ((Index::idx_t*)listIndices[listId])[listOffset];
+                index = ((idx_t*)listIndices[listId])[listOffset];
             } else {
-                index = (listId << 32 | (Index::idx_t)listOffset);
+                index = (listId << 32 | (idx_t)listOffset);
             }
         }
 
@@ -155,11 +155,11 @@ void runPass2SelectLists(
         DeviceVector<void*>& listIndices,
         IndicesOptions indicesOptions,
         Tensor<int, 2, true>& prefixSumOffsets,
-        Tensor<Index::idx_t, 2, true>& ivfListIds,
+        Tensor<idx_t, 2, true>& ivfListIds,
         int k,
         bool chooseLargest,
         Tensor<float, 2, true>& outDistances,
-        Tensor<Index::idx_t, 2, true>& outIndices,
+        Tensor<idx_t, 2, true>& outIndices,
         cudaStream_t stream) {
     auto grid = dim3(ivfListIds.getSize(0));
 

--- a/faiss/gpu/impl/IndexUtils.cu
+++ b/faiss/gpu/impl/IndexUtils.cu
@@ -22,25 +22,25 @@ int getMaxKSelection() {
     return GPU_MAX_SELECTION_K;
 }
 
-void validateKSelect(Index::idx_t k) {
+void validateKSelect(idx_t k) {
     FAISS_THROW_IF_NOT_FMT(
-            k > 0 && k < (Index::idx_t)getMaxKSelection(),
+            k > 0 && k < (idx_t)getMaxKSelection(),
             "GPU index only supports min/max-K selection up to %d (requested %zu)",
             getMaxKSelection(),
             k);
 }
 
-void validateNProbe(Index::idx_t nprobe) {
+void validateNProbe(idx_t nprobe) {
     FAISS_THROW_IF_NOT_FMT(
-            nprobe > 0 && nprobe < (Index::idx_t)getMaxKSelection(),
+            nprobe > 0 && nprobe < (idx_t)getMaxKSelection(),
             "GPU IVF index only supports nprobe selection up to %d (requested %zu)",
             getMaxKSelection(),
             nprobe);
 }
 
-void validateNumVectors(Index::idx_t n) {
+void validateNumVectors(idx_t n) {
     FAISS_THROW_IF_NOT_FMT(
-            n <= (Index::idx_t)std::numeric_limits<int>::max(),
+            n <= (idx_t)std::numeric_limits<int>::max(),
             "GPU index only supports up to %d indices (requested %zu)",
             std::numeric_limits<int>::max(),
             n);

--- a/faiss/gpu/impl/IndexUtils.h
+++ b/faiss/gpu/impl/IndexUtils.h
@@ -20,13 +20,13 @@ namespace gpu {
 int getMaxKSelection();
 
 // Validate the k parameter for search
-void validateKSelect(Index::idx_t k);
+void validateKSelect(idx_t k);
 
 // Validate the nprobe parameter for search
-void validateNProbe(Index::idx_t nprobe);
+void validateNProbe(idx_t nprobe);
 
 /// Validate the n (number of vectors) parameter for add, search, reconstruct
-void validateNumVectors(Index::idx_t n);
+void validateNumVectors(idx_t n);
 
 } // namespace gpu
 } // namespace faiss

--- a/faiss/gpu/impl/PQCodeDistances-inl.cuh
+++ b/faiss/gpu/impl/PQCodeDistances-inl.cuh
@@ -32,7 +32,7 @@ __global__ void __launch_bounds__(288, 3) pqCodeDistances(
         int queriesPerBlock,
         Tensor<CentroidT, 2, true> coarseCentroids,
         Tensor<float, 3, true> pqCentroids,
-        Tensor<Index::idx_t, 2, true> coarseIndices,
+        Tensor<idx_t, 2, true> coarseIndices,
         // (query id)(coarse)(subquantizer)(code) -> dist
         Tensor<OutCodeT, 4, true> outCodeDistances) {
     const auto numSubQuantizers = pqCentroids.getSize(0);
@@ -96,7 +96,7 @@ __global__ void __launch_bounds__(288, 3) pqCodeDistances(
         // Load list of coarse centroids found
         for (int i = threadIdx.x; i < coarseIndices.getSize(1);
              i += blockDim.x) {
-            // FIXME: coarseIndices is now Index::idx_t but the smem allocation
+            // FIXME: coarseIndices is now idx_t but the smem allocation
             // of coarseIds is still int. In practical limitation, everything
             // should still fit into int32
             coarseIds[i] = (int)coarseIndices[queryId][i];
@@ -284,7 +284,7 @@ template <typename CentroidT, bool L2Residual>
 __global__ void pqResidualVector(
         Tensor<float, 2, true> queries,
         Tensor<CentroidT, 2, true> coarseCentroids,
-        Tensor<Index::idx_t, 2, true> coarseIndices,
+        Tensor<idx_t, 2, true> coarseIndices,
         int numSubDim,
         // output is transposed:
         // (sub q)(query id)(centroid id)(sub dim)
@@ -292,7 +292,7 @@ __global__ void pqResidualVector(
     auto queryId = blockIdx.x;
     auto centroidId = blockIdx.y;
 
-    Index::idx_t realCentroidId = coarseIndices[queryId][centroidId];
+    idx_t realCentroidId = coarseIndices[queryId][centroidId];
 
     for (int dim = threadIdx.x; dim < queries.getSize(1); dim += blockDim.x) {
         float q = queries[queryId][dim];
@@ -323,7 +323,7 @@ void runPQResidualVector(
         Tensor<float, 3, true>& pqCentroids,
         Tensor<float, 2, true>& queries,
         Tensor<CentroidT, 2, true>& coarseCentroids,
-        Tensor<Index::idx_t, 2, true>& coarseIndices,
+        Tensor<idx_t, 2, true>& coarseIndices,
         Tensor<float, 4, true>& residual,
         bool l2Residual,
         cudaStream_t stream) {
@@ -401,7 +401,7 @@ void runPQCodeDistancesMM(
         Tensor<float, 2, true>& queries,
         Tensor<CentroidT, 2, true>& coarseCentroids,
         Tensor<float, 2, true>& coarseDistances,
-        Tensor<Index::idx_t, 2, true>& coarseIndices,
+        Tensor<idx_t, 2, true>& coarseIndices,
         // Output is (query)(centroid)(sub q)(code)
         NoTypeTensor<4, true>& outCodeDistances,
         bool l2Distance,
@@ -590,7 +590,7 @@ void runPQCodeDistances(
         Tensor<float, 2, true>& queries,
         Tensor<CentroidT, 2, true>& coarseCentroids,
         Tensor<float, 2, true>& coarseDistances,
-        Tensor<Index::idx_t, 2, true>& coarseIndices,
+        Tensor<idx_t, 2, true>& coarseIndices,
         NoTypeTensor<4, true>& outCodeDistances,
         bool useMMImplementation,
         bool l2Distance,

--- a/faiss/gpu/impl/PQCodeDistances.cuh
+++ b/faiss/gpu/impl/PQCodeDistances.cuh
@@ -28,7 +28,7 @@ void runPQCodeDistances(
         Tensor<float, 2, true>& queries,
         Tensor<CentroidT, 2, true>& coarseCentroids,
         Tensor<float, 2, true>& coarseDistances,
-        Tensor<Index::idx_t, 2, true>& coarseIndices,
+        Tensor<idx_t, 2, true>& coarseIndices,
         NoTypeTensor<4, true>& outCodeDistances,
         bool useMMImplementation,
         bool l2Distance,

--- a/faiss/gpu/impl/PQScanMultiPassNoPrecomputed-inl.cuh
+++ b/faiss/gpu/impl/PQScanMultiPassNoPrecomputed-inl.cuh
@@ -28,7 +28,7 @@ template <typename EncodeT, int EncodeBits, typename CodeDistanceT>
 __global__ void pqScanInterleaved(
         Tensor<float, 2, true> queries,
         Tensor<float, 3, true> pqCentroids,
-        Tensor<Index::idx_t, 2, true> ivfListIds,
+        Tensor<idx_t, 2, true> ivfListIds,
         Tensor<CodeDistanceT, 4, true> codeDistances,
         void** listCodes,
         int* listLengths,
@@ -38,7 +38,7 @@ __global__ void pqScanInterleaved(
     auto queryId = blockIdx.y;
     auto probeId = blockIdx.x;
 
-    Index::idx_t listId = ivfListIds[queryId][probeId];
+    idx_t listId = ivfListIds[queryId][probeId];
     // Safety guard in case NaNs in input cause no list ID to be generated
     if (listId == -1) {
         return;
@@ -174,7 +174,7 @@ template <int NumSubQuantizers, typename LookupT, typename LookupVecT>
 __global__ void pqScanNoPrecomputedMultiPass(
         Tensor<float, 2, true> queries,
         Tensor<float, 3, true> pqCentroids,
-        Tensor<Index::idx_t, 2, true> ivfListIds,
+        Tensor<idx_t, 2, true> ivfListIds,
         Tensor<LookupT, 4, true> codeDistances,
         void** listCodes,
         int* listLengths,
@@ -195,7 +195,7 @@ __global__ void pqScanNoPrecomputedMultiPass(
     int outBase = *(prefixSumOffsets[queryId][probeId].data() - 1);
     float* distanceOut = distance[outBase].data();
 
-    Index::idx_t listId = ivfListIds[queryId][probeId];
+    idx_t listId = ivfListIds[queryId][probeId];
     // Safety guard in case NaNs in input cause no list ID to be generated
     if (listId == -1) {
         return;
@@ -277,7 +277,7 @@ void runMultiPassTile(
         Tensor<float, 3, true>& pqCentroidsInnermostCode,
         NoTypeTensor<4, true>& codeDistances,
         Tensor<float, 2, true>& coarseDistances,
-        Tensor<Index::idx_t, 2, true>& coarseIndices,
+        Tensor<idx_t, 2, true>& coarseIndices,
         bool useFloat16Lookup,
         bool useMMCodeDistance,
         bool interleavedCodeLayout,
@@ -296,7 +296,7 @@ void runMultiPassTile(
         int k,
         faiss::MetricType metric,
         Tensor<float, 2, true>& outDistances,
-        Tensor<Index::idx_t, 2, true>& outIndices,
+        Tensor<idx_t, 2, true>& outIndices,
         cudaStream_t stream) {
     // We only support two metrics at the moment
     FAISS_ASSERT(
@@ -526,7 +526,7 @@ void runPQScanMultiPassNoPrecomputed(
         Tensor<CentroidT, 2, true>& centroids,
         Tensor<float, 3, true>& pqCentroidsInnermostCode,
         Tensor<float, 2, true>& coarseDistances,
-        Tensor<Index::idx_t, 2, true>& coarseIndices,
+        Tensor<idx_t, 2, true>& coarseIndices,
         bool useFloat16Lookup,
         bool useMMCodeDistance,
         bool interleavedCodeLayout,
@@ -543,7 +543,7 @@ void runPQScanMultiPassNoPrecomputed(
         // output
         Tensor<float, 2, true>& outDistances,
         // output
-        Tensor<Index::idx_t, 2, true>& outIndices,
+        Tensor<idx_t, 2, true>& outIndices,
         GpuResources* res) {
     constexpr int kMinQueryTileSize = 8;
     constexpr int kMaxQueryTileSize = 65536; // typical max gridDim.y

--- a/faiss/gpu/impl/PQScanMultiPassNoPrecomputed.cuh
+++ b/faiss/gpu/impl/PQScanMultiPassNoPrecomputed.cuh
@@ -24,7 +24,7 @@ void runPQScanMultiPassNoPrecomputed(
         Tensor<CentroidT, 2, true>& centroids,
         Tensor<float, 3, true>& pqCentroidsInnermostCode,
         Tensor<float, 2, true>& coarseDistances,
-        Tensor<Index::idx_t, 2, true>& coarseIndices,
+        Tensor<idx_t, 2, true>& coarseIndices,
         bool useFloat16Lookup,
         bool useMMCodeDistance,
         bool interleavedCodeLayout,
@@ -41,7 +41,7 @@ void runPQScanMultiPassNoPrecomputed(
         // output
         Tensor<float, 2, true>& outDistances,
         // output
-        Tensor<Index::idx_t, 2, true>& outIndices,
+        Tensor<idx_t, 2, true>& outIndices,
         GpuResources* res);
 
 } // namespace gpu

--- a/faiss/gpu/impl/PQScanMultiPassPrecomputed.cu
+++ b/faiss/gpu/impl/PQScanMultiPassPrecomputed.cu
@@ -35,7 +35,7 @@ __global__ void pqScanPrecomputedInterleaved(
         Tensor<CodeDistanceT, 3, true> precompTerm2,
         // (query id)(sub q)(code id)
         Tensor<CodeDistanceT, 3, true> precompTerm3,
-        Tensor<Index::idx_t, 2, true> ivfListIds,
+        Tensor<idx_t, 2, true> ivfListIds,
         void** listCodes,
         int* listLengths,
         Tensor<int, 2, true> prefixSumOffsets,
@@ -44,7 +44,7 @@ __global__ void pqScanPrecomputedInterleaved(
     auto queryId = blockIdx.y;
     auto probeId = blockIdx.x;
 
-    Index::idx_t listId = ivfListIds[queryId][probeId];
+    idx_t listId = ivfListIds[queryId][probeId];
     // Safety guard in case NaNs in input cause no list ID to be generated
     if (listId == -1) {
         return;
@@ -206,7 +206,7 @@ __global__ void pqScanPrecomputedMultiPass(
         Tensor<float, 2, true> precompTerm1,
         Tensor<LookupT, 3, true> precompTerm2,
         Tensor<LookupT, 3, true> precompTerm3,
-        Tensor<Index::idx_t, 2, true> ivfListIds,
+        Tensor<idx_t, 2, true> ivfListIds,
         void** listCodes,
         int* listLengths,
         Tensor<int, 2, true> prefixSumOffsets,
@@ -227,7 +227,7 @@ __global__ void pqScanPrecomputedMultiPass(
     int outBase = *(prefixSumOffsets[queryId][probeId].data() - 1);
     float* distanceOut = distance[outBase].data();
 
-    Index::idx_t listId = ivfListIds[queryId][probeId];
+    idx_t listId = ivfListIds[queryId][probeId];
     // Safety guard in case NaNs in input cause no list ID to be generated
     if (listId == -1) {
         return;
@@ -310,7 +310,7 @@ void runMultiPassTile(
         Tensor<float, 2, true>& precompTerm1,
         NoTypeTensor<3, true>& precompTerm2,
         NoTypeTensor<3, true>& precompTerm3,
-        Tensor<Index::idx_t, 2, true>& ivfListIds,
+        Tensor<idx_t, 2, true>& ivfListIds,
         bool useFloat16Lookup,
         bool interleavedCodeLayout,
         int bitsPerSubQuantizer,
@@ -327,7 +327,7 @@ void runMultiPassTile(
         Tensor<int, 3, true>& heapIndices,
         int k,
         Tensor<float, 2, true>& outDistances,
-        Tensor<Index::idx_t, 2, true>& outIndices,
+        Tensor<idx_t, 2, true>& outIndices,
         cudaStream_t stream) {
     // Calculate offset lengths, so we know where to write out
     // intermediate results
@@ -540,7 +540,7 @@ void runPQScanMultiPassPrecomputed(
         NoTypeTensor<3, true>& precompTerm2,
         // (query id)(sub q)(code id)
         NoTypeTensor<3, true>& precompTerm3,
-        Tensor<Index::idx_t, 2, true>& ivfListIds,
+        Tensor<idx_t, 2, true>& ivfListIds,
         bool useFloat16Lookup,
         bool interleavedCodeLayout,
         int bitsPerSubQuantizer,
@@ -555,7 +555,7 @@ void runPQScanMultiPassPrecomputed(
         // output
         Tensor<float, 2, true>& outDistances,
         // output
-        Tensor<Index::idx_t, 2, true>& outIndices,
+        Tensor<idx_t, 2, true>& outIndices,
         GpuResources* res) {
     constexpr int kMinQueryTileSize = 8;
     constexpr int kMaxQueryTileSize = 65536; // typical max gridDim.y

--- a/faiss/gpu/impl/PQScanMultiPassPrecomputed.cuh
+++ b/faiss/gpu/impl/PQScanMultiPassPrecomputed.cuh
@@ -23,7 +23,7 @@ void runPQScanMultiPassPrecomputed(
         Tensor<float, 2, true>& precompTerm1,
         NoTypeTensor<3, true>& precompTerm2,
         NoTypeTensor<3, true>& precompTerm3,
-        Tensor<Index::idx_t, 2, true>& ivfListIds,
+        Tensor<idx_t, 2, true>& ivfListIds,
         bool useFloat16Lookup,
         bool interleavedCodeLayout,
         int bitsPerSubQuantizer,
@@ -38,7 +38,7 @@ void runPQScanMultiPassPrecomputed(
         // output
         Tensor<float, 2, true>& outDistances,
         // output
-        Tensor<Index::idx_t, 2, true>& outIndices,
+        Tensor<idx_t, 2, true>& outIndices,
         GpuResources* res);
 
 } // namespace gpu

--- a/faiss/gpu/impl/RemapIndices.cpp
+++ b/faiss/gpu/impl/RemapIndices.cpp
@@ -14,11 +14,11 @@ namespace gpu {
 // Utility function to translate (list id, offset) to a user index on
 // the CPU. In a cpp in order to use OpenMP
 void ivfOffsetToUserIndex(
-        Index::idx_t* indices,
+        idx_t* indices,
         int numLists,
         int queries,
         int k,
-        const std::vector<std::vector<Index::idx_t>>& listOffsetToUserIndex) {
+        const std::vector<std::vector<idx_t>>& listOffsetToUserIndex) {
     FAISS_ASSERT(numLists == listOffsetToUserIndex.size());
 
 #pragma omp parallel for

--- a/faiss/gpu/impl/RemapIndices.h
+++ b/faiss/gpu/impl/RemapIndices.h
@@ -16,11 +16,11 @@ namespace gpu {
 /// Utility function to translate (list id, offset) to a user index on
 /// the CPU. In a cpp in order to use OpenMP.
 void ivfOffsetToUserIndex(
-        Index::idx_t* indices,
+        idx_t* indices,
         int numLists,
         int queries,
         int k,
-        const std::vector<std::vector<Index::idx_t>>& listOffsetToUserIndex);
+        const std::vector<std::vector<idx_t>>& listOffsetToUserIndex);
 
 } // namespace gpu
 } // namespace faiss

--- a/faiss/gpu/impl/VectorResidual.cu
+++ b/faiss/gpu/impl/VectorResidual.cu
@@ -86,20 +86,20 @@ void calcResidual(
 void runCalcResidual(
         Tensor<float, 2, true>& vecs,
         Tensor<float, 2, true>& centroids,
-        Tensor<Index::idx_t, 1, true>& vecToCentroid,
+        Tensor<idx_t, 1, true>& vecToCentroid,
         Tensor<float, 2, true>& residuals,
         cudaStream_t stream) {
-    calcResidual<Index::idx_t, float>(
+    calcResidual<idx_t, float>(
             vecs, centroids, vecToCentroid, residuals, stream);
 }
 
 void runCalcResidual(
         Tensor<float, 2, true>& vecs,
         Tensor<half, 2, true>& centroids,
-        Tensor<Index::idx_t, 1, true>& vecToCentroid,
+        Tensor<idx_t, 1, true>& vecToCentroid,
         Tensor<float, 2, true>& residuals,
         cudaStream_t stream) {
-    calcResidual<Index::idx_t, half>(
+    calcResidual<idx_t, half>(
             vecs, centroids, vecToCentroid, residuals, stream);
 }
 
@@ -190,38 +190,38 @@ void gatherReconstructByRange(
 }
 
 void runReconstruct(
-        Tensor<Index::idx_t, 1, true>& ids,
+        Tensor<idx_t, 1, true>& ids,
         Tensor<float, 2, true>& vecs,
         Tensor<float, 2, true>& out,
         cudaStream_t stream) {
-    gatherReconstructByIds<Index::idx_t, float>(ids, vecs, out, stream);
+    gatherReconstructByIds<idx_t, float>(ids, vecs, out, stream);
 }
 
 void runReconstruct(
-        Tensor<Index::idx_t, 1, true>& ids,
+        Tensor<idx_t, 1, true>& ids,
         Tensor<half, 2, true>& vecs,
         Tensor<float, 2, true>& out,
         cudaStream_t stream) {
-    gatherReconstructByIds<Index::idx_t, half>(ids, vecs, out, stream);
+    gatherReconstructByIds<idx_t, half>(ids, vecs, out, stream);
 }
 
 void runReconstruct(
-        Index::idx_t start,
-        Index::idx_t num,
+        idx_t start,
+        idx_t num,
         Tensor<float, 2, true>& vecs,
         Tensor<float, 2, true>& out,
         cudaStream_t stream) {
-    gatherReconstructByRange<Index::idx_t, float>(
+    gatherReconstructByRange<idx_t, float>(
             start, num, vecs, out, stream);
 }
 
 void runReconstruct(
-        Index::idx_t start,
-        Index::idx_t num,
+        idx_t start,
+        idx_t num,
         Tensor<half, 2, true>& vecs,
         Tensor<float, 2, true>& out,
         cudaStream_t stream) {
-    gatherReconstructByRange<Index::idx_t, half>(start, num, vecs, out, stream);
+    gatherReconstructByRange<idx_t, half>(start, num, vecs, out, stream);
 }
 
 } // namespace gpu

--- a/faiss/gpu/impl/VectorResidual.cuh
+++ b/faiss/gpu/impl/VectorResidual.cuh
@@ -17,40 +17,40 @@ namespace gpu {
 void runCalcResidual(
         Tensor<float, 2, true>& vecs,
         Tensor<float, 2, true>& centroids,
-        Tensor<Index::idx_t, 1, true>& vecToCentroid,
+        Tensor<idx_t, 1, true>& vecToCentroid,
         Tensor<float, 2, true>& residuals,
         cudaStream_t stream);
 
 void runCalcResidual(
         Tensor<float, 2, true>& vecs,
         Tensor<half, 2, true>& centroids,
-        Tensor<Index::idx_t, 1, true>& vecToCentroid,
+        Tensor<idx_t, 1, true>& vecToCentroid,
         Tensor<float, 2, true>& residuals,
         cudaStream_t stream);
 
 // Gather vectors
 void runReconstruct(
-        Tensor<Index::idx_t, 1, true>& listIds,
+        Tensor<idx_t, 1, true>& listIds,
         Tensor<float, 2, true>& vecs,
         Tensor<float, 2, true>& out,
         cudaStream_t stream);
 
 void runReconstruct(
-        Tensor<Index::idx_t, 1, true>& listIds,
+        Tensor<idx_t, 1, true>& listIds,
         Tensor<half, 2, true>& vecs,
         Tensor<float, 2, true>& out,
         cudaStream_t stream);
 
 void runReconstruct(
-        Index::idx_t start,
-        Index::idx_t num,
+        idx_t start,
+        idx_t num,
         Tensor<float, 2, true>& vecs,
         Tensor<float, 2, true>& out,
         cudaStream_t stream);
 
 void runReconstruct(
-        Index::idx_t start,
-        Index::idx_t num,
+        idx_t start,
+        idx_t num,
         Tensor<half, 2, true>& vecs,
         Tensor<float, 2, true>& out,
         cudaStream_t stream);

--- a/faiss/gpu/impl/scan/IVFInterleavedImpl.cuh
+++ b/faiss/gpu/impl/scan/IVFInterleavedImpl.cuh
@@ -15,7 +15,7 @@
                                                         \
     void ivfInterleavedScanImpl_##WARP_Q##_(            \
             Tensor<float, 2, true>& queries,            \
-            Tensor<Index::idx_t, 2, true>& listIds,     \
+            Tensor<idx_t, 2, true>& listIds,     \
             DeviceVector<void*>& listData,              \
             DeviceVector<void*>& listIndices,           \
             IndicesOptions indicesOptions,              \
@@ -26,7 +26,7 @@
             Tensor<float, 3, true>& residualBase,       \
             GpuScalarQuantizer* scalarQ,                \
             Tensor<float, 2, true>& outDistances,       \
-            Tensor<Index::idx_t, 2, true>& outIndices,  \
+            Tensor<idx_t, 2, true>& outIndices,  \
             GpuResources* res) {                        \
         FAISS_ASSERT(k <= WARP_Q);                      \
                                                         \
@@ -39,7 +39,7 @@
                                                        \
     void ivfInterleavedScanImpl_##WARP_Q##_(           \
             Tensor<float, 2, true>& queries,           \
-            Tensor<Index::idx_t, 2, true>& listIds,    \
+            Tensor<idx_t, 2, true>& listIds,    \
             DeviceVector<void*>& listData,             \
             DeviceVector<void*>& listIndices,          \
             IndicesOptions indicesOptions,             \
@@ -50,7 +50,7 @@
             Tensor<float, 3, true>& residualBase,      \
             GpuScalarQuantizer* scalarQ,               \
             Tensor<float, 2, true>& outDistances,      \
-            Tensor<Index::idx_t, 2, true>& outIndices, \
+            Tensor<idx_t, 2, true>& outIndices, \
             GpuResources* res)
 
 #define IVF_INTERLEAVED_CALL(WARP_Q)    \

--- a/faiss/gpu/perf/PerfBinaryFlat.cu
+++ b/faiss/gpu/perf/PerfBinaryFlat.cu
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
 
     // Time faiss CPU
     HostTensor<int, 2, true> cpuDistances({numQueries, FLAGS_k});
-    HostTensor<faiss::IndexBinary::idx_t, 2, true> cpuIndices(
+    HostTensor<faiss::idx_t, 2, true> cpuIndices(
             {numQueries, FLAGS_k});
 
     if (FLAGS_cpu) {
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
     }
 
     HostTensor<int, 2, true> gpuDistances({numQueries, FLAGS_k});
-    HostTensor<faiss::Index::idx_t, 2, true> gpuIndices({numQueries, FLAGS_k});
+    HostTensor<faiss::idx_t, 2, true> gpuIndices({numQueries, FLAGS_k});
 
     CUDA_VERIFY(cudaProfilerStart());
     faiss::gpu::synchronizeAllDevices();

--- a/faiss/gpu/perf/PerfFlat.cu
+++ b/faiss/gpu/perf/PerfFlat.cu
@@ -95,7 +95,7 @@ int main(int argc, char** argv) {
 
     // Time faiss CPU
     HostTensor<float, 2, true> cpuDistances({numQueries, FLAGS_k});
-    HostTensor<faiss::Index::idx_t, 2, true> cpuIndices({numQueries, FLAGS_k});
+    HostTensor<faiss::idx_t, 2, true> cpuIndices({numQueries, FLAGS_k});
 
     if (FLAGS_cpu) {
         float cpuTime = 0.0f;
@@ -113,7 +113,7 @@ int main(int argc, char** argv) {
     }
 
     HostTensor<float, 2, true> gpuDistances({numQueries, FLAGS_k});
-    HostTensor<faiss::Index::idx_t, 2, true> gpuIndices({numQueries, FLAGS_k});
+    HostTensor<faiss::idx_t, 2, true> gpuIndices({numQueries, FLAGS_k});
 
     CUDA_VERIFY(cudaProfilerStart());
     faiss::gpu::synchronizeAllDevices();

--- a/faiss/gpu/perf/PerfIVFFlat.cu
+++ b/faiss/gpu/perf/PerfIVFFlat.cu
@@ -93,7 +93,7 @@ int main(int argc, char** argv) {
 
     // Time faiss CPU
     HostTensor<float, 2, true> cpuDistances({numQueries, FLAGS_k});
-    HostTensor<faiss::Index::idx_t, 2, true> cpuIndices({numQueries, FLAGS_k});
+    HostTensor<faiss::idx_t, 2, true> cpuIndices({numQueries, FLAGS_k});
 
     float cpuTime = 0.0f;
 
@@ -112,7 +112,7 @@ int main(int argc, char** argv) {
     printf("CPU time %.3f ms\n", cpuTime);
 
     HostTensor<float, 2, true> gpuDistances({numQueries, FLAGS_k});
-    HostTensor<faiss::Index::idx_t, 2, true> gpuIndices({numQueries, FLAGS_k});
+    HostTensor<faiss::idx_t, 2, true> gpuIndices({numQueries, FLAGS_k});
 
     CUDA_VERIFY(cudaProfilerStart());
     faiss::gpu::synchronizeAllDevices();

--- a/faiss/gpu/perf/PerfIVFPQ.cu
+++ b/faiss/gpu/perf/PerfIVFPQ.cu
@@ -103,7 +103,7 @@ int main(int argc, char** argv) {
 
     // Time faiss CPU
     HostTensor<float, 2, true> cpuDistances({numQueries, FLAGS_k});
-    HostTensor<faiss::Index::idx_t, 2, true> cpuIndices({numQueries, FLAGS_k});
+    HostTensor<faiss::idx_t, 2, true> cpuIndices({numQueries, FLAGS_k});
 
     float cpuTime = 0.0f;
 
@@ -122,7 +122,7 @@ int main(int argc, char** argv) {
     printf("CPU time %.3f ms\n", cpuTime);
 
     HostTensor<float, 2, true> gpuDistances({numQueries, FLAGS_k});
-    HostTensor<faiss::Index::idx_t, 2, true> gpuIndices({numQueries, FLAGS_k});
+    HostTensor<faiss::idx_t, 2, true> gpuIndices({numQueries, FLAGS_k});
 
     CUDA_VERIFY(cudaProfilerStart());
     faiss::gpu::synchronizeAllDevices();

--- a/faiss/gpu/test/TestGpuDistance.cu
+++ b/faiss/gpu/test/TestGpuDistance.cu
@@ -60,7 +60,7 @@ void testTransposition(
     cpuIndex.add(numVecs, vecs.data());
 
     std::vector<float> cpuDistance(numQuery * k, 0);
-    std::vector<faiss::Index::idx_t> cpuIndices(numQuery * k, -1);
+    std::vector<faiss::idx_t> cpuIndices(numQuery * k, -1);
 
     cpuIndex.search(
             numQuery, queries.data(), k, cpuDistance.data(), cpuIndices.data());
@@ -97,7 +97,7 @@ void testTransposition(
     runTransposeAny(gpuQueries, 0, 1, queriesT, stream);
 
     std::vector<float> gpuDistance(numQuery * k, 0);
-    std::vector<faiss::Index::idx_t> gpuIndices(numQuery * k, -1);
+    std::vector<faiss::idx_t> gpuIndices(numQuery * k, -1);
 
     GpuDistanceParams args;
     args.metric = metric;

--- a/faiss/gpu/test/TestGpuIndexBinaryFlat.cpp
+++ b/faiss/gpu/test/TestGpuIndexBinaryFlat.cpp
@@ -18,9 +18,9 @@
 
 void compareBinaryDist(
         const std::vector<int>& cpuDist,
-        const std::vector<faiss::IndexBinary::idx_t>& cpuLabels,
+        const std::vector<faiss::idx_t>& cpuLabels,
         const std::vector<int>& gpuDist,
-        const std::vector<faiss::IndexBinary::idx_t>& gpuLabels,
+        const std::vector<faiss::idx_t>& gpuLabels,
         int numQuery,
         int k) {
     for (int i = 0; i < numQuery; ++i) {
@@ -29,8 +29,8 @@ void compareBinaryDist(
         // encounters the values. The last set of equivalent distances seen in
         // the min-k might be truncated, so we can't check that set, but all
         // others we can check.
-        std::set<faiss::IndexBinary::idx_t> cpuLabelSet;
-        std::set<faiss::IndexBinary::idx_t> gpuLabelSet;
+        std::set<faiss::idx_t> cpuLabelSet;
+        std::set<faiss::idx_t> gpuLabelSet;
 
         int curDist = -1;
 
@@ -89,13 +89,13 @@ void testGpuIndexBinaryFlat(int kOverride = -1) {
     auto query = faiss::gpu::randBinaryVecs(numQuery, dims);
 
     std::vector<int> cpuDist(numQuery * k);
-    std::vector<faiss::IndexBinary::idx_t> cpuLabels(numQuery * k);
+    std::vector<faiss::idx_t> cpuLabels(numQuery * k);
 
     cpuIndex.search(
             numQuery, query.data(), k, cpuDist.data(), cpuLabels.data());
 
     std::vector<int> gpuDist(numQuery * k);
-    std::vector<faiss::IndexBinary::idx_t> gpuLabels(numQuery * k);
+    std::vector<faiss::idx_t> gpuLabels(numQuery * k);
 
     gpuIndex.search(
             numQuery, query.data(), k, gpuDist.data(), gpuLabels.data());

--- a/faiss/gpu/test/TestGpuIndexFlat.cpp
+++ b/faiss/gpu/test/TestGpuIndexFlat.cpp
@@ -220,7 +220,7 @@ TEST(TestGpuIndexFlat, QueryEmpty) {
     std::vector<float> queries(numQuery * dim, 1.0f);
 
     std::vector<float> dist(numQuery * k, 0);
-    std::vector<faiss::Index::idx_t> ind(numQuery * k);
+    std::vector<faiss::idx_t> ind(numQuery * k);
 
     gpuIndex.search(numQuery, queries.data(), k, dist.data(), ind.data());
 
@@ -437,7 +437,7 @@ TEST(TestGpuIndexFlat, Residual) {
     cpuIndex.add(numVecs, vecs.data());
     gpuIndex.add(numVecs, vecs.data());
 
-    auto indexVecs = std::vector<faiss::Index::idx_t>{0, 2, 4, 6, 8};
+    auto indexVecs = std::vector<faiss::idx_t>{0, 2, 4, 6, 8};
     auto queryVecs = faiss::gpu::randVecs(indexVecs.size(), dim);
 
     auto residualsCpu = std::vector<float>(indexVecs.size() * dim);
@@ -517,7 +517,7 @@ TEST(TestGpuIndexFlat, Reconstruct) {
 
         // Test reconstruct_batch
         if (false) {
-            auto reconstructKeys = std::vector<faiss::Index::idx_t>{1, 3, 5};
+            auto reconstructKeys = std::vector<faiss::idx_t>{1, 3, 5};
             auto reconstructVecs =
                     std::vector<float>(reconstructKeys.size() * dim);
 
@@ -565,7 +565,7 @@ TEST(TestGpuIndexFlat, SearchAndReconstruct) {
     gpuIndex.add(nb, xb.data());
 
     std::vector<float> refDistance(nq * k, 0);
-    std::vector<faiss::Index::idx_t> refIndices(nq * k, -1);
+    std::vector<faiss::idx_t> refIndices(nq * k, -1);
     std::vector<float> refReconstruct(nq * k * dim, 0);
     cpuIndex.search_and_reconstruct(
             nq,
@@ -576,7 +576,7 @@ TEST(TestGpuIndexFlat, SearchAndReconstruct) {
             refReconstruct.data());
 
     std::vector<float> testDistance(nq * k, 0);
-    std::vector<faiss::Index::idx_t> testIndices(nq * k, -1);
+    std::vector<faiss::idx_t> testIndices(nq * k, -1);
     std::vector<float> testReconstruct(nq * k * dim, 0);
     gpuIndex.search_and_reconstruct(
             nq,
@@ -606,7 +606,7 @@ TEST(TestGpuIndexFlat, SearchAndReconstruct) {
     // above will ensure a decent number of matches), reconstruction should be
     // the same for the vectors that do match
     for (int i = 0; i < nq; ++i) {
-        std::unordered_map<faiss::Index::idx_t, int> refLocation;
+        std::unordered_map<faiss::idx_t, int> refLocation;
 
         for (int j = 0; j < k; ++j) {
             refLocation.insert(std::make_pair(refIndices[i * k + j], j));

--- a/faiss/gpu/test/TestGpuIndexIVFFlat.cpp
+++ b/faiss/gpu/test/TestGpuIndexIVFFlat.cpp
@@ -441,7 +441,7 @@ TEST(TestGpuIndexIVFFlat, QueryNaN) {
             numQuery * opt.dim, std::numeric_limits<float>::quiet_NaN());
 
     std::vector<float> distances(numQuery * opt.k, 0);
-    std::vector<faiss::Index::idx_t> indices(numQuery * opt.k, 0);
+    std::vector<faiss::idx_t> indices(numQuery * opt.k, 0);
 
     gpuIndex.search(
             numQuery, nans.data(), opt.k, distances.data(), indices.data());
@@ -490,7 +490,7 @@ TEST(TestGpuIndexIVFFlat, AddNaN) {
 
     std::vector<float> queryVecs = faiss::gpu::randVecs(opt.numQuery, opt.dim);
     std::vector<float> distance(opt.numQuery * opt.k, 0);
-    std::vector<faiss::Index::idx_t> indices(opt.numQuery * opt.k, 0);
+    std::vector<faiss::idx_t> indices(opt.numQuery * opt.k, 0);
 
     // should not crash
     gpuIndex.search(

--- a/faiss/gpu/test/TestGpuIndexIVFPQ.cpp
+++ b/faiss/gpu/test/TestGpuIndexIVFPQ.cpp
@@ -655,7 +655,7 @@ TEST(TestGpuIndexIVFPQ, QueryNaN) {
             numQuery * opt.dim, std::numeric_limits<float>::quiet_NaN());
 
     std::vector<float> distances(numQuery * opt.k, 0);
-    std::vector<faiss::Index::idx_t> indices(numQuery * opt.k, 0);
+    std::vector<faiss::idx_t> indices(numQuery * opt.k, 0);
 
     gpuIndex.search(
             numQuery, nans.data(), opt.k, distances.data(), indices.data());
@@ -711,7 +711,7 @@ TEST(TestGpuIndexIVFPQ, AddNaN) {
 
     std::vector<float> queryVecs = faiss::gpu::randVecs(opt.numQuery, opt.dim);
     std::vector<float> distance(opt.numQuery * opt.k, 0);
-    std::vector<faiss::Index::idx_t> indices(opt.numQuery * opt.k, 0);
+    std::vector<faiss::idx_t> indices(opt.numQuery * opt.k, 0);
 
     // should not crash
     gpuIndex.search(

--- a/faiss/gpu/test/TestUtils.cpp
+++ b/faiss/gpu/test/TestUtils.cpp
@@ -97,7 +97,7 @@ void compareIndices(
         float pctMaxDiffN) {
     // Compare
     std::vector<float> refDistance(numQuery * k, 0);
-    std::vector<faiss::Index::idx_t> refIndices(numQuery * k, -1);
+    std::vector<faiss::idx_t> refIndices(numQuery * k, -1);
     refIndex.search(
             numQuery,
             queryVecs.data(),
@@ -106,7 +106,7 @@ void compareIndices(
             refIndices.data());
 
     std::vector<float> testDistance(numQuery * k, 0);
-    std::vector<faiss::Index::idx_t> testIndices(numQuery * k, -1);
+    std::vector<faiss::idx_t> testIndices(numQuery * k, -1);
     testIndex.search(
             numQuery,
             queryVecs.data(),
@@ -162,9 +162,9 @@ inline T lookup(const T* p, int i, int j, int /*dim1*/, int dim2) {
 
 void compareLists(
         const float* refDist,
-        const faiss::Index::idx_t* refInd,
+        const faiss::idx_t* refInd,
         const float* testDist,
-        const faiss::Index::idx_t* testInd,
+        const faiss::idx_t* testInd,
         int dim1,
         int dim2,
         const std::string& configMsg,
@@ -181,10 +181,10 @@ void compareLists(
     int numResults = dim1 * dim2;
 
     // query -> {index -> result position}
-    std::vector<std::unordered_map<faiss::Index::idx_t, int>> refIndexMap;
+    std::vector<std::unordered_map<faiss::idx_t, int>> refIndexMap;
 
     for (int query = 0; query < dim1; ++query) {
-        std::unordered_map<faiss::Index::idx_t, int> indices;
+        std::unordered_map<faiss::idx_t, int> indices;
 
         for (int result = 0; result < dim2; ++result) {
             indices[lookup(refInd, query, result, dim1, dim2)] = result;
@@ -208,7 +208,7 @@ void compareLists(
 
     for (int query = 0; query < dim1; ++query) {
         std::vector<int> diffs;
-        std::set<faiss::Index::idx_t> uniqueIndices;
+        std::set<faiss::idx_t> uniqueIndices;
 
         auto& indices = refIndexMap[query];
 

--- a/faiss/gpu/test/TestUtils.h
+++ b/faiss/gpu/test/TestUtils.h
@@ -93,9 +93,9 @@ void compareIndices(
 /// Display specific differences in the two (distance, index) lists
 void compareLists(
         const float* refDist,
-        const faiss::Index::idx_t* refInd,
+        const faiss::idx_t* refInd,
         const float* testDist,
-        const faiss::Index::idx_t* testInd,
+        const faiss::idx_t* testInd,
         int dim1,
         int dim2,
         const std::string& configMsg,
@@ -130,13 +130,13 @@ void testIVFEquality(A& cpuIndex, B& gpuIndex) {
         EXPECT_EQ(cpuCodes, gpuCodes);
 
         // Index equality
-        std::vector<Index::idx_t> cpuIndices(cpuLists->list_size(i));
+        std::vector<idx_t> cpuIndices(cpuLists->list_size(i));
 
         auto si = faiss::InvertedLists::ScopedIds(cpuLists, i);
         std::memcpy(
                 cpuIndices.data(),
                 si.get(),
-                cpuLists->list_size(i) * sizeof(faiss::Index::idx_t));
+                cpuLists->list_size(i) * sizeof(faiss::idx_t));
         EXPECT_EQ(cpuIndices, gpuIndex.getListIndices(i));
     }
 }

--- a/faiss/gpu/test/demo_ivfpq_indexing_gpu.cpp
+++ b/faiss/gpu/test/demo_ivfpq_indexing_gpu.cpp
@@ -130,7 +130,7 @@ int main() {
                k,
                nq);
 
-        std::vector<faiss::Index::idx_t> nns(k * nq);
+        std::vector<faiss::idx_t> nns(k * nq);
         std::vector<float> dis(k * nq);
 
         index.search(nq, queries.data(), k, dis.data(), nns.data());

--- a/faiss/impl/AdditiveQuantizer.h
+++ b/faiss/impl/AdditiveQuantizer.h
@@ -157,7 +157,7 @@ struct AdditiveQuantizer : Quantizer {
      * Support for exhaustive distance computations with all the centroids.
      * Hence, the number of these centroids should not be too large.
      ****************************************************************************/
-    using idx_t = Index::idx_t;
+    
 
     /// decoding function for a code in a 64-bit word
     void decode_64bit(idx_t n, float* x) const;

--- a/faiss/impl/AuxIndexStructures.h
+++ b/faiss/impl/AuxIndexStructures.h
@@ -18,7 +18,7 @@
 #include <mutex>
 #include <vector>
 
-#include <faiss/Index.h>
+#include <faiss/MetricType.h>
 #include <faiss/impl/platform_macros.h>
 
 namespace faiss {
@@ -30,8 +30,6 @@ namespace faiss {
 struct RangeSearchResult {
     size_t nq;    ///< nb of queries
     size_t* lims; ///< size (nq + 1)
-
-    typedef Index::idx_t idx_t;
 
     idx_t* labels;    ///< result for query i is labels[lims[i]:lims[i+1]]
     float* distances; ///< corresponding distances (not sorted)
@@ -62,7 +60,6 @@ struct RangeSearchResult {
 /** List of temporary buffers used to store results before they are
  *  copied to the RangeSearchResult object. */
 struct BufferList {
-    typedef Index::idx_t idx_t;
 
     // buffer sizes in # entries
     size_t buffer_size;
@@ -94,7 +91,6 @@ struct RangeSearchPartialResult;
 
 /// result structure for a single query
 struct RangeQueryResult {
-    using idx_t = Index::idx_t;
     idx_t qno;   //< id of the query
     size_t nres; //< nb of results for this query
     RangeSearchPartialResult* pres;

--- a/faiss/impl/DistanceComputer.h
+++ b/faiss/impl/DistanceComputer.h
@@ -23,7 +23,6 @@ namespace faiss {
  * that has additional methods to handle the inverted list context.
  ***********************************************************/
 struct DistanceComputer {
-    using idx_t = Index::idx_t;
 
     /// called before computing distances. Pointer x should remain valid
     /// while operator () is called

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -509,7 +509,6 @@ void HNSW::add_with_locks(
 
 namespace {
 
-using idx_t = HNSW::idx_t;
 using MinimaxHeap = HNSW::MinimaxHeap;
 using Node = HNSW::Node;
 /** Do a BFS on the candidates list */

--- a/faiss/impl/HNSW.h
+++ b/faiss/impl/HNSW.h
@@ -52,10 +52,7 @@ struct SearchParametersHNSW : SearchParameters {
 
 struct HNSW {
     /// internal storage of vectors (32 bits: this is expensive)
-    typedef int storage_idx_t;
-
-    /// Faiss results are 64-bit
-    typedef Index::idx_t idx_t;
+    using storage_idx_t = int32_t;
 
     typedef std::pair<float, storage_idx_t> Node;
 

--- a/faiss/impl/IDSelector.cpp
+++ b/faiss/impl/IDSelector.cpp
@@ -92,7 +92,7 @@ IDSelectorBatch::IDSelectorBatch(size_t n, const idx_t* indices) {
     mask = ((idx_t)1 << nbits) - 1;
     bloom.resize((idx_t)1 << (nbits - 3), 0);
     for (idx_t i = 0; i < n; i++) {
-        Index::idx_t id = indices[i];
+        idx_t id = indices[i];
         set.insert(id);
         id &= mask;
         bloom[id >> 3] |= 1 << (id & 7);

--- a/faiss/impl/IDSelector.h
+++ b/faiss/impl/IDSelector.h
@@ -19,7 +19,6 @@ namespace faiss {
 
 /** Encapsulates a set of ids to handle. */
 struct IDSelector {
-    using idx_t = Index::idx_t;
     virtual bool is_member(idx_t id) const = 0;
     virtual ~IDSelector() {}
 };

--- a/faiss/impl/NNDescent.h
+++ b/faiss/impl/NNDescent.h
@@ -90,7 +90,7 @@ struct Nhood {
 
 struct NNDescent {
     using storage_idx_t = int;
-    using idx_t = Index::idx_t;
+    
 
     using KNNGraph = std::vector<nndescent::Nhood>;
 

--- a/faiss/impl/NSG.cpp
+++ b/faiss/impl/NSG.cpp
@@ -29,7 +29,7 @@ constexpr int EMPTY_ID = -1;
    distances. This makes supporting INNER_PRODUCE search easier */
 
 struct NegativeDistanceComputer : DistanceComputer {
-    using idx_t = Index::idx_t;
+    
 
     /// owned by this
     DistanceComputer* basedis;

--- a/faiss/impl/NSG.h
+++ b/faiss/impl/NSG.h
@@ -98,10 +98,7 @@ DistanceComputer* storage_distance_computer(const Index* storage);
 
 struct NSG {
     /// internal storage of vectors (32 bits: this is expensive)
-    using storage_idx_t = int;
-
-    /// Faiss results are 64-bit
-    using idx_t = Index::idx_t;
+    using storage_idx_t = int32_t;
 
     int ntotal; ///< nb of nodes
 

--- a/faiss/impl/ProductQuantizer.h
+++ b/faiss/impl/ProductQuantizer.h
@@ -23,7 +23,7 @@ namespace faiss {
 
 /** Product Quantizer. Implemented only for METRIC_L2 */
 struct ProductQuantizer : Quantizer {
-    using idx_t = Index::idx_t;
+    
 
     size_t M;     ///< number of subquantizers
     size_t nbits; ///< number of bits per quantization index

--- a/faiss/impl/Quantizer.h
+++ b/faiss/impl/Quantizer.h
@@ -8,7 +8,7 @@ namespace faiss {
 
 /** Product Quantizer. Implemented only for METRIC_L2 */
 struct Quantizer {
-    using idx_t = Index::idx_t;
+    
 
     size_t d;         ///< size of the input vectors
     size_t code_size; ///< bytes per indexed vector

--- a/faiss/impl/ResidualQuantizer.cpp
+++ b/faiss/impl/ResidualQuantizer.cpp
@@ -143,7 +143,7 @@ void beam_search_encode_step(
     // we have to fill in the whole output matrix
     FAISS_THROW_IF_NOT(new_beam_size <= beam_size * K);
 
-    using idx_t = Index::idx_t;
+    
 
     std::vector<float> cent_distances;
     std::vector<idx_t> cent_ids;
@@ -545,7 +545,7 @@ size_t ResidualQuantizer::memory_per_point(int beam_size) const {
     mem = beam_size * d * 2 * sizeof(float); // size for 2 beams at a time
     mem += beam_size * beam_size *
             (sizeof(float) +
-             sizeof(Index::idx_t)); // size for 1 beam search result
+             sizeof(idx_t)); // size for 1 beam search result
     return mem;
 }
 

--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -54,7 +54,7 @@ namespace faiss {
 
 namespace {
 
-typedef Index::idx_t idx_t;
+
 typedef ScalarQuantizer::QuantizerType QuantizerType;
 typedef ScalarQuantizer::RangeStat RangeStat;
 using SQDistanceComputer = ScalarQuantizer::SQDistanceComputer;
@@ -1131,7 +1131,7 @@ void ScalarQuantizer::train_residual(
     ScopeDeleter<float> del_x(x_in == x ? nullptr : x);
 
     if (by_residual) {
-        std::vector<Index::idx_t> idx(n);
+        std::vector<idx_t> idx(n);
         quantizer->assign(n, x, idx.data());
 
         std::vector<float> residuals(n * d);

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -65,7 +65,7 @@ namespace faiss {
 static void read_index_header(Index* idx, IOReader* f) {
     READ1(idx->d);
     READ1(idx->ntotal);
-    Index::idx_t dummy;
+    idx_t dummy;
     READ1(dummy);
     READ1(dummy);
     READ1(idx->is_trained);
@@ -439,7 +439,7 @@ static void read_direct_map(DirectMap* dm, IOReader* f) {
     dm->type = (DirectMap::Type)maintain_direct_map;
     READVECTOR(dm->array);
     if (dm->type == DirectMap::Hashtable) {
-        using idx_t = Index::idx_t;
+        
         std::vector<std::pair<idx_t, idx_t>> v;
         READVECTOR(v);
         std::unordered_map<idx_t, idx_t>& map = dm->hashtable;
@@ -453,7 +453,7 @@ static void read_direct_map(DirectMap* dm, IOReader* f) {
 static void read_ivf_header(
         IndexIVF* ivf,
         IOReader* f,
-        std::vector<std::vector<Index::idx_t>>* ids = nullptr) {
+        std::vector<std::vector<idx_t>>* ids = nullptr) {
     read_index_header(ivf, f);
     READ1(ivf->nlist);
     READ1(ivf->nprobe);
@@ -470,7 +470,7 @@ static void read_ivf_header(
 // used for legacy formats
 static ArrayInvertedLists* set_array_invlist(
         IndexIVF* ivf,
-        std::vector<std::vector<Index::idx_t>>& ids) {
+        std::vector<std::vector<idx_t>>& ids) {
     ArrayInvertedLists* ail =
             new ArrayInvertedLists(ivf->nlist, ivf->code_size);
     std::swap(ail->ids, ids);
@@ -487,7 +487,7 @@ static IndexIVFPQ* read_ivfpq(IOReader* f, uint32_t h, int io_flags) {
             : nullptr;
     IndexIVFPQ* ivpq = ivfpqr ? ivfpqr : new IndexIVFPQ();
 
-    std::vector<std::vector<Index::idx_t>> ids;
+    std::vector<std::vector<idx_t>> ids;
     read_ivf_header(ivpq, f, legacy ? &ids : nullptr);
     READ1(ivpq->by_residual);
     READ1(ivpq->code_size);
@@ -731,7 +731,7 @@ Index* read_index(IOReader* f, int io_flags) {
         idx = ivaqfs;
     } else if (h == fourcc("IvFl") || h == fourcc("IvFL")) { // legacy
         IndexIVFFlat* ivfl = new IndexIVFFlat();
-        std::vector<std::vector<Index::idx_t>> ids;
+        std::vector<std::vector<idx_t>> ids;
         read_ivf_header(ivfl, f, &ids);
         ivfl->code_size = ivfl->d * sizeof(float);
         ArrayInvertedLists* ail = set_array_invlist(ivfl, ids);
@@ -754,10 +754,10 @@ Index* read_index(IOReader* f, int io_flags) {
         read_ivf_header(ivfl, f);
         ivfl->code_size = ivfl->d * sizeof(float);
         {
-            std::vector<Index::idx_t> tab;
+            std::vector<idx_t> tab;
             READVECTOR(tab);
             for (long i = 0; i < tab.size(); i += 2) {
-                std::pair<Index::idx_t, Index::idx_t> pair(tab[i], tab[i + 1]);
+                std::pair<idx_t, idx_t> pair(tab[i], tab[i + 1]);
                 ivfl->instances.insert(pair);
             }
         }
@@ -788,7 +788,7 @@ Index* read_index(IOReader* f, int io_flags) {
         idx = idxl;
     } else if (h == fourcc("IvSQ")) { // legacy
         IndexIVFScalarQuantizer* ivsc = new IndexIVFScalarQuantizer();
-        std::vector<std::vector<Index::idx_t>> ids;
+        std::vector<std::vector<idx_t>> ids;
         read_ivf_header(ivsc, f, &ids);
         read_ScalarQuantizer(&ivsc->sq, f);
         READ1(ivsc->code_size);
@@ -1072,7 +1072,7 @@ static void read_index_binary_header(IndexBinary* idx, IOReader* f) {
 static void read_binary_ivf_header(
         IndexBinaryIVF* ivf,
         IOReader* f,
-        std::vector<std::vector<Index::idx_t>>* ids = nullptr) {
+        std::vector<std::vector<idx_t>>* ids = nullptr) {
     read_index_binary_header(ivf, f);
     READ1(ivf->nlist);
     READ1(ivf->nprobe);

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -84,7 +84,7 @@ namespace faiss {
 static void write_index_header(const Index* idx, IOWriter* f) {
     WRITE1(idx->d);
     WRITE1(idx->ntotal);
-    Index::idx_t dummy = 1 << 20;
+    idx_t dummy = 1 << 20;
     WRITE1(dummy);
     WRITE1(dummy);
     WRITE1(idx->is_trained);
@@ -373,7 +373,7 @@ static void write_direct_map(const DirectMap* dm, IOWriter* f) {
     WRITE1(maintain_direct_map);
     WRITEVECTOR(dm->array);
     if (dm->type == DirectMap::Hashtable) {
-        using idx_t = Index::idx_t;
+        
         std::vector<std::pair<idx_t, idx_t>> v;
         const std::unordered_map<idx_t, idx_t>& map = dm->hashtable;
         v.resize(map.size());
@@ -615,7 +615,7 @@ void write_index(const Index* idx, IOWriter* f) {
         WRITE1(h);
         write_ivf_header(ivfl, f);
         {
-            std::vector<Index::idx_t> tab(2 * ivfl->instances.size());
+            std::vector<idx_t> tab(2 * ivfl->instances.size());
             long i = 0;
             for (auto it = ivfl->instances.begin(); it != ivfl->instances.end();
                  ++it) {
@@ -900,7 +900,7 @@ static void write_binary_multi_hash_map(
         size_t ntotal,
         IOWriter* f) {
     int id_bits = 0;
-    while ((ntotal > ((Index::idx_t)1 << id_bits))) {
+    while ((ntotal > ((idx_t)1 << id_bits))) {
         id_bits++;
     }
     WRITE1(id_bits);

--- a/faiss/impl/kmeans1d.cpp
+++ b/faiss/impl/kmeans1d.cpp
@@ -20,7 +20,7 @@
 
 namespace faiss {
 
-using idx_t = Index::idx_t;
+
 using LookUpFunc = std::function<float(idx_t, idx_t)>;
 
 void reduce(

--- a/faiss/impl/kmeans1d.h
+++ b/faiss/impl/kmeans1d.h
@@ -22,10 +22,10 @@ namespace faiss {
  * @param argmins  argmin of each row
  */
 void smawk(
-        const Index::idx_t nrows,
-        const Index::idx_t ncols,
+        const idx_t nrows,
+        const idx_t ncols,
         const float* x,
-        Index::idx_t* argmins);
+        idx_t* argmins);
 
 /** Exact 1D K-Means by dynamic programming
  *

--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -7,6 +7,10 @@
 
 #pragma once
 
+// basic int types and size_t
+#include <cstdint>
+#include <cstdio>
+
 #ifdef _MSC_VER
 
 /*******************************************************
@@ -87,3 +91,9 @@ inline int __builtin_clzll(uint64_t x) {
 #define ALIGNED(x) __attribute__((aligned(x)))
 
 #endif // _MSC_VER
+
+#if defined(__GNUC__) || defined(__clang__)
+#define FAISS_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#else
+#define FAISS_DEPRECATED(msg)
+#endif // GCC or Clang

--- a/faiss/invlists/BlockInvertedLists.cpp
+++ b/faiss/invlists/BlockInvertedLists.cpp
@@ -61,7 +61,7 @@ const uint8_t* BlockInvertedLists::get_codes(size_t list_no) const {
     return codes[list_no].get();
 }
 
-const InvertedLists::idx_t* BlockInvertedLists::get_ids(size_t list_no) const {
+const idx_t* BlockInvertedLists::get_ids(size_t list_no) const {
     assert(list_no < nlist);
     return ids[list_no].data();
 }

--- a/faiss/invlists/DirectMap.cpp
+++ b/faiss/invlists/DirectMap.cpp
@@ -68,7 +68,7 @@ void DirectMap::clear() {
     hashtable.clear();
 }
 
-DirectMap::idx_t DirectMap::get(idx_t key) const {
+idx_t DirectMap::get(idx_t key) const {
     if (type == Array) {
         FAISS_THROW_IF_NOT_MSG(key >= 0 && key < array.size(), "invalid key");
         idx_t lo = array[key];

--- a/faiss/invlists/DirectMap.h
+++ b/faiss/invlists/DirectMap.h
@@ -15,6 +15,8 @@
 
 namespace faiss {
 
+struct IDSelector;
+
 // When offsets list id + offset are encoded in an uint64
 // we call this LO = list-offset
 
@@ -34,8 +36,6 @@ inline uint64_t lo_offset(uint64_t lo) {
  * Direct map: a way to map back from ids to inverted lists
  */
 struct DirectMap {
-    typedef Index::idx_t idx_t;
-
     enum Type {
         NoMap = 0,    // default
         Array = 1,    // sequential ids (only for add, no add_with_ids)
@@ -91,8 +91,6 @@ struct DirectMap {
 
 /// Thread-safe way of updating the direct_map
 struct DirectMapAdd {
-    typedef Index::idx_t idx_t;
-
     using Type = DirectMap::Type;
 
     DirectMap& direct_map;

--- a/faiss/invlists/InvertedLists.cpp
+++ b/faiss/invlists/InvertedLists.cpp
@@ -25,8 +25,7 @@ InvertedLists::InvertedLists(size_t nlist, size_t code_size)
 
 InvertedLists::~InvertedLists() {}
 
-InvertedLists::idx_t InvertedLists::get_single_id(size_t list_no, size_t offset)
-        const {
+idx_t InvertedLists::get_single_id(size_t list_no, size_t offset) const {
     assert(offset < list_size(list_no));
     const idx_t* ids = get_ids(list_no);
     idx_t id = ids[offset];
@@ -158,7 +157,7 @@ const uint8_t* ArrayInvertedLists::get_codes(size_t list_no) const {
     return codes[list_no].data();
 }
 
-const InvertedLists::idx_t* ArrayInvertedLists::get_ids(size_t list_no) const {
+const idx_t* ArrayInvertedLists::get_ids(size_t list_no) const {
     assert(list_no < nlist);
     return ids[list_no].data();
 }
@@ -267,7 +266,7 @@ void HStackInvertedLists::release_codes(size_t, const uint8_t* codes) const {
     delete[] codes;
 }
 
-const Index::idx_t* HStackInvertedLists::get_ids(size_t list_no) const {
+const idx_t* HStackInvertedLists::get_ids(size_t list_no) const {
     idx_t *ids = new idx_t[list_size(list_no)], *c = ids;
 
     for (int i = 0; i < ils.size(); i++) {
@@ -281,8 +280,7 @@ const Index::idx_t* HStackInvertedLists::get_ids(size_t list_no) const {
     return ids;
 }
 
-Index::idx_t HStackInvertedLists::get_single_id(size_t list_no, size_t offset)
-        const {
+idx_t HStackInvertedLists::get_single_id(size_t list_no, size_t offset) const {
     for (int i = 0; i < ils.size(); i++) {
         const InvertedLists* il = ils[i];
         size_t sz = il->list_size(list_no);
@@ -311,8 +309,6 @@ void HStackInvertedLists::prefetch_lists(const idx_t* list_nos, int nlist)
  ******************************************/
 
 namespace {
-
-using idx_t = InvertedLists::idx_t;
 
 idx_t translate_list_no(const SliceInvertedLists* sil, idx_t list_no) {
     FAISS_THROW_IF_NOT(list_no >= 0 && list_no < sil->nlist);
@@ -349,12 +345,11 @@ void SliceInvertedLists::release_codes(size_t list_no, const uint8_t* codes)
     return il->release_codes(translate_list_no(this, list_no), codes);
 }
 
-const Index::idx_t* SliceInvertedLists::get_ids(size_t list_no) const {
+const idx_t* SliceInvertedLists::get_ids(size_t list_no) const {
     return il->get_ids(translate_list_no(this, list_no));
 }
 
-Index::idx_t SliceInvertedLists::get_single_id(size_t list_no, size_t offset)
-        const {
+idx_t SliceInvertedLists::get_single_id(size_t list_no, size_t offset) const {
     return il->get_single_id(translate_list_no(this, list_no), offset);
 }
 
@@ -379,8 +374,6 @@ void SliceInvertedLists::prefetch_lists(const idx_t* list_nos, int nlist)
  ******************************************/
 
 namespace {
-
-using idx_t = InvertedLists::idx_t;
 
 // find the invlist this number belongs to
 int translate_list_no(const VStackInvertedLists* vil, idx_t list_no) {
@@ -449,14 +442,13 @@ void VStackInvertedLists::release_codes(size_t list_no, const uint8_t* codes)
     return ils[i]->release_codes(list_no, codes);
 }
 
-const Index::idx_t* VStackInvertedLists::get_ids(size_t list_no) const {
+const idx_t* VStackInvertedLists::get_ids(size_t list_no) const {
     int i = translate_list_no(this, list_no);
     list_no -= cumsz[i];
     return ils[i]->get_ids(list_no);
 }
 
-Index::idx_t VStackInvertedLists::get_single_id(size_t list_no, size_t offset)
-        const {
+idx_t VStackInvertedLists::get_single_id(size_t list_no, size_t offset) const {
     int i = translate_list_no(this, list_no);
     list_no -= cumsz[i];
     return ils[i]->get_single_id(list_no, offset);

--- a/faiss/invlists/InvertedLists.h
+++ b/faiss/invlists/InvertedLists.h
@@ -15,7 +15,7 @@
  * the interface.
  */
 
-#include <faiss/Index.h>
+#include <faiss/MetricType.h>
 #include <vector>
 
 namespace faiss {
@@ -28,8 +28,6 @@ namespace faiss {
  *   are allowed
  */
 struct InvertedLists {
-    typedef Index::idx_t idx_t;
-
     size_t nlist;     ///< number of possible key values
     size_t code_size; ///< code size per vector in bytes
 

--- a/faiss/invlists/OnDiskInvertedLists.cpp
+++ b/faiss/invlists/OnDiskInvertedLists.cpp
@@ -154,7 +154,7 @@ struct OnDiskInvertedLists::OngoingPrefetch {
             const OnDiskInvertedLists* od = pf->od;
             od->locks->lock_1(list_no);
             size_t n = od->list_size(list_no);
-            const Index::idx_t* idx = od->get_ids(list_no);
+            const idx_t* idx = od->get_ids(list_no);
             const uint8_t* codes = od->get_codes(list_no);
             int cs = 0;
             for (size_t i = 0; i < n; i++) {
@@ -389,7 +389,7 @@ const uint8_t* OnDiskInvertedLists::get_codes(size_t list_no) const {
     return ptr + lists[list_no].offset;
 }
 
-const Index::idx_t* OnDiskInvertedLists::get_ids(size_t list_no) const {
+const idx_t* OnDiskInvertedLists::get_ids(size_t list_no) const {
     if (lists[list_no].offset == INVALID_OFFSET) {
         return nullptr;
     }
@@ -781,7 +781,7 @@ InvertedLists* OnDiskInvertedListsIOHook::read_ArrayInvertedLists(
         OnDiskInvertedLists::List& l = ails->lists[i];
         l.size = l.capacity = sizes[i];
         l.offset = o;
-        o += l.size * (sizeof(OnDiskInvertedLists::idx_t) + ails->code_size);
+        o += l.size * (sizeof(idx_t) + ails->code_size);
     }
     // resume normal reading of file
     fseek(fdesc, o, SEEK_SET);

--- a/faiss/python/python_callbacks.cpp
+++ b/faiss/python/python_callbacks.cpp
@@ -118,7 +118,7 @@ PyCallbackIDSelector::PyCallbackIDSelector(PyObject* callback)
     Py_INCREF(callback);
 }
 
-bool PyCallbackIDSelector::is_member(idx_t id) const {
+bool PyCallbackIDSelector::is_member(faiss::idx_t id) const {
     FAISS_THROW_IF_NOT((id >> 32) == 0);
     PyThreadLock gil;
     PyObject* result = PyObject_CallFunction(callback, "(n)", int(id));

--- a/faiss/python/python_callbacks.h
+++ b/faiss/python/python_callbacks.h
@@ -54,7 +54,7 @@ struct PyCallbackIDSelector : faiss::IDSelector {
 
     explicit PyCallbackIDSelector(PyObject* callback);
 
-    bool is_member(idx_t id) const override;
+    bool is_member(faiss::idx_t id) const override;
 
     ~PyCallbackIDSelector() override;
 };

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -1006,8 +1006,8 @@ float * cast_integer_to_float_ptr (int64_t x) {
     return (float*)x;
 }
 
-faiss::Index::idx_t* cast_integer_to_idx_t_ptr (int64_t x) {
-    return (faiss::Index::idx_t*)x;
+faiss::idx_t* cast_integer_to_idx_t_ptr (int64_t x) {
+    return (faiss::idx_t*)x;
 }
 
 int * cast_integer_to_int_ptr (int64_t x) {

--- a/faiss/utils/extra_distances.cpp
+++ b/faiss/utils/extra_distances.cpp
@@ -92,7 +92,7 @@ void knn_extra_metrics_template(
 template <class VD>
 struct ExtraDistanceComputer : FlatCodesDistanceComputer {
     VD vd;
-    Index::idx_t nb;
+    idx_t nb;
     const float* q;
     const float* b;
 

--- a/tests/test_binary_flat.cpp
+++ b/tests/test_binary_flat.cpp
@@ -42,7 +42,7 @@ TEST(BinaryFlat, accuracy) {
         }
 
         int k = 5;
-        std::vector<faiss::IndexBinary::idx_t> nns(k * nq);
+        std::vector<faiss::idx_t> nns(k * nq);
         std::vector<int> dis(k * nq);
 
         index.search(nq, queries.data(), k, dis.data(), nns.data());

--- a/tests/test_dealloc_invlists.cpp
+++ b/tests/test_dealloc_invlists.cpp
@@ -24,7 +24,7 @@ using namespace faiss;
 
 namespace {
 
-typedef Index::idx_t idx_t;
+
 
 // dimension of the vectors to index
 int d = 32;

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -11,7 +11,7 @@ import os
 import io
 import sys
 import pickle
-from multiprocessing.dummy import Pool as ThreadPool
+from multiprocessing.pool import ThreadPool
 
 
 class TestIOVariants(unittest.TestCase):

--- a/tests/test_ivfpq_codec.cpp
+++ b/tests/test_ivfpq_codec.cpp
@@ -34,7 +34,7 @@ double eval_codec_error(long ncentroids, long m, const std::vector<float>& v) {
 
     // encode and decode to compute reconstruction error
 
-    std::vector<faiss::Index::idx_t> keys(nb);
+    std::vector<faiss::idx_t> keys(nb);
     std::vector<uint8_t> codes(nb * m);
     index.encode_multiple(nb, keys.data(), v.data(), codes.data(), true);
 

--- a/tests/test_ivfpq_indexing.cpp
+++ b/tests/test_ivfpq_indexing.cpp
@@ -71,14 +71,14 @@ TEST(IVFPQ, accuracy) {
             queries[i] = distrib(rng);
         }
 
-        std::vector<faiss::Index::idx_t> gt_nns(nq);
+        std::vector<faiss::idx_t> gt_nns(nq);
         std::vector<float> gt_dis(nq);
 
         index_gt.search(nq, queries.data(), 1, gt_dis.data(), gt_nns.data());
 
         index.nprobe = 5;
         int k = 5;
-        std::vector<faiss::Index::idx_t> nns(k * nq);
+        std::vector<faiss::idx_t> nns(k * nq);
         std::vector<float> dis(k * nq);
 
         index.search(nq, queries.data(), k, dis.data(), nns.data());

--- a/tests/test_lowlevel_ivf.cpp
+++ b/tests/test_lowlevel_ivf.cpp
@@ -29,7 +29,7 @@ using namespace faiss;
 
 namespace {
 
-typedef Index::idx_t idx_t;
+
 
 // dimension of the vectors to index
 int d = 32;

--- a/tests/test_mem_leak.cpp
+++ b/tests/test_mem_leak.cpp
@@ -40,7 +40,7 @@ TEST(MEM_LEAK, ivfflat) {
         double t0 = getmillisecs();
 
         for (int i = 0; i < N2; i++) {
-            std::vector<Index::idx_t> I(10 * bs);
+            std::vector<idx_t> I(10 * bs);
             std::vector<float> D(10 * bs);
 
             tfidf_faiss_index.search(

--- a/tests/test_merge.cpp
+++ b/tests/test_merge.cpp
@@ -48,7 +48,7 @@ struct Tempfilename {
 
 pthread_mutex_t Tempfilename::mutex = PTHREAD_MUTEX_INITIALIZER;
 
-typedef faiss::Index::idx_t idx_t;
+typedef faiss::idx_t idx_t;
 
 // parameters to use for the test
 int d = 64;

--- a/tests/test_ondisk_ivf.cpp
+++ b/tests/test_ondisk_ivf.cpp
@@ -80,10 +80,10 @@ TEST(ONDISK, make_invlists) {
     int ntot = 0;
     for (int i = 0; i < nlist; i++) {
         int size = ivf.list_size(i);
-        const faiss::Index::idx_t* ids = ivf.get_ids(i);
+        const faiss::idx_t* ids = ivf.get_ids(i);
         const uint8_t* codes = ivf.get_codes(i);
         for (int j = 0; j < size; j++) {
-            faiss::Index::idx_t id = ids[j];
+            faiss::idx_t id = ids[j];
             const int* ar = (const int*)&codes[code_size * j];
             EXPECT_EQ(ar[0], id);
             EXPECT_EQ(ar[1], i);
@@ -113,7 +113,7 @@ TEST(ONDISK, test_add) {
     faiss::float_rand(xq.data(), d * nq, 34567);
 
     std::vector<float> ref_D(nq * k);
-    std::vector<faiss::Index::idx_t> ref_I(nq * k);
+    std::vector<faiss::idx_t> ref_I(nq * k);
 
     index.search(nq, xq.data(), k, ref_D.data(), ref_I.data());
 
@@ -131,7 +131,7 @@ TEST(ONDISK, test_add) {
         index2.add(nb, xb.data());
 
         std::vector<float> new_D(nq * k);
-        std::vector<faiss::Index::idx_t> new_I(nq * k);
+        std::vector<faiss::idx_t> new_I(nq * k);
 
         index2.search(nq, xq.data(), k, new_D.data(), new_I.data());
 
@@ -146,7 +146,7 @@ TEST(ONDISK, test_add) {
         faiss::Index* index3 = faiss::read_index(filename2.c_str());
 
         std::vector<float> new_D(nq * k);
-        std::vector<faiss::Index::idx_t> new_I(nq * k);
+        std::vector<faiss::idx_t> new_I(nq * k);
 
         index3->search(nq, xq.data(), k, new_D.data(), new_I.data());
 
@@ -192,10 +192,10 @@ TEST(ONDISK, make_invlists_threaded) {
     int ntot = 0;
     for (int i = 0; i < nlist; i++) {
         int size = ivf.list_size(i);
-        const faiss::Index::idx_t* ids = ivf.get_ids(i);
+        const faiss::idx_t* ids = ivf.get_ids(i);
         const uint8_t* codes = ivf.get_codes(i);
         for (int j = 0; j < size; j++) {
-            faiss::Index::idx_t id = ids[j];
+            faiss::idx_t id = ids[j];
             const int* ar = (const int*)&codes[code_size * j];
             EXPECT_EQ(ar[0], id);
             EXPECT_EQ(ar[1], i);

--- a/tests/test_pairs_decoding.cpp
+++ b/tests/test_pairs_decoding.cpp
@@ -21,7 +21,7 @@
 
 namespace {
 
-typedef faiss::Index::idx_t idx_t;
+typedef faiss::idx_t idx_t;
 
 /*************************************************************
  * Test utils

--- a/tests/test_params_override.cpp
+++ b/tests/test_params_override.cpp
@@ -27,7 +27,7 @@ using namespace faiss;
 
 namespace {
 
-typedef Index::idx_t idx_t;
+
 
 // dimension of the vectors to index
 int d = 32;

--- a/tests/test_sliding_ivf.cpp
+++ b/tests/test_sliding_ivf.cpp
@@ -22,7 +22,7 @@
 
 using namespace faiss;
 
-typedef Index::idx_t idx_t;
+
 
 // dimension of the vectors to index
 int d = 32;
@@ -81,7 +81,7 @@ void make_index_slices(
         Index* index = sub_indexes.back().get();
 
         auto xb = make_data(nb * d);
-        std::vector<faiss::Index::idx_t> ids(nb);
+        std::vector<faiss::idx_t> ids(nb);
         std::mt19937 rng;
         std::uniform_int_distribution<> distrib;
         for (int j = 0; j < nb; j++) {

--- a/tests/test_threaded_index.cpp
+++ b/tests/test_threaded_index.cpp
@@ -19,6 +19,8 @@ namespace {
 
 struct TestException : public std::exception {};
 
+using idx_t = faiss::idx_t;
+
 struct MockIndex : public faiss::Index {
     explicit MockIndex(idx_t d) : faiss::Index(d) {
         resetMock();
@@ -66,7 +68,7 @@ struct MockIndex : public faiss::Index {
 
 template <typename IndexT>
 struct MockThreadedIndex : public faiss::ThreadedIndex<IndexT> {
-    using idx_t = faiss::Index::idx_t;
+    using idx_t = faiss::idx_t;
 
     explicit MockThreadedIndex(bool threaded)
             : faiss::ThreadedIndex<IndexT>(threaded) {}
@@ -178,7 +180,7 @@ TEST(ThreadedIndex, TestReplica) {
 
         std::vector<float> x(n * d);
         std::vector<float> distances(n * k);
-        std::vector<faiss::Index::idx_t> labels(n * k);
+        std::vector<faiss::idx_t> labels(n * k);
 
         replica.add(n, x.data());
 
@@ -227,7 +229,7 @@ TEST(ThreadedIndex, TestShards) {
 
         std::vector<float> x(n * d);
         std::vector<float> distances(n * k);
-        std::vector<faiss::Index::idx_t> labels(n * k);
+        std::vector<faiss::idx_t> labels(n * k);
 
         shards.add(n, x.data());
 

--- a/tests/test_transfer_invlists.cpp
+++ b/tests/test_transfer_invlists.cpp
@@ -33,7 +33,7 @@ int nlist = 40;
 
 using namespace faiss;
 
-typedef faiss::Index::idx_t idx_t;
+typedef faiss::idx_t idx_t;
 
 std::vector<float> get_data(size_t nb, int seed) {
     std::vector<float> x(nb * d);

--- a/tutorial/cpp/1-Flat.cpp
+++ b/tutorial/cpp/1-Flat.cpp
@@ -12,7 +12,7 @@
 #include <faiss/IndexFlat.h>
 
 // 64-bit int
-using idx_t = faiss::Index::idx_t;
+using idx_t = faiss::idx_t;
 
 int main() {
     int d = 64;      // dimension

--- a/tutorial/cpp/2-IVFFlat.cpp
+++ b/tutorial/cpp/2-IVFFlat.cpp
@@ -13,7 +13,7 @@
 #include <faiss/IndexFlat.h>
 #include <faiss/IndexIVFFlat.h>
 
-using idx_t = faiss::Index::idx_t;
+using idx_t = faiss::idx_t;
 
 int main() {
     int d = 64;      // dimension

--- a/tutorial/cpp/3-IVFPQ.cpp
+++ b/tutorial/cpp/3-IVFPQ.cpp
@@ -12,7 +12,7 @@
 #include <faiss/IndexFlat.h>
 #include <faiss/IndexIVFPQ.h>
 
-using idx_t = faiss::Index::idx_t;
+using idx_t = faiss::idx_t;
 
 int main() {
     int d = 64;      // dimension


### PR DESCRIPTION
Summary:
A few more or less cosmetic improvements
* Index::idx_t was in the Index object, which does not make much sense, this diff moves it to faiss::idx_t
* replace multiprocessing.dummy with multiprocessing.pool
* add Alexandr as a core contributor of Faiss in the README ;-)

```
for i in $( find . -name \*.cu -o -name \*.cuh -o -name \*.h -o -name \*.cpp ) ; do
  sed -i s/Index::idx_t/idx_t/ $i
done
```

Differential Revision: D41437507

