### PR TITLE
Faiss GPU: add device specifier for bfKnn

### DIFF
--- a/contrib/torch_utils.py
+++ b/contrib/torch_utils.py
@@ -490,10 +490,10 @@ for symbol in dir(faiss_module):
             handle_torch_Index(the_class)
 
 # allows torch tensor usage with bfKnn
-def torch_replacement_knn_gpu(res, xq, xb, k, D=None, I=None, metric=faiss.METRIC_L2):
+def torch_replacement_knn_gpu(res, xq, xb, k, D=None, I=None, metric=faiss.METRIC_L2, device=-1):
     if type(xb) is np.ndarray:
         # Forward to faiss __init__.py base method
-        return faiss.knn_gpu_numpy(res, xq, xb, k, D, I, metric)
+        return faiss.knn_gpu_numpy(res, xq, xb, k, D, I, metric, device)
 
     nb, d = xb.size()
     if xb.is_contiguous():
@@ -570,6 +570,7 @@ def torch_replacement_knn_gpu(res, xq, xb, k, D=None, I=None, metric=faiss.METRI
     args.outDistances = D_ptr
     args.outIndices = I_ptr
     args.outIndicesType = I_type
+    args.device = device
 
     with using_stream(res):
         faiss.bfKnn(res, args)
@@ -579,7 +580,7 @@ def torch_replacement_knn_gpu(res, xq, xb, k, D=None, I=None, metric=faiss.METRI
 torch_replace_method(faiss_module, 'knn_gpu', torch_replacement_knn_gpu, True, True)
 
 # allows torch tensor usage with bfKnn for all pairwise distances
-def torch_replacement_pairwise_distance_gpu(res, xq, xb, D=None, metric=faiss.METRIC_L2):
+def torch_replacement_pairwise_distance_gpu(res, xq, xb, D=None, metric=faiss.METRIC_L2, device=-1):
     if type(xb) is np.ndarray:
         # Forward to faiss __init__.py base method
         return faiss.pairwise_distance_gpu_numpy(res, xq, xb, D, metric)
@@ -643,6 +644,7 @@ def torch_replacement_pairwise_distance_gpu(res, xq, xb, D=None, metric=faiss.ME
     args.queryType = xq_type
     args.numQueries = nq
     args.outDistances = D_ptr
+    args.device = device
 
     with using_stream(res):
         faiss.bfKnn(res, args)

--- a/faiss/gpu/GpuDistance.h
+++ b/faiss/gpu/GpuDistance.h
@@ -45,7 +45,8 @@ struct GpuDistanceParams {
               outDistances(nullptr),
               ignoreOutDistances(false),
               outIndicesType(IndicesDataType::I64),
-              outIndices(nullptr) {}
+              outIndices(nullptr),
+              device(-1) {}
 
     //
     // Search parameters
@@ -112,6 +113,17 @@ struct GpuDistanceParams {
     /// innermost (row major). Not used if k == -1 (all pairwise distances)
     IndicesDataType outIndicesType;
     void* outIndices;
+
+    //
+    // Execution information
+    //
+
+    /// On which GPU device should the search run?
+    /// -1 indicates that the current CUDA thread-local device
+    /// (via cudaGetDevice/cudaSetDevice) is used
+    /// Otherwise, an integer 0 <= device < numDevices indicates the device for
+    /// execution
+    int device;
 };
 
 /// A wrapper for gpu/impl/Distance.cuh to expose direct brute-force k-nearest

--- a/faiss/gpu/test/TestGpuDistance.cu
+++ b/faiss/gpu/test/TestGpuDistance.cu
@@ -112,6 +112,7 @@ void testTransposition(
     args.numQueries = numQuery;
     args.outDistances = gpuDistance.data();
     args.outIndices = gpuIndices.data();
+    args.device = device;
 
     bfKnn(&res, args);
 

--- a/faiss/gpu/test/test_gpu_basics.py
+++ b/faiss/gpu/test/test_gpu_basics.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 import numpy as np
 import faiss
+import random
 from common_faiss_tests import get_dataset_2
 
 class ReferencedObject(unittest.TestCase):
@@ -252,6 +253,7 @@ class TestKnn(unittest.TestCase):
         params.numQueries = nq
         params.outDistances = faiss.swig_ptr(out_d)
         params.outIndices = faiss.swig_ptr(out_i)
+        params.device = random.randrange(0, faiss.get_num_gpus())
 
         faiss.bfKnn(res, params)
 
@@ -279,6 +281,7 @@ class TestKnn(unittest.TestCase):
         params.vectorType = faiss.DistanceDataType_F16
         params.queries = faiss.swig_ptr(qs_f16)
         params.queryType = faiss.DistanceDataType_F16
+        params.device = random.randrange(0, faiss.get_num_gpus())
 
         out_d_f16 = np.empty((nq, k), dtype=np.float32)
         out_i_f16 = np.empty((nq, k), dtype=np.int64)
@@ -286,6 +289,7 @@ class TestKnn(unittest.TestCase):
         params.outDistances = faiss.swig_ptr(out_d_f16)
         params.outIndices = faiss.swig_ptr(out_i_f16)
         params.outIndicesType = faiss.IndicesDataType_I64
+        params.device = random.randrange(0, faiss.get_num_gpus())
 
         faiss.bfKnn(res, params)
 
@@ -335,6 +339,7 @@ class TestAllPairwiseDistance(unittest.TestCase):
             params.queries = faiss.swig_ptr(qs)
             params.numQueries = nq
             params.outDistances = faiss.swig_ptr(out_d)
+            params.device = random.randrange(0, faiss.get_num_gpus())
 
             faiss.bfKnn(res, params)
 
@@ -367,6 +372,7 @@ class TestAllPairwiseDistance(unittest.TestCase):
 
             out_d_f16 = np.empty((nq, k), dtype=np.float32)
             params.outDistances = faiss.swig_ptr(out_d_f16)
+            params.device = random.randrange(0, faiss.get_num_gpus())
 
             faiss.bfKnn(res, params)
 

--- a/faiss/python/gpu_wrappers.py
+++ b/faiss/python/gpu_wrappers.py
@@ -52,7 +52,7 @@ def index_cpu_to_gpus_list(index, co=None, gpus=None, ngpu=-1):
 # allows numpy ndarray usage with bfKnn
 
 
-def knn_gpu(res, xq, xb, k, D=None, I=None, metric=METRIC_L2):
+def knn_gpu(res, xq, xb, k, D=None, I=None, metric=METRIC_L2, device=-1):
     """
     Compute the k nearest neighbors of a vector on one GPU without constructing an index
 
@@ -72,8 +72,14 @@ def knn_gpu(res, xq, xb, k, D=None, I=None, metric=METRIC_L2):
         Output array for distances of the nearest neighbors, shape (nq, k)
     I : array_like, optional
         Output array for the nearest neighbors, shape (nq, k)
-    distance_type : MetricType, optional
-        distance measure to use (either METRIC_L2 or METRIC_INNER_PRODUCT)
+    metric : MetricType, optional
+        Distance measure to use (either METRIC_L2 or METRIC_INNER_PRODUCT)
+    device: int, optional
+        Which CUDA device in the system to run the search on. -1 indicates that
+        the current thread-local device state (via cudaGetDevice) should be used
+        (can also be set via torch.cuda.set_device in PyTorch)
+        Otherwise, an integer 0 <= device < numDevices indicates the GPU on which
+        the computation should be run
 
     Returns
     -------
@@ -159,6 +165,7 @@ def knn_gpu(res, xq, xb, k, D=None, I=None, metric=METRIC_L2):
     args.outDistances = D_ptr
     args.outIndices = I_ptr
     args.outIndicesType = I_type
+    args.device = device
 
     # no stream synchronization needed, inputs and outputs are guaranteed to
     # be on the CPU (numpy arrays)
@@ -169,7 +176,7 @@ def knn_gpu(res, xq, xb, k, D=None, I=None, metric=METRIC_L2):
 # allows numpy ndarray usage with bfKnn for all pairwise distances
 
 
-def pairwise_distance_gpu(res, xq, xb, D=None, metric=METRIC_L2):
+def pairwise_distance_gpu(res, xq, xb, D=None, metric=METRIC_L2, device=-1):
     """
     Compute all pairwise distances between xq and xb on one GPU without constructing an index
 
@@ -185,8 +192,14 @@ def pairwise_distance_gpu(res, xq, xb, D=None, metric=METRIC_L2):
         `dtype` must be float32.
     D : array_like, optional
         Output array for all pairwise distances, shape (nq, nb)
-    distance_type : MetricType, optional
-        distance measure to use (either METRIC_L2 or METRIC_INNER_PRODUCT)
+    metric : MetricType, optional
+        Distance measure to use (either METRIC_L2 or METRIC_INNER_PRODUCT)
+    device: int, optional
+        Which CUDA device in the system to run the search on. -1 indicates that
+        the current thread-local device state (via cudaGetDevice) should be used
+        (can also be set via torch.cuda.set_device in PyTorch)
+        Otherwise, an integer 0 <= device < numDevices indicates the GPU on which
+        the computation should be run
 
     Returns
     -------
@@ -255,6 +268,7 @@ def pairwise_distance_gpu(res, xq, xb, D=None, metric=METRIC_L2):
     args.queryType = xq_type
     args.numQueries = nq
     args.outDistances = D_ptr
+    args.device = device
 
     # no stream synchronization needed, inputs and outputs are guaranteed to
     # be on the CPU (numpy arrays)


### PR DESCRIPTION
Summary:
The `bfKnn` C++ function and `knn_gpu` Python functions for running brute-force k-NN on the GPU did not have a way to specify the GPU device on which the search should run, as it simply used the current thread-local `cudaGetDevice(...)` setting in the CUDA runtime API.

This is unlike the GPU index classes which takes a device argument in the index config struct. Now, both the C++ and Python interface to bfKnn have an optional argument to specify the device.

Default behavior is the current behavior; if the `device` is -1 then the current CUDA thread-local device is used, otherwise we perform the work on the desired device.

Reviewed By: mdouze

Differential Revision: D41448254

