### PR TITLE
fix Windows build

### DIFF
--- a/conda/faiss-gpu/meta.yaml
+++ b/conda/faiss-gpu/meta.yaml
@@ -39,12 +39,12 @@ outputs:
         - llvm-openmp  # [osx]
         - cmake >=3.18
         - make  # [not win]
+        - mkl-devel =2021
       host:
-        - mkl =2018
+        - mkl =2021
         - cudatoolkit {{ cudatoolkit }}
       run:
-        - mkl >=2018  # [not win]
-        - mkl >=2018,<2021  # [win]
+        - mkl >=2021
         - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
     test:
       requires:

--- a/conda/faiss/meta.yaml
+++ b/conda/faiss/meta.yaml
@@ -38,11 +38,11 @@ outputs:
         - llvm-openmp  # [osx]
         - cmake >=3.17
         - make  # [not win]
+        - mkl-devel =2021
       host:
-        - mkl =2018
+        - mkl =2021
       run:
-        - mkl >=2018  # [not win]
-        - mkl >=2018,<2021  # [win]
+        - mkl >=2021  # [win]
     test:
       requires:
         - conda-build
@@ -65,8 +65,7 @@ outputs:
         - make  # [not win]
       host:
         - python {{ python }}
-        - numpy =1.16  # [not win]
-        - numpy =1.11  # [win]
+        - numpy =1.16
         - {{ pin_subpackage('libfaiss', exact=True) }}
       run:
         - python {{ python }}


### PR DESCRIPTION
Summary: Bumping `mkl` to 2021 and installing `mkl-devel` in the build environment to fix the Windows nightly build.

Differential Revision: D41534391

