### PR TITLE
Fix test timeouts

### DIFF
--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -776,7 +776,7 @@ class TestNSG(unittest.TestCase):
         """Test IndexNSGPQ"""
         d = self.xq.shape[1]
         R, pq_M = 32, 4
-        index = faiss.index_factory(d, f"NSG{R}_PQ{pq_M}")
+        index = faiss.index_factory(d, f"NSG{R}_PQ{pq_M}np")
         assert isinstance(index, faiss.IndexNSGPQ)
         idxpq = faiss.downcast_index(index.storage)
         assert index.nsg.R == R and idxpq.pq.M == pq_M

--- a/tests/test_merge_index.py
+++ b/tests/test_merge_index.py
@@ -163,7 +163,7 @@ class TestMerge2(unittest.TestCase):
         self.do_flat_codes_test("Flat")
 
     def test_merge_IndexPQ(self):
-        self.do_flat_codes_test("PQ8")
+        self.do_flat_codes_test("PQ8np")
 
     def test_merge_IndexLSH(self):
         self.do_flat_codes_test("LSHr")


### PR DESCRIPTION
Summary:
The Faiss tests run in dev mode are very slow
The PQ polysemous training is particularly sensitive to this with the default settings.
This diff adds a "np" suffix to two PQ factory strings to disable polysemous training. The tests that are detected as flaky because they occasionally time out.

Differential Revision: D41955699

