### PR TITLE
Add facilities for approximate evaluation of min-k distances via heap. Affects RQ / PRQ / RQ_LUT / PRQ_LUT

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -195,6 +195,9 @@ set(FAISS_HEADERS
   utils/distances_fused/avx512.h
   utils/distances_fused/distances_fused.h
   utils/distances_fused/simdlib_based.h
+  utils/approx_topk/approx_topk.h
+  utils/approx_topk/avx2-inl.h
+  utils/approx_topk/generic.h
 )
 
 if(NOT WIN32)

--- a/faiss/impl/ResidualQuantizer.h
+++ b/faiss/impl/ResidualQuantizer.h
@@ -13,6 +13,8 @@
 #include <faiss/Clustering.h>
 #include <faiss/impl/AdditiveQuantizer.h>
 
+#include <faiss/utils/approx_topk/approx_topk.h>
+
 namespace faiss {
 
 /** Residual quantizer with variable number of bits per sub-quantizer
@@ -56,6 +58,10 @@ struct ResidualQuantizer : AdditiveQuantizer {
 
     /// use LUT for beam search
     int use_beam_LUT;
+
+    /// Currently used mode of approximate min-k computations.
+    /// Default value is EXACT_TOPK.
+    ApproxTopK_mode_t approx_topk_mode;
 
     /// clustering parameters
     ProgressiveDimClusteringParameters cp;
@@ -183,7 +189,8 @@ void beam_search_encode_step(
         int32_t* new_codes,
         float* new_residuals,
         float* new_distances,
-        Index* assign_index = nullptr);
+        Index* assign_index = nullptr,
+        ApproxTopK_mode_t approx_topk = ApproxTopK_mode_t::EXACT_TOPK);
 
 /** Encode a set of vectors using their dot products with the codebooks
  *
@@ -202,7 +209,8 @@ void beam_search_encode_step_tab(
         const int32_t* codes,   // n * beam_size * m
         const float* distances, // n * beam_size
         size_t new_beam_size,
-        int32_t* new_codes,    // n * new_beam_size * (m + 1)
-        float* new_distances); // n * new_beam_size
+        int32_t* new_codes,   // n * new_beam_size * (m + 1)
+        float* new_distances, // n * new_beam_size
+        ApproxTopK_mode_t approx_topk = ApproxTopK_mode_t::EXACT_TOPK);
 
 }; // namespace faiss

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -508,7 +508,7 @@ void gpu_sync_all_devices()
 %include <faiss/impl/AuxIndexStructures.h>
 %include <faiss/impl/IDSelector.h>
 
-
+%include <faiss/utils/approx_topk/approx_topk.h>
 
 #ifdef GPU_WRAPPER
 

--- a/faiss/utils/approx_topk/approx_topk.h
+++ b/faiss/utils/approx_topk/approx_topk.h
@@ -1,0 +1,100 @@
+// This file contains an implementation of approximate top-k search
+// using heap. It was initially created for a beam search.
+//
+// The core idea is the following.
+// Say we need to find beam_size indices with the minimal distance
+// values. It is done via heap (priority_queue) using the following
+// pseudocode:
+//
+//   def baseline():
+//     distances = np.empty([beam_size * n], dtype=float)
+//     indices = np.empty([beam_size * n], dtype=int)
+//
+//     heap = Heap(max_heap_size=beam_size)
+//
+//     for i in range(0, beam_size * n):
+//         heap.push(distances[i], indices[i])
+//
+// Basically, this is what heap_addn() function from utils/Heap.h does.
+//
+// The following scheme can be used for approximate beam search.
+// Say, we need to find elements with min distance.
+// Basically, we split n elements of every beam into NBUCKETS buckets
+// and track the index with the minimal distance for every bucket.
+// This can be effectively SIMD-ed and significantly lowers the number
+// of operations, but yields approximate results for beam_size >= 2.
+//
+//  def approximate_v1():
+//    distances = np.empty([beam_size * n], dtype=float)
+//    indices = np.empty([beam_size * n], dtype=int)
+//
+//    heap = Heap(max_heap_size=beam_size)
+//
+//    for beam in range(0, beam_size):
+//      # The value of 32 is just an example.
+//      # The value may be varied: the larger the value is,
+//      #  the slower and the more precise vs baseline beam search is
+//      NBUCKETS = 32
+//
+//     local_min_distances = [HUGE_VALF] * NBUCKETS
+//     local_min_indices = [0] * NBUCKETS
+//
+//      for i in range(0, n / NBUCKETS):
+//        for j in range(0, NBUCKETS):
+//          idx = beam * n + i * NBUCKETS + j
+//          if distances[idx] < local_min_distances[j]:
+//            local_min_distances[i] = distances[idx]
+//            local_min_indices[i] = indices[idx]
+//
+//    for j in range(0, NBUCKETS):
+//      heap.push(local_min_distances[j], local_min_indices[j])
+//
+// The accuracy can be improved by tracking min-2 elements for every
+// bucket. Such a min-2 implementation with NBUCKETS buckets provides
+// better accuracy than top-1 implementation with 2 * NBUCKETS buckets.
+// Min-3 is also doable. One can use min-N approach, but I'm not sure
+// whether min-4 and above are practical, because of the lack of SIMD
+// registers (unless AVX-512 version is used).
+//
+// C++ template for top-N implementation is provided. The code
+// assumes that indices[idx] == idx. One can write a code that lifts
+// such an assumption easily.
+//
+// Currently, the code that tracks elements with min distances is implemented
+//    (Max Heap). Min Heap option can be added easily.
+
+#pragma once
+
+#include <faiss/impl/platform_macros.h>
+
+/// Represents the mode of use of approximate top-k computations
+/// that allows to trade accuracy vs speed. So, every options
+/// besides EXACT_TOPK increases the speed.
+///
+/// B represents the number of buckets.
+/// D is the number of min-k elements to track within every bucket.
+///
+/// Default option is EXACT_TOPK.
+/// APPROX_TOPK_BUCKETS_B16_D2 is worth starting from, if you'd like
+/// to experiment a bit.
+///
+/// It seems that only the limited number of combinations are
+/// meaningful, because of the limited supply of SIMD registers.
+/// Also, certain combinations, such as B32_D1 and B16_D1, were concluded
+/// to be not very precise in benchmarks, so ones were not introduced.
+///
+/// TODO: Consider d-ary SIMD heap.
+
+enum ApproxTopK_mode_t : int {
+    EXACT_TOPK = 0,
+    APPROX_TOPK_BUCKETS_B32_D2 = 1,
+    APPROX_TOPK_BUCKETS_B8_D3 = 2,
+    APPROX_TOPK_BUCKETS_B16_D2 = 3,
+    APPROX_TOPK_BUCKETS_B8_D2 = 4,
+};
+
+#ifdef __AVX2__
+#include <faiss/utils/approx_topk/avx2-inl.h>
+#else
+#include <faiss/utils/approx_topk/generic.h>
+#endif

--- a/faiss/utils/approx_topk/avx2-inl.h
+++ b/faiss/utils/approx_topk/avx2-inl.h
@@ -1,0 +1,186 @@
+#pragma once
+
+#include <immintrin.h>
+
+#include <limits>
+
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/utils/Heap.h>
+
+namespace faiss {
+
+template <typename C, uint32_t NBUCKETS, uint32_t N>
+struct HeapWithBuckets {
+    // this case was not implemented yet.
+};
+
+template <uint32_t NBUCKETS, uint32_t N>
+struct HeapWithBuckets<CMax<float, int>, NBUCKETS, N> {
+    static constexpr uint32_t NBUCKETS_8 = NBUCKETS / 8;
+    static_assert(
+            (NBUCKETS) > 0 && ((NBUCKETS % 8) == 0),
+            "Number of buckets needs to be 8, 16, 24, ...");
+
+    static void addn(
+            // number of elements
+            const uint32_t n,
+            // distances. It is assumed to have n elements.
+            const float* const __restrict distances,
+            // number of best elements to keep
+            const uint32_t k,
+            // output distances
+            float* const __restrict bh_val,
+            // output indices, each being within [0, n) range
+            int32_t* const __restrict bh_ids) {
+        // forward a call to bs_addn with 1 beam
+        bs_addn(1, n, distances, k, bh_val, bh_ids);
+    }
+
+    static void bs_addn(
+            // beam_size parameter of Beam Search algorithm
+            const uint32_t beam_size,
+            // number of elements per beam
+            const uint32_t n_per_beam,
+            // distances. It is assumed to have (n_per_beam * beam_size)
+            // elements.
+            const float* const __restrict distances,
+            // number of best elements to keep
+            const uint32_t k,
+            // output distances
+            float* const __restrict bh_val,
+            // output indices, each being within [0, n_per_beam * beam_size)
+            // range
+            int32_t* const __restrict bh_ids) {
+        // // Basically, the function runs beam_size iterations.
+        // // Every iteration NBUCKETS * N elements are added to a regular heap.
+        // // So, maximum number of added elements is beam_size * NBUCKETS * N.
+        // // This number is expected to be less or equal than k.
+        // FAISS_THROW_IF_NOT_FMT(
+        //         beam_size * NBUCKETS * N >= k,
+        //         "Cannot pick %d elements, only %d. "
+        //         "Check the function and template arguments values.",
+        //         k,
+        //         beam_size * NBUCKETS * N);
+
+        using C = CMax<float, int>;
+
+        // main loop
+        for (uint32_t beam_index = 0; beam_index < beam_size; beam_index++) {
+            __m256 min_distances_i[NBUCKETS_8][N];
+            __m256i min_indices_i[NBUCKETS_8][N];
+
+            for (uint32_t j = 0; j < NBUCKETS_8; j++) {
+                for (uint32_t p = 0; p < N; p++) {
+                    min_distances_i[j][p] =
+                            _mm256_set1_ps(std::numeric_limits<float>::max());
+                    min_indices_i[j][p] =
+                            _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
+                }
+            }
+
+            __m256i current_indices = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
+            __m256i indices_delta = _mm256_set1_epi32(NBUCKETS);
+
+            const uint32_t nb = (n_per_beam / NBUCKETS) * NBUCKETS;
+
+            // put the data into buckets
+            for (uint32_t ip = 0; ip < nb; ip += NBUCKETS) {
+                for (uint32_t j = 0; j < NBUCKETS_8; j++) {
+                    const __m256 distances_reg = _mm256_loadu_ps(
+                            distances + j * 8 + ip + n_per_beam * beam_index);
+
+                    // loop. Compiler should get rid of unneeded ops
+                    __m256 distance_candidate = distances_reg;
+                    __m256i indices_candidate = current_indices;
+
+                    for (uint32_t p = 0; p < N; p++) {
+                        const __m256 comparison = _mm256_cmp_ps(
+                                min_distances_i[j][p],
+                                distance_candidate,
+                                _CMP_LE_OS);
+
+                        // // blend seems to be slower that min
+                        // const __m256 min_distances_new = _mm256_blendv_ps(
+                        //         distance_candidate,
+                        //         min_distances_i[j][p],
+                        //         comparison);
+                        const __m256 min_distances_new = _mm256_min_ps(
+                                distance_candidate, min_distances_i[j][p]);
+                        const __m256i min_indices_new =
+                                _mm256_castps_si256(_mm256_blendv_ps(
+                                        _mm256_castsi256_ps(indices_candidate),
+                                        _mm256_castsi256_ps(
+                                                min_indices_i[j][p]),
+                                        comparison));
+
+                        // // blend seems to be slower that min
+                        // const __m256 max_distances_new = _mm256_blendv_ps(
+                        //         min_distances_i[j][p],
+                        //         distance_candidate,
+                        //         comparison);
+                        const __m256 max_distances_new = _mm256_max_ps(
+                                min_distances_i[j][p], distances_reg);
+                        const __m256i max_indices_new =
+                                _mm256_castps_si256(_mm256_blendv_ps(
+                                        _mm256_castsi256_ps(
+                                                min_indices_i[j][p]),
+                                        _mm256_castsi256_ps(indices_candidate),
+                                        comparison));
+
+                        distance_candidate = max_distances_new;
+                        indices_candidate = max_indices_new;
+
+                        min_distances_i[j][p] = min_distances_new;
+                        min_indices_i[j][p] = min_indices_new;
+                    }
+                }
+
+                current_indices =
+                        _mm256_add_epi32(current_indices, indices_delta);
+            }
+
+            // fix the indices
+            for (uint32_t j = 0; j < NBUCKETS_8; j++) {
+                const __m256i offset =
+                        _mm256_set1_epi32(n_per_beam * beam_index + j * 8);
+                for (uint32_t p = 0; p < N; p++) {
+                    min_indices_i[j][p] =
+                            _mm256_add_epi32(min_indices_i[j][p], offset);
+                }
+            }
+
+            // merge every bucket into the regular heap
+            for (uint32_t p = 0; p < N; p++) {
+                for (uint32_t j = 0; j < NBUCKETS_8; j++) {
+                    int32_t min_indices_scalar[8];
+                    float min_distances_scalar[8];
+
+                    _mm256_storeu_si256(
+                            (__m256i*)min_indices_scalar, min_indices_i[j][p]);
+                    _mm256_storeu_ps(
+                            min_distances_scalar, min_distances_i[j][p]);
+
+                    heap_addn<C>(
+                            k,
+                            bh_val,
+                            bh_ids,
+                            min_distances_scalar,
+                            min_indices_scalar,
+                            8);
+                }
+            }
+
+            // process leftovers
+            for (uint32_t ip = nb; ip < n_per_beam; ip++) {
+                const int32_t index = ip + n_per_beam * beam_index;
+                const float value = distances[index];
+
+                if (C::cmp(bh_val[0], value)) {
+                    heap_replace_top<C>(k, bh_val, bh_ids, value, index);
+                }
+            }
+        }
+    }
+};
+
+} // namespace faiss

--- a/faiss/utils/approx_topk/generic.h
+++ b/faiss/utils/approx_topk/generic.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/utils/Heap.h>
+
+namespace faiss {
+
+// This is the implementation of the idea and it is very slow,
+// because a compiler is unable to vectorize it properly.
+
+template <typename C, uint32_t NBUCKETS, uint32_t N>
+struct HeapWithBuckets {
+    // this case was not implemented yet.
+};
+
+template <uint32_t NBUCKETS, uint32_t N>
+struct HeapWithBuckets<CMax<float, int>, NBUCKETS, N> {
+    static void addn(
+            // number of elements
+            const uint32_t n,
+            // distances. It is assumed to have n elements.
+            const float* const __restrict distances,
+            // number of best elements to keep
+            const uint32_t k,
+            // output distances
+            float* const __restrict bh_val,
+            // output indices, each being within [0, n) range
+            int32_t* const __restrict bh_ids) {
+        // forward a call to bs_addn with 1 beam
+        bs_addn(1, n, distances, k, bh_val, bh_ids);
+    }
+
+    static void bs_addn(
+            // beam_size parameter of Beam Search algorithm
+            const uint32_t beam_size,
+            // number of elements per beam
+            const uint32_t n_per_beam,
+            // distances. It is assumed to have (n_per_beam * beam_size)
+            // elements.
+            const float* const __restrict distances,
+            // number of best elements to keep
+            const uint32_t k,
+            // output distances
+            float* const __restrict bh_val,
+            // output indices, each being within [0, n_per_beam * beam_size)
+            // range
+            int32_t* const __restrict bh_ids) {
+        // // Basically, the function runs beam_size iterations.
+        // // Every iteration NBUCKETS * N elements are added to a regular heap.
+        // // So, maximum number of added elements is beam_size * NBUCKETS * N.
+        // // This number is expected to be less or equal than k.
+        // FAISS_THROW_IF_NOT_FMT(
+        //         beam_size * NBUCKETS * N >= k,
+        //         "Cannot pick %d elements, only %d. "
+        //         "Check the function and template arguments values.",
+        //         k,
+        //         beam_size * NBUCKETS * N);
+
+        using C = CMax<float, int>;
+
+        // main loop
+        for (uint32_t beam_index = 0; beam_index < beam_size; beam_index++) {
+            float min_distances_i[N][NBUCKETS];
+            int min_indices_i[N][NBUCKETS];
+
+            for (uint32_t p = 0; p < N; p++) {
+                for (uint32_t j = 0; j < NBUCKETS; j++) {
+                    min_distances_i[p][j] = std::numeric_limits<float>::max();
+                    min_indices_i[p][j] = 0;
+                }
+            }
+
+            const uint32_t nb = (n_per_beam / NBUCKETS) * NBUCKETS;
+
+            // put the data into buckets
+            for (uint32_t ip = 0; ip < nb; ip += NBUCKETS) {
+                for (uint32_t j = 0; j < NBUCKETS; j++) {
+                    const int index = j + ip + n_per_beam * beam_index;
+                    const float distance = distances[index];
+
+                    int index_candidate = index;
+                    float distance_candidate = distance;
+
+                    for (uint32_t p = 0; p < N; p++) {
+                        if (distance_candidate < min_distances_i[p][j]) {
+                            std::swap(
+                                    distance_candidate, min_distances_i[p][j]);
+                            std::swap(index_candidate, min_indices_i[p][j]);
+                        }
+                    }
+                }
+            }
+
+            // merge every bucket into the regular heap
+            for (uint32_t p = 0; p < N; p++) {
+                for (uint32_t j = 0; j < NBUCKETS; j++) {
+                    if (C::cmp(bh_val[0], min_distances_i[p][j])) {
+                        heap_replace_top<C>(
+                                k,
+                                bh_val,
+                                bh_ids,
+                                min_distances_i[p][j],
+                                min_indices_i[p][j]);
+                    }
+                }
+            }
+
+            // process leftovers
+            for (uint32_t ip = nb; ip < n_per_beam; ip++) {
+                const int32_t index = ip + n_per_beam * beam_index;
+                const float value = distances[index];
+
+                if (C::cmp(bh_val[0], value)) {
+                    heap_replace_top<C>(k, bh_val, bh_ids, value, index);
+                }
+            }
+        }
+    }
+};
+
+} // namespace faiss

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(FAISS_TEST_SRC
   test_cppcontrib_sa_decode.cpp
   test_cppcontrib_uintreader.cpp
   test_simdlib.cpp
+  test_approx_topk.cpp
 )
 
 add_executable(faiss_test ${FAISS_TEST_SRC})

--- a/tests/test_approx_topk.cpp
+++ b/tests/test_approx_topk.cpp
@@ -1,0 +1,218 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <random>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <faiss/utils/approx_topk/approx_topk.h>
+
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/FaissException.h>
+#include <faiss/utils/Heap.h>
+
+//
+using namespace faiss;
+
+//
+template <uint32_t NBUCKETS, uint32_t N>
+void test_approx_topk(
+        const uint32_t beamSize,
+        const uint32_t nPerBeam,
+        const uint32_t k,
+        const uint32_t nDatasetsToTest,
+        const bool verbose) {
+    if (verbose) {
+        printf("-----------\n");
+    }
+
+    // generate random data
+    std::default_random_engine rng(123);
+    std::uniform_real_distribution<float> u(0, 1);
+
+    // matches
+    size_t nMatches = 0;
+    // the element was completely missed in approx version.
+    size_t nMissed = 0;
+    // the element is available
+    size_t nAvailable = 0;
+    // the distance is the same, but the index is different.
+    size_t nSoftMismatches = 0;
+    // the distances are different
+    size_t nHardMismatches = 0;
+    // error of distances
+    double sqrError = 0.0;
+
+    //
+    double timeBaseline = 0.0;
+    double timeApprox = 0.0;
+
+    for (size_t iDataset = 0; iDataset < nDatasetsToTest; iDataset++) {
+        const size_t n = (size_t)(nPerBeam)*beamSize;
+        std::vector<float> distances(n, 0);
+        for (size_t i = 0; i < n; i++) {
+            distances[i] = u(rng);
+        }
+
+        //
+        using C = CMax<float, int>;
+
+        // do a regular beam search
+        std::vector<float> baselineDistances(k, C::neutral());
+        std::vector<int> baselineIndices(k, -1);
+
+        auto startBaseline = std::chrono::high_resolution_clock::now();
+        heap_addn<C>(
+                k,
+                baselineDistances.data(),
+                baselineIndices.data(),
+                distances.data(),
+                nullptr,
+                nPerBeam * beamSize);
+        auto endBaseline = std::chrono::high_resolution_clock::now();
+        std::chrono::duration<double> diffBaseline =
+                endBaseline - startBaseline;
+        timeBaseline += diffBaseline.count();
+
+        heap_reorder<C>(k, baselineDistances.data(), baselineIndices.data());
+
+        // do an approximate beam search
+        std::vector<float> approxDistances(k, C::neutral());
+        std::vector<int> approxIndices(k, -1);
+
+        auto startApprox = std::chrono::high_resolution_clock::now();
+        try {
+            HeapWithBuckets<C, NBUCKETS, N>::bs_addn(
+                    beamSize,
+                    nPerBeam,
+                    distances.data(),
+                    k,
+                    approxDistances.data(),
+                    approxIndices.data());
+        } catch (const faiss::FaissException& ex) {
+            //
+            if (verbose) {
+                printf("Skipping the case.\n");
+            }
+            return;
+        }
+
+        auto endApprox = std::chrono::high_resolution_clock::now();
+        std::chrono::duration<double> diffApprox = endApprox - startApprox;
+        timeApprox += diffApprox.count();
+
+        heap_reorder<C>(k, approxDistances.data(), approxIndices.data());
+
+        bool bGotMismatches = false;
+
+        // the error
+        for (uint32_t i = 0; i < k; i++) {
+            if (baselineDistances[i] != approxDistances[i]) {
+                nHardMismatches += 1;
+
+                double diff = baselineDistances[i] - approxDistances[i];
+                sqrError += diff * diff;
+
+                bGotMismatches = true;
+
+                if (verbose) {
+                    printf("i=%d, bs.d=%f, bs.i=%d, app.d=%f, app.i=%d\n",
+                           i,
+                           baselineDistances[i],
+                           baselineIndices[i],
+                           approxDistances[i],
+                           approxIndices[i]);
+                }
+            } else {
+                if (baselineIndices[i] != approxIndices[i]) {
+                    nSoftMismatches += 1;
+                } else {
+                    nMatches += 1;
+                }
+            }
+        }
+
+        if (bGotMismatches) {
+            if (verbose) {
+                printf("\n");
+            }
+        }
+
+        //
+        std::unordered_set<int> bsIndicesHS(
+                baselineIndices.cbegin(), baselineIndices.cend());
+        for (uint32_t i = 0; i < k; i++) {
+            auto itr = bsIndicesHS.find(approxIndices[i]);
+            if (itr != bsIndicesHS.cend()) {
+                nAvailable += 1;
+            } else {
+                nMissed += 1;
+            }
+        }
+    }
+
+    if (verbose) {
+        printf("%d, %d, %d, %d, %d, %d: %ld, %ld, %ld, %f, %ld, %ld, %f, %f\n",
+               NBUCKETS,
+               N,
+               beamSize,
+               nPerBeam,
+               k,
+               nDatasetsToTest,
+               nMatches,
+               nSoftMismatches,
+               nHardMismatches,
+               sqrError,
+               nAvailable,
+               nMissed,
+               timeBaseline,
+               timeApprox);
+    }
+
+    // just confirm that the error is not crazy
+    if (NBUCKETS * N * beamSize >= k) {
+        EXPECT_TRUE(nAvailable > nMissed);
+    } else {
+        // it is possible that the results are crazy here. Skip it.
+    }
+}
+
+//
+TEST(TEST_APPROX_TOPK, COMMON) {
+    constexpr bool verbose = false;
+
+    //
+    const uint32_t nDifferentDatasets = 8;
+
+    uint32_t kValues[] = {1, 2, 3, 5, 8, 13, 21, 34};
+
+    for (size_t codebookBitSize = 8; codebookBitSize <= 10; codebookBitSize++) {
+        const uint32_t codebookSize = 1 << codebookBitSize;
+        for (const auto k : kValues) {
+            test_approx_topk<1 * 8, 3>(
+                    1, codebookSize, k, nDifferentDatasets, verbose);
+            test_approx_topk<1 * 8, 3>(
+                    k, codebookSize, k, nDifferentDatasets, verbose);
+
+            test_approx_topk<1 * 8, 2>(
+                    1, codebookSize, k, nDifferentDatasets, verbose);
+            test_approx_topk<1 * 8, 2>(
+                    k, codebookSize, k, nDifferentDatasets, verbose);
+
+            test_approx_topk<2 * 8, 2>(
+                    1, codebookSize, k, nDifferentDatasets, verbose);
+            test_approx_topk<2 * 8, 2>(
+                    k, codebookSize, k, nDifferentDatasets, verbose);
+
+            test_approx_topk<4 * 8, 2>(
+                    1, codebookSize, k, nDifferentDatasets, verbose);
+            test_approx_topk<4 * 8, 2>(
+                    k, codebookSize, k, nDifferentDatasets, verbose);
+        }
+    }
+}
+
+//


### PR DESCRIPTION
Summary:
The core idea.
Instead of putting every element of the dataset into MaxHeap, split the dataset into buckets and let every bucket track elements min-1, min-2 or min-3 distances.

Applied to ResidualQuantizer class for vector codec purposes.

An example
```
rq.approx_heap_mode = faiss.ResidualQuantizer.ApproxHeap_buckets_b8_d3
```

Differential Revision: D42044398

