### PR TITLE
[faiss] increase circleci no_output_timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
       - checkout
       - run:
           name: Build faiss library
+          no_output_timeout: 30m
           command: |
             cmake -B build -DBUILD_TESTING=ON -DFAISS_ENABLE_GPU=OFF \
                   -DFAISS_OPT_LEVEL=<< parameters.opt_level >> \
@@ -57,6 +58,7 @@ jobs:
           steps:
             - run:
                 name: Build faiss_avx2 library
+                no_output_timeout: 30m
                 command: make -k -C build -j3 faiss_avx2 swigfaiss_avx2
       - run:
           name: Test faiss library
@@ -91,6 +93,7 @@ jobs:
       - checkout
       - run:
           name: Conda build
+          no_output_timeout: 30m
           command: |
             conda install -y -q conda-build
             cd conda
@@ -226,6 +229,7 @@ jobs:
             conda config --set anaconda_upload yes
       - run:
           name: Build packages
+          no_output_timeout: 30m
           environment:
             PACKAGE_TYPE: <<parameters.label>>
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
                   -DFAISS_OPT_LEVEL=<< parameters.opt_level >> \
                   -DFAISS_ENABLE_C_API=ON \
                   -DCMAKE_BUILD_TYPE=Release -DBLA_VENDOR=Intel10_64_dyn .
-            make -k -C build -j`nproc` faiss
+            make -k -C build -j$(nproc) faiss
       - when:
           condition:
             equal: [ "avx2", << parameters.opt_level >> ]
@@ -59,17 +59,17 @@ jobs:
             - run:
                 name: Build faiss_avx2 library
                 no_output_timeout: 30m
-                command: make -k -C build -j`nproc` faiss_avx2 swigfaiss_avx2
+                command: make -k -C build -j$(nproc) faiss_avx2 swigfaiss_avx2
       - run:
           name: Test faiss library
           command: |
-            make -C build -j`nproc` faiss_test
+            make -C build -j$(nproc) faiss_test
             export GTEST_OUTPUT="xml:$(realpath .)/test-results/googletest/"
             make -C build test
       - run:
           name: Build python extension
           command: |
-            make -C build -j`nproc` swigfaiss
+            make -C build -j$(nproc) swigfaiss
             cd build/faiss/python
             python3 setup.py build
       - run:
@@ -169,17 +169,17 @@ jobs:
                   -DFAISS_ENABLE_C_API=ON \
                   -DCMAKE_BUILD_TYPE=Release \
                   -DPython_EXECUTABLE=$PYTHON .
-            make -k -C build -j`nproc` faiss
+            make -k -C build -j$(nproc) faiss
       - run:
           name: Test faiss library
           command: |
-            make -C build -j`nproc` faiss_test
+            make -C build -j$(nproc) faiss_test
             export GTEST_OUTPUT="xml:$(realpath .)/test-results/googletest/"
             make -C build test
       - run:
           name: Build python extension
           command: |
-            make -C build -j`nproc` swigfaiss
+            make -C build -j$(nproc) swigfaiss
             cd build/faiss/python
             $PYTHON setup.py build
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
                   -DFAISS_OPT_LEVEL=<< parameters.opt_level >> \
                   -DFAISS_ENABLE_C_API=ON \
                   -DCMAKE_BUILD_TYPE=Release -DBLA_VENDOR=Intel10_64_dyn .
-            make -k -C build -j3 faiss
+            make -k -C build -j`nproc` faiss
       - when:
           condition:
             equal: [ "avx2", << parameters.opt_level >> ]
@@ -59,17 +59,17 @@ jobs:
             - run:
                 name: Build faiss_avx2 library
                 no_output_timeout: 30m
-                command: make -k -C build -j3 faiss_avx2 swigfaiss_avx2
+                command: make -k -C build -j`nproc` faiss_avx2 swigfaiss_avx2
       - run:
           name: Test faiss library
           command: |
-            make -C build -j3 faiss_test
+            make -C build -j`nproc` faiss_test
             export GTEST_OUTPUT="xml:$(realpath .)/test-results/googletest/"
             make -C build test
       - run:
           name: Build python extension
           command: |
-            make -C build -j3 swigfaiss
+            make -C build -j`nproc` swigfaiss
             cd build/faiss/python
             python3 setup.py build
       - run:
@@ -169,17 +169,17 @@ jobs:
                   -DFAISS_ENABLE_C_API=ON \
                   -DCMAKE_BUILD_TYPE=Release \
                   -DPython_EXECUTABLE=$PYTHON .
-            make -k -C build -j3 faiss
+            make -k -C build -j`nproc` faiss
       - run:
           name: Test faiss library
           command: |
-            make -C build -j3 faiss_test
+            make -C build -j`nproc` faiss_test
             export GTEST_OUTPUT="xml:$(realpath .)/test-results/googletest/"
             make -C build test
       - run:
           name: Build python extension
           command: |
-            make -C build -j3 swigfaiss
+            make -C build -j`nproc` swigfaiss
             cd build/faiss/python
             $PYTHON setup.py build
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,7 @@ jobs:
   build_linux_conda:
     docker:
       - image: continuumio/miniconda3
+    resource_class: medium+
     steps:
       - checkout
       - run:
@@ -220,6 +221,7 @@ jobs:
         default: main
     docker:
       - image: continuumio/miniconda3
+    resource_class: medium+
     steps:
       - checkout
       - run:

--- a/conda/faiss-gpu/build-lib.sh
+++ b/conda/faiss-gpu/build-lib.sh
@@ -19,7 +19,7 @@ cmake -B _build \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DCMAKE_BUILD_TYPE=Release .
 
-make -C _build -j`nproc` faiss faiss_avx2
+make -C _build -j$(nproc) faiss faiss_avx2
 
 cmake --install _build --prefix $PREFIX
 cmake --install _build --prefix _libfaiss_stage/

--- a/conda/faiss-gpu/build-lib.sh
+++ b/conda/faiss-gpu/build-lib.sh
@@ -19,7 +19,7 @@ cmake -B _build \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DCMAKE_BUILD_TYPE=Release .
 
-make -C _build -j $CPU_COUNT faiss faiss_avx2
+make -C _build -j`nproc` faiss faiss_avx2
 
 cmake --install _build --prefix $PREFIX
 cmake --install _build --prefix _libfaiss_stage/

--- a/conda/faiss-gpu/build-pkg.sh
+++ b/conda/faiss-gpu/build-pkg.sh
@@ -16,7 +16,7 @@ cmake -B _build_python_${PY_VER} \
       -DPython_EXECUTABLE=$PYTHON \
       faiss/python
 
-make -C _build_python_${PY_VER} -j`nproc` swigfaiss swigfaiss_avx2
+make -C _build_python_${PY_VER} -j$(nproc) swigfaiss swigfaiss_avx2
 
 # Build actual python module.
 cd _build_python_${PY_VER}/

--- a/conda/faiss-gpu/build-pkg.sh
+++ b/conda/faiss-gpu/build-pkg.sh
@@ -16,7 +16,7 @@ cmake -B _build_python_${PY_VER} \
       -DPython_EXECUTABLE=$PYTHON \
       faiss/python
 
-make -C _build_python_${PY_VER} -j $CPU_COUNT swigfaiss swigfaiss_avx2
+make -C _build_python_${PY_VER} -j`nproc` swigfaiss swigfaiss_avx2
 
 # Build actual python module.
 cd _build_python_${PY_VER}/

--- a/conda/faiss/build-lib.sh
+++ b/conda/faiss/build-lib.sh
@@ -18,7 +18,7 @@ cmake -B _build \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DCMAKE_BUILD_TYPE=Release .
 
-make -C _build -j $CPU_COUNT faiss faiss_avx2
+make -C _build -j`nproc` faiss faiss_avx2
 
 cmake --install _build --prefix $PREFIX
 cmake --install _build --prefix _libfaiss_stage/

--- a/conda/faiss/build-lib.sh
+++ b/conda/faiss/build-lib.sh
@@ -18,7 +18,7 @@ cmake -B _build \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DCMAKE_BUILD_TYPE=Release .
 
-make -C _build -j`nproc` faiss faiss_avx2
+make -C _build -j$(nproc) faiss faiss_avx2
 
 cmake --install _build --prefix $PREFIX
 cmake --install _build --prefix _libfaiss_stage/

--- a/conda/faiss/build-pkg.sh
+++ b/conda/faiss/build-pkg.sh
@@ -16,7 +16,7 @@ cmake -B _build_python_${PY_VER} \
       -DPython_EXECUTABLE=$PYTHON \
       faiss/python
 
-make -C _build_python_${PY_VER} -j`nproc` swigfaiss swigfaiss_avx2
+make -C _build_python_${PY_VER} -j$(nproc) swigfaiss swigfaiss_avx2
 
 # Build actual python module.
 cd _build_python_${PY_VER}/

--- a/conda/faiss/build-pkg.sh
+++ b/conda/faiss/build-pkg.sh
@@ -16,7 +16,7 @@ cmake -B _build_python_${PY_VER} \
       -DPython_EXECUTABLE=$PYTHON \
       faiss/python
 
-make -C _build_python_${PY_VER} -j $CPU_COUNT swigfaiss swigfaiss_avx2
+make -C _build_python_${PY_VER} -j`nproc` swigfaiss swigfaiss_avx2
 
 # Build actual python module.
 cd _build_python_${PY_VER}/


### PR DESCRIPTION
Linux builds are regularly failing with “Too long with no output (exceeded 10m0s): context deadline exceeded” 

https://app.circleci.com/pipelines/github/facebookresearch/faiss/3343/workflows/a6357953-bbaa-438c-acfa-2507ceb008e8/jobs/16680?invite=true#step-103-467

Applying the fix suggested in https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded-
