### PR TITLE
indicate default values in class declaration

### DIFF
--- a/c_api/IndexIVF_c.cpp
+++ b/c_api/IndexIVF_c.cpp
@@ -61,7 +61,10 @@ int faiss_IndexIVF_copy_subset_to(
         idx_t a2) {
     try {
         reinterpret_cast<const IndexIVF*>(index)->copy_subset_to(
-                *reinterpret_cast<IndexIVF*>(other), subset_type, a1, a2);
+                *reinterpret_cast<IndexIVF*>(other),
+                static_cast<faiss::InvertedLists::subset_type_t>(subset_type),
+                a1,
+                a2);
     }
     CATCH_AND_HANDLE
 }

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -37,27 +37,19 @@ using ScopedCodes = InvertedLists::ScopedCodes;
  ******************************************/
 
 Level1Quantizer::Level1Quantizer(Index* quantizer, size_t nlist)
-        : quantizer(quantizer),
-          nlist(nlist),
-          quantizer_trains_alone(0),
-          own_fields(false),
-          clustering_index(nullptr) {
+        : quantizer(quantizer), nlist(nlist) {
     // here we set a low # iterations because this is typically used
     // for large clusterings (nb this is not used for the MultiIndex,
     // for which quantizer_trains_alone = true)
     cp.niter = 10;
 }
 
-Level1Quantizer::Level1Quantizer()
-        : quantizer(nullptr),
-          nlist(0),
-          quantizer_trains_alone(0),
-          own_fields(false),
-          clustering_index(nullptr) {}
+Level1Quantizer::Level1Quantizer() {}
 
 Level1Quantizer::~Level1Quantizer() {
-    if (own_fields)
+    if (own_fields) {
         delete quantizer;
+    }
 }
 
 void Level1Quantizer::train_q1(
@@ -170,10 +162,7 @@ IndexIVF::IndexIVF(
           Level1Quantizer(quantizer, nlist),
           invlists(new ArrayInvertedLists(nlist, code_size)),
           own_invlists(true),
-          code_size(code_size),
-          nprobe(1),
-          max_codes(0),
-          parallel_mode(0) {
+          code_size(code_size) {
     FAISS_THROW_IF_NOT(d == quantizer->d);
     is_trained = quantizer->is_trained && (quantizer->ntotal == nlist);
     // Spherical by default if the metric is inner_product

--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -31,19 +31,23 @@ namespace faiss {
  * of the lists (especially training)
  */
 struct Level1Quantizer {
-    Index* quantizer; ///< quantizer that maps vectors to inverted lists
-    size_t nlist;     ///< number of possible key values
+    /// quantizer that maps vectors to inverted lists
+    Index* quantizer = nullptr;
+
+    /// number of inverted lists
+    size_t nlist = 0;
 
     /**
      * = 0: use the quantizer as index in a kmeans training
      * = 1: just pass on the training set to the train() of the quantizer
      * = 2: kmeans training on a flat index + add the centroids to the quantizer
      */
-    char quantizer_trains_alone;
-    bool own_fields; ///< whether object owns the quantizer (false by default)
+    char quantizer_trains_alone = 0;
+    bool own_fields = false; ///< whether object owns the quantizer
 
     ClusteringParameters cp; ///< to override default clustering params
-    Index* clustering_index; ///< to override index used during clustering
+    /// to override index used during clustering
+    Index* clustering_index = nullptr;
 
     /// Trains the quantizer and calls train_residual to train sub-quantizers
     void train_q1(
@@ -65,11 +69,10 @@ struct Level1Quantizer {
 };
 
 struct SearchParametersIVF : SearchParameters {
-    size_t nprobe;    ///< number of probes at query time
-    size_t max_codes; ///< max nb of codes to visit to do a query
+    size_t nprobe = 1;    ///< number of probes at query time
+    size_t max_codes = 0; ///< max nb of codes to visit to do a query
     SearchParameters* quantizer_params = nullptr;
 
-    SearchParametersIVF() : nprobe(1), max_codes(0) {}
     virtual ~SearchParametersIVF() {}
 };
 
@@ -102,13 +105,12 @@ struct CodePacker;
  */
 struct IndexIVF : Index, Level1Quantizer {
     /// Access to the actual data
-    InvertedLists* invlists;
-    bool own_invlists;
+    InvertedLists* invlists = nullptr;
+    bool own_invlists = false;
 
-    size_t code_size; ///< code size per vector in bytes
-
-    size_t nprobe;    ///< number of probes at query time
-    size_t max_codes; ///< max nb of codes to visit to do a query
+    size_t code_size = 0; ///< code size per vector in bytes
+    size_t nprobe = 1;    ///< number of probes at query time
+    size_t max_codes = 0; ///< max nb of codes to visit to do a query
 
     /** Parallel mode determines how queries are parallelized with OpenMP
      *
@@ -120,7 +122,7 @@ struct IndexIVF : Index, Level1Quantizer {
      * PARALLEL_MODE_NO_HEAP_INIT: binary or with the previous to
      * prevent the heap to be initialized and finalized
      */
-    int parallel_mode;
+    int parallel_mode = 0;
     const int PARALLEL_MODE_NO_HEAP_INIT = 1024;
 
     /** optional map that maps back ids to invlist entries. This

--- a/faiss/gpu/GpuClonerOptions.cpp
+++ b/faiss/gpu/GpuClonerOptions.cpp
@@ -10,17 +10,9 @@
 namespace faiss {
 namespace gpu {
 
-GpuClonerOptions::GpuClonerOptions()
-        : indicesOptions(INDICES_64_BIT),
-          useFloat16CoarseQuantizer(false),
-          useFloat16(false),
-          usePrecomputed(false),
-          reserveVecs(0),
-          storeTransposed(false),
-          verbose(false) {}
+GpuClonerOptions::GpuClonerOptions() {}
 
-GpuMultipleClonerOptions::GpuMultipleClonerOptions()
-        : shard(false), shard_type(1) {}
+GpuMultipleClonerOptions::GpuMultipleClonerOptions() {}
 
 } // namespace gpu
 } // namespace faiss

--- a/faiss/gpu/GpuClonerOptions.h
+++ b/faiss/gpu/GpuClonerOptions.h
@@ -18,26 +18,26 @@ struct GpuClonerOptions {
 
     /// how should indices be stored on index types that support indices
     /// (anything but GpuIndexFlat*)?
-    IndicesOptions indicesOptions;
+    IndicesOptions indicesOptions = INDICES_64_BIT;
 
     /// is the coarse quantizer in float16?
-    bool useFloat16CoarseQuantizer;
+    bool useFloat16CoarseQuantizer = false;
 
     /// for GpuIndexIVFFlat, is storage in float16?
     /// for GpuIndexIVFPQ, are intermediate calculations in float16?
-    bool useFloat16;
+    bool useFloat16 = false;
 
     /// use precomputed tables?
-    bool usePrecomputed;
+    bool usePrecomputed = false;
 
     /// reserve vectors in the invfiles?
-    long reserveVecs;
+    long reserveVecs = 0;
 
     /// For GpuIndexFlat, store data in transposed layout?
-    bool storeTransposed;
+    bool storeTransposed = false;
 
     /// Set verbose options on the index
-    bool verbose;
+    bool verbose = false;
 };
 
 struct GpuMultipleClonerOptions : public GpuClonerOptions {
@@ -45,10 +45,10 @@ struct GpuMultipleClonerOptions : public GpuClonerOptions {
 
     /// Whether to shard the index across GPUs, versus replication
     /// across GPUs
-    bool shard;
+    bool shard = false;
 
     /// IndexIVF::copy_subset_to subset type
-    int shard_type;
+    int shard_type = 1;
 };
 
 } // namespace gpu

--- a/faiss/impl/AdditiveQuantizer.cpp
+++ b/faiss/impl/AdditiveQuantizer.cpp
@@ -54,14 +54,7 @@ AdditiveQuantizer::AdditiveQuantizer(
         : Quantizer(d),
           M(nbits.size()),
           nbits(nbits),
-          verbose(false),
-          is_trained(false),
-          max_mem_distances(5 * (size_t(1) << 30)), // 5 GiB
           search_type(search_type) {
-    norm_max = norm_min = NAN;
-    tot_bits = 0;
-    total_codebook_size = 0;
-    only_8bit = false;
     set_derived_values();
 }
 

--- a/faiss/impl/AdditiveQuantizer.h
+++ b/faiss/impl/AdditiveQuantizer.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <cstdint>
 #include <vector>
 
@@ -29,13 +30,13 @@ struct AdditiveQuantizer : Quantizer {
 
     // derived values
     std::vector<uint64_t> codebook_offsets;
-    size_t tot_bits;            ///< total number of bits (indexes + norms)
-    size_t norm_bits;           ///< bits allocated for the norms
-    size_t total_codebook_size; ///< size of the codebook in vectors
-    bool only_8bit;             ///< are all nbits = 8 (use faster decoder)
+    size_t tot_bits = 0;            ///< total number of bits (indexes + norms)
+    size_t norm_bits = 0;           ///< bits allocated for the norms
+    size_t total_codebook_size = 0; ///< size of the codebook in vectors
+    bool only_8bit = false;         ///< are all nbits = 8 (use faster decoder)
 
-    bool verbose;    ///< verbose during training?
-    bool is_trained; ///< is trained or not
+    bool verbose = false;    ///< verbose during training?
+    bool is_trained = false; ///< is trained or not
 
     IndexFlat1D qnorm;            ///< store and search norms
     std::vector<float> norm_tabs; ///< store norms of codebook entries for 4-bit
@@ -43,7 +44,7 @@ struct AdditiveQuantizer : Quantizer {
 
     /// norms and distance matrixes with beam search can get large, so use this
     /// to control for the amount of memory that can be allocated
-    size_t max_mem_distances;
+    size_t max_mem_distances = 5 * (size_t(1) << 30);
 
     /// encode a norm into norm_bits bits
     uint64_t encode_norm(float norm) const;
@@ -145,7 +146,7 @@ struct AdditiveQuantizer : Quantizer {
     Search_type_t search_type;
 
     /// min/max for quantization of norms
-    float norm_min, norm_max;
+    float norm_min = NAN, norm_max = NAN;
 
     template <bool is_IP, Search_type_t effective_search_type>
     float compute_1_distance_LUT(const uint8_t* codes, const float* LUT) const;

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -47,11 +47,6 @@ void HNSW::neighbor_range(idx_t no, int layer_no, size_t* begin, size_t* end)
 
 HNSW::HNSW(int M) : rng(12345) {
     set_default_probas(M, 1.0 / log(M));
-    max_level = -1;
-    entry_point = -1;
-    efSearch = 16;
-    efConstruction = 40;
-    upper_beam = 1;
     offsets.push_back(0);
 }
 

--- a/faiss/impl/HNSW.h
+++ b/faiss/impl/HNSW.h
@@ -121,25 +121,25 @@ struct HNSW {
 
     /// entry point in the search structure (one of the points with maximum
     /// level
-    storage_idx_t entry_point;
+    storage_idx_t entry_point = -1;
 
     faiss::RandomGenerator rng;
 
     /// maximum level
-    int max_level;
+    int max_level = -1;
 
     /// expansion factor at construction time
-    int efConstruction;
+    int efConstruction = 40;
 
     /// expansion factor at search time
-    int efSearch;
+    int efSearch = 16;
 
     /// during search: do we check whether the next best distance is good
     /// enough?
     bool check_relative_distance = true;
 
     /// number of entry points in levels > 0.
-    int upper_beam;
+    int upper_beam = 1;
 
     /// use bounded queue during exploration
     bool search_bounded_queue = true;

--- a/faiss/impl/LocalSearchQuantizer.cpp
+++ b/faiss/impl/LocalSearchQuantizer.cpp
@@ -160,23 +160,7 @@ LocalSearchQuantizer::LocalSearchQuantizer(
         Search_type_t search_type)
         : AdditiveQuantizer(d, std::vector<size_t>(M, nbits), search_type) {
     K = (1 << nbits);
-
-    train_iters = 25;
-    train_ils_iters = 8;
-    icm_iters = 4;
-
-    encode_ils_iters = 16;
-
-    p = 0.5f;
-    lambd = 1e-2f;
-
-    chunk_size = 10000;
-    nperts = 4;
-
-    random_seed = 0x12345;
     std::srand(random_seed);
-
-    icm_encoder_factory = nullptr;
 }
 
 LocalSearchQuantizer::~LocalSearchQuantizer() {

--- a/faiss/impl/LocalSearchQuantizer.h
+++ b/faiss/impl/LocalSearchQuantizer.h
@@ -45,22 +45,21 @@ struct IcmEncoderFactory;
 struct LocalSearchQuantizer : AdditiveQuantizer {
     size_t K; ///< number of codes per codebook
 
-    size_t train_iters; ///< number of iterations in training
+    size_t train_iters = 25;      ///< number of iterations in training
+    size_t encode_ils_iters = 16; ///< iterations of local search in encoding
+    size_t train_ils_iters = 8;   ///< iterations of local search in training
+    size_t icm_iters = 4;         ///< number of iterations in icm
 
-    size_t encode_ils_iters; ///< iterations of local search in encoding
-    size_t train_ils_iters;  ///< iterations of local search in training
-    size_t icm_iters;        ///< number of iterations in icm
+    float p = 0.5f;      ///< temperature factor
+    float lambd = 1e-2f; ///< regularization factor
 
-    float p;     ///< temperature factor
-    float lambd; ///< regularization factor
+    size_t chunk_size = 10000; ///< nb of vectors to encode at a time
 
-    size_t chunk_size; ///< nb of vectors to encode at a time
+    int random_seed = 0x12345; ///< seed for random generator
+    size_t nperts = 4;         ///< number of perturbation in each code
 
-    int random_seed; ///< seed for random generator
-    size_t nperts;   ///< number of perturbation in each code
-
-    ///< if non-NULL, use this encoder to encode
-    lsq::IcmEncoderFactory* icm_encoder_factory;
+    ///< if non-NULL, use this encoder to encode (owned by the object)
+    lsq::IcmEncoderFactory* icm_encoder_factory = nullptr;
 
     bool update_codebooks_with_double = true;
 

--- a/faiss/impl/NNDescent.cpp
+++ b/faiss/impl/NNDescent.cpp
@@ -147,14 +147,8 @@ using namespace nndescent;
 
 constexpr int NUM_EVAL_POINTS = 100;
 
-NNDescent::NNDescent(const int d, const int K) : K(K), random_seed(2021), d(d) {
-    ntotal = 0;
-    has_built = false;
-    S = 10;
-    R = 100;
+NNDescent::NNDescent(const int d, const int K) : K(K), d(d) {
     L = K + 50;
-    iter = 10;
-    search_L = 0;
 }
 
 NNDescent::~NNDescent() {}

--- a/faiss/impl/NNDescent.h
+++ b/faiss/impl/NNDescent.h
@@ -132,19 +132,20 @@ struct NNDescent {
             std::vector<int>& ctrl_points,
             std::vector<std::vector<int>>& acc_eval_set);
 
-    bool has_built;
+    bool has_built = false;
+
+    int S = 10;  // number of sample neighbors to be updated for each node
+    int R = 100; // size of reverse links, 0 means the reverse links will not be
+                 // used
+    int iter = 10;          // number of iterations to iterate over
+    int search_L = 0;       // size of candidate pool in searching
+    int random_seed = 2021; // random seed for generators
 
     int K; // K in KNN graph
-    int S; // number of sample neighbors to be updated for each node
-    int R; // size of reverse links, 0 means the reverse links will not be used
-    int L; // size of the candidate pool in building
-    int iter;        // number of iterations to iterate over
-    int search_L;    // size of candidate pool in searching
-    int random_seed; // random seed for generators
-
     int d; // dimensions
+    int L; // size of the candidate pool in building
 
-    int ntotal;
+    int ntotal = 0;
 
     KNNGraph graph;
     std::vector<int> final_graph;

--- a/faiss/impl/NSG.cpp
+++ b/faiss/impl/NSG.cpp
@@ -138,9 +138,6 @@ inline int insert_into_pool(Neighbor* addr, int K, Neighbor nn) {
 NSG::NSG(int R) : R(R), rng(0x0903) {
     L = R + 32;
     C = R + 100;
-    search_L = 16;
-    ntotal = 0;
-    is_built = false;
     srand(0x1998);
 }
 

--- a/faiss/impl/NSG.h
+++ b/faiss/impl/NSG.h
@@ -100,7 +100,7 @@ struct NSG {
     /// internal storage of vectors (32 bits: this is expensive)
     using storage_idx_t = int32_t;
 
-    int ntotal; ///< nb of nodes
+    int ntotal = 0; ///< nb of nodes
 
     // construction-time parameters
     int R; ///< nb of neighbors per node
@@ -108,13 +108,13 @@ struct NSG {
     int C; ///< candidate pool size at construction time
 
     // search-time parameters
-    int search_L; ///< length of the search path
+    int search_L = 16; ///< length of the search path
 
     int enterpoint; ///< enterpoint
 
     std::shared_ptr<nsg::Graph<int>> final_graph; ///< NSG graph structure
 
-    bool is_built; ///< NSG is built or not
+    bool is_built = false; ///< NSG is built or not
 
     RandomGenerator rng; ///< random generator
 

--- a/faiss/impl/PolysemousTraining.cpp
+++ b/faiss/impl/PolysemousTraining.cpp
@@ -35,19 +35,6 @@ namespace faiss {
  * Optimization code
  ****************************************************/
 
-SimulatedAnnealingParameters::SimulatedAnnealingParameters() {
-    // set some reasonable defaults for the optimization
-    init_temperature = 0.7;
-    temperature_decay = pow(0.9, 1 / 500.);
-    // reduce by a factor 0.9 every 500 it
-    n_iter = 500000;
-    n_redo = 2;
-    seed = 123;
-    verbose = 0;
-    only_bit_flips = false;
-    init_random = false;
-}
-
 // what would the cost update be if iw and jw were swapped?
 // default implementation just computes both and computes the difference
 double PermutationObjective::cost_update(const int* perm, int iw, int jw)

--- a/faiss/impl/PolysemousTraining.h
+++ b/faiss/impl/PolysemousTraining.h
@@ -17,18 +17,19 @@ namespace faiss {
 /// parameters used for the simulated annealing method
 struct SimulatedAnnealingParameters {
     // optimization parameters
-    double init_temperature;  // init probability of accepting a bad swap
-    double temperature_decay; // at each iteration the temp is multiplied by
-                              // this
-    int n_iter;               // nb of iterations
-    int n_redo;               // nb of runs of the simulation
-    int seed;                 // random seed
-    int verbose;
-    bool only_bit_flips; // restrict permutation changes to bit flips
-    bool init_random;    // initialize with a random permutation (not identity)
+    double init_temperature = 0.7; // init probability of accepting a bad swap
+    // at each iteration the temp is multiplied by this
+    double temperature_decay = 0.9997893011688015; // = 0.9^(1/500)
+    int n_iter = 500000;                           // nb of iterations
+    int n_redo = 2; // nb of runs of the simulation
+    int seed = 123; // random seed
+    int verbose = 0;
+    bool only_bit_flips = false; // restrict permutation changes to bit flips
+    bool init_random =
+            false; // initialize with a random permutation (not identity)
 
     // set reasonable defaults
-    SimulatedAnnealingParameters();
+    SimulatedAnnealingParameters() {}
 };
 
 /// abstract class for the loss function

--- a/faiss/impl/ProductAdditiveQuantizer.cpp
+++ b/faiss/impl/ProductAdditiveQuantizer.cpp
@@ -65,13 +65,6 @@ void ProductAdditiveQuantizer::init(
         M += q->M;
         nbits.insert(nbits.end(), q->nbits.begin(), q->nbits.end());
     }
-    verbose = false;
-    is_trained = false;
-    norm_max = norm_min = NAN;
-    code_size = 0;
-    tot_bits = 0;
-    total_codebook_size = 0;
-    only_8bit = false;
     set_derived_values();
 
     // ProductAdditiveQuantizer

--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -1047,12 +1047,11 @@ SQDistanceComputer* select_distance_computer(
  ********************************************************************/
 
 ScalarQuantizer::ScalarQuantizer(size_t d, QuantizerType qtype)
-        : Quantizer(d), qtype(qtype), rangestat(RS_minmax), rangestat_arg(0) {
+        : Quantizer(d), qtype(qtype) {
     set_derived_sizes();
 }
 
-ScalarQuantizer::ScalarQuantizer()
-        : qtype(QT_8bit), rangestat(RS_minmax), rangestat_arg(0), bits(0) {}
+ScalarQuantizer::ScalarQuantizer() {}
 
 void ScalarQuantizer::set_derived_sizes() {
     switch (qtype) {

--- a/faiss/impl/ScalarQuantizer.h
+++ b/faiss/impl/ScalarQuantizer.h
@@ -34,7 +34,7 @@ struct ScalarQuantizer : Quantizer {
         QT_6bit,        ///< 6 bits per component
     };
 
-    QuantizerType qtype;
+    QuantizerType qtype = QT_8bit;
 
     /** The uniform encoder can estimate the range of representable
      * values of the unform encoder using different statistics. Here
@@ -48,11 +48,11 @@ struct ScalarQuantizer : Quantizer {
         RS_optim,     ///< alternate optimization of reconstruction error
     };
 
-    RangeStat rangestat;
-    float rangestat_arg;
+    RangeStat rangestat = RS_minmax;
+    float rangestat_arg = 0;
 
     /// bits per scalar code
-    size_t bits;
+    size_t bits = 0;
 
     /// trained values (including the range)
     std::vector<float> trained;


### PR DESCRIPTION
Summary: This is a cosmetic diff where default values for scalar fields are moved to the .h file where the object is declared rather than in the object constructor. The advantage is that it is easier to read the default value of a parameter from just the class.

Reviewed By: alexanderguzhva

Differential Revision: D42722205

