### PR TITLE
iterable inverted lists

### DIFF
--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -423,6 +423,13 @@ struct InvertedListScanner {
             float radius,
             RangeQueryResult& result) const;
 
+    virtual size_t iterate_codes(
+            InvertedListsIterator* iterator,
+            size_t& n,
+            float* distances,
+            idx_t* labels,
+            size_t k) const;
+
     virtual ~InvertedListScanner() {}
 };
 


### PR DESCRIPTION
Summary:
Publishing for visibility/RFC

Adding support for iterable inverted lists, eg.  key value stores.

Reviewed By: mdouze

Differential Revision: D42778489

