### PR TITLE
implemented fvec_L2sqr_ny_y_transposed() plus an AVX2 code for it

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -203,6 +203,7 @@ set(FAISS_HEADERS
   utils/approx_topk/approx_topk.h
   utils/approx_topk/avx2-inl.h
   utils/approx_topk/generic.h
+  utils/transpose/transpose-avx2-inl.h
 )
 
 if(NOT WIN32)

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -170,6 +170,9 @@ set(FAISS_HEADERS
   impl/platform_macros.h
   impl/pq4_fast_scan.h
   impl/simd_result_handlers.h
+  impl/ivfpq/code_distance.h
+  impl/ivfpq/code_distance-generic.h
+  impl/ivfpq/code_distance-avx2.h
   invlists/BlockInvertedLists.h
   invlists/DirectMap.h
   invlists/InvertedLists.h

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -33,9 +33,7 @@
 
 #include <faiss/impl/ProductQuantizer.h>
 
-#ifdef __AVX2__
-#include <immintrin.h>
-#endif
+#include <faiss/impl/ivfpq/code_distance.h>
 
 namespace faiss {
 
@@ -889,140 +887,29 @@ struct IVFPQScannerT : QueryTables {
      * Scaning the codes: simple PQ scan.
      *****************************************************/
 
-#ifdef __AVX2__
-    /// Returns the distance to a single code.
-    /// General-purpose version.
-    template <class SearchResultType, typename T = PQDecoder>
-    typename std::enable_if<!(std::is_same<T, PQDecoder8>::value), float>::
-            type inline distance_single_code(const uint8_t* code) const {
-        PQDecoder decoder(code, pq.nbits);
+    // This is the baseline version of scan_list_with_tables().
+    // It demonstrates what this function actually does.
+    //
+    // /// version of the scan where we use precomputed tables.
+    // template <class SearchResultType>
+    // void scan_list_with_table(
+    //         size_t ncode,
+    //         const uint8_t* codes,
+    //         SearchResultType& res) const {
+    //
+    //     for (size_t j = 0; j < ncode; j++, codes += pq.code_size) {
+    //         if (res.skip_entry(j)) {
+    //             continue;
+    //         }
+    //         float dis = dis0 + distance_single_code<PQDecoder>(
+    //             pq, sim_table, codes);
+    //         res.add(j, dis);
+    //     }
+    // }
 
-        const float* tab = sim_table;
-        float result = 0;
-
-        for (size_t m = 0; m < pq.M; m++) {
-            result += tab[decoder.decode()];
-            tab += pq.ksub;
-        }
-
-        return result;
-    }
-
-    /// Returns the distance to a single code.
-    /// Specialized AVX2 PQDecoder8 version.
-    template <class SearchResultType, typename T = PQDecoder>
-    typename std::enable_if<(std::is_same<T, PQDecoder8>::value), float>::
-            type inline distance_single_code(const uint8_t* code) const {
-        float result = 0;
-
-        size_t m = 0;
-        const size_t pqM16 = pq.M / 16;
-
-        const float* tab = sim_table;
-
-        if (pqM16 > 0) {
-            // process 16 values per loop
-
-            const __m256i ksub = _mm256_set1_epi32(pq.ksub);
-            __m256i offsets_0 = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
-            offsets_0 = _mm256_mullo_epi32(offsets_0, ksub);
-
-            // accumulators of partial sums
-            __m256 partialSum = _mm256_setzero_ps();
-
-            // loop
-            for (m = 0; m < pqM16 * 16; m += 16) {
-                // load 16 uint8 values
-                const __m128i mm1 =
-                        _mm_loadu_si128((const __m128i_u*)(code + m));
-                {
-                    // convert uint8 values (low part of __m128i) to int32
-                    // values
-                    const __m256i idx1 = _mm256_cvtepu8_epi32(mm1);
-
-                    // add offsets
-                    const __m256i indices_to_read_from =
-                            _mm256_add_epi32(idx1, offsets_0);
-
-                    // gather 8 values, similar to 8 operations of tab[idx]
-                    __m256 collected = _mm256_i32gather_ps(
-                            tab, indices_to_read_from, sizeof(float));
-                    tab += pq.ksub * 8;
-
-                    // collect partial sums
-                    partialSum = _mm256_add_ps(partialSum, collected);
-                }
-
-                // move high 8 uint8 to low ones
-                const __m128i mm2 =
-                        _mm_unpackhi_epi64(mm1, _mm_setzero_si128());
-                {
-                    // convert uint8 values (low part of __m128i) to int32
-                    // values
-                    const __m256i idx1 = _mm256_cvtepu8_epi32(mm2);
-
-                    // add offsets
-                    const __m256i indices_to_read_from =
-                            _mm256_add_epi32(idx1, offsets_0);
-
-                    // gather 8 values, similar to 8 operations of tab[idx]
-                    __m256 collected = _mm256_i32gather_ps(
-                            tab, indices_to_read_from, sizeof(float));
-                    tab += pq.ksub * 8;
-
-                    // collect partial sums
-                    partialSum = _mm256_add_ps(partialSum, collected);
-                }
-            }
-
-            // horizontal sum for partialSum
-            const __m256 h0 = _mm256_hadd_ps(partialSum, partialSum);
-            const __m256 h1 = _mm256_hadd_ps(h0, h0);
-
-            // extract high and low __m128 regs from __m256
-            const __m128 h2 = _mm256_extractf128_ps(h1, 1);
-            const __m128 h3 = _mm256_castps256_ps128(h1);
-
-            // get a final hsum into all 4 regs
-            const __m128 h4 = _mm_add_ss(h2, h3);
-
-            // extract f[0] from __m128
-            const float hsum = _mm_cvtss_f32(h4);
-            result += hsum;
-        }
-
-        //
-        if (m < pq.M) {
-            // process leftovers
-            PQDecoder decoder(code + m, pq.nbits);
-
-            for (; m < pq.M; m++) {
-                result += tab[decoder.decode()];
-                tab += pq.ksub;
-            }
-        }
-
-        return result;
-    }
-
-#else
-    /// Returns the distance to a single code.
-    /// General-purpose version.
-    template <class SearchResultType>
-    inline float distance_single_code(const uint8_t* code) const {
-        PQDecoder decoder(code, pq.nbits);
-
-        const float* tab = sim_table;
-        float result = 0;
-
-        for (size_t m = 0; m < pq.M; m++) {
-            result += tab[decoder.decode()];
-            tab += pq.ksub;
-        }
-
-        return result;
-    }
-#endif
+    // This is the modified version of scan_list_with_tables().
+    // It was observed that doing manual unrolling of the loop that
+    //    utilizes distance_single_code() speeds up the computations.
 
     /// version of the scan where we use precomputed tables.
     template <class SearchResultType>
@@ -1030,12 +917,65 @@ struct IVFPQScannerT : QueryTables {
             size_t ncode,
             const uint8_t* codes,
             SearchResultType& res) const {
-        for (size_t j = 0; j < ncode; j++, codes += pq.code_size) {
+        int counter = 0;
+
+        size_t saved_j[4] = {0, 0, 0, 0};
+        for (size_t j = 0; j < ncode; j++) {
             if (res.skip_entry(j)) {
                 continue;
             }
-            float dis = dis0 + distance_single_code<SearchResultType>(codes);
-            res.add(j, dis);
+
+            saved_j[0] = (counter == 0) ? j : saved_j[0];
+            saved_j[1] = (counter == 1) ? j : saved_j[1];
+            saved_j[2] = (counter == 2) ? j : saved_j[2];
+            saved_j[3] = (counter == 3) ? j : saved_j[3];
+
+            counter += 1;
+            if (counter == 4) {
+                float distance_0 = 0;
+                float distance_1 = 0;
+                float distance_2 = 0;
+                float distance_3 = 0;
+                distance_four_codes<PQDecoder>(
+                        pq,
+                        sim_table,
+                        codes + saved_j[0] * pq.code_size,
+                        codes + saved_j[1] * pq.code_size,
+                        codes + saved_j[2] * pq.code_size,
+                        codes + saved_j[3] * pq.code_size,
+                        distance_0,
+                        distance_1,
+                        distance_2,
+                        distance_3);
+
+                res.add(saved_j[0], dis0 + distance_0);
+                res.add(saved_j[1], dis0 + distance_1);
+                res.add(saved_j[2], dis0 + distance_2);
+                res.add(saved_j[3], dis0 + distance_3);
+                counter = 0;
+            }
+        }
+
+        if (counter >= 1) {
+            float dis =
+                    dis0 +
+                    distance_single_code<PQDecoder>(
+                            pq, sim_table, codes + saved_j[0] * pq.code_size);
+            res.add(saved_j[0], dis);
+        }
+        if (counter >= 2) {
+            float dis =
+                    dis0 +
+                    distance_single_code<PQDecoder>(
+                            pq, sim_table, codes + saved_j[1] * pq.code_size);
+            res.add(saved_j[1], dis);
+        }
+        if (counter >= 3) {
+            float dis =
+                    dis0 +
+                    distance_single_code<PQDecoder>(
+                            pq, sim_table, codes + saved_j[2] * pq.code_size);
+            res.add(saved_j[2], dis);
         }
     }
 
@@ -1104,6 +1044,46 @@ struct IVFPQScannerT : QueryTables {
      * Scanning codes with polysemous filtering
      *****************************************************/
 
+    // This is the baseline version of scan_list_polysemous_hc().
+    // It demonstrates what this function actually does.
+
+    //     template <class HammingComputer, class SearchResultType>
+    //     void scan_list_polysemous_hc(
+    //             size_t ncode,
+    //             const uint8_t* codes,
+    //             SearchResultType& res) const {
+    //         int ht = ivfpq.polysemous_ht;
+    //         size_t n_hamming_pass = 0, nup = 0;
+    //
+    //         int code_size = pq.code_size;
+    //
+    //         HammingComputer hc(q_code.data(), code_size);
+    //
+    //         for (size_t j = 0; j < ncode; j++, codes += code_size) {
+    //             if (res.skip_entry(j)) {
+    //                 continue;
+    //             }
+    //             const uint8_t* b_code = codes;
+    //             int hd = hc.hamming(b_code);
+    //             if (hd < ht) {
+    //                 n_hamming_pass++;
+    //
+    //                 float dis =
+    //                         dis0 +
+    //                         distance_single_code<PQDecoder>(
+    //                             pq, sim_table, codes);
+    //
+    //                 res.add(j, dis);
+    //             }
+    //         }
+    // #pragma omp critical
+    //         { indexIVFPQ_stats.n_hamming_pass += n_hamming_pass; }
+    //     }
+
+    // This is the modified version of scan_list_with_tables().
+    // It was observed that doing manual unrolling of the loop that
+    //    utilizes distance_single_code() speeds up the computations.
+
     template <class HammingComputer, class SearchResultType>
     void scan_list_polysemous_hc(
             size_t ncode,
@@ -1114,23 +1094,103 @@ struct IVFPQScannerT : QueryTables {
 
         int code_size = pq.code_size;
 
+        size_t saved_j[8];
+        int counter = 0;
+
         HammingComputer hc(q_code.data(), code_size);
 
-        for (size_t j = 0; j < ncode; j++, codes += code_size) {
+        for (size_t j = 0; j < (ncode / 4) * 4; j += 4) {
+            const uint8_t* b_code = codes + j * code_size;
+
+            // Unrolling is a key. Basically, doing multiple popcount
+            // operations one after another speeds things up.
+
+            // 9999999 is just an arbitrary large number
+            int hd0 = (res.skip_entry(j + 0))
+                    ? 99999999
+                    : hc.hamming(b_code + 0 * code_size);
+            int hd1 = (res.skip_entry(j + 1))
+                    ? 99999999
+                    : hc.hamming(b_code + 1 * code_size);
+            int hd2 = (res.skip_entry(j + 2))
+                    ? 99999999
+                    : hc.hamming(b_code + 2 * code_size);
+            int hd3 = (res.skip_entry(j + 3))
+                    ? 99999999
+                    : hc.hamming(b_code + 3 * code_size);
+
+            saved_j[counter] = j + 0;
+            counter = (hd0 < ht) ? (counter + 1) : counter;
+            saved_j[counter] = j + 1;
+            counter = (hd1 < ht) ? (counter + 1) : counter;
+            saved_j[counter] = j + 2;
+            counter = (hd2 < ht) ? (counter + 1) : counter;
+            saved_j[counter] = j + 3;
+            counter = (hd3 < ht) ? (counter + 1) : counter;
+
+            if (counter >= 4) {
+                // process four codes at the same time
+                n_hamming_pass += 4;
+
+                float distance_0 = dis0;
+                float distance_1 = dis0;
+                float distance_2 = dis0;
+                float distance_3 = dis0;
+                distance_four_codes<PQDecoder>(
+                        pq,
+                        sim_table,
+                        codes + saved_j[0] * pq.code_size,
+                        codes + saved_j[1] * pq.code_size,
+                        codes + saved_j[2] * pq.code_size,
+                        codes + saved_j[3] * pq.code_size,
+                        distance_0,
+                        distance_1,
+                        distance_2,
+                        distance_3);
+
+                res.add(saved_j[0], dis0 + distance_0);
+                res.add(saved_j[1], dis0 + distance_1);
+                res.add(saved_j[2], dis0 + distance_2);
+                res.add(saved_j[3], dis0 + distance_3);
+
+                //
+                counter -= 4;
+                saved_j[0] = saved_j[4];
+                saved_j[1] = saved_j[5];
+                saved_j[2] = saved_j[6];
+                saved_j[3] = saved_j[7];
+            }
+        }
+
+        for (size_t kk = 0; kk < counter; kk++) {
+            n_hamming_pass++;
+
+            float dis =
+                    dis0 +
+                    distance_single_code<PQDecoder>(
+                            pq, sim_table, codes + saved_j[kk] * pq.code_size);
+
+            res.add(saved_j[kk], dis);
+        }
+
+        // process leftovers
+        for (size_t j = (ncode / 4) * 4; j < ncode; j++) {
             if (res.skip_entry(j)) {
                 continue;
             }
-            const uint8_t* b_code = codes;
+            const uint8_t* b_code = codes + j * code_size;
             int hd = hc.hamming(b_code);
             if (hd < ht) {
                 n_hamming_pass++;
 
-                float dis =
-                        dis0 + distance_single_code<SearchResultType>(codes);
+                float dis = dis0 +
+                        distance_single_code<PQDecoder>(
+                                    pq, sim_table, codes + j * code_size);
 
                 res.add(j, dis);
             }
         }
+
 #pragma omp critical
         { indexIVFPQ_stats.n_hamming_pass += n_hamming_pass; }
     }

--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -421,15 +421,28 @@ void ProductQuantizer::compute_codes(const float* x, uint8_t* codes, size_t n)
 
 void ProductQuantizer::compute_distance_table(const float* x, float* dis_table)
         const {
-    size_t m;
-
-    for (m = 0; m < M; m++) {
-        fvec_L2sqr_ny(
-                dis_table + m * ksub,
-                x + m * dsub,
-                get_centroids(m, 0),
-                dsub,
-                ksub);
+    if (transposed_centroids.empty()) {
+        // use regular version
+        for (size_t m = 0; m < M; m++) {
+            fvec_L2sqr_ny(
+                    dis_table + m * ksub,
+                    x + m * dsub,
+                    get_centroids(m, 0),
+                    dsub,
+                    ksub);
+        }
+    } else {
+        // transposed centroids are available, use'em
+        for (size_t m = 0; m < M; m++) {
+            fvec_L2sqr_ny_transposed(
+                    dis_table + m * ksub,
+                    x + m * dsub,
+                    transposed_centroids.data() + m * ksub,
+                    centroids_sq_lengths.data() + m * ksub,
+                    dsub,
+                    M * ksub,
+                    ksub);
+        }
     }
 }
 

--- a/faiss/impl/ivfpq/code_distance-avx2.h
+++ b/faiss/impl/ivfpq/code_distance-avx2.h
@@ -1,0 +1,291 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef __AVX2__
+
+#include <immintrin.h>
+
+#include <type_traits>
+
+#include <faiss/impl/ivfpq/code_distance-generic.h>
+
+namespace {
+
+// Computes a horizontal sum over an __m256 register
+inline float horizontal_sum(const __m256 reg) {
+    const __m256 h0 = _mm256_hadd_ps(reg, reg);
+    const __m256 h1 = _mm256_hadd_ps(h0, h0);
+
+    // extract high and low __m128 regs from __m256
+    const __m128 h2 = _mm256_extractf128_ps(h1, 1);
+    const __m128 h3 = _mm256_castps256_ps128(h1);
+
+    // get a final hsum into all 4 regs
+    const __m128 h4 = _mm_add_ss(h2, h3);
+
+    // extract f[0] from __m128
+    const float hsum = _mm_cvtss_f32(h4);
+    return hsum;
+}
+
+} // namespace
+
+namespace faiss {
+
+template <typename PQDecoderT>
+typename std::enable_if<!std::is_same<PQDecoderT, PQDecoder8>::value, float>::
+        type inline distance_single_code_avx2(
+                // the product quantizer
+                const ProductQuantizer& pq,
+                // precomputed distances, layout (M, ksub)
+                const float* sim_table,
+                const uint8_t* code) {
+    // default implementation
+    return distance_single_code_generic<PQDecoderT>(pq, sim_table, code);
+}
+
+template <typename PQDecoderT>
+typename std::enable_if<std::is_same<PQDecoderT, PQDecoder8>::value, float>::
+        type inline distance_single_code_avx2(
+                // the product quantizer
+                const ProductQuantizer& pq,
+                // precomputed distances, layout (M, ksub)
+                const float* sim_table,
+                const uint8_t* code) {
+    float result = 0;
+
+    size_t m = 0;
+    const size_t pqM16 = pq.M / 16;
+
+    const float* tab = sim_table;
+
+    if (pqM16 > 0) {
+        // process 16 values per loop
+
+        const __m256i ksub = _mm256_set1_epi32(pq.ksub);
+        __m256i offsets_0 = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
+        offsets_0 = _mm256_mullo_epi32(offsets_0, ksub);
+
+        // accumulators of partial sums
+        __m256 partialSum = _mm256_setzero_ps();
+
+        // loop
+        for (m = 0; m < pqM16 * 16; m += 16) {
+            // load 16 uint8 values
+            const __m128i mm1 = _mm_loadu_si128((const __m128i_u*)(code + m));
+            {
+                // convert uint8 values (low part of __m128i) to int32
+                // values
+                const __m256i idx1 = _mm256_cvtepu8_epi32(mm1);
+
+                // add offsets
+                const __m256i indices_to_read_from =
+                        _mm256_add_epi32(idx1, offsets_0);
+
+                // gather 8 values, similar to 8 operations of tab[idx]
+                __m256 collected = _mm256_i32gather_ps(
+                        tab, indices_to_read_from, sizeof(float));
+                tab += pq.ksub * 8;
+
+                // collect partial sums
+                partialSum = _mm256_add_ps(partialSum, collected);
+            }
+
+            // move high 8 uint8 to low ones
+            const __m128i mm2 = _mm_unpackhi_epi64(mm1, _mm_setzero_si128());
+            {
+                // convert uint8 values (low part of __m128i) to int32
+                // values
+                const __m256i idx1 = _mm256_cvtepu8_epi32(mm2);
+
+                // add offsets
+                const __m256i indices_to_read_from =
+                        _mm256_add_epi32(idx1, offsets_0);
+
+                // gather 8 values, similar to 8 operations of tab[idx]
+                __m256 collected = _mm256_i32gather_ps(
+                        tab, indices_to_read_from, sizeof(float));
+                tab += pq.ksub * 8;
+
+                // collect partial sums
+                partialSum = _mm256_add_ps(partialSum, collected);
+            }
+        }
+
+        // horizontal sum for partialSum
+        result += horizontal_sum(partialSum);
+    }
+
+    //
+    if (m < pq.M) {
+        // process leftovers
+        PQDecoder8 decoder(code + m, pq.nbits);
+
+        for (; m < pq.M; m++) {
+            result += tab[decoder.decode()];
+            tab += pq.ksub;
+        }
+    }
+
+    return result;
+}
+
+template <typename PQDecoderT>
+typename std::enable_if<!std::is_same<PQDecoderT, PQDecoder8>::value, void>::
+        type
+        distance_four_codes_avx2(
+                // the product quantizer
+                const ProductQuantizer& pq,
+                // precomputed distances, layout (M, ksub)
+                const float* sim_table,
+                // codes
+                const uint8_t* __restrict code0,
+                const uint8_t* __restrict code1,
+                const uint8_t* __restrict code2,
+                const uint8_t* __restrict code3,
+                // computed distances
+                float& result0,
+                float& result1,
+                float& result2,
+                float& result3) {
+    distance_four_codes_generic<PQDecoderT>(
+            pq,
+            sim_table,
+            code0,
+            code1,
+            code2,
+            code3,
+            result0,
+            result1,
+            result2,
+            result3);
+}
+
+// Combines 4 operations of distance_single_code()
+template <typename PQDecoderT>
+typename std::enable_if<std::is_same<PQDecoderT, PQDecoder8>::value, void>::type
+distance_four_codes_avx2(
+        // the product quantizer
+        const ProductQuantizer& pq,
+        // precomputed distances, layout (M, ksub)
+        const float* sim_table,
+        // codes
+        const uint8_t* __restrict code0,
+        const uint8_t* __restrict code1,
+        const uint8_t* __restrict code2,
+        const uint8_t* __restrict code3,
+        // computed distances
+        float& result0,
+        float& result1,
+        float& result2,
+        float& result3) {
+    result0 = 0;
+    result1 = 0;
+    result2 = 0;
+    result3 = 0;
+
+    size_t m = 0;
+    const size_t pqM16 = pq.M / 16;
+
+    constexpr intptr_t N = 4;
+
+    const float* tab = sim_table;
+
+    if (pqM16 > 0) {
+        // process 16 values per loop
+        const __m256i ksub = _mm256_set1_epi32(pq.ksub);
+        __m256i offsets_0 = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
+        offsets_0 = _mm256_mullo_epi32(offsets_0, ksub);
+
+        // accumulators of partial sums
+        __m256 partialSums[N];
+        for (intptr_t j = 0; j < N; j++) {
+            partialSums[j] = _mm256_setzero_ps();
+        }
+
+        // loop
+        for (m = 0; m < pqM16 * 16; m += 16) {
+            // load 16 uint8 values
+            __m128i mm1[N];
+            mm1[0] = _mm_loadu_si128((const __m128i_u*)(code0 + m));
+            mm1[1] = _mm_loadu_si128((const __m128i_u*)(code1 + m));
+            mm1[2] = _mm_loadu_si128((const __m128i_u*)(code2 + m));
+            mm1[3] = _mm_loadu_si128((const __m128i_u*)(code3 + m));
+
+            // process first 8 codes
+            for (intptr_t j = 0; j < N; j++) {
+                // convert uint8 values (low part of __m128i) to int32
+                // values
+                const __m256i idx1 = _mm256_cvtepu8_epi32(mm1[j]);
+
+                // add offsets
+                const __m256i indices_to_read_from =
+                        _mm256_add_epi32(idx1, offsets_0);
+
+                // gather 8 values, similar to 8 operations of tab[idx]
+                __m256 collected = _mm256_i32gather_ps(
+                        tab, indices_to_read_from, sizeof(float));
+
+                // collect partial sums
+                partialSums[j] = _mm256_add_ps(partialSums[j], collected);
+            }
+            tab += pq.ksub * 8;
+
+            // process next 8 codes
+            for (intptr_t j = 0; j < N; j++) {
+                // move high 8 uint8 to low ones
+                const __m128i mm2 =
+                        _mm_unpackhi_epi64(mm1[j], _mm_setzero_si128());
+
+                // convert uint8 values (low part of __m128i) to int32
+                // values
+                const __m256i idx1 = _mm256_cvtepu8_epi32(mm2);
+
+                // add offsets
+                const __m256i indices_to_read_from =
+                        _mm256_add_epi32(idx1, offsets_0);
+
+                // gather 8 values, similar to 8 operations of tab[idx]
+                __m256 collected = _mm256_i32gather_ps(
+                        tab, indices_to_read_from, sizeof(float));
+
+                // collect partial sums
+                partialSums[j] = _mm256_add_ps(partialSums[j], collected);
+            }
+
+            tab += pq.ksub * 8;
+        }
+
+        // horizontal sum for partialSum
+        result0 += horizontal_sum(partialSums[0]);
+        result1 += horizontal_sum(partialSums[1]);
+        result2 += horizontal_sum(partialSums[2]);
+        result3 += horizontal_sum(partialSums[3]);
+    }
+
+    //
+    if (m < pq.M) {
+        // process leftovers
+        PQDecoder8 decoder0(code0 + m, pq.nbits);
+        PQDecoder8 decoder1(code1 + m, pq.nbits);
+        PQDecoder8 decoder2(code2 + m, pq.nbits);
+        PQDecoder8 decoder3(code3 + m, pq.nbits);
+        for (; m < pq.M; m++) {
+            result0 += tab[decoder0.decode()];
+            result1 += tab[decoder1.decode()];
+            result2 += tab[decoder2.decode()];
+            result3 += tab[decoder3.decode()];
+            tab += pq.ksub;
+        }
+    }
+}
+
+} // namespace faiss
+
+#endif

--- a/faiss/impl/ivfpq/code_distance-generic.h
+++ b/faiss/impl/ivfpq/code_distance-generic.h
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <faiss/impl/ProductQuantizer.h>
+
+namespace faiss {
+
+/// Returns the distance to a single code.
+template <typename PQDecoderT>
+inline float distance_single_code_generic(
+        // the product quantizer
+        const ProductQuantizer& pq,
+        // precomputed distances, layout (M, ksub)
+        const float* sim_table,
+        // the code
+        const uint8_t* code) {
+    PQDecoderT decoder(code, pq.nbits);
+
+    const float* tab = sim_table;
+    float result = 0;
+
+    for (size_t m = 0; m < pq.M; m++) {
+        result += tab[decoder.decode()];
+        tab += pq.ksub;
+    }
+
+    return result;
+}
+
+/// Combines 4 operations of distance_single_code()
+/// General-purpose version.
+template <typename PQDecoderT>
+inline void distance_four_codes_generic(
+        // the product quantizer
+        const ProductQuantizer& pq,
+        // precomputed distances, layout (M, ksub)
+        const float* sim_table,
+        // codes
+        const uint8_t* __restrict code0,
+        const uint8_t* __restrict code1,
+        const uint8_t* __restrict code2,
+        const uint8_t* __restrict code3,
+        // computed distances
+        float& result0,
+        float& result1,
+        float& result2,
+        float& result3) {
+    PQDecoderT decoder0(code0, pq.nbits);
+    PQDecoderT decoder1(code1, pq.nbits);
+    PQDecoderT decoder2(code2, pq.nbits);
+    PQDecoderT decoder3(code3, pq.nbits);
+
+    const float* tab = sim_table;
+    result0 = 0;
+    result1 = 0;
+    result2 = 0;
+    result3 = 0;
+
+    for (size_t m = 0; m < pq.M; m++) {
+        result0 += tab[decoder0.decode()];
+        result1 += tab[decoder1.decode()];
+        result2 += tab[decoder2.decode()];
+        result3 += tab[decoder3.decode()];
+        tab += pq.ksub;
+    }
+}
+
+} // namespace faiss

--- a/faiss/impl/ivfpq/code_distance.h
+++ b/faiss/impl/ivfpq/code_distance.h
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <faiss/impl/platform_macros.h>
+
+// This directory contains functions to compute a distance
+// from a given PQ code to a query vector, given that the
+// distances to a query vector for pq.M codebooks are precomputed.
+//
+// The code was originally the part of IndexIVFPQ.cpp.
+// The baseline implementation can be found in
+//   code_distance-generic.h, distance_single_code_generic().
+
+// The reason for this somewhat unusual structure is that
+// custom implementations may need to fall off to generic
+// implementation in certain cases. So, say, avx2 header file
+// needs to reference the generic header file. This is
+// why the names of the functions for custom implementations
+// have this _generic or _avx2 suffix.
+
+#ifdef __AVX2__
+
+#include <faiss/impl/ivfpq/code_distance-avx2.h>
+
+namespace faiss {
+
+template <typename PQDecoderT>
+inline float distance_single_code(
+        // the product quantizer
+        const ProductQuantizer& pq,
+        // precomputed distances, layout (M, ksub)
+        const float* sim_table,
+        // the code
+        const uint8_t* code) {
+    return distance_single_code_avx2<PQDecoderT>(pq, sim_table, code);
+}
+
+template <typename PQDecoderT>
+inline void distance_four_codes(
+        // the product quantizer
+        const ProductQuantizer& pq,
+        // precomputed distances, layout (M, ksub)
+        const float* sim_table,
+        // codes
+        const uint8_t* __restrict code0,
+        const uint8_t* __restrict code1,
+        const uint8_t* __restrict code2,
+        const uint8_t* __restrict code3,
+        // computed distances
+        float& result0,
+        float& result1,
+        float& result2,
+        float& result3) {
+    distance_four_codes_avx2<PQDecoderT>(
+            pq,
+            sim_table,
+            code0,
+            code1,
+            code2,
+            code3,
+            result0,
+            result1,
+            result2,
+            result3);
+}
+
+} // namespace faiss
+
+#else
+
+#include <faiss/impl/ivfpq/code_distance-generic.h>
+
+namespace faiss {
+
+template <typename PQDecoderT>
+inline float distance_single_code(
+        // the product quantizer
+        const ProductQuantizer& pq,
+        // precomputed distances, layout (M, ksub)
+        const float* sim_table,
+        // the code
+        const uint8_t* code) {
+    return distance_single_code_generic<PQDecoderT>(pq, sim_table, code);
+}
+
+template <typename PQDecoderT>
+inline void distance_four_codes(
+        // the product quantizer
+        const ProductQuantizer& pq,
+        // precomputed distances, layout (M, ksub)
+        const float* sim_table,
+        // codes
+        const uint8_t* __restrict code0,
+        const uint8_t* __restrict code1,
+        const uint8_t* __restrict code2,
+        const uint8_t* __restrict code3,
+        // computed distances
+        float& result0,
+        float& result1,
+        float& result2,
+        float& result3) {
+    distance_four_codes_generic<PQDecoderT>(
+            pq,
+            sim_table,
+            code0,
+            code1,
+            code2,
+            code3,
+            result0,
+            result1,
+            result2,
+            result3);
+}
+
+} // namespace faiss
+
+#endif

--- a/faiss/impl/ivfpq/code_distance_avx512.h
+++ b/faiss/impl/ivfpq/code_distance_avx512.h
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// // // AVX-512 version. It is not used, but let it be for the future
+// // // needs.
+// // template <class SearchResultType, typename T = PQDecoder>
+// // typename std::enable_if<(std::is_same<T, PQDecoder8>::value), void>::
+// //         type distance_four_codes(
+// //     const uint8_t* __restrict code0,
+// //     const uint8_t* __restrict code1,
+// //     const uint8_t* __restrict code2,
+// //     const uint8_t* __restrict code3,
+// //     float& result0,
+// //     float& result1,
+// //     float& result2,
+// //     float& result3
+// // ) const {
+// //     result0 = 0;
+// //     result1 = 0;
+// //     result2 = 0;
+// //     result3 = 0;
+
+// //     size_t m = 0;
+// //     const size_t pqM16 = pq.M / 16;
+
+// //     constexpr intptr_t N = 4;
+
+// //     const float* tab = sim_table;
+
+// //     if (pqM16 > 0) {
+// //         // process 16 values per loop
+// //         const __m512i ksub = _mm512_set1_epi32(pq.ksub);
+// //         __m512i offsets_0 = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7,
+// //              8, 9, 10, 11, 12, 13, 14, 15);
+// //         offsets_0 = _mm512_mullo_epi32(offsets_0, ksub);
+
+// //         // accumulators of partial sums
+// //         __m512 partialSums[N];
+// //         for (intptr_t j = 0; j < N; j++) {
+// //             partialSums[j] = _mm512_setzero_ps();
+// //         }
+
+// //         // loop
+// //         for (m = 0; m < pqM16 * 16; m += 16) {
+// //             // load 16 uint8 values
+// //             __m128i mm1[N];
+// //             mm1[0] = _mm_loadu_si128((const __m128i_u*)(code0 + m));
+// //             mm1[1] = _mm_loadu_si128((const __m128i_u*)(code1 + m));
+// //             mm1[2] = _mm_loadu_si128((const __m128i_u*)(code2 + m));
+// //             mm1[3] = _mm_loadu_si128((const __m128i_u*)(code3 + m));
+
+// //             // process first 8 codes
+// //             for (intptr_t j = 0; j < N; j++) {
+// //                 // convert uint8 values (low part of __m128i) to int32
+// //                 // values
+// //                 const __m512i idx1 = _mm512_cvtepu8_epi32(mm1[j]);
+
+// //                 // add offsets
+// //                 const __m512i indices_to_read_from =
+// //                     _mm512_add_epi32(idx1, offsets_0);
+
+// //                 // gather 8 values, similar to 8 operations of
+// // //                    tab[idx]
+// //                 __m512 collected =
+// //                        _mm512_i32gather_ps(
+// //                             indices_to_read_from, tab, sizeof(float));
+
+// //                 // collect partial sums
+// //                 partialSums[j] = _mm512_add_ps(partialSums[j],
+// //                    collected);
+// //             }
+// //             tab += pq.ksub * 16;
+
+// //         }
+
+// //         // horizontal sum for partialSum
+// //         result0 += _mm512_reduce_add_ps(partialSums[0]);
+// //         result1 += _mm512_reduce_add_ps(partialSums[1]);
+// //         result2 += _mm512_reduce_add_ps(partialSums[2]);
+// //         result3 += _mm512_reduce_add_ps(partialSums[3]);
+// //     }
+
+// //     //
+// //     if (m < pq.M) {
+// //         // process leftovers
+// //         PQDecoder decoder0(code0 + m, pq.nbits);
+// //         PQDecoder decoder1(code1 + m, pq.nbits);
+// //         PQDecoder decoder2(code2 + m, pq.nbits);
+// //         PQDecoder decoder3(code3 + m, pq.nbits);
+// //         for (; m < pq.M; m++) {
+// //             result0 += tab[decoder0.decode()];
+// //             result1 += tab[decoder1.decode()];
+// //             result2 += tab[decoder2.decode()];
+// //             result3 += tab[decoder3.decode()];
+// //             tab += pq.ksub;
+// //         }
+// //     }
+// // }

--- a/faiss/utils/distances.h
+++ b/faiss/utils/distances.h
@@ -73,6 +73,17 @@ void fvec_L2sqr_ny(
         size_t d,
         size_t ny);
 
+/* compute ny square L2 distance between x and a set of transposed contiguous
+   y vectors. squared lengths of y should be provided as well */
+void fvec_L2sqr_ny_transposed(
+        float* dis,
+        const float* x,
+        const float* y,
+        const float* y_sqlen,
+        size_t d,
+        size_t d_offset,
+        size_t ny);
+
 /* compute ny square L2 distance between x and a set of contiguous y vectors
    and return the index of the nearest vector.
    return 0 if ny == 0. */

--- a/faiss/utils/transpose/transpose-avx2-inl.h
+++ b/faiss/utils/transpose/transpose-avx2-inl.h
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// This file contains transposing kernels for AVX2 for
+// tiny float/int32 matrices, such as 8x2.
+
+#ifdef __AVX2__
+
+#include <immintrin.h>
+
+namespace faiss {
+
+// 8x2 -> 2x8
+inline void transpose_8x2(
+        const __m256 i0,
+        const __m256 i1,
+        __m256& o0,
+        __m256& o1) {
+    // say, we have the following as in input:
+    // i0:  00 01 10 11 20 21 30 31
+    // i1:  40 41 50 51 60 61 70 71
+
+    // 00 01 10 11 40 41 50 51
+    const __m256 r0 = _mm256_permute2f128_ps(i0, i1, _MM_SHUFFLE(0, 2, 0, 0));
+    // 20 21 30 31 60 61 70 71
+    const __m256 r1 = _mm256_permute2f128_ps(i0, i1, _MM_SHUFFLE(0, 3, 0, 1));
+
+    // 00 10 20 30 40 50 60 70
+    o0 = _mm256_shuffle_ps(r0, r1, _MM_SHUFFLE(2, 0, 2, 0));
+    // 01 11 21 31 41 51 61 71
+    o1 = _mm256_shuffle_ps(r0, r1, _MM_SHUFFLE(3, 1, 3, 1));
+}
+
+// 8x4 -> 4x8
+inline void transpose_8x4(
+        const __m256 i0,
+        const __m256 i1,
+        const __m256 i2,
+        const __m256 i3,
+        __m256& o0,
+        __m256& o1,
+        __m256& o2,
+        __m256& o3) {
+    // say, we have the following as an input:
+    // i0:  00 01 02 03 10 11 12 13
+    // i1:  20 21 22 23 30 31 32 33
+    // i2:  40 41 42 43 50 51 52 53
+    // i3:  60 61 62 63 70 71 72 73
+
+    // 00 01 02 03 40 41 42 43
+    const __m256 r0 = _mm256_permute2f128_ps(i0, i2, _MM_SHUFFLE(0, 2, 0, 0));
+    // 20 21 22 23 60 61 62 63
+    const __m256 r1 = _mm256_permute2f128_ps(i1, i3, _MM_SHUFFLE(0, 2, 0, 0));
+    // 10 11 12 13 50 51 52 53
+    const __m256 r2 = _mm256_permute2f128_ps(i0, i2, _MM_SHUFFLE(0, 3, 0, 1));
+    // 30 31 32 33 70 71 72 73
+    const __m256 r3 = _mm256_permute2f128_ps(i1, i3, _MM_SHUFFLE(0, 3, 0, 1));
+
+    // 00 02 10 12 40 42 50 52
+    const __m256 t0 = _mm256_shuffle_ps(r0, r2, _MM_SHUFFLE(2, 0, 2, 0));
+    // 01 03 11 13 41 43 51 53
+    const __m256 t1 = _mm256_shuffle_ps(r0, r2, _MM_SHUFFLE(3, 1, 3, 1));
+    // 20 22 30 32 60 62 70 72
+    const __m256 t2 = _mm256_shuffle_ps(r1, r3, _MM_SHUFFLE(2, 0, 2, 0));
+    // 21 23 31 33 61 63 71 73
+    const __m256 t3 = _mm256_shuffle_ps(r1, r3, _MM_SHUFFLE(3, 1, 3, 1));
+
+    // 00 10 20 30 40 50 60 70
+    o0 = _mm256_shuffle_ps(t0, t2, _MM_SHUFFLE(2, 0, 2, 0));
+    // 01 11 21 31 41 51 61 71
+    o1 = _mm256_shuffle_ps(t1, t3, _MM_SHUFFLE(2, 0, 2, 0));
+    // 02 12 22 32 42 52 62 72
+    o2 = _mm256_shuffle_ps(t0, t2, _MM_SHUFFLE(3, 1, 3, 1));
+    // 03 13 23 33 43 53 63 73
+    o3 = _mm256_shuffle_ps(t1, t3, _MM_SHUFFLE(3, 1, 3, 1));
+}
+
+inline void transpose_8x8(
+        const __m256 i0,
+        const __m256 i1,
+        const __m256 i2,
+        const __m256 i3,
+        const __m256 i4,
+        const __m256 i5,
+        const __m256 i6,
+        const __m256 i7,
+        __m256& o0,
+        __m256& o1,
+        __m256& o2,
+        __m256& o3,
+        __m256& o4,
+        __m256& o5,
+        __m256& o6,
+        __m256& o7) {
+    // say, we have the following as an input:
+    // i0:  00 01 02 03 04 05 06 07
+    // i1:  10 11 12 13 14 15 16 17
+    // i2:  20 21 22 23 24 25 26 27
+    // i3:  30 31 32 33 34 35 36 37
+    // i4:  40 41 42 43 44 45 46 47
+    // i5:  50 51 52 53 54 55 56 57
+    // i6:  60 61 62 63 64 65 66 67
+    // i7:  70 71 72 73 74 75 76 77
+
+    // 00 10 01 11 04 14 05 15
+    const __m256 r0 = _mm256_unpacklo_ps(i0, i1);
+    // 02 12 03 13 06 16 07 17
+    const __m256 r1 = _mm256_unpackhi_ps(i0, i1);
+    // 20 30 21 31 24 34 25 35
+    const __m256 r2 = _mm256_unpacklo_ps(i2, i3);
+    // 22 32 23 33 26 36 27 37
+    const __m256 r3 = _mm256_unpackhi_ps(i2, i3);
+    // 40 50 41 51 44 54 45 55
+    const __m256 r4 = _mm256_unpacklo_ps(i4, i5);
+    // 42 52 43 53 46 56 47 57
+    const __m256 r5 = _mm256_unpackhi_ps(i4, i5);
+    // 60 70 61 71 64 74 65 75
+    const __m256 r6 = _mm256_unpacklo_ps(i6, i7);
+    // 62 72 63 73 66 76 67 77
+    const __m256 r7 = _mm256_unpackhi_ps(i6, i7);
+
+    // 00 10 20 30 04 14 24 34
+    const __m256 rr0 = _mm256_shuffle_ps(r0, r2, _MM_SHUFFLE(1, 0, 1, 0));
+    // 01 11 21 31 05 15 25 35
+    const __m256 rr1 = _mm256_shuffle_ps(r0, r2, _MM_SHUFFLE(3, 2, 3, 2));
+    // 02 12 22 32 06 16 26 36
+    const __m256 rr2 = _mm256_shuffle_ps(r1, r3, _MM_SHUFFLE(1, 0, 1, 0));
+    // 03 13 23 33 07 17 27 37
+    const __m256 rr3 = _mm256_shuffle_ps(r1, r3, _MM_SHUFFLE(3, 2, 3, 2));
+    // 40 50 60 70 44 54 64 74
+    const __m256 rr4 = _mm256_shuffle_ps(r4, r6, _MM_SHUFFLE(1, 0, 1, 0));
+    // 41 51 61 71 45 55 65 75
+    const __m256 rr5 = _mm256_shuffle_ps(r4, r6, _MM_SHUFFLE(3, 2, 3, 2));
+    // 42 52 62 72 46 56 66 76
+    const __m256 rr6 = _mm256_shuffle_ps(r5, r7, _MM_SHUFFLE(1, 0, 1, 0));
+    // 43 53 63 73 47 57 67 77
+    const __m256 rr7 = _mm256_shuffle_ps(r5, r7, _MM_SHUFFLE(3, 2, 3, 2));
+
+    // 00 10 20 30 40 50 60 70
+    o0 = _mm256_permute2f128_ps(rr0, rr4, 0x20);
+    // 01 11 21 31 41 51 61 71
+    o1 = _mm256_permute2f128_ps(rr1, rr5, 0x20);
+    // 02 12 22 32 42 52 62 72
+    o2 = _mm256_permute2f128_ps(rr2, rr6, 0x20);
+    // 03 13 23 33 43 53 63 73
+    o3 = _mm256_permute2f128_ps(rr3, rr7, 0x20);
+    // 04 14 24 34 44 54 64 74
+    o4 = _mm256_permute2f128_ps(rr0, rr4, 0x31);
+    // 05 15 25 35 45 55 65 75
+    o5 = _mm256_permute2f128_ps(rr1, rr5, 0x31);
+    // 06 16 26 36 46 56 66 76
+    o6 = _mm256_permute2f128_ps(rr2, rr6, 0x31);
+    // 07 17 27 37 47 57 67 77
+    o7 = _mm256_permute2f128_ps(rr3, rr7, 0x31);
+}
+
+} // namespace faiss
+
+#endif


### PR DESCRIPTION
Summary: Add fvec_L2sqr_ny_y_transposed() call which is used by ProductQuantizer in case of pq.sync_transposed_centroids() is enabled.

Differential Revision: D43057940

