### PR TITLE
Add info about building C API to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -108,6 +108,8 @@ Several options can be passed to CMake, among which:
   - `-DBUILD_TESTING=OFF` in order to disable building C++ tests,
   - `-DBUILD_SHARED_LIBS=ON` in order to build a shared library (possible values
   are `ON` and `OFF`),
+  - `-DFAISS_ENABLE_C_API=ON` in order to enable building [C API](c_api/INSTALL.md) (possible values
+    are `ON` and `OFF`), 
 - optimization-related options:
   - `-DCMAKE_BUILD_TYPE=Release` in order to enable generic compiler
   optimization options (enables `-O3` on gcc for instance),


### PR DESCRIPTION
This PR adds missing info about building C API to installation guide