### PR TITLE
faiss: use autovectorization for inner product

### DIFF
--- a/tests/test_contrib_with_scipy.py
+++ b/tests/test_contrib_with_scipy.py
@@ -56,13 +56,13 @@ class TestClustering(unittest.TestCase):
         D, I = clustering.sparse_assign_to_dense(xsparse, centroids)
 
         np.testing.assert_array_equal(Iref.ravel(), I)
-        np.testing.assert_array_almost_equal(Dref.ravel(), D, decimal=4)
+        np.testing.assert_array_almost_equal(Dref.ravel(), D, decimal=3)
 
         D, I = clustering.sparse_assign_to_dense_blocks(
             xsparse, centroids, qbs=123, bbs=33, nt=4)
 
         np.testing.assert_array_equal(Iref.ravel(), I)
-        np.testing.assert_array_almost_equal(Dref.ravel(), D, decimal=4)
+        np.testing.assert_array_almost_equal(Dref.ravel(), D, decimal=3)
 
     def test_sparse_kmeans(self):
         """ demo on how to cluster sparse data into dense clusters """

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -46,7 +46,9 @@ class TestIndexFlat(unittest.TestCase):
             Iref = all_dis.argsort(axis=1)[:, ::-1][:, :k]
 
         Dref = all_dis[np.arange(nq)[:, None], Iref]
-        self.assertLessEqual((Iref != I1).sum(), Iref.size * 0.0001)
+
+        # not too many elements are off.
+        self.assertLessEqual((Iref != I1).sum(), Iref.size * 0.0002)
         #  np.testing.assert_equal(Iref, I1)
         np.testing.assert_almost_equal(Dref, D1, decimal=5)
 


### PR DESCRIPTION
Summary:
Using autovectorization to get the proper urnolling.

Previous version timings are:

Before
```
faiss_ip_10000                        2.10us   475.62K
faiss_n2_10000                        4.23us   236.30K
```

After
```
faiss_ip_10000                         1.21us   827.16K
faiss_n2_10000                       640.68ns     1.56M
```

Differential Revision: D43353199

