### PR TITLE
remove unused fvec_inner_product_ref() and fvec_norm_L2sqr_ref()

### DIFF
--- a/faiss/utils/distances_simd.cpp
+++ b/faiss/utils/distances_simd.cpp
@@ -89,28 +89,12 @@ float fvec_Linf_ref(const float* x, const float* y, size_t d) {
     return res;
 }
 
-float fvec_inner_product_ref(const float* x, const float* y, size_t d) {
-    size_t i;
-    float res = 0;
-    for (i = 0; i < d; i++)
-        res += x[i] * y[i];
-    return res;
-}
-
 float fvec_inner_product(const float* x, const float* y, size_t d) {
     float res = 0.F;
     for (size_t i = 0; i != d; ++i) {
 #pragma float_control(precise, off)
         res += x[i] * y[i];
     }
-    return res;
-}
-
-float fvec_norm_L2sqr_ref(const float* x, size_t d) {
-    size_t i;
-    double res = 0;
-    for (i = 0; i < d; i++)
-        res += x[i] * x[i];
     return res;
 }
 


### PR DESCRIPTION
Summary:
fvec_inner_product_ref() is no longer needed, use fvec_inner_product() instead

fvec_norm_L2sqr_ref() is no longer needed, use fvec_norm_L2sqr() instead

Differential Revision: D43369468

