### PR TITLE
More pragmas fixes

### DIFF
--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -105,17 +105,22 @@ inline int __builtin_clzll(uint64_t x) {
 // Localized enablement of imprecise floating point operations
 // You need to use all 3 macros to cover all compilers.
 #if defined(_MSC_VER)
-#define FAISS_PRAGMA_IMPRECISE_OP
+#define FAISS_PRAGMA_IMPRECISE_LOOP
 #define FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN \
     __pragma(float_control(precise, off, push))
 #define FAISS_PRAGMA_IMPRECISE_FUNCTION_END __pragma(float_control(pop))
 #elif defined(_GCC_)
-#define FAISS_PRAGMA_IMPRECISE_OP
+#define FAISS_PRAGMA_IMPRECISE_LOOP
 #define FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN \
-    GCC optimize("-funroll-loops -fassociative-math -fno-signed-zeros")
+    _Pragma(" GCC optimize (\"unroll-loops,associative-math,no-signed-zeros\")")
+#define FAISS_PRAGMA_IMPRECISE_FUNCTION_END
+#elif defined(__clang__)
+#define FAISS_PRAGMA_IMPRECISE_LOOP \
+    _Pragma("clang loop vectorize(enable) interleave(enable)")
+#define FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN
 #define FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 #else
-#define FAISS_PRAGMA_IMPRECISE_OP _Pragma("float_control(precise, off)")
+#define FAISS_PRAGMA_IMPRECISE_LOOP
 #define FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN
 #define FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 #endif

--- a/faiss/utils/distances_simd.cpp
+++ b/faiss/utils/distances_simd.cpp
@@ -214,8 +214,8 @@ void fvec_inner_products_ny_ref(
 FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN
 float fvec_inner_product(const float* x, const float* y, size_t d) {
     float res = 0.F;
+    FAISS_PRAGMA_IMPRECISE_LOOP
     for (size_t i = 0; i != d; ++i) {
-        FAISS_PRAGMA_IMPRECISE_OP
         res += x[i] * y[i];
     }
     return res;
@@ -227,8 +227,8 @@ float fvec_norm_L2sqr(const float* x, size_t d) {
     // the double in the _ref is suspected to be a typo. Some of the manual
     // implementations this replaces used float.
     float res = 0;
+    FAISS_PRAGMA_IMPRECISE_LOOP
     for (size_t i = 0; i != d; ++i) {
-        FAISS_PRAGMA_IMPRECISE_OP
         res += x[i] * x[i];
     }
 

--- a/tests/test_fast_scan.py
+++ b/tests/test_fast_scan.py
@@ -82,7 +82,7 @@ class TestSearch(unittest.TestCase):
         t1 = time.time()
         pqfs_t = t1 - t0
         print('PQ16x4fs search time:', pqfs_t)
-        self.assertLess(pqfs_t * 5, pq_t)
+        self.assertLess(pqfs_t * 4, pq_t)
 
 
 class TestRounding(unittest.TestCase):


### PR DESCRIPTION
Summary:
So - judging by D43412645 there are no pragmas on clang arm.
Also: https://godbolt.org/z/4Yz4Wb5a8
We can still try to use a compiler flag there. I think what compiler generates is still on par with what you had before by hand but there is probably a substential improvement that can be made.

If you need it, you can put more effort into it.
If you want me to - I can bring back the code you had for arm neon though I don't think it'd do you much good

Differential Revision: D43437450

