### PR TITLE
remove unused fvec_inner_product_ref() and fvec_norm_L2sqr_ref()

### DIFF
--- a/faiss/utils/distances_simd.cpp
+++ b/faiss/utils/distances_simd.cpp
@@ -89,22 +89,6 @@ float fvec_Linf_ref(const float* x, const float* y, size_t d) {
     return res;
 }
 
-float fvec_inner_product_ref(const float* x, const float* y, size_t d) {
-    size_t i;
-    float res = 0;
-    for (i = 0; i < d; i++)
-        res += x[i] * y[i];
-    return res;
-}
-
-float fvec_norm_L2sqr_ref(const float* x, size_t d) {
-    size_t i;
-    double res = 0;
-    for (i = 0; i < d; i++)
-        res += x[i] * x[i];
-    return res;
-}
-
 void fvec_L2sqr_ny_ref(
         float* dis,
         const float* x,


### PR DESCRIPTION
Summary:
fvec_inner_product_ref() is no longer needed, using fvec_inner_product() instead in all the cases

fvec_norm_L2sqr_ref() is no longer needed, using fvec_norm_L2sqr() instead in all the cases

Differential Revision: D43472582

