### PR TITLE
Remove exclusion from Doxyfile

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -786,7 +786,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */impl/*
+EXCLUDE_PATTERNS       = 
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
The Doxyfile is used to generate the Faiss documentation in faiss.ai. In its current config it skips over important classes like ProductQuantizer. Hence this diff that forces it to pass over the impl/ subdirectories.