### PR TITLE
Proposal IDSelectorCombination

### DIFF
--- a/faiss/impl/IDSelector.h
+++ b/faiss/impl/IDSelector.h
@@ -131,36 +131,43 @@ struct IDSelectorAll : IDSelector {
     virtual ~IDSelectorAll() {}
 };
 
-/// represents the different logical operators we could use to evaulate
-/// different combinations of selectors.
-enum LogicalOperator {
-    Operator_OR = 0,
-    Operator_AND = 1,
-    Operator_XOR = 2,
-};
-
-/// combines two IDSelectors with a LogicalOperator
-struct IDSelectorCombination : IDSelector {
+/// does an AND operation on the the two given IDSelector's is_membership
+/// results.
+struct IDSelectorAnd : IDSelector {
     const IDSelector* lhs;
     const IDSelector* rhs;
-    const LogicalOperator op;
-    IDSelectorCombination(
-            const IDSelector* lhs,
-            const IDSelector* rhs,
-            LogicalOperator op)
-            : lhs(lhs), rhs(rhs), op(op) {}
+    IDSelectorAnd(const IDSelector* lhs, const IDSelector* rhs)
+            : lhs(lhs), rhs(rhs) {}
     bool is_member(idx_t id) const final {
-        if (op == Operator_OR) {
-            return lhs->is_member(id) || rhs->is_member(id);
-        } else if (op == Operator_AND) {
-            return lhs->is_member(id) && rhs->is_member(id);
-        } else if (op == Operator_XOR) {
-            return lhs->is_member(id) ^ rhs->is_member(id);
-        }
+        return lhs->is_member(id) && rhs->is_member(id);
+    };
+    virtual ~IDSelectorAnd() {}
+};
 
-        return false;
-    }
-    virtual ~IDSelectorCombination() {}
+/// does an OR operation on the the two given IDSelector's is_membership
+/// results.
+struct IDSelectorOr : IDSelector {
+    const IDSelector* lhs;
+    const IDSelector* rhs;
+    IDSelectorOr(const IDSelector* lhs, const IDSelector* rhs)
+            : lhs(lhs), rhs(rhs) {}
+    bool is_member(idx_t id) const final {
+        return lhs->is_member(id) || rhs->is_member(id);
+    };
+    virtual ~IDSelectorOr() {}
+};
+
+/// does an XOR operation on the the two given IDSelector's is_membership
+/// results.
+struct IDSelectorXOr : IDSelector {
+    const IDSelector* lhs;
+    const IDSelector* rhs;
+    IDSelectorXOr(const IDSelector* lhs, const IDSelector* rhs)
+            : lhs(lhs), rhs(rhs) {}
+    bool is_member(idx_t id) const final {
+        return lhs->is_member(id) ^ rhs->is_member(id);
+    };
+    virtual ~IDSelectorXOr() {}
 };
 
 } // namespace faiss

--- a/faiss/impl/IDSelector.h
+++ b/faiss/impl/IDSelector.h
@@ -131,4 +131,36 @@ struct IDSelectorAll : IDSelector {
     virtual ~IDSelectorAll() {}
 };
 
+/// represents the different logical operators we could use to evaulate
+/// different combinations of selectors.
+enum LogicalOperator {
+    Operator_OR = 0,
+    Operator_AND = 1,
+    Operator_XOR = 2,
+};
+
+/// combines two IDSelectors with a LogicalOperator
+struct IDSelectorCombination : IDSelector {
+    const IDSelector* lhs;
+    const IDSelector* rhs;
+    const LogicalOperator op;
+    IDSelectorCombination(
+            const IDSelector* lhs,
+            const IDSelector* rhs,
+            LogicalOperator op)
+            : lhs(lhs), rhs(rhs), op(op) {}
+    bool is_member(idx_t id) const final {
+        if (op == Operator_OR) {
+            return lhs->is_member(id) || rhs->is_member(id);
+        } else if (op == Operator_AND) {
+            return lhs->is_member(id) && rhs->is_member(id);
+        } else if (op == Operator_XOR) {
+            return lhs->is_member(id) ^ rhs->is_member(id);
+        }
+
+        return false;
+    }
+    virtual ~IDSelectorCombination() {}
+};
+
 } // namespace faiss

--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -189,9 +189,9 @@ add_ref_in_constructor(BufferedIOWriter, 0)
 add_ref_in_constructor(BufferedIOReader, 0)
 
 add_ref_in_constructor(IDSelectorNot, 0)
-add_ref_in_constructor(IDSelectorAnd, 0)
-add_ref_in_constructor(IDSelectorOr, 0)
-add_ref_in_constructor(IDSelectorXOr, 0)
+add_ref_in_constructor(IDSelectorAnd, slice(2))
+add_ref_in_constructor(IDSelectorOr, slice(2))
+add_ref_in_constructor(IDSelectorXOr, slice(2))
 
 # seems really marginal...
 # remove_ref_from_method(IndexReplicas, 'removeIndex', 0)

--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -189,6 +189,9 @@ add_ref_in_constructor(BufferedIOWriter, 0)
 add_ref_in_constructor(BufferedIOReader, 0)
 
 add_ref_in_constructor(IDSelectorNot, 0)
+add_ref_in_constructor(IDSelectorAnd, 0)
+add_ref_in_constructor(IDSelectorOr, 0)
+add_ref_in_constructor(IDSelectorXOr, 0)
 
 # seems really marginal...
 # remove_ref_from_method(IndexReplicas, 'removeIndex', 0)

--- a/tests/test_search_params.py
+++ b/tests/test_search_params.py
@@ -100,17 +100,20 @@ class TestSelector(unittest.TestCase):
             ]).astype('int64')
             sel = faiss.IDSelectorNot(faiss.IDSelectorBatch(inverse_subset))
         elif id_selector_type == "or":
-            lhs_sel = faiss.IDSelectorBatch(lhs_subset)
-            rhs_sel = faiss.IDSelectorBatch(rhs_subset)
-            sel = faiss.IDSelectorOr(lhs_sel, rhs_sel)
+            sel = faiss.IDSelectorOr(
+                faiss.IDSelectorBatch(lhs_subset), 
+                faiss.IDSelectorBatch(rhs_subset)
+            )
         elif id_selector_type == "and":
-            lhs_sel = faiss.IDSelectorBatch(lhs_subset)
-            rhs_sel = faiss.IDSelectorBatch(rhs_subset)
-            sel = faiss.IDSelectorAnd(lhs_sel, rhs_sel)
+            sel = faiss.IDSelectorAnd(
+                faiss.IDSelectorBatch(lhs_subset), 
+                faiss.IDSelectorBatch(rhs_subset)
+            )
         elif id_selector_type == "xor":
-            lhs_sel = faiss.IDSelectorBatch(lhs_subset)
-            rhs_sel = faiss.IDSelectorBatch(rhs_subset)
-            sel = faiss.IDSelectorXOr(lhs_sel, rhs_sel)
+            sel = faiss.IDSelectorXOr(
+                faiss.IDSelectorBatch(lhs_subset), 
+                faiss.IDSelectorBatch(rhs_subset)
+            )
         else:
             sel = faiss.IDSelectorBatch(subset)
 

--- a/tests/test_search_params.py
+++ b/tests/test_search_params.py
@@ -33,6 +33,12 @@ class TestSelector(unittest.TestCase):
         # reference result
         if "range" in id_selector_type:
             subset = np.arange(30, 80).astype('int64')
+        elif "combination" in id_selector_type:
+            lhs_rs = np.random.RandomState(123)
+            lhs_subset = lhs_rs.choice(ds.nb, 50, replace=False).astype("int64")
+            rhs_rs = np.random.RandomState(456)
+            rhs_subset = rhs_rs.choice(ds.nb, 20, replace=False).astype("int64")
+            subset = np.unique(np.concatenate((lhs_subset, rhs_subset), 0))
         else:
             rs = np.random.RandomState(123)
             subset = rs.choice(ds.nb, 50, replace=False).astype("int64")
@@ -81,6 +87,10 @@ class TestSelector(unittest.TestCase):
                 if i not in ssubset
             ]).astype('int64')
             sel = faiss.IDSelectorNot(faiss.IDSelectorBatch(inverse_subset))
+        elif id_selector_type == "combination":
+            lhs_sel = faiss.IDSelectorBatch(lhs_subset)
+            rhs_sel = faiss.IDSelectorBatch(rhs_subset)
+            sel = faiss.IDSelectorCombination(lhs_sel, rhs_sel, faiss.Operator_OR)
         else:
             sel = faiss.IDSelectorBatch(subset)
 
@@ -148,6 +158,9 @@ class TestSelector(unittest.TestCase):
 
     def test_Flat_id_not(self):
         self.do_test_id_selector("Flat", id_selector_type="not")
+    
+    def test_Flat_id_combination(self):
+        self.do_test_id_selector("Flat", id_selector_type="combination")
 
     # not implemented
 

--- a/tests/test_search_params.py
+++ b/tests/test_search_params.py
@@ -23,7 +23,7 @@ class TestSelector(unittest.TestCase):
     def do_test_id_selector(self, index_key, id_selector_type="batch", mt=faiss.METRIC_L2):
         """ Verify that the id selector returns the subset of results that are
         members according to the IDSelector.
-        Supports id_selector_type="batch", "bitmap", "range", "range_sorted", "not"
+        Supports id_selector_type="batch", "bitmap", "range", "range_sorted", "and", "or", "xor"
         """
         ds = datasets.SyntheticDataset(32, 1000, 100, 20)
         index = faiss.index_factory(ds.d, index_key, mt)
@@ -33,12 +33,24 @@ class TestSelector(unittest.TestCase):
         # reference result
         if "range" in id_selector_type:
             subset = np.arange(30, 80).astype('int64')
-        elif "combination" in id_selector_type:
+        elif id_selector_type == "or":
             lhs_rs = np.random.RandomState(123)
             lhs_subset = lhs_rs.choice(ds.nb, 50, replace=False).astype("int64")
             rhs_rs = np.random.RandomState(456)
             rhs_subset = rhs_rs.choice(ds.nb, 20, replace=False).astype("int64")
-            subset = np.unique(np.concatenate((lhs_subset, rhs_subset), 0))
+            subset = np.union1d(lhs_subset, rhs_subset)
+        elif id_selector_type == "and":
+            lhs_rs = np.random.RandomState(123)
+            lhs_subset = lhs_rs.choice(ds.nb, 50, replace=False).astype("int64")
+            rhs_rs = np.random.RandomState(456)
+            rhs_subset = rhs_rs.choice(ds.nb, 10, replace=False).astype("int64")
+            subset = np.intersect1d(lhs_subset, rhs_subset)
+        elif id_selector_type == "xor":
+            lhs_rs = np.random.RandomState(123)
+            lhs_subset = lhs_rs.choice(ds.nb, 50, replace=False).astype("int64")
+            rhs_rs = np.random.RandomState(456)
+            rhs_subset = rhs_rs.choice(ds.nb, 40, replace=False).astype("int64")
+            subset = np.setxor1d(lhs_subset, rhs_subset)
         else:
             rs = np.random.RandomState(123)
             subset = rs.choice(ds.nb, 50, replace=False).astype("int64")
@@ -87,10 +99,18 @@ class TestSelector(unittest.TestCase):
                 if i not in ssubset
             ]).astype('int64')
             sel = faiss.IDSelectorNot(faiss.IDSelectorBatch(inverse_subset))
-        elif id_selector_type == "combination":
+        elif id_selector_type == "or":
             lhs_sel = faiss.IDSelectorBatch(lhs_subset)
             rhs_sel = faiss.IDSelectorBatch(rhs_subset)
-            sel = faiss.IDSelectorCombination(lhs_sel, rhs_sel, faiss.Operator_OR)
+            sel = faiss.IDSelectorOr(lhs_sel, rhs_sel)
+        elif id_selector_type == "and":
+            lhs_sel = faiss.IDSelectorBatch(lhs_subset)
+            rhs_sel = faiss.IDSelectorBatch(rhs_subset)
+            sel = faiss.IDSelectorAnd(lhs_sel, rhs_sel)
+        elif id_selector_type == "xor":
+            lhs_sel = faiss.IDSelectorBatch(lhs_subset)
+            rhs_sel = faiss.IDSelectorBatch(rhs_subset)
+            sel = faiss.IDSelectorXOr(lhs_sel, rhs_sel)
         else:
             sel = faiss.IDSelectorBatch(subset)
 
@@ -159,8 +179,8 @@ class TestSelector(unittest.TestCase):
     def test_Flat_id_not(self):
         self.do_test_id_selector("Flat", id_selector_type="not")
     
-    def test_Flat_id_combination(self):
-        self.do_test_id_selector("Flat", id_selector_type="combination")
+    def test_Flat_id_or(self):
+        self.do_test_id_selector("Flat", id_selector_type="or")
 
     # not implemented
 


### PR DESCRIPTION
Adds support for an IDSelector that takes in two IDSelectors and can perform a boolean operation on their is_member outcomes.

Current implementation is pretty naive and doesn't try to do any optimizations on the types of IDSelectors combined.

Also test cases are definitely lacking but can add more once approach is agreed upon.