### PR TITLE
Support of 12-bit vector codecs for SaDecodeKernels

### DIFF
--- a/faiss/cppcontrib/SaDecodeKernels.h
+++ b/faiss/cppcontrib/SaDecodeKernels.h
@@ -16,20 +16,31 @@
 //   * PQ[1]x8
 // Additionally, AVX2 and ARM versions support
 //   * Residual[1]x8,PQ[2]x10
+//   * Residual[1]x8,PQ[2]x12
 //   * Residual[1]x8,PQ[2]x16
 //   * Residual[1]x10,PQ[2]x10
+//   * Residual[1]x10,PQ[2]x12
 //   * Residual[1]x10,PQ[2]x16
+//   * Residual[1]x12,PQ[2]x10
+//   * Residual[1]x12,PQ[2]x12
+//   * Residual[1]x12,PQ[2]x16
 //   * Residual[1]x16,PQ[2]x10
+//   * Residual[1]x16,PQ[2]x12
 //   * Residual[1]x16,PQ[2]x16
 //   * Residual1x[9-16 bit],PQ[1]x10 (such as Residual1x9,PQ16x10)
+//   * * (use with COARSE_BITS=16)
+//   * Residual1x[9-16 bit],PQ[1]x12 (such as Residual1x9,PQ16x12)
 //   * * (use with COARSE_BITS=16)
 //   * Residual1x[9-16 bit],PQ[1]x16 (such as Residual1x9,PQ16x16)
 //   * * (use with COARSE_BITS=16)
 //   * PQ[1]x10
+//   * PQ[1]x12
 //   * PQ[1]x16
 //   * IVF256,PQ[1]x10 (such as IVF256,PQ16x10np)
+//   * IVF256,PQ[1]x12 (such as IVF256,PQ16x12np)
 //   * IVF256,PQ[1]x16 (such as IVF256,PQ16x16np)
 //   * IVF[2^9-2^16 bit],PQ[1]x10 (such as IVF1024,PQ16x10np)
+//   * IVF[2^9-2^16 bit],PQ[1]x12 (such as IVF1024,PQ16x12np)
 //   * IVF[2^9-2^16 bit],PQ[1]x16 (such as IVF1024,PQ16x16np)
 //
 // The goal was to achieve the maximum performance, so the template version it

--- a/faiss/cppcontrib/SaDecodeKernels.h
+++ b/faiss/cppcontrib/SaDecodeKernels.h
@@ -27,8 +27,10 @@
 //   * * (use with COARSE_BITS=16)
 //   * PQ[1]x10
 //   * PQ[1]x16
-// Unfortunately, currently Faiss does not support something like
-//   IVF256,PQ16x10np
+//   * IVF256,PQ[1]x10 (such as IVF256,PQ16x10np)
+//   * IVF256,PQ[1]x16 (such as IVF256,PQ16x16np)
+//   * IVF[2^9-2^16 bit],PQ[1]x10 (such as IVF1024,PQ16x10np)
+//   * IVF[2^9-2^16 bit],PQ[1]x16 (such as IVF1024,PQ16x16np)
 //
 // The goal was to achieve the maximum performance, so the template version it
 // is. The provided index families share the same code for sa_decode.
@@ -62,6 +64,10 @@
 //   decoder.
 // For example, "Residual4x10,PQ16x10np" for 256-dim data translates into
 //   Index2LevelDecoder<256,64,16,10,10>
+// For example, "IVF1024,PQ16x10np" for 256-dim data translates into
+//   Index2LevelDecoder<256,256,16,10,10>. But as there are only 1 coarse code
+//   element, Index2LevelDecoder<256,256,16,16,10> can be used as a faster
+//   decoder.
 //
 // Additional supported values for COARSE_BITS and FINE_BITS may be added later.
 //

--- a/faiss/cppcontrib/sa_decode/Level2-avx2-inl.h
+++ b/faiss/cppcontrib/sa_decode/Level2-avx2-inl.h
@@ -1858,10 +1858,12 @@ struct Index2LevelDecoderImpl<
 
 // Suitable for IVF256,PQ[1]x8
 // Subtable for IVF256,PQ[1]x10 (such as IVF256,PQ16x10np)
+// Subtable for IVF256,PQ[1]x12 (such as IVF256,PQ16x12np)
 // Suitable for IVF256,PQ[1]x16 (such as IVF256,PQ16x16np)
 // Suitable for Residual[1]x8,PQ[2]x8
 // Suitable for IVF[2^9-2^16 bit],PQ[1]x8 (such as IVF1024,PQ16np)
 // Suitable for IVF[2^9-2^16 bit],PQ[1]x10 (such as IVF1024,PQ16x10np)
+// Suitable for IVF[2^9-2^16 bit],PQ[1]x12 (such as IVF1024,PQ16x12np)
 // Suitable for IVF[2^9-2^16 bit],PQ[1]x16 (such as IVF1024,PQ16x16np)
 // Suitable for Residual[1]x[9-16 bit],PQ[2]x[3] (such as Residual2x9,PQ8)
 template <
@@ -1872,11 +1874,13 @@ template <
         intptr_t FINE_BITS = 8>
 struct Index2LevelDecoder {
     static_assert(
-            COARSE_BITS == 8 || COARSE_BITS == 10 || COARSE_BITS == 16,
-            "Only 8, 10 or 16 bits are currently supported for COARSE_BITS");
+            COARSE_BITS == 8 || COARSE_BITS == 10 || COARSE_BITS == 12 ||
+                    COARSE_BITS == 16,
+            "Only 8, 10, 12 or 16 bits are currently supported for COARSE_BITS");
     static_assert(
-            FINE_BITS == 8 || FINE_BITS == 10 || FINE_BITS == 16,
-            "Only 8, 10 or 16 bits are currently supported for FINE_BITS");
+            FINE_BITS == 8 || FINE_BITS == 10 || FINE_BITS == 12 ||
+                    FINE_BITS == 16,
+            "Only 8, 10, 12 or 16 bits are currently supported for FINE_BITS");
 
     static constexpr intptr_t dim = DIM;
     static constexpr intptr_t coarseSize = COARSE_SIZE;

--- a/faiss/cppcontrib/sa_decode/Level2-avx2-inl.h
+++ b/faiss/cppcontrib/sa_decode/Level2-avx2-inl.h
@@ -1857,8 +1857,12 @@ struct Index2LevelDecoderImpl<
 } // namespace
 
 // Suitable for IVF256,PQ[1]x8
+// Subtable for IVF256,PQ[1]x10 (such as IVF256,PQ16x10np)
+// Suitable for IVF256,PQ[1]x16 (such as IVF256,PQ16x16np)
 // Suitable for Residual[1]x8,PQ[2]x8
-// Suitable for IVF[9-16 bit],PQ[1]x8 (such as IVF1024,PQ16np)
+// Suitable for IVF[2^9-2^16 bit],PQ[1]x8 (such as IVF1024,PQ16np)
+// Suitable for IVF[2^9-2^16 bit],PQ[1]x10 (such as IVF1024,PQ16x10np)
+// Suitable for IVF[2^9-2^16 bit],PQ[1]x16 (such as IVF1024,PQ16x16np)
 // Suitable for Residual[1]x[9-16 bit],PQ[2]x[3] (such as Residual2x9,PQ8)
 template <
         intptr_t DIM,

--- a/faiss/cppcontrib/sa_decode/Level2-neon-inl.h
+++ b/faiss/cppcontrib/sa_decode/Level2-neon-inl.h
@@ -1946,9 +1946,13 @@ struct Index2LevelDecoderImpl<
 } // namespace
 
 // Suitable for IVF256,PQ[1]x8
+// Subtable for IVF256,PQ[1]x10 (such as IVF256,PQ16x10np)
+// Suitable for IVF256,PQ[1]x16 (such as IVF256,PQ16x16np)
 // Suitable for Residual[1]x8,PQ[2]x8
-// Suitable for IVF[9-16 bit],PQ[1]x8 (such as IVF1024,PQ16np)
-// Suitable for Residual1x[9-16 bit],PQ[1]x8 (such as Residual1x9,PQ8)
+// Suitable for IVF[2^9-2^16 bit],PQ[1]x8 (such as IVF1024,PQ16np)
+// Suitable for IVF[2^9-2^16 bit],PQ[1]x10 (such as IVF1024,PQ16x10np)
+// Suitable for IVF[2^9-2^16 bit],PQ[1]x16 (such as IVF1024,PQ16x16np)
+// Suitable for Residual[1]x[9-16 bit],PQ[2]x[3] (such as Residual2x9,PQ8)
 template <
         intptr_t DIM,
         intptr_t COARSE_SIZE,

--- a/faiss/cppcontrib/sa_decode/Level2-neon-inl.h
+++ b/faiss/cppcontrib/sa_decode/Level2-neon-inl.h
@@ -1947,10 +1947,12 @@ struct Index2LevelDecoderImpl<
 
 // Suitable for IVF256,PQ[1]x8
 // Subtable for IVF256,PQ[1]x10 (such as IVF256,PQ16x10np)
+// Subtable for IVF256,PQ[1]x12 (such as IVF256,PQ16x12np)
 // Suitable for IVF256,PQ[1]x16 (such as IVF256,PQ16x16np)
 // Suitable for Residual[1]x8,PQ[2]x8
 // Suitable for IVF[2^9-2^16 bit],PQ[1]x8 (such as IVF1024,PQ16np)
 // Suitable for IVF[2^9-2^16 bit],PQ[1]x10 (such as IVF1024,PQ16x10np)
+// Suitable for IVF[2^9-2^16 bit],PQ[1]x12 (such as IVF1024,PQ16x12np)
 // Suitable for IVF[2^9-2^16 bit],PQ[1]x16 (such as IVF1024,PQ16x16np)
 // Suitable for Residual[1]x[9-16 bit],PQ[2]x[3] (such as Residual2x9,PQ8)
 template <
@@ -1961,11 +1963,13 @@ template <
         intptr_t FINE_BITS = 8>
 struct Index2LevelDecoder {
     static_assert(
-            COARSE_BITS == 8 || COARSE_BITS == 10 || COARSE_BITS == 16,
-            "Only 8, 10 or 16 bits are currently supported for COARSE_BITS");
+            COARSE_BITS == 8 || COARSE_BITS == 10 || COARSE_BITS == 12 ||
+                    COARSE_BITS == 16,
+            "Only 8, 10, 12 or 16 bits are currently supported for COARSE_BITS");
     static_assert(
-            FINE_BITS == 8 || FINE_BITS == 10 || FINE_BITS == 16,
-            "Only 8, 10 or 16 bits are currently supported for FINE_BITS");
+            FINE_BITS == 8 || FINE_BITS == 10 || FINE_BITS == 12 ||
+                    FINE_BITS == 16,
+            "Only 8, 10, 12 or 16 bits are currently supported for FINE_BITS");
 
     static constexpr intptr_t dim = DIM;
     static constexpr intptr_t coarseSize = COARSE_SIZE;

--- a/faiss/cppcontrib/sa_decode/PQ-avx2-inl.h
+++ b/faiss/cppcontrib/sa_decode/PQ-avx2-inl.h
@@ -1493,12 +1493,14 @@ struct IndexPQDecoderImpl<
 
 // Suitable for PQ[1]x8
 // Suitable for PQ[1]x10
+// Suitable for PQ[1]x12
 // Suitable for PQ[1]x16
 template <intptr_t DIM, intptr_t FINE_SIZE, intptr_t FINE_BITS = 8>
 struct IndexPQDecoder {
     static_assert(
-            FINE_BITS == 8 || FINE_BITS == 10 || FINE_BITS == 16,
-            "Only 8, 10 or 16 bits are currently supported for FINE_BITS");
+            FINE_BITS == 8 || FINE_BITS == 10 || FINE_BITS == 12 ||
+                    FINE_BITS == 16,
+            "Only 8, 10, 12 or 16 bits are currently supported for FINE_BITS");
 
     static constexpr intptr_t dim = DIM;
     static constexpr intptr_t fineSize = FINE_SIZE;

--- a/faiss/cppcontrib/sa_decode/PQ-neon-inl.h
+++ b/faiss/cppcontrib/sa_decode/PQ-neon-inl.h
@@ -1328,12 +1328,14 @@ struct IndexPQDecoderImpl<
 
 // Suitable for PQ[1]x8
 // Suitable for PQ[1]x10
+// Suitable for PQ[1]x12
 // Suitable for PQ[1]x16
 template <intptr_t DIM, intptr_t FINE_SIZE, intptr_t FINE_BITS = 8>
 struct IndexPQDecoder {
     static_assert(
-            FINE_BITS == 8 || FINE_BITS == 10 || FINE_BITS == 16,
-            "Only 8, 10 or 16 bits are currently supported for FINE_BITS");
+            FINE_BITS == 8 || FINE_BITS == 10 || FINE_BITS == 12 ||
+                    FINE_BITS == 16,
+            "Only 8, 10, 12 or 16 bits are currently supported for FINE_BITS");
 
     static constexpr intptr_t dim = DIM;
     static constexpr intptr_t fineSize = FINE_SIZE;

--- a/tests/test_cppcontrib_sa_decode.cpp
+++ b/tests/test_cppcontrib_sa_decode.cpp
@@ -1239,6 +1239,32 @@ TEST(TEST_CPPCONTRIB_SA_DECODE, D160_PQ20x10) {
     testIndexPQDecoder<T>(NSAMPLES * 4, 160, "PQ20x10np");
 }
 
+TEST(TEST_CPPCONTRIB_SA_DECODE, D256_IVF256_PQ16x10) {
+    using T = faiss::cppcontrib::Index2LevelDecoder<256, 256, 16, 8, 10>;
+    testIndex2LevelDecoder<T>(NSAMPLES * 4, 256, "IVF256,PQ16x10np");
+}
+
+TEST(TEST_CPPCONTRIB_SA_DECODE, D256_MINMAXFP16_IVF256_PQ16x10) {
+    using SubT = faiss::cppcontrib::Index2LevelDecoder<256, 256, 16, 8, 10>;
+    using T = faiss::cppcontrib::IndexMinMaxFP16Decoder<SubT>;
+    testMinMaxIndex2LevelDecoder<T>(
+            NSAMPLES * 4, 256, "MinMaxFP16,IVF256,PQ16x10np");
+}
+
+TEST(TEST_CPPCONTRIB_SA_DECODE, D256_MINMAXFP16_IVF1024_PQ16x10) {
+    using SubT = faiss::cppcontrib::Index2LevelDecoder<256, 256, 16, 10, 10>;
+    using T = faiss::cppcontrib::IndexMinMaxFP16Decoder<SubT>;
+    testMinMaxIndex2LevelDecoder<T>(
+            NSAMPLES * 4, 256, "MinMaxFP16,IVF1024,PQ16x10np");
+}
+
+TEST(TEST_CPPCONTRIB_SA_DECODE, D256_MINMAXFP16_IVF1024_PQ16x10_ALTERNATIVE) {
+    using SubT = faiss::cppcontrib::Index2LevelDecoder<256, 256, 16, 16, 10>;
+    using T = faiss::cppcontrib::IndexMinMaxFP16Decoder<SubT>;
+    testMinMaxIndex2LevelDecoder<T>(
+            NSAMPLES * 4, 256, "MinMaxFP16,IVF1024,PQ16x10np");
+}
+
 TEST(TEST_CPPCONTRIB_SA_DECODE, D160_Residual4x8_PQ8x10) {
     using T = faiss::cppcontrib::Index2LevelDecoder<160, 40, 20, 8, 10>;
     testIndex2LevelDecoder<T>(NSAMPLES * 4, 160, "Residual4x8,PQ8x10");

--- a/tests/test_cppcontrib_sa_decode.cpp
+++ b/tests/test_cppcontrib_sa_decode.cpp
@@ -1234,14 +1234,29 @@ TEST(TEST_CPPCONTRIB_SA_DECODE, D256_PQ16x10) {
     testIndexPQDecoder<T>(NSAMPLES * 4, 256, "PQ16x10np");
 }
 
+TEST(TEST_CPPCONTRIB_SA_DECODE, D256_PQ16x12) {
+    using T = faiss::cppcontrib::IndexPQDecoder<256, 16, 12>;
+    testIndexPQDecoder<T>(NSAMPLES * 16, 256, "PQ16x12np");
+}
+
 TEST(TEST_CPPCONTRIB_SA_DECODE, D160_PQ20x10) {
     using T = faiss::cppcontrib::IndexPQDecoder<160, 8, 10>;
     testIndexPQDecoder<T>(NSAMPLES * 4, 160, "PQ20x10np");
 }
 
+TEST(TEST_CPPCONTRIB_SA_DECODE, D160_PQ20x12) {
+    using T = faiss::cppcontrib::IndexPQDecoder<160, 8, 12>;
+    testIndexPQDecoder<T>(NSAMPLES * 16, 160, "PQ20x12np");
+}
+
 TEST(TEST_CPPCONTRIB_SA_DECODE, D256_IVF256_PQ16x10) {
     using T = faiss::cppcontrib::Index2LevelDecoder<256, 256, 16, 8, 10>;
     testIndex2LevelDecoder<T>(NSAMPLES * 4, 256, "IVF256,PQ16x10np");
+}
+
+TEST(TEST_CPPCONTRIB_SA_DECODE, D256_IVF256_PQ16x12) {
+    using T = faiss::cppcontrib::Index2LevelDecoder<256, 256, 16, 8, 12>;
+    testIndex2LevelDecoder<T>(NSAMPLES * 16, 256, "IVF256,PQ16x12np");
 }
 
 TEST(TEST_CPPCONTRIB_SA_DECODE, D256_MINMAXFP16_IVF256_PQ16x10) {
@@ -1281,6 +1296,11 @@ TEST(TEST_CPPCONTRIB_SA_DECODE, D256_Residual1x9_PQ16x10) {
 TEST(TEST_CPPCONTRIB_SA_DECODE, D256_Residual4x10_PQ16x10) {
     using T = faiss::cppcontrib::Index2LevelDecoder<256, 64, 16, 10, 10>;
     testIndex2LevelDecoder<T>(NSAMPLES * 4, 256, "Residual4x10,PQ16x10");
+}
+
+TEST(TEST_CPPCONTRIB_SA_DECODE, D256_Residual4x12_PQ16x12) {
+    using T = faiss::cppcontrib::Index2LevelDecoder<256, 64, 16, 12, 12>;
+    testIndex2LevelDecoder<T>(NSAMPLES * 16, 256, "Residual4x12,PQ16x12");
 }
 
 #endif

--- a/tests/test_cppcontrib_uintreader.cpp
+++ b/tests/test_cppcontrib_uintreader.cpp
@@ -105,6 +105,10 @@ TEST(TEST_CPPCONTRIB_UINTREADER, Test10bit) {
     TestUintReaderBits<10>();
 }
 
+TEST(TEST_CPPCONTRIB_UINTREADER, Test12bit) {
+    TestUintReaderBits<12>();
+}
+
 TEST(TEST_CPPCONTRIB_UINTREADER, Test16bit) {
     TestUintReaderBits<16>();
 }


### PR DESCRIPTION
Differential Revision: D43838494

