### PR TITLE
Fix decoding of large fast_scan blocks

### DIFF
--- a/faiss/impl/pq4_fast_scan.cpp
+++ b/faiss/impl/pq4_fast_scan.cpp
@@ -127,7 +127,7 @@ namespace {
 // get the specific address of the vector inside a block
 // shift is used for determine the if the saved in bits 0..3 (false) or
 // bits 4..7 (true)
-uint8_t get_vector_specific_address(
+size_t get_vector_specific_address(
         size_t bbs,
         size_t vector_id,
         size_t sq,

--- a/tests/test_RCQ_cropping.cpp
+++ b/tests/test_RCQ_cropping.cpp
@@ -10,6 +10,9 @@
 #include <faiss/utils/random.h>
 #include <gtest/gtest.h>
 
+/* This test creates a 3-level RCQ and performs a search on it.
+ * Then it crops the RCQ to just the 2 first levels and verifies that
+ * the 3-level vectors are in a subtree that was visited in the 2-level RCQ. */
 TEST(RCQ_cropping, test_cropping) {
     size_t nq = 10, nt = 2000, nb = 1000, d = 32;
 
@@ -63,6 +66,7 @@ TEST(RCQ_cropping, test_cropping) {
                 idx_t coarse = Inew[q * nprobe + j];
                 if ((fine & mask) == coarse) {
                     found = true;
+                    break;
                 }
             }
             EXPECT_TRUE(found);

--- a/tests/test_fast_scan.py
+++ b/tests/test_fast_scan.py
@@ -708,3 +708,18 @@ class TestPAQFastScan(unittest.TestCase):
     def test_io(self):
         self.subtest_io('PLSQ2x3x4fs_Nlsq2x4')
         self.subtest_io('PRQ2x3x4fs_Nrq2x4')
+
+
+class TestBlockDecode(unittest.TestCase):
+
+    def test_issue_2739(self):
+        ds = datasets.SyntheticDataset(960, 200, 1, 0)
+        M = 32
+        index = faiss.index_factory(ds.d, f"PQ{M}x4fs")
+        index.train(ds.get_train())
+        index.add(ds.get_database())
+
+        np.testing.assert_array_equal(
+            index.pq.decode(index.pq.compute_codes(ds.get_database()))[0, ::100],
+            index.reconstruct(0)[::100]
+        )


### PR DESCRIPTION
Summary:
There was a bug in the decoding code for large blocks, see
https://github.com/facebookresearch/faiss/issues/2739

this diff adds a test that exposes the bug, and fixes it.

Differential Revision: D43872441

