### PR TITLE
faiss/utils/simdlib_avx2.h: avoid C++20 ambiguous overloaded operator

### DIFF
--- a/faiss/utils/simdlib_avx2.h
+++ b/faiss/utils/simdlib_avx2.h
@@ -152,8 +152,8 @@ struct simd16uint16 : simd256bit {
     }
 
     // returns binary masks
-    simd16uint16 operator==(simd256bit other) const {
-        return simd16uint16(_mm256_cmpeq_epi16(i, other.i));
+    friend simd16uint16 operator==(const simd256bit lhs, const simd256bit rhs) {
+        return simd16uint16(_mm256_cmpeq_epi16(lhs.i, rhs.i));
     }
 
     simd16uint16 operator~() const {


### PR DESCRIPTION
Summary:
Resolves errors from overloaded ambiguous operators:
```
faiss/utils/partitioning.cpp:283:34: error: ISO C++20 considers use of overloaded operator '==' (with operand types 'faiss::simd16uint16' and 'faiss::simd16uint16') to be ambiguous despite there being a unique best viable function [-Werror,-Wambiguous-reversed-operator]
```

Reviewed By: meyering

Differential Revision: D44186458

