### PR TITLE
Prepare for v1.7.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,19 +14,21 @@ the Facebook Faiss team.  Feel free to add entries here if you submit a PR.
 - Added big batch IVF search for conducting efficient search with big batches of queries
 - Checkpointing in big batch search support
 - Precomputed centroids support
-- Range search support
 - Support for iterable inverted lists for eg. key value stores
 - 64-bit indexing arithmetic support in FAISS GPU
 - IndexIVFShards now handle IVF indexes with a common quantizer
 - Jaccard distance support
 - CodePacker for non-contiguous code layouts
 - Approximate evaluation of min-k distances via heap
-- Various optimisations: speed up in ProductQuantizer::compute_codes() for certain PQ parameters, Speedup ResidualQuantizer sa_encode() by pooling memory allocations
 - Conda packages for osx-arm64 (Apple M1) and linux-aarch64 (ARM64) architectures
-- Added Python 3.10 and removed Python 3.7 support
+- Support for Python 3.10 
+
+### Removed
 - CUDA 10 is no longer supported
-- No cmake build for Linux or OSX arm64, replaced both with a conda build target only
-- FAISS gpu builds without Docker image
+- Removed Python 3.7 support
+
+### Changed
+- Various optimisations: speed up in ProductQuantizer::compute_codes() for certain PQ parameters, Speedup ResidualQuantizer sa_encode() by pooling memory allocations
 
 ### Fixed
 - HSNW bug fixed which improves the recall rate! Special thanks to zh Wang @hhy3 for this.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,17 +15,16 @@ the Facebook Faiss team.  Feel free to add entries here if you submit a PR.
 - Checkpointing in big batch search support
 - Precomputed centroids support
 - Range search support
-- Iterable inverted lists support eg.  key value stores
+- Support for iterable inverted lists for eg. key value stores
 - 64-bit indexing arithmetic support in FAISS GPU
 - IndexIVFShards now handle IVF indexes with a common quantizer
 - Jaccard distance support
 - CodePacker for non-contiguous code layouts
 - Approximate evaluation of min-k distances via heap
 - Various optimisations: speed up in ProductQuantizer::compute_codes() for certain PQ parameters, Speedup ResidualQuantizer sa_encode() by pooling memory allocations
-- M1 conda support
-- Python 3.10 support
+- Conda packages for osx-arm64 (Apple M1) and linux-aarch64 (ARM64) architectures
+- Added Python 3.10 and removed Python 3.7 support
 - CUDA 10 is no longer supported
-- Support for Linux arm64 conda packages
 - No cmake build for Linux or OSX arm64, replaced both with a conda build target only
 - FAISS gpu builds without Docker image
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,11 @@ the Facebook Faiss team.  Feel free to add entries here if you submit a PR.
 - FAISS gpu builds without Docker image
 
 ### Fixed
-- Fix HSNW bug which improves the recall rate
-- Faiss GPU IVF large query batch fix 
+- HSNW bug fixed which improves the recall rate! Special thanks to zh Wang @hhy3 for this.
+- Faiss GPU IVF large query batch fix
 - Faiss + Torch fixes, re-enable k = 2048
 - Fix the number of distance computations to match max_codes parameter
 - Fix decoding of large fast_scan blocks
-- Workflows have a consistent naming scheme, `OSX arm64 (conda)`,  `Linux x86_64 (cmake)` etc.
 
 
 ## [1.7.3] - 2022-11-3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,12 @@ the Facebook Faiss team.  Feel free to add entries here if you submit a PR.
 - Approximate evaluation of top-k distances for ResidualQuantizer and IndexBinaryFlat
 - Added support for 12-bit PQ / IVFPQ fine quantizer decoders for standalone vector codecs (faiss/cppcontrib)
 - Conda packages for osx-arm64 (Apple M1) and linux-aarch64 (ARM64) architectures
-- Support for Python 3.10 
+- Support for Python 3.10
 
 ### Removed
-- CUDA 10 is no longer supported
-- Removed Python 3.7 support
+- CUDA 10 is no longer supported in precompiled packages
+- Removed Python 3.7 support for precompiled packages
+- Removed constraint for using fine quantizer with no greater than 8 bits for IVFPQ, for example, now it is possible to use IVF256,PQ10x12 for a CPU index
 
 ### Changed
 - Various performance optimizations for PQ / IVFPQ for AVX2 and ARM for training (fused distance+nearest kernel), search (faster kernels for distance_to_code() and scan_list_*()) and vector encoding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ the Facebook Faiss team.  Feel free to add entries here if you submit a PR.
 - IndexIVFShards now handle IVF indexes with a common quantizer
 - Jaccard distance support
 - CodePacker for non-contiguous code layouts
-- Approximate evaluation of min-k distances via heap
+- Approximate evaluation of top-k distances for ResidualQuantizer and IndexBinaryFlat
+- Added support for 12-bit PQ / IVFPQ fine quantizer decoders for standalone vector codecs (faiss/cppcontrib)
 - Conda packages for osx-arm64 (Apple M1) and linux-aarch64 (ARM64) architectures
 - Support for Python 3.10 
 
@@ -28,7 +29,11 @@ the Facebook Faiss team.  Feel free to add entries here if you submit a PR.
 - Removed Python 3.7 support
 
 ### Changed
-- Various optimisations: speed up in ProductQuantizer::compute_codes() for certain PQ parameters, Speedup ResidualQuantizer sa_encode() by pooling memory allocations
+- Various performance optimizations for PQ / IVFPQ for AVX2 and ARM for training (fused distance+nearest kernel), search (faster kernels for distance_to_code() and scan_list_*()) and vector encoding
+- A magnitude faster CPU code for LSQ/PLSQ training and vector encoding (reworked code)
+- Performance improvements for Hamming Code computations for AVX2 and ARM (reworked code)
+- Improved auto-vectorization support for IP and L2 distance computations (better handling of pragmas)
+- Improved ResidualQuantizer vector encoding (pooling memory allocations, avoid r/w to a temporary buffer)
 
 ### Fixed
 - HSNW bug fixed which improves the recall rate! Special thanks to zh Wang @hhy3 for this.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ We try to indicate most contributions here with the contributor names who are no
 the Facebook Faiss team.  Feel free to add entries here if you submit a PR.
 
 ## [Unreleased]
+## [1.7.4] - 2023-04-12
+### Added
+- Added big batch IVF search for conducting efficient search with big batches of queries
+- Checkpointing in big batch search support
+- Precomputed centroids support
+- Range search support
+- Iterable inverted lists support eg.  key value stores
+- 64-bit indexing arithmetic support in FAISS GPU
+- IndexIVFShards now handle IVF indexes with a common quantizer
+- Jaccard distance support
+- CodePacker for non-contiguous code layouts
+- Approximate evaluation of min-k distances via heap
+- Various optimisations: speed up in ProductQuantizer::compute_codes() for certain PQ parameters, Speedup ResidualQuantizer sa_encode() by pooling memory allocations
+- M1 conda support
+- Python 3.10 support
+- CUDA 10 is no longer supported
+- Support for Linux arm64 conda packages
+- No cmake build for Linux or OSX arm64, replaced both with a conda build target only
+- FAISS gpu builds without Docker image
+
+### Fixed
+- Fix HSNW bug which improves the recall rate
+- Faiss GPU IVF large query batch fix 
+- Faiss + Torch fixes, re-enable k = 2048
+- Fix the number of distance computations to match max_codes parameter
+- Fix decoding of large fast_scan blocks
+- Workflows have a consistent naming scheme, `OSX arm64 (conda)`,  `Linux x86_64 (cmake)` etc.
+
 
 ## [1.7.3] - 2022-11-3
 ### Added
@@ -224,7 +252,8 @@ by conda install -c pytorch faiss-gpu cudatoolkit=10.0.
 - C bindings.
 - Extended tutorial to GPU indices.
 
-[Unreleased]: https://github.com/facebookresearch/faiss/compare/v1.7.2...HEAD
+[Unreleased]: https://github.com/facebookresearch/faiss/compare/v1.7.4...HEAD
+[1.7.4]: https://github.com/facebookresearch/faiss/compare/v1.7.3...v1.7.4
 [1.7.3]: https://github.com/facebookresearch/faiss/compare/v1.7.2...v1.7.3
 [1.7.2]: https://github.com/facebookresearch/faiss/compare/v1.7.1...v1.7.2
 [1.7.1]: https://github.com/facebookresearch/faiss/compare/v1.7.0...v1.7.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
 project(faiss
-  VERSION 1.7.3
+  VERSION 1.7.4
   DESCRIPTION "A library for efficient similarity search and clustering of dense vectors."
   HOMEPAGE_URL "https://github.com/facebookresearch/faiss"
   LANGUAGES CXX)

--- a/faiss/Index.h
+++ b/faiss/Index.h
@@ -18,7 +18,7 @@
 
 #define FAISS_VERSION_MAJOR 1
 #define FAISS_VERSION_MINOR 7
-#define FAISS_VERSION_PATCH 3
+#define FAISS_VERSION_PATCH 4
 
 /**
  * @namespace faiss

--- a/faiss/python/setup.py
+++ b/faiss/python/setup.py
@@ -53,7 +53,7 @@ are implemented on the GPU. It is developed by Facebook AI Research.
 """
 setup(
     name='faiss',
-    version='1.7.3',
+    version='1.7.4',
     description='A library for efficient similarity search and clustering of dense vectors',
     long_description=long_description,
     url='https://github.com/facebookresearch/faiss',


### PR DESCRIPTION
Updated the changelog with features since last release, see https://github.com/facebookresearch/faiss/compare/1.7.3_release...main for details. Please comment if you want to highlight anything that I've missed.