### PR TITLE
stop expensive osx arm64 builds on every diff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,11 +269,6 @@ workflows:
           name: Windows x86_64 (conda)
           exec: windows-x86_64-cpu
       - build_conda:
-          name: OSX arm64 (conda)
-          exec: macosx-arm64-cpu
-          requires:
-            - Linux arm64 (conda)
-      - build_conda:
           name: Linux arm64 (conda)
           exec: linux-arm64-cpu
       - build_conda:


### PR DESCRIPTION
Summary: I don't think this provides much extra signal on top of Linux arm64, and we will still have the nightly. It's by far the most expensive to run, so let's save the $$$ and the planet.

Differential Revision: D45389825

