### PR TITLE
support range search from GPU

### DIFF
--- a/contrib/evaluation.py
+++ b/contrib/evaluation.py
@@ -226,7 +226,7 @@ def range_PR_multiple_thresholds(
 # Functions that compare search results with a reference result.
 # They are intended for use in tests
 
-def test_ref_knn_with_draws(Dref, Iref, Dnew, Inew):
+def check_ref_knn_with_draws(Dref, Iref, Dnew, Inew):
     """ test that knn search results are identical, raise if not """
     np.testing.assert_array_almost_equal(Dref, Dnew, decimal=5)
     # here we have to be careful because of draws
@@ -243,14 +243,14 @@ def test_ref_knn_with_draws(Dref, Iref, Dnew, Inew):
             testcase.assertEqual(set(Iref[i, mask]), set(Inew[i, mask]))
 
 
-def test_ref_range_results(lims_ref, Dref, Iref,
-                           lims_new, Dnew, Inew):
+def check_ref_range_results(Lref, Dref, Iref,
+                            Lnew, Dnew, Inew):
     """ compare range search results wrt. a reference result,
     throw if it fails """
-    np.testing.assert_array_equal(lims_ref, lims_new)
-    nq = len(lims_ref) - 1
+    np.testing.assert_array_equal(Lref, Lnew)
+    nq = len(Lref) - 1
     for i in range(nq):
-        l0, l1 = lims_ref[i], lims_ref[i + 1]
+        l0, l1 = Lref[i], Lref[i + 1]
         Ii_ref = Iref[l0:l1]
         Ii_new = Inew[l0:l1]
         Di_ref = Dref[l0:l1]

--- a/contrib/ivf_tools.py
+++ b/contrib/ivf_tools.py
@@ -77,7 +77,7 @@ def range_search_preassigned(index_ivf, x, radius, list_nos, coarse_dis=None):
     res = faiss.RangeSearchResult(n)
     sp = faiss.swig_ptr
 
-    index_ivf.range_search_preassigned(
+    index_ivf.range_search_preassigned_c(
         n, sp(x), radius,
         sp(list_nos), sp(coarse_dis),
         res

--- a/faiss/gpu/GpuCloner.cpp
+++ b/faiss/gpu/GpuCloner.cpp
@@ -309,6 +309,7 @@ Index* ToGpuClonerMultiple::clone_Index_to_shards(const Index* index) {
 
     std::vector<faiss::Index*> shards(n);
 
+#pragma omp parallel for
     for (idx_t i = 0; i < n; i++) {
         // make a shallow copy
         if (reserveVecs) {

--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -22,7 +22,7 @@ from faiss.array_conversions import *
 from faiss.extra_wrappers import kmin, kmax, pairwise_distances, rand, randint, \
     lrand, randn, rand_smooth_vectors, eval_intersection, normalize_L2, \
     ResultHeap, knn, Kmeans, checksum, matrix_bucket_sort_inplace, bucket_sort, \
-    merge_knn_results
+    merge_knn_results, MapInt64ToInt64
 
 
 __version__ = "%d.%d.%d" % (FAISS_VERSION_MAJOR,

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -794,14 +794,138 @@ faiss::Quantizer * downcast_Quantizer (faiss::Quantizer *aq)
 #endif
 
 
+/*******************************************************************
+ * How should the template objects appear in the scripting language?
+ *******************************************************************/
 
-// Python-specific: do not release GIL any more, as functions below
-// use the Python/C API
+// answer: the same as the C++ typedefs, but we still have to redefine them
+
+%template() faiss::CMin<float, int64_t>;
+%template() faiss::CMin<int, int64_t>;
+%template() faiss::CMax<float, int64_t>;
+%template() faiss::CMax<int, int64_t>;
+
+%template(float_minheap_array_t) faiss::HeapArray<faiss::CMin<float, int64_t> >;
+%template(int_minheap_array_t) faiss::HeapArray<faiss::CMin<int, int64_t> >;
+%template(float_maxheap_array_t) faiss::HeapArray<faiss::CMax<float, int64_t> >;
+%template(int_maxheap_array_t) faiss::HeapArray<faiss::CMax<int, int64_t> >;
+
+%template(CMin_float_partition_fuzzy)
+    faiss::partition_fuzzy<faiss::CMin<float, int64_t> >;
+%template(CMax_float_partition_fuzzy)
+    faiss::partition_fuzzy<faiss::CMax<float, int64_t> >;
+
+%template(AlignedTableUint8) faiss::AlignedTable<uint8_t>;
+%template(AlignedTableUint16) faiss::AlignedTable<uint16_t>;
+%template(AlignedTableFloat32) faiss::AlignedTable<float>;
+
+
+// SWIG seems to have some trouble resolving function template types here, so
+// declare explicitly
+
+%define INSTANTIATE_uint16_partition_fuzzy(C, id_t)
+
+%inline %{
+
+uint16_t C ## _uint16_partition_fuzzy(
+        uint16_t *vals, id_t *ids, size_t n,
+        size_t q_min, size_t q_max, size_t * q_out)
+{
+    return faiss::partition_fuzzy<faiss::C<unsigned short, id_t> >(
+        vals, ids, n, q_min, q_max, q_out);
+}
+
+%}
+
+%enddef
+
+INSTANTIATE_uint16_partition_fuzzy(CMin, int64_t)
+INSTANTIATE_uint16_partition_fuzzy(CMax, int64_t)
+INSTANTIATE_uint16_partition_fuzzy(CMin, int)
+INSTANTIATE_uint16_partition_fuzzy(CMax, int)
+
+// Same for merge_knn_results
+
+// same define as explicit instanciation in Heap.cpp
+%define INSTANTIATE_merge_knn_results(C, distance_t)
+
+%inline %{
+void merge_knn_results_ ## C(
+    size_t n, size_t k, int nshard,
+    const distance_t *all_distances, const faiss::idx_t *all_labels,
+    distance_t *distances, faiss::idx_t *labels)
+{
+    faiss::merge_knn_results<faiss::idx_t, faiss::C<distance_t, int>>(
+        n, k, nshard, all_distances, all_labels, distances, labels);
+}
+%}
+
+%enddef
+
+INSTANTIATE_merge_knn_results(CMin, float);
+INSTANTIATE_merge_knn_results(CMax, float);
+INSTANTIATE_merge_knn_results(CMin, int32_t);
+INSTANTIATE_merge_knn_results(CMax, int32_t);
+
+
+
+%inline %{
+
+/*******************************************************************
+ * numpy misses a hash table implementation, hence this class. It
+ * represents not found values as -1 like in the Index implementation
+ *******************************************************************/
+
+
+struct MapLong2Long {
+    std::unordered_map<int64_t, int64_t> map;
+
+    void add(size_t n, const int64_t *keys, const int64_t *vals) {
+        map.reserve(map.size() + n);
+        for (size_t i = 0; i < n; i++) {
+            map[keys[i]] = vals[i];
+        }
+    }
+
+    int64_t search(int64_t key) const {
+        auto ptr = map.find(key);
+        if (ptr == map.end()) {
+            return -1;
+        } else {
+            return ptr->second;
+        }
+    }
+
+    void search_multiple(size_t n, int64_t *keys, int64_t * vals) {
+        for (size_t i = 0; i < n; i++) {
+            vals[i] = search(keys[i]);
+        }
+    }
+};
+
+%}
+
+
+/*******************************************************************
+ * Expose a few basic functions
+ *******************************************************************/
+
+
+void omp_set_num_threads (int num_threads);
+int omp_get_max_threads ();
+void *memcpy(void *dest, const void *src, size_t n);
+
+
+
+
+/*******************************************************************
+ * Python-specific: do not release GIL any more, as functions below
+ * use the Python/C API
+ *******************************************************************/
+
 #ifdef SWIGPYTHON
 %exception;
 #endif
-
-
 
 
 
@@ -858,6 +982,9 @@ PyObject *swig_ptr (PyObject *a)
     }
     if(PyArray_TYPE(ao) == NPY_INT32) {
         return SWIG_NewPointerObj(data, SWIGTYPE_p_int, 0);
+    }
+    if(PyArray_TYPE(ao) == NPY_BOOL) {
+        return SWIG_NewPointerObj(data, SWIGTYPE_p_bool, 0);
     }
     if(PyArray_TYPE(ao) == NPY_UINT64) {
 #ifdef SWIGWORDSIZE64
@@ -936,90 +1063,6 @@ REV_SWIG_PTR(uint64_t, NPY_UINT64);
 
 
 /*******************************************************************
- * How should the template objects appear in the scripting language?
- *******************************************************************/
-
-// answer: the same as the C++ typedefs, but we still have to redefine them
-
-%template() faiss::CMin<float, int64_t>;
-%template() faiss::CMin<int, int64_t>;
-%template() faiss::CMax<float, int64_t>;
-%template() faiss::CMax<int, int64_t>;
-
-%template(float_minheap_array_t) faiss::HeapArray<faiss::CMin<float, int64_t> >;
-%template(int_minheap_array_t) faiss::HeapArray<faiss::CMin<int, int64_t> >;
-%template(float_maxheap_array_t) faiss::HeapArray<faiss::CMax<float, int64_t> >;
-%template(int_maxheap_array_t) faiss::HeapArray<faiss::CMax<int, int64_t> >;
-
-%template(CMin_float_partition_fuzzy)
-    faiss::partition_fuzzy<faiss::CMin<float, int64_t> >;
-%template(CMax_float_partition_fuzzy)
-    faiss::partition_fuzzy<faiss::CMax<float, int64_t> >;
-
-%template(AlignedTableUint8) faiss::AlignedTable<uint8_t>;
-%template(AlignedTableUint16) faiss::AlignedTable<uint16_t>;
-%template(AlignedTableFloat32) faiss::AlignedTable<float>;
-
-
-// SWIG seems to have some trouble resolving function template types here, so
-// declare explicitly
-
-%define INSTANTIATE_uint16_partition_fuzzy(C, id_t)
-
-%inline %{
-
-uint16_t C ## _uint16_partition_fuzzy(
-        uint16_t *vals, id_t *ids, size_t n,
-        size_t q_min, size_t q_max, size_t * q_out)
-{
-    return faiss::partition_fuzzy<faiss::C<unsigned short, id_t> >(
-        vals, ids, n, q_min, q_max, q_out);
-}
-
-%}
-
-%enddef
-
-INSTANTIATE_uint16_partition_fuzzy(CMin, int64_t)
-INSTANTIATE_uint16_partition_fuzzy(CMax, int64_t)
-INSTANTIATE_uint16_partition_fuzzy(CMin, int)
-INSTANTIATE_uint16_partition_fuzzy(CMax, int)
-
-// Same for merge_knn_results
-
-// same define as explicit instanciation in Heap.cpp
-%define INSTANTIATE_merge_knn_results(C, distance_t)
-
-%inline %{
-void merge_knn_results_ ## C(
-    size_t n, size_t k, int nshard,
-    const distance_t *all_distances, const faiss::idx_t *all_labels,
-    distance_t *distances, faiss::idx_t *labels)
-{
-    faiss::merge_knn_results<faiss::idx_t, faiss::C<distance_t, int>>(
-        n, k, nshard, all_distances, all_labels, distances, labels);
-}
-%}
-
-%enddef
-
-INSTANTIATE_merge_knn_results(CMin, float);
-INSTANTIATE_merge_knn_results(CMax, float);
-INSTANTIATE_merge_knn_results(CMin, int32_t);
-INSTANTIATE_merge_knn_results(CMax, int32_t);
-
-
-/*******************************************************************
- * Expose a few basic functions
- *******************************************************************/
-
-
-void omp_set_num_threads (int num_threads);
-int omp_get_max_threads ();
-void *memcpy(void *dest, const void *src, size_t n);
-
-
-/*******************************************************************
  * For Faiss/Pytorch interop via pointers encoded as longs
  *******************************************************************/
 
@@ -1047,42 +1090,6 @@ void * cast_integer_to_void_ptr (int64_t x) {
 %}
 
 
-/*******************************************************************
- * Range search interface
- *******************************************************************/
-
-
-%inline %{
-
-// numpy misses a hash table implementation, hence this class. It
-// represents not found values as -1 like in the Index implementation
-
-struct MapLong2Long {
-    std::unordered_map<int64_t, int64_t> map;
-
-    void add(size_t n, const int64_t *keys, const int64_t *vals) {
-        map.reserve(map.size() + n);
-        for (size_t i = 0; i < n; i++) {
-            map[keys[i]] = vals[i];
-        }
-    }
-
-    int64_t search(int64_t key) {
-        if (map.count(key) == 0) {
-            return -1;
-        } else {
-            return map[key];
-        }
-    }
-
-    void search_multiple(size_t n, int64_t *keys, int64_t * vals) {
-        for (size_t i = 0; i < n; i++) {
-            vals[i] = search(keys[i]);
-        }
-    }
-};
-
-%}
 
 
 

--- a/faiss/utils/partitioning.h
+++ b/faiss/utils/partitioning.h
@@ -71,4 +71,5 @@ struct PartitionStats {
 // global var that collects them all
 FAISS_API extern PartitionStats partition_stats;
 
+
 } // namespace faiss

--- a/faiss/utils/sorting.h
+++ b/faiss/utils/sorting.h
@@ -68,4 +68,31 @@ void matrix_bucket_sort_inplace(
         int64_t* lims,
         int nt = 0);
 
+/** Hashtable implementation for int64 -> int64 with external storage
+ * implemented for fast batch add and lookup.
+ *
+ * tab is of size  2 * (1 << log2_capacity)
+ * n is the number of elements to add or search
+ *
+ * adding several values in a same batch: an arbitrary one gets added
+ * in different batches: the newer batch overwrites.
+ * raises an exception if capacity is exhausted.
+ */
+
+void hashtable_int64_to_int64_init(int log2_capacity, int64_t* tab);
+
+void hashtable_int64_to_int64_add(
+        int log2_capacity,
+        int64_t* tab,
+        size_t n,
+        const int64_t* keys,
+        const int64_t* vals);
+
+void hashtable_int64_to_int64_lookup(
+        int log2_capacity,
+        const int64_t* tab,
+        size_t n,
+        const int64_t* keys,
+        int64_t* vals);
+
 } // namespace faiss

--- a/faiss/utils/utils.h
+++ b/faiss/utils/utils.h
@@ -163,6 +163,39 @@ uint64_t hash_bytes(const uint8_t* bytes, int64_t n);
 /** Whether OpenMP annotations were respected. */
 bool check_openmp();
 
+/** This class is used to combine range and knn search results
+ * in contrib.exhaustive_search.range_search_gpu */
+
+struct CombinerRangeKNN {
+    int64_t nq;    /// nb of queries
+    size_t k;      /// number of neighbors for the knn search part
+    float r2;      /// range search radius
+    bool keep_max; /// whether to keep max values instead of min.
+
+    CombinerRangeKNN(int64_t nq, size_t k, float r2, bool keep_max)
+            : nq(nq), k(k), r2(r2), keep_max(keep_max) {}
+
+    /// Knn search results
+    const int64_t* I = nullptr; /// size nq * k
+    const float* D = nullptr;   /// size nq * k
+
+    /// optional: range search results (ignored if mask is NULL)
+    const bool* mask =
+            nullptr; /// mask for where knn results are valid, size nq
+    // range search results for remaining entries nrange = sum(mask)
+    const int64_t* lim_remain = nullptr; /// size nrange + 1
+    const float* D_remain = nullptr;     /// size lim_remain[nrange]
+    const int64_t* I_remain = nullptr;   /// size lim_remain[nrange]
+
+    const int64_t* L_res = nullptr; /// size nq + 1
+    // Phase 1: compute sizes into limits array (of size nq + 1)
+    void compute_sizes(int64_t* L_res);
+
+    /// Phase 2: caller allocates D_res and I_res (size L_res[nq])
+    /// Phase 3: fill in D_res and I_res
+    void write_result(float* D_res, int64_t* I_res);
+};
+
 } // namespace faiss
 
 #endif /* FAISS_utils_h */

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -130,7 +130,7 @@ class TestExhaustiveSearch(unittest.TestCase):
             xq, ds.database_iterator(bs=100), threshold, ngpu=0,
             metric_type=metric)
 
-        evaluation.test_ref_range_results(
+        evaluation.check_ref_range_results(
             ref_lims, ref_D, ref_I,
             new_lims, new_D, new_I
         )
@@ -161,7 +161,7 @@ class TestExhaustiveSearch(unittest.TestCase):
         _, new_lims, new_D, new_I = range_search_max_results(
             index, matrix_iterator(xq, 100), threshold, max_results=1e10)
 
-        evaluation.test_ref_range_results(
+        evaluation.check_ref_range_results(
             ref_lims, ref_D, ref_I,
             new_lims, new_D, new_I
         )
@@ -175,7 +175,7 @@ class TestExhaustiveSearch(unittest.TestCase):
 
         ref_lims, ref_D, ref_I = index.range_search(xq, new_threshold)
 
-        evaluation.test_ref_range_results(
+        evaluation.check_ref_range_results(
             ref_lims, ref_D, ref_I,
             new_lims, new_D, new_I
         )
@@ -435,7 +435,7 @@ class TestRangeSearchMaxResults(unittest.TestCase):
             min_results=Dref.size, clip_to_min=True
         )
 
-        evaluation.test_ref_range_results(
+        evaluation.check_ref_range_results(
             lims_ref, Dref, Iref,
             lims_new, Dnew, Inew
         )

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1112,9 +1112,6 @@ class TestReconsHash(unittest.TestCase):
     def test_IVFPQ(self):
         self.do_test("IVF5,PQ4x4np")
 
-if __name__ == '__main__':
-    unittest.main()
-
 
 class TestValidIndexParams(unittest.TestCase):
 

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -40,6 +40,8 @@ class PartitionTests:
         self.do_partition(160, (70, 80))
 
 
+def pointer_to_minus1():
+    return np.array([-1], dtype='int64').view("uint64")
 
 class TestPartitioningFloat(unittest.TestCase, PartitionTests):
 
@@ -67,7 +69,7 @@ class TestPartitioningFloat(unittest.TestCase, PartitionTests):
             )
         else:
             q_min, q_max = q
-            q = np.array([-1], dtype='uint64')
+            q = pointer_to_minus1()
             faiss.CMax_float_partition_fuzzy(
                 sp(vals), sp(ids), n,
                 q_min, q_max, sp(q)
@@ -117,7 +119,7 @@ class TestPartitioningFloatMin(unittest.TestCase, PartitionTests):
             )
         else:
             q_min, q_max = q
-            q = np.array([-1], dtype='uint64')
+            q = pointer_to_minus1()
             faiss.CMin_float_partition_fuzzy(
                 sp(vals), sp(ids), n,
                 q_min, q_max, sp(q)
@@ -164,7 +166,7 @@ class TestPartitioningUint16(unittest.TestCase, PartitionTests):
                 tab_a.get(), sp(ids), n, q, q, None)
         else:
             q_min, q_max = q
-            q = np.array([-1], dtype='uint64')
+            q = pointer_to_minus1()
             faiss.CMax_uint16_partition_fuzzy(
                 tab_a.get(), sp(ids), n,
                 q_min, q_max, sp(q)
@@ -213,7 +215,7 @@ class TestPartitioningUint16Min(unittest.TestCase, PartitionTests):
                 tab_a.get(), sp(ids), n, q, q, None)
         else:
             q_min, q_max = q
-            q = np.array([-1], dtype='uint64')
+            q = pointer_to_minus1()
             thresh2 = faiss.CMin_uint16_partition_fuzzy(
                 tab_a.get(), sp(ids), n,
                 q_min, q_max, sp(q)


### PR DESCRIPTION
Summary:
Optimized range search function where the GPU computes by default and falls back on gpu for queries where there are too many results.

Parallelize the CPU to GPU cloning, it seems to work.

Support range_search_preassigned in Python

Fix long-standing issue with SWIG exposed functions that did not release the GIL (in particular the MapLong2Long)

Reviewed By: algoriddle

Differential Revision: D45672301

