### PR TITLE
Use uint8_t instead of uint32_t for faiss::VisitedTable.visno

### DIFF
--- a/faiss/impl/AuxIndexStructures.h
+++ b/faiss/impl/AuxIndexStructures.h
@@ -165,7 +165,7 @@ struct FAISS_API InterruptCallback {
 /// set implementation optimized for fast access.
 struct VisitedTable {
     std::vector<uint8_t> visited;
-    int visno;
+    uint8_t visno;
 
     explicit VisitedTable(int size) : visited(size), visno(1) {}
 


### PR DESCRIPTION
Differential Revision: D46125491

