### PR TITLE
Update INSTALL.md Instructions for Compatibility with PyTorch

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,11 +31,11 @@ $ conda install -c pytorch/label/nightly faiss-cpu
 $ conda install -c pytorch/label/nightly faiss-gpu
 ```
 
-A combination of versions that installs GPU Faiss with CUDA 11.4 and Pytorch (as of 2023-05-08):
+A combination of versions that installs GPU Faiss with CUDA 11.4 and Pytorch (as of 2023-05-26):
 ```
 conda create --name faiss_1.7.4 python=3.10
 conda activate faiss_1.7.4
-conda install faiss-gpu=1.7.4 -c pytorch -c nvidia
+conda install mkl==2021.4.0 faiss-gpu=1.7.4 -c pytorch -c nvidia
 conda install faiss-gpu pytorch pytorch-cuda -c pytorch -c nvidia
 conda install -c conda-forge notebook
 conda install -y matplotlib


### PR DESCRIPTION
This pull request proposes a fix to the current installation process, addressing an incompatibility issue while installing.

Issue:
Currently, the installation defaults to using the latest version of Intel's Math Kernel Library (MKL) which is `mkl==2023.1.0`. However, this version omits the library file `libmkl_intel_lp64.so.1` (and similar `lib` files) which has been replaced by `libmkl_intel_lp64.so.2`. The absence of `libmkl_intel_lp64.so.1` leads to an import error when trying to import faiss, as follows:

```
ImportError: libmkl_intel_lp64.so.1: cannot open shared object file: No such file or directory
```

Solution:
I have resolved this issue by directing the conda installer to use the MKL version `mkl==2021.4.0` which includes the `libmkl_intel_lp64.so.1` file, instead of the latest version. This adjustment ensures that faiss is imported successfully, thereby facilitating the desired compatibility with PyTorch.

Please consider this change to enhance the user experience when installing this package.