### PR TITLE
Fix windows CI

### DIFF
--- a/faiss/utils/utils.cpp
+++ b/faiss/utils/utils.cpp
@@ -28,6 +28,7 @@
 #include <omp.h>
 
 #include <algorithm>
+#include <type_traits>
 #include <vector>
 
 #include <faiss/impl/AuxIndexStructures.h>
@@ -447,7 +448,10 @@ uint64_t bvec_checksum(size_t n, const uint8_t* a) {
 
 void bvecs_checksum(size_t n, size_t d, const uint8_t* a, uint64_t* cs) {
 #pragma omp parallel for if (n > 1000)
-    for (size_t i = 0; i < n; i++) {
+    for (std::make_signed<std::size_t>::type i_ = 0;
+         static_cast<std::size_t>(i_) < n;
+         i_++) {
+        const auto i = static_cast<std::size_t>(i_);
         cs[i] = bvec_checksum(d, a + i * d);
     }
 }

--- a/faiss/utils/utils.cpp
+++ b/faiss/utils/utils.cpp
@@ -447,10 +447,12 @@ uint64_t bvec_checksum(size_t n, const uint8_t* a) {
 }
 
 void bvecs_checksum(size_t n, size_t d, const uint8_t* a, uint64_t* cs) {
-#pragma omp parallel for if (n > 1000)
-    for (std::make_signed<std::size_t>::type i_ = 0;
-         static_cast<std::size_t>(i_) < n;
-         i_++) {
+    // MSVC can't accept unsigned index for #pragma omp parallel for
+    // so below codes only accept n <= std::numeric_limits<ssize_t>::max()
+    using ssize_t = std::make_signed<std::size_t>::type;
+    const ssize_t size = n;
+#pragma omp parallel for if (size > 1000)
+    for (ssize_t i_ = 0; i_ < size; i_++) {
         const auto i = static_cast<std::size_t>(i_);
         cs[i] = bvec_checksum(d, a + i * d);
     }


### PR DESCRIPTION
#2882 added [a for loop, which has unsigned index, qualified with `#pragma omp parallel for`](https://github.com/facebookresearch/faiss/pull/2882/files#diff-5a89dcb99a1cce3f297c7f7dfc8e221306b281d4ced6dac1e0fc0fa54188195fR449-R452), but it seems that [MSVC doesn't support unsigned index with `#pragma omp parallel for`](https://app.circleci.com/pipelines/github/facebookresearch/faiss/4220/workflows/ee72de05-6ead-42d9-8ec5-44772e9fd41b/jobs/22529?invite=true#step-104-333) (I think this would not be conformed to OpenMP specification, but...)

I (finally) change the loop with signed index. This changes introduce the precondition `n <= std::numeric_limits<std::make_signed_t<std::size_t>>::max()` , but usually this is `true` I think, so I just put this limitation as a comment instead of any `FAISS_ASSERT` or something like that.