### PR TITLE
Remove unused unordered_map include.

### DIFF
--- a/faiss/AutoTune.h
+++ b/faiss/AutoTune.h
@@ -11,7 +11,6 @@
 #define FAISS_AUTO_TUNE_H
 
 #include <stdint.h>
-#include <unordered_map>
 #include <vector>
 
 #include <faiss/Index.h>


### PR DESCRIPTION
Summary: This makes builds brittle and slows down builds.

Differential Revision: D46445595

