### PR TITLE
fix IndexHNSW add verbos

### DIFF
--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -216,7 +216,7 @@ void hnsw_add_vertices(
 
                     if (prev_display >= 0 && i - i0 > prev_display + 10000) {
                         prev_display = i - i0;
-                        printf("  %d / %d\r", i - i0, i1 - i0);
+                        printf("  %d / %d\r", (i - i0) * omp_get_num_threads(), i1 - i0);
                         fflush(stdout);
                     }
                     if (counter % check_period == 0) {


### PR DESCRIPTION
because schedule(dynamic) change to schedule(static)，The indexes shown in the progress are only the blocks allocated to process 0, so it should be multiplied by the number of processes