### PR TITLE
Relax IVF AQ FastScan

### DIFF
--- a/faiss/python/extra_wrappers.py
+++ b/faiss/python/extra_wrappers.py
@@ -108,7 +108,7 @@ def checksum(a):
     """ compute a checksum for quick-and-dirty comparisons of arrays """
     a = a.view('uint8')
     if a.ndim == 1:
-        return bvec_checksum(s.size, swig_ptr(a))
+        return bvec_checksum(a.size, swig_ptr(a))
     n, d = a.shape
     cs = np.zeros(n, dtype='uint64')
     bvecs_checksum(n, d, swig_ptr(a), swig_ptr(cs))

--- a/tests/test_fast_scan_ivf.py
+++ b/tests/test_fast_scan_ivf.py
@@ -558,7 +558,7 @@ class TestIVFAQFastScan(unittest.TestCase):
         recall1 = (I1 == gt).sum() / nq
 
         print(aq, st, by_residual, implem, metric_type, recall_ref, recall1)
-        assert abs(recall_ref - recall1) < 0.05
+        assert abs(recall_ref - recall1) < 0.051
 
     def xx_test_accuracy(self):
         # generated programatically below


### PR DESCRIPTION
Summary:
This test fails on some occasions.
After investigation it turns out this is due to non reproducible behavior IndexIVFFastScan::search_implem_14 with a parallel loop, where there are ties in the resutls (ie. the resulting distances are the same but not the ids).
As a workaround I relaxed the test slightly.
+ a fix in the checksum function.

Differential Revision: D47229086

