### PR TITLE
Added version to nighly install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,7 +34,7 @@ dependency where necessary:
 $ conda install -c pytorch/label/nightly faiss-cpu
 
 # GPU(+CPU) version
-$ conda install -c pytorch/label/nightly -c nvidia faiss-gpu
+$ conda install -c pytorch/label/nightly -c nvidia faiss-gpu=1.7.4
 ```
 
 A combination of versions that installs GPU Faiss with CUDA 11.4 and Pytorch (as of 2023-06-19):


### PR DESCRIPTION
The gpu nightly package install command did not install v1.7.4, see [P801820926](https://www.internalfb.com/intern/paste/P801820926)

Adding the version fixes this issues, see [P801849181] (https://www.internalfb.com/intern/paste/P801849181)

Funnily enough, faiss-cpu nightly command works fine, see [P801848411](https://www.internalfb.com/intern/paste/P801848411)