### PR TITLE
remove avx2 from raft cmake contbuild

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,6 @@ workflows:
       - build_cmake:
           name: Linux x86_64 GPU w/ RAFT (cmake)
           exec: linux-x86_64-gpu
-          opt_level: "avx2"
           gpu: "ON"
           raft: "ON"
           requires:


### PR DESCRIPTION
Summary: Unnecessary for contbuild and doubles the build time.

Differential Revision: D48148734

