### PR TITLE
Clean up batch comments + obey IO_FLAG_SKIP_PRECOMPUTE_TABLE

### DIFF
--- a/faiss/impl/AdditiveQuantizer.cpp
+++ b/faiss/impl/AdditiveQuantizer.cpp
@@ -370,6 +370,8 @@ void AdditiveQuantizer::compute_LUT(
 
 namespace {
 
+/* compute inner products of one query with all centroids, given a look-up
+ * table of all inner producst with codebook entries */
 void compute_inner_prod_with_LUT(
         const AdditiveQuantizer& aq,
         const float* LUT,

--- a/faiss/impl/AdditiveQuantizer.h
+++ b/faiss/impl/AdditiveQuantizer.h
@@ -49,11 +49,13 @@ struct AdditiveQuantizer : Quantizer {
     /// encode a norm into norm_bits bits
     uint64_t encode_norm(float norm) const;
 
+    /// encode norm by non-uniform scalar quantization
     uint32_t encode_qcint(
-            float x) const; ///< encode norm by non-uniform scalar quantization
+            float x) const;
 
+    /// decode norm by non-uniform scalar quantization
     float decode_qcint(uint32_t c)
-            const; ///< decode norm by non-uniform scalar quantization
+            const;
 
     /// Encodes how search is performed and how vectors are encoded
     enum Search_type_t {

--- a/faiss/impl/ResidualQuantizer.h
+++ b/faiss/impl/ResidualQuantizer.h
@@ -144,9 +144,7 @@ struct ResidualQuantizer : AdditiveQuantizer {
      */
     size_t memory_per_point(int beam_size = -1) const;
 
-    /** Cross products used in codebook tables
-     *
-     * These are used to keep trak of norms of centroids.
+    /** Cross products used in codebook tables used for beam_LUT = 1
      */
     void compute_codebook_tables();
 
@@ -194,6 +192,15 @@ void beam_search_encode_step(
 
 /** Encode a set of vectors using their dot products with the codebooks
  *
+ * @param K           number of vectors in the codebook
+ * @param n           nb of vectors to encode
+ * @param beam_size   input beam size
+ * @param codebook_cross_norms inner product of this codebook with the m
+ *                             previously encoded codebooks
+ * @param codebook_offsets     offsets into codebook_cross_norms for each
+ *                             previous codebook
+ * @param query_cp    dot products of query vectors with ???
+ * @param cent_norms_i  norms of centroids
  */
 void beam_search_encode_step_tab(
         size_t K,

--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -298,10 +298,10 @@ def serialize_index(index):
     return vector_to_array(writer.data)
 
 
-def deserialize_index(data):
+def deserialize_index(data, io_flags=0):
     reader = VectorIOReader()
     copy_array_to_vector(data, reader.data)
-    return read_index(reader)
+    return read_index(reader, io_flags)
 
 
 def serialize_index_binary(index):


### PR DESCRIPTION
Summary: To avoid OOM when loading some RCQs, don't precompute cross product tables when io_flags contains bit IO_FLAG_SKIP_PRECOMPUTE_TABLE

Differential Revision: D48448616

