### PR TITLE
Using expanded distance forms in `RaftFlatIndex.cu`

### DIFF
--- a/faiss/gpu/StandardGpuResources.cpp
+++ b/faiss/gpu/StandardGpuResources.cpp
@@ -432,6 +432,9 @@ raft::device_resources& StandardGpuResourcesImpl::getRaftHandle(int device) {
         // Make sure we are using the stream the user may have already assigned
         // to the current GpuResources
         raftHandles_.emplace(std::make_pair(device, getDefaultStream(device)));
+
+        // Initialize cublas handle
+        raftHandles_[device].get_cublas_handle();
     }
 
     // Otherwise, our base default handle

--- a/faiss/gpu/impl/RaftUtils.h
+++ b/faiss/gpu/impl/RaftUtils.h
@@ -35,9 +35,7 @@ inline raft::distance::DistanceType faiss_to_raft(
     switch (metric) {
         case MetricType::METRIC_INNER_PRODUCT:
             return raft::distance::DistanceType::InnerProduct;
-        case MetricType::METRIC_L2:
-            return exactDistance ? raft::distance::DistanceType::L2Unexpanded
-                                 : raft::distance::DistanceType::L2Expanded;
+        case MetricType::METRIC_L2: return raft::distance::DistanceType::L2Expanded;
         case MetricType::METRIC_L1:
             return raft::distance::DistanceType::L1;
         case MetricType::METRIC_Linf:

--- a/faiss/gpu/impl/RaftUtils.h
+++ b/faiss/gpu/impl/RaftUtils.h
@@ -35,7 +35,8 @@ inline raft::distance::DistanceType faiss_to_raft(
     switch (metric) {
         case MetricType::METRIC_INNER_PRODUCT:
             return raft::distance::DistanceType::InnerProduct;
-        case MetricType::METRIC_L2: return raft::distance::DistanceType::L2Expanded;
+        case MetricType::METRIC_L2:
+            return raft::distance::DistanceType::L2Expanded;
         case MetricType::METRIC_L1:
             return raft::distance::DistanceType::L1;
         case MetricType::METRIC_Linf:


### PR DESCRIPTION
This is a minor bug that comes with a perf impact. The classic FAISS `FlatIndex` always uses expanded form of distance computation even though an argument `exactDistances` is provided. `RaftFlatIndex` was using this argument to determine whether the computation should be exhaustive. 

This PR includes one additional change to eagerly initialize the `cublas_handle` on the `device_resources` instance when it's created. 