### PR TITLE
Fix is_trained in IndexHNSWSQ

### DIFF
--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -907,7 +907,7 @@ IndexHNSWSQ::IndexHNSWSQ(
         int M,
         MetricType metric)
         : IndexHNSW(new IndexScalarQuantizer(d, qtype, metric), M) {
-    is_trained = false;
+    is_trained = this->storage->is_trained;
     own_fields = true;
 }
 


### PR DESCRIPTION
### Description
Even though `is_trained` is set as `true` in [IndexScalarQuantizer](https://github.com/facebookresearch/faiss/blob/main/faiss/IndexScalarQuantizer.cpp#L34). It is again overwritten as `false` in [IndexHNSW](https://github.com/facebookresearch/faiss/blob/main/faiss/IndexHNSW.cpp#L910) which is failing at this [validation check](https://github.com/facebookresearch/faiss/blob/main/faiss/IndexHNSW.cpp#L363) while ingesting vectors. Raising this PR with a small change to fix it.