### PR TITLE
Fix chunk-based processing in ResidualCoarseQuantizer::search()

### DIFF
--- a/faiss/IndexAdditiveQuantizer.cpp
+++ b/faiss/IndexAdditiveQuantizer.cpp
@@ -560,7 +560,7 @@ void ResidualCoarseQuantizer::search(
         }
         for (idx_t i0 = 0; i0 < n; i0 += bs) {
             idx_t i1 = std::min(n, i0 + bs);
-            search(i1 - i0, x + i0 * d, k, distances + i0 * k, labels + i0 * k);
+            search(i1 - i0, x + i0 * d, k, distances + i0 * k, labels + i0 * k, params_in);
             InterruptCallback::check();
         }
         return;


### PR DESCRIPTION
Adds a missing function argument to ResidualCoarseQuantizer() whenever the data is processed in chunks