### PR TITLE
Faiss GPU: improve error information for GPU OOM

### DIFF
--- a/faiss/gpu/GpuDistance.cu
+++ b/faiss/gpu/GpuDistance.cu
@@ -30,7 +30,7 @@
 #include <faiss/gpu/utils/CopyUtils.cuh>
 #include <faiss/gpu/utils/DeviceTensor.cuh>
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 #include <faiss/gpu/impl/RaftUtils.h>
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/device_resources.hpp>
@@ -46,7 +46,7 @@
 namespace faiss {
 namespace gpu {
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 using namespace raft::distance;
 using namespace raft::neighbors;
 #endif
@@ -226,7 +226,7 @@ void bfKnn(GpuResourcesProvider* prov, const GpuDistanceParams& args) {
             "limitation: both vectorType and queryType must currently "
             "be the same (F32 or F16");
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
     // Note: For now, RAFT bfknn requires queries and vectors to be same layout
     if (args.use_raft && args.queriesRowMajor == args.vectorsRowMajor) {
         DistanceType distance = faiss_to_raft(args.metric, false);

--- a/faiss/gpu/GpuIndexFlat.cu
+++ b/faiss/gpu/GpuIndexFlat.cu
@@ -89,8 +89,7 @@ GpuIndexFlat::GpuIndexFlat(
 GpuIndexFlat::~GpuIndexFlat() {}
 
 void GpuIndexFlat::resetIndex_(int dims) {
-#if defined USE_NVIDIA_RAFT
-
+#ifdef USE_NVIDIA_RAFT
     if (flatConfig_.use_raft) {
         data_.reset(new RaftFlatIndex(
                 resources_.get(),

--- a/faiss/gpu/GpuResources.cpp
+++ b/faiss/gpu/GpuResources.cpp
@@ -168,7 +168,7 @@ cudaStream_t GpuResources::getDefaultStreamCurrentDevice() {
     return getDefaultStream(getCurrentDevice());
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 raft::device_resources& GpuResources::getRaftHandleCurrentDevice() {
     return getRaftHandle(getCurrentDevice());
 }

--- a/faiss/gpu/GpuResources.h
+++ b/faiss/gpu/GpuResources.h
@@ -30,7 +30,7 @@
 #include <utility>
 #include <vector>
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 #include <raft/core/device_resources.hpp>
 #endif
 
@@ -206,7 +206,7 @@ class GpuResources {
     /// given device
     virtual cudaStream_t getDefaultStream(int device) = 0;
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
     /// Returns the raft handle for the given device which can be used to
     /// make calls to other raft primitives.
     virtual raft::device_resources& getRaftHandle(int device) = 0;

--- a/faiss/gpu/StandardGpuResources.cpp
+++ b/faiss/gpu/StandardGpuResources.cpp
@@ -20,7 +20,7 @@
  * limitations under the License.
  */
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 #include <raft/core/device_resources.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
 #include <rmm/mr/device/managed_memory_resource.hpp>
@@ -90,7 +90,7 @@ std::string allocsToString(const std::unordered_map<void*, AllocRequest>& map) {
 
 StandardGpuResourcesImpl::StandardGpuResourcesImpl()
         :
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
           cmr(new rmm::mr::cuda_memory_resource),
           mmr(new rmm::mr::managed_memory_resource),
           pmr(new rmm::mr::pinned_memory_resource),
@@ -107,9 +107,11 @@ StandardGpuResourcesImpl::StandardGpuResourcesImpl()
 }
 
 StandardGpuResourcesImpl::~StandardGpuResourcesImpl() {
+#ifndef USE_NVIDIA_RAFT
     // The temporary memory allocator has allocated memory through us, so clean
     // that up before we finish fully de-initializing ourselves
     tempMemory_.clear();
+#endif
 
     // Make sure all allocations have been freed
     bool allocError = false;
@@ -159,7 +161,7 @@ StandardGpuResourcesImpl::~StandardGpuResourcesImpl() {
     }
 
     if (pinnedMemAlloc_) {
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
         pmr->deallocate(pinnedMemAlloc_, pinnedMemAllocSize_);
 #else
         auto err = cudaFreeHost(pinnedMemAlloc_);
@@ -171,6 +173,25 @@ StandardGpuResourcesImpl::~StandardGpuResourcesImpl() {
                 cudaGetErrorString(err));
 #endif
     }
+}
+
+std::string StandardGpuResourcesImpl::getAllocatorState() const {
+    std::stringstream ss;
+
+    for (auto v : allocs_) {
+        auto device = v.first;
+
+        ss << "GPU device " << device << " allocator state:\n"
+           << "==========\n"
+           << "Device free memory: " << getFreeMemory(device) << " bytes\n"
+           << "Allocator temp memory remaining: "
+           << getTempMemoryAvailable(device) << "bytes\n"
+           << "Outstanding Faiss allocations:\n"
+           << "==========\n"
+           << allocsToString(v.second) << "\n";
+    }
+
+    return ss.str();
 }
 
 size_t StandardGpuResourcesImpl::getDefaultTempMemForGPU(
@@ -211,6 +232,9 @@ void StandardGpuResourcesImpl::setTempMemory(size_t size) {
         // adjust based on general limits
         tempMemSize_ = getDefaultTempMemForGPU(-1, size);
 
+        // Don't allocate a temporary memory region if we are using RAFT,
+        // just pass all allocations to RAFT
+#ifndef USE_NVIDIA_RAFT
         // We need to re-initialize memory resources for all current devices
         // that have been initialized. This should be safe to do, even if we are
         // currently running work, because the cudaFree call that this implies
@@ -227,6 +251,7 @@ void StandardGpuResourcesImpl::setTempMemory(size_t size) {
                     // adjust for this specific device
                     getDefaultTempMemForGPU(device, tempMemSize_)));
         }
+#endif
     }
 }
 
@@ -308,7 +333,7 @@ void StandardGpuResourcesImpl::initializeForDevice(int device) {
     // If this is the first device that we're initializing, create our
     // pinned memory allocation
     if (defaultStreams_.empty() && pinnedMemSize_ > 0) {
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
         // If this is the first device that we're initializing, create our
         // pinned memory allocation
         if (defaultStreams_.empty() && pinnedMemSize_ > 0) {
@@ -395,6 +420,8 @@ void StandardGpuResourcesImpl::initializeForDevice(int device) {
     FAISS_ASSERT(allocs_.count(device) == 0);
     allocs_[device] = std::unordered_map<void*, AllocRequest>();
 
+    // Don't use our temporary memory facility if we are using RAFT
+#ifndef USE_NVIDIA_RAFT
     FAISS_ASSERT(tempMemory_.count(device) == 0);
     auto mem = std::unique_ptr<StackDeviceMemory>(new StackDeviceMemory(
             this,
@@ -403,6 +430,7 @@ void StandardGpuResourcesImpl::initializeForDevice(int device) {
             getDefaultTempMemForGPU(device, tempMemSize_)));
 
     tempMemory_.emplace(device, std::move(mem));
+#endif
 }
 
 cublasHandle_t StandardGpuResourcesImpl::getBlasHandle(int device) {
@@ -423,7 +451,7 @@ cudaStream_t StandardGpuResourcesImpl::getDefaultStream(int device) {
     return defaultStreams_[device];
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 raft::device_resources& StandardGpuResourcesImpl::getRaftHandle(int device) {
     initializeForDevice(device);
 
@@ -473,6 +501,14 @@ void* StandardGpuResourcesImpl::allocMemory(const AllocRequest& req) {
     void* p = nullptr;
 
     if (adjReq.space == MemorySpace::Temporary) {
+#ifdef USE_NVIDIA_RAFT
+        // just pass to the RAFT allocator, we don't pre-reserve temporary
+        // memory
+        try {
+            p = cmr->allocate(adjReq.size, adjReq.stream);
+        } catch (const std::bad_alloc& rmm_ex) {
+        }
+#else
         // If we don't have enough space in our temporary memory manager, we
         // need to allocate this request separately
         auto& tempMem = tempMemory_[adjReq.device];
@@ -485,7 +521,7 @@ void* StandardGpuResourcesImpl::allocMemory(const AllocRequest& req) {
 
             if (allocLogging_) {
                 std::cout
-                        << "StandardGpuResources: alloc fail "
+                        << "StandardGpuResources: temp alloc denied "
                         << adjReq.toString()
                         << " (no temp space); retrying as MemorySpace::Device\n";
             }
@@ -495,13 +531,24 @@ void* StandardGpuResourcesImpl::allocMemory(const AllocRequest& req) {
 
         // Otherwise, we can handle this locally
         p = tempMemory_[adjReq.device]->allocMemory(adjReq.stream, adjReq.size);
-
+#endif
     } else if (adjReq.space == MemorySpace::Device) {
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
         try {
             p = cmr->allocate(adjReq.size, adjReq.stream);
         } catch (const std::bad_alloc& rmm_ex) {
-            FAISS_THROW_MSG("CUDA memory allocation error");
+            std::stringstream ss;
+            ss << "StandardGpuResources: RAFT device allocator fail "
+               << adjReq.toString() << "\n"
+               << "Exception: " << rmm_ex.what() << "\n"
+               << getAllocatorState() << "\n";
+
+            auto str = ss.str();
+            if (allocLogging_) {
+                std::cout << str;
+            }
+
+            FAISS_THROW_MSG(str.c_str());
         }
 #else
         auto err = cudaMalloc(&p, adjReq.size);
@@ -514,24 +561,35 @@ void* StandardGpuResourcesImpl::allocMemory(const AllocRequest& req) {
             cudaGetLastError();
 
             std::stringstream ss;
-            ss << "StandardGpuResources: alloc fail " << adjReq.toString()
-               << " (cudaMalloc error " << cudaGetErrorString(err) << " ["
-               << (int)err << "])\n";
-            auto str = ss.str();
+            ss << "StandardGpuResources: Faiss device allocator fail "
+               << adjReq.toString() << " (cudaMalloc error " << int(err) << " "
+               << cudaGetErrorString(err) << ")\n"
+               << getAllocatorState() << "\n";
 
+            auto str = ss.str();
             if (allocLogging_) {
                 std::cout << str;
             }
 
-            FAISS_THROW_IF_NOT_FMT(err == cudaSuccess, "%s", str.c_str());
+            FAISS_THROW_MSG(str.c_str());
         }
 #endif
     } else if (adjReq.space == MemorySpace::Unified) {
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
         try {
             p = mmr->allocate(adjReq.size, adjReq.stream);
         } catch (const std::bad_alloc& rmm_ex) {
-            FAISS_THROW_MSG("CUDA memory allocation error");
+            std::stringstream ss;
+            ss << "StandardGpuResources: RAFT managed mem allocator fail "
+               << adjReq.toString() << " exception: " << rmm_ex.what() << "\n"
+               << getAllocatorState() << "\n";
+
+            auto str = ss.str();
+            if (allocLogging_) {
+                std::cout << str;
+            }
+
+            FAISS_THROW_MSG(str.c_str());
         }
 #else
         auto err = cudaMallocManaged(&p, adjReq.size);
@@ -543,16 +601,17 @@ void* StandardGpuResourcesImpl::allocMemory(const AllocRequest& req) {
             cudaGetLastError();
 
             std::stringstream ss;
-            ss << "StandardGpuResources: alloc fail " << adjReq.toString()
-               << " failed (cudaMallocManaged error " << cudaGetErrorString(err)
-               << " [" << (int)err << "])\n";
-            auto str = ss.str();
+            ss << "StandardGpuResources: Faiss managed mem allocator fail "
+               << adjReq.toString() << " (cudaMallocManaged error " << int(err)
+               << " " << cudaGetErrorString(err) << "\n"
+               << getAllocatorState() << "\n";
 
+            auto str = ss.str();
             if (allocLogging_) {
                 std::cout << str;
             }
 
-            FAISS_THROW_IF_NOT_FMT(err == cudaSuccess, "%s", str.c_str());
+            FAISS_THROW_MSG(str.c_str());
         }
 #endif
     } else {
@@ -587,12 +646,15 @@ void StandardGpuResourcesImpl::deallocMemory(int device, void* p) {
     }
 
     if (req.space == MemorySpace::Temporary) {
+#ifdef USE_NVIDIA_RAFT
+        cmr->deallocate(p, req.size, req.stream);
+#else
         tempMemory_[device]->deallocMemory(device, req.stream, req.size, p);
-
+#endif
     } else if (
             req.space == MemorySpace::Device ||
             req.space == MemorySpace::Unified) {
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
         if (req.space == MemorySpace::Device) {
             cmr->deallocate(p, req.size, req.stream);
         } else if (req.space == MemorySpace::Unified) {
@@ -616,11 +678,15 @@ void StandardGpuResourcesImpl::deallocMemory(int device, void* p) {
 
 size_t StandardGpuResourcesImpl::getTempMemoryAvailable(int device) const {
     FAISS_ASSERT(isInitialized(device));
-
+#ifdef USE_NVIDIA_RAFT
+    // we don't reserve temporary memory in advance with RAFT
+    return 0;
+#else
     auto it = tempMemory_.find(device);
     FAISS_ASSERT(it != tempMemory_.end());
 
     return it->second->getSizeAvailable();
+#endif
 }
 
 std::map<int, std::map<std::string, std::pair<int, size_t>>>
@@ -657,6 +723,10 @@ std::shared_ptr<GpuResources> StandardGpuResources::getResources() {
     return res_;
 }
 
+std::string StandardGpuResources::getAllocatorState() const {
+    return res_->getAllocatorState();
+}
+
 void StandardGpuResources::noTempMemory() {
     res_->noTempMemory();
 }
@@ -690,7 +760,7 @@ cudaStream_t StandardGpuResources::getDefaultStream(int device) {
     return res_->getDefaultStream(device);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 raft::device_resources& StandardGpuResources::getRaftHandle(int device) {
     return res_->getRaftHandle(device);
 }

--- a/faiss/gpu/impl/RaftFlatIndex.cu
+++ b/faiss/gpu/impl/RaftFlatIndex.cu
@@ -20,6 +20,8 @@
  * limitations under the License.
  */
 
+#ifdef USE_NVIDIA_RAFT
+
 #include <faiss/gpu/impl/RaftUtils.h>
 #include <faiss/gpu/impl/RaftFlatIndex.cuh>
 #include <faiss/gpu/utils/ConversionOperators.cuh>
@@ -154,3 +156,5 @@ void RaftFlatIndex::query(
 
 } // namespace gpu
 } // namespace faiss
+
+#endif // USE_NVIDIA_RAFT

--- a/faiss/gpu/impl/RaftFlatIndex.cuh
+++ b/faiss/gpu/impl/RaftFlatIndex.cuh
@@ -21,6 +21,7 @@
  */
 
 #pragma once
+#ifdef USE_NVIDIA_RAFT
 
 #include <faiss/MetricType.h>
 #include <faiss/gpu/GpuResources.h>
@@ -67,3 +68,5 @@ class RaftFlatIndex : public FlatIndex {
 
 } // namespace gpu
 } // namespace faiss
+
+#endif // USE_NVIDIA_RAFT

--- a/faiss/gpu/test/TestGpuDistance.cu
+++ b/faiss/gpu/test/TestGpuDistance.cu
@@ -168,7 +168,7 @@ void testTransposition(
     args.outIndices = gpuIndices.data();
     args.device = device;
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
     args.use_raft = use_raft;
 #else
     FAISS_THROW_IF_NOT_MSG(
@@ -196,7 +196,7 @@ TEST(TestGpuDistance, Transposition_RR) {
     testTransposition(false, false, faiss::MetricType::METRIC_INNER_PRODUCT);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 TEST(TestRaftGpuDistance, Transposition_RR) {
     testTransposition(false, false, faiss::MetricType::METRIC_L2, true);
     testTransposition(
@@ -208,7 +208,7 @@ TEST(TestGpuDistance, Transposition_RC) {
     testTransposition(false, true, faiss::MetricType::METRIC_L2);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 TEST(TestRaftGpuDistance, Transposition_RC) {
     testTransposition(false, true, faiss::MetricType::METRIC_L2, true);
 }
@@ -218,7 +218,7 @@ TEST(TestGpuDistance, Transposition_CR) {
     testTransposition(true, false, faiss::MetricType::METRIC_L2);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 TEST(TestRaftGpuDistance, Transposition_CR) {
     testTransposition(true, false, faiss::MetricType::METRIC_L2, true);
 }
@@ -228,7 +228,7 @@ TEST(TestGpuDistance, Transposition_CC) {
     testTransposition(true, true, faiss::MetricType::METRIC_L2);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 TEST(TestRaftGpuDistance, Transposition_CC) {
     testTransposition(true, true, faiss::MetricType::METRIC_L2, true);
 }
@@ -238,7 +238,7 @@ TEST(TestGpuDistance, L1) {
     testTransposition(false, false, faiss::MetricType::METRIC_L1);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 TEST(TestRaftGpuDistance, L1) {
     testTransposition(false, false, faiss::MetricType::METRIC_L1, true);
 }
@@ -249,7 +249,7 @@ TEST(TestGpuDistance, L1_RC) {
     testTransposition(false, true, faiss::MetricType::METRIC_L1);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 // Test other transpositions with the general distance kernel
 TEST(TestRaftGpuDistance, L1_RC) {
     testTransposition(false, true, faiss::MetricType::METRIC_L1, true);
@@ -260,7 +260,7 @@ TEST(TestGpuDistance, L1_CR) {
     testTransposition(true, false, faiss::MetricType::METRIC_L1);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 TEST(TestRaftGpuDistance, L1_CR) {
     testTransposition(true, false, faiss::MetricType::METRIC_L1, true);
 }
@@ -270,7 +270,7 @@ TEST(TestGpuDistance, L1_CC) {
     testTransposition(true, true, faiss::MetricType::METRIC_L1);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 TEST(TestRaftGpuDistance, L1_CC) {
     testTransposition(true, true, faiss::MetricType::METRIC_L1, true);
 }
@@ -281,7 +281,7 @@ TEST(TestGpuDistance, Linf) {
     testTransposition(false, false, faiss::MetricType::METRIC_Linf);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 // Test remainder of metric types
 TEST(TestRaftGpuDistance, Linf) {
     testTransposition(false, false, faiss::MetricType::METRIC_Linf, true);
@@ -292,7 +292,7 @@ TEST(TestGpuDistance, Lp) {
     testTransposition(false, false, faiss::MetricType::METRIC_Lp, false, 3);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 TEST(TestRaftGpuDistance, Lp) {
     testTransposition(false, false, faiss::MetricType::METRIC_Lp, true, 3);
 }
@@ -302,7 +302,7 @@ TEST(TestGpuDistance, Canberra) {
     testTransposition(false, false, faiss::MetricType::METRIC_Canberra);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 TEST(TestRaftGpuDistance, Canberra) {
     testTransposition(false, false, faiss::MetricType::METRIC_Canberra, true);
 }
@@ -316,7 +316,7 @@ TEST(TestGpuDistance, JensenShannon) {
     testTransposition(false, false, faiss::MetricType::METRIC_JensenShannon);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 TEST(TestRaftGpuDistance, JensenShannon) {
     testTransposition(
             false, false, faiss::MetricType::METRIC_JensenShannon, true);

--- a/faiss/gpu/test/TestGpuIndexFlat.cpp
+++ b/faiss/gpu/test/TestGpuIndexFlat.cpp
@@ -114,7 +114,7 @@ TEST(TestGpuIndexFlat, IP_Float32) {
 
         testFlat(opt);
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
         opt.use_raft = true;
         testFlat(opt);
 #endif
@@ -128,7 +128,7 @@ TEST(TestGpuIndexFlat, L1_Float32) {
 
     testFlat(opt);
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
     opt.use_raft = true;
     testFlat(opt);
 #endif
@@ -141,7 +141,7 @@ TEST(TestGpuIndexFlat, Lp_Float32) {
     opt.useFloat16 = false;
 
     testFlat(opt);
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
     opt.use_raft = true;
     testFlat(opt);
 #endif
@@ -155,7 +155,7 @@ TEST(TestGpuIndexFlat, L2_Float32) {
         opt.useFloat16 = false;
 
         testFlat(opt);
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
         opt.use_raft = true;
         testFlat(opt);
 #endif
@@ -173,7 +173,7 @@ TEST(TestGpuIndexFlat, L2_k_2048) {
         opt.numVecsOverride = 10000;
 
         testFlat(opt);
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
         opt.use_raft = true;
         testFlat(opt);
 #endif
@@ -189,7 +189,7 @@ TEST(TestGpuIndexFlat, L2_Float32_K1) {
         opt.kOverride = 1;
 
         testFlat(opt);
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
         opt.use_raft = true;
         testFlat(opt);
 #endif
@@ -203,7 +203,7 @@ TEST(TestGpuIndexFlat, IP_Float16) {
         opt.useFloat16 = true;
 
         testFlat(opt);
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
         opt.use_raft = true;
         testFlat(opt);
 #endif
@@ -217,7 +217,7 @@ TEST(TestGpuIndexFlat, L2_Float16) {
         opt.useFloat16 = true;
 
         testFlat(opt);
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
         opt.use_raft = true;
         testFlat(opt);
 #endif
@@ -233,7 +233,7 @@ TEST(TestGpuIndexFlat, L2_Float16_K1) {
         opt.kOverride = 1;
 
         testFlat(opt);
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
         opt.use_raft = true;
         testFlat(opt);
 #endif
@@ -254,7 +254,7 @@ TEST(TestGpuIndexFlat, L2_Tiling) {
         opt.kOverride = 64;
 
         testFlat(opt);
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
         opt.use_raft = true;
         testFlat(opt);
 #endif
@@ -342,7 +342,7 @@ TEST(TestGpuIndexFlat, CopyFrom) {
     testCopyFrom(false);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 TEST(TestRaftGpuIndexFlat, CopyFrom) {
     testCopyFrom(true);
 }
@@ -393,7 +393,7 @@ TEST(TestGpuIndexFlat, CopyTo) {
     testCopyTo(false);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 TEST(TestRaftGpuIndexFlat, CopyTo) {
     testCopyTo(true);
 }
@@ -451,7 +451,7 @@ TEST(TestGpuIndexFlat, UnifiedMemory) {
     testUnifiedMemory(false);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 TEST(TestRaftGpuIndexFlat, UnifiedMemory) {
     testUnifiedMemory(true);
 }
@@ -512,7 +512,7 @@ TEST(TestGpuIndexFlat, LargeIndex) {
     testLargeIndex(false);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 TEST(TestRaftGpuIndexFlat, LargeIndex) {
     testLargeIndex(true);
 }
@@ -565,7 +565,7 @@ TEST(TestGpuIndexFlat, Residual) {
     testResidual(false);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 TEST(TestRaftGpuIndexFlat, Residual) {
     testResidual(true);
 }
@@ -656,7 +656,7 @@ void testReconstruct(bool use_raft) {
 TEST(TestGpuIndexFlat, Reconstruct) {
     testReconstruct(false);
 }
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 TEST(TestRaftGpuIndexFlat, Reconstruct) {
     testReconstruct(true);
 }
@@ -754,7 +754,7 @@ TEST(TestGpuIndexFlat, SearchAndReconstruct) {
     testSearchAndReconstruct(false);
 }
 
-#if defined USE_NVIDIA_RAFT
+#ifdef USE_NVIDIA_RAFT
 TEST(TestRaftGpuIndexFlat, SearchAndReconstruct) {
     testSearchAndReconstruct(true);
 }


### PR DESCRIPTION
Summary:
This diff updates logging in case of GPU out of memory errors, whether from `cudaMalloc` directly or from the RAFT allocator. In case of a memory error, allocator state (including an indication of CUDA-reported free memory on the device) is returned as part of the exception message, like this:

```
C++ exception with description "Error in virtual void *faiss::gpu::StandardGpuResourcesImpl::allocMemory(const faiss::gpu::AllocRequest &) at fbcode/faiss/gpu/StandardGpuResources.cpp:570: StandardGpuResources: Faiss device allocator fail type IVFLists dev 1 space Device stream 0x7fa07623b440 size 1024 bytes                                                                                                                                   Allocator state:                                                                                                                                                GPU device 1 allocator state:                                                                                                                                   ==========                                                                                                                                                      Device free memory: 82400968704 bytes                                                                                                                           Allocator temp memory remaining: 1610612720
Outstanding Faiss allocations:
Alloc type TemporaryMemoryBuffer: 1 allocations, 1610612736 bytes
Alloc type FlatData: 2 allocations, 59648 bytes
```

In the case where Faiss is built using RAFT, previously no error information was provided if the RAFT memory manager had an OOM error, but now it will produce a string similar to the above. The Faiss memory manager (StandardGpuResources) continues to log all allocations made and passed to the RAFT memory manager, so we can also receive an indication of what is allocated and for what purpose.

In addition, this fixes the issue where Faiss GPU would not compile (in fbcode at least) if the `USE_NVIDIA_RAFT` define was not available. Now the library compiles both with and without RAFT.

Also updated the `#if defined USE_NVIDIA_RAFT` to #ifdef USE_NVIDIA_RAFT` to better conform to the rest of the GPU code.

This diff also disables the temporary memory allocation of 1.5 GB made up front if RAFT is being used, which is really what is intended for using the RAFT memory manager. Otherwise this diff does not change the runtime behavior of Faiss GPU otherwise, but this diff is being made to better debug GPU OOM issues with Faiss usage.

Reviewed By: mdouze

Differential Revision: D49260364


