### PR TITLE
Fix SingleBestResultHandler bug. if IndexFlatL2 empty data then search topk = 1 return label = 0 not -1.

### DIFF
--- a/faiss/impl/ResultHandler.h
+++ b/faiss/impl/ResultHandler.h
@@ -446,7 +446,7 @@ struct SingleBestResultHandler {
         void begin(const size_t current_idx) {
             this->current_idx = current_idx;
             min_dis = HUGE_VALF;
-            min_idx = 0;
+            min_idx = -1;
         }
 
         /// add one result for query i


### PR DESCRIPTION
Fix SingleBestResultHandler bug. if IndexFlatL2 empty data then search topk = 1 return label = 0 not -1.

for example

 int d = 64;      // dimension
    int nb = 100000; // database size
    int nq = 1;      // nb of queries

    std::mt19937 rng;
    std::uniform_real_distribution<> distrib;

    float* xb = new float[d * nb];
    float* xq = new float[d * nq];

    for (int i = 0; i < nb; i++) {
        for (int j = 0; j < d; j++)
            xb[d * i + j] = distrib(rng);
        xb[d * i] += i / 1000.;
    }

    for (int i = 0; i < nq; i++) {
        for (int j = 0; j < d; j++)
            xq[d * i + j] = distrib(rng);
        xq[d * i] += i / 1000.;
    }

    faiss::IndexFlatL2 index(d); // call constructor
    printf("is_trained = %s\n", index.is_trained ? "true" : "false");

    int k = 1;

    { // sanity check: search 1 first vectors of xb
        idx_t* I = new idx_t[k * nq];
        float* D = new float[k * nq];

        index.search(nq, xb, k, D, I); // *I = 0 not -1
	}