### PR TITLE
Mark raft symbols with hidden visibility

### DIFF
--- a/faiss/gpu/CMakeLists.txt
+++ b/faiss/gpu/CMakeLists.txt
@@ -242,10 +242,30 @@ if(FAISS_ENABLE_RAFT)
           impl/RaftFlatIndex.cuh)
   list(APPEND FAISS_GPU_SRC
           impl/RaftFlatIndex.cu
-	  impl/RaftIVFFlat.cu)
+	        impl/RaftIVFFlat.cu)
 
   target_compile_definitions(faiss PUBLIC USE_NVIDIA_RAFT=1)
   target_compile_definitions(faiss_avx2 PUBLIC USE_NVIDIA_RAFT=1)
+
+  # Mark all functions as hidden so that we don't generate
+  # global 'public' functions that also exist in libraft.so
+  #
+  # This ensures that faiss functions will call the local version
+  # inside libfaiss.so . This is needed to ensure that things
+  # like raft cublas resources are created and used within the same
+  # dynamic library + CUDA runtime context which are requirements
+  # for valid execution
+  #
+  # To still allow these classes to be used by consumers, the
+  # respective classes/types in the headers are explicitly marked
+  # as 'public' so they can be used by consumers
+  set_source_files_properties(
+    GpuDistance.cu
+    StandardGpuResources.cpp
+    impl/RaftFlatIndex.cu
+    impl/RaftIVFFlat.cu
+    TARGET_DIRECTORY faiss
+    PROPERTIES COMPILE_OPTIONS "-fvisibility=hidden")
 endif()
 
 # Export FAISS_GPU_HEADERS variable to parent scope.

--- a/faiss/gpu/GpuDistance.h
+++ b/faiss/gpu/GpuDistance.h
@@ -9,6 +9,7 @@
 
 #include <faiss/Index.h>
 
+#pragma GCC visibility push(default)
 namespace faiss {
 namespace gpu {
 
@@ -168,3 +169,4 @@ void bruteForceKnn(
 
 } // namespace gpu
 } // namespace faiss
+#pragma GCC visibility pop

--- a/faiss/gpu/StandardGpuResources.h
+++ b/faiss/gpu/StandardGpuResources.h
@@ -37,6 +37,7 @@
 #include <unordered_map>
 #include <vector>
 
+#pragma GCC visibility push(default)
 namespace faiss {
 namespace gpu {
 
@@ -260,3 +261,4 @@ class StandardGpuResources : public GpuResourcesProvider {
 
 } // namespace gpu
 } // namespace faiss
+#pragma GCC visibility pop

--- a/faiss/gpu/impl/RaftFlatIndex.cuh
+++ b/faiss/gpu/impl/RaftFlatIndex.cuh
@@ -28,6 +28,7 @@
 #include <faiss/gpu/utils/DeviceTensor.cuh>
 #include <faiss/gpu/utils/DeviceVector.cuh>
 
+#pragma GCC visibility push(default)
 namespace faiss {
 namespace gpu {
 
@@ -67,3 +68,4 @@ class RaftFlatIndex : public FlatIndex {
 
 } // namespace gpu
 } // namespace faiss
+#pragma GCC visibility pop

--- a/faiss/gpu/impl/RaftIVFFlat.cuh
+++ b/faiss/gpu/impl/RaftIVFFlat.cuh
@@ -32,6 +32,7 @@
 
 #include <optional>
 
+#pragma GCC visibility push(default)
 namespace faiss {
 namespace gpu {
 
@@ -147,3 +148,4 @@ struct RaftIVFFlatCodePackerInterleaved : CodePacker {
 
 } // namespace gpu
 } // namespace faiss
+#pragma GCC visibility pop

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ find_package(OpenMP REQUIRED)
 target_link_libraries(faiss_test PRIVATE
   OpenMP::OpenMP_CXX
   gtest_main
+  $<$<BOOL:${FAISS_ENABLE_RAFT}>:raft::raft>
 )
 
 # Defines `gtest_discover_tests()`.


### PR DESCRIPTION
Symbols that are public are de-duplicated across all shared libraries. This can cause issues since raft resources have state that isn't valid across shared library boundaries.

So we mark all the raft symbols as hidden so that we ensure that faiss raft functions call the local ( per .so ) version of the function.