### PR TITLE
fix swig ownership when assigning to struct pointer field

### DIFF
--- a/faiss/python/class_wrappers.py
+++ b/faiss/python/class_wrappers.py
@@ -1066,28 +1066,6 @@ def add_to_referenced_objects(self, ref):
     else:
         self.referenced_objects.append(ref)
 
-class RememberSwigOwnership:
-    """
-    SWIG's seattr transfers ownership of SWIG wrapped objects to the class
-    (btw this seems to contradict https://www.swig.org/Doc1.3/Python.html#Python_nn22
-    31.4.2)
-    This interferes with how we manage ownership: with the referenced_objects
-    table. Therefore, we reset the thisown field in this context manager.
-    """
-
-    def __init__(self, obj):
-        self.obj = obj
-
-    def __enter__(self):
-        if hasattr(self.obj, "thisown"):
-            self.old_thisown = self.obj.thisown
-        else:
-            self.old_thisown = None
-
-    def __exit__(self, *ignored):
-        if self.old_thisown is not None:
-            self.obj.thisown = self.old_thisown
-
 
 def handle_SearchParameters(the_class):
     """ this wrapper is to enable initializations of the form
@@ -1102,8 +1080,7 @@ def handle_SearchParameters(the_class):
         self.original_init()
         for k, v in args.items():
             assert hasattr(self, k)
-            with RememberSwigOwnership(v):
-                setattr(self, k, v)
+            setattr(self, k, v)
             if type(v) not in (int, float, bool, str):
                 add_to_referenced_objects(self, v)
 

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -199,6 +199,20 @@ typedef uint64_t size_t;
     Py_END_ALLOW_THREADS
 }
 
+/********************************************************
+ * Don't transfer ownership when assigning to a struct field
+ ********************************************************/
+
+// https://github.com/swig/swig/issues/2709
+// override default behavior
+%typemap(in, noblock=1) SWIGTYPE * (void  *argp = 0, int res = 0) {
+  res = SWIG_ConvertPtr($input, &argp,$descriptor, /* $disown | */ %convertptr_flags);
+  if (!SWIG_IsOK(res)) {
+    %argument_fail(res, "$type", $symname, $argnum);
+  }
+  $1 = %reinterpret_cast(argp, $ltype);
+}
+
 #endif
 
 

--- a/tests/test_search_params.py
+++ b/tests/test_search_params.py
@@ -370,6 +370,13 @@ class TestSearchParams(unittest.TestCase):
         self.assertTrue(sel1.this.own())
         self.assertTrue(sel2.this.own())
 
+    def test_ownership_2(self):
+        subset = np.arange(0, 5000000)
+        sel = faiss.IDSelectorBatch(subset)
+        assert sel.this.own()    # True: correct
+        _ = faiss.SearchParameters(sel=sel)
+        assert sel.this.own()   # False: why???
+
 
 class TestSelectorCallback(unittest.TestCase):
 


### PR DESCRIPTION
Summary: When faiss is called from SWIG, it is usually assumed that Python will do all the memory management, therefore assigning to a pointer in C++ should not transfer ownerhsip (default SWIG behavior). This diff fixed that.

Differential Revision: D51529085


