### PR TITLE
improve ScalarQuantizer performance, ESPECIALLY on old GCC

### DIFF
--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -82,6 +82,8 @@ inline int __builtin_clzll(uint64_t x) {
 #define __F16C__ 1
 #endif
 
+#define FAISS_ALWAYS_INLINE __forceinline
+
 #else
 /*******************************************************
  * Linux and OSX
@@ -97,6 +99,8 @@ inline int __builtin_clzll(uint64_t x) {
 #else
 #define ALIGNED(x) __attribute__((aligned(x)))
 #endif
+
+#define FAISS_ALWAYS_INLINE __attribute__((always_inline)) inline
 
 #endif
 


### PR DESCRIPTION
Introduces `FAISS_ALWAYS_INLINE` pragma directive and improves `ScalarQuantizer` performance with it. 

Most of performance-critical methods for `ScalarQuantizer` are marked with this new directive, because a compiler (especially, an old one) may be unable to inline it properly. In some of my GCC experiments, such an inlining yields +50% queries per second in a search.