### PR TITLE
Fix is_trained in IndexNSGSQ

### DIFF
--- a/faiss/IndexNSG.cpp
+++ b/faiss/IndexNSG.cpp
@@ -309,7 +309,7 @@ IndexNSGSQ::IndexNSGSQ(
         int M,
         MetricType metric)
         : IndexNSG(new IndexScalarQuantizer(d, qtype, metric), M) {
-    is_trained = false;
+    is_trained = this->storage->is_trained;
     own_fields = true;
 }
 


### PR DESCRIPTION
Same as #3034 

When using IndexNSGSQ with fp16, do not require training