### PR TITLE
Fix potential buffer overflow

### DIFF
--- a/faiss/MetaIndexes.cpp
+++ b/faiss/MetaIndexes.cpp
@@ -96,7 +96,7 @@ void IndexSplitVectors::search(
         float* sub_x = new float[sub_d * n];
         ScopeDeleter<float> del1(sub_x);
         for (idx_t i = 0; i < n; i++)
-            memcpy(sub_x + i * sub_d, x + ofs + i * d, sub_d * sizeof(sub_x));
+            memcpy(sub_x + i * sub_d, x + ofs + i * d, sub_d * sizeof(float));
         sub_index->search(n, sub_x, k, distances1, labels1);
         if (index->verbose)
             printf("end query shard %d\n", no);


### PR DESCRIPTION
Size of pointer `sub_x` used instead of size of its data. This is likely to lead to a buffer overflow if the user is not lucky enough to be in a x32 bit machine where `sizeof(float*) == sizeof(float)`. 
You probably intend to write `sizeof(*sub_x)` or `sizeof(float)` ?