### PR TITLE
Add NegativeDistanceComputer::distances_batch_4 override

### DIFF
--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -87,6 +87,23 @@ struct NegativeDistanceComputer : DistanceComputer {
         return -(*basedis)(i);
     }
 
+    void distances_batch_4(
+            const idx_t idx0,
+            const idx_t idx1,
+            const idx_t idx2,
+            const idx_t idx3,
+            float& dis0,
+            float& dis1,
+            float& dis2,
+            float& dis3) override {
+        basedis->distances_batch_4(
+                idx0, idx1, idx2, idx3, dis0, dis1, dis2, dis3);
+        dis0 = -dis0;
+        dis1 = -dis1;
+        dis2 = -dis2;
+        dis3 = -dis3;
+    }
+
     /// compute distance between two stored vectors
     float symmetric_dis(idx_t i, idx_t j) override {
         return -basedis->symmetric_dis(i, j);


### PR DESCRIPTION
Summary:
Enables vectorized distance calculation in [NegativeDistanceComputer](https://github.com/facebookresearch/faiss/blob/b109d086a2a200b1697481dd3d79faedc585a623/faiss/IndexHNSW.cpp#L74), whenever supported by the [NegativeDistanceComputer::basedis](https://github.com/facebookresearch/faiss/blob/b109d086a2a200b1697481dd3d79faedc585a623/faiss/IndexHNSW.cpp#L76).

Otherwise the default sequential calculation of [DistanceComputer::distances_batch_4](https://github.com/facebookresearch/faiss/blob/b109d086a2a200b1697481dd3d79faedc585a623/faiss/impl/DistanceComputer.h#L36-L54) is always chosen.

Differential Revision: D51596177


