### PR TITLE
Introduce result collector for HNSW

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -162,6 +162,8 @@ set(FAISS_HEADERS
   impl/ProductQuantizer.h
   impl/Quantizer.h
   impl/ResidualQuantizer.h
+  impl/ResultCollector.h
+  impl/ResultCollectorFactory.h
   impl/ResultHandler.h
   impl/ScalarQuantizer.h
   impl/ThreadedIndex-inl.h

--- a/faiss/Index.h
+++ b/faiss/Index.h
@@ -38,11 +38,12 @@
 
 namespace faiss {
 
-/// Forward declarations see impl/AuxIndexStructures.h, impl/IDSelector.h and
-/// impl/DistanceComputer.h
+/// Forward declarations see impl/AuxIndexStructures.h, impl/IDSelector.h,
+/// impl/DistanceComputer.h, and impl/ResultCollectorFactory.h
 struct IDSelector;
 struct RangeSearchResult;
 struct DistanceComputer;
+struct ResultCollectorFactory;
 
 /** Parent class for the optional search paramenters.
  *
@@ -52,6 +53,7 @@ struct DistanceComputer;
 struct SearchParameters {
     /// if non-null, only these IDs will be considered during search.
     IDSelector* sel = nullptr;
+    ResultCollectorFactory* col = nullptr;
     /// make sure we can dynamic_cast this
     virtual ~SearchParameters() {}
 };

--- a/faiss/impl/ResultCollector.h
+++ b/faiss/impl/ResultCollector.h
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <unordered_set>
+#include <vector>
+
+#include <faiss/MetricType.h>
+#include <faiss/utils/Heap.h>
+
+/** ResultCollector is intended to define how to collect search result */
+
+namespace faiss {
+
+/** Encapsulates a set of ids to handle. */
+struct ResultCollector {
+    // For each result, collect method is called to store result
+    virtual void collect(
+            int k,
+            int& nres,
+            float* bh_val,
+            idx_t* bh_ids,
+            float val,
+            idx_t ids) = 0;
+
+    // This method is called after all result is collected
+    virtual void finalize(idx_t nres, idx_t* bh_ids) = 0;
+    virtual ~ResultCollector() {}
+};
+
+struct DefaultCollector : ResultCollector {
+    void collect(
+            int k,
+            int& nres,
+            float* bh_val,
+            idx_t* bh_ids,
+            float val,
+            idx_t ids) override {
+        if (nres < k) {
+            faiss::maxheap_push(++nres, bh_val, bh_ids, val, ids);
+        } else if (val < bh_val[0]) {
+            faiss::maxheap_replace_top(nres, bh_val, bh_ids, val, ids);
+        }
+    }
+
+    void finalize(idx_t nres, idx_t* bh_ids) override {
+        // Do nothing
+    }
+
+    ~DefaultCollector() override {}
+};
+
+} // namespace faiss

--- a/faiss/impl/ResultCollectorFactory.h
+++ b/faiss/impl/ResultCollectorFactory.h
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <faiss/impl/ResultCollector.h>
+namespace faiss {
+
+/** ResultCollector is intended to define how to collect search result */
+struct ResultCollectorFactory {
+    DefaultCollector defaultCollector;
+
+    // For each result, collect method is called to store result
+    virtual ResultCollector* newCollector() {
+        return &defaultCollector;
+    }
+
+    virtual void deleteCollector(ResultCollector* collector) {
+        // Do nothing
+    }
+    // This method is called after all result is collected
+    virtual ~ResultCollectorFactory() {}
+};
+
+} // namespace faiss


### PR DESCRIPTION
Introduce result collector for HNSW

The result collector is to be used by caller to implement their own logic to collect result. One of example is deduplicating result based on group id. https://github.com/facebookresearch/faiss/issues/3087