### PR TITLE
Fix compile error

### DIFF
--- a/faiss/utils/WorkerThread.h
+++ b/faiss/utils/WorkerThread.h
@@ -9,6 +9,7 @@
 
 #include <condition_variable>
 #include <deque>
+#include <functional>
 #include <future>
 #include <thread>
 


### PR DESCRIPTION
`WorkerThread.h` uses `std::function` but it does not have `#include <functional>` and this causes compile errors in some cases. This simple PR fixes this issue.