### PR TITLE
Add SIMD NEON Optimization for QT_FP16 in Scalar Quantizer

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -189,6 +189,7 @@ set(FAISS_HEADERS
   utils/extra_distances.h
   utils/fp16-fp16c.h
   utils/fp16-inl.h
+  utils/fp16-fp16.h
   utils/fp16.h
   utils/hamming-inl.h
   utils/hamming.h

--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -767,8 +767,8 @@ struct SimilarityL2<8> {
         float32x4_t sub0 = vsubq_f32(yiv.val[0], x.val[0]);
         float32x4_t sub1 = vsubq_f32(yiv.val[1], x.val[1]);
 
-        float32x4_t accu8_0 = vaddq_f32(accu8.val[0], vmulq_f32(sub0, sub0));
-        float32x4_t accu8_1 = vaddq_f32(accu8.val[1], vmulq_f32(sub1, sub1));
+        float32x4_t accu8_0 = vfmaq_f32(accu8.val[0], sub0, sub0);
+        float32x4_t accu8_1 = vfmaq_f32(accu8.val[1], sub1, sub1);
 
         float32x4x2_t accu8_temp = vzipq_f32(accu8_0, accu8_1);
         accu8 = vuzpq_f32(accu8_temp.val[0], accu8_temp.val[1]);
@@ -780,8 +780,8 @@ struct SimilarityL2<8> {
         float32x4_t sub0 = vsubq_f32(y.val[0], x.val[0]);
         float32x4_t sub1 = vsubq_f32(y.val[1], x.val[1]);
 
-        float32x4_t accu8_0 = vaddq_f32(accu8.val[0], vmulq_f32(sub0, sub0));
-        float32x4_t accu8_1 = vaddq_f32(accu8.val[1], vmulq_f32(sub1, sub1));
+        float32x4_t accu8_0 = vfmaq_f32(accu8.val[0], sub0, sub0);
+        float32x4_t accu8_1 = vfmaq_f32(accu8.val[1], sub1, sub1);
 
         float32x4x2_t accu8_temp = vzipq_f32(accu8_0, accu8_1);
         accu8 = vuzpq_f32(accu8_temp.val[0], accu8_temp.val[1]);
@@ -892,10 +892,8 @@ struct SimilarityIP<8> {
         float32x4x2_t yiv = vld1q_f32_x2(yi);
         yi += 8;
 
-        float32x4_t accu8_0 =
-                vaddq_f32(accu8.val[0], vmulq_f32(yiv.val[0], x.val[0]));
-        float32x4_t accu8_1 =
-                vaddq_f32(accu8.val[1], vmulq_f32(yiv.val[1], x.val[1]));
+        float32x4_t accu8_0 = vfmaq_f32(accu8.val[0], yiv.val[0], x.val[0]);
+        float32x4_t accu8_1 = vfmaq_f32(accu8.val[1], yiv.val[1], x.val[1]);
         float32x4x2_t accu8_temp = vzipq_f32(accu8_0, accu8_1);
         accu8 = vuzpq_f32(accu8_temp.val[0], accu8_temp.val[1]);
     }
@@ -903,10 +901,8 @@ struct SimilarityIP<8> {
     FAISS_ALWAYS_INLINE void add_8_components_2(
             float32x4x2_t x1,
             float32x4x2_t x2) {
-        float32x4_t accu8_0 =
-                vaddq_f32(accu8.val[0], vmulq_f32(x1.val[0], x2.val[0]));
-        float32x4_t accu8_1 =
-                vaddq_f32(accu8.val[1], vmulq_f32(x1.val[1], x2.val[1]));
+        float32x4_t accu8_0 = vfmaq_f32(accu8.val[0], x1.val[0], x2.val[0]);
+        float32x4_t accu8_1 = vfmaq_f32(accu8.val[1], x1.val[1], x2.val[1]);
         float32x4x2_t accu8_temp = vzipq_f32(accu8_0, accu8_1);
         accu8 = vuzpq_f32(accu8_temp.val[0], accu8_temp.val[1]);
     }

--- a/faiss/utils/fp16-fp16.h
+++ b/faiss/utils/fp16-fp16.h
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <arm_neon.h>
+#include <cstdint>
+
+namespace faiss {
+
+inline uint16_t encode_fp16(float x) {
+    float32x4_t fx4 = vdupq_n_f32(x);
+    float16x4_t f16x4 = vcvt_f16_f32(fx4);
+    uint16x4_t ui16x4 = vreinterpret_u16_f16(f16x4);
+    return vduph_lane_u16(ui16x4, 3);
+}
+
+inline float decode_fp16(uint16_t x) {
+    uint16x4_t ui16x4 = vdup_n_u16(x);
+    float16x4_t f16x4 = vreinterpret_f16_u16(ui16x4);
+    float32x4_t fx4 = vcvt_f32_f16(f16x4);
+    return vdups_laneq_f32(fx4, 3);
+}
+
+} // namespace faiss

--- a/faiss/utils/fp16.h
+++ b/faiss/utils/fp16.h
@@ -13,6 +13,8 @@
 
 #if defined(__F16C__)
 #include <faiss/utils/fp16-fp16c.h>
+#elif defined(__aarch64__)
+#include <faiss/utils/fp16-fp16.h>
 #else
 #include <faiss/utils/fp16-inl.h>
 #endif


### PR DESCRIPTION
### Description
We have SIMD support for x86 architecture using AVX2 optimization. But, we don't have a similar optimization for ARM architecture in Scalar Quantizer for the Quantization Type `QT_FP16`. This PR adds SIMD support for ARM using NEON optimization.

### Issues resolved 
https://github.com/facebookresearch/faiss/issues/3014

