### PR TITLE
Fix AVX512 build targets in CMakeLists.txt

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -230,7 +230,7 @@ set(FAISS_HEADERS ${FAISS_HEADERS} PARENT_SCOPE)
 add_library(faiss ${FAISS_SRC})
 
 add_library(faiss_avx2 ${FAISS_SRC})
-if(NOT FAISS_OPT_LEVEL STREQUAL "avx2")
+if(NOT FAISS_OPT_LEVEL STREQUAL "avx2" AND NOT FAISS_OPT_LEVEL STREQUAL "avx512")
   set_target_properties(faiss_avx2 PROPERTIES EXCLUDE_FROM_ALL TRUE)
 endif()
 if(NOT WIN32)


### PR DESCRIPTION
When `FAISS_OPT_LEVEL=avx512`, the current default target omits the `avx2` build, which conflicts with the install targets that specify both `avx2` and `avx512` builds. This PR fixes the default build targets for AVX512.

Install targets:

https://github.com/facebookresearch/faiss/blob/e19de27d72b47bb8782bc173725c45c46c9782eb/faiss/CMakeLists.txt#L332

With this PR, cmake can build and install without any error.

```bash
cmake -B build -DFAISS_OPT_LEVEL=avx512 .
cmake --build build --config Release -j
cmake --install build
```