### PR TITLE
Index pretransform support in search_preassigned

### DIFF
--- a/contrib/ivf_tools.py
+++ b/contrib/ivf_tools.py
@@ -32,6 +32,11 @@ def search_preassigned(index_ivf, xq, k, list_nos, coarse_dis=None):
     Supports indexes with pretransforms (as opposed to the
     IndexIVF.search_preassigned, that cannot be applied with pretransform).
     """
+    if isinstance(index_ivf, faiss.IndexPreTransform):
+        assert index_ivf.chain.size() == 1, "chain must have only one component"
+        transform = faiss.downcast_VectorTransform(index_ivf.chain.at(0))
+        xq = transform.apply(xq)
+        index_ivf = faiss.downcast_index(index_ivf.index)
     n, d = xq.shape
     if isinstance(index_ivf, faiss.IndexBinaryIVF):
         d *= 8


### PR DESCRIPTION
Summary: This diff fixes issue [#3113](https://github.com/facebookresearch/faiss/issues/3113), e.g. introduces support for index pretransform in `search_preassigned`.

Differential Revision: D53188584


