### PR TITLE
HNSW search use efSearch from params if provided

### DIFF
--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -829,7 +829,7 @@ HNSWStats HNSW::search(
             greedy_update_nearest(*this, qdis, level, nearest, d_nearest);
         }
 
-        int ef = std::max(efSearch, k);
+        int ef = std::max(params ? params->efSearch : efSearch, k);        
         if (search_bounded_queue) { // this is the most common branch
             MinimaxHeap candidates(ef);
 

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -829,7 +829,7 @@ HNSWStats HNSW::search(
             greedy_update_nearest(*this, qdis, level, nearest, d_nearest);
         }
 
-        int ef = std::max(params ? params->efSearch : efSearch, k);        
+        int ef = std::max(params ? params->efSearch : efSearch, k);
         if (search_bounded_queue) { // this is the most common branch
             MinimaxHeap candidates(ef);
 


### PR DESCRIPTION
I found that HNSW search method uses its own efSearch to create candidates, which should be got from params if provided I think? 