### PR TITLE
faiss gpu: fix DeviceVector reallocations

### DIFF
--- a/faiss/gpu/utils/DeviceVector.cuh
+++ b/faiss/gpu/utils/DeviceVector.cuh
@@ -132,7 +132,7 @@ class DeviceVector {
     bool resize(size_t newSize, cudaStream_t stream) {
         bool mem = false;
 
-        if (num_ < newSize) {
+        if (newSize > capacity_) {
             mem = reserve(getNewCapacity_(newSize), stream);
         }
 
@@ -249,7 +249,7 @@ class DeviceVector {
         if (preferredSize <= kDeviceVector_2x_Limit) {
             return utils::nextHighestPowerOf2(preferredSize);
         } else if (preferredSize <= kDeviceVector_1_25x_Limit) {
-            return preferredSize + (preferredSize << 2);
+            return preferredSize + (preferredSize >> 2);
         } else {
             return preferredSize;
         }


### PR DESCRIPTION
Summary:
Per https://github.com/facebookresearch/faiss/issues/3251 there are two problems with DeviceVector resizing and capacity growth. The first is that if you resize a vector with enough capacity available for the new size, it will go ahead and re-allocate memory anyways.

The second is that the calculation that was supposed to produce x + 0.25 * x was actually producing x + 4 * x for determining the new size of the allocated memory for a vector. This is also fixed.

Differential Revision: D53813207


