### PR TITLE
Dim reduction support in OIVFBBS

### DIFF
--- a/demos/offline_ivf/config_ssnpp.yaml
+++ b/demos/offline_ivf/config_ssnpp.yaml
@@ -6,6 +6,7 @@ index:
   non-prod:
   - 'IVF16384,PQ128'
   - 'IVF32768,PQ128'
+  - 'OPQ64_128,IVF4096,PQ64'
 nprobe:
   prod:
     - 512

--- a/demos/offline_ivf/offline_ivf.py
+++ b/demos/offline_ivf/offline_ivf.py
@@ -178,7 +178,7 @@ class OfflineIVF:
             idxs.append(np.empty((0,), dtype=np.uint32))
         bs = 1_000_000
         i = 0
-        for buffer in tqdm(self.xb_ds.iterate(0, bs, np.float32)):
+        for buffer in tqdm(self._iterate_transformed(self.xb_ds, 0, bs, np.float32)):
             for j in range(len(codecs)):
                 codec, codeset, idx = codecs[j], codesets[j], idxs[j]
                 uniq = codeset.insert(codec.sa_encode(buffer))
@@ -325,11 +325,18 @@ class OfflineIVF:
                         ),
                         file=sys.stdout,
                     ):
-                        assert xb_j.shape[1] == index.d
-                        index.add_with_ids(
-                            xb_j,
-                            np.arange(start + jj, start + jj + xb_j.shape[0]),
-                        )
+                        if is_pretransform_index(index):
+                            assert xb_j.shape[1] == index.chain.at(0).d_out
+                            index_ivf.add_with_ids(
+                                xb_j,
+                                np.arange(start + jj, start + jj + xb_j.shape[0]),
+                            )
+                        else:
+                            assert xb_j.shape[1] == index.d
+                            index.add_with_ids(
+                                xb_j,
+                                np.arange(start + jj, start + jj + xb_j.shape[0]),
+                            )
                         jj += xb_j.shape[0]
                         logging.info(jj)
                         assert (
@@ -728,10 +735,14 @@ class OfflineIVF:
                             os.remove(Ifn)
                             os.remove(Dfn)
 
-            try:  # TODO: modify shape for pretransform case
+            try:
+                if is_pretransform_index(index):
+                    d = index.chain.at(0).d_out
+                else:
+                    d = self.input_d
                 with open(Ifn, "xb") as f, open(Dfn, "xb") as g:
                     xq_i = np.empty(
-                        shape=(self.xq_bs, self.input_d), dtype=np.float16
+                        shape=(self.xq_bs, d), dtype=np.float16
                     )
                     q_assign = np.empty(
                         (self.xq_bs, self.nprobe), dtype=np.int32
@@ -893,8 +904,7 @@ class OfflineIVF:
             for j in range(SMALL_DATA_SAMPLE):
                 assert np.where(I[j] == j + r)[0].size > 0, (
                     f"I[j]: {I[j]}, j: {j}, i: {i}, shard_size:"
-                    f" {self.shard_size}"
-                )
+                    f" {self.shard_size}")
 
         logging.info("search results...")
         index_ivf.nprobe = self.nprobe


### PR DESCRIPTION
This PR adds support for dimensionality reduction in OIVFBBS. I tested the code with an index `OPQ64_128,IVF4096,PQ64` using the ssnpp embeddings - this index string is added to the config_ssnpp.yaml to showcase this functionality.