### PR TITLE
Adding test for IndexBinaryFlat.reconstruct_n()

### DIFF
--- a/tests/test_index_binary.py
+++ b/tests/test_index_binary.py
@@ -143,6 +143,15 @@ class TestBinaryFlat(unittest.TestCase):
         # nb tests is actually low...
         self.assertTrue(nt1 > 19 and nt2 > 19)
 
+    def test_reconstruct(self):
+        index = faiss.IndexBinaryFlat(64)
+        input_vector = np.random.randint(0, 255, size=(10, index.code_size)).astype("uint8")
+        index.add(input_vector)
+
+        reconstructed_vector = index.reconstruct_n(0, 4)
+        assert reconstructed_vector.shape == (4, index.code_size)
+        assert np.all(input_vector[:4] == reconstructed_vector)
+
 
 class TestBinaryIVF(unittest.TestCase):
 


### PR DESCRIPTION
Summary:
**Context**
[Issue 2751](https://github.com/facebookresearch/faiss/issues/2751) is already fixed as class wrappers has replacement definition of reconstruct_n in handle_IndexBinary.

**In this diff**,
Writing test test_reconstruct for binary index to validate fix for above issue.

Differential Revision: D55168600


