### PR TITLE
Convert circleci workflows to github actions

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -1,0 +1,103 @@
+name: Build cmake
+inputs:
+  opt_level:
+    description: 'The optimization level'
+    required: false
+    default: generic
+  gpu:
+    description: 'The GPU to use'
+    required: false
+    default: OFF
+  raft:
+    description: 'The raft to use'
+    required: false
+    default: OFF
+runs:
+  using: composite
+  steps:
+    - name: Setup miniconda
+      uses: conda-incubator/setup-miniconda@v3.0.3
+      with:
+        python-version: '3.11'
+        miniconda-version: latest
+    - name: Set up environment
+      shell: bash
+      run: |
+        conda config --set solver libmamba
+        conda update -y -q conda
+    - name: Install env using main channel
+      if: inputs.raft == 'OFF'
+      shell: bash
+      run: |
+        conda install -y -q python=3.11 cmake make swig=4.0.2 mkl=2023 mkl-devel=2023 numpy scipy pytest gxx_linux-64 sysroot_linux-64
+    - name: Install env using conda-forge channel
+      if: inputs.raft == 'ON'
+      shell: bash
+      run: |
+        conda install -y -q python=3.11 cmake make swig=4.0.2 mkl=2023 mkl-devel=2023 numpy scipy pytest gxx_linux-64 sysroot_linux-64=2.28 libraft cuda-version=11.8 cuda-toolkit -c rapidsai-nightly -c "nvidia/label/cuda-11.8.0" -c conda-forge
+    - name: Install CUDA
+      if: inputs.gpu == 'ON' && inputs.raft == 'OFF'
+      shell: bash
+      run: |
+        conda install -y -q cuda-toolkit -c "nvidia/label/cuda-11.8.0"
+    - name: Build all targets
+      shell: bash
+      run: |
+        eval "$(conda shell.bash hook)"
+        conda activate
+        cmake -B build \
+              -DBUILD_TESTING=ON \
+              -DBUILD_SHARED_LIBS=ON \
+              -DFAISS_ENABLE_GPU=${{ inputs.gpu }} \
+              -DFAISS_ENABLE_RAFT=${{ inputs.raft }} \
+              -DFAISS_OPT_LEVEL=${{ inputs.opt_level }} \
+              -DFAISS_ENABLE_C_API=ON \
+              -DPYTHON_EXECUTABLE=$CONDA/bin/python \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DBLA_VENDOR=Intel10_64_dyn \
+              -DCMAKE_CUDA_FLAGS="-gencode arch=compute_75,code=sm_75" \
+              .
+        make -k -C build -j$(nproc)
+    - name: C++ tests
+      shell: bash
+      run: |
+        export GTEST_OUTPUT="xml:$(realpath .)/test-results/googletest/"
+        make -C build test
+    - name: Install Python extension
+      shell: bash
+      working-directory: build/faiss/python
+      run: |
+        $CONDA/bin/python setup.py install
+    - name: Install pytest
+      shell: bash
+      run: |
+        conda install -y pytest
+        echo "$CONDA/bin" >> $GITHUB_PATH
+    - name: Python tests (CPU only)
+      if: inputs.gpu == 'OFF'
+      shell: bash
+      run: |
+        conda install -y -q pytorch -c pytorch
+        pytest --junitxml=test-results/pytest/results.xml tests/test_*.py
+        pytest --junitxml=test-results/pytest/results-torch.xml tests/torch_*.py
+    - name: Python tests (CPU + GPU)
+      if: inputs.gpu == 'ON'
+      shell: bash
+      run: |
+        conda install -y -q pytorch pytorch-cuda=11.8 -c pytorch -c nvidia/label/cuda-11.8.0
+        pytest --junitxml=test-results/pytest/results.xml tests/test_*.py
+        pytest --junitxml=test-results/pytest/results-torch.xml tests/torch_*.py
+        cp tests/common_faiss_tests.py faiss/gpu/test
+        pytest --junitxml=test-results/pytest/results-gpu.xml faiss/gpu/test/test_*.py
+        pytest --junitxml=test-results/pytest/results-gpu-torch.xml faiss/gpu/test/torch_*.py
+    - name: Test avx2 loading
+      if: inputs.opt_level == 'avx2'
+      shell: bash
+      run: |
+        FAISS_DISABLE_CPU_FEATURES=AVX2 LD_DEBUG=libs $CONDA/bin/python -c "import faiss" 2>&1 | grep faiss.so
+        LD_DEBUG=libs $CONDA/bin/python -c "import faiss" 2>&1 | grep faiss_avx2.so
+    - name: Upload test results
+      uses: actions/upload-artifact@v4.3.1
+      with:
+        name: test-results-${{ inputs.opt_level }}-${{ inputs.gpu }}-${{ inputs.raft }}
+        path: test-results

--- a/.github/actions/build_conda/action.yml
+++ b/.github/actions/build_conda/action.yml
@@ -1,0 +1,98 @@
+name: Build conda
+description: Build conda
+inputs:
+  label:
+    description: "Label"
+    default: ""
+    required: false
+  cuda:
+    description: "cuda"
+    default: ""
+    required: false
+  raft:
+    description: "raft"
+    default: ""
+    required: false
+  compiler_version:
+    description: "compiler_version"
+    default: ""
+    required: false
+runs:
+  using: composite
+  steps:
+    - name: Choose shell
+      shell: bash
+      id: choose_shell
+      run: |
+        # if runner.os != 'Windows' use bash, else use pwsh
+        if [ "${{ runner.os }}" != "Windows" ]; then
+          echo "shell=bash" >> "$GITHUB_OUTPUT"
+        else
+          echo "shell=pwsh" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Setup miniconda
+      uses: conda-incubator/setup-miniconda@v3.0.3
+      with:
+        python-version: '3.11'
+        miniconda-version:  latest
+    - name: Install conda build tools
+      shell: ${{ steps.choose_shell.outputs.shell }}
+      run: |
+        # conda config --set solver libmamba
+        # conda config --set verbosity 3
+        conda update -y -q conda
+        conda install -y -q conda-build
+    - name: Enable anaconda uploads
+      if: inputs.label != ''
+      shell: ${{ steps.choose_shell.outputs.shell }}
+      env:
+        PACKAGE_TYPE: inputs.label
+      run: |
+        conda install -y -q anaconda-client
+        conda config --set anaconda_upload yes
+    - name: Conda build (CPU)
+      if: inputs.label == '' && inputs.cuda == ''
+      shell: ${{ steps.choose_shell.outputs.shell }}
+      working-directory: conda
+      run: |
+        conda build faiss --python 3.11 -c pytorch
+    - name: Conda build (CPU) w/ anaconda upload
+      if: inputs.label != '' && inputs.cuda == ''
+      shell: ${{ steps.choose_shell.outputs.shell }}
+      working-directory: conda
+      env:
+        PACKAGE_TYPE: inputs.label
+      run: |
+        conda build faiss --user pytorch --label ${{ inputs.label }} -c pytorch
+    - name: Conda build (GPU)
+      if: inputs.label == '' && inputs.cuda != '' && inputs.raft == ''
+      shell: ${{ steps.choose_shell.outputs.shell }}
+      working-directory: conda
+      run: |
+        conda build faiss-gpu --variants '{ "cudatoolkit": "${{ inputs.cuda }}", "c_compiler_version": "${{ inputs.compiler_version }}", "cxx_compiler_version": "${{ inputs.compiler_version }}" }' \
+            -c pytorch -c nvidia/label/cuda-${{ inputs.cuda }} -c nvidia
+    - name: Conda build (GPU) w/ anaconda upload
+      if: inputs.label != '' && inputs.cuda != '' && inputs.raft == ''
+      shell: ${{ steps.choose_shell.outputs.shell }}
+      working-directory: conda
+      env:
+        PACKAGE_TYPE: inputs.label
+      run: |
+        conda build faiss-gpu --variants '{ "cudatoolkit": "${{ inputs.cuda }}", "c_compiler_version": "${{ inputs.compiler_version }}", "cxx_compiler_version": "${{ inputs.compiler_version }}" }' \
+            --user pytorch --label ${{ inputs.label }} -c pytorch -c nvidia/label/cuda-${{ inputs.cuda }} -c nvidia
+    - name: Conda build (GPU w/ RAFT)
+      if: inputs.label == '' && inputs.cuda != '' && inputs.raft != ''
+      shell: ${{ steps.choose_shell.outputs.shell }}
+      working-directory: conda
+      run: |
+        conda build faiss-gpu-raft --variants '{ "cudatoolkit": "${{ inputs.cuda }}", "c_compiler_version": "${{ inputs.compiler_version }}", "cxx_compiler_version": "${{ inputs.compiler_version }}" }' \
+            -c pytorch -c nvidia/label/cuda-${{ inputs.cuda }} -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge
+    - name: Conda build (GPU w/ RAFT) w/ anaconda upload
+      if: inputs.label != '' && inputs.cuda != '' && inputs.raft != ''
+      shell: ${{ steps.choose_shell.outputs.shell }}
+      working-directory: conda
+      env:
+        PACKAGE_TYPE: inputs.label
+      run: |
+        conda build faiss-gpu-raft --variants '{ "cudatoolkit": "${{ inputs.cuda }}", "c_compiler_version": "${{ inputs.compiler_version }}", "cxx_compiler_version": "${{ inputs.compiler_version }}" }' \
+            --user pytorch --label ${{ inputs.label }} -c pytorch -c nvidia/label/cuda-${{ inputs.cuda }} -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,182 @@
+name: Build
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  push:
+    tags:
+      - 'v*'
+env:
+  OMP_NUM_THREADS: '10'
+  MKL_THREADING_LAYER: GNU
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git-core clang-format-11
+      - name: Verify clang-format
+        run: |
+            git ls-files | grep -E  '\.(cpp|h|cu|cuh)$' | xargs clang-format-11 -i
+            if git diff --quiet; then
+              echo "Formatting OK!"
+            else
+              echo "Formatting not OK!"
+              echo "------------------"
+              git --no-pager diff --color
+              exit 1
+            fi
+  linux-x86_64-cmake:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_cmake
+  linux-x86_64-AVX2-cmake:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_cmake
+        with:
+          opt_level: avx2
+  linux-x86_64-AVX512-cmake:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_cmake
+        with:
+          opt_level: avx512
+  linux-x86_64-GPU-cmake:
+    needs: linux-x86_64-AVX2-cmake
+    runs-on: 4-core-ubuntu-gpu-t4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_cmake
+        with:
+          gpu: ON
+  linux-x86_64-GPU-w-RAFT-cmake:
+    needs: linux-x86_64-GPU-cmake
+    runs-on: 4-core-ubuntu-gpu-t4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_cmake
+        with:
+          gpu: ON
+          raft: ON
+  linux-x86_64-conda:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_conda
+  windows-x86_64-conda:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_conda
+  linux-arm64-conda:
+    runs-on: 4-core-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_conda
+  linux-x86_64-packages:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_conda
+        with:
+          label: main
+  linux-x86_64-GPU-packages-CUDA-11-4-4:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: 4-core-ubuntu-gpu-t4
+    env:
+      CUDA_ARCHS: "60-real;61-real;62-real;70-real;72-real;75-real;80;86-real"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_conda
+        with:
+          label: main
+          cuda: "11.4.4"
+          compiler_version: "11.2"
+  linux-x86_64-GPU-RAFT-packages-CUDA11-8-0:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: 4-core-ubuntu-gpu-t4
+    env:
+      CUDA_ARCHS: "70-real;72-real;75-real;80;86-real"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_conda
+        with:
+          label: main
+          raft: "ON"
+          cuda: "11.8.0"
+          compiler_version: "11.2"
+  linux-x86_64-GPU-packages-CUDA-12-1-1:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: 4-core-ubuntu-gpu-t4
+    env:
+      CUDA_ARCHS: "70-real;72-real;75-real;80;86-real"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_conda
+        with:
+          label: main
+          cuda: "12.1.1"
+          compiler_version: "11.2"
+  linux-x86_64-GPU-RAFT-packages-CUDA12-1-1:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: 4-core-ubuntu-gpu-t4
+    env:
+      CUDA_ARCHS: "70-real;72-real;75-real;80;86-real"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_conda
+        with:
+          label: main
+          raft: "ON"
+          cuda: "12.1.1"
+          compiler_version: "11.2"
+  windows-x86_64-packages:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_conda
+        with:
+          label: main
+  OSX-arm64-packages:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: macos-13
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_conda
+        with:
+          label: main
+  linux-arm64-packages:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: 4-core-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_conda
+        with:
+          label: main


### PR DESCRIPTION
This pull request converts the CircleCI workflows to GitHub actions workflows.  

## Notes
The dependencies between jobs seems to not be necessary, and I assume they exist only to limit spend on expensive jobs when less expensive jobs are failing. I have left the `needs: *` dependency definitions commented out in the workflow.

Some jobs in the workflow require GPU runners. Some jobs in the workflow require ARM runners. I have configured the following runner groups.
- 4-core-gpu
- 4-core-arm

## Errors
I did my best to make all the jobs work, but lacking knowledge specific to this project makes it nearly impossible for me to get everything working. Someone with better knowledge of this project will need to address these error.  

`linux-x86_64-AVX512-cmake` job fails with the following error:  
<details>
<summary>Error</summary>  

```
CMake Error at /home/runner/miniconda3/share/cmake-3.26/Modules/GoogleTestAddTests.cmake:112 (message):
make[2]: Leaving directory '/home/runner/work/faiss/faiss/build'
  Error running test executable.

    Path: '/home/runner/work/faiss/faiss/build/tests/faiss_test'
    Result: Illegal instruction
```
</details>

---
`linux-x86_64-GPU-cmake` job fails with the following error:  
<details>
<summary>Error</summary>  

```
/home/runner/miniconda3/bin/../lib/gcc/x86_64-conda-linux-gnu/11.2.0/../../../../x86_64-conda-linux-gnu/bin/ld: ../faiss/libfaiss.so: undefined reference to `__libc_single_threaded'
collect2: error: ld returned 1 exit status
```
</details>

---
`windows-x86_64-conda` job fails with the following error:  
<details>
<summary>Error</summary>  

```
CMake Error at CMakeLists.txt:42 (project):
  Generator

    Visual Studio 16 2019

  could not find any instance of Visual Studio.



-- Configuring incomplete, errors occurred!
Traceback (most recent call last):
  File "C:\Users\runneradmin\miniconda3\envs\test\Scripts\conda-build-script.py", line 10, in <module>
    sys.exit(execute())
             ^^^^^^^^^
  File "C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages\conda_build\cli\main_build.py", line 581, in execute
    api.build(
  File "C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages\conda_build\api.py", line 250, in build
    return build_tree(
           ^^^^^^^^^^^
  File "C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages\conda_build\build.py", line 3762, in build_tree
    packages_from_this = build(
                         ^^^^^^
  File "C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages\conda_build\build.py", line 2839, in build
    newly_built_packages = bundlers[pkg_type](output_d, m, env, stats)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages\conda_build\build.py", line 1908, in bundle_conda
    utils.check_call_env(
  File "C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages\conda_build\utils.py", line 408, in check_call_env
    return _func_defaulting_env_to_os_environ("call", *popenargs, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages\conda_build\utils.py", line 384, in _func_defaulting_env_to_os_environ
    raise subprocess.CalledProcessError(proc.returncode, _args)
subprocess.CalledProcessError: Command '['C:\\Windows\\system32\\cmd.exe', '/d', '/c', 'C:\\Users\\runneradmin\\miniconda3\\envs\\test\\conda-bld\\faiss-pkg_1711501857970\\work\\build-lib.bat']' returned non-zero exit status 1.
Error: Process completed with exit code 1.
```
</details>

---
`linux-x86_64-GPU-packages-CUDA-11-4-4` job fails with the following error:  
<details>
<summary>Error</summary>  

```
CMake Error at /home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_build_env/share/cmake-3.26/Modules/CMakeDetermineCompilerId.cmake:751 (message):
  Compiling the CUDA compiler identification source file
  "CMakeCUDACompilerId.cu" failed.

  Compiler:
  /home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_build_env/bin/nvcc


  Build flags:

  Id flags: --keep;--keep-dir;tmp -v



  The output was:

  1

  #$ _NVVM_BRANCH_=nvvm

  #$ _SPACE_=

  #$ _CUDART_=cudart

  #$
  _HERE_=/home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_build_env/bin


  #$
  _THERE_=/home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_build_env/bin


  #$ _TARGET_SIZE_=

  #$ _TARGET_DIR_=

  #$ _TARGET_SIZE_=64

  #$
  TOP=/home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_build_env/bin/..


  #$
  NVVMIR_LIBRARY_DIR=/home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_build_env/bin/../nvvm/libdevice


  #$
  LD_LIBRARY_PATH=/home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_build_env/bin/../lib:


  #$
  PATH=/home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_build_env/bin/../nvvm/bin:/home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_build_env/bin:/home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_build_env/bin:/home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/bin:/home/runner/miniconda3/condabin:/home/runner/miniconda3/condabin:/opt/ngc-cli:/opt/miniconda/condabin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin


  #$
  INCLUDES="-I/home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_build_env/bin/../include"


  #$ LIBRARIES=
  "-L/home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_build_env/bin/../lib/stubs"
  "-L/home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_build_env/bin/../lib"


  #$ CUDAFE_FLAGS=

  #$ PTXAS_FLAGS=

  #$ rm tmp/a_dlink.reg.c

  #$ gcc -D__CUDA_ARCH__=520 -E -x c++ -DCUDA_DOUBLE_MATH_FUNCTIONS
  -D__CUDACC__ -D__NVCC__
  "-I/home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_build_env/bin/../include"
  -D__CUDACC_VER_MAJOR__=11 -D__CUDACC_VER_MINOR__=4
  -D__CUDACC_VER_BUILD__=152 -D__CUDA_API_VER_MAJOR__=11
  -D__CUDA_API_VER_MINOR__=4 -include "cuda_runtime.h" -m64
  "CMakeCUDACompilerId.cu" -o "tmp/CMakeCUDACompilerId.cpp1.ii"

  #$ cicc --c++17 --gnu_version=110400 --orig_src_file_name
  "CMakeCUDACompilerId.cu" --allow_managed -arch compute_52 -m64
  --no-version-ident -ftz=0 -prec_div=1 -prec_sqrt=1 -fmad=1
  --include_file_name "CMakeCUDACompilerId.fatbin.c" -tused
  --gen_module_id_file --module_id_file_name
  "tmp/CMakeCUDACompilerId.module_id" --gen_c_file_name
  "tmp/CMakeCUDACompilerId.cudafe1.c" --stub_file_name
  "tmp/CMakeCUDACompilerId.cudafe1.stub.c" --gen_device_file_name
  "tmp/CMakeCUDACompilerId.cudafe1.gpu" "tmp/CMakeCUDACompilerId.cpp1.ii" -o
  "tmp/CMakeCUDACompilerId.ptx"

  /usr/include/stdio.h(189): error: attribute "__malloc__" does not take
  arguments



  /usr/include/stdio.h(201): error: attribute "__malloc__" does not take
  arguments



  /usr/include/stdio.h(223): error: attribute "__malloc__" does not take
  arguments



  /usr/include/stdio.h(260): error: attribute "__malloc__" does not take
  arguments



  /usr/include/stdio.h(285): error: attribute "__malloc__" does not take
  arguments



  /usr/include/stdio.h(294): error: attribute "__malloc__" does not take
  arguments



  /usr/include/stdio.h(303): error: attribute "__malloc__" does not take
  arguments



  /usr/include/stdio.h(309): error: attribute "__malloc__" does not take
  arguments



  /usr/include/stdio.h(315): error: attribute "__malloc__" does not take
  arguments



  /usr/include/stdio.h(830): error: attribute "__malloc__" does not take
  arguments



  /usr/include/stdlib.h(566): error: attribute "__malloc__" does not take
  arguments



  /usr/include/stdlib.h(570): error: attribute "__malloc__" does not take
  arguments



  /usr/include/stdlib.h(799): error: attribute "__malloc__" does not take
  arguments



  13 errors detected in the compilation of "CMakeCUDACompilerId.cu".

  # --error 0x1 --





Call Stack (most recent call first):
  /home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_build_env/share/cmake-3.26/Modules/CMakeDetermineCompilerId.cmake:8 (CMAKE_DETERMINE_COMPILER_ID_BUILD)
  /home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_build_env/share/cmake-3.26/Modules/CMakeDetermineCompilerId.cmake:53 (__determine_compiler_id_test)
  /home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/_build_env/share/cmake-3.26/Modules/CMakeDetermineCUDACompiler.cmake:307 (CMAKE_DETERMINE_COMPILER_ID)
  CMakeLists.txt:42 (project)


-- Configuring incomplete, errors occurred!

# >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<

    Traceback (most recent call last):
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda/exception_handler.py", line 17, in __call__
        return func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda/cli/main.py", line 83, in main_subshell
        exit_code = do_call(args, parser)
                    ^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda/cli/conda_argparse.py", line 175, in do_call
        result = plugin_subcommand.action(getattr(args, "_args", args))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/plugin.py", line 17, in build
        return execute(args)
               ^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/cli/main_build.py", line 581, in execute
        api.build(
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/api.py", line 250, in build
        return build_tree(
               ^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/build.py", line 3762, in build_tree
        packages_from_this = build(
                             ^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/build.py", line 2839, in build
        newly_built_packages = bundlers[pkg_type](output_d, m, env, stats)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/build.py", line 1908, in bundle_conda
        utils.check_call_env(
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/utils.py", line 408, in check_call_env
        return _func_defaulting_env_to_os_environ("call", *popenargs, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/utils.py", line 384, in _func_defaulting_env_to_os_environ
        raise subprocess.CalledProcessError(proc.returncode, _args)
    subprocess.CalledProcessError: Command '['/usr/bin/bash', '-e', '/home/runner/miniconda3/conda-bld/faiss-pkg_1711562812250/work/build-lib.sh']' returned non-zero exit status 1.

`$ /home/runner/miniconda3/condabin/conda build faiss-gpu --variants { "cudatoolkit": "11.4.4", "c_compiler_version": "11.2", "cxx_compiler_version": "11.2" } --user pytorch --label main -c pytorch -c nvidia/label/cuda-11.4.4 -c nvidia`

  environment variables:
                 CIO_TEST=<not set>
                    CONDA=/home/runner/miniconda3
    CONDA_ALLOW_SOFTLINKS=false
           CONDA_PKGS_DIR=/home/runner/conda_pkgs_dir
               CONDA_ROOT=/home/runner/miniconda3
           CURL_CA_BUNDLE=<not set>
       GITHUB_ACTION_PATH=/home/runner/work/faiss/faiss/./.github/actions/build_conda
        GITHUB_EVENT_PATH=/home/runner/work/_temp/_github_workflow/event.json
              GITHUB_PATH=/home/runner/work/_temp/_runner_file_commands/add_path_0d0cf8a2-a36c-
                          4ab0-ba22-e4d1421282bc
               LD_PRELOAD=<not set>
                     PATH=/home/runner/miniconda3/condabin:/opt/ngc-cli:/opt/miniconda/condabin:
                          /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/game
                          s:/usr/local/games:/snap/bin
       REQUESTS_CA_BUNDLE=<not set>
            SSL_CERT_FILE=<not set>

     active environment : None
       user config file : /home/runner/.condarc
 populated config files : /home/runner/.condarc
          conda version : 24.3.0
    conda-build version : 24.3.0
         python version : 3.12.1.final.0
                 solver : libmamba (default)
       virtual packages : __archspec=1=zen2
                          __conda=24.3.0=0
                          __cuda=12.2=0
                          __glibc=2.35=0
                          __linux=6.2.0=0
                          __unix=0=0
       base environment : /home/runner/miniconda3  (writable)
      conda av data dir : /home/runner/miniconda3/etc/conda
  conda av metadata url : None
           channel URLs : https://repo.anaconda.com/pkgs/main/linux-64
                          https://repo.anaconda.com/pkgs/main/noarch
                          https://repo.anaconda.com/pkgs/r/linux-64
                          https://repo.anaconda.com/pkgs/r/noarch
          package cache : /home/runner/conda_pkgs_dir
       envs directories : /home/runner/miniconda3/envs
                          /home/runner/.conda/envs
               platform : linux-64
             user-agent : conda/24.3.0 requests/2.31.0 CPython/3.12.1 Linux/6.2.0-1011-azure ubuntu/22.04.3 glibc/2.35 solver/libmamba conda-libmamba-solver/23.12.0 libmambapy/1.5.3
                UID:GID : 1001:100
             netrc file : None
           offline mode : False


An unexpected error has occurred. Conda has prepared the above report.
If you suspect this error is being caused by a malfunctioning plugin,
consider using the --no-plugins option to turn off plugins.

Example: conda --no-plugins install <package>

Alternatively, you can set the CONDA_NO_PLUGINS environment variable on
the command line to run the command without plugins enabled.

Example: CONDA_NO_PLUGINS=true conda install <package>

Upload successful.
Error: Process completed with exit code 1.
```
</details>

---
`linux-x86_64-GPU-RAFT-packages-CUDA11-8-0` job fails with the following error:
<details>
<summary>Error</summary>

```
CMake Error at /home/runner/miniconda3/conda-bld/faiss-pkg_1711571792861/_build_env/share/cmake-3.29/Modules/FindCUDAToolkit.cmake:855 (message):
  Could not find nvcc, please set CUDAToolkit_ROOT.
Call Stack (most recent call first):
  CMakeLists.txt:114 (find_package)


-- Configuring incomplete, errors occurred!

# >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<

    Traceback (most recent call last):
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda/exception_handler.py", line 17, in __call__
        return func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda/cli/main.py", line 83, in main_subshell
        exit_code = do_call(args, parser)
                    ^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda/cli/conda_argparse.py", line 175, in do_call
        result = plugin_subcommand.action(getattr(args, "_args", args))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/plugin.py", line 17, in build
        return execute(args)
               ^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/cli/main_build.py", line 581, in execute
        api.build(
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/api.py", line 250, in build
        return build_tree(
               ^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/build.py", line 3762, in build_tree
        packages_from_this = build(
                             ^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/build.py", line 2839, in build
        newly_built_packages = bundlers[pkg_type](output_d, m, env, stats)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/build.py", line 1908, in bundle_conda
        utils.check_call_env(
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/utils.py", line 408, in check_call_env
        return _func_defaulting_env_to_os_environ("call", *popenargs, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/utils.py", line 384, in _func_defaulting_env_to_os_environ
        raise subprocess.CalledProcessError(proc.returncode, _args)
    subprocess.CalledProcessError: Command '['/usr/bin/bash', '-e', '/home/runner/miniconda3/conda-bld/faiss-pkg_1711571792861/work/build-pkg.sh']' returned non-zero exit status 1.

`$ /home/runner/miniconda3/condabin/conda build faiss-gpu-raft --variants { "cudatoolkit": "11.8.0", "c_compiler_version": "11.2", "cxx_compiler_version": "11.2" } --user pytorch --label main -c pytorch -c nvidia/label/cuda-11.8.0 -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge`

  environment variables:
                 CIO_TEST=<not set>
                    CONDA=/home/runner/miniconda3
    CONDA_ALLOW_SOFTLINKS=false
```
</details>

---
`linux-x86_64-GPU-packages-CUDA-12-1-1` job fails with the following error:
<details>
<summary>Error</summary>

```
CMake Error at /home/runner/miniconda3/conda-bld/faiss-pkg_1711571788943/_build_env/share/cmake-3.26/Modules/FindCUDAToolkit.cmake:777 (message):
  Could not find nvcc, please set CUDAToolkit_ROOT.
Call Stack (most recent call first):
  CMakeLists.txt:114 (find_package)


-- Configuring incomplete, errors occurred!

# >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<

    Traceback (most recent call last):
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda/exception_handler.py", line 17, in __call__
        return func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda/cli/main.py", line 83, in main_subshell
        exit_code = do_call(args, parser)
                    ^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda/cli/conda_argparse.py", line 175, in do_call
        result = plugin_subcommand.action(getattr(args, "_args", args))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/plugin.py", line 17, in build
        return execute(args)
               ^^^^^^^^^^^^^
```
</details>

---
`linux-x86_64-GPU-RAFT-packages-CUDA12-1-1` job fails with the following error:
<details>
<summary>Error</summary>

```
CMake Error at /home/runner/miniconda3/conda-bld/faiss-pkg_1711571797816/_build_env/share/cmake-3.29/Modules/FindCUDAToolkit.cmake:855 (message):
  Could not find nvcc, please set CUDAToolkit_ROOT.
Call Stack (most recent call first):
  CMakeLists.txt:114 (find_package)


-- Configuring incomplete, errors occurred!

# >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<

    Traceback (most recent call last):
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda/exception_handler.py", line 17, in __call__
        return func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda/cli/main.py", line 83, in main_subshell
        exit_code = do_call(args, parser)
                    ^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda/cli/conda_argparse.py", line 175, in do_call
        result = plugin_subcommand.action(getattr(args, "_args", args))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/plugin.py", line 17, in build
        return execute(args)
               ^^^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/cli/main_build.py", line 581, in execute
        api.build(
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/api.py", line 250, in build
        return build_tree(
               ^^^^^^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/build.py", line 3762, in build_tree
        packages_from_this = build(
                             ^^^^^^
      File "/home/runner/miniconda3/lib/python3.12/site-packages/conda_build/build.py", line 2839, in build
        newly_built_packages = bundlers[pkg_type](output_d, m, env, stats)
```
</details>

---
`windows-x86_64-packages` job fails with the following error:
<details>
<summary>Error</summary>

```
CMake Error at CMakeLists.txt:42 (project):
  Generator

    Visual Studio 16 2019

  could not find any instance of Visual Studio.



-- Configuring incomplete, errors occurred!
Traceback (most recent call last):
  File "C:\Users\runneradmin\miniconda3\envs\test\Scripts\conda-build-script.py", line 10, in <module>
    sys.exit(execute())
             ^^^^^^^^^
  File "C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages\conda_build\cli\main_build.py", line 581, in execute
    api.build(
  File "C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages\conda_build\api.py", line 250, in build
    return build_tree(
           ^^^^^^^^^^^
  File "C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages\conda_build\build.py", line 3762, in build_tree
    packages_from_this = build(
                         ^^^^^^
  File "C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages\conda_build\build.py", line 2839, in build
    newly_built_packages = bundlers[pkg_type](output_d, m, env, stats)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages\conda_build\build.py", line 1908, in bundle_conda
    utils.check_call_env(
  File "C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages\conda_build\utils.py", line 408, in check_call_env
    return _func_defaulting_env_to_os_environ("call", *popenargs, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages\conda_build\utils.py", line 384, in _func_defaulting_env_to_os_environ
    raise subprocess.CalledProcessError(proc.returncode, _args)
subprocess.CalledProcessError: Command '['C:\\Windows\\system32\\cmd.exe', '/d', '/c', 'C:\\Users\\runneradmin\\miniconda3\\envs\\test\\conda-bld\\faiss-pkg_1711571662616\\work\\build-lib.bat']' returned non-zero exit status 1.
Error: Process completed with exit code 1.
```
</details>

---
`OSX-arm64-packages` job fails with the following error:
<details>
<summary>Error</summary>

```
CMakeFiles/cmTC_8330e.dir/testCXXCompiler.cxx.o -o cmTC_8330e 
    ld: unsupported tapi file type '!tapi-tbd' in YAML file '/Applications/Xcode_15.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/libSystem.tbd' for architecture x86_64
    clang-14: error: linker command failed with exit code 1 (use -v to see invocation)
    make[1]: *** [CMakeFiles/cmTC_8330e.dir/build.make:100: cmTC_8330e] Error 1
    make[1]: Leaving directory '/Users/runner/miniconda3/conda-bld/faiss-pkg_1711571588527/work/_build/CMakeFiles/CMakeScratch/TryCompile-Z5yjE3'
    make: *** [Makefile:127: cmTC_8330e/fast] Error 2
    
    

  

  CMake will not be able to correctly generate this project.
Call Stack (most recent call first):
  CMakeLists.txt:42 (project)



# >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<

    Traceback (most recent call last):
      File "/Users/runner/miniconda3/lib/python3.12/site-packages/conda/exception_handler.py", line 17, in __call__
        return func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^
      File "/Users/runner/miniconda3/lib/python3.12/site-packages/conda/cli/main.py", line 83, in main_subshell
        exit_code = do_call(args, parser)
                    ^^^^^^^^^^^^^^^^^^^^^
      File "/Users/runner/miniconda3/lib/python3.12/site-packages/conda/cli/conda_argparse.py", line 175, in do_call
        result = plugin_subcommand.action(getattr(args, "_args", args))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/runner/miniconda3/lib/python3.12/site-packages/conda_build/plugin.py", line 17, in build
        return execute(args)
               ^^^^^^^^^^^^^
      File "/Users/runner/miniconda3/lib/python3.12/site-packages/conda_build/cli/main_build.py", line 581, in execute
        api.build(
      File "/Users/runner/miniconda3/lib/python3.12/site-packages/conda_build/api.py", line 250, in build
        return build_tree(
               ^^^^^^^^^^^
      File "/Users/runner/miniconda3/lib/python3.12/site-packages/conda_build/build.py", line 3762, in build_tree
        packages_from_this = build(
                             ^^^^^^
      File "/Users/runner/miniconda3/lib/python3.12/site-packages/conda_build/build.py", line 2839, in build
        newly_built_packages = bundlers[pkg_type](output_d, m, env, stats)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/runner/miniconda3/lib/python3.12/site-packages/conda_build/build.py", line 1908, in bundle_conda
        utils.check_call_env(
      File "/Users/runner/miniconda3/lib/python3.12/site-packages/conda_build/utils.py", line 408, in check_call_env
        return _func_defaulting_env_to_os_environ("call", *popenargs, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Users/runner/miniconda3/lib/python3.12/site-packages/conda_build/utils.py", line 384, in _func_defaulting_env_to_os_environ
        raise subprocess.CalledProcessError(proc.returncode, _args)
    subprocess.CalledProcessError: Command '['/bin/bash', '-e', '/Users/runner/miniconda3/conda-bld/faiss-pkg_1711571588527/work/build-lib-osx.sh']' returned non-zero exit status 1.

`$ /Users/runner/miniconda3/condabin/conda build faiss --user pytorch --label main -c pytorch`
```
</details>

---
[Here is the latest workflow run in my fork](https://github.com/robandpdx-org/faiss/actions/runs/8459695783).  

---
https://fburl.com/workplace/f6mz6tmw