### PR TITLE
Fix the endianness issue in AIX while running the benchmark.

### DIFF
--- a/contrib/vecs_io.py
+++ b/contrib/vecs_io.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import sys
 import numpy as np
 
 """
@@ -13,6 +14,8 @@ definition of the formats here: http://corpus-texmex.irisa.fr/
 
 def ivecs_read(fname):
     a = np.fromfile(fname, dtype='int32')
+    if sys.byteorder == 'big':
+      a.byteswap(inplace=True)
     d = a[0]
     return a.reshape(-1, d + 1)[:, 1:].copy()
 

--- a/faiss/cppcontrib/detail/UintReader.h
+++ b/faiss/cppcontrib/detail/UintReader.h
@@ -32,7 +32,7 @@ struct Uint8Reader {
                 if (N_ELEMENTS > CPOS + 3) {
                     const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     return (code32) >> 24;
 #else
                     return (code32 & 0x000000FF);
@@ -45,7 +45,7 @@ struct Uint8Reader {
                 if (N_ELEMENTS > CPOS + 2) {
                     const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     return (code32 & 0x00FF0000) >> 16;
 #else
                     return (code32 & 0x0000FF00) >> 8;
@@ -58,7 +58,7 @@ struct Uint8Reader {
                 if (N_ELEMENTS > CPOS + 1) {
                     const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     return (code32 & 0x0000FF00) >> 8;
 #else
                     return (code32 & 0x00FF0000) >> 16;
@@ -71,7 +71,7 @@ struct Uint8Reader {
                 if (N_ELEMENTS > CPOS) {
                     const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     return (code32 & 0x000000FF);
 #else
                     return (code32) >> 24;
@@ -106,14 +106,14 @@ struct Uint10Reader {
                 if (N_ELEMENTS > CPOS + 2) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 5);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return (code32 & 0b0000001111111111);
                 } else {
                     uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 5 + 0);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     code16 = Swap2Bytes(code16);
 #endif
                     return (code16 & 0b0000001111111111);
@@ -123,14 +123,14 @@ struct Uint10Reader {
                 if (N_ELEMENTS > CPOS + 1) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 5);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return (code32 & 0b000011111111110000000000) >> 10;
                 } else {
                     uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 5 + 1);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     code16 = Swap2Bytes(code16);
 #endif
                     return (code16 & 0b0000111111111100) >> 2;
@@ -140,14 +140,14 @@ struct Uint10Reader {
                 if (N_ELEMENTS > CPOS) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 5);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return (code32 & 0b00111111111100000000000000000000) >> 20;
                 } else {
                     uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 5 + 2);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     code16 = Swap2Bytes(code16);
 #endif
                     return (code16 & 0b0011111111110000) >> 4;
@@ -156,7 +156,7 @@ struct Uint10Reader {
             case 3: {
                 uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                         codes + ELEMENT_TO_READ * 5 + 3);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                 code16 = Swap2Bytes(code16);
 #endif
                 return (code16 & 0b1111111111000000) >> 6;
@@ -187,14 +187,14 @@ struct Uint12Reader {
                 if (N_ELEMENTS > CPOS + 2) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 6);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return (code32 & 0b0000111111111111);
                 } else {
                     uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 6 + 0);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     code16 = Swap2Bytes(code16);
 #endif
                     return (code16 & 0b0000111111111111);
@@ -204,14 +204,14 @@ struct Uint12Reader {
                 if (N_ELEMENTS > CPOS + 1) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 6);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return (code32 & 0b111111111111000000000000) >> 12;
                 } else {
                     uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 6 + 1);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     code16 = Swap2Bytes(code16);
 #endif
                     return (code16 & 0b1111111111110000) >> 4;
@@ -221,14 +221,14 @@ struct Uint12Reader {
                 if (N_ELEMENTS > CPOS + 1) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 6 + 2);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return (code32 & 0b000011111111111100000000) >> 8;
                 } else {
                     uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 6 + 3);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     code16 = Swap2Bytes(code16);
 #endif
                     return (code16 & 0b0000111111111111);
@@ -238,14 +238,14 @@ struct Uint12Reader {
                 if (N_ELEMENTS > CPOS) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 6 + 2);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return (code32 & 0b11111111111100000000000000000000) >> 20;
                 } else {
                     uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 6 + 4);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     code16 = Swap2Bytes(code16);
 #endif
                     return (code16 & 0b1111111111110000) >> 4;
@@ -272,14 +272,14 @@ struct Uint16Reader {
                 if (N_ELEMENTS > CPOS + 1) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return (code32 & 0x0000FFFF);
                 } else {
                     const uint16_t* const __restrict codesFp16 =
                             reinterpret_cast<const uint16_t*>(codes);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     uint16_t rt = codesFp16[CPOS];
                     rt = Swap2Bytes(rt);
                     return rt;
@@ -291,14 +291,14 @@ struct Uint16Reader {
                 if (N_ELEMENTS > CPOS) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return code32 >> 16;
                 } else {
                     const uint16_t* const __restrict codesFp16 =
                             reinterpret_cast<const uint16_t*>(codes);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
                     uint16_t rt = codesFp16[CPOS];
                     rt = Swap2Bytes(rt);
                     return rt;

--- a/faiss/cppcontrib/detail/UintReader.h
+++ b/faiss/cppcontrib/detail/UintReader.h
@@ -8,6 +8,16 @@
 #pragma once
 
 #include <cstdint>
+#include <faiss/impl/platform_macros.h>
+
+#ifdef FAISS_BIG_ENDIAN
+#define Swap2Bytes(val) ((((val) >> 8) & 0x00FF) | (((val) << 8) & 0xFF00))
+
+#define Swap4Bytes(val)                                           \
+    ((((val) >> 24) & 0x000000FF) | (((val) >> 8) & 0x0000FF00) | \
+     (((val) << 8) & 0x00FF0000) | (((val) << 24) & 0xFF000000))
+
+#endif
 
 namespace faiss {
 namespace cppcontrib {
@@ -31,7 +41,11 @@ struct Uint8Reader {
                 if (N_ELEMENTS > CPOS + 3) {
                     const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
-                    return (code32 & 0x000000FF);
+#ifdef FAISS_BIG_ENDIAN
+                     return (code32) >> 24;
+#else
+                     return (code32 & 0x000000FF);
+#endif
                 } else {
                     return codes[CPOS];
                 }
@@ -40,7 +54,11 @@ struct Uint8Reader {
                 if (N_ELEMENTS > CPOS + 2) {
                     const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
+#ifdef FAISS_BIG_ENDIAN
+                    return (code32 & 0x00FF0000) >> 16;
+#else
                     return (code32 & 0x0000FF00) >> 8;
+#endif
                 } else {
                     return codes[CPOS];
                 }
@@ -49,7 +67,11 @@ struct Uint8Reader {
                 if (N_ELEMENTS > CPOS + 1) {
                     const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
+#ifdef FAISS_BIG_ENDIAN
+                    return (code32 & 0x0000FF00) >> 8;
+#else
                     return (code32 & 0x00FF0000) >> 16;
+#endif
                 } else {
                     return codes[CPOS];
                 }
@@ -58,7 +80,11 @@ struct Uint8Reader {
                 if (N_ELEMENTS > CPOS) {
                     const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
+#ifdef FAISS_BIG_ENDIAN
+                    return (code32 & 0x000000FF);
+#else
                     return (code32) >> 24;
+#endif
                 } else {
                     return codes[CPOS];
                 }
@@ -87,40 +113,61 @@ struct Uint10Reader {
         switch (SUB_ELEMENT) {
             case 0: {
                 if (N_ELEMENTS > CPOS + 2) {
-                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                    uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 5);
+#ifdef FAISS_BIG_ENDIAN
+                    code32 = Swap4Bytes(code32);
+#endif
                     return (code32 & 0b0000001111111111);
                 } else {
-                    const uint16_t code16 = *reinterpret_cast<const uint16_t*>(
+                    uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 5 + 0);
+#ifdef FAISS_BIG_ENDIAN
+                    code16 = Swap2Bytes(code16);
+#endif
                     return (code16 & 0b0000001111111111);
                 }
             }
             case 1: {
                 if (N_ELEMENTS > CPOS + 1) {
-                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                    uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 5);
+#ifdef FAISS_BIG_ENDIAN
+                    code32 = Swap4Bytes(code32);
+#endif
                     return (code32 & 0b000011111111110000000000) >> 10;
                 } else {
-                    const uint16_t code16 = *reinterpret_cast<const uint16_t*>(
+                    uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 5 + 1);
+#ifdef FAISS_BIG_ENDIAN
+                    code16 = Swap2Bytes(code16);
+#endif
                     return (code16 & 0b0000111111111100) >> 2;
                 }
             }
             case 2: {
                 if (N_ELEMENTS > CPOS) {
-                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                    uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 5);
+#ifdef FAISS_BIG_ENDIAN
+                    code32 = Swap4Bytes(code32);
+#endif
                     return (code32 & 0b00111111111100000000000000000000) >> 20;
                 } else {
-                    const uint16_t code16 = *reinterpret_cast<const uint16_t*>(
+                    uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 5 + 2);
+#ifdef FAISS_BIG_ENDIAN
+                    code16 = Swap2Bytes(code16);
+#endif
                     return (code16 & 0b0011111111110000) >> 4;
                 }
             }
             case 3: {
-                const uint16_t code16 = *reinterpret_cast<const uint16_t*>(
+                uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                         codes + ELEMENT_TO_READ * 5 + 3);
+#ifdef FAISS_BIG_ENDIAN
+                code16 = Swap2Bytes(code16);
+#endif
                 return (code16 & 0b1111111111000000) >> 6;
             }
         }
@@ -147,45 +194,69 @@ struct Uint12Reader {
         switch (SUB_ELEMENT) {
             case 0: {
                 if (N_ELEMENTS > CPOS + 2) {
-                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                    uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 6);
+#ifdef FAISS_BIG_ENDIAN
+                    code32 = Swap4Bytes(code32);
+#endif
                     return (code32 & 0b0000111111111111);
                 } else {
-                    const uint16_t code16 = *reinterpret_cast<const uint16_t*>(
+                    uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 6 + 0);
+#ifdef FAISS_BIG_ENDIAN
+                    code16 = Swap2Bytes(code16);
+#endif
                     return (code16 & 0b0000111111111111);
                 }
             }
             case 1: {
                 if (N_ELEMENTS > CPOS + 1) {
-                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                    uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 6);
+#ifdef FAISS_BIG_ENDIAN
+                    code32 = Swap4Bytes(code32);
+#endif
                     return (code32 & 0b111111111111000000000000) >> 12;
                 } else {
-                    const uint16_t code16 = *reinterpret_cast<const uint16_t*>(
+                    uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 6 + 1);
+#ifdef FAISS_BIG_ENDIAN
+                    code16 = Swap2Bytes(code16);
+#endif
                     return (code16 & 0b1111111111110000) >> 4;
                 }
             }
             case 2: {
                 if (N_ELEMENTS > CPOS + 1) {
-                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                    uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 6 + 2);
+#ifdef FAISS_BIG_ENDIAN
+                    code32 = Swap4Bytes(code32);
+#endif
                     return (code32 & 0b000011111111111100000000) >> 8;
                 } else {
-                    const uint16_t code16 = *reinterpret_cast<const uint16_t*>(
+                    uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 6 + 3);
+#ifdef FAISS_BIG_ENDIAN
+                    code16 = Swap2Bytes(code16);
+#endif
                     return (code16 & 0b0000111111111111);
                 }
             }
             case 3: {
                 if (N_ELEMENTS > CPOS) {
-                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                    uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 6 + 2);
+#ifdef FAISS_BIG_ENDIAN
+                    code32 = Swap4Bytes(code32);
+#endif
                     return (code32 & 0b11111111111100000000000000000000) >> 20;
                 } else {
-                    const uint16_t code16 = *reinterpret_cast<const uint16_t*>(
+                    uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 6 + 4);
+#ifdef FAISS_BIG_ENDIAN
+                    code16 = Swap2Bytes(code16);
+#endif
                     return (code16 & 0b1111111111110000) >> 4;
                 }
             }
@@ -208,23 +279,39 @@ struct Uint16Reader {
         switch (SUB_ELEMENT) {
             case 0: {
                 if (N_ELEMENTS > CPOS + 1) {
-                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                    uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
+#ifdef FAISS_BIG_ENDIAN
+                    code32 = Swap4Bytes(code32);
+#endif
                     return (code32 & 0x0000FFFF);
                 } else {
-                    const uint16_t* const __restrict codesFp16 =
+                     const uint16_t* const __restrict codesFp16 =
                             reinterpret_cast<const uint16_t*>(codes);
-                    return codesFp16[CPOS];
+#ifdef FAISS_BIG_ENDIAN
+                     uint16_t rt = codesFp16[CPOS];
+                     rt=Swap2Bytes(rt);
+                     return rt;
+#endif
+                     return codesFp16[CPOS];
                 }
             }
             case 1: {
                 if (N_ELEMENTS > CPOS) {
-                    const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
+                    uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
+#ifdef FAISS_BIG_ENDIAN
+                    code32 = Swap4Bytes(code32);
+#endif
                     return code32 >> 16;
                 } else {
                     const uint16_t* const __restrict codesFp16 =
                             reinterpret_cast<const uint16_t*>(codes);
+#ifdef FAISS_BIG_ENDIAN
+                    uint16_t rt = codesFp16[CPOS];
+                    rt=Swap2Bytes(rt);
+                    return rt;
+#endif
                     return codesFp16[CPOS];
                 }
             }

--- a/faiss/cppcontrib/detail/UintReader.h
+++ b/faiss/cppcontrib/detail/UintReader.h
@@ -10,15 +10,6 @@
 #include <faiss/impl/platform_macros.h>
 #include <cstdint>
 
-#ifdef FAISS_BIG_ENDIAN
-#define Swap2Bytes(val) ((((val) >> 8) & 0x00FF) | (((val) << 8) & 0xFF00))
-
-#define Swap4Bytes(val)                                           \
-    ((((val) >> 24) & 0x000000FF) | (((val) >> 8) & 0x0000FF00) | \
-     (((val) << 8) & 0x00FF0000) | (((val) << 24) & 0xFF000000))
-
-#endif
-
 namespace faiss {
 namespace cppcontrib {
 namespace detail {
@@ -41,7 +32,7 @@ struct Uint8Reader {
                 if (N_ELEMENTS > CPOS + 3) {
                     const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     return (code32) >> 24;
 #else
                     return (code32 & 0x000000FF);
@@ -54,7 +45,7 @@ struct Uint8Reader {
                 if (N_ELEMENTS > CPOS + 2) {
                     const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     return (code32 & 0x00FF0000) >> 16;
 #else
                     return (code32 & 0x0000FF00) >> 8;
@@ -67,7 +58,7 @@ struct Uint8Reader {
                 if (N_ELEMENTS > CPOS + 1) {
                     const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     return (code32 & 0x0000FF00) >> 8;
 #else
                     return (code32 & 0x00FF0000) >> 16;
@@ -80,7 +71,7 @@ struct Uint8Reader {
                 if (N_ELEMENTS > CPOS) {
                     const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     return (code32 & 0x000000FF);
 #else
                     return (code32) >> 24;
@@ -115,14 +106,14 @@ struct Uint10Reader {
                 if (N_ELEMENTS > CPOS + 2) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 5);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return (code32 & 0b0000001111111111);
                 } else {
                     uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 5 + 0);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     code16 = Swap2Bytes(code16);
 #endif
                     return (code16 & 0b0000001111111111);
@@ -132,14 +123,14 @@ struct Uint10Reader {
                 if (N_ELEMENTS > CPOS + 1) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 5);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return (code32 & 0b000011111111110000000000) >> 10;
                 } else {
                     uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 5 + 1);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     code16 = Swap2Bytes(code16);
 #endif
                     return (code16 & 0b0000111111111100) >> 2;
@@ -149,14 +140,14 @@ struct Uint10Reader {
                 if (N_ELEMENTS > CPOS) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 5);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return (code32 & 0b00111111111100000000000000000000) >> 20;
                 } else {
                     uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 5 + 2);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     code16 = Swap2Bytes(code16);
 #endif
                     return (code16 & 0b0011111111110000) >> 4;
@@ -165,7 +156,7 @@ struct Uint10Reader {
             case 3: {
                 uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                         codes + ELEMENT_TO_READ * 5 + 3);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                 code16 = Swap2Bytes(code16);
 #endif
                 return (code16 & 0b1111111111000000) >> 6;
@@ -196,14 +187,14 @@ struct Uint12Reader {
                 if (N_ELEMENTS > CPOS + 2) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 6);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return (code32 & 0b0000111111111111);
                 } else {
                     uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 6 + 0);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     code16 = Swap2Bytes(code16);
 #endif
                     return (code16 & 0b0000111111111111);
@@ -213,14 +204,14 @@ struct Uint12Reader {
                 if (N_ELEMENTS > CPOS + 1) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 6);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return (code32 & 0b111111111111000000000000) >> 12;
                 } else {
                     uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 6 + 1);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     code16 = Swap2Bytes(code16);
 #endif
                     return (code16 & 0b1111111111110000) >> 4;
@@ -230,14 +221,14 @@ struct Uint12Reader {
                 if (N_ELEMENTS > CPOS + 1) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 6 + 2);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return (code32 & 0b000011111111111100000000) >> 8;
                 } else {
                     uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 6 + 3);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     code16 = Swap2Bytes(code16);
 #endif
                     return (code16 & 0b0000111111111111);
@@ -247,14 +238,14 @@ struct Uint12Reader {
                 if (N_ELEMENTS > CPOS) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 6 + 2);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return (code32 & 0b11111111111100000000000000000000) >> 20;
                 } else {
                     uint16_t code16 = *reinterpret_cast<const uint16_t*>(
                             codes + ELEMENT_TO_READ * 6 + 4);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     code16 = Swap2Bytes(code16);
 #endif
                     return (code16 & 0b1111111111110000) >> 4;
@@ -281,14 +272,14 @@ struct Uint16Reader {
                 if (N_ELEMENTS > CPOS + 1) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return (code32 & 0x0000FFFF);
                 } else {
                     const uint16_t* const __restrict codesFp16 =
                             reinterpret_cast<const uint16_t*>(codes);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     uint16_t rt = codesFp16[CPOS];
                     rt = Swap2Bytes(rt);
                     return rt;
@@ -300,14 +291,14 @@ struct Uint16Reader {
                 if (N_ELEMENTS > CPOS) {
                     uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     code32 = Swap4Bytes(code32);
 #endif
                     return code32 >> 16;
                 } else {
                     const uint16_t* const __restrict codesFp16 =
                             reinterpret_cast<const uint16_t*>(codes);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
                     uint16_t rt = codesFp16[CPOS];
                     rt = Swap2Bytes(rt);
                     return rt;

--- a/faiss/cppcontrib/detail/UintReader.h
+++ b/faiss/cppcontrib/detail/UintReader.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <cstdint>
 #include <faiss/impl/platform_macros.h>
+#include <cstdint>
 
 #ifdef FAISS_BIG_ENDIAN
 #define Swap2Bytes(val) ((((val) >> 8) & 0x00FF) | (((val) << 8) & 0xFF00))
@@ -42,9 +42,9 @@ struct Uint8Reader {
                     const uint32_t code32 = *reinterpret_cast<const uint32_t*>(
                             codes + ELEMENT_TO_READ * 4);
 #ifdef FAISS_BIG_ENDIAN
-                     return (code32) >> 24;
+                    return (code32) >> 24;
 #else
-                     return (code32 & 0x000000FF);
+                    return (code32 & 0x000000FF);
 #endif
                 } else {
                     return codes[CPOS];
@@ -286,14 +286,14 @@ struct Uint16Reader {
 #endif
                     return (code32 & 0x0000FFFF);
                 } else {
-                     const uint16_t* const __restrict codesFp16 =
+                    const uint16_t* const __restrict codesFp16 =
                             reinterpret_cast<const uint16_t*>(codes);
 #ifdef FAISS_BIG_ENDIAN
-                     uint16_t rt = codesFp16[CPOS];
-                     rt=Swap2Bytes(rt);
-                     return rt;
+                    uint16_t rt = codesFp16[CPOS];
+                    rt=Swap2Bytes(rt);
+                    return rt;
 #endif
-                     return codesFp16[CPOS];
+                    return codesFp16[CPOS];
                 }
             }
             case 1: {
@@ -309,7 +309,7 @@ struct Uint16Reader {
                             reinterpret_cast<const uint16_t*>(codes);
 #ifdef FAISS_BIG_ENDIAN
                     uint16_t rt = codesFp16[CPOS];
-                    rt=Swap2Bytes(rt);
+                    rt = Swap2Bytes(rt);
                     return rt;
 #endif
                     return codesFp16[CPOS];

--- a/faiss/cppcontrib/detail/UintReader.h
+++ b/faiss/cppcontrib/detail/UintReader.h
@@ -290,7 +290,7 @@ struct Uint16Reader {
                             reinterpret_cast<const uint16_t*>(codes);
 #ifdef FAISS_BIG_ENDIAN
                     uint16_t rt = codesFp16[CPOS];
-                    rt=Swap2Bytes(rt);
+                    rt = Swap2Bytes(rt);
                     return rt;
 #endif
                     return codesFp16[CPOS];

--- a/faiss/cppcontrib/sa_decode/Level2-inl.h
+++ b/faiss/cppcontrib/sa_decode/Level2-inl.h
@@ -14,6 +14,9 @@
 #include <faiss/cppcontrib/detail/CoarseBitType.h>
 #include <faiss/impl/platform_macros.h>
 
+namespace faiss {
+namespace cppcontrib {
+
 bool isBigEndian() {
 #ifdef FAISS_BIG_ENDIAN
     return true;
@@ -21,9 +24,6 @@ bool isBigEndian() {
     return false;
 #endif
 }
-
-namespace faiss {
-namespace cppcontrib {
 
 ////////////////////////////////////////////////////////////////////////////////////
 /// Index2LevelDecoder

--- a/faiss/cppcontrib/sa_decode/Level2-inl.h
+++ b/faiss/cppcontrib/sa_decode/Level2-inl.h
@@ -12,6 +12,15 @@
 #include <cstdint>
 
 #include <faiss/cppcontrib/detail/CoarseBitType.h>
+#include <faiss/impl/platform_macros.h>
+
+#ifdef FAISS_BIG_ENDIAN
+#define Swap2Bytes(val) ((((val) >> 8) & 0x00FF) | (((val) << 8) & 0xFF00))
+#endif
+
+#ifndef FAISS_BIG_ENDIAN
+#define FAISS_BIG_ENDIAN 0
+#endif
 
 namespace faiss {
 namespace cppcontrib {
@@ -72,9 +81,14 @@ struct Index2LevelDecoder {
             const intptr_t coarseCentroidOffset = i % COARSE_SIZE;
             const intptr_t fineCentroidIdx = i / FINE_SIZE;
             const intptr_t fineCentroidOffset = i % FINE_SIZE;
-
-            const intptr_t coarseCode = coarse[coarseCentroidIdx];
-            const intptr_t fineCode = fine[fineCentroidIdx];
+            intptr_t coarseCode, fineCode;
+            if (FAISS_BIG_ENDIAN && sizeof(coarse_storage_type) == 2) {
+                coarseCode = Swap2Bytes(coarse[coarseCentroidIdx]);
+                fineCode = Swap2Bytes(fine[fineCentroidIdx]);
+            } else {
+                coarseCode = coarse[coarseCentroidIdx];
+                fineCode = fine[fineCentroidIdx];
+            }
 
             const float* const __restrict coarsePtr = pqCoarseCentroids +
                     (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode) *
@@ -112,9 +126,14 @@ struct Index2LevelDecoder {
             const intptr_t fineCentroidIdx = i / FINE_SIZE;
             const intptr_t fineCentroidOffset = i % FINE_SIZE;
 
-            const intptr_t coarseCode = coarse[coarseCentroidIdx];
-            const intptr_t fineCode = fine[fineCentroidIdx];
-
+            intptr_t coarseCode, fineCode;
+            if (FAISS_BIG_ENDIAN && sizeof(coarse_storage_type) == 2) {
+                coarseCode = Swap2Bytes(coarse[coarseCentroidIdx]);
+                fineCode = Swap2Bytes(fine[fineCentroidIdx]);
+            } else {
+                coarseCode = coarse[coarseCentroidIdx];
+                fineCode = fine[fineCentroidIdx];
+            }
             const float* const __restrict coarsePtr = pqCoarseCentroids +
                     (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode) *
                             COARSE_SIZE +
@@ -162,11 +181,18 @@ struct Index2LevelDecoder {
             const intptr_t coarseCentroidOffset = i % COARSE_SIZE;
             const intptr_t fineCentroidIdx = i / FINE_SIZE;
             const intptr_t fineCentroidOffset = i % FINE_SIZE;
-
-            const intptr_t coarseCode0 = coarse0[coarseCentroidIdx];
-            const intptr_t fineCode0 = fine0[fineCentroidIdx];
-            const intptr_t coarseCode1 = coarse1[coarseCentroidIdx];
-            const intptr_t fineCode1 = fine1[fineCentroidIdx];
+            intptr_t coarseCode0, coarseCode1, fineCode0, fineCode1;
+            if (FAISS_BIG_ENDIAN && sizeof(coarse_storage_type) == 2) {
+                coarseCode0 = Swap2Bytes(coarse0[coarseCentroidIdx]);
+                fineCode0 = Swap2Bytes(fine0[fineCentroidIdx]);
+                coarseCode1 = Swap2Bytes(coarse1[coarseCentroidIdx]);
+                fineCode1 = Swap2Bytes(fine1[fineCentroidIdx]);
+            } else {
+                coarseCode0 = coarse0[coarseCentroidIdx];
+                fineCode0 = fine0[fineCentroidIdx];
+                coarseCode1 = coarse1[coarseCentroidIdx];
+                fineCode1 = fine1[fineCentroidIdx];
+            }
 
             const float* const __restrict coarsePtr0 = pqCoarseCentroids0 +
                     (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) *
@@ -222,11 +248,18 @@ struct Index2LevelDecoder {
             const intptr_t coarseCentroidOffset = i % COARSE_SIZE;
             const intptr_t fineCentroidIdx = i / FINE_SIZE;
             const intptr_t fineCentroidOffset = i % FINE_SIZE;
-
-            const intptr_t coarseCode0 = coarse0[coarseCentroidIdx];
-            const intptr_t fineCode0 = fine0[fineCentroidIdx];
-            const intptr_t coarseCode1 = coarse1[coarseCentroidIdx];
-            const intptr_t fineCode1 = fine1[fineCentroidIdx];
+            intptr_t coarseCode0, coarseCode1, fineCode0, fineCode1;
+            if (FAISS_BIG_ENDIAN && sizeof(coarse_storage_type) == 2) {
+                coarseCode0 = Swap2Bytes(coarse0[coarseCentroidIdx]);
+                fineCode0 = Swap2Bytes(fine0[fineCentroidIdx]);
+                coarseCode1 = Swap2Bytes(coarse1[coarseCentroidIdx]);
+                fineCode1 = Swap2Bytes(fine1[fineCentroidIdx]);
+            } else {
+                coarseCode0 = coarse0[coarseCentroidIdx];
+                fineCode0 = fine0[fineCentroidIdx];
+                coarseCode1 = coarse1[coarseCentroidIdx];
+                fineCode1 = fine1[fineCentroidIdx];
+            }
 
             const float* const __restrict coarsePtr0 = pqCoarseCentroids +
                     (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) *
@@ -292,13 +325,23 @@ struct Index2LevelDecoder {
             const intptr_t coarseCentroidOffset = i % COARSE_SIZE;
             const intptr_t fineCentroidIdx = i / FINE_SIZE;
             const intptr_t fineCentroidOffset = i % FINE_SIZE;
-
-            const intptr_t coarseCode0 = coarse0[coarseCentroidIdx];
-            const intptr_t fineCode0 = fine0[fineCentroidIdx];
-            const intptr_t coarseCode1 = coarse1[coarseCentroidIdx];
-            const intptr_t fineCode1 = fine1[fineCentroidIdx];
-            const intptr_t coarseCode2 = coarse2[coarseCentroidIdx];
-            const intptr_t fineCode2 = fine2[fineCentroidIdx];
+            intptr_t coarseCode0, coarseCode1, fineCode0, fineCode1;
+            intptr_t coarseCode2, fineCode2;
+            if (FAISS_BIG_ENDIAN && sizeof(coarse_storage_type) == 2) {
+                coarseCode0 = Swap2Bytes(coarse0[coarseCentroidIdx]);
+                fineCode0 = Swap2Bytes(fine0[fineCentroidIdx]);
+                coarseCode1 = Swap2Bytes(coarse1[coarseCentroidIdx]);
+                fineCode1 = Swap2Bytes(fine1[fineCentroidIdx]);
+                coarseCode2 = Swap2Bytes(coarse2[coarseCentroidIdx]);
+                fineCode2 = Swap2Bytes(fine2[fineCentroidIdx]);
+            } else {
+                coarseCode0 = coarse0[coarseCentroidIdx];
+                fineCode0 = fine0[fineCentroidIdx];
+                coarseCode1 = coarse1[coarseCentroidIdx];
+                fineCode1 = fine1[fineCentroidIdx];
+                coarseCode2 = coarse2[coarseCentroidIdx];
+                fineCode2 = fine2[fineCentroidIdx];
+            }
 
             const float* const __restrict coarsePtr0 = pqCoarseCentroids0 +
                     (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) *
@@ -369,13 +412,23 @@ struct Index2LevelDecoder {
             const intptr_t coarseCentroidOffset = i % COARSE_SIZE;
             const intptr_t fineCentroidIdx = i / FINE_SIZE;
             const intptr_t fineCentroidOffset = i % FINE_SIZE;
-
-            const intptr_t coarseCode0 = coarse0[coarseCentroidIdx];
-            const intptr_t fineCode0 = fine0[fineCentroidIdx];
-            const intptr_t coarseCode1 = coarse1[coarseCentroidIdx];
-            const intptr_t fineCode1 = fine1[fineCentroidIdx];
-            const intptr_t coarseCode2 = coarse2[coarseCentroidIdx];
-            const intptr_t fineCode2 = fine2[fineCentroidIdx];
+            intptr_t coarseCode0, fineCode0, coarseCode1, fineCode1;
+            intptr_t coarseCode2, fineCode2;
+            if (FAISS_BIG_ENDIAN && sizeof(coarse_storage_type) == 2) {
+                coarseCode0 = Swap2Bytes(coarse0[coarseCentroidIdx]);
+                fineCode0 = Swap2Bytes(fine0[fineCentroidIdx]);
+                coarseCode1 = Swap2Bytes(coarse1[coarseCentroidIdx]);
+                fineCode1 = Swap2Bytes(fine1[fineCentroidIdx]);
+                coarseCode2 = Swap2Bytes(coarse2[coarseCentroidIdx]);
+                fineCode2 = Swap2Bytes(fine2[fineCentroidIdx]);
+            } else {
+                coarseCode0 = coarse0[coarseCentroidIdx];
+                fineCode0 = fine0[fineCentroidIdx];
+                coarseCode1 = coarse1[coarseCentroidIdx];
+                fineCode1 = fine1[fineCentroidIdx];
+                coarseCode2 = coarse2[coarseCentroidIdx];
+                fineCode2 = fine2[fineCentroidIdx];
+            }
 
             const float* const __restrict coarsePtr0 = pqCoarseCentroids +
                     (coarseCentroidIdx * COARSE_TABLE_BYTES + coarseCode0) *

--- a/faiss/cppcontrib/sa_decode/Level2-inl.h
+++ b/faiss/cppcontrib/sa_decode/Level2-inl.h
@@ -14,6 +14,15 @@
 #include <faiss/cppcontrib/detail/CoarseBitType.h>
 #include <faiss/impl/platform_macros.h>
 
+bool isBigEndian() {
+    #ifdef FAISS_BIG_ENDIAN
+        return true;
+    #else
+        return false;
+    #endif
+}
+
+
 namespace faiss {
 namespace cppcontrib {
 
@@ -74,7 +83,7 @@ struct Index2LevelDecoder {
             const intptr_t fineCentroidIdx = i / FINE_SIZE;
             const intptr_t fineCentroidOffset = i % FINE_SIZE;
             intptr_t coarseCode, fineCode;
-            if (FAISS_BIG_ENDIAN && sizeof(coarse_storage_type) == 2) {
+            if (isBigEndian() && sizeof(coarse_storage_type) == 2) {
                 coarseCode = Swap2Bytes(coarse[coarseCentroidIdx]);
                 fineCode = Swap2Bytes(fine[fineCentroidIdx]);
             } else {
@@ -119,7 +128,7 @@ struct Index2LevelDecoder {
             const intptr_t fineCentroidOffset = i % FINE_SIZE;
 
             intptr_t coarseCode, fineCode;
-            if (FAISS_BIG_ENDIAN && sizeof(coarse_storage_type) == 2) {
+            if (isBigEndian() && sizeof(coarse_storage_type) == 2) {
                 coarseCode = Swap2Bytes(coarse[coarseCentroidIdx]);
                 fineCode = Swap2Bytes(fine[fineCentroidIdx]);
             } else {
@@ -174,7 +183,7 @@ struct Index2LevelDecoder {
             const intptr_t fineCentroidIdx = i / FINE_SIZE;
             const intptr_t fineCentroidOffset = i % FINE_SIZE;
             intptr_t coarseCode0, coarseCode1, fineCode0, fineCode1;
-            if (FAISS_BIG_ENDIAN && sizeof(coarse_storage_type) == 2) {
+            if (isBigEndian() && sizeof(coarse_storage_type) == 2) {
                 coarseCode0 = Swap2Bytes(coarse0[coarseCentroidIdx]);
                 fineCode0 = Swap2Bytes(fine0[fineCentroidIdx]);
                 coarseCode1 = Swap2Bytes(coarse1[coarseCentroidIdx]);
@@ -241,7 +250,7 @@ struct Index2LevelDecoder {
             const intptr_t fineCentroidIdx = i / FINE_SIZE;
             const intptr_t fineCentroidOffset = i % FINE_SIZE;
             intptr_t coarseCode0, coarseCode1, fineCode0, fineCode1;
-            if (FAISS_BIG_ENDIAN && sizeof(coarse_storage_type) == 2) {
+            if (isBigEndian() && sizeof(coarse_storage_type) == 2) {
                 coarseCode0 = Swap2Bytes(coarse0[coarseCentroidIdx]);
                 fineCode0 = Swap2Bytes(fine0[fineCentroidIdx]);
                 coarseCode1 = Swap2Bytes(coarse1[coarseCentroidIdx]);
@@ -319,7 +328,7 @@ struct Index2LevelDecoder {
             const intptr_t fineCentroidOffset = i % FINE_SIZE;
             intptr_t coarseCode0, coarseCode1, fineCode0, fineCode1;
             intptr_t coarseCode2, fineCode2;
-            if (FAISS_BIG_ENDIAN && sizeof(coarse_storage_type) == 2) {
+            if (isBigEndian() && sizeof(coarse_storage_type) == 2) {
                 coarseCode0 = Swap2Bytes(coarse0[coarseCentroidIdx]);
                 fineCode0 = Swap2Bytes(fine0[fineCentroidIdx]);
                 coarseCode1 = Swap2Bytes(coarse1[coarseCentroidIdx]);
@@ -406,7 +415,7 @@ struct Index2LevelDecoder {
             const intptr_t fineCentroidOffset = i % FINE_SIZE;
             intptr_t coarseCode0, fineCode0, coarseCode1, fineCode1;
             intptr_t coarseCode2, fineCode2;
-            if (FAISS_BIG_ENDIAN && sizeof(coarse_storage_type) == 2) {
+            if (isBigEndian() && sizeof(coarse_storage_type) == 2) {
                 coarseCode0 = Swap2Bytes(coarse0[coarseCentroidIdx]);
                 fineCode0 = Swap2Bytes(fine0[fineCentroidIdx]);
                 coarseCode1 = Swap2Bytes(coarse1[coarseCentroidIdx]);

--- a/faiss/cppcontrib/sa_decode/Level2-inl.h
+++ b/faiss/cppcontrib/sa_decode/Level2-inl.h
@@ -15,11 +15,11 @@
 #include <faiss/impl/platform_macros.h>
 
 bool isBigEndian() {
-    #ifdef FAISS_BIG_ENDIAN
-        return true;
-    #else
-        return false;
-    #endif
+#ifdef FAISS_BIG_ENDIAN
+    return true;
+#else
+    return false;
+#endif
 }
 
 

--- a/faiss/cppcontrib/sa_decode/Level2-inl.h
+++ b/faiss/cppcontrib/sa_decode/Level2-inl.h
@@ -22,7 +22,6 @@ bool isBigEndian() {
 #endif
 }
 
-
 namespace faiss {
 namespace cppcontrib {
 

--- a/faiss/cppcontrib/sa_decode/Level2-inl.h
+++ b/faiss/cppcontrib/sa_decode/Level2-inl.h
@@ -20,6 +20,7 @@
 
 #ifndef FAISS_BIG_ENDIAN
 #define FAISS_BIG_ENDIAN 0
+#define Swap2Bytes(val) val
 #endif
 
 namespace faiss {

--- a/faiss/cppcontrib/sa_decode/Level2-inl.h
+++ b/faiss/cppcontrib/sa_decode/Level2-inl.h
@@ -14,15 +14,6 @@
 #include <faiss/cppcontrib/detail/CoarseBitType.h>
 #include <faiss/impl/platform_macros.h>
 
-#ifdef FAISS_BIG_ENDIAN
-#define Swap2Bytes(val) ((((val) >> 8) & 0x00FF) | (((val) << 8) & 0xFF00))
-#endif
-
-#ifndef FAISS_BIG_ENDIAN
-#define FAISS_BIG_ENDIAN 0
-#define Swap2Bytes(val) val
-#endif
-
 namespace faiss {
 namespace cppcontrib {
 

--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -169,11 +169,9 @@ inline int __builtin_clzll(uint64_t x) {
 /*******************************************************
  * BIGENDIAN specific macros
  *******************************************************/
-#define FAISS_BIG_ENDIAN 0
 #if !defined(_MSC_VER) && \
         (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
-#undef FAISS_BIG_ENDIAN
-#define FAISS_BIG_ENDIAN 1
+#define FAISS_BIG_ENDIAN
 #endif
 
 #define Swap2Bytes(val) ((((val) >> 8) & 0x00FF) | (((val) << 8) & 0xFF00))

--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -165,3 +165,11 @@ inline int __builtin_clzll(uint64_t x) {
 #endif
 
 // clang-format on
+
+/*******************************************************
+ * BIGENDIAN specific macros
+ *******************************************************/
+#if !defined(_MSC_VER) && \
+        (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
+#define FAISS_BIG_ENDIAN 1
+#endif

--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -169,7 +169,15 @@ inline int __builtin_clzll(uint64_t x) {
 /*******************************************************
  * BIGENDIAN specific macros
  *******************************************************/
+#define FAISS_BIG_ENDIAN 0
 #if !defined(_MSC_VER) && \
         (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
+#undef FAISS_BIG_ENDIAN
 #define FAISS_BIG_ENDIAN 1
 #endif
+
+#define Swap2Bytes(val) ((((val) >> 8) & 0x00FF) | (((val) << 8) & 0xFF00))
+
+#define Swap4Bytes(val)                                           \
+    ((((val) >> 24) & 0x000000FF) | (((val) >> 8) & 0x0000FF00) | \
+     (((val) << 8) & 0x00FF0000) | (((val) << 24) & 0xFF000000))

--- a/faiss/impl/pq4_fast_scan.cpp
+++ b/faiss/impl/pq4_fast_scan.cpp
@@ -59,7 +59,7 @@ void pq4_pack_codes(
         return;
     }
     memset(blocks, 0, nb * nsq / 2);
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
     const uint8_t perm0[16] = {
             8, 0, 9, 1, 10, 2, 11, 3, 12, 4, 13, 5, 14, 6, 15, 7};
 #else
@@ -99,7 +99,7 @@ void pq4_pack_codes_range(
         size_t bbs,
         size_t nsq,
         uint8_t* blocks) {
-#ifdef FAISS_BIG_ENDIAN
+#if FAISS_BIG_ENDIAN
     const uint8_t perm0[16] = {
             8, 0, 9, 1, 10, 2, 11, 3, 12, 4, 13, 5, 14, 6, 15, 7};
 #else

--- a/faiss/impl/pq4_fast_scan.cpp
+++ b/faiss/impl/pq4_fast_scan.cpp
@@ -8,6 +8,7 @@
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/pq4_fast_scan.h>
 #include <faiss/impl/simd_result_handlers.h>
+#include <faiss/impl/platform_macros.h>
 
 #include <array>
 
@@ -50,6 +51,7 @@ void pq4_pack_codes(
         size_t bbs,
         size_t nsq,
         uint8_t* blocks) {
+
     FAISS_THROW_IF_NOT(bbs % 32 == 0);
     FAISS_THROW_IF_NOT(nb % bbs == 0);
     FAISS_THROW_IF_NOT(nsq % 2 == 0);
@@ -58,8 +60,7 @@ void pq4_pack_codes(
         return;
     }
     memset(blocks, 0, nb * nsq / 2);
-#if !defined(_MSC_VER) && \
-        (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
+#ifdef FAISS_BIG_ENDIAN
     const uint8_t perm0[16] = {
             8, 0, 9, 1, 10, 2, 11, 3, 12, 4, 13, 5, 14, 6, 15, 7};
 #else
@@ -99,8 +100,7 @@ void pq4_pack_codes_range(
         size_t bbs,
         size_t nsq,
         uint8_t* blocks) {
-#if !defined(_MSC_VER) && \
-        (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
+#ifdef FAISS_BIG_ENDIAN
     const uint8_t perm0[16] = {
             8, 0, 9, 1, 10, 2, 11, 3, 12, 4, 13, 5, 14, 6, 15, 7};
 #else

--- a/faiss/impl/pq4_fast_scan.cpp
+++ b/faiss/impl/pq4_fast_scan.cpp
@@ -59,7 +59,7 @@ void pq4_pack_codes(
         return;
     }
     memset(blocks, 0, nb * nsq / 2);
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
     const uint8_t perm0[16] = {
             8, 0, 9, 1, 10, 2, 11, 3, 12, 4, 13, 5, 14, 6, 15, 7};
 #else
@@ -99,7 +99,7 @@ void pq4_pack_codes_range(
         size_t bbs,
         size_t nsq,
         uint8_t* blocks) {
-#if FAISS_BIG_ENDIAN
+#ifdef FAISS_BIG_ENDIAN
     const uint8_t perm0[16] = {
             8, 0, 9, 1, 10, 2, 11, 3, 12, 4, 13, 5, 14, 6, 15, 7};
 #else

--- a/faiss/impl/pq4_fast_scan.cpp
+++ b/faiss/impl/pq4_fast_scan.cpp
@@ -6,9 +6,9 @@
  */
 
 #include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/platform_macros.h>
 #include <faiss/impl/pq4_fast_scan.h>
 #include <faiss/impl/simd_result_handlers.h>
-#include <faiss/impl/platform_macros.h>
 
 #include <array>
 
@@ -51,7 +51,6 @@ void pq4_pack_codes(
         size_t bbs,
         size_t nsq,
         uint8_t* blocks) {
-
     FAISS_THROW_IF_NOT(bbs % 32 == 0);
     FAISS_THROW_IF_NOT(nb % bbs == 0);
     FAISS_THROW_IF_NOT(nsq % 2 == 0);

--- a/faiss/impl/pq4_fast_scan.cpp
+++ b/faiss/impl/pq4_fast_scan.cpp
@@ -58,7 +58,8 @@ void pq4_pack_codes(
         return;
     }
     memset(blocks, 0, nb * nsq / 2);
-#if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#if !defined(_MSC_VER) || \
+    (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
     const uint8_t perm0[16] = {
             8, 0, 9, 1, 10, 2, 11, 3, 12, 4, 13, 5, 14, 6, 15, 7};
 #else
@@ -98,7 +99,8 @@ void pq4_pack_codes_range(
         size_t bbs,
         size_t nsq,
         uint8_t* blocks) {
-#if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#if !defined(_MSC_VER) || \
+    (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
     const uint8_t perm0[16] = {
             8, 0, 9, 1, 10, 2, 11, 3, 12, 4, 13, 5, 14, 6, 15, 7};
 #else

--- a/faiss/impl/pq4_fast_scan.cpp
+++ b/faiss/impl/pq4_fast_scan.cpp
@@ -59,7 +59,7 @@ void pq4_pack_codes(
     }
     memset(blocks, 0, nb * nsq / 2);
 #if !defined(_MSC_VER) && \
-    (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
+        (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
     const uint8_t perm0[16] = {
             8, 0, 9, 1, 10, 2, 11, 3, 12, 4, 13, 5, 14, 6, 15, 7};
 #else
@@ -100,7 +100,7 @@ void pq4_pack_codes_range(
         size_t nsq,
         uint8_t* blocks) {
 #if !defined(_MSC_VER) && \
-    (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
+        (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
     const uint8_t perm0[16] = {
             8, 0, 9, 1, 10, 2, 11, 3, 12, 4, 13, 5, 14, 6, 15, 7};
 #else

--- a/faiss/impl/pq4_fast_scan.cpp
+++ b/faiss/impl/pq4_fast_scan.cpp
@@ -58,8 +58,13 @@ void pq4_pack_codes(
         return;
     }
     memset(blocks, 0, nb * nsq / 2);
+#if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+    const uint8_t perm0[16] = {
+            8, 0, 9, 1, 10, 2, 11, 3, 12, 4, 13, 5, 14, 6, 15, 7};
+#else
     const uint8_t perm0[16] = {
             0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15};
+#endif
 
     uint8_t* codes2 = blocks;
     for (size_t i0 = 0; i0 < nb; i0 += bbs) {
@@ -93,8 +98,13 @@ void pq4_pack_codes_range(
         size_t bbs,
         size_t nsq,
         uint8_t* blocks) {
+#if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+    const uint8_t perm0[16] = {
+            8, 0, 9, 1, 10, 2, 11, 3, 12, 4, 13, 5, 14, 6, 15, 7};
+#else
     const uint8_t perm0[16] = {
             0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15};
+#endif
 
     // range of affected blocks
     size_t block0 = i0 / bbs;

--- a/faiss/impl/pq4_fast_scan.cpp
+++ b/faiss/impl/pq4_fast_scan.cpp
@@ -58,7 +58,7 @@ void pq4_pack_codes(
         return;
     }
     memset(blocks, 0, nb * nsq / 2);
-#if !defined(_MSC_VER) || \
+#if !defined(_MSC_VER) && \
     (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
     const uint8_t perm0[16] = {
             8, 0, 9, 1, 10, 2, 11, 3, 12, 4, 13, 5, 14, 6, 15, 7};
@@ -99,7 +99,7 @@ void pq4_pack_codes_range(
         size_t bbs,
         size_t nsq,
         uint8_t* blocks) {
-#if !defined(_MSC_VER) || \
+#if !defined(_MSC_VER) && \
     (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
     const uint8_t perm0[16] = {
             8, 0, 9, 1, 10, 2, 11, 3, 12, 4, 13, 5, 14, 6, 15, 7};

--- a/faiss/python/CMakeLists.txt
+++ b/faiss/python/CMakeLists.txt
@@ -67,11 +67,20 @@ else()
   find_package(faiss REQUIRED)
 endif()
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+swig_add_library(swigfaiss
+  TYPE MODULE
+  LANGUAGE python
+  SOURCES swigfaiss.swig
+)
+else ()
 swig_add_library(swigfaiss
   TYPE SHARED
   LANGUAGE python
   SOURCES swigfaiss.swig
 )
+endif()
+
 set_property(TARGET swigfaiss PROPERTY SWIG_COMPILE_OPTIONS -doxygen)
 
 set_property(SOURCE swigfaiss_avx2.swig
@@ -159,6 +168,10 @@ add_library(faiss_python_callbacks EXCLUDE_FROM_ALL
 set_property(TARGET faiss_python_callbacks
   PROPERTY POSITION_INDEPENDENT_CODE ON
 )
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+target_link_libraries(faiss_python_callbacks PRIVATE faiss)
+endif()
 
 # Hack so that python_callbacks.h can be included as
 # `#include <faiss/python/python_callbacks.h>`.


### PR DESCRIPTION
This pull request is for issue https://github.com/facebookresearch/faiss/issues/3330. This patch makes sure that packed code arrays are in big endian format. Kindly let us know if we need any changes or if we can have a better approach.