### PR TITLE
Fix deprecated use of 0/NULL in faiss/gpu/test/demo_ivfpq_indexing_gpu.cpp + 1

### DIFF
--- a/faiss/gpu/test/demo_ivfpq_indexing_gpu.cpp
+++ b/faiss/gpu/test/demo_ivfpq_indexing_gpu.cpp
@@ -20,7 +20,7 @@
 
 double elapsed() {
     struct timeval tv;
-    gettimeofday(&tv, NULL);
+    gettimeofday(&tv, nullptr);
     return tv.tv_sec + tv.tv_usec * 1e-6;
 }
 


### PR DESCRIPTION
Summary:
`nullptr` is typesafe. `0` and `NULL` are not. In the future, only `nullptr` will be allowed.

This diff helps us embrace the future _now_ in service of enabling `-Wzero-as-null-pointer-constant`.

Differential Revision: D55755257


