### PR TITLE
Switch sprintf to snprintf

### DIFF
--- a/faiss/impl/io.cpp
+++ b/faiss/impl/io.cpp
@@ -267,7 +267,7 @@ std::string fourcc_inv_printable(uint32_t x) {
             str += c;
         } else {
             char buf[10];
-            sprintf(buf, "\\x%02x", c);
+            snprintf(buf, sizeof(buf), "\\x%02x", c);
             str += buf;
         }
     }

--- a/faiss/utils/simdlib_neon.h
+++ b/faiss/utils/simdlib_neon.h
@@ -168,9 +168,16 @@ static inline std::string elements_to_string(const char* fmt, const S& simd) {
     simd.store(bytes);
     char res[1000], *ptr = res;
     for (size_t i = 0; i < N; ++i) {
-        ptr += sprintf(ptr, fmt, bytes[i]);
+        int bytesWritten =
+                snprintf(ptr, sizeof(res) - (ptr - res), fmt, bytes[i]);
+        if (bytesWritten >= 0) {
+            ptr += bytesWritten;
+        } else {
+            break;
+        }
     }
     // strip last ,
+
     ptr[-1] = 0;
     return std::string(res);
 }


### PR DESCRIPTION
Summary:
'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead


{F1484071654}

Differential Revision: D56009251


