### PR TITLE
remove unused code

### DIFF
--- a/faiss/utils/simdlib_neon.h
+++ b/faiss/utils/simdlib_neon.h
@@ -170,14 +170,10 @@ static inline std::string elements_to_string(const char* fmt, const S& simd) {
     for (size_t i = 0; i < N; ++i) {
         int bytesWritten =
                 snprintf(ptr, sizeof(res) - (ptr - res), fmt, bytes[i]);
-        if (bytesWritten >= 0) {
-            ptr += bytesWritten;
-        } else {
-            break;
-        }
+        ptr += bytesWritten;
     }
-    // strip last ,
-
+    // The format usually contains a ',' separator so this is to remove the last
+    // separator.
     ptr[-1] = 0;
     return std::string(res);
 }


### PR DESCRIPTION
Summary: This will never happen because N is fixed at compile time and the buffer is large enough. It is misleading to add error handling code for a case that will never happen.

Differential Revision: D56274458


