### PR TITLE
Switch clang-format-11 to clang-format-18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
       - run:
           name: Install clang-format
           command: |
-            apt-get -y update
-            apt-get -y install wget
+            apt-get update -y
+            apt-get install -y wget
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
             echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-18 main" | tee -a /etc/apt/sources.list
             apt-get update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,12 +38,15 @@ jobs:
       - run:
           name: Install clang-format
           command: |
+            apt-get install wget
+            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+            echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-18 main" | tee -a /etc/apt/sources.list
             apt-get update
-            apt-get install -y git-core clang-format-11
+            apt-get install -y git-core clang-format-18
       - run:
           name: Verify clang-format
           command: |
-             git ls-files | grep -E  '\.(cpp|h|cu|cuh)$' | xargs clang-format-11 -i
+             git ls-files | grep -E  '\.(cpp|h|cu|cuh)$' | xargs clang-format-18 -i
              if git diff --quiet; then
                echo "Formatting OK!"
              else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
       - run:
           name: Install clang-format
           command: |
+            apt-get update
             apt-get install wget
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
             echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-18 main" | tee -a /etc/apt/sources.list

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,10 @@ jobs:
           command: |
             apt-get update -y
             apt-get install -y wget
-            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-18 main" | tee -a /etc/apt/sources.list
-            apt-get update
+            apt install -y lsb-release wget software-properties-common gnupg
+            wget https://apt.llvm.org/llvm.sh
+            chmod u+x llvm.sh
+            ./llvm.sh 18
             apt-get install -y git-core clang-format-18
       - run:
           name: Verify clang-format

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,7 @@ jobs:
           command: |
             apt-get update -y
             apt-get install -y wget
-            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-            echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-18 main" | tee -a /etc/apt/sources.list
+            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-18 main" | tee -a /etc/apt/sources.list
             apt-get update
             apt-get install -y git-core clang-format-18
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
       - run:
           name: Install clang-format
           command: |
-            apt-get update
-            apt-get install wget
+            apt-get -y update
+            apt-get -y install wget
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
             echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-18 main" | tee -a /etc/apt/sources.list
             apt-get update


### PR DESCRIPTION
In this commit https://github.com/facebookresearch/faiss/commit/ab2b7f50936b3bafd4e076f798413da2399482bd, they changed format based on clang-format-18. However, we still sue clang-format-11 in our circle ci job which caused the failure. In this PR, we are going to switch to clang-format-18