### PR TITLE
Enable linux-x86_64-GPU-w-RAFT-cmake build via GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,15 @@ jobs:
       - uses: ./.github/actions/build_cmake
         with:
           opt_level: avx2
+  linux-x86_64-GPU-w-RAFT-cmake:
+    runs-on: 4-core-ubuntu-gpu-t4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_cmake
+        with:
+          gpu: ON
+          raft: ON
   linux-x86_64-conda:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Summary: Migration to GitHub Actions

Differential Revision: D57133934
