### PR TITLE
sys.big_endian to sys.byteorder

### DIFF
--- a/contrib/vecs_io.py
+++ b/contrib/vecs_io.py
@@ -14,7 +14,7 @@ definition of the formats here: http://corpus-texmex.irisa.fr/
 
 def ivecs_read(fname):
     a = np.fromfile(fname, dtype='int32')
-    if sys.big_endian:
+    if sys.byteorder == 'big':
         a.byteswap(inplace=True)
     d = a[0]
     return a.reshape(-1, d + 1)[:, 1:].copy()
@@ -25,7 +25,7 @@ def fvecs_read(fname):
 
 
 def ivecs_mmap(fname):
-    assert not sys.big_endian
+    assert sys.byteorder != 'big'
     a = np.memmap(fname, dtype='int32', mode='r')
     d = a[0]
     return a.reshape(-1, d + 1)[:, 1:]
@@ -37,7 +37,7 @@ def fvecs_mmap(fname):
 
 def bvecs_mmap(fname):
     x = np.memmap(fname, dtype='uint8', mode='r')
-    if sys.big_endian:
+    if sys.byteorder == 'big':
         da = x[:4][::-1].copy()
         d = da.view('int32')[0]
     else:
@@ -50,7 +50,7 @@ def ivecs_write(fname, m):
     m1 = np.empty((n, d + 1), dtype='int32')
     m1[:, 0] = d
     m1[:, 1:] = m
-    if sys.big_endian:
+    if sys.byteorder == 'big':
         m1.byteswap(inplace=True)
     m1.tofile(fname)
 


### PR DESCRIPTION
Summary:
Found vec_io failing when running some benchmarking.
There is no such field named big_endian in sys. So, reverting it to original field byteorder

Differential Revision: D56718607


