### PR TITLE
Add disabled linux-x86_64-AVX512-cmake build on GitHub Actions

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -25,21 +25,21 @@ runs:
       run: |
         conda config --set solver libmamba
         conda update -y -q conda
-    - name: Install env using main channel
-      if: inputs.raft == 'OFF'
+    - name: Configure conda environment
       shell: bash
       run: |
-        conda install -y -q python=3.11 cmake make swig mkl=2023 mkl-devel=2023 numpy scipy pytest gxx_linux-64=11.2 sysroot_linux-64
-    - name: Install env using conda-forge channel
-      if: inputs.raft == 'ON'
-      shell: bash
-      run: |
-        conda install -y -q python=3.11 cmake make swig mkl=2023 mkl-devel=2023 numpy scipy pytest gxx_linux-64=11.2 sysroot_linux-64=2.28 libraft cuda-version=11.8 cuda-toolkit -c rapidsai-nightly -c "nvidia/label/cuda-11.8.0" -c conda-forge
+        conda install -y -q -c conda-forge gxx_linux-64=11.2 sysroot_linux-64=2.28
+        conda install -y -q python=3.11 cmake make swig mkl=2023 mkl-devel=2023 numpy scipy pytest
     - name: Install CUDA
       if: inputs.gpu == 'ON' && inputs.raft == 'OFF'
       shell: bash
       run: |
         conda install -y -q cuda-toolkit -c "nvidia/label/cuda-11.8.0"
+    - name: Install RAFT
+      if: inputs.raft == 'ON'
+      shell: bash
+      run: |
+        conda install -y -q libraft cuda-version=11.8 cuda-toolkit -c rapidsai-nightly -c "nvidia/label/cuda-11.8.0" -c conda-forge
     - name: Build all targets
       shell: bash
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,15 @@ jobs:
       - uses: ./.github/actions/build_cmake
         with:
           opt_level: avx2
+  linux-x86_64-AVX512-cmake:
+    if: false # TODO: enable when GitHub Actions adds AVX-512 hosts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_cmake
+        with:
+          opt_level: avx512
   linux-x86_64-GPU-cmake:
     needs: linux-x86_64-AVX2-cmake
     runs-on: 4-core-ubuntu-gpu-t4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,15 @@ jobs:
       - uses: ./.github/actions/build_cmake
         with:
           opt_level: avx2
+  linux-x86_64-GPU-cmake:
+    needs: linux-x86_64-AVX2-cmake
+    runs-on: 4-core-ubuntu-gpu-t4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/build_cmake
+        with:
+          gpu: ON
   linux-x86_64-GPU-w-RAFT-cmake:
     runs-on: 4-core-ubuntu-gpu-t4
     steps:


### PR DESCRIPTION
Summary: GitHub Actions currently does not support runners with AVX-512  but committed to add this support in early 2025. We will be running these on CircleCI until then. This placeholder build configuration will allow us to enable it with a 1-liner when the hosts are available.

Differential Revision: D57261783
