### PR TITLE
Delete Raft Handle

### DIFF
--- a/faiss/gpu/StandardGpuResources.cpp
+++ b/faiss/gpu/StandardGpuResources.cpp
@@ -260,9 +260,9 @@ void StandardGpuResourcesImpl::setDefaultStream(
 #if defined USE_NVIDIA_RAFT
         // delete the raft handle for this device, which will be initialized
         // with the updated stream during any subsequent calls to getRaftHandle
-        auto it = raftHandles_.find(device);
-        if (it != raftHandles_.end()) {
-            raftHandles_.erase(it);
+        auto it2 = raftHandles_.find(device);
+        if (it2 != raftHandles_.end()) {
+            raftHandles_.erase(it2);
         }
 #endif
     }
@@ -286,9 +286,9 @@ void StandardGpuResourcesImpl::revertDefaultStream(int device) {
 #if defined USE_NVIDIA_RAFT
         // delete the raft handle for this device, which will be initialized
         // with the updated stream during any subsequent calls to getRaftHandle
-        auto it = raftHandles_.find(device);
-        if (it != raftHandles_.end()) {
-            raftHandles_.erase(it);
+        auto it2 = raftHandles_.find(device);
+        if (it2 != raftHandles_.end()) {
+            raftHandles_.erase(it2);
         }
 #endif
     }

--- a/faiss/gpu/StandardGpuResources.cpp
+++ b/faiss/gpu/StandardGpuResources.cpp
@@ -257,6 +257,14 @@ void StandardGpuResourcesImpl::setDefaultStream(
         if (prevStream != stream) {
             streamWait({stream}, {prevStream});
         }
+#if defined USE_NVIDIA_RAFT
+        // delete the raft handle for this device, which will be initialized
+        // with the updated stream during any subsequent calls to getRaftHandle
+        auto it = raftHandles_.find(device);
+        if (it != raftHandles_.end()) {
+            raftHandles_.erase(it);
+        }
+#endif
     }
 
     userDefaultStreams_[device] = stream;
@@ -275,6 +283,14 @@ void StandardGpuResourcesImpl::revertDefaultStream(int device) {
 
             streamWait({newStream}, {prevStream});
         }
+#if defined USE_NVIDIA_RAFT
+        // delete the raft handle for this device, which will be initialized
+        // with the updated stream during any subsequent calls to getRaftHandle
+        auto it = raftHandles_.find(device);
+        if (it != raftHandles_.end()) {
+            raftHandles_.erase(it);
+        }
+#endif
     }
 
     userDefaultStreams_.erase(device);


### PR DESCRIPTION
Small Raft related modification to StandardGpuResources:
if the stream for a particular device is modified by a user, delete the Raft handle for that device. On any subsequent call to `getRaftHandle(device)`, a new raft handle with the updated stream will be created.
Closes https://github.com/facebookresearch/faiss/issues/3424