### PR TITLE
Remove unused variables in faiss/IndexIVFFastScan.cpp

### DIFF
--- a/faiss/IndexIVFFastScan.cpp
+++ b/faiss/IndexIVFFastScan.cpp
@@ -914,10 +914,6 @@ void IndexIVFFastScan::search_implem_10(
         size_t* nlist_out,
         const NormTableScaler* scaler,
         const IVFSearchParameters* params) const {
-    const size_t max_codes = params ? params->max_codes : this->max_codes;
-    const SearchParameters* quantizer_params =
-            params ? params->quantizer_params : nullptr;
-
     size_t dim12 = ksub * M2;
     AlignedTable<uint8_t> dis_tables;
     AlignedTable<uint16_t> biases;

--- a/tutorial/cpp/6-HNSW.cpp
+++ b/tutorial/cpp/6-HNSW.cpp
@@ -37,7 +37,6 @@ int main() {
         xq[d * i] += i / 1000.;
     }
 
-    int nlist = 100;
     int k = 4;
 
     faiss::IndexHNSWFlat index(d, 32);


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code, or (b) qualifies the variable with `[[maybe_unused]]`, mostly in cases where the variable _is_ used, but, eg, in an `assert` statement that isn't present in production code.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D57344013


