### PR TITLE
Delete unnecessary print(f) functions in Tests

### DIFF
--- a/tests/common_faiss_tests.py
+++ b/tests/common_faiss_tests.py
@@ -49,7 +49,6 @@ class Randu10k:
         for rank in 1, 10, 100:
             e[rank] = ((I[:, :rank] == self.gt.reshape(-1, 1)).sum() /
                        float(self.nq))
-        # print("1-recalls: %s" % e)
         return e
 
 

--- a/tests/test_RCQ_cropping.cpp
+++ b/tests/test_RCQ_cropping.cpp
@@ -28,7 +28,6 @@ TEST(RCQCropping, test_cropping) {
     faiss::ResidualCoarseQuantizer rcq(d, nbits);
 
     rcq.train(nt, xt);
-    // fprintf(stderr, "nb centroids: %zd\n", rcq.ntotal);
 
     // the test below works only for beam size == nprobe
     rcq.set_beam_factor(1.0);
@@ -44,7 +43,6 @@ TEST(RCQCropping, test_cropping) {
     nbits.pop_back();
     faiss::ResidualCoarseQuantizer rcq_cropped(d, nbits);
     rcq_cropped.initialize_from(rcq);
-    // fprintf(stderr, "cropped nb centroids: %zd\n", rcq_cropped.ntotal);
 
     EXPECT_EQ(rcq_cropped.ntotal, rcq.ntotal >> last_nbits);
 

--- a/tests/test_approx_topk.cpp
+++ b/tests/test_approx_topk.cpp
@@ -32,9 +32,6 @@ void test_approx_topk(
         const uint32_t k,
         const uint32_t nDatasetsToTest,
         const bool verbose) {
-    if (verbose) {
-        printf("-----------\n");
-    }
 
     // generate random data
     std::default_random_engine rng(123);
@@ -100,10 +97,6 @@ void test_approx_topk(
                     approxDistances.data(),
                     approxIndices.data());
         } catch (const faiss::FaissException&) {
-            //
-            if (verbose) {
-                printf("Skipping the case.\n");
-            }
             return;
         }
 
@@ -124,15 +117,6 @@ void test_approx_topk(
                 sqrError += diff * diff;
 
                 bGotMismatches = true;
-
-                if (verbose) {
-                    printf("i=%d, bs.d=%f, bs.i=%d, app.d=%f, app.i=%d\n",
-                           i,
-                           baselineDistances[i],
-                           baselineIndices[i],
-                           approxDistances[i],
-                           approxIndices[i]);
-                }
             } else {
                 if (baselineIndices[i] != approxIndices[i]) {
                     nSoftMismatches += 1;
@@ -143,9 +127,6 @@ void test_approx_topk(
         }
 
         if (bGotMismatches) {
-            if (verbose) {
-                printf("\n");
-            }
         }
 
         //
@@ -159,24 +140,6 @@ void test_approx_topk(
                 nMissed += 1;
             }
         }
-    }
-
-    if (verbose) {
-        printf("%d, %d, %d, %d, %d, %d: %ld, %ld, %ld, %f, %ld, %ld, %f, %f\n",
-               NBUCKETS,
-               N,
-               beamSize,
-               nPerBeam,
-               k,
-               nDatasetsToTest,
-               nMatches,
-               nSoftMismatches,
-               nHardMismatches,
-               sqrError,
-               nAvailable,
-               nMissed,
-               timeBaseline,
-               timeApprox);
     }
 
     // just confirm that the error is not crazy

--- a/tests/test_binary_hashindex.py
+++ b/tests/test_binary_hashindex.py
@@ -58,7 +58,6 @@ class TestRange(unittest.TestCase):
 
         Lref, Dref, Iref = index_ref.range_search(xq, radius)
 
-        print("nb res: ", Lref[-1])
 
         index = faiss.IndexBinaryHash(d, 10)
         index.add(xb)
@@ -80,8 +79,6 @@ class TestRange(unittest.TestCase):
                 self.assertTrue(snew <= set(ref))
             nfound.append(Lnew[-1])
             ndis.append(stats.ndis)
-        print('nfound=', nfound)
-        print('ndis=', ndis)
         nfound = np.array(nfound)
         self.assertTrue(nfound[-1] == Lref[-1])
         self.assertTrue(np.all(nfound[1:] >= nfound[:-1]))
@@ -99,8 +96,6 @@ class TestRange(unittest.TestCase):
         radius = 55
 
         Lref, Dref, Iref = index_ref.range_search(xq, radius)
-
-        print("nb res: ", Lref[-1])
 
         nfound = []
         ndis = []
@@ -123,8 +118,6 @@ class TestRange(unittest.TestCase):
                 self.assertTrue(snew <= set(ref))
             nfound.append(Lnew[-1])
             ndis.append(stats.ndis)
-        print('nfound=', nfound)
-        print('ndis=', ndis)
         nfound = np.array(nfound)
         # self.assertTrue(nfound[-1] == Lref[-1])
         self.assertTrue(np.all(nfound[1:] >= nfound[:-1]))
@@ -163,7 +156,6 @@ class TestKnn(unittest.TestCase):
                     # no duplicates
                     self.assertTrue(len(new) == len(snew))
                     nf += len(set(ref) & snew)
-                print('nfound', nh, nbit, nf)
                 nfound[(nh, nbit)] = nf
             self.assertGreater(nfound[(nh, 4)], nfound[(nh, 7)])
 
@@ -175,7 +167,6 @@ class TestKnn(unittest.TestCase):
             np.testing.assert_array_equal(Inew, I2)
             np.testing.assert_array_equal(Dnew, D2)
 
-        print('nfound=', nfound)
         self.assertGreater(3, abs(nfound[(0, 7)] - nfound[(1, 7)]))
         self.assertGreater(nfound[(3, 7)], nfound[(1, 7)])
         self.assertGreater(nfound[(5, 7)], nfound[(3, 7)])

--- a/tests/test_build_blocks.py
+++ b/tests/test_build_blocks.py
@@ -189,7 +189,6 @@ class TestNyFuncs(unittest.TestCase):
         for d in 1, 2, 4, 8, 12, 16:
             x = rs.rand(d).astype('float32')
             for ny in 128, 129, 130:
-                print("d=%d ny=%d" % (d, ny))
                 y = rs.rand(ny, d).astype('float32')
                 ref = ((x - y) ** 2).sum(1)
                 new = np.zeros(ny, dtype='float32')
@@ -204,7 +203,6 @@ class TestNyFuncs(unittest.TestCase):
         for d in 1, 2, 4, 8, 12, 16:
             x = rs.rand(d).astype('float32')
             for ny in 128, 129, 130:
-                print("d=%d ny=%d" % (d, ny))
                 y = rs.rand(ny, d).astype('float32')
                 ref = (x * y).sum(1)
                 new = np.zeros(ny, dtype='float32')
@@ -220,7 +218,6 @@ class TestMatrixStats(unittest.TestCase):
         m = rs.rand(40, 20).astype('float32')
         m[5:10] = 0
         comments = faiss.MatrixStats(m).comments
-        print(comments)
         assert 'has 5 copies' in comments
         assert '5 null vectors' in comments
 
@@ -229,7 +226,6 @@ class TestMatrixStats(unittest.TestCase):
         m = rs.rand(40, 20).astype('float32')
         m[::2] = m[1::2]
         comments = faiss.MatrixStats(m).comments
-        print(comments)
         assert '20 vectors are distinct' in comments
 
     def test_dead_dims(self):
@@ -237,7 +233,6 @@ class TestMatrixStats(unittest.TestCase):
         m = rs.rand(40, 20).astype('float32')
         m[:, 5:10] = 0
         comments = faiss.MatrixStats(m).comments
-        print(comments)
         assert '5 dimensions are constant' in comments
 
     def test_rogue_means(self):
@@ -245,7 +240,6 @@ class TestMatrixStats(unittest.TestCase):
         m = rs.rand(40, 20).astype('float32')
         m[:, 5:10] += 12345
         comments = faiss.MatrixStats(m).comments
-        print(comments)
         assert '5 dimensions are too large wrt. their variance' in comments
 
     def test_normalized(self):
@@ -253,7 +247,6 @@ class TestMatrixStats(unittest.TestCase):
         m = rs.rand(40, 20).astype('float32')
         faiss.normalize_L2(m)
         comments = faiss.MatrixStats(m).comments
-        print(comments)
         assert 'vectors are normalized' in comments
 
     def test_hash(self):
@@ -300,7 +293,6 @@ class TestScalarQuantizer(unittest.TestCase):
                 D, I = index.search(x[3:], 1)
 
                 # assert D[0, 0] == Dref[0, 0]
-                # print(D[0, 0], ((x[3] - x[2]) ** 2).sum())
                 assert D[0, 0] == ((x[3] - x[2]) ** 2).sum()
 
     def test_6bit_equiv(self):
@@ -313,8 +305,6 @@ class TestScalarQuantizer(unittest.TestCase):
             index = faiss.IndexScalarQuantizer(
                 d, faiss.ScalarQuantizer.QT_6bit)
             index.train(trainset)
-
-            print('cs=', index.code_size)
 
             x = rs.randint(64, size=(100, d)).astype('float32')
 
@@ -330,7 +320,6 @@ class TestScalarQuantizer(unittest.TestCase):
             for i in range(20):
                 for j in range(10):
                     dis = ((y[i] - x2[I[i, j]]) ** 2).sum()
-                    # print(dis, D[i, j])
                     assert abs(D[i, j] - dis) / dis < 1e-5
 
     def test_reconstruct(self):
@@ -371,7 +360,6 @@ class TestRandom(unittest.TestCase):
         x = faiss.randint(20000, vmax=100)
         assert np.all(x >= 0) and np.all(x < 100)
         c = np.bincount(x, minlength=100)
-        print(c)
         assert c.max() - c.min() < 50 * 2
 
     def test_rand_vector(self):
@@ -473,7 +461,6 @@ class TestSWIGWrap(unittest.TestCase):
         """ tests swig_ptr and rev_swig_ptr for this type of array """
         a = np.arange(12).astype(dtype)
         ptr = faiss.swig_ptr(a)
-        print(ptr)
         a2 = faiss.rev_swig_ptr(ptr, 12)
         np.testing.assert_array_equal(a, a2)
 
@@ -547,7 +534,6 @@ class TestNNDescentKNNG(unittest.TestCase):
                         recalls += 1
                         break
         recall = 1.0 * recalls / (nb * K)
-        print('Metric: {}, knng accuracy: {}'.format(metric_names[metric], recall))
         assert recall > 0.99
 
     def test_small_nndescent(self):
@@ -656,7 +642,6 @@ class TestBucketSort(unittest.TestCase):
             rows, _ = np.where(tab == b)
             rows.sort()
             tab2[lims[b]:lims[b + 1]].sort()
-            # print(rows, tab2[lims[b] : lims[b + 1]])
             rows = set(rows)
             self.assertEqual(rows, set(tab2[lims[b]:lims[b + 1]]))
 

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -110,9 +110,6 @@ class TestClustering(unittest.TestCase):
         cdis2_first = cdis2[:5].sum()
         cdis2_last = cdis2[5:].sum()
 
-        print(cdis1_first, cdis1_last)
-        print(cdis2_first, cdis2_last)
-
         # with the new clustering, the last should be much (*2) closer
         # to their centroids
         self.assertGreater(cdis1_last, cdis1_first * 2)

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -147,7 +147,6 @@ class TestExhaustiveSearch(unittest.TestCase):
         xb = ds.get_database()
         D, I = faiss.knn(xq, xb, 10, metric=metric)
         threshold = float(D[:, -1].mean())
-        print(threshold)
 
         index = faiss.IndexFlat(32, metric)
         index.add(xb)
@@ -251,7 +250,6 @@ class TestRangeEval(unittest.TestCase):
         Inew = np.hstack(Inew)
 
         precision, recall = evaluation.range_PR(lims_ref, Iref, lims_new, Inew)
-        print(precision, recall)
 
         self.assertEqual(precision, 0.6)
         self.assertEqual(recall, 0.6)

--- a/tests/test_contrib_with_scipy.py
+++ b/tests/test_contrib_with_scipy.py
@@ -44,7 +44,6 @@ class TestClustering(unittest.TestCase):
         faiss.normalize_L2(xt)
 
         mask = np.abs(xt) > 0.045
-        # print("fraction:", mask.sum() / mask.size) # around 10% non-zeros
         xt[np.logical_not(mask)] = 0
 
         centroids = ds.get_queries()
@@ -72,7 +71,6 @@ class TestClustering(unittest.TestCase):
         faiss.normalize_L2(xt)
 
         mask = np.abs(xt) > 0.045
-        # print("fraction:", mask.sum() / mask.size) # around 10% non-zeros
         xt[np.logical_not(mask)] = 0
 
         km = faiss.Kmeans(ds.d, 50)

--- a/tests/test_graph_based.py
+++ b/tests/test_graph_based.py
@@ -209,7 +209,6 @@ class TestNSG(unittest.TestCase):
         Dnsg, Insg = index.search(self.xq, 1)
 
         recalls = (Iref == Insg).sum()
-        print('metric: {}, nb equal: {}'.format(metrics[metric], recalls))
         self.assertGreaterEqual(recalls, thresh)
         self.subtest_connectivity(index, self.xb.shape[0])
         self.subtest_io_and_clone(index, Dnsg, Insg)
@@ -230,7 +229,6 @@ class TestNSG(unittest.TestCase):
         Dnsg, Insg = index.search(self.xq, 1)
 
         recalls = (Iref == Insg).sum()
-        print('metric: {}, nb equal: {}'.format(metrics[metric], recalls))
         self.assertGreaterEqual(recalls, thresh)
         self.subtest_connectivity(index, self.xb.shape[0])
 
@@ -286,7 +284,6 @@ class TestNSG(unittest.TestCase):
         index.add(self.xb)
         Dnsg, Insg = index.search(self.xq, 1)
         recalls = (Iref == Insg).sum()
-        print('metric: {}, nb equal: {}'.format(metrics[metric], recalls))
         self.assertGreaterEqual(recalls, 475)
         self.subtest_connectivity(index, self.xb.shape[0])
 
@@ -294,7 +291,6 @@ class TestNSG(unittest.TestCase):
         index.add(self.xb)
         Dnsg, Insg = index.search(self.xq, 1)
         recalls = (Iref == Insg).sum()
-        print('metric: {}, nb equal: {}'.format(metrics[metric], recalls))
         self.assertGreaterEqual(recalls, 475)
         self.subtest_connectivity(index, self.xb.shape[0])
 
@@ -335,7 +331,6 @@ class TestNSG(unittest.TestCase):
 
         # test accuracy
         recalls = (Iref == I).sum()
-        print("IndexNSGPQ", recalls)
         self.assertGreaterEqual(recalls, 190)  # 193
 
         # test I/O
@@ -361,7 +356,6 @@ class TestNSG(unittest.TestCase):
 
         # test accuracy
         recalls = (Iref == I).sum()
-        print("IndexNSGSQ", recalls)
         self.assertGreaterEqual(recalls, 405)  # 411
 
         # test I/O
@@ -395,7 +389,6 @@ class TestNNDescent(unittest.TestCase):
 
         # test accuracy
         recalls = (Iref == I).sum()
-        print("IndexNNDescentFlat", recalls)
         self.assertGreaterEqual(recalls, 450)  # 462
 
         # do some IO tests

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -338,7 +338,6 @@ class TestScalarQuantizer(unittest.TestCase):
             D, I = index.search(xq, 10)
 
             nok[qname] = (I[:, 0] == I_ref[:, 0]).sum()
-        print(nok, nq)
 
         self.assertGreaterEqual(nok['flat'], nq * 0.6)
         # The tests below are a bit fragile, it happens that the
@@ -372,8 +371,6 @@ class TestScalarQuantizer(unittest.TestCase):
             index.add(xb)
             D, I = index.search(xq, 10)
             nok[qname] = (I[:, 0] == I_ref[:, 0]).sum()
-
-        print(nok, nq)
 
         self.assertGreaterEqual(nok['QT_8bit'], nq * 0.9)
         self.assertGreaterEqual(nok['QT_8bit'], nok['QT_4bit'])
@@ -442,7 +439,6 @@ class TestSearchAndReconstruct(unittest.TestCase):
 
         recons_err = np.mean(norm1(R_flat - xb[I_flat]))
 
-        print('Reconstruction error = %.3f' % recons_err)
         if eps is not None:
             self.assertLessEqual(recons_err, eps)
 
@@ -638,7 +634,6 @@ class TestReconsException(unittest.TestCase):
 
         # should not raise an exception
         index.reconstruct(5)
-        print(index.ntotal)
         index.reconstruct(150)
 
 

--- a/tests/test_index_accuracy.py
+++ b/tests/test_index_accuracy.py
@@ -56,7 +56,6 @@ class IndexAccuracy(unittest.TestCase):
         Dref, Iref = ivfk.search(ev.xq, 100)
         ivfk.parallel_mode = 1
         Dnew, Inew = ivfk.search(ev.xq, 100)
-        print((Iref != Inew).sum(), Iref.size)
         assert (Iref != Inew).sum() < Iref.size / 5000.0
         assert np.all(Dref == Dnew)
 
@@ -136,8 +135,6 @@ class IndexAccuracy(unittest.TestCase):
 
         res = ev.launch("Polysemous ht=%d" % index.polysemous_ht, index)
         e_polysemous = ev.evalres(res)
-        print(e_baseline, e_polysemous, index.polysemous_ht)
-        print(stats.n_hamming_pass, stats.ncode)
         # The randu dataset is difficult, so we are not too picky on
         # the results. Here we assert that we have < 10 % loss when
         # computing full PQ on fewer than 20% of the data.
@@ -248,7 +245,6 @@ class TestSQFlavors(unittest.TestCase):
             index.nprobe = 4  # hopefully more robust than 1
             D, I = index.search(xq, 10)
             ninter = faiss.eval_intersection(I, gt_I)
-            print("(%d, %s): %d, " % (mt, repr(qname), ninter))
             assert abs(ninter - self.ref_results[(mt, qname)]) <= 10
 
             if qname == "6bit":
@@ -264,7 +260,6 @@ class TestSQFlavors(unittest.TestCase):
                 radius = float(D[:, -1].max())
             else:
                 radius = float(D[:, -1].min())
-            # print("radius", radius)
 
             lims, D3, I3 = index.range_search(xq, radius)
             ntot = ndiff = 0
@@ -278,14 +273,11 @@ class TestSQFlavors(unittest.TestCase):
                 Iref = set(I2[i, mask])
                 ndiff += len(Inew ^ Iref)
                 ntot += len(Iref)
-            # print("ndiff %d / %d" % (ndiff, ntot))
             assert ndiff < ntot * 0.01
 
             for pm in 1, 2:
-                # print("parallel_mode=%d" % pm)
                 index.parallel_mode = pm
                 lims4, D4, I4 = index.range_search(xq, radius)
-                # print("sizes", lims4[1:] - lims4[:-1])
                 for qno in range(len(lims) - 1):
                     Iref = I3[lims[qno]: lims[qno + 1]]
                     Inew = I4[lims4[qno]: lims4[qno + 1]]
@@ -431,11 +423,7 @@ class TestNNDescent(unittest.TestCase):
                         recalls += 1
                         break
         recall = 1.0 * recalls / (nq * topk)
-        print(
-            "Metric: {}, L: {}, Recall@{}: {}".format(
-                metric_names[metric], search_L, topk, recall
-            )
-        )
+
         assert recall > threshold, "{} <= {}".format(recall, threshold)
 
 
@@ -485,7 +473,6 @@ class TestPQFlavors(unittest.TestCase):
             D, I = index.search(xq, 10)
 
             ninter = faiss.eval_intersection(I, gt_I)
-            print("(%d, %s): %d, " % (mt, by_residual, ninter))
 
             assert abs(ninter - self.ref_results[mt, by_residual]) <= 3
 
@@ -499,10 +486,6 @@ class TestPQFlavors(unittest.TestCase):
                 index.polysemous_ht = 20
                 D, I = index.search(xq, 10)
                 ninter = faiss.eval_intersection(I, gt_I)
-                print(
-                    "(%d, %s, %d): %d, "
-                    % (mt, by_residual, index.polysemous_ht, ninter)
-                )
 
                 # polysemous behaves bizarrely on ARM
                 assert (
@@ -516,7 +499,6 @@ class TestPQFlavors(unittest.TestCase):
                 radius = float(D[:, -1].max())
             else:
                 radius = float(D[:, -1].min())
-            print("radius", radius)
 
             lims, D3, I3 = index.range_search(xq, radius)
             ntot = ndiff = 0
@@ -530,7 +512,6 @@ class TestPQFlavors(unittest.TestCase):
                 Iref = set(I2[i, mask])
                 ndiff += len(Inew ^ Iref)
                 ntot += len(Iref)
-            print("ndiff %d / %d" % (ndiff, ntot))
             assert ndiff < ntot * 0.02
 
     def test_IVFPQ_non8bit(self):
@@ -555,7 +536,6 @@ class TestPQFlavors(unittest.TestCase):
 
             D, I = index.search(xq, 10)
             ninter[v] = faiss.eval_intersection(I, gt_I)
-        print("ninter=", ninter)
         # this should be the case but we don't observe
         # that... Probavly too few test points
         #  assert ninter['2x8'] > ninter['8x2']
@@ -623,9 +603,6 @@ class OPQRelativeAccuracy(unittest.TestCase):
         res = ev.launch("OPQ", index)
         e_opq = ev.evalres(res)
 
-        print("e_pq=%s" % e_pq)
-        print("e_opq=%s" % e_opq)
-
         # verify that OPQ better than PQ
         for r in 1, 10, 100:
             assert e_opq[r] > e_pq[r]
@@ -656,7 +633,6 @@ class OPQRelativeAccuracy(unittest.TestCase):
 
         # verify same on OIVFPQ
         for r in 1, 10, 100:
-            print(e_oivfpq[r], e_ivfpq[r])
             assert e_oivfpq[r] >= e_ivfpq[r]
 
 
@@ -738,8 +714,6 @@ class TestSpectralHash(unittest.TestCase):
             D, I = index_lsh.search(xq, 10)
             ninter = faiss.eval_intersection(I, gt_I)
 
-            print("LSH baseline: %d" % ninter)
-
             for period in 10.0, 1.0:
 
                 for tt in "global centroid centroid_half median".split():
@@ -758,9 +732,6 @@ class TestSpectralHash(unittest.TestCase):
                     ninter = faiss.eval_intersection(I, gt_I)
                     key = (nbit, tt, period)
 
-                    print("(%d, %s, %g): %d, " % (nbit, repr(tt), period,
-                                                  ninter))
-                    print(abs(ninter - self.ref_results[key]))
                     assert abs(ninter - self.ref_results[key]) <= 14
 
 
@@ -799,7 +770,6 @@ class TestRefine(unittest.TestCase):
         # check that with refinement, the recall@10 is the same as
         # the original recall@100
         recall2 = (I2 == Iref[:, :1]).sum()
-        # print("recalls", recall1, recall2)
         self.assertEqual(recall1, recall2)
 
     def test_IP(self):

--- a/tests/test_index_composite.py
+++ b/tests/test_index_composite.py
@@ -168,8 +168,6 @@ class TestRemove(unittest.TestCase):
         index.remove_ids(remove_set)
         index.add_with_ids(X[5:, :], idx[5:])
 
-        print (index.search(X, 1))
-
         for i in range(10):
             _, searchres = index.search(X[i:i + 1, :], 1)
             if idx[i] in remove_set:
@@ -856,7 +854,6 @@ class TestSearchAndReconstruct(unittest.TestCase):
 
         recons_err = np.mean(norm1(R_flat - xb[I_flat]))
 
-        print('Reconstruction error = %.3f' % recons_err)
         if eps is not None:
             self.assertLessEqual(recons_err, eps)
 
@@ -954,7 +951,6 @@ class TestSearchAndGetCodes(unittest.TestCase):
         index.nprobe = 10
         Dref, Iref = index.search(ds.get_queries(), 10)
 
-        #print(index.search_and_return_codes)
         D, I, codes = index.search_and_return_codes(
             ds.get_queries(), 10, include_listnos=True)
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -102,7 +102,6 @@ class TestCallbacks(unittest.TestCase):
                 reader = faiss.BufferedIOReader(reader, bsz)
 
                 y = np.zeros_like(x)
-                print('nbytes=', y.nbytes)
                 reader(faiss.swig_ptr(y), y.nbytes, 1)
 
             np.testing.assert_array_equal(x, y)

--- a/tests/test_ivflib.py
+++ b/tests/test_ivflib.py
@@ -125,7 +125,7 @@ class TestSearchWithParameters(unittest.TestCase):
 
         Dpre, _ = index.search(xq, 15)
         radius = float(np.median(Dpre[:, -1]))
-        print("Radius=", radius)
+
         stats = faiss.cvar.indexIVF_stats
         stats.reset()
         Lref, Dref, Iref = index.range_search(xq, radius)

--- a/tests/test_local_search_quantizer.py
+++ b/tests/test_local_search_quantizer.py
@@ -195,8 +195,6 @@ class TestComponents(unittest.TestCase):
         lsq.train(xt)
         err_float = eval_codec(lsq, xb)
 
-        # 6533.377 vs 25457.99
-        print(err_double, err_float)
         self.assertLess(err_double, err_float)
 
     def test_compute_binary_terms(self):
@@ -348,7 +346,6 @@ class TestLocalSearchQuantizer(unittest.TestCase):
         pq.train(xt)
         err_pq = eval_codec(pq, xb)
 
-        print(err_lsq, err_pq)
         self.assertLess(err_lsq, err_pq)
 
 
@@ -463,7 +460,6 @@ class TestIndexIVFLocalSearchQuantizer(unittest.TestCase):
             index.nprobe = nprobe
             D, I = index.search(ds.get_queries(), 10)
             inter = faiss.eval_intersection(I, ds.get_groundtruth(10))
-            # print("nprobe=", nprobe, "inter=", inter)
             inters.append(inter)
 
         inters = np.array(inters)
@@ -528,7 +524,6 @@ class TestProductLocalSearchQuantizer(unittest.TestCase):
         pq.train(xt)
         err_pq = eval_codec(pq, xb)
 
-        print(err_plsq, err_pq)
         self.assertLess(err_plsq, err_pq)
 
     def test_with_lsq(self):
@@ -549,7 +544,6 @@ class TestProductLocalSearchQuantizer(unittest.TestCase):
         lsq.train(xt)
         err_lsq = eval_codec(lsq, xb)
 
-        print(err_plsq, err_lsq)
         self.assertEqual(err_plsq, err_lsq)
 
     def test_lut(self):
@@ -664,7 +658,6 @@ class TestIndexIVFProductLocalSearchQuantizer(unittest.TestCase):
         """check that the error is in the same ballpark as LSQ."""
         inter1 = self.eval_index_accuracy("IVF32,PLSQ2x2x5_Nqint8")
         inter2 = self.eval_index_accuracy("IVF32,LSQ4x5_Nqint8")
-        # print(inter1, inter2)  # 381 vs 374
         self.assertGreaterEqual(inter1 * 1.1, inter2)
 
     def test_factory(self):

--- a/tests/test_lowlevel_ivf.cpp
+++ b/tests/test_lowlevel_ivf.cpp
@@ -364,21 +364,9 @@ void test_lowlevel_access_binary(const char* index_key) {
             }
         }
 
-        printf("new before reroder: [");
-        for (int j = 0; j < k; j++)
-            printf("%" PRId64 ",%d ", I[j], D[j]);
-        printf("]\n");
-
         // re-order heap
         heap_reorder<CMax<int32_t, idx_t>>(k, D.data(), I.data());
 
-        printf("ref: [");
-        for (int j = 0; j < k; j++)
-            printf("%" PRId64 ",%d ", I_ref[j], D_ref[j]);
-        printf("]\nnew: [");
-        for (int j = 0; j < k; j++)
-            printf("%" PRId64 ",%d ", I[j], D[j]);
-        printf("]\n");
 
         // check that we have the same results as the reference search
         for (int j = 0; j < k; j++) {

--- a/tests/test_mem_leak.cpp
+++ b/tests/test_mem_leak.cpp
@@ -51,16 +51,9 @@ TEST(MEM_LEAK, ivfflat) {
                     D.data(),
                     I.data());
             if (i % 100 == 0) {
-                printf("[%.2f s] BS %d %d: %ld kB %.2f bytes/it\r",
-                       (getmillisecs() - t0) / 1000,
-                       bs,
-                       i,
-                       get_mem_usage_kb(),
-                       (get_mem_usage_kb() - m0) * 1024.0 / (i + 1));
                 fflush(stdout);
             }
         }
-        printf("\n");
         EXPECT_GE(50 * bs, (get_mem_usage_kb() - m0) * 1024.0 / N2);
     }
 }

--- a/tests/test_merge_index.py
+++ b/tests/test_merge_index.py
@@ -49,10 +49,8 @@ class TestMerge1(unittest.TestCase):
         # trains the quantizer
         ref_index.train(xt)
 
-        print('ref search')
         ref_index.add(xb)
         _Dref, Iref = ref_index.search(xq, k)
-        print(Iref[:5, :6])
 
         indexes = []
         ni = 3
@@ -67,15 +65,11 @@ class TestMerge1(unittest.TestCase):
         index = indexes[0]
 
         for i in range(1, ni):
-            print('merge ntotal=%d other.ntotal=%d ' % (
-                index.ntotal, indexes[i].ntotal))
             index.merge_from(indexes[i], index.ntotal)
 
         _D, I = index.search(xq, k)
-        print(I[:5, :6])
 
         ndiff = (I != Iref).sum()
-        print('%d / %d differences' % (ndiff, nq * k))
         assert (ndiff < nq * k / 1000.)
 
     def test_merge(self):
@@ -101,7 +95,6 @@ class TestMerge1(unittest.TestCase):
             id_list = gen.permutation(nb * 7)[:nb].astype('int64')
             index.add_with_ids(xb, id_list)
 
-        print('ref search ntotal=%d' % index.ntotal)
         Dref, Iref = index.search(xq, k)
 
         toremove = np.zeros(nq * k, dtype='int64')
@@ -114,17 +107,11 @@ class TestMerge1(unittest.TestCase):
                     nr = nr + 1
                     toremove[nr] = Iref[i, j]
 
-        print('nr=', nr)
-
         idsel = faiss.IDSelectorBatch(
             nr, faiss.swig_ptr(toremove))
 
         for i in range(nr):
             assert (idsel.is_member(int(toremove[i])))
-
-        nremoved = index.remove_ids(idsel)
-
-        print('nremoved=%d ntotal=%d' % (nremoved, index.ntotal))
 
         D, I = index.search(xq, k)
 

--- a/tests/test_meta_index.py
+++ b/tests/test_meta_index.py
@@ -82,10 +82,8 @@ class Shards(unittest.TestCase):
         k = 32
         ref_index = faiss.IndexFlatL2(d)
 
-        print('ref search')
         ref_index.add(xb)
         _Dref, Iref = ref_index.search(xq, k)
-        print(Iref[:5, :6])
 
         shard_index = faiss.IndexShards(d)
         shard_index_2 = faiss.IndexShards(d, True, False)
@@ -109,7 +107,6 @@ class Shards(unittest.TestCase):
         for test_no in range(3):
             with_threads = test_no == 1
 
-            print('shard search test_no = %d' % test_no)
             if with_threads:
                 remember_nt = faiss.omp_get_max_threads()
                 faiss.omp_set_num_threads(1)
@@ -122,14 +119,11 @@ class Shards(unittest.TestCase):
             else:
                 _D, I = shard_index_2.search(xq, k)
 
-            print(I[:5, :6])
-
             if with_threads:
                 faiss.omp_set_num_threads(remember_nt)
 
             ndiff = (I != Iref).sum()
 
-            print('%d / %d differences' % (ndiff, nq * k))
             assert (ndiff < nq * k / 1000.)
 
     def test_shards_ivf(self):

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -49,7 +49,6 @@ class TestPartitioningFloat(unittest.TestCase, PartitionTests):
         if seed is None:
             for i in range(50):
                 self.do_partition(n, q, maxval, i + 1234)
-        # print("seed=", seed)
         rs = np.random.RandomState(seed)
         if maxval is None:
             vals = rs.rand(n).astype('float32')
@@ -95,7 +94,6 @@ class TestPartitioningFloatMin(unittest.TestCase, PartitionTests):
         if seed is None:
             for i in range(50):
                 self.do_partition(n, q, maxval, i + 1234)
-        # print("seed=", seed)
         rs = np.random.RandomState(seed)
         if maxval is None:
             vals = rs.rand(n).astype('float32')
@@ -148,7 +146,6 @@ class TestPartitioningUint16(unittest.TestCase, PartitionTests):
             for i in range(50):
                 self.do_partition(n, q, maxval, i + 1234)
 
-        # print("seed=", seed)
         rs = np.random.RandomState(seed)
         vals = rs.randint(maxval, size=n).astype('uint16')
         ids = (rs.permutation(n) + 12345).astype('int64')
@@ -160,7 +157,6 @@ class TestPartitioningUint16(unittest.TestCase, PartitionTests):
         tab_a = faiss.AlignedTableUint16()
         faiss.copy_array_to_AlignedTable(vals, tab_a)
 
-        # print("tab a type", tab_a.get())
         if type(q) == int:
             faiss.CMax_uint16_partition_fuzzy(
                 tab_a.get(), sp(ids), n, q, q, None)
@@ -196,7 +192,6 @@ class TestPartitioningUint16Min(unittest.TestCase, PartitionTests):
         if seed is None:
             for i in range(50):
                 self.do_partition(n, q, maxval, i + 1234)
-        # print("seed=", seed)
         rs = np.random.RandomState(seed)
         vals = rs.randint(maxval, size=n).astype('uint16')
         ids = (rs.permutation(n) + 12345).astype('int64')
@@ -209,7 +204,6 @@ class TestPartitioningUint16Min(unittest.TestCase, PartitionTests):
         vals_inv = (65535 - vals).astype('uint16')
         faiss.copy_array_to_AlignedTable(vals_inv, tab_a)
 
-        # print("tab a type", tab_a.get())
         if type(q) == int:
             faiss.CMin_uint16_partition_fuzzy(
                 tab_a.get(), sp(ids), n, q, q, None)

--- a/tests/test_product_quantizer.py
+++ b/tests/test_product_quantizer.py
@@ -26,7 +26,6 @@ class TestProductQuantizer(unittest.TestCase):
         x2 = pq.decode(codes)
         diff = ((x - x2)**2).sum()
 
-        # print("diff=", diff)
         # diff= 4418.0562
         self.assertGreater(5000, diff)
 
@@ -71,7 +70,6 @@ class TestProductQuantizer(unittest.TestCase):
 
     def test_codec(self):
         for i in range(16):
-            print("Testing nbits=%d" % (i + 1))
             self.do_test_codec(i + 1)
 
 

--- a/tests/test_residual_quantizer.py
+++ b/tests/test_residual_quantizer.py
@@ -211,7 +211,6 @@ class TestResidualQuantizer(unittest.TestCase):
 
         # in practice RQ is often better than PQ but it does not the case here, so just check
         # that we are within some factor.
-        # print(err_pq, err_rq)
         self.assertLess(err_rq, err_pq * 1.2)
 
     def test_beam_size(self):
@@ -321,10 +320,8 @@ def retrain_AQ_codebook(index, xt):
 
     x_decoded = index.sa_decode(codes_packed)
     MSE = ((xt - x_decoded) ** 2).sum() / n
-    # print(f"Initial MSE on training set: {MSE:g}")
 
     codes = unpack_codes(index.rq, codes_packed)
-    # print("ref codes", codes[0])
     codebook_offsets = faiss.vector_to_array(rq.codebook_offsets)
 
     # build sparse code matrix (represented as a dense matrix)
@@ -343,7 +340,6 @@ def retrain_AQ_codebook(index, xt):
         B, residuals, rank, singvals = scipy.linalg.lstsq(C, xt, )
 
     MSE = ((C @ B - xt) ** 2).sum() / n
-    # print(f"MSE after retrainining: {MSE:g}")
 
     # replace codebook
     # faiss.copy_array_to_vector(B.astype('float32').ravel(), index.rq.codebooks)
@@ -503,7 +499,6 @@ class TestIndexResidualQuantizer(unittest.TestCase):
         xt_decoded = ir.sa_decode(ir.sa_encode(xt))
         err_after_refined = ((xt - xt_decoded) ** 2).sum()
 
-        # print(err_before, err_after_refined)
         # ref run 7474.98 / 7006.1777
         self.assertGreater(err_before, err_after_refined * 1.06)
 
@@ -781,7 +776,6 @@ class TestIndexResidualQuantizerSearch(unittest.TestCase):
             else:
                 inter_2 = faiss.eval_intersection(I2, gt)
                 self.assertGreaterEqual(inter_ref, inter_2)
-                # print(st, inter_ref, inter_2)
 
 
 ###########################################################
@@ -814,7 +808,6 @@ class TestIVFResidualQuantizer(unittest.TestCase):
             index.nprobe = nprobe
             D, I = index.search(ds.get_queries(), 10)
             inter = faiss.eval_intersection(I, ds.get_groundtruth(10))
-            # print(st, "nprobe=", nprobe, "inter=", inter)
             inters.append(inter)
 
         # do a little I/O test
@@ -909,18 +902,13 @@ class TestIVFResidualQuantizer(unittest.TestCase):
             D, I = index.search(ds.get_queries(), 10)
             index.rq.search_type = faiss.AdditiveQuantizer.ST_LUT_nonorm
             D2, I2 = index.search(ds.get_queries(), 10)
-            # print(D[:5] - D2[:5])
-            # print(I[:5])
             np.testing.assert_array_almost_equal(D, D2, decimal=5)
             # there are many ties because the codes are so short
             self.assertLess((I != I2).sum(), I.size * 0.1)
 
             # D2, I2 = index2.search(ds.get_queries(), 10)
-            # print(D[:5])
-            # print(D2[:5])
 
             inter = faiss.eval_intersection(I, ds.get_groundtruth(10))
-            # print("nprobe=", nprobe, "inter=", inter)
             inters.append(inter)
         self.assertTrue(np.all(inters[1:4] >= inters[:3]))
 
@@ -978,8 +966,6 @@ def beam_search_encode_step_tab(codes, L, distances, codebook_cross_prods_i,
         for i in range(n):
             for b in range(beam_size):
                 dotprods[i, b, :] += cb[codes[i, b, j]]
-
-    # print("dps", dotprods[:3, :2, :4])
 
     new_distances += 2 * dotprods
     cent_distances = new_distances
@@ -1166,7 +1152,6 @@ class TestProductResidualQuantizer(unittest.TestCase):
         pq.train(xt)
         err_pq = eval_codec(pq, xb)
 
-        # print(err_prq, err_pq)
         self.assertLess(err_prq, err_pq)
 
     def test_with_rq(self):
@@ -1187,7 +1172,6 @@ class TestProductResidualQuantizer(unittest.TestCase):
         rq.train(xt)
         err_rq = eval_codec(rq, xb)
 
-        # print(err_prq, err_rq)
         self.assertEqual(err_prq, err_rq)
 
 
@@ -1271,7 +1255,6 @@ class TestIndexIVFProductResidualQuantizer(unittest.TestCase):
         """check that the error is in the same ballpark as RQ."""
         inter1 = self.eval_index_accuracy("IVF100,PRQ2x2x5_Nqint8")
         inter2 = self.eval_index_accuracy("IVF100,RQ4x5_Nqint8")
-        # print(inter1, inter2)  # 392 vs 374
         self.assertGreaterEqual(inter1 * 1.1, inter2)
 
     def test_factory(self):

--- a/tests/test_rowwise_minmax.py
+++ b/tests/test_rowwise_minmax.py
@@ -45,7 +45,6 @@ class TestIndexRowwiseMinmax(unittest.TestCase):
 
         # make sure that the reconstruction error is not crazy
         reconstruction_err = ((x - decoded) ** 2).sum()
-        print(reconstruction_err)
 
         self.assertLess(reconstruction_err, 0.6)
 

--- a/tests/test_search_params.py
+++ b/tests/test_search_params.py
@@ -465,7 +465,6 @@ class TestSortedIDSelectorRange(unittest.TestCase):
         sp = faiss.swig_ptr
         selr.find_sorted_ids_bounds(
             len(ids), sp(ids), sp(j01[:1]), sp(j01[1:]))
-        print(j01)
         assert j01[0] >= j01[1]
 
 

--- a/tests/test_sliding_ivf.cpp
+++ b/tests/test_sliding_ivf.cpp
@@ -74,8 +74,6 @@ void make_index_slices(
     for (int i = 0; i < total_size; i++) {
         sub_indexes.emplace_back(clone_index(trained_index));
 
-        printf("preparing sub-index # %d\n", i);
-
         Index* index = sub_indexes.back().get();
 
         auto xb = make_data(nb * d);
@@ -122,13 +120,11 @@ int test_sliding_window(const char* index_key) {
     auto xq = make_data(nq * d);
 
     for (int i = 0; i < total_size + window_size; i++) {
-        printf("doing step %d / %d\n", i, total_size + window_size);
 
         // update the index
         window.step(
                 i < total_size ? sub_indexes[i].get() : nullptr,
                 i >= window_size);
-        printf("   current n_slice = %d\n", window.n_slice);
 
         auto new_res = search_index(index.get(), xq.data());
 
@@ -159,7 +155,6 @@ int test_sliding_invlists(const char* index_key) {
     auto xq = make_data(nq * d);
 
     for (int i = 0; i < total_size + window_size; i++) {
-        printf("doing step %d / %d\n", i, total_size + window_size);
 
         // update the index
         std::vector<const InvertedLists*> ils;
@@ -178,8 +173,6 @@ int test_sliding_invlists(const char* index_key) {
         // will be deleted by the index
         index_ivf->replace_invlists(ci, true);
 
-        printf("   nb invlists = %zd\n", ils.size());
-
         auto new_res = search_index(index.get(), xq.data());
 
         std::unique_ptr<Index> merged_index(
@@ -194,7 +187,6 @@ int test_sliding_invlists(const char* index_key) {
             if (ref_res[j] != new_res[j])
                 ndiff++;
         }
-        printf("  nb differences: %zd / %zd\n", ndiff, ref_res.size());
         EXPECT_EQ(ref_res, new_res);
     }
     return 0;

--- a/tests/test_standalone_codec.py
+++ b/tests/test_standalone_codec.py
@@ -142,7 +142,6 @@ class TestAccuracy(unittest.TestCase):
         for factory_string in lowac, highac:
 
             codec = faiss.index_factory(d, factory_string)
-            print('sa codec: code size %d' % codec.sa_code_size())
             codec.train(xt)
 
             codes = codec.sa_encode(x)
@@ -151,7 +150,6 @@ class TestAccuracy(unittest.TestCase):
             err = ((x - x2) ** 2).sum()
             errs.append(err)
 
-        print(errs)
         self.assertGreater(errs[0], errs[1])
 
         self.assertGreater(max_errs[0], errs[0])
@@ -214,7 +212,6 @@ class LatticeTest(unittest.TestCase):
             code = repeats.encode(swig_ptr(vec))
             vec2 = np.zeros(dim, dtype='float32')
             repeats.decode(code, swig_ptr(vec2))
-            # print(vec2)
             assert np.all(vec == vec2)
 
     def test_ZnSphereCodec_encode_centroid(self):
@@ -222,7 +219,6 @@ class LatticeTest(unittest.TestCase):
         r2 = 5
         ref_codec = faiss.ZnSphereCodec(dim, r2)
         codec = faiss.ZnSphereCodecRec(dim, r2)
-        # print(ref_codec.nv, codec.nv)
         assert ref_codec.nv == codec.nv
         s = set()
         for i in range(ref_codec.nv):
@@ -237,7 +233,6 @@ class LatticeTest(unittest.TestCase):
         dim = 16
         r2 = 6
         codec = faiss.ZnSphereCodecRec(dim, r2)
-        # print("nv=", codec.nv)
         for i in range(codec.nv):
             c = np.zeros(dim, dtype='float32')
             codec.decode(i, swig_ptr(c))
@@ -300,15 +295,10 @@ class TestBitstring(unittest.TestCase):
         for i in range(nbyte):
             self.assertTrue(((bignum >> (i * 8)) & 255) == bs[i])
 
-        #for i in range(nbyte):
-        #    print(bin(bs[i] + 256)[3:], end=' ')
-        # print()
-
         br = faiss.BitstringReader(swig_ptr(bs), nbyte)
 
         for nbit, xref in ctrl:
             xnew = br.read(nbit)
-            # print('nbit %d xref %x xnew %x' % (nbit, xref, xnew))
             self.assertTrue(xnew == xref)
 
     def test_arrays(self):


### PR DESCRIPTION
Summary: This commit focus on reducing the length of the unnecessary log and strengthen the codebase.

Differential Revision: D57405802


