### PR TITLE
Fix CUDA 11.4.4 builds under CircleCI

### DIFF
--- a/.github/actions/build_conda/action.yml
+++ b/.github/actions/build_conda/action.yml
@@ -44,7 +44,7 @@ runs:
       if: inputs.label != ''
       shell: ${{ steps.choose_shell.outputs.shell }}
       env:
-        PACKAGE_TYPE: inputs.label
+        PACKAGE_TYPE: ${{ inputs.label }}
       run: |
         conda install -y -q anaconda-client
         conda config --set anaconda_upload yes
@@ -59,7 +59,7 @@ runs:
       shell: ${{ steps.choose_shell.outputs.shell }}
       working-directory: conda
       env:
-        PACKAGE_TYPE: inputs.label
+        PACKAGE_TYPE: ${{ inputs.label }}
       run: |
         conda build faiss --user pytorch --label ${{ inputs.label }} -c pytorch
     - name: Conda build (GPU)
@@ -74,7 +74,7 @@ runs:
       shell: ${{ steps.choose_shell.outputs.shell }}
       working-directory: conda
       env:
-        PACKAGE_TYPE: inputs.label
+        PACKAGE_TYPE: ${{ inputs.label }}
       run: |
         conda build faiss-gpu --variants '{ "cudatoolkit": "${{ inputs.cuda }}", "c_compiler_version": "${{ inputs.compiler_version }}", "cxx_compiler_version": "${{ inputs.compiler_version }}" }' \
             --user pytorch --label ${{ inputs.label }} -c pytorch -c nvidia/label/cuda-${{ inputs.cuda }} -c nvidia
@@ -90,7 +90,7 @@ runs:
       shell: ${{ steps.choose_shell.outputs.shell }}
       working-directory: conda
       env:
-        PACKAGE_TYPE: inputs.label
+        PACKAGE_TYPE: ${{ inputs.label }}
       run: |
         conda build faiss-gpu-raft --variants '{ "cudatoolkit": "${{ inputs.cuda }}", "c_compiler_version": "${{ inputs.compiler_version }}", "cxx_compiler_version": "${{ inputs.compiler_version }}" }' \
             --user pytorch --label ${{ inputs.label }} -c pytorch -c nvidia/label/cuda-${{ inputs.cuda }} -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,7 @@ jobs:
     runs-on: 4-core-ubuntu-gpu-t4
     env:
       CUDA_ARCHS: "60-real;61-real;62-real;70-real;72-real;75-real;80;86-real"
+      FAISS_FLATTEN_CONDA_INCLUDES: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/conda/faiss-gpu/meta.yaml
+++ b/conda/faiss-gpu/meta.yaml
@@ -43,9 +43,7 @@ outputs:
         - {{ pin_compatible('libfaiss', exact=True) }}
       script_env:
         - CUDA_ARCHS
-        {% if cudatoolkit == '11.4.4' %}
-        - FAISS_FLATTEN_CONDA_INCLUDES=1
-        {% endif %}
+        - FAISS_FLATTEN_CONDA_INCLUDES
     requirements:
       build:
         - {{ compiler('cxx') }}


### PR DESCRIPTION
Summary: Flattening Conda include directories breaks CUDA 11.4.4 build on Ubuntu 20 / v5 kernel. This change updates the logic to only flatten includes on Ubuntu 22 / v6 kernel (aka as running on GitHub Actions runners).

Differential Revision: D57602154
