### PR TITLE
Fix cron schedule for nightlies via GitHub Actions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,7 @@
 name: Nightly
 on:
   schedule:
-    - cron:  '1 10 * * *'
+    - cron:  '10 1 * * *'
 env:
   OMP_NUM_THREADS: '10'
   MKL_THREADING_LAYER: GNU


### PR DESCRIPTION
Summary: Hour and minute values are swapped, the goal is to run is at 1:10am UTC.

Differential Revision: D57654059
