### PR TITLE
Optimize IndexIDMap2::construct_rev_map function.     accelerate the build speed when deleting the ID while retaining the feature of forced reconstruction.

### DIFF
--- a/benchs/bench_cppcontrib_sa_decode.cpp
+++ b/benchs/bench_cppcontrib_sa_decode.cpp
@@ -214,9 +214,8 @@ static void verifyIndex2LevelDecoder(
         double error = getError(n, d, outputFaiss, outputKernel1);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "store_seq"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel << "\t" << error << std::endl;
+                  << "store_seq" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel << "\t" << error << std::endl;
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -264,9 +263,8 @@ static void verifyIndex2LevelDecoder(
         const double error = getError(n, d, outputFaiss, outputKernel1);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "store_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel << "\t" << error << std::endl;
+                  << "store_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel << "\t" << error << std::endl;
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -327,9 +325,8 @@ static void verifyIndex2LevelDecoder(
         const double error1 = getError(n, d, outputFaiss, outputKernel1);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel1 << "\t" << error1 << std::endl;
+                  << "accum_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel1 << "\t" << error1 << std::endl;
 
         // kernels: accum 2 points, shared centroids
         StopWatch swKernel2;
@@ -357,9 +354,8 @@ static void verifyIndex2LevelDecoder(
         const double error2 = getError(n, d, outputFaiss, outputKernel2);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum2_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel2 << "\t" << error2 << std::endl;
+                  << "accum2_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel2 << "\t" << error2 << std::endl;
 
         // kernels: accum 2 points, unique centroids
         StopWatch swKernel2u;
@@ -389,9 +385,8 @@ static void verifyIndex2LevelDecoder(
         const double error2u = getError(n, d, outputFaiss, outputKernel2u);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum2u_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel2u << "\t" << error2u << std::endl;
+                  << "accum2u_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel2u << "\t" << error2u << std::endl;
 
         // kernels: accum 3 points, shared centroids
         StopWatch swKernel3;
@@ -424,9 +419,8 @@ static void verifyIndex2LevelDecoder(
         const double error3 = getError(n, d, outputFaiss, outputKernel3);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum3_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel3 << "\t" << error3 << std::endl;
+                  << "accum3_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel3 << "\t" << error3 << std::endl;
 
         // kernels: accum 3 points, unique centroids
         StopWatch swKernel3u;
@@ -463,9 +457,8 @@ static void verifyIndex2LevelDecoder(
         const double error3u = getError(n, d, outputFaiss, outputKernel3u);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum3u_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel3u << "\t" << error3u << std::endl;
+                  << "accum3u_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel3u << "\t" << error3u << std::endl;
     }
 }
 
@@ -532,9 +525,8 @@ static void verifyMinMaxIndex2LevelDecoder(
         double error = getError(n, d, outputFaiss, outputKernel1);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "store_seq"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel << "\t" << error << std::endl;
+                  << "store_seq" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel << "\t" << error << std::endl;
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -582,9 +574,8 @@ static void verifyMinMaxIndex2LevelDecoder(
         const double error = getError(n, d, outputFaiss, outputKernel1);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "store_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel << "\t" << error << std::endl;
+                  << "store_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel << "\t" << error << std::endl;
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -651,9 +642,8 @@ static void verifyMinMaxIndex2LevelDecoder(
         const double error1 = getError(n, d, outputFaiss, outputKernel1);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel1 << "\t" << error1 << std::endl;
+                  << "accum_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel1 << "\t" << error1 << std::endl;
 
         // kernels: accum 2 points, shared centroids
         StopWatch swKernel2;
@@ -686,9 +676,8 @@ static void verifyMinMaxIndex2LevelDecoder(
         const double error2 = getError(n, d, outputFaiss, outputKernel2);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum2_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel2 << "\t" << error2 << std::endl;
+                  << "accum2_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel2 << "\t" << error2 << std::endl;
 
         // kernels: accum 2 points, unique centroids
         StopWatch swKernel2u;
@@ -723,9 +712,8 @@ static void verifyMinMaxIndex2LevelDecoder(
         const double error2u = getError(n, d, outputFaiss, outputKernel2u);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum2u_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel2u << "\t" << error2u << std::endl;
+                  << "accum2u_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel2u << "\t" << error2u << std::endl;
 
         // kernels: accum 3 points, shared centroids
         StopWatch swKernel3;
@@ -763,9 +751,8 @@ static void verifyMinMaxIndex2LevelDecoder(
         const double error3 = getError(n, d, outputFaiss, outputKernel3);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum3_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel3 << "\t" << error3 << std::endl;
+                  << "accum3_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel3 << "\t" << error3 << std::endl;
 
         // kernels: accum 3 points, unique centroids
         StopWatch swKernel3u;
@@ -807,9 +794,8 @@ static void verifyMinMaxIndex2LevelDecoder(
         const double error3u = getError(n, d, outputFaiss, outputKernel3u);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum3u_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel3u << "\t" << error3u << std::endl;
+                  << "accum3u_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel3u << "\t" << error3u << std::endl;
     }
 }
 
@@ -866,9 +852,8 @@ static void verifyIndexPQDecoder(
         double error = getError(n, d, outputFaiss, outputKernel1);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "store_seq"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel << "\t" << error << std::endl;
+                  << "store_seq" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel << "\t" << error << std::endl;
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -915,9 +900,8 @@ static void verifyIndexPQDecoder(
         const double error = getError(n, d, outputFaiss, outputKernel1);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "store_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel << "\t" << error << std::endl;
+                  << "store_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel << "\t" << error << std::endl;
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -978,9 +962,8 @@ static void verifyIndexPQDecoder(
         const double error1 = getError(n, d, outputFaiss, outputKernel1);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel1 << "\t" << error1 << std::endl;
+                  << "accum_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel1 << "\t" << error1 << std::endl;
 
         // kernels: accum 2 points, shared centroids
         StopWatch swKernel2;
@@ -1007,9 +990,8 @@ static void verifyIndexPQDecoder(
         const double error2 = getError(n, d, outputFaiss, outputKernel2);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum2_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel2 << "\t" << error2 << std::endl;
+                  << "accum2_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel2 << "\t" << error2 << std::endl;
 
         // kernels: accum 2 points, unique centroids
         StopWatch swKernel2u;
@@ -1037,9 +1019,8 @@ static void verifyIndexPQDecoder(
         const double error2u = getError(n, d, outputFaiss, outputKernel2u);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum2u_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel2u << "\t" << error2u << std::endl;
+                  << "accum2u_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel2u << "\t" << error2u << std::endl;
 
         // kernels: accum 3 points, shared centroids
         StopWatch swKernel3;
@@ -1071,9 +1052,8 @@ static void verifyIndexPQDecoder(
         const double error3 = getError(n, d, outputFaiss, outputKernel3);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum3_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel3 << "\t" << error3 << std::endl;
+                  << "accum3_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel3 << "\t" << error3 << std::endl;
 
         // kernels: accum 3 points, unique centroids
         StopWatch swKernel3u;
@@ -1107,9 +1087,8 @@ static void verifyIndexPQDecoder(
         const double error3u = getError(n, d, outputFaiss, outputKernel3u);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum3u_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel3u << "\t" << error3u << std::endl;
+                  << "accum3u_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel3u << "\t" << error3u << std::endl;
     }
 }
 
@@ -1171,9 +1150,8 @@ static void verifyMinMaxIndexPQDecoder(
         double error = getError(n, d, outputFaiss, outputKernel1);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "store_seq"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel << "\t" << error << std::endl;
+                  << "store_seq" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel << "\t" << error << std::endl;
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1220,9 +1198,8 @@ static void verifyMinMaxIndexPQDecoder(
         const double error = getError(n, d, outputFaiss, outputKernel1);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "store_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel << "\t" << error << std::endl;
+                  << "store_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel << "\t" << error << std::endl;
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1288,9 +1265,8 @@ static void verifyMinMaxIndexPQDecoder(
         const double error1 = getError(n, d, outputFaiss, outputKernel1);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel1 << "\t" << error1 << std::endl;
+                  << "accum_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel1 << "\t" << error1 << std::endl;
 
         // kernels: accum 2 points, shared centroids
         StopWatch swKernel2;
@@ -1322,9 +1298,8 @@ static void verifyMinMaxIndexPQDecoder(
         const double error2 = getError(n, d, outputFaiss, outputKernel2);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum2_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel2 << "\t" << error2 << std::endl;
+                  << "accum2_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel2 << "\t" << error2 << std::endl;
 
         // kernels: accum 2 points, unique centroids
         StopWatch swKernel2u;
@@ -1357,9 +1332,8 @@ static void verifyMinMaxIndexPQDecoder(
         const double error2u = getError(n, d, outputFaiss, outputKernel2u);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum2u_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel2u << "\t" << error2u << std::endl;
+                  << "accum2u_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel2u << "\t" << error2u << std::endl;
 
         // kernels: accum 3 points, shared centroids
         StopWatch swKernel3;
@@ -1396,9 +1370,8 @@ static void verifyMinMaxIndexPQDecoder(
         const double error3 = getError(n, d, outputFaiss, outputKernel3);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum3_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel3 << "\t" << error3 << std::endl;
+                  << "accum3_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel3 << "\t" << error3 << std::endl;
 
         // kernels: accum 3 points, unique centroids
         StopWatch swKernel3u;
@@ -1437,9 +1410,8 @@ static void verifyMinMaxIndexPQDecoder(
         const double error3u = getError(n, d, outputFaiss, outputKernel3u);
 
         std::cout << description << "\t" << n << "\t" << d << "\t"
-                  << "accum3u_rnd"
-                  << "\t" << nIterations << "\t" << timeFaiss << "\t"
-                  << timeKernel3u << "\t" << error3u << std::endl;
+                  << "accum3u_rnd" << "\t" << nIterations << "\t" << timeFaiss
+                  << "\t" << timeKernel3u << "\t" << error3u << std::endl;
     }
 }
 
@@ -1512,14 +1484,9 @@ int main(int argc, char** argv) {
             (N_ITERATIONS % 6) == 0, "Number of iterations should be 6*x");
 
     // print the header
-    std::cout << "Codec\t"
-              << "n\t"
-              << "d\t"
-              << "Experiment\t"
-              << "Iterations\t"
-              << "Faiss time\t"
-              << "SADecodeKernel time\t"
-              << "Error" << std::endl;
+    std::cout << "Codec\t" << "n\t" << "d\t" << "Experiment\t" << "Iterations\t"
+              << "Faiss time\t" << "SADecodeKernel time\t" << "Error"
+              << std::endl;
 
     // The following experiment types are available:
     // * store_seq - decode a contiguous block of codes into vectors, one by one

--- a/faiss/IndexBinaryIVF.cpp
+++ b/faiss/IndexBinaryIVF.cpp
@@ -456,7 +456,7 @@ void search_knn_hamming_heap(
             }
 
         } // parallel for
-    }     // parallel
+    } // parallel
 
     indexIVF_stats.nq += n;
     indexIVF_stats.nlist += nlistv;

--- a/faiss/IndexIDMap.h
+++ b/faiss/IndexIDMap.h
@@ -11,6 +11,7 @@
 #include <faiss/IndexBinary.h>
 #include <faiss/impl/IDSelector.h>
 
+#include <limits>
 #include <unordered_map>
 #include <vector>
 
@@ -78,6 +79,10 @@ struct IndexIDMap2Template : IndexIDMapTemplate<IndexT> {
     using distance_t = typename IndexT::distance_t;
 
     std::unordered_map<idx_t, idx_t> rev_map;
+    std::vector<idx_t> delete_id_map_value;
+    idx_t min_max_id_map_index[2]{
+            std::numeric_limits<idx_t>::min(),
+            std::numeric_limits<idx_t>::min()};
 
     explicit IndexIDMap2Template(IndexT* index);
 

--- a/faiss/gpu/utils/Tensor.cuh
+++ b/faiss/gpu/utils/Tensor.cuh
@@ -232,13 +232,12 @@ class Tensor {
     }
 
     /// Returns a read/write view of a portion of our tensor.
-    __host__ __device__ inline detail::SubTensor<TensorType, Dim - 1, PtrTraits>
-    operator[](IndexT);
+    __host__ __device__ inline detail::
+            SubTensor<TensorType, Dim - 1, PtrTraits> operator[](IndexT);
 
     /// Returns a read/write view of a portion of our tensor (const).
     __host__ __device__ inline const detail::
-            SubTensor<TensorType, Dim - 1, PtrTraits>
-            operator[](IndexT) const;
+            SubTensor<TensorType, Dim - 1, PtrTraits> operator[](IndexT) const;
 
     /// Returns the size of a given dimension, `[0, Dim - 1]`. No bounds
     /// checking.

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -110,8 +110,8 @@ void HNSW::print_neighbor_stats(int level) const {
            level,
            nb_neighbors(level));
     size_t tot_neigh = 0, tot_common = 0, tot_reciprocal = 0, n_node = 0;
-#pragma omp parallel for reduction(+: tot_neigh) reduction(+: tot_common) \
-  reduction(+: tot_reciprocal) reduction(+: n_node)
+#pragma omp parallel for reduction(+ : tot_neigh) reduction(+ : tot_common) \
+        reduction(+ : tot_reciprocal) reduction(+ : n_node)
     for (int i = 0; i < levels.size(); i++) {
         if (levels[i] > level) {
             n_node++;

--- a/faiss/invlists/OnDiskInvertedLists.cpp
+++ b/faiss/invlists/OnDiskInvertedLists.cpp
@@ -394,8 +394,8 @@ const idx_t* OnDiskInvertedLists::get_ids(size_t list_no) const {
         return nullptr;
     }
 
-    return (
-        const idx_t*)(ptr + lists[list_no].offset + code_size * lists[list_no].capacity);
+    return (const idx_t*)(ptr + lists[list_no].offset +
+                          code_size * lists[list_no].capacity);
 }
 
 void OnDiskInvertedLists::update_entries(


### PR DESCRIPTION
Optimize IndexIDMap2::construct_rev_map function.
    accelerate the build speed when deleting the ID while retaining the feature of forced reconstruction.