### PR TITLE
Fix CUDA 11.4.4 nightly in GitHub Actions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: 4-core-ubuntu-gpu-t4
     env:
       CUDA_ARCHS: "60-real;61-real;62-real;70-real;72-real;75-real;80;86-real"
+      FAISS_FLATTEN_CONDA_INCLUDES: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Summary: Previous diff (D57602154) fixed the CircleCI version and the PR build version of GHA but not the nightly one.

Differential Revision: D57680576
