### PR TITLE
Gate all PR builds behind linux-x86_64-cmake in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ env:
   MKL_THREADING_LAYER: GNU
 jobs:
   format:
+    name: Format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,12 +38,14 @@ jobs:
               exit 1
             fi
   linux-x86_64-cmake:
+    name: Linux x86_64 (cmake)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: ./.github/actions/build_cmake
   linux-x86_64-AVX2-cmake:
+    name: Linux x86_64 AVX2 (cmake)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -51,6 +54,7 @@ jobs:
         with:
           opt_level: avx2
   linux-x86_64-AVX512-cmake:
+    name: Linux x86_64 AVX512 (cmake)
     if: false # TODO: enable when GitHub Actions adds AVX-512 hosts
     runs-on: ubuntu-latest
     steps:
@@ -60,6 +64,7 @@ jobs:
         with:
           opt_level: avx512
   linux-x86_64-GPU-cmake:
+    name: Linux x86_64 GPU (cmake)
     needs: linux-x86_64-AVX2-cmake
     runs-on: 4-core-ubuntu-gpu-t4
     steps:
@@ -69,6 +74,7 @@ jobs:
         with:
           gpu: ON
   linux-x86_64-GPU-w-RAFT-cmake:
+    name: Linux x86_64 GPU w/ RAFT (cmake)
     runs-on: 4-core-ubuntu-gpu-t4
     steps:
       - name: Checkout
@@ -78,6 +84,7 @@ jobs:
           gpu: ON
           raft: ON
   linux-x86_64-conda:
+    name: Linux x86_64 (conda)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -87,6 +94,7 @@ jobs:
           fetch-tags: true
       - uses: ./.github/actions/build_conda
   windows-x86_64-conda:
+    name: Windows x86_64 (conda)
     runs-on: windows-2019
     steps:
       - name: Checkout
@@ -96,6 +104,7 @@ jobs:
           fetch-tags: true
       - uses: ./.github/actions/build_conda
   linux-arm64-conda:
+    name: Linux arm64 (conda)
     runs-on: 2-core-ubuntu-arm
     steps:
       - name: Checkout
@@ -105,6 +114,7 @@ jobs:
           fetch-tags: true
       - uses: ./.github/actions/build_conda
   linux-x86_64-packages:
+    name: Linux x86_64 packages
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
@@ -117,6 +127,7 @@ jobs:
         with:
           label: main
   linux-x86_64-GPU-packages-CUDA-11-4-4:
+    name: Linux x86_64 GPU packages (CUDA 11.4.4)
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: 4-core-ubuntu-gpu-t4
     env:
@@ -134,6 +145,7 @@ jobs:
           cuda: "11.4.4"
           compiler_version: "11.2"
   linux-x86_64-GPU-RAFT-packages-CUDA11-8-0:
+    name: Linux x86_64 GPU w/ RAFT packages (CUDA 11.8.0)
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: 4-core-ubuntu-gpu-t4
     env:
@@ -151,6 +163,7 @@ jobs:
           cuda: "11.8.0"
           compiler_version: "11.2"
   linux-x86_64-GPU-packages-CUDA-12-1-1:
+    name: Linux x86_64 GPU packages (CUDA 12.1.1)
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: 4-core-ubuntu-gpu-t4
     env:
@@ -167,6 +180,7 @@ jobs:
           cuda: "12.1.1"
           compiler_version: "11.2"
   linux-x86_64-GPU-RAFT-packages-CUDA12-1-1:
+    name: Linux x86_64 GPU w/ RAFT packages (CUDA 12.1.1)
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: 4-core-ubuntu-gpu-t4
     env:
@@ -184,6 +198,7 @@ jobs:
           cuda: "12.1.1"
           compiler_version: "11.2"
   windows-x86_64-packages:
+    name: Windows x86_64 packages
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-2019
     steps:
@@ -196,6 +211,7 @@ jobs:
         with:
           label: main
   osx-arm64-packages:
+    name: OSX arm64 packages
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-14
     steps:
@@ -208,6 +224,7 @@ jobs:
         with:
           label: main
   linux-arm64-packages:
+    name: Linux arm64 packages
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: 2-core-ubuntu-arm
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: ./.github/actions/build_cmake
   linux-x86_64-AVX2-cmake:
     name: Linux x86_64 AVX2 (cmake)
+    needs: linux-x86_64-cmake
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -56,6 +57,7 @@ jobs:
   linux-x86_64-AVX512-cmake:
     name: Linux x86_64 AVX512 (cmake)
     if: false # TODO: enable when GitHub Actions adds AVX-512 hosts
+    needs: linux-x86_64-cmake
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -65,7 +67,7 @@ jobs:
           opt_level: avx512
   linux-x86_64-GPU-cmake:
     name: Linux x86_64 GPU (cmake)
-    needs: linux-x86_64-AVX2-cmake
+    needs: linux-x86_64-cmake
     runs-on: 4-core-ubuntu-gpu-t4
     steps:
       - name: Checkout
@@ -75,6 +77,7 @@ jobs:
           gpu: ON
   linux-x86_64-GPU-w-RAFT-cmake:
     name: Linux x86_64 GPU w/ RAFT (cmake)
+    needs: linux-x86_64-cmake
     runs-on: 4-core-ubuntu-gpu-t4
     steps:
       - name: Checkout
@@ -85,6 +88,7 @@ jobs:
           raft: ON
   linux-x86_64-conda:
     name: Linux x86_64 (conda)
+    needs: linux-x86_64-cmake
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -95,6 +99,7 @@ jobs:
       - uses: ./.github/actions/build_conda
   windows-x86_64-conda:
     name: Windows x86_64 (conda)
+    needs: linux-x86_64-cmake
     runs-on: windows-2019
     steps:
       - name: Checkout
@@ -105,6 +110,7 @@ jobs:
       - uses: ./.github/actions/build_conda
   linux-arm64-conda:
     name: Linux arm64 (conda)
+    needs: linux-x86_64-cmake
     runs-on: 2-core-ubuntu-arm
     steps:
       - name: Checkout


### PR DESCRIPTION
Summary: The long tail will still be the RAFT build but we can save on cost if the build has errors by incurring ~10m penalty added by waiting for the basic cmake build to complete. Both GPU and RAFT builds will start together so this will take less time overall to complete.

Differential Revision: D57707298
