### PR TITLE
Disable CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,190 +5,8 @@ executors:
     docker:
       - image: continuumio/miniconda3
     resource_class: large
-  linux-x86_64-gpu:
-    environment:
-      CONDA_ARCH: Linux-x86_64
-    machine:
-      image: linux-cuda-12:default
-    resource_class: gpu.nvidia.medium
-  linux-arm64-cpu:
-    environment:
-      CONDA_ARCH: Linux-aarch64
-    machine:
-      image: ubuntu-2204:current
-    resource_class: arm.medium
-  macosx-arm64-cpu:
-    environment:
-      CONDA_ARCH: MacOSX-arm64
-    macos:
-      xcode: 14.2.0 # minimum supported for M1
-    resource_class: macos.m1.large.gen1
-  windows-x86_64-cpu:
-    machine:
-      image: windows-server-2019-vs2019:2023.04.1
-      shell: bash.exe
-    resource_class: windows.medium
 
 jobs:
-  format:
-    docker:
-      - image: ubuntu:22.04
-    steps:
-      - checkout
-      - run:
-          name: Install clang-format
-          command: |
-            apt-get update -y
-            apt-get install -y wget
-            apt install -y lsb-release wget software-properties-common gnupg
-            wget https://apt.llvm.org/llvm.sh
-            chmod u+x llvm.sh
-            ./llvm.sh 18
-            apt-get install -y git-core clang-format-18
-      - run:
-          name: Verify clang-format
-          command: |
-             git ls-files | grep -E  '\.(cpp|h|cu|cuh)$' | xargs clang-format-18 -i
-             if git diff --quiet; then
-               echo "Formatting OK!"
-             else
-               echo "Formatting not OK!"
-               echo "------------------"
-               git --no-pager diff --color
-               exit 1
-             fi
-
-  build_conda:
-    parameters:
-      label:
-        type: string
-        default: ""
-      cuda:
-        type: string
-        default: ""
-      raft:
-        type: string
-        default: ""
-      cuda_archs:
-        type: string
-        default: ""
-      compiler_version:
-        type: string
-        default: ""
-      exec:
-        type: executor
-    executor: << parameters.exec >>
-    environment:
-      OMP_NUM_THREADS: 10
-      PACKAGE_TYPE: <<parameters.label>>
-      CUDA_ARCHS: <<parameters.cuda_archs>>
-    steps:
-      - checkout
-      - run:
-          name: Install conda
-          command: |
-            if [ -n "${CONDA_ARCH}" ]
-            then
-              curl https://repo.anaconda.com/miniconda/Miniconda3-latest-${CONDA_ARCH}.sh --output miniconda.sh
-              bash miniconda.sh -b -p $HOME/miniconda
-              ~/miniconda/bin/conda init
-            fi
-      - run:
-          name: Install conda build tools
-          command: |
-            # conda config --set solver libmamba
-            # conda config --set verbosity 3
-            conda update -y -q conda
-            conda install -y -q conda-build
-      - when:
-          condition: << parameters.label >>
-          steps:
-            - run:
-                name: Enable anaconda uploads
-                command: |
-                  conda install -y -q anaconda-client
-                  conda config --set anaconda_upload yes
-      - when:
-          condition:
-            and:
-              - not: << parameters.label >>
-              - not: << parameters.cuda >>
-          steps:
-            - run:
-                name: Conda build (CPU)
-                no_output_timeout: 30m
-                command: |
-                  cd conda
-                  conda build faiss --python 3.11 -c pytorch
-      - when:
-          condition:
-            and:
-              - << parameters.label >>
-              - not: << parameters.cuda >>
-          steps:
-            - run:
-                name: Conda build (CPU) w/ anaconda upload
-                no_output_timeout: 30m
-                command: |
-                  cd conda
-                  conda build faiss --user pytorch --label <<parameters.label>> -c pytorch
-      - when:
-          condition:
-            and:
-              - not: << parameters.label >>
-              - << parameters.cuda >>
-              - not: << parameters.raft >>
-          steps:
-            - run:
-                name: Conda build (GPU)
-                no_output_timeout: 60m
-                command: |
-                  cd conda
-                  conda build faiss-gpu --variants '{ "cudatoolkit": "<<parameters.cuda>>", "c_compiler_version": "<<parameters.compiler_version>>", "cxx_compiler_version": "<<parameters.compiler_version>>" }' \
-                      -c pytorch -c nvidia/label/cuda-<<parameters.cuda>> -c nvidia
-      - when:
-          condition:
-            and:
-              - << parameters.label >>
-              - << parameters.cuda >>
-              - not: << parameters.raft >>
-          steps:
-            - run:
-                name: Conda build (GPU) w/ anaconda upload
-                no_output_timeout: 60m
-                command: |
-                  cd conda
-                  conda build faiss-gpu --variants '{ "cudatoolkit": "<<parameters.cuda>>", "c_compiler_version": "<<parameters.compiler_version>>", "cxx_compiler_version": "<<parameters.compiler_version>>" }' \
-                      --user pytorch --label <<parameters.label>> -c pytorch -c nvidia/label/cuda-<<parameters.cuda>> -c nvidia
-      - when:
-          condition:
-            and:
-              - not: << parameters.label >>
-              - << parameters.cuda >>
-              - << parameters.raft >>
-          steps:
-            - run:
-                name: Conda build (GPU w/ RAFT)
-                no_output_timeout: 60m
-                command: |
-                  cd conda
-                  conda build faiss-gpu-raft --variants '{ "cudatoolkit": "<<parameters.cuda>>", "c_compiler_version": "<<parameters.compiler_version>>", "cxx_compiler_version": "<<parameters.compiler_version>>" }' \
-                      -c pytorch -c nvidia/label/cuda-<<parameters.cuda>> -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge
-      - when:
-          condition:
-            and:
-              - << parameters.label >>
-              - << parameters.cuda >>
-              - << parameters.raft >>
-          steps:
-            - run:
-                name: Conda build (GPU w/ RAFT) w/ anaconda upload
-                no_output_timeout: 60m
-                command: |
-                  cd conda
-                  conda build faiss-gpu-raft --variants '{ "cudatoolkit": "<<parameters.cuda>>", "c_compiler_version": "<<parameters.compiler_version>>", "cxx_compiler_version": "<<parameters.compiler_version>>" }' \
-                      --user pytorch --label <<parameters.label>> -c pytorch -c nvidia/label/cuda-<<parameters.cuda>> -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge
-
   build_cmake:
     parameters:
       exec:
@@ -196,12 +14,6 @@ jobs:
       opt_level:
         type: string
         default: generic
-      gpu:
-        type: string
-        default: "OFF"
-      raft:
-        type: string
-        default: "OFF"
     executor: << parameters.exec >>
     environment:
       OMP_NUM_THREADS: 10
@@ -222,32 +34,10 @@ jobs:
           command: |
             conda config --set solver libmamba
             conda update -y -q conda
-      - when:
-          condition:
-            equal: [ "OFF", << parameters.raft >> ]
-          steps:
-            - run:
-                name: Install env using main channel
-                command: |
-                  conda install -y -q python=3.11 cmake make swig mkl=2023 mkl-devel=2023 numpy scipy pytest gxx_linux-64=11.2 sysroot_linux-64
-      - when:
-          condition:
-            equal: [ "ON", << parameters.raft >> ]
-          steps:
-            - run:
-                name: Install env using conda-forge channel
-                command: |
-                  conda install -y -q python=3.11 cmake make swig mkl=2023 mkl-devel=2023 numpy scipy pytest gxx_linux-64=11.2 sysroot_linux-64=2.28 libraft cuda-version=11.8 cuda-toolkit -c rapidsai-nightly -c "nvidia/label/cuda-11.8.0" -c conda-forge
-      - when:
-          condition:
-            and:
-              - equal: [ "ON", << parameters.gpu >> ]
-              - equal: [ "OFF", << parameters.raft >> ]
-          steps:
-            - run:
-                name: Install CUDA
-                command: |
-                  conda install -y -q cuda-toolkit -c "nvidia/label/cuda-11.8.0"
+      - run:
+          name: Install env using main channel
+          command: |
+            conda install -y -q python=3.11 cmake make swig mkl=2023 mkl-devel=2023 numpy scipy pytest gxx_linux-64=11.2 sysroot_linux-64
       - run:
           name: Build all targets
           no_output_timeout: 30m
@@ -257,8 +47,8 @@ jobs:
             cmake -B build \
                   -DBUILD_TESTING=ON \
                   -DBUILD_SHARED_LIBS=ON \
-                  -DFAISS_ENABLE_GPU=<< parameters.gpu >> \
-                  -DFAISS_ENABLE_RAFT=<< parameters.raft >> \
+                  -DFAISS_ENABLE_GPU=OFF \
+                  -DFAISS_ENABLE_RAFT=OFF \
                   -DFAISS_OPT_LEVEL=<< parameters.opt_level >> \
                   -DFAISS_ENABLE_C_API=ON \
                   -DPYTHON_EXECUTABLE=$(which python) \
@@ -277,38 +67,12 @@ jobs:
           command: |
             cd build/faiss/python
             python setup.py install
-      - when:
-          condition:
-            equal: [ "OFF", << parameters.gpu >> ]
-          steps:
-            - run:
-                name: Python tests (CPU only)
-                command: |
-                  conda install -y -q pytorch -c pytorch
-                  pytest --junitxml=test-results/pytest/results.xml tests/test_*.py
-                  pytest --junitxml=test-results/pytest/results-torch.xml tests/torch_*.py
-      - when:
-          condition:
-            equal: [ "ON", << parameters.gpu >> ]
-          steps:
-            - run:
-                name: Python tests (CPU + GPU)
-                command: |
-                  conda install -y -q pytorch pytorch-cuda=11.8 -c pytorch -c nvidia/label/cuda-11.8.0
-                  pytest --junitxml=test-results/pytest/results.xml tests/test_*.py
-                  pytest --junitxml=test-results/pytest/results-torch.xml tests/torch_*.py
-                  cp tests/common_faiss_tests.py faiss/gpu/test
-                  pytest --junitxml=test-results/pytest/results-gpu.xml faiss/gpu/test/test_*.py
-                  pytest --junitxml=test-results/pytest/results-gpu-torch.xml faiss/gpu/test/torch_*.py
-      - when:
-          condition:
-            equal: [ "avx2", << parameters.opt_level >> ]
-          steps:
-            - run:
-                name: Test avx2 loading
-                command: |
-                  FAISS_DISABLE_CPU_FEATURES=AVX2 LD_DEBUG=libs python -c "import faiss" 2>&1 | grep faiss.so
-                  LD_DEBUG=libs python -c "import faiss" 2>&1 | grep faiss_avx2.so
+      - run:
+          name: Python tests (CPU only)
+          command: |
+            conda install -y -q pytorch -c pytorch
+            pytest --junitxml=test-results/pytest/results.xml tests/test_*.py
+            pytest --junitxml=test-results/pytest/results-torch.xml tests/torch_*.py
       - store_test_results:
           path: test-results
 
@@ -316,180 +80,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - format:
-          name: Format
-      - build_cmake:
-          name: Linux x86_64 (cmake)
-          exec: linux-x86_64-cpu
-      - build_cmake:
-          name: Linux x86_64 AVX2 (cmake)
-          exec: linux-x86_64-cpu
-          opt_level: "avx2"
       - build_cmake:
           name: Linux x86_64 AVX512 (cmake)
           exec: linux-x86_64-cpu
           opt_level: "avx512"
-      - build_cmake:
-          name: Linux x86_64 GPU (cmake)
-          exec: linux-x86_64-gpu
-          gpu: "ON"
-          requires:
-            - Linux x86_64 AVX2 (cmake)
-      - build_cmake:
-          name: Linux x86_64 GPU w/ RAFT (cmake)
-          exec: linux-x86_64-gpu
-          gpu: "ON"
-          raft: "ON"
-          requires:
-            - Linux x86_64 GPU (cmake)
-      - build_conda:
-          name: Linux x86_64 (conda)
-          exec: linux-x86_64-cpu
-      - build_conda:
-          name: Windows x86_64 (conda)
-          exec: windows-x86_64-cpu
-      - build_conda:
-          name: Linux arm64 (conda)
-          exec: linux-arm64-cpu
-      - build_conda:
-          name: Linux x86_64 packages
-          exec: linux-x86_64-cpu
-          label: main
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-      - build_conda:
-          name: Linux x86_64 GPU packages (CUDA 11.4.4)
-          exec: linux-x86_64-gpu
-          label: main
-          cuda: "11.4.4"
-          cuda_archs: "60-real;61-real;62-real;70-real;72-real;75-real;80;86-real"
-          compiler_version: "11.2"
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-      - build_conda:
-          name: Linux x86_64 GPU w/ RAFT packages (CUDA 11.8.0)
-          exec: linux-x86_64-gpu
-          label: main
-          raft: "ON"
-          cuda: "11.8.0"
-          cuda_archs: "70-real;72-real;75-real;80;86-real"
-          compiler_version: "11.2"
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-      - build_conda:
-          name: Linux x86_64 GPU packages (CUDA 12.1.1)
-          exec: linux-x86_64-gpu
-          label: main
-          cuda: "12.1.1"
-          cuda_archs: "70-real;72-real;75-real;80;86-real"
-          compiler_version: "11.2"
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-      - build_conda:
-          name: Linux x86_64 GPU w/ RAFT packages (CUDA 12.1.1)
-          exec: linux-x86_64-gpu
-          label: main
-          raft: "ON"
-          cuda: "12.1.1"
-          cuda_archs: "70-real;72-real;75-real;80;86-real"
-          compiler_version: "11.2"
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-      - build_conda:
-          name: Windows x86_64 packages
-          exec: windows-x86_64-cpu
-          label: main
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-      - build_conda:
-          name: OSX arm64 packages
-          exec: macosx-arm64-cpu
-          label: main
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-      - build_conda:
-          name: Linux arm64 packages
-          exec: linux-arm64-cpu
-          label: main
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - main
-    jobs:
-      - build_conda:
-          name: Linux x86_64 nightlies
-          exec: linux-x86_64-cpu
-          label: nightly
-      - build_conda:
-          name: Linux x86_64 GPU nightlies (CUDA 11.4.4)
-          exec: linux-x86_64-gpu
-          label: nightly
-          cuda: "11.4.4"
-          cuda_archs: "60-real;61-real;62-real;70-real;72-real;75-real;80;86-real"
-          compiler_version: "11.2"
-      - build_conda:
-          name: Linux x86_64 GPU w/ RAFT nightlies (CUDA 11.8.0)
-          exec: linux-x86_64-gpu
-          label: nightly
-          raft: "ON"
-          cuda: "11.8.0"
-          cuda_archs: "70-real;72-real;75-real;80;86-real"
-          compiler_version: "11.2"
-      - build_conda:
-          name: Linux x86_64 GPU nightlies (CUDA 12.1.1)
-          exec: linux-x86_64-gpu
-          label: nightly
-          cuda: "12.1.1"
-          cuda_archs: "70-real;72-real;75-real;80;86-real"
-          compiler_version: "11.2"
-      - build_conda:
-          name: Linux x86_64 GPU w/ RAFT nightlies (CUDA 12.1.1)
-          exec: linux-x86_64-gpu
-          label: nightly
-          raft: "ON"
-          cuda: "12.1.1"
-          cuda_archs: "70-real;72-real;75-real;80;86-real"
-          compiler_version: "11.2"
-      - build_conda:
-          name: Windows x86_64 nightlies
-          exec: windows-x86_64-cpu
-          label: nightly
-      - build_conda:
-          name: OSX arm64 nightlies
-          exec: macosx-arm64-cpu
-          label: nightly
-      - build_conda:
-          name: Linux arm64 nightlies
-          exec: linux-arm64-cpu
-          label: nightly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ env:
   MKL_THREADING_LAYER: GNU
 jobs:
   format:
+    name: Format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,12 +38,14 @@ jobs:
               exit 1
             fi
   linux-x86_64-cmake:
+    name: Linux x86_64 (cmake)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: ./.github/actions/build_cmake
   linux-x86_64-AVX2-cmake:
+    name: Linux x86_64 AVX2 (cmake)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -51,6 +54,7 @@ jobs:
         with:
           opt_level: avx2
   linux-x86_64-AVX512-cmake:
+    name: Linux x86_64 AVX512 (cmake)
     if: false # TODO: enable when GitHub Actions adds AVX-512 hosts
     runs-on: ubuntu-latest
     steps:
@@ -60,6 +64,7 @@ jobs:
         with:
           opt_level: avx512
   linux-x86_64-GPU-cmake:
+    name: Linux x86_64 GPU (cmake)
     needs: linux-x86_64-AVX2-cmake
     runs-on: 4-core-ubuntu-gpu-t4
     steps:
@@ -69,6 +74,7 @@ jobs:
         with:
           gpu: ON
   linux-x86_64-GPU-w-RAFT-cmake:
+    name: Linux x86_64 GPU w/ RAFT (cmake)
     runs-on: 4-core-ubuntu-gpu-t4
     steps:
       - name: Checkout
@@ -78,6 +84,7 @@ jobs:
           gpu: ON
           raft: ON
   linux-x86_64-conda:
+    name: Linux x86_64 (conda)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -87,6 +94,7 @@ jobs:
           fetch-tags: true
       - uses: ./.github/actions/build_conda
   windows-x86_64-conda:
+    name: Windows x86_64 (conda)
     runs-on: windows-2019
     steps:
       - name: Checkout
@@ -96,6 +104,7 @@ jobs:
           fetch-tags: true
       - uses: ./.github/actions/build_conda
   linux-arm64-conda:
+    name: Linux arm64 (conda)
     runs-on: 2-core-ubuntu-arm
     steps:
       - name: Checkout
@@ -105,6 +114,7 @@ jobs:
           fetch-tags: true
       - uses: ./.github/actions/build_conda
   linux-x86_64-packages:
+    name: Linux x86_64 packages
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
@@ -117,6 +127,7 @@ jobs:
         with:
           label: main
   linux-x86_64-GPU-packages-CUDA-11-4-4:
+    name: Linux x86_64 GPU packages (CUDA 11.4.4)
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: 4-core-ubuntu-gpu-t4
     env:
@@ -134,6 +145,7 @@ jobs:
           cuda: "11.4.4"
           compiler_version: "11.2"
   linux-x86_64-GPU-RAFT-packages-CUDA11-8-0:
+    name: Linux x86_64 GPU w/ RAFT packages (CUDA 11.8.0)
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: 4-core-ubuntu-gpu-t4
     env:
@@ -151,6 +163,7 @@ jobs:
           cuda: "11.8.0"
           compiler_version: "11.2"
   linux-x86_64-GPU-packages-CUDA-12-1-1:
+    name: Linux x86_64 GPU packages (CUDA 12.1.1)
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: 4-core-ubuntu-gpu-t4
     env:
@@ -167,6 +180,7 @@ jobs:
           cuda: "12.1.1"
           compiler_version: "11.2"
   linux-x86_64-GPU-RAFT-packages-CUDA12-1-1:
+    name: Linux x86_64 GPU w/ RAFT packages (CUDA 12.1.1)
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: 4-core-ubuntu-gpu-t4
     env:
@@ -184,6 +198,7 @@ jobs:
           cuda: "12.1.1"
           compiler_version: "11.2"
   windows-x86_64-packages:
+    name: Windows x86_64 packages
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-2019
     steps:
@@ -196,6 +211,7 @@ jobs:
         with:
           label: main
   osx-arm64-packages:
+    name: OSX arm64 packages
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-14
     steps:
@@ -208,6 +224,7 @@ jobs:
         with:
           label: main
   linux-arm64-packages:
+    name: Linux arm64 packages
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: 2-core-ubuntu-arm
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: ./.github/actions/build_cmake
   linux-x86_64-AVX2-cmake:
     name: Linux x86_64 AVX2 (cmake)
+    needs: linux-x86_64-cmake
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -56,6 +57,7 @@ jobs:
   linux-x86_64-AVX512-cmake:
     name: Linux x86_64 AVX512 (cmake)
     if: false # TODO: enable when GitHub Actions adds AVX-512 hosts
+    needs: linux-x86_64-cmake
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -65,7 +67,7 @@ jobs:
           opt_level: avx512
   linux-x86_64-GPU-cmake:
     name: Linux x86_64 GPU (cmake)
-    needs: linux-x86_64-AVX2-cmake
+    needs: linux-x86_64-cmake
     runs-on: 4-core-ubuntu-gpu-t4
     steps:
       - name: Checkout
@@ -75,6 +77,7 @@ jobs:
           gpu: ON
   linux-x86_64-GPU-w-RAFT-cmake:
     name: Linux x86_64 GPU w/ RAFT (cmake)
+    needs: linux-x86_64-cmake
     runs-on: 4-core-ubuntu-gpu-t4
     steps:
       - name: Checkout
@@ -85,6 +88,7 @@ jobs:
           raft: ON
   linux-x86_64-conda:
     name: Linux x86_64 (conda)
+    needs: linux-x86_64-cmake
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -95,6 +99,7 @@ jobs:
       - uses: ./.github/actions/build_conda
   windows-x86_64-conda:
     name: Windows x86_64 (conda)
+    needs: linux-x86_64-cmake
     runs-on: windows-2019
     steps:
       - name: Checkout
@@ -105,6 +110,7 @@ jobs:
       - uses: ./.github/actions/build_conda
   linux-arm64-conda:
     name: Linux arm64 (conda)
+    needs: linux-x86_64-cmake
     runs-on: 2-core-ubuntu-arm
     steps:
       - name: Checkout


### PR DESCRIPTION
Summary: AVX-512 must remain on CircleCI until GitHub provides runners with AVX-512 support (ETA: Q1 2025).

Differential Revision: D57707621


