### PR TITLE
Remove extra semi colon from deprecated/libmccpp/ThreadSafeClientPool.h

### DIFF
--- a/tests/test_common_ivf_empty_index.cpp
+++ b/tests/test_common_ivf_empty_index.cpp
@@ -23,7 +23,7 @@ namespace {
 
 int d = 64;
 
-}; // namespace
+} // namespace
 
 std::vector<float> get_random_vectors(size_t n, int seed) {
     std::vector<float> x(n * d);


### PR DESCRIPTION
Summary:
`-Wextra-semi` or `-Wextra-semi-stmt`

If the code compiles, this is safe to land.

Reviewed By: palmje

Differential Revision: D57632759


