### PR TITLE
Remove unnecessary shell settings in build workflows since

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -21,27 +21,22 @@ runs:
         python-version: '3.11'
         miniconda-version: latest
     - name: Initialize Conda environment
-      shell: bash
       run: |
         conda config --set solver libmamba
         conda update -y -q conda
     - name: Configure Conda environment
-      shell: bash
       run: |
         conda install -y -q -c conda-forge gxx_linux-64=11.2 sysroot_linux-64=2.28
         conda install -y -q python=3.11 cmake make swig mkl=2023 mkl-devel=2023 numpy scipy pytest
     - name: Install CUDA
       if: inputs.gpu == 'ON' && inputs.raft == 'OFF'
-      shell: bash
       run: |
         conda install -y -q cuda-toolkit -c "nvidia/label/cuda-11.8.0"
     - name: Install RAFT
       if: inputs.raft == 'ON'
-      shell: bash
       run: |
         conda install -y -q libraft cuda-version=11.8 cuda-toolkit -c rapidsai-nightly -c "nvidia/label/cuda-11.8.0" -c conda-forge
     - name: Build all targets
-      shell: bash
       run: |
         eval "$(conda shell.bash hook)"
         conda activate
@@ -59,30 +54,25 @@ runs:
               .
         make -k -C build -j$(nproc)
     - name: C++ tests
-      shell: bash
       run: |
         export GTEST_OUTPUT="xml:$(realpath .)/test-results/googletest/"
         make -C build test
     - name: Install Python extension
-      shell: bash
       working-directory: build/faiss/python
       run: |
         $CONDA/bin/python setup.py install
     - name: Install pytest
-      shell: bash
       run: |
         conda install -y pytest
         echo "$CONDA/bin" >> $GITHUB_PATH
     - name: Python tests (CPU only)
       if: inputs.gpu == 'OFF'
-      shell: bash
       run: |
         conda install -y -q pytorch -c pytorch
         pytest --junitxml=test-results/pytest/results.xml tests/test_*.py
         pytest --junitxml=test-results/pytest/results-torch.xml tests/torch_*.py
     - name: Python tests (CPU + GPU)
       if: inputs.gpu == 'ON'
-      shell: bash
       run: |
         conda install -y -q pytorch pytorch-cuda=11.8 -c pytorch -c nvidia/label/cuda-11.8.0
         pytest --junitxml=test-results/pytest/results.xml tests/test_*.py
@@ -92,7 +82,6 @@ runs:
         pytest --junitxml=test-results/pytest/results-gpu-torch.xml faiss/gpu/test/torch_*.py
     - name: Test avx2 loading
       if: inputs.opt_level == 'avx2'
-      shell: bash
       run: |
         FAISS_DISABLE_CPU_FEATURES=AVX2 LD_DEBUG=libs $CONDA/bin/python -c "import faiss" 2>&1 | grep faiss.so
         LD_DEBUG=libs $CONDA/bin/python -c "import faiss" 2>&1 | grep faiss_avx2.so

--- a/.github/actions/build_conda/action.yml
+++ b/.github/actions/build_conda/action.yml
@@ -20,29 +20,17 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Choose shell
-      shell: bash
-      id: choose_shell
-      run: |
-        # Use pwsh on Windows; bash everywhere else
-        if [ "${{ runner.os }}" != "Windows" ]; then
-          echo "shell=bash" >> "$GITHUB_OUTPUT"
-        else
-          echo "shell=pwsh" >> "$GITHUB_OUTPUT"
-        fi
     - name: Setup miniconda
       uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: '3.11'
         miniconda-version:  latest
     - name: Install conda build tools
-      shell: ${{ steps.choose_shell.outputs.shell }}
       run: |
         conda update -y -q conda
         conda install -y -q conda-build
     - name: Enable anaconda uploads
       if: inputs.label != ''
-      shell: ${{ steps.choose_shell.outputs.shell }}
       env:
         PACKAGE_TYPE: ${{ inputs.label }}
       run: |
@@ -50,13 +38,11 @@ runs:
         conda config --set anaconda_upload yes
     - name: Conda build (CPU)
       if: inputs.label == '' && inputs.cuda == ''
-      shell: ${{ steps.choose_shell.outputs.shell }}
       working-directory: conda
       run: |
         conda build faiss --python 3.11 -c pytorch
     - name: Conda build (CPU) w/ anaconda upload
       if: inputs.label != '' && inputs.cuda == ''
-      shell: ${{ steps.choose_shell.outputs.shell }}
       working-directory: conda
       env:
         PACKAGE_TYPE: ${{ inputs.label }}
@@ -64,14 +50,12 @@ runs:
         conda build faiss --user pytorch --label ${{ inputs.label }} -c pytorch
     - name: Conda build (GPU)
       if: inputs.label == '' && inputs.cuda != '' && inputs.raft == ''
-      shell: ${{ steps.choose_shell.outputs.shell }}
       working-directory: conda
       run: |
         conda build faiss-gpu --variants '{ "cudatoolkit": "${{ inputs.cuda }}", "c_compiler_version": "${{ inputs.compiler_version }}", "cxx_compiler_version": "${{ inputs.compiler_version }}" }' \
             -c pytorch -c nvidia/label/cuda-${{ inputs.cuda }} -c nvidia
     - name: Conda build (GPU) w/ anaconda upload
       if: inputs.label != '' && inputs.cuda != '' && inputs.raft == ''
-      shell: ${{ steps.choose_shell.outputs.shell }}
       working-directory: conda
       env:
         PACKAGE_TYPE: ${{ inputs.label }}
@@ -80,14 +64,12 @@ runs:
             --user pytorch --label ${{ inputs.label }} -c pytorch -c nvidia/label/cuda-${{ inputs.cuda }} -c nvidia
     - name: Conda build (GPU w/ RAFT)
       if: inputs.label == '' && inputs.cuda != '' && inputs.raft != ''
-      shell: ${{ steps.choose_shell.outputs.shell }}
       working-directory: conda
       run: |
         conda build faiss-gpu-raft --variants '{ "cudatoolkit": "${{ inputs.cuda }}", "c_compiler_version": "${{ inputs.compiler_version }}", "cxx_compiler_version": "${{ inputs.compiler_version }}" }' \
             -c pytorch -c nvidia/label/cuda-${{ inputs.cuda }} -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge
     - name: Conda build (GPU w/ RAFT) w/ anaconda upload
       if: inputs.label != '' && inputs.cuda != '' && inputs.raft != ''
-      shell: ${{ steps.choose_shell.outputs.shell }}
       working-directory: conda
       env:
         PACKAGE_TYPE: ${{ inputs.label }}


### PR DESCRIPTION
Summary: GitHub Actions automatically configures the shell settings based on the OS of the runner being used and these steps and settings are unnecessary.

Differential Revision: D57866743


