### PR TITLE
Add conda bin to path early in the cmake GitHub action (#3510)

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -30,6 +30,7 @@ runs:
       run: |
         conda install -y -q -c conda-forge gxx_linux-64=11.2 sysroot_linux-64=2.28
         conda install -y -q python=3.11 cmake make swig mkl=2023 mkl-devel=2023 numpy scipy pytest
+        echo "$CONDA/bin" >> $GITHUB_PATH
     - name: Install CUDA
       if: inputs.gpu == 'ON' && inputs.raft == 'OFF'
       shell: bash
@@ -72,7 +73,6 @@ runs:
       shell: bash
       run: |
         conda install -y pytest
-        echo "$CONDA/bin" >> $GITHUB_PATH
     - name: Python tests (CPU only)
       if: inputs.gpu == 'OFF'
       shell: bash


### PR DESCRIPTION
Summary:

GitHub hosted runners some with the build-essentials package pre-installed, self-hosted runners on AWS do not have this package. This made it all steps other than the `all targets` one fall back to the system executables which unintentially worked on GitHub hosted runners but not on the self-hosted ones. This diff fixes it by pulling the line that adds conda bin to path early in the cmake build action.

Reviewed By: asadoughi

Differential Revision: D58513853
