### PR TITLE
typo in test_io_no_storage

### DIFF
--- a/tests/test_graph_based.py
+++ b/tests/test_graph_based.py
@@ -144,7 +144,7 @@ class TestHNSW(unittest.TestCase):
         index2 = faiss.deserialize_index(
             faiss.serialize_index(index, faiss.IO_FLAG_SKIP_STORAGE)
         )
-        self.assertEquals(index2.storage, None)
+        self.assertEqual(index2.storage, None)
         self.assertRaises(
             RuntimeError,
             index2.search, self.xb, 1)


### PR DESCRIPTION
Summary: Fix typo `test_io_no_storage`

Reviewed By: kuarora, asadoughi

Differential Revision: D58540190
