### PR TITLE
Bump libraft to 24.06 to unblock nightly RAFT builds

### DIFF
--- a/conda/faiss-gpu-raft/meta.yaml
+++ b/conda/faiss-gpu-raft/meta.yaml
@@ -58,7 +58,7 @@ outputs:
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
         - mkl =2023  # [x86_64]
         - openblas  # [not x86_64]
-        - libraft =24.04
+        - libraft =24.06
         - cuda-version {{ cuda_constraints }}
       run:
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
@@ -66,7 +66,7 @@ outputs:
         - openblas  # [not x86_64]
         - cuda-cudart {{ cuda_constraints }}
         - libcublas {{ libcublas_constraints }}
-        - libraft =24.04
+        - libraft =24.06
         - cuda-version {{ cuda_constraints }}
     test:
       requires:


### PR DESCRIPTION
Summary: Quick fix to unblock nightly

Differential Revision: D58694193


