### PR TITLE
Adding missing includes which are necessary for building.

### DIFF
--- a/tests/test_ivf_index.cpp
+++ b/tests/test_ivf_index.cpp
@@ -12,6 +12,8 @@
 #include <cstring>
 #include <map>
 #include <random>
+#include <set>
+#include <algorithm>
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
The current version of Faiss cannot be built due to missing `#include`s on a test file `tests/test_ivf_index.cpp`. This is better described in issue [#3532](https://github.com/facebookresearch/faiss/issues/3532).

This adds the missing imports.