### PR TITLE
Fix seg faults in CAGRA C++ unit tests

### DIFF
--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -463,9 +463,7 @@ void IndexHNSW::search_level_0(
             vt.advance();
         }
 #pragma omp critical
-        {
-            hnsw_stats.combine(search_stats);
-        }
+        { hnsw_stats.combine(search_stats); }
     }
     if (is_similarity_metric(this->metric_type)) {
 // we need to revert the negated distances

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -463,7 +463,9 @@ void IndexHNSW::search_level_0(
             vt.advance();
         }
 #pragma omp critical
-        { hnsw_stats.combine(search_stats); }
+        {
+            hnsw_stats.combine(search_stats);
+        }
     }
     if (is_similarity_metric(this->metric_type)) {
 // we need to revert the negated distances
@@ -948,7 +950,7 @@ void IndexHNSWCagra::search(
 
             std::random_device rd;
             std::mt19937 gen(rd());
-            std::uniform_int_distribution<idx_t> distrib(0, this->ntotal);
+            std::uniform_int_distribution<idx_t> distrib(0, this->ntotal - 1);
 
             for (idx_t j = 0; j < num_base_level_search_entrypoints; j++) {
                 auto idx = distrib(gen);

--- a/faiss/gpu/test/TestGpuIndexCagra.cu
+++ b/faiss/gpu/test/TestGpuIndexCagra.cu
@@ -198,7 +198,7 @@ void copyToTest(
         faiss::MetricType metric,
         double expected_recall,
         bool base_level_only) {
-    for (int tries = 0; tries < 5; ++tries) {
+    for (int tries = 0; tries < 100; ++tries) {
         Options opt;
         if (opt.buildAlgo == faiss::gpu::graph_build_algo::NN_DESCENT &&
             metric == faiss::METRIC_INNER_PRODUCT) {
@@ -330,24 +330,27 @@ void copyToTest(
                 recall_score.view(),
                 copy_ref_dis_mds_opt,
                 ref_dis_mds_opt);
+        std::cout << "run: " << tries
+                  << ", recall_score: " << *recall_score.data_handle()
+                  << std::endl;
         ASSERT_TRUE(*recall_score.data_handle() > expected_recall);
     }
 }
 
 TEST(TestGpuIndexCagra, Float32_CopyTo_L2) {
-    copyToTest(faiss::METRIC_L2, 0.95, false);
+    copyToTest(faiss::METRIC_L2, 0.98, false);
 }
 
 TEST(TestGpuIndexCagra, Float32_CopyTo_L2_BaseLevelOnly) {
-    copyToTest(faiss::METRIC_L2, 0.95, true);
+    copyToTest(faiss::METRIC_L2, 0.98, true);
 }
 
 TEST(TestGpuIndexCagra, Float32_CopyTo_IP) {
-    copyToTest(faiss::METRIC_INNER_PRODUCT, 0.95, false);
+    copyToTest(faiss::METRIC_INNER_PRODUCT, 0.98, false);
 }
 
 TEST(TestGpuIndexCagra, Float32_CopyTo_IP_BaseLevelOnly) {
-    copyToTest(faiss::METRIC_INNER_PRODUCT, 0.95, true);
+    copyToTest(faiss::METRIC_INNER_PRODUCT, 0.98, true);
 }
 
 void copyFromTest(faiss::MetricType metric, double expected_recall) {
@@ -468,7 +471,7 @@ int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
 
     // just run with a fixed test seed
-    faiss::gpu::setTestSeed(100);
+    faiss::gpu::setTestSeed(101);
 
     return RUN_ALL_TESTS();
 }

--- a/faiss/gpu/test/TestGpuIndexCagra.cu
+++ b/faiss/gpu/test/TestGpuIndexCagra.cu
@@ -182,7 +182,7 @@ void queryTest(faiss::MetricType metric, double expected_recall) {
                 recall_score.view(),
                 test_dis_mds_opt,
                 ref_dis_mds_opt);
-        ASSERT_TRUE(*recall_score.data_handle() > expected_recall);
+        ASSERT_GT(*recall_score.data_handle() > expected_recall);
     }
 }
 
@@ -198,7 +198,7 @@ void copyToTest(
         faiss::MetricType metric,
         double expected_recall,
         bool base_level_only) {
-    for (int tries = 0; tries < 100; ++tries) {
+    for (int tries = 0; tries < 5; ++tries) {
         Options opt;
         if (opt.buildAlgo == faiss::gpu::graph_build_algo::NN_DESCENT &&
             metric == faiss::METRIC_INNER_PRODUCT) {
@@ -333,7 +333,7 @@ void copyToTest(
         std::cout << "run: " << tries
                   << ", recall_score: " << *recall_score.data_handle()
                   << std::endl;
-        ASSERT_TRUE(*recall_score.data_handle() > expected_recall);
+        ASSERT_GT(*recall_score.data_handle() > expected_recall);
     }
 }
 
@@ -455,7 +455,7 @@ void copyFromTest(faiss::MetricType metric, double expected_recall) {
                 recall_score.view(),
                 copy_test_dis_mds_opt,
                 test_dis_mds_opt);
-        ASSERT_TRUE(*recall_score.data_handle() > expected_recall);
+        ASSERT_GT(*recall_score.data_handle() > expected_recall);
     }
 }
 
@@ -471,7 +471,7 @@ int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
 
     // just run with a fixed test seed
-    faiss::gpu::setTestSeed(101);
+    faiss::gpu::setTestSeed(100);
 
     return RUN_ALL_TESTS();
 }

--- a/faiss/gpu/test/TestGpuIndexCagra.cu
+++ b/faiss/gpu/test/TestGpuIndexCagra.cu
@@ -335,19 +335,19 @@ void copyToTest(
 }
 
 TEST(TestGpuIndexCagra, Float32_CopyTo_L2) {
-    copyToTest(faiss::METRIC_L2, 0.98, false);
+    copyToTest(faiss::METRIC_L2, 0.95, false);
 }
 
 TEST(TestGpuIndexCagra, Float32_CopyTo_L2_BaseLevelOnly) {
-    copyToTest(faiss::METRIC_L2, 0.98, true);
+    copyToTest(faiss::METRIC_L2, 0.95, true);
 }
 
 TEST(TestGpuIndexCagra, Float32_CopyTo_IP) {
-    copyToTest(faiss::METRIC_INNER_PRODUCT, 0.98, false);
+    copyToTest(faiss::METRIC_INNER_PRODUCT, 0.95, false);
 }
 
 TEST(TestGpuIndexCagra, Float32_CopyTo_IP_BaseLevelOnly) {
-    copyToTest(faiss::METRIC_INNER_PRODUCT, 0.98, true);
+    copyToTest(faiss::METRIC_INNER_PRODUCT, 0.95, true);
 }
 
 void copyFromTest(faiss::MetricType metric, double expected_recall) {

--- a/faiss/gpu/test/TestGpuIndexCagra.cu
+++ b/faiss/gpu/test/TestGpuIndexCagra.cu
@@ -182,7 +182,7 @@ void queryTest(faiss::MetricType metric, double expected_recall) {
                 recall_score.view(),
                 test_dis_mds_opt,
                 ref_dis_mds_opt);
-        ASSERT_GT(*recall_score.data_handle() > expected_recall);
+        ASSERT_GT(*recall_score.data_handle(), expected_recall);
     }
 }
 
@@ -330,7 +330,7 @@ void copyToTest(
                 recall_score.view(),
                 copy_ref_dis_mds_opt,
                 ref_dis_mds_opt);
-        ASSERT_GT(*recall_score.data_handle() > expected_recall);
+        ASSERT_GT(*recall_score.data_handle(), expected_recall);
     }
 }
 
@@ -452,7 +452,7 @@ void copyFromTest(faiss::MetricType metric, double expected_recall) {
                 recall_score.view(),
                 copy_test_dis_mds_opt,
                 test_dis_mds_opt);
-        ASSERT_GT(*recall_score.data_handle() > expected_recall);
+        ASSERT_GT(*recall_score.data_handle(), expected_recall);
     }
 }
 

--- a/faiss/gpu/test/TestGpuIndexCagra.cu
+++ b/faiss/gpu/test/TestGpuIndexCagra.cu
@@ -330,9 +330,6 @@ void copyToTest(
                 recall_score.view(),
                 copy_ref_dis_mds_opt,
                 ref_dis_mds_opt);
-        std::cout << "run: " << tries
-                  << ", recall_score: " << *recall_score.data_handle()
-                  << std::endl;
         ASSERT_GT(*recall_score.data_handle() > expected_recall);
     }
 }


### PR DESCRIPTION
The issue was that `uniform_int_distribution` generates numbers in the range `[0, ntotal]` and not `[0, ntotal)`, which was an oversight on my part. This PR also attempts to reduce the tolerance for `copyTo` tests as we have seen those fail intermittently.

cc @ramilbakhshyiev @mdouze @cjnolet 