### PR TITLE
Non-Blocking AVX512 Build on self-hosted github runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
       - uses: ./.github/actions/build_cmake
         with:
           opt_level: avx512
+        continue-on-error: true # non-blocking mode for now
   linux-x86_64-GPU-cmake:
     name: Linux x86_64 GPU (cmake)
     needs: linux-x86_64-cmake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ jobs:
   linux-x86_64-AVX512-cmake:
     name: Linux x86_64 AVX512 (cmake)
     continue-on-error: true # non-blocking mode for now
+    needs: linux-x86_64-cmake
     runs-on: faiss-aws-m7i.xlarge
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,11 +56,11 @@ jobs:
           opt_level: avx2
   linux-x86_64-AVX512-cmake:
     name: Linux x86_64 AVX512 (cmake)
-    if: false # TODO: enable when GitHub Actions adds AVX-512 hosts
-    needs: linux-x86_64-cmake
-    runs-on: ubuntu-latest
+    continue-on-error: true # non-blocking mode for now
+    runs-on: faiss-aws-m7i.xlarge
     steps:
       - name: Checkout
+        continue-on-error: true # non-blocking mode for now
         uses: actions/checkout@v4
       - uses: ./.github/actions/build_cmake
         with:


### PR DESCRIPTION
Start beta-testing AVX512 Build on self-hosted github runner with label faiss-aws-m7i.xlarge. This build is non-blocking on the PRs right now (via the parameter `continue-on-error`)