### PR TITLE
Adding missing includes which are necessary for building

### DIFF
--- a/tests/test_ivf_index.cpp
+++ b/tests/test_ivf_index.cpp
@@ -6,12 +6,14 @@
  */
 
 #include <omp.h>
+#include <algorithm>
 #include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <map>
 #include <random>
+#include <set>
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Summary:
The current version of Faiss cannot be built due to missing #includes on a test file tests/test_ivf_index.cpp. This is better described in issue #3532.


https://github.com/facebookresearch/faiss/pull/3533

Differential Revision: D59314273


