### PR TITLE
Create autoclose GHA workflow

### DIFF
--- a/.github/workflows/autoclose
+++ b/.github/workflows/autoclose
@@ -1,0 +1,24 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          only-labels: autoclose
+          labels-to-remove-when-unstale: autoclose
+          days-before-issue-stale: 7
+          days-before-issue-close: 7
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 7 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
After a reviewer labels the issue as "autoclose", issues will be labeled as "stale" after 7 days of no update and close after an additional 7 days.


See https://docs.github.com/en/actions/managing-issues-and-pull-requests/closing-inactive-issues and https://github.com/marketplace/actions/close-stale-issues