### PR TITLE
Fix CI for AVX512

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
     name: Linux x86_64 AVX512 (cmake)
     continue-on-error: true # non-blocking mode for now
     needs: linux-x86_64-cmake
-    runs-on: faiss-aws-m7i.xlarge
+    runs-on: faiss-aws-m7i.large
     steps:
       - name: Checkout
         continue-on-error: true # non-blocking mode for now


### PR DESCRIPTION
With the refactoring diff landed in [D59650573](https://www.internalfb.com/diff/D59650573), we take in the instance type string for aws and register it as the label for the runner. There was a typo in the previous registration (`m7i.xlarge` instead of `m7i.large`). The refactoring diff fixed the typo from the runner registration side but we need to fix it on the CI side as well so CI can find the runners

Test Plan: CI's AVX512 run on Github Action should succeed instead of stuck in pending