### PR TITLE
Add ARM64 build to build_cmake actions for SVE

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -28,9 +28,20 @@ runs:
         conda update -y -q conda
         echo "$CONDA/bin" >> $GITHUB_PATH
 
-        # install base packages
-        conda install -y -q -c conda-forge gxx_linux-64=11.2 sysroot_linux-64=2.28
-        conda install -y -q python=3.11 cmake make swig mkl=2023 mkl-devel=2023 numpy scipy pytest
+        conda install -y -q python=3.11 cmake make swig numpy scipy pytest
+
+        # install base packages for ARM64
+        if [ "${{ runner.arch }}" = "ARM64" ]; then
+          conda install -y -q -c conda-forge openblas gxx_linux-aarch64 sysroot_linux-aarch64
+        fi
+
+        # install base packages for X86_64
+        if [ "${{ runner.arch }}" = "X64" ]; then
+          # TODO: unpin versions for gxx_linux-64 and sysroot_linux-64 and merge it with ARM64 below
+          conda install -y -q -c conda-forge gxx_linux-64=11.2 sysroot_linux-64=2.28
+          conda install -y -q mkl=2023 mkl-devel=2023 
+        fi
+
 
         # install CUDA packages
         if [ "${{ inputs.gpu }}" = "ON" ] && [ "${{ inputs.raft }}" = "OFF" ]; then
@@ -53,19 +64,25 @@ runs:
       shell: bash
       run: |
         eval "$(conda shell.bash hook)"
+
+        args=(
+          -DBUILD_TESTING=ON 
+          -DBUILD_SHARED_LIBS=ON 
+          -DFAISS_ENABLE_GPU=${{ inputs.gpu }} 
+          -DFAISS_ENABLE_RAFT=${{ inputs.raft }} 
+          -DFAISS_OPT_LEVEL=${{ inputs.opt_level }} 
+          -DFAISS_ENABLE_C_API=ON 
+          -DPYTHON_EXECUTABLE=$CONDA/bin/python 
+          -DCMAKE_BUILD_TYPE=Release 
+        )
+        if [ "${{ runner.arch }}" = "X64" ]; then
+          args+=(
+            -DBLA_VENDOR=Intel10_64_dyn 
+            -DCMAKE_CUDA_FLAGS=\"-gencode arch=compute_75,code=sm_75\"
+          )
+        fi
         conda activate
-        cmake -B build \
-              -DBUILD_TESTING=ON \
-              -DBUILD_SHARED_LIBS=ON \
-              -DFAISS_ENABLE_GPU=${{ inputs.gpu }} \
-              -DFAISS_ENABLE_RAFT=${{ inputs.raft }} \
-              -DFAISS_OPT_LEVEL=${{ inputs.opt_level }} \
-              -DFAISS_ENABLE_C_API=ON \
-              -DPYTHON_EXECUTABLE=$CONDA/bin/python \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DBLA_VENDOR=Intel10_64_dyn \
-              -DCMAKE_CUDA_FLAGS="-gencode arch=compute_75,code=sm_75" \
-              .
+        cmake -B build "${args[@]}" .
         make -k -C build -j$(nproc)
     - name: C++ tests
       shell: bash
@@ -101,5 +118,5 @@ runs:
     - name: Upload test results
       uses: actions/upload-artifact@v4
       with:
-        name: test-results-${{ inputs.opt_level }}-${{ inputs.gpu }}-${{ inputs.raft }}
+        name: test-results-${{ runner.arch }}-${{ inputs.opt_level }}-${{ inputs.gpu }}-${{ inputs.raft }}
         path: test-results

--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -39,7 +39,7 @@ runs:
         if [ "${{ runner.arch }}" = "X64" ]; then
           # TODO: unpin versions for gxx_linux-64 and sysroot_linux-64 and merge it with ARM64 below
           conda install -y -q -c conda-forge gxx_linux-64=11.2 sysroot_linux-64=2.28
-          conda install -y -q mkl=2023 mkl-devel=2023 
+          conda install -y -q mkl=2023 mkl-devel=2023
         fi
 
 
@@ -67,28 +67,32 @@ runs:
         conda activate
 
         if [ "${{ runner.arch }}" = "X64" ]; then
-          cmake -B build -DBUILD_TESTING=ON \
-            -DBUILD_SHARED_LIBS=ON  \
-            -DFAISS_ENABLE_GPU=${{ inputs.gpu }}  \
-            -DFAISS_ENABLE_RAFT=${{ inputs.raft }}  \
-            -DFAISS_OPT_LEVEL=${{ inputs.opt_level }}  \
-            -DFAISS_ENABLE_C_API=ON  \
-            -DPYTHON_EXECUTABLE=$CONDA/bin/python  \
-            -DCMAKE_BUILD_TYPE=Release  \
-            -DBLA_VENDOR=Intel10_64_dyn \
-            -DCMAKE_CUDA_FLAGS="-gencode arch=compute_75,code=sm_75" \
-            .
-        fi
-        if [ "${{ runner.arch }}" = "ARM64" ]; then
-          cmake -B build -DBUILD_TESTING=ON \
-            -DBUILD_SHARED_LIBS=ON  \
-            -DFAISS_ENABLE_GPU=${{ inputs.gpu }}  \
-            -DFAISS_ENABLE_RAFT=${{ inputs.raft }}  \
-            -DFAISS_OPT_LEVEL=${{ inputs.opt_level }}  \
-            -DFAISS_ENABLE_C_API=ON  \
-            -DPYTHON_EXECUTABLE=$CONDA/bin/python  \
-            -DCMAKE_BUILD_TYPE=Release  \
-            .
+          cmake -B build \
+                -DBUILD_TESTING=ON \
+                -DBUILD_SHARED_LIBS=ON  \
+                -DFAISS_ENABLE_GPU=${{ inputs.gpu }}  \
+                -DFAISS_ENABLE_RAFT=${{ inputs.raft }}  \
+                -DFAISS_OPT_LEVEL=${{ inputs.opt_level }}  \
+                -DFAISS_ENABLE_C_API=ON  \
+                -DPYTHON_EXECUTABLE=$CONDA/bin/python  \
+                -DCMAKE_BUILD_TYPE=Release  \
+                -DBLA_VENDOR=Intel10_64_dyn \
+                -DCMAKE_CUDA_FLAGS="-gencode arch=compute_75,code=sm_75" \
+                .
+        elif [ "${{ runner.arch }}" = "ARM64" ]; then
+          cmake -B build \
+                -DBUILD_TESTING=ON \
+                -DBUILD_SHARED_LIBS=ON  \
+                -DFAISS_ENABLE_GPU=${{ inputs.gpu }}  \
+                -DFAISS_ENABLE_RAFT=${{ inputs.raft }}  \
+                -DFAISS_OPT_LEVEL=${{ inputs.opt_level }}  \
+                -DFAISS_ENABLE_C_API=ON  \
+                -DPYTHON_EXECUTABLE=$CONDA/bin/python  \
+                -DCMAKE_BUILD_TYPE=Release  \
+                .
+        else
+          echo "Encountered unexpected platform ${{ runner.arch }}"
+          exit 1
         fi
         make -k -C build -j$(nproc)
     - name: C++ tests

--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -82,7 +82,7 @@ runs:
           )
         fi
         conda activate
-        cmake -B build "${args[@]}" .
+        cmake -B build "${args[*]}" .
         make -k -C build -j$(nproc)
     - name: C++ tests
       shell: bash

--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -64,25 +64,32 @@ runs:
       shell: bash
       run: |
         eval "$(conda shell.bash hook)"
-
-        args=(
-          -DBUILD_TESTING=ON 
-          -DBUILD_SHARED_LIBS=ON 
-          -DFAISS_ENABLE_GPU=${{ inputs.gpu }} 
-          -DFAISS_ENABLE_RAFT=${{ inputs.raft }} 
-          -DFAISS_OPT_LEVEL=${{ inputs.opt_level }} 
-          -DFAISS_ENABLE_C_API=ON 
-          -DPYTHON_EXECUTABLE=$CONDA/bin/python 
-          -DCMAKE_BUILD_TYPE=Release 
-        )
-        if [ "${{ runner.arch }}" = "X64" ]; then
-          args+=(
-            -DBLA_VENDOR=Intel10_64_dyn 
-            -DCMAKE_CUDA_FLAGS=\"-gencode arch=compute_75,code=sm_75\"
-          )
-        fi
         conda activate
-        cmake -B build "${args[@]}" .
+
+        if [ "${{ runner.arch }}" = "X64" ]; then
+          cmake -B build -DBUILD_TESTING=ON \
+            -DBUILD_SHARED_LIBS=ON  \
+            -DFAISS_ENABLE_GPU=${{ inputs.gpu }}  \
+            -DFAISS_ENABLE_RAFT=${{ inputs.raft }}  \
+            -DFAISS_OPT_LEVEL=${{ inputs.opt_level }}  \
+            -DFAISS_ENABLE_C_API=ON  \
+            -DPYTHON_EXECUTABLE=$CONDA/bin/python  \
+            -DCMAKE_BUILD_TYPE=Release  \
+            -DBLA_VENDOR=Intel10_64_dyn \
+            -DCMAKE_CUDA_FLAGS="-gencode arch=compute_75,code=sm_75" \
+            .
+        fi
+        if [ "${{ runner.arch }}" = "ARM64" ]; then
+          cmake -B build -DBUILD_TESTING=ON \
+            -DBUILD_SHARED_LIBS=ON  \
+            -DFAISS_ENABLE_GPU=${{ inputs.gpu }}  \
+            -DFAISS_ENABLE_RAFT=${{ inputs.raft }}  \
+            -DFAISS_OPT_LEVEL=${{ inputs.opt_level }}  \
+            -DFAISS_ENABLE_C_API=ON  \
+            -DPYTHON_EXECUTABLE=$CONDA/bin/python  \
+            -DCMAKE_BUILD_TYPE=Release  \
+            .
+        fi
         make -k -C build -j$(nproc)
     - name: C++ tests
       shell: bash

--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -78,11 +78,11 @@ runs:
         if [ "${{ runner.arch }}" = "X64" ]; then
           args+=(
             -DBLA_VENDOR=Intel10_64_dyn 
-            -DCMAKE_CUDA_FLAGS="-gencode arch=compute_75,code=sm_75"
+            -DCMAKE_CUDA_FLAGS=\"-gencode arch=compute_75,code=sm_75\"
           )
         fi
         conda activate
-        cmake -B build "${args[*]}" .
+        cmake -B build "${args[@]}" .
         make -k -C build -j$(nproc)
     - name: C++ tests
       shell: bash

--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -78,7 +78,7 @@ runs:
         if [ "${{ runner.arch }}" = "X64" ]; then
           args+=(
             -DBLA_VENDOR=Intel10_64_dyn 
-            -DCMAKE_CUDA_FLAGS=\"-gencode arch=compute_75,code=sm_75\"
+            -DCMAKE_CUDA_FLAGS="-gencode arch=compute_75,code=sm_75"
           )
         fi
         conda activate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
         continue-on-error: true # non-blocking mode for now
   linux-x86_64-GPU-cmake:
     name: Linux x86_64 GPU (cmake)
-    # needs: linux-x86_64-cmake
+    needs: linux-x86_64-cmake
     runs-on: 4-core-ubuntu-gpu-t4
     steps:
       - name: Checkout
@@ -79,7 +79,7 @@ jobs:
           gpu: ON
   linux-x86_64-GPU-w-RAFT-cmake:
     name: Linux x86_64 GPU w/ RAFT (cmake)
-    # needs: linux-x86_64-cmake
+    needs: linux-x86_64-cmake
     runs-on: 4-core-ubuntu-gpu-t4
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,19 @@ jobs:
         with:
           gpu: ON
           raft: ON
+  linux-arm64-SVE-cmake:
+    name: Linux arm64 SVE (cmake)
+    runs-on: faiss-aws-r8g.large
+    continue-on-error: true # non-blocking mode for now
+    steps:
+      - name: Checkout
+        continue-on-error: true # non-blocking mode for now
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/build_cmake
+        continue-on-error: true # non-blocking mode for now
+      # TODO: uncomment this once SVE PR is merged
+      #   with:
+      #     opt_level: sve
   linux-x86_64-conda:
     name: Linux x86_64 (conda)
     needs: linux-x86_64-cmake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: ./.github/actions/build_cmake
         continue-on-error: true # non-blocking mode for now
-      # TODO: uncomment this once SVE PR is merged
+      # TODO(T197096427): uncomment this once SVE PR is merged
       #   with:
       #     opt_level: sve
   linux-x86_64-conda:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
         continue-on-error: true # non-blocking mode for now
   linux-x86_64-GPU-cmake:
     name: Linux x86_64 GPU (cmake)
-    needs: linux-x86_64-cmake
+    # needs: linux-x86_64-cmake
     runs-on: 4-core-ubuntu-gpu-t4
     steps:
       - name: Checkout
@@ -79,7 +79,7 @@ jobs:
           gpu: ON
   linux-x86_64-GPU-w-RAFT-cmake:
     name: Linux x86_64 GPU w/ RAFT (cmake)
-    needs: linux-x86_64-cmake
+    # needs: linux-x86_64-cmake
     runs-on: 4-core-ubuntu-gpu-t4
     steps:
       - name: Checkout


### PR DESCRIPTION
Add instructions to download arm64 specific conda dependencies and cmake command and run it on CI. This should prepare us to turn on CI with SVE optimization