### PR TITLE
Unpin gxx_linux-64 requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: Install env using main channel
           command: |
-            conda install -y -q python=3.11 cmake make swig mkl=2023 mkl-devel=2023 numpy scipy pytest gxx_linux-64=11.2 sysroot_linux-64
+            conda install -y -q python=3.11 cmake make swig mkl=2023 mkl-devel=2023 numpy scipy pytest gxx_linux-64 sysroot_linux-64
       - run:
           name: Build all targets
           no_output_timeout: 30m

--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -41,30 +41,25 @@ runs:
 
         # install base packages for X86_64
         if [ "${{ runner.arch }}" = "X64" ]; then
-          # TODO: unpin versions for gxx_linux-64 and sysroot_linux-64 and merge it with ARM64 below
-          if [ "${{ inputs.rocm }}" = "ON" ]; then
-            conda install -y -q -c conda-forge gxx_linux-64 sysroot_linux-64
-          else
-            conda install -y -q -c conda-forge gxx_linux-64=11.2 sysroot_linux-64=2.28
-          fi
+          # TODO: merge this with ARM64
+          conda install -y -q -c conda-forge gxx_linux-64 sysroot_linux-64
           conda install -y -q mkl=2023 mkl-devel=2023
         fi
 
-
         # install CUDA packages
         if [ "${{ inputs.gpu }}" = "ON" ] && [ "${{ inputs.raft }}" = "OFF" ]; then
-          conda install -y -q cuda-toolkit -c "nvidia/label/cuda-11.8.0"
+          conda install -y -q cuda-toolkit -c "nvidia/label/cuda-12.4.0"
         fi
 
         # install RAFT packages
         if [ "${{ inputs.raft }}" = "ON" ]; then
-          conda install -y -q libraft cuda-version=11.8 cuda-toolkit -c rapidsai-nightly -c "nvidia/label/cuda-11.8.0" -c conda-forge
+          conda install -y -q libraft cuda-version=12.4 cuda-toolkit -c rapidsai-nightly -c "nvidia/label/cuda-12.4.0" -c conda-forge
         fi
 
         # install test packages
         conda install -y pytest
         if [ "${{ inputs.gpu }}" = "ON" ]; then
-          conda install -y -q pytorch pytorch-cuda=11.8 -c pytorch -c nvidia/label/cuda-11.8.0
+          conda install -y -q pytorch pytorch-cuda=12.4 -c pytorch -c nvidia/label/cuda-12.4.0
         else
           conda install -y -q pytorch -c pytorch
         fi

--- a/.github/actions/build_conda/action.yml
+++ b/.github/actions/build_conda/action.yml
@@ -13,10 +13,6 @@ inputs:
     description: "Enable RAFT support."
     default: ""
     required: false
-  compiler_version:
-    description: "compiler_version"
-    default: "Compiler version for C/C++/CUDA."
-    required: false
 runs:
   using: composite
   steps:
@@ -67,7 +63,7 @@ runs:
       shell: ${{ steps.choose_shell.outputs.shell }}
       working-directory: conda
       run: |
-        conda build faiss-gpu --variants '{ "cudatoolkit": "${{ inputs.cuda }}", "c_compiler_version": "${{ inputs.compiler_version }}", "cxx_compiler_version": "${{ inputs.compiler_version }}" }' \
+        conda build faiss-gpu --variants '{ "cudatoolkit": "${{ inputs.cuda }}" }' \
             -c pytorch -c nvidia/label/cuda-${{ inputs.cuda }} -c nvidia
     - name: Conda build (GPU) w/ anaconda upload
       if: inputs.label != '' && inputs.cuda != '' && inputs.raft == ''
@@ -76,14 +72,14 @@ runs:
       env:
         PACKAGE_TYPE: ${{ inputs.label }}
       run: |
-        conda build faiss-gpu --variants '{ "cudatoolkit": "${{ inputs.cuda }}", "c_compiler_version": "${{ inputs.compiler_version }}", "cxx_compiler_version": "${{ inputs.compiler_version }}" }' \
+        conda build faiss-gpu --variants '{ "cudatoolkit": "${{ inputs.cuda }}" }' \
             --user pytorch --label ${{ inputs.label }} -c pytorch -c nvidia/label/cuda-${{ inputs.cuda }} -c nvidia
     - name: Conda build (GPU w/ RAFT)
       if: inputs.label == '' && inputs.cuda != '' && inputs.raft != ''
       shell: ${{ steps.choose_shell.outputs.shell }}
       working-directory: conda
       run: |
-        conda build faiss-gpu-raft --variants '{ "cudatoolkit": "${{ inputs.cuda }}", "c_compiler_version": "${{ inputs.compiler_version }}", "cxx_compiler_version": "${{ inputs.compiler_version }}" }' \
+        conda build faiss-gpu-raft --variants '{ "cudatoolkit": "${{ inputs.cuda }}" }' \
             -c pytorch -c nvidia/label/cuda-${{ inputs.cuda }} -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge
     - name: Conda build (GPU w/ RAFT) w/ anaconda upload
       if: inputs.label != '' && inputs.cuda != '' && inputs.raft != ''
@@ -92,5 +88,5 @@ runs:
       env:
         PACKAGE_TYPE: ${{ inputs.label }}
       run: |
-        conda build faiss-gpu-raft --variants '{ "cudatoolkit": "${{ inputs.cuda }}", "c_compiler_version": "${{ inputs.compiler_version }}", "cxx_compiler_version": "${{ inputs.compiler_version }}" }' \
+        conda build faiss-gpu-raft --variants '{ "cudatoolkit": "${{ inputs.cuda }}" }' \
             --user pytorch --label ${{ inputs.label }} -c pytorch -c nvidia/label/cuda-${{ inputs.cuda }} -c nvidia -c rapidsai -c rapidsai-nightly -c conda-forge

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,6 @@ jobs:
         with:
           label: main
           cuda: "11.4.4"
-          compiler_version: "11.2"
   linux-x86_64-GPU-RAFT-packages-CUDA11-8-0:
     name: Linux x86_64 GPU w/ RAFT packages (CUDA 11.8.0)
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -187,7 +186,6 @@ jobs:
           label: main
           raft: "ON"
           cuda: "11.8.0"
-          compiler_version: "11.2"
   linux-x86_64-GPU-packages-CUDA-12-1-1:
     name: Linux x86_64 GPU packages (CUDA 12.1.1)
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -204,7 +202,6 @@ jobs:
         with:
           label: main
           cuda: "12.1.1"
-          compiler_version: "11.2"
   linux-x86_64-GPU-RAFT-packages-CUDA12-1-1:
     name: Linux x86_64 GPU w/ RAFT packages (CUDA 12.1.1)
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -222,7 +219,6 @@ jobs:
           label: main
           raft: "ON"
           cuda: "12.1.1"
-          compiler_version: "11.2"
   windows-x86_64-packages:
     name: Windows x86_64 packages
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           label: nightly
           cuda: "11.4.4"
-          compiler_version: "11.2"
   linux-x86_64-GPU-RAFT-CUDA11-8-0-nightly:
     name: Linux x86_64 GPU w/ RAFT nightlies (CUDA 11.8.0)
     runs-on: 4-core-ubuntu-gpu-t4
@@ -57,7 +56,6 @@ jobs:
           label: nightly
           raft: "ON"
           cuda: "11.8.0"
-          compiler_version: "11.2"
   linux-x86_64-GPU-CUDA-12-1-1-nightly:
     name: Linux x86_64 GPU nightlies (CUDA 12.1.1)
     runs-on: 4-core-ubuntu-gpu-t4
@@ -75,7 +73,6 @@ jobs:
         with:
           label: nightly
           cuda: "12.1.1"
-          compiler_version: "11.2"
   linux-x86_64-GPU-RAFT-CUDA12-1-1-nightly:
     name: Linux x86_64 GPU w/ RAFT nightlies (CUDA 12.1.1)
     runs-on: 4-core-ubuntu-gpu-t4
@@ -94,7 +91,6 @@ jobs:
           label: nightly
           raft: "ON"
           cuda: "12.1.1"
-          compiler_version: "11.2"
   windows-x86_64-nightly:
     name: Windows x86_64 nightlies
     runs-on: windows-2019


### PR DESCRIPTION
Summary: The TestPartitioning.TestPartitioningBigRange test case fails on gcc version 13.2. We can avoid this by requiring gcc version 11.2 where the test case works.

Differential Revision: D59988036
