### PR TITLE
Add warning on adding nbits to LSH index factory

### DIFF
--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -531,7 +531,15 @@ Index* parse_other_indexes(
 
     // IndexLSH
     if (match("LSH([0-9]*)(r?)(t?)")) {
-        int nbits = sm[1].length() > 0 ? std::stoi(sm[1].str()) : d;
+        int nbits;
+        if (sm[1].length() > 0) {
+            nbits = std::stoi(sm[1].str());
+        } else {
+            nbits = d;
+            fprintf(stderr,
+                    "WARN: nbits not specified, defaulting to d = %d\n",
+                    d);
+        }
         bool rotate_data = sm[2].length() > 0;
         bool train_thresholds = sm[3].length() > 0;
         FAISS_THROW_IF_NOT(metric == METRIC_L2);


### PR DESCRIPTION
Summary: We will write a warning if nbits is not specified while using index factory with LSH. The warning lets users know we will be using default d as nbits.

Differential Revision: D60187935
