### PR TITLE
Back out "Add warning on adding nbits to LSH index factory"

### DIFF
--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -531,15 +531,7 @@ Index* parse_other_indexes(
 
     // IndexLSH
     if (match("LSH([0-9]*)(r?)(t?)")) {
-        int nbits;
-        if (sm[1].length() > 0) {
-            nbits = std::stoi(sm[1].str());
-        } else {
-            nbits = d;
-            fprintf(stderr,
-                    "WARN: nbits not specified, defaulting to d = %d\n",
-                    d);
-        }
+        int nbits = sm[1].length() > 0 ? std::stoi(sm[1].str()) : d;
         bool rotate_data = sm[2].length() > 0;
         bool train_thresholds = sm[3].length() > 0;
         FAISS_THROW_IF_NOT(metric == METRIC_L2);


### PR DESCRIPTION
Summary:
Seems like this may not be necessary because it is the the expected behavior.

See: https://github.com/facebookresearch/faiss/pull/3687#issuecomment-2249397476

Differential Revision: D60241747
