### PR TITLE
add test for external modules

### DIFF
--- a/faiss/python/faiss_example_external_module.swig
+++ b/faiss/python/faiss_example_external_module.swig
@@ -1,0 +1,133 @@
+
+%module faiss_example_external_module;
+
+
+// Put C++ includes here
+%{
+
+#include <faiss/impl/FaissException.h>
+#include <faiss/impl/IDSelector.h>
+
+%}
+
+#pragma SWIG nowarn=322
+
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+
+typedef signed char int8_t;
+typedef short int16_t;
+typedef int int32_t;
+
+#ifdef SWIGWORDSIZE64
+typedef unsigned long uint64_t;
+typedef long int64_t;
+#else
+typedef unsigned long long uint64_t;
+typedef long long int64_t;
+#endif
+
+typedef uint64_t size_t;
+
+// This means: assume what's declared in these .h files is provided
+// by the Faiss module.
+%import(module="faiss") "faiss/MetricType.h"
+%import(module="faiss") "faiss/impl/IDSelector.h"
+
+// functions to be parsed here
+
+// This is important to release GIL and do Faiss exception handing
+%exception {
+    Py_BEGIN_ALLOW_THREADS
+    try {
+        $action
+    } catch(faiss::FaissException & e) {
+        PyEval_RestoreThread(_save);
+
+        if (PyErr_Occurred()) {
+            // some previous code already set the error type.
+        } else {
+            PyErr_SetString(PyExc_RuntimeError, e.what());
+        }
+        SWIG_fail;
+    } catch(std::bad_alloc & ba) {
+        PyEval_RestoreThread(_save);
+        PyErr_SetString(PyExc_MemoryError, "std::bad_alloc");
+        SWIG_fail;
+    }
+    Py_END_ALLOW_THREADS
+}
+
+
+// any class or function declared below will be made available
+// in the module.
+%inline %{
+
+struct IDSelectorModulo : faiss::IDSelector {
+    int mod;
+
+    IDSelectorModulo(int mod): mod(mod) {}
+
+    bool is_member(faiss::idx_t id) const {
+        return id % mod == 0;
+    }
+
+    ~IDSelectorModulo() override {}
+};
+
+faiss::idx_t sum_of_idx(size_t n, const faiss::idx_t *tab) {
+    faiss::idx_t sum = 0;
+    for(size_t i = 0; i < n; i++) {
+        sum += tab[i];
+    }
+    return sum;
+}
+
+float sum_of_float32(size_t n, const float *tab) {
+    float sum = 0;
+    for(size_t i = 0; i < n; i++) {
+        sum += tab[i];
+    }
+    return sum;
+}
+
+double sum_of_float64(size_t n, const double *tab) {
+    double sum = 0;
+    for(size_t i = 0; i < n; i++) {
+        sum += tab[i];
+    }
+    return sum;
+}
+
+%}
+
+/**********************************************
+ * To test if passing a swig_ptr on all array types works
+ **********************************************/
+
+%define SUM_OF_TYPE(ty)
+
+%inline %{
+
+ty##_t sum_of_##ty (size_t n, const ty##_t * tab) {
+    ty##_t sum = 0;
+    for(size_t i = 0; i < n; i++) {
+        sum += tab[i];
+    }
+    return sum;
+}
+
+%}
+
+%enddef
+
+SUM_OF_TYPE(uint8);
+SUM_OF_TYPE(uint16);
+SUM_OF_TYPE(uint32);
+SUM_OF_TYPE(uint64);
+
+SUM_OF_TYPE(int8);
+SUM_OF_TYPE(int16);
+SUM_OF_TYPE(int32);
+SUM_OF_TYPE(int64);

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -33,7 +33,24 @@
 #pragma SWIG nowarn=512
 #pragma SWIG nowarn=362
 
-%include <stdint.i>
+// we need explict control of these typedefs...
+// %include <stdint.i>
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+
+// char != unsigned char AND char != signed char so be explicit
+typedef signed char int8_t;
+typedef short int16_t;
+typedef int int32_t;
+
+#ifdef SWIGWORDSIZE64
+typedef unsigned long uint64_t;
+typedef long int64_t;
+#else
+typedef unsigned long long uint64_t;
+typedef long long int64_t;
+#endif
 
 typedef uint64_t size_t;
 
@@ -239,10 +256,15 @@ namespace std {
 // primitive array types
 %template(Float32Vector) std::vector<float>;
 %template(Float64Vector) std::vector<double>;
+
+// werid interaction within C++ between char and signed char
+%ignore Int8Vector::swap;
+
 %template(Int8Vector) std::vector<int8_t>;
 %template(Int16Vector) std::vector<int16_t>;
 %template(Int32Vector) std::vector<int32_t>;
 %template(Int64Vector) std::vector<int64_t>;
+
 %template(UInt8Vector) std::vector<uint8_t>;
 %template(UInt16Vector) std::vector<uint16_t>;
 %template(UInt32Vector) std::vector<uint32_t>;
@@ -1086,6 +1108,13 @@ void *memcpy(void *dest, const void *src, size_t n);
 
 #ifdef SWIGPYTHON
 
+// transfer SWIG flag to C++
+#ifdef SWIGWORDSIZE64
+%{
+#define SWIGWORDSIZE64_CPP
+%}
+#endif
+
 %{
 PyObject *swig_ptr (PyObject *a)
 {
@@ -1120,7 +1149,7 @@ PyObject *swig_ptr (PyObject *a)
         return SWIG_NewPointerObj(data, SWIGTYPE_p_unsigned_char, 0);
     }
     if(PyArray_TYPE(ao) == NPY_INT8) {
-        return SWIG_NewPointerObj(data, SWIGTYPE_p_char, 0);
+        return SWIG_NewPointerObj(data, SWIGTYPE_p_signed_char, 0);
     }
     if(PyArray_TYPE(ao) == NPY_UINT16) {
         return SWIG_NewPointerObj(data, SWIGTYPE_p_unsigned_short, 0);
@@ -1141,16 +1170,17 @@ PyObject *swig_ptr (PyObject *a)
     // Convert npy64 either long or long long  and it depends on how compiler define int64_t.
     // In the 64bit machine, typically the int64_t should be long but it is not hold for Apple osx.
     // In this case, we want to convert npy64 to long_Long in osx
-#if __SIZEOF_LONG__ == 8 && !defined(__APPLE__)
+#ifdef SWIGWORDSIZE64_CPP
         return SWIG_NewPointerObj(data, SWIGTYPE_p_unsigned_long, 0);
 #else
         return SWIG_NewPointerObj(data, SWIGTYPE_p_unsigned_long_long, 0);
 #endif
     }
     if(PyArray_TYPE(ao) == NPY_INT64) {
-#if __SIZEOF_LONG__ == 8 && !defined(__APPLE__)
+#ifdef SWIGWORDSIZE64_CPP
         return SWIG_NewPointerObj(data, SWIGTYPE_p_long, 0);
 #else
+#error
         return SWIG_NewPointerObj(data, SWIGTYPE_p_long_long, 0);
 #endif
     }

--- a/tests/test_external_module.py
+++ b/tests/test_external_module.py
@@ -1,0 +1,66 @@
+
+import unittest
+
+import numpy as np
+
+import faiss
+try:
+    import faiss_example_external_module as external_module 
+except ModuleNotFoundError:
+    external_module = None 
+
+@unittest.skipIf(external_module is None, "cannot load external_module")
+class TestCustomIDSelector(unittest.TestCase):
+    """ test if we can construct a custom IDSelector """
+
+    def test_IDSelector(self):
+        ids = external_module.IDSelectorModulo(3)
+        self.assertFalse(ids.is_member(1))
+        self.assertTrue(ids.is_member(3))
+
+
+@unittest.skipIf(external_module is None, "cannot load external_module")
+class TestArrayConversions(unittest.TestCase):
+
+    def test_idx_array(self):
+        tab = np.arange(10).astype('int64')
+        new_sum = external_module.sum_of_idx(len(tab), faiss.swig_ptr(tab))
+        self.assertEqual(new_sum, tab.sum())
+
+    def do_array_test(self, ty):
+        tab = np.arange(10).astype(ty)
+        func = getattr(external_module, 'sum_of_' + ty)
+        print("perceived type", faiss.swig_ptr(tab))
+        new_sum = func(len(tab), faiss.swig_ptr(tab))
+        self.assertEqual(new_sum, tab.sum())
+
+    def test_sum_uint8(self):
+        self.do_array_test('uint8')
+
+    def test_sum_uint16(self):
+        self.do_array_test('uint16')
+
+    def test_sum_uint32(self):
+        self.do_array_test('uint32')
+
+    def test_sum_uint64(self):
+        self.do_array_test('uint64')
+
+    # this conversion does not work
+    def test_sum_int8(self):
+        self.do_array_test('int8')
+
+    def test_sum_int16(self):
+        self.do_array_test('int16')
+
+    def test_sum_int32(self):
+        self.do_array_test('int32')
+
+    def test_sum_int64(self):
+        self.do_array_test('int64')
+
+    def test_sum_float32(self):
+        self.do_array_test('float32')
+
+    def test_sum_float64(self):
+        self.do_array_test('float64')


### PR DESCRIPTION
Summary:
External modules should work fine as plug-ins to Faiss in the following cases:

* additional objects that can be passed in as callbacks to Faiss

* functions that use `faiss.swig_ptr` to pass in arrays.

The `swig_ptr` functionality does not always work well (also depending on the platform). Therefore this diff adds a small external swig file to test that everything works smoothly on that end.

Differential Revision: D60379753


