### PR TITLE
Gate ARM SVE build behind base Linux build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,7 @@ jobs:
           raft: ON
   linux-arm64-SVE-cmake:
     name: Linux arm64 SVE (cmake)
+    needs: linux-x86_64-cmake
     runs-on: faiss-aws-r8g.large
     continue-on-error: true # non-blocking mode for now
     steps:


### PR DESCRIPTION
Summary: Gating ARM SVE behind the plain vanilla linux x64 build like all the other builds.

Differential Revision: D60425535
