### PR TITLE
github issue 2996

### DIFF
--- a/faiss/python/class_wrappers.py
+++ b/faiss/python/class_wrappers.py
@@ -1227,6 +1227,9 @@ def handle_IDSelectorSubset(the_class, class_owns, force_int64=True):
             if not class_owns:
                 add_to_referenced_objects(self, subset)
         self.original_init(*args)
+        print("inside replacement_init 1: " + str(self.this.own()))
+        self.this.own(True)
+        print("inside replacement_init 2: " + str(self.this.own()))
 
     the_class.__init__ = replacement_init
 

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -46,6 +46,22 @@ typedef uint64_t size_t;
  * the language includes for their respective matrix libraries.
  *******************************************************************/
 
+%typemap(in, noblock=1) faiss::IDSelector * sel(void  *argp = 0, int res = 0) {
+  printf("IN TYPEMAP. Prints last, but gets parsed first. Setting $1 = NULL shows that.\n");
+  int own;
+  SwigPyObject *sobj;
+  own = 0;
+  res = SWIG_ConvertPtrAndOwn($input, &argp, $descriptor, 0, &own);
+  sobj = SWIG_Python_GetSwigThis($input);
+  printf("sobj own? %d\n", sobj->own); // TODO: what about ownership after conversion?
+  printf("OWN after conversion: %d\n", own);
+  if (!SWIG_IsOK(res)) { 
+    %argument_fail(res, "$type", $symname, $argnum); 
+  }
+  $1 = %reinterpret_cast(argp, $ltype);
+  printf("$1 pointer:  %p  %s\n", $1, $ltype);
+}
+
 %{
 
 

--- a/tests/test_search_params.py
+++ b/tests/test_search_params.py
@@ -397,6 +397,31 @@ class TestSearchParams(unittest.TestCase):
         self.assertTrue(sel1.this.own())
         self.assertTrue(sel2.this.own())
 
+    def test_ownership_2(self):
+        res = []
+        params = faiss.SearchParameters()
+        subset = np.arange(0, 5000000)
+        print("creating temp")
+        # temp = faiss.IDSelectorBatch(subset)
+        # print("temp result: " + str(temp))
+        print("creating params.sel")
+        params.sel = faiss.IDSelectorBatch(subset)
+        print("params.sel result: " + str(params.sel))
+        print("outside in test: " + str(params.sel.this.own()) + "   " + str(params.sel.thisown))
+        # params.sel = temp # With this line, NO PRINT AT ALL. Without this line, prints JUST hi2
+        # for _ in range(20):
+        #     params = faiss.SearchParameters()
+        #     subset = np.arange(0, 5000000)
+        #     params.sel = faiss.IDSelectorBatch(subset)
+        #     # print("outside in test: " + str(params.sel.this.own()) + "   " + str(params.sel.thisown))
+        #     # params.sel.this.own(True)
+        #     mem_usage = faiss.get_mem_usage_kb() / 1024 ** 2
+        #     res.append(round(mem_usage, 2))
+        print(res)
+        gc.collect()
+        print("last line?")
+        self.assertTrue(False)
+
 
 class TestSelectorCallback(unittest.TestCase):
 


### PR DESCRIPTION
Summary:
Background
--
Issue: https://github.com/facebookresearch/faiss/issues/2996

Prior attempted fix: https://github.com/facebookresearch/faiss/pull/3007/files#diff-d704f33c46a4ef2936c8cf2a66b05f1993e25e79ee5c19d4b63c4e0cf46b0a42

It is a confirmed and reproducible memory leak every time. There is a workaround. See the task comments.

Relevant SWIG docs: https://www.swig.org/Doc4.1/SWIGDocumentation.html#Typemaps_nn2

Current status
--
The below command reproduces it and gets the SWIG typemap to activate.
Asked SWIG folks for help thus far to get the typemap to activate: https://github.com/swig/swig/issues/2709.

`buck test faiss/tests:test_search_params -- test_ownership_2`

But I can't get the ownership to work in the typemap. Further investigation can see how we can get the ownership to work.

Differential Revision: D60151215
