### PR TITLE
suppress warning

### DIFF
--- a/faiss/utils/extra_distances-inl.h
+++ b/faiss/utils/extra_distances-inl.h
@@ -9,6 +9,7 @@
  *  and inner product */
 
 #include <faiss/MetricType.h>
+#include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/distances.h>
 #include <cmath>
 #include <type_traits>
@@ -193,6 +194,8 @@ typename Consumer::T dispatch_VectorDistance(
         DISPATCH_VD(METRIC_Jaccard);
         DISPATCH_VD(METRIC_NaNEuclidean);
         DISPATCH_VD(METRIC_ABS_INNER_PRODUCT);
+        default:
+            FAISS_THROW_FMT("Invalid metric %d", metric);
     }
 #undef DISPATCH_VD
 }


### PR DESCRIPTION
suppress below warning:

```
In file included from /path/to/faiss/faiss/utils/extra_distances.h:59,
                 from /path/to/faiss/faiss/IndexFlatCodes.cpp:16:
/path/to/faiss/faiss/utils/extra_distances-inl.h: In function ‘typename Consumer::T faiss::dispatch_VectorDistance(size_t, MetricType, float, Consumer&, Types ...) [with Consumer = {anonymous}::Run_get_distance_computer; Types = {const IndexFlatCodes*}]’:
/path/to/faiss/faiss/utils/extra_distances-inl.h:198:1: warning: control reaches end of non-void function [-Wreturn-type]
  198 | }
      | ^
```