### PR TITLE
turn on blocking build for AVX512 and SVE on GhA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,17 +56,14 @@ jobs:
           opt_level: avx2
   linux-x86_64-AVX512-cmake:
     name: Linux x86_64 AVX512 (cmake)
-    continue-on-error: true # non-blocking mode for now
     needs: linux-x86_64-cmake
     runs-on: faiss-aws-m7i.large
     steps:
       - name: Checkout
-        continue-on-error: true # non-blocking mode for now
         uses: actions/checkout@v4
       - uses: ./.github/actions/build_cmake
         with:
           opt_level: avx512
-        continue-on-error: true # non-blocking mode for now
   linux-x86_64-GPU-cmake:
     name: Linux x86_64 GPU (cmake)
     needs: linux-x86_64-cmake
@@ -103,13 +100,10 @@ jobs:
     name: Linux arm64 SVE (cmake)
     needs: linux-x86_64-cmake
     runs-on: faiss-aws-r8g.large
-    continue-on-error: true # non-blocking mode for now
     steps:
       - name: Checkout
-        continue-on-error: true # non-blocking mode for now
         uses: actions/checkout@v4
       - uses: ./.github/actions/build_cmake
-        continue-on-error: true # non-blocking mode for now
         with:
           opt_level: sve
   linux-x86_64-conda:


### PR DESCRIPTION
Summary:
they have been running in shadow mode for quite some time now.
 I spot-checked the builds for the past 10 jobs and they all look good. Since `continue-on-error` will always mark a job as "green" even if it fails, I need a way to holistically verify these builds actually work reliably. Turning the builds to blocking to accomplish that.

Differential Revision: D60692521
