### PR TITLE
CMake step to symlink system libraries for RAFT and ROCm

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -100,16 +100,19 @@ runs:
         # Cleanup
         sudo apt-get autoclean && sudo apt-get clean
         sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
+    - name: ROCm - Hipify
+      if: inputs.rocm == 'ON'
+      shell: bash
+      run: ./faiss/gpu/hipify.sh
+    - name: Symblink system dependencies
+      if: inputs.raft == 'ON' || inputs.rocm == 'ON'
+      shell: bash
+      run: |
         # symblink system libraries for HIP compiler
         sudo ln -s /lib/x86_64-linux-gnu/libc.so.6 /lib64/libc.so.6
         sudo ln -s /lib/x86_64-linux-gnu/libc_nonshared.a /usr/lib64/libc_nonshared.a
         sudo ln -s /usr/lib/x86_64-linux-gnu/libpthread.so.0 /lib64/libpthread.so.0
         sudo ln -s /home/runner/miniconda3/x86_64-conda-linux-gnu/sysroot/usr/lib64/libpthread_nonshared.a /usr/lib64/libpthread_nonshared.a
-    - name: ROCm - Hipify
-      if: inputs.rocm == 'ON'
-      shell: bash
-      run: ./faiss/gpu/hipify.sh
     - name: Build all targets
       shell: bash
       run: |


### PR DESCRIPTION
Summary: This step is necessary for both of the builds with newer gxx_linux package version. ROCm is already using this symlinking and this change expands it to RAFT as well.

Differential Revision: D60830977


