### PR TITLE
Append ROCm flag to compile definitions for Python instead of overwriting

### DIFF
--- a/faiss/python/CMakeLists.txt
+++ b/faiss/python/CMakeLists.txt
@@ -39,7 +39,7 @@ macro(configure_swigfaiss source)
       COMPILE_DEFINITIONS GPU_WRAPPER
     )
     if (FAISS_ENABLE_ROCM)
-      set_source_files_properties(${source} PROPERTIES
+      set_property(SOURCE ${source} APPEND PROPERTY
         COMPILE_DEFINITIONS FAISS_ENABLE_ROCM
       )
     endif()


### PR DESCRIPTION
Summary: Before this change, the CMake line was setting (instead of appending to) compile definitions for Python code which replace the GPU wrappers flag and resulting in Python library compiling with no GPU code which failed ROCm tests.

Differential Revision: D61007640


