### PR TITLE
Use $HOME variable to find Conda binaries instead of hard-coded path

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -107,7 +107,7 @@ runs:
         sudo ln -s /lib/x86_64-linux-gnu/libc.so.6 /lib64/libc.so.6
         sudo ln -s /lib/x86_64-linux-gnu/libc_nonshared.a /usr/lib64/libc_nonshared.a
         sudo ln -s /usr/lib/x86_64-linux-gnu/libpthread.so.0 /lib64/libpthread.so.0
-        sudo ln -s /home/runner/miniconda3/x86_64-conda-linux-gnu/sysroot/usr/lib64/libpthread_nonshared.a /usr/lib64/libpthread_nonshared.a
+        sudo ln -s $HOME/miniconda3/x86_64-conda-linux-gnu/sysroot/usr/lib64/libpthread_nonshared.a /usr/lib64/libpthread_nonshared.a
     - name: Build all targets
       shell: bash
       run: |

--- a/faiss/python/CMakeLists.txt
+++ b/faiss/python/CMakeLists.txt
@@ -39,7 +39,7 @@ macro(configure_swigfaiss source)
       COMPILE_DEFINITIONS GPU_WRAPPER
     )
     if (FAISS_ENABLE_ROCM)
-      set_source_files_properties(${source} PROPERTIES
+      set_property(SOURCE ${source} APPEND PROPERTY
         COMPILE_DEFINITIONS FAISS_ENABLE_ROCM
       )
     endif()


### PR DESCRIPTION
Summary: This fixes containerized builds that will be needed for ROCm.

Differential Revision: D61007764


