### PR TITLE
minor refactors to move logic near to the places where it's required.

### DIFF
--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -228,12 +228,7 @@ void IndexIVF::add_core(
     FAISS_THROW_IF_NOT(is_trained);
     direct_map.check_can_add(xids);
 
-    size_t nadd = 0, nminus1 = 0;
-
-    for (size_t i = 0; i < n; i++) {
-        if (coarse_idx[i] < 0)
-            nminus1++;
-    }
+    size_t nadd = 0;
 
     std::unique_ptr<uint8_t[]> flat_codes(new uint8_t[n * code_size]);
     encode_vectors(n, x, coarse_idx, flat_codes.get());
@@ -266,6 +261,11 @@ void IndexIVF::add_core(
     }
 
     if (verbose) {
+        size_t nminus1 = 0;
+        for (size_t i = 0; i < n; i++) {
+            if (coarse_idx[i] < 0)
+                nminus1++;
+        }
         printf("    added %zd / %" PRId64 " vectors (%zd -1s)\n",
                nadd,
                n,
@@ -276,11 +276,8 @@ void IndexIVF::add_core(
 }
 
 void IndexIVF::make_direct_map(bool b) {
-    if (b) {
-        direct_map.set_type(DirectMap::Array, invlists, ntotal);
-    } else {
-        direct_map.set_type(DirectMap::NoMap, invlists, ntotal);
-    }
+    DirectMap::Type type = b ? DirectMap::Array : DirectMap::NoMap;
+    direct_map.set_type(type, invlists, ntotal);
 }
 
 void IndexIVF::set_direct_map_type(DirectMap::Type type) {

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -318,16 +318,14 @@ void IndexIVFPQ::reconstruct_from_offset(
         float* recons) const {
     const uint8_t* code = invlists->get_single_code(list_no, offset);
 
+    pq.decode(code, recons);
     if (by_residual) {
         std::vector<float> centroid(d);
         quantizer->reconstruct(list_no, centroid.data());
 
-        pq.decode(code, recons);
         for (int i = 0; i < d; ++i) {
             recons[i] += centroid[i];
         }
-    } else {
-        pq.decode(code, recons);
     }
 }
 

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -192,11 +192,10 @@ void IndexIVFPQ::sa_decode(idx_t n, const uint8_t* codes, float* x) const {
 #pragma omp for
         for (idx_t i = 0; i < n; i++) {
             const uint8_t* code = codes + i * (code_size + coarse_size);
-            int64_t list_no = decode_listno(code);
             float* xi = x + i * d;
             pq.decode(code + coarse_size, xi);
             if (by_residual) {
-                quantizer->reconstruct(list_no, residual.data());
+                quantizer->reconstruct(decode_listno(code), residual.data());
                 for (size_t j = 0; j < d; j++) {
                     xi[j] += residual[j];
                 }


### PR DESCRIPTION
Summary:
Minor refactors:
* move `nminus1` calculation in IVF to debug block (removes redundant calculation when `verbose` is not set)
* `decode_listno` in IVFPQ only when encoding is `by_residual`
* use ternary (`?`) to avoid if/else block.

Differential Revision: D61283444
