### PR TITLE
Add midding hipStream SWIG typedef to fix ROCm memleak in Python

### DIFF
--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -352,6 +352,8 @@ void gpu_sync_all_devices()
 %include  <faiss/gpu-rocm/GpuResources.h>
 %include  <faiss/gpu-rocm/StandardGpuResources.h>
 
+typedef ihipStream_t* hipStream_t;
+
 %inline %{
 
 // interop between pytorch exposed hipStream_t and faiss


### PR DESCRIPTION
Summary: This fixes the memleak and the warning received after running Python tests under ROCm since no destructor was declared and objects would remain allocated.

Differential Revision: D61357579


