### PR TITLE
Reorder imports in torch_test_contrib_gpu

### DIFF
--- a/faiss/gpu/test/torch_test_contrib_gpu.py
+++ b/faiss/gpu/test/torch_test_contrib_gpu.py
@@ -3,10 +3,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import faiss
 import torch
 import unittest
 import numpy as np
+import faiss
 import faiss.contrib.torch_utils
 
 def to_column_major_torch(x):

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -352,6 +352,8 @@ void gpu_sync_all_devices()
 %include  <faiss/gpu-rocm/GpuResources.h>
 %include  <faiss/gpu-rocm/StandardGpuResources.h>
 
+typedef ihipStream_t* hipStream_t;
+
 %inline %{
 
 // interop between pytorch exposed hipStream_t and faiss


### PR DESCRIPTION
Summary: This fixes CUDA errors inside faiss in the test environment. If torch is loaded first (this change) then both torch and faiss see all GPUs available on the machine in the ROCm build. Without this change, torch sees the GPUs and faiss does not. AMD team is looking at finding the root cause but we wanted to fix this for now.

Differential Revision: D61358018


