### PR TITLE
Specify to retry only on failed jobs

### DIFF
--- a/.github/workflows/retry_build.yml
+++ b/.github/workflows/retry_build.yml
@@ -16,4 +16,10 @@ jobs:
           GH_DEBUG: api
         run: |
           gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
-          gh run rerun ${{ inputs.run_id }} --failed
+
+          # Only retry if there are failed jobs
+          if gh run view ${{ inputs.run_id }} --exit-status; then
+            echo Workflow succeeded - no retry necessary.
+          else
+            gh run rerun ${{ inputs.run_id }} --failed
+          fi


### PR DESCRIPTION
Summary: It looks like there are many failures on the retry build workflow, but these are mainly due to retry attempts with the --failed flag being unable to rerun workflows that don't have any failed jobs.

Differential Revision: D61489426
