### PR TITLE
Build SVE CI with openblas that was compiled with USE_OPENMP=1

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -36,7 +36,12 @@ runs:
 
         # install base packages for ARM64
         if [ "${{ runner.arch }}" = "ARM64" ]; then
-          conda install -y -q -c conda-forge openblas gxx_linux-aarch64 sysroot_linux-aarch64
+          # installing libmamba-solver is necessary for openblas=*=*openmp*
+          conda install --solver=classic conda-forge::conda-libmamba-solver conda-forge::libmamba conda-forge::libmambapy conda-forge::libarchive
+
+          # installing openblas that was compiled with USE_OPENMP=1.
+          # Context: https://github.com/facebookresearch/faiss/wiki/Troubleshooting#surprising-faiss-openmp-and-openblas-interaction
+          conda install -y -q -c conda-forge openblas=*=*openmp* gxx_linux-aarch64 sysroot_linux-aarch64
         fi
 
         # install base packages for X86_64


### PR DESCRIPTION
I noticed by default, conda install openblas installs `libopenblas-pthreads` on our SVE CI. This can be problematic as described in https://github.com/facebookresearch/faiss/wiki/Troubleshooting#surprising-faiss-openmp-and-openblas-interaction

Updating installation of openblas to be more specific and use the version that works well with openmp.

Sees version `0.3.27-openmp_h1b0c31a_0` for openblas instead of `pthread`