### PR TITLE
add cont_build.yml

### DIFF
--- a/.github/workflows/cont_build.yml
+++ b/.github/workflows/cont_build.yml
@@ -1,0 +1,32 @@
+  name: Continuous Build (once a day)
+on:
+  schedule:
+    - cron:  '10 6 * * *'
+env:
+  OMP_NUM_THREADS: '10'
+  MKL_THREADING_LAYER: GNU
+jobs:
+  linux-arm64-SVE-cont-build:
+    name: Linux arm64 SVE Contbuild
+    needs: linux-x86_64-nightly
+    runs-on: faiss-aws-r8g.large
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build and Test (cmake)
+        uses: ./.github/actions/build_cmake
+        with:
+          opt_level: sve
+  auto-retry:
+    name: Auto retry on failure
+    if: fromJSON(github.run_attempt) < 2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start rerun workflow
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
+        run: |
+          gh workflow run retry_build.yml \
+            -F run_id=${{ github.run_id }}


### PR DESCRIPTION
Summary: SVE is the platform that is not covered by nightlies. This meant that an external dependency change breaking the SVE CI will not be obviously surfaced unless there has been a PR. Adding a `cont_build.yml` that is the start of continuous runs for certain workflows that we care about (keeping it separate from nightlies since nightlies are reserved for conda publication). Moving forward, this workflow will be leveraged by regression testing as well (those should also run continuously to gather reliable baselines and to prevent regressions caused by external dependencies)

Reviewed By: junjieqi

Differential Revision: D61564187


