### PR TITLE
Add sampling fields to dataset descriptor

### DIFF
--- a/benchs/bench_fw/descriptors.py
+++ b/benchs/bench_fw/descriptors.py
@@ -80,6 +80,11 @@ class DatasetDescriptor:
 
     embedding_column: Optional[str] = None
 
+    sampling_rate: Optional[float] = None
+
+    # sampling column for xdb
+    sampling_column: Optional[str] = None
+
     def __hash__(self):
         return hash(self.get_filename())
 


### PR DESCRIPTION
Summary: Fields sampling_column and sampling_rate are added to dataset descriptor for supporting sampling in dataset readers.

Differential Revision: D61569067
