### PR TITLE
fix get_compile_options bug

### DIFF
--- a/faiss/utils/utils.cpp
+++ b/faiss/utils/utils.cpp
@@ -117,8 +117,9 @@ std::string get_compile_options() {
 
 #ifdef __AVX2__
     options += "AVX2 ";
-#elif __AVX512F__
+#ifdef __AVX512F__
     options += "AVX512 ";
+#endif
 #elif defined(__ARM_FEATURE_SVE)
     options += "SVE NEON ";
 #elif defined(__aarch64__)


### PR DESCRIPTION
Summary: Right now when avx512 is turned on, we will only return AVX2 in options. My understanding is turning on avx512 sets both the macros `__AVX2__` and `__AVX512F__`: https://fburl.com/vgh7jg9p

Reviewed By: asadoughi

Differential Revision: D61674490
