### PR TITLE
Enable most of C++ tests on ROCm

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -131,7 +131,6 @@ runs:
               .
         make -k -C build -j$(nproc)
     - name: C++ tests
-      if: inputs.rocm == 'OFF'
       shell: bash
       run: |
         export GTEST_OUTPUT="xml:$(realpath .)/test-results/googletest/"

--- a/faiss/gpu/test/TestGpuIndexIVFPQ.cpp
+++ b/faiss/gpu/test/TestGpuIndexIVFPQ.cpp
@@ -307,6 +307,8 @@ void testMMCodeDistance(faiss::MetricType mt) {
     }
 }
 
+// FIXME: https://github.com/facebookresearch/faiss/issues/3787
+#ifndef USE_AMD_ROCM
 TEST(TestGpuIndexIVFPQ, Query_L2_MMCodeDistance) {
     testMMCodeDistance(faiss::MetricType::METRIC_L2);
 }
@@ -314,6 +316,7 @@ TEST(TestGpuIndexIVFPQ, Query_L2_MMCodeDistance) {
 TEST(TestGpuIndexIVFPQ, Query_IP_MMCodeDistance) {
     testMMCodeDistance(faiss::MetricType::METRIC_INNER_PRODUCT);
 }
+#endif // USE_AMD_ROCM
 
 TEST(TestGpuIndexIVFPQ, Float16Coarse) {
     Options opt;


### PR DESCRIPTION
Summary:
ROCm build successfully passes all but 2 GPU tests and we want to enable the passing test on CI while skipping the 2 failing tests to make progress. The 2 failing tests are failing specifically on the hardware type that we use for our runners and the AMD team is actively working on root causing it and providing a fix:
`TestGpuIndexIVFPQ.Query_L2_MMCodeDistance`
`TestGpuIndexIVFPQ.Query_IP_MMCodeDistance`

Differential Revision: D61688657


