### PR TITLE
[IGNORE] 3526: numpy 2 hacks

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -63,9 +63,9 @@ runs:
           : # skip torch install via conda, we need to install via pip to get
             #  ROCm-enabled version until it's supported in conda by PyTorch
         elif [ "${{ inputs.gpu }}" = "ON" ]; then
-          conda install -y -q pytorch pytorch-cuda=12.4 -c pytorch -c nvidia/label/cuda-12.4.0
+          conda install -y -q pytorch pytorch-cuda=12.4 -c pytorch>=2 -c nvidia/label/cuda-12.4.0
         else
-          conda install -y -q pytorch -c pytorch
+          conda install -y -q pytorch -c pytorch>=2
         fi
     - name: ROCm - Install dependencies
       if: inputs.rocm == 'ON'

--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -32,7 +32,8 @@ runs:
         conda update -y -q conda
         echo "$CONDA/bin" >> $GITHUB_PATH
 
-        conda install -y -q python=3.11 cmake make swig numpy scipy pytest
+        conda install -y -q -c conda-forge numpy=2.0
+        conda install -y -q python=3.11 cmake make swig scipy pytest
 
         # install base packages for ARM64
         if [ "${{ runner.arch }}" = "ARM64" ]; then

--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -32,7 +32,7 @@ runs:
         conda update -y -q conda
         echo "$CONDA/bin" >> $GITHUB_PATH
 
-        conda install -y -q -c conda-forge numpy=2.0
+        conda install -y -q -c conda-forge numpy=2.1.0
         conda install -y -q python=3.11 cmake make swig scipy pytest
 
         # install base packages for ARM64

--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -63,9 +63,9 @@ runs:
           : # skip torch install via conda, we need to install via pip to get
             #  ROCm-enabled version until it's supported in conda by PyTorch
         elif [ "${{ inputs.gpu }}" = "ON" ]; then
-          conda install -y -q pytorch pytorch-cuda=12.4 -c pytorch>=2 -c nvidia/label/cuda-12.4.0
+          conda install -y -q pytorch pytorch-cuda=12.4 -c "pytorch>=2" -c nvidia/label/cuda-12.4.0
         else
-          conda install -y -q pytorch -c pytorch>=2
+          conda install -y -q pytorch -c "pytorch>=2"
         fi
     - name: ROCm - Install dependencies
       if: inputs.rocm == 'ON'

--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -63,9 +63,9 @@ runs:
           : # skip torch install via conda, we need to install via pip to get
             #  ROCm-enabled version until it's supported in conda by PyTorch
         elif [ "${{ inputs.gpu }}" = "ON" ]; then
-          conda install -y -q pytorch pytorch-cuda=12.4 -c "pytorch>=2" -c nvidia/label/cuda-12.4.0
+          conda install -y -q "pytorch>=2" pytorch-cuda=12.4 -c pytorch -c nvidia/label/cuda-12.4.0
         else
-          conda install -y -q pytorch -c "pytorch>=2"
+          conda install -y -q "pytorch>=2" -c pytorch
         fi
     - name: ROCm - Install dependencies
       if: inputs.rocm == 'ON'

--- a/faiss/python/loader.py
+++ b/faiss/python/loader.py
@@ -44,7 +44,7 @@ def supported_instruction_sets():
     import numpy
     if Version(numpy.__version__) >= Version("1.19"):
         # use private API as next-best thing until numpy/numpy#18058 is solved
-        from numpy.core._multiarray_umath import __cpu_features__
+        from numpy._core._multiarray_umath import __cpu_features__
         # __cpu_features__ is a dictionary with CPU features
         # as keys, and True / False as values
         supported = {k for k, v in __cpu_features__.items() if v}

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -373,7 +373,7 @@ class TestPreassigned(unittest.TestCase):
         D, I = ivf_tools.search_preassigned(index, xq, 4, a)
         radius = D.max() * 1.01
 
-        lims, DR, IR = ivf_tools.range_search_preassigned(index, xq, radius, a)
+        lims, DR, IR = ivf_tools.range_search_preassigned(index, xq, float(radius), a)
 
         # with that radius the k-NN results are a subset of the range search
         # results


### PR DESCRIPTION
ran with numpy==2.1.0 on OS X
* need to understand why SWIG is not converting np.float32 as float * as it was before
* numpy/numpy/18058 mentions we should be using show_config() or perhaps show_runtime() instead of the internal api