### PR TITLE
Use weights_only for load

### DIFF
--- a/demos/demo_qinco.py
+++ b/demos/demo_qinco.py
@@ -36,7 +36,7 @@ import model_qinco
 
 with torch.no_grad():
 
-    qinco = torch.load("/tmp/bigann_8x8_L2.pt", weights_only=True)
+    qinco = torch.load("/tmp/bigann_8x8_L2.pt", weights_only=False)
     qinco.eval()
     # print(qinco)
     if True:

--- a/demos/demo_qinco.py
+++ b/demos/demo_qinco.py
@@ -36,7 +36,7 @@ import model_qinco
 
 with torch.no_grad():
 
-    qinco = torch.load("/tmp/bigann_8x8_L2.pt")
+    qinco = torch.load("/tmp/bigann_8x8_L2.pt", weights_only=True)
     qinco.eval()
     # print(qinco)
     if True:


### PR DESCRIPTION
`torch.load` without `weights_only` parameter is unsafe. Explicitly set `weights_only` to False only if you trust the data you load and full pickle functionality is needed, otherwise set `weights_only=True`.

If `weights_only=True` doesn't work for some cases, then explicit `weights_only=False` should be used.

Found with https://github.com/pytorch-labs/torchfix/