### PR TITLE
avx512 compilation option

### DIFF
--- a/faiss/utils/utils.cpp
+++ b/faiss/utils/utils.cpp
@@ -115,11 +115,10 @@ std::string get_compile_options() {
     options += "OPTIMIZE ";
 #endif
 
-#ifdef __AVX2__
-    options += "AVX2 ";
 #ifdef __AVX512F__
     options += "AVX512 ";
-#endif
+#elif defined(__AVX2__)
+    options += "AVX2 ";
 #elif defined(__ARM_FEATURE_SVE)
     options += "SVE NEON ";
 #elif defined(__aarch64__)


### PR DESCRIPTION
Summary: Alexander left a comment on the previous PR: https://github.com/facebookresearch/faiss/pull/3785#issuecomment-2305864630. The contract for the function seems to be that it will only append a single compilation option, not a list of options. Fixing it to comply with the contract.

Reviewed By: asadoughi, ramilbakhshyiev

Differential Revision: D61803839
