### PR TITLE
Nightly failure fix - ignore searched vectors with identical distances

### DIFF
--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -16,6 +16,7 @@ import re
 import warnings
 
 from common_faiss_tests import get_dataset, get_dataset_2
+from faiss.contrib.evaluation import check_ref_knn_with_draws
 
 class TestModuleInterface(unittest.TestCase):
 
@@ -422,7 +423,7 @@ class TestSearchAndReconstruct(unittest.TestCase):
         D, I, R = index.search_and_reconstruct(xq, k)
 
         np.testing.assert_almost_equal(D, D_ref, decimal=5)
-        self.assertTrue((I == I_ref).all())
+        check_ref_knn_with_draws(D_ref, I_ref, D, I)
         self.assertEqual(R.shape[:2], I.shape)
         self.assertEqual(R.shape[2], d)
 


### PR DESCRIPTION
Summary:
test_IndexIVFRQ is failing nightly GPU w/RAFT builds. These are false positive failures for the edge cases when the distance of a query vector to two candidate vectors is identical. In such cases, the search and search_and_reconstruct return these candidate vectors in a different order (on GPU w/Raft).

Current fix is to ignore the order of such ids with identical distances by sorting on distance and use id as tiebreaker. There is negligible performance implication (5ms extra), given the test candidate size is low.

Differential Revision: D61977915
