### PR TITLE
Allow k and M suffixes in IVF indexes

### DIFF
--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -238,6 +238,18 @@ class TestFactoryV2(unittest.TestCase):
         index = faiss.index_factory(123, "IVF456,Flat")
         self.assertEqual(index.__class__, faiss.IndexIVFFlat)
 
+    def test_ivf_suffix_k(self):
+        index = faiss.index_factory(123, "IVF3k,Flat")
+        self.assertEqual(index.nlist, 3072)
+
+    def test_ivf_suffix_M(self):
+        index = faiss.index_factory(123, "IVF1M,Flat")
+        self.assertEqual(index.nlist, 1024 * 1024)
+
+    def test_ivf_suffix_HNSW_M(self):
+        index = faiss.index_factory(123, "IVF1M_HNSW,Flat")
+        self.assertEqual(index.nlist, 1024 * 1024)
+
     def test_idmap(self):
         index = faiss.index_factory(123, "Flat,IDMap")
         self.assertEqual(index.__class__, faiss.IndexIDMap)


### PR DESCRIPTION
Summary:
Allows factory strings like `IVF3k,Flat` as a shorthand for 3072 centroids.

The main question is whether k or M should be metric (k=1000) or power of 2 (k=1024):

* pro-metric: standard,

* pro-power of 2: in practice we use powers of 2 most often

The suffixes ki and Mi should be used for powers of 2 but this makes the notation more heavy (which is what we wanted to avoid in the first place).

So I picked power of 2.

Differential Revision: D62019941
