### PR TITLE
Fix deprecated use of 0/NULL

### DIFF
--- a/faiss/gpu/test/demo_ivfpq_indexing_gpu.cpp
+++ b/faiss/gpu/test/demo_ivfpq_indexing_gpu.cpp
@@ -20,7 +20,7 @@
 
 double elapsed() {
     struct timeval tv;
-    gettimeofday(&tv, NULL);
+    gettimeofday(&tv, nullptr);
     return tv.tv_sec + tv.tv_usec * 1e-6;
 }
 

--- a/faiss/gpu/utils/Timer.cpp
+++ b/faiss/gpu/utils/Timer.cpp
@@ -14,7 +14,10 @@ namespace faiss {
 namespace gpu {
 
 KernelTimer::KernelTimer(cudaStream_t stream)
-        : startEvent_(0), stopEvent_(0), stream_(stream), valid_(true) {
+        : startEvent_(nullptr),
+          stopEvent_(nullptr),
+          stream_(stream),
+          valid_(true) {
     CUDA_VERIFY(cudaEventCreate(&startEvent_));
     CUDA_VERIFY(cudaEventCreate(&stopEvent_));
 

--- a/faiss/gpu/utils/Timer.h
+++ b/faiss/gpu/utils/Timer.h
@@ -18,7 +18,7 @@ class KernelTimer {
    public:
     /// Constructor starts the timer and adds an event into the current
     /// device stream
-    KernelTimer(cudaStream_t stream = 0);
+    KernelTimer(cudaStream_t stream = nullptr);
 
     /// Destructor releases event resources
     ~KernelTimer();


### PR DESCRIPTION
Summary: `nullptr` is typesafe. `0` and `NULL` are not. We are interested in enabling `-Wzero-as-null-pointer-constant` for first-party code, and only `nullptr` will be allowed.

Differential Revision: D62083883


