### PR TITLE
Prevent reordering of imports by auto formatter to avoid crashes

### DIFF
--- a/tests/torch_test_contrib.py
+++ b/tests/torch_test_contrib.py
@@ -3,11 +3,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import torch
-import unittest
-import numpy as np
-import faiss
-import faiss.contrib.torch_utils
+import torch  # usort: skip
+import unittest   # usort: skip
+import numpy as np   # usort: skip
+
+import faiss   # usort: skip
+import faiss.contrib.torch_utils  # usort: skip
 
 class TestTorchUtilsCPU(unittest.TestCase):
     # tests add, search

--- a/tests/torch_test_neural_net.py
+++ b/tests/torch_test_neural_net.py
@@ -3,14 +3,15 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import torch
-from torch import nn
-import unittest
-import numpy as np
-import faiss
+import torch  # usort: skip
+from torch import nn  # usort: skip
+import unittest  # usort: skip
+import numpy as np  # usort: skip
 
-from faiss.contrib import datasets
-from faiss.contrib.inspect_tools import get_additive_quantizer_codebooks
+import faiss  # usort: skip
+
+from faiss.contrib import datasets  # usort: skip
+from faiss.contrib.inspect_tools import get_additive_quantizer_codebooks  # usort: skip
 
 
 class TestLayer(unittest.TestCase):


### PR DESCRIPTION
Summary:
Apparently this is the generally accepted way to do this.

https://usort.readthedocs.io/en/stable/guide.html#import-blocks

What do you tihnk?

Differential Revision: D62147522
