### PR TITLE
remove compile options label from gbench

### DIFF
--- a/faiss/perf_tests/bench_scalar_quantizer_accuracy.cpp
+++ b/faiss/perf_tests/bench_scalar_quantizer_accuracy.cpp
@@ -27,7 +27,6 @@ static void bench_reconstruction_error(
         ScalarQuantizer::QuantizerType type,
         int d,
         int n) {
-    state.SetLabel(faiss::get_compile_options());
     std::vector<float> x(d * n);
 
     float_rand(x.data(), d * n, 12345);
@@ -64,7 +63,6 @@ static void bench_reconstruction_error(
     state.counters["ndiff_for_idempotence"] = ndiff;
 
     state.counters["code_size_two"] = codes.size();
-    state.SetLabel(faiss::get_compile_options());
 }
 
 int main(int argc, char** argv) {

--- a/faiss/perf_tests/bench_scalar_quantizer_decode.cpp
+++ b/faiss/perf_tests/bench_scalar_quantizer_decode.cpp
@@ -27,7 +27,6 @@ static void bench_decode(
         ScalarQuantizer::QuantizerType type,
         int d,
         int n) {
-    state.SetLabel(faiss::get_compile_options());
     std::vector<float> x(d * n);
 
     float_rand(x.data(), d * n, 12345);

--- a/faiss/perf_tests/bench_scalar_quantizer_distance.cpp
+++ b/faiss/perf_tests/bench_scalar_quantizer_distance.cpp
@@ -27,7 +27,6 @@ static void bench_distance(
         ScalarQuantizer::QuantizerType type,
         int n,
         int d) {
-    state.SetLabel(faiss::get_compile_options());
     std::vector<float> x(d * n);
 
     float_rand(x.data(), d * n, 12345);
@@ -45,8 +44,6 @@ static void bench_distance(
     // encode
     std::vector<uint8_t> codes(code_size * n);
     sq.compute_codes(x.data(), codes.data(), n);
-
-    state.SetLabel(faiss::get_compile_options());
 
     std::unique_ptr<ScalarQuantizer::SQDistanceComputer> dc(
             sq.get_distance_computer());

--- a/faiss/perf_tests/bench_scalar_quantizer_encode.cpp
+++ b/faiss/perf_tests/bench_scalar_quantizer_encode.cpp
@@ -28,7 +28,6 @@ static void bench_encode(
         ScalarQuantizer::QuantizerType type,
         int d,
         int n) {
-    state.SetLabel(faiss::get_compile_options());
     std::vector<float> x(d * n);
 
     float_rand(x.data(), d * n, 12345);


### PR DESCRIPTION
Summary:
Looks like ServiceLab does not handle any metric that is not integer: https://fburl.com/code/chqi5hcr The current experiments are erroring with the message https://fburl.com/servicelab/99s69hbf:
```
ERROR:windtunnel.benchmarks.gbench_benchmark_runner.gbench_benchmark_runner:exception occurred while processing benchmark (this usually means a benchmark is misconfigured) faiss/perf_tests/scalar_quantizer_distance_test1/bench_scalar_quantizer_distance:QT_bf16_128d_2000n/iterations invalid literal for int() with base 10: 'OPTIMIZE AVX2 '
Traceback (most recent call last):
  File "windtunnel/benchmarks/gbench_benchmark_runner/gbench_benchmark_runner.py", line 116, in parse_gbench_results
    int(entry[metric_name]),
ValueError: invalid literal for int() with base 10: 'OPTIMIZE AVX2 '
```

Removing the label that's causing the failure. We can track the optimization mode via experiment names, or a dummy counter name in the future as I roll out multi-platform experiments.

Differential Revision: D62166280
