### PR TITLE
Re-enable Query_L2_MMCodeDistance and Query_IP_MMCodeDistance tests for ROCm

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -51,13 +51,14 @@ runs:
           conda install -y -q mkl=2023 mkl-devel=2023
         fi
 
-        # install CUDA packages
-        if [ "${{ inputs.gpu }}" = "ON" ] && [ "${{ inputs.raft }}" = "OFF" ]; then
+        # no CUDA needed for ROCm so skip this
+        if [ "${{ inputs.rocm }}" = "ON" ]; then
+          :
+        # regular CUDA for GPU builds
+        elif [ "${{ inputs.gpu }}" = "ON" ] && [ "${{ inputs.raft }}" = "OFF" ]; then
           conda install -y -q cuda-toolkit -c "nvidia/label/cuda-12.4.0"
-        fi
-
-        # install RAFT packages
-        if [ "${{ inputs.raft }}" = "ON" ]; then
+        # and CUDA from RAFT channel for RAFT builds
+        elif [ "${{ inputs.raft }}" = "ON" ]; then
           conda install -y -q libraft cuda-version=12.4 cuda-toolkit -c rapidsai-nightly -c "nvidia/label/cuda-12.4.0" -c conda-forge
         fi
 

--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -84,7 +84,7 @@ runs:
         UBUNTU_VERSION_NAME=`cat /etc/os-release | grep UBUNTU_CODENAME | awk -F= '{print $2}'`
 
         # Set ROCm version
-        ROCM_VERSION="6.1.1"
+        ROCM_VERSION="6.2"
 
         # Download, prepare, and install the package signing key
         mkdir --parents --mode=0755 /etc/apt/keyrings

--- a/faiss/gpu/test/TestGpuIndexIVFPQ.cpp
+++ b/faiss/gpu/test/TestGpuIndexIVFPQ.cpp
@@ -307,8 +307,6 @@ void testMMCodeDistance(faiss::MetricType mt) {
     }
 }
 
-// FIXME: https://github.com/facebookresearch/faiss/issues/3787
-#ifndef USE_AMD_ROCM
 TEST(TestGpuIndexIVFPQ, Query_L2_MMCodeDistance) {
     testMMCodeDistance(faiss::MetricType::METRIC_L2);
 }
@@ -316,7 +314,6 @@ TEST(TestGpuIndexIVFPQ, Query_L2_MMCodeDistance) {
 TEST(TestGpuIndexIVFPQ, Query_IP_MMCodeDistance) {
     testMMCodeDistance(faiss::MetricType::METRIC_INNER_PRODUCT);
 }
-#endif // USE_AMD_ROCM
 
 TEST(TestGpuIndexIVFPQ, Float16Coarse) {
     Options opt;


### PR DESCRIPTION
Summary: This fixes 3787 now that we do not install CUDA for ROCm builds.

Differential Revision: D62283662


