### PR TITLE
Changes to onboard Digraph to FAISS wrapper

### DIFF
--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -61,15 +61,15 @@ namespace faiss {
 
 int index_factory_verbose = 0;
 
+bool re_match(const std::string& s, const std::string& pat, std::smatch& sm) {
+    return std::regex_match(s, sm, std::regex(pat));
+}
+
 namespace {
 
 /***************************************************************
  * Small functions
  */
-
-bool re_match(const std::string& s, const std::string& pat, std::smatch& sm) {
-    return std::regex_match(s, sm, std::regex(pat));
-}
 
 // find first pair of matching parentheses
 void find_matching_parentheses(

--- a/faiss/index_factory.h
+++ b/faiss/index_factory.h
@@ -9,8 +9,11 @@
 
 #include <faiss/Index.h>
 #include <faiss/IndexBinary.h>
+#include <regex>
 
 namespace faiss {
+
+bool re_match(const std::string& s, const std::string& pat, std::smatch& sm);
 
 /** Build and index with the sequence of processing steps described in
  *  the string. */


### PR DESCRIPTION
Summary:
Minimal changes in FAISS to onboard Digraph to telemetry wrapper.
- In FAISS, I changed one unnamed namespace to named, so the telemetry wrapper can use those functions. Otherwise we have to copy it all. Please let me know if you have concerns.
- In telemetry wrapper side, Implemented minimal index_factory and IndexIDMap which Digraph uses.
- Digraph has an index type of IDMap,Flat hard coded. The train/add/search flow will hit IndexFlat.train(), IndexIDMap.add_with_ids(), and IndexFlat.search().

Differential Revision: D62325176
