### PR TITLE
Adding bucket/path (blobstore) in dataset descriptor

### DIFF
--- a/benchs/bench_fw/descriptors.py
+++ b/benchs/bench_fw/descriptors.py
@@ -85,6 +85,10 @@ class DatasetDescriptor:
     # sampling column for xdb
     sampling_column: Optional[str] = None
 
+    # blob store
+    bucket: Optional[str] = None
+    path: Optional[str] = None
+
     def __hash__(self):
         return hash(self.get_filename())
 

--- a/contrib/datasets.py
+++ b/contrib/datasets.py
@@ -130,6 +130,11 @@ else:
     dataset_basedir = 'data/'
 
 
+def set_dataset_basedir(path):
+    global dataset_basedir
+    dataset_basedir = path
+
+
 class DatasetSIFT1M(Dataset):
     """
     The original dataset is available at: http://corpus-texmex.irisa.fr/


### PR DESCRIPTION
Summary:
same as title.
Dataset can be referred from blobstore

Differential Revision: D62476993
