### PR TITLE
Change some local read_index functions to be exposed by a header

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -243,7 +243,7 @@ void read_InvertedLists(IndexIVF* ivf, IOReader* f, int io_flags) {
     ivf->own_invlists = true;
 }
 
-static void read_ProductQuantizer(ProductQuantizer* pq, IOReader* f) {
+void read_ProductQuantizer(ProductQuantizer* pq, IOReader* f) {
     READ1(pq->d);
     READ1(pq->M);
     READ1(pq->nbits);
@@ -353,7 +353,7 @@ static void read_ProductLocalSearchQuantizer(
     }
 }
 
-static void read_ScalarQuantizer(ScalarQuantizer* ivsc, IOReader* f) {
+void read_ScalarQuantizer(ScalarQuantizer* ivsc, IOReader* f) {
     READ1(ivsc->qtype);
     READ1(ivsc->rangestat);
     READ1(ivsc->rangestat_arg);
@@ -476,7 +476,7 @@ void read_ivf_header(
 }
 
 // used for legacy formats
-static ArrayInvertedLists* set_array_invlist(
+ArrayInvertedLists* set_array_invlist(
         IndexIVF* ivf,
         std::vector<std::vector<idx_t>>& ids) {
     ArrayInvertedLists* ail =

--- a/faiss/impl/index_read_utils.h
+++ b/faiss/impl/index_read_utils.h
@@ -16,6 +16,8 @@
 #pragma once
 
 namespace faiss {
+struct ProductQuantizer;
+struct ScalarQuantizer;
 
 void read_index_header(Index* idx, IOReader* f);
 void read_direct_map(DirectMap* dm, IOReader* f);
@@ -24,6 +26,11 @@ void read_ivf_header(
         IOReader* f,
         std::vector<std::vector<idx_t>>* ids = nullptr);
 void read_InvertedLists(IndexIVF* ivf, IOReader* f, int io_flags);
+ArrayInvertedLists* set_array_invlist(
+        IndexIVF* ivf,
+        std::vector<std::vector<idx_t>>& ids);
+void read_ProductQuantizer(ProductQuantizer* pq, IOReader* f);
+void read_ScalarQuantizer(ScalarQuantizer* ivsc, IOReader* f);
 
 } // namespace faiss
 


### PR DESCRIPTION
Summary: We need some more functions exposed for use in telemetry wrapper classes. This PR changes some functions in read_index to be non static and exposes them in the header.

Differential Revision: D62623242
