### PR TITLE
assign_index should default to null

### DIFF
--- a/faiss/impl/residual_quantizer_encode_steps.cpp
+++ b/faiss/impl/residual_quantizer_encode_steps.cpp
@@ -664,8 +664,6 @@ void refine_beam_mp(
     std::unique_ptr<Index> assign_index;
     if (rq.assign_index_factory) {
         assign_index.reset((*rq.assign_index_factory)(rq.d));
-    } else {
-        assign_index.reset(new IndexFlatL2(rq.d));
     }
 
     // main loop
@@ -701,7 +699,9 @@ void refine_beam_mp(
                 assign_index.get(),
                 rq.approx_topk_mode);
 
-        assign_index->reset();
+        if (assign_index != nullptr) {
+            assign_index->reset();
+        }
 
         std::swap(codes_ptr, new_codes_ptr);
         std::swap(residuals_ptr, new_residuals_ptr);


### PR DESCRIPTION
Summary:
Laser clients are calling RCQ search with a query size of 1 and the bulk of the overhead came from IndexFlat add/search. With a small query size, using IndexFlatL2 does lots of unnecessary copies to the IndexFlatL2.

By default, we should fall back to https://fburl.com/code/jpt236mz branch unless the client overrides `assign_index` with `assign_index_factory`.

Differential Revision: D62644305
