### PR TITLE
Add explicit instanciations of `search_dispatch_implem`

### DIFF
--- a/faiss/IndexFastScan.cpp
+++ b/faiss/IndexFastScan.cpp
@@ -549,6 +549,22 @@ void IndexFastScan::search_implem_14(
     }
 }
 
+template void IndexFastScan::search_dispatch_implem<true>(
+        idx_t n,
+        const float* x,
+        idx_t k,
+        float* distances,
+        idx_t* labels,
+        const NormTableScaler* scaler) const;
+
+template void IndexFastScan::search_dispatch_implem<false>(
+        idx_t n,
+        const float* x,
+        idx_t k,
+        float* distances,
+        idx_t* labels,
+        const NormTableScaler* scaler) const;
+
 void IndexFastScan::reconstruct(idx_t key, float* recons) const {
     std::vector<uint8_t> code(code_size, 0);
     BitstringWriter bsw(code.data(), code_size);


### PR DESCRIPTION
Since commit 32f0e8cf92cd2275b60364517bb1cce67aa29a55 (https://github.com/facebookresearch/faiss/pull/3190) faiss fails to build on gcc7.

For some reason gcc7 needs these explicit instanciations (or rather, for some reason later versions are OK without them). This commit partially revers that commit, adding back the explicit instanciations.