### PR TITLE
Fix several typos in code detected by lintian

### DIFF
--- a/faiss/AutoTune.h
+++ b/faiss/AutoTune.h
@@ -86,7 +86,7 @@ struct OperatingPoint {
     double perf;     ///< performance measure (output of a Criterion)
     double t;        ///< corresponding execution time (ms)
     std::string key; ///< key that identifies this op pt
-    int64_t cno;     ///< integer identifer
+    int64_t cno;     ///< integer identifier
 };
 
 struct OperatingPoints {

--- a/faiss/IndexBinaryHNSW.h
+++ b/faiss/IndexBinaryHNSW.h
@@ -21,7 +21,7 @@ namespace faiss {
 struct IndexBinaryHNSW : IndexBinary {
     typedef HNSW::storage_idx_t storage_idx_t;
 
-    // the link strcuture
+    // the link structure
     HNSW hnsw;
 
     // the sequential storage

--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -479,7 +479,7 @@ struct InvertedListScanner {
     virtual float distance_to_code(const uint8_t* code) const = 0;
 
     /** scan a set of codes, compute distances to current query and
-     * update heap of results if necessary. Default implemetation
+     * update heap of results if necessary. Default implementation
      * calls distance_to_code.
      *
      * @param n      number of codes to scan

--- a/faiss/IndexIVFFastScan.cpp
+++ b/faiss/IndexIVFFastScan.cpp
@@ -694,7 +694,7 @@ void IndexIVFFastScan::range_search_dispatch_implem(
             search_implem_10(
                     n, x, *handler.get(), cq, &ndis, &nlist_visited, scaler);
         } else {
-            FAISS_THROW_FMT("Range search implem %d not impemented", impl);
+            FAISS_THROW_FMT("Range search implem %d not implemented", impl);
         }
     } else {
         // explicitly slice over threads

--- a/faiss/IndexNNDescent.h
+++ b/faiss/IndexNNDescent.h
@@ -26,7 +26,7 @@ struct IndexNNDescent : Index {
 
     /// Faiss results are 64-bit
 
-    // the link strcuture
+    // the link structure
     NNDescent nndescent;
 
     // the sequential storage

--- a/faiss/IndexNSG.h
+++ b/faiss/IndexNSG.h
@@ -24,7 +24,7 @@ namespace faiss {
  * link structure built on top */
 
 struct IndexNSG : Index {
-    /// the link strcuture
+    /// the link structure
     NSG nsg;
 
     /// the sequential storage

--- a/faiss/IndexPreTransform.h
+++ b/faiss/IndexPreTransform.h
@@ -23,7 +23,7 @@ struct SearchParametersPreTransform : SearchParameters {
 /** Index that applies a LinearTransform transform on vectors before
  *  handing them over to a sub-index */
 struct IndexPreTransform : Index {
-    std::vector<VectorTransform*> chain; ///! chain of tranforms
+    std::vector<VectorTransform*> chain; ///! chain of transforms
     Index* index;                        ///! the sub-index
 
     bool own_fields; ///! whether pointers are deleted in destructor

--- a/faiss/impl/AuxIndexStructures.h
+++ b/faiss/impl/AuxIndexStructures.h
@@ -122,7 +122,7 @@ struct RangeSearchPartialResult : BufferList {
     void copy_result(bool incremental = false);
 
     /// merge a set of PartialResult's into one RangeSearchResult
-    /// on ouptut the partialresults are empty!
+    /// on output the partialresults are empty!
     static void merge(
             std::vector<RangeSearchPartialResult*>& partial_results,
             bool do_delete = true);

--- a/faiss/impl/pq4_fast_scan_search_1.cpp
+++ b/faiss/impl/pq4_fast_scan_search_1.cpp
@@ -217,7 +217,7 @@ void pq4_accumulate_loop(
         SIMDResultHandler& res,
         const NormTableScaler* scaler) {
     Run_pq4_accumulate_loop consumer;
-    dispatch_SIMDResultHanlder(
+    dispatch_SIMDResultHandler(
             res, consumer, nq, nb, bbs, nsq, codes, LUT, scaler);
 }
 

--- a/faiss/impl/pq4_fast_scan_search_qbs.cpp
+++ b/faiss/impl/pq4_fast_scan_search_qbs.cpp
@@ -751,7 +751,7 @@ void pq4_accumulate_loop_qbs(
         SIMDResultHandler& res,
         const NormTableScaler* scaler) {
     Run_pq4_accumulate_loop_qbs consumer;
-    dispatch_SIMDResultHanlder(res, consumer, qbs, nb, nsq, codes, LUT, scaler);
+    dispatch_SIMDResultHandler(res, consumer, qbs, nb, nsq, codes, LUT, scaler);
 }
 
 /***************************************************************

--- a/faiss/impl/residual_quantizer_encode_steps.h
+++ b/faiss/impl/residual_quantizer_encode_steps.h
@@ -25,7 +25,7 @@ namespace faiss {
  * It allows low-level access to the encoding function, exposed mainly for unit
  * tests.
  *
- * @param n              number of vectors to hanlde
+ * @param n              number of vectors to handle
  * @param residuals      vectors to encode, size (n, beam_size, d)
  * @param cent           centroids, size (K, d)
  * @param beam_size      input beam size

--- a/faiss/impl/simd_result_handlers.h
+++ b/faiss/impl/simd_result_handlers.h
@@ -535,7 +535,7 @@ struct ReservoirHandler : ResultHandlerCompare<C, with_id_map> {
     }
 };
 
-/** Result hanlder for range search. The difficulty is that the range distances
+/** Result handler for range search. The difficulty is that the range distances
  * have to be scaled using the scaler.
  */
 
@@ -713,7 +713,7 @@ struct PartialRangeHandler : RangeHandler<C, with_id_map> {
  */
 
 template <class C, bool W, class Consumer, class... Types>
-void dispatch_SIMDResultHanlder_fixedCW(
+void dispatch_SIMDResultHandler_fixedCW(
         SIMDResultHandler& res,
         Consumer& consumer,
         Types... args) {
@@ -733,19 +733,19 @@ void dispatch_SIMDResultHanlder_fixedCW(
 }
 
 template <class C, class Consumer, class... Types>
-void dispatch_SIMDResultHanlder_fixedC(
+void dispatch_SIMDResultHandler_fixedC(
         SIMDResultHandler& res,
         Consumer& consumer,
         Types... args) {
     if (res.with_fields) {
-        dispatch_SIMDResultHanlder_fixedCW<C, true>(res, consumer, args...);
+        dispatch_SIMDResultHandler_fixedCW<C, true>(res, consumer, args...);
     } else {
-        dispatch_SIMDResultHanlder_fixedCW<C, false>(res, consumer, args...);
+        dispatch_SIMDResultHandler_fixedCW<C, false>(res, consumer, args...);
     }
 }
 
 template <class Consumer, class... Types>
-void dispatch_SIMDResultHanlder(
+void dispatch_SIMDResultHandler(
         SIMDResultHandler& res,
         Consumer& consumer,
         Types... args) {
@@ -763,18 +763,18 @@ void dispatch_SIMDResultHanlder(
         }
     } else if (res.sizeof_ids == sizeof(int)) {
         if (res.is_CMax) {
-            dispatch_SIMDResultHanlder_fixedC<CMax<uint16_t, int>>(
+            dispatch_SIMDResultHandler_fixedC<CMax<uint16_t, int>>(
                     res, consumer, args...);
         } else {
-            dispatch_SIMDResultHanlder_fixedC<CMin<uint16_t, int>>(
+            dispatch_SIMDResultHandler_fixedC<CMin<uint16_t, int>>(
                     res, consumer, args...);
         }
     } else if (res.sizeof_ids == sizeof(int64_t)) {
         if (res.is_CMax) {
-            dispatch_SIMDResultHanlder_fixedC<CMax<uint16_t, int64_t>>(
+            dispatch_SIMDResultHandler_fixedC<CMax<uint16_t, int64_t>>(
                     res, consumer, args...);
         } else {
-            dispatch_SIMDResultHanlder_fixedC<CMin<uint16_t, int64_t>>(
+            dispatch_SIMDResultHandler_fixedC<CMin<uint16_t, int64_t>>(
                     res, consumer, args...);
         }
     } else {

--- a/faiss/invlists/BlockInvertedLists.cpp
+++ b/faiss/invlists/BlockInvertedLists.cpp
@@ -127,7 +127,7 @@ void BlockInvertedLists::update_entries(
         size_t,
         const idx_t*,
         const uint8_t*) {
-    FAISS_THROW_MSG("not impemented");
+    FAISS_THROW_MSG("not implemented");
 }
 
 BlockInvertedLists::~BlockInvertedLists() {

--- a/faiss/utils/distances.h
+++ b/faiss/utils/distances.h
@@ -285,7 +285,7 @@ FAISS_API extern int distance_compute_blas_database_bs;
 // rather than a heap
 FAISS_API extern int distance_compute_min_k_reservoir;
 
-/** Return the k nearest neighors of each of the nx vectors x among the ny
+/** Return the k nearest neighbors of each of the nx vectors x among the ny
  *  vector y, w.r.t to max inner product.
  *
  * @param x    query vectors, size nx * d
@@ -301,7 +301,7 @@ void knn_inner_product(
         float_minheap_array_t* res,
         const IDSelector* sel = nullptr);
 
-/**  Return the k nearest neighors of each of the nx vectors x among the ny
+/**  Return the k nearest neighbors of each of the nx vectors x among the ny
  *  vector y, for the inner product metric.
  *
  * @param x    query vectors, size nx * d
@@ -320,7 +320,7 @@ void knn_inner_product(
         int64_t* indexes,
         const IDSelector* sel = nullptr);
 
-/** Return the k nearest neighors of each of the nx vectors x among the ny
+/** Return the k nearest neighbors of each of the nx vectors x among the ny
  *  vector y, for the L2 distance
  * @param x    query vectors, size nx * d
  * @param y    database vectors, size ny * d
@@ -338,7 +338,7 @@ void knn_L2sqr(
         const float* y_norm2 = nullptr,
         const IDSelector* sel = nullptr);
 
-/**  Return the k nearest neighors of each of the nx vectors x among the ny
+/**  Return the k nearest neighbors of each of the nx vectors x among the ny
  *  vector y, for the L2 distance
  *
  * @param x    query vectors, size nx * d
@@ -413,7 +413,7 @@ void knn_L2sqr_by_idx(
 /// Forward declaration, see AuxIndexStructures.h
 struct RangeSearchResult;
 
-/** Return the k nearest neighors of each of the nx vectors x among the ny
+/** Return the k nearest neighbors of each of the nx vectors x among the ny
  *  vector y, w.r.t to max inner product
  *
  * @param x      query vectors, size nx * d

--- a/faiss/utils/hamming.cpp
+++ b/faiss/utils/hamming.cpp
@@ -364,7 +364,7 @@ void fvec2bitvec(const float* __restrict x, uint8_t* __restrict b, size_t d) {
 }
 
 /* Same but for n vectors.
-   Ensure that the ouptut b is byte-aligned (pad with 0s). */
+   Ensure that the output b is byte-aligned (pad with 0s). */
 void fvecs2bitvecs(
         const float* __restrict x,
         uint8_t* __restrict b,


### PR DESCRIPTION
All typos are not names of public APIs, thus safe to fix.

Closes #3859