### PR TITLE
simplify and refactor create_servicelab_experiment utility

### DIFF
--- a/faiss/perf_tests/bench_no_multithreading_rcq_search.cpp
+++ b/faiss/perf_tests/bench_no_multithreading_rcq_search.cpp
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gflags/gflags.h>
+
+#include <benchmark/benchmark.h>
+#include <faiss/IndexAdditiveQuantizer.h> // @manual=//faiss:faiss_no_multithreading
+#include <faiss/utils/random.h> // @manual=//faiss:faiss_no_multithreading
+
+using namespace faiss;
+DEFINE_uint32(iterations, 20, "iterations");
+DEFINE_uint32(nprobe, 1, "nprobe");
+DEFINE_uint32(batch_size, 1, "batch_size");
+DEFINE_double(beam_factor, 4.0, "beam factor");
+
+static void bench_search(
+        benchmark::State& state,
+        int batch_size,
+        int nprobe,
+        float beam_factor) {
+    int d = 512;
+    int nt = 2 << 15;
+    std::vector<float> xt(d * nt);
+
+    float_rand(xt.data(), d * nt, 12345);
+    ResidualCoarseQuantizer rq(d, {16, 8});
+    rq.verbose = false;
+    rq.train(nt, xt.data());
+
+    std::vector<float> xq(d * batch_size);
+    float_rand(xq.data(), d * batch_size, 12345);
+
+    std::vector<float> distances(nprobe * batch_size);
+    std::vector<int64_t> clusterIndices(nprobe * batch_size);
+    SearchParametersResidualCoarseQuantizer param;
+    param.beam_factor = beam_factor;
+    for (auto _ : state) {
+        rq.search(
+                batch_size,
+                xq.data(),
+                nprobe,
+                distances.data(),
+                clusterIndices.data(),
+                &param);
+    }
+}
+
+int main(int argc, char** argv) {
+    benchmark::Initialize(&argc, argv);
+    gflags::AllowCommandLineReparsing();
+    gflags::ParseCommandLineFlags(&argc, &argv, true);
+    int iterations = FLAGS_iterations;
+    int nprobe = FLAGS_nprobe;
+    float beam_factor = FLAGS_beam_factor;
+    int batch_size = FLAGS_batch_size;
+    benchmark::RegisterBenchmark(
+            "search", bench_search, batch_size, nprobe, beam_factor)
+            ->Iterations(iterations);
+    benchmark::RunSpecifiedBenchmarks();
+    benchmark::Shutdown();
+}

--- a/faiss/perf_tests/bench_scalar_quantizer_accuracy.cpp
+++ b/faiss/perf_tests/bench_scalar_quantizer_accuracy.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <faiss/perf_tests/utils.h>
-#include <fmt/format.h>
 #include <gflags/gflags.h>
 #include <cstdio>
 #include <map>
@@ -76,7 +75,7 @@ int main(int argc, char** argv) {
 
     for (auto& [bench_name, quantizer_type] : benchs) {
         benchmark::RegisterBenchmark(
-                fmt::format("{}_{}d_{}n", bench_name, d, n).c_str(),
+                bench_name.c_str(),
                 bench_reconstruction_error,
                 quantizer_type,
                 d,

--- a/faiss/perf_tests/bench_scalar_quantizer_decode.cpp
+++ b/faiss/perf_tests/bench_scalar_quantizer_decode.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <faiss/perf_tests/utils.h>
-#include <fmt/format.h>
 #include <gflags/gflags.h>
 #include <omp.h>
 #include <cstdio>
@@ -63,11 +62,7 @@ int main(int argc, char** argv) {
 
     for (auto& [bench_name, quantizer_type] : benchs) {
         benchmark::RegisterBenchmark(
-                fmt::format("{}_{}d_{}n", bench_name, d, n).c_str(),
-                bench_decode,
-                quantizer_type,
-                d,
-                n)
+                bench_name.c_str(), bench_decode, quantizer_type, d, n)
                 ->Iterations(iterations);
     }
 

--- a/faiss/perf_tests/bench_scalar_quantizer_distance.cpp
+++ b/faiss/perf_tests/bench_scalar_quantizer_distance.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <fmt/format.h>
 #include <gflags/gflags.h>
 #include <omp.h>
 #include <cstdio>
@@ -72,11 +71,7 @@ int main(int argc, char** argv) {
 
     for (auto& [bench_name, quantizer_type] : benchs) {
         benchmark::RegisterBenchmark(
-                fmt::format("{}_{}d_{}n", bench_name, d, n).c_str(),
-                bench_distance,
-                quantizer_type,
-                d,
-                n)
+                bench_name.c_str(), bench_distance, quantizer_type, d, n)
                 ->Iterations(iterations);
     }
     benchmark::RunSpecifiedBenchmarks();

--- a/faiss/perf_tests/bench_scalar_quantizer_encode.cpp
+++ b/faiss/perf_tests/bench_scalar_quantizer_encode.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <fmt/format.h>
 #include <gflags/gflags.h>
 #include <omp.h>
 #include <cstdio>
@@ -57,11 +56,7 @@ int main(int argc, char** argv) {
 
     for (auto& [bench_name, quantizer_type] : benchs) {
         benchmark::RegisterBenchmark(
-                fmt::format("{}_{}d_{}n", bench_name, d, n).c_str(),
-                bench_encode,
-                quantizer_type,
-                d,
-                n)
+                bench_name.c_str(), bench_encode, quantizer_type, d, n)
                 ->Iterations(iterations);
     }
 


### PR DESCRIPTION
Summary: `create_servicelab_experiment`'s metrics' key calculation and benchmarks were specific to scalar quantizer. Refactor it so we can reuse the same utility for RCQ. Fix the previous naming suggestion for the position of `_profile` in the experiment name as well

Reviewed By: junjieqi

Differential Revision: D62770846
