### PR TITLE
FIx a bug for a non-simdlib code of ResidualQuantizer

### DIFF
--- a/faiss/impl/residual_quantizer_encode_steps.cpp
+++ b/faiss/impl/residual_quantizer_encode_steps.cpp
@@ -95,7 +95,7 @@ void accum_and_store_tab(
         for (size_t ij = 1; ij < M; ij++) {
             reg += cbs[ij][kk];
         }
-        output[b * K + kk] = reg;
+        output[kk] = reg;
     }
 }
 
@@ -152,7 +152,7 @@ void accum_and_add_tab(
         for (size_t ij = 1; ij < M; ij++) {
             reg += cbs[ij][kk];
         }
-        output[b * K + kk] += reg;
+        output[kk] += reg;
     }
 }
 


### PR DESCRIPTION
This causes an access violation error. 

The reason why this was not caught in unit tests for AVX/NEON is that this code branch is unlikely to be used. 

The reason why this was not caught in unit tests for a plain non-SIMD binary is unclear.

More ResidualQuantizer patches to follow.
