### PR TITLE
[faiss] Fix CI 2.0: Compile SQ for avx512

### DIFF
--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -402,9 +402,12 @@ struct QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 1>
 #if defined(__AVX512F__)
 
 template <class Codec>
-struct QuantizerTemplate<Codec, true, 16> : QuantizerTemplate<Codec, true, 1> {
+struct QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 16>
+        : QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 1> {
     QuantizerTemplate(size_t d, const std::vector<float>& trained)
-            : QuantizerTemplate<Codec, true, 1>(d, trained) {}
+            : QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 1>(
+                      d,
+                      trained) {}
 
     FAISS_ALWAYS_INLINE __m512
     reconstruct_16_components(const uint8_t* code, int i) const {
@@ -502,10 +505,13 @@ struct QuantizerTemplate<Codec, QuantizerTemplateScaling::NON_UNIFORM, 1>
 #if defined(__AVX512F__)
 
 template <class Codec>
-struct QuantizerTemplate<Codec, false, 16>
-        : QuantizerTemplate<Codec, false, 1> {
+struct QuantizerTemplate<Codec, QuantizerTemplateScaling::NON_UNIFORM, 16>
+        : QuantizerTemplate<Codec, QuantizerTemplateScaling::NON_UNIFORM, 1> {
     QuantizerTemplate(size_t d, const std::vector<float>& trained)
-            : QuantizerTemplate<Codec, false, 1>(d, trained) {}
+            : QuantizerTemplate<
+                      Codec,
+                      QuantizerTemplateScaling::NON_UNIFORM,
+                      1>(d, trained) {}
 
     FAISS_ALWAYS_INLINE __m512
     reconstruct_16_components(const uint8_t* code, int i) const {


### PR DESCRIPTION
https://github.com/facebookresearch/faiss/pull/3870 conflicted with changes in https://github.com/facebookresearch/faiss/pull/3853 Rebasing D62989543 for PR 3853 internally did not catch the breakage since we don't have avx512 coverage internally unfortunately :( 

=== Test Plan ===
Tested on a local machine and compilation and C++ tests worked
CI for AVX512 and conda build should succeed