### PR TITLE
Update INSTALL.md to ensure AVX2 and AV512 support for python package

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -177,6 +177,22 @@ $ (cd build/faiss/python && python setup.py install)
 The first command builds the python bindings for Faiss, while the second one
 generates and installs the python package.
 
+If making use of optimization options, build the correct target before swigfaiss.
+
+For AVX2:
+
+``` shell
+$ make -C build -j faiss_avx2
+```
+
+For AVX512:
+
+``` shell
+$ make -C build -j faiss_avx512
+```
+
+This will ensure the creation of neccesary files when building and installing the python package.
+
 ## Step 4: Installing the C++ library and headers (optional)
 
 ``` shell

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -167,16 +167,6 @@ The `-j` option enables parallel compilation of multiple units, leading to a
 faster build, but increasing the chances of running out of memory, in which case
 it is recommended to set the `-j` option to a fixed value (such as `-j4`).
 
-## Step 3: Building the python bindings (optional)
-
-``` shell
-$ make -C build -j swigfaiss
-$ (cd build/faiss/python && python setup.py install)
-```
-
-The first command builds the python bindings for Faiss, while the second one
-generates and installs the python package.
-
 If making use of optimization options, build the correct target before swigfaiss.
 
 For AVX2:
@@ -192,6 +182,17 @@ $ make -C build -j faiss_avx512
 ```
 
 This will ensure the creation of neccesary files when building and installing the python package.
+
+## Step 3: Building the python bindings (optional)
+
+``` shell
+$ make -C build -j swigfaiss
+$ (cd build/faiss/python && python setup.py install)
+```
+
+The first command builds the python bindings for Faiss, while the second one
+generates and installs the python package.
+
 
 ## Step 4: Installing the C++ library and headers (optional)
 


### PR DESCRIPTION
Following the current documentation creates the python package without AVX2 or AV512 support. Updated documentation notes that corresponding faiss version must be built before swigfaiss.

fixes facebookresearch/faiss#3883

