### PR TITLE
Implement the kmeans that uses GPU based faiss liberary

### DIFF
--- a/faiss/python/extra_wrappers.py
+++ b/faiss/python/extra_wrappers.py
@@ -481,6 +481,7 @@ class Kmeans:
         self.d = d
         self.reset(k)
         self.gpu = False
+        self.index = None
         if "progressive_dim_steps" in kwargs:
             self.cp = ProgressiveDimClusteringParameters()
         else:


### PR DESCRIPTION
Summary:
As titled.
The previous implementation doesn't explicitly use GPU. This version of Faiss is only an interface for C++ library therefore its way more efficient

Differential Revision: D64050016


