### PR TITLE
Updated conda CI label from staging to main, INSTALL.md

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         with:
-          label: staging
+          label: main
   linux-x86_64-GPU-packages-CUDA-11-4-4:
     name: Linux x86_64 GPU packages (CUDA 11.4.4)
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -197,7 +197,7 @@ jobs:
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         with:
-          label: staging
+          label: main
           cuda: "11.4.4"
   linux-x86_64-GPU-RAFT-packages-CUDA11-8-0:
     name: Linux x86_64 GPU w/ RAFT packages (CUDA 11.8.0)
@@ -216,7 +216,7 @@ jobs:
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         with:
-          label: staging
+          label: main
           raft: "ON"
           cuda: "11.8.0"
   linux-x86_64-GPU-packages-CUDA-12-1-1:
@@ -236,7 +236,7 @@ jobs:
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         with:
-          label: staging
+          label: main
           cuda: "12.1.1"
   linux-x86_64-GPU-RAFT-packages-CUDA12-1-1:
     name: Linux x86_64 GPU w/ RAFT packages (CUDA 12.1.1)
@@ -255,7 +255,7 @@ jobs:
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         with:
-          label: staging
+          label: main
           raft: "ON"
           cuda: "12.1.1"
   windows-x86_64-packages:
@@ -273,7 +273,7 @@ jobs:
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         with:
-          label: staging
+          label: main
   osx-arm64-packages:
     name: OSX arm64 packages
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -289,7 +289,7 @@ jobs:
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         with:
-          label: staging
+          label: main
   linux-arm64-packages:
     name: Linux arm64 packages
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -305,4 +305,4 @@ jobs:
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         with:
-          label: staging
+          label: main

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,21 +4,21 @@ The supported way to install Faiss is through [conda](https://docs.conda.io).
 Stable releases are pushed regularly to the pytorch conda channel, as well as
 pre-release nightly builds.
 
-- The CPU-only faiss-cpu conda package is currently available on Linux (x86_64 and arm64), OSX (arm64 only), and Windows (x86_64)
-- faiss-gpu, containing both CPU and GPU indices, is available on Linux (x86_64 only) for CUDA 11.4 and 12.1
-- NEW: faiss-gpu-raft containing both CPU and GPU indices provided by NVIDIA RAFT, is available on Linux (x86_64 only) for CUDA 11.8 and 12.1.
+- The CPU-only faiss-cpu conda package is currently available on Linux (x86-64 and aarch64), OSX (arm64 only), and Windows (x86-64)
+- faiss-gpu, containing both CPU and GPU indices, is available on Linux (x86-64 only) for CUDA 11.4 and 12.1
+- faiss-gpu-raft containing both CPU and GPU indices provided by NVIDIA RAFT, is available on Linux (x86-64 only) for CUDA 11.8 and 12.1.
 
 To install the latest stable release:
 
 ``` shell
 # CPU-only version
-$ conda install -c pytorch faiss-cpu=1.8.0
+$ conda install -c pytorch faiss-cpu=1.9.0
 
 # GPU(+CPU) version
-$ conda install -c pytorch -c nvidia faiss-gpu=1.8.0
+$ conda install -c pytorch -c nvidia faiss-gpu=1.9.0
 
 # GPU(+CPU) version with NVIDIA RAFT
-$ conda install -c pytorch -c nvidia -c rapidsai -c conda-forge faiss-gpu-raft=1.8.0
+$ conda install -c pytorch -c nvidia -c rapidsai -c conda-forge faiss-gpu-raft=1.9.0
 
 # GPU(+CPU) version using AMD ROCm not yet available
 ```
@@ -35,10 +35,10 @@ Nightly pre-release packages can be installed as follows:
 $ conda install -c pytorch/label/nightly faiss-cpu
 
 # GPU(+CPU) version
-$ conda install -c pytorch/label/nightly -c nvidia faiss-gpu=1.8.0
+$ conda install -c pytorch/label/nightly -c nvidia faiss-gpu=1.9.0
 
 # GPU(+CPU) version with NVIDIA RAFT
-conda install -c pytorch -c nvidia -c rapidsai -c conda-forge faiss-gpu-raft=1.8.0 pytorch pytorch-cuda numpy
+conda install -c pytorch -c nvidia -c rapidsai -c conda-forge faiss-gpu-raft=1.9.0 pytorch pytorch-cuda numpy
 
 # GPU(+CPU) version using AMD ROCm not yet available
 ```
@@ -80,7 +80,7 @@ conda-forge package "feedstock".
 
 Faiss can be built from source using CMake.
 
-Faiss is supported on x86_64 machines on Linux, OSX, and Windows. It has been
+Faiss is supported on x86-64 machines on Linux, OSX, and Windows. It has been
 found to run on other platforms as well, see
 [other platforms](https://github.com/facebookresearch/faiss/wiki/Related-projects#bindings-to-other-languages-and-porting-to-other-platforms).
 


### PR DESCRIPTION
* Replaced 1.8.0 to 1.9.0.
* Fixed x86-64 architecture reference: https://en.wikipedia.org/wiki/X86-64

Tested with: `conda install -c pytorch/label/staging faiss-cpu`