### PR TITLE
Fix total_rows

### DIFF
--- a/benchs/bench_fw/descriptors.py
+++ b/benchs/bench_fw/descriptors.py
@@ -113,7 +113,9 @@ class DatasetDescriptor:
         assert self.tablename is not None
         filename += self.tablename
         if self.partitions is not None:
-            filename += "_" + "_".join(self.partitions).replace("=", "_")
+            filename += "_" + "_".join(
+                self.partitions
+            ).replace("=", "_").replace("/", "_")
         if self.num_vectors is not None:
             filename += f"_{self.num_vectors}"
         filename += "."


### PR DESCRIPTION
Summary:
Reverted splitting of partition string to align with previous behavior of finding partition intersection rather than the union.
Also changed util dependency from laser to vector_search, which makes more sense.

Differential Revision: D64274531


