### PR TITLE
Resolve "duplicate-license-header": Find and replace duplicate license headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+# @lint-ignore-every LICENSELINT
 # Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.
 #

--- a/c_api/AutoTune_c.cpp
+++ b/c_api/AutoTune_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "AutoTune_c.h"

--- a/c_api/AutoTune_c.h
+++ b/c_api/AutoTune_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_AUTO_TUNE_C_H

--- a/c_api/Clustering_c.cpp
+++ b/c_api/Clustering_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "Clustering_c.h"

--- a/c_api/Clustering_c.h
+++ b/c_api/Clustering_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved
 // -*- c -*-
 
 #ifndef FAISS_CLUSTERING_C_H

--- a/c_api/IndexBinary_c.cpp
+++ b/c_api/IndexBinary_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "IndexBinary_c.h"

--- a/c_api/IndexBinary_c.h
+++ b/c_api/IndexBinary_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved
 // -*- c -*-
 
 #ifndef FAISS_INDEX_BINARY_C_H

--- a/c_api/IndexFlat_c.cpp
+++ b/c_api/IndexFlat_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "IndexFlat_c.h"

--- a/c_api/IndexFlat_c.h
+++ b/c_api/IndexFlat_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved
 // -*- c -*-
 
 #ifndef FAISS_INDEX_FLAT_C_H

--- a/c_api/IndexIVFFlat_c.cpp
+++ b/c_api/IndexIVFFlat_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "IndexIVFFlat_c.h"

--- a/c_api/IndexIVFFlat_c.h
+++ b/c_api/IndexIVFFlat_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_INDEX_IVF_FLAT_C_H

--- a/c_api/IndexIVF_c.cpp
+++ b/c_api/IndexIVF_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "IndexIVF_c.h"

--- a/c_api/IndexIVF_c.h
+++ b/c_api/IndexIVF_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_INDEX_IVF_C_H

--- a/c_api/IndexLSH_c.cpp
+++ b/c_api/IndexLSH_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "IndexLSH_c.h"

--- a/c_api/IndexLSH_c.h
+++ b/c_api/IndexLSH_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #ifndef INDEX_LSH_C_H

--- a/c_api/IndexPreTransform_c.cpp
+++ b/c_api/IndexPreTransform_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "IndexPreTransform_c.h"

--- a/c_api/IndexPreTransform_c.h
+++ b/c_api/IndexPreTransform_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_INDEX_PRETRANSFORM_C_H

--- a/c_api/IndexReplicas_c.h
+++ b/c_api/IndexReplicas_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #ifndef INDEXREPLICAS_C_H

--- a/c_api/IndexScalarQuantizer_c.cpp
+++ b/c_api/IndexScalarQuantizer_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "IndexScalarQuantizer_c.h"

--- a/c_api/IndexScalarQuantizer_c.h
+++ b/c_api/IndexScalarQuantizer_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_INDEX_SCALAR_QUANTIZER_C_H

--- a/c_api/IndexShards_c.h
+++ b/c_api/IndexShards_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #ifndef INDEXSHARDS_C_H

--- a/c_api/Index_c.cpp
+++ b/c_api/Index_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "Index_c.h"

--- a/c_api/Index_c.h
+++ b/c_api/Index_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved
 // -*- c -*-
 
 #ifndef FAISS_INDEX_C_H

--- a/c_api/MetaIndexes_c.cpp
+++ b/c_api/MetaIndexes_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "MetaIndexes_c.h"

--- a/c_api/MetaIndexes_c.h
+++ b/c_api/MetaIndexes_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #ifndef METAINDEXES_C_H

--- a/c_api/VectorTransform_c.cpp
+++ b/c_api/VectorTransform_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "VectorTransform_c.h"

--- a/c_api/VectorTransform_c.h
+++ b/c_api/VectorTransform_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_VECTOR_TRANSFORM_C_H

--- a/c_api/clone_index_c.cpp
+++ b/c_api/clone_index_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//  Copyright 2004-present Facebook. All Rights Reserved
 // -*- c++ -*-
 // I/O code for indexes
 

--- a/c_api/clone_index_c.h
+++ b/c_api/clone_index_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//  Copyright 2004-present Facebook. All Rights Reserved
 // -*- c++ -*-
 // I/O code for indexes
 

--- a/c_api/error_c.h
+++ b/c_api/error_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_ERROR_C_H

--- a/c_api/error_impl.cpp
+++ b/c_api/error_impl.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "error_impl.h"

--- a/c_api/error_impl.h
+++ b/c_api/error_impl.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include <exception>

--- a/c_api/example_c.c
+++ b/c_api/example_c.c
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #include <stdio.h>

--- a/c_api/faiss_c.h
+++ b/c_api/faiss_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 /// Macros and typedefs for C wrapper API declarations

--- a/c_api/gpu/DeviceUtils_c.cpp
+++ b/c_api/gpu/DeviceUtils_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "DeviceUtils_c.h"

--- a/c_api/gpu/DeviceUtils_c.h
+++ b/c_api/gpu/DeviceUtils_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_DEVICE_UTILS_C_H

--- a/c_api/gpu/GpuAutoTune_c.cpp
+++ b/c_api/gpu/GpuAutoTune_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "GpuAutoTune_c.h"

--- a/c_api/gpu/GpuAutoTune_c.h
+++ b/c_api/gpu/GpuAutoTune_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_GPU_AUTO_TUNE_C_H

--- a/c_api/gpu/GpuClonerOptions_c.cpp
+++ b/c_api/gpu/GpuClonerOptions_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "GpuClonerOptions_c.h"

--- a/c_api/gpu/GpuClonerOptions_c.h
+++ b/c_api/gpu/GpuClonerOptions_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_GPU_CLONER_OPTIONS_C_H

--- a/c_api/gpu/GpuIndex_c.cpp
+++ b/c_api/gpu/GpuIndex_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "GpuIndex_c.h"

--- a/c_api/gpu/GpuIndex_c.h
+++ b/c_api/gpu/GpuIndex_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_GPU_INDEX_C_H

--- a/c_api/gpu/GpuIndicesOptions_c.h
+++ b/c_api/gpu/GpuIndicesOptions_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_GPU_INDICES_OPTIONS_C_H

--- a/c_api/gpu/GpuResources_c.cpp
+++ b/c_api/gpu/GpuResources_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "GpuResources_c.h"

--- a/c_api/gpu/GpuResources_c.h
+++ b/c_api/gpu/GpuResources_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_GPU_RESOURCES_C_H

--- a/c_api/gpu/StandardGpuResources_c.cpp
+++ b/c_api/gpu/StandardGpuResources_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "StandardGpuResources_c.h"

--- a/c_api/gpu/StandardGpuResources_c.h
+++ b/c_api/gpu/StandardGpuResources_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_STANDARD_GPURESOURCES_C_H

--- a/c_api/gpu/example_gpu_c.c
+++ b/c_api/gpu/example_gpu_c.c
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #include <stdio.h>

--- a/c_api/gpu/macros_impl.h
+++ b/c_api/gpu/macros_impl.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #ifndef GPU_MACROS_IMPL_H

--- a/c_api/impl/AuxIndexStructures_c.cpp
+++ b/c_api/impl/AuxIndexStructures_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "AuxIndexStructures_c.h"

--- a/c_api/impl/AuxIndexStructures_c.h
+++ b/c_api/impl/AuxIndexStructures_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_AUX_INDEX_STRUCTURES_C_H

--- a/c_api/index_factory_c.cpp
+++ b/c_api/index_factory_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "index_factory_c.h"

--- a/c_api/index_factory_c.h
+++ b/c_api/index_factory_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_INDEX_FACTORY_C_H

--- a/c_api/index_io_c.cpp
+++ b/c_api/index_io_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//  Copyright 2004-present Facebook. All Rights Reserved
 // -*- c++ -*-
 // I/O code for indexes
 

--- a/c_api/index_io_c.h
+++ b/c_api/index_io_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//  Copyright 2004-present Facebook. All Rights Reserved
 // -*- c++ -*-
 // I/O code for indexes
 

--- a/c_api/macros_impl.h
+++ b/c_api/macros_impl.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 /// Utility macros for the C wrapper implementation.

--- a/c_api/utils/distances_c.cpp
+++ b/c_api/utils/distances_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "distances_c.h"

--- a/c_api/utils/distances_c.h
+++ b/c_api/utils/distances_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_DISTANCES_C_H

--- a/c_api/utils/utils_c.cpp
+++ b/c_api/utils/utils_c.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c++ -*-
 
 #include "utils_c.h"

--- a/c_api/utils/utils_c.h
+++ b/c_api/utils/utils_c.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// Copyright 2004-present Facebook. All Rights Reserved.
 // -*- c -*-
 
 #ifndef FAISS_UTILS_C_H

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -1,4 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# @lint-ignore-every LICENSELINT
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the

--- a/cmake/link_to_faiss_lib.cmake
+++ b/cmake/link_to_faiss_lib.cmake
@@ -1,4 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# @lint-ignore-every LICENSELINT
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the

--- a/faiss/gpu/GpuDistance.cu
+++ b/faiss/gpu/GpuDistance.cu
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/GpuIndex.h
+++ b/faiss/gpu/GpuIndex.h
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/GpuIndexCagra.cu
+++ b/faiss/gpu/GpuIndexCagra.cu
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/GpuIndexCagra.h
+++ b/faiss/gpu/GpuIndexCagra.h
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/GpuResources.cpp
+++ b/faiss/gpu/GpuResources.cpp
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/GpuResources.h
+++ b/faiss/gpu/GpuResources.h
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/StandardGpuResources.cpp
+++ b/faiss/gpu/StandardGpuResources.cpp
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/StandardGpuResources.h
+++ b/faiss/gpu/StandardGpuResources.h
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/impl/FlatIndex.cu
+++ b/faiss/gpu/impl/FlatIndex.cu
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/impl/FlatIndex.cuh
+++ b/faiss/gpu/impl/FlatIndex.cuh
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/impl/RaftCagra.cu
+++ b/faiss/gpu/impl/RaftCagra.cu
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/impl/RaftCagra.cuh
+++ b/faiss/gpu/impl/RaftCagra.cuh
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/impl/RaftFlatIndex.cu
+++ b/faiss/gpu/impl/RaftFlatIndex.cu
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/impl/RaftFlatIndex.cuh
+++ b/faiss/gpu/impl/RaftFlatIndex.cuh
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/impl/RaftIVFFlat.cu
+++ b/faiss/gpu/impl/RaftIVFFlat.cu
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/impl/RaftIVFFlat.cuh
+++ b/faiss/gpu/impl/RaftIVFFlat.cuh
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/impl/RaftIVFPQ.cu
+++ b/faiss/gpu/impl/RaftIVFPQ.cu
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/impl/RaftIVFPQ.cuh
+++ b/faiss/gpu/impl/RaftIVFPQ.cuh
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/test/TestGpuDistance.cu
+++ b/faiss/gpu/test/TestGpuDistance.cu
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/test/TestGpuIndexCagra.cu
+++ b/faiss/gpu/test/TestGpuIndexCagra.cu
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/test/TestGpuIndexIVFFlat.cpp
+++ b/faiss/gpu/test/TestGpuIndexIVFFlat.cpp
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/utils/RaftUtils.cu
+++ b/faiss/gpu/utils/RaftUtils.cu
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/faiss/gpu/utils/RaftUtils.h
+++ b/faiss/gpu/utils/RaftUtils.h
@@ -1,3 +1,4 @@
+// @lint-ignore-every LICENSELINT
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *


### PR DESCRIPTION
Summary:
This diff just finds and replaces duplicate license headers.

See the errors for "duplicate-license-header" in D64429711 under "linter-coverage-verification" signal.

Differential Revision: D64484123
