### PR TITLE
Add VectorTransform read from filename to the C API

### DIFF
--- a/c_api/index_io_c.cpp
+++ b/c_api/index_io_c.cpp
@@ -15,6 +15,7 @@
 
 using faiss::Index;
 using faiss::IndexBinary;
+using faiss::VectorTransform;
 
 int faiss_write_index(const FaissIndex* idx, FILE* f) {
     try {
@@ -81,6 +82,14 @@ int faiss_read_index_binary_fname(
     try {
         auto out = faiss::read_index_binary(fname, io_flags);
         *p_out = reinterpret_cast<FaissIndexBinary*>(out);
+    }
+    CATCH_AND_HANDLE
+}
+
+int faiss_read_VectorTransform_fname(const char* fname, FaissVectorTransform** p_out) {
+    try {
+        auto out = faiss::read_VectorTransform(fname);
+        *p_out = reinterpret_cast<FaissVectorTransform*>(out);
     }
     CATCH_AND_HANDLE
 }

--- a/c_api/index_io_c.cpp
+++ b/c_api/index_io_c.cpp
@@ -85,7 +85,9 @@ int faiss_read_index_binary_fname(
     CATCH_AND_HANDLE
 }
 
-int faiss_read_VectorTransform_fname(const char* fname, FaissVectorTransform** p_out) {
+int faiss_read_VectorTransform_fname(
+        const char* fname,
+        FaissVectorTransform** p_out) {
     try {
         auto out = faiss::read_VectorTransform(fname);
         *p_out = reinterpret_cast<FaissVectorTransform*>(out);

--- a/c_api/index_io_c.h
+++ b/c_api/index_io_c.h
@@ -16,6 +16,7 @@
 #include "IndexBinary_c.h"
 #include "Index_c.h"
 #include "faiss_c.h"
+#include "VectorTransform_c.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -72,6 +73,11 @@ int faiss_read_index_binary_fname(
         const char* fname,
         int io_flags,
         FaissIndexBinary** p_out);
+
+/** Read vector transform from a file.
+ * This is equivalent to `faiss:read_VectorTransform` when a file path is given.
+ */
+int faiss_read_VectorTransform_fname(const char* fname, FaissVectorTransform** p_out);
 #ifdef __cplusplus
 }
 #endif

--- a/c_api/index_io_c.h
+++ b/c_api/index_io_c.h
@@ -14,8 +14,8 @@
 #include <stdio.h>
 #include "IndexBinary_c.h"
 #include "Index_c.h"
-#include "faiss_c.h"
 #include "VectorTransform_c.h"
+#include "faiss_c.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -76,7 +76,9 @@ int faiss_read_index_binary_fname(
 /** Read vector transform from a file.
  * This is equivalent to `faiss:read_VectorTransform` when a file path is given.
  */
-int faiss_read_VectorTransform_fname(const char* fname, FaissVectorTransform** p_out);
+int faiss_read_VectorTransform_fname(
+        const char* fname,
+        FaissVectorTransform** p_out);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This adds read_VectorTransform to the C API. This is helpful for independently loading a vector transform rather than as an IndexPreTransform.