### PR TITLE
fix some more nvidia licenses that get erased

### DIFF
--- a/benchs/bench_ivfflat_raft.py
+++ b/benchs/bench_ivfflat_raft.py
@@ -1,4 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# @lint-ignore-every LICENSELINT
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/benchs/bench_ivfpq_raft.py
+++ b/benchs/bench_ivfpq_raft.py
@@ -1,4 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# @lint-ignore-every LICENSELINT
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/faiss/gpu/CMakeLists.txt
+++ b/faiss/gpu/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# @lint-ignore-every LICENSELINT
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the

--- a/faiss/gpu/test/CMakeLists.txt
+++ b/faiss/gpu/test/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# @lint-ignore-every LICENSELINT
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the


### PR DESCRIPTION
Summary:
These were getting erased in D64484165.

Similar to D64481766, we need to add lint ignore to not erase Nvidia license.

Without the changes in this diff to ignore lint, screenshots show these 4 files erase the license when running the lint command:

Before lint:
 {F1941712401} 

After lint:
 {F1941712573}

Differential Revision: D64712875


