### PR TITLE
Update RAFT CI with pytorch 2.4.1

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -63,7 +63,7 @@ runs:
           : # skip torch install via conda, we need to install via pip to get
             #  ROCm-enabled version until it's supported in conda by PyTorch
         elif [ "${{ inputs.gpu }}" = "ON" ]; then
-          conda install -y -q pytorch pytorch-cuda=12.4 -c pytorch -c nvidia/label/cuda-12.4.0
+          conda install -y -q "pytorch<2.5" pytorch-cuda=12.4 -c pytorch -c nvidia/label/cuda-12.4.0
         else
           conda install -y -q pytorch -c pytorch
         fi


### PR DESCRIPTION
Related to testing in https://github.com/facebookresearch/faiss/pull/3974

Based on comparing the logs of two runs:
- failing: https://github.com/facebookresearch/faiss/actions/runs/11409771344/job/31751246207
- passing: https://github.com/facebookresearch/faiss/actions/runs/11368781432/job/31625550227