### PR TITLE
Use count_if to compute nminus1.

### DIFF
--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -228,12 +228,9 @@ void IndexIVF::add_core(
     FAISS_THROW_IF_NOT(is_trained);
     direct_map.check_can_add(xids);
 
-    size_t nadd = 0, nminus1 = 0;
-
-    for (size_t i = 0; i < n; i++) {
-        if (coarse_idx[i] < 0)
-            nminus1++;
-    }
+    size_t nadd = 0;
+    const size_t nminus1 = std::count_if(
+            coarse_idx, coarse_idx + n, [](idx_t idx) { return idx < 0; });
 
     std::unique_ptr<uint8_t[]> flat_codes(new uint8_t[n * code_size]);
     encode_vectors(n, x, coarse_idx, flat_codes.get());


### PR DESCRIPTION
Summary:
it's more concise, idiomatic and less error prone. This also makes it
very easy to experiment with `ExecutionPolicy` param to control whether this check
should be vectorized/parallelized

Differential Revision: D64978862


