### PR TITLE
add validity check AlignedTableTightAlloc clear method

### DIFF
--- a/faiss/utils/AlignedTable.h
+++ b/faiss/utils/AlignedTable.h
@@ -63,7 +63,9 @@ struct AlignedTableTightAlloc {
     }
 
     void clear() {
-        memset(ptr, 0, nbytes());
+        if (numel > 0) {
+            memset(ptr, 0, nbytes());
+        }
     }
     size_t size() const {
         return numel;


### PR DESCRIPTION
Summary:
Avoid null pointer error by checking that `numel > 0`.
It's equivalent of checking`ptr != null` but keeping numel check for consistency.

Bug reported in: https://github.com/facebookresearch/faiss/issues/3994

Differential Revision: D65073502


