### PR TITLE
fix merge_flat_ondisk stress run failures

### DIFF
--- a/tests/test_merge.cpp
+++ b/tests/test_merge.cpp
@@ -60,7 +60,7 @@ struct CommonData {
 };
 
 CommonData cd;
-
+std::string temp_filename_template = "/tmp/faiss_tmp_XXXXXX";
 /// perform a search on shards, then merge and search again and
 /// compare results.
 int compare_merged(
@@ -71,7 +71,7 @@ int compare_merged(
     std::vector<float> refD(k * nq);
 
     index_shards->search(nq, cd.queries.data(), k, refD.data(), refI.data());
-    Tempfilename filename(&temp_file_mutex, "/tmp/faiss_tmp_XXXXXX");
+    Tempfilename filename(&temp_file_mutex, temp_filename_template);
 
     std::vector<idx_t> newI(k * nq);
     std::vector<float> newD(k * nq);
@@ -191,7 +191,7 @@ TEST(MERGE, merge_flat_vt) {
 TEST(MERGE, merge_flat_ondisk) {
     faiss::IndexShards index_shards(d, false, false);
     index_shards.own_indices = true;
-    Tempfilename filename(&temp_file_mutex, "/tmp/faiss_tmp_XXXXXX");
+    Tempfilename filename(&temp_file_mutex, temp_filename_template);
 
     for (int i = 0; i < nindex; i++) {
         auto ivf = new faiss::IndexIVFFlat(&cd.quantizer, d, nlist);

--- a/tests/test_util.h
+++ b/tests/test_util.h
@@ -10,17 +10,16 @@
 
 #include <faiss/IndexIVFPQ.h>
 #include <unistd.h>
-#include <cstdlib>
 
 struct Tempfilename {
     pthread_mutex_t* mutex;
     std::string filename;
 
-    Tempfilename(pthread_mutex_t* mutex, std::string filename) {
+    Tempfilename(pthread_mutex_t* mutex, std::string filename_template) {
         this->mutex = mutex;
-        this->filename = filename;
+        this->filename = filename_template;
         pthread_mutex_lock(mutex);
-        int fd = mkstemp(&filename[0]);
+        int fd = mkstemp(&this->filename[0]);
         close(fd);
         pthread_mutex_unlock(mutex);
     }


### PR DESCRIPTION
Summary:
Fixed the bug causing `merge_flat_ondisk` stress run failures.

Running multiple `merge_flat_ondisk` tests simultaneously fails which is causing buck stress-run failures.
https://www.internalfb.com/intern/test/562950025349567/

Root cause: we were updating input copy (which was discarded) of the filename template instead of the local copy.

Differential Revision: D65074463


