### PR TITLE
Add index binary to telemetry

### DIFF
--- a/faiss/cppcontrib/factory_tools.cpp
+++ b/faiss/cppcontrib/factory_tools.cpp
@@ -25,7 +25,15 @@ const std::map<faiss::ScalarQuantizer::QuantizerType, std::string> sq_types = {
 };
 
 int get_hnsw_M(const faiss::IndexHNSW* index) {
-    if (index->hnsw.cum_nneighbor_per_level.size() >= 1) {
+    if (index->hnsw.cum_nneighbor_per_level.size() > 1) {
+        return index->hnsw.cum_nneighbor_per_level[1] / 2;
+    }
+    // Avoid runtime error, just return 0.
+    return 0;
+}
+
+int get_hnsw_M(const faiss::IndexBinaryHNSW* index) {
+    if (index->hnsw.cum_nneighbor_per_level.size() > 1) {
         return index->hnsw.cum_nneighbor_per_level[1] / 2;
     }
     // Avoid runtime error, just return 0.
@@ -148,6 +156,34 @@ std::string reverse_index_factory(const faiss::Index* index) {
             const faiss::IndexIDMap* idmap =
                     dynamic_cast<const faiss::IndexIDMap*>(index)) {
         return std::string("IDMap,") + reverse_index_factory(idmap->index);
+    }
+    // Avoid runtime error, just return empty string for logging.
+    return "";
+}
+
+std::string reverse_index_factory(const faiss::IndexBinary* index) {
+    std::string prefix;
+    if (dynamic_cast<const faiss::IndexBinaryFlat*>(index)) {
+        return "BFlat";
+    } else if (
+            const faiss::IndexBinaryIVF* ivf_index =
+                    dynamic_cast<const faiss::IndexBinaryIVF*>(index)) {
+        const faiss::IndexBinary* quantizer = ivf_index->quantizer;
+
+        if (dynamic_cast<const faiss::IndexBinaryFlat*>(quantizer)) {
+            return "BIVF" + std::to_string(ivf_index->nlist);
+        } else if (
+                const faiss::IndexBinaryHNSW* hnsw_index =
+                        dynamic_cast<const faiss::IndexBinaryHNSW*>(
+                                quantizer)) {
+            return "BIVF" + std::to_string(ivf_index->nlist) + "_HNSW" +
+                    std::to_string(get_hnsw_M(hnsw_index));
+        }
+        // Add further cases for BinaryIVF here.
+    } else if (
+            const faiss::IndexBinaryHNSW* hnsw_index =
+                    dynamic_cast<const faiss::IndexBinaryHNSW*>(index)) {
+        return "BHNSW" + std::to_string(get_hnsw_M(hnsw_index));
     }
     // Avoid runtime error, just return empty string for logging.
     return "";

--- a/faiss/cppcontrib/factory_tools.h
+++ b/faiss/cppcontrib/factory_tools.h
@@ -9,6 +9,9 @@
 
 #pragma once
 
+#include <faiss/IndexBinaryFlat.h>
+#include <faiss/IndexBinaryHNSW.h>
+#include <faiss/IndexBinaryIVF.h>
 #include <faiss/IndexHNSW.h>
 #include <faiss/IndexIDMap.h>
 #include <faiss/IndexIVFFlat.h>
@@ -21,5 +24,6 @@
 namespace faiss {
 
 std::string reverse_index_factory(const faiss::Index* index);
+std::string reverse_index_factory(const faiss::IndexBinary* index);
 
 } // namespace faiss


### PR DESCRIPTION
Summary:
It was mentioned in S461104 chat to cover all index types. This adds Binary for telemetry as well as the reverse factory string for binary indexes, which we did not support before.

Unit test covers 4 ways of reading a binary index.

The reverse factory string util is not complete. The remaining binary index types could get added later.

Differential Revision: D65102643


