### PR TITLE
Fix shadowed variable in faiss/IndexAdditiveQuantizer.cpp

### DIFF
--- a/faiss/IndexAdditiveQuantizer.cpp
+++ b/faiss/IndexAdditiveQuantizer.cpp
@@ -528,7 +528,7 @@ void ResidualCoarseQuantizer::search(
         float* distances,
         idx_t* labels,
         const SearchParameters* params_in) const {
-    float beam_factor = this->beam_factor;
+    float beam_factor_2 = this->beam_factor;
     if (params_in) {
         auto params =
                 dynamic_cast<const SearchParametersResidualCoarseQuantizer*>(
@@ -536,15 +536,15 @@ void ResidualCoarseQuantizer::search(
         FAISS_THROW_IF_NOT_MSG(
                 params,
                 "need SearchParametersResidualCoarseQuantizer parameters");
-        beam_factor = params->beam_factor;
+        beam_factor_2 = params->beam_factor;
     }
 
-    if (beam_factor < 0) {
+    if (beam_factor_2 < 0) {
         AdditiveCoarseQuantizer::search(n, x, k, distances, labels);
         return;
     }
 
-    int beam_size = int(k * beam_factor);
+    int beam_size = int(k * beam_factor_2);
     if (beam_size > ntotal) {
         beam_size = ntotal;
     }

--- a/faiss/IndexIVFFastScan.cpp
+++ b/faiss/IndexIVFFastScan.cpp
@@ -57,17 +57,17 @@ IndexIVFFastScan::IndexIVFFastScan() {
 
 void IndexIVFFastScan::init_fastscan(
         size_t M,
-        size_t nbits,
+        size_t nbits_2,
         size_t nlist,
         MetricType /* metric */,
-        int bbs) {
-    FAISS_THROW_IF_NOT(bbs % 32 == 0);
-    FAISS_THROW_IF_NOT(nbits == 4);
+        int bbs_2) {
+    FAISS_THROW_IF_NOT(bbs_2 % 32 == 0);
+    FAISS_THROW_IF_NOT(nbits_2 == 4);
 
     this->M = M;
-    this->nbits = nbits;
-    this->bbs = bbs;
-    ksub = (1 << nbits);
+    this->nbits = nbits_2;
+    this->bbs = bbs_2;
+    ksub = (1 << nbits_2);
     M2 = roundup(M, 2);
     code_size = M2 / 2;
 
@@ -1029,11 +1029,11 @@ void IndexIVFFastScan::search_implem_12(
 
     // prepare the result handlers
 
-    int qbs2 = this->qbs2 ? this->qbs2 : 11;
+    int qbs2_2 = this->qbs2 ? this->qbs2 : 11;
 
     std::vector<uint16_t> tmp_bias;
     if (biases.get()) {
-        tmp_bias.resize(qbs2);
+        tmp_bias.resize(qbs2_2);
         handler.dbias = tmp_bias.data();
     }
 
@@ -1046,7 +1046,7 @@ void IndexIVFFastScan::search_implem_12(
         int list_no = qcs[i0].list_no;
         size_t i1 = i0 + 1;
 
-        while (i1 < qcs.size() && i1 < i0 + qbs2) {
+        while (i1 < qcs.size() && i1 < i0 + qbs2_2) {
             if (qcs[i1].list_no != list_no) {
                 break;
             }
@@ -1066,7 +1066,7 @@ void IndexIVFFastScan::search_implem_12(
         std::vector<int> q_map(nc), lut_entries(nc);
         AlignedTable<uint8_t> LUT(nc * dim12);
         memset(LUT.get(), -1, nc * dim12);
-        int qbs = pq4_preferred_qbs(nc);
+        int qbs_2 = pq4_preferred_qbs(nc);
 
         for (size_t i = i0; i < i1; i++) {
             const QC& qc = qcs[i];
@@ -1078,7 +1078,7 @@ void IndexIVFFastScan::search_implem_12(
             }
         }
         pq4_pack_LUT_qbs_q_map(
-                qbs, M2, dis_tables.get(), lut_entries.data(), LUT.get());
+                qbs_2, M2, dis_tables.get(), lut_entries.data(), LUT.get());
 
         // access the inverted list
 
@@ -1094,7 +1094,7 @@ void IndexIVFFastScan::search_implem_12(
         handler.id_map = ids.get();
 
         pq4_accumulate_loop_qbs(
-                qbs, list_size, M2, codes.get(), LUT.get(), handler, scaler);
+                qbs_2, list_size, M2, codes.get(), LUT.get(), handler, scaler);
         // prepare for next loop
         i0 = i1;
     }
@@ -1232,11 +1232,11 @@ void IndexIVFFastScan::search_implem_14(
                 is_max, impl, n, k, local_dis.data(), local_idx.data(), sel));
         handler->begin(normalizers.get());
 
-        int qbs2 = this->qbs2 ? this->qbs2 : 11;
+        int qbs2_2 = this->qbs2 ? this->qbs2 : 11;
 
         std::vector<uint16_t> tmp_bias;
         if (biases.get()) {
-            tmp_bias.resize(qbs2);
+            tmp_bias.resize(qbs2_2);
             handler->dbias = tmp_bias.data();
         }
 
@@ -1256,7 +1256,7 @@ void IndexIVFFastScan::search_implem_14(
             std::vector<int> q_map(nc), lut_entries(nc);
             AlignedTable<uint8_t> LUT(nc * dim12);
             memset(LUT.get(), -1, nc * dim12);
-            int qbs = pq4_preferred_qbs(nc);
+            int qbs_2 = pq4_preferred_qbs(nc);
 
             for (size_t i = i0; i < i1; i++) {
                 const QC& qc = qcs[i];
@@ -1269,7 +1269,7 @@ void IndexIVFFastScan::search_implem_14(
                 }
             }
             pq4_pack_LUT_qbs_q_map(
-                    qbs, M2, dis_tables.get(), lut_entries.data(), LUT.get());
+                    qbs_2, M2, dis_tables.get(), lut_entries.data(), LUT.get());
 
             // access the inverted list
 
@@ -1285,7 +1285,7 @@ void IndexIVFFastScan::search_implem_14(
             handler->id_map = ids.get();
 
             pq4_accumulate_loop_qbs(
-                    qbs,
+                    qbs_2,
                     list_size,
                     M2,
                     codes.get(),

--- a/faiss/impl/NSG.cpp
+++ b/faiss/impl/NSG.cpp
@@ -301,8 +301,8 @@ void NSG::search_on_graph(
             retset[k].flag = false;
             int n = retset[k].id;
 
-            size_t nneigh = graph.get_neighbors(n, neighbors.data());
-            for (int m = 0; m < nneigh; m++) {
+            size_t nneigh_2 = graph.get_neighbors(n, neighbors.data());
+            for (int m = 0; m < nneigh_2; m++) {
                 int id = neighbors[m];
                 if (id > ntotal || vt.get(id)) {
                     continue;


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D65347906


