### PR TITLE
introduce data splits in dataset descriptor

### DIFF
--- a/benchs/bench_fw/descriptors.py
+++ b/benchs/bench_fw/descriptors.py
@@ -85,6 +85,15 @@ class DatasetDescriptor:
 
     embedding_id_column: Optional[str] = None
 
+    # unused in open-source
+    splits_distribution: Optional[List[List[bytes]]] = None
+
+    # unused in open-source
+    splits: Optional[List[bytes]] = None
+
+    # unused in open-source
+    serialized_df: Optional[str] = None
+
     sampling_rate: Optional[float] = None
 
     # sampling column for xdb


### PR DESCRIPTION
Summary: This should enable us to read units of data where the unit is a split instead of reading X number of rows.

Reviewed By: asadoughi

Differential Revision: D65429573


