### PR TITLE
Increase discovery timeout for ROCm CI failures

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,4 +87,4 @@ target_link_libraries(faiss_test PRIVATE
 
 # Defines `gtest_discover_tests()`.
 include(GoogleTest)
-gtest_discover_tests(faiss_test)
+gtest_discover_tests(faiss_test PROPERTIES DISCOVERY_TIMEOUT 60)


### PR DESCRIPTION
Differential Revision: D65434932


