### PR TITLE
Faiss GPU: bfloat16 brute-force kNN support

### DIFF
--- a/faiss/gpu/GpuDistance.cu
+++ b/faiss/gpu/GpuDistance.cu
@@ -242,7 +242,7 @@ void bfKnn(GpuResourcesProvider* prov, const GpuDistanceParams& args) {
     FAISS_THROW_IF_NOT_MSG(
             args.vectorType == args.queryType,
             "limitation: both vectorType and queryType must currently "
-            "be the same (F32 or F16");
+            "be the same (F32 / F16 / BF16");
 
 #if defined USE_NVIDIA_RAFT
     // Note: For now, RAFT bfknn requires queries and vectors to be same layout
@@ -374,6 +374,8 @@ void bfKnn(GpuResourcesProvider* prov, const GpuDistanceParams& args) {
         bfKnnConvert<float>(prov, args);
     } else if (args.vectorType == DistanceDataType::F16) {
         bfKnnConvert<half>(prov, args);
+    } else if (args.vectorType == DistanceDataType::BF16) {
+        bfKnnConvert<__nv_bfloat16>(prov, args);
     } else {
         FAISS_THROW_MSG("unknown vectorType");
     }
@@ -440,8 +442,10 @@ void bfKnn_single_query_shard(
             args.k > 0,
             "bfKnn_tiling: tiling vectors is only supported for k > 0");
     size_t distance_size = args.vectorType == DistanceDataType::F32 ? 4
-            : args.vectorType == DistanceDataType::F16              ? 2
-                                                                    : 0;
+            : (args.vectorType == DistanceDataType::F16 ||
+               args.vectorType == DistanceDataType::BF16)
+            ? 2
+            : 0;
     FAISS_THROW_IF_NOT_MSG(
             distance_size > 0, "bfKnn_tiling: unknown vectorType");
     size_t shard_size = vectorsMemoryLimit / (args.dims * distance_size);
@@ -498,8 +502,10 @@ void bfKnn_tiling(
             args.k > 0,
             "bfKnn_tiling: tiling queries is only supported for k > 0");
     size_t distance_size = args.queryType == DistanceDataType::F32 ? 4
-            : args.queryType == DistanceDataType::F16              ? 2
-                                                                   : 0;
+            : (args.queryType == DistanceDataType::F16 ||
+               args.queryType == DistanceDataType::BF16)
+            ? 2
+            : 0;
     FAISS_THROW_IF_NOT_MSG(
             distance_size > 0, "bfKnn_tiling: unknown queryType");
     size_t label_size = args.outIndicesType == IndicesDataType::I64 ? 8

--- a/faiss/gpu/GpuDistance.h
+++ b/faiss/gpu/GpuDistance.h
@@ -19,6 +19,7 @@ class GpuResourcesProvider;
 enum class DistanceDataType {
     F32 = 1,
     F16,
+    BF16,
 };
 
 // Scalar type of the indices data

--- a/faiss/gpu/impl/Distance.cu
+++ b/faiss/gpu/impl/Distance.cu
@@ -504,6 +504,27 @@ void runAllPairwiseL2Distance(
             outDistances);
 }
 
+void runAllPairwiseL2Distance(
+        GpuResources* res,
+        cudaStream_t stream,
+        Tensor<__nv_bfloat16, 2, true>& vectors,
+        bool vectorsRowMajor,
+        Tensor<float, 1, true>* vectorNorms,
+        Tensor<__nv_bfloat16, 2, true>& queries,
+        bool queriesRowMajor,
+        Tensor<float, 2, true>& outDistances) {
+    runAllPairwiseDistance<__nv_bfloat16>(
+            true,
+            res,
+            stream,
+            vectors,
+            vectorsRowMajor,
+            vectorNorms,
+            queries,
+            queriesRowMajor,
+            outDistances);
+}
+
 void runAllPairwiseIPDistance(
         GpuResources* res,
         cudaStream_t stream,
@@ -533,6 +554,26 @@ void runAllPairwiseIPDistance(
         bool queriesRowMajor,
         Tensor<float, 2, true>& outDistances) {
     runAllPairwiseDistance<half>(
+            false,
+            res,
+            stream,
+            vectors,
+            vectorsRowMajor,
+            nullptr,
+            queries,
+            queriesRowMajor,
+            outDistances);
+}
+
+void runAllPairwiseIPDistance(
+        GpuResources* res,
+        cudaStream_t stream,
+        Tensor<__nv_bfloat16, 2, true>& vectors,
+        bool vectorsRowMajor,
+        Tensor<__nv_bfloat16, 2, true>& queries,
+        bool queriesRowMajor,
+        Tensor<float, 2, true>& outDistances) {
+    runAllPairwiseDistance<__nv_bfloat16>(
             false,
             res,
             stream,
@@ -596,6 +637,32 @@ void runL2Distance(
             ignoreOutDistances);
 }
 
+void runL2Distance(
+        GpuResources* res,
+        cudaStream_t stream,
+        Tensor<__nv_bfloat16, 2, true>& vectors,
+        bool vectorsRowMajor,
+        Tensor<float, 1, true>* vectorNorms,
+        Tensor<__nv_bfloat16, 2, true>& queries,
+        bool queriesRowMajor,
+        int k,
+        Tensor<float, 2, true>& outDistances,
+        Tensor<idx_t, 2, true>& outIndices,
+        bool ignoreOutDistances) {
+    runL2Distance<__nv_bfloat16>(
+            res,
+            stream,
+            vectors,
+            vectorsRowMajor,
+            vectorNorms,
+            queries,
+            queriesRowMajor,
+            k,
+            outDistances,
+            outIndices,
+            ignoreOutDistances);
+}
+
 void runIPDistance(
         GpuResources* res,
         cudaStream_t stream,
@@ -629,6 +696,28 @@ void runIPDistance(
         Tensor<float, 2, true>& outDistances,
         Tensor<idx_t, 2, true>& outIndices) {
     runIPDistance<half>(
+            res,
+            stream,
+            vectors,
+            vectorsRowMajor,
+            queries,
+            queriesRowMajor,
+            k,
+            outDistances,
+            outIndices);
+}
+
+void runIPDistance(
+        GpuResources* res,
+        cudaStream_t stream,
+        Tensor<__nv_bfloat16, 2, true>& vectors,
+        bool vectorsRowMajor,
+        Tensor<__nv_bfloat16, 2, true>& queries,
+        bool queriesRowMajor,
+        int k,
+        Tensor<float, 2, true>& outDistances,
+        Tensor<idx_t, 2, true>& outIndices) {
+    runIPDistance<__nv_bfloat16>(
             res,
             stream,
             vectors,

--- a/faiss/gpu/impl/Distance.cuh
+++ b/faiss/gpu/impl/Distance.cuh
@@ -41,6 +41,16 @@ void runAllPairwiseL2Distance(
         bool queriesRowMajor,
         Tensor<float, 2, true>& outDistances);
 
+void runAllPairwiseL2Distance(
+        GpuResources* res,
+        cudaStream_t stream,
+        Tensor<__nv_bfloat16, 2, true>& vectors,
+        bool vectorsRowMajor,
+        Tensor<float, 1, true>* vectorNorms,
+        Tensor<__nv_bfloat16, 2, true>& queries,
+        bool queriesRowMajor,
+        Tensor<float, 2, true>& outDistances);
+
 void runAllPairwiseIPDistance(
         GpuResources* res,
         cudaStream_t stream,
@@ -56,6 +66,15 @@ void runAllPairwiseIPDistance(
         Tensor<half, 2, true>& vectors,
         bool vectorsRowMajor,
         Tensor<half, 2, true>& queries,
+        bool queriesRowMajor,
+        Tensor<float, 2, true>& outDistances);
+
+void runAllPairwiseIPDistance(
+        GpuResources* res,
+        cudaStream_t stream,
+        Tensor<__nv_bfloat16, 2, true>& vectors,
+        bool vectorsRowMajor,
+        Tensor<__nv_bfloat16, 2, true>& queries,
         bool queriesRowMajor,
         Tensor<float, 2, true>& outDistances);
 
@@ -91,6 +110,19 @@ void runL2Distance(
         Tensor<idx_t, 2, true>& outIndices,
         bool ignoreOutDistances = false);
 
+void runL2Distance(
+        GpuResources* resources,
+        cudaStream_t stream,
+        Tensor<__nv_bfloat16, 2, true>& vectors,
+        bool vectorsRowMajor,
+        Tensor<float, 1, true>* vectorNorms,
+        Tensor<__nv_bfloat16, 2, true>& queries,
+        bool queriesRowMajor,
+        int k,
+        Tensor<float, 2, true>& outDistances,
+        Tensor<idx_t, 2, true>& outIndices,
+        bool ignoreOutDistances = false);
+
 /// Calculates brute-force inner product distance between `vectors`
 /// and `queries`, returning the k closest results seen
 void runIPDistance(
@@ -110,6 +142,17 @@ void runIPDistance(
         Tensor<half, 2, true>& vectors,
         bool vectorsRowMajor,
         Tensor<half, 2, true>& queries,
+        bool queriesRowMajor,
+        int k,
+        Tensor<float, 2, true>& outDistances,
+        Tensor<idx_t, 2, true>& outIndices);
+
+void runIPDistance(
+        GpuResources* resources,
+        cudaStream_t stream,
+        Tensor<__nv_bfloat16, 2, true>& vectors,
+        bool vectorsRowMajor,
+        Tensor<__nv_bfloat16, 2, true>& queries,
         bool queriesRowMajor,
         int k,
         Tensor<float, 2, true>& outDistances,

--- a/faiss/gpu/impl/GpuScalarQuantizer.cuh
+++ b/faiss/gpu/impl/GpuScalarQuantizer.cuh
@@ -154,7 +154,7 @@ struct Codec<ScalarQuantizer::QuantizerType::QT_fp16, 1> {
     inline __device__ void decode(void* data, idx_t vec, int d, float* out)
             const {
         half* p = (half*)&((uint8_t*)data)[vec * bytesPerVec];
-        out[0] = Convert<half, float>()(p[d]);
+        out[0] = ConvertTo<float>::to(p[d]);
     }
 
     inline __device__ float decodePartial(
@@ -172,7 +172,7 @@ struct Codec<ScalarQuantizer::QuantizerType::QT_fp16, 1> {
             int d,
             float v[kDimPerIter]) const {
         half* p = (half*)&((uint8_t*)data)[vec * bytesPerVec];
-        p[d] = Convert<float, half>()(v[0]);
+        p[d] = ConvertTo<half>::to(v[0]);
     }
 
     inline __device__ void encodePartial(
@@ -191,11 +191,11 @@ struct Codec<ScalarQuantizer::QuantizerType::QT_fp16, 1> {
     static constexpr int kEncodeBits = 16;
 
     inline __device__ EncodeT encodeNew(int dim, float v) const {
-        return Convert<float, half>()(v);
+        return ConvertTo<half>::to(v);
     }
 
     inline __device__ float decodeNew(int dim, EncodeT v) const {
-        return Convert<half, float>()(v);
+        return ConvertTo<float>::to(v);
     }
 
     int bytesPerVec;

--- a/faiss/gpu/impl/L2Norm.cu
+++ b/faiss/gpu/impl/L2Norm.cu
@@ -276,5 +276,15 @@ void runL2Norm(
     runL2Norm<half, half2>(input, inputRowMajor, output, normSquared, stream);
 }
 
+void runL2Norm(
+        Tensor<__nv_bfloat16, 2, true>& input,
+        bool inputRowMajor,
+        Tensor<float, 1, true>& output,
+        bool normSquared,
+        cudaStream_t stream) {
+    runL2Norm<__nv_bfloat16, __nv_bfloat162>(
+            input, inputRowMajor, output, normSquared, stream);
+}
+
 } // namespace gpu
 } // namespace faiss

--- a/faiss/gpu/impl/L2Norm.cuh
+++ b/faiss/gpu/impl/L2Norm.cuh
@@ -27,5 +27,12 @@ void runL2Norm(
         bool normSquared,
         cudaStream_t stream);
 
+void runL2Norm(
+        Tensor<__nv_bfloat16, 2, true>& input,
+        bool inputRowMajor,
+        Tensor<float, 1, true>& output,
+        bool normSquared,
+        cudaStream_t stream);
+
 } // namespace gpu
 } // namespace faiss

--- a/faiss/gpu/impl/VectorResidual.cu
+++ b/faiss/gpu/impl/VectorResidual.cu
@@ -114,10 +114,8 @@ __global__ void gatherReconstructByIds(
     auto vec = vecs[id];
     auto outVec = out[blockIdx.x];
 
-    Convert<T, float> conv;
-
     for (idx_t i = threadIdx.x; i < vecs.getSize(1); i += blockDim.x) {
-        outVec[i] = id == idx_t(-1) ? 0.0f : conv(vec[i]);
+        outVec[i] = id == idx_t(-1) ? 0.0f : ConvertTo<float>::to(vec[i]);
     }
 }
 
@@ -131,10 +129,8 @@ __global__ void gatherReconstructByRange(
     auto vec = vecs[id];
     auto outVec = out[blockIdx.x];
 
-    Convert<T, float> conv;
-
     for (idx_t i = threadIdx.x; i < vecs.getSize(1); i += blockDim.x) {
-        outVec[i] = id == idx_t(-1) ? 0.0f : conv(vec[i]);
+        outVec[i] = id == idx_t(-1) ? 0.0f : ConvertTo<float>::to(vec[i]);
     }
 }
 

--- a/faiss/gpu/test/TestGpuDistance.cu
+++ b/faiss/gpu/test/TestGpuDistance.cu
@@ -32,6 +32,13 @@
 #include <sstream>
 #include <vector>
 
+enum class TestThresholds {
+    Normal,
+    BF16,
+    // Linf has worse error than the other metrics for bf16
+    BF16_Linf,
+};
+
 void evaluate_bfknn(
         faiss::gpu::GpuDistanceParams& args,
         faiss::gpu::GpuResourcesProvider* res,
@@ -43,15 +50,38 @@ void evaluate_bfknn(
         int k,
         bool colMajorVecs,
         bool colMajorQueries,
-        faiss::MetricType metric) {
+        faiss::MetricType metric,
+        TestThresholds thresh = TestThresholds::Normal) {
     using namespace faiss::gpu;
 
     bfKnn(res, args);
 
     std::stringstream str;
-    str << "using raft " << args.use_raft << "metric " << metric
+    str << "using raft " << args.use_raft << " metric " << metric
         << " colMajorVecs " << colMajorVecs << " colMajorQueries "
         << colMajorQueries;
+
+    float maxRelativeError;
+    float pctMaxDiff1;
+    float pctMaxDiffN;
+
+    switch (thresh) {
+        case TestThresholds::Normal:
+            maxRelativeError = 6e-3f;
+            pctMaxDiff1 = 0.1f;
+            pctMaxDiffN = 0.015f;
+            break;
+        case TestThresholds::BF16:
+            maxRelativeError = 1.5e-2f;
+            pctMaxDiff1 = 0.3f;
+            pctMaxDiffN = 0.1f;
+            break;
+        case TestThresholds::BF16_Linf:
+            maxRelativeError = 1.5e-2f;
+            pctMaxDiff1 = 0.53f;
+            pctMaxDiffN = 0.2f;
+            break;
+    }
 
     compareLists(
             cpuDistance.data(),
@@ -64,9 +94,9 @@ void evaluate_bfknn(
             false,
             false,
             true,
-            6e-3f,
-            0.1f,
-            0.015f);
+            maxRelativeError,
+            pctMaxDiff1,
+            pctMaxDiffN);
 }
 
 void testTransposition(
@@ -191,10 +221,157 @@ void testTransposition(
             metric);
 }
 
+void testTransposition_bf16(
+        bool colMajorVecs,
+        bool colMajorQueries,
+        faiss::MetricType metric,
+        bool use_raft = false,
+        float metricArg = 0) {
+    using namespace faiss::gpu;
+
+    int device = randVal(0, getNumDevices() - 1);
+
+    StandardGpuResources res;
+    res.noTempMemory();
+
+    int dim = randVal(20, 150);
+    int numVecs = randVal(10, 30000);
+    int numQuery = randVal(1, 1024);
+    int k = std::min(numVecs, randVal(20, 70));
+
+    // Input data for CPU
+    std::vector<float> vecs = randVecs(numVecs, dim);
+    std::vector<float> queries = randVecs(numQuery, dim);
+
+    if ((metric == faiss::MetricType::METRIC_JensenShannon) ||
+        (metric == faiss::MetricType::METRIC_Jaccard)) {
+        // make values positive
+        for (auto& v : vecs) {
+            v = std::abs(v);
+            if (v == 0) {
+                v = 1e-6;
+            }
+        }
+
+        for (auto& q : queries) {
+            q = std::abs(q);
+            if (q == 0) {
+                q = 1e-6;
+            }
+        }
+    }
+
+    // The CPU index is our reference for the results
+    faiss::IndexFlat cpuIndex(dim, metric);
+    cpuIndex.metric_arg = metricArg;
+    cpuIndex.add(numVecs, vecs.data());
+
+    std::vector<float> cpuDistance(numQuery * k, 0);
+    std::vector<faiss::idx_t> cpuIndices(numQuery * k, -1);
+
+    cpuIndex.search(
+            numQuery, queries.data(), k, cpuDistance.data(), cpuIndices.data());
+
+    // The transpose and distance code assumes the desired device is already set
+    DeviceScope scope(device);
+    auto stream = res.getDefaultStream(device);
+
+    // Convert float32 data to bfloat16 via truncation not rounding
+    // (just copy high 2 bytes)
+    std::vector<uint16_t> bf16_vecs(vecs.size());
+    std::vector<uint16_t> bf16_queries(queries.size());
+
+    auto fn_f32_bf16 = [](float v) {
+        uint32_t vi;
+        std::memcpy(&vi, &v, sizeof(uint32_t));
+        return uint16_t(vi >> 16);
+    };
+
+    std::transform(vecs.begin(), vecs.end(), bf16_vecs.begin(), fn_f32_bf16);
+    std::transform(
+            queries.begin(), queries.end(), bf16_queries.begin(), fn_f32_bf16);
+
+    // Copy input data to GPU, and pre-transpose both vectors and queries for
+    // passing. Just use uint16_t in lieu of __nv_bfloat16
+    auto gpuVecs = toDeviceNonTemporary<uint16_t, 2>(
+            res.getResources().get(),
+            device,
+            bf16_vecs.data(),
+            stream,
+            {numVecs, dim});
+    auto gpuQueries = toDeviceNonTemporary<uint16_t, 2>(
+            res.getResources().get(),
+            device,
+            bf16_queries.data(),
+            stream,
+            {numQuery, dim});
+
+    DeviceTensor<uint16_t, 2, true> vecsT(
+            res.getResources().get(),
+            makeDevAlloc(AllocType::Other, stream),
+            {dim, numVecs});
+    runTransposeAny(gpuVecs, 0, 1, vecsT, stream);
+
+    DeviceTensor<uint16_t, 2, true> queriesT(
+            res.getResources().get(),
+            makeDevAlloc(AllocType::Other, stream),
+            {dim, numQuery});
+    runTransposeAny(gpuQueries, 0, 1, queriesT, stream);
+
+    std::vector<float> gpuDistance(numQuery * k, 0);
+    std::vector<faiss::idx_t> gpuIndices(numQuery * k, -1);
+
+    GpuDistanceParams args;
+    args.metric = metric;
+    args.metricArg = metricArg;
+    args.k = k;
+    args.dims = dim;
+    args.vectors = colMajorVecs ? vecsT.data() : gpuVecs.data();
+    args.vectorType = DistanceDataType::BF16;
+    args.vectorsRowMajor = !colMajorVecs;
+    args.numVectors = numVecs;
+    args.queries = colMajorQueries ? queriesT.data() : gpuQueries.data();
+    args.queryType = DistanceDataType::BF16;
+    args.queriesRowMajor = !colMajorQueries;
+    args.numQueries = numQuery;
+    args.outDistances = gpuDistance.data();
+    args.outIndices = gpuIndices.data();
+    args.device = device;
+
+#if defined USE_NVIDIA_RAFT
+    args.use_raft = use_raft;
+#else
+    FAISS_THROW_IF_NOT_MSG(
+            !use_raft,
+            "RAFT has not been compiled into the current version so it cannot be used.");
+#endif
+
+    evaluate_bfknn(
+            args,
+            &res,
+            cpuDistance,
+            cpuIndices,
+            gpuDistance,
+            gpuIndices,
+            numQuery,
+            k,
+            colMajorVecs,
+            colMajorQueries,
+            metric,
+            metric == faiss::MetricType::METRIC_Linf ? TestThresholds::BF16_Linf
+                                                     : TestThresholds::BF16);
+}
+
 // Test different memory layouts for brute-force k-NN
 TEST(TestGpuDistance, Transposition_RR) {
     testTransposition(false, false, faiss::MetricType::METRIC_L2);
     testTransposition(false, false, faiss::MetricType::METRIC_INNER_PRODUCT);
+}
+
+TEST(TestGpuDistance, Transposition_RR_BF16) {
+    testTransposition_bf16(false, false, faiss::MetricType::METRIC_L2);
+    testTransposition_bf16(
+            false, false, faiss::MetricType::METRIC_INNER_PRODUCT);
 }
 
 #if defined USE_NVIDIA_RAFT
@@ -209,6 +386,10 @@ TEST(TestGpuDistance, Transposition_RC) {
     testTransposition(false, true, faiss::MetricType::METRIC_L2);
 }
 
+TEST(TestGpuDistance, Transposition_RC_BF16) {
+    testTransposition_bf16(false, true, faiss::MetricType::METRIC_L2);
+}
+
 #if defined USE_NVIDIA_RAFT
 TEST(TestRaftGpuDistance, Transposition_RC) {
     testTransposition(false, true, faiss::MetricType::METRIC_L2, true);
@@ -217,6 +398,10 @@ TEST(TestRaftGpuDistance, Transposition_RC) {
 
 TEST(TestGpuDistance, Transposition_CR) {
     testTransposition(true, false, faiss::MetricType::METRIC_L2);
+}
+
+TEST(TestGpuDistance, Transposition_CR_BF16) {
+    testTransposition_bf16(true, false, faiss::MetricType::METRIC_L2);
 }
 
 #if defined USE_NVIDIA_RAFT
@@ -229,6 +414,10 @@ TEST(TestGpuDistance, Transposition_CC) {
     testTransposition(true, true, faiss::MetricType::METRIC_L2);
 }
 
+TEST(TestGpuDistance, Transposition_CC_BF16) {
+    testTransposition_bf16(true, true, faiss::MetricType::METRIC_L2);
+}
+
 #if defined USE_NVIDIA_RAFT
 TEST(TestRaftGpuDistance, Transposition_CC) {
     testTransposition(true, true, faiss::MetricType::METRIC_L2, true);
@@ -237,6 +426,10 @@ TEST(TestRaftGpuDistance, Transposition_CC) {
 
 TEST(TestGpuDistance, L1) {
     testTransposition(false, false, faiss::MetricType::METRIC_L1);
+}
+
+TEST(TestGpuDistance, L1_BF16) {
+    testTransposition_bf16(false, false, faiss::MetricType::METRIC_L1);
 }
 
 #if defined USE_NVIDIA_RAFT
@@ -250,8 +443,11 @@ TEST(TestGpuDistance, L1_RC) {
     testTransposition(false, true, faiss::MetricType::METRIC_L1);
 }
 
+TEST(TestGpuDistance, L1_RC_BF16) {
+    testTransposition_bf16(false, true, faiss::MetricType::METRIC_L1);
+}
+
 #if defined USE_NVIDIA_RAFT
-// Test other transpositions with the general distance kernel
 TEST(TestRaftGpuDistance, L1_RC) {
     testTransposition(false, true, faiss::MetricType::METRIC_L1, true);
 }
@@ -259,6 +455,10 @@ TEST(TestRaftGpuDistance, L1_RC) {
 
 TEST(TestGpuDistance, L1_CR) {
     testTransposition(true, false, faiss::MetricType::METRIC_L1);
+}
+
+TEST(TestGpuDistance, L1_CR_BF16) {
+    testTransposition_bf16(true, false, faiss::MetricType::METRIC_L1);
 }
 
 #if defined USE_NVIDIA_RAFT
@@ -269,6 +469,10 @@ TEST(TestRaftGpuDistance, L1_CR) {
 
 TEST(TestGpuDistance, L1_CC) {
     testTransposition(true, true, faiss::MetricType::METRIC_L1);
+}
+
+TEST(TestGpuDistance, L1_CC_BF16) {
+    testTransposition_bf16(true, true, faiss::MetricType::METRIC_L1);
 }
 
 #if defined USE_NVIDIA_RAFT
@@ -282,8 +486,11 @@ TEST(TestGpuDistance, Linf) {
     testTransposition(false, false, faiss::MetricType::METRIC_Linf);
 }
 
+TEST(TestGpuDistance, Linf_BF16) {
+    testTransposition_bf16(false, false, faiss::MetricType::METRIC_Linf);
+}
+
 #if defined USE_NVIDIA_RAFT
-// Test remainder of metric types
 TEST(TestRaftGpuDistance, Linf) {
     testTransposition(false, false, faiss::MetricType::METRIC_Linf, true);
 }
@@ -291,6 +498,11 @@ TEST(TestRaftGpuDistance, Linf) {
 
 TEST(TestGpuDistance, Lp) {
     testTransposition(false, false, faiss::MetricType::METRIC_Lp, false, 3);
+}
+
+TEST(TestGpuDistance, Lp_BF16) {
+    testTransposition_bf16(
+            false, false, faiss::MetricType::METRIC_Lp, false, 3);
 }
 
 #if defined USE_NVIDIA_RAFT
@@ -303,6 +515,10 @@ TEST(TestGpuDistance, Canberra) {
     testTransposition(false, false, faiss::MetricType::METRIC_Canberra);
 }
 
+TEST(TestGpuDistance, Canberra_BF16) {
+    testTransposition_bf16(false, false, faiss::MetricType::METRIC_Canberra);
+}
+
 #if defined USE_NVIDIA_RAFT
 TEST(TestRaftGpuDistance, Canberra) {
     testTransposition(false, false, faiss::MetricType::METRIC_Canberra, true);
@@ -313,8 +529,17 @@ TEST(TestGpuDistance, BrayCurtis) {
     testTransposition(false, false, faiss::MetricType::METRIC_BrayCurtis);
 }
 
+TEST(TestGpuDistance, BrayCurtis_BF16) {
+    testTransposition_bf16(false, false, faiss::MetricType::METRIC_BrayCurtis);
+}
+
 TEST(TestGpuDistance, JensenShannon) {
     testTransposition(false, false, faiss::MetricType::METRIC_JensenShannon);
+}
+
+TEST(TestGpuDistance, JensenShannon_BF16) {
+    testTransposition_bf16(
+            false, false, faiss::MetricType::METRIC_JensenShannon);
 }
 
 #if defined USE_NVIDIA_RAFT
@@ -326,6 +551,10 @@ TEST(TestRaftGpuDistance, JensenShannon) {
 
 TEST(TestGpuDistance, Jaccard) {
     testTransposition(false, false, faiss::MetricType::METRIC_Jaccard);
+}
+
+TEST(TestGpuDistance, Jaccard_BF16) {
+    testTransposition_bf16(false, false, faiss::MetricType::METRIC_Jaccard);
 }
 
 int main(int argc, char** argv) {

--- a/faiss/gpu/utils/ConversionOperators.cuh
+++ b/faiss/gpu/utils/ConversionOperators.cuh
@@ -22,29 +22,34 @@ namespace gpu {
 // Conversion utilities
 //
 
-template <typename From, typename To>
-struct Convert {
-    inline __device__ To operator()(From v) const {
-        return (To)v;
-    }
-};
+// template <typename From, typename To>
+// struct Convert {
+//     inline __device__ To operator()(From v) const {
+//         return (To)v;
+//     }
+// };
 
-template <>
-struct Convert<float, half> {
-    inline __device__ half operator()(float v) const {
-        return __float2half(v);
-    }
-};
+// template <>
+// struct Convert<float, half> {
+//     inline __device__ half operator()(float v) const {
+//         return __float2half(v);
+//     }
+// };
 
-template <>
-struct Convert<half, float> {
-    inline __device__ float operator()(half v) const {
-        return __half2float(v);
-    }
-};
+// template <>
+// struct Convert<half, float> {
+//     inline __device__ float operator()(half v) const {
+//         return __half2float(v);
+//     }
+// };
 
 template <typename T>
-struct ConvertTo {};
+struct ConvertTo {
+    template <typename U>
+    static inline __device__ T to(U v) {
+        return T(v);
+    }
+};
 
 template <>
 struct ConvertTo<float> {
@@ -53,6 +58,9 @@ struct ConvertTo<float> {
     }
     static inline __device__ float to(half v) {
         return __half2float(v);
+    }
+    static inline __device__ float to(__nv_bfloat16 v) {
+        return __bfloat162float(v);
     }
 };
 
@@ -103,6 +111,26 @@ struct ConvertTo<Half4> {
     }
     static inline __device__ Half4 to(Half4 v) {
         return v;
+    }
+};
+
+template <>
+struct ConvertTo<__nv_bfloat16> {
+    static inline __device__ __nv_bfloat16 to(float v) {
+        return __float2bfloat16(v);
+    }
+    static inline __device__ __nv_bfloat16 to(half v) {
+        return __float2bfloat16(__half2float(v));
+    }
+    static inline __device__ __nv_bfloat16 to(__nv_bfloat16 v) {
+        return v;
+    }
+};
+
+template <typename From, typename To>
+struct Convert {
+    inline __device__ To operator()(From v) const {
+        return ConvertTo<To>::to(v);
     }
 };
 

--- a/faiss/gpu/utils/MathOperators.cuh
+++ b/faiss/gpu/utils/MathOperators.cuh
@@ -13,7 +13,7 @@
 //
 // Templated wrappers to express math for different scalar and vector
 // types, so kernels can have the same written form but can operate
-// over half and float, and on vector types transparently
+// over half, bfloat16 and float, and on vector types transparently
 //
 
 namespace faiss {
@@ -553,6 +553,210 @@ struct Math<Half8> {
         h.a = Math<Half4>::zero();
         h.b = Math<Half4>::zero();
         return h;
+    }
+};
+
+template <>
+struct Math<__nv_bfloat16> {
+    typedef __nv_bfloat16 ScalarType;
+
+    static inline __device__ __nv_bfloat16
+    add(__nv_bfloat16 a, __nv_bfloat16 b) {
+#ifdef FAISS_USE_FULL_FLOAT16
+        return __hadd(a, b);
+#else
+        return __float2bfloat16(__bfloat162float(a) + __bfloat162float(b));
+#endif
+    }
+
+    static inline __device__ __nv_bfloat16
+    sub(__nv_bfloat16 a, __nv_bfloat16 b) {
+#ifdef FAISS_USE_FULL_FLOAT16
+        return __hsub(a, b);
+#else
+        return __float2bfloat16(__bfloat162float(a) - __bfloat162float(b));
+#endif
+    }
+
+    static inline __device__ __nv_bfloat16
+    mul(__nv_bfloat16 a, __nv_bfloat16 b) {
+#ifdef FAISS_USE_FULL_FLOAT16
+        return __hmul(a, b);
+#else
+        return __float2bfloat16(__bfloat162float(a) * __bfloat162float(b));
+#endif
+    }
+
+    static inline __device__ __nv_bfloat16 neg(__nv_bfloat16 v) {
+#ifdef FAISS_USE_FULL_FLOAT16
+        return __hneg(v);
+#else
+        return __float2bfloat16(-__bfloat162float(v));
+#endif
+    }
+
+    static inline __device__ float reduceAdd(__nv_bfloat16 v) {
+        return ConvertTo<float>::to(v);
+    }
+
+    static inline __device__ bool lt(__nv_bfloat16 a, __nv_bfloat16 b) {
+#ifdef FAISS_USE_FULL_FLOAT16
+        return __hlt(a, b);
+#else
+        return __bfloat162float(a) < __bfloat162float(b);
+#endif
+    }
+
+    static inline __device__ bool gt(__nv_bfloat16 a, __nv_bfloat16 b) {
+#ifdef FAISS_USE_FULL_FLOAT16
+        return __hgt(a, b);
+#else
+        return __bfloat162float(a) > __bfloat162float(b);
+#endif
+    }
+
+    static inline __device__ bool eq(__nv_bfloat16 a, __nv_bfloat16 b) {
+#ifdef FAISS_USE_FULL_FLOAT16
+        return __heq(a, b);
+#else
+        return __bfloat162float(a) == __bfloat162float(b);
+#endif
+    }
+
+    static inline __device__ __nv_bfloat16 zero() {
+#if CUDA_VERSION >= 9000 || defined(USE_AMD_ROCM)
+        return 0;
+#else
+        __nv_bfloat16 h;
+        h.x = 0;
+        return h;
+#endif
+    }
+};
+
+template <>
+struct Math<__nv_bfloat162> {
+    typedef __nv_bfloat16 ScalarType;
+
+    static inline __device__ __nv_bfloat162
+    add(__nv_bfloat162 a, __nv_bfloat162 b) {
+#ifdef FAISS_USE_FULL_FLOAT16
+        return __hadd2(a, b);
+#else
+        float2 af = __bfloat1622float2(a);
+        float2 bf = __bfloat1622float2(b);
+
+        af.x += bf.x;
+        af.y += bf.y;
+
+        return __float22bfloat162_rn(af);
+#endif
+    }
+
+    static inline __device__ __nv_bfloat162
+    sub(__nv_bfloat162 a, __nv_bfloat162 b) {
+#ifdef FAISS_USE_FULL_FLOAT16
+        return __hsub2(a, b);
+#else
+        float2 af = __bfloat1622float2(a);
+        float2 bf = __bfloat1622float2(b);
+
+        af.x -= bf.x;
+        af.y -= bf.y;
+
+        return __float22bfloat162_rn(af);
+#endif
+    }
+
+    static inline __device__ __nv_bfloat162
+    add(__nv_bfloat162 a, __nv_bfloat16 b) {
+#ifdef FAISS_USE_FULL_FLOAT16
+        __nv_bfloat162 b2 = __bfloat162bfloat162(b);
+        return __hadd2(a, b2);
+#else
+        float2 af = __bfloat1622float2(a);
+        float bf = __bfloat162float(b);
+
+        af.x += bf;
+        af.y += bf;
+
+        return __float22bfloat162_rn(af);
+#endif
+    }
+
+    static inline __device__ __nv_bfloat162
+    sub(__nv_bfloat162 a, __nv_bfloat16 b) {
+#ifdef FAISS_USE_FULL_FLOAT16
+        __nv_bfloat162 b2 = __bfloat162bfloat162(b);
+        return __hsub2(a, b2);
+#else
+        float2 af = __bfloat1622float2(a);
+        float bf = __bfloat162float(b);
+
+        af.x -= bf;
+        af.y -= bf;
+
+        return __float22bfloat162_rn(af);
+#endif
+    }
+
+    static inline __device__ __nv_bfloat162
+    mul(__nv_bfloat162 a, __nv_bfloat162 b) {
+#ifdef FAISS_USE_FULL_FLOAT16
+        return __hmul2(a, b);
+#else
+        float2 af = __bfloat1622float2(a);
+        float2 bf = __bfloat1622float2(b);
+
+        af.x *= bf.x;
+        af.y *= bf.y;
+
+        return __float22bfloat162_rn(af);
+#endif
+    }
+
+    static inline __device__ __nv_bfloat162
+    mul(__nv_bfloat162 a, __nv_bfloat16 b) {
+#ifdef FAISS_USE_FULL_FLOAT16
+        __nv_bfloat162 b2 = __bfloat162bfloat162(b);
+        return __hmul2(a, b2);
+#else
+        float2 af = __bfloat1622float2(a);
+        float bf = __bfloat162float(b);
+
+        af.x *= bf;
+        af.y *= bf;
+
+        return __float22bfloat162_rn(af);
+#endif
+    }
+
+    static inline __device__ __nv_bfloat162 neg(__nv_bfloat162 v) {
+#ifdef FAISS_USE_FULL_FLOAT16
+        return __hneg2(v);
+#else
+        float2 vf = __bfloat1622float2(v);
+        vf.x = -vf.x;
+        vf.y = -vf.y;
+
+        return __float22bfloat162_rn(vf);
+#endif
+    }
+
+    static inline __device__ float reduceAdd(__nv_bfloat162 v) {
+        float2 vf = __bfloat1622float2(v);
+        vf.x += vf.y;
+
+        return vf.x;
+    }
+
+    // not implemented for vector types
+    // static inline __device__ bool lt(__nv_bfloat162 a, __nv_bfloat162 b);
+    // static inline __device__ bool gt(__nv_bfloat162 a, __nv_bfloat162 b);
+    // static inline __device__ bool eq(__nv_bfloat162 a, __nv_bfloat162 b);
+
+    static inline __device__ __nv_bfloat162 zero() {
+        return __bfloat162bfloat162(Math<__nv_bfloat16>::zero());
     }
 };
 

--- a/faiss/gpu/utils/MatrixMult-inl.cuh
+++ b/faiss/gpu/utils/MatrixMult-inl.cuh
@@ -30,6 +30,11 @@ template <>
 struct GetCudaType<half> {
     static constexpr hipblasDatatype_t Type = HIPBLAS_R_16F;
 };
+
+template <>
+struct GetCudaType<__nv_bfloat16> {
+    static constexpr hipblasDatatype_t Type = HIPBLAS_R_16B;
+};
 #else
 template <>
 struct GetCudaType<float> {
@@ -39,6 +44,11 @@ struct GetCudaType<float> {
 template <>
 struct GetCudaType<half> {
     static constexpr cudaDataType_t Type = CUDA_R_16F;
+};
+
+template <>
+struct GetCudaType<__nv_bfloat16> {
+    static constexpr cudaDataType_t Type = CUDA_R_16BF;
 };
 #endif
 


### PR DESCRIPTION
Summary:
This diff adds support for bfloat16 vector/query data types with the GPU brute-force k-nearest neighbor function (`bfKnn`).

The change is largely just plumbing the new data type through the template hierarchy (so distances can be computed in bfloat16).

Of note, by design, all final distance results are produced in float32 regardless of input data type (float32, float16, bfloat16). This is because the true nearest neighbors in many data sets can often differ by only ~1000 float32 ULPs in terms of distance which will result in possible false equivalency. This seems to be one area where lossy compression/quantization thoughout does not work as well (and is also why `CUBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION` is set in `StandardGpuResources.cpp`. However, given that there is native bf16 x bf16 = fp32 tensor core support on Ampere+ architectures, the matrix multiplication itself should 

WARNING: The one thing this diff does not yet handle properly is header inclusion / compilation for GPUs older than Ampere. This will need to be fixed before landing (so that compiling with an older CUDA SDK or compiling for the Volta architecture will simply error out at runtime properly with lack of support, instead of failing to compile (?)

Differential Revision: D65459723


