### PR TITLE
write distributed_kmeans centroids and assignments to hive tables

### DIFF
--- a/benchs/bench_fw/descriptors.py
+++ b/benchs/bench_fw/descriptors.py
@@ -83,6 +83,8 @@ class DatasetDescriptor:
 
     embedding_column: Optional[str] = None
 
+    embedding_id_column: Optional[str] = None
+
     sampling_rate: Optional[float] = None
 
     # sampling column for xdb


### PR DESCRIPTION
Summary: Exposing an option to run kmeans centroids and assignments to hive table which should bring us close in parity with Digraph's Kmeans API. This is needed for cluster balance data quality checks for large scale centroids

Reviewed By: kuarora

Differential Revision: D64835789


