### PR TITLE
facebook-unused-include-check in fbcode/faiss

### DIFF
--- a/benchs/bench_cppcontrib_sa_decode.cpp
+++ b/benchs/bench_cppcontrib_sa_decode.cpp
@@ -20,9 +20,7 @@
 #include <faiss/Index2Layer.h>
 #include <faiss/IndexIVFPQ.h>
 #include <faiss/IndexPQ.h>
-#include <faiss/impl/io.h>
 #include <faiss/index_factory.h>
-#include <faiss/index_io.h>
 
 #include <faiss/IndexRowwiseMinMax.h>
 #include <faiss/cppcontrib/SaDecodeKernels.h>

--- a/benchs/bench_hamming_computer.cpp
+++ b/benchs/bench_hamming_computer.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <omp.h>
 #include <cstdio>
 #include <vector>
 

--- a/benchs/bench_heap_replace.cpp
+++ b/benchs/bench_heap_replace.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <omp.h>
 #include <cstdio>
 
 #include <faiss/impl/FaissAssert.h>

--- a/demos/demo_imi_flat.cpp
+++ b/demos/demo_imi_flat.cpp
@@ -15,7 +15,6 @@
 #include <faiss/IndexFlat.h>
 #include <faiss/IndexIVFFlat.h>
 #include <faiss/IndexPQ.h>
-#include <faiss/index_io.h>
 
 double elapsed() {
     struct timeval tv;

--- a/demos/demo_sift1M.cpp
+++ b/demos/demo_sift1M.cpp
@@ -12,8 +12,6 @@
 #include <cstring>
 
 #include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
 
 #include <sys/time.h>
 

--- a/faiss/IndexAdditiveQuantizer.cpp
+++ b/faiss/IndexAdditiveQuantizer.cpp
@@ -16,7 +16,6 @@
 #include <faiss/impl/ResultHandler.h>
 #include <faiss/utils/distances.h>
 #include <faiss/utils/extra_distances.h>
-#include <faiss/utils/utils.h>
 
 namespace faiss {
 

--- a/faiss/IndexAdditiveQuantizerFastScan.cpp
+++ b/faiss/IndexAdditiveQuantizerFastScan.cpp
@@ -8,10 +8,7 @@
 #include <faiss/IndexAdditiveQuantizerFastScan.h>
 
 #include <cassert>
-#include <climits>
 #include <memory>
-
-#include <omp.h>
 
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/LocalSearchQuantizer.h>

--- a/faiss/IndexBinaryFlat.cpp
+++ b/faiss/IndexBinaryFlat.cpp
@@ -14,7 +14,6 @@
 #include <faiss/impl/IDSelector.h>
 #include <faiss/utils/Heap.h>
 #include <faiss/utils/hamming.h>
-#include <faiss/utils/utils.h>
 #include <cstring>
 
 namespace faiss {

--- a/faiss/IndexBinaryHNSW.cpp
+++ b/faiss/IndexBinaryHNSW.cpp
@@ -15,11 +15,6 @@
 #include <cstring>
 #include <memory>
 
-#include <queue>
-#include <unordered_set>
-
-#include <sys/stat.h>
-#include <sys/types.h>
 #include <cstdint>
 
 #include <faiss/IndexBinaryFlat.h>

--- a/faiss/IndexBinaryHash.cpp
+++ b/faiss/IndexBinaryHash.cpp
@@ -19,7 +19,6 @@
 
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/impl/platform_macros.h>
 
 namespace faiss {
 

--- a/faiss/IndexFastScan.cpp
+++ b/faiss/IndexFastScan.cpp
@@ -17,11 +17,7 @@
 #include <faiss/impl/IDSelector.h>
 #include <faiss/impl/LookupTableScaler.h>
 #include <faiss/impl/ResultHandler.h>
-#include <faiss/utils/distances.h>
-#include <faiss/utils/extra_distances.h>
 #include <faiss/utils/hamming.h>
-#include <faiss/utils/random.h>
-#include <faiss/utils/utils.h>
 
 #include <faiss/impl/pq4_fast_scan.h>
 #include <faiss/impl/simd_result_handlers.h>

--- a/faiss/IndexFlat.cpp
+++ b/faiss/IndexFlat.cpp
@@ -16,7 +16,6 @@
 #include <faiss/utils/extra_distances.h>
 #include <faiss/utils/prefetch.h>
 #include <faiss/utils/sorting.h>
-#include <faiss/utils/utils.h>
 #include <cstring>
 
 namespace faiss {

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -19,10 +19,7 @@
 #include <memory>
 #include <queue>
 #include <random>
-#include <unordered_set>
 
-#include <sys/stat.h>
-#include <sys/types.h>
 #include <cstdint>
 
 #include <faiss/Index2Layer.h>
@@ -31,7 +28,6 @@
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/ResultHandler.h>
-#include <faiss/utils/distances.h>
 #include <faiss/utils/random.h>
 #include <faiss/utils/sorting.h>
 

--- a/faiss/IndexIDMap.cpp
+++ b/faiss/IndexIDMap.cpp
@@ -12,7 +12,6 @@
 #include <cinttypes>
 #include <cstdint>
 #include <cstdio>
-#include <limits>
 
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -18,7 +18,6 @@
 #include <cinttypes>
 #include <cstdio>
 #include <limits>
-#include <memory>
 
 #include <faiss/utils/hamming.h>
 #include <faiss/utils/utils.h>

--- a/faiss/IndexIVFAdditiveQuantizer.cpp
+++ b/faiss/IndexIVFAdditiveQuantizer.cpp
@@ -16,7 +16,6 @@
 #include <faiss/impl/ResultHandler.h>
 #include <faiss/utils/distances.h>
 #include <faiss/utils/extra_distances.h>
-#include <faiss/utils/utils.h>
 
 namespace faiss {
 

--- a/faiss/IndexIVFAdditiveQuantizerFastScan.cpp
+++ b/faiss/IndexIVFAdditiveQuantizerFastScan.cpp
@@ -11,8 +11,6 @@
 #include <cinttypes>
 #include <cstdio>
 
-#include <omp.h>
-
 #include <memory>
 
 #include <faiss/impl/AuxIndexStructures.h>
@@ -23,7 +21,6 @@
 #include <faiss/utils/distances.h>
 #include <faiss/utils/hamming.h>
 #include <faiss/utils/quantize_lut.h>
-#include <faiss/utils/simdlib.h>
 #include <faiss/utils/utils.h>
 
 namespace faiss {

--- a/faiss/IndexIVFFastScan.cpp
+++ b/faiss/IndexIVFFastScan.cpp
@@ -23,7 +23,6 @@
 #include <faiss/impl/pq4_fast_scan.h>
 #include <faiss/impl/simd_result_handlers.h>
 #include <faiss/invlists/BlockInvertedLists.h>
-#include <faiss/utils/distances.h>
 #include <faiss/utils/hamming.h>
 #include <faiss/utils/quantize_lut.h>
 #include <faiss/utils/utils.h>

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -22,7 +22,6 @@
 #include <faiss/utils/utils.h>
 
 #include <faiss/Clustering.h>
-#include <faiss/IndexFlat.h>
 
 #include <faiss/utils/hamming.h>
 

--- a/faiss/IndexIVFPQFastScan.cpp
+++ b/faiss/IndexIVFPQFastScan.cpp
@@ -11,21 +11,17 @@
 #include <cinttypes>
 #include <cstdio>
 
-#include <omp.h>
-
 #include <memory>
 
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/distances.h>
 #include <faiss/utils/simdlib.h>
-#include <faiss/utils/utils.h>
 
 #include <faiss/invlists/BlockInvertedLists.h>
 
 #include <faiss/impl/pq4_fast_scan.h>
 #include <faiss/impl/simd_result_handlers.h>
-#include <faiss/utils/quantize_lut.h>
 
 namespace faiss {
 

--- a/faiss/IndexIVFSpectralHash.cpp
+++ b/faiss/IndexIVFSpectralHash.cpp
@@ -19,7 +19,6 @@
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/hamming.h>
-#include <faiss/utils/utils.h>
 
 namespace faiss {
 

--- a/faiss/IndexLSH.cpp
+++ b/faiss/IndexLSH.cpp
@@ -15,7 +15,6 @@
 
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/hamming.h>
-#include <faiss/utils/utils.h>
 
 namespace faiss {
 

--- a/faiss/IndexNSG.cpp
+++ b/faiss/IndexNSG.cpp
@@ -9,8 +9,6 @@
 
 #include <faiss/IndexNSG.h>
 
-#include <omp.h>
-
 #include <cinttypes>
 #include <memory>
 
@@ -18,7 +16,6 @@
 #include <faiss/IndexNNDescent.h>
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/utils/Heap.h>
 #include <faiss/utils/distances.h>
 
 namespace faiss {

--- a/faiss/IndexPQFastScan.cpp
+++ b/faiss/IndexPQFastScan.cpp
@@ -8,10 +8,7 @@
 #include <faiss/IndexPQFastScan.h>
 
 #include <cassert>
-#include <climits>
 #include <memory>
-
-#include <omp.h>
 
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/pq4_fast_scan.h>

--- a/faiss/IndexRefine.cpp
+++ b/faiss/IndexRefine.cpp
@@ -11,8 +11,6 @@
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/Heap.h>
-#include <faiss/utils/distances.h>
-#include <faiss/utils/utils.h>
 
 namespace faiss {
 

--- a/faiss/IndexScalarQuantizer.cpp
+++ b/faiss/IndexScalarQuantizer.cpp
@@ -14,7 +14,6 @@
 
 #include <omp.h>
 
-#include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/IDSelector.h>
 #include <faiss/impl/ScalarQuantizer.h>

--- a/faiss/MetaIndexes.cpp
+++ b/faiss/MetaIndexes.cpp
@@ -16,7 +16,6 @@
 
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/impl/IDSelector.h>
 #include <faiss/utils/Heap.h>
 #include <faiss/utils/WorkerThread.h>
 #include <faiss/utils/random.h>

--- a/faiss/gpu/GpuAutoTune.cpp
+++ b/faiss/gpu/GpuAutoTune.cpp
@@ -17,10 +17,7 @@
 #include <faiss/gpu/GpuIndexFlat.h>
 #include <faiss/gpu/GpuIndexIVFFlat.h>
 #include <faiss/gpu/GpuIndexIVFPQ.h>
-#include <faiss/gpu/GpuIndexIVFScalarQuantizer.h>
 #include <faiss/gpu/impl/IndexUtils.h>
-#include <faiss/gpu/utils/DeviceUtils.h>
-#include <faiss/impl/FaissAssert.h>
 
 namespace faiss {
 namespace gpu {

--- a/faiss/gpu/perf/PerfIVFPQAdd.cpp
+++ b/faiss/gpu/perf/PerfIVFPQAdd.cpp
@@ -14,7 +14,6 @@
 #include <faiss/gpu/utils/DeviceUtils.h>
 #include <faiss/gpu/utils/Timer.h>
 #include <gflags/gflags.h>
-#include <map>
 #include <vector>
 
 DEFINE_int32(batches, 10, "number of batches of vectors to add");

--- a/faiss/impl/AdditiveQuantizer.cpp
+++ b/faiss/impl/AdditiveQuantizer.cpp
@@ -24,7 +24,6 @@
 #include <faiss/utils/Heap.h>
 #include <faiss/utils/distances.h>
 #include <faiss/utils/hamming.h>
-#include <faiss/utils/utils.h>
 
 extern "C" {
 

--- a/faiss/impl/ProductAdditiveQuantizer.cpp
+++ b/faiss/impl/ProductAdditiveQuantizer.cpp
@@ -11,7 +11,6 @@
 #include <cstdio>
 #include <cstring>
 #include <memory>
-#include <random>
 
 #include <algorithm>
 
@@ -20,7 +19,6 @@
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/distances.h>
 #include <faiss/utils/hamming.h>
-#include <faiss/utils/utils.h>
 
 extern "C" {
 

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -13,9 +13,6 @@
 #include <cstdio>
 #include <cstdlib>
 
-#include <sys/stat.h>
-#include <sys/types.h>
-
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/io.h>
 #include <faiss/impl/io_macros.h>

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -13,13 +13,9 @@
 #include <cstdio>
 #include <cstdlib>
 
-#include <sys/stat.h>
-#include <sys/types.h>
-
 #include <faiss/invlists/InvertedListsIOHook.h>
 
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/impl/io.h>
 #include <faiss/impl/io_macros.h>
 #include <faiss/utils/hamming.h>
 

--- a/faiss/impl/kmeans1d.cpp
+++ b/faiss/impl/kmeans1d.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <algorithm>
-#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <numeric>

--- a/faiss/impl/lattice_Zn.cpp
+++ b/faiss/impl/lattice_Zn.cpp
@@ -16,7 +16,6 @@
 
 #include <algorithm>
 #include <queue>
-#include <unordered_map>
 #include <unordered_set>
 
 #include <faiss/impl/platform_macros.h>

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -20,7 +20,6 @@
 
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/random.h>
-#include <faiss/utils/utils.h>
 
 #include <faiss/Index2Layer.h>
 #include <faiss/IndexAdditiveQuantizer.h>

--- a/faiss/invlists/OnDiskInvertedLists.cpp
+++ b/faiss/invlists/OnDiskInvertedLists.cpp
@@ -15,7 +15,6 @@
 
 #include <sys/mman.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 #include <faiss/impl/FaissAssert.h>

--- a/faiss/utils/extra_distances.cpp
+++ b/faiss/utils/extra_distances.cpp
@@ -15,7 +15,6 @@
 
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/DistanceComputer.h>
-#include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/utils.h>
 
 namespace faiss {

--- a/perf_tests/bench_scalar_quantizer_accuracy.cpp
+++ b/perf_tests/bench_scalar_quantizer_accuracy.cpp
@@ -14,7 +14,6 @@
 #include <faiss/impl/ScalarQuantizer.h>
 #include <faiss/utils/distances.h>
 #include <faiss/utils/random.h>
-#include <faiss/utils/utils.h>
 
 using namespace faiss;
 DEFINE_uint32(d, 128, "dimension");

--- a/perf_tests/bench_scalar_quantizer_decode.cpp
+++ b/perf_tests/bench_scalar_quantizer_decode.cpp
@@ -14,7 +14,6 @@
 #include <benchmark/benchmark.h>
 #include <faiss/impl/ScalarQuantizer.h>
 #include <faiss/utils/random.h>
-#include <faiss/utils/utils.h>
 
 using namespace faiss;
 DEFINE_uint32(d, 128, "dimension");

--- a/perf_tests/bench_scalar_quantizer_distance.cpp
+++ b/perf_tests/bench_scalar_quantizer_distance.cpp
@@ -14,7 +14,6 @@
 #include <faiss/impl/ScalarQuantizer.h>
 #include <faiss/perf_tests/utils.h>
 #include <faiss/utils/random.h>
-#include <faiss/utils/utils.h>
 
 using namespace faiss;
 DEFINE_uint32(d, 128, "dimension");

--- a/perf_tests/bench_scalar_quantizer_encode.cpp
+++ b/perf_tests/bench_scalar_quantizer_encode.cpp
@@ -15,7 +15,6 @@
 #include <faiss/perf_tests/utils.h>
 #include <faiss/utils/distances.h>
 #include <faiss/utils/random.h>
-#include <faiss/utils/utils.h>
 
 using namespace faiss;
 DEFINE_uint32(d, 128, "dimension");

--- a/tests/test_approx_topk.cpp
+++ b/tests/test_approx_topk.cpp
@@ -17,7 +17,6 @@
 
 #include <faiss/utils/approx_topk/approx_topk.h>
 
-#include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/FaissException.h>
 #include <faiss/utils/Heap.h>
 

--- a/tests/test_common_ivf_empty_index.cpp
+++ b/tests/test_common_ivf_empty_index.cpp
@@ -7,7 +7,6 @@
 
 #include <gtest/gtest.h>
 
-#include <omp.h>
 #include <cstddef>
 #include <memory>
 #include <vector>

--- a/tests/test_dealloc_invlists.cpp
+++ b/tests/test_dealloc_invlists.cpp
@@ -18,7 +18,6 @@
 #include <faiss/IVFlib.h>
 #include <faiss/IndexIVF.h>
 #include <faiss/index_factory.h>
-#include <faiss/index_io.h>
 
 using namespace faiss;
 

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -17,7 +17,6 @@
 #include <faiss/impl/HNSW.h>
 #include <faiss/impl/ResultHandler.h>
 #include <faiss/utils/random.h>
-#include <faiss/utils/utils.h>
 
 int reference_pop_min(faiss::HNSW::MinimaxHeap& heap, float* vmin_out) {
     assert(heap.k > 0);

--- a/tests/test_ivf_index.cpp
+++ b/tests/test_ivf_index.cpp
@@ -8,9 +8,6 @@
 #include <omp.h>
 #include <algorithm>
 #include <cstddef>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
 #include <map>
 #include <random>
 #include <set>
@@ -20,7 +17,6 @@
 #include <faiss/IndexFlat.h>
 #include <faiss/IndexIVFFlat.h>
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/index_io.h>
 
 namespace {
 

--- a/tests/test_ivfpq_codec.cpp
+++ b/tests/test_ivfpq_codec.cpp
@@ -16,7 +16,6 @@
 #include <faiss/IndexFlat.h>
 #include <faiss/IndexIVFPQ.h>
 #include <faiss/utils/distances.h>
-#include <faiss/utils/utils.h>
 
 namespace {
 

--- a/tests/test_ivfpq_indexing.cpp
+++ b/tests/test_ivfpq_indexing.cpp
@@ -13,7 +13,6 @@
 
 #include <faiss/IndexFlat.h>
 #include <faiss/IndexIVFPQ.h>
-#include <faiss/index_io.h>
 
 TEST(IVFPQ, accuracy) {
     // dimension of the vectors to index

--- a/tests/test_lowlevel_ivf.cpp
+++ b/tests/test_lowlevel_ivf.cpp
@@ -21,9 +21,7 @@
 #include <faiss/IndexBinaryIVF.h>
 #include <faiss/IndexIVF.h>
 #include <faiss/IndexPreTransform.h>
-#include <faiss/VectorTransform.h>
 #include <faiss/index_factory.h>
-#include <faiss/index_io.h>
 
 using namespace faiss;
 

--- a/tests/test_ondisk_ivf.cpp
+++ b/tests/test_ondisk_ivf.cpp
@@ -9,7 +9,6 @@
 #include <cstdlib>
 #include <random>
 
-#include <omp.h>
 #include <unistd.h>
 
 #include <pthread.h>

--- a/tests/test_transfer_invlists.cpp
+++ b/tests/test_transfer_invlists.cpp
@@ -14,7 +14,6 @@
 #include <faiss/AutoTune.h>
 #include <faiss/IVFlib.h>
 #include <faiss/IndexIVFFlat.h>
-#include <faiss/VectorTransform.h>
 #include <faiss/clone_index.h>
 #include <faiss/impl/io.h>
 #include <faiss/index_factory.h>


### PR DESCRIPTION
Summary:
Remove headers flagged by facebook-unused-include-check over fbcode.faiss.

+ format and autodeps

This is a codemod. It was automatically generated and will be landed once it is approved and tests are passing in sandcastle.
You have been added as a reviewer by Sentinel or Butterfly.

Autodiff project: uif
Autodiff partition: fbcode.faiss
Autodiff bookmark: ad.uif.fbcode.faiss

Reviewed By: dtolnay

Differential Revision: D65957849
