### PR TITLE
Constrain conda version for Windows build

### DIFF
--- a/.github/actions/build_conda/action.yml
+++ b/.github/actions/build_conda/action.yml
@@ -34,8 +34,8 @@ runs:
     - name: Install conda build tools
       shell: ${{ steps.choose_shell.outputs.shell }}
       run: |
-        conda update -y -q conda
-        conda install -y -q conda-build
+        conda update -y -q "conda<24.11.0"
+        conda install -y -q "conda-build<24.11.0"
     - name: Enable anaconda uploads
       if: inputs.label != ''
       shell: ${{ steps.choose_shell.outputs.shell }}

--- a/.github/actions/build_conda/action.yml
+++ b/.github/actions/build_conda/action.yml
@@ -34,8 +34,8 @@ runs:
     - name: Install conda build tools
       shell: ${{ steps.choose_shell.outputs.shell }}
       run: |
-        conda update -y -q "conda<24.11.0"
-        conda install -y -q "conda-build<24.11.0"
+        conda update -y -q "conda!=24.11.0"
+        conda install -y -q "conda-build!=24.11.0"
     - name: Enable anaconda uploads
       if: inputs.label != ''
       shell: ${{ steps.choose_shell.outputs.shell }}

--- a/.github/actions/build_conda/action.yml
+++ b/.github/actions/build_conda/action.yml
@@ -34,7 +34,7 @@ runs:
     - name: Install conda build tools
       shell: ${{ steps.choose_shell.outputs.shell }}
       run: |
-        conda update -y -q "conda!=24.11.0"
+        conda install -y -q "conda!=24.11.0"
         conda install -y -q "conda-build!=24.11.0"
     - name: Enable anaconda uploads
       if: inputs.label != ''


### PR DESCRIPTION
Failure in nightly build due to https://github.com/conda/conda-build/issues/5549: https://github.com/facebookresearch/faiss/actions/runs/11967515834/job/33370335745