### PR TITLE
Fix SCD Table test flakiness

### DIFF
--- a/tests/test_disable_pq_sdc_tables.cpp
+++ b/tests/test_disable_pq_sdc_tables.cpp
@@ -18,7 +18,15 @@
 pthread_mutex_t temp_file_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 TEST(IO, TestReadHNSWPQ_whenSDCDisabledFlagPassed_thenDisableSDCTable) {
-    Tempfilename index_filename(&temp_file_mutex, "/tmp/faiss_TestReadHNSWPQ");
+    // Create a temp file name with a randomized component for stress runs
+    std::random_device rd;
+    std::mt19937 mt(rd());
+    std::uniform_real_distribution<float> dist(0, 9999999);
+    std::string temp_file_name =
+            "/tmp/faiss_TestReadHNSWPQ" + std::to_string(int(dist(mt)));
+    Tempfilename index_filename(&temp_file_mutex, temp_file_name);
+
+    // Create a HNSW index with PQ encoding
     int d = 32, n = 256;
     std::default_random_engine rng(123);
     std::uniform_real_distribution<float> u(0, 100);


### PR DESCRIPTION
Summary:
Test often fails due to bad file descriptor: https://www.internalfb.com/intern/testinfra/diagnostics/12384899035372280.281475109760157.1733399744/

This is due to the filename in the test being the same across all runs - when there are multiple concurrent runs, there will be problems accessing the file.

The solution is to add a randomized component to the temp file, similar to other tests like ```test_io_with_options```, which prevents concurrent accesses of a file.

Differential Revision: D66846937


