### PR TITLE
Update __init__.py

### DIFF
--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -170,7 +170,7 @@ try:
     add_ref_in_constructor(GpuIndexIVFPQ, 1)
     add_ref_in_constructor(GpuIndexIVFScalarQuantizer, 1)
 except NameError as e:
-    logging.info("Failed to load GPU Faiss: %s. Will not load constructor refs for GPU indexes." % e.args[0])
+    logger.info("Failed to load GPU Faiss: %s. Will not load constructor refs for GPU indexes." % e.args[0])
 
 add_ref_in_constructor(IndexIVFFlat, 0)
 add_ref_in_constructor(IndexIVFFlatDedup, 0)

--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -9,6 +9,7 @@
 # causes a ton of useless warnings.
 
 import numpy as np
+import logging
 import sys
 import inspect
 
@@ -29,6 +30,8 @@ from faiss.extra_wrappers import kmin, kmax, pairwise_distances, rand, randint, 
 __version__ = "%d.%d.%d" % (FAISS_VERSION_MAJOR,
                             FAISS_VERSION_MINOR,
                             FAISS_VERSION_PATCH)
+
+logger = logging.getLogger(__name__)
 
 class_wrappers.handle_Clustering(Clustering)
 class_wrappers.handle_Clustering1D(Clustering1D)
@@ -161,14 +164,13 @@ def add_ref_in_function(function_name, parameter_no):
 
 
 try:
-    from swigfaiss_gpu import GpuIndexIVFFlat, GpuIndexBinaryFlat, GpuIndexFlat, GpuIndexIVFPQ, GpuIndexIVFScalarQuantizer
     add_ref_in_constructor(GpuIndexIVFFlat, 1)
     add_ref_in_constructor(GpuIndexBinaryFlat, 1)
     add_ref_in_constructor(GpuIndexFlat, 1)
     add_ref_in_constructor(GpuIndexIVFPQ, 1)
     add_ref_in_constructor(GpuIndexIVFScalarQuantizer, 1)
-except ImportError as e:
-    print("Failed to load GPU Faiss: %s. Will not load constructor refs for GPU indexes." % e.args[0])
+except NameError as e:
+    logging.info("Failed to load GPU Faiss: %s. Will not load constructor refs for GPU indexes." % e.args[0])
 
 add_ref_in_constructor(IndexIVFFlat, 0)
 add_ref_in_constructor(IndexIVFFlatDedup, 0)


### PR DESCRIPTION
Fix erroneous logging `Failed to load GPU Faiss: No module named 'swigfaiss_gpu'. Will not load constructor refs for GPU indexes.` when I was running on a GPU-based index just fine.

`GpuIndex...` is loaded via loader.py.