### PR TITLE
Update benchmarking library code to work for IdMap index as well

### DIFF
--- a/benchs/bench_fw/index.py
+++ b/benchs/bench_fw/index.py
@@ -677,6 +677,13 @@ class Index(IndexBase):
                 lambda: add_preassigned(index_ivf, xbt, QI.ravel()),
                 once=True,
             )
+        elif isinstance(index, faiss.IndexIDMap):
+            _, t, _ = timer(
+                "add_with_ids",
+                lambda: index.add_with_ids(
+                    xb, np.arange(len(xb), dtype='int32')),
+                once=True,
+            )
         else:
             _, t, _ = timer(
                 "add",


### PR DESCRIPTION
Summary: Update benchmarking library code to work for IdMap index as well by calling add_with_ids instead of add since ids are required for IDMap index

Differential Revision: D67254267


