### PR TITLE
Fix IndexIVFFastScan reconstruct_from_offset method

### DIFF
--- a/benchs/bench_fw/index.py
+++ b/benchs/bench_fw/index.py
@@ -677,6 +677,13 @@ class Index(IndexBase):
                 lambda: add_preassigned(index_ivf, xbt, QI.ravel()),
                 once=True,
             )
+        elif isinstance(index, faiss.IndexIDMap):
+            _, t, _ = timer(
+                "add_with_ids",
+                lambda: index.add_with_ids(
+                    xb, np.arange(len(xb), dtype='int32')),
+                once=True,
+            )
         else:
             _, t, _ = timer(
                 "add",

--- a/faiss/IndexIVFFastScan.cpp
+++ b/faiss/IndexIVFFastScan.cpp
@@ -1353,10 +1353,11 @@ void IndexIVFFastScan::reconstruct_from_offset(
         int64_t offset,
         float* recons) const {
     // unpack codes
-    InvertedLists::ScopedCodes list_codes(invlists, list_no);
-    std::vector<uint8_t> code(code_size, 0);
+    size_t coarse_size = coarse_code_size();
+    std::vector<uint8_t> code(coarse_size + code_size, 0);
     encode_listno(list_no, code.data());
-    BitstringWriter bsw(code.data() + coarse_code_size(), code_size);
+    InvertedLists::ScopedCodes list_codes(invlists, list_no);
+    BitstringWriter bsw(code.data() + coarse_size, code_size);
 
     for (size_t m = 0; m < M; m++) {
         uint8_t c =

--- a/faiss/IndexIVFFastScan.cpp
+++ b/faiss/IndexIVFFastScan.cpp
@@ -1372,10 +1372,11 @@ void IndexIVFFastScan::reconstruct_orig_invlists() {
     FAISS_THROW_IF_NOT(orig_invlists != nullptr);
     FAISS_THROW_IF_NOT(orig_invlists->list_size(0) == 0);
 
+#pragma omp parallel for if (nlist > 100)
     for (size_t list_no = 0; list_no < nlist; list_no++) {
         InvertedLists::ScopedCodes codes(invlists, list_no);
         InvertedLists::ScopedIds ids(invlists, list_no);
-        size_t list_size = orig_invlists->list_size(list_no);
+        size_t list_size = invlists->list_size(list_no);
         std::vector<uint8_t> code(code_size, 0);
 
         for (size_t offset = 0; offset < list_size; offset++) {

--- a/faiss/IndexIVFFastScan.cpp
+++ b/faiss/IndexIVFFastScan.cpp
@@ -1355,22 +1355,16 @@ void IndexIVFFastScan::reconstruct_from_offset(
     // unpack codes
     InvertedLists::ScopedCodes list_codes(invlists, list_no);
     std::vector<uint8_t> code(code_size, 0);
-    BitstringWriter bsw(code.data(), code_size);
+    encode_listno(list_no, code.data());
+    BitstringWriter bsw(code.data() + coarse_code_size(), code_size);
+
     for (size_t m = 0; m < M; m++) {
         uint8_t c =
                 pq4_get_packed_element(list_codes.get(), bbs, M2, offset, m);
         bsw.write(c, nbits);
     }
-    sa_decode(1, code.data(), recons);
 
-    // add centroid to it
-    if (by_residual) {
-        std::vector<float> centroid(d);
-        quantizer->reconstruct(list_no, centroid.data());
-        for (int i = 0; i < d; ++i) {
-            recons[i] += centroid[i];
-        }
-    }
+    sa_decode(1, code.data(), recons);
 }
 
 void IndexIVFFastScan::reconstruct_orig_invlists() {

--- a/faiss/IndexIVFPQFastScan.cpp
+++ b/faiss/IndexIVFPQFastScan.cpp
@@ -76,6 +76,7 @@ IndexIVFPQFastScan::IndexIVFPQFastScan(const IndexIVFPQ& orig, int bbs)
                precomputed_table.nbytes());
     }
 
+#pragma omp parallel for if (nlist > 100)
     for (size_t i = 0; i < nlist; i++) {
         size_t nb = orig.invlists->list_size(i);
         size_t nb2 = roundup(nb, bbs);

--- a/tests/test_fast_scan_ivf.py
+++ b/tests/test_fast_scan_ivf.py
@@ -8,7 +8,6 @@ import os
 import unittest
 import tempfile
 
-import faiss.invlists
 import numpy as np
 import faiss
 


### PR DESCRIPTION
Resolves issue #4089 - IndexIVFPQFastScan crashes with certain nlist values

The `reconstruct_from_offset` method in `IndexIVFFastScan` was incorrectly reconstructing vectors, causing crashes when the `nlist` parameter was not byte-aligned (e.g. 100 instead of 256).

The root cause was that the `list_no` (Voronoi cell number) was not being properly encoded into the `code` vector before passing it to the `sa_decode` function. This resulted in invalid `list_no` values being read in `sa_decode`, triggering the assertion failure `'list_no >= 0 && list_no < nlist'` when `nlist` in some cases.

This PR fixes the issue with the following changes to `reconstruct_from_offset`:

1. Encode the `list_no` into the beginning of the `code` vector using the existing `encode_listno` method
2. Start the `BitstringWriter` after the coarse code portion of `code` (shifted by `coarse_code_size()` bytes)
3. Remove the residual centroid addition logic, as it is already handled in `sa_decode`

After these changes:
- Crashes no longer occur for any `nlist` value 
- Reconstruction is now correct, matching the output of `IndexIVFPQ`

Fixes #4089

Please review and let me know if any changes are needed. Thanks!