### PR TITLE
Expose accumulate_to_mem from faiss interface

### DIFF
--- a/faiss/impl/pq4_fast_scan.h
+++ b/faiss/impl/pq4_fast_scan.h
@@ -189,4 +189,22 @@ void pq4_accumulate_loop_qbs(
         SIMDResultHandler& res,
         const NormTableScaler* scaler = nullptr);
 
+/** Wrapper of pq4_accumulate_loop_qbs using simple StoreResultHandler
+ *  and DummyScaler
+ *
+ * @param nq      number of queries
+ * @param ntotal2 number of database elements (multiple of 32)
+ * @param nsq     number of sub-quantizers (muliple of 2)
+ * @param codes   packed codes array
+ * @param LUT     packed look-up table
+ * @param accu    array to store the results
+ */
+void accumulate_to_mem(
+        int nq,
+        size_t ntotal2,
+        int nsq,
+        const uint8_t* codes,
+        const uint8_t* LUT,
+        uint16_t* accu);
+
 } // namespace faiss


### PR DESCRIPTION
Summary:
Expose interface of accumulate_to_mem.

accumulate_to_mem calls pq4 fast scan accumulate with a dummy scaler and a StoreResultHandler. The function is not currently in use anywhere.

Differential Revision: D67299378


