### PR TITLE
Remove unused(and wrong) io macro

### DIFF
--- a/faiss/impl/io_macros.h
+++ b/faiss/impl/io_macros.h
@@ -45,13 +45,6 @@
         READANDCHECK((vec).data(), size);                            \
     }
 
-#define READSTRING(s)                     \
-    {                                     \
-        size_t size = (s).size();         \
-        WRITEANDCHECK(&size, 1);          \
-        WRITEANDCHECK((s).c_str(), size); \
-    }
-
 #define WRITEANDCHECK(ptr, n)                         \
     {                                                 \
         size_t ret = (*f)(ptr, sizeof(*(ptr)), n);    \


### PR DESCRIPTION
`READSTRING` is not used and also the function's meaning is actually WRITESTRING, just remove it