### PR TITLE
Add `ngpu` default argument to `knn_ground_truth`

### DIFF
--- a/contrib/exhaustive_search.py
+++ b/contrib/exhaustive_search.py
@@ -11,7 +11,7 @@ import logging
 
 LOG = logging.getLogger(__name__)
 
-def knn_ground_truth(xq, db_iterator, k, metric_type=faiss.METRIC_L2, ngpu=-1):
+def knn_ground_truth(xq, db_iterator, k, metric_type=faiss.METRIC_L2, shard=False, ngpu=-1):
     """Computes the exact KNN search results for a dataset that possibly
     does not fit in RAM but for which we have an iterator that
     returns it block by block.
@@ -28,7 +28,9 @@ def knn_ground_truth(xq, db_iterator, k, metric_type=faiss.METRIC_L2, ngpu=-1):
 
     if ngpu:
         LOG.info('running on %d GPUs' % ngpu)
-        index = faiss.index_cpu_to_all_gpus(index)
+        co = faiss.GpuMultipleClonerOptions()
+        co.shard = shard
+        index = faiss.index_cpu_to_all_gpus(index, co=co, ngpu=ngpu)
 
     # compute ground-truth by blocks, and add to heaps
     i0 = 0

--- a/contrib/exhaustive_search.py
+++ b/contrib/exhaustive_search.py
@@ -11,7 +11,7 @@ import logging
 
 LOG = logging.getLogger(__name__)
 
-def knn_ground_truth(xq, db_iterator, k, metric_type=faiss.METRIC_L2):
+def knn_ground_truth(xq, db_iterator, k, metric_type=faiss.METRIC_L2, ngpu=-1):
     """Computes the exact KNN search results for a dataset that possibly
     does not fit in RAM but for which we have an iterator that
     returns it block by block.
@@ -23,8 +23,11 @@ def knn_ground_truth(xq, db_iterator, k, metric_type=faiss.METRIC_L2):
     rh = faiss.ResultHeap(nq, k, keep_max=keep_max)
 
     index = faiss.IndexFlat(d, metric_type)
-    if faiss.get_num_gpus():
-        LOG.info('running on %d GPUs' % faiss.get_num_gpus())
+    if ngpu == -1:
+        ngpu = faiss.get_num_gpus()
+
+    if ngpu:
+        LOG.info('running on %d GPUs' % ngpu)
         index = faiss.index_cpu_to_all_gpus(index)
 
     # compute ground-truth by blocks, and add to heaps

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -50,7 +50,7 @@ class TestComputeGT(unittest.TestCase):
                 yield xb[i0:i0 + bs]
 
         Dnew, Inew = knn_ground_truth(
-            xq, matrix_iterator(xb, 1000), 10, metric)
+            xq, matrix_iterator(xb, 1000), 10, metric, ngpu=0)
 
         np.testing.assert_array_equal(Iref, Inew)
         # decimal = 4 required when run on GPU


### PR DESCRIPTION
This pull request introduces a new default argument, `ngpu=-1`, to the `knn_ground_truth` function in the `faiss.contrib`.

## Purpose of Change

### Bug Fix

In the current implementation, running tests under the tests directory (CPU tests) in an environment with faiss-gpu installed would inadvertently use the GPU and cause unintended behavior.
This pull request prevents the GPU from being used during CPU-only tests by explicitly controlling GPU allocation via the ngpu parameter.

### API Consistency

Other functions that call `faiss.get_num_gpus` in `faiss.contrib`, such as `range_search_max_results` and `range_ground_truth`, already include the `ngpu` argument.
Adding this parameter to `knn_ground_truth` will ensure consistency across the API, reduce potential confusion, and improve ease of use.