### PR TITLE
Disable retry build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -144,5 +144,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_DEBUG: api
         run: |
-          gh workflow run retry_build.yml \
-            -F run_id=${{ github.run_id }}
+          echo Disabled auto retry workflow
+          # gh workflow run retry_build.yml \
+          #   -F run_id=${{ github.run_id }}

--- a/.github/workflows/retry_build.yml
+++ b/.github/workflows/retry_build.yml
@@ -15,11 +15,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_DEBUG: api
         run: |
-          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          while gh run view ${{ inputs.run_id }} --json status | grep -q in_progress
+          do
+            echo Workflow in progress - sleeping for 10 minutes then checking again
+            sleep 10m
+          done
 
           # Only retry if there are failed jobs
           if gh run view ${{ inputs.run_id }} --exit-status; then
             echo Workflow succeeded - no retry necessary.
           else
+            echo Workflow failed - initiating retry.
             gh run rerun ${{ inputs.run_id }} --failed
           fi


### PR DESCRIPTION
Summary: ```gh run``` seems to time out every now and then, crashing the retry build. Changing to use ```gh view``` may resolve this issue.

Differential Revision: D68032708


