### PR TITLE
fix: gpu tests link failure with static lib

### DIFF
--- a/faiss/gpu/CMakeLists.txt
+++ b/faiss/gpu/CMakeLists.txt
@@ -258,12 +258,12 @@ if(FAISS_ENABLE_CUVS)
           utils/CuvsUtils.cu)
 endif()
 
-add_library(faiss_gpu STATIC ${FAISS_GPU_SRC})
-set_target_properties(faiss_gpu PROPERTIES
+add_library(faiss_gpu_objs OBJECT ${FAISS_GPU_SRC})
+set_target_properties(faiss_gpu_objs PROPERTIES
   POSITION_INDEPENDENT_CODE ON
   WINDOWS_EXPORT_ALL_SYMBOLS ON
 )
-target_include_directories(faiss_gpu PUBLIC
+target_include_directories(faiss_gpu_objs PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
 
 if(FAISS_ENABLE_CUVS)
@@ -293,7 +293,7 @@ if(FAISS_ENABLE_CUVS)
     utils/CuvsUtils.cu
     TARGET_DIRECTORY faiss
     PROPERTIES COMPILE_OPTIONS "-fvisibility=hidden")
-  target_compile_definitions(faiss_gpu PUBLIC USE_NVIDIA_CUVS=1)
+  target_compile_definitions(faiss_gpu_objs PUBLIC USE_NVIDIA_CUVS=1)
 endif()
 
 if (FAISS_ENABLE_ROCM)
@@ -303,11 +303,13 @@ endif()
 # Export FAISS_GPU_HEADERS variable to parent scope.
 set(FAISS_GPU_HEADERS ${FAISS_GPU_HEADERS} PARENT_SCOPE)
 
-target_link_libraries(faiss PRIVATE  "$<LINK_LIBRARY:WHOLE_ARCHIVE,faiss_gpu>")
-target_link_libraries(faiss_avx2 PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,faiss_gpu>")
-target_link_libraries(faiss_avx512 PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,faiss_gpu>")
-target_link_libraries(faiss_avx512_spr PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,faiss_gpu>")
-target_link_libraries(faiss_sve PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,faiss_gpu>")
+target_link_libraries(faiss PRIVATE  faiss_gpu_objs)
+target_link_libraries(faiss_avx2 PRIVATE faiss_gpu_objs)
+target_link_libraries(faiss_avx512 PRIVATE faiss_gpu_objs)
+target_link_libraries(faiss_avx512_spr PRIVATE faiss_gpu_objs)
+target_link_libraries(faiss_sve PRIVATE faiss_gpu_objs)
+
+install(TARGETS faiss_gpu_objs EXPORT faiss-targets)
 
 foreach(header ${FAISS_GPU_HEADERS})
   get_filename_component(dir ${header} DIRECTORY )
@@ -317,8 +319,8 @@ foreach(header ${FAISS_GPU_HEADERS})
 endforeach()
 
 if (FAISS_ENABLE_ROCM)
-  target_link_libraries(faiss_gpu PRIVATE hip::host roc::hipblas)
-  target_compile_options(faiss_gpu PRIVATE)
+  target_link_libraries(faiss_gpu_objs PRIVATE hip::host roc::hipblas)
+  target_compile_options(faiss_gpu_objs PRIVATE)
 else()
   # Prepares a host linker script and enables host linker to support
   # very large device object files.
@@ -333,12 +335,12 @@ else()
   }
   ]=]
   )
-  target_link_options(faiss_gpu PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/fatbin.ld")
+  target_link_options(faiss_gpu_objs PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/fatbin.ld")
 
 
   find_package(CUDAToolkit REQUIRED)
-  target_link_libraries(faiss_gpu PRIVATE CUDA::cudart CUDA::cublas $<$<BOOL:${FAISS_ENABLE_CUVS}>:cuvs::cuvs> $<$<BOOL:${FAISS_ENABLE_CUVS}>:OpenMP::OpenMP_CXX>)
-  target_compile_options(faiss_gpu PRIVATE
+  target_link_libraries(faiss_gpu_objs PRIVATE CUDA::cudart CUDA::cublas $<$<BOOL:${FAISS_ENABLE_CUVS}>:cuvs::cuvs> $<$<BOOL:${FAISS_ENABLE_CUVS}>:OpenMP::OpenMP_CXX>)
+  target_compile_options(faiss_gpu_objs PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:-Xfatbin=-compress-all
     --expt-extended-lambda --expt-relaxed-constexpr
     $<$<BOOL:${FAISS_ENABLE_CUVS}>:-Xcompiler=${OpenMP_CXX_FLAGS}>>)


### PR DESCRIPTION
# The bug
build gpu test with static lib failed undefined reference from gpu source code to cpu source, e.g.
`GpuAutoTune.cpp:(.text+0x3bc): undefined reference to 'typeinfo for faiss::Index'`

# build config:
`cmake -S . -B build -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=ON -DFAISS_ENABLE_GPU=ON`
the link command would be like: `c++ -o faiss/gpu/test/TestCodePacking faiss/libfaiss.a -Wl,--push-state,--whole-archive  faiss/gpu/libfaiss_gpu.a  -Wl,--pop-state ...`
key point is linking to faiss_gpu after faiss which is a classic link order issue of "undefined reference"

# my fix:
make faiss_gpu an `OBJECT` library.

# Bouns
TestXXX files get small because '--whole-archive' propagated to test link command.

