### PR TITLE
Reenable auto retry workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -144,6 +144,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_DEBUG: api
         run: |
-          echo Disabled auto retry workflow
-          # gh workflow run retry_build.yml \
-          #   -F run_id=${{ github.run_id }}
+          gh workflow run retry_build.yml \
+            -F run_id=${{ github.run_id }}


### PR DESCRIPTION
Summary: Auto retry build should have been made more reliable in D68032708, so reenable it.

Differential Revision: D68636531


