### PR TITLE
Added support for building for MinGW, in addition to MSVC

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -341,6 +341,10 @@ if(WIN32)
   target_compile_definitions(faiss_sve PRIVATE FAISS_MAIN_LIB)
 endif()
 
+if(WIN32)
+  set_target_properties(faiss PROPERTIES LINK_FLAGS "-Wl,--export-all-symbols")
+endif()
+
 string(FIND "${CMAKE_CXX_FLAGS}" "FINTEGER" finteger_idx)
 if (${finteger_idx} EQUAL -1)
   target_compile_definitions(faiss PRIVATE FINTEGER=int)

--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -11,7 +11,7 @@
 #include <cstdint>
 #include <cstdio>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 
 /*******************************************************
  * Windows specific macros
@@ -23,11 +23,11 @@
 #define FAISS_API __declspec(dllimport)
 #endif // FAISS_MAIN_LIB
 
-#ifdef _MSC_VER
 #define strtok_r strtok_s
-#endif // _MSC_VER
 
+#ifdef _MSC_VER
 #define __PRETTY_FUNCTION__ __FUNCSIG__
+#endif // _MSC_VER
 
 #define posix_memalign(p, a, s) \
     (((*(p)) = _aligned_malloc((s), (a))), *(p) ? 0 : errno)
@@ -37,6 +37,7 @@
 #define ALIGNED(x) __declspec(align(x))
 
 // redefine the GCC intrinsics with Windows equivalents
+#ifdef _MSC_VER
 
 #include <intrin.h>
 #include <limits.h>
@@ -100,6 +101,8 @@ inline int __builtin_clzll(uint64_t x) {
 #define __FMA__ 1
 #define __F16C__ 1
 #endif
+
+#endif // _MSC_VER
 
 #define FAISS_ALWAYS_INLINE __forceinline
 

--- a/faiss/invlists/InvertedListsIOHook.cpp
+++ b/faiss/invlists/InvertedListsIOHook.cpp
@@ -13,9 +13,9 @@
 
 #include <faiss/invlists/BlockInvertedLists.h>
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 #include <faiss/invlists/OnDiskInvertedLists.h>
-#endif // !_MSC_VER
+#endif // !_WIN32
 
 namespace faiss {
 
@@ -33,7 +33,7 @@ namespace {
 /// std::vector that deletes its contents
 struct IOHookTable : std::vector<InvertedListsIOHook*> {
     IOHookTable() {
-#ifndef _MSC_VER
+#ifndef _WIN32
         push_back(new OnDiskInvertedListsIOHook());
 #endif
         push_back(new BlockInvertedListsIOHook());


### PR DESCRIPTION
This PR enables building with GCC for Windows using MinGW, using a completely standard cmake procedure, e.g.,
```
cmake -B build -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TARGET_TOOLCHAIN} -DCMAKE_BUILD_TYPE=Release -DFAISS_ENABLE_GPU=OFF -DFAISS_ENABLE_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON -DFAISS_ENABLE_C_API=ON
```

as detailed in the build recipe for the Julia ecosystem at https://github.com/JuliaPackaging/Yggdrasil/blob/334df79335424690bdbb9bdc432bc65affa92c8e/F/Faiss/common.jl#L8-L64