### PR TITLE
Fix the order of parameters in bench_scalar_quantizer_distance.

### DIFF
--- a/perf_tests/bench_scalar_quantizer_distance.cpp
+++ b/perf_tests/bench_scalar_quantizer_distance.cpp
@@ -23,8 +23,8 @@ DEFINE_uint32(iterations, 20, "iterations");
 static void bench_distance(
         benchmark::State& state,
         ScalarQuantizer::QuantizerType type,
-        int n,
-        int d) {
+        int d,
+        int n) {
     std::vector<float> x(d * n);
 
     float_rand(x.data(), d * n, 12345);


### PR DESCRIPTION
I believe the order of the parameters was not intended to be that way. This PR fixes it.