### PR TITLE
Memory-mapping and Zero-copy deserializers

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -69,12 +69,12 @@ set(FAISS_SRC
   impl/io.cpp
   impl/kmeans1d.cpp
   impl/lattice_Zn.cpp
+  impl/mapped_io.cpp
   impl/pq4_fast_scan.cpp
   impl/pq4_fast_scan_search_1.cpp
   impl/pq4_fast_scan_search_qbs.cpp
   impl/residual_quantizer_encode_steps.cpp
-  impl/io.cpp
-  impl/lattice_Zn.cpp
+  impl/zerocopy_io.cpp
   impl/NNDescent.cpp
   invlists/BlockInvertedLists.cpp
   invlists/DirectMap.cpp

--- a/faiss/IVFlib.cpp
+++ b/faiss/IVFlib.cpp
@@ -201,7 +201,27 @@ static void shift_and_add(
 }
 
 template <class T>
+static void shift_and_add(
+        MaybeOwnedVector<T>& dst,
+        size_t remove,
+        const MaybeOwnedVector<T>& src) {
+    if (remove > 0)
+        memmove(dst.data(),
+                dst.data() + remove,
+                (dst.size() - remove) * sizeof(T));
+    size_t insert_point = dst.size() - remove;
+    dst.resize(insert_point + src.size());
+    memcpy(dst.data() + insert_point, src.data(), src.size() * sizeof(T));
+}
+
+template <class T>
 static void remove_from_begin(std::vector<T>& v, size_t remove) {
+    if (remove > 0)
+        v.erase(v.begin(), v.begin() + remove);
+}
+
+template <class T>
+static void remove_from_begin(MaybeOwnedVector<T>& v, size_t remove) {
     if (remove > 0)
         v.erase(v.begin(), v.begin() + remove);
 }

--- a/faiss/IndexBinaryFlat.h
+++ b/faiss/IndexBinaryFlat.h
@@ -14,6 +14,7 @@
 
 #include <faiss/IndexBinary.h>
 
+#include <faiss/impl/maybe_owned_vector.h>
 #include <faiss/utils/approx_topk/mode.h>
 
 namespace faiss {
@@ -21,7 +22,7 @@ namespace faiss {
 /** Index that stores the full vectors and performs exhaustive search. */
 struct IndexBinaryFlat : IndexBinary {
     /// database vectors, size ntotal * d / 8
-    std::vector<uint8_t> xb;
+    MaybeOwnedVector<uint8_t> xb;
 
     /** Select between using a heap or counting to select the k smallest values
      * when scanning inverted lists.

--- a/faiss/IndexFlatCodes.cpp
+++ b/faiss/IndexFlatCodes.cpp
@@ -110,7 +110,7 @@ CodePacker* IndexFlatCodes::get_CodePacker() const {
 }
 
 void IndexFlatCodes::permute_entries(const idx_t* perm) {
-    std::vector<uint8_t> new_codes(codes.size());
+    MaybeOwnedVector<uint8_t> new_codes(codes.size());
 
     for (idx_t i = 0; i < ntotal; i++) {
         memcpy(new_codes.data() + i * code_size,

--- a/faiss/IndexFlatCodes.h
+++ b/faiss/IndexFlatCodes.h
@@ -7,9 +7,11 @@
 
 #pragma once
 
+#include <vector>
+
 #include <faiss/Index.h>
 #include <faiss/impl/DistanceComputer.h>
-#include <vector>
+#include <faiss/impl/maybe_owned_vector.h>
 
 namespace faiss {
 
@@ -21,7 +23,7 @@ struct IndexFlatCodes : Index {
     size_t code_size;
 
     /// encoded dataset, size ntotal * code_size
-    std::vector<uint8_t> codes;
+    MaybeOwnedVector<uint8_t> codes;
 
     IndexFlatCodes();
 

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -1085,7 +1085,7 @@ void HNSW::permute_entries(const idx_t* map) {
     // swap everyone
     std::swap(levels, new_levels);
     std::swap(offsets, new_offsets);
-    std::swap(neighbors, new_neighbors);
+    neighbors = std::move(new_neighbors);
 }
 
 /**************************************************************

--- a/faiss/impl/HNSW.h
+++ b/faiss/impl/HNSW.h
@@ -15,6 +15,7 @@
 
 #include <faiss/Index.h>
 #include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/maybe_owned_vector.h>
 #include <faiss/impl/platform_macros.h>
 #include <faiss/utils/Heap.h>
 #include <faiss/utils/random.h>
@@ -121,7 +122,7 @@ struct HNSW {
 
     /// neighbors[offsets[i]:offsets[i+1]] is the list of neighbors of vector i
     /// for all levels. this is where all storage goes.
-    std::vector<storage_idx_t> neighbors;
+    MaybeOwnedVector<storage_idx_t> neighbors;
 
     /// entry point in the search structure (one of the points with maximum
     /// level

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -53,7 +53,166 @@
 #include <faiss/IndexBinaryHash.h>
 #include <faiss/IndexBinaryIVF.h>
 
+// mmap-ing and viewing facilities
+#include <faiss/impl/maybe_owned_vector.h>
+
+#include <faiss/impl/mapped_io.h>
+#include <faiss/impl/zerocopy_io.h>
+
 namespace faiss {
+
+/*************************************************************
+ * Mmap-ing and viewing facilities
+ **************************************************************/
+
+template <typename VectorT>
+void read_vector_with_size(VectorT& target, IOReader* f, size_t size) {
+    ZeroCopyIOReader* zr = dynamic_cast<ZeroCopyIOReader*>(f);
+    if (zr != nullptr) {
+        if constexpr (is_maybe_owned_vector_v<VectorT>) {
+            // create a view
+            char* address = nullptr;
+            size_t nread = zr->get_data_view(
+                    (void**)&address,
+                    sizeof(typename VectorT::value_type),
+                    size);
+
+            FAISS_THROW_IF_NOT_FMT(
+                    nread == (size),
+                    "read error in %s: %zd != %zd (%s)",
+                    f->name.c_str(),
+                    nread,
+                    size_t(size),
+                    strerror(errno));
+
+            VectorT view = VectorT::create_view(address, nread);
+            target = std::move(view);
+
+            return;
+        }
+    }
+
+    target.resize(size);
+    READANDCHECK(target.data(), size);
+}
+
+template <typename VectorT>
+void read_vector(VectorT& target, IOReader* f) {
+    // is it a mmap-enabled reader?
+    MappedFileIOReader* mf = dynamic_cast<MappedFileIOReader*>(f);
+    if (mf != nullptr) {
+        // check if the use case is right
+        if constexpr (is_maybe_owned_vector_v<VectorT>) {
+            // read the size
+            size_t size = 0;
+            READANDCHECK(&size, 1);
+            // ok, mmap and check
+            char* address = nullptr;
+            const size_t nread = mf->mmap(
+                    (void**)&address,
+                    sizeof(typename VectorT::value_type),
+                    size);
+
+            FAISS_THROW_IF_NOT_FMT(
+                    nread == (size),
+                    "read error in %s: %zd != %zd (%s)",
+                    f->name.c_str(),
+                    nread,
+                    size,
+                    strerror(errno));
+
+            VectorT mmapped_view =
+                    VectorT::create_view(address, nread, mf->mmap_owner);
+            target = std::move(mmapped_view);
+
+            return;
+        }
+    }
+
+    // is it a zero-copy reader?
+    ZeroCopyIOReader* zr = dynamic_cast<ZeroCopyIOReader*>(f);
+    if (zr != nullptr) {
+        if constexpr (is_maybe_owned_vector_v<VectorT>) {
+            // read the size first
+            size_t size = target.size();
+            READANDCHECK(&size, 1);
+
+            // create a view
+            char* address = nullptr;
+            size_t nread = zr->get_data_view(
+                    (void**)&address,
+                    sizeof(typename VectorT::value_type),
+                    size);
+            VectorT view = VectorT::create_view(address, nread, nullptr);
+            target = std::move(view);
+
+            return;
+        }
+    }
+
+    // the default case
+    READVECTOR(target);
+}
+
+template <typename VectorT>
+void read_xb_vector(VectorT& target, IOReader* f) {
+    // is it a mmap-enabled reader?
+    MappedFileIOReader* mf = dynamic_cast<MappedFileIOReader*>(f);
+    if (mf != nullptr) {
+        // check if the use case is right
+        if constexpr (is_maybe_owned_vector_v<VectorT>) {
+            // read the size
+            size_t size = 0;
+            READANDCHECK(&size, 1);
+
+            size *= 4;
+
+            // ok, mmap and check
+            char* address = nullptr;
+            const size_t nread = mf->mmap(
+                    (void**)&address,
+                    sizeof(typename VectorT::value_type),
+                    size);
+
+            FAISS_THROW_IF_NOT_FMT(
+                    nread == (size),
+                    "read error in %s: %zd != %zd (%s)",
+                    f->name.c_str(),
+                    nread,
+                    size,
+                    strerror(errno));
+
+            VectorT mmapped_view =
+                    VectorT::create_view(address, nread, mf->mmap_owner);
+            target = std::move(mmapped_view);
+
+            return;
+        }
+    }
+
+    ZeroCopyIOReader* zr = dynamic_cast<ZeroCopyIOReader*>(f);
+    if (zr != nullptr) {
+        if constexpr (std::is_same_v<VectorT, MaybeOwnedVector<uint8_t>>) {
+            // read the size first
+            size_t size = target.size();
+            READANDCHECK(&size, 1);
+
+            size *= 4;
+
+            char* address = nullptr;
+            size_t nread = zr->get_data_view(
+                    (void**)&address,
+                    sizeof(typename VectorT::value_type),
+                    size);
+            VectorT view = VectorT::create_view(address, nread, nullptr);
+            target = std::move(view);
+            return;
+        }
+    }
+
+    // the default case
+    READXBVECTOR(target);
+}
 
 /*************************************************************
  * Read
@@ -275,7 +434,7 @@ static void read_AdditiveQuantizer(AdditiveQuantizer* aq, IOReader* f) {
         aq->search_type == AdditiveQuantizer::ST_norm_cqint4 ||
         aq->search_type == AdditiveQuantizer::ST_norm_lsq2x4 ||
         aq->search_type == AdditiveQuantizer::ST_norm_rq2x4) {
-        READXBVECTOR(aq->qnorm.codes);
+        read_xb_vector(aq->qnorm.codes, f);
         aq->qnorm.ntotal = aq->qnorm.codes.size() / 4;
         aq->qnorm.update_permutation();
     }
@@ -365,7 +524,7 @@ static void read_HNSW(HNSW* hnsw, IOReader* f) {
     READVECTOR(hnsw->cum_nneighbor_per_level);
     READVECTOR(hnsw->levels);
     READVECTOR(hnsw->offsets);
-    READVECTOR(hnsw->neighbors);
+    read_vector(hnsw->neighbors, f);
 
     READ1(hnsw->entry_point);
     READ1(hnsw->max_level);
@@ -545,7 +704,7 @@ Index* read_index(IOReader* f, int io_flags) {
         }
         read_index_header(idxf, f);
         idxf->code_size = idxf->d * sizeof(float);
-        READXBVECTOR(idxf->codes);
+        read_xb_vector(idxf->codes, f);
         FAISS_THROW_IF_NOT(
                 idxf->codes.size() == idxf->ntotal * idxf->code_size);
         // leak!
@@ -576,7 +735,7 @@ Index* read_index(IOReader* f, int io_flags) {
             idxl->rrot = *rrot;
             delete rrot;
         }
-        READVECTOR(idxl->codes);
+        read_vector(idxl->codes, f);
         FAISS_THROW_IF_NOT(
                 idxl->rrot.d_in == idxl->d && idxl->rrot.d_out == idxl->nbits);
         FAISS_THROW_IF_NOT(
@@ -589,7 +748,7 @@ Index* read_index(IOReader* f, int io_flags) {
         read_index_header(idxp, f);
         read_ProductQuantizer(&idxp->pq, f);
         idxp->code_size = idxp->pq.code_size;
-        READVECTOR(idxp->codes);
+        read_vector(idxp->codes, f);
         if (h == fourcc("IxPo") || h == fourcc("IxPq")) {
             READ1(idxp->search_type);
             READ1(idxp->encode_signs);
@@ -611,28 +770,28 @@ Index* read_index(IOReader* f, int io_flags) {
             read_ResidualQuantizer(&idxr->rq, f, io_flags);
         }
         READ1(idxr->code_size);
-        READVECTOR(idxr->codes);
+        read_vector(idxr->codes, f);
         idx = idxr;
     } else if (h == fourcc("IxLS")) {
         auto idxr = new IndexLocalSearchQuantizer();
         read_index_header(idxr, f);
         read_LocalSearchQuantizer(&idxr->lsq, f);
         READ1(idxr->code_size);
-        READVECTOR(idxr->codes);
+        read_vector(idxr->codes, f);
         idx = idxr;
     } else if (h == fourcc("IxPR")) {
         auto idxpr = new IndexProductResidualQuantizer();
         read_index_header(idxpr, f);
         read_ProductResidualQuantizer(&idxpr->prq, f, io_flags);
         READ1(idxpr->code_size);
-        READVECTOR(idxpr->codes);
+        read_vector(idxpr->codes, f);
         idx = idxpr;
     } else if (h == fourcc("IxPL")) {
         auto idxpl = new IndexProductLocalSearchQuantizer();
         read_index_header(idxpl, f);
         read_ProductLocalSearchQuantizer(&idxpl->plsq, f);
         READ1(idxpl->code_size);
-        READVECTOR(idxpl->codes);
+        read_vector(idxpl->codes, f);
         idx = idxpl;
     } else if (h == fourcc("ImRQ")) {
         ResidualCoarseQuantizer* idxr = new ResidualCoarseQuantizer();
@@ -789,7 +948,7 @@ Index* read_index(IOReader* f, int io_flags) {
         IndexScalarQuantizer* idxs = new IndexScalarQuantizer();
         read_index_header(idxs, f);
         read_ScalarQuantizer(&idxs->sq, f);
-        READVECTOR(idxs->codes);
+        read_vector(idxs->codes, f);
         idxs->code_size = idxs->sq.code_size;
         idx = idxs;
     } else if (h == fourcc("IxLa")) {
@@ -947,7 +1106,7 @@ Index* read_index(IOReader* f, int io_flags) {
         READ1(idxp->code_size_1);
         READ1(idxp->code_size_2);
         READ1(idxp->code_size);
-        READVECTOR(idxp->codes);
+        read_vector(idxp->codes, f);
         idx = idxp;
     } else if (
             h == fourcc("IHNf") || h == fourcc("IHNp") || h == fourcc("IHNs") ||
@@ -1071,14 +1230,28 @@ Index* read_index(IOReader* f, int io_flags) {
 }
 
 Index* read_index(FILE* f, int io_flags) {
-    FileIOReader reader(f);
-    return read_index(&reader, io_flags);
+    if ((io_flags & IO_FLAG_MMAP_IFC) == IO_FLAG_MMAP_IFC) {
+        // enable mmap-supporting IOReader
+        auto owner = std::make_shared<MmappedFileMappingOwner>(f);
+        MappedFileIOReader reader(owner);
+        return read_index(&reader, io_flags);
+    } else {
+        FileIOReader reader(f);
+        return read_index(&reader, io_flags);
+    }
 }
 
 Index* read_index(const char* fname, int io_flags) {
-    FileIOReader reader(fname);
-    Index* idx = read_index(&reader, io_flags);
-    return idx;
+    if ((io_flags & IO_FLAG_MMAP_IFC) == IO_FLAG_MMAP_IFC) {
+        // enable mmap-supporting IOReader
+        auto owner = std::make_shared<MmappedFileMappingOwner>(fname);
+        MappedFileIOReader reader(owner);
+        return read_index(&reader, io_flags);
+    } else {
+        FileIOReader reader(fname);
+        Index* idx = read_index(&reader, io_flags);
+        return idx;
+    }
 }
 
 VectorTransform* read_VectorTransform(const char* fname) {

--- a/faiss/impl/io.h
+++ b/faiss/impl/io.h
@@ -20,8 +20,6 @@
 #include <string>
 #include <vector>
 
-#include <faiss/Index.h>
-
 namespace faiss {
 
 struct IOReader {

--- a/faiss/impl/io.h
+++ b/faiss/impl/io.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <cstdio>
 #include <string>
 #include <vector>

--- a/faiss/impl/io_macros.h
+++ b/faiss/impl/io_macros.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <faiss/impl/maybe_owned_vector.h>
+
 /*************************************************************
  * I/O macros
  *
@@ -36,13 +38,14 @@
     }
 
 // will fail if we write 256G of data at once...
-#define READVECTOR(vec)                                              \
-    {                                                                \
-        size_t size;                                                 \
-        READANDCHECK(&size, 1);                                      \
-        FAISS_THROW_IF_NOT(size >= 0 && size < (uint64_t{1} << 40)); \
-        (vec).resize(size);                                          \
-        READANDCHECK((vec).data(), size);                            \
+#define READVECTOR(vec)                                                \
+    {                                                                  \
+        static_assert(!faiss::is_maybe_owned_vector_v<decltype(vec)>); \
+        size_t size;                                                   \
+        READANDCHECK(&size, 1);                                        \
+        FAISS_THROW_IF_NOT(size >= 0 && size < (uint64_t{1} << 40));   \
+        (vec).resize(size);                                            \
+        READANDCHECK((vec).data(), size);                              \
     }
 
 #define WRITEANDCHECK(ptr, n)                         \
@@ -76,12 +79,13 @@
         WRITEANDCHECK((vec).data(), size * 4);     \
     }
 
-#define READXBVECTOR(vec)                                            \
-    {                                                                \
-        size_t size;                                                 \
-        READANDCHECK(&size, 1);                                      \
-        FAISS_THROW_IF_NOT(size >= 0 && size < (uint64_t{1} << 40)); \
-        size *= 4;                                                   \
-        (vec).resize(size);                                          \
-        READANDCHECK((vec).data(), size);                            \
+#define READXBVECTOR(vec)                                              \
+    {                                                                  \
+        size_t size;                                                   \
+        static_assert(!faiss::is_maybe_owned_vector_v<decltype(vec)>); \
+        READANDCHECK(&size, 1);                                        \
+        FAISS_THROW_IF_NOT(size >= 0 && size < (uint64_t{1} << 40));   \
+        size *= 4;                                                     \
+        (vec).resize(size);                                            \
+        READANDCHECK((vec).data(), size);                              \
     }

--- a/faiss/impl/io_macros.h
+++ b/faiss/impl/io_macros.h
@@ -38,14 +38,13 @@
     }
 
 // will fail if we write 256G of data at once...
-#define READVECTOR(vec)                                                \
-    {                                                                  \
-        static_assert(!faiss::is_maybe_owned_vector_v<decltype(vec)>); \
-        size_t size;                                                   \
-        READANDCHECK(&size, 1);                                        \
-        FAISS_THROW_IF_NOT(size >= 0 && size < (uint64_t{1} << 40));   \
-        (vec).resize(size);                                            \
-        READANDCHECK((vec).data(), size);                              \
+#define READVECTOR(vec)                                              \
+    {                                                                \
+        size_t size;                                                 \
+        READANDCHECK(&size, 1);                                      \
+        FAISS_THROW_IF_NOT(size >= 0 && size < (uint64_t{1} << 40)); \
+        (vec).resize(size);                                          \
+        READANDCHECK((vec).data(), size);                            \
     }
 
 #define WRITEANDCHECK(ptr, n)                         \
@@ -79,13 +78,12 @@
         WRITEANDCHECK((vec).data(), size * 4);     \
     }
 
-#define READXBVECTOR(vec)                                              \
-    {                                                                  \
-        size_t size;                                                   \
-        static_assert(!faiss::is_maybe_owned_vector_v<decltype(vec)>); \
-        READANDCHECK(&size, 1);                                        \
-        FAISS_THROW_IF_NOT(size >= 0 && size < (uint64_t{1} << 40));   \
-        size *= 4;                                                     \
-        (vec).resize(size);                                            \
-        READANDCHECK((vec).data(), size);                              \
+#define READXBVECTOR(vec)                                            \
+    {                                                                \
+        size_t size;                                                 \
+        READANDCHECK(&size, 1);                                      \
+        FAISS_THROW_IF_NOT(size >= 0 && size < (uint64_t{1} << 40)); \
+        size *= 4;                                                   \
+        (vec).resize(size);                                          \
+        READANDCHECK((vec).data(), size);                            \
     }

--- a/faiss/impl/mapped_io.cpp
+++ b/faiss/impl/mapped_io.cpp
@@ -94,6 +94,7 @@ struct MmappedFileMappingOwner::PImpl {
 struct MmappedFileMappingOwner::PImpl {
     void* ptr = nullptr;
     size_t ptr_size = 0;
+    HANDLE mapping_handle = INVALID_HANDLE_VALUE;
 
     PImpl(const std::string& filename) {
         HANDLE file_handle = CreateFile(
@@ -123,7 +124,7 @@ struct MmappedFileMappingOwner::PImpl {
         }
 
         // create a mapping
-        HANDLE mapping_handle = CreateFileMapping(
+        mapping_handle = CreateFileMapping(
                 file_handle, nullptr, PAGE_READONLY, 0, 0, nullptr);
         if (mapping_handle == 0) {
             const auto error = GetLastError();
@@ -169,7 +170,7 @@ struct MmappedFileMappingOwner::PImpl {
         }
 
         // create a mapping
-        HANDLE mapping_handle = CreateFileMapping(
+        mapping_handle = CreateFileMapping(
                 file_handle, nullptr, PAGE_READONLY, 0, 0, nullptr);
         if (mapping_handle == 0) {
             const auto error = GetLastError();
@@ -190,10 +191,11 @@ struct MmappedFileMappingOwner::PImpl {
     }
 
     ~PImpl() {
-        if (ptr != nullptr) {
+        if (mapping_handle != INVALID_HANDLE_VALUE) {
             UnmapViewOfFile(ptr);
-            CloseHandle(ptr);
+            CloseHandle(mapping_handle);
 
+            mapping_handle = INVALID_HANDLE_VALUE;
             ptr = nullptr;
         }
     }

--- a/faiss/impl/mapped_io.cpp
+++ b/faiss/impl/mapped_io.cpp
@@ -1,0 +1,163 @@
+#include <stdio.h>
+#include <string.h>
+
+#ifdef __linux__
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#elif defined(_WIN32)
+
+#include <Windows.h>
+
+#endif
+
+#include <cstring>
+
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/mapped_io.h>
+
+namespace faiss {
+
+#ifdef __linux__
+
+struct MmappedFileMappingOwner::PImpl {
+    void* ptr = nullptr;
+    size_t ptr_size = 0;
+
+    PImpl(FILE* f) {
+        // get the size
+        struct stat s;
+        int status = fstat(fileno(f), &s);
+        FAISS_THROW_IF_NOT_FMT(
+                status >= 0, "fstat() failed: %s", strerror(errno));
+
+        const size_t filesize = s.st_size;
+
+        void* address =
+                mmap(nullptr, filesize, PROT_READ, MAP_SHARED, fileno(f), 0);
+        FAISS_THROW_IF_NOT_FMT(
+                address != nullptr, "could not mmap(): %s", strerror(errno));
+
+        // btw, fd can be closed here
+
+        // set 'random' access pattern
+        // todo: check the error
+        madvise(address, filesize, MADV_RANDOM);
+
+        // save it
+        ptr = address;
+        ptr_size = filesize;
+    }
+
+    ~PImpl() {
+        // todo: check for an error
+        munmap(ptr, ptr_size);
+    }
+};
+
+#elif defined(_WIN32)
+
+struct MmappedFileMappingOwner::PImpl {
+    PImpl(FILE* f) {
+        // todo: use CreateFileMapping and MapViewOfFile
+        FAISS_THROW_FMT("Not implemented");
+    }
+
+    ~PImpl() {
+        // todo: use UnmapViewOfFile
+        FAISS_THROW_FMT("Not implemented");
+    }
+};
+
+#else
+
+struct MmappedFileMappingOwner::PImpl {
+    PImpl(FILE* f) {
+        FAISS_THROW_FMT("Not implemented");
+    }
+
+    ~PImpl() {
+        FAISS_THROW_FMT("Not implemented");
+    }
+};
+
+#endif
+
+MmappedFileMappingOwner::MmappedFileMappingOwner(const std::string& filename) {
+    auto fd = std::unique_ptr<FILE, decltype(&fclose)>(
+            fopen(filename.c_str(), "r"), &fclose);
+    FAISS_THROW_IF_NOT_FMT(
+            fd.get(),
+            "could not open %s for reading: %s",
+            filename.c_str(),
+            strerror(errno));
+
+    p_impl = std::make_unique<MmappedFileMappingOwner::PImpl>(fd.get());
+}
+
+MmappedFileMappingOwner::MmappedFileMappingOwner(FILE* f) {
+    p_impl = std::make_unique<MmappedFileMappingOwner::PImpl>(f);
+}
+
+MmappedFileMappingOwner::~MmappedFileMappingOwner() = default;
+
+//
+void* MmappedFileMappingOwner::data() const {
+    return p_impl->ptr;
+}
+
+size_t MmappedFileMappingOwner::size() const {
+    return p_impl->ptr_size;
+}
+
+MappedFileIOReader::MappedFileIOReader(
+        const std::shared_ptr<MmappedFileMappingOwner>& owner)
+        : mmap_owner(owner) {}
+
+// this operation performs a copy
+size_t MappedFileIOReader::operator()(void* ptr, size_t size, size_t nitems) {
+    char* ptr_c = nullptr;
+
+    const size_t actual_nitems = this->mmap((void**)&ptr_c, size, nitems);
+    if (actual_nitems > 0) {
+        memcpy(ptr, ptr_c, size * actual_nitems);
+    }
+
+    return actual_nitems;
+}
+
+// this operation returns a mmapped address, owned by mmap_owner
+size_t MappedFileIOReader::mmap(void** ptr, size_t size, size_t nitems) {
+    if (size == 0) {
+        return nitems;
+    }
+
+    size_t actual_size = size * nitems;
+    if (pos + size * nitems > mmap_owner->size()) {
+        actual_size = mmap_owner->size() - pos;
+    }
+
+    size_t actual_nitems = (actual_size + size - 1) / size;
+    if (actual_nitems == 0) {
+        return 0;
+    }
+
+    // get an address
+    *ptr = (void*)(reinterpret_cast<const char*>(mmap_owner->data()) + pos);
+
+    // alter pos
+    pos += size * actual_nitems;
+
+    return actual_nitems;
+}
+
+int MappedFileIOReader::filedescriptor() {
+    // todo
+    return -1;
+}
+
+} // namespace faiss

--- a/faiss/impl/mapped_io.cpp
+++ b/faiss/impl/mapped_io.cpp
@@ -238,6 +238,10 @@ MappedFileIOReader::MappedFileIOReader(
 
 // this operation performs a copy
 size_t MappedFileIOReader::operator()(void* ptr, size_t size, size_t nitems) {
+    if (size * nitems == 0) {
+        return 0;
+    }
+
     char* ptr_c = nullptr;
 
     const size_t actual_nitems = this->mmap((void**)&ptr_c, size, nitems);

--- a/faiss/impl/mapped_io.h
+++ b/faiss/impl/mapped_io.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include <faiss/impl/io.h>
+#include <faiss/impl/maybe_owned_vector.h>
+
+namespace faiss {
+
+// holds a memory-mapped region over a file
+struct MmappedFileMappingOwner : public MaybeOwnedVectorOwner {
+    MmappedFileMappingOwner(const std::string& filename);
+    MmappedFileMappingOwner(FILE* f);
+    ~MmappedFileMappingOwner();
+
+    void* data() const;
+    size_t size() const;
+
+    struct PImpl;
+    std::unique_ptr<PImpl> p_impl;
+};
+
+// A deserializer that supports memory-mapped files.
+// All de-allocations should happen as soon as the index gets destroyed,
+//   after all underlying the MaybeOwnerVector objects are destroyed.
+struct MappedFileIOReader : IOReader {
+    std::shared_ptr<MmappedFileMappingOwner> mmap_owner;
+
+    size_t pos = 0;
+
+    MappedFileIOReader(const std::shared_ptr<MmappedFileMappingOwner>& owner);
+
+    // perform a copy
+    size_t operator()(void* ptr, size_t size, size_t nitems) override;
+    // perform a quasi-read that returns a mmapped address, owned by mmap_owner,
+    //   and updates the position
+    size_t mmap(void** ptr, size_t size, size_t nitems);
+
+    int filedescriptor() override;
+};
+
+} // namespace faiss

--- a/faiss/impl/maybe_owned_vector.h
+++ b/faiss/impl/maybe_owned_vector.h
@@ -50,6 +50,13 @@ struct MaybeOwnedVector {
         c_size = owned_data.size();
     }
 
+    MaybeOwnedVector(const std::vector<T>& vec)
+            : MaybeOwnedVector<T>(vec.size()) {
+        if (!vec.empty()) {
+            memcpy(owned_data.data(), vec.data(), vec.size() * sizeof(T));
+        }
+    }
+
     MaybeOwnedVector(const MaybeOwnedVector& other) {
         is_owned = other.is_owned;
         owned_data = other.owned_data;

--- a/faiss/impl/maybe_owned_vector.h
+++ b/faiss/impl/maybe_owned_vector.h
@@ -22,8 +22,6 @@ struct MaybeOwnedVector {
     using self_type = MaybeOwnedVector<T>;
     using iterator = typename std::vector<T>::iterator;
     using const_iterator = typename std::vector<T>::const_iterator;
-    using reference = typename std::vector<T>::reference;
-    using const_reference = typename std::vector<T>::const_reference;
     using size_type = typename std::vector<T>::size_type;
 
     bool is_owned = true;
@@ -166,7 +164,7 @@ struct MaybeOwnedVector {
         return c_ptr[idx];
     }
 
-    iterator at(size_type pos) {
+    T& at(size_type pos) {
         FAISS_ASSERT_MSG(
                 is_owned,
                 "This operation cannot be performed on a viewed vector");
@@ -174,7 +172,7 @@ struct MaybeOwnedVector {
         return owned_data.at(pos);
     }
 
-    const_iterator at(size_type pos) const {
+    const T& at(size_type pos) const {
         FAISS_ASSERT_MSG(
                 is_owned,
                 "This operation cannot be performed on a viewed vector");

--- a/faiss/impl/maybe_owned_vector.h
+++ b/faiss/impl/maybe_owned_vector.h
@@ -183,7 +183,11 @@ struct MaybeOwnedVector {
                 is_owned,
                 "This operation cannot be performed on a viewed vector");
 
-        return owned_data.erase(begin, end);
+        auto result = owned_data.erase(begin, end);
+        c_ptr = owned_data.data();
+        c_size = owned_data.size();
+
+        return result;
     }
 
     void clear() {

--- a/faiss/impl/maybe_owned_vector.h
+++ b/faiss/impl/maybe_owned_vector.h
@@ -20,7 +20,11 @@ template <typename T>
 struct MaybeOwnedVector {
     using value_type = T;
     using self_type = MaybeOwnedVector<T>;
-    using vec_iterator = typename std::vector<T>::const_iterator;
+    using iterator = typename std::vector<T>::iterator;
+    using const_iterator = typename std::vector<T>::const_iterator;
+    using reference = typename std::vector<T>::reference;
+    using const_reference = typename std::vector<T>::const_reference;
+    using size_type = typename std::vector<T>::size_type;
 
     bool is_owned = true;
 
@@ -162,7 +166,23 @@ struct MaybeOwnedVector {
         return c_ptr[idx];
     }
 
-    vec_iterator begin() const {
+    iterator at(size_type pos) {
+        FAISS_ASSERT_MSG(
+                is_owned,
+                "This operation cannot be performed on a viewed vector");
+
+        return owned_data.at(pos);
+    }
+
+    const_iterator at(size_type pos) const {
+        FAISS_ASSERT_MSG(
+                is_owned,
+                "This operation cannot be performed on a viewed vector");
+
+        return owned_data.at(pos);
+    }
+
+    iterator begin() {
         FAISS_ASSERT_MSG(
                 is_owned,
                 "This operation cannot be performed on a viewed vector");
@@ -170,7 +190,15 @@ struct MaybeOwnedVector {
         return owned_data.begin();
     }
 
-    vec_iterator end() const {
+    const_iterator begin() const {
+        FAISS_ASSERT_MSG(
+                is_owned,
+                "This operation cannot be performed on a viewed vector");
+
+        return owned_data.begin();
+    }
+
+    iterator end() {
         FAISS_ASSERT_MSG(
                 is_owned,
                 "This operation cannot be performed on a viewed vector");
@@ -178,12 +206,33 @@ struct MaybeOwnedVector {
         return owned_data.end();
     }
 
-    vec_iterator erase(vec_iterator begin, vec_iterator end) {
+    const_iterator end() const {
+        FAISS_ASSERT_MSG(
+                is_owned,
+                "This operation cannot be performed on a viewed vector");
+
+        return owned_data.end();
+    }
+
+    iterator erase(const_iterator begin, const_iterator end) {
         FAISS_ASSERT_MSG(
                 is_owned,
                 "This operation cannot be performed on a viewed vector");
 
         auto result = owned_data.erase(begin, end);
+        c_ptr = owned_data.data();
+        c_size = owned_data.size();
+
+        return result;
+    }
+
+    template <class InputIt>
+    iterator insert(const_iterator pos, InputIt first, InputIt last) {
+        FAISS_ASSERT_MSG(
+                is_owned,
+                "This operation cannot be performed on a viewed vector");
+
+        auto result = owned_data.insert(pos, first, last);
         c_ptr = owned_data.data();
         c_size = owned_data.size();
 

--- a/faiss/impl/maybe_owned_vector.h
+++ b/faiss/impl/maybe_owned_vector.h
@@ -1,0 +1,232 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <faiss/impl/FaissAssert.h>
+
+namespace faiss {
+
+// An interface for an owner of a MaybeOwnedVector.
+struct MaybeOwnedVectorOwner {
+    virtual ~MaybeOwnedVectorOwner() = default;
+};
+
+// a container that either works as std::vector<T> that owns its own memory,
+//    or as a view of a memory buffer, with a known size
+template <typename T>
+struct MaybeOwnedVector {
+    using value_type = T;
+    using self_type = MaybeOwnedVector<T>;
+    using vec_iterator = typename std::vector<T>::const_iterator;
+
+    bool is_owned = true;
+
+    // this one is used if is_owned == true
+    std::vector<T> owned_data;
+
+    // these three are used if is_owned == false
+    T* view_data = nullptr;
+    // the number of T elements
+    size_t view_size = 0;
+    // who owns the data.
+    // This field can be nullptr, and it is present ONLY in order
+    //   to avoid possible tricky memory / resource leaks.
+    std::shared_ptr<MaybeOwnedVectorOwner> owner;
+
+    // points either to view_data, or to owned.data()
+    T* c_ptr = nullptr;
+    // uses either view_size, or owned.size();
+    size_t c_size = 0;
+
+    MaybeOwnedVector() = default;
+    MaybeOwnedVector(const size_t initial_size) {
+        is_owned = true;
+
+        owned_data.resize(initial_size);
+        c_ptr = owned_data.data();
+        c_size = owned_data.size();
+    }
+
+    MaybeOwnedVector(const MaybeOwnedVector& other) {
+        is_owned = other.is_owned;
+        owned_data = other.owned_data;
+
+        view_data = other.view_data;
+        view_size = other.view_size;
+        owner = other.owner;
+
+        if (is_owned) {
+            c_ptr = owned_data.data();
+            c_size = owned_data.size();
+        } else {
+            c_ptr = view_data;
+            c_size = view_size;
+        }
+    }
+
+    MaybeOwnedVector(MaybeOwnedVector&& other) {
+        is_owned = other.is_owned;
+        owned_data = std::move(other.owned_data);
+
+        view_data = other.view_data;
+        view_size = other.view_size;
+        owner = std::move(other.owner);
+        other.owner = nullptr;
+
+        if (is_owned) {
+            c_ptr = owned_data.data();
+            c_size = owned_data.size();
+        } else {
+            c_ptr = view_data;
+            c_size = view_size;
+        }
+    }
+
+    MaybeOwnedVector& operator=(const MaybeOwnedVector& other) {
+        if (this == &other) {
+            return *this;
+        }
+
+        // create a copy
+        MaybeOwnedVector cloned(other);
+        // swap
+        swap(*this, cloned);
+
+        return *this;
+    }
+
+    MaybeOwnedVector& operator=(MaybeOwnedVector&& other) {
+        if (this == &other) {
+            return *this;
+        }
+
+        // moved
+        MaybeOwnedVector moved(std::move(other));
+        // swap
+        swap(*this, moved);
+
+        return *this;
+    }
+
+    MaybeOwnedVector(std::vector<T>&& other) {
+        is_owned = true;
+
+        owned_data = std::move(other);
+        c_ptr = owned_data.data();
+        c_size = owned_data.size();
+    }
+
+    static MaybeOwnedVector create_view(
+            void* address,
+            const size_t n_elements,
+            const std::shared_ptr<MaybeOwnedVectorOwner>& owner) {
+        MaybeOwnedVector vec;
+        vec.is_owned = false;
+        vec.view_data = reinterpret_cast<T*>(address);
+        vec.view_size = n_elements;
+        vec.owner = owner;
+
+        vec.c_ptr = vec.view_data;
+        vec.c_size = vec.view_size;
+
+        return vec;
+    }
+
+    const T* data() const {
+        return c_ptr;
+    }
+
+    T* data() {
+        return c_ptr;
+    }
+
+    size_t size() const {
+        return c_size;
+    }
+
+    T& operator[](const size_t idx) {
+        return c_ptr[idx];
+    }
+
+    const T& operator[](const size_t idx) const {
+        return c_ptr[idx];
+    }
+
+    vec_iterator begin() const {
+        FAISS_ASSERT_MSG(
+                is_owned,
+                "This operation cannot be performed on a viewed vector");
+
+        return owned_data.begin();
+    }
+
+    vec_iterator end() const {
+        FAISS_ASSERT_MSG(
+                is_owned,
+                "This operation cannot be performed on a viewed vector");
+
+        return owned_data.end();
+    }
+
+    vec_iterator erase(vec_iterator begin, vec_iterator end) {
+        FAISS_ASSERT_MSG(
+                is_owned,
+                "This operation cannot be performed on a viewed vector");
+
+        return owned_data.erase(begin, end);
+    }
+
+    void clear() {
+        FAISS_ASSERT_MSG(
+                is_owned,
+                "This operation cannot be performed on a viewed vector");
+
+        owned_data.clear();
+        c_ptr = owned_data.data();
+        c_size = owned_data.size();
+    }
+
+    void resize(const size_t new_size) {
+        FAISS_ASSERT_MSG(
+                is_owned,
+                "This operation cannot be performed on a viewed vector");
+
+        owned_data.resize(new_size);
+        c_ptr = owned_data.data();
+        c_size = owned_data.size();
+    }
+
+    void resize(const size_t new_size, const value_type v) {
+        FAISS_ASSERT_MSG(
+                is_owned,
+                "This operation cannot be performed on a viewed vector");
+
+        owned_data.resize(new_size, v);
+        c_ptr = owned_data.data();
+        c_size = owned_data.size();
+    }
+
+    friend void swap(self_type& a, self_type& b) {
+        std::swap(a.is_owned, b.is_owned);
+        std::swap(a.owned_data, b.owned_data);
+        std::swap(a.view_data, b.view_data);
+        std::swap(a.view_size, b.view_size);
+        std::swap(a.owner, b.owner);
+        std::swap(a.c_ptr, b.c_ptr);
+        std::swap(a.c_size, b.c_size);
+    }
+};
+
+template <typename T>
+struct is_maybe_owned_vector : std::false_type {};
+
+template <typename T>
+struct is_maybe_owned_vector<MaybeOwnedVector<T>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_maybe_owned_vector_v = is_maybe_owned_vector<T>::value;
+
+} // namespace faiss

--- a/faiss/impl/zerocopy_io.cpp
+++ b/faiss/impl/zerocopy_io.cpp
@@ -37,6 +37,10 @@ void ZeroCopyIOReader::reset() {
 }
 
 size_t ZeroCopyIOReader::operator()(void* ptr, size_t size, size_t nitems) {
+    if (size * nitems == 0) {
+        return 0;
+    }
+
     if (rp_ >= total_) {
         return 0;
     }

--- a/faiss/impl/zerocopy_io.cpp
+++ b/faiss/impl/zerocopy_io.cpp
@@ -1,0 +1,56 @@
+#include <faiss/impl/zerocopy_io.h>
+#include <cstring>
+
+namespace faiss {
+
+ZeroCopyIOReader::ZeroCopyIOReader(uint8_t* data, size_t size)
+        : data_(data), rp_(0), total_(size) {}
+
+ZeroCopyIOReader::~ZeroCopyIOReader() {}
+
+size_t ZeroCopyIOReader::get_data_view(void** ptr, size_t size, size_t nitems) {
+    if (size == 0) {
+        return nitems;
+    }
+
+    size_t actual_size = size * nitems;
+    if (rp_ + size * nitems > total_) {
+        actual_size = total_ - rp_;
+    }
+
+    size_t actual_nitems = (actual_size + size - 1) / size;
+    if (actual_nitems == 0) {
+        return 0;
+    }
+
+    // get an address
+    *ptr = (void*)(reinterpret_cast<const char*>(data_ + rp_));
+
+    // alter pos
+    rp_ += size * actual_nitems;
+
+    return actual_nitems;
+}
+
+void ZeroCopyIOReader::reset() {
+    rp_ = 0;
+}
+
+size_t ZeroCopyIOReader::operator()(void* ptr, size_t size, size_t nitems) {
+    if (rp_ >= total_) {
+        return 0;
+    }
+    size_t nremain = (total_ - rp_) / size;
+    if (nremain < nitems) {
+        nitems = nremain;
+    }
+    memcpy(ptr, (data_ + rp_), size * nitems);
+    rp_ += size * nitems;
+    return nitems;
+}
+
+int ZeroCopyIOReader::filedescriptor() {
+    return -1; // Indicating no file descriptor available for memory buffer
+}
+
+} // namespace faiss

--- a/faiss/impl/zerocopy_io.h
+++ b/faiss/impl/zerocopy_io.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+
+#include <faiss/impl/io.h>
+
+namespace faiss {
+
+// ZeroCopyIOReader just maps the data from a given pointer.
+struct ZeroCopyIOReader : public faiss::IOReader {
+    uint8_t* data_;
+    size_t rp_ = 0;
+    size_t total_ = 0;
+
+    ZeroCopyIOReader(uint8_t* data, size_t size);
+    ~ZeroCopyIOReader();
+
+    void reset();
+    size_t get_data_view(void** ptr, size_t size, size_t nitems);
+    size_t operator()(void* ptr, size_t size, size_t nitems) override;
+
+    int filedescriptor() override;
+};
+
+} // namespace faiss

--- a/faiss/index_io.h
+++ b/faiss/index_io.h
@@ -62,6 +62,10 @@ const int IO_FLAG_PQ_SKIP_SDC_TABLE = 32;
 // try to memmap data (useful to load an ArrayInvertedLists as an
 // OnDiskInvertedLists)
 const int IO_FLAG_MMAP = IO_FLAG_SKIP_IVF_DATA | 0x646f0000;
+// mmap that handles codes for IndexFlatCodes-derived indices and HNSW.
+// this is a temporary solution, it is expected to be merged with IO_FLAG_MMAP
+//   after OnDiskInvertedLists get properly updated.
+const int IO_FLAG_MMAP_IFC = 1 << 9;
 
 Index* read_index(const char* fname, int io_flags = 0);
 Index* read_index(FILE* f, int io_flags = 0);

--- a/faiss/invlists/InvertedLists.cpp
+++ b/faiss/invlists/InvertedLists.cpp
@@ -330,8 +330,8 @@ void ArrayInvertedLists::update_entries(
 }
 
 void ArrayInvertedLists::permute_invlists(const idx_t* map) {
-    std::vector<std::vector<uint8_t>> new_codes(nlist);
-    std::vector<std::vector<idx_t>> new_ids(nlist);
+    std::vector<MaybeOwnedVector<uint8_t>> new_codes(nlist);
+    std::vector<MaybeOwnedVector<idx_t>> new_ids(nlist);
 
     for (size_t i = 0; i < nlist; i++) {
         size_t o = map[i];

--- a/faiss/invlists/InvertedLists.h
+++ b/faiss/invlists/InvertedLists.h
@@ -15,8 +15,10 @@
  * the interface.
  */
 
-#include <faiss/MetricType.h>
 #include <vector>
+
+#include <faiss/MetricType.h>
+#include <faiss/impl/maybe_owned_vector.h>
 
 namespace faiss {
 
@@ -241,8 +243,8 @@ struct InvertedLists {
 
 /// simple (default) implementation as an array of inverted lists
 struct ArrayInvertedLists : InvertedLists {
-    std::vector<std::vector<uint8_t>> codes; // binary codes, size nlist
-    std::vector<std::vector<idx_t>> ids;     ///< Inverted lists for indexes
+    std::vector<MaybeOwnedVector<uint8_t>> codes; // binary codes, size nlist
+    std::vector<MaybeOwnedVector<idx_t>> ids; ///< Inverted lists for indexes
 
     ArrayInvertedLists(size_t nlist, size_t code_size);
 

--- a/faiss/python/array_conversions.py
+++ b/faiss/python/array_conversions.py
@@ -106,6 +106,13 @@ def vector_to_array(v):
     classname = v.__class__.__name__
     if classname.startswith('AlignedTable'):
         return AlignedTable_to_array(v)
+    if classname.startswith('MaybeOwnedVector'):
+        dtype = np.dtype(vector_name_map[classname[16:]])
+        a = np.empty(v.size(), dtype=dtype)
+        if v.size() > 0:
+            memcpy(swig_ptr(a), v.data(), a.nbytes)
+        return a
+
     assert classname.endswith('Vector')
     dtype = np.dtype(vector_name_map[classname[:-6]])
     a = np.empty(v.size(), dtype=dtype)

--- a/faiss/python/array_conversions.py
+++ b/faiss/python/array_conversions.py
@@ -129,6 +129,17 @@ def copy_array_to_vector(a, v):
     """ copy a numpy array to a vector """
     n, = a.shape
     classname = v.__class__.__name__
+    if classname.startswith('MaybeOwnedVector'):
+        assert v.is_owned, 'cannot copy to an non-owned MaybeOwnedVector'
+        dtype = np.dtype(vector_name_map[classname[16:]])
+        assert dtype == a.dtype, (
+            'cannot copy a %s array to a %s (should be %s)' % (
+                a.dtype, classname, dtype))
+        v.resize(n)
+        if n > 0:
+            memcpy(v.data(), swig_ptr(a), a.nbytes)
+        return
+
     assert classname.endswith('Vector')
     dtype = np.dtype(vector_name_map[classname[:-6]])
     assert dtype == a.dtype, (

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -32,6 +32,7 @@
 #pragma SWIG nowarn=341
 #pragma SWIG nowarn=512
 #pragma SWIG nowarn=362
+#pragma SWIG nowarn=509
 
 // we need explict control of these typedefs...
 // %include <stdint.i>

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -286,6 +286,9 @@ namespace std {
 %template(RepeatVector) std::vector<faiss::Repeat>;
 %template(ClusteringIterationStatsVector) std::vector<faiss::ClusteringIterationStats>;
 %template(ParameterRangeVector) std::vector<faiss::ParameterRange>;
+%template(MaybeOwnedVectorUInt8Vector) std::vector<faiss::MaybeOwnedVector<uint8_t> >;
+%template(MaybeOwnedVectorInt32Vector) std::vector<faiss::MaybeOwnedVector<int32_t> >;
+%template(MaybeOwnedVectorFloat32Vector) std::vector<faiss::MaybeOwnedVector<float> >;
 
 #ifndef SWIGWIN
 %template(OnDiskOneListVector) std::vector<faiss::OnDiskOneList>;

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -1005,6 +1005,10 @@ faiss::Quantizer * downcast_Quantizer (faiss::Quantizer *aq)
 %template(AlignedTableUint16) faiss::AlignedTable<uint16_t>;
 %template(AlignedTableFloat32) faiss::AlignedTable<float>;
 
+%template(MaybeOwnedVectorUInt8) faiss::MaybeOwnedVector<uint8_t>;
+%template(MaybeOwnedVectorInt32) faiss::MaybeOwnedVector<int32_t>;
+%template(MaybeOwnedVectorFloat32) faiss::MaybeOwnedVector<float>;
+
 
 // SWIG seems to have some trouble resolving function template types here, so
 // declare explicitly

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -184,6 +184,9 @@ typedef uint64_t size_t;
 
 #include <faiss/IndexNeuralNetCodec.h>
 
+#include <faiss/impl/mapped_io.h>
+#include <faiss/impl/zerocopy_io.h>
+
 %}
 
 /********************************************************
@@ -633,6 +636,8 @@ struct faiss::simd16uint16 {};
 
 %include <faiss/IndexNeuralNetCodec.h>
 
+%include <faiss/impl/mapped_io.h>
+%include <faiss/impl/zerocopy_io.h>
 
 %ignore faiss::BufferList::Buffer;
 %ignore faiss::RangeSearchPartialResult::QueryResult;

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -81,6 +81,11 @@ typedef uint64_t size_t;
 
 #endif
 
+#include <faiss/impl/io.h>
+
+#include <faiss/impl/maybe_owned_vector.h>
+#include <faiss/impl/mapped_io.h>
+#include <faiss/impl/zerocopy_io.h>
 
 #include <faiss/IndexFlat.h>
 #include <faiss/VectorTransform.h>
@@ -183,9 +188,6 @@ typedef uint64_t size_t;
 #include <faiss/IndexLattice.h>
 
 #include <faiss/IndexNeuralNetCodec.h>
-
-#include <faiss/impl/mapped_io.h>
-#include <faiss/impl/zerocopy_io.h>
 
 %}
 
@@ -509,6 +511,14 @@ void gpu_sync_all_devices()
 
 %include <faiss/impl/DistanceComputer.h>
 
+%include <faiss/impl/io.h>
+
+%ignore faiss::MmappedFileMappingOwner::p_impl;
+
+%include <faiss/impl/maybe_owned_vector.h>
+%include <faiss/impl/mapped_io.h>
+%include <faiss/impl/zerocopy_io.h>
+
 %newobject *::get_FlatCodesDistanceComputer() const;
 %include  <faiss/IndexFlatCodes.h>
 %include  <faiss/IndexFlat.h>
@@ -636,8 +646,6 @@ struct faiss::simd16uint16 {};
 
 %include <faiss/IndexNeuralNetCodec.h>
 
-%include <faiss/impl/mapped_io.h>
-%include <faiss/impl/zerocopy_io.h>
 
 %ignore faiss::BufferList::Buffer;
 %ignore faiss::RangeSearchPartialResult::QueryResult;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,8 @@ set(FAISS_TEST_SRC
   test_callback.cpp
   test_utils.cpp
   test_hamming.cpp
+  test_mmap.cpp
+  test_zerocopy.cpp
 )
 
 add_executable(faiss_test ${FAISS_TEST_SRC})

--- a/tests/test_fast_scan_ivf.py
+++ b/tests/test_fast_scan_ivf.py
@@ -270,8 +270,9 @@ class TestEquivPQ(unittest.TestCase):
         index_pq = faiss.index_factory(32, "PQ16x4np")
         index_pq.pq = index.pq
         index_pq.is_trained = True
-        index_pq.codes = faiss. downcast_InvertedLists(
+        codevec = faiss.downcast_InvertedLists(
             index.invlists).codes.at(0)
+        index_pq.codes = faiss.MaybeOwnedVectorUInt8(codevec)
         index_pq.ntotal = index.ntotal
         Dnew, Inew = index_pq.search(xq, 4)
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -494,6 +494,8 @@ class TestIOFlatMMap(unittest.TestCase):
 
         fd, fname = tempfile.mkstemp()
         os.close(fd)
+
+        index2 = None
         try:
             faiss.write_index(index, fname)
             index2 = faiss.read_index(fname, faiss.IO_FLAG_MMAP_IFC)
@@ -501,8 +503,16 @@ class TestIOFlatMMap(unittest.TestCase):
             np.testing.assert_array_equal(Iref, Inew)
             np.testing.assert_array_equal(Dref, Dnew)
         finally:
+            del index2
+
             if os.path.exists(fname):
-                os.unlink(fname)
+                # skip the error. On Windows, index2 holds the handle file, 
+                #   so it cannot be ensured that the file can be deleted
+                #   unless index2 is collected by a GC
+                try:
+                    os.unlink(fname)
+                except:
+                    pass
 
     def test_zerocopy(self): 
         xt, xb, xq = get_dataset_2(32, 0, 100, 50)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -481,3 +481,39 @@ class TestIVFPQRead(unittest.TestCase):
         finally:
             if os.path.exists(fname):
                 os.unlink(fname)
+
+
+
+class TestIOFlatMMap(unittest.TestCase):
+    def test_mmap(self): 
+        xt, xb, xq = get_dataset_2(32, 0, 100, 50)
+        index = faiss.index_factory(32, "SQfp16", faiss.METRIC_L2)
+        # does not need training 
+        index.add(xb)
+        Dref, Iref = index.search(xq, 10)
+
+        fd, fname = tempfile.mkstemp()
+        os.close(fd)
+        try:
+            faiss.write_index(index, fname)
+            index2 = faiss.read_index(fname, faiss.IO_FLAG_MMAP_IFC)
+            Dnew, Inew = index2.search(xq, 10)
+            np.testing.assert_array_equal(Iref, Inew)
+            np.testing.assert_array_equal(Dref, Dnew)
+        finally:
+            if os.path.exists(fname):
+                os.unlink(fname)
+
+    def test_zerocopy(self): 
+        xt, xb, xq = get_dataset_2(32, 0, 100, 50)
+        index = faiss.index_factory(32, "SQfp16", faiss.METRIC_L2)
+        # does not need training 
+        index.add(xb)
+        Dref, Iref = index.search(xq, 10)
+
+        serialized_index = faiss.serialize_index(index)
+        reader = faiss.ZeroCopyIOReader(faiss.swig_ptr(serialized_index), serialized_index.size)
+        index2 = faiss.read_index(reader)
+        Dnew, Inew = index2.search(xq, 10)
+        np.testing.assert_array_equal(Iref, Inew)
+        np.testing.assert_array_equal(Dref, Dnew)

--- a/tests/test_mmap.cpp
+++ b/tests/test_mmap.cpp
@@ -32,7 +32,7 @@ std::vector<float> make_data(const size_t n, const size_t d, size_t seed) {
     return database;
 }
 
-}
+} // namespace
 
 TEST(TestMmap, mmap_flatcodes) {
     // the logic is the following:

--- a/tests/test_mmap.cpp
+++ b/tests/test_mmap.cpp
@@ -19,6 +19,8 @@
 #include <faiss/impl/io.h>
 #include <faiss/index_io.h>
 
+namespace {
+
 std::vector<float> make_data(const size_t n, const size_t d, size_t seed) {
     std::vector<float> database(n * d);
     std::mt19937 rng(seed);
@@ -28,6 +30,8 @@ std::vector<float> make_data(const size_t n, const size_t d, size_t seed) {
         database[i] = distrib(rng);
     }
     return database;
+}
+
 }
 
 TEST(TestMmap, mmap_flatcodes) {

--- a/tests/test_mmap.cpp
+++ b/tests/test_mmap.cpp
@@ -15,6 +15,7 @@
 #include <random>
 #include <vector>
 
+#include <faiss/IndexBinaryFlat.h>
 #include <faiss/IndexFlat.h>
 #include <faiss/impl/io.h>
 #include <faiss/index_io.h>
@@ -32,19 +33,33 @@ std::vector<float> make_data(const size_t n, const size_t d, size_t seed) {
     return database;
 }
 
+std::vector<uint8_t> make_binary_data(
+        const size_t n,
+        const size_t d,
+        size_t seed) {
+    std::vector<uint8_t> database(n * d);
+    std::mt19937 rng(seed);
+    std::uniform_int_distribution<uint8_t> distrib(0, 255);
+
+    for (size_t i = 0; i < n * d; i++) {
+        database[i] = distrib(rng);
+    }
+    return database;
+}
+
 } // namespace
 
-TEST(TestMmap, mmap_flatcodes) {
-    // the logic is the following:
-    //   1. generate two flatcodes-based indices, Index1 and Index2
-    //   2. serialize both indices into std::vector<> buffers, Buf1 and Buf2
-    //   3. save Buf1 into a temporary file, File1
-    //   4. deserialize Index1 using mmap feature on File1 into Index1MM
-    //   5. ensure that Index1MM acts as Index2 if we write the data from Buf2
-    //      on top of the existing File1
-    //   6. ensure that Index1MM acts as Index1 if we write the data from Buf1
-    //      on top of the existing File1 again
+// the logic is the following:
+//   1. generate two flatcodes-based indices, Index1 and Index2
+//   2. serialize both indices into std::vector<> buffers, Buf1 and Buf2
+//   3. save Buf1 into a temporary file, File1
+//   4. deserialize Index1 using mmap feature on File1 into Index1MM
+//   5. ensure that Index1MM acts as Index2 if we write the data from Buf2
+//      on top of the existing File1
+//   6. ensure that Index1MM acts as Index1 if we write the data from Buf1
+//      on top of the existing File1 again
 
+TEST(TestMmap, mmap_flatcodes) {
     // generate data
     const size_t nt = 1000;
     const size_t nq = 10;
@@ -137,6 +152,110 @@ TEST(TestMmap, mmap_flatcodes) {
 
     // perform a search
     std::vector<float> cand_dis_3(k * nq);
+    std::vector<faiss::idx_t> cand_ids_3(k * nq);
+    index1mm->search(nq, xq.data(), k, cand_dis_3.data(), cand_ids_3.data());
+
+    // match vs ref1
+    ASSERT_EQ(ref_ids_1, cand_ids_3);
+    ASSERT_EQ(ref_dis_1, cand_dis_3);
+}
+
+TEST(TestMmap, mmap_binary_flatcodes) {
+    // generate data
+    const size_t nt = 1000;
+    const size_t nq = 10;
+    // in bits
+    const size_t d = 64;
+    // in bytes
+    const size_t d8 = (d + 7) / 8;
+    const size_t k = 25;
+
+    std::vector<uint8_t> xt1 = make_binary_data(nt, d8, 123);
+    std::vector<uint8_t> xt2 = make_binary_data(nt, d8, 456);
+    std::vector<uint8_t> xq = make_binary_data(nq, d8, 789);
+
+    // ensure that the data is different
+    ASSERT_NE(xt1, xt2);
+
+    // make index1 and create reference results
+    faiss::IndexBinaryFlat index1(d);
+    index1.train(nt, xt1.data());
+    index1.add(nt, xt1.data());
+
+    std::vector<int32_t> ref_dis_1(k * nq);
+    std::vector<faiss::idx_t> ref_ids_1(k * nq);
+    index1.search(nq, xq.data(), k, ref_dis_1.data(), ref_ids_1.data());
+
+    // make index2 and create reference results
+    faiss::IndexBinaryFlat index2(d);
+    index2.train(nt, xt2.data());
+    index2.add(nt, xt2.data());
+
+    std::vector<int32_t> ref_dis_2(k * nq);
+    std::vector<faiss::idx_t> ref_ids_2(k * nq);
+    index2.search(nq, xq.data(), k, ref_dis_2.data(), ref_ids_2.data());
+
+    // ensure that the results are different
+    ASSERT_NE(ref_dis_1, ref_dis_2);
+    ASSERT_NE(ref_ids_1, ref_ids_2);
+
+    // serialize both in a form of vectors
+    faiss::VectorIOWriter wr1;
+    faiss::write_index_binary(&index1, &wr1);
+
+    faiss::VectorIOWriter wr2;
+    faiss::write_index_binary(&index2, &wr2);
+
+    // generate a temporary file and write index1 into it
+    std::string tmpname = std::tmpnam(nullptr);
+
+    {
+        std::ofstream ofs(tmpname);
+        ofs.write((const char*)wr1.data.data(), wr1.data.size());
+    }
+
+    // create a mmap index
+    std::unique_ptr<faiss::IndexBinary> index1mm(
+            faiss::read_index_binary(tmpname.c_str(), faiss::IO_FLAG_MMAP_IFC));
+
+    ASSERT_NE(index1mm, nullptr);
+
+    // perform a search
+    std::vector<int32_t> cand_dis_1(k * nq);
+    std::vector<faiss::idx_t> cand_ids_1(k * nq);
+    index1mm->search(nq, xq.data(), k, cand_dis_1.data(), cand_ids_1.data());
+
+    // match vs ref1
+    ASSERT_EQ(ref_ids_1, cand_ids_1);
+    ASSERT_EQ(ref_dis_1, cand_dis_1);
+
+    // ok now, overwrite the internals of the file without recreating it
+    {
+        std::ofstream ofs(tmpname);
+        ofs.seekp(0, std::ios::beg);
+
+        ofs.write((const char*)wr2.data.data(), wr2.data.size());
+    }
+
+    // perform a search
+    std::vector<int32_t> cand_dis_2(k * nq);
+    std::vector<faiss::idx_t> cand_ids_2(k * nq);
+    index1mm->search(nq, xq.data(), k, cand_dis_2.data(), cand_ids_2.data());
+
+    // match vs ref1
+    ASSERT_EQ(ref_ids_2, cand_ids_2);
+    ASSERT_EQ(ref_dis_2, cand_dis_2);
+
+    // write back data1
+    {
+        std::ofstream ofs(tmpname);
+        ofs.seekp(0, std::ios::beg);
+
+        ofs.write((const char*)wr1.data.data(), wr1.data.size());
+    }
+
+    // perform a search
+    std::vector<int32_t> cand_dis_3(k * nq);
     std::vector<faiss::idx_t> cand_ids_3(k * nq);
     index1mm->search(nq, xq.data(), k, cand_dis_3.data(), cand_ids_3.data());
 

--- a/tests/test_mmap.cpp
+++ b/tests/test_mmap.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include <faiss/IndexFlat.h>
+#include <faiss/impl/io.h>
+#include <faiss/index_io.h>
+
+std::vector<float> make_data(const size_t n, const size_t d, size_t seed) {
+    std::vector<float> database(n * d);
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> distrib;
+
+    for (size_t i = 0; i < n * d; i++) {
+        database[i] = distrib(rng);
+    }
+    return database;
+}
+
+TEST(TestMmap, mmap_flatcodes) {
+    // the logic is the following:
+    //   1. generate two flatcodes-based indices, Index1 and Index2
+    //   2. serialize both indices into std::vector<> buffers, Buf1 and Buf2
+    //   3. save Buf1 into a temporary file, File1
+    //   4. deserialize Index1 using mmap feature on File1 into Index1MM
+    //   5. ensure that Index1MM acts as Index2 if we write the data from Buf2
+    //      on top of the existing File1
+    //   6. ensure that Index1MM acts as Index1 if we write the data from Buf1
+    //      on top of the existing File1 again
+
+    // generate data
+    const size_t nt = 1000;
+    const size_t nq = 10;
+    const size_t d = 32;
+    const size_t k = 25;
+
+    std::vector<float> xt1 = make_data(nt, d, 123);
+    std::vector<float> xt2 = make_data(nt, d, 456);
+    std::vector<float> xq = make_data(nq, d, 789);
+
+    // ensure that the data is different
+    ASSERT_NE(xt1, xt2);
+
+    // make index1 and create reference results
+    faiss::IndexFlatL2 index1(d);
+    index1.train(nt, xt1.data());
+    index1.add(nt, xt1.data());
+
+    std::vector<float> ref_dis_1(k * nq);
+    std::vector<faiss::idx_t> ref_ids_1(k * nq);
+    index1.search(nq, xq.data(), k, ref_dis_1.data(), ref_ids_1.data());
+
+    // make index2 and create reference results
+    faiss::IndexFlatL2 index2(d);
+    index2.train(nt, xt2.data());
+    index2.add(nt, xt2.data());
+
+    std::vector<float> ref_dis_2(k * nq);
+    std::vector<faiss::idx_t> ref_ids_2(k * nq);
+    index2.search(nq, xq.data(), k, ref_dis_2.data(), ref_ids_2.data());
+
+    // ensure that the results are different
+    ASSERT_NE(ref_dis_1, ref_dis_2);
+    ASSERT_NE(ref_ids_1, ref_ids_2);
+
+    // serialize both in a form of vectors
+    faiss::VectorIOWriter wr1;
+    faiss::write_index(&index1, &wr1);
+
+    faiss::VectorIOWriter wr2;
+    faiss::write_index(&index2, &wr2);
+
+    // generate a temporary file and write index1 into it
+    std::string tmpname = std::tmpnam(nullptr);
+
+    {
+        std::ofstream ofs(tmpname);
+        ofs.write((const char*)wr1.data.data(), wr1.data.size());
+    }
+
+    // create a mmap index
+    std::unique_ptr<faiss::Index> index1mm(
+            faiss::read_index(tmpname.c_str(), faiss::IO_FLAG_MMAP_IFC));
+
+    ASSERT_NE(index1mm, nullptr);
+
+    // perform a search
+    std::vector<float> cand_dis_1(k * nq);
+    std::vector<faiss::idx_t> cand_ids_1(k * nq);
+    index1mm->search(nq, xq.data(), k, cand_dis_1.data(), cand_ids_1.data());
+
+    // match vs ref1
+    ASSERT_EQ(ref_ids_1, cand_ids_1);
+    ASSERT_EQ(ref_dis_1, cand_dis_1);
+
+    // ok now, overwrite the internals of the file without recreating it
+    {
+        std::ofstream ofs(tmpname);
+        ofs.seekp(0, std::ios::beg);
+
+        ofs.write((const char*)wr2.data.data(), wr2.data.size());
+    }
+
+    // perform a search
+    std::vector<float> cand_dis_2(k * nq);
+    std::vector<faiss::idx_t> cand_ids_2(k * nq);
+    index1mm->search(nq, xq.data(), k, cand_dis_2.data(), cand_ids_2.data());
+
+    // match vs ref1
+    ASSERT_EQ(ref_ids_2, cand_ids_2);
+    ASSERT_EQ(ref_dis_2, cand_dis_2);
+
+    // write back data1
+    {
+        std::ofstream ofs(tmpname);
+        ofs.seekp(0, std::ios::beg);
+
+        ofs.write((const char*)wr1.data.data(), wr1.data.size());
+    }
+
+    // perform a search
+    std::vector<float> cand_dis_3(k * nq);
+    std::vector<faiss::idx_t> cand_ids_3(k * nq);
+    index1mm->search(nq, xq.data(), k, cand_dis_3.data(), cand_ids_3.data());
+
+    // match vs ref1
+    ASSERT_EQ(ref_ids_1, cand_ids_3);
+    ASSERT_EQ(ref_dis_1, cand_dis_3);
+}

--- a/tests/test_zerocopy.cpp
+++ b/tests/test_zerocopy.cpp
@@ -30,7 +30,7 @@ std::vector<float> make_data(const size_t n, const size_t d, size_t seed) {
     return database;
 }
 
-}
+} // namespace
 
 TEST(TestZeroCopy, zerocopy_flatcodes) {
     // the logic is the following:

--- a/tests/test_zerocopy.cpp
+++ b/tests/test_zerocopy.cpp
@@ -12,6 +12,7 @@
 #include <random>
 #include <vector>
 
+#include <faiss/IndexBinaryFlat.h>
 #include <faiss/IndexFlat.h>
 #include <faiss/impl/io.h>
 #include <faiss/impl/zerocopy_io.h>
@@ -30,16 +31,30 @@ std::vector<float> make_data(const size_t n, const size_t d, size_t seed) {
     return database;
 }
 
+std::vector<uint8_t> make_binary_data(
+        const size_t n,
+        const size_t d,
+        size_t seed) {
+    std::vector<uint8_t> database(n * d);
+    std::mt19937 rng(seed);
+    std::uniform_int_distribution<uint8_t> distrib(0, 255);
+
+    for (size_t i = 0; i < n * d; i++) {
+        database[i] = distrib(rng);
+    }
+    return database;
+}
+
 } // namespace
 
-TEST(TestZeroCopy, zerocopy_flatcodes) {
-    // the logic is the following:
-    //   1. generate two flatcodes-based indices, Index1 and Index2
-    //   2. serialize both indices into std::vector<> buffers, Buf1 and Buf2
-    //   3. deserialize Index1 using zero-copy feature on Buf1 into Index1ZC
-    //   4. ensure that Index1ZC acts as Index2 if we write the data from Buf2
-    //      on top of the existing Buf1
+// the logic is the following:
+//   1. generate two flatcodes-based indices, Index1 and Index2
+//   2. serialize both indices into std::vector<> buffers, Buf1 and Buf2
+//   3. deserialize Index1 using zero-copy feature on Buf1 into Index1ZC
+//   4. ensure that Index1ZC acts as Index2 if we write the data from Buf2
+//      on top of the existing Buf1
 
+TEST(TestZeroCopy, zerocopy_flatcodes) {
     // generate data
     const size_t nt = 1000;
     const size_t nq = 10;
@@ -123,6 +138,102 @@ TEST(TestZeroCopy, zerocopy_flatcodes) {
 
     // perform a search
     std::vector<float> cand_dis_3(k * nq);
+    std::vector<faiss::idx_t> cand_ids_3(k * nq);
+    index1zc->search(nq, xq.data(), k, cand_dis_3.data(), cand_ids_3.data());
+
+    // match vs ref1
+    ASSERT_EQ(ref_ids_1, cand_ids_3);
+    ASSERT_EQ(ref_dis_1, cand_dis_3);
+}
+
+TEST(TestZeroCopy, zerocopy_binary_flatcodes) {
+    // generate data
+    const size_t nt = 1000;
+    const size_t nq = 10;
+    // in bits
+    const size_t d = 64;
+    // in bytes
+    const size_t d8 = (d + 7) / 8;
+    const size_t k = 25;
+
+    std::vector<uint8_t> xt1 = make_binary_data(nt, d8, 123);
+    std::vector<uint8_t> xt2 = make_binary_data(nt, d8, 456);
+    std::vector<uint8_t> xq = make_binary_data(nq, d8, 789);
+
+    // ensure that the data is different
+    ASSERT_NE(xt1, xt2);
+
+    // make index1 and create reference results
+    faiss::IndexBinaryFlat index1(d);
+    index1.train(nt, xt1.data());
+    index1.add(nt, xt1.data());
+
+    std::vector<int32_t> ref_dis_1(k * nq);
+    std::vector<faiss::idx_t> ref_ids_1(k * nq);
+    index1.search(nq, xq.data(), k, ref_dis_1.data(), ref_ids_1.data());
+
+    // make index2 and create reference results
+    faiss::IndexBinaryFlat index2(d);
+    index2.train(nt, xt2.data());
+    index2.add(nt, xt2.data());
+
+    std::vector<int32_t> ref_dis_2(k * nq);
+    std::vector<faiss::idx_t> ref_ids_2(k * nq);
+    index2.search(nq, xq.data(), k, ref_dis_2.data(), ref_ids_2.data());
+
+    // ensure that the results are different
+    ASSERT_NE(ref_dis_1, ref_dis_2);
+    ASSERT_NE(ref_ids_1, ref_ids_2);
+
+    // serialize both in a form of vectors
+    faiss::VectorIOWriter wr1;
+    faiss::write_index_binary(&index1, &wr1);
+
+    faiss::VectorIOWriter wr2;
+    faiss::write_index_binary(&index2, &wr2);
+
+    ASSERT_EQ(wr1.data.size(), wr2.data.size());
+
+    // clone a buffer
+    std::vector<uint8_t> buffer = wr1.data;
+
+    // create a zero-copy index
+    faiss::ZeroCopyIOReader reader(buffer.data(), buffer.size());
+    std::unique_ptr<faiss::IndexBinary> index1zc(
+            faiss::read_index_binary(&reader));
+
+    ASSERT_NE(index1zc, nullptr);
+
+    // perform a search
+    std::vector<int32_t> cand_dis_1(k * nq);
+    std::vector<faiss::idx_t> cand_ids_1(k * nq);
+    index1zc->search(nq, xq.data(), k, cand_dis_1.data(), cand_ids_1.data());
+
+    // match vs ref1
+    ASSERT_EQ(ref_ids_1, cand_ids_1);
+    ASSERT_EQ(ref_dis_1, cand_dis_1);
+
+    // overwrite buffer without moving it
+    for (size_t i = 0; i < buffer.size(); i++) {
+        buffer[i] = wr2.data[i];
+    }
+
+    // perform a search
+    std::vector<int32_t> cand_dis_2(k * nq);
+    std::vector<faiss::idx_t> cand_ids_2(k * nq);
+    index1zc->search(nq, xq.data(), k, cand_dis_2.data(), cand_ids_2.data());
+
+    // match vs ref2
+    ASSERT_EQ(ref_ids_2, cand_ids_2);
+    ASSERT_EQ(ref_dis_2, cand_dis_2);
+
+    // overwrite again
+    for (size_t i = 0; i < buffer.size(); i++) {
+        buffer[i] = wr1.data[i];
+    }
+
+    // perform a search
+    std::vector<int32_t> cand_dis_3(k * nq);
     std::vector<faiss::idx_t> cand_ids_3(k * nq);
     index1zc->search(nq, xq.data(), k, cand_dis_3.data(), cand_ids_3.data());
 

--- a/tests/test_zerocopy.cpp
+++ b/tests/test_zerocopy.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include <faiss/IndexFlat.h>
+#include <faiss/impl/io.h>
+#include <faiss/impl/zerocopy_io.h>
+#include <faiss/index_io.h>
+
+std::vector<float> make_data(const size_t n, const size_t d, size_t seed) {
+    std::vector<float> database(n * d);
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> distrib;
+
+    for (size_t i = 0; i < n * d; i++) {
+        database[i] = distrib(rng);
+    }
+    return database;
+}
+
+TEST(TestZeroCopy, zerocopy_flatcodes) {
+    // the logic is the following:
+    //   1. generate two flatcodes-based indices, Index1 and Index2
+    //   2. serialize both indices into std::vector<> buffers, Buf1 and Buf2
+    //   3. deserialize Index1 using zero-copy feature on Buf1 into Index1ZC
+    //   4. ensure that Index1ZC acts as Index2 if we write the data from Buf2
+    //      on top of the existing Buf1
+
+    // generate data
+    const size_t nt = 1000;
+    const size_t nq = 10;
+    const size_t d = 32;
+    const size_t k = 25;
+
+    std::vector<float> xt1 = make_data(nt, d, 123);
+    std::vector<float> xt2 = make_data(nt, d, 456);
+    std::vector<float> xq = make_data(nq, d, 789);
+
+    // ensure that the data is different
+    ASSERT_NE(xt1, xt2);
+
+    // make index1 and create reference results
+    faiss::IndexFlatL2 index1(d);
+    index1.train(nt, xt1.data());
+    index1.add(nt, xt1.data());
+
+    std::vector<float> ref_dis_1(k * nq);
+    std::vector<faiss::idx_t> ref_ids_1(k * nq);
+    index1.search(nq, xq.data(), k, ref_dis_1.data(), ref_ids_1.data());
+
+    // make index2 and create reference results
+    faiss::IndexFlatL2 index2(d);
+    index2.train(nt, xt2.data());
+    index2.add(nt, xt2.data());
+
+    std::vector<float> ref_dis_2(k * nq);
+    std::vector<faiss::idx_t> ref_ids_2(k * nq);
+    index2.search(nq, xq.data(), k, ref_dis_2.data(), ref_ids_2.data());
+
+    // ensure that the results are different
+    ASSERT_NE(ref_dis_1, ref_dis_2);
+    ASSERT_NE(ref_ids_1, ref_ids_2);
+
+    // serialize both in a form of vectors
+    faiss::VectorIOWriter wr1;
+    faiss::write_index(&index1, &wr1);
+
+    faiss::VectorIOWriter wr2;
+    faiss::write_index(&index2, &wr2);
+
+    ASSERT_EQ(wr1.data.size(), wr2.data.size());
+
+    // clone a buffer
+    std::vector<uint8_t> buffer = wr1.data;
+
+    // create a zero-copy index
+    faiss::ZeroCopyIOReader reader(buffer.data(), buffer.size());
+    std::unique_ptr<faiss::Index> index1zc(faiss::read_index(&reader));
+
+    ASSERT_NE(index1zc, nullptr);
+
+    // perform a search
+    std::vector<float> cand_dis_1(k * nq);
+    std::vector<faiss::idx_t> cand_ids_1(k * nq);
+    index1zc->search(nq, xq.data(), k, cand_dis_1.data(), cand_ids_1.data());
+
+    // match vs ref1
+    ASSERT_EQ(ref_ids_1, cand_ids_1);
+    ASSERT_EQ(ref_dis_1, cand_dis_1);
+
+    // overwrite buffer without moving it
+    for (size_t i = 0; i < buffer.size(); i++) {
+        buffer[i] = wr2.data[i];
+    }
+
+    // perform a search
+    std::vector<float> cand_dis_2(k * nq);
+    std::vector<faiss::idx_t> cand_ids_2(k * nq);
+    index1zc->search(nq, xq.data(), k, cand_dis_2.data(), cand_ids_2.data());
+
+    // match vs ref2
+    ASSERT_EQ(ref_ids_2, cand_ids_2);
+    ASSERT_EQ(ref_dis_2, cand_dis_2);
+
+    // overwrite again
+    for (size_t i = 0; i < buffer.size(); i++) {
+        buffer[i] = wr1.data[i];
+    }
+
+    // perform a search
+    std::vector<float> cand_dis_3(k * nq);
+    std::vector<faiss::idx_t> cand_ids_3(k * nq);
+    index1zc->search(nq, xq.data(), k, cand_dis_3.data(), cand_ids_3.data());
+
+    // match vs ref1
+    ASSERT_EQ(ref_ids_1, cand_ids_3);
+    ASSERT_EQ(ref_dis_1, cand_dis_3);
+}

--- a/tests/test_zerocopy.cpp
+++ b/tests/test_zerocopy.cpp
@@ -17,6 +17,8 @@
 #include <faiss/impl/zerocopy_io.h>
 #include <faiss/index_io.h>
 
+namespace {
+
 std::vector<float> make_data(const size_t n, const size_t d, size_t seed) {
     std::vector<float> database(n * d);
     std::mt19937 rng(seed);
@@ -26,6 +28,8 @@ std::vector<float> make_data(const size_t n, const size_t d, size_t seed) {
         database[i] = distrib(rng);
     }
     return database;
+}
+
 }
 
 TEST(TestZeroCopy, zerocopy_flatcodes) {


### PR DESCRIPTION
This PR introduces a backport of a combination of https://github.com/zilliztech/knowhere/pull/996 and https://github.com/zilliztech/knowhere/pull/1032 that allow to have memory-mapped and zerocopy indces.

The root underlying idea is that we replace certain `std::vector<>` containers with a custom `faiss::MaybeOwnedVector<>` container, which may behave either as `std::vector<>`, or as a view of a certain pointer / descriptor. We don't replace all the instances of `std::vector<>`, but the largest ones.

This change affects `IndexFlatCodes`-based and `IndexHNSW` CPU indices.

(done) alter IVF lists as well.
(done) alter binary indices as well.

Memory-mapped index works like this:
```C++
std::unique_ptr<faiss::Index> index_mm(
            faiss::read_index(filenamename.c_str(), faiss::IO_FLAG_MMAP_IFC));
```
In theory, it should be ready to be used from Python. All the descriptor management should be working.

Zero-copy index works like this:
```C++
#include <faiss/impl/zerocopy_io.h>

faiss::ZeroCopyIOReader reader(buffer.data(), buffer.size());
std::unique_ptr<faiss::Index> index_zc(faiss::read_index(&reader));
```
All the pointer management for `faiss::ZeroCopyIOReader` should be handled manually.
I'm not sure how to plug this into Python yet, maybe, some ref-counting is required.

(done) some refactoring
