### PR TITLE
Remove unused variable

### DIFF
--- a/faiss/impl/code_distance/code_distance-sve.h
+++ b/faiss/impl/code_distance/code_distance-sve.h
@@ -217,8 +217,6 @@ static void distance_four_codes_sve_for_small_m(
 
     const auto offsets_0 = svindex_u32(0, static_cast<uint32_t>(ksub));
 
-    const auto quad_lanes = svcntw();
-
     // loop
     const auto pg = svwhilelt_b32_u64(0, M);
 


### PR DESCRIPTION
Summary:
Removing unused variable.

This piece of code began to be compiled after armv9a has been set as default compilation profile

Reviewed By: andrewjcg

Differential Revision: D69946389


