### PR TITLE
Fix build by removing unused variable

### DIFF
--- a/faiss/impl/code_distance/code_distance-sve.h
+++ b/faiss/impl/code_distance/code_distance-sve.h
@@ -217,8 +217,6 @@ static void distance_four_codes_sve_for_small_m(
 
     const auto offsets_0 = svindex_u32(0, static_cast<uint32_t>(ksub));
 
-    const auto quad_lanes = svcntw();
-
     // loop
     const auto pg = svwhilelt_b32_u64(0, M);
 


### PR DESCRIPTION
Summary: Given the unused variable enforcement, there is one unused variable when using arm64 architecture. This diff is addressing that.

Differential Revision: D69960020


