### PR TITLE
Fix Sapphire Rapids never loading in Python bindings

### DIFF
--- a/faiss/python/loader.py
+++ b/faiss/python/loader.py
@@ -108,7 +108,7 @@ if has_AVX512_SPR:
         loaded = False
 
 has_AVX512 = any("AVX512" in x.upper() for x in instruction_sets)
-if has_AVX512:
+if has_AVX512 and not loaded:
     try:
         logger.info("Loading faiss with AVX512 support.")
         from .swigfaiss_avx512 import *


### PR DESCRIPTION
If both `avx512` and `avx512_spr` are compiled, Sapphire Rapids capabilities are never loaded when using the Python bindings, as the `avx512` import always overrides the `avx512_spr` one. 

This very small PR solves the issue. 
