### PR TITLE
Make static method in header inline

### DIFF
--- a/faiss/impl/code_distance/code_distance-sve.h
+++ b/faiss/impl/code_distance/code_distance-sve.h
@@ -196,7 +196,7 @@ distance_four_codes_sve(
             result3);
 }
 
-static void distance_four_codes_sve_for_small_m(
+static inline void distance_four_codes_sve_for_small_m(
         // the product quantizer
         const size_t M,
         // precomputed distances, layout (M, ksub)


### PR DESCRIPTION
Summary:
Got build failure with flags `[-Werror,-Wunneeded-internal-declaration]`
```
faiss/impl/code_distance/code_distance-sve.h:199:13
error: 'static' function 'distance_four_codes_sve_for_small_m' declared in header file should be declared 'static inline' [-Werror,-Wunneeded-internal-declaration]
```

Reviewed By: vit-ka

Differential Revision: D70279069


