### PR TITLE
Fix LLVM-19 compilation issue in faiss/AutoTune.cpp

### DIFF
--- a/faiss/AutoTune.cpp
+++ b/faiss/AutoTune.cpp
@@ -314,7 +314,7 @@ bool ParameterSpace::combination_ge(size_t c1, size_t c2) const {
 }
 
 #define DC(classname) \
-    const classname* ix = dynamic_cast<const classname*>(index)
+    [[maybe_unused]] const classname* ix = dynamic_cast<const classname*>(index)
 
 static void init_pq_ParameterRange(
         const ProductQuantizer& pq,


### PR DESCRIPTION
Summary: LLVM-19 is incoming. This fixes an issue preventing it. Delays to previous platform upgrades cost $3M/week.

Differential Revision: D70449926


