### PR TITLE
Use `nullptr` in faiss/gpu/StandardGpuResources.cpp

### DIFF
--- a/faiss/gpu/StandardGpuResources.cpp
+++ b/faiss/gpu/StandardGpuResources.cpp
@@ -411,7 +411,7 @@ void StandardGpuResourcesImpl::initializeForDevice(int device) {
     raftHandles_.emplace(std::make_pair(device, defaultStream));
 #endif
 
-    cudaStream_t asyncCopyStream = 0;
+    cudaStream_t asyncCopyStream = nullptr;
     CUDA_VERIFY(
             cudaStreamCreateWithFlags(&asyncCopyStream, cudaStreamNonBlocking));
 


### PR DESCRIPTION
Summary:
`nullptr` is preferable to `0` or `NULL`. Let's use it everywhere so we can enable `-Wzero-as-null-pointer-constant`.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dtolnay

Differential Revision: D70818157


