### PR TITLE
Pin vc14_runtime for nightly fix

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -30,122 +30,230 @@ jobs:
               git --no-pager diff --color
               exit 1
             fi
-  linux-x86_64-cmake:
-    name: Linux x86_64 (cmake)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build and Test (cmake)
-        uses: ./.github/actions/build_cmake
-  linux-x86_64-AVX2-cmake:
-    name: Linux x86_64 AVX2 (cmake)
-    needs: linux-x86_64-cmake
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build and Test (cmake)
-        uses: ./.github/actions/build_cmake
-        with:
-          opt_level: avx2
-  linux-x86_64-AVX512-cmake:
-    name: Linux x86_64 AVX512 (cmake)
-    needs: linux-x86_64-cmake
-    runs-on: faiss-aws-m7i.large
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build and Test (cmake)
-        uses: ./.github/actions/build_cmake
-        with:
-          opt_level: avx512
-  linux-x86_64-AVX512_SPR-cmake:
-    name: Linux x86_64 AVX512_SPR (cmake)
-    needs: linux-x86_64-cmake
-    runs-on: faiss-aws-m7i.large
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build and Test (cmake)
-        uses: ./.github/actions/build_cmake
-        with:
-          opt_level: avx512_spr
-  linux-x86_64-GPU-cmake:
-    name: Linux x86_64 GPU (cmake)
-    needs: linux-x86_64-cmake
-    runs-on: 4-core-ubuntu-gpu-t4
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build and Test (cmake)
-        uses: ./.github/actions/build_cmake
-        with:
-          gpu: ON
-  linux-x86_64-GPU-w-CUVS-cmake:
-    name: Linux x86_64 GPU w/ cuVS (cmake)
-    needs: linux-x86_64-cmake
-    runs-on: 4-core-ubuntu-gpu-t4
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build and Test (cmake)
-        uses: ./.github/actions/build_cmake
-        with:
-          gpu: ON
-          cuvs: ON
-  linux-x86_64-GPU-w-ROCm-cmake:
-    name: Linux x86_64 GPU w/ ROCm (cmake)
-    needs: linux-x86_64-cmake
-    runs-on: faiss-amd-MI200
-    container:
-      image: ubuntu:22.04
-      options: --device=/dev/kfd --device=/dev/dri --ipc=host --shm-size 16G --group-add video --cap-add=SYS_PTRACE --cap-add=SYS_ADMIN
-    steps:
-      - name: Container setup
-        run: |
-            if [ -f /.dockerenv ]; then
-              apt-get update && apt-get install -y sudo && apt-get install -y git
-              git config --global --add safe.directory '*'
-            else
-              echo 'Skipping. Current job is not running inside a container.'
-            fi
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build and Test (cmake)
-        uses: ./.github/actions/build_cmake
-        with:
-          gpu: ON
-          rocm: ON
-  linux-arm64-SVE-cmake:
-    name: Linux arm64 SVE (cmake)
-    needs: linux-x86_64-cmake
-    runs-on: faiss-aws-r8g.large
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build and Test (cmake)
-        uses: ./.github/actions/build_cmake
-        with:
-          opt_level: sve
-        env:
-          # Context: https://github.com/facebookresearch/faiss/wiki/Troubleshooting#surprising-faiss-openmp-and-openblas-interaction
-          OPENBLAS_NUM_THREADS: '1'
-  linux-x86_64-conda:
-    name: Linux x86_64 (conda)
-    needs: linux-x86_64-cmake
-    runs-on: ubuntu-latest
+  # linux-x86_64-cmake:
+  #   name: Linux x86_64 (cmake)
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Build and Test (cmake)
+  #       uses: ./.github/actions/build_cmake
+  # linux-x86_64-AVX2-cmake:
+  #   name: Linux x86_64 AVX2 (cmake)
+  #   needs: linux-x86_64-cmake
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Build and Test (cmake)
+  #       uses: ./.github/actions/build_cmake
+  #       with:
+  #         opt_level: avx2
+  # linux-x86_64-AVX512-cmake:
+  #   name: Linux x86_64 AVX512 (cmake)
+  #   needs: linux-x86_64-cmake
+  #   runs-on: faiss-aws-m7i.large
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Build and Test (cmake)
+  #       uses: ./.github/actions/build_cmake
+  #       with:
+  #         opt_level: avx512
+  # linux-x86_64-AVX512_SPR-cmake:
+  #   name: Linux x86_64 AVX512_SPR (cmake)
+  #   needs: linux-x86_64-cmake
+  #   runs-on: faiss-aws-m7i.large
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Build and Test (cmake)
+  #       uses: ./.github/actions/build_cmake
+  #       with:
+  #         opt_level: avx512_spr
+  # linux-x86_64-GPU-cmake:
+  #   name: Linux x86_64 GPU (cmake)
+  #   needs: linux-x86_64-cmake
+  #   runs-on: 4-core-ubuntu-gpu-t4
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Build and Test (cmake)
+  #       uses: ./.github/actions/build_cmake
+  #       with:
+  #         gpu: ON
+  # linux-x86_64-GPU-w-CUVS-cmake:
+  #   name: Linux x86_64 GPU w/ cuVS (cmake)
+  #   needs: linux-x86_64-cmake
+  #   runs-on: 4-core-ubuntu-gpu-t4
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Build and Test (cmake)
+  #       uses: ./.github/actions/build_cmake
+  #       with:
+  #         gpu: ON
+  #         cuvs: ON
+  # linux-x86_64-GPU-w-ROCm-cmake:
+  #   name: Linux x86_64 GPU w/ ROCm (cmake)
+  #   needs: linux-x86_64-cmake
+  #   runs-on: faiss-amd-MI200
+  #   container:
+  #     image: ubuntu:22.04
+  #     options: --device=/dev/kfd --device=/dev/dri --ipc=host --shm-size 16G --group-add video --cap-add=SYS_PTRACE --cap-add=SYS_ADMIN
+  #   steps:
+  #     - name: Container setup
+  #       run: |
+  #           if [ -f /.dockerenv ]; then
+  #             apt-get update && apt-get install -y sudo && apt-get install -y git
+  #             git config --global --add safe.directory '*'
+  #           else
+  #             echo 'Skipping. Current job is not running inside a container.'
+  #           fi
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Build and Test (cmake)
+  #       uses: ./.github/actions/build_cmake
+  #       with:
+  #         gpu: ON
+  #         rocm: ON
+  # linux-arm64-SVE-cmake:
+  #   name: Linux arm64 SVE (cmake)
+  #   needs: linux-x86_64-cmake
+  #   runs-on: faiss-aws-r8g.large
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Build and Test (cmake)
+  #       uses: ./.github/actions/build_cmake
+  #       with:
+  #         opt_level: sve
+  #       env:
+  #         # Context: https://github.com/facebookresearch/faiss/wiki/Troubleshooting#surprising-faiss-openmp-and-openblas-interaction
+  #         OPENBLAS_NUM_THREADS: '1'
+  # linux-x86_64-conda:
+  #   name: Linux x86_64 (conda)
+  #   needs: linux-x86_64-cmake
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #         fetch-tags: true
+  #     - name: Build and Package (conda)
+  #       uses: ./.github/actions/build_conda
+  # windows-x86_64-conda:
+  #   name: Windows x86_64 (conda)
+  #   needs: linux-x86_64-cmake
+  #   runs-on: windows-2019
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #         fetch-tags: true
+  #     - name: Build and Package (conda)
+  #       uses: ./.github/actions/build_conda
+  # linux-arm64-conda:
+  #   name: Linux arm64 (conda)
+  #   needs: linux-x86_64-cmake
+  #   runs-on: 2-core-ubuntu-arm
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #         fetch-tags: true
+  #     - name: Build and Package (conda)
+  #       uses: ./.github/actions/build_conda
+  linux-x86_64-nightly:
+    name: Linux x86_64 nightlies
+    runs-on: 4-core-ubuntu
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
-      - name: Build and Package (conda)
-        uses: ./.github/actions/build_conda
-  windows-x86_64-conda:
-    name: Windows x86_64 (conda)
-    needs: linux-x86_64-cmake
+      - uses: ./.github/actions/build_conda
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        with:
+          label: nightly
+  linux-x86_64-GPU-CUDA-11-4-4-nightly:
+    name: Linux x86_64 GPU nightlies (CUDA 11.4.4)
+    runs-on: 4-core-ubuntu-gpu-t4
+    env:
+      CUDA_ARCHS: "60-real;61-real;62-real;70-real;72-real;75-real;80;86-real"
+      FAISS_FLATTEN_CONDA_INCLUDES: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: ./.github/actions/build_conda
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        with:
+          label: nightly
+          cuda: "11.4.4"
+  linux-x86_64-GPU-CUVS-CUDA11-8-0-nightly:
+    name: Linux x86_64 GPU w/ cuVS nightlies (CUDA 11.8.0)
+    runs-on: 4-core-ubuntu-gpu-t4
+    env:
+      CUDA_ARCHS: "70-real;72-real;75-real;80;86-real"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: ./.github/actions/build_conda
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        with:
+          label: nightly
+          cuvs: "ON"
+          cuda: "11.8.0"
+  linux-x86_64-GPU-CUDA-12-1-1-nightly:
+    name: Linux x86_64 GPU nightlies (CUDA 12.1.1)
+    runs-on: 4-core-ubuntu-gpu-t4
+    env:
+      CUDA_ARCHS: "70-real;72-real;75-real;80;86-real"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: ./.github/actions/build_conda
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        with:
+          label: nightly
+          cuda: "12.1.1"
+  linux-x86_64-GPU-CUVS-CUDA12-4-0-nightly:
+    name: Linux x86_64 GPU w/ cuVS nightlies (CUDA 12.4.0)
+    runs-on: 4-core-ubuntu-gpu-t4
+    env:
+      CUDA_ARCHS: "70-real;72-real;75-real;80;86-real"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: ./.github/actions/build_conda
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        with:
+          label: nightly
+          cuvs: "ON"
+          cuda: "12.4.0"
+  windows-x86_64-nightly:
+    name: Windows x86_64 nightlies
     runs-on: windows-2019
     steps:
       - name: Checkout
@@ -153,11 +261,27 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-      - name: Build and Package (conda)
-        uses: ./.github/actions/build_conda
-  linux-arm64-conda:
-    name: Linux arm64 (conda)
-    needs: linux-x86_64-cmake
+      - uses: ./.github/actions/build_conda
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        with:
+          label: nightly
+  osx-arm64-nightly:
+    name: OSX arm64 nightlies
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: ./.github/actions/build_conda
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        with:
+          label: nightly
+  linux-arm64-nightly:
+    name: Linux arm64 nightlies
     runs-on: 2-core-ubuntu-arm
     steps:
       - name: Checkout
@@ -165,5 +289,9 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-      - name: Build and Package (conda)
-        uses: ./.github/actions/build_conda
+      - uses: ./.github/actions/build_conda
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        with:
+          label: nightly
+  # @nocommit

--- a/conda/faiss/meta.yaml
+++ b/conda/faiss/meta.yaml
@@ -43,6 +43,7 @@ outputs:
         - cmake >=3.24.0
         - make =4.2 # [not win and not (osx and arm64)]
         - make =4.4 # [osx and arm64]
+        - vc14_runtime =14.42.34433  # [win]
         {% if PY_VER == '3.9' or PY_VER == '3.10' or PY_VER == '3.11' %}
         - mkl-devel =2023.0  # [x86_64]
         - python_abi <3.12
@@ -53,6 +54,7 @@ outputs:
         {% endif %}
       host:
         - python {{ python }}
+        - vc14_runtime =14.42.34433  # [win]
         {% if PY_VER == '3.9' or PY_VER == '3.10' or PY_VER == '3.11' %}
         - mkl =2023.0  # [x86_64]
         - python_abi <3.12
@@ -64,6 +66,7 @@ outputs:
         - openblas =0.3.29 # [not x86_64]
       run:
         - python {{ python }}
+        - vc14_runtime =14.42.34433  # [win]
         {% if PY_VER == '3.9' or PY_VER == '3.10' or PY_VER == '3.11' %}
         - mkl =2023.0  # [x86_64]
         - python_abi <3.12
@@ -99,6 +102,7 @@ outputs:
         - make =4.2 # [not win and not (osx and arm64)]
         - make =4.4 # [osx and arm64]
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64 and not win]
+        - vc14_runtime =14.42.34433  # [win]
         {% if PY_VER == '3.9' or PY_VER == '3.10' or PY_VER == '3.11' %}
         - mkl =2023.0  # [x86_64]
         - python_abi <3.12
@@ -112,6 +116,7 @@ outputs:
         - numpy >=1.19,<2
         - {{ pin_subpackage('libfaiss', exact=True) }}
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64 and not win]
+        - vc14_runtime =14.42.34433  # [win]
         {% if PY_VER == '3.9' or PY_VER == '3.10' or PY_VER == '3.11' %}
         - mkl =2023.0  # [x86_64]
         - python_abi <3.12
@@ -125,6 +130,7 @@ outputs:
         - numpy >=1.19,<2
         - packaging
         - {{ pin_subpackage('libfaiss', exact=True) }}
+        - vc14_runtime =14.42.34433  # [win]
         {% if PY_VER == '3.9' or PY_VER == '3.10' or PY_VER == '3.11' %}
         - mkl =2023.0  # [x86_64]
         - python_abi <3.12


### PR DESCRIPTION
Summary:
Seems like an update to vc14_runtime has caused nightlies to fail: https://github.com/facebookresearch/faiss/actions/runs/13714957634/job/38362967507

Pinning it to the most recently successful nightly's version: https://github.com/facebookresearch/faiss/actions/runs/13612759807/job/38054300489

Differential Revision: D70904925


