### PR TITLE
RaBitQ implementation

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -28,6 +28,7 @@ set(FAISS_SRC
   IndexIVFAdditiveQuantizerFastScan.cpp
   IndexIVFPQFastScan.cpp
   IndexIVFPQR.cpp
+  IndexIVFRaBitQ.cpp
   IndexIVFSpectralHash.cpp
   IndexLSH.cpp
   IndexNNDescent.cpp
@@ -39,6 +40,7 @@ set(FAISS_SRC
   IndexIVFIndependentQuantizer.cpp
   IndexPQFastScan.cpp
   IndexPreTransform.cpp
+  IndexRaBitQ.cpp
   IndexRefine.cpp
   IndexReplicas.cpp
   IndexRowwiseMinMax.cpp
@@ -60,6 +62,7 @@ set(FAISS_SRC
   impl/PolysemousTraining.cpp
   impl/ProductQuantizer.cpp
   impl/AdditiveQuantizer.cpp
+  impl/RaBitQuantizer.cpp
   impl/ResidualQuantizer.cpp
   impl/LocalSearchQuantizer.cpp
   impl/ProductAdditiveQuantizer.cpp
@@ -123,6 +126,7 @@ set(FAISS_HEADERS
   IndexIVFAdditiveQuantizerFastScan.h
   IndexIVFPQFastScan.h
   IndexIVFPQR.h
+  IndexIVFRaBitQ.h
   IndexIVFSpectralHash.h
   IndexLSH.h
   IndexNeuralNetCodec.h
@@ -136,6 +140,7 @@ set(FAISS_HEADERS
   IndexPreTransform.h
   IndexRefine.h
   IndexReplicas.h
+  IndexRaBitQ.h
   IndexRowwiseMinMax.h
   IndexScalarQuantizer.h
   IndexShards.h
@@ -164,6 +169,7 @@ set(FAISS_HEADERS
   impl/ProductQuantizer-inl.h
   impl/ProductQuantizer.h
   impl/Quantizer.h
+  impl/RaBitQuantizer.h
   impl/ResidualQuantizer.h
   impl/ResultHandler.h
   impl/ScalarQuantizer.h

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -455,7 +455,7 @@ void IndexIVF::search_preassigned(
 #pragma omp parallel if (do_parallel) reduction(+ : nlistv, ndis, nheap)
     {
         std::unique_ptr<InvertedListScanner> scanner(
-                get_InvertedListScanner_2(store_pairs, sel, params));
+                get_InvertedListScanner(store_pairs, sel, params));
 
         /*****************************************************
          * Depending on parallel_mode, there are two possible ways
@@ -796,7 +796,7 @@ void IndexIVF::range_search_preassigned(
     {
         RangeSearchPartialResult pres(result);
         std::unique_ptr<InvertedListScanner> scanner(
-                get_InvertedListScanner_2(store_pairs, sel, params));
+                get_InvertedListScanner(store_pairs, sel, params));
         FAISS_THROW_IF_NOT(scanner.get());
         all_pres[omp_get_thread_num()] = &pres;
 
@@ -912,17 +912,9 @@ void IndexIVF::range_search_preassigned(
 
 InvertedListScanner* IndexIVF::get_InvertedListScanner(
         bool /*store_pairs*/,
-        const IDSelector* /* sel */) const {
+        const IDSelector* /* sel */,
+        const IVFSearchParameters* /* params */) const {
     FAISS_THROW_MSG("get_InvertedListScanner not implemented");
-}
-
-InvertedListScanner* IndexIVF::get_InvertedListScanner_2(
-        bool store_pairs,
-        const IDSelector* sel,
-        const IVFSearchParameters* /* search_params */) const {
-    // By default, search_params are ignored, and the call
-    //   is forwarded to get_InvertedListScanner().
-    return get_InvertedListScanner(store_pairs, sel);
 }
 
 void IndexIVF::reconstruct(idx_t key, float* recons) const {

--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -313,10 +313,24 @@ struct IndexIVF : Index, IndexIVFInterface {
     /** Get a scanner for this index (store_pairs means ignore labels)
      *
      * The default search implementation uses this to compute the distances
+     * through a call to get_InvertedListScanner_2().
      */
     virtual InvertedListScanner* get_InvertedListScanner(
             bool store_pairs = false,
             const IDSelector* sel = nullptr) const;
+
+    /** Get a scanner for this index (store_pairs means ignore labels).
+     * This extended version allows passing custom parameters for the search
+     * into a generated InvertedListScanner object instance.
+     *
+     * The default search implementation uses this to compute the distances.
+     * The default implementation of this function just forward the call
+     * to get_InvertedListScanner() function.
+     */
+    virtual InvertedListScanner* get_InvertedListScanner_2(
+            bool store_pairs = false,
+            const IDSelector* sel = nullptr,
+            const IVFSearchParameters* search_params = nullptr) const;
 
     /** reconstruct a vector. Works only if maintain_direct_map is set to 1 or 2
      */

--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -312,25 +312,13 @@ struct IndexIVF : Index, IndexIVFInterface {
 
     /** Get a scanner for this index (store_pairs means ignore labels)
      *
-     * The default search implementation uses this to compute the distances
-     * through a call to get_InvertedListScanner_2().
+     * The default search implementation uses this to compute the distances.
+     * Use sel instead of params->sel, because sel can get overriden.
      */
     virtual InvertedListScanner* get_InvertedListScanner(
             bool store_pairs = false,
-            const IDSelector* sel = nullptr) const;
-
-    /** Get a scanner for this index (store_pairs means ignore labels).
-     * This extended version allows passing custom parameters for the search
-     * into a generated InvertedListScanner object instance.
-     *
-     * The default search implementation uses this to compute the distances.
-     * The default implementation of this function just forward the call
-     * to get_InvertedListScanner() function.
-     */
-    virtual InvertedListScanner* get_InvertedListScanner_2(
-            bool store_pairs = false,
             const IDSelector* sel = nullptr,
-            const IVFSearchParameters* search_params = nullptr) const;
+            const IVFSearchParameters* params = nullptr) const;
 
     /** reconstruct a vector. Works only if maintain_direct_map is set to 1 or 2
      */

--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -313,7 +313,8 @@ struct IndexIVF : Index, IndexIVFInterface {
     /** Get a scanner for this index (store_pairs means ignore labels)
      *
      * The default search implementation uses this to compute the distances.
-     * Use sel instead of params->sel, because sel can get overriden.
+     * Use sel instead of params->sel, because sel is initialized with
+     * params->sel, but may get overriden by IndexIVF's internal logic.
      */
     virtual InvertedListScanner* get_InvertedListScanner(
             bool store_pairs = false,

--- a/faiss/IndexIVFAdditiveQuantizer.cpp
+++ b/faiss/IndexIVFAdditiveQuantizer.cpp
@@ -253,7 +253,8 @@ struct AQInvertedListScannerLUT : AQInvertedListScanner {
 
 InvertedListScanner* IndexIVFAdditiveQuantizer::get_InvertedListScanner(
         bool store_pairs,
-        const IDSelector* sel) const {
+        const IDSelector* sel,
+        const IVFSearchParameters*) const {
     FAISS_THROW_IF_NOT(!sel);
     if (metric_type == METRIC_INNER_PRODUCT) {
         if (aq->search_type == AdditiveQuantizer::ST_decompress) {

--- a/faiss/IndexIVFAdditiveQuantizer.h
+++ b/faiss/IndexIVFAdditiveQuantizer.h
@@ -52,7 +52,8 @@ struct IndexIVFAdditiveQuantizer : IndexIVF {
 
     InvertedListScanner* get_InvertedListScanner(
             bool store_pairs,
-            const IDSelector* sel) const override;
+            const IDSelector* sel,
+            const IVFSearchParameters* params) const override;
 
     void sa_decode(idx_t n, const uint8_t* codes, float* x) const override;
 

--- a/faiss/IndexIVFFlat.cpp
+++ b/faiss/IndexIVFFlat.cpp
@@ -223,7 +223,8 @@ InvertedListScanner* get_InvertedListScanner1(
 
 InvertedListScanner* IndexIVFFlat::get_InvertedListScanner(
         bool store_pairs,
-        const IDSelector* sel) const {
+        const IDSelector* sel,
+        const IVFSearchParameters*) const {
     if (sel) {
         return get_InvertedListScanner1<true>(this, store_pairs, sel);
     } else {

--- a/faiss/IndexIVFFlat.h
+++ b/faiss/IndexIVFFlat.h
@@ -44,7 +44,8 @@ struct IndexIVFFlat : IndexIVF {
 
     InvertedListScanner* get_InvertedListScanner(
             bool store_pairs,
-            const IDSelector* sel) const override;
+            const IDSelector* sel,
+            const IVFSearchParameters* params) const override;
 
     void reconstruct_from_offset(int64_t list_no, int64_t offset, float* recons)
             const override;

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -1321,7 +1321,8 @@ InvertedListScanner* get_InvertedListScanner2(
 
 InvertedListScanner* IndexIVFPQ::get_InvertedListScanner(
         bool store_pairs,
-        const IDSelector* sel) const {
+        const IDSelector* sel,
+        const IVFSearchParameters*) const {
     if (sel) {
         return get_InvertedListScanner2<true>(*this, store_pairs, sel);
     } else {

--- a/faiss/IndexIVFPQ.h
+++ b/faiss/IndexIVFPQ.h
@@ -134,7 +134,8 @@ struct IndexIVFPQ : IndexIVF {
 
     InvertedListScanner* get_InvertedListScanner(
             bool store_pairs,
-            const IDSelector* sel) const override;
+            const IDSelector* sel,
+            const IVFSearchParameters* params) const override;
 
     /// build precomputed table
     void precompute_table();

--- a/faiss/IndexIVFRaBitQ.cpp
+++ b/faiss/IndexIVFRaBitQ.cpp
@@ -171,7 +171,7 @@ struct RaBitInvertedListScanner : InvertedListScanner {
     }
 };
 
-InvertedListScanner* IndexIVFRaBitQ::get_InvertedListScanner_2(
+InvertedListScanner* IndexIVFRaBitQ::get_InvertedListScanner(
         bool store_pairs,
         const IDSelector* sel,
         const IVFSearchParameters* search_params_in) const {

--- a/faiss/IndexIVFRaBitQ.cpp
+++ b/faiss/IndexIVFRaBitQ.cpp
@@ -1,0 +1,275 @@
+#include <faiss/IndexIVFRaBitQ.h>
+
+#include <omp.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/RaBitQuantizer.h>
+
+namespace faiss {
+
+IndexIVFRaBitQ::IndexIVFRaBitQ(
+        Index* quantizer,
+        const size_t d,
+        const size_t nlist,
+        MetricType metric)
+        : IndexIVF(quantizer, d, nlist, 0, metric), rabitq(d) {
+    code_size = rabitq.code_size;
+    invlists->code_size = code_size;
+    is_trained = false;
+
+    by_residual = true;
+}
+
+IndexIVFRaBitQ::IndexIVFRaBitQ() {
+    by_residual = true;
+}
+
+void IndexIVFRaBitQ::train_encoder(
+        idx_t n,
+        const float* x,
+        const idx_t* assign) {
+    rabitq.train(n, x);
+}
+
+void IndexIVFRaBitQ::encode_vectors(
+        idx_t n,
+        const float* x,
+        const idx_t* list_nos,
+        uint8_t* codes,
+        bool include_listnos) const {
+    size_t coarse_size = include_listnos ? coarse_code_size() : 0;
+    memset(codes, 0, (code_size + coarse_size) * n);
+
+#pragma omp parallel if (n > 1000)
+    {
+        std::vector<float> centroid(d);
+
+#pragma omp for
+        for (idx_t i = 0; i < n; i++) {
+            int64_t list_no = list_nos[i];
+            if (list_no >= 0) {
+                const float* xi = x + i * d;
+                uint8_t* code = codes + i * (code_size + coarse_size);
+
+                // both by_residual and !by_residual lead to the same code
+                quantizer->reconstruct(list_no, centroid.data());
+                rabitq.compute_codes_core(
+                        xi, code + coarse_size, 1, centroid.data());
+
+                if (coarse_size) {
+                    encode_listno(list_no, code);
+                }
+            }
+        }
+    }
+}
+
+void IndexIVFRaBitQ::add_core(
+        idx_t n,
+        const float* x,
+        const idx_t* xids,
+        const idx_t* precomputed_idx,
+        void* inverted_list_context) {
+    FAISS_THROW_IF_NOT(is_trained);
+
+    DirectMapAdd dm_add(direct_map, n, xids);
+
+#pragma omp parallel
+    {
+        std::vector<uint8_t> one_code(code_size);
+        std::vector<float> centroid(d);
+
+        int nt = omp_get_num_threads();
+        int rank = omp_get_thread_num();
+
+        // each thread takes care of a subset of lists
+        for (size_t i = 0; i < n; i++) {
+            int64_t list_no = precomputed_idx[i];
+            if (list_no >= 0 && list_no % nt == rank) {
+                int64_t id = xids ? xids[i] : ntotal + i;
+
+                const float* xi = x + i * d;
+
+                // both by_residual and !by_residual lead to the same code
+                quantizer->reconstruct(list_no, centroid.data());
+                rabitq.compute_codes_core(
+                        xi, one_code.data(), 1, centroid.data());
+
+                size_t ofs = invlists->add_entry(
+                        list_no, id, one_code.data(), inverted_list_context);
+
+                dm_add.add(i, list_no, ofs);
+
+            } else if (rank == 0 && list_no == -1) {
+                dm_add.add(i, -1, 0);
+            }
+        }
+    }
+
+    ntotal += n;
+}
+
+struct RaBitInvertedListScanner : InvertedListScanner {
+    const IndexIVFRaBitQ& ivf_rabitq;
+
+    std::vector<float> reconstructed_centroid;
+    std::vector<float> query_vector;
+
+    std::unique_ptr<RaBitQuantizer::RaBitDistanceComputer> dc;
+
+    uint8_t qb = 0;
+
+    RaBitInvertedListScanner(
+            const IndexIVFRaBitQ& ivf_rabitq_in,
+            bool store_pairs = false,
+            const IDSelector* sel = nullptr,
+            uint8_t qb_in = 0)
+            : InvertedListScanner(store_pairs, sel),
+              ivf_rabitq{ivf_rabitq_in},
+              qb{qb_in} {
+        keep_max = is_similarity_metric(ivf_rabitq.metric_type);
+        code_size = ivf_rabitq.code_size;
+    }
+
+    /// from now on we handle this query.
+    void set_query(const float* query_vector_in) override {
+        query_vector.assign(query_vector_in, query_vector_in + ivf_rabitq.d);
+
+        internal_try_setup_dc();
+    }
+
+    /// following codes come from this inverted list
+    void set_list(idx_t list_no, float coarse_dis) override {
+        this->list_no = list_no;
+
+        reconstructed_centroid.resize(ivf_rabitq.d);
+        ivf_rabitq.quantizer->reconstruct(
+                list_no, reconstructed_centroid.data());
+
+        internal_try_setup_dc();
+    }
+
+    /// compute a single query-to-code distance
+    float distance_to_code(const uint8_t* code) const override {
+        return dc->distance_to_code(code);
+    }
+
+    void internal_try_setup_dc() {
+        if (!query_vector.empty() && !reconstructed_centroid.empty()) {
+            // both query_vector and centroid are available!
+            // set up DistanceComputer
+            dc.reset(ivf_rabitq.rabitq.get_distance_computer(
+                    qb, ivf_rabitq.metric_type, reconstructed_centroid.data()));
+
+            dc->set_query(query_vector.data());
+        }
+    }
+};
+
+InvertedListScanner* IndexIVFRaBitQ::get_InvertedListScanner_2(
+        bool store_pairs,
+        const IDSelector* sel,
+        const IVFSearchParameters* search_params_in) const {
+    uint8_t used_qb = qb;
+    if (search_params_in != nullptr) {
+        const auto* search_params =
+                dynamic_cast<const IVFRaBitQSearchParameters*>(
+                        search_params_in);
+        FAISS_THROW_IF_NOT_MSG(search_params, "invalid search params");
+
+        used_qb = search_params->qb;
+    }
+
+    return new RaBitInvertedListScanner(*this, store_pairs, sel, used_qb);
+}
+
+void IndexIVFRaBitQ::reconstruct_from_offset(
+        int64_t list_no,
+        int64_t offset,
+        float* recons) const {
+    const uint8_t* code = invlists->get_single_code(list_no, offset);
+
+    std::vector<float> centroid(d);
+    quantizer->reconstruct(list_no, centroid.data());
+
+    rabitq.decode_core(code, recons, 1, centroid.data());
+}
+
+void IndexIVFRaBitQ::sa_decode(idx_t n, const uint8_t* codes, float* x) const {
+    size_t coarse_size = coarse_code_size();
+
+#pragma omp parallel
+    {
+        std::vector<float> centroid(d);
+
+#pragma omp for
+        for (idx_t i = 0; i < n; i++) {
+            const uint8_t* code = codes + i * (code_size + coarse_size);
+            int64_t list_no = decode_listno(code);
+            float* xi = x + i * d;
+
+            quantizer->reconstruct(list_no, centroid.data());
+            rabitq.decode_core(code + coarse_size, xi, 1, centroid.data());
+        }
+    }
+}
+
+struct IVFRaBitDistanceComputer : DistanceComputer {
+    const float* q = nullptr;
+    const IndexIVFRaBitQ* parent = nullptr;
+
+    void set_query(const float* x) override;
+
+    float operator()(idx_t i) override;
+
+    float symmetric_dis(idx_t i, idx_t j) override;
+};
+
+void IVFRaBitDistanceComputer::set_query(const float* x) {
+    q = x;
+}
+
+float IVFRaBitDistanceComputer::operator()(idx_t i) {
+    // find the appropriate list
+    idx_t lo = parent->direct_map.get(i);
+    uint64_t list_no = lo_listno(lo);
+    uint64_t offset = lo_offset(lo);
+
+    const uint8_t* code = parent->invlists->get_single_code(list_no, offset);
+
+    // ok, we know the appropriate cluster that we need
+    std::vector<float> centroid(parent->d);
+    parent->quantizer->reconstruct(list_no, centroid.data());
+
+    // compute the distance
+    float distance = 0;
+
+    std::unique_ptr<RaBitQuantizer::RaBitDistanceComputer> dc(
+            parent->rabitq.get_distance_computer(
+                    parent->qb, parent->metric_type, centroid.data()));
+    dc->set_query(q);
+    distance = dc->distance_to_code(code);
+
+    // deallocate
+    parent->invlists->release_codes(list_no, code);
+
+    // done
+    return distance;
+}
+
+float IVFRaBitDistanceComputer::symmetric_dis(idx_t i, idx_t j) {
+    FAISS_THROW_MSG("Not implemented");
+}
+
+DistanceComputer* IndexIVFRaBitQ::get_distance_computer() const {
+    IVFRaBitDistanceComputer* dc = new IVFRaBitDistanceComputer;
+    dc->parent = this;
+    return dc;
+}
+
+} // namespace faiss

--- a/faiss/IndexIVFRaBitQ.h
+++ b/faiss/IndexIVFRaBitQ.h
@@ -46,10 +46,10 @@ struct IndexIVFRaBitQ : IndexIVF {
             const idx_t* precomputed_idx,
             void* inverted_list_context = nullptr) override;
 
-    InvertedListScanner* get_InvertedListScanner_2(
+    InvertedListScanner* get_InvertedListScanner(
             bool store_pairs,
             const IDSelector* sel,
-            const IVFSearchParameters* search_params) const override;
+            const IVFSearchParameters* params) const override;
 
     void reconstruct_from_offset(int64_t list_no, int64_t offset, float* recons)
             const override;

--- a/faiss/IndexIVFRaBitQ.h
+++ b/faiss/IndexIVFRaBitQ.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <faiss/Index.h>
+#include <faiss/IndexIVF.h>
+
+#include <faiss/impl/RaBitQuantizer.h>
+
+namespace faiss {
+
+struct IVFRaBitQSearchParameters : IVFSearchParameters {
+    uint8_t qb = 0;
+};
+
+// * by_residual is true, just by design
+struct IndexIVFRaBitQ : IndexIVF {
+    RaBitQuantizer rabitq;
+
+    // the default number of bits to quantize a query with.
+    // use '0' to disable quantization and use raw fp32 values.
+    uint8_t qb = 0;
+
+    IndexIVFRaBitQ(
+            Index* quantizer,
+            const size_t d,
+            const size_t nlist,
+            MetricType metric = METRIC_L2);
+
+    IndexIVFRaBitQ();
+
+    void train_encoder(idx_t n, const float* x, const idx_t* assign) override;
+
+    void encode_vectors(
+            idx_t n,
+            const float* x,
+            const idx_t* list_nos,
+            uint8_t* codes,
+            bool include_listnos = false) const override;
+
+    void add_core(
+            idx_t n,
+            const float* x,
+            const idx_t* xids,
+            const idx_t* precomputed_idx,
+            void* inverted_list_context = nullptr) override;
+
+    InvertedListScanner* get_InvertedListScanner_2(
+            bool store_pairs,
+            const IDSelector* sel,
+            const IVFSearchParameters* search_params) const override;
+
+    void reconstruct_from_offset(int64_t list_no, int64_t offset, float* recons)
+            const override;
+
+    void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
+
+    // unfortunately
+    DistanceComputer* get_distance_computer() const override;
+};
+
+} // namespace faiss

--- a/faiss/IndexIVFSpectralHash.cpp
+++ b/faiss/IndexIVFSpectralHash.cpp
@@ -301,7 +301,8 @@ struct BuildScanner {
 
 InvertedListScanner* IndexIVFSpectralHash::get_InvertedListScanner(
         bool store_pairs,
-        const IDSelector* sel) const {
+        const IDSelector* sel,
+        const IVFSearchParameters*) const {
     FAISS_THROW_IF_NOT(!sel);
     BuildScanner bs;
     return dispatch_HammingComputer(code_size, bs, this, store_pairs);

--- a/faiss/IndexIVFSpectralHash.h
+++ b/faiss/IndexIVFSpectralHash.h
@@ -71,7 +71,8 @@ struct IndexIVFSpectralHash : IndexIVF {
 
     InvertedListScanner* get_InvertedListScanner(
             bool store_pairs,
-            const IDSelector* sel) const override;
+            const IDSelector* sel,
+            const IVFSearchParameters* params) const override;
 
     /** replace the vector transform for an empty (and possibly untrained) index
      */

--- a/faiss/IndexRaBitQ.cpp
+++ b/faiss/IndexRaBitQ.cpp
@@ -7,9 +7,8 @@ namespace faiss {
 
 IndexRaBitQ::IndexRaBitQ() = default;
 
-IndexRaBitQ::IndexRaBitQ(idx_t d, MetricType metric) :
-    IndexFlatCodes(0, d, metric), rabitq(d)
-{
+IndexRaBitQ::IndexRaBitQ(idx_t d, MetricType metric)
+        : IndexFlatCodes(0, d, metric), rabitq(d) {
     code_size = rabitq.code_size;
 
     is_trained = false;
@@ -32,7 +31,7 @@ void IndexRaBitQ::train(idx_t n, const float* x) {
 
     center = std::move(centroid);
 
-    // 
+    //
     rabitq.train(n, x);
     is_trained = true;
 }
@@ -55,7 +54,8 @@ FlatCodesDistanceComputer* IndexRaBitQ::get_FlatCodesDistanceComputer() const {
     return dc;
 }
 
-FlatCodesDistanceComputer* IndexRaBitQ::get_quantized_distance_computer(const uint8_t qb) const {
+FlatCodesDistanceComputer* IndexRaBitQ::get_quantized_distance_computer(
+        const uint8_t qb) const {
     RaBitQuantizer::RaBitDistanceComputer* dc =
             rabitq.get_distance_computer(qb, metric_type, center.data());
     dc->code_size = rabitq.code_size;
@@ -80,8 +80,7 @@ struct Run_search_with_dc_res {
 #pragma omp parallel // if (res.nq > 100)
         {
             std::unique_ptr<FlatCodesDistanceComputer> dc(
-                index->get_quantized_distance_computer(qb)
-            );
+                    index->get_quantized_distance_computer(qb));
             SingleResultHandler resi(res);
 #pragma omp for
             for (int64_t q = 0; q < res.nq; q++) {
@@ -99,7 +98,7 @@ struct Run_search_with_dc_res {
     }
 };
 
-}
+} // namespace
 
 void IndexRaBitQ::search(
         idx_t n,
@@ -107,15 +106,14 @@ void IndexRaBitQ::search(
         idx_t k,
         float* distances,
         idx_t* labels,
-        const SearchParameters* params_in
-) const {
+        const SearchParameters* params_in) const {
     uint8_t used_qb = qb;
     if (auto params = dynamic_cast<const RaBitQSearchParameters*>(params_in)) {
         used_qb = params->qb;
     }
 
     const IDSelector* sel = (params_in != nullptr) ? params_in->sel : nullptr;
-    Run_search_with_dc_res r {.qb = used_qb};
+    Run_search_with_dc_res r{.qb = used_qb};
     dispatch_knn_ResultHandler(
             n, distances, labels, k, metric_type, sel, r, this, x);
 }
@@ -125,16 +123,15 @@ void IndexRaBitQ::range_search(
         const float* x,
         float radius,
         RangeSearchResult* result,
-        const SearchParameters* params_in
-) const {
+        const SearchParameters* params_in) const {
     uint8_t used_qb = qb;
     if (auto params = dynamic_cast<const RaBitQSearchParameters*>(params_in)) {
         used_qb = params->qb;
     }
 
     const IDSelector* sel = (params_in != nullptr) ? params_in->sel : nullptr;
-    Run_search_with_dc_res r {.qb = used_qb};
+    Run_search_with_dc_res r{.qb = used_qb};
     dispatch_range_ResultHandler(result, radius, metric_type, sel, r, this, x);
 }
 
-}
+} // namespace faiss

--- a/faiss/IndexRaBitQ.cpp
+++ b/faiss/IndexRaBitQ.cpp
@@ -1,0 +1,140 @@
+#include <faiss/IndexRaBitQ.h>
+
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/ResultHandler.h>
+
+namespace faiss {
+
+IndexRaBitQ::IndexRaBitQ() = default;
+
+IndexRaBitQ::IndexRaBitQ(idx_t d, MetricType metric) :
+    IndexFlatCodes(0, d, metric), rabitq(d)
+{
+    code_size = rabitq.code_size;
+
+    is_trained = false;
+}
+
+void IndexRaBitQ::train(idx_t n, const float* x) {
+    // compute a centroid
+    std::vector<float> centroid(d, 0);
+    for (size_t i = 0; i < n; i++) {
+        for (size_t j = 0; j < d; j++) {
+            centroid[j] += x[i * d + j];
+        }
+    }
+
+    if (n != 0) {
+        for (size_t j = 0; j < d; j++) {
+            centroid[j] /= (float)n;
+        }
+    }
+
+    center = std::move(centroid);
+
+    // 
+    rabitq.train(n, x);
+    is_trained = true;
+}
+
+void IndexRaBitQ::sa_encode(idx_t n, const float* x, uint8_t* bytes) const {
+    FAISS_THROW_IF_NOT(is_trained);
+    rabitq.compute_codes_core(x, bytes, n, center.data());
+}
+
+void IndexRaBitQ::sa_decode(idx_t n, const uint8_t* bytes, float* x) const {
+    FAISS_THROW_IF_NOT(is_trained);
+    rabitq.decode_core(bytes, x, n, center.data());
+}
+
+FlatCodesDistanceComputer* IndexRaBitQ::get_FlatCodesDistanceComputer() const {
+    RaBitQuantizer::RaBitDistanceComputer* dc =
+            rabitq.get_distance_computer(qb, metric_type, center.data());
+    dc->code_size = rabitq.code_size;
+    dc->codes = codes.data();
+    return dc;
+}
+
+FlatCodesDistanceComputer* IndexRaBitQ::get_quantized_distance_computer(const uint8_t qb) const {
+    RaBitQuantizer::RaBitDistanceComputer* dc =
+            rabitq.get_distance_computer(qb, metric_type, center.data());
+    dc->code_size = rabitq.code_size;
+    dc->codes = codes.data();
+    return dc;
+}
+
+namespace {
+
+struct Run_search_with_dc_res {
+    using T = void;
+
+    uint8_t qb = 0;
+
+    template <class BlockResultHandler>
+    void f(BlockResultHandler& res, const IndexRaBitQ* index, const float* xq) {
+        size_t ntotal = index->ntotal;
+        using SingleResultHandler =
+                typename BlockResultHandler::SingleResultHandler;
+        const int d = index->d;
+
+#pragma omp parallel // if (res.nq > 100)
+        {
+            std::unique_ptr<FlatCodesDistanceComputer> dc(
+                index->get_quantized_distance_computer(qb)
+            );
+            SingleResultHandler resi(res);
+#pragma omp for
+            for (int64_t q = 0; q < res.nq; q++) {
+                resi.begin(q);
+                dc->set_query(xq + d * q);
+                for (size_t i = 0; i < ntotal; i++) {
+                    if (res.is_in_selection(i)) {
+                        float dis = (*dc)(i);
+                        resi.add_result(dis, i);
+                    }
+                }
+                resi.end();
+            }
+        }
+    }
+};
+
+}
+
+void IndexRaBitQ::search(
+        idx_t n,
+        const float* x,
+        idx_t k,
+        float* distances,
+        idx_t* labels,
+        const SearchParameters* params_in
+) const {
+    uint8_t used_qb = qb;
+    if (auto params = dynamic_cast<const RaBitQSearchParameters*>(params_in)) {
+        used_qb = params->qb;
+    }
+
+    const IDSelector* sel = (params_in != nullptr) ? params_in->sel : nullptr;
+    Run_search_with_dc_res r {.qb = used_qb};
+    dispatch_knn_ResultHandler(
+            n, distances, labels, k, metric_type, sel, r, this, x);
+}
+
+void IndexRaBitQ::range_search(
+        idx_t n,
+        const float* x,
+        float radius,
+        RangeSearchResult* result,
+        const SearchParameters* params_in
+) const {
+    uint8_t used_qb = qb;
+    if (auto params = dynamic_cast<const RaBitQSearchParameters*>(params_in)) {
+        used_qb = params->qb;
+    }
+
+    const IDSelector* sel = (params_in != nullptr) ? params_in->sel : nullptr;
+    Run_search_with_dc_res r {.qb = used_qb};
+    dispatch_range_ResultHandler(result, radius, metric_type, sel, r, this, x);
+}
+
+}

--- a/faiss/IndexRaBitQ.cpp
+++ b/faiss/IndexRaBitQ.cpp
@@ -8,7 +8,7 @@ namespace faiss {
 IndexRaBitQ::IndexRaBitQ() = default;
 
 IndexRaBitQ::IndexRaBitQ(idx_t d, MetricType metric)
-        : IndexFlatCodes(0, d, metric), rabitq(d) {
+        : IndexFlatCodes(0, d, metric), rabitq(d, metric) {
     code_size = rabitq.code_size;
 
     is_trained = false;
@@ -47,8 +47,8 @@ void IndexRaBitQ::sa_decode(idx_t n, const uint8_t* bytes, float* x) const {
 }
 
 FlatCodesDistanceComputer* IndexRaBitQ::get_FlatCodesDistanceComputer() const {
-    RaBitQuantizer::RaBitDistanceComputer* dc =
-            rabitq.get_distance_computer(qb, metric_type, center.data());
+    FlatCodesDistanceComputer* dc =
+            rabitq.get_distance_computer(qb, center.data());
     dc->code_size = rabitq.code_size;
     dc->codes = codes.data();
     return dc;
@@ -56,8 +56,8 @@ FlatCodesDistanceComputer* IndexRaBitQ::get_FlatCodesDistanceComputer() const {
 
 FlatCodesDistanceComputer* IndexRaBitQ::get_quantized_distance_computer(
         const uint8_t qb) const {
-    RaBitQuantizer::RaBitDistanceComputer* dc =
-            rabitq.get_distance_computer(qb, metric_type, center.data());
+    FlatCodesDistanceComputer* dc =
+            rabitq.get_distance_computer(qb, center.data());
     dc->code_size = rabitq.code_size;
     dc->codes = codes.data();
     return dc;

--- a/faiss/IndexRaBitQ.cpp
+++ b/faiss/IndexRaBitQ.cpp
@@ -113,7 +113,9 @@ void IndexRaBitQ::search(
     }
 
     const IDSelector* sel = (params_in != nullptr) ? params_in->sel : nullptr;
-    Run_search_with_dc_res r{.qb = used_qb};
+    Run_search_with_dc_res r;
+    r.qb = used_qb;
+
     dispatch_knn_ResultHandler(
             n, distances, labels, k, metric_type, sel, r, this, x);
 }
@@ -130,7 +132,9 @@ void IndexRaBitQ::range_search(
     }
 
     const IDSelector* sel = (params_in != nullptr) ? params_in->sel : nullptr;
-    Run_search_with_dc_res r{.qb = used_qb};
+    Run_search_with_dc_res r;
+    r.qb = used_qb;
+
     dispatch_range_ResultHandler(result, radius, metric_type, sel, r, this, x);
 }
 

--- a/faiss/IndexRaBitQ.h
+++ b/faiss/IndexRaBitQ.h
@@ -34,7 +34,8 @@ struct IndexRaBitQ : IndexFlatCodes {
 
     // returns a quantized-to-qb bits DC if qb_in > 0
     // returns a default fp32-based DC if qb_in == 0
-    FlatCodesDistanceComputer* get_quantized_distance_computer(const uint8_t qb_in) const;
+    FlatCodesDistanceComputer* get_quantized_distance_computer(
+            const uint8_t qb_in) const;
 
     // Don't rely on sa_decode(), bcz it is good for IP, but not for L2.
     //   As a result, use get_FlatCodesDistanceComputer() for the search.
@@ -54,4 +55,4 @@ struct IndexRaBitQ : IndexFlatCodes {
             const SearchParameters* params = nullptr) const override;
 };
 
-}
+} // namespace faiss

--- a/faiss/IndexRaBitQ.h
+++ b/faiss/IndexRaBitQ.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <faiss/IndexFlatCodes.h>
+#include <faiss/impl/RaBitQuantizer.h>
+
+namespace faiss {
+
+struct RaBitQSearchParameters : SearchParameters {
+    uint8_t qb = 0;
+};
+
+struct IndexRaBitQ : IndexFlatCodes {
+    RaBitQuantizer rabitq;
+
+    // center of all points
+    std::vector<float> center;
+
+    // the default number of bits to quantize a query with.
+    // use '0' to disable quantization and use raw fp32 values.
+    uint8_t qb = 0;
+
+    IndexRaBitQ();
+
+    IndexRaBitQ(idx_t d, MetricType metric = METRIC_L2);
+
+    void train(idx_t n, const float* x) override;
+
+    void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override;
+    void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
+
+    // returns a quantized-to-qb bits DC if qb > 0
+    // returns a default fp32-based DC if qb == 0
+    FlatCodesDistanceComputer* get_FlatCodesDistanceComputer() const override;
+
+    // returns a quantized-to-qb bits DC if qb_in > 0
+    // returns a default fp32-based DC if qb_in == 0
+    FlatCodesDistanceComputer* get_quantized_distance_computer(const uint8_t qb_in) const;
+
+    // Don't rely on sa_decode(), bcz it is good for IP, but not for L2.
+    //   As a result, use get_FlatCodesDistanceComputer() for the search.
+    void search(
+            idx_t n,
+            const float* x,
+            idx_t k,
+            float* distances,
+            idx_t* labels,
+            const SearchParameters* params = nullptr) const override;
+
+    void range_search(
+            idx_t n,
+            const float* x,
+            float radius,
+            RangeSearchResult* result,
+            const SearchParameters* params = nullptr) const override;
+};
+
+}

--- a/faiss/IndexScalarQuantizer.cpp
+++ b/faiss/IndexScalarQuantizer.cpp
@@ -254,7 +254,8 @@ void IndexIVFScalarQuantizer::add_core(
 
 InvertedListScanner* IndexIVFScalarQuantizer::get_InvertedListScanner(
         bool store_pairs,
-        const IDSelector* sel) const {
+        const IDSelector* sel,
+        const IVFSearchParameters*) const {
     return sq.select_InvertedListScanner(
             metric_type, quantizer, store_pairs, sel, by_residual);
 }

--- a/faiss/IndexScalarQuantizer.h
+++ b/faiss/IndexScalarQuantizer.h
@@ -96,7 +96,8 @@ struct IndexIVFScalarQuantizer : IndexIVF {
 
     InvertedListScanner* get_InvertedListScanner(
             bool store_pairs,
-            const IDSelector* sel) const override;
+            const IDSelector* sel,
+            const IVFSearchParameters* params) const override;
 
     void reconstruct_from_offset(int64_t list_no, int64_t offset, float* recons)
             const override;

--- a/faiss/impl/RaBitQuantizer.cpp
+++ b/faiss/impl/RaBitQuantizer.cpp
@@ -475,7 +475,7 @@ float RaBitQuantizer::RaBitDistanceComputer::symmetric_dis(idx_t i, idx_t j) {
     FAISS_THROW_MSG("Not implemented");
 }
 
-float symmetric_dis_core(
+float RaBitQuantizer::symmetric_dis_core(
         const uint8_t* code_i,
         const float* centroid_i,
         const uint8_t* code_j,

--- a/faiss/impl/RaBitQuantizer.cpp
+++ b/faiss/impl/RaBitQuantizer.cpp
@@ -215,7 +215,7 @@ float RaBitDistanceComputerNotQ::distance_to_code_L2(
     //
     // compute <q,o> using floats
     float dot_qo = 0;
-    // It was a willful decision (after the discussion) to not to pre-cache 
+    // It was a willful decision (after the discussion) to not to pre-cache
     //   the sum of all bits, just in order to reduce the overhead per vector.
     uint64_t sum_q = 0;
     for (size_t i = 0; i < d; i++) {
@@ -345,7 +345,7 @@ float RaBitDistanceComputerQ::distance_to_code_L2(const uint8_t* code) const {
         dot_qo += (count_dot << j);
     }
 
-    // It was a willful decision (after the discussion) to not to pre-cache 
+    // It was a willful decision (after the discussion) to not to pre-cache
     //   the sum of all bits, just in order to reduce the overhead per vector.
     uint64_t sum_q = 0;
     {

--- a/faiss/impl/RaBitQuantizer.cpp
+++ b/faiss/impl/RaBitQuantizer.cpp
@@ -64,7 +64,7 @@ void RaBitQuantizer::compute_codes_core(
 
     // compute codes
 #pragma omp parallel for if (n > 1000)
-    for (size_t i = 0; i < n; i++) {
+    for (int64_t i = 0; i < n; i++) {
         // ||or - c||^2
         float norm_L2sqr = 0;
         // ||or||^2, which is equal to ||P(or)||^2 and ||P^(-1)(or)||^2
@@ -137,7 +137,7 @@ void RaBitQuantizer::decode_core(
     const float inv_d_sqrt = (d == 0) ? 1.0f : (1.0f / std::sqrt((float)d));
 
 #pragma omp parallel for if (n > 1000)
-    for (size_t i = 0; i < n; i++) {
+    for (int64_t i = 0; i < n; i++) {
         const uint8_t* code = codes + i * code_size;
 
         // split the code into parts

--- a/faiss/impl/RaBitQuantizer.cpp
+++ b/faiss/impl/RaBitQuantizer.cpp
@@ -1,0 +1,487 @@
+#include <faiss/impl/RaBitQuantizer.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/platform_macros.h>
+#include <faiss/utils/distances.h>
+
+namespace faiss {
+
+struct FactorsData {
+    // ||or - c||
+    float factor_0 = 0;
+    // sum_xb
+    float factor_1 = 0;
+    float factor_2 = 0;
+    // ||or||^2
+    float factor_3 = 0;
+};
+
+struct QueryFactorsData {
+    float c1 = 0;
+    float c2 = 0;
+    float c34 = 0;
+
+    float qr_to_c_L2sqr = 0;
+    float qr_norm_L2sqr = 0;
+};
+
+static size_t get_code_size(const size_t d) {
+    return (d + 7) / 8 + sizeof(FactorsData);
+}
+
+RaBitQuantizer::RaBitQuantizer(size_t d) : Quantizer(d, get_code_size(d)) {}
+
+void RaBitQuantizer::train(size_t n, const float* x) {
+    // does nothing
+}
+
+void RaBitQuantizer::compute_codes(const float* x, uint8_t* codes, size_t n)
+        const {
+    compute_codes_core(x, codes, n, centroid);
+}
+
+void RaBitQuantizer::compute_codes_core(
+        const float* x,
+        uint8_t* codes,
+        size_t n,
+        const float* centroid_in) const {
+    FAISS_ASSERT(codes != nullptr);
+    FAISS_ASSERT(x != nullptr);
+
+    if (n == 0) {
+        return;
+    }
+
+    // compute some helper constants
+    const float inv_d_sqrt = (d == 0) ? 1.0f : (1.0f / std::sqrt((float)d));
+
+    // compute codes
+#pragma omp parallel for if (n > 1000)
+    for (size_t i = 0; i < n; i++) {
+        // ||or - c||^2
+        float norm_L2sqr = 0;
+        // ||or||^2, which is equal to ||P(or)||^2 and ||P^(-1)(or)||^2
+        float or_L2sqr = 0;
+        // sum of bits
+        size_t sum_xb = 0;
+        // dot product
+        float dp_oO = 0;
+
+        // the code
+        uint8_t* code = codes + i * code_size;
+        FactorsData* fac = reinterpret_cast<FactorsData*>(code + (d + 7) / 8);
+
+        // cleanup it
+        if (code != nullptr) {
+            memset(code, 0, code_size);
+        }
+
+        for (size_t j = 0; j < d; j++) {
+            const float or_minus_c = x[i * d + j] -
+                    ((centroid_in == nullptr) ? 0 : centroid_in[j]);
+            norm_L2sqr += or_minus_c * or_minus_c;
+            or_L2sqr += x[i * d + j] * x[i * d + j];
+
+            const bool xb = (or_minus_c > 0);
+            sum_xb += xb ? 1 : 0;
+
+            dp_oO += xb ? or_minus_c : (-or_minus_c);
+
+            // store the output data
+            if (code != nullptr) {
+                if (xb) {
+                    // enable a particular bit
+                    code[j / 8] |= (1 << (j % 8));
+                }
+            }
+        }
+
+        // compute factors
+
+        // compute the inverse norm
+        const float inv_norm_L2 =
+                (std::abs(norm_L2sqr) < std::numeric_limits<float>::epsilon())
+                ? 1.0f
+                : (1.0f / std::sqrt(norm_L2sqr));
+        dp_oO *= inv_norm_L2;
+        dp_oO *= inv_d_sqrt;
+
+        const float inv_dp_oO =
+                (std::abs(dp_oO) < std::numeric_limits<float>::epsilon())
+                ? 1.0f
+                : (1.0f / dp_oO);
+
+        fac->factor_0 = norm_L2sqr;
+        fac->factor_1 = sum_xb;
+        fac->factor_2 = inv_dp_oO * std::sqrt(norm_L2sqr);
+        fac->factor_3 = or_L2sqr;
+    }
+}
+
+void RaBitQuantizer::decode(const uint8_t* codes, float* x, size_t n) const {
+    decode_core(codes, x, n, centroid);
+}
+
+void RaBitQuantizer::decode_core(
+        const uint8_t* codes,
+        float* x,
+        size_t n,
+        const float* centroid_in) const {
+    const float inv_d_sqrt = (d == 0) ? 1.0f : (1.0f / std::sqrt((float)d));
+
+#pragma omp parallel for if (n > 1000)
+    for (size_t i = 0; i < n; i++) {
+        const uint8_t* code = codes + i * code_size;
+
+        // split the code into parts
+        const uint8_t* binary_data = code;
+        const FactorsData* fac =
+                reinterpret_cast<const FactorsData*>(code + (d + 7) / 8);
+
+        //
+        for (size_t j = 0; j < d; j++) {
+            // extract i-th bit
+            const uint8_t masker = (1 << (j % 8));
+            const float bit = ((binary_data[j / 8] & masker) == masker) ? 1 : 0;
+
+            // compute the output code
+            x[i * d + j] = (bit - 0.5f) * fac->factor_2 * 2 * inv_d_sqrt +
+                    ((centroid_in == nullptr) ? 0 : centroid_in[j]);
+        }
+    }
+}
+
+RaBitQuantizer::RaBitDistanceComputer::RaBitDistanceComputer() = default;
+
+float RaBitQuantizer::RaBitDistanceComputer::distance_to_code(
+        const uint8_t* code) {
+    if (metric == MetricType::METRIC_INNER_PRODUCT) {
+        return distance_to_code_IP(code);
+    } else if (metric == MetricType::METRIC_L2) {
+        return distance_to_code_L2(code);
+    } else {
+        FAISS_THROW_MSG("This distance type is not supported");
+    }
+}
+
+struct RaBitDistanceComputerNotQ : RaBitQuantizer::RaBitDistanceComputer {
+    // the rotated query (qr - c)
+    std::vector<float> rotated_q;
+    // some additional numbers for the query
+    QueryFactorsData query_fac;
+
+    RaBitDistanceComputerNotQ();
+
+    float distance_to_code_IP(const uint8_t* code) const override;
+    float distance_to_code_L2(const uint8_t* code) const override;
+
+    void set_query(const float* x) override;
+};
+
+struct RaBitDistanceComputerQ : RaBitQuantizer::RaBitDistanceComputer {
+    // the rotated and quantized query (qr - c)
+    std::vector<uint8_t> rotated_qq;
+    // we're using the proposed relayout-ed scheme from 3.3 that allows
+    //    using popcounts for computing the distance.
+    std::vector<uint8_t> rearranged_rotated_qq;
+    // some additional numbers for the query
+    QueryFactorsData query_fac;
+
+    // the number of bits for SQ quantization of the query (qb > 0)
+    uint8_t qb = 8;
+    // the smallest value divisible by 8 that is not smaller than dim
+    size_t popcount_aligned_dim = 0;
+
+    RaBitDistanceComputerQ();
+
+    float distance_to_code_IP(const uint8_t* code) const override;
+    float distance_to_code_L2(const uint8_t* code) const override;
+
+    void set_query(const float* x) override;
+};
+
+RaBitDistanceComputerNotQ::RaBitDistanceComputerNotQ() = default;
+
+float RaBitDistanceComputerNotQ::distance_to_code_L2(
+        const uint8_t* code) const {
+    // split the code into parts
+    const uint8_t* binary_data = code;
+    const FactorsData* fac =
+            reinterpret_cast<const FactorsData*>(code + (d + 7) / 8);
+
+    // this is the baseline code
+    //
+    // compute <q,o> using floats
+    float dot_qo = 0;
+    for (size_t i = 0; i < d; i++) {
+        // extract i-th bit
+        const uint8_t masker = (1 << (i % 8));
+        const float bit = ((binary_data[i / 8] & masker) == masker) ? 1 : 0;
+
+        // accumulate dp
+        dot_qo += bit * rotated_q[i];
+    }
+
+    float final_dot = 0;
+    // dot-product itself
+    final_dot += query_fac.c1 * dot_qo;
+    // normalizer coefficients
+    final_dot += query_fac.c2 * fac->factor_1;
+    // normalizer coefficients
+    final_dot -= query_fac.c34;
+
+    // this is ||or - c||^2
+    const float or_c_l2sqr = fac->factor_0;
+
+    // ||or - q||^ 2 = ||or - c||^2 + ||qr - c||^2 -
+    //     2 * ||or - c|| * ||qr - c|| * <q,o>
+    const float dist_l2sqr = or_c_l2sqr + query_fac.qr_to_c_L2sqr -
+            2 * fac->factor_2 * final_dot;
+    return dist_l2sqr;
+}
+
+float RaBitDistanceComputerNotQ::distance_to_code_IP(
+        const uint8_t* code) const {
+    // split the code into parts
+    const FactorsData* fac =
+            reinterpret_cast<const FactorsData*>(code + (d + 7) / 8);
+
+    // this is ||or - q||^2
+    const float l2 = distance_to_code_L2(code);
+    // this is ||q||^2
+    const float query_norm_sqr = query_fac.qr_norm_L2sqr;
+    // this is ||or||^2
+    const float or_norm_sqr = fac->factor_3;
+
+    // 2 * (or, q) = (||or - q||^2 - ||q||^2 - ||or||^2)
+    return -0.5f * (l2 - query_norm_sqr - or_norm_sqr);
+}
+
+void RaBitDistanceComputerNotQ::set_query(const float* x) {
+    // compute the distance from the query to the centroid
+    if (centroid != nullptr) {
+        query_fac.qr_to_c_L2sqr = fvec_L2sqr(x, centroid, d);
+    } else {
+        query_fac.qr_to_c_L2sqr = fvec_norm_L2sqr(x, d);
+    }
+
+    // subtract c, obtain P^(-1)(qr - c)
+    rotated_q.resize(d);
+    for (size_t i = 0; i < d; i++) {
+        rotated_q[i] = x[i] - ((centroid == nullptr) ? 0 : centroid[i]);
+    }
+
+    // compute some numbers
+    const float inv_d = (d == 0) ? 1.0f : (1.0f / std::sqrt((float)d));
+
+    // do not quantize the query
+    float sum_q = 0;
+    for (size_t i = 0; i < d; i++) {
+        sum_q += rotated_q[i];
+    }
+
+    query_fac.c1 = 2 * inv_d;
+    query_fac.c2 = 0;
+    query_fac.c34 = sum_q * inv_d;
+
+    if (metric == MetricType::METRIC_INNER_PRODUCT) {
+        // precompute if needed
+        query_fac.qr_norm_L2sqr = fvec_norm_L2sqr(x, d);
+    }
+}
+
+RaBitDistanceComputerQ::RaBitDistanceComputerQ() = default;
+
+float RaBitDistanceComputerQ::distance_to_code_L2(const uint8_t* code) const {
+    // split the code into parts
+    const uint8_t* binary_data = code;
+    const FactorsData* fac =
+            reinterpret_cast<const FactorsData*>(code + (d + 7) / 8);
+
+    // // this is the baseline code
+    // //
+    // // compute <q,o> using integers
+    // size_t dot_qo = 0;
+    // for (size_t i = 0; i < d; i++) {
+    //     // extract i-th bit
+    //     const uint8_t masker = (1 << (i % 8));
+    //     const uint8_t bit = ((binary_data[i / 8] & masker) == masker) ? 1 :
+    //     0;
+    //
+    //     // accumulate dp
+    //     dot_qo += bit * rotated_qq[i];
+    // }
+
+    // this is the scheme for popcount
+    const size_t di_8b = (d + 7) / 8;
+    const size_t di_64b = (di_8b / 8) * 8;
+
+    unsigned long long dot_qo = 0;
+    for (size_t j = 0; j < qb; j++) {
+        const uint8_t* query_j = rearranged_rotated_qq.data() + j * di_8b;
+
+        // process 64-bit popcounts
+        unsigned long long count = 0;
+        for (size_t i = 0; i < di_64b; i += 8) {
+            const auto qv = *(const unsigned long long*)(query_j + i);
+            const auto yv = *(const unsigned long long*)(binary_data + i);
+            count += __builtin_popcountll(qv & yv);
+        }
+
+        // process leftovers
+        for (size_t i = di_64b; i < di_8b; i++) {
+            const auto qv = *(query_j + i);
+            const auto yv = *(binary_data + i);
+            count += __builtin_popcount(qv & yv);
+        }
+
+        dot_qo += (count << j);
+    }
+
+    float final_dot = 0;
+    // dot-product itself
+    final_dot += query_fac.c1 * dot_qo;
+    // normalizer coefficients
+    final_dot += query_fac.c2 * fac->factor_1;
+    // normalizer coefficients
+    final_dot -= query_fac.c34;
+
+    // this is ||or - c||^2
+    const float or_c_l2sqr = fac->factor_0;
+
+    // ||or - q||^ 2 = ||or - c||^2 + ||qr - c||^2 -
+    //     2 * ||or - c|| * ||qr - c|| * <q,o>
+    const float dist_l2sqr = or_c_l2sqr + query_fac.qr_to_c_L2sqr -
+            2 * fac->factor_2 * final_dot;
+    return dist_l2sqr;
+}
+
+float RaBitDistanceComputerQ::distance_to_code_IP(const uint8_t* code) const {
+    // split the code into parts
+    const FactorsData* fac =
+            reinterpret_cast<const FactorsData*>(code + (d + 7) / 8);
+
+    // this is ||or - q||^2
+    const float l2 = distance_to_code_L2(code);
+    // this is ||q||^2
+    const float query_norm_sqr = query_fac.qr_norm_L2sqr;
+    // this is ||or||^2
+    const float or_norm_sqr = fac->factor_3;
+
+    // -2 * (or, q) = (||or - q||^2 - ||q||^2 - ||or||^2)
+    return -0.5f * (l2 - query_norm_sqr - or_norm_sqr);
+}
+
+void RaBitDistanceComputerQ::set_query(const float* x) {
+    // compute the distance from the query to the centroid
+    if (centroid != nullptr) {
+        query_fac.qr_to_c_L2sqr = fvec_L2sqr(x, centroid, d);
+    } else {
+        query_fac.qr_to_c_L2sqr = fvec_norm_L2sqr(x, d);
+    }
+
+    // allocate space
+    rotated_qq.resize(d);
+
+    // rotate the query
+    std::vector<float> rotated_q(d);
+    for (size_t i = 0; i < d; i++) {
+        rotated_q[i] = x[i] - ((centroid == nullptr) ? 0 : centroid[i]);
+    }
+
+    // compute some numbers
+    const float inv_d = (d == 0) ? 1.0f : (1.0f / std::sqrt((float)d));
+
+    // quantize the query. compute min and max
+    float v_min = std::numeric_limits<float>::max();
+    float v_max = std::numeric_limits<float>::lowest();
+    for (size_t i = 0; i < d; i++) {
+        const float v_q = rotated_q[i];
+        v_min = std::min(v_min, v_q);
+        v_max = std::max(v_max, v_q);
+    }
+
+    const float pow_2_qb = 1 << qb;
+
+    const float delta = (v_max - v_min) / (pow_2_qb - 1);
+    const float inv_delta = 1.0f / delta;
+
+    size_t sum_qq = 0;
+    for (int32_t i = 0; i < d; i++) {
+        const float v_q = rotated_q[i];
+
+        // a default non-randomized SQ
+        const int v_qq = std::round((v_q - v_min) * inv_delta);
+
+        rotated_qq[i] = std::min(255, std::max(0, v_qq));
+        sum_qq += v_qq;
+    }
+
+    // rearrange the query vector
+    popcount_aligned_dim = ((d + 7) / 8) * 8;
+    size_t offset = (d + 7) / 8;
+
+    rearranged_rotated_qq.resize(offset * qb);
+    std::fill(rearranged_rotated_qq.begin(), rearranged_rotated_qq.end(), 0);
+
+    for (size_t idim = 0; idim < d; idim++) {
+        for (size_t iv = 0; iv < qb; iv++) {
+            const bool bit = ((rotated_qq[idim] & (1 << iv)) != 0);
+            rearranged_rotated_qq[iv * offset + idim / 8] |=
+                    bit ? (1 << (idim % 8)) : 0;
+        }
+    }
+
+    query_fac.c1 = 2 * delta * inv_d;
+    query_fac.c2 = 2 * v_min * inv_d;
+    query_fac.c34 = inv_d * (delta * sum_qq + d * v_min);
+
+    if (metric == MetricType::METRIC_INNER_PRODUCT) {
+        // precompute if needed
+        query_fac.qr_norm_L2sqr = fvec_norm_L2sqr(x, d);
+    }
+}
+
+RaBitQuantizer::RaBitDistanceComputer* RaBitQuantizer::get_distance_computer(
+        uint8_t qb,
+        MetricType metric,
+        const float* centroid_in) const {
+    if (qb == 0) {
+        auto dc = std::make_unique<RaBitDistanceComputerNotQ>();
+        dc->metric = metric;
+        dc->d = d;
+        dc->centroid = centroid_in;
+
+        return dc.release();
+    } else {
+        auto dc = std::make_unique<RaBitDistanceComputerQ>();
+        dc->metric = metric;
+        dc->d = d;
+        dc->centroid = centroid_in;
+        dc->qb = qb;
+
+        return dc.release();
+    }
+}
+
+float RaBitQuantizer::RaBitDistanceComputer::symmetric_dis(idx_t i, idx_t j) {
+    FAISS_THROW_MSG("Not implemented");
+}
+
+float symmetric_dis_core(
+        const uint8_t* code_i,
+        const float* centroid_i,
+        const uint8_t* code_j,
+        const float* centroid_j,
+        const size_t d) {
+    FAISS_THROW_MSG("Not implemented");
+}
+
+} // namespace faiss

--- a/faiss/impl/RaBitQuantizer.h
+++ b/faiss/impl/RaBitQuantizer.h
@@ -81,14 +81,6 @@ struct RaBitQuantizer : Quantizer {
             uint8_t qb,
             MetricType metric,
             const float* centroid_in = nullptr) const;
-
-    // a generalized version
-    static float symmetric_dis_core(
-            const uint8_t* code_i,
-            const float* centroid_i,
-            const uint8_t* code_j,
-            const float* centroid_j,
-            const size_t d);
 };
 
 } // namespace faiss

--- a/faiss/impl/RaBitQuantizer.h
+++ b/faiss/impl/RaBitQuantizer.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <faiss/MetricType.h>
+#include <faiss/impl/DistanceComputer.h>
+#include <faiss/impl/Quantizer.h>
+
+namespace faiss {
+
+// the reference implementation of the https://arxiv.org/pdf/2405.12497
+//   Jianyang Gao, Cheng Long, "RaBitQ: Quantizing High-Dimensional Vectors
+//   with a Theoretical Error Bound for Approximate Nearest Neighbor Search".
+//
+// It is assumed that the Random Matrix Rotation is performed externally.
+struct RaBitQuantizer : Quantizer {
+    // all RaBitQ operations are provided against a centroid, which needs
+    //   to be provided Externally (!). Nullptr value implies that the centroid
+    //   consists of zero values.
+    // This is the default value that can be customized using XYZ_core() calls.
+    //   Such a customization is needed for IVF calls.
+    //
+    // This particular pointer will NOT be serialized.
+    float* centroid = nullptr;
+
+    RaBitQuantizer(size_t d = 0);
+
+    void train(size_t n, const float* x) override;
+
+    // every vector is expected to take (d + 7) / 8 + sizeof(FactorsData) bytes,
+    void compute_codes(const float* x, uint8_t* codes, size_t n) const override;
+
+    void compute_codes_core(
+            const float* x,
+            uint8_t* codes,
+            size_t n,
+            const float* centroid_in) const;
+
+    // The decode output is Heavily geared towards maintaining the IP, not L2.
+    // This means that the reconstructed codes maybe less accurate than one may
+    //   expect, if one computes an L2 distance between a reconstructed code and
+    //   the corresponding original vector.
+    // But value of the dot product between a query and the original vector
+    //   might be very close to the value of the dot product between a query and
+    //   the reconstructed code.
+    // Basically, it seems to be related to the distributions of values, not
+    //   values.
+    void decode(const uint8_t* codes, float* x, size_t n) const override;
+
+    void decode_core(
+            const uint8_t* codes,
+            float* x,
+            size_t n,
+            const float* centroid_in) const;
+
+    struct RaBitDistanceComputer : FlatCodesDistanceComputer {
+        // dimensionality
+        size_t d = 0;
+        // a centroid to use
+        const float* centroid = nullptr;
+
+        // the metric
+        MetricType metric = MetricType::METRIC_L2;
+
+        RaBitDistanceComputer();
+
+        float distance_to_code(const uint8_t* code) override;
+
+        virtual float distance_to_code_IP(const uint8_t* code) const = 0;
+        virtual float distance_to_code_L2(const uint8_t* code) const = 0;
+
+        float symmetric_dis(idx_t i, idx_t j) override;
+    };
+
+    // returns the distance computer.
+    // specify qb = 0 to get an DC that does not quantize a query
+    // specify qb > 0 to have SQ qb-bits query
+    RaBitDistanceComputer* get_distance_computer(
+            uint8_t qb,
+            MetricType metric,
+            const float* centroid_in = nullptr) const;
+
+    // a generalized version
+    static float symmetric_dis_core(
+            const uint8_t* code_i,
+            const float* centroid_i,
+            const uint8_t* code_j,
+            const float* centroid_j,
+            const size_t d);
+};
+
+} // namespace faiss

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -445,6 +445,7 @@ static void read_RaBitQuantizer(RaBitQuantizer* rabitq, IOReader* f) {
     // don't care about rabitq->centroid
     READ1(rabitq->d);
     READ1(rabitq->code_size);
+    READ1(rabitq->metric_type);
 }
 
 void read_direct_map(DirectMap* dm, IOReader* f) {

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -33,6 +33,7 @@
 #include <faiss/IndexIVFPQ.h>
 #include <faiss/IndexIVFPQFastScan.h>
 #include <faiss/IndexIVFPQR.h>
+#include <faiss/IndexIVFRaBitQ.h>
 #include <faiss/IndexIVFSpectralHash.h>
 #include <faiss/IndexLSH.h>
 #include <faiss/IndexLattice.h>
@@ -41,6 +42,7 @@
 #include <faiss/IndexPQ.h>
 #include <faiss/IndexPQFastScan.h>
 #include <faiss/IndexPreTransform.h>
+#include <faiss/IndexRaBitQ.h>
 #include <faiss/IndexRefine.h>
 #include <faiss/IndexRowwiseMinMax.h>
 #include <faiss/IndexScalarQuantizer.h>
@@ -437,6 +439,12 @@ ProductQuantizer* read_ProductQuantizer(IOReader* reader) {
     read_ProductQuantizer(pq, reader);
     del.release();
     return pq;
+}
+
+static void read_RaBitQuantizer(RaBitQuantizer* rabitq, IOReader* f) {
+    // don't care about rabitq->centroid
+    READ1(rabitq->d);
+    READ1(rabitq->code_size);
 }
 
 void read_direct_map(DirectMap* dm, IOReader* f) {
@@ -1060,6 +1068,24 @@ Index* read_index(IOReader* f, int io_flags) {
         imm->own_fields = true;
 
         idx = imm;
+    } else if (h == fourcc("Ixrq")) {
+        IndexRaBitQ* idxq = new IndexRaBitQ();
+        read_index_header(idxq, f);
+        read_RaBitQuantizer(&idxq->rabitq, f);
+        READVECTOR(idxq->codes);
+        READVECTOR(idxq->center);
+        READ1(idxq->qb);
+        idxq->code_size = idxq->rabitq.code_size;
+        idx = idxq;
+    } else if (h == fourcc("Iwrq")) {
+        IndexIVFRaBitQ* ivrq = new IndexIVFRaBitQ();
+        read_ivf_header(ivrq, f);
+        read_RaBitQuantizer(&ivrq->rabitq, f);
+        READ1(ivrq->code_size);
+        READ1(ivrq->by_residual);
+        READ1(ivrq->qb);
+        read_InvertedLists(ivrq, f, io_flags);
+        idx = ivrq;
     } else {
         FAISS_THROW_FMT(
                 "Index type 0x%08x (\"%s\") not recognized",

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -370,6 +370,7 @@ static void write_RaBitQuantizer(const RaBitQuantizer* rabitq, IOWriter* f) {
     // don't care about rabitq->centroid
     WRITE1(rabitq->d);
     WRITE1(rabitq->code_size);
+    WRITE1(rabitq->metric_type);
 }
 
 static void write_direct_map(const DirectMap* dm, IOWriter* f) {

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -32,6 +32,7 @@
 #include <faiss/IndexIVFPQ.h>
 #include <faiss/IndexIVFPQFastScan.h>
 #include <faiss/IndexIVFPQR.h>
+#include <faiss/IndexIVFRaBitQ.h>
 #include <faiss/IndexIVFSpectralHash.h>
 #include <faiss/IndexLSH.h>
 #include <faiss/IndexLattice.h>
@@ -40,6 +41,7 @@
 #include <faiss/IndexPQ.h>
 #include <faiss/IndexPQFastScan.h>
 #include <faiss/IndexPreTransform.h>
+#include <faiss/IndexRaBitQ.h>
 #include <faiss/IndexRefine.h>
 #include <faiss/IndexRowwiseMinMax.h>
 #include <faiss/IndexScalarQuantizer.h>
@@ -362,6 +364,12 @@ static void write_NNDescent(const NNDescent* nnd, IOWriter* f) {
     WRITE1(nnd->has_built);
 
     WRITEVECTOR(nnd->final_graph);
+}
+
+static void write_RaBitQuantizer(const RaBitQuantizer* rabitq, IOWriter* f) {
+    // don't care about rabitq->centroid
+    WRITE1(rabitq->d);
+    WRITE1(rabitq->code_size);
 }
 
 static void write_direct_map(const DirectMap* dm, IOWriter* f) {
@@ -850,6 +858,26 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
         WRITE1(h);
         write_index_header(imm_2, f);
         write_index(imm_2->index, f);
+    } else if (
+            const IndexRaBitQ* idxq = dynamic_cast<const IndexRaBitQ*>(idx)) {
+        uint32_t h = fourcc("Ixrq");
+        WRITE1(h);
+        write_index_header(idx, f);
+        write_RaBitQuantizer(&idxq->rabitq, f);
+        WRITEVECTOR(idxq->codes);
+        WRITEVECTOR(idxq->center);
+        WRITE1(idxq->qb);
+    } else if (
+            const IndexIVFRaBitQ* ivrq =
+                    dynamic_cast<const IndexIVFRaBitQ*>(idx)) {
+        uint32_t h = fourcc("Iwrq");
+        WRITE1(h);
+        write_ivf_header(ivrq, f);
+        write_RaBitQuantizer(&ivrq->rabitq, f);
+        WRITE1(ivrq->code_size);
+        WRITE1(ivrq->by_residual);
+        WRITE1(ivrq->qb);
+        write_InvertedLists(ivrq->invlists, f);
     } else {
         FAISS_THROW_MSG("don't know how to serialize this type of index");
     }

--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -76,6 +76,7 @@ inline int __builtin_clzll(uint64_t x) {
 
 #define __builtin_popcount __popcnt
 #define __builtin_popcountl __popcnt64
+#define __builtin_popcountll __popcnt64
 
 #ifndef __clang__
 #define __m128i_u __m128i

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -30,6 +30,7 @@
 #include <faiss/IndexIVFPQ.h>
 #include <faiss/IndexIVFPQFastScan.h>
 #include <faiss/IndexIVFPQR.h>
+#include <faiss/IndexIVFRaBitQ.h>
 #include <faiss/IndexIVFSpectralHash.h>
 #include <faiss/IndexLSH.h>
 #include <faiss/IndexLattice.h>
@@ -37,6 +38,7 @@
 #include <faiss/IndexPQ.h>
 #include <faiss/IndexPQFastScan.h>
 #include <faiss/IndexPreTransform.h>
+#include <faiss/IndexRaBitQ.h>
 #include <faiss/IndexRefine.h>
 #include <faiss/IndexRowwiseMinMax.h>
 #include <faiss/IndexScalarQuantizer.h>
@@ -182,6 +184,8 @@ std::vector<size_t> aq_parse_nbits(std::string stok) {
     }
     return nbits;
 }
+
+const std::string rabitq_pattern = "(RaBitQ)";
 
 /***************************************************************
  * Parse VectorTransform
@@ -433,6 +437,9 @@ IndexIVF* parse_IndexIVF(
         }
         return index_ivf;
     }
+    if (match(rabitq_pattern)) {
+        return new IndexIVFRaBitQ(get_q(), d, nlist, mt);
+    }
     return nullptr;
 }
 
@@ -652,6 +659,11 @@ Index* parse_other_indexes(
             return new IndexProductLocalSearchQuantizerFastScan(
                     d, nsplits, Msub, 4, metric, st, bbs);
         }
+    }
+
+    // IndexRaBitQ
+    if (match(rabitq_pattern)) {
+        return new IndexRaBitQ(d, metric);
     }
 
     return nullptr;

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -184,6 +184,10 @@ typedef uint64_t size_t;
 
 #include <faiss/IndexNeuralNetCodec.h>
 
+#include <faiss/impl/RaBitQuantizer.h>
+#include <faiss/IndexRaBitQ.h>
+#include <faiss/IndexIVFRaBitQ.h>
+
 %}
 
 /********************************************************
@@ -633,6 +637,9 @@ struct faiss::simd16uint16 {};
 
 %include <faiss/IndexNeuralNetCodec.h>
 
+%include <faiss/impl/RaBitQuantizer.h>
+%include <faiss/IndexRaBitQ.h>
+%include <faiss/IndexIVFRaBitQ.h>
 
 %ignore faiss::BufferList::Buffer;
 %ignore faiss::RangeSearchPartialResult::QueryResult;

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -62,6 +62,14 @@ class TestFactory(unittest.TestCase):
         assert index.sa_code_size() == 64 * 4
         assert index.chain.at(0).d_out == 64
 
+    def test_factory_6(self):
+        index = faiss.index_factory(128, "RaBitQ")
+        assert index.d == 128
+        assert index.metric_type == faiss.METRIC_L2
+        index = faiss.index_factory(128, "IVF256,RaBitQ")
+        assert index.d == 128
+        assert index.metric_type == faiss.METRIC_L2
+
     def test_factory_HNSW(self):
         index = faiss.index_factory(12, "HNSW32")
         assert index.storage.sa_code_size() == 12 * 4

--- a/tests/test_rabitq.py
+++ b/tests/test_rabitq.py
@@ -1,0 +1,397 @@
+import numpy as np
+import unittest
+import faiss
+
+from faiss.contrib import datasets, evaluation
+
+
+def random_rotation(d, seed=123): 
+    rs = np.random.RandomState(seed)
+    Q, _ = np.linalg.qr(rs.randn(d, d))
+    return Q
+
+
+# based on https://gist.github.com/mdouze/0b2386c31d7fb8b20ae04f3fcbbf4d9d
+class ReferenceRabitQ: 
+    """ Exact translation of the paper 
+    https://dl.acm.org/doi/pdf/10.1145/3654970
+    This is both a quantizer and serves to store the codes
+    """ 
+
+    def __init__(self, d, Bq=4): 
+        self.d = d 
+        self.Bq = Bq
+
+    def train(self, xtrain, P): 
+        self.centroid = xtrain.mean(0) 
+        self.P = P
+
+    def rotation(self, x): 
+        return x @ self.P 
+
+    def inv_rotation(self, x): 
+        return x @ self.P.T 
+    
+    def add(self, Or): 
+        # centering & normalization
+        Orc = Or - self.centroid                
+        self.O_norms = np.sqrt((Orc ** 2).sum(1))  # need to store the norms
+        O = Orc / self.O_norms[:, None]
+
+        # 3.1.3 
+        self.Xbarb = (self.inv_rotation(Orc) > 0).astype('int8') # 0, 1
+        # here the encoded vectors are stored as an int array for simplicity but 
+        # in the real code it would be as a packed uint8 array 
+        # self.Xbarb = np.packbits(self.inv_rotation(Orc) > 0, axis=1)
+                
+        # reconstruct to compute <o, obar>
+        Obar = self.rotation((2 * self.Xbarb - 1) / np.sqrt(self.d))
+        self.o_Obar = (O * Obar).sum(1)   # store dot products 
+
+    def distances(self, Qr): 
+        """ compute distance estimates for the queries to the stored vectors """
+        nq = len(Qr)
+        nb = len(self.Xbarb)
+        d = self.d
+        Bq = self.Bq
+        
+        rs = np.random.RandomState(123)
+
+        # preproc Qr
+        Qrc = Qr - self.centroid
+        Qrc_norms = np.sqrt((Qrc ** 2).sum(1))[:, None]
+        Q = Qrc
+        Qprime = self.inv_rotation(Q)
+
+        # quantize queries to Bq bits
+        mins, maxes = Qprime.min(axis=1)[:, None], Qprime.max(axis=1)[:, None]
+        Delta = (maxes - mins) / (2 ** Bq - 1) 
+
+        # article mentioned a randomized variant
+        # qbar = np.floor((Qprime - mins) / Delta + rs.rand(nq, d))
+
+        # we'll use a non-randomized for the comparison purposes
+        qbar = np.round((Qprime - mins) / Delta)
+        # in the real implementation, this would be re-ordered in least- to most-significant bit 
+        
+        # dot product matrix, integers -- this is the expensive operation
+        dp = (qbar[:, None, :] * self.Xbarb[None, :, :]).sum(2)
+
+        # the operations below roll back the normalizations to get the distance estimates
+        # it is likely that they could be merged or some of them could be left out because we 
+        # are interested only in top-k
+        
+        # compute <xbar, qbar> (eq 19-20)
+        sum_X = self.Xbarb.sum(1)
+        sum_Q = qbar.sum(1)[:, None]
+        sD = np.sqrt(d)
+        xbar_qbar = (
+            2 * Delta / sD * dp         
+            + 2 * mins / sD * sum_X 
+            - Delta / sD * sum_Q 
+            - sD * mins            
+        )
+        # <xbar, qbar> is close to <xbar, q'> thm 3.3
+        # <xbar, q'> = <obar, q>  eq 17
+
+        # <obar, q> / <obar, o> estimates <q, o> (thm 3.2)
+        q_o = xbar_qbar / self.o_Obar     
+        
+        # eq 1-2 to de-normalize and get distances
+        dis2_q_o = self.O_norms ** 2 + Qrc_norms ** 2 - 2 * self.O_norms * q_o
+
+        return dis2_q_o
+
+
+class ReferenceIVFRabitQ: 
+    """ straightforward IVF implementation """ 
+
+    def __init__(self, d, nlist, Bq=4): 
+        self.d = d
+        self.nlist = nlist 
+        self.invlists = [
+            ReferenceRabitQ(d, Bq)
+            for _ in range(nlist)
+        ]
+        self.quantizer = None
+        self.nprobe = 1
+
+    def train(self, xtrain, P): 
+        if self.quantizer is None: 
+            km = faiss.Kmeans(self.d, self.nlist, niter=10)
+            km.train(xtrain)
+            centroids = km.centroids
+            self.quantizer = faiss.IndexFlatL2(self.d)
+            self.quantizer.add(centroids) 
+        else: 
+            centroids = self.quantizer.reconstruct_n()
+        # Override the RabitQ train() to use a common random rotation 
+        #  and force centroids from the coarse quantizer 
+        for list_no, rq in enumerate(self.invlists): 
+            rq.centroid = centroids[list_no]
+            rq.P = P 
+
+    def add(self, x): 
+        _, keys = self.quantizer.search(x, 1)
+        keys = keys.ravel()
+        n_per_invlist = np.bincount(keys, minlength=self.nlist)
+        order = np.argsort(keys)
+        i0 = 0
+        for list_no, rab in enumerate(self.invlists): 
+            i1 = i0 + n_per_invlist[list_no]
+            rab.list_size = i1 - i0
+            if i1 > i0: 
+                ids = order[i0:i1]
+                rab.ids = ids
+                rab.add(x[ids])
+            i0 = i1
+
+    def search(self, x, k): 
+        nq = len(x)
+        nprobe = self.nprobe
+        D = np.zeros((nq, k), dtype='float32')
+        I = np.zeros((nq, k), dtype=int)
+        D[:] = np.nan
+        I[:] = -1
+        _, Ic = self.quantizer.search(x, nprobe)
+        
+        for qno, xq in enumerate(x): 
+            # naive top-k implemetation with a full sort 
+            q_dis = []
+            q_ids = []
+            for probe in range(nprobe): 
+                rab = self.invlists[Ic[qno, probe]]
+                if rab.list_size == 0: 
+                    continue
+                # we cannot exploit the batch version of the queries (in this form)
+                dis = rab.distances(xq[None, :])
+                q_ids.append(rab.ids)
+                q_dis.append(dis.ravel())
+            q_dis = np.hstack(q_dis)
+            q_ids = np.hstack(q_ids)
+            o = q_dis.argsort()
+            kq = min(k, len(q_dis))
+            D[qno, :kq] = q_dis[o[:kq]]
+            I[qno, :kq] = q_ids[o[:kq]]
+        return D, I 
+
+
+class TestRaBitQ(unittest.TestCase):
+    def do_comparison_vs_pq_test(self, metric_type=faiss.METRIC_L2):
+        ds = datasets.SyntheticDataset(128, 4096, 4096, 100)
+        k = 10
+
+        # PQ 8-to-1
+        index_pq = faiss.IndexPQ(ds.d, 16, 8, metric_type)
+        index_pq.train(ds.get_train())
+        index_pq.add(ds.get_database())
+        _, I_pq = index_pq.search(ds.get_queries(), k)
+
+        index_rbq = faiss.IndexRaBitQ(ds.d, metric_type)
+        index_rbq.train(ds.get_train())
+        index_rbq.add(ds.get_database())
+        _, I_rbq = index_rbq.search(ds.get_queries(), k)
+
+        # try quantized query
+        rbq_params = faiss.RaBitQSearchParameters(qb=8)
+        _, I_rbq_q8 = index_rbq.search(ds.get_queries(), k, params=rbq_params)
+
+        rbq_params = faiss.RaBitQSearchParameters(qb=4)
+        _, I_rbq_q4 = index_rbq.search(ds.get_queries(), k, params=rbq_params)
+
+        index_flat = faiss.IndexFlat(ds.d, metric_type)
+        index_flat.train(ds.get_train())
+        index_flat.add(ds.get_database())
+        _, I_f = index_flat.search(ds.get_queries(), k)
+
+        # ensure that RaBitQ and PQ are relatively close
+        eval_pq = faiss.eval_intersection(I_pq[:, :k], I_f[:, :k]) / (ds.nq * k)
+        eval_rbq = faiss.eval_intersection(I_rbq[:, :k], I_f[:, :k]) / (ds.nq * k)
+        eval_rbq_q8 = faiss.eval_intersection(I_rbq_q8[:, :k], I_f[:, :k]) / (ds.nq * k)
+        eval_rbq_q4 = faiss.eval_intersection(I_rbq_q4[:, :k], I_f[:, :k]) / (ds.nq * k)
+
+        print(f"PQ is {eval_pq}, RaBitQ is {eval_rbq}, q8 RaBitQ is {eval_rbq_q8}, q4 RaBitQ is {eval_rbq_q4}")
+
+        np.testing.assert_(abs(eval_pq - eval_rbq) < 0.05)
+        np.testing.assert_(abs(eval_pq - eval_rbq_q8) < 0.05)
+        np.testing.assert_(abs(eval_pq - eval_rbq_q4) < 0.05)
+        np.testing.assert_(eval_pq > 0.55)
+
+    def test_comparison_vs_pq_L2(self):
+        self.do_comparison_vs_pq_test(faiss.METRIC_L2)    
+
+    def test_comparison_vs_pq_IP(self):
+        self.do_comparison_vs_pq_test(faiss.METRIC_INNER_PRODUCT) 
+
+    def test_comparison_vs_ref_L2_rrot(self, rrot_seed=123):
+        ds = datasets.SyntheticDataset(128, 4096, 4096, 1)
+
+        ref_rbq = ReferenceRabitQ(ds.d, Bq=8)
+        ref_rbq.train(ds.get_train(), random_rotation(ds.d, rrot_seed))
+        ref_rbq.add(ds.get_database())
+
+        index_rbq = faiss.IndexRaBitQ(ds.d, faiss.METRIC_L2)
+        index_rbq.qb = 8
+
+        # wrap with random rotations
+        rrot = faiss.RandomRotationMatrix(ds.d, ds.d)
+        rrot.init(rrot_seed)
+
+        index_cand = faiss.IndexPreTransform(rrot, index_rbq)
+        index_cand.train(ds.get_train())
+        index_cand.add(ds.get_database())
+
+        ref_dis = ref_rbq.distances(ds.get_queries())
+
+        dc = index_cand.get_distance_computer()
+        xq = ds.get_queries()
+
+        # ensure that the correlation coefficient is very high
+        dc_dist = [0] * ds.nb
+
+        dc.set_query(faiss.swig_ptr(xq[0]))
+        for j in range(ds.nb):
+            dc_dist[j] = dc(j)
+
+        corr = np.corrcoef(dc_dist, ref_dis[0])[0, 1]
+        print(corr)
+        np.testing.assert_(corr > 0.9)
+
+    def test_comparison_vs_ref_L2(self):
+        ds = datasets.SyntheticDataset(128, 4096, 4096, 1)
+
+        ref_rbq = ReferenceRabitQ(ds.d, Bq=8)
+        ref_rbq.train(ds.get_train(), np.identity(ds.d))
+        ref_rbq.add(ds.get_database())
+
+        index_rbq = faiss.IndexRaBitQ(ds.d, faiss.METRIC_L2)
+        index_rbq.qb = 8
+        index_rbq.train(ds.get_train())
+        index_rbq.add(ds.get_database())
+
+        ref_dis = ref_rbq.distances(ds.get_queries())
+
+        dc = index_rbq.get_distance_computer()
+        xq = ds.get_queries()
+
+        dc.set_query(faiss.swig_ptr(xq[0]))
+        for j in range(ds.nb):
+            upd_dis = dc(j)
+            # print(f"{j} {ref_dis[0][j]} {upd_dis}")
+            np.testing.assert_(abs(ref_dis[0][j] - upd_dis) < 0.001)
+
+    def do_test_serde(self, description):
+        ds = datasets.SyntheticDataset(32, 1000, 100, 20)
+
+        xt = ds.get_train()
+        xb = ds.get_database()        
+
+        index = faiss.index_factory(ds.d, description)
+        index.train(ds.get_train())
+        index.add(ds.get_database())
+
+        Dref, Iref = index.search(ds.get_queries(), 10)
+
+        b = faiss.serialize_index(index)
+        index2 = faiss.deserialize_index(b)
+
+        Dnew, Inew = index2.search(ds.get_queries(), 10)
+
+        np.testing.assert_equal(Dref, Dnew)
+        np.testing.assert_equal(Iref, Inew)
+
+    def test_serde_rabitq(self):
+        self.do_test_serde("RaBitQ")
+
+
+class TestIVFRaBitQ(unittest.TestCase):
+    def test_comparison_vs_ref_L2(self):
+        ds = datasets.SyntheticDataset(128, 4096, 4096, 100)
+
+        k = 10
+        nlist = 200
+        ref_rbq = ReferenceIVFRabitQ(ds.d, nlist, Bq=4)
+        ref_rbq.train(ds.get_train(), np.identity(ds.d))
+        ref_rbq.add(ds.get_database())
+
+        index_flat = faiss.IndexFlat(ds.d, faiss.METRIC_L2)
+        index_rbq = faiss.IndexIVFRaBitQ(index_flat, ds.d, nlist, faiss.METRIC_L2)
+        index_rbq.qb = 4
+        index_rbq.train(ds.get_train())
+        index_rbq.add(ds.get_database())
+
+        for nprobe in 1, 4, 16: 
+            ref_rbq.nprobe = nprobe 
+            Dref, Iref = ref_rbq.search(ds.get_queries(), k)
+            r_ref_k = faiss.eval_intersection(Iref[:, :k], ds.get_groundtruth()[:, :k]) / (ds.nq * k)
+            print(f"{nprobe=} k-recall@10={r_ref_k}")
+
+            params = faiss.IVFRaBitQSearchParameters()
+            params.qb = index_rbq.qb
+            params.nprobe = nprobe
+            Dnew, Inew, stats2 = faiss.search_with_parameters(index_rbq, ds.get_queries(), k, params, output_stats=True)
+            r_new_k = faiss.eval_intersection(Inew[:, :k], ds.get_groundtruth()[:, :k]) / (ds.nq * k)
+            print(f"{nprobe=} k-recall@10={r_new_k}")
+
+            np.testing.assert_almost_equal(r_ref_k, r_new_k, 3)
+
+    def test_comparison_vs_ref_L2_rrot(self):
+        ds = datasets.SyntheticDataset(128, 4096, 4096, 100)
+
+        k = 10
+        nlist = 200
+        rrot_seed = 123
+
+        ref_rbq = ReferenceIVFRabitQ(ds.d, nlist, Bq=4)
+        ref_rbq.train(ds.get_train(), random_rotation(ds.d, rrot_seed))
+        ref_rbq.add(ds.get_database())
+
+        index_flat = faiss.IndexFlat(ds.d, faiss.METRIC_L2)
+        index_rbq = faiss.IndexIVFRaBitQ(index_flat, ds.d, nlist, faiss.METRIC_L2)
+        index_rbq.qb = 4
+
+        # wrap with random rotations
+        rrot = faiss.RandomRotationMatrix(ds.d, ds.d)
+        rrot.init(rrot_seed)
+
+        index_cand = faiss.IndexPreTransform(rrot, index_rbq)
+        index_cand.train(ds.get_train())
+        index_cand.add(ds.get_database())
+
+        for nprobe in 1, 4, 16: 
+            ref_rbq.nprobe = nprobe 
+            Dref, Iref = ref_rbq.search(ds.get_queries(), k)
+            r_ref_k = faiss.eval_intersection(Iref[:, :k], ds.get_groundtruth()[:, :k]) / (ds.nq * k)
+            print(f"{nprobe=} k-recall@10={r_ref_k}")
+
+            params = faiss.IVFRaBitQSearchParameters()
+            params.qb = index_rbq.qb
+            params.nprobe = nprobe
+            Dnew, Inew, stats2 = faiss.search_with_parameters(index_cand, ds.get_queries(), k, params, output_stats=True)
+            r_new_k = faiss.eval_intersection(Inew[:, :k], ds.get_groundtruth()[:, :k]) / (ds.nq * k)
+            print(f"{nprobe=} k-recall@10={r_new_k}")
+
+            np.testing.assert_almost_equal(r_ref_k, r_new_k, 2)
+
+    def do_test_serde(self, description):
+        ds = datasets.SyntheticDataset(32, 1000, 100, 20)
+
+        xt = ds.get_train()
+        xb = ds.get_database()        
+
+        index = faiss.index_factory(ds.d, description)
+        index.train(ds.get_train())
+        index.add(ds.get_database())
+
+        Dref, Iref = index.search(ds.get_queries(), 10)
+
+        b = faiss.serialize_index(index)
+        index2 = faiss.deserialize_index(b)
+
+        Dnew, Inew = index2.search(ds.get_queries(), 10)
+
+        np.testing.assert_equal(Dref, Dnew)
+        np.testing.assert_equal(Iref, Inew)
+
+    def test_serde_ivfrabitq(self):
+        self.do_test_serde("IVF16,RaBitQ")

--- a/tests/test_rabitq.py
+++ b/tests/test_rabitq.py
@@ -395,3 +395,32 @@ class TestIVFRaBitQ(unittest.TestCase):
 
     def test_serde_ivfrabitq(self):
         self.do_test_serde("IVF16,RaBitQ")
+
+
+class TestRaBitQuantizerEncodeDecode(unittest.TestCase):
+    def do_test_encode_decode(self, d, metric):
+        # rabitq must precisely reconstruct a vector, 
+        #   which consists of +A and -A values
+
+        seed = 123
+        rs = np.random.RandomState(seed)
+
+        ampl = 100
+        n = 10
+        vec = (2 * rs.randint(0, 2, d * n) - 1).astype(np.float32) * ampl
+        vec = np.reshape(vec, (n, d))
+
+        quantizer = faiss.RaBitQuantizer(d, metric)
+
+        # encode and decode
+        vec_q = quantizer.compute_codes(vec)
+        vec_rec = quantizer.decode(vec_q)
+
+        # verify
+        np.testing.assert_equal(vec, vec_rec)
+
+    def test_encode_decode_L2(self):
+        self.do_test_encode_decode(16, faiss.METRIC_L2)
+
+    def test_encode_decode_IP(self):
+        self.do_test_encode_decode(16, faiss.METRIC_INNER_PRODUCT)


### PR DESCRIPTION
This is a reference implementation of the https://arxiv.org/pdf/2405.12497
> Jianyang Gao, Cheng Long, "RaBitQ: Quantizing High-Dimensional Vectors with a Theoretical Error Bound for Approximate Nearest Neighbor Search".

The goal is to correctly set up the internals using Faiss.

The following comments for the implementation:
* The code does not include the computations for the symmetric distance, because it is absent in the original article. This can be added later, though.
* The original `RaBitQ` includes random matrix rotation as a part of it, but I've decided to rely on external `faiss::IndexPreTransform` and `faiss::RandomRotationMatrix` facilities. 
* Certain features required internal changes in `faiss::IndexIVF`, but I did that as least invasive as possible, without breaking the backward compatibility.
* Not sure about naming convensions, maybe certain classes and structures need to be renamed
* `METRIC_INNER_PRODUCT` is supported as well
* More unit tests are needed?
* I did not bring any hardware-specific optimizations, bcz this is a reference implementation. Certain `simdlib` facilities may be added later, if needed

Here's how to use IndexRaBitQ
```Python
        ds = datasets.SyntheticDataset(...)

        index_rbq = faiss.IndexRaBitQ(ds.d, faiss.METRIC_L2)
        index_rbq.qb = 8

        # wrap with random rotations
        rrot = faiss.RandomRotationMatrix(ds.d, ds.d)
        rrot.init(rrot_seed)

        index_cand = faiss.IndexPreTransform(rrot, index_rbq)
        index_cand.train(ds.get_train())
        index_cand.add(ds.get_database())
```

Here's how to use IndexIVFRaBitQ
```Python
        ds = datasets.SyntheticDataset(...)

        index_flat = faiss.IndexFlat(ds.d, faiss.METRIC_L2)
        index_rbq = faiss.IndexIVFRaBitQ(index_flat, ds.d, nlist, faiss.METRIC_L2)
        index_rbq.qb = 8

        # wrap with random rotations
        rrot = faiss.RandomRotationMatrix(ds.d, ds.d)
        rrot.init(rrot_seed)

        index_cand = faiss.IndexPreTransform(rrot, index_rbq)
        index_cand.train(ds.get_train())
        index_cand.add(ds.get_database())
```