### PR TITLE
Address compile errors and warnings

### DIFF
--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -8,9 +8,7 @@
 #include <faiss/IndexHNSW.h>
 
 #include <omp.h>
-#include <cassert>
 #include <cinttypes>
-#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -124,7 +122,7 @@ void hnsw_add_vertices(
         int i1 = n;
 
         for (int pt_level = hist.size() - 1;
-             pt_level >= !index_hnsw.init_level0;
+             pt_level >= int(!index_hnsw.init_level0);
              pt_level--) {
             int i0 = i1 - hist[pt_level];
 

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -8,7 +8,6 @@
 #include <faiss/impl/HNSW.h>
 
 #include <cstddef>
-#include <string>
 
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/DistanceComputer.h>

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -11,9 +11,6 @@
 
 #include <faiss/index_factory.h>
 
-#include <cinttypes>
-#include <cmath>
-
 #include <map>
 
 #include <regex>
@@ -164,7 +161,7 @@ const std::string aq_norm_pattern =
 const std::string paq_def_pattern = "([0-9]+)x([0-9]+)x([0-9]+)";
 
 AdditiveQuantizer::Search_type_t aq_parse_search_type(
-        std::string stok,
+        const std::string& stok,
         MetricType metric) {
     if (stok == "") {
         return metric == METRIC_L2 ? AdditiveQuantizer::ST_decompress
@@ -766,7 +763,7 @@ std::unique_ptr<Index> index_factory_sub(
     }
 
     if (verbose) {
-        printf("after () normalization: %s %ld parenthesis indexes d=%d\n",
+        printf("after () normalization: %s %zd parenthesis indexes d=%d\n",
                description.c_str(),
                parenthesis_indexes.size(),
                d);


### PR DESCRIPTION
Summary:
Nightly has been broken and PRs have been blocked: https://github.com/facebookresearch/faiss/actions/runs/13798181461/job/38595760879?pr=4055

There are compiler errors in Autotune.cpp and warnings in some other files that this diff seeks to address.

Differential Revision: D71135388


