### PR TITLE
Fix bug with metric_arg in IndexHNSW

### DIFF
--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -210,7 +210,9 @@ IndexHNSW::IndexHNSW(int d, int M, MetricType metric)
         : Index(d, metric), hnsw(M) {}
 
 IndexHNSW::IndexHNSW(Index* storage, int M)
-        : Index(storage->d, storage->metric_type), hnsw(M), storage(storage) {}
+        : Index(storage->d, storage->metric_type), hnsw(M), storage(storage) {
+    metric_arg = storage->metric_arg;
+}
 
 IndexHNSW::~IndexHNSW() {
     if (own_fields) {
@@ -332,7 +334,6 @@ void IndexHNSW::add(idx_t n, const float* x) {
             storage,
             "Please use IndexHNSWFlat (or variants) instead of IndexHNSW directly");
     FAISS_THROW_IF_NOT(is_trained);
-    storage->metric_arg = metric_arg;
     int n0 = ntotal;
     storage->add(n, x);
     ntotal = storage->ntotal;

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -332,6 +332,7 @@ void IndexHNSW::add(idx_t n, const float* x) {
             storage,
             "Please use IndexHNSWFlat (or variants) instead of IndexHNSW directly");
     FAISS_THROW_IF_NOT(is_trained);
+    storage->metric_arg = metric_arg;
     int n0 = ntotal;
     storage->add(n, x);
     ntotal = storage->ntotal;

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -193,10 +193,11 @@ TEST(HNSW, Test_popmin_infinite_distances) {
     }
 }
 
-TEST(HNSW, Test_IndexHNSWFlat_METRIC_Lp) {
+TEST(HNSW, Test_IndexHNSW_METRIC_Lp) {
     // Create an HNSW index with METRIC_Lp and metric_arg = 3
-    faiss::IndexHNSWFlat index(1, 32, faiss::METRIC_Lp);
-    index.metric_arg = 3;
+    faiss::IndexFlat storage_index(1, faiss::METRIC_Lp);
+    storage_index.metric_arg = 3;
+    faiss::IndexHNSW index(&storage_index, 32);
 
     // Add a single data point
     float data[1] = {0.0};

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -193,6 +193,26 @@ TEST(HNSW, Test_popmin_infinite_distances) {
     }
 }
 
+TEST(HNSW, Test_IndexHNSWFlat_METRIC_Lp) {
+    // Create an HNSW index with METRIC_Lp and metric_arg = 3
+    faiss::IndexHNSWFlat index(1, 32, faiss::METRIC_Lp);
+    index.metric_arg = 3;
+
+    // Add a single data point
+    float data[1] = {0.0};
+    index.add(1, data);
+
+    // Prepare a query
+    float query[1] = {2.0};
+    float distance;
+    faiss::idx_t label;
+
+    index.search(1, query, 1, &distance, &label);
+
+    EXPECT_NEAR(distance, 8.0, 1e-5); // Distance should be 8.0 (2^3)
+    EXPECT_EQ(label, 0); // Label should be 0
+}
+
 class HNSWTest : public testing::Test {
    protected:
     HNSWTest() {

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -210,7 +210,7 @@ TEST(HNSW, Test_IndexHNSWFlat_METRIC_Lp) {
     index.search(1, query, 1, &distance, &label);
 
     EXPECT_NEAR(distance, 8.0, 1e-5); // Distance should be 8.0 (2^3)
-    EXPECT_EQ(label, 0); // Label should be 0
+    EXPECT_EQ(label, 0);              // Label should be 0
 }
 
 class HNSWTest : public testing::Test {


### PR DESCRIPTION
Fix #4224.

The issue is that `IndexHNSW`'s internal `Index* storage` doesn't inherit `metric_arg`. One solution is to set `metric_arg` in `IndexHNSW::add`, which is what I did. Not sure what the best place to do this would be.