### PR TITLE
fix bug: IVFPQ of raft/cuvs does not require redundant check  

### DIFF
--- a/faiss/gpu/GpuIndexIVFPQ.cu
+++ b/faiss/gpu/GpuIndexIVFPQ.cu
@@ -568,15 +568,14 @@ void GpuIndexIVFPQ::verifyPQSettings_() const {
         }
     }
 
-    // The number of bytes per encoded vector must be one we support
-    FAISS_THROW_IF_NOT_FMT(
-            ivfpqConfig_.interleavedLayout ||
-                    IVFPQ::isSupportedPQCodeLength(subQuantizers_),
-            "Number of bytes per encoded vector / sub-quantizers (%d) "
-            "is not supported",
-            subQuantizers_);
-
     if (!should_use_cuvs(config_)) {
+        // The number of bytes per encoded vector must be one we support
+        FAISS_THROW_IF_NOT_FMT(
+                ivfpqConfig_.interleavedLayout ||
+                        IVFPQ::isSupportedPQCodeLength(subQuantizers_),
+                "Number of bytes per encoded vector / sub-quantizers (%d) "
+                "is not supported",
+                subQuantizers_);
         // Sub-quantizers must evenly divide dimensions available
         FAISS_THROW_IF_NOT_FMT(
                 this->d % subQuantizers_ == 0,


### PR DESCRIPTION
The IVFPQ of raft/cuvs does not require pq length check for Faiss' original implementation. This check make IVFPQ support limited parameters than raft/cuvs in vain.
The check of supported PQ code length here 
https://github.com/facebookresearch/faiss/blob/df6a8f6b4e6ed4c509e52d1e015f87fd742c17df/faiss/gpu/impl/IVFPQ.cu#L80-L102

is for Faiss' original CUDA implementation. Raft/cuvs support more choices.

The wiki of faiss also describe the limitation (https://github.com/facebookresearch/faiss/wiki/Faiss-on-the-GPU#limitations), which needs to be update, too. Raft/cuvs is not limited to those choices.