### PR TITLE
fix `IVFPQFastScan::RangeSearch()` on the `ARM` architecture

### DIFF
--- a/faiss/impl/simd_result_handlers.h
+++ b/faiss/impl/simd_result_handlers.h
@@ -576,7 +576,7 @@ struct RangeHandler : ResultHandlerCompare<C, with_id_map> {
         normalizers = norms;
         for (int q = 0; q < nq; ++q) {
             thresholds[q] =
-                    normalizers[2 * q] * (radius - normalizers[2 * q + 1]);
+                    int(normalizers[2 * q] * (radius - normalizers[2 * q + 1]));
         }
     }
 


### PR DESCRIPTION
the problem happens if `radius - normalizers[2 * q + 1]` is negative. Thus, it is possible to provide reasonable parameters to `IVFPQFastScan::RangeSearch()` and get an empty result.

I have no idea WHY (hardware implementation, it seems), but the following code 
```C++
#include <cstddef>
#include <cstdint>
#include <iostream>

int main() {
    float f = -25.5f;
    uint16_t t = f;
    std::cout << t << std::endl;
    return 0;
}
```
prints `65511` on `x86` and `0` on ARM on the same compiler.

Thus, it is needed to wrap the `float` value with `int` to preserve a correct cast:
```C++
    uint16_t t = (int)f;
``` 

Who would have thought...

It is useful to find some C++ compiler command line flags that will generate a compilation error on such a behavior.
