### PR TITLE
Fix a placeholder for 'unimplemented' in mapped_io.cpp

### DIFF
--- a/faiss/impl/mapped_io.cpp
+++ b/faiss/impl/mapped_io.cpp
@@ -227,12 +227,15 @@ struct MmappedFileMappingOwner::PImpl {
 #else
 
 struct MmappedFileMappingOwner::PImpl {
-    PImpl(FILE* f) {
-        FAISS_THROW_FMT("Not implemented");
+    void* ptr = nullptr;
+    size_t ptr_size = 0;
+
+    PImpl(const std::string& filename) {
+        FAISS_THROW_MSG("Not implemented");
     }
 
-    ~PImpl() {
-        FAISS_THROW_FMT("Not implemented");
+    PImpl(FILE* f) {
+        FAISS_THROW_MSG("Not implemented");
     }
 };
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -11,6 +11,7 @@ import os
 import io
 import sys
 import pickle
+import platform
 from multiprocessing.pool import ThreadPool
 from common_faiss_tests import get_dataset_2
 
@@ -485,6 +486,10 @@ class TestIVFPQRead(unittest.TestCase):
 
 
 class TestIOFlatMMap(unittest.TestCase):
+    @unittest.skipIf(
+        platform.system() not in ["Windows", "Linux"],
+        "supported OSes only"
+    )
     def test_mmap(self): 
         xt, xb, xq = get_dataset_2(32, 0, 100, 50)
         index = faiss.index_factory(32, "SQfp16", faiss.METRIC_L2)


### PR DESCRIPTION
This should fix a problem on macos compilation (just compilation), as discussed in https://github.com/facebookresearch/faiss/pull/4250#issuecomment-2767317033
@mnorris11 please verify

