### PR TITLE
Handle insufficient driver gracefully

### DIFF
--- a/faiss/gpu/utils/DeviceUtils.cu
+++ b/faiss/gpu/utils/DeviceUtils.cu
@@ -30,7 +30,7 @@ void setCurrentDevice(int device) {
 int getNumDevices() {
     int numDev = -1;
     cudaError_t err = cudaGetDeviceCount(&numDev);
-    if (cudaErrorNoDevice == err) {
+    if (cudaErrorNoDevice == err || cudaErrorInsufficientDriver == err) {
         numDev = 0;
     } else {
         CUDA_VERIFY(err);


### PR DESCRIPTION
Gracefully handle insufficient drivers (ex. no driver available.)

Resolves #4251 