### PR TITLE
Skip mmap test case in AIX.

### DIFF
--- a/tests/test_mmap.cpp
+++ b/tests/test_mmap.cpp
@@ -60,6 +60,9 @@ std::vector<uint8_t> make_binary_data(
 //      on top of the existing File1 again
 
 TEST(TestMmap, mmap_flatcodes) {
+#ifdef _AIX
+    GTEST_SKIP() << "Skipping test on AIX.";
+#endif
     // generate data
     const size_t nt = 1000;
     const size_t nq = 10;
@@ -161,6 +164,9 @@ TEST(TestMmap, mmap_flatcodes) {
 }
 
 TEST(TestMmap, mmap_binary_flatcodes) {
+#ifdef _AIX
+    GTEST_SKIP() << "Skipping test on AIX.";
+#endif
     // generate data
     const size_t nt = 1000;
     const size_t nq = 10;


### PR DESCRIPTION
In AIX, the recent mmap feature is not implemented. So we can skip these test case.

In our internal CI's when we run the test cases, we have two failures.
 21/132 Test  #21: TestMmap.mmap_flatcodes ...........................................***Failed    0.03 sec
        Start  22: TestMmap.mmap_binary_flatcodes
 22/132 Test  #22: TestMmap.mmap_binary_flatcodes ....................................***Failed    0.04 sec
 
Currently these two test cases run since it is written in C. We want to block them like the PR [here](https://github.com/facebookresearch/faiss/commit/df9e2c48d6504fbc6052743aee6bf0b3e4b1f486#diff-26824e205001fe146a1634cf74c1dda1cdb8a07b6216545990b773a12da705d4R15-R489) does.

Kindly let me know what you think.