### PR TITLE
Add normalize_l2 boolean to distributed training API

### DIFF
--- a/benchs/bench_fw/descriptors.py
+++ b/benchs/bench_fw/descriptors.py
@@ -223,6 +223,7 @@ class CodecDescriptor(IndexBaseDescriptor):
     factory: Optional[str] = None
     construction_params: Optional[List[Dict[str, int]]] = None
     training_vectors: Optional[DatasetDescriptor] = None
+    normalize_l2: bool = False
     FILENAME_PREFIX: str = "xt"
 
     def __post_init__(self):


### PR DESCRIPTION
Summary: Add normalize_l2 boolean to distributed training API. This is just adding the field, implementation will come in the next diff

Reviewed By: junjieqi

Differential Revision: D72621956


