### PR TITLE
Implement is_spherical and normalize_L2 booleans as part of the training APIs

### DIFF
--- a/benchs/bench_fw/descriptors.py
+++ b/benchs/bench_fw/descriptors.py
@@ -224,6 +224,7 @@ class CodecDescriptor(IndexBaseDescriptor):
     construction_params: Optional[List[Dict[str, int]]] = None
     training_vectors: Optional[DatasetDescriptor] = None
     normalize_l2: bool = False
+    is_spherical: bool = False
     FILENAME_PREFIX: str = "xt"
 
     def __post_init__(self):


### PR DESCRIPTION
Summary: Implement is_spherical and normalize_L2 booleans as part of the training APIs

Differential Revision: D72685672


