### PR TITLE
Add missing header in faiss/CMakeLists.txt

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -163,6 +163,7 @@ set(FAISS_HEADERS
   impl/LocalSearchQuantizer.h
   impl/ProductAdditiveQuantizer.h
   impl/LookupTableScaler.h
+  impl/maybe_owned_vector.h
   impl/NNDescent.h
   impl/NSG.h
   impl/PolysemousTraining.h


### PR DESCRIPTION
Summary:
This oss issue says we should be including this file in the build: https://github.com/facebookresearch/faiss/issues/4281

I am a noob a this, let me know if this I am missing something here.

Differential Revision: D72768634


