### PR TITLE
Fix nightly by pinning conda-build to prevent regression in 25.3.2 (#4286)

### DIFF
--- a/.github/actions/build_conda/action.yml
+++ b/.github/actions/build_conda/action.yml
@@ -44,7 +44,7 @@ runs:
         # Ensure starting packages are from conda-forge.
         conda list --show-channel-urls
         conda install -y -q "conda!=24.11.0"
-        conda install -y -q "conda-build!=24.11.0" "liblief=0.14.1"
+        conda install -y -q "conda-build=25.3.1" "liblief=0.14.1"
         conda list --show-channel-urls
     - name: Enable anaconda uploads
       if: inputs.label != ''


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/facebookresearch/faiss/pull/4286

Differential Revision: D72801907


