### PR TITLE
Fix Type Error in Conditional Logic

### DIFF
--- a/faiss/python/class_wrappers.py
+++ b/faiss/python/class_wrappers.py
@@ -1038,7 +1038,7 @@ def handle_VectorTransform(the_class):
 
 def handle_AutoTuneCriterion(the_class):
     def replacement_set_groundtruth(self, D, I):
-        if D:
+        if D is not None:
             assert I.shape == D.shape
         self.nq, self.gt_nnn = I.shape
         self.set_groundtruth_c(


### PR DESCRIPTION
The old logic was asking for `D`'s shape, which indicated that it should be a NumPy array. However, if you check the truth value of a NumPy array, you get an error.

The code is checking for the existence of `D`. The most direct way to handle that is to make sure that it isn't `None`.