### PR TITLE
Fix overflow of int32 in IndexNSG

### DIFF
--- a/faiss/impl/NNDescent.cpp
+++ b/faiss/impl/NNDescent.cpp
@@ -400,7 +400,7 @@ void NNDescent::build(DistanceComputer& qdis, const int n, bool verbose) {
     init_graph(qdis);
     nndescent(qdis, verbose);
 
-    final_graph.resize(ntotal * K);
+    final_graph.resize(uint64_t(ntotal) * K);
 
     // Store the neighbor link structure into final_graph
     // Clear the old graph


### PR DESCRIPTION
Summary:
See https://github.com/facebookresearch/faiss/issues/4295

int overflow in IndexNSG flow

Differential Revision: D73048518


