### PR TITLE
Added option to build GPU libraries separately

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ option(FAISS_ENABLE_MKL "Enable MKL." ON)
 option(FAISS_ENABLE_PYTHON "Build Python extension." ON)
 option(FAISS_ENABLE_C_API "Build C API." OFF)
 option(FAISS_ENABLE_EXTRAS "Build extras like benchmarks and demos" ON)
+option(FAISS_BUILD_GPU_SHARED_LIBS "Build GPU shared libraries." OFF)
 option(FAISS_USE_LTO "Enable Link-Time optimization" OFF)
 
 if(FAISS_ENABLE_GPU)

--- a/c_api/gpu/CMakeLists.txt
+++ b/c_api/gpu/CMakeLists.txt
@@ -3,7 +3,15 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-target_sources(faiss_c PRIVATE
+if(FAISS_BUILD_GPU_SHARED_LIBS)
+  add_library(faiss_gpu_c)
+  target_link_libraries(faiss_gpu_c PRIVATE faiss_gpu)
+  set(FAISS_GPU_C faiss_gpu_c)
+else()
+  set(FAISS_GPU_C faiss_c)
+endif()
+
+target_sources(FAISS_GPU_C PRIVATE
   DeviceUtils_c.cpp
   GpuAutoTune_c.cpp
   GpuClonerOptions_c.cpp
@@ -16,11 +24,11 @@ file(GLOB FAISS_C_API_GPU_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.h")
 faiss_install_headers("${FAISS_C_API_GPU_HEADERS}" c_api/gpu)
 
 if (FAISS_ENABLE_ROCM)
-  target_link_libraries(faiss_c PUBLIC hip::host roc::hipblas)
+  target_link_libraries(FAISS_GPU_C PUBLIC hip::host roc::hipblas)
 else()
   find_package(CUDAToolkit REQUIRED)
-  target_link_libraries(faiss_c PUBLIC CUDA::cudart CUDA::cublas $<$<BOOL:${FAISS_ENABLE_CUVS}>:cuvs::cuvs>)
+  target_link_libraries(FAISS_GPU_C PUBLIC CUDA::cudart CUDA::cublas $<$<BOOL:${FAISS_ENABLE_CUVS}>:cuvs::cuvs>)
 endif()
 
 add_executable(example_gpu_c EXCLUDE_FROM_ALL example_gpu_c.c)
-target_link_libraries(example_gpu_c PRIVATE faiss_c)
+target_link_libraries(example_gpu_c PRIVATE FAISS_GPU_C)

--- a/faiss/gpu/CMakeLists.txt
+++ b/faiss/gpu/CMakeLists.txt
@@ -258,7 +258,11 @@ if(FAISS_ENABLE_CUVS)
           utils/CuvsUtils.cu)
 endif()
 
-add_library(faiss_gpu STATIC ${FAISS_GPU_SRC})
+if(FAISS_BUILD_GPU_SHARED_LIBS)
+  add_library(faiss_gpu SHARED ${FAISS_GPU_SRC})
+else()
+  add_library(faiss_gpu STATIC ${FAISS_GPU_SRC})
+endif()
 set_target_properties(faiss_gpu PROPERTIES
   POSITION_INDEPENDENT_CODE ON
   WINDOWS_EXPORT_ALL_SYMBOLS ON
@@ -308,11 +312,13 @@ endif()
 # Export FAISS_GPU_HEADERS variable to parent scope.
 set(FAISS_GPU_HEADERS ${FAISS_GPU_HEADERS} PARENT_SCOPE)
 
-target_link_libraries(faiss PRIVATE  "$<LINK_LIBRARY:WHOLE_ARCHIVE,faiss_gpu>")
-target_link_libraries(faiss_avx2 PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,faiss_gpu>")
-target_link_libraries(faiss_avx512 PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,faiss_gpu>")
-target_link_libraries(faiss_avx512_spr PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,faiss_gpu>")
-target_link_libraries(faiss_sve PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,faiss_gpu>")
+if(NOT FAISS_BUILD_GPU_SHARED_LIBS)
+  target_link_libraries(faiss PRIVATE  "$<LINK_LIBRARY:WHOLE_ARCHIVE,faiss_gpu>")
+  target_link_libraries(faiss_avx2 PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,faiss_gpu>")
+  target_link_libraries(faiss_avx512 PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,faiss_gpu>")
+  target_link_libraries(faiss_avx512_spr PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,faiss_gpu>")
+  target_link_libraries(faiss_sve PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,faiss_gpu>")
+endif()
 
 foreach(header ${FAISS_GPU_HEADERS})
   get_filename_component(dir ${header} DIRECTORY )


### PR DESCRIPTION
In some cases, it might be preferable to have GPU support as an optional add-on feature, e.g., in Julia. This PR adds a cmake option to enable the GPU library, and the GPU C library, to be built as separate libraries.

This enables a consumer to `dlopen` (`libfaiss_c`, and) `libfaiss`, and if, e.g., CUDA is available to also load the CUDA (`libfaiss_gpu_c`, and) `libfaiss_gpu`.
