### PR TITLE
Update Swig File for CAGRA Params

### DIFF
--- a/faiss/gpu/test/test_cagra.py
+++ b/faiss/gpu/test/test_cagra.py
@@ -23,7 +23,14 @@ class TestComputeGT(unittest.TestCase):
 
         res = faiss.StandardGpuResources()
 
-        index = faiss.GpuIndexCagra(res, d, metric)
+        # attempt to set custom IVF-PQ params
+        cagraIndexConfig = faiss.GpuIndexCagraConfig()
+        cagraIndexIVFPQConfig = faiss.IVFPQBuildCagraConfig()
+        cagraIndexIVFPQConfig.kmeans_trainset_fraction = 0.1
+        cagraIndexConfig.ivf_pq_params = cagraIndexIVFPQConfig
+        cagraIndexConfig.build_algo = faiss.graph_build_algo_IVF_PQ
+
+        index = faiss.GpuIndexCagra(res, d, metric, cagraIndexConfig)
         index.train(ds.get_database())
         Dnew, Inew = index.search(ds.get_queries(), k)
         

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -406,6 +406,8 @@ int64_t cast_cudastream_t_to_integer(hipStream_t x) {
 
 %shared_ptr(faiss::gpu::GpuResources);
 %shared_ptr(faiss::gpu::StandardGpuResourcesImpl);
+%shared_ptr(faiss::gpu::IVFPQBuildCagraConfig);
+%shared_ptr(faiss::gpu::IVFPQSearchCagraConfig);
 
 %{
 


### PR DESCRIPTION
IVF-PQ params are currently stored as `shared_ptr` objects in the Cagra param struct. This PR updates the swig file to reflect this. Without this change, setting custom IVF-PQ params via the python side throws the following error:
Script:
```
cagraIndexConfig = faiss.GpuIndexCagraConfig()
cagraIndexIVFPQConfig = faiss.IVFPQBuildCagraConfig()
cagraIndexIVFPQConfig.kmeans_trainset_fraction = 0.1
cagraIndexConfig.ivf_pq_params = cagraIndexIVFPQConfig
```
Error:
```
TypeError                                 Traceback (most recent call last)
Cell In[15], line 8
      6 cagraIndexIVFPQConfig = faiss.IVFPQBuildCagraConfig()
      7 cagraIndexIVFPQConfig.kmeans_trainset_fraction = 0.1
----> 8 cagraIndexConfig.ivf_pq_params = cagraIndexIVFPQConfig
      9 cagraIndexConfig.build_algo = faiss.graph_build_algo_IVF_PQ

TypeError: in method 'GpuIndexCagraConfig_ivf_pq_params_set', argument 2 of type 'std::shared_ptr< faiss::gpu::IVFPQBuildCagraConfig > *'
```

This PR should solve this error.
Also testing custom IVF-PQ params in the cagra python tests to test this in CI.