### PR TITLE
Increase top-k limit on GPU

### DIFF
--- a/faiss/gpu/GpuAutoTune.cpp
+++ b/faiss/gpu/GpuAutoTune.cpp
@@ -54,8 +54,10 @@ void GpuParameterSpace::initialize(const Index* index) {
         ParameterRange& pr = add_range("nprobe");
         for (int i = 0; i < 12; i++) {
             size_t nprobe = 1 << i;
-            if (nprobe >= ix->getNumLists() || nprobe > getMaxKSelection())
+            if (nprobe >= ix->getNumLists() ||
+                nprobe > getMaxKSelection(false)) {
                 break;
+            }
             pr.values.push_back(nprobe);
         }
 

--- a/faiss/gpu/GpuIndex.cu
+++ b/faiss/gpu/GpuIndex.cu
@@ -264,7 +264,7 @@ void GpuIndex::assign(idx_t n, const float* x, idx_t* labels, idx_t k) const {
     DeviceScope scope(config_.device);
     FAISS_THROW_IF_NOT_MSG(this->is_trained, "Index not trained");
 
-    validateKSelect(k);
+    validateKSelect(k, should_use_cuvs(config_));
 
     auto stream = resources_->getDefaultStream(config_.device);
 
@@ -288,7 +288,7 @@ void GpuIndex::search(
     DeviceScope scope(config_.device);
     FAISS_THROW_IF_NOT_MSG(this->is_trained, "Index not trained");
 
-    validateKSelect(k);
+    validateKSelect(k, should_use_cuvs(config_));
 
     if (n == 0 || k == 0) {
         // nothing to search

--- a/faiss/gpu/GpuIndexBinaryFlat.cu
+++ b/faiss/gpu/GpuIndexBinaryFlat.cu
@@ -148,7 +148,7 @@ void GpuIndexBinaryFlat::search(
 
     FAISS_THROW_IF_NOT_MSG(!params, "params not implemented");
 
-    validateKSelect(k);
+    validateKSelect(k, binaryFlatConfig_.use_cuvs);
 
     // The input vectors may be too large for the GPU, but we still
     // assume that the output distances and labels are not.

--- a/faiss/gpu/GpuIndexIVF.cu
+++ b/faiss/gpu/GpuIndexIVF.cu
@@ -154,7 +154,7 @@ void GpuIndexIVF::copyFrom(const faiss::IndexIVF* index) {
     FAISS_ASSERT(index->nlist > 0);
     nlist = index->nlist;
 
-    validateNProbe(index->nprobe);
+    validateNProbe(index->nprobe, should_use_cuvs(config_));
     nprobe = index->nprobe;
 
     // The metric type may have changed as well, so we might have to
@@ -317,7 +317,7 @@ int GpuIndexIVF::getCurrentNProbe_(const SearchParameters* params) const {
         }
     }
 
-    validateNProbe(use_nprobe);
+    validateNProbe(use_nprobe, should_use_cuvs(config_));
     // We use int internally for nprobe
     return int(use_nprobe);
 }
@@ -367,7 +367,7 @@ void GpuIndexIVF::search_preassigned(
     FAISS_THROW_IF_NOT_MSG(this->is_trained, "GpuIndexIVF not trained");
     FAISS_ASSERT(baseIndex_);
 
-    validateKSelect(k);
+    validateKSelect(k, should_use_cuvs(config_));
 
     if (n == 0 || k == 0) {
         // nothing to search
@@ -375,7 +375,7 @@ void GpuIndexIVF::search_preassigned(
     }
 
     idx_t use_nprobe = params ? params->nprobe : this->nprobe;
-    validateNProbe(use_nprobe);
+    validateNProbe(use_nprobe, should_use_cuvs(config_));
 
     size_t max_codes = params ? params->max_codes : this->max_codes;
     FAISS_THROW_IF_NOT_FMT(

--- a/faiss/gpu/impl/Distance.cu
+++ b/faiss/gpu/impl/Distance.cu
@@ -19,6 +19,7 @@
 #include <faiss/gpu/utils/Limits.cuh>
 #include <faiss/gpu/utils/MatrixMult.cuh>
 
+#include <faiss/gpu/impl/IndexUtils.h>
 #include <thrust/device_ptr.h>
 #include <thrust/execution_policy.h>
 #include <thrust/fill.h>
@@ -201,7 +202,7 @@ void runDistance(
 
     // We can have any number of vectors to query against, even less than k, in
     // which case we'll return -1 for the index
-    FAISS_ASSERT(k <= GPU_MAX_SELECTION_K); // select limitation
+    FAISS_ASSERT(k <= getMaxKSelection(false)); // select limitation
 
     // Temporary output memory space we'll use
     DeviceTensor<float, 2, true> distanceBuf1(

--- a/faiss/gpu/impl/IndexUtils.cu
+++ b/faiss/gpu/impl/IndexUtils.cu
@@ -18,23 +18,26 @@ namespace gpu {
 /// Returns the maximum k-selection value supported based on the CUDA SDK that
 /// we were compiled with. .cu files can use DeviceDefs.cuh, but this is for
 /// non-CUDA files
-int getMaxKSelection() {
+int getMaxKSelection(bool use_cuvs) {
+    if (use_cuvs) {
+        return 16384;
+    }
     return GPU_MAX_SELECTION_K;
 }
 
-void validateKSelect(int k) {
+void validateKSelect(int k, bool use_cuvs) {
     FAISS_THROW_IF_NOT_FMT(
-            k > 0 && k <= getMaxKSelection(),
+            k > 0 && k <= getMaxKSelection(use_cuvs),
             "GPU index only supports min/max-K selection up to %d (requested %d)",
-            getMaxKSelection(),
+            getMaxKSelection(use_cuvs),
             k);
 }
 
-void validateNProbe(size_t nprobe) {
+void validateNProbe(size_t nprobe, bool use_cuvs) {
     FAISS_THROW_IF_NOT_FMT(
-            nprobe > 0 && nprobe <= (size_t)getMaxKSelection(),
+            nprobe > 0 && nprobe <= (size_t)getMaxKSelection(use_cuvs),
             "GPU IVF index only supports nprobe selection up to %d (requested %zu)",
-            getMaxKSelection(),
+            getMaxKSelection(use_cuvs),
             nprobe);
 }
 

--- a/faiss/gpu/impl/IndexUtils.h
+++ b/faiss/gpu/impl/IndexUtils.h
@@ -17,13 +17,13 @@ namespace gpu {
 /// Returns the maximum k-selection value supported based on the CUDA SDK that
 /// we were compiled with. .cu files can use DeviceDefs.cuh, but this is for
 /// non-CUDA files
-int getMaxKSelection();
+int getMaxKSelection(bool use_cuvs = false);
 
 // Validate the k parameter for search
-void validateKSelect(int k);
+void validateKSelect(int k, bool use_cuvs = false);
 
 // Validate the nprobe parameter for search
-void validateNProbe(size_t nprobe);
+void validateNProbe(size_t nprobe, bool use_cuvs = false);
 
 } // namespace gpu
 } // namespace faiss

--- a/faiss/gpu/test/TestGpuIndexBinaryFlat.cpp
+++ b/faiss/gpu/test/TestGpuIndexBinaryFlat.cpp
@@ -79,7 +79,7 @@ void testGpuIndexBinaryFlat(int kOverride = -1) {
 
     int k = kOverride > 0
             ? kOverride
-            : faiss::gpu::randVal(1, faiss::gpu::getMaxKSelection());
+            : faiss::gpu::randVal(1, faiss::gpu::getMaxKSelection(false));
     int numVecs = faiss::gpu::randVal(k + 1, 20000);
     int numQuery = faiss::gpu::randVal(1, 1000);
 

--- a/faiss/gpu/test/TestGpuIndexFlat.cpp
+++ b/faiss/gpu/test/TestGpuIndexFlat.cpp
@@ -56,7 +56,8 @@ void testFlat(const TestFlatOptions& opt) {
     int k = opt.useFloat16
             ? std::min(faiss::gpu::randVal(1, 50), numVecs)
             : std::min(
-                      faiss::gpu::randVal(1, faiss::gpu::getMaxKSelection()),
+                      faiss::gpu::randVal(
+                              1, faiss::gpu::getMaxKSelection(opt.use_cuvs)),
                       numVecs);
     if (opt.kOverride > 0) {
         k = opt.kOverride;
@@ -164,7 +165,7 @@ TEST(TestGpuIndexFlat, L2_Float32) {
 
 // At least one test for the k > 1024 select
 TEST(TestGpuIndexFlat, L2_k_2048) {
-    if (faiss::gpu::getMaxKSelection() >= 2048) {
+    if (faiss::gpu::getMaxKSelection(false) >= 2048) {
         TestFlatOptions opt;
         opt.metric = faiss::MetricType::METRIC_L2;
         opt.useFloat16 = false;

--- a/faiss/gpu/test/test_cuvs.py
+++ b/faiss/gpu/test/test_cuvs.py
@@ -15,6 +15,21 @@ from faiss.contrib.datasets import SyntheticDataset
     "only if CUVS is compiled in")
 class TestBfKnn(unittest.TestCase):
 
+    def test_large_k_search(self):
+        k = 10_000
+        ds = SyntheticDataset(32, 100_000, 100_000, 1000)
+        res = faiss.StandardGpuResources()
+        config = faiss.GpuIndexFlatConfig()
+        config.use_cuvs = True
+        index_gpu = faiss.GpuIndexFlatL2(res, ds.d, config)
+
+        index_gpu.add(ds.get_database())
+
+        # Try larger than 2048
+        _, I = index_gpu.search(ds.get_queries(), k)
+        np.testing.assert_equal(I.shape, (ds.nq, k))
+
+
     def test_bfKnn(self):
 
         ds = SyntheticDataset(32, 0, 4321, 1234)


### PR DESCRIPTION
Differential Revision: D74007435

We cannot just use ifdef USE_NVIDIA_CUVS #define GPU_MAX_SELECTION_K 16384, because we may compile such that USE_NVIDIA_CUVS but we are not presently using a cuVS index.
- Distance.cu is part of Faiss GPU code, so it hard codes to false.
- TestGpuIndexBinaryFlat also just hard codes to false, because it has some interaction with CPU BinaryFlat index. It doesn't use cuVS currently, so no need to expand that test (I think)
- We don't need to deal with GpuAutoTune for cuVS indexes for now, so it hard codes to false. This can be updated later if we want to. We would need to move the config out of protected in GpuIndex.h.
- Other call sites set it to the value of the config.use_cuvs.

