### PR TITLE
cmake: install missing header `impl/zerocopy_io.h`

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -185,6 +185,7 @@ set(FAISS_HEADERS
   impl/pq4_fast_scan.h
   impl/residual_quantizer_encode_steps.h
   impl/simd_result_handlers.h
+  impl/zerocopy_io.h
   impl/code_distance/code_distance.h
   impl/code_distance/code_distance-generic.h
   impl/code_distance/code_distance-avx2.h


### PR DESCRIPTION
Not installing this header would make `tests/test_zerocopy.cpp` fail to compile outside the project source tree.

```
[1/35] /usr/bin/c++  -I/tmp/autopkgtest.v36ELd/autopkgtest_tmp/tests/../include -O3 -DNDEBUG -fopenmp -DGTEST_HAS_PTHREAD=1 -MD -MT CMakeFiles/faiss_test.dir/test_zerocopy.cpp.o -MF CMakeFiles/faiss_test.dir/test_zerocopy.cpp.o.d -o CMakeFiles/faiss_test.dir/test_zerocopy.cpp.o -c /tmp/autopkgtest.v36ELd/autopkgtest_tmp/tests/test_zerocopy.cpp
FAILED: CMakeFiles/faiss_test.dir/test_zerocopy.cpp.o
/usr/bin/c++  -I/tmp/autopkgtest.v36ELd/autopkgtest_tmp/tests/../include -O3 -DNDEBUG -fopenmp -DGTEST_HAS_PTHREAD=1 -MD -MT CMakeFiles/faiss_test.dir/test_zerocopy.cpp.o -MF CMakeFiles/faiss_test.dir/test_zerocopy.cpp.o.d -o CMakeFiles/faiss_test.dir/test_zerocopy.cpp.o -c /tmp/autopkgtest.v36ELd/autopkgtest_tmp/tests/test_zerocopy.cpp
/tmp/autopkgtest.v36ELd/autopkgtest_tmp/tests/test_zerocopy.cpp:18:10: fatal error: faiss/impl/zerocopy_io.h: No such file or directory
   18 | #include <faiss/impl/zerocopy_io.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```