### PR TITLE
Use packaging.version for correct version parsing

### DIFF
--- a/faiss/python/loader.py
+++ b/faiss/python/loader.py
@@ -8,9 +8,8 @@ import subprocess
 import logging
 import os
 
+from packaging.version import Version
 
-def Version(v):
-    return [int(x) for x in v.split('.')]
 
 def supported_instruction_sets():
     """


### PR DESCRIPTION
If you use a version of numpy that has non-numeric components to the version number (e.g. a [local version identifier](https://peps.python.org/pep-0440/#local-version-identifiers)), `faiss` will not import because the hand-rolled version parsing expects only digits:
```
$ /venv/bin/python -c 'import numpy; print(numpy.__version__)'
2.0.2+hrt0
$ /venv/bin/python -c 'import faiss'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/venv/lib/python3.12/site-packages/faiss/__init__.py", line 17, in <module>
    from .loader import *
  File "/venv/lib/python3.12/site-packages/faiss/loader.py", line 91, in <module>
    instruction_sets = supported_instruction_sets()
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.12/site-packages/faiss/loader.py", line 47, in supported_instruction_sets
    if Version(numpy.__version__) >= Version("1.19"):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.12/site-packages/faiss/loader.py", line 13, in Version
    return [int(x) for x in v.split('.')]
            ^^^^^^
ValueError: invalid literal for int() with base 10: '2+hrt0'
```

This project depends on `packaging`, but the use was removed in #3807 (though the metadata wasn't). This restores the correct parsing of `Version`. If you'd prefer not to add this dependency, what is your suggestion for correctly parsing the numpy version (also, the `install_requires` line should be updated)