### PR TITLE
[BUG] Copy IVF Centroids to Host for CPU Quantizer

### DIFF
--- a/faiss/gpu/GpuIndexIVFFlat.cu
+++ b/faiss/gpu/GpuIndexIVFFlat.cu
@@ -266,11 +266,20 @@ void GpuIndexIVFFlat::train(idx_t n, const float* x) {
                     raft_handle, cuvs_index_params, dataset_h);
         }
 
-        quantizer->train(
-                nlist, cuvs_ivfflat_index.value().centers().data_handle());
-        quantizer->add(
-                nlist, cuvs_ivfflat_index.value().centers().data_handle());
-        raft_handle.sync_stream();
+        if (isGpuIndex(quantizer)) {
+            quantizer->train(
+                    nlist, cuvs_ivfflat_index.value().centers().data_handle());
+            quantizer->add(
+                    nlist, cuvs_ivfflat_index.value().centers().data_handle());
+        } else {
+            // transfer centroids to host
+            auto host_centroids = toHost<float, 2>(
+                    cuvs_ivfflat_index.value().centers().data_handle(),
+                    raft_handle.get_stream(),
+                    {nlist, this->d});
+            quantizer->train(nlist, host_centroids.data_handle());
+            quantizer->add(nlist, host_centroids.data_handle());
+        }
 
         cuvsIndex_->setCuvsIndex(std::move(*cuvs_ivfflat_index));
 #else

--- a/faiss/gpu/GpuIndexIVFPQ.cu
+++ b/faiss/gpu/GpuIndexIVFPQ.cu
@@ -424,8 +424,18 @@ void GpuIndexIVFPQ::train(idx_t n, const float* x) {
         cuvs::neighbors::ivf_pq::helpers::extract_centers(
                 raft_handle, cuvs_ivfpq_index.value(), cluster_centers.view());
 
-        quantizer->train(nlist, cluster_centers.data_handle());
-        quantizer->add(nlist, cluster_centers.data_handle());
+        if (isGpuIndex(quantizer)) {
+            quantizer->train(nlist, cluster_centers.data_handle());
+            quantizer->add(nlist, cluster_centers.data_handle());
+        } else {
+            // transfer centroids to host
+            auto host_centroids = toHost<float, 2>(
+                    cluster_centers.data_handle(),
+                    raft_handle.get_stream(),
+                    {nlist, this->d});
+            quantizer->train(nlist, host_centroids.data_handle());
+            quantizer->add(nlist, host_centroids.data_handle());
+        }
 
         raft::copy(
                 pq.get_centroids(0, 0),


### PR DESCRIPTION
For cuVS IVF indexes, identify if the coarse quantizer is a CPU index before adding the IVF centroids to it.