### PR TITLE
Fix incorrect constructor docstring for IndexScalarQuantizer

### DIFF
--- a/faiss/IndexScalarQuantizer.h
+++ b/faiss/IndexScalarQuantizer.h
@@ -29,8 +29,8 @@ struct IndexScalarQuantizer : IndexFlatCodes {
     /** Constructor.
      *
      * @param d      dimensionality of the input vectors
-     * @param M      number of subquantizers
-     * @param nbits  number of bit per subvector index
+     * @param qtype  type of scalar quantizer (e.g., QT_4bit)
+     * @param metric distance metric used for search (default: METRIC_L2)
      */
     IndexScalarQuantizer(
             int d,


### PR DESCRIPTION
This PR fixes a docstring inconsistency in the IndexScalarQuantizer constructor.

The current doc refers to M and nbits, which are not actual parameters.
This change updates the documentation to reflect the correct usage: (d, qtype, metric).