### PR TITLE
Pass in "own_invlists" to ivf index constructor

### DIFF
--- a/faiss/IndexBinaryIVF.cpp
+++ b/faiss/IndexBinaryIVF.cpp
@@ -26,9 +26,16 @@
 
 namespace faiss {
 
-IndexBinaryIVF::IndexBinaryIVF(IndexBinary* quantizer, size_t d, size_t nlist)
+IndexBinaryIVF::IndexBinaryIVF(
+        IndexBinary* quantizer,
+        size_t d,
+        size_t nlist,
+        bool own_invlists)
         : IndexBinary(d),
-          invlists(new ArrayInvertedLists(nlist, code_size)),
+          invlists(
+                  own_invlists ? new ArrayInvertedLists(nlist, code_size)
+                               : nullptr),
+          own_invlists(own_invlists),
           quantizer(quantizer),
           nlist(nlist) {
     FAISS_THROW_IF_NOT(d == quantizer->d);

--- a/faiss/IndexBinaryIVF.h
+++ b/faiss/IndexBinaryIVF.h
@@ -68,7 +68,11 @@ struct IndexBinaryIVF : IndexBinary {
      * identifier. The pointer is borrowed: the quantizer should not
      * be deleted while the IndexBinaryIVF is in use.
      */
-    IndexBinaryIVF(IndexBinary* quantizer, size_t d, size_t nlist);
+    IndexBinaryIVF(
+            IndexBinary* quantizer,
+            size_t d,
+            size_t nlist,
+            bool own_invlists = true);
 
     IndexBinaryIVF();
 

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -158,11 +158,14 @@ IndexIVF::IndexIVF(
         size_t d,
         size_t nlist,
         size_t code_size,
-        MetricType metric)
+        MetricType metric,
+        bool own_invlists)
         : Index(d, metric),
           IndexIVFInterface(quantizer, nlist),
-          invlists(new ArrayInvertedLists(nlist, code_size)),
-          own_invlists(true),
+          invlists(
+                  own_invlists ? new ArrayInvertedLists(nlist, code_size)
+                               : nullptr),
+          own_invlists(own_invlists),
           code_size(code_size) {
     FAISS_THROW_IF_NOT(d == quantizer->d);
     is_trained = quantizer->is_trained && (quantizer->ntotal == nlist);

--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -210,7 +210,8 @@ struct IndexIVF : Index, IndexIVFInterface {
             size_t d,
             size_t nlist,
             size_t code_size,
-            MetricType metric = METRIC_L2);
+            MetricType metric = METRIC_L2,
+            bool own_invlists = true);
 
     void reset() override;
 

--- a/faiss/IndexIVFAdditiveQuantizer.cpp
+++ b/faiss/IndexIVFAdditiveQuantizer.cpp
@@ -28,8 +28,9 @@ IndexIVFAdditiveQuantizer::IndexIVFAdditiveQuantizer(
         Index* quantizer,
         size_t d,
         size_t nlist,
-        MetricType metric)
-        : IndexIVF(quantizer, d, nlist, 0, metric), aq(aq) {
+        MetricType metric,
+        bool own_invlists)
+        : IndexIVF(quantizer, d, nlist, 0, metric, own_invlists), aq(aq) {
     by_residual = true;
 }
 
@@ -301,10 +302,20 @@ IndexIVFResidualQuantizer::IndexIVFResidualQuantizer(
         size_t nlist,
         const std::vector<size_t>& nbits,
         MetricType metric,
-        Search_type_t search_type)
-        : IndexIVFAdditiveQuantizer(&rq, quantizer, d, nlist, metric),
+        Search_type_t search_type,
+        bool own_invlists)
+        : IndexIVFAdditiveQuantizer(
+                  &rq,
+                  quantizer,
+                  d,
+                  nlist,
+                  metric,
+                  own_invlists),
           rq(d, nbits, search_type) {
-    code_size = invlists->code_size = rq.code_size;
+    code_size = rq.code_size;
+    if (invlists) {
+        invlists->code_size = code_size;
+    }
 }
 
 IndexIVFResidualQuantizer::IndexIVFResidualQuantizer()
@@ -317,14 +328,16 @@ IndexIVFResidualQuantizer::IndexIVFResidualQuantizer(
         size_t M,     /* number of subquantizers */
         size_t nbits, /* number of bit per subvector index */
         MetricType metric,
-        Search_type_t search_type)
+        Search_type_t search_type,
+        bool own_invlists)
         : IndexIVFResidualQuantizer(
                   quantizer,
                   d,
                   nlist,
                   std::vector<size_t>(M, nbits),
                   metric,
-                  search_type) {}
+                  search_type,
+                  own_invlists) {}
 
 IndexIVFResidualQuantizer::~IndexIVFResidualQuantizer() = default;
 
@@ -339,10 +352,20 @@ IndexIVFLocalSearchQuantizer::IndexIVFLocalSearchQuantizer(
         size_t M,     /* number of subquantizers */
         size_t nbits, /* number of bit per subvector index */
         MetricType metric,
-        Search_type_t search_type)
-        : IndexIVFAdditiveQuantizer(&lsq, quantizer, d, nlist, metric),
+        Search_type_t search_type,
+        bool own_invlists)
+        : IndexIVFAdditiveQuantizer(
+                  &lsq,
+                  quantizer,
+                  d,
+                  nlist,
+                  metric,
+                  own_invlists),
           lsq(d, M, nbits, search_type) {
-    code_size = invlists->code_size = lsq.code_size;
+    code_size = lsq.code_size;
+    if (invlists) {
+        invlists->code_size = code_size;
+    }
 }
 
 IndexIVFLocalSearchQuantizer::IndexIVFLocalSearchQuantizer()
@@ -362,10 +385,20 @@ IndexIVFProductResidualQuantizer::IndexIVFProductResidualQuantizer(
         size_t Msub,
         size_t nbits,
         MetricType metric,
-        Search_type_t search_type)
-        : IndexIVFAdditiveQuantizer(&prq, quantizer, d, nlist, metric),
+        Search_type_t search_type,
+        bool own_invlists)
+        : IndexIVFAdditiveQuantizer(
+                  &prq,
+                  quantizer,
+                  d,
+                  nlist,
+                  metric,
+                  own_invlists),
           prq(d, nsplits, Msub, nbits, search_type) {
-    code_size = invlists->code_size = prq.code_size;
+    code_size = prq.code_size;
+    if (invlists) {
+        invlists->code_size = code_size;
+    }
 }
 
 IndexIVFProductResidualQuantizer::IndexIVFProductResidualQuantizer()
@@ -385,10 +418,20 @@ IndexIVFProductLocalSearchQuantizer::IndexIVFProductLocalSearchQuantizer(
         size_t Msub,
         size_t nbits,
         MetricType metric,
-        Search_type_t search_type)
-        : IndexIVFAdditiveQuantizer(&plsq, quantizer, d, nlist, metric),
+        Search_type_t search_type,
+        bool own_invlists)
+        : IndexIVFAdditiveQuantizer(
+                  &plsq,
+                  quantizer,
+                  d,
+                  nlist,
+                  metric,
+                  own_invlists),
           plsq(d, nsplits, Msub, nbits, search_type) {
-    code_size = invlists->code_size = plsq.code_size;
+    code_size = plsq.code_size;
+    if (invlists) {
+        invlists->code_size = code_size;
+    }
 }
 
 IndexIVFProductLocalSearchQuantizer::IndexIVFProductLocalSearchQuantizer()

--- a/faiss/IndexIVFAdditiveQuantizer.h
+++ b/faiss/IndexIVFAdditiveQuantizer.h
@@ -35,7 +35,8 @@ struct IndexIVFAdditiveQuantizer : IndexIVF {
             Index* quantizer,
             size_t d,
             size_t nlist,
-            MetricType metric = METRIC_L2);
+            MetricType metric = METRIC_L2,
+            bool own_invlists = true);
 
     explicit IndexIVFAdditiveQuantizer(AdditiveQuantizer* aq);
 
@@ -82,7 +83,8 @@ struct IndexIVFResidualQuantizer : IndexIVFAdditiveQuantizer {
             size_t nlist,
             const std::vector<size_t>& nbits,
             MetricType metric = METRIC_L2,
-            Search_type_t search_type = AdditiveQuantizer::ST_decompress);
+            Search_type_t search_type = AdditiveQuantizer::ST_decompress,
+            bool own_invlists = true);
 
     IndexIVFResidualQuantizer(
             Index* quantizer,
@@ -91,7 +93,8 @@ struct IndexIVFResidualQuantizer : IndexIVFAdditiveQuantizer {
             size_t M,     /* number of subquantizers */
             size_t nbits, /* number of bit per subvector index */
             MetricType metric = METRIC_L2,
-            Search_type_t search_type = AdditiveQuantizer::ST_decompress);
+            Search_type_t search_type = AdditiveQuantizer::ST_decompress,
+            bool own_invlists = true);
 
     IndexIVFResidualQuantizer();
 
@@ -118,7 +121,8 @@ struct IndexIVFLocalSearchQuantizer : IndexIVFAdditiveQuantizer {
             size_t M,     /* number of subquantizers */
             size_t nbits, /* number of bit per subvector index */
             MetricType metric = METRIC_L2,
-            Search_type_t search_type = AdditiveQuantizer::ST_decompress);
+            Search_type_t search_type = AdditiveQuantizer::ST_decompress,
+            bool own_invlists = true);
 
     IndexIVFLocalSearchQuantizer();
 
@@ -147,7 +151,8 @@ struct IndexIVFProductResidualQuantizer : IndexIVFAdditiveQuantizer {
             size_t Msub,
             size_t nbits,
             MetricType metric = METRIC_L2,
-            Search_type_t search_type = AdditiveQuantizer::ST_decompress);
+            Search_type_t search_type = AdditiveQuantizer::ST_decompress,
+            bool own_invlists = true);
 
     IndexIVFProductResidualQuantizer();
 
@@ -176,7 +181,8 @@ struct IndexIVFProductLocalSearchQuantizer : IndexIVFAdditiveQuantizer {
             size_t Msub,
             size_t nbits,
             MetricType metric = METRIC_L2,
-            Search_type_t search_type = AdditiveQuantizer::ST_decompress);
+            Search_type_t search_type = AdditiveQuantizer::ST_decompress,
+            bool own_invlists = true);
 
     IndexIVFProductLocalSearchQuantizer();
 

--- a/faiss/IndexIVFAdditiveQuantizerFastScan.h
+++ b/faiss/IndexIVFAdditiveQuantizerFastScan.h
@@ -50,9 +50,15 @@ struct IndexIVFAdditiveQuantizerFastScan : IndexIVFFastScan {
             size_t d,
             size_t nlist,
             MetricType metric = METRIC_L2,
-            int bbs = 32);
+            int bbs = 32,
+            bool own_invlists = true);
 
-    void init(AdditiveQuantizer* aq, size_t nlist, MetricType metric, int bbs);
+    void init(
+            AdditiveQuantizer* aq,
+            size_t nlist,
+            MetricType metric,
+            int bbs,
+            bool own_invlists);
 
     IndexIVFAdditiveQuantizerFastScan();
 
@@ -110,7 +116,8 @@ struct IndexIVFLocalSearchQuantizerFastScan
             size_t nbits,
             MetricType metric = METRIC_L2,
             Search_type_t search_type = AdditiveQuantizer::ST_norm_lsq2x4,
-            int bbs = 32);
+            int bbs = 32,
+            bool own_invlists = true);
 
     IndexIVFLocalSearchQuantizerFastScan();
 };
@@ -126,7 +133,8 @@ struct IndexIVFResidualQuantizerFastScan : IndexIVFAdditiveQuantizerFastScan {
             size_t nbits,
             MetricType metric = METRIC_L2,
             Search_type_t search_type = AdditiveQuantizer::ST_norm_lsq2x4,
-            int bbs = 32);
+            int bbs = 32,
+            bool own_invlists = true);
 
     IndexIVFResidualQuantizerFastScan();
 };
@@ -144,7 +152,8 @@ struct IndexIVFProductLocalSearchQuantizerFastScan
             size_t nbits,
             MetricType metric = METRIC_L2,
             Search_type_t search_type = AdditiveQuantizer::ST_norm_lsq2x4,
-            int bbs = 32);
+            int bbs = 32,
+            bool own_invlists = true);
 
     IndexIVFProductLocalSearchQuantizerFastScan();
 };
@@ -162,7 +171,8 @@ struct IndexIVFProductResidualQuantizerFastScan
             size_t nbits,
             MetricType metric = METRIC_L2,
             Search_type_t search_type = AdditiveQuantizer::ST_norm_lsq2x4,
-            int bbs = 32);
+            int bbs = 32,
+            bool own_invlists = true);
 
     IndexIVFProductResidualQuantizerFastScan();
 };

--- a/faiss/IndexIVFFastScan.cpp
+++ b/faiss/IndexIVFFastScan.cpp
@@ -40,8 +40,9 @@ IndexIVFFastScan::IndexIVFFastScan(
         size_t d,
         size_t nlist,
         size_t code_size,
-        MetricType metric)
-        : IndexIVF(quantizer, d, nlist, code_size, metric) {
+        MetricType metric,
+        bool own_invlists)
+        : IndexIVF(quantizer, d, nlist, code_size, metric, own_invlists) {
     // unlike other indexes, we prefer no residuals for performance reasons.
     by_residual = false;
     FAISS_THROW_IF_NOT(metric == METRIC_L2 || metric == METRIC_INNER_PRODUCT);
@@ -60,7 +61,8 @@ void IndexIVFFastScan::init_fastscan(
         size_t nbits_init,
         size_t nlist,
         MetricType /* metric */,
-        int bbs_2) {
+        int bbs_2,
+        bool own_invlists) {
     FAISS_THROW_IF_NOT(bbs_2 % 32 == 0);
     FAISS_THROW_IF_NOT(nbits_init == 4);
     FAISS_THROW_IF_NOT(fine_quantizer->d == d);
@@ -75,7 +77,9 @@ void IndexIVFFastScan::init_fastscan(
     FAISS_THROW_IF_NOT(code_size == fine_quantizer->code_size);
 
     is_trained = false;
-    replace_invlists(new BlockInvertedLists(nlist, get_CodePacker()), true);
+    if (own_invlists) {
+        replace_invlists(new BlockInvertedLists(nlist, get_CodePacker()), true);
+    }
 }
 
 void IndexIVFFastScan::init_code_packer() {

--- a/faiss/IndexIVFFastScan.h
+++ b/faiss/IndexIVFFastScan.h
@@ -68,7 +68,8 @@ struct IndexIVFFastScan : IndexIVF {
             size_t d,
             size_t nlist,
             size_t code_size,
-            MetricType metric = METRIC_L2);
+            MetricType metric = METRIC_L2,
+            bool own_invlists = true);
 
     IndexIVFFastScan();
 
@@ -79,7 +80,8 @@ struct IndexIVFFastScan : IndexIVF {
             size_t nbits,
             size_t nlist,
             MetricType metric,
-            int bbs);
+            int bbs,
+            bool own_invlists);
 
     // initialize the CodePacker in the InvertedLists
     void init_code_packer();

--- a/faiss/IndexIVFFlat.cpp
+++ b/faiss/IndexIVFFlat.cpp
@@ -33,8 +33,15 @@ IndexIVFFlat::IndexIVFFlat(
         Index* quantizer,
         size_t d,
         size_t nlist,
-        MetricType metric)
-        : IndexIVF(quantizer, d, nlist, sizeof(float) * d, metric) {
+        MetricType metric,
+        bool own_invlists)
+        : IndexIVF(
+                  quantizer,
+                  d,
+                  nlist,
+                  sizeof(float) * d,
+                  metric,
+                  own_invlists) {
     code_size = sizeof(float) * d;
     by_residual = false;
 }
@@ -247,8 +254,9 @@ IndexIVFFlatDedup::IndexIVFFlatDedup(
         Index* quantizer,
         size_t d,
         size_t nlist_,
-        MetricType metric_type)
-        : IndexIVFFlat(quantizer, d, nlist_, metric_type) {}
+        MetricType metric_type,
+        bool own_invlists)
+        : IndexIVFFlat(quantizer, d, nlist_, metric_type, own_invlists) {}
 
 void IndexIVFFlatDedup::train(idx_t n, const float* x) {
     std::unordered_map<uint64_t, idx_t> map;

--- a/faiss/IndexIVFFlat.h
+++ b/faiss/IndexIVFFlat.h
@@ -26,7 +26,8 @@ struct IndexIVFFlat : IndexIVF {
             Index* quantizer,
             size_t d,
             size_t nlist_,
-            MetricType = METRIC_L2);
+            MetricType = METRIC_L2,
+            bool own_invlists = true);
 
     void add_core(
             idx_t n,
@@ -65,7 +66,8 @@ struct IndexIVFFlatDedup : IndexIVFFlat {
             Index* quantizer,
             size_t d,
             size_t nlist_,
-            MetricType = METRIC_L2);
+            MetricType = METRIC_L2,
+            bool own_invlists = true);
 
     /// also dedups the training set
     void train(idx_t n, const float* x) override;

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -46,10 +46,14 @@ IndexIVFPQ::IndexIVFPQ(
         size_t nlist,
         size_t M,
         size_t nbits_per_idx,
-        MetricType metric)
-        : IndexIVF(quantizer, d, nlist, 0, metric), pq(d, M, nbits_per_idx) {
+        MetricType metric,
+        bool own_invlists)
+        : IndexIVF(quantizer, d, nlist, 0, metric, own_invlists),
+          pq(d, M, nbits_per_idx) {
     code_size = pq.code_size;
-    invlists->code_size = code_size;
+    if (own_invlists) {
+        invlists->code_size = code_size;
+    }
     is_trained = false;
     by_residual = true;
     use_precomputed_table = 0;

--- a/faiss/IndexIVFPQ.h
+++ b/faiss/IndexIVFPQ.h
@@ -56,7 +56,8 @@ struct IndexIVFPQ : IndexIVF {
             size_t nlist,
             size_t M,
             size_t nbits_per_idx,
-            MetricType metric = METRIC_L2);
+            MetricType metric = METRIC_L2,
+            bool own_invlists = true);
 
     void encode_vectors(
             idx_t n,

--- a/faiss/IndexIVFPQFastScan.cpp
+++ b/faiss/IndexIVFPQFastScan.cpp
@@ -38,11 +38,13 @@ IndexIVFPQFastScan::IndexIVFPQFastScan(
         size_t M,
         size_t nbits,
         MetricType metric,
-        int bbs)
-        : IndexIVFFastScan(quantizer, d, nlist, 0, metric), pq(d, M, nbits) {
+        int bbs,
+        bool own_invlists)
+        : IndexIVFFastScan(quantizer, d, nlist, 0, metric, own_invlists),
+          pq(d, M, nbits) {
     by_residual = false; // set to false by default because it's faster
 
-    init_fastscan(&pq, M, nbits, nlist, metric, bbs);
+    init_fastscan(&pq, M, nbits, nlist, metric, bbs, own_invlists);
 }
 
 IndexIVFPQFastScan::IndexIVFPQFastScan() {
@@ -57,12 +59,19 @@ IndexIVFPQFastScan::IndexIVFPQFastScan(const IndexIVFPQ& orig, int bbs)
                   orig.d,
                   orig.nlist,
                   orig.pq.code_size,
-                  orig.metric_type),
+                  orig.metric_type,
+                  orig.own_invlists),
           pq(orig.pq) {
     FAISS_THROW_IF_NOT(orig.pq.nbits == 4);
 
     init_fastscan(
-            &pq, orig.pq.M, orig.pq.nbits, orig.nlist, orig.metric_type, bbs);
+            &pq,
+            orig.pq.M,
+            orig.pq.nbits,
+            orig.nlist,
+            orig.metric_type,
+            bbs,
+            orig.own_invlists);
 
     by_residual = orig.by_residual;
     ntotal = orig.ntotal;

--- a/faiss/IndexIVFPQFastScan.h
+++ b/faiss/IndexIVFPQFastScan.h
@@ -47,7 +47,8 @@ struct IndexIVFPQFastScan : IndexIVFFastScan {
             size_t M,
             size_t nbits,
             MetricType metric = METRIC_L2,
-            int bbs = 32);
+            int bbs = 32,
+            bool own_invlists = true);
 
     IndexIVFPQFastScan();
 

--- a/faiss/IndexIVFPQR.cpp
+++ b/faiss/IndexIVFPQR.cpp
@@ -30,8 +30,16 @@ IndexIVFPQR::IndexIVFPQR(
         size_t M,
         size_t nbits_per_idx,
         size_t M_refine,
-        size_t nbits_per_idx_refine)
-        : IndexIVFPQ(quantizer, d, nlist, M, nbits_per_idx),
+        size_t nbits_per_idx_refine,
+        bool own_invlists)
+        : IndexIVFPQ(
+                  quantizer,
+                  d,
+                  nlist,
+                  M,
+                  nbits_per_idx,
+                  METRIC_L2,
+                  own_invlists),
           refine_pq(d, M_refine, nbits_per_idx_refine),
           k_factor(4) {
     by_residual = true;

--- a/faiss/IndexIVFPQR.h
+++ b/faiss/IndexIVFPQR.h
@@ -30,7 +30,8 @@ struct IndexIVFPQR : IndexIVFPQ {
             size_t M,
             size_t nbits_per_idx,
             size_t M_refine,
-            size_t nbits_per_idx_refine);
+            size_t nbits_per_idx_refine,
+            bool own_invlists = true);
 
     void reset() override;
 

--- a/faiss/IndexIVFRaBitQ.cpp
+++ b/faiss/IndexIVFRaBitQ.cpp
@@ -23,10 +23,14 @@ IndexIVFRaBitQ::IndexIVFRaBitQ(
         Index* quantizer,
         const size_t d,
         const size_t nlist,
-        MetricType metric)
-        : IndexIVF(quantizer, d, nlist, 0, metric), rabitq(d, metric) {
+        MetricType metric,
+        bool own_invlists)
+        : IndexIVF(quantizer, d, nlist, 0, metric, own_invlists),
+          rabitq(d, metric) {
     code_size = rabitq.code_size;
-    invlists->code_size = code_size;
+    if (own_invlists) {
+        invlists->code_size = code_size;
+    }
     is_trained = false;
 
     by_residual = true;

--- a/faiss/IndexIVFRaBitQ.h
+++ b/faiss/IndexIVFRaBitQ.h
@@ -33,7 +33,8 @@ struct IndexIVFRaBitQ : IndexIVF {
             Index* quantizer,
             const size_t d,
             const size_t nlist,
-            MetricType metric = METRIC_L2);
+            MetricType metric = METRIC_L2,
+            bool own_invlists = true);
 
     IndexIVFRaBitQ();
 

--- a/faiss/IndexIVFSpectralHash.cpp
+++ b/faiss/IndexIVFSpectralHash.cpp
@@ -27,8 +27,15 @@ IndexIVFSpectralHash::IndexIVFSpectralHash(
         size_t d,
         size_t nlist,
         int nbit,
-        float period)
-        : IndexIVF(quantizer, d, nlist, (nbit + 7) / 8, METRIC_L2),
+        float period,
+        bool own_invlists)
+        : IndexIVF(
+                  quantizer,
+                  d,
+                  nlist,
+                  (nbit + 7) / 8,
+                  METRIC_L2,
+                  own_invlists),
           nbit(nbit),
           period(period) {
     RandomRotationMatrix* rr = new RandomRotationMatrix(d, nbit);

--- a/faiss/IndexIVFSpectralHash.h
+++ b/faiss/IndexIVFSpectralHash.h
@@ -56,7 +56,8 @@ struct IndexIVFSpectralHash : IndexIVF {
             size_t d,
             size_t nlist,
             int nbit,
-            float period);
+            float period,
+            bool own_invlists = true);
 
     IndexIVFSpectralHash();
 

--- a/faiss/IndexScalarQuantizer.cpp
+++ b/faiss/IndexScalarQuantizer.cpp
@@ -122,12 +122,15 @@ IndexIVFScalarQuantizer::IndexIVFScalarQuantizer(
         size_t nlist,
         ScalarQuantizer::QuantizerType qtype,
         MetricType metric,
-        bool by_residual)
-        : IndexIVF(quantizer, d, nlist, 0, metric), sq(d, qtype) {
+        bool by_residual,
+        bool own_invlists)
+        : IndexIVF(quantizer, d, nlist, 0, metric, own_invlists), sq(d, qtype) {
     code_size = sq.code_size;
     this->by_residual = by_residual;
-    // was not known at construction time
-    invlists->code_size = code_size;
+    if (invlists) {
+        // was not known at construction time
+        invlists->code_size = code_size;
+    }
     is_trained = false;
 }
 

--- a/faiss/IndexScalarQuantizer.h
+++ b/faiss/IndexScalarQuantizer.h
@@ -72,7 +72,8 @@ struct IndexIVFScalarQuantizer : IndexIVF {
             size_t nlist,
             ScalarQuantizer::QuantizerType qtype,
             MetricType metric = METRIC_L2,
-            bool by_residual = true);
+            bool by_residual = true,
+            bool own_invlists = true);
 
     IndexIVFScalarQuantizer();
 

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -311,7 +311,8 @@ IndexIVF* parse_IndexIVF(
         const std::string& code_string,
         std::unique_ptr<Index>& quantizer,
         size_t nlist,
-        MetricType mt) {
+        MetricType mt,
+        bool own_il) {
     std::smatch sm;
     auto match = [&sm, &code_string](const std::string pattern) {
         return re_match(code_string, pattern, sm);
@@ -320,18 +321,19 @@ IndexIVF* parse_IndexIVF(
     int d = quantizer->d;
 
     if (match("Flat")) {
-        return new IndexIVFFlat(get_q(), d, nlist, mt);
+        return new IndexIVFFlat(get_q(), d, nlist, mt, own_il);
     }
     if (match("FlatDedup")) {
-        return new IndexIVFFlatDedup(get_q(), d, nlist, mt);
+        return new IndexIVFFlatDedup(get_q(), d, nlist, mt, own_il);
     }
     if (match(sq_pattern)) {
         return new IndexIVFScalarQuantizer(
-                get_q(), d, nlist, sq_types[sm[1].str()], mt);
+                get_q(), d, nlist, sq_types[sm[1].str()], mt, own_il);
     }
     if (match("PQ([0-9]+)(x[0-9]+)?(np)?")) {
         int M = mres_to_int(sm[1]), nbit = mres_to_int(sm[2], 8, 1);
-        IndexIVFPQ* index_ivf = new IndexIVFPQ(get_q(), d, nlist, M, nbit, mt);
+        IndexIVFPQ* index_ivf =
+                new IndexIVFPQ(get_q(), d, nlist, M, nbit, mt, own_il);
         index_ivf->do_polysemous_training = sm[3].str() != "np";
         return index_ivf;
     }
@@ -340,13 +342,13 @@ IndexIVF* parse_IndexIVF(
                 mt == METRIC_L2,
                 "IVFPQR not implemented for inner product search");
         int M1 = mres_to_int(sm[1]), M2 = mres_to_int(sm[2]);
-        return new IndexIVFPQR(get_q(), d, nlist, M1, 8, M2, 8);
+        return new IndexIVFPQR(get_q(), d, nlist, M1, 8, M2, 8, own_il);
     }
     if (match("PQ([0-9]+)x4fs(r?)(_[0-9]+)?")) {
         int M = mres_to_int(sm[1]);
         int bbs = mres_to_int(sm[3], 32, 1);
-        IndexIVFPQFastScan* index_ivf =
-                new IndexIVFPQFastScan(get_q(), d, nlist, M, 4, mt, bbs);
+        IndexIVFPQFastScan* index_ivf = new IndexIVFPQFastScan(
+                get_q(), d, nlist, M, 4, mt, bbs, own_il);
         index_ivf->by_residual = sm[2].str() == "r";
         return index_ivf;
     }
@@ -357,11 +359,11 @@ IndexIVF* parse_IndexIVF(
         IndexIVF* index_ivf;
         if (sm[1].str() == "RQ") {
             index_ivf = new IndexIVFResidualQuantizer(
-                    get_q(), d, nlist, nbits, mt, st);
+                    get_q(), d, nlist, nbits, mt, st, own_il);
         } else {
             FAISS_THROW_IF_NOT(nbits.size() > 0);
             index_ivf = new IndexIVFLocalSearchQuantizer(
-                    get_q(), d, nlist, nbits.size(), nbits[0], mt, st);
+                    get_q(), d, nlist, nbits.size(), nbits[0], mt, st, own_il);
         }
         return index_ivf;
     }
@@ -373,10 +375,10 @@ IndexIVF* parse_IndexIVF(
         IndexIVF* index_ivf;
         if (sm[1].str() == "PRQ") {
             index_ivf = new IndexIVFProductResidualQuantizer(
-                    get_q(), d, nlist, nsplits, Msub, nbit, mt, st);
+                    get_q(), d, nlist, nsplits, Msub, nbit, mt, st, own_il);
         } else {
             index_ivf = new IndexIVFProductLocalSearchQuantizer(
-                    get_q(), d, nlist, nsplits, Msub, nbit, mt, st);
+                    get_q(), d, nlist, nsplits, Msub, nbit, mt, st, own_il);
         }
         return index_ivf;
     }
@@ -387,10 +389,10 @@ IndexIVF* parse_IndexIVF(
         IndexIVFAdditiveQuantizerFastScan* index_ivf;
         if (sm[1].str() == "RQ") {
             index_ivf = new IndexIVFResidualQuantizerFastScan(
-                    get_q(), d, nlist, M, 4, mt, st, bbs);
+                    get_q(), d, nlist, M, 4, mt, st, bbs, own_il);
         } else {
             index_ivf = new IndexIVFLocalSearchQuantizerFastScan(
-                    get_q(), d, nlist, M, 4, mt, st, bbs);
+                    get_q(), d, nlist, M, 4, mt, st, bbs, own_il);
         }
         index_ivf->by_residual = (sm[3].str() == "r");
         return index_ivf;
@@ -404,10 +406,10 @@ IndexIVF* parse_IndexIVF(
         IndexIVFAdditiveQuantizerFastScan* index_ivf;
         if (sm[1].str() == "PRQ") {
             index_ivf = new IndexIVFProductResidualQuantizerFastScan(
-                    get_q(), d, nlist, nsplits, Msub, 4, mt, st, bbs);
+                    get_q(), d, nlist, nsplits, Msub, 4, mt, st, bbs, own_il);
         } else {
             index_ivf = new IndexIVFProductLocalSearchQuantizerFastScan(
-                    get_q(), d, nlist, nsplits, Msub, 4, mt, st, bbs);
+                    get_q(), d, nlist, nsplits, Msub, 4, mt, st, bbs, own_il);
         }
         index_ivf->by_residual = (sm[4].str() == "r");
         return index_ivf;
@@ -425,8 +427,8 @@ IndexIVF* parse_IndexIVF(
         // the rationale for -1e10 is that this corresponds to simple
         // thresholding
         float period = sm[3].length() > 0 ? std::stof(sm[3]) : -1e10;
-        IndexIVFSpectralHash* index_ivf =
-                new IndexIVFSpectralHash(get_q(), d, nlist, outdim, period);
+        IndexIVFSpectralHash* index_ivf = new IndexIVFSpectralHash(
+                get_q(), d, nlist, outdim, period, own_il);
         index_ivf->replace_vt(vt.release(), true);
         if (sm[4].length()) {
             std::string s = sm[4].str();
@@ -440,7 +442,7 @@ IndexIVF* parse_IndexIVF(
         return index_ivf;
     }
     if (match(rabitq_pattern)) {
-        return new IndexIVFRaBitQ(get_q(), d, nlist, mt);
+        return new IndexIVFRaBitQ(get_q(), d, nlist, mt, own_il);
     }
     return nullptr;
 }
@@ -677,7 +679,8 @@ Index* parse_other_indexes(
 std::unique_ptr<Index> index_factory_sub(
         int d,
         std::string description,
-        MetricType metric) {
+        MetricType metric,
+        bool own_invlists = true) {
     // handle composite indexes
 
     bool verbose = index_factory_verbose;
@@ -894,8 +897,8 @@ std::unique_ptr<Index> index_factory_sub(
                 return std::unique_ptr<Index>(index_2l);
             }
 
-            IndexIVF* index_ivf =
-                    parse_IndexIVF(code_description, quantizer, nlist, metric);
+            IndexIVF* index_ivf = parse_IndexIVF(
+                    code_description, quantizer, nlist, metric, own_invlists);
 
             FAISS_THROW_IF_NOT_FMT(
                     index_ivf,
@@ -911,25 +914,32 @@ std::unique_ptr<Index> index_factory_sub(
 
 } // anonymous namespace
 
-Index* index_factory(int d, const char* description, MetricType metric) {
-    return index_factory_sub(d, description, metric).release();
+Index* index_factory(
+        int d,
+        const char* description,
+        MetricType metric,
+        bool own_invlists) {
+    return index_factory_sub(d, description, metric, own_invlists).release();
 }
 
-IndexBinary* index_binary_factory(int d, const char* description) {
+IndexBinary* index_binary_factory(
+        int d,
+        const char* description,
+        bool own_invlists) {
     IndexBinary* index = nullptr;
 
     int ncentroids = -1;
     int M, nhash, b;
 
     if (sscanf(description, "BIVF%d_HNSW%d", &ncentroids, &M) == 2) {
-        IndexBinaryIVF* index_ivf =
-                new IndexBinaryIVF(new IndexBinaryHNSW(d, M), d, ncentroids);
+        IndexBinaryIVF* index_ivf = new IndexBinaryIVF(
+                new IndexBinaryHNSW(d, M), d, ncentroids, own_invlists);
         index_ivf->own_fields = true;
         index = index_ivf;
 
     } else if (sscanf(description, "BIVF%d", &ncentroids) == 1) {
-        IndexBinaryIVF* index_ivf =
-                new IndexBinaryIVF(new IndexBinaryFlat(d), d, ncentroids);
+        IndexBinaryIVF* index_ivf = new IndexBinaryIVF(
+                new IndexBinaryFlat(d), d, ncentroids, own_invlists);
         index_ivf->own_fields = true;
         index = index_ivf;
 

--- a/faiss/index_factory.h
+++ b/faiss/index_factory.h
@@ -17,11 +17,17 @@ namespace faiss {
 Index* index_factory(
         int d,
         const char* description,
-        MetricType metric = METRIC_L2);
+        MetricType metric = METRIC_L2,
+        // Whether to maintain inverted list within faiss index (only applicable
+        // to IndexIVF*)
+        bool own_invlists = true);
 
 /// set to > 0 to get more logs from index_factory
 FAISS_API extern int index_factory_verbose;
 
-IndexBinary* index_binary_factory(int d, const char* description);
+IndexBinary* index_binary_factory(
+        int d,
+        const char* description,
+        bool own_invlists = true);
 
 } // namespace faiss


### PR DESCRIPTION
Summary:
Unicorn index maintains its own posting lists and only uses faiss index as quantizer. Therefore invlists allocated within faiss index are unused.

Pass in an option "own_invlists" (already a field in IndexIVF) to optionally initializes invlists

Differential Revision: D75012827


