### PR TITLE
Fix input param for IndexIVFScalarQuantizer in index_factory

### DIFF
--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -328,7 +328,13 @@ IndexIVF* parse_IndexIVF(
     }
     if (match(sq_pattern)) {
         return new IndexIVFScalarQuantizer(
-                get_q(), d, nlist, sq_types[sm[1].str()], mt, own_il);
+                get_q(),
+                d,
+                nlist,
+                sq_types[sm[1].str()],
+                mt,
+                /*by_residual=*/true,
+                own_il);
     }
     if (match("PQ([0-9]+)(x[0-9]+)?(np)?")) {
         int M = mres_to_int(sm[1]), nbit = mres_to_int(sm[2], 8, 1);


### PR DESCRIPTION
Summary: Previous change missed `by_residual` parameter for IndexIVFScalarQuantizer, which is default to true and happen to share the same value as default of `own_invlists`. Fix the input value for `by_residual`.

Differential Revision: D75192013


