### PR TITLE
Improve naming due to codemod

### DIFF
--- a/faiss/IndexNSG.cpp
+++ b/faiss/IndexNSG.cpp
@@ -101,7 +101,7 @@ void IndexNSG::search(
     }
 }
 
-void IndexNSG::build(idx_t n, const float* x, idx_t* knn_graph, int GK_2) {
+void IndexNSG::build(idx_t n, const float* x, idx_t* knn_graph, int gk) {
     FAISS_THROW_IF_NOT_MSG(
             storage,
             "Please use IndexNSGFlat (or variants) instead of IndexNSG directly");
@@ -112,9 +112,9 @@ void IndexNSG::build(idx_t n, const float* x, idx_t* knn_graph, int GK_2) {
     ntotal = storage->ntotal;
 
     // check the knn graph
-    check_knn_graph(knn_graph, n, GK_2);
+    check_knn_graph(knn_graph, n, gk);
 
-    const nsg::Graph<idx_t> knng(knn_graph, n, GK_2);
+    const nsg::Graph<idx_t> knng(knn_graph, n, gk);
     nsg.build(storage, n, knng, verbose);
     is_built = true;
 }


### PR DESCRIPTION
Summary:
**The diff does not introduce any functionality changes.**
In this diff, we improve the naming of the variable resulted from codemod which was invoked to handle shadow variable issue

Only one file was modified in the diff:
- `fbcode/faiss/IndexNSG.cpp` 
    - The `build` method's parameter name `GK_2` was renamed to `gk`. 
    - Using lowercase for local variables to differentiate them from global constants or macros (`GK`), which is in uppercase 



Several improvements are found and could be part of this diff stack:
1. missing unit test for the affected function which allows supporting pre-computed KNN
2. missing unit tests: check_knn_graph
3. potential for segfault: when pre-built KNN is sent via Cpp and an incorrect and higher K is sent then the code will cause segfault due to unauthorized MEM access

Differential Revision: D75473628


