### PR TITLE
Change uint8_t* => const uint8_t* in faiss::ZeroCopyIOReader

### DIFF
--- a/faiss/impl/zerocopy_io.cpp
+++ b/faiss/impl/zerocopy_io.cpp
@@ -10,7 +10,7 @@
 
 namespace faiss {
 
-ZeroCopyIOReader::ZeroCopyIOReader(uint8_t* data, size_t size)
+ZeroCopyIOReader::ZeroCopyIOReader(const uint8_t* data, size_t size)
         : data_(data), rp_(0), total_(size) {}
 
 ZeroCopyIOReader::~ZeroCopyIOReader() {}

--- a/faiss/impl/zerocopy_io.h
+++ b/faiss/impl/zerocopy_io.h
@@ -15,11 +15,11 @@ namespace faiss {
 
 // ZeroCopyIOReader just maps the data from a given pointer.
 struct ZeroCopyIOReader : public faiss::IOReader {
-    uint8_t* data_;
+    const uint8_t* data_;
     size_t rp_ = 0;
     size_t total_ = 0;
 
-    ZeroCopyIOReader(uint8_t* data, size_t size);
+    ZeroCopyIOReader(const uint8_t* data, size_t size);
     ~ZeroCopyIOReader();
 
     void reset();


### PR DESCRIPTION
Summary: Took a look at the code and I don't think data_ pointer is ever modified. Even when it's cast it's cast to a const char *. So changing to const uint8_t*

Differential Revision: D75988982


