### PR TITLE
Add cuVS filter conversion utility

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -98,7 +98,7 @@ The optional requirements are:
 - for AMD GPUs:
   - AMD ROCm,
 - for using NVIDIA cuVS implementations:
-  - libcuvs=24.12
+  - libcuvs=25.04
 - for the python bindings:
   - python 3,
   - numpy,

--- a/faiss/gpu/CMakeLists.txt
+++ b/faiss/gpu/CMakeLists.txt
@@ -248,6 +248,7 @@ if(FAISS_ENABLE_CUVS)
           impl/CuvsFlatIndex.cuh
           impl/CuvsIVFFlat.cuh
           impl/CuvsIVFPQ.cuh
+          utils/CuvsFilterConvert.h
           utils/CuvsUtils.h)
   list(APPEND FAISS_GPU_SRC
           GpuIndexCagra.cu
@@ -255,6 +256,7 @@ if(FAISS_ENABLE_CUVS)
           impl/CuvsFlatIndex.cu
           impl/CuvsIVFFlat.cu
           impl/CuvsIVFPQ.cu
+          utils/CuvsFilterConvert.cu
           utils/CuvsUtils.cu)
 endif()
 
@@ -295,6 +297,7 @@ if(FAISS_ENABLE_CUVS)
     impl/CuvsFlatIndex.cu
     impl/CuvsIVFFlat.cu
     impl/CuvsIVFPQ.cu
+    utils/CuvsFilterConvert.cu
     utils/CuvsUtils.cu
     TARGET_DIRECTORY faiss
     PROPERTIES COMPILE_OPTIONS "-fvisibility=hidden")

--- a/faiss/gpu/test/CMakeLists.txt
+++ b/faiss/gpu/test/CMakeLists.txt
@@ -50,6 +50,7 @@ faiss_gpu_test(TestGpuResidualQuantizer.cpp)
 faiss_gpu_test(TestGpuDistance.${GPU_EXT_PREFIX})
 faiss_gpu_test(TestGpuSelect.${GPU_EXT_PREFIX})
 if(FAISS_ENABLE_CUVS)
+  faiss_gpu_test(TestGpuFilterConvert.cu)
   faiss_gpu_test(TestGpuIndexCagra.cu)
 endif()
 

--- a/faiss/gpu/test/TestGpuFilterConvert.cu
+++ b/faiss/gpu/test/TestGpuFilterConvert.cu
@@ -1,0 +1,251 @@
+// @lint-ignore-every LICENSELINT
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <faiss/IndexHNSW.h>
+#include <faiss/MetricType.h>
+#include <faiss/gpu/GpuResources.h>
+#include <faiss/gpu/StandardGpuResources.h>
+#include <faiss/gpu/test/TestUtils.h>
+#include <faiss/gpu/utils/CuvsFilterConvert.h>
+#include <faiss/gpu/utils/CopyUtils.cuh>
+#include <faiss/gpu/utils/DeviceTensor.cuh>
+#include <optional>
+#include <vector>
+
+#include <raft/core/host_mdarray.hpp>
+#include <raft/core/resource/cuda_stream.hpp>
+#include <raft/core/bitset.cuh>
+#include <raft/core/copy.cuh>
+
+struct Options {
+    Options() {
+        bitset_len = faiss::gpu::randVal(100, 100000);
+    }
+
+    std::string toString() const {
+        std::stringstream str;
+        str << "bitset_len " << bitset_len;
+
+        return str.str();
+    }
+
+    size_t bitset_len;
+};
+
+void run_complex() {
+    Options spec;
+    faiss::gpu::StandardGpuResources res;
+    res.noTempMemory();
+    auto gpuRes = res.getResources();
+    const raft::device_resources& raft_handle =
+            gpuRes->getRaftHandleCurrentDevice();
+    // generate random selectors
+    auto imin = faiss::gpu::randVal(0, spec.bitset_len - 2);
+    auto imax = faiss::gpu::randVal(1, spec.bitset_len - 1);
+    if (imin > imax)
+        std::swap(imin, imax);
+    auto range_selector = faiss::IDSelectorRange(imin, imax);
+
+    std::vector<faiss::idx_t> array_selector_indices(
+            faiss::gpu::randVal(10, 50));
+    for (int i = 0; i < array_selector_indices.size(); i++) {
+        array_selector_indices[i] = faiss::gpu::randVal(0, spec.bitset_len - 1);
+    }
+    auto array_selector = faiss::IDSelectorArray(
+            array_selector_indices.size(), array_selector_indices.data());
+
+    auto or_selector = faiss::IDSelectorOr(&range_selector, &array_selector);
+
+    auto bitmap_faiss_cpu = std::vector<uint8_t>((spec.bitset_len + 8) / 8);
+    for (uint32_t i = 0; i < bitmap_faiss_cpu.size(); i++) {
+        bitmap_faiss_cpu[i] = (uint8_t)faiss::gpu::randVal(0, 255);
+    }
+    auto bitmap_selector =
+            faiss::IDSelectorBitmap(spec.bitset_len, bitmap_faiss_cpu.data());
+    auto not_bitmap_selector = faiss::IDSelectorNot(&bitmap_selector);
+
+    auto xor_selector =
+            faiss::IDSelectorXOr(&or_selector, &not_bitmap_selector);
+
+    // convert to cuVS bitset
+    auto bitset = cuvs::core::bitset<uint32_t, uint32_t>(
+            raft_handle, spec.bitset_len, false);
+    faiss::gpu::convert_to_bitset(gpuRes.get(), xor_selector, bitset.view());
+
+    // verify
+    auto bitset_converted_cpu =
+            raft::make_host_vector<uint32_t, uint32_t>(bitset.n_elements());
+    auto bitset_converted_cpu_view =
+            cuvs::core::bitset_view<uint32_t, uint32_t>(
+                    bitset_converted_cpu.data_handle(), spec.bitset_len);
+    raft::copy(raft_handle, bitset_converted_cpu.view(), bitset.to_mdspan());
+    raft::resource::sync_stream(raft_handle);
+    for (uint32_t i = 0; i < spec.bitset_len; i++) {
+        if (bitset_converted_cpu_view.test(i) != xor_selector.is_member(i)) {
+            ASSERT_TRUE(
+                    testing::AssertionFailure()
+                    << "actual=" << bitset_converted_cpu_view.test(i)
+                    << " != expected=" << xor_selector.is_member(i) << " @" << i
+                    << " bitset_len: " << spec.bitset_len);
+        }
+    }
+}
+
+void run_range() {
+    Options spec;
+    faiss::gpu::StandardGpuResources res;
+    res.noTempMemory();
+    auto gpuRes = res.getResources();
+    const raft::device_resources& raft_handle =
+            gpuRes->getRaftHandleCurrentDevice();
+    // take random imin and imax, check all ids
+    using bitset_t = uint32_t;
+    auto imin = faiss::gpu::randVal(0, spec.bitset_len - 2);
+    auto imax = faiss::gpu::randVal(1, spec.bitset_len - 1);
+    if (imin > imax)
+        std::swap(imin, imax);
+    auto selector = faiss::IDSelectorRange(imin, imax);
+    auto bitset = cuvs::core::bitset<bitset_t, uint32_t>(
+            raft_handle, spec.bitset_len, false);
+    auto nbits = sizeof(bitset_t) * 8;
+
+    faiss::gpu::convert_to_bitset(gpuRes.get(), selector, bitset.view());
+    auto bitset_converted_cpu =
+            raft::make_host_vector<bitset_t, uint32_t>(bitset.n_elements());
+    raft::copy(raft_handle, bitset_converted_cpu.view(), bitset.to_mdspan());
+    raft::resource::sync_stream(raft_handle);
+    auto bitset_view_cpu = cuvs::core::bitset_view<bitset_t, uint32_t>(
+            bitset_converted_cpu.data_handle(), spec.bitset_len);
+    for (uint64_t i = 0; i < spec.bitset_len; i++) {
+        if (bitset_view_cpu.test(i) != selector.is_member(i)) {
+            ASSERT_TRUE(
+                    testing::AssertionFailure()
+                    << "actual=" << bitset_view_cpu.test(i)
+                    << " != expected=" << selector.is_member(i) << " @" << i
+                    << " bitset_len: " << spec.bitset_len << " imin: " << imin
+                    << " imax: " << imax
+                    << " bit_element: " << bitset_converted_cpu(i / nbits));
+        }
+    }
+}
+
+void run_bitmap() {
+    Options spec;
+
+    faiss::gpu::StandardGpuResources res;
+    res.noTempMemory();
+    auto gpuRes = res.getResources();
+    const raft::device_resources& raft_handle =
+            gpuRes->getRaftHandleCurrentDevice();
+    // generate random bitmap selector
+    auto bitmap_faiss_cpu = std::vector<uint8_t>((spec.bitset_len + 8) / 8);
+    for (uint32_t i = 0; i < bitmap_faiss_cpu.size(); i++) {
+        bitmap_faiss_cpu[i] = (uint8_t)faiss::gpu::randVal(0, 255);
+    }
+    auto bitmap_selector =
+            faiss::IDSelectorBitmap(spec.bitset_len, bitmap_faiss_cpu.data());
+    auto bitset = cuvs::core::bitset<uint32_t, uint32_t>(
+            raft_handle, spec.bitset_len, false);
+    faiss::gpu::convert_to_bitset(gpuRes.get(), bitmap_selector, bitset.view());
+
+    auto bitset_converted_cpu =
+            raft::make_host_vector<uint32_t, uint32_t>(bitset.n_elements());
+    raft::copy(raft_handle, bitset_converted_cpu.view(), bitset.to_mdspan());
+    raft::resource::sync_stream(raft_handle);
+    auto bitset_converted_cpu_view =
+            cuvs::core::bitset_view<uint32_t, uint32_t>(
+                    bitset_converted_cpu.data_handle(), spec.bitset_len);
+    for (uint32_t i = 0; i < spec.bitset_len; i++) {
+        if (bitset_converted_cpu_view.test(i) != bitmap_selector.is_member(i)) {
+            ASSERT_TRUE(
+                    testing::AssertionFailure()
+                    << "actual=" << bitset_converted_cpu_view.test(i)
+                    << " != expected=" << bitmap_selector.is_member(i) << " @"
+                    << i << " bitset_len: " << spec.bitset_len
+                    << " bitset_expected: " << bitmap_faiss_cpu[i / 8]
+                    << " bitset_actual: " << bitset_converted_cpu(i / 32));
+        }
+    }
+}
+
+void run_array() {
+    Options spec;
+    faiss::gpu::StandardGpuResources res;
+    res.noTempMemory();
+    auto gpuRes = res.getResources();
+    const raft::device_resources& raft_handle =
+            gpuRes->getRaftHandleCurrentDevice();
+    // generate random array selector
+    int n = spec.bitset_len / 20; // select 5% of the bitset length
+    std::vector<faiss::idx_t> array_selector_indices(n);
+    for (int i = 0; i < n; i++) {
+        array_selector_indices[i] = faiss::gpu::randVal(0, spec.bitset_len - 1);
+    }
+    auto array_selector =
+            faiss::IDSelectorArray(n, array_selector_indices.data());
+    auto bitset = cuvs::core::bitset<uint32_t, uint32_t>(
+            raft_handle, spec.bitset_len, false);
+    faiss::gpu::convert_to_bitset(gpuRes.get(), array_selector, bitset.view());
+
+    auto bitset_converted_cpu =
+            raft::make_host_vector<uint32_t, uint32_t>(bitset.n_elements());
+    raft::copy(raft_handle, bitset_converted_cpu.view(), bitset.to_mdspan());
+    raft::resource::sync_stream(raft_handle);
+    auto bitset_converted_cpu_view =
+            cuvs::core::bitset_view<uint32_t, uint32_t>(
+                    bitset_converted_cpu.data_handle(), spec.bitset_len);
+    for (uint32_t i = 0; i < spec.bitset_len; i++) {
+        if (bitset_converted_cpu_view.test(i) != array_selector.is_member(i)) {
+            ASSERT_TRUE(
+                    testing::AssertionFailure()
+                    << "actual=" << bitset_converted_cpu_view.test(i)
+                    << " != expected=" << array_selector.is_member(i) << " @"
+                    << i << " bitset_len: " << spec.bitset_len);
+        }
+    }
+}
+
+TEST(TestGpuFilterConvert, Complex) {
+    run_complex();
+}
+
+TEST(TestGpuFilterConvert, Bitmap) {
+    run_bitmap();
+}
+
+TEST(TestGpuFilterConvert, Array) {
+    run_array();
+}
+
+TEST(TestGpuFilterConvert, Range) {
+    run_range();
+}
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+
+    // just run with a fixed test seed
+    faiss::gpu::setTestSeed(100);
+
+    return RUN_ALL_TESTS();
+}

--- a/faiss/gpu/utils/CuvsFilterConvert.cu
+++ b/faiss/gpu/utils/CuvsFilterConvert.cu
@@ -32,14 +32,7 @@
 
 namespace faiss::gpu {
 
-/**
- * @brief CUDA kernel to set a range of bits in a bitset to true
- *
- * @param bitset_data Pointer to the bitset data
- * @param imin Starting index
- * @param imax Ending index
- * @param n_elements_to_set Number of elements to set
- */
+/// CUDA kernel to set a range of bits in a bitset to true
 template <typename bitset_t>
 RAFT_KERNEL set_range_kernel(
         bitset_t* bitset_data,
@@ -74,12 +67,6 @@ RAFT_KERNEL set_range_kernel(
     }
 }
 
-/**
- * @brief Convert a Faiss IDSelectorRange to a cuvs::core::bitset_view
- *
- * @param selector The Faiss IDSelectorRange to convert
- * @param bitset The cuvs::core::bitset_view to store the result
- */
 void convert_to_bitset_range(
         raft::resources const& res,
         const faiss::IDSelectorRange& selector,
@@ -117,12 +104,6 @@ void convert_to_bitset_range(
     }
 }
 
-/**
- * @brief Convert a Faiss IDSelectorRange to a cuvs::core::bitset_view
- *
- * @param selector The Faiss IDSelectorRange to convert
- * @param bitset The cuvs::core::bitset_view to store the result
- */
 void convert_to_bitset_array(
         raft::resources const& res,
         const faiss::IDSelectorArray& selector,
@@ -215,14 +196,6 @@ void convert_to_bitset_bruteforce(
     raft::resource::sync_stream(res);
 }
 
-/**
- * @brief Convert a Faiss IDSelector to a cuvs::core::bitset_view
- *
- * @param selector The Faiss IDSelector to convert
- * @param bitset The cuvs::core::bitset_view to store the result
- * @param num_threads Number of threads to use for the conversion. If 0, the
- * number of threads is set to the number of available threads.
- */
 void convert_to_bitset(
         faiss::gpu::GpuResources* res,
         const faiss::IDSelector& selector,

--- a/faiss/gpu/utils/CuvsFilterConvert.cu
+++ b/faiss/gpu/utils/CuvsFilterConvert.cu
@@ -1,0 +1,257 @@
+// @lint-ignore-every LICENSELINT
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuvs/core/bitset.hpp>
+#include <faiss/gpu/GpuResources.h>
+#include <faiss/impl/IDSelector.h>
+#include <omp.h>
+#include <raft/core/host_mdarray.hpp>
+#include <thrust/for_each.h>
+#include <raft/core/bitset.cuh>
+#include <raft/core/copy.cuh>
+
+namespace faiss::gpu {
+
+/**
+ * @brief CUDA kernel to set a range of bits in a bitset to true
+ *
+ * @param bitset_data Pointer to the bitset data
+ * @param imin Starting index
+ * @param imax Ending index
+ * @param n_elements_to_set Number of elements to set
+ */
+template <typename bitset_t>
+RAFT_KERNEL set_range_kernel(
+        bitset_t* bitset_data,
+        uint32_t imin,
+        uint32_t imax,
+        uint32_t n_elements_to_set) {
+    uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const uint32_t nbits = sizeof(bitset_t) * 8;
+
+    uint32_t current_index = (imin / nbits) + idx;
+    bitset_t mask = 0;
+    if (idx < n_elements_to_set) {
+        if (n_elements_to_set == 1) {
+            // Special case: range is within a single element
+            int bit_offset = imin % nbits;
+            mask = (bitset_t{1} << bit_offset) - 1;
+            bit_offset = imax % nbits;
+            mask = mask ^ ((bitset_t{1} << bit_offset) - 1);
+        } else if (idx == 0) {
+            // First element: set bits from imin to end
+            int bit_offset = imin % nbits;
+            mask = ~((bitset_t{1} << bit_offset) - 1);
+        } else if (idx == n_elements_to_set - 1) {
+            // Last element: set bits from start to imax
+            int bit_offset = imax % nbits;
+            mask = (bitset_t{1} << bit_offset) - 1;
+        } else {
+            // Middle elements: set all bits
+            mask = ~mask;
+        }
+        atomicOr(&bitset_data[current_index], mask);
+    }
+}
+
+/**
+ * @brief Convert a Faiss IDSelectorRange to a cuvs::core::bitset_view
+ *
+ * @param selector The Faiss IDSelectorRange to convert
+ * @param bitset The cuvs::core::bitset_view to store the result
+ */
+void convert_to_bitset_range(
+        raft::resources const& res,
+        const faiss::IDSelectorRange& selector,
+        cuvs::core::bitset_view<uint32_t, uint32_t> bitset) {
+    RAFT_EXPECTS(
+            bitset.size() >= selector.imax,
+            "IDSelectorRange is out of range for the given bitset");
+    const uint32_t nbits = sizeof(uint32_t) * 8;
+    auto original_nbits = bitset.get_original_nbits();
+    if (original_nbits == 0) {
+        original_nbits = nbits;
+    }
+    uint32_t imin = selector.imin;
+    uint32_t imax = selector.imax;
+
+    uint32_t n_elements_to_set = 1 + (imax + original_nbits) / original_nbits;
+    n_elements_to_set -= (imin + original_nbits) / original_nbits;
+    auto stream = raft::resource::get_cuda_stream(res);
+
+    const int threads_per_block = 256;
+    const int blocks =
+            (n_elements_to_set + threads_per_block - 1) / threads_per_block;
+
+    if (nbits == original_nbits) {
+        set_range_kernel<uint32_t><<<blocks, threads_per_block, 0, stream>>>(
+                (uint32_t*)bitset.data(), imin, imax, n_elements_to_set);
+    } else if (original_nbits == 8) {
+        set_range_kernel<uint8_t><<<blocks, threads_per_block, 0, stream>>>(
+                (uint8_t*)bitset.data(), imin, imax, n_elements_to_set);
+    } else if (original_nbits == 64) {
+        set_range_kernel<uint64_t><<<blocks, threads_per_block, 0, stream>>>(
+                (uint64_t*)bitset.data(), imin, imax, n_elements_to_set);
+    } else {
+        throw std::invalid_argument("Unsupported original_nbits");
+    }
+}
+
+/**
+ * @brief Convert a Faiss IDSelectorRange to a cuvs::core::bitset_view
+ *
+ * @param selector The Faiss IDSelectorRange to convert
+ * @param bitset The cuvs::core::bitset_view to store the result
+ */
+void convert_to_bitset_array(
+        raft::resources const& res,
+        const faiss::IDSelectorArray& selector,
+        cuvs::core::bitset_view<uint32_t, uint32_t> bitset) {
+    uint32_t n = selector.n;
+    auto d_indexes_to_set =
+            raft::make_device_vector<faiss::idx_t, uint32_t>(res, n);
+    raft::copy(
+            res,
+            d_indexes_to_set.view(),
+            raft::make_host_vector_view<const faiss::idx_t, uint32_t>(
+                    selector.ids, n));
+    thrust::for_each_n(
+            raft::resource::get_thrust_policy(res),
+            d_indexes_to_set.data_handle(),
+            n,
+            [bitset] __device__(const faiss::idx_t sample_index) {
+                bitset.set(sample_index, true);
+            });
+}
+
+RAFT_KERNEL set_bitmap_kernel(
+        uint32_t* new_bitset_data,
+        uint8_t* original_bitmap_data,
+        uint32_t n_elements,
+        uint32_t bitset_original_nbits) {
+    uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    uint32_t bit_index = 0;
+    uint32_t bit_offset = 0;
+    raft::core::compute_original_nbits_position(
+            uint32_t{8}, bitset_original_nbits, idx * 8, bit_index, bit_offset);
+    if (idx < n_elements) {
+        uint32_t mask = original_bitmap_data[idx];
+        atomicOr(&new_bitset_data[bit_index], mask << bit_offset);
+    }
+}
+
+void convert_to_bitset_bitmap(
+        raft::resources const& res,
+        const faiss::IDSelectorBitmap& selector,
+        cuvs::core::bitset_view<uint32_t, uint32_t> bitset) {
+    uint32_t n = selector.n;
+    auto bitset_original_nbits = bitset.get_original_nbits();
+    if (bitset_original_nbits == 0) {
+        bitset_original_nbits = sizeof(uint32_t) * 8;
+    }
+    RAFT_EXPECTS(
+            bitset.size() == n,
+            "IDSelectorBitmap is out of range for the given bitset");
+    auto stream = raft::resource::get_cuda_stream(res);
+    auto n_elements = (selector.n + 7) / 8;
+    auto d_bitmap =
+            raft::make_device_vector<uint8_t, uint32_t>(res, n_elements);
+    auto d_bitmap_ptr = d_bitmap.data_handle();
+    raft::copy(
+            res,
+            d_bitmap.view(),
+            raft::make_host_vector_view<const uint8_t, uint32_t>(
+                    selector.bitmap, n_elements));
+
+    const int threads_per_block = 256;
+    const int blocks = (n_elements + threads_per_block - 1) / threads_per_block;
+
+    set_bitmap_kernel<<<blocks, threads_per_block, 0, stream>>>(
+            bitset.data(), d_bitmap_ptr, n_elements, bitset_original_nbits);
+}
+
+void convert_to_bitset_bruteforce(
+        raft::resources const& res,
+        const faiss::IDSelector& selector,
+        cuvs::core::bitset_view<uint32_t, uint32_t> bitset,
+        int num_threads = 0) {
+    auto bitset_cpu =
+            raft::make_host_vector<uint32_t, uint32_t>(bitset.n_elements());
+    auto nbits = sizeof(uint32_t) * 8;
+    if (num_threads == 0)
+        num_threads = omp_get_max_threads();
+#pragma omp parallel for num_threads(num_threads)
+    for (uint32_t i = 0; i < bitset.n_elements(); i++) {
+        uint32_t element = uint32_t{0};
+        for (uint32_t j = 0; j < nbits; j++) {
+            if (i * nbits + j < bitset.size() &&
+                selector.is_member(i * nbits + j)) {
+                element |= (uint32_t{1} << j);
+            }
+        }
+        bitset_cpu(i) = element;
+    }
+    raft::copy(res, bitset.to_mdspan(), bitset_cpu.view());
+    raft::resource::sync_stream(res);
+}
+
+/**
+ * @brief Convert a Faiss IDSelector to a cuvs::core::bitset_view
+ *
+ * @param selector The Faiss IDSelector to convert
+ * @param bitset The cuvs::core::bitset_view to store the result
+ * @param num_threads Number of threads to use for the conversion. If 0, the
+ * number of threads is set to the number of available threads.
+ */
+void convert_to_bitset(
+        faiss::gpu::GpuResources* res,
+        const faiss::IDSelector& selector,
+        cuvs::core::bitset_view<uint32_t, uint32_t> bitset,
+        int num_threads) {
+    raft::device_resources& raft_handle = res->getRaftHandleCurrentDevice();
+    // If the selector is simple, we can use the specialized functions
+    // Otherwise use the brute force method
+    try {
+        auto range_selector =
+                dynamic_cast<const faiss::IDSelectorRange&>(selector);
+        convert_to_bitset_range(raft_handle, range_selector, bitset);
+        return;
+    } catch (const std::bad_cast& e) {
+    }
+    try {
+        auto array_selector =
+                dynamic_cast<const faiss::IDSelectorArray&>(selector);
+        convert_to_bitset_array(raft_handle, array_selector, bitset);
+        return;
+    } catch (const std::bad_cast& e) {
+    }
+    try {
+        auto bitmap_selector =
+                dynamic_cast<const faiss::IDSelectorBitmap&>(selector);
+        convert_to_bitset_bitmap(raft_handle, bitmap_selector, bitset);
+        return;
+    } catch (const std::bad_cast& e) {
+    }
+    convert_to_bitset_bruteforce(raft_handle, selector, bitset, num_threads);
+}
+} // namespace faiss::gpu

--- a/faiss/gpu/utils/CuvsFilterConvert.h
+++ b/faiss/gpu/utils/CuvsFilterConvert.h
@@ -1,0 +1,44 @@
+// @lint-ignore-every LICENSELINT
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuvs/core/bitset.hpp>
+#include <faiss/gpu/GpuResources.h>
+#include <faiss/impl/IDSelector.h>
+
+#pragma GCC visibility push(default)
+namespace faiss::gpu {
+/**
+ * @brief Convert a Faiss IDSelector to a cuvs::core::bitset_view
+ *
+ * @param res The GpuResources object to use for the conversion
+ * @param selector The Faiss IDSelector to convert
+ * @param bitset The cuvs::core::bitset_view to store the result
+ * @param num_threads Number of threads to use for the conversion. If 0, the
+ * number of threads is set to the number of available threads.
+ */
+void convert_to_bitset(
+        faiss::gpu::GpuResources* res,
+        const faiss::IDSelector& selector,
+        cuvs::core::bitset_view<uint32_t, uint32_t> bitset,
+        int num_threads = 0);
+} // namespace faiss::gpu

--- a/faiss/gpu/utils/CuvsFilterConvert.h
+++ b/faiss/gpu/utils/CuvsFilterConvert.h
@@ -27,15 +27,12 @@
 
 #pragma GCC visibility push(default)
 namespace faiss::gpu {
-/**
- * @brief Convert a Faiss IDSelector to a cuvs::core::bitset_view
- *
- * @param res The GpuResources object to use for the conversion
- * @param selector The Faiss IDSelector to convert
- * @param bitset The cuvs::core::bitset_view to store the result
- * @param num_threads Number of threads to use for the conversion. If 0, the
- * number of threads is set to the number of available threads.
- */
+/// Convert a Faiss IDSelector to a cuvs::core::bitset_view
+/// @param res The GpuResources object to use for the conversion
+/// @param selector The Faiss IDSelector to convert
+/// @param bitset The cuvs::core::bitset_view to store the result
+/// @param num_threads Number of threads to use for the conversion. If 0, the
+/// number of threads is set to the number of available threads.
 void convert_to_bitset(
         faiss::gpu::GpuResources* res,
         const faiss::IDSelector& selector,


### PR DESCRIPTION
cuVS is using a different filter type than FAISS. This PR will add conversion function from `FAISS::IDSelector` to `cuvs::core::bitset_view` to allow users to do pre-filtering on their searches.