### PR TITLE
Add Virtual Destructor to FlatIndex Class

### DIFF
--- a/faiss/gpu/impl/FlatIndex.cuh
+++ b/faiss/gpu/impl/FlatIndex.cuh
@@ -97,6 +97,9 @@ class FlatIndex {
     /// Free all storage
     void reset();
 
+    // Add a virtual destructor to avoid warnings
+    virtual ~FlatIndex() {}
+
    protected:
     /// Collection of GPU resources that we use
     GpuResources* resources_;


### PR DESCRIPTION
Summary:
This change introduces a virtual destructor to the FlatIndex class to ensure proper cleanup of derived class objects when they are deleted through a base class pointer. This modification addresses the compiler warning about deleting objects with virtual functions but non-virtual destructors, thereby preventing potential resource leaks and undefined behavior.

Original Errors:
```
libgcc/include/c++/trunk/bits/unique_ptr.h:85:1: error: delete called on non-final 'faiss::gpu::FlatIndex' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-abstract-non-virtual-dtor]
   85 | delete __ptr; 
      | ^
libgcc/include/c++/trunk/bits/unique_ptr.h:361:1: note: in instantiation of member function 'std::default_delete<faiss::gpu::FlatIndex>::operator()' requested here
  361 | get_deleter()(std::move(__ptr)); }  
      | ^
faiss/gpu/GpuIndexFlat.cu:28:15: note: in instantiation of member function 'std::unique_ptr<faiss::gpu::FlatIndex>::~unique_ptr' requested here
   28 | GpuIndexFlat::GpuIndexFlat(GpuResourcesProvider *
      |               ^
1 error generated.
```

Reviewed By: zhuhan0

Differential Revision: D76303668


