### PR TITLE
fix IndexIVFFastScan  ndis/nlist stat

### DIFF
--- a/faiss/IndexIVFFastScan.cpp
+++ b/faiss/IndexIVFFastScan.cpp
@@ -819,7 +819,7 @@ void IndexIVFFastScan::search_implem_1(
                     heap_ids,
                     scaler);
             nlist_visited++;
-            ndis++;
+            ndis += ls;
         }
         heap_reorder<C>(k, heap_dis, heap_ids);
     }
@@ -930,7 +930,7 @@ void IndexIVFFastScan::search_implem_10(
 
     bool single_LUT = !lookup_table_is_3d();
 
-    size_t ndis = 0;
+    size_t ndis = 0, nlist_visited = 0;
     int qmap1[1];
 
     handler.q_map = qmap1;
@@ -978,13 +978,14 @@ void IndexIVFFastScan::search_implem_10(
                     handler,
                     scaler);
 
-            ndis++;
+            ndis += ls;
+            nlist_visited++;
         }
     }
 
     handler.end();
     *ndis_out = ndis;
-    *nlist_out = nlist;
+    *nlist_out = nlist_visited;
 }
 
 void IndexIVFFastScan::search_implem_12(
@@ -1044,7 +1045,7 @@ void IndexIVFFastScan::search_implem_12(
         handler.dbias = tmp_bias.data();
     }
 
-    size_t ndis = 0;
+    size_t ndis = 0, nlist_visited = 0;
 
     size_t i0 = 0;
     uint64_t t_copy_pack = 0, t_scan = 0;
@@ -1066,6 +1067,7 @@ void IndexIVFFastScan::search_implem_12(
             i0 = i1;
             continue;
         }
+        nlist_visited++;
 
         // re-organize LUTs and biases into the right order
         int nc = i1 - i0;
@@ -1124,7 +1126,7 @@ void IndexIVFFastScan::search_implem_12(
     IVFFastScan_stats.t_scan += t_scan;
 
     *ndis_out = ndis;
-    *nlist_out = nlist;
+    *nlist_out = nlist_visited;
 }
 
 void IndexIVFFastScan::search_implem_14(


### PR DESCRIPTION
IndexIVFFastScan indexIVF_stats seems wrong.
my demo code:
```
import numpy as np
import faiss

# 创建索引
index = faiss.index_factory(128, "IVF100,PQ64x4fs", faiss.METRIC_INNER_PRODUCT)

num_vectors = 10000
dim = 128
np.random.seed(1234)  # 为了可重复性

vectors = np.random.rand(num_vectors, dim).astype('float32')

index.train(vectors)
index.add(vectors)

faiss.cvar.indexIVF_stats.reset()
index.search(vectors[:2], 10)  # 查询前10个最相似的向量

stats = faiss.cvar.indexIVF_stats
print(stats.nlist, stats.nq, stats.ndis)
```
# main branch output
<img width="227" alt="image" src="https://github.com/user-attachments/assets/d32f49c3-2cb3-471c-92fb-d1e9d2dad5b6" />
     
nlist(nb of inverted lists scanned) shouldn't be 200, it should be 2.      
ndis(nb of distances computed) is wrong in some fastscan implem.
# after my fix.
<img width="269" alt="image" src="https://github.com/user-attachments/assets/9eafe957-80b9-41dc-9f1f-37d03e80beb7" />


