### PR TITLE
Fix unreachable-break issue in faiss/IndexAdditiveQuantizer.cpp +1

### DIFF
--- a/faiss/IndexAdditiveQuantizer.cpp
+++ b/faiss/IndexAdditiveQuantizer.cpp
@@ -221,7 +221,6 @@ FlatCodesDistanceComputer* IndexAdditiveQuantizer::
                     return new AQDistanceComputerLUT<
                             false,
                             AdditiveQuantizer::ST_norm_cqint8>(*this);
-                    break;
 #undef DISPATCH
                 default:
                     FAISS_THROW_FMT(


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wunreachable-code-break` which identifies `break` statements that cannot be reached. These compromise readability, are misleading, and may identify bugs. This diff removes such statements.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dtolnay, mdouze

Differential Revision: D76476282
