### PR TITLE
Support decode_vectors (sa_decode but no decode_listnos) in multiple IVF index

### DIFF
--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -959,6 +959,14 @@ bool IndexIVF::check_ids_sorted() const {
     return nflip == 0;
 }
 
+void IndexIVF::decode_vectors(
+        idx_t n,
+        const uint8_t* codes,
+        const idx_t*,
+        float* x) const {
+    FAISS_THROW_MSG("decode_vectors not implemented");
+}
+
 /* standalone codec interface */
 size_t IndexIVF::sa_code_size() const {
     size_t coarse_size = coarse_code_size();

--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -254,6 +254,20 @@ struct IndexIVF : Index, IndexIVFInterface {
             uint8_t* codes,
             bool include_listno = false) const = 0;
 
+    /** Decodes a set of vectors as they would appear in a given set of inverted
+     * lists (inverse of encode_vectors)
+     *
+     * @param codes      input codes, size n * code_size
+     * @param x          output decoded vectors
+     * @param list_nos   input listnos, size n
+     *
+     */
+    virtual void decode_vectors(
+            idx_t n,
+            const uint8_t* codes,
+            const idx_t* list_nos,
+            float* x) const;
+
     /** Add vectors that are computed with the standalone codec
      *
      * @param codes  codes to add size n * sa_code_size()

--- a/faiss/IndexIVFFlat.cpp
+++ b/faiss/IndexIVFFlat.cpp
@@ -122,6 +122,18 @@ void IndexIVFFlat::encode_vectors(
     }
 }
 
+void IndexIVFFlat::decode_vectors(
+        idx_t n,
+        const uint8_t* codes,
+        const idx_t* listnos,
+        float* x) const {
+    for (size_t i = 0; i < n; i++) {
+        const uint8_t* code = codes + i * code_size;
+        float* xi = x + i * d;
+        memcpy(xi, code, code_size);
+    }
+}
+
 void IndexIVFFlat::sa_decode(idx_t n, const uint8_t* bytes, float* x) const {
     size_t coarse_size = coarse_code_size();
     for (size_t i = 0; i < n; i++) {

--- a/faiss/IndexIVFFlat.h
+++ b/faiss/IndexIVFFlat.h
@@ -43,6 +43,12 @@ struct IndexIVFFlat : IndexIVF {
             uint8_t* codes,
             bool include_listnos = false) const override;
 
+    void decode_vectors(
+            idx_t n,
+            const uint8_t* codes,
+            const idx_t* list_nos,
+            float* x) const override;
+
     InvertedListScanner* get_InvertedListScanner(
             bool store_pairs,
             const IDSelector* sel,

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -185,6 +185,14 @@ void IndexIVFPQ::encode_vectors(
     }
 }
 
+void IndexIVFPQ::decode_vectors(
+        idx_t n,
+        const uint8_t* codes,
+        const idx_t* listnos,
+        float* x) const {
+    return decode_multiple(n, listnos, codes, x);
+}
+
 void IndexIVFPQ::sa_decode(idx_t n, const uint8_t* codes, float* x) const {
     size_t coarse_size = coarse_code_size();
 

--- a/faiss/IndexIVFPQ.h
+++ b/faiss/IndexIVFPQ.h
@@ -66,6 +66,12 @@ struct IndexIVFPQ : IndexIVF {
             uint8_t* codes,
             bool include_listnos = false) const override;
 
+    void decode_vectors(
+            idx_t n,
+            const uint8_t* codes,
+            const idx_t* listnos,
+            float* x) const override;
+
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
 
     void add_core(

--- a/faiss/IndexIVFRaBitQ.cpp
+++ b/faiss/IndexIVFRaBitQ.cpp
@@ -80,6 +80,27 @@ void IndexIVFRaBitQ::encode_vectors(
     }
 }
 
+void IndexIVFRaBitQ::decode_vectors(
+        idx_t n,
+        const uint8_t* codes,
+        const idx_t* listnos,
+        float* x) const {
+#pragma omp parallel
+    {
+        std::vector<float> centroid(d);
+
+#pragma omp for
+        for (idx_t i = 0; i < n; i++) {
+            const uint8_t* code = codes + i * code_size;
+            int64_t list_no = listnos[i];
+            float* xi = x + i * d;
+
+            quantizer->reconstruct(list_no, centroid.data());
+            rabitq.decode_core(code, xi, 1, centroid.data());
+        }
+    }
+}
+
 void IndexIVFRaBitQ::add_core(
         idx_t n,
         const float* x,

--- a/faiss/IndexIVFRaBitQ.h
+++ b/faiss/IndexIVFRaBitQ.h
@@ -47,6 +47,12 @@ struct IndexIVFRaBitQ : IndexIVF {
             uint8_t* codes,
             bool include_listnos = false) const override;
 
+    void decode_vectors(
+            idx_t n,
+            const uint8_t* codes,
+            const idx_t* list_nos,
+            float* x) const override;
+
     void add_core(
             idx_t n,
             const float* x,

--- a/faiss/IndexScalarQuantizer.cpp
+++ b/faiss/IndexScalarQuantizer.cpp
@@ -182,6 +182,15 @@ void IndexIVFScalarQuantizer::encode_vectors(
     }
 }
 
+void IndexIVFScalarQuantizer::decode_vectors(
+        idx_t n,
+        const uint8_t* codes,
+        const idx_t*,
+        float* x) const {
+    FAISS_THROW_IF_NOT(is_trained);
+    return sq.decode(codes, x, n);
+}
+
 void IndexIVFScalarQuantizer::sa_decode(idx_t n, const uint8_t* codes, float* x)
         const {
     std::unique_ptr<ScalarQuantizer::SQuantizer> squant(sq.select_quantizer());

--- a/faiss/IndexScalarQuantizer.h
+++ b/faiss/IndexScalarQuantizer.h
@@ -88,6 +88,12 @@ struct IndexIVFScalarQuantizer : IndexIVF {
             uint8_t* codes,
             bool include_listnos = false) const override;
 
+    void decode_vectors(
+            idx_t n,
+            const uint8_t* codes,
+            const idx_t* list_nos,
+            float* x) const override;
+
     void add_core(
             idx_t n,
             const float* x,


### PR DESCRIPTION
Summary:
Unicorn now uses faiss opaquely, and we need support for decode vectors without decoding listnos, since we used encode_vectors without encoding listno in the codes.

Add decode_vectors, the inverse of encode_vectors, that for now doesn't decode listnos at all (can be changed)

Differential Revision: D76870386


