### PR TITLE
cmake: disable installing external documents under docs/faiss

### DIFF
--- a/perf_tests/CMakeLists.txt
+++ b/perf_tests/CMakeLists.txt
@@ -6,6 +6,7 @@
 # @lint-ignore-every LINEWRAP
 project(faiss_perf_tests)
 set(BENCHMARK_ENABLE_TESTING OFF)
+set(BENCHMARK_INSTALL_DOCS OFF)
 
 include(FetchContent)
 FetchContent_Declare(googlebenchmark


### PR DESCRIPTION
Related issue: #4405 

Building and installing faiss with CMake installs documents from `google/benchmark` under `docs/faiss/`.
Turning off the `BENCHMARK_INSTALL_DOCS` ([google/benchmark CMakeList.txt](https://github.com/google/benchmark/blob/main/src/CMakeLists.txt#L191)) option prevents this issue. 

