### PR TITLE
remove ABS_INNER_PRODUCT metric

### DIFF
--- a/faiss/MetricType.h
+++ b/faiss/MetricType.h
@@ -36,8 +36,6 @@ enum MetricType {
     METRIC_Jaccard,
     /// Squared Eucliden distance, ignoring NaNs
     METRIC_NaNEuclidean,
-    /// abs(x | y): the distance to a hyperplane
-    METRIC_ABS_INNER_PRODUCT,
     /// Gower's distance - numeric dimensions are in [0,1] and categorical
     /// dimensions are negative integers
     METRIC_GOWER,

--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -164,14 +164,12 @@ def add_ref_in_function(function_name, parameter_no):
     setattr(this_module, function_name, replacement_function)
 
 
-try:
+if "GPU" in get_compile_options():
     add_ref_in_constructor(GpuIndexIVFFlat, 1)
     add_ref_in_constructor(GpuIndexBinaryFlat, 1)
     add_ref_in_constructor(GpuIndexFlat, 1)
     add_ref_in_constructor(GpuIndexIVFPQ, 1)
     add_ref_in_constructor(GpuIndexIVFScalarQuantizer, 1)
-except NameError as e:
-    logger.info("Failed to load GPU Faiss: %s. Will not load constructor refs for GPU indexes. This is only an error if you're trying to use GPU Faiss." % e.args[0])
 
 add_ref_in_constructor(IndexIVFFlat, 0)
 add_ref_in_constructor(IndexIVFFlatDedup, 0)

--- a/faiss/utils/extra_distances-inl.h
+++ b/faiss/utils/extra_distances-inl.h
@@ -153,17 +153,6 @@ inline float VectorDistance<METRIC_NaNEuclidean>::operator()(
 }
 
 template <>
-inline float VectorDistance<METRIC_ABS_INNER_PRODUCT>::operator()(
-        const float* x,
-        const float* y) const {
-    float accu = 0;
-    for (size_t i = 0; i < d; i++) {
-        accu += fabs(x[i] * y[i]);
-    }
-    return accu;
-}
-
-template <>
 inline float VectorDistance<METRIC_GOWER>::operator()(
         const float* x,
         const float* y) const {
@@ -227,7 +216,6 @@ typename Consumer::T dispatch_VectorDistance(
         DISPATCH_VD(METRIC_JensenShannon);
         DISPATCH_VD(METRIC_Jaccard);
         DISPATCH_VD(METRIC_NaNEuclidean);
-        DISPATCH_VD(METRIC_ABS_INNER_PRODUCT);
         DISPATCH_VD(METRIC_GOWER);
         default:
             FAISS_THROW_FMT("Invalid metric %d", metric);

--- a/tests/test_extra_distances.py
+++ b/tests/test_extra_distances.py
@@ -114,13 +114,6 @@ class TestExtraDistances(unittest.TestCase):
         new_dis = faiss.pairwise_distances(x, q, faiss.METRIC_NaNEuclidean)
         self.assertTrue(np.isnan(new_dis[0]))
 
-    def test_abs_inner_product(self):
-        xq, yb = self.make_example()
-        dis = faiss.pairwise_distances(xq, yb, faiss.METRIC_ABS_INNER_PRODUCT)
-
-        gt_dis = np.abs(xq @ yb.T)
-        np.testing.assert_allclose(dis, gt_dis, atol=1e-5)
-
     def test_gower(self):
         # Create test data with mixed numeric and categorical features
         # First 2 dimensions are numeric (0-1), last 2 are categorical
@@ -246,7 +239,6 @@ class TestExtraDistances(unittest.TestCase):
             xq_out_of_range, yb_out_of_range, faiss.METRIC_GOWER
         )
         self.assertTrue(np.all(np.isnan(dis_out_of_range)))
-
 
 class TestKNN(unittest.TestCase):
     """ test that the knn search gives the same as distance matrix + argmin """

--- a/tests/test_graph_based.py
+++ b/tests/test_graph_based.py
@@ -201,21 +201,6 @@ class TestHNSW(unittest.TestCase):
             )
             self.assertEqual(index3.storage, None)
 
-    def test_abs_inner_product(self):
-        """Test HNSW with abs inner product (not a real distance, so dubious that triangular inequality works)"""
-        d = self.xq.shape[1]
-        xb = self.xb - self.xb.mean(axis=0)  # need to be centered to give interesting directions
-        xq = self.xq - self.xq.mean(axis=0)
-        Dref, Iref = faiss.knn(xq, xb, 10, faiss.METRIC_ABS_INNER_PRODUCT)
-
-        index = faiss.IndexHNSWFlat(d, 32, faiss.METRIC_ABS_INNER_PRODUCT)
-        index.add(xb)
-        Dnew, Inew = index.search(xq, 10)
-
-        inter = faiss.eval_intersection(Iref, Inew)
-        # 4769 vs. 500*10
-        self.assertGreater(inter, Iref.size * 0.9)
-
     def test_hnsw_reset(self):
         d = self.xb.shape[1]
         index_flat = faiss.IndexFlat(d)


### PR DESCRIPTION
Summary: The METRIC_ABS_INNER_PRODUCT metric is not useful, see rationale here: https://github.com/facebookresearch/faiss/issues/4407

Differential Revision: D77150028


