### PR TITLE
Add support for IndexIDMap with Cagra fp16

### DIFF
--- a/faiss/Index.h
+++ b/faiss/Index.h
@@ -61,6 +61,7 @@ struct DistanceComputer;
 enum NumericType {
     Float32,
     Float16,
+    UInt8,
 };
 
 inline size_t get_numeric_type_size(NumericType numeric_type) {

--- a/faiss/IndexBinary.h
+++ b/faiss/IndexBinary.h
@@ -54,6 +54,15 @@ struct IndexBinary {
      * @param x      training vecors, size n * d / 8
      */
     virtual void train(idx_t n, const uint8_t* x);
+    // This typed train function is a dummy to enable overriding of typed train
+    // function in the templated IndexIDMap struct.
+    virtual void train(idx_t n, const void* x, NumericType numeric_type) {
+        if (numeric_type == NumericType::UInt8) {
+            train(n, static_cast<const uint8_t*>(x));
+        } else {
+            FAISS_THROW_MSG("IndexBinary::train: unsupported numeric type");
+        }
+    }
 
     /** Add n vectors of dimension d to the index.
      *
@@ -61,6 +70,15 @@ struct IndexBinary {
      * @param x      input matrix, size n * d / 8
      */
     virtual void add(idx_t n, const uint8_t* x) = 0;
+    // This typed add function is a dummy to enable overriding of typed add
+    // function in the templated IndexIDMap struct.
+    virtual void add(idx_t n, const void* x, NumericType numeric_type) {
+        if (numeric_type == NumericType::UInt8) {
+            add(n, static_cast<const uint8_t*>(x));
+        } else {
+            FAISS_THROW_MSG("IndexBinary::add: unsupported numeric type");
+        }
+    }
 
     /** Same as add, but stores xids instead of sequential ids.
      *
@@ -70,6 +88,20 @@ struct IndexBinary {
      * @param xids if non-null, ids to store for the vectors (size n)
      */
     virtual void add_with_ids(idx_t n, const uint8_t* x, const idx_t* xids);
+    // This typed add_with_ids function is a dummy to enable overriding of typed
+    // add_with_ids function in the templated IndexIDMap struct.
+    virtual void add_with_ids(
+            idx_t n,
+            const void* x,
+            NumericType numeric_type,
+            const idx_t* xids) {
+        if (numeric_type == NumericType::UInt8) {
+            add_with_ids(n, static_cast<const uint8_t*>(x), xids);
+        } else {
+            FAISS_THROW_MSG(
+                    "IndexBinary::add_with_ids: unsupported numeric type");
+        }
+    }
 
     /** Query n vectors of dimension d to the index.
      *
@@ -87,6 +119,27 @@ struct IndexBinary {
             int32_t* distances,
             idx_t* labels,
             const SearchParameters* params = nullptr) const = 0;
+    // This typed search function is a dummy to enable overriding of typed
+    // search function in the templated IndexIDMap struct.
+    virtual void search(
+            idx_t n,
+            const void* x,
+            NumericType numeric_type,
+            idx_t k,
+            int32_t* distances,
+            idx_t* labels,
+            const SearchParameters* params = nullptr) const {
+        if (numeric_type == NumericType::UInt8) {
+            search(n,
+                   static_cast<const uint8_t*>(x),
+                   k,
+                   distances,
+                   labels,
+                   params);
+        } else {
+            FAISS_THROW_MSG("IndexBinary::search: unsupported numeric type");
+        }
+    }
 
     /** Query n vectors of dimension d to the index.
      *

--- a/faiss/IndexIDMap.h
+++ b/faiss/IndexIDMap.h
@@ -31,6 +31,11 @@ struct IndexIDMapTemplate : IndexT {
     /// @param xids if non-null, ids to store for the vectors (size n)
     void add_with_ids(idx_t n, const component_t* x, const idx_t* xids)
             override;
+    void add_with_ids(
+            idx_t n,
+            const void* x,
+            NumericType numeric_type,
+            const idx_t* xids) override;
 
     /// this will fail. Use add_with_ids
     void add(idx_t n, const component_t* x) override;
@@ -42,8 +47,17 @@ struct IndexIDMapTemplate : IndexT {
             distance_t* distances,
             idx_t* labels,
             const SearchParameters* params = nullptr) const override;
+    void search(
+            idx_t n,
+            const void* x,
+            NumericType numeric_type,
+            idx_t k,
+            distance_t* distances,
+            idx_t* labels,
+            const SearchParameters* params = nullptr) const override;
 
     void train(idx_t n, const component_t* x) override;
+    void train(idx_t n, const void* x, NumericType numeric_type) override;
 
     void reset() override;
 

--- a/faiss/gpu/test/test_cagra.py
+++ b/faiss/gpu/test/test_cagra.py
@@ -15,7 +15,7 @@ import numpy as np
     "only if cuVS is compiled in")
 class TestComputeGT(unittest.TestCase):
 
-    def do_compute_GT(self, metric):
+    def do_compute_GT(self, metric, fp16):
         d = 64
         k = 12
         ds = datasets.SyntheticDataset(d, 0, 10000, 100)
@@ -31,57 +31,31 @@ class TestComputeGT(unittest.TestCase):
         cagraIndexConfig.build_algo = faiss.graph_build_algo_IVF_PQ
 
         index = faiss.GpuIndexCagra(res, d, metric, cagraIndexConfig)
-        index.train(ds.get_database())
-        Dnew, Inew = index.search(ds.get_queries(), k)
+        database = ds.get_database().astype(np.float16) if fp16 else ds.get_database()
+        index.train(database)
+        queries = ds.get_queries().astype(np.float16) if fp16 else ds.get_queries()
+        Dnew, Inew = index.search(queries, k)
         
         evaluation.check_ref_knn_with_draws(Dref, Iref, Dnew, Inew, k)
 
     def test_compute_GT_L2(self):
-        self.do_compute_GT(faiss.METRIC_L2)
+        self.do_compute_GT(faiss.METRIC_L2, False)
 
     def test_compute_GT_IP(self):
-        self.do_compute_GT(faiss.METRIC_INNER_PRODUCT)
+        self.do_compute_GT(faiss.METRIC_INNER_PRODUCT, False)
 
-@unittest.skipIf(
-    "CUVS" not in faiss.get_compile_options(),
-    "only if cuVS is compiled in")
-class TestComputeGTFP16(unittest.TestCase):
+    def test_compute_GT_L2_FP16(self):
+        self.do_compute_GT(faiss.METRIC_L2, True)
 
-    def do_compute_GT(self, metric):
-        d = 64
-        k = 12
-        ds = datasets.SyntheticDataset(d, 0, 10000, 100)
-        Dref, Iref = faiss.knn(ds.get_queries(), ds.get_database(), k, metric)
-
-        res = faiss.StandardGpuResources()
-
-        # attempt to set custom IVF-PQ params
-        cagraIndexConfig = faiss.GpuIndexCagraConfig()
-        cagraIndexIVFPQConfig = faiss.IVFPQBuildCagraConfig()
-        cagraIndexIVFPQConfig.kmeans_trainset_fraction = 0.1
-        cagraIndexConfig.ivf_pq_params = cagraIndexIVFPQConfig
-        cagraIndexConfig.build_algo = faiss.graph_build_algo_IVF_PQ
-
-        index = faiss.GpuIndexCagra(res, d, metric, cagraIndexConfig)
-        fp16_data = ds.get_database().astype(np.float16)
-        index.train(fp16_data, faiss.Float16)
-        fp16_queries = ds.get_queries().astype(np.float16)
-        Dnew, Inew = index.search(fp16_queries, k, numeric_type=faiss.Float16)
-        
-        evaluation.check_ref_knn_with_draws(Dref, Iref, Dnew, Inew, k)
-
-    def test_compute_GT_L2(self):
-        self.do_compute_GT(faiss.METRIC_L2)
-
-    def test_compute_GT_IP(self):
-        self.do_compute_GT(faiss.METRIC_INNER_PRODUCT)
+    def test_compute_GT_IP_FP16(self):
+        self.do_compute_GT(faiss.METRIC_INNER_PRODUCT, True)
 
 @unittest.skipIf(
     "CUVS" not in faiss.get_compile_options(),
     "only if cuVS is compiled in")
 class TestInterop(unittest.TestCase):
 
-    def do_interop(self, metric):
+    def do_interop(self, metric, fp16):
         d = 64
         k = 12
         ds = datasets.SyntheticDataset(d, 0, 10000, 100)
@@ -89,10 +63,13 @@ class TestInterop(unittest.TestCase):
         res = faiss.StandardGpuResources()
 
         index = faiss.GpuIndexCagra(res, d, metric)
-        index.train(ds.get_database())
-        Dnew, Inew = index.search(ds.get_queries(), k)
+        database = ds.get_database().astype(np.float16) if fp16 else ds.get_database()
+        index.train(database)
+        queries = ds.get_queries().astype(np.float16) if fp16 else ds.get_queries()
+        Dnew, Inew = index.search(queries, k)
 
         cpu_index = faiss.index_gpu_to_cpu(index)
+        # cpu index always search in fp32
         Dref, Iref = cpu_index.search(ds.get_queries(), k)
         
         evaluation.check_ref_knn_with_draws(Dref, Iref, Dnew, Inew, k)
@@ -101,49 +78,55 @@ class TestInterop(unittest.TestCase):
             faiss.serialize_index(cpu_index))
 
         gpu_index = faiss.index_cpu_to_gpu(res, 0, deserialized_index)
-        Dnew2, Inew2 = gpu_index.search(ds.get_queries(), k)
+        Dnew2, Inew2 = gpu_index.search(queries, k)
 
         evaluation.check_ref_knn_with_draws(Dnew2, Inew2, Dnew, Inew, k)
 
     def test_interop_L2(self):
-        self.do_interop(faiss.METRIC_L2)
+        self.do_interop(faiss.METRIC_L2, False)
 
     def test_interop_IP(self):
-        self.do_interop(faiss.METRIC_INNER_PRODUCT)
+        self.do_interop(faiss.METRIC_INNER_PRODUCT, False)
+
+    def test_interop_L2_FP16(self):
+        self.do_interop(faiss.METRIC_L2, True)
+
+    def test_interop_IP_FP16(self):
+        self.do_interop(faiss.METRIC_INNER_PRODUCT, True)
+
 
 @unittest.skipIf(
     "CUVS" not in faiss.get_compile_options(),
     "only if cuVS is compiled in")
-class TestInteropFP16(unittest.TestCase):
+class TestIDMapCagra(unittest.TestCase):
 
-    def do_interop(self, metric):
+    def do_IDMapCagra(self, metric, fp16):
         d = 64
         k = 12
         ds = datasets.SyntheticDataset(d, 0, 10000, 100)
+        Dref, Iref = faiss.knn(ds.get_queries(), ds.get_database(), k, metric)
 
         res = faiss.StandardGpuResources()
 
         index = faiss.GpuIndexCagra(res, d, metric)
-        fp16_data = ds.get_database().astype(np.float16)
-        index.train(fp16_data, faiss.Float16)
-        fp16_queries = ds.get_queries().astype(np.float16)
-        Dnew, Inew = index.search(fp16_queries, k, numeric_type=faiss.Float16)
+        idMapIndex = faiss.IndexIDMap(index)
+        database = ds.get_database().astype(np.float16) if fp16 else ds.get_database()
+        idMapIndex.train(database)
+        ids = [i for i in range(10000)]
+        idMapIndex.add_with_ids(database, ids)
+        queries = ds.get_queries().astype(np.float16) if fp16 else ds.get_queries()
+        Dnew, Inew = idMapIndex.search(queries, k)
 
-        cpu_index = faiss.index_gpu_to_cpu(index)
-        Dref, Iref = cpu_index.search(ds.get_queries(), k)
-        
         evaluation.check_ref_knn_with_draws(Dref, Iref, Dnew, Inew, k)
 
-        deserialized_index = faiss.deserialize_index(
-            faiss.serialize_index(cpu_index))
+    def test_IDMapCagra_L2(self):
+        self.do_IDMapCagra(faiss.METRIC_L2, False)
 
-        gpu_index = faiss.index_cpu_to_gpu(res, 0, deserialized_index)
-        Dnew2, Inew2 = gpu_index.search(fp16_queries, k, numeric_type=faiss.Float16)
+    def test_IDMapCagra_IP(self):
+        self.do_IDMapCagra(faiss.METRIC_INNER_PRODUCT, False)
 
-        evaluation.check_ref_knn_with_draws(Dnew2, Inew2, Dnew, Inew, k)
+    def test_IDMapCagra_L2_FP16(self):
+        self.do_IDMapCagra(faiss.METRIC_L2, True)
 
-    def test_interop_L2(self):
-        self.do_interop(faiss.METRIC_L2)
-
-    def test_interop_IP(self):
-        self.do_interop(faiss.METRIC_INNER_PRODUCT)
+    def test_IDMapCagra_IP_FP16(self):
+        self.do_IDMapCagra(faiss.METRIC_INNER_PRODUCT, True)

--- a/faiss/python/class_wrappers.py
+++ b/faiss/python/class_wrappers.py
@@ -230,9 +230,9 @@ def handle_Index(the_class):
             x = np.ascontiguousarray(x, dtype='float32')
         else:
             x = np.ascontiguousarray(x, dtype='float16')
-        self.add_c(n, swig_ptr(x))
+        self.add_c(n, swig_ptr(x), numeric_type)
 
-    def replacement_add_with_ids(self, x, ids):
+    def replacement_add_with_ids(self, x, ids, numeric_type = faiss.Float32):
         """Adds vectors with arbitrary ids to the index (not all indexes support this).
         The index must be trained before vectors can be added to it.
         Vector `i` is stored in `x[i]` and has id `ids[i]`.
@@ -248,10 +248,13 @@ def handle_Index(the_class):
         """
         n, d = x.shape
         assert d == self.d
-        x = np.ascontiguousarray(x, dtype='float32')
+        if numeric_type == faiss.Float32:
+            x = np.ascontiguousarray(x, dtype='float32')
+        else:
+            x = np.ascontiguousarray(x, dtype='float16')
         ids = np.ascontiguousarray(ids, dtype='int64')
         assert ids.shape == (n, ), 'not same nb of vectors as ids'
-        self.add_with_ids_c(n, swig_ptr(x), swig_ptr(ids))
+        self.add_with_ids_c(n, swig_ptr(x), numeric_type, swig_ptr(ids))
 
     def replacement_assign(self, x, k, labels=None):
         """Find the k nearest neighbors of the set of vectors x in the index.
@@ -295,6 +298,7 @@ def handle_Index(the_class):
             Query vectors, shape (n, d) where d is appropriate for the index.
             `dtype` must be float32.
         """
+        print("we are here")
         n, d = x.shape
         assert d == self.d
         if numeric_type == faiss.Float32:
@@ -302,7 +306,8 @@ def handle_Index(the_class):
             self.train_c(n, swig_ptr(x))
         else:
             x = np.ascontiguousarray(x, dtype='float16')
-            self.train_c(n, swig_ptr(x), faiss.Float16)
+            print("we are here to train")
+            self.train_c(n, swig_ptr(x), numeric_type)
         
 
     def replacement_search(self, x, k, *, params=None, D=None, I=None, numeric_type = faiss.Float32):
@@ -350,7 +355,7 @@ def handle_Index(the_class):
             I = np.empty((n, k), dtype=np.int64)
         else:
             assert I.shape == (n, k)
-
+        print("we are here in replacement search")
         if numeric_type == faiss.Float32:
             self.search_c(n, swig_ptr(x), k, swig_ptr(D), swig_ptr(I), params)
         else:


### PR DESCRIPTION
This PR does 2 things
- Enable support fot `IndexIDMap` with Cagra fp16 (original support introduced in https://github.com/facebookresearch/faiss/pull/4188)
    - Added tests in `test_cagra.py`
- Reflecting feedback about python API from https://github.com/facebookresearch/faiss/pull/4384#discussion_r2167013214 