### PR TITLE
fix: add avx2 in python if avx512 enabled

### DIFF
--- a/faiss/python/CMakeLists.txt
+++ b/faiss/python/CMakeLists.txt
@@ -138,7 +138,7 @@ swig_add_library(swigfaiss_avx2
   SOURCES swigfaiss_avx2.swig
 )
 set_property(TARGET swigfaiss_avx2 PROPERTY SWIG_COMPILE_OPTIONS -doxygen)
-if(NOT FAISS_OPT_LEVEL STREQUAL "avx2")
+if(NOT FAISS_OPT_LEVEL STREQUAL "avx2" AND NOT FAISS_OPT_LEVEL STREQUAL "avx512" AND NOT FAISS_OPT_LEVEL STREQUAL "avx512_spr")
   set_target_properties(swigfaiss_avx2 PROPERTIES EXCLUDE_FROM_ALL TRUE)
 endif()
 

--- a/tests/test_fast_scan.py
+++ b/tests/test_fast_scan.py
@@ -44,6 +44,7 @@ class TestSearch(unittest.TestCase):
     # not exploitable, hence the flag test on that as well.
     @unittest.skipUnless(
         ('AVX2' in faiss.get_compile_options() or
+        'AVX512' in faiss.get_compile_options() or
         'NEON' in faiss.get_compile_options()) and
         "OPTIMIZE" in faiss.get_compile_options(),
         "only test while building with avx2 or neon")


### PR DESCRIPTION
when OPT_LEVEL is set to avx512, python package should include avx2, too.
Then, it's able to fallback to avx2 if avx512 is not available but avx2 is available.