### PR TITLE
Fix building on mingw

### DIFF
--- a/faiss/impl/mapped_io.cpp
+++ b/faiss/impl/mapped_io.cpp
@@ -168,12 +168,12 @@ struct MmappedFileMappingOwner::PImpl {
         const int fd = _fileno(f);
         if (fd == -1) {
             // no good
-            FAISS_THROW_FMT("could not get a HANDLE");
+            FAISS_THROW_MSG("could not get a HANDLE");
         }
 
         HANDLE file_handle = (HANDLE)_get_osfhandle(fd);
         if (file_handle == INVALID_HANDLE_VALUE) {
-            FAISS_THROW_FMT("could not get an OS HANDLE");
+            FAISS_THROW_MSG("could not get an OS HANDLE");
         }
 
         // get the size of the file


### PR DESCRIPTION
This restores the ability to compile with mingw introduced in #4145. I am not sure why msvc does allow this, but using the `_FMT` macro without any `vaargs` causes a trailing comma in the arguments list. which is not allowed in c++. This switches it over to the `_MSG` macro instead avoiding this issue.