### PR TITLE
Use c++11 only in headers

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -78,7 +78,7 @@ bool read_vector_base(
         const std::optional<size_t> beforeknown_size,
         const std::optional<size_t> size_multiplier) {
     // check if the use case is right
-    if constexpr (is_maybe_owned_vector_v<VectorT>) {
+    if constexpr (is_maybe_owned_vector_v(VectorT)) {
         // is it a mmap-enabled reader?
         MappedFileIOReader* mf = dynamic_cast<MappedFileIOReader*>(f);
         if (mf != nullptr) {

--- a/faiss/impl/maybe_owned_vector.h
+++ b/faiss/impl/maybe_owned_vector.h
@@ -295,8 +295,7 @@ struct is_maybe_owned_vector : std::false_type {};
 template <typename T>
 struct is_maybe_owned_vector<MaybeOwnedVector<T>> : std::true_type {};
 
-template <typename T>
-inline constexpr bool is_maybe_owned_vector_v = is_maybe_owned_vector<T>::value;
+#define is_maybe_owned_vector_v(T) is_maybe_owned_vector<T>::value
 
 template <typename T>
 bool operator==(


### PR DESCRIPTION
This is a small patch, I understand that you would rather use c++17 as in the rest of the codebase.

I am currently in a situation where I need to include c++11 headers, and c++17 headers (faiss). Since this is just a small patch I am hoping you would accept this! However, if you would rather keep using c++17 features in the headers, I can keep this as downstream patch for myself.