### PR TITLE
Add option to link cuda statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 # Valid values are "generic", "avx2", "avx512", "avx512_spr", "sve".
 option(FAISS_OPT_LEVEL "" "generic")
 option(FAISS_ENABLE_GPU "Enable support for GPU indexes." ON)
+option(FAISS_GPU_STATIC "Link GPU libraries statically." OFF)
 option(FAISS_ENABLE_CUVS "Enable cuVS for GPU indexes." OFF)
 option(FAISS_ENABLE_ROCM "Enable ROCm for GPU indexes." OFF)
 option(FAISS_ENABLE_MKL "Enable MKL." ON)

--- a/faiss/gpu/CMakeLists.txt
+++ b/faiss/gpu/CMakeLists.txt
@@ -169,6 +169,15 @@ set(FAISS_GPU_HEADERS
   utils/warpselect/WarpSelectImpl.cuh
 )
 
+set(CUDA_LIBS CUDA::cudart CUDA::cublas)
+if(FAISS_GPU_STATIC)
+	if(FAISS_ENABLE_ROCM)
+		message(WARNING "Linking ROCm staticcally is unsupported at the time. Continuing with dynamic linking.")
+	else()
+		set(CUDA_LIBS CUDA::cudart_static CUDA::cublas_static)
+	endif()
+endif()
+
 function(generate_ivf_interleaved_code)
   set(SUB_CODEC_TYPE
     "faiss::gpu::Codec<0, 1>"
@@ -351,7 +360,7 @@ else()
 
 
   find_package(CUDAToolkit REQUIRED)
-  target_link_libraries(faiss_gpu_objs PRIVATE CUDA::cudart CUDA::cublas $<$<BOOL:${FAISS_ENABLE_CUVS}>:cuvs::cuvs> $<$<BOOL:${FAISS_ENABLE_CUVS}>:OpenMP::OpenMP_CXX>)
+  target_link_libraries(faiss_gpu_objs PRIVATE ${CUDA_LIBS} $<$<BOOL:${FAISS_ENABLE_CUVS}>:cuvs::cuvs> $<$<BOOL:${FAISS_ENABLE_CUVS}>:OpenMP::OpenMP_CXX>)
   target_compile_options(faiss_gpu_objs PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:-Xfatbin=-compress-all
     --expt-extended-lambda --expt-relaxed-constexpr


### PR DESCRIPTION
When linking to cuda dynamically, and the target does not have cuda installed, the user can not even start code with FAISS compiled with cuda. Therefore it could be useful to link the CUDA runtime/blas statically instead to avoid requiring CUDA on the users end.