### PR TITLE
Improve naming of the residual_quantizer_encode_steps.cpp file

### DIFF
--- a/faiss/impl/residual_quantizer_encode_steps.cpp
+++ b/faiss/impl/residual_quantizer_encode_steps.cpp
@@ -292,8 +292,8 @@ void beam_search_encode_step(
                     cent_ids.data() + i * beam_size * new_beam_size;
 
             // here we could be a tad more efficient by merging sorted arrays
-            for (int i_2 = 0; i_2 < new_beam_size; i_2++) {
-                new_distances_i[i_2] = C::neutral();
+            for (int j = 0; j < new_beam_size; j++) {
+                new_distances_i[j] = C::neutral();
             }
             std::vector<int> perm(new_beam_size, -1);
             heap_addn<C>(
@@ -325,8 +325,8 @@ void beam_search_encode_step(
             const float* cent_distances_i =
                     cent_distances.data() + i * beam_size * K;
             // then we have to select the best results
-            for (int i_2 = 0; i_2 < new_beam_size; i_2++) {
-                new_distances_i[i_2] = C::neutral();
+            for (int j = 0; j < new_beam_size; j++) {
+                new_distances_i[j] = C::neutral();
             }
             std::vector<int> perm(new_beam_size, -1);
 
@@ -558,8 +558,8 @@ void beam_search_encode_step_tab(
         const float* cent_distances_i = cent_distances.data();
 
         // then we have to select the best results
-        for (int i_2 = 0; i_2 < new_beam_size; i_2++) {
-            new_distances_i[i_2] = C::neutral();
+        for (int j = 0; j < new_beam_size; j++) {
+            new_distances_i[j] = C::neutral();
         }
         std::vector<int> perm(new_beam_size, -1);
 


### PR DESCRIPTION
Summary: In D52959180, the codemod changed the variable i to i_2 in the inner loops to avoid conflict with the outer loop's i. Since i, j, and k are standard iterator names, I changed i_2 to j in three inner loops for clarity.

Reviewed By: mnorris11

Differential Revision: D78199003


