### PR TITLE
`int8` support for cuVS cagra

### DIFF
--- a/faiss/Index.h
+++ b/faiss/Index.h
@@ -61,6 +61,8 @@ struct DistanceComputer;
 enum NumericType {
     Float32,
     Float16,
+    UInt8,
+    Int8,
 };
 
 inline size_t get_numeric_type_size(NumericType numeric_type) {
@@ -69,6 +71,9 @@ inline size_t get_numeric_type_size(NumericType numeric_type) {
             return 4;
         case NumericType::Float16:
             return 2;
+        case NumericType::UInt8:
+        case NumericType::Int8:
+            return 1;
         default:
             FAISS_THROW_MSG(
                     "Unknown Numeric Type. Only supports Float32, Float16");

--- a/faiss/gpu/GpuCloner.cpp
+++ b/faiss/gpu/GpuCloner.cpp
@@ -94,7 +94,7 @@ Index* ToCPUCloner::clone_Index(const Index* index) {
 #if defined USE_NVIDIA_CUVS
     else if (auto icg = dynamic_cast<const GpuIndexCagra*>(index)) {
         IndexHNSWCagra* res = new IndexHNSWCagra();
-        if (icg->get_numeric_type() == faiss::NumericType::Float16) {
+        if (icg->get_numeric_type() != faiss::NumericType::Float32) {
             res->base_level_only = true;
         }
         icg->copyTo(res);

--- a/faiss/gpu/GpuIndex.cu
+++ b/faiss/gpu/GpuIndex.cu
@@ -194,6 +194,8 @@ void GpuIndex::addPaged_(
         dispatch(float{});
     } else if (numeric_type == NumericType::Float16) {
         dispatch(half{});
+    } else if (numeric_type == NumericType::Int8) {
+        dispatch(int8_t{});
     } else {
         FAISS_THROW_MSG("GpuIndex::addPaged_: Unsupported numeric type");
     }
@@ -251,6 +253,8 @@ void GpuIndex::addPage_(
         dispatch(float{});
     } else if (numeric_type == NumericType::Float16) {
         dispatch(half{});
+    } else if (numeric_type == NumericType::Int8) {
+        dispatch(int8_t{});
     } else {
         FAISS_THROW_MSG("GpuIndex::addPage_: Unsupported numeric type");
     }
@@ -419,6 +423,22 @@ void GpuIndex::searchNonPaged_(
                 outDistancesData,
                 outIndicesData,
                 params);
+    } else if (numeric_type == NumericType::Int8) {
+        auto vecs = toDeviceTemporary<int8_t, 2>(
+                resources_.get(),
+                config_.device,
+                const_cast<int8_t*>(static_cast<const int8_t*>(x)),
+                stream,
+                {n, this->d});
+
+        searchImplEx_(
+                n,
+                static_cast<const void*>(vecs.data()),
+                numeric_type,
+                k,
+                outDistancesData,
+                outIndicesData,
+                params);
     } else {
         FAISS_THROW_MSG("GpuIndex::search: Unsupported numeric type");
     }
@@ -484,6 +504,16 @@ void GpuIndex::searchFromCpuPaged_(
                         num,
                         static_cast<const void*>(
                                 static_cast<const half*>(x) + cur * this->d),
+                        numeric_type,
+                        k,
+                        outDistancesSlice.data(),
+                        outIndicesSlice.data(),
+                        params);
+            } else if (numeric_type == NumericType::Int8) {
+                searchNonPaged_(
+                        num,
+                        static_cast<const void*>(
+                                static_cast<const int8_t*>(x) + cur * this->d),
                         numeric_type,
                         k,
                         outDistancesSlice.data(),
@@ -645,6 +675,8 @@ void GpuIndex::searchFromCpuPaged_(
         dispatch(float{});
     } else if (numeric_type == NumericType::Float16) {
         dispatch(half{});
+    } else if (numeric_type == NumericType::Int8) {
+        dispatch(int8_t{});
     } else {
         FAISS_THROW_MSG(
                 "GpuIndex::searchFromCpuPaged_: Unsupported numeric type");

--- a/faiss/gpu/GpuIndex.cu
+++ b/faiss/gpu/GpuIndex.cu
@@ -431,7 +431,7 @@ void GpuIndex::searchNonPaged_(
                 stream,
                 {n, this->d});
 
-        searchImplEx_(
+        searchImpl_(
                 n,
                 static_cast<const void*>(vecs.data()),
                 numeric_type,

--- a/faiss/gpu/GpuIndexCagra.h
+++ b/faiss/gpu/GpuIndexCagra.h
@@ -312,7 +312,8 @@ struct GpuIndexCagra : public GpuIndex {
     std::variant<
             std::monostate,
             std::shared_ptr<CuvsCagra<float>>,
-            std::shared_ptr<CuvsCagra<half>>>
+            std::shared_ptr<CuvsCagra<half>>,
+            std::shared_ptr<CuvsCagra<int8_t>>>
             index_;
 };
 

--- a/faiss/gpu/impl/CuvsCagra.cu
+++ b/faiss/gpu/impl/CuvsCagra.cu
@@ -335,5 +335,6 @@ const data_t* CuvsCagra<data_t>::get_training_dataset() const {
 
 template class CuvsCagra<float>;
 template class CuvsCagra<half>;
+template class CuvsCagra<int8_t>;
 } // namespace gpu
 } // namespace faiss

--- a/faiss/gpu/test/test_cagra.py
+++ b/faiss/gpu/test/test_cagra.py
@@ -15,11 +15,26 @@ import numpy as np
     "only if cuVS is compiled in")
 class TestComputeGT(unittest.TestCase):
 
-    def do_compute_GT(self, metric):
+    def do_compute_GT(self, metric, numeric_type):
         d = 64
         k = 12
-        ds = datasets.SyntheticDataset(d, 0, 10000, 100)
-        Dref, Iref = faiss.knn(ds.get_queries(), ds.get_database(), k, metric)
+        if numeric_type == faiss.Int8:
+            data_base_nt = np.random.randint(-128, 128, size=(10000, d), dtype=np.int8)
+            data_query_nt = np.random.randint(-128, 128, size=(100, d), dtype=np.int8)
+            data_base = data_base_nt.astype(np.float32)
+            data_query = data_query_nt.astype(np.float32)
+        else:
+            ds = datasets.SyntheticDataset(d, 0, 10000, 100)
+            data_base = ds.get_database()  #fp32
+            data_query = ds.get_queries()   #fp32
+            if numeric_type == faiss.Float16:
+                data_base_nt = data_base.astype(np.float16)
+                data_query_nt = data_query.astype(np.float16)
+            elif numeric_type == faiss.Float32:
+                data_base_nt = data_base
+                data_query_nt = data_query
+
+        Dref, Iref = faiss.knn(data_query, data_base, k, metric)
 
         res = faiss.StandardGpuResources()
 
@@ -31,69 +46,62 @@ class TestComputeGT(unittest.TestCase):
         cagraIndexConfig.build_algo = faiss.graph_build_algo_IVF_PQ
 
         index = faiss.GpuIndexCagra(res, d, metric, cagraIndexConfig)
-        index.train(ds.get_database())
-        Dnew, Inew = index.search(ds.get_queries(), k)
+        index.train(data_base_nt, numeric_type=numeric_type)
+        Dnew, Inew = index.search(data_query_nt, k, numeric_type=numeric_type)
         
         evaluation.check_ref_knn_with_draws(Dref, Iref, Dnew, Inew, k)
 
     def test_compute_GT_L2(self):
-        self.do_compute_GT(faiss.METRIC_L2)
+        self.do_compute_GT(faiss.METRIC_L2, faiss.Float32)
 
     def test_compute_GT_IP(self):
-        self.do_compute_GT(faiss.METRIC_INNER_PRODUCT)
+        self.do_compute_GT(faiss.METRIC_INNER_PRODUCT, faiss.Float32)
 
-@unittest.skipIf(
-    "CUVS" not in faiss.get_compile_options(),
-    "only if cuVS is compiled in")
-class TestComputeGTFP16(unittest.TestCase):
+    def test_compute_GT_L2_FP16(self):
+        self.do_compute_GT(faiss.METRIC_L2, faiss.Float16)
 
-    def do_compute_GT(self, metric):
-        d = 64
-        k = 12
-        ds = datasets.SyntheticDataset(d, 0, 10000, 100)
-        Dref, Iref = faiss.knn(ds.get_queries(), ds.get_database(), k, metric)
+    def test_compute_GT_IP_FP16(self):
+        self.do_compute_GT(faiss.METRIC_INNER_PRODUCT, faiss.Float16)
 
-        res = faiss.StandardGpuResources()
+    def test_compute_GT_L2_Int8(self):
+        self.do_compute_GT(faiss.METRIC_L2, faiss.Int8)
 
-        # attempt to set custom IVF-PQ params
-        cagraIndexConfig = faiss.GpuIndexCagraConfig()
-        cagraIndexIVFPQConfig = faiss.IVFPQBuildCagraConfig()
-        cagraIndexIVFPQConfig.kmeans_trainset_fraction = 0.1
-        cagraIndexConfig.ivf_pq_params = cagraIndexIVFPQConfig
-        cagraIndexConfig.build_algo = faiss.graph_build_algo_IVF_PQ
-
-        index = faiss.GpuIndexCagra(res, d, metric, cagraIndexConfig)
-        fp16_data = ds.get_database().astype(np.float16)
-        index.train(fp16_data, faiss.Float16)
-        fp16_queries = ds.get_queries().astype(np.float16)
-        Dnew, Inew = index.search(fp16_queries, k, numeric_type=faiss.Float16)
-        
-        evaluation.check_ref_knn_with_draws(Dref, Iref, Dnew, Inew, k)
-
-    def test_compute_GT_L2(self):
-        self.do_compute_GT(faiss.METRIC_L2)
-
-    def test_compute_GT_IP(self):
-        self.do_compute_GT(faiss.METRIC_INNER_PRODUCT)
+    def test_compute_GT_IP_Int8(self):
+        self.do_compute_GT(faiss.METRIC_INNER_PRODUCT, faiss.Int8)
 
 @unittest.skipIf(
     "CUVS" not in faiss.get_compile_options(),
     "only if cuVS is compiled in")
 class TestInterop(unittest.TestCase):
 
-    def do_interop(self, metric):
+    def do_interop(self, metric, numeric_type):
         d = 64
         k = 12
-        ds = datasets.SyntheticDataset(d, 0, 10000, 100)
+        if numeric_type == faiss.Int8:
+            data_base_nt = np.random.randint(-128, 128, size=(10000, d), dtype=np.int8)
+            data_query_nt = np.random.randint(-128, 128, size=(100, d), dtype=np.int8)
+            data_base = data_base_nt.astype(np.float32)
+            data_query = data_query_nt.astype(np.float32)
+        else:
+            ds = datasets.SyntheticDataset(d, 0, 10000, 100)
+            data_base = ds.get_database()  #fp32
+            data_query = ds.get_queries()   #fp32
+            if numeric_type == faiss.Float16:
+                data_base_nt = data_base.astype(np.float16)
+                data_query_nt = data_query.astype(np.float16)
+            elif numeric_type == faiss.Float32:
+                data_base_nt = data_base
+                data_query_nt = data_query
 
         res = faiss.StandardGpuResources()
 
         index = faiss.GpuIndexCagra(res, d, metric)
-        index.train(ds.get_database())
-        Dnew, Inew = index.search(ds.get_queries(), k)
+        index.train(data_base_nt, numeric_type=numeric_type)
+        Dnew, Inew = index.search(data_query_nt, k, numeric_type=numeric_type)
 
         cpu_index = faiss.index_gpu_to_cpu(index)
-        Dref, Iref = cpu_index.search(ds.get_queries(), k)
+        # cpu index always search in fp32
+        Dref, Iref = cpu_index.search(data_query, k)
         
         evaluation.check_ref_knn_with_draws(Dref, Iref, Dnew, Inew, k)
 
@@ -101,49 +109,80 @@ class TestInterop(unittest.TestCase):
             faiss.serialize_index(cpu_index))
 
         gpu_index = faiss.index_cpu_to_gpu(res, 0, deserialized_index)
-        Dnew2, Inew2 = gpu_index.search(ds.get_queries(), k)
+        Dnew2, Inew2 = gpu_index.search(data_query_nt, k, numeric_type=numeric_type)
 
         evaluation.check_ref_knn_with_draws(Dnew2, Inew2, Dnew, Inew, k)
 
     def test_interop_L2(self):
-        self.do_interop(faiss.METRIC_L2)
+        self.do_interop(faiss.METRIC_L2, faiss.Float32)
 
     def test_interop_IP(self):
-        self.do_interop(faiss.METRIC_INNER_PRODUCT)
+        self.do_interop(faiss.METRIC_INNER_PRODUCT, faiss.Float32)
+
+    def test_interop_L2_FP16(self):
+        self.do_interop(faiss.METRIC_L2, faiss.Float16)
+
+    def test_interop_IP_FP16(self):
+        self.do_interop(faiss.METRIC_INNER_PRODUCT, faiss.Float16)
+
+    def test_interop_L2_Int8(self):
+        self.do_interop(faiss.METRIC_L2, faiss.Int8)
+
+    def test_interop_IP_Int8(self):
+        self.do_interop(faiss.METRIC_INNER_PRODUCT, faiss.Int8)
+
 
 @unittest.skipIf(
     "CUVS" not in faiss.get_compile_options(),
     "only if cuVS is compiled in")
-class TestInteropFP16(unittest.TestCase):
+class TestIDMapCagra(unittest.TestCase):
 
-    def do_interop(self, metric):
+    def do_IDMapCagra(self, metric, numeric_type):
         d = 64
         k = 12
-        ds = datasets.SyntheticDataset(d, 0, 10000, 100)
+        if numeric_type == faiss.Int8:
+            data_base_nt = np.random.randint(-128, 128, size=(10000, d), dtype=np.int8)
+            data_query_nt = np.random.randint(-128, 128, size=(100, d), dtype=np.int8)
+            data_base = data_base_nt.astype(np.float32)
+            data_query = data_query_nt.astype(np.float32)
+        else:
+            ds = datasets.SyntheticDataset(d, 0, 10000, 100)
+            data_base = ds.get_database()  #fp32
+            data_query = ds.get_queries()   #fp32
+            if numeric_type == faiss.Float16:
+                data_base_nt = data_base.astype(np.float16)
+                data_query_nt = data_query.astype(np.float16)
+            elif numeric_type == faiss.Float32:
+                data_base_nt = data_base
+                data_query_nt = data_query
+
+        Dref, Iref = faiss.knn(data_query, data_base, k, metric)
 
         res = faiss.StandardGpuResources()
 
         index = faiss.GpuIndexCagra(res, d, metric)
-        fp16_data = ds.get_database().astype(np.float16)
-        index.train(fp16_data, faiss.Float16)
-        fp16_queries = ds.get_queries().astype(np.float16)
-        Dnew, Inew = index.search(fp16_queries, k, numeric_type=faiss.Float16)
+        idMapIndex = faiss.IndexIDMap(index)
+        idMapIndex.train(data_base_nt, numeric_type=numeric_type)
+        ids = np.array([i for i in range(10000)])
+        idMapIndex.add_with_ids(data_base_nt, ids, numeric_type=numeric_type)
+        Dnew, Inew = idMapIndex.search(data_query_nt, k, numeric_type=numeric_type)
 
-        cpu_index = faiss.index_gpu_to_cpu(index)
-        Dref, Iref = cpu_index.search(ds.get_queries(), k)
-        
         evaluation.check_ref_knn_with_draws(Dref, Iref, Dnew, Inew, k)
 
-        deserialized_index = faiss.deserialize_index(
-            faiss.serialize_index(cpu_index))
+    def test_IDMapCagra_L2(self):
+        self.do_IDMapCagra(faiss.METRIC_L2, faiss.Float32)
 
-        gpu_index = faiss.index_cpu_to_gpu(res, 0, deserialized_index)
-        Dnew2, Inew2 = gpu_index.search(fp16_queries, k, numeric_type=faiss.Float16)
+    def test_IDMapCagra_IP(self):
+        self.do_IDMapCagra(faiss.METRIC_INNER_PRODUCT, faiss.Float32)
 
-        evaluation.check_ref_knn_with_draws(Dnew2, Inew2, Dnew, Inew, k)
+    def test_IDMapCagra_L2_FP16(self):
+        self.do_IDMapCagra(faiss.METRIC_L2, faiss.Float16)
 
-    def test_interop_L2(self):
-        self.do_interop(faiss.METRIC_L2)
+    def test_IDMapCagra_IP_FP16(self):
+        self.do_IDMapCagra(faiss.METRIC_INNER_PRODUCT, faiss.Float16)
 
-    def test_interop_IP(self):
-        self.do_interop(faiss.METRIC_INNER_PRODUCT)
+    def test_IDMapCagra_L2_Int8(self):
+        self.do_IDMapCagra(faiss.METRIC_L2, faiss.Int8)
+
+    def test_IDMapCagra_IP_Int8(self):
+        self.do_IDMapCagra(faiss.METRIC_INNER_PRODUCT, faiss.Int8)

--- a/faiss/gpu/test/test_cagra.py
+++ b/faiss/gpu/test/test_cagra.py
@@ -31,9 +31,9 @@ class TestComputeGT(unittest.TestCase):
             # Normalize for inner product to avoid duplicate neighbors
             if metric == faiss.METRIC_INNER_PRODUCT:
                 # Normalize database vectors
-                database = database / np.linalg.norm(database, axis=1, keepdims=True)
+                data_base = data_base / np.linalg.norm(data_base, axis=1, keepdims=True)
                 # Normalize query vectors
-                queries = queries / np.linalg.norm(queries, axis=1, keepdims=True)
+                data_query = data_query / np.linalg.norm(data_query, axis=1, keepdims=True)
             if numeric_type == faiss.Float16:
                 data_base_nt = data_base.astype(np.float16)
                 data_query_nt = data_query.astype(np.float16)

--- a/faiss/python/class_wrappers.py
+++ b/faiss/python/class_wrappers.py
@@ -42,6 +42,15 @@ def _check_dtype_uint8(codes):
                         " uint8, but found %s" % ("codes", codes.dtype))
     return np.ascontiguousarray(codes)
 
+def _numeric_to_str(numeric_type):
+    if numeric_type == faiss.Float32:
+        return 'float32'
+    elif numeric_type == faiss.Float16:
+        return 'float16'
+    elif numeric_type == faiss.Int8:
+        return 'int8'
+    else:
+        raise ValueError("numeric type must be either faiss.Float32, faiss.Float16, or faiss.Int8")
 
 def replace_method(the_class, name, replacement, ignore_missing=False):
     """ Replaces a method in a class with another version. The old method
@@ -226,13 +235,10 @@ def handle_Index(the_class):
 
         n, d = x.shape
         assert d == self.d
-        if numeric_type == faiss.Float32:
-            x = np.ascontiguousarray(x, dtype='float32')
-        else:
-            x = np.ascontiguousarray(x, dtype='float16')
-        self.add_c(n, swig_ptr(x))
+        x = np.ascontiguousarray(x, dtype=_numeric_to_str(numeric_type))
+        self.addEx(n, swig_ptr(x), numeric_type)
 
-    def replacement_add_with_ids(self, x, ids):
+    def replacement_add_with_ids(self, x, ids, numeric_type = faiss.Float32):
         """Adds vectors with arbitrary ids to the index (not all indexes support this).
         The index must be trained before vectors can be added to it.
         Vector `i` is stored in `x[i]` and has id `ids[i]`.
@@ -248,10 +254,11 @@ def handle_Index(the_class):
         """
         n, d = x.shape
         assert d == self.d
-        x = np.ascontiguousarray(x, dtype='float32')
-        ids = np.ascontiguousarray(ids, dtype='int64')
         assert ids.shape == (n, ), 'not same nb of vectors as ids'
-        self.add_with_ids_c(n, swig_ptr(x), swig_ptr(ids))
+        x = np.ascontiguousarray(x, dtype=_numeric_to_str(numeric_type))
+        ids = np.ascontiguousarray(ids, dtype='int64')
+        self.add_with_idsEx(n, swig_ptr(x), numeric_type, swig_ptr(ids))
+
 
     def replacement_assign(self, x, k, labels=None):
         """Find the k nearest neighbors of the set of vectors x in the index.
@@ -297,12 +304,8 @@ def handle_Index(the_class):
         """
         n, d = x.shape
         assert d == self.d
-        if numeric_type == faiss.Float32:
-            x = np.ascontiguousarray(x, dtype='float32')
-            self.train_c(n, swig_ptr(x))
-        else:
-            x = np.ascontiguousarray(x, dtype='float16')
-            self.train_c(n, swig_ptr(x), faiss.Float16)
+        x = np.ascontiguousarray(x, dtype=_numeric_to_str(numeric_type))
+        self.trainEx(n, swig_ptr(x), numeric_type)
         
 
     def replacement_search(self, x, k, *, params=None, D=None, I=None, numeric_type = faiss.Float32):
@@ -333,10 +336,7 @@ def handle_Index(the_class):
         """
 
         n, d = x.shape
-        if numeric_type == faiss.Float32:
-            x = np.ascontiguousarray(x, dtype='float32')
-        else:
-            x = np.ascontiguousarray(x, dtype='float16')
+        x = np.ascontiguousarray(x, _numeric_to_str(numeric_type))
         assert d == self.d
 
         assert k > 0
@@ -351,10 +351,7 @@ def handle_Index(the_class):
         else:
             assert I.shape == (n, k)
 
-        if numeric_type == faiss.Float32:
-            self.search_c(n, swig_ptr(x), k, swig_ptr(D), swig_ptr(I), params)
-        else:
-            self.search_c(n, swig_ptr(x), faiss.Float16, k, swig_ptr(D), swig_ptr(I), params)
+        self.searchEx(n, swig_ptr(x), numeric_type, k, swig_ptr(D), swig_ptr(I), params)
         return D, I
 
     def replacement_search_and_reconstruct(self, x, k, *, params=None, D=None, I=None, R=None):


### PR DESCRIPTION
Closes https://github.com/facebookresearch/faiss/issues/4430 by exposing int8 for cuVS cagra.
This PR (https://github.com/facebookresearch/faiss/pull/4411) needs to be merged before this one .