### PR TITLE
try to add nightly conda publish for Faiss classic GPU with CUDA 12.4

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,6 +55,23 @@ jobs:
         with:
           label: nightly
           cuda: "12.1.1"
+  linux-x86_64-GPU-CUDA-12-4-nightly:
+    name: Linux x86_64 GPU nightlies (CUDA 12.4.0)
+    runs-on: 4-core-ubuntu-gpu-t4
+    env:
+      CUDA_ARCHS: "70-real;72-real;75-real;80;86-real"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: ./.github/actions/build_conda
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        with:
+          label: nightly
+          cuda: "12.4.0"
   linux-x86_64-GPU-CUVS-CUDA12-4-0-nightly:
     name: Linux x86_64 GPU w/ cuVS nightlies (CUDA 12.4.0)
     runs-on: 4-core-ubuntu-gpu-t4

--- a/conda/faiss-gpu/meta.yaml
+++ b/conda/faiss-gpu/meta.yaml
@@ -12,6 +12,9 @@
 {% elif cudatoolkit == '12.1.1' %}
 {% set cuda_constraints=">=12.1,<13" %}
 {% set libcublas_constraints=">=12.1,<13" %}
+{% elif cudatoolkit == '12.4.0' %}
+{% set cuda_constraints=">=12.4,<13" %}
+{% set libcublas_constraints=">=12.4,<13" %}
 {% endif %}
 
 package:


### PR DESCRIPTION
Differential Revision: D78716765

It already works in cmake, builds are using 12.4 by default

Need to see if nightly passes

