### PR TITLE
Remove cuVS CUDA 11.8 CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,24 +38,6 @@ jobs:
         with:
           label: nightly
           cuda: "11.4.4"
-  linux-x86_64-GPU-CUVS-CUDA11-8-0-nightly:
-    name: Linux x86_64 GPU w/ cuVS nightlies (CUDA 11.8.0)
-    runs-on: 4-core-ubuntu-gpu-t4
-    env:
-      CUDA_ARCHS: "70-real;72-real;75-real;80;86-real"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-      - uses: ./.github/actions/build_conda
-        env:
-          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
-        with:
-          label: nightly
-          cuvs: "ON"
-          cuda: "11.8.0"
   linux-x86_64-GPU-CUDA-12-1-1-nightly:
     name: Linux x86_64 GPU nightlies (CUDA 12.1.1)
     runs-on: 4-core-ubuntu-gpu-t4


### PR DESCRIPTION
Summary:
NVIDIA said they will no longer support cuVS on CUDA 11, so we can remove this CI.

Faiss classic GPU is still tested against CUDA 11. We can evaluate later if we want to remove it.

Differential Revision: D78751250


