### PR TITLE
Revert D78330300

### DIFF
--- a/faiss/utils/distances_fused/distances_fused.cpp
+++ b/faiss/utils/distances_fused/distances_fused.cpp
@@ -7,6 +7,9 @@
 
 #include <faiss/utils/distances_fused/distances_fused.h>
 
+#include <faiss/impl/platform_macros.h> // NOLINT
+
+#include <faiss/utils/distances_fused/avx512.h> // NOLINT
 #include <faiss/utils/distances_fused/simdlib_based.h>
 
 namespace faiss {


### PR DESCRIPTION
Summary:
This diff reverts D78330300
This breaks when AVX512 is enabled.

Depends on D78330300

Differential Revision: D78815923


