### PR TITLE
Fix indexes after fp16 change

### DIFF
--- a/faiss/IndexPreTransform.cpp
+++ b/faiss/IndexPreTransform.cpp
@@ -115,6 +115,13 @@ void IndexPreTransform::train(idx_t n, const float* x) {
     is_trained = true;
 }
 
+void IndexPreTransform::train(
+        idx_t n,
+        const void* x,
+        NumericType numeric_type) {
+    Index::train(n, x, numeric_type);
+}
+
 const float* IndexPreTransform::apply_chain(idx_t n, const float* x) const {
     const float* prev_x = x;
     std::unique_ptr<const float[]> del;
@@ -150,6 +157,10 @@ void IndexPreTransform::add(idx_t n, const float* x) {
     ntotal = index->ntotal;
 }
 
+void IndexPreTransform::add(idx_t n, const void* x, NumericType numeric_type) {
+    Index::add(n, x, numeric_type);
+}
+
 void IndexPreTransform::add_with_ids(
         idx_t n,
         const float* x,
@@ -183,6 +194,17 @@ void IndexPreTransform::search(
     std::unique_ptr<const float[]> del(xt == x ? nullptr : xt);
     index->search(
             n, xt, k, distances, labels, extract_index_search_params(params));
+}
+
+void IndexPreTransform::search(
+        idx_t n,
+        const void* x,
+        NumericType numeric_type,
+        idx_t k,
+        float* distances,
+        idx_t* labels,
+        const SearchParameters* params) const {
+    Index::search(n, x, numeric_type, k, distances, labels, params);
 }
 
 void IndexPreTransform::range_search(

--- a/faiss/IndexPreTransform.h
+++ b/faiss/IndexPreTransform.h
@@ -38,8 +38,10 @@ struct IndexPreTransform : Index {
     void prepend_transform(VectorTransform* ltrans);
 
     void train(idx_t n, const float* x) override;
+    void train(idx_t n, const void* x, NumericType numeric_type) override;
 
     void add(idx_t n, const float* x) override;
+    void add(idx_t n, const void* x, NumericType numeric_type) override;
 
     void add_with_ids(idx_t n, const float* x, const idx_t* xids) override;
 
@@ -52,6 +54,14 @@ struct IndexPreTransform : Index {
     void search(
             idx_t n,
             const float* x,
+            idx_t k,
+            float* distances,
+            idx_t* labels,
+            const SearchParameters* params = nullptr) const override;
+    void search(
+            idx_t n,
+            const void* x,
+            NumericType numeric_type,
             idx_t k,
             float* distances,
             idx_t* labels,

--- a/faiss/gpu/test/test_cagra.py
+++ b/faiss/gpu/test/test_cagra.py
@@ -49,7 +49,7 @@ class TestComputeGT(unittest.TestCase):
         index.train(database, numeric_type=numeric_type)
         queries = ds.get_queries().astype(np.float16) if numeric_type == faiss.Float16 else ds.get_queries()
         Dnew, Inew = index.search(queries, k, numeric_type=numeric_type)
-        
+
         evaluation.check_ref_knn_with_draws(Dref, Iref, Dnew, Inew, k)
 
     def test_compute_GT_L2(self):
@@ -77,15 +77,23 @@ class TestInterop(unittest.TestCase):
         res = faiss.StandardGpuResources()
 
         index = faiss.GpuIndexCagra(res, d, metric)
-        database = ds.get_database().astype(np.float16) if numeric_type == faiss.Float16 else ds.get_database()
+        database = (
+            ds.get_database().astype(np.float16)
+            if numeric_type == faiss.Float16
+            else ds.get_database()
+        )
         index.train(database, numeric_type=numeric_type)
-        queries = ds.get_queries().astype(np.float16) if numeric_type == faiss.Float16 else ds.get_queries()
+        queries = (
+            ds.get_queries().astype(np.float16)
+            if numeric_type == faiss.Float16
+            else ds.get_queries()
+        )
         Dnew, Inew = index.search(queries, k, numeric_type=numeric_type)
 
         cpu_index = faiss.index_gpu_to_cpu(index)
         # cpu index always search in fp32
         Dref, Iref = cpu_index.search(ds.get_queries(), k)
-        
+
         evaluation.check_ref_knn_with_draws(Dref, Iref, Dnew, Inew, k)
 
         deserialized_index = faiss.deserialize_index(


### PR DESCRIPTION
Summary:
This broke some tests that rely on Faiss.

Unsure why Phabricator did not catch them.

Rollback Plan:

Differential Revision: D78826360


