### PR TITLE
Remove unused platform_macros.h include from MetricType.h

### DIFF
--- a/faiss/MetricType.h
+++ b/faiss/MetricType.h
@@ -10,7 +10,8 @@
 #ifndef FAISS_METRIC_TYPE_H
 #define FAISS_METRIC_TYPE_H
 
-#include <faiss/impl/platform_macros.h>
+#include <cstdint>
+#include <cstdio>
 
 namespace faiss {
 


### PR DESCRIPTION
Summary:
## Instructions about RACER Diffs:
**This diff was generated by Racer AI agent on behalf of [Junjie Qi](https://www.internalfb.com/profile/view/100004163713284) for T233050949. If the diff quality is poor, consider contacting the user to provide clearer instructions on the task.**

- If you are happy with the changes, commandeer it if minor edits are needed. (**we encourage commandeer to get the diff credit**)
- If you are not happy with the changes, please comment on the diff with clear actions and send it back to the author. Racer will pick it up and re-generate.
- If you really feel the Racer is not helping with this change (alas, some complex changes are hard for AI) feel free to abandon this diff.

## Summary:
Removed unused `#include <faiss/impl/platform_macros.h>` from MetricType.h and replaced it with the specific standard library includes that are actually needed: `<cstdint>` and `<cstdio>`.

The platform_macros.h header contains many Windows-specific macros and definitions that are not used in MetricType.h. The file only needs `int64_t` for the `idx_t` typedef and potentially `size_t` for compatibility. This change reduces unnecessary dependencies and makes the header more focused on its actual requirements.
---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=d9aabefb-6e83-11f0-b070-4edc7931fd32&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=d9aabefb-6e83-11f0-b070-4edc7931fd32&tab=Trace)

Differential Revision: D79398973


