### PR TITLE
Bug fix for faiss_Index_sa_code_size

### DIFF
--- a/c_api/Index_c.cpp
+++ b/c_api/Index_c.cpp
@@ -195,7 +195,7 @@ int faiss_Index_compute_residual_n(
 
 int faiss_Index_sa_code_size(const FaissIndex* index, size_t* size) {
     try {
-        reinterpret_cast<const faiss::Index*>(index)->sa_code_size();
+        *size = reinterpret_cast<const faiss::Index*>(index)->sa_code_size();
     }
     CATCH_AND_HANDLE
 }


### PR DESCRIPTION
Summary:
The C api has a bug where we don't set the size in this method. The CPP api sets it correctly https://www.internalfb.com/code/fbsource/[630a7e128132fa049cea4b73d9d9eb079e0608d6]/fbcode/assistant/knowledge/search/external/faiss/faiss_c_api.cpp?lines=164

Created from CodeHub with https://fburl.com/edit-in-codehub

Differential Revision: D79453787
