### PR TITLE
Remove unused standard library includes from index_io.h

### DIFF
--- a/faiss/index_io.h
+++ b/faiss/index_io.h
@@ -11,9 +11,6 @@
 #define FAISS_INDEX_IO_H
 
 #include <cstdio>
-#include <string>
-#include <typeinfo>
-#include <vector>
 
 /** I/O functions can read/write to a filename, a file handle or to an
  * object that abstracts the medium.


### PR DESCRIPTION
Summary:
## Instructions about RACER Diffs:
**This diff was generated by Racer AI agent on behalf of [Junjie Qi](https://www.internalfb.com/profile/view/100004163713284) for T233050949. If the diff quality is poor, consider contacting the user to provide clearer instructions on the task.**

- If you are happy with the changes, commandeer it if minor edits are needed. (**we encourage commandeer to get the diff credit**)
- If you are not happy with the changes, please comment on the diff with clear actions and send it back to the author. Racer will pick it up and re-generate.
- If you really feel the Racer is not helping with this change (alas, some complex changes are hard for AI) feel free to abandon this diff.

## Summary:
Removed three unused standard library includes from index_io.h:
- `#include <string>` - Not used in the header file
- `#include <typeinfo>` - Not used in the header file
- `#include <vector>` - Not used in the header file

The index_io.h header file contains I/O function declarations for reading/writing Faiss indexes. All function signatures use `const char*`, `FILE*`, and custom Faiss types, with no usage of std::string, std::vector, or typeid. The header only needs `<cstdio>` for FILE type support.
 ---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=d9aabefb-6e83-11f0-b070-4edc7931fd32&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=d9aabefb-6e83-11f0-b070-4edc7931fd32&tab=Trace)

Differential Revision: D79400116
