### PR TITLE
Remove unused import header from IndexBinaryHNSW.cpp

### DIFF
--- a/faiss/IndexBinaryHNSW.cpp
+++ b/faiss/IndexBinaryHNSW.cpp
@@ -26,7 +26,6 @@
 #include <faiss/utils/hamming.h>
 #include <faiss/utils/random.h>
 
-#include <algorithm>
 #include <random>
 
 namespace faiss {


### PR DESCRIPTION
Summary:
## Instructions about RACER Diffs:
**This diff was generated by Racer AI agent on behalf of [Junjie Qi](https://www.internalfb.com/profile/view/100004163713284) for T233050949. If the diff quality is poor, consider contacting the user to provide clearer instructions on the task.**

- If you are happy with the changes, commandeer it if minor edits are needed. (**we encourage commandeer to get the diff credit**)
- If you are not happy with the changes, please comment on the diff with clear actions and send it back to the author. Racer will pick it up and re-generate.
- If you really feel the Racer is not helping with this change (alas, some complex changes are hard for AI) feel free to abandon this diff.

## Summary:
Removed unused import header `#include <algorithm>` from IndexBinaryHNSW.cpp. This header was included but not actually used in the code, making it an unnecessary sentinel reviewer.
 ---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=e79a132f-7163-11f0-bb3e-ae1c19f8ff68&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=e79a132f-7163-11f0-bb3e-ae1c19f8ff68&tab=Trace)

Reviewed By: limqiying

Differential Revision: D79582071
