### PR TITLE
Remove unused cmath include from AutoTune.cpp

### DIFF
--- a/faiss/AutoTune.cpp
+++ b/faiss/AutoTune.cpp
@@ -14,7 +14,6 @@
 #include <faiss/AutoTune.h>
 
 #include <cinttypes>
-#include <cmath>
 
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/random.h>


### PR DESCRIPTION
Summary:
## Instructions about RACER Diffs:
This diff was generated by Racer AI agent for your convenience on top of T233787758.

- If you are happy with the changes, commandeer it if minor edits are needed. (**we encourage commandeer to get the diff credit**)
- If you are not happy with the changes, please comment on the diff with clear actions and send it back to the author. Racer will pick it up and re-generate.
- If you really feel the Racer is not helping with this change (alas, some complex changes are hard for AI) feel free to abandon this diff.

## Summary:
Remove unused `#include <cmath>` from AutoTune.cpp as part of unused header cleanup. The cmath header was included but no math functions (sqrt, log, exp, pow, sin, cos, etc.) are actually used in the implementation.
---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=3ce94466-735e-11f0-a1a2-92d93dbc02cb&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=3ce94466-735e-11f0-a1a2-92d93dbc02cb&tab=Trace)

Differential Revision: D79790353


