### PR TITLE
Remove invalid assertion checking #neighbors == graph degree

### DIFF
--- a/faiss/gpu/GpuIndexBinaryCagra.cu
+++ b/faiss/gpu/GpuIndexBinaryCagra.cu
@@ -359,7 +359,6 @@ void GpuIndexBinaryCagra::copyTo(faiss::IndexBinaryHNSWCagra* index) const {
     for (idx_t i = 0; i < n_train; i++) {
         size_t begin, end;
         index->hnsw.neighbor_range(i, 0, &begin, &end);
-        FAISS_ASSERT(end - begin == graph_degree);
 
         for (size_t j = begin; j < end; j++) {
             index->hnsw.neighbors[j] = graph[i * graph_degree + (j - begin)];


### PR DESCRIPTION
# Description
As fixed in https://github.com/facebookresearch/faiss/pull/4516, graph degree can be adjusted when small number of vectors are provided. Therefore, the number of neighbors (precisely, the maximum number of neighbors) can be smaller than graph degree after it was adjusted.

This PR is to remove the assertion check that fails if #neighbors not equals to graph degree, which is not always true.

