### PR TITLE
Change extended API suffix from `Ex` to `_ex`

### DIFF
--- a/contrib/torch_utils.py
+++ b/contrib/torch_utils.py
@@ -152,10 +152,10 @@ def handle_torch_Index(the_class):
 
             # On the GPU, use proper stream ordering
             with using_stream(self.getResources()):
-                self.addEx(n, x_ptr, numeric_type)
+                self.add_ex(n, x_ptr, numeric_type)
         else:
             # CPU torch
-            self.addEx(n, x_ptr, numeric_type)
+            self.add_ex(n, x_ptr, numeric_type)
 
     def torch_replacement_add_with_ids(self, x, ids, numeric_type = faiss.Float32):
         if type(x) is np.ndarray:
@@ -181,10 +181,10 @@ def handle_torch_Index(the_class):
 
             # On the GPU, use proper stream ordering
             with using_stream(self.getResources()):
-                self.add_with_idsEx(n, x_ptr, numeric_type, ids_ptr)
+                self.add_with_ids_ex(n, x_ptr, numeric_type, ids_ptr)
         else:
             # CPU torch
-            self.add_with_idsEx(n, x_ptr, numeric_type, ids_ptr)
+            self.add_with_ids_ex(n, x_ptr, numeric_type, ids_ptr)
 
     def torch_replacement_assign(self, x, k, labels=None):
         if type(x) is np.ndarray:
@@ -235,10 +235,10 @@ def handle_torch_Index(the_class):
 
             # On the GPU, use proper stream ordering
             with using_stream(self.getResources()):
-                self.trainEx(n, x_ptr, numeric_type)
+                self.train_ex(n, x_ptr, numeric_type)
         else:
             # CPU torch
-            self.trainEx(n, x_ptr, numeric_type)
+            self.train_ex(n, x_ptr, numeric_type)
 
     def search_methods_common(x, k, D, I, numeric_type=faiss.Float32):
         n, d = x.shape
@@ -281,10 +281,10 @@ def handle_torch_Index(the_class):
 
             # On the GPU, use proper stream ordering
             with using_stream(self.getResources()):
-                self.searchEx(n, x_ptr, numeric_type, k, D_ptr, I_ptr)
+                self.search_ex(n, x_ptr, numeric_type, k, D_ptr, I_ptr)
         else:
             # CPU torch
-            self.searchEx(n, x_ptr, numeric_type, k, D_ptr, I_ptr)
+            self.search_ex(n, x_ptr, numeric_type, k, D_ptr, I_ptr)
 
         return D, I
 

--- a/faiss/Index.h
+++ b/faiss/Index.h
@@ -129,7 +129,7 @@ struct Index {
      */
     virtual void train(idx_t n, const float* x);
 
-    virtual void trainEx(idx_t n, const void* x, NumericType numeric_type) {
+    virtual void train_ex(idx_t n, const void* x, NumericType numeric_type) {
         if (numeric_type == NumericType::Float32) {
             train(n, static_cast<const float*>(x));
         } else {
@@ -147,7 +147,7 @@ struct Index {
      */
     virtual void add(idx_t n, const float* x) = 0;
 
-    virtual void addEx(idx_t n, const void* x, NumericType numeric_type) {
+    virtual void add_ex(idx_t n, const void* x, NumericType numeric_type) {
         if (numeric_type == NumericType::Float32) {
             add(n, static_cast<const float*>(x));
         } else {
@@ -165,7 +165,7 @@ struct Index {
      * @param xids      if non-null, ids to store for the vectors (size n)
      */
     virtual void add_with_ids(idx_t n, const float* x, const idx_t* xids);
-    virtual void add_with_idsEx(
+    virtual void add_with_ids_ex(
             idx_t n,
             const void* x,
             NumericType numeric_type,
@@ -196,7 +196,7 @@ struct Index {
             idx_t* labels,
             const SearchParameters* params = nullptr) const = 0;
 
-    virtual void searchEx(
+    virtual void search_ex(
             idx_t n,
             const void* x,
             NumericType numeric_type,

--- a/faiss/IndexBinary.h
+++ b/faiss/IndexBinary.h
@@ -52,7 +52,7 @@ struct IndexBinary {
      * @param x      training vecors, size n * d / 8
      */
     virtual void train(idx_t n, const uint8_t* x);
-    virtual void trainEx(idx_t n, const void* x, NumericType numeric_type) {
+    virtual void train_ex(idx_t n, const void* x, NumericType numeric_type) {
         if (numeric_type == NumericType::UInt8) {
             train(n, static_cast<const uint8_t*>(x));
         } else {
@@ -66,7 +66,7 @@ struct IndexBinary {
      * @param x      input matrix, size n * d / 8
      */
     virtual void add(idx_t n, const uint8_t* x) = 0;
-    virtual void addEx(idx_t n, const void* x, NumericType numeric_type) {
+    virtual void add_ex(idx_t n, const void* x, NumericType numeric_type) {
         if (numeric_type == NumericType::UInt8) {
             add(n, static_cast<const uint8_t*>(x));
         } else {
@@ -82,7 +82,7 @@ struct IndexBinary {
      * @param xids if non-null, ids to store for the vectors (size n)
      */
     virtual void add_with_ids(idx_t n, const uint8_t* x, const idx_t* xids);
-    virtual void add_with_idsEx(
+    virtual void add_with_ids_ex(
             idx_t n,
             const void* x,
             NumericType numeric_type,
@@ -111,7 +111,7 @@ struct IndexBinary {
             int32_t* distances,
             idx_t* labels,
             const SearchParameters* params = nullptr) const = 0;
-    virtual void searchEx(
+    virtual void search_ex(
             idx_t n,
             const void* x,
             NumericType numeric_type,

--- a/faiss/IndexIDMap.cpp
+++ b/faiss/IndexIDMap.cpp
@@ -59,7 +59,7 @@ IndexIDMapTemplate<IndexT>::IndexIDMapTemplate(IndexT* index) : index(index) {
 }
 
 template <typename IndexT>
-void IndexIDMapTemplate<IndexT>::addEx(
+void IndexIDMapTemplate<IndexT>::add_ex(
         idx_t,
         const void*,
         NumericType numeric_type) {
@@ -78,11 +78,11 @@ void IndexIDMapTemplate<IndexT>::add(
 }
 
 template <typename IndexT>
-void IndexIDMapTemplate<IndexT>::trainEx(
+void IndexIDMapTemplate<IndexT>::train_ex(
         idx_t n,
         const void* x,
         NumericType numeric_type) {
-    index->trainEx(n, x, numeric_type);
+    index->train_ex(n, x, numeric_type);
     this->is_trained = index->is_trained;
 }
 
@@ -90,7 +90,8 @@ template <typename IndexT>
 void IndexIDMapTemplate<IndexT>::train(
         idx_t n,
         const typename IndexT::component_t* x) {
-    trainEx(n,
+    train_ex(
+            n,
             static_cast<const void*>(x),
             component_t_to_numeric<typename IndexT::component_t>());
 }
@@ -103,12 +104,12 @@ void IndexIDMapTemplate<IndexT>::reset() {
 }
 
 template <typename IndexT>
-void IndexIDMapTemplate<IndexT>::add_with_idsEx(
+void IndexIDMapTemplate<IndexT>::add_with_ids_ex(
         idx_t n,
         const void* x,
         NumericType numeric_type,
         const idx_t* xids) {
-    index->addEx(n, x, numeric_type);
+    index->add_ex(n, x, numeric_type);
     for (idx_t i = 0; i < n; i++) {
         id_map.push_back(xids[i]);
     }
@@ -120,7 +121,7 @@ void IndexIDMapTemplate<IndexT>::add_with_ids(
         idx_t n,
         const typename IndexT::component_t* x,
         const idx_t* xids) {
-    add_with_idsEx(
+    add_with_ids_ex(
             n,
             static_cast<const void*>(x),
             component_t_to_numeric<typename IndexT::component_t>(),
@@ -166,7 +167,7 @@ struct ScopedSelChange {
 } // namespace
 
 template <typename IndexT>
-void IndexIDMapTemplate<IndexT>::searchEx(
+void IndexIDMapTemplate<IndexT>::search_ex(
         idx_t n,
         const void* x,
         NumericType numeric_type,
@@ -193,7 +194,7 @@ void IndexIDMapTemplate<IndexT>::searchEx(
             sel_change.set(params_non_const, &this_idtrans);
         }
     }
-    index->searchEx(n, x, numeric_type, k, distances, labels, params);
+    index->search_ex(n, x, numeric_type, k, distances, labels, params);
     idx_t* li = labels;
 #pragma omp parallel for
     for (idx_t i = 0; i < n * k; i++) {
@@ -209,7 +210,7 @@ void IndexIDMapTemplate<IndexT>::search(
         typename IndexT::distance_t* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    searchEx(
+    search_ex(
             n,
             static_cast<const void*>(x),
             component_t_to_numeric<typename IndexT::component_t>(),
@@ -301,13 +302,13 @@ IndexIDMap2Template<IndexT>::IndexIDMap2Template(IndexT* index)
         : IndexIDMapTemplate<IndexT>(index) {}
 
 template <typename IndexT>
-void IndexIDMap2Template<IndexT>::add_with_idsEx(
+void IndexIDMap2Template<IndexT>::add_with_ids_ex(
         idx_t n,
         const void* x,
         NumericType numeric_type,
         const idx_t* xids) {
     size_t prev_ntotal = this->ntotal;
-    IndexIDMapTemplate<IndexT>::add_with_idsEx(n, x, numeric_type, xids);
+    IndexIDMapTemplate<IndexT>::add_with_ids_ex(n, x, numeric_type, xids);
     for (size_t i = prev_ntotal; i < this->ntotal; i++) {
         rev_map[this->id_map[i]] = i;
     }
@@ -318,7 +319,7 @@ void IndexIDMap2Template<IndexT>::add_with_ids(
         idx_t n,
         const typename IndexT::component_t* x,
         const idx_t* xids) {
-    add_with_idsEx(
+    add_with_ids_ex(
             n,
             static_cast<const void*>(x),
             component_t_to_numeric<typename IndexT::component_t>(),

--- a/faiss/IndexIDMap.h
+++ b/faiss/IndexIDMap.h
@@ -31,7 +31,7 @@ struct IndexIDMapTemplate : IndexT {
     /// @param xids if non-null, ids to store for the vectors (size n)
     void add_with_ids(idx_t n, const component_t* x, const idx_t* xids)
             override;
-    void add_with_idsEx(
+    void add_with_ids_ex(
             idx_t n,
             const void* x,
             NumericType numeric_type,
@@ -39,7 +39,7 @@ struct IndexIDMapTemplate : IndexT {
 
     /// this will fail. Use add_with_ids
     void add(idx_t n, const component_t* x) override;
-    void addEx(idx_t n, const void* x, NumericType numeric_type) override;
+    void add_ex(idx_t n, const void* x, NumericType numeric_type) override;
 
     void search(
             idx_t n,
@@ -48,7 +48,7 @@ struct IndexIDMapTemplate : IndexT {
             distance_t* distances,
             idx_t* labels,
             const SearchParameters* params = nullptr) const override;
-    void searchEx(
+    void search_ex(
             idx_t n,
             const void* x,
             NumericType numeric_type,
@@ -58,7 +58,7 @@ struct IndexIDMapTemplate : IndexT {
             const SearchParameters* params = nullptr) const override;
 
     void train(idx_t n, const component_t* x) override;
-    void trainEx(idx_t n, const void* x, NumericType numeric_type) override;
+    void train_ex(idx_t n, const void* x, NumericType numeric_type) override;
 
     void reset() override;
 
@@ -104,7 +104,7 @@ struct IndexIDMap2Template : IndexIDMapTemplate<IndexT> {
 
     void add_with_ids(idx_t n, const component_t* x, const idx_t* xids)
             override;
-    void add_with_idsEx(
+    void add_with_ids_ex(
             idx_t n,
             const void* x,
             NumericType numeric_type,

--- a/faiss/gpu/GpuCloner.cpp
+++ b/faiss/gpu/GpuCloner.cpp
@@ -239,7 +239,7 @@ Index* ToGpuCloner::clone_Index(const Index* index) {
         config.device = device;
         GpuIndexCagra* res =
                 new GpuIndexCagra(provider, icg->d, icg->metric_type, config);
-        res->copyFromEx(icg, icg->get_numeric_type());
+        res->copyFrom_ex(icg, icg->get_numeric_type());
         return res;
     }
 #endif

--- a/faiss/gpu/GpuIndex.h
+++ b/faiss/gpu/GpuIndex.h
@@ -77,13 +77,13 @@ class GpuIndex : public faiss::Index {
     /// as needed
     /// Handles paged adds if the add set is too large; calls addInternal_
     void add(idx_t, const float* x) override;
-    void addEx(idx_t, const void* x, NumericType numeric_type) override;
+    void add_ex(idx_t, const void* x, NumericType numeric_type) override;
 
     /// `x` and `ids` can be resident on the CPU or any GPU; copies are
     /// performed as needed
     /// Handles paged adds if the add set is too large; calls addInternal_
     void add_with_ids(idx_t n, const float* x, const idx_t* ids) override;
-    void add_with_idsEx(
+    void add_with_ids_ex(
             idx_t n,
             const void* x,
             NumericType numeric_type,
@@ -103,7 +103,7 @@ class GpuIndex : public faiss::Index {
             float* distances,
             idx_t* labels,
             const SearchParameters* params = nullptr) const override;
-    void searchEx(
+    void search_ex(
             idx_t n,
             const void* x,
             NumericType numeric_type,
@@ -139,7 +139,7 @@ class GpuIndex : public faiss::Index {
    protected:
     /// Copy what we need from the CPU equivalent
     void copyFrom(const faiss::Index* index);
-    void copyFromEx(const faiss::Index* index, NumericType numeric_type) {
+    void copyFrom_ex(const faiss::Index* index, NumericType numeric_type) {
         if (numeric_type == NumericType::Float32) {
             copyFrom(index);
         } else {
@@ -149,7 +149,7 @@ class GpuIndex : public faiss::Index {
 
     /// Copy what we have to the CPU equivalent
     void copyTo(faiss::Index* index) const;
-    void copyToEx(faiss::Index* index, NumericType numeric_type) {
+    void copyTo_ex(faiss::Index* index, NumericType numeric_type) {
         if (numeric_type == NumericType::Float32) {
             copyTo(index);
         } else {
@@ -165,7 +165,7 @@ class GpuIndex : public faiss::Index {
     /// All data is guaranteed to be resident on our device
     virtual void addImpl_(idx_t n, const float* x, const idx_t* ids) = 0;
 
-    virtual void addImplEx_(
+    virtual void addImpl_ex_(
             idx_t n,
             const void* x,
             NumericType numeric_type,
@@ -187,7 +187,7 @@ class GpuIndex : public faiss::Index {
             idx_t* labels,
             const SearchParameters* params) const = 0;
 
-    virtual void searchImplEx_(
+    virtual void searchImpl_ex_(
             idx_t n,
             const void* x,
             NumericType numeric_type,
@@ -212,7 +212,7 @@ class GpuIndex : public faiss::Index {
     /// Handles paged adds if the add set is too large, passes to
     /// addImpl_ to actually perform the add for the current page
     void addPaged_(idx_t n, const float* x, const idx_t* ids);
-    void addPagedEx_(
+    void addPaged_ex_(
             idx_t n,
             const void* x,
             NumericType numeric_type,
@@ -220,7 +220,7 @@ class GpuIndex : public faiss::Index {
 
     /// Calls addImpl_ for a single page of GPU-resident data
     void addPage_(idx_t n, const float* x, const idx_t* ids);
-    void addPageEx_(
+    void addPage_ex_(
             idx_t n,
             const void* x,
             NumericType numeric_type,
@@ -235,7 +235,7 @@ class GpuIndex : public faiss::Index {
             idx_t* outIndicesData,
             const SearchParameters* params) const;
 
-    void searchNonPagedEx_(
+    void searchNonPaged_ex_(
             idx_t n,
             const void* x,
             NumericType numeric_type,
@@ -253,7 +253,7 @@ class GpuIndex : public faiss::Index {
             float* outDistancesData,
             idx_t* outIndicesData,
             const SearchParameters* params) const;
-    void searchFromCpuPagedEx_(
+    void searchFromCpuPaged_ex_(
             idx_t n,
             const void* x,
             NumericType numeric_type,

--- a/faiss/gpu/GpuIndexCagra.cu
+++ b/faiss/gpu/GpuIndexCagra.cu
@@ -42,7 +42,7 @@ GpuIndexCagra::GpuIndexCagra(
     this->is_trained = false;
 }
 
-void GpuIndexCagra::trainEx(idx_t n, const void* x, NumericType numeric_type) {
+void GpuIndexCagra::train_ex(idx_t n, const void* x, NumericType numeric_type) {
     numeric_type_ = numeric_type;
     bool index_is_initialized = !std::holds_alternative<std::monostate>(index_);
 
@@ -151,15 +151,15 @@ void GpuIndexCagra::trainEx(idx_t n, const void* x, NumericType numeric_type) {
 }
 
 void GpuIndexCagra::train(idx_t n, const float* x) {
-    trainEx(n, static_cast<const void*>(x), NumericType::Float32);
+    train_ex(n, static_cast<const void*>(x), NumericType::Float32);
 }
 
-void GpuIndexCagra::addEx(idx_t n, const void* x, NumericType numeric_type) {
-    trainEx(n, x, numeric_type);
+void GpuIndexCagra::add_ex(idx_t n, const void* x, NumericType numeric_type) {
+    train_ex(n, x, numeric_type);
 }
 
 void GpuIndexCagra::add(idx_t n, const float* x) {
-    addEx(n, x, NumericType::Float32);
+    add_ex(n, x, NumericType::Float32);
 }
 
 bool GpuIndexCagra::addImplRequiresIDs_() const {
@@ -170,15 +170,15 @@ void GpuIndexCagra::addImpl_(idx_t n, const float* x, const idx_t* ids) {
     FAISS_THROW_MSG("adding vectors is not supported by GpuIndexCagra.");
 };
 
-void GpuIndexCagra::addImplEx_(
+void GpuIndexCagra::addImpl_ex_(
         idx_t n,
         const void* x,
         NumericType numeric_type,
         const idx_t* ids) {
-    GpuIndex::addImplEx_(n, x, numeric_type, ids);
+    GpuIndex::addImpl_ex_(n, x, numeric_type, ids);
 }
 
-void GpuIndexCagra::searchImplEx_(
+void GpuIndexCagra::searchImpl_ex_(
         idx_t n,
         const void* x,
         NumericType numeric_type,
@@ -289,7 +289,7 @@ void GpuIndexCagra::searchImpl_(
         float* distances,
         idx_t* labels,
         const SearchParameters* search_params) const {
-    searchImplEx_(
+    searchImpl_ex_(
             n,
             static_cast<const void*>(x),
             NumericType::Float32,
@@ -299,7 +299,7 @@ void GpuIndexCagra::searchImpl_(
             search_params);
 }
 
-void GpuIndexCagra::copyFromEx(
+void GpuIndexCagra::copyFrom_ex(
         const faiss::IndexHNSWCagra* index,
         NumericType numeric_type) {
     FAISS_ASSERT(index);
@@ -386,7 +386,7 @@ void GpuIndexCagra::copyFromEx(
 }
 
 void GpuIndexCagra::copyFrom(const faiss::IndexHNSWCagra* index) {
-    copyFromEx(index, NumericType::Float32);
+    copyFrom_ex(index, NumericType::Float32);
 }
 
 void GpuIndexCagra::copyTo(faiss::IndexHNSWCagra* index) const {

--- a/faiss/gpu/GpuIndexCagra.h
+++ b/faiss/gpu/GpuIndexCagra.h
@@ -258,7 +258,7 @@ struct GpuIndexCagra : public GpuIndex {
     /// the base dataset. Use this function when you want to add vectors with
     /// ids. Ref: https://github.com/facebookresearch/faiss/issues/4107
     void add(idx_t n, const float* x) override;
-    void addEx(idx_t n, const void* x, NumericType numeric_type) override;
+    void add_ex(idx_t n, const void* x, NumericType numeric_type) override;
 
     /// Trains CAGRA based on the given vector data.
     /// NB: The use of the train function here is to build the CAGRA graph on
@@ -266,12 +266,12 @@ struct GpuIndexCagra : public GpuIndex {
     /// of vectors (without IDs) to the index. There is no external quantizer to
     /// be trained here.
     void train(idx_t n, const float* x) override;
-    void trainEx(idx_t n, const void* x, NumericType numeric_type) override;
+    void train_ex(idx_t n, const void* x, NumericType numeric_type) override;
 
     /// Initialize ourselves from the given CPU index; will overwrite
     /// all data in ourselves
     void copyFrom(const faiss::IndexHNSWCagra* index);
-    void copyFromEx(
+    void copyFrom_ex(
             const faiss::IndexHNSWCagra* index,
             NumericType numeric_type);
 
@@ -289,7 +289,7 @@ struct GpuIndexCagra : public GpuIndex {
     bool addImplRequiresIDs_() const override;
 
     void addImpl_(idx_t n, const float* x, const idx_t* ids) override;
-    void addImplEx_(
+    void addImpl_ex_(
             idx_t n,
             const void* x,
             NumericType numeric_type,
@@ -303,7 +303,7 @@ struct GpuIndexCagra : public GpuIndex {
             float* distances,
             idx_t* labels,
             const SearchParameters* search_params) const override;
-    void searchImplEx_(
+    void searchImpl_ex_(
             idx_t n,
             const void* x,
             NumericType numeric_type,

--- a/faiss/gpu/test/TestGpuIndexCagra.cu
+++ b/faiss/gpu/test/TestGpuIndexCagra.cu
@@ -234,7 +234,7 @@ void queryTestFP16(faiss::MetricType metric, double expected_recall) {
             trainVecs_half[i] = __float2half(trainVecs[i]);
         }
 
-        gpuIndex.trainEx(
+        gpuIndex.train_ex(
                 opt.numTrain,
                 static_cast<void*>(trainVecs_half.data()),
                 faiss::NumericType::Float16);
@@ -272,7 +272,7 @@ void queryTestFP16(faiss::MetricType metric, double expected_recall) {
         for (size_t i = 0; i < queryVecs.size(); ++i) {
             queryVecs_half[i] = __float2half(queryVecs[i]);
         }
-        gpuIndex.searchEx(
+        gpuIndex.search_ex(
                 opt.numQuery,
                 queryVecs_half.data(),
                 faiss::NumericType::Float16,
@@ -527,7 +527,7 @@ void copyToTestFP16(
         }
 
         faiss::gpu::GpuIndexCagra gpuIndex(&res, opt.dim, metric, config);
-        gpuIndex.trainEx(
+        gpuIndex.train_ex(
                 opt.numTrain,
                 static_cast<void*>(trainVecs_half.data()),
                 faiss::NumericType::Float16);
@@ -782,7 +782,7 @@ void copyFromTestFP16(faiss::MetricType metric, double expected_recall) {
 
         // convert to gpu index
         faiss::gpu::GpuIndexCagra copiedGpuIndex(&res, cpuIndex.d, metric);
-        copiedGpuIndex.copyFromEx(&cpuIndex, faiss::NumericType::Float16);
+        copiedGpuIndex.copyFrom_ex(&cpuIndex, faiss::NumericType::Float16);
 
         // train gpu index
         faiss::gpu::GpuIndexCagraConfig config;
@@ -803,7 +803,7 @@ void copyFromTestFP16(faiss::MetricType metric, double expected_recall) {
             trainVecs_half[i] = __float2half(trainVecs[i]);
         }
 
-        gpuIndex.trainEx(
+        gpuIndex.train_ex(
                 opt.numTrain,
                 static_cast<void*>(trainVecs_half.data()),
                 faiss::NumericType::Float16);
@@ -829,7 +829,7 @@ void copyFromTestFP16(faiss::MetricType metric, double expected_recall) {
                 gpuRes.get(), devAlloc, {opt.numQuery, opt.k});
         faiss::gpu::DeviceTensor<faiss::idx_t, 2, true> copyTestIndices(
                 gpuRes.get(), devAlloc, {opt.numQuery, opt.k});
-        copiedGpuIndex.searchEx(
+        copiedGpuIndex.search_ex(
                 opt.numQuery,
                 queryVecs_half.data(),
                 faiss::NumericType::Float16,
@@ -841,7 +841,7 @@ void copyFromTestFP16(faiss::MetricType metric, double expected_recall) {
                 gpuRes.get(), devAlloc, {opt.numQuery, opt.k});
         faiss::gpu::DeviceTensor<faiss::idx_t, 2, true> testIndices(
                 gpuRes.get(), devAlloc, {opt.numQuery, opt.k});
-        gpuIndex.searchEx(
+        gpuIndex.search_ex(
                 opt.numQuery,
                 queryVecs_half.data(),
                 faiss::NumericType::Float16,

--- a/faiss/python/class_wrappers.py
+++ b/faiss/python/class_wrappers.py
@@ -239,7 +239,7 @@ def handle_Index(the_class):
         if numeric_type == faiss.Float32:
             self.add_c(n, swig_ptr(x))
         else:
-            self.addEx(n, swig_ptr(x), numeric_type)
+            self.add_ex(n, swig_ptr(x), numeric_type)
 
     def replacement_add_with_ids(self, x, ids, numeric_type = faiss.Float32):
         """Adds vectors with arbitrary ids to the index (not all indexes support this).
@@ -263,7 +263,7 @@ def handle_Index(the_class):
         if numeric_type == faiss.Float32:
             self.add_with_ids_c(n, swig_ptr(x), swig_ptr(ids))
         else:
-            self.add_with_idsEx(n, swig_ptr(x), numeric_type, swig_ptr(ids))
+            self.add_with_ids_ex(n, swig_ptr(x), numeric_type, swig_ptr(ids))
 
 
     def replacement_assign(self, x, k, labels=None):
@@ -314,7 +314,7 @@ def handle_Index(the_class):
         if numeric_type == faiss.Float32:
             self.train_c(n, swig_ptr(x))
         else:
-            self.trainEx(n, swig_ptr(x), numeric_type)
+            self.train_ex(n, swig_ptr(x), numeric_type)
         
 
     def replacement_search(self, x, k, *, params=None, D=None, I=None, numeric_type = faiss.Float32):
@@ -363,7 +363,7 @@ def handle_Index(the_class):
         if numeric_type == faiss.Float32:
             self.search_c(n, swig_ptr(x), k, swig_ptr(D), swig_ptr(I), params)
         else:
-            self.searchEx(n, swig_ptr(x), numeric_type, k, swig_ptr(D), swig_ptr(I), params)
+            self.search_ex(n, swig_ptr(x), numeric_type, k, swig_ptr(D), swig_ptr(I), params)
         return D, I
 
     def replacement_search_and_reconstruct(self, x, k, *, params=None, D=None, I=None, R=None):


### PR DESCRIPTION
There has been a request to change the extended API suffix from `Ex` to `_ex` to match lowercase+underscores used in faiss.