### PR TITLE
Remove unused includes from AutoTune.cpp

### DIFF
--- a/faiss/AutoTune.cpp
+++ b/faiss/AutoTune.cpp
@@ -20,15 +20,14 @@
 #include <faiss/utils/utils.h>
 
 #include <faiss/IndexHNSW.h>
+#include <faiss/IndexIDMap.h>
 #include <faiss/IndexIVF.h>
-#include <faiss/IndexIVFFlat.h>
 #include <faiss/IndexIVFPQ.h>
 #include <faiss/IndexIVFPQR.h>
 #include <faiss/IndexPQ.h>
 #include <faiss/IndexPreTransform.h>
 #include <faiss/IndexRefine.h>
 #include <faiss/IndexShardsIVF.h>
-#include <faiss/MetaIndexes.h>
 
 namespace faiss {
 


### PR DESCRIPTION
Summary:
## Instructions about RACER Diffs:
This diff was generated by Racer AI agent for your convenience on top of T233787758.

- If you are happy with the changes, commandeer it if minor edits are needed. (**we encourage commandeer to get the diff credit**)
- If you are not happy with the changes, please comment on the diff with clear actions and send it back to the author. Racer will pick it up and re-generate.
- If you really feel the Racer is not helping with this change (alas, some complex changes are hard for AI) feel free to abandon this diff.

## Summary:
Remove unused #include directives from AutoTune.cpp to clean up the code:

- Remove `<faiss/IndexIVFFlat.h>` (not used in dynamic_cast calls)
- Remove `<faiss/MetaIndexes.h>` (not used, IndexIDMap is in separate header)  
- Add `<faiss/IndexIDMap.h>` (needed for IndexIDMap usage on line 455)

This reduces compilation dependencies and improves build times by removing unnecessary header includes.
---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=8a513fda-79a7-11f0-b9f1-8ac89c030522&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=8a513fda-79a7-11f0-b9f1-8ac89c030522&tab=Trace)

Differential Revision: D80323324


