### PR TITLE
Remove unused include from IVFlib.cpp

### DIFF
--- a/faiss/IVFlib.cpp
+++ b/faiss/IVFlib.cpp
@@ -9,7 +9,6 @@
 #include <omp.h>
 
 #include <memory>
-#include <numeric>
 
 #include <faiss/IndexAdditiveQuantizer.h>
 #include <faiss/IndexIVFAdditiveQuantizer.h>


### PR DESCRIPTION
Summary:
## Instructions about RACER Diffs:
This diff was generated by Racer AI agent for your convenience on top of T233787758.

- If you are happy with the changes, commandeer it if minor edits are needed. (**we encourage commandeer to get the diff credit**)
- If you are not happy with the changes, please comment on the diff with clear actions and send it back to the author. Racer will pick it up and re-generate.
- If you really feel the Racer is not helping with this change (alas, some complex changes are hard for AI) feel free to abandon this diff.

## Summary:
Remove unused `#include <numeric>` directive from IVFlib.cpp to clean up the code.

Analysis confirmed that no functions from the `<numeric>` header (std::accumulate, std::iota, std::adjacent_difference, std::inner_product, std::partial_sum) are used in this file.

This reduces compilation dependencies and improves build times by removing unnecessary header includes.
---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=8a513fda-79a7-11f0-b9f1-8ac89c030522&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=8a513fda-79a7-11f0-b9f1-8ac89c030522&tab=Trace)

Differential Revision: D80324209


