### PR TITLE
Remove unnecessary std::move on temporaries to fix `-Wpessimizing-move` warnings in DeviceTensor-inl.cuh

### DIFF
--- a/faiss/gpu/utils/DeviceTensor-inl.cuh
+++ b/faiss/gpu/utils/DeviceTensor-inl.cuh
@@ -76,8 +76,8 @@ __host__ DeviceTensor<T, Dim, InnerContig, IndexT, PtrTraits>::DeviceTensor(
         const AllocInfo& info,
         const IndexT sizes[Dim])
         : Tensor<T, Dim, InnerContig, IndexT, PtrTraits>(nullptr, sizes) {
-    this->reservation_ = std::move(
-            res->allocMemoryHandle(AllocRequest(info, this->getSizeInBytes())));
+    this->reservation_ =
+            res->allocMemoryHandle(AllocRequest(info, this->getSizeInBytes()));
     this->data_ = (T*)reservation_.get();
 
     FAISS_ASSERT(this->data_ || (this->getSizeInBytes() == 0));
@@ -95,8 +95,8 @@ __host__ DeviceTensor<T, Dim, InnerContig, IndexT, PtrTraits>::DeviceTensor(
         const AllocInfo& info,
         std::initializer_list<IndexT> sizes)
         : Tensor<T, Dim, InnerContig, IndexT, PtrTraits>(nullptr, sizes) {
-    this->reservation_ = std::move(
-            res->allocMemoryHandle(AllocRequest(info, this->getSizeInBytes())));
+    this->reservation_ =
+            res->allocMemoryHandle(AllocRequest(info, this->getSizeInBytes()));
     this->data_ = (T*)reservation_.get();
 
     FAISS_ASSERT(this->data_ || (this->getSizeInBytes() == 0));
@@ -155,8 +155,8 @@ __host__ DeviceTensor<T, Dim, InnerContig, IndexT, PtrTraits>::DeviceTensor(
                   nullptr,
                   t.sizes(),
                   t.strides()) {
-    this->reservation_ = std::move(
-            res->allocMemoryHandle(AllocRequest(info, this->getSizeInBytes())));
+    this->reservation_ =
+            res->allocMemoryHandle(AllocRequest(info, this->getSizeInBytes()));
     this->data_ = (T*)reservation_.get();
 
     FAISS_ASSERT(this->data_ || (this->getSizeInBytes() == 0));


### PR DESCRIPTION
Summary:
This diff removes redundant `std::move` calls when assigning the result of `res->allocMemoryHandle(...)` to `this->reservation_` in `faiss/gpu/utils/DeviceTensor-inl.cuh`.
The compiler warning `-Wpessimizing-move` was triggered because `std::move` was applied to a temporary object, which inhibits copy elision and is unnecessary.
Assigning the temporary directly allows the compiler to optimize the move/copy, resolves the warning, and improves code clarity.

Differential Revision: D80820854


