### PR TITLE
fix test_binary_cagra tests failure

### DIFF
--- a/faiss/gpu/test/test_binary_cagra.py
+++ b/faiss/gpu/test/test_binary_cagra.py
@@ -29,8 +29,6 @@ from faiss.contrib import evaluation
 @unittest.skipIf(
     "CUVS" not in faiss.get_compile_options(),
     "only if cuVS is compiled in")
-
-
 class TestInterop(unittest.TestCase):
 
     def do_interop(self):
@@ -67,8 +65,6 @@ class TestInterop(unittest.TestCase):
 @unittest.skipIf(
     "CUVS" not in faiss.get_compile_options(),
     "only if cuVS is compiled in")
-
-
 class TestComputeGT(unittest.TestCase):
 
     def do_compute_GT(self, build_algo=None):
@@ -107,8 +103,6 @@ class TestComputeGT(unittest.TestCase):
 @unittest.skipIf(
     "CUVS" not in faiss.get_compile_options(),
     "only if cuVS is compiled in")
-
-
 class TestIndexBinaryIDMap(unittest.TestCase):
     """Test IndexBinaryIDMap functionality with GpuIndexBinaryCagra"""
 


### PR DESCRIPTION
Summary:
https://github.com/facebookresearch/faiss/actions/runs/17147707531/job/48654701266

nightly is broken likely because {D80682723} accidentally added lines between the method and its decorator D:

Reviewed By: juancarpio27

Differential Revision: D80831740


