### PR TITLE
Use Development.Module component in CMake FindPython

### DIFF
--- a/faiss/python/CMakeLists.txt
+++ b/faiss/python/CMakeLists.txt
@@ -265,7 +265,7 @@ target_include_directories(swigfaiss_sve PRIVATE ${PROJECT_SOURCE_DIR}/../..)
 target_include_directories(faiss_example_external_module PRIVATE ${PROJECT_SOURCE_DIR}/../..)
 
 find_package(Python REQUIRED
-  COMPONENTS Development NumPy
+  COMPONENTS Development.Module NumPy
 )
 
 add_library(faiss_python_callbacks EXCLUDE_FROM_ALL


### PR DESCRIPTION
This PR updates the CMake configuration for the Python extension.

The current configuration specifies `Development` python component that includes the unnecessary `Development.Embed` sub-component. For a Python extension, only `Development.Module` component is required. The current configuration leads to a cmake build failure in the `manylinux` environment.

https://cmake.org/cmake/help/latest/module/FindPython.html

**Additional context**
I found this issue while I was testing the `scikit-build-core` backend to build wheel packages in this repository:
https://github.com/kyamagu/faiss-build