### PR TITLE
resolve Open Source requirement violations

### DIFF
--- a/benchs/bench_ivfflat_cuvs.py
+++ b/benchs/bench_ivfflat_cuvs.py
@@ -1,5 +1,5 @@
 # @lint-ignore-every LICENSELINT
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/benchs/bench_ivfpq_cuvs.py
+++ b/benchs/bench_ivfpq_cuvs.py
@@ -1,5 +1,5 @@
 # @lint-ignore-every LICENSELINT
-# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/faiss/gpu/test/TestGpuIcmEncoder.cpp
+++ b/faiss/gpu/test/TestGpuIcmEncoder.cpp
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include <faiss/gpu/GpuIcmEncoder.h>
 #include <faiss/gpu/StandardGpuResources.h>
 #include <faiss/gpu/test/TestUtils.h>

--- a/faiss/python/faiss_example_external_module.swig
+++ b/faiss/python/faiss_example_external_module.swig
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Summary:
Seems like open source requirements require header to specify:

- (Meta Platforms, Inc. and affiliates)
- (Facebook, Inc(\.|,)? and **its** affiliates)

Whereas the current headers specify a hybrid of the above two options. "Copyright (c) Meta Platforms, Inc. and its affiliates."

Causing it to be marked as violating. Fixing this issue.

Differential Revision: D80989808


