### PR TITLE
Fix missing object reference in Faiss python wrapper for IndexIVFRaBitQ

### DIFF
--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -218,6 +218,8 @@ add_ref_in_constructor(IDSelectorTranslated, slice(2))
 add_ref_in_constructor(IDSelectorXOr, slice(2))
 add_ref_in_constructor(IndexIVFIndependentQuantizer, slice(3))
 
+add_ref_in_constructor(IndexIVFRaBitQ, 0)
+
 # seems really marginal...
 # remove_ref_from_method(IndexReplicas, 'removeIndex', 0)
 


### PR DESCRIPTION
Summary: Lacking this, `IndexIVFRaBitQ` doesn't keep `quantizer` alive.

Differential Revision: D81061367


