### PR TITLE
fix python blank space lints

### DIFF
--- a/benchs/bench_all_ivf/bench_all_ivf.py
+++ b/benchs/bench_all_ivf/bench_all_ivf.py
@@ -104,6 +104,7 @@ def eval_setting(index, xq, gt, k, inter, min_time):
 # Training
 ######################################################
 
+
 def run_train(args, ds, res):
     nq, d = ds.nq, ds.d
     nb, d = ds.nq, ds.d
@@ -234,6 +235,7 @@ def run_train(args, ds, res):
 ######################################################
 # Populating index
 ######################################################
+
 
 def run_add(args, ds, index, res):
 

--- a/benchs/bench_all_ivf/cmp_with_scann.py
+++ b/benchs/bench_all_ivf/cmp_with_scann.py
@@ -23,6 +23,7 @@ def eval_recalls(name, I, gt, times):
     s += "time: %.4f s (± %.4f)" % (np.mean(times), np.std(times))
     print(s)
 
+
 def eval_inters(name, I, gt, times):
     k = I.shape[1]
     s = "%-40s inter" % name
@@ -167,6 +168,7 @@ def main():
 ###############################################################
 # SCANN
 ###############################################################
+
 
 def scann_make_index(xb, distance_measure, scann_dir, reorder_k):
     import scann

--- a/benchs/bench_all_ivf/datasets_oss.py
+++ b/benchs/bench_all_ivf/datasets_oss.py
@@ -17,6 +17,7 @@ print("path:", faiss_datasets.__file__)
 
 faiss_datasets.dataset_basedir = '/checkpoint/matthijs/simsearch/'
 
+
 def sanitize(x):
     return np.ascontiguousarray(x, dtype='float32')
 

--- a/benchs/bench_all_ivf/parse_bench_all_ivf.py
+++ b/benchs/bench_all_ivf/parse_bench_all_ivf.py
@@ -153,6 +153,7 @@ def collect_results_for(db='deep1M', prefix="autotune."):
 
     return allres, allstats
 
+
 def extract_pareto_optimal(allres, keys, recall_idx=0, times_idx=3):
     bigtab = []
     for i, k in enumerate(keys):
@@ -182,6 +183,7 @@ def extract_pareto_optimal(allres, keys, recall_idx=0, times_idx=3):
     ops = bigtab_sorted[:, selection]
 
     return selected_keys, ops
+
 
 def plot_subset(
     allres, allstats, selected_methods, recall_idx, times_idx=3,

--- a/benchs/bench_for_interrupt.py
+++ b/benchs/bench_for_interrupt.py
@@ -14,6 +14,7 @@ import argparse
 
 parser = argparse.ArgumentParser()
 
+
 def aa(*args, **kwargs):
     group.add_argument(*args, **kwargs)
 

--- a/benchs/bench_fw_codecs.py
+++ b/benchs/bench_fw_codecs.py
@@ -13,6 +13,7 @@ from faiss.benchs.bench_fw.descriptors import DatasetDescriptor, IndexDescriptor
 
 logging.basicConfig(level=logging.INFO)
 
+
 def factory_factory(d):
     return [
         ("SQ4", None, 256 * (2 ** 10), None),
@@ -77,6 +78,7 @@ def factory_factory(d):
         if d % sub == 0
     ]
 
+
 def run_local(rp):
     bio, d, tablename, distance_metric = rp
     if tablename == "contriever":
@@ -119,6 +121,7 @@ def run_local(rp):
     )
     benchmark.set_io(bio)
     benchmark.benchmark(result_file="result.json", train=True, reconstruct=False, knn=False, range=False)
+
 
 def run(bio, d, tablename, distance_metric):
     bio.launch_jobs(run_local, [(bio, d, tablename, distance_metric)], local=True)

--- a/benchs/bench_fw_ivf.py
+++ b/benchs/bench_fw_ivf.py
@@ -71,6 +71,7 @@ def bigann(bio):
         benchmark.set_io(bio)
         benchmark.benchmark(f"result{scale}.json", local=False, train=True, reconstruct=False, knn=True, range=False)
 
+
 def ssnpp(bio):
     benchmark = Benchmark(
         num_threads=32,

--- a/benchs/bench_gpu_1bn.py
+++ b/benchs/bench_gpu_1bn.py
@@ -123,10 +123,12 @@ if not os.path.isdir(cacheroot):
 # we mem-map the biggest files to avoid having them in memory all at
 # once
 
+
 def mmap_fvecs(fname):
     x = np.memmap(fname, dtype='int32', mode='r')
     d = x[0]
     return x.view('float32').reshape(-1, d + 1)[:, 1:]
+
 
 def mmap_bvecs(fname):
     x = np.memmap(fname, dtype='uint8', mode='r')
@@ -559,6 +561,7 @@ def compute_populated_index(preproc):
         gpu_index = None
 
     return gpu_index, indexall
+
 
 def compute_populated_index_2(preproc):
 

--- a/benchs/bench_pq_tables.py
+++ b/benchs/bench_pq_tables.py
@@ -11,12 +11,12 @@ import faiss
 
 os.system("grep -m1 'model name' < /proc/cpuinfo")
 
+
 def format_tab(x):
     return "\n".join("\t".join("%g" % xi for xi in row) for row in x)
 
 
 def run_bench(d, dsub, nbit=8, metric=None):
-
     M = d // dsub
     pq = faiss.ProductQuantizer(d, M, nbit)
     pq.train(faiss.randn((max(1000, pq.ksub * 50), d), 123))

--- a/benchs/distributed_ondisk/distributed_query_demo.py
+++ b/benchs/distributed_ondisk/distributed_query_demo.py
@@ -43,10 +43,12 @@ sindex.set_parallel_mode(1)
 sindex.set_prefetch_nthread(0)
 sindex.set_omp_num_threads(64)
 
+
 def ivecs_read(fname):
     a = np.fromfile(fname, dtype='int32')
     d = a[0]
     return a.reshape(-1, d + 1)[:, 1:].copy()
+
 
 def fvecs_read(fname):
     return ivecs_read(fname).view('float32')

--- a/benchs/distributed_ondisk/make_index_vslice.py
+++ b/benchs/distributed_ondisk/make_index_vslice.py
@@ -9,10 +9,12 @@ import faiss
 import argparse
 from multiprocessing.pool import ThreadPool
 
+
 def ivecs_mmap(fname):
     a = np.memmap(fname, dtype='int32', mode='r')
     d = a[0]
     return a.reshape(-1, d + 1)[:, 1:]
+
 
 def fvecs_mmap(fname):
     return ivecs_mmap(fname).view('float32')
@@ -55,6 +57,7 @@ def rate_limited_iter(l):
 
 deep1bdir = "/datasets01_101/simsearch/041218/deep1b/"
 workdir = "/checkpoint/matthijs/ondisk_distributed/"
+
 
 def main():
     parser = argparse.ArgumentParser(

--- a/benchs/distributed_ondisk/make_trained_index.py
+++ b/benchs/distributed_ondisk/make_trained_index.py
@@ -34,10 +34,12 @@ index = faiss.IndexPreTransform(
         )
     )
 
+
 def ivecs_mmap(fname):
     a = np.memmap(fname, dtype='int32', mode='r')
     d = a[0]
     return a.reshape(-1, d + 1)[:, 1:]
+
 
 def fvecs_mmap(fname):
     return ivecs_mmap(fname).view('float32')

--- a/benchs/distributed_ondisk/search_server.py
+++ b/benchs/distributed_ondisk/search_server.py
@@ -16,7 +16,6 @@ import argparse
 # Server implementation
 ############################################################
 
-
 class MyServer(rpc.Server):
     """ Assign version that can be exposed via RPC """
     def __init__(self, s, index):
@@ -25,6 +24,7 @@ class MyServer(rpc.Server):
 
     def __getattr__(self, f):
         return getattr(self.index, f)
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -96,6 +96,7 @@ class ResultHeap:
 
     def finalize(self):
         self.heaps.reorder()
+
 
 def distribute_weights(weights, nbin):
     """ assign a set of weights to a smaller set of bins to balance them """

--- a/benchs/kmeans_mnist.py
+++ b/benchs/kmeans_mnist.py
@@ -18,6 +18,7 @@ ngpu = int(sys.argv[2])
 
 # Load Leon's file format
 
+
 def load_mnist(fname):
     print("load", fname)
     f = open(fname)

--- a/contrib/clustering.py
+++ b/contrib/clustering.py
@@ -18,8 +18,10 @@ try:
 except ImportError:
     print("scipy not accessible, Python k-means will not work")
 
+
 def print_nop(*arg, **kwargs):
     pass
+
 
 def two_level_clustering(xt, nc1, nc2, rebalance=True, clustering_niter=25, **args):
     """

--- a/contrib/evaluation.py
+++ b/contrib/evaluation.py
@@ -13,6 +13,7 @@ from multiprocessing.pool import ThreadPool
 ###############################################################
 # Simple functions to evaluate knn results
 
+
 def knn_intersection_measure(I1, I2):
     """ computes the intersection measure of two result tables
     """
@@ -26,6 +27,7 @@ def knn_intersection_measure(I1, I2):
 
 ###############################################################
 # Range search results can be compared with Precision-Recall
+
 
 def filter_range_results(lims, D, I, thresh):
     """ select a set of results """
@@ -122,6 +124,7 @@ def counts_to_PR(ngt, nres, ninter, mode="overall"):
 
     else:
         raise AssertionError()
+
 
 def sort_range_res_2(lims, D, I):
     """ sort 2 arrays using the first as key """

--- a/contrib/exhaustive_search.py
+++ b/contrib/exhaustive_search.py
@@ -11,6 +11,7 @@ import logging
 
 LOG = logging.getLogger(__name__)
 
+
 def knn_ground_truth(xq, db_iterator, k, metric_type=faiss.METRIC_L2, shard=False, ngpu=-1):
     """Computes the exact KNN search results for a dataset that possibly
     does not fit in RAM but for which we have an iterator that

--- a/contrib/torch_utils.py
+++ b/contrib/torch_utils.py
@@ -56,6 +56,7 @@ def swig_ptr_from_FloatTensor(x):
     return faiss.cast_integer_to_float_ptr(
         x.untyped_storage().data_ptr() + x.storage_offset() * 4)
 
+
 def swig_ptr_from_BFloat16Tensor(x):
     """ gets a Faiss SWIG pointer from a pytorch tensor (on CPU or GPU) """
     assert x.is_contiguous()
@@ -82,6 +83,7 @@ def swig_ptr_from_IndicesTensor(x):
 ##################################################################
 # utilities
 ##################################################################
+
 
 @contextlib.contextmanager
 def using_stream(res, pytorch_stream=None):

--- a/demos/demo_auto_tune.py
+++ b/demos/demo_auto_tune.py
@@ -22,10 +22,12 @@ import faiss
 # Small I/O functions
 #################################################################
 
+
 def ivecs_read(fname):
     a = np.fromfile(fname, dtype="int32")
     d = a[0]
     return a.reshape(-1, d + 1)[:, 1:].copy()
+
 
 def fvecs_read(fname):
     return ivecs_read(fname).view('float32')

--- a/faiss/gpu/perf/slow.py
+++ b/faiss/gpu/perf/slow.py
@@ -8,6 +8,7 @@
 import faiss
 import numpy as np
 
+
 def test_slow():
     d = 256
     index = faiss.index_cpu_to_gpu(faiss.StandardGpuResources(),

--- a/faiss/gpu/test/test_cagra.py
+++ b/faiss/gpu/test/test_cagra.py
@@ -10,6 +10,7 @@ import faiss
 from faiss.contrib import datasets, evaluation
 import numpy as np
 
+
 @unittest.skipIf(
     "CUVS" not in faiss.get_compile_options(),
     "only if cuVS is compiled in")

--- a/faiss/gpu/test/test_gpu_basics.py
+++ b/faiss/gpu/test/test_gpu_basics.py
@@ -257,6 +257,7 @@ class TestGpuRef(unittest.TestCase):
 
         index.train(training_data)
 
+
 def make_t(num, d, clamp=False, seed=None):
     rs = None
     if seed is None:

--- a/faiss/gpu/test/test_gpu_index_serialize.py
+++ b/faiss/gpu/test/test_gpu_index_serialize.py
@@ -7,6 +7,7 @@ import unittest
 import numpy as np
 import faiss
 
+
 def make_t(num, d):
     rs = np.random.RandomState(123)
     return rs.rand(num, d).astype('float32')

--- a/faiss/gpu/test/torch_test_contrib_gpu.py
+++ b/faiss/gpu/test/torch_test_contrib_gpu.py
@@ -20,6 +20,7 @@ def to_column_major_torch(x):
         # was default setting before memory_format was introduced
         return x.t().clone().t()
 
+
 def to_column_major_numpy(x):
     return x.T.copy().T
 

--- a/faiss/python/class_wrappers.py
+++ b/faiss/python/class_wrappers.py
@@ -34,11 +34,13 @@ from faiss.loader import (
 # because it is unclear how the conversion should occur: with a view
 # (= cast) or conversion?
 
+
 def _check_dtype_uint8(codes):
     if codes.dtype != 'uint8':
         raise TypeError("Input argument %s must be ndarray of dtype "
                         " uint8, but found %s" % ("codes", codes.dtype))
     return np.ascontiguousarray(codes)
+
 
 def _numeric_to_str(numeric_type):
     if numeric_type == faiss.Float32:
@@ -49,6 +51,7 @@ def _numeric_to_str(numeric_type):
         return 'int8'
     else:
         raise ValueError("numeric type must be either faiss.Float32, faiss.Float16, or faiss.Int8")
+
 
 def replace_method(the_class, name, replacement, ignore_missing=False):
     """ Replaces a method in a class with another version. The old method
@@ -1364,6 +1367,7 @@ def handle_Linear(the_class):
 ######################################################
 # Syntatic sugar for QINCo and QINCoStep
 ######################################################
+
 
 def handle_QINCoStep(the_class):
     the_class.original_init = the_class.__init__

--- a/tests/test_binary_io.py
+++ b/tests/test_binary_io.py
@@ -13,6 +13,7 @@ import faiss
 import os
 import tempfile
 
+
 def make_binary_dataset(d, nb, nt, nq):
     assert d % 8 == 0
     x = np.random.randint(256, size=(nb + nq + nt, int(d / 8))).astype('uint8')

--- a/tests/test_fast_scan_ivf.py
+++ b/tests/test_fast_scan_ivf.py
@@ -151,6 +151,7 @@ def verify_with_draws(testcase, Dref, Iref, Dnew, Inew):
             mask = Dref[i, :] == dis
             testcase.assertEqual(set(Iref[i, mask]), set(Inew[i, mask]))
 
+
 def three_metrics(Dref, Iref, Dnew, Inew):
     nq = Iref.shape[0]
     recall_at_1 = (Iref[:, 0] == Inew[:, 0]).sum() / nq
@@ -547,7 +548,7 @@ class TestTraining(unittest.TestCase):
 
 
 class TestReconstruct(unittest.TestCase):
-    """ test reconstruct and sa_encode / sa_decode 
+    """ test reconstruct and sa_encode / sa_decode
     (also for a few additive quantizer variants) """
 
     def do_test(self, by_residual=False):
@@ -576,7 +577,7 @@ class TestReconstruct(unittest.TestCase):
         index.reconstruct_orig_invlists()
         assert index.orig_invlists.compute_ntotal() == index.ntotal
 
-        # compare with non fast-scan index 
+        # compare with non fast-scan index
         index2 = faiss.IndexIVFPQ(
             index.quantizer, d, 50, d // 2, 4, metric)
         index2.by_residual = by_residual

--- a/tests/test_residual_quantizer.py
+++ b/tests/test_residual_quantizer.py
@@ -12,6 +12,8 @@ from faiss.contrib import datasets
 from faiss.contrib.inspect_tools import get_additive_quantizer_codebooks
 
 ###########################################################
+
+
 # Reference implementation of encoding with beam search
 ###########################################################
 


### PR DESCRIPTION
Summary:
**What:** Fixed 73 Python \E302 linting errors by adding missing blank lines before function definitions.

**Why:** Python PEP 8 style guide requires 2 blank lines before top-level function and class definitions. The codebase had functions with only 1 blank line preceding them, causing linting failures.

**Changes:** Added one additional blank line before function definitions across 12 files in the faiss codebase to meet the "expected 2 blank lines, found 1" requirement.

**Impact:** Brings Python code into compliance with standard formatting rules without affecting functionality.

Reviewed By: trang-nm-nguyen

Differential Revision: D81080938


