### PR TITLE
add #pragma once to some header files

### DIFF
--- a/faiss/gpu/perf/IndexWrapper-inl.h
+++ b/faiss/gpu/perf/IndexWrapper-inl.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <faiss/impl/FaissAssert.h>
 
 namespace faiss {

--- a/faiss/impl/ProductQuantizer-inl.h
+++ b/faiss/impl/ProductQuantizer-inl.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 namespace faiss {
 
 inline PQEncoderGeneric::PQEncoderGeneric(

--- a/faiss/impl/ThreadedIndex-inl.h
+++ b/faiss/impl/ThreadedIndex-inl.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 #include <faiss/impl/FaissAssert.h>
 #include <exception>
 #include <iostream>

--- a/faiss/utils/extra_distances-inl.h
+++ b/faiss/utils/extra_distances-inl.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 /** In this file are the implementations of extra metrics beyond L2
  *  and inner product */
 

--- a/faiss/utils/hamming-inl.h
+++ b/faiss/utils/hamming-inl.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#pragma once
+
 namespace faiss {
 
 // BitstringWriter and BitstringReader functions


### PR DESCRIPTION
Summary:
*   Prevents potential compilation errors from multiple definitions
*   Improves compilation performance by avoiding redundant processing

Rollback Plan:

Differential Revision: D81094022


