### PR TITLE
add missing explicit specifier

### DIFF
--- a/faiss/IVFlib.h
+++ b/faiss/IVFlib.h
@@ -100,7 +100,7 @@ struct SlidingIndexWindow {
     std::vector<std::vector<size_t>> sizes;
 
     /// index should be initially empty and trained
-    SlidingIndexWindow(Index* index);
+    explicit SlidingIndexWindow(Index* index);
 
     /** Add one index to the current index and remove the oldest one.
      *

--- a/faiss/IndexIVFRaBitQ.cpp
+++ b/faiss/IndexIVFRaBitQ.cpp
@@ -156,7 +156,7 @@ struct RaBitInvertedListScanner : InvertedListScanner {
 
     uint8_t qb = 0;
 
-    RaBitInvertedListScanner(
+    explicit RaBitInvertedListScanner(
             const IndexIVFRaBitQ& ivf_rabitq_in,
             bool store_pairs = false,
             const IDSelector* sel = nullptr,

--- a/faiss/IndexRaBitQ.h
+++ b/faiss/IndexRaBitQ.h
@@ -28,7 +28,7 @@ struct IndexRaBitQ : IndexFlatCodes {
 
     IndexRaBitQ();
 
-    IndexRaBitQ(idx_t d, MetricType metric = METRIC_L2);
+    explicit IndexRaBitQ(idx_t d, MetricType metric = METRIC_L2);
 
     void train(idx_t n, const float* x) override;
 

--- a/faiss/impl/IDSelector.h
+++ b/faiss/impl/IDSelector.h
@@ -116,7 +116,7 @@ struct IDSelectorBitmap : IDSelector {
 /** reverts the membership test of another selector */
 struct IDSelectorNot : IDSelector {
     const IDSelector* sel;
-    IDSelectorNot(const IDSelector* sel) : sel(sel) {}
+    explicit IDSelectorNot(const IDSelector* sel) : sel(sel) {}
     bool is_member(idx_t id) const final {
         return !sel->is_member(id);
     }

--- a/faiss/impl/io.h
+++ b/faiss/impl/io.h
@@ -65,9 +65,9 @@ struct FileIOReader : IOReader {
     FILE* f = nullptr;
     bool need_close = false;
 
-    FileIOReader(FILE* rf);
+    explicit FileIOReader(FILE* rf);
 
-    FileIOReader(const char* fname);
+    explicit FileIOReader(const char* fname);
 
     ~FileIOReader() override;
 
@@ -80,9 +80,9 @@ struct FileIOWriter : IOWriter {
     FILE* f = nullptr;
     bool need_close = false;
 
-    FileIOWriter(FILE* wf);
+    explicit FileIOWriter(FILE* wf);
 
-    FileIOWriter(const char* fname);
+    explicit FileIOWriter(const char* fname);
 
     ~FileIOWriter() override;
 

--- a/faiss/impl/mapped_io.cpp
+++ b/faiss/impl/mapped_io.cpp
@@ -33,7 +33,7 @@ struct MmappedFileMappingOwner::PImpl {
     void* ptr = nullptr;
     size_t ptr_size = 0;
 
-    PImpl(const std::string& filename) {
+    explicit PImpl(const std::string& filename) {
         auto f = std::unique_ptr<FILE, decltype(&fclose)>(
                 fopen(filename.c_str(), "r"), &fclose);
         FAISS_THROW_IF_NOT_FMT(
@@ -64,7 +64,7 @@ struct MmappedFileMappingOwner::PImpl {
         ptr_size = filesize;
     }
 
-    PImpl(FILE* f) {
+    explicit PImpl(FILE* f) {
         // get the size
         struct stat s;
         int status = fstat(fileno(f), &s);

--- a/faiss/impl/mapped_io.h
+++ b/faiss/impl/mapped_io.h
@@ -18,8 +18,8 @@ namespace faiss {
 
 // holds a memory-mapped region over a file
 struct MmappedFileMappingOwner : public MaybeOwnedVectorOwner {
-    MmappedFileMappingOwner(const std::string& filename);
-    MmappedFileMappingOwner(FILE* f);
+    explicit MmappedFileMappingOwner(const std::string& filename);
+    explicit MmappedFileMappingOwner(FILE* f);
     ~MmappedFileMappingOwner();
 
     void* data() const;
@@ -37,7 +37,8 @@ struct MappedFileIOReader : IOReader {
 
     size_t pos = 0;
 
-    MappedFileIOReader(const std::shared_ptr<MmappedFileMappingOwner>& owner);
+    explicit MappedFileIOReader(
+            const std::shared_ptr<MmappedFileMappingOwner>& owner);
 
     // perform a copy
     size_t operator()(void* ptr, size_t size, size_t nitems) override;

--- a/faiss/impl/maybe_owned_vector.h
+++ b/faiss/impl/maybe_owned_vector.h
@@ -51,7 +51,7 @@ struct MaybeOwnedVector {
     size_t c_size = 0;
 
     MaybeOwnedVector() = default;
-    MaybeOwnedVector(const size_t initial_size) {
+    explicit MaybeOwnedVector(const size_t initial_size) {
         is_owned = true;
 
         owned_data.resize(initial_size);

--- a/tests/test_dealloc_invlists.cpp
+++ b/tests/test_dealloc_invlists.cpp
@@ -70,7 +70,7 @@ std::vector<idx_t> search_index(Index* index, const float* xq) {
 struct EncapsulateInvertedLists : InvertedLists {
     const InvertedLists* il;
 
-    EncapsulateInvertedLists(const InvertedLists* il)
+    explicit EncapsulateInvertedLists(const InvertedLists* il)
             : InvertedLists(il->nlist, il->code_size), il(il) {}
 
     static void* memdup(const void* m, size_t size) {


### PR DESCRIPTION
Summary:
The C++ Core Guidelines recommend marking single-argument constructors as `explicit` unless implicit conversion is specifically intended.

(if implicit conversion is needed for any of these, let me know!)

Differential Revision: D81175916


