### PR TITLE
Remove unused imports from faiss directory files

### DIFF
--- a/benchs/bench_ivfpq_cuvs.py
+++ b/benchs/bench_ivfpq_cuvs.py
@@ -24,14 +24,13 @@ import faiss
 import time
 import argparse
 import rmm
-import ctypes
 
 try:
     from faiss.contrib.datasets_fb import \
-        DatasetSIFT1M, DatasetDeep1B, DatasetBigANN
+        DatasetSIFT1M
 except ImportError:
     from faiss.contrib.datasets import \
-        DatasetSIFT1M, DatasetDeep1B, DatasetBigANN
+        DatasetSIFT1M
 
 
 # ds = DatasetDeep1B(10**6)

--- a/benchs/distributed_ondisk/distributed_query_demo.py
+++ b/benchs/distributed_ondisk/distributed_query_demo.py
@@ -3,8 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
-import faiss
 import numpy as np
 import time
 import rpc

--- a/benchs/distributed_ondisk/merge_to_ondisk.py
+++ b/benchs/distributed_ondisk/merge_to_ondisk.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
 import faiss
 import argparse
 from multiprocessing.pool import ThreadPool

--- a/contrib/torch/clustering.py
+++ b/contrib/torch/clustering.py
@@ -11,7 +11,8 @@ import faiss.contrib.torch_utils
 import torch
 
 # the kmeans can produce both torch and numpy centroids
-from faiss.contrib.clustering import kmeans
+from faiss.contrib.clustering import kmeans  # noqa: F401 some libraries import kmeans from here
+
 
 
 class DatasetAssign:

--- a/faiss/python/setup.py
+++ b/faiss/python/setup.py
@@ -9,7 +9,7 @@ import os
 import platform
 import shutil
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 # make the faiss python package dir
 shutil.rmtree("faiss", ignore_errors=True)

--- a/tests/test_search_params.py
+++ b/tests/test_search_params.py
@@ -8,7 +8,6 @@ import numpy as np
 import faiss
 import unittest
 import sys
-import gc
 
 from faiss.contrib import datasets
 from faiss.contrib.evaluation import sort_range_res_2, check_ref_range_results


### PR DESCRIPTION
Summary:
- Remove unused imports: json, requests from faiss_issues_and_pull_requests_triage.py
- Remove unused imports: os, faiss from distributed_query_demo.py
- Remove unused import: gc from test_search_params.py
- Remove unused import: os from merge_to_ondisk.py
- Remove unused import: find_packages from setup.py
- Remove unused imports: ctypes, DatasetDeep1B, DatasetBigANN from bench_ivfpq_cuvs.py
- Remove unused import: faiss.contrib.clustering.kmeans from clustering.py

Rollback Plan:

Differential Revision: D81179450


