### PR TITLE
add "override" to overriden destructors

### DIFF
--- a/faiss/Index2Layer.h
+++ b/faiss/Index2Layer.h
@@ -47,7 +47,7 @@ struct Index2Layer : IndexFlatCodes {
             MetricType metric = METRIC_L2);
 
     Index2Layer();
-    ~Index2Layer();
+    ~Index2Layer() override;
 
     void train(idx_t n, const float* x) override;
 

--- a/faiss/IndexBinaryFromFloat.h
+++ b/faiss/IndexBinaryFromFloat.h
@@ -32,7 +32,7 @@ struct IndexBinaryFromFloat : IndexBinary {
 
     explicit IndexBinaryFromFloat(Index* index);
 
-    ~IndexBinaryFromFloat();
+    ~IndexBinaryFromFloat() override;
 
     void add(idx_t n, const uint8_t* x) override;
 

--- a/faiss/IndexBinaryHash.h
+++ b/faiss/IndexBinaryHash.h
@@ -99,7 +99,7 @@ struct IndexBinaryMultiHash : IndexBinary {
 
     IndexBinaryMultiHash();
 
-    ~IndexBinaryMultiHash();
+    ~IndexBinaryMultiHash() override;
 
     void reset() override;
 

--- a/faiss/IndexIVFAdditiveQuantizer.cpp
+++ b/faiss/IndexIVFAdditiveQuantizer.cpp
@@ -198,7 +198,7 @@ struct AQInvertedListScanner : InvertedListScanner {
         }
     }
 
-    ~AQInvertedListScanner() = default;
+    ~AQInvertedListScanner() override = default;
 };
 
 template <bool is_IP>

--- a/faiss/IndexNeuralNetCodec.h
+++ b/faiss/IndexNeuralNetCodec.h
@@ -29,7 +29,7 @@ struct IndexNeuralNetCodec : IndexFlatCodes {
     void sa_encode(idx_t n, const float* x, uint8_t* codes) const override;
     void sa_decode(idx_t n, const uint8_t* codes, float* x) const override;
 
-    ~IndexNeuralNetCodec() {}
+    ~IndexNeuralNetCodec() override {}
 };
 
 struct IndexQINCo : IndexNeuralNetCodec {

--- a/faiss/impl/AdditiveQuantizer.h
+++ b/faiss/impl/AdditiveQuantizer.h
@@ -212,7 +212,7 @@ struct AdditiveQuantizer : Quantizer {
             idx_t* labels,
             const float* centroid_norms) const;
 
-    virtual ~AdditiveQuantizer();
+    virtual ~AdditiveQuantizer() override;
 };
 
 } // namespace faiss

--- a/faiss/impl/DistanceComputer.h
+++ b/faiss/impl/DistanceComputer.h
@@ -100,7 +100,7 @@ struct NegativeDistanceComputer : DistanceComputer {
         return -basedis->symmetric_dis(i, j);
     }
 
-    virtual ~NegativeDistanceComputer() {
+    virtual ~NegativeDistanceComputer() override {
         delete basedis;
     }
 };
@@ -125,7 +125,7 @@ struct FlatCodesDistanceComputer : DistanceComputer {
     /// compute distance of current query to an encoded vector
     virtual float distance_to_code(const uint8_t* code) = 0;
 
-    virtual ~FlatCodesDistanceComputer() {}
+    virtual ~FlatCodesDistanceComputer() override {}
 };
 
 } // namespace faiss

--- a/faiss/impl/ProductAdditiveQuantizer.h
+++ b/faiss/impl/ProductAdditiveQuantizer.h
@@ -46,7 +46,7 @@ struct ProductAdditiveQuantizer : AdditiveQuantizer {
 
     ProductAdditiveQuantizer();
 
-    virtual ~ProductAdditiveQuantizer();
+    virtual ~ProductAdditiveQuantizer() override;
 
     void init(
             size_t d,

--- a/faiss/impl/zerocopy_io.h
+++ b/faiss/impl/zerocopy_io.h
@@ -20,7 +20,7 @@ struct ZeroCopyIOReader : public faiss::IOReader {
     size_t total_ = 0;
 
     ZeroCopyIOReader(const uint8_t* data, size_t size);
-    ~ZeroCopyIOReader();
+    ~ZeroCopyIOReader() override;
 
     void reset();
     size_t get_data_view(void** ptr, size_t size, size_t nitems);

--- a/faiss/utils/NeuralNet.h
+++ b/faiss/utils/NeuralNet.h
@@ -141,7 +141,7 @@ struct QINCo : NeuralNetCodec {
 
     nn::Int32Tensor2D encode(const nn::Tensor2D& x) const override;
 
-    virtual ~QINCo() {}
+    virtual ~QINCo() override {}
 };
 
 } // namespace faiss


### PR DESCRIPTION
Summary:
The addition of the `override` keyword to destructors is a C++ best practice that became standard with C++11. 

1.  **Explicit Intent Declaration**: The `override` keyword explicitly indicates that a function is intended to override a virtual function from a base class. This makes the code self-documenting and clarifies the programmer's intent.
    
2.  **Compile-Time Safety**: When `override` is used, the compiler verifies that the function actually overrides a virtual function. If the base class signature changes or if there's a typo in the function signature, the compiler will generate an error instead of silently creating a new function.
    
3.  **Modern C++ Best Practice**: Since C++11, using `override` for all overriding functions (including destructors) is considered essential for writing safe, maintainable code.

Reviewed By: junjieqi

Differential Revision: D81268184


