### PR TITLE
RaBitQ: SIMD helper simplification, use faster popcount for doc-side sum

### DIFF
--- a/benchs/bench_rabitq_simd.cpp
+++ b/benchs/bench_rabitq_simd.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <benchmark/benchmark.h>
+#include <faiss/utils/AlignedTable.h>
+#include <faiss/utils/rabitq_simd.h>
+#include <faiss/utils/random.h>
+
+namespace faiss {
+
+const auto& randomData() {
+    static auto data = [] {
+        AlignedTable<uint8_t> x(10 << 20); // 10 MiB
+        byte_rand(x.data(), x.size(), 456);
+        return x;
+    }();
+    return data;
+}
+
+void bench_rabitq_generic(benchmark::State& state, auto distFn) {
+    uint8_t qb = state.range(0);
+    size_t d = state.range(1);
+    size_t size = (d + 7) / 8;
+
+    auto& x = randomData();
+    AlignedTable<uint8_t> q(qb * size);
+    byte_rand(q.data(), q.size(), 123);
+
+    size_t n = x.size() / size;
+
+    uint64_t sum = 0;
+    size_t r = 0;
+    for (auto _ : state) {
+        ++r;
+        for (size_t i = 0; i < n; ++i) {
+            sum += distFn(q.data(), x.data() + i * size, d, qb);
+        }
+        benchmark::DoNotOptimize(sum);
+    }
+    state.SetItemsProcessed(n * r);
+    state.SetBytesProcessed(r * x.size());
+}
+
+uint64_t rabitq_simple_popcnt(const uint8_t* data, size_t size) {
+    uint64_t sum = 0;
+    size_t i = 0;
+    for (; i + 8 <= size; i += 8) {
+        const auto yv = *(const uint64_t*)(data + i);
+        sum += __builtin_popcountll(yv);
+    }
+    for (; i < size; ++i) {
+        const auto yv = *(data + i);
+        sum += __builtin_popcount(yv);
+    }
+    return sum;
+}
+
+void bench_rabitq_sum(benchmark::State& state) {
+    bench_rabitq_generic(
+            state,
+            [](const uint8_t* /*q*/, const uint8_t* x, size_t d, size_t /* qb*/)
+                    -> int64_t { return rabitq_simple_popcnt(x, d); });
+}
+
+void bench_rabitq_and_dot_product(benchmark::State& state) {
+    bench_rabitq_generic(
+            state,
+            [](const uint8_t* q, const uint8_t* x, size_t d, size_t qb)
+                    -> int64_t { return rabitq_dp_popcnt(q, x, d, qb); });
+}
+
+void bench_rabitq_and_dot_product_with_sum(benchmark::State& state) {
+    bench_rabitq_generic(
+            state,
+            [](const uint8_t* q, const uint8_t* x, size_t d, size_t qb)
+                    -> int64_t {
+                auto sum_q = rabitq_simple_popcnt(x, d);
+                auto dp = rabitq_dp_popcnt(q, x, d, qb);
+                // Synthetic operation using both inputs for benchmarking.
+                return sum_q + dp;
+            });
+}
+
+const std::vector<int64_t> qbs{1, 2, 4, 8};
+const std::vector<int64_t> dims{64, 100, 256, 512, 1000, 1024, 3072};
+
+BENCHMARK(bench_rabitq_sum)->ArgsProduct({{0}, dims})->ArgNames({"qb", "d"});
+BENCHMARK(bench_rabitq_and_dot_product)
+        ->ArgsProduct({qbs, dims})
+        ->ArgNames({"qb", "d"});
+BENCHMARK(bench_rabitq_and_dot_product_with_sum)
+        ->ArgsProduct({qbs, dims})
+        ->ArgNames({"qb", "d"});
+BENCHMARK_MAIN();
+
+} // namespace faiss

--- a/faiss/utils/rabitq_simd.h
+++ b/faiss/utils/rabitq_simd.h
@@ -14,15 +14,17 @@
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || \
         defined(_M_IX86)
 #include <immintrin.h>
-#endif
+#endif // defined(__x86_64__) || defined(_M_X64) || defined(__i386__) ||
 
-namespace faiss {
+namespace faiss::rabitq {
 
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || \
         defined(_M_IX86)
 /**
  * Returns the lookup table for AVX512 popcount operations.
  * This table is used for lookup-based popcount implementation.
+ *
+ * Source: https://github.com/WojciechMula/sse-popcount.
  *
  * @return Lookup table as __m512i register
  */
@@ -94,7 +96,7 @@ inline __m512i get_lookup_512() {
             /* 1 */ 1,
             /* 0 */ 0);
 }
-#endif
+#endif // defined(__AVX512F__)
 #if defined(__AVX2__)
 /**
  * Returns the lookup table for AVX2 popcount operations.
@@ -137,409 +139,204 @@ inline __m256i get_lookup_256() {
             /* e */ 3,
             /* f */ 4);
 }
-#endif
+#endif // defined(__AVX2__)
 
 #if defined(__AVX512F__)
 /**
- * Performs lookup-based popcount on AVX512 registers.
+ * Popcount for a 512-bit register, using lookup tables if necessary.
  *
- * @param v_and Input vector to count bits in
- * @return Vector with popcount results
+ * @param v Input vector to count bits in
+ * @return Vector int32_t[16] with popcount results.
  */
-inline __m512i popcount_lookup_avx512(__m512i v_and) {
+inline __m512i popcount_512(__m512i v) {
+#if defined(__AVX512VPOPCNTDQ__)
+    return _mm512_popcnt_epi64(v);
+#else
     const __m512i lookup = get_lookup_512();
     const __m512i low_mask = _mm512_set1_epi8(0x0f);
 
-    const __m512i lo = _mm512_and_si512(v_and, low_mask);
-    const __m512i hi = _mm512_and_si512(_mm512_srli_epi16(v_and, 4), low_mask);
-    const __m512i popcnt1 = _mm512_shuffle_epi8(lookup, lo);
-    const __m512i popcnt2 = _mm512_shuffle_epi8(lookup, hi);
-    return _mm512_add_epi8(popcnt1, popcnt2);
+    const __m512i lo = _mm512_and_si512(v, low_mask);
+    const __m512i hi = _mm512_and_si512(_mm512_srli_epi16(v, 4), low_mask);
+    const __m512i popcnt_lo = _mm512_shuffle_epi8(lookup, lo);
+    const __m512i popcnt_hi = _mm512_shuffle_epi8(lookup, hi);
+    const __m512i popcnt = _mm512_add_epi8(popcnt_lo, popcnt_hi);
+    return _mm512_sad_epu8(_mm512_setzero_si512(), popcnt);
+#endif // defined(__AVX512VPOPCNTDQ__)
 }
-#endif
+#endif // defined(__AVX512F__)
+
 #if defined(__AVX2__)
 /**
- * Performs lookup-based popcount on AVX2 registers.
+ * Popcount for a 256-bit register, using lookup tables if necessary.
  *
- * @param v_and Input vector to count bits in
- * @return Vector with popcount results
+ * @param v Input vector to count bits in
+ * @return uint64_t[4] of popcounts for each portion of the input vector.
  */
-inline __m256i popcount_lookup_avx2(__m256i v_and) {
+inline __m256i popcount_256(__m256i v) {
     const __m256i lookup = get_lookup_256();
     const __m256i low_mask = _mm256_set1_epi8(0x0f);
 
-    const __m256i lo = _mm256_and_si256(v_and, low_mask);
-    const __m256i hi = _mm256_and_si256(_mm256_srli_epi16(v_and, 4), low_mask);
-    const __m256i popcnt1 = _mm256_shuffle_epi8(lookup, lo);
-    const __m256i popcnt2 = _mm256_shuffle_epi8(lookup, hi);
-    return _mm256_add_epi8(popcnt1, popcnt2);
+    const __m256i lo = _mm256_and_si256(v, low_mask);
+    const __m256i hi = _mm256_and_si256(_mm256_srli_epi16(v, 4), low_mask);
+    const __m256i popcnt_lo = _mm256_shuffle_epi8(lookup, lo);
+    const __m256i popcnt_hi = _mm256_shuffle_epi8(lookup, hi);
+    const __m256i popcnt = _mm256_add_epi8(popcnt_lo, popcnt_hi);
+    // Reduce uint8_t[32] into uint64_t[4] by addition.
+    return _mm256_sad_epu8(_mm256_setzero_si256(), popcnt);
 }
-#endif
-#endif
 
-#if defined(__AVX512F__) && defined(__AVX512VPOPCNTDQ__)
-
-/**
- * AVX512-optimized version of dot product computation between query and binary
- * data. Requires AVX512F and AVX512VPOPCNTDQ instruction sets.
- *
- * @param query          Pointer to rearranged rotated query data
- * @param binary_data    Pointer to binary data
- * @param d              Dimension
- * @param qb             Number of quantization bits
- * @return               Dot product result as float
- */
-inline float rabitq_dp_popcnt_avx512(
-        const uint8_t* query,
-        const uint8_t* binary_data,
-        size_t d,
-        size_t qb) {
-    __m512i sum_512 = _mm512_setzero_si512();
-
-    const size_t di_8b = (d + 7) / 8;
-
-    const size_t d_512 = (d / 512) * 512;
-    const size_t d_256 = (d / 256) * 256;
-    const size_t d_128 = (d / 128) * 128;
-
-    for (size_t i = 0; i < d_512; i += 512) {
-        __m512i v_x = _mm512_loadu_si512((const __m512i*)(binary_data + i / 8));
-        for (size_t j = 0; j < qb; j++) {
-            __m512i v_q = _mm512_loadu_si512(
-                    (const __m512i*)(query + j * di_8b + i / 8));
-            __m512i v_and = _mm512_and_si512(v_q, v_x);
-            __m512i v_popcnt = _mm512_popcnt_epi32(v_and);
-            sum_512 = _mm512_add_epi32(sum_512, _mm512_slli_epi32(v_popcnt, j));
-        }
-    }
-
-    __m256i sum_256 = _mm256_add_epi32(
-            _mm512_extracti32x8_epi32(sum_512, 0),
-            _mm512_extracti32x8_epi32(sum_512, 1));
-
-    if (d_256 != d_512) {
-        __m256i v_x =
-                _mm256_loadu_si256((const __m256i*)(binary_data + d_512 / 8));
-        for (size_t j = 0; j < qb; j++) {
-            __m256i v_q = _mm256_loadu_si256(
-                    (const __m256i*)(query + j * di_8b + d_512 / 8));
-            __m256i v_and = _mm256_and_si256(v_q, v_x);
-            __m256i v_popcnt = _mm256_popcnt_epi32(v_and);
-            sum_256 = _mm256_add_epi32(sum_256, _mm256_slli_epi32(v_popcnt, j));
-        }
-    }
-
-    __m128i sum_128 = _mm_add_epi32(
-            _mm256_extracti32x4_epi32(sum_256, 0),
-            _mm256_extracti32x4_epi32(sum_256, 1));
-
-    if (d_128 != d_256) {
-        __m128i v_x =
-                _mm_loadu_si128((const __m128i*)(binary_data + d_256 / 8));
-        for (size_t j = 0; j < qb; j++) {
-            __m128i v_q = _mm_loadu_si128(
-                    (const __m128i*)(query + j * di_8b + d_256 / 8));
-            __m128i v_and = _mm_and_si128(v_q, v_x);
-            __m128i v_popcnt = _mm_popcnt_epi32(v_and);
-            sum_128 = _mm_add_epi32(sum_128, _mm_slli_epi32(v_popcnt, j));
-        }
-    }
-
-    if (d != d_128) {
-        const size_t leftovers = d - d_128;
-        const __mmask16 mask = (1 << ((leftovers + 7) / 8)) - 1;
-
-        __m128i v_x = _mm_maskz_loadu_epi8(
-                mask, (const __m128i*)(binary_data + d_128 / 8));
-        for (size_t j = 0; j < qb; j++) {
-            __m128i v_q = _mm_maskz_loadu_epi8(
-                    mask, (const __m128i*)(query + j * di_8b + d_128 / 8));
-            __m128i v_and = _mm_and_si128(v_q, v_x);
-            __m128i v_popcnt = _mm_popcnt_epi32(v_and);
-            sum_128 = _mm_add_epi32(sum_128, _mm_slli_epi32(v_popcnt, j));
-        }
-    }
-
-    int sum_64le = 0;
-    sum_64le += _mm_extract_epi32(sum_128, 0);
-    sum_64le += _mm_extract_epi32(sum_128, 1);
-    sum_64le += _mm_extract_epi32(sum_128, 2);
-    sum_64le += _mm_extract_epi32(sum_128, 3);
-
-    return static_cast<float>(sum_64le);
-}
-#endif
-
-#if defined(__AVX512F__) && !defined(__AVX512VPOPCNTDQ__)
-/**
- * AVX512-optimized version of dot product computation between query and binary
- * data. Uses AVX512F instructions but does not require AVX512VPOPCNTDQ.
- *
- * @param query          Pointer to rearranged rotated query data
- * @param binary_data    Pointer to binary data
- * @param d              Dimension
- * @param qb             Number of quantization bits
- * @return               Dot product result as float
- */
-inline float rabitq_dp_popcnt_avx512_fallback(
-        const uint8_t* query,
-        const uint8_t* binary_data,
-        size_t d,
-        size_t qb) {
-    const size_t di_8b = (d + 7) / 8;
-    const size_t d_512 = (d / 512) * 512;
-    const size_t d_256 = (d / 256) * 256;
-    const size_t d_128 = (d / 128) * 128;
-
-    // Use the lookup-based popcount helper function
-
-    __m512i sum_512 = _mm512_setzero_si512();
-
-    // Process 512 bits (64 bytes) at a time using lookup-based popcount
-    for (size_t i = 0; i < d_512; i += 512) {
-        __m512i v_x = _mm512_loadu_si512((const __m512i*)(binary_data + i / 8));
-        for (size_t j = 0; j < qb; j++) {
-            __m512i v_q = _mm512_loadu_si512(
-                    (const __m512i*)(query + j * di_8b + i / 8));
-            __m512i v_and = _mm512_and_si512(v_q, v_x);
-
-            // Use the popcount_lookup_avx512 helper function
-            __m512i v_popcnt = popcount_lookup_avx512(v_and);
-
-            // Sum bytes to 32-bit integers
-            __m512i v_sad = _mm512_sad_epu8(v_popcnt, _mm512_setzero_si512());
-
-            // Shift by j and add to sum
-            __m512i v_shifted = _mm512_slli_epi64(v_sad, j);
-            sum_512 = _mm512_add_epi64(sum_512, v_shifted);
-        }
-    }
-
-    // Handle 256-bit section if needed
-    __m256i sum_256 = _mm256_setzero_si256();
-    if (d_256 != d_512) {
-        __m256i v_x =
-                _mm256_loadu_si256((const __m256i*)(binary_data + d_512 / 8));
-        for (size_t j = 0; j < qb; j++) {
-            __m256i v_q = _mm256_loadu_si256(
-                    (const __m256i*)(query + j * di_8b + d_512 / 8));
-            __m256i v_and = _mm256_and_si256(v_q, v_x);
-
-            // Use the popcount_lookup_avx2 helper function
-            __m256i v_popcnt = popcount_lookup_avx2(v_and);
-
-            // Sum bytes to 64-bit integers
-            __m256i v_sad = _mm256_sad_epu8(v_popcnt, _mm256_setzero_si256());
-
-            // Shift by j and add to sum
-            __m256i v_shifted = _mm256_slli_epi64(v_sad, j);
-            sum_256 = _mm256_add_epi64(sum_256, v_shifted);
-        }
-    }
-
-    // Handle 128-bit section and leftovers
-    __m128i sum_128 = _mm_setzero_si128();
-    if (d_128 != d_256) {
-        __m128i v_x =
-                _mm_loadu_si128((const __m128i*)(binary_data + d_256 / 8));
-        for (size_t j = 0; j < qb; j++) {
-            __m128i v_q = _mm_loadu_si128(
-                    (const __m128i*)(query + j * di_8b + d_256 / 8));
-            __m128i v_and = _mm_and_si128(v_q, v_x);
-
-            // Scalar popcount for each 64-bit lane
-            uint64_t lane0 = _mm_extract_epi64(v_and, 0);
-            uint64_t lane1 = _mm_extract_epi64(v_and, 1);
-            uint64_t pop0 = __builtin_popcountll(lane0) << j;
-            uint64_t pop1 = __builtin_popcountll(lane1) << j;
-            sum_128 = _mm_add_epi64(sum_128, _mm_set_epi64x(pop1, pop0));
-        }
-    }
-
-    // Handle remaining bytes (less than 16)
-    uint64_t sum_leftover = 0;
-    size_t d_leftover = d - d_128;
-    if (d_leftover > 0) {
-        for (size_t j = 0; j < qb; j++) {
-            for (size_t k = 0; k < (d_leftover + 7) / 8; ++k) {
-                uint8_t qv = query[j * di_8b + d_128 / 8 + k];
-                uint8_t yv = binary_data[d_128 / 8 + k];
-                sum_leftover += (__builtin_popcount(qv & yv) << j);
-            }
-        }
-    }
-
-    // Horizontal sum of all lanes
-    uint64_t sum = 0;
-
-    // Sum from 512-bit registers
-    alignas(64) uint64_t lanes512[8];
-    _mm512_store_si512((__m512i*)lanes512, sum_512);
-    for (int i = 0; i < 8; ++i) {
-        sum += lanes512[i];
-    }
-
-    // Sum from 256-bit registers
-    alignas(32) uint64_t lanes256[4];
-    _mm256_store_si256((__m256i*)lanes256, sum_256);
-    for (int i = 0; i < 4; ++i) {
-        sum += lanes256[i];
-    }
-
-    // Sum from 128-bit registers
-    alignas(16) uint64_t lanes128[2];
-    _mm_store_si128((__m128i*)lanes128, sum_128);
-    sum += lanes128[0] + lanes128[1];
-
-    // Add leftovers
-    sum += sum_leftover;
-
-    return static_cast<float>(sum);
-}
-#endif
-
-#ifdef __AVX2__
-
-/**
- * AVX2-optimized version of dot product computation between query and binary
- * data.
- *
- * @param query          Pointer to rearranged rotated query data
- * @param binary_data    Pointer to binary data
- * @param d              Dimension
- * @param qb             Number of quantization bits
- * @return               Dot product result as float
- */
-
-inline float rabitq_dp_popcnt_avx2(
-        const uint8_t* query,
-        const uint8_t* binary_data,
-        size_t d,
-        size_t qb) {
-    const size_t di_8b = (d + 7) / 8;
-    const size_t d_256 = (d / 256) * 256;
-    const size_t d_128 = (d / 128) * 128;
-
-    // Use the lookup-based popcount helper function
-
-    __m256i sum_256 = _mm256_setzero_si256();
-
-    // Process 256 bits (32 bytes) at a time using lookup-based popcount
-    for (size_t i = 0; i < d_256; i += 256) {
-        __m256i v_x = _mm256_loadu_si256((const __m256i*)(binary_data + i / 8));
-        for (size_t j = 0; j < qb; j++) {
-            __m256i v_q = _mm256_loadu_si256(
-                    (const __m256i*)(query + j * di_8b + i / 8));
-            __m256i v_and = _mm256_and_si256(v_q, v_x);
-
-            // Use the popcount_lookup_avx2 helper function
-            __m256i v_popcnt = popcount_lookup_avx2(v_and);
-
-            // Convert byte counts to 64-bit lanes and shift by j
-            __m256i v_sad = _mm256_sad_epu8(v_popcnt, _mm256_setzero_si256());
-            __m256i v_shifted = _mm256_slli_epi64(v_sad, static_cast<int>(j));
-            sum_256 = _mm256_add_epi64(sum_256, v_shifted);
-        }
-    }
-
-    // Handle leftovers with 128-bit SIMD
-    __m128i sum_128 = _mm_setzero_si128();
-    if (d_128 != d_256) {
-        __m128i v_x =
-                _mm_loadu_si128((const __m128i*)(binary_data + d_256 / 8));
-        for (size_t j = 0; j < qb; j++) {
-            __m128i v_q = _mm_loadu_si128(
-                    (const __m128i*)(query + j * di_8b + d_256 / 8));
-            __m128i v_and = _mm_and_si128(v_q, v_x);
-            // Scalar popcount for each 64-bit lane
-            uint64_t lane0 = _mm_extract_epi64(v_and, 0);
-            uint64_t lane1 = _mm_extract_epi64(v_and, 1);
-            uint64_t pop0 = __builtin_popcountll(lane0) << j;
-            uint64_t pop1 = __builtin_popcountll(lane1) << j;
-            sum_128 = _mm_add_epi64(sum_128, _mm_set_epi64x(pop1, pop0));
-        }
-    }
-
-    // Handle remaining bytes (less than 16)
-    uint64_t sum_leftover = 0;
-    size_t d_leftover = d - d_128;
-    if (d_leftover > 0) {
-        for (size_t j = 0; j < qb; j++) {
-            for (size_t k = 0; k < (d_leftover + 7) / 8; ++k) {
-                uint8_t qv = query[j * di_8b + d_128 / 8 + k];
-                uint8_t yv = binary_data[d_128 / 8 + k];
-                sum_leftover += (__builtin_popcount(qv & yv) << j);
-            }
-        }
-    }
-
-    // Horizontal sum of all lanes
-    uint64_t sum = 0;
-    // sum_256: 4 lanes of 64 bits
+inline uint64_t reduce_add_256(__m256i v) {
     alignas(32) uint64_t lanes[4];
-    _mm256_store_si256((__m256i*)lanes, sum_256);
-    for (int i = 0; i < 4; ++i) {
-        sum += lanes[i];
-    }
-    // sum_128: 2 lanes of 64 bits
-    alignas(16) uint64_t lanes128[2];
-    _mm_store_si128((__m128i*)lanes128, sum_128);
-    sum += lanes128[0] + lanes128[1];
-    // leftovers
-    sum += sum_leftover;
-
-    return static_cast<float>(sum);
+    _mm256_store_si256((__m256i*)lanes, v);
+    return lanes[0] + lanes[1] + lanes[2] + lanes[3];
 }
-#endif
+#endif // defined(__AVX2__)
+
+#if defined(__SSE4_1__)
+inline __m128i popcount_128(__m128i v) {
+    // Scalar popcount for each 64-bit lane
+    uint64_t lane0 = _mm_extract_epi64(v, 0);
+    uint64_t lane1 = _mm_extract_epi64(v, 1);
+    uint64_t pop0 = __builtin_popcountll(lane0);
+    uint64_t pop1 = __builtin_popcountll(lane1);
+    return _mm_set_epi64x(pop1, pop0);
+}
+
+inline uint64_t reduce_add_128(__m128i v) {
+    alignas(16) uint64_t lanes[2];
+    _mm_store_si128((__m128i*)lanes, v);
+    return lanes[0] + lanes[1];
+}
+#endif // defined(__SSE4_1__)
+#endif // defined(__x86_64__) || defined(_M_X64) || defined(__i386__) ||
 
 /**
  * Compute dot product between query and binary data using popcount operations.
  *
  * @param query          Pointer to rearranged rotated query data
- * @param binary_data    Pointer to binary data
+ * @param data    Pointer to binary data
  * @param d              Dimension
  * @param qb             Number of quantization bits
- * @return               Dot product result as float
+ * @return               Unsigned integer dot product
  */
-inline float rabitq_dp_popcnt(
+inline uint64_t bitwise_and_dot_product(
         const uint8_t* query,
-        const uint8_t* binary_data,
-        size_t d,
+        const uint8_t* data,
+        size_t size,
         size_t qb) {
-#if defined(__AVX512F__) && defined(__AVX512VPOPCNTDQ__)
-    return rabitq_dp_popcnt_avx512(query, binary_data, d, qb);
-#elif defined(__AVX512F__)
-    return rabitq_dp_popcnt_avx512_fallback(query, binary_data, d, qb);
-#elif defined(__AVX2__)
-    return rabitq_dp_popcnt_avx2(query, binary_data, d, qb);
-#else
-    const size_t di_8b = (d + 7) / 8;
-    const size_t di_64b = (di_8b / 8) * 8;
-
-    uint64_t dot_qo = 0;
-    for (size_t j = 0; j < qb; j++) {
-        const uint8_t* query_j = query + j * di_8b;
-
-        // process 64-bit popcounts
-        uint64_t count_dot = 0;
-        for (size_t i = 0; i < di_64b; i += 8) {
-            const auto qv = *(const uint64_t*)(query_j + i);
-            const auto yv = *(const uint64_t*)(binary_data + i);
-            count_dot += __builtin_popcountll(qv & yv);
+    uint64_t sum = 0;
+    size_t offset = 0;
+#if defined(__AVX512F__)
+    // Handle 512-bit chunks.
+    if (size_t step = 512 / 8; offset + step <= size) {
+        __m512i sum_512 = _mm512_setzero_si512();
+        for (; offset + step <= size; offset += step) {
+            __m512i v_x = _mm512_loadu_si512((const __m512i*)(data + offset));
+            for (int j = 0; j < qb; j++) {
+                __m512i v_q = _mm512_loadu_si512(
+                        (const __m512i*)(query + j * size + offset));
+                __m512i v_and = _mm512_and_si512(v_q, v_x);
+                __m512i v_popcnt = popcount_512(v_and);
+                __m512i v_shifted = _mm512_slli_epi64(v_popcnt, j);
+                sum_512 = _mm512_add_epi64(sum_512, v_shifted);
+            }
         }
-
-        // process leftovers
-        for (size_t i = di_64b; i < di_8b; i++) {
-            const auto qv = *(query_j + i);
-            const auto yv = *(binary_data + i);
-            count_dot += __builtin_popcount(qv & yv);
-        }
-
-        dot_qo += (count_dot << j);
+        sum += _mm512_reduce_add_epi64(sum_512);
     }
-
-    return static_cast<float>(dot_qo);
-#endif
+#endif // defined(__AVX512F__)
+#if defined(__AVX2__)
+    if (size_t step = 256 / 8; offset + step <= size) {
+        __m256i sum_256 = _mm256_setzero_si256();
+        for (; offset + step <= size; offset += step) {
+            __m256i v_x = _mm256_loadu_si256((const __m256i*)(data + offset));
+            for (int j = 0; j < qb; j++) {
+                __m256i v_q = _mm256_loadu_si256(
+                        (const __m256i*)(query + j * size + offset));
+                __m256i v_and = _mm256_and_si256(v_q, v_x);
+                __m256i v_popcnt = popcount_256(v_and);
+                __m256i v_shifted = _mm256_slli_epi64(v_popcnt, j);
+                sum_256 = _mm256_add_epi64(sum_256, v_shifted);
+            }
+        }
+        sum += reduce_add_256(sum_256);
+    }
+#endif // defined(__AVX2__)
+#if defined(__SSE4_1__)
+    __m128i sum_128 = _mm_setzero_si128();
+    for (size_t step = 128 / 8; offset + step <= size; offset += step) {
+        __m128i v_x = _mm_loadu_si128((const __m128i*)(data + offset));
+        for (int j = 0; j < qb; j++) {
+            __m128i v_q = _mm_loadu_si128(
+                    (const __m128i*)(query + j * size + offset));
+            __m128i v_and = _mm_and_si128(v_q, v_x);
+            __m128i v_popcnt = popcount_128(v_and);
+            __m128i v_shifted = _mm_slli_epi64(v_popcnt, j);
+            sum_128 = _mm_add_epi64(sum_128, v_shifted);
+        }
+    }
+    sum += reduce_add_128(sum_128);
+#endif // defined(__SSE4_1__)
+    for (size_t step = 64 / 8; offset + step <= size; offset += step) {
+        const auto yv = *(const uint64_t*)(data + offset);
+        for (int j = 0; j < qb; j++) {
+            const auto qv = *(const uint64_t*)(query + j * size + offset);
+            sum += __builtin_popcountll(qv & yv) << j;
+        }
+    }
+    for (; offset < size; ++offset) {
+        const auto yv = *(data + offset);
+        for (int j = 0; j < qb; j++) {
+            const auto qv = *(query + j * size + offset);
+            sum += __builtin_popcount(qv & yv) << j;
+        }
+    }
+    return sum;
 }
 
-} // namespace faiss
+inline uint64_t popcount(const uint8_t* data, size_t size) {
+    uint64_t sum = 0;
+    size_t offset = 0;
+#if defined(__AVX512F__)
+    // Handle 512-bit chunks.
+    if (offset + 512 / 8 <= size) {
+        __m512i sum_512 = _mm512_setzero_si512();
+        for (size_t end; (end = offset + 512 / 8) <= size; offset = end) {
+            __m512i v_x = _mm512_loadu_si512((const __m512i*)(data + offset));
+            __m512i v_popcnt = popcount_512(v_x);
+            sum_512 = _mm512_add_epi64(sum_512, v_popcnt);
+        }
+        sum += _mm512_reduce_add_epi64(sum_512);
+    }
+#endif // defined(__AVX512F__)
+#if defined(__AVX2__)
+    if (offset + 256 / 8 <= size) {
+        __m256i sum_256 = _mm256_setzero_si256();
+        for (size_t end; (end = offset + 256 / 8) <= size; offset = end) {
+            __m256i v_x = _mm256_loadu_si256((const __m256i*)(data + offset));
+            __m256i v_popcnt = popcount_256(v_x);
+            sum_256 = _mm256_add_epi64(sum_256, v_popcnt);
+        }
+        sum += reduce_add_256(sum_256);
+    }
+#endif // defined(__AVX2__)
+#if defined(__SSE4_1__)
+    __m128i sum_128 = _mm_setzero_si128();
+    for (size_t step = 128 / 8; offset + step <= size; offset += step) {
+        __m128i v_x = _mm_loadu_si128((const __m128i*)(data + offset));
+        sum_128 = _mm_add_epi64(sum_128, popcount_128(v_x));
+    }
+    sum += reduce_add_128(sum_128);
+#endif // defined(__SSE4_1__)
+
+    for (size_t step = 64 / 8; offset + step <= size; offset += step) {
+        const auto yv = *(const uint64_t*)(data + offset);
+        sum += __builtin_popcountll(yv);
+    }
+    for (; offset < size; ++offset) {
+        const auto yv = *(data + offset);
+        sum += __builtin_popcount(yv);
+    }
+    return sum;
+}
+
+} // namespace faiss::rabitq

--- a/tests/test_rabitq.py
+++ b/tests/test_rabitq.py
@@ -17,6 +17,11 @@ def random_rotation(d, seed=123):
     return Q
 
 
+# Exercise SIMD codepaths, maintain multiple of 16.
+TEST_DIM = 512 * 2 + 256 + 128 + 64 + 16  # 1488
+TEST_N = 4096
+
+
 # based on https://gist.github.com/mdouze/0b2386c31d7fb8b20ae04f3fcbbf4d9d
 class ReferenceRabitQ:
     """Exact translation of the paper
@@ -175,53 +180,63 @@ class ReferenceIVFRabitQ:
 
 class TestRaBitQ(unittest.TestCase):
     def do_comparison_vs_pq_test(self, metric_type=faiss.METRIC_L2):
-        ds = datasets.SyntheticDataset(128, 4096, 4096, 100)
+        ds = datasets.SyntheticDataset(TEST_DIM, TEST_N, TEST_N, 100)
         k = 10
-
-        # PQ 8-to-1
-        index_pq = faiss.IndexPQ(ds.d, 16, 8, metric_type)
-        index_pq.train(ds.get_train())
-        index_pq.add(ds.get_database())
-        _, I_pq = index_pq.search(ds.get_queries(), k)
-
-        index_rbq = faiss.IndexRaBitQ(ds.d, metric_type)
-        index_rbq.train(ds.get_train())
-        index_rbq.add(ds.get_database())
-        _, I_rbq = index_rbq.search(ds.get_queries(), k)
-
-        # try quantized query
-        rbq_params = faiss.RaBitQSearchParameters(qb=8)
-        _, I_rbq_q8 = index_rbq.search(ds.get_queries(), k, params=rbq_params)
-
-        rbq_params = faiss.RaBitQSearchParameters(qb=4)
-        _, I_rbq_q4 = index_rbq.search(ds.get_queries(), k, params=rbq_params)
 
         index_flat = faiss.IndexFlat(ds.d, metric_type)
         index_flat.train(ds.get_train())
         index_flat.add(ds.get_database())
         _, I_f = index_flat.search(ds.get_queries(), k)
 
-        # ensure that RaBitQ and PQ are relatively close
-        eval_pq = faiss.eval_intersection(I_pq[:, :k], I_f[:, :k])
-        eval_pq /= ds.nq * k
-        eval_rbq = faiss.eval_intersection(I_rbq[:, :k], I_f[:, :k])
-        eval_rbq /= ds.nq * k
-        eval_rbq_q8 = faiss.eval_intersection(I_rbq_q8[:, :k], I_f[:, :k])
-        eval_rbq_q8 /= ds.nq * k
-        eval_rbq_q4 = faiss.eval_intersection(I_rbq_q4[:, :k], I_f[:, :k])
-        eval_rbq_q4 /= ds.nq * k
+        def eval_I(I):
+            return faiss.eval_intersection(I, I_f) / I_f.ravel().shape[0]
 
-        print(
-            f"PQ is {eval_pq}, "
-            f"RaBitQ is {eval_rbq}, "
-            f"q8 RaBitQ is {eval_rbq_q8}, "
-            f"q4 RaBitQ is {eval_rbq_q4}"
-        )
+        print()
 
-        np.testing.assert_(abs(eval_pq - eval_rbq) < 0.05)
-        np.testing.assert_(abs(eval_pq - eval_rbq_q8) < 0.05)
-        np.testing.assert_(abs(eval_pq - eval_rbq_q4) < 0.05)
-        np.testing.assert_(eval_pq > 0.55)
+        for random_rotate in [False, True]:
+
+            # PQ{D/4}x4fs, also 1 bit per query dimension
+            index_pq = faiss.IndexPQFastScan(ds.d, ds.d // 4, 4, metric_type)
+            # Share a single quantizer (much faster, minimal recall change)
+            index_pq.pq.train_type = faiss.ProductQuantizer.Train_shared
+            if random_rotate:
+                # wrap with random rotations
+                rrot = faiss.RandomRotationMatrix(ds.d, ds.d)
+                rrot.init(123)
+
+                index_pq = faiss.IndexPreTransform(rrot, index_pq)
+            index_pq.train(ds.get_train())
+            index_pq.add(ds.get_database())
+
+            D_pq, I_pq = index_pq.search(ds.get_queries(), k)
+            loss_pq = 1 - eval_I(I_pq)
+            print(f"{random_rotate=:1}, {loss_pq=:5.3f}")
+            np.testing.assert_(loss_pq < 0.25, f"{loss_pq}")
+
+            index_rbq = faiss.IndexRaBitQ(ds.d, metric_type)
+            if random_rotate:
+                # wrap with random rotations
+                rrot = faiss.RandomRotationMatrix(ds.d, ds.d)
+                rrot.init(123)
+
+                index_rbq = faiss.IndexPreTransform(rrot, index_rbq)
+            index_rbq.train(ds.get_train())
+            index_rbq.add(ds.get_database())
+
+            for qb in [1, 2, 3, 4, 8]:
+                params = faiss.RaBitQSearchParameters(qb=qb)
+                _, I_rbq = index_rbq.search(ds.get_queries(), k, params=params)
+
+                # ensure that RaBitQ and PQ are relatively close
+                loss_rbq = 1 - eval_I(I_rbq)
+                ratio_threshold = 2 ** (1 / qb)
+                print(
+                    f"{random_rotate=:1}, {params.qb=}: "
+                    f"{loss_rbq=:5.3f} = loss_pq * {loss_rbq / loss_pq:5.3f}"
+                    f" < {ratio_threshold=:.2f}"
+                )
+
+                np.testing.assert_(loss_rbq < loss_pq * ratio_threshold)
 
     def test_comparison_vs_pq_L2(self):
         self.do_comparison_vs_pq_test(faiss.METRIC_L2)
@@ -230,7 +245,7 @@ class TestRaBitQ(unittest.TestCase):
         self.do_comparison_vs_pq_test(faiss.METRIC_INNER_PRODUCT)
 
     def test_comparison_vs_ref_L2_rrot(self, rrot_seed=123):
-        ds = datasets.SyntheticDataset(128, 4096, 4096, 1)
+        ds = datasets.SyntheticDataset(TEST_DIM, TEST_N, TEST_N, 1)
 
         ref_rbq = ReferenceRabitQ(ds.d, Bq=8)
         ref_rbq.train(ds.get_train(), random_rotation(ds.d, rrot_seed))
@@ -264,7 +279,7 @@ class TestRaBitQ(unittest.TestCase):
         np.testing.assert_(corr > 0.9)
 
     def test_comparison_vs_ref_L2(self):
-        ds = datasets.SyntheticDataset(128, 4096, 4096, 1)
+        ds = datasets.SyntheticDataset(TEST_DIM, TEST_N, TEST_N, 1)
 
         ref_rbq = ReferenceRabitQ(ds.d, Bq=8)
         ref_rbq.train(ds.get_train(), np.identity(ds.d))
@@ -276,6 +291,7 @@ class TestRaBitQ(unittest.TestCase):
         index_rbq.add(ds.get_database())
 
         ref_dis = ref_rbq.distances(ds.get_queries())
+        mean_dist = ref_dis.mean()
 
         dc = index_rbq.get_distance_computer()
         xq = ds.get_queries()
@@ -283,8 +299,10 @@ class TestRaBitQ(unittest.TestCase):
         dc.set_query(faiss.swig_ptr(xq[0]))
         for j in range(ds.nb):
             upd_dis = dc(j)
-            # print(f"{j} {ref_dis[0][j]} {upd_dis}")
-            np.testing.assert_(abs(ref_dis[0][j] - upd_dis) < 0.001)
+            np.testing.assert_(
+                abs(ref_dis[0][j] - upd_dis) < mean_dist * 0.00001,
+                f"{j} {ref_dis[0][j]} {upd_dis}",
+            )
 
     def do_test_serde(self, description):
         ds = datasets.SyntheticDataset(32, 1000, 100, 20)
@@ -308,8 +326,90 @@ class TestRaBitQ(unittest.TestCase):
 
 
 class TestIVFRaBitQ(unittest.TestCase):
+    def do_comparison_vs_pq_test(self, metric_type=faiss.METRIC_L2):
+        nlist = 64
+        nprobe = 8
+        nq = 1000
+        ds = datasets.SyntheticDataset(TEST_DIM, TEST_N, TEST_N, nq)
+        k = 10
+
+        d = ds.d
+        xb = ds.get_database()
+        xt = ds.get_train()
+        xq = ds.get_queries()
+
+        quantizer = faiss.IndexFlat(d, metric_type)
+        index_flat = faiss.IndexIVFFlat(quantizer, d, nlist, metric_type)
+        index_flat.train(xt)
+        index_flat.add(xb)
+        D_f, I_f = index_flat.search(
+            xq, k, params=faiss.IVFSearchParameters(nprobe=nprobe)
+        )
+
+        def eval_I(I):
+            return faiss.eval_intersection(I, I_f) / I_f.ravel().shape[0]
+
+        print()
+
+        for random_rotate in [False, True]:
+            quantizer = faiss.IndexFlat(d, metric_type)
+            index_rbq = faiss.IndexIVFRaBitQ(quantizer, d, nlist, metric_type)
+            if random_rotate:
+                # wrap with random rotations
+                rrot = faiss.RandomRotationMatrix(d, d)
+                rrot.init(123)
+
+                index_rbq = faiss.IndexPreTransform(rrot, index_rbq)
+            index_rbq.train(xt)
+            index_rbq.add(xb)
+
+            # PQ{D/4}x4fs, also 1 bit per query dimension,
+            # reusing quantizer from index_rbq.
+            index_pq = faiss.IndexIVFPQFastScan(
+                quantizer, d, nlist, d // 4, 4, metric_type
+            )
+            # Share a single quantizer (much faster, minimal recall change)
+            index_pq.pq.train_type = faiss.ProductQuantizer.Train_shared
+            if random_rotate:
+                # wrap with random rotations
+                rrot = faiss.RandomRotationMatrix(d, d)
+                rrot.init(123)
+
+                index_pq = faiss.IndexPreTransform(rrot, index_pq)
+            index_pq.train(xt)
+            index_pq.add(xb)
+
+            D_pq, I_pq = index_pq.search(
+                xq, k, params=faiss.IVFPQSearchParameters(nprobe=nprobe)
+            )
+            loss_pq = 1 - eval_I(I_pq)
+
+            print(f"{random_rotate=:1}, {loss_pq=:5.3f}")
+            np.testing.assert_(loss_pq < 0.25, f"{loss_pq}")
+
+            for qb in [1, 2, 3, 4, 8]:
+                params = faiss.IVFRaBitQSearchParameters(nprobe=nprobe, qb=qb)
+                D_rbq, I_rbq = index_rbq.search(xq, k, params=params)
+
+                # ensure that RaBitQ and PQ are relatively close
+                loss_rbq = 1 - eval_I(I_rbq)
+                ratio_threshold = 2 ** (1 / qb)
+                print(
+                    f"{random_rotate=:1}, {params.qb=}: "
+                    f"{loss_rbq=:5.3f} = loss_pq * {loss_rbq / loss_pq:5.3f}"
+                    f" < {ratio_threshold=:.2f}"
+                )
+
+                np.testing.assert_(loss_rbq < loss_pq * ratio_threshold)
+
+    def test_comparison_vs_pq_L2(self):
+        self.do_comparison_vs_pq_test(faiss.METRIC_L2)
+
+    def test_comparison_vs_pq_IP(self):
+        self.do_comparison_vs_pq_test(faiss.METRIC_INNER_PRODUCT)
+
     def test_comparison_vs_ref_L2(self):
-        ds = datasets.SyntheticDataset(128, 4096, 4096, 100)
+        ds = datasets.SyntheticDataset(TEST_DIM, TEST_N, TEST_N, 100)
 
         k = 10
         nlist = 200
@@ -318,9 +418,7 @@ class TestIVFRaBitQ(unittest.TestCase):
         ref_rbq.add(ds.get_database())
 
         index_flat = faiss.IndexFlat(ds.d, faiss.METRIC_L2)
-        index_rbq = faiss.IndexIVFRaBitQ(
-            index_flat, ds.d, nlist, faiss.METRIC_L2
-        )
+        index_rbq = faiss.IndexIVFRaBitQ(index_flat, ds.d, nlist, faiss.METRIC_L2)
         index_rbq.qb = 4
         index_rbq.train(ds.get_train())
         index_rbq.add(ds.get_database())
@@ -358,9 +456,7 @@ class TestIVFRaBitQ(unittest.TestCase):
         ref_rbq.add(ds.get_database())
 
         index_flat = faiss.IndexFlat(ds.d, faiss.METRIC_L2)
-        index_rbq = faiss.IndexIVFRaBitQ(
-            index_flat, ds.d, nlist, faiss.METRIC_L2
-        )
+        index_rbq = faiss.IndexIVFRaBitQ(index_flat, ds.d, nlist, faiss.METRIC_L2)
         index_rbq.qb = 4
 
         # wrap with random rotations


### PR DESCRIPTION
Summary: `rabitq_simd.h` had significant duplication across different helper methods, often with the tail of the method being identical.

Differential Revision: D81825790


