### PR TITLE
Fix nightly by updating mkl version

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -50,7 +50,7 @@ runs:
         if [ "${{ runner.arch }}" = "X64" ]; then
           # TODO: merge this with ARM64
           conda install -y -q -c conda-forge gxx_linux-64=14.2 sysroot_linux-64=2.17
-          conda install -y -q mkl=2022.2.1 mkl-devel=2022.2.1
+          conda install -y -q mkl=2024.2.2 mkl-devel=2024.2.2
         fi
 
         # no CUDA needed for ROCm so skip this
@@ -58,10 +58,10 @@ runs:
           :
         # regular CUDA for GPU builds
         elif [ "${{ inputs.gpu }}" = "ON" ] && [ "${{ inputs.cuvs }}" = "OFF" ]; then
-          conda install -y -q cuda-toolkit=12.4 -c "nvidia/label/cuda-12.4.0"
+          conda install -y -q cuda-toolkit=12.6 gxx_linux-64=12.4 -c "nvidia/label/cuda-12.6"
         # and CUDA from cuVS channel for cuVS builds
         elif [ "${{ inputs.cuvs }}" = "ON" ]; then
-          conda install -y -q libcuvs=25.08 'cuda-version>=12.0,<=12.5' cuda-toolkit=12.4.1 gxx_linux-64=12.4 -c rapidsai -c rapidsai-nightly -c conda-forge
+          conda install -y -q libcuvs=25.08 'cuda-version=12.6' cuda-toolkit=12.6 gxx_linux-64=12.4 -c rapidsai -c rapidsai-nightly -c conda-forge
         fi
 
         # install test packages
@@ -69,8 +69,9 @@ runs:
           : # skip torch install via conda, we need to install via pip to get
             #  ROCm-enabled version until it's supported in conda by PyTorch
         elif [ "${{ inputs.gpu }}" = "ON" ]; then
-          conda install -y -q "pytorch<2.5" pytorch-cuda=12.4 -c pytorch -c "nvidia/label/cuda-12.4.0"
+          conda install -y -q "pytorch>=2.7" "pytorch-gpu>=2.7" -c pytorch -c "nvidia/label/12.6"
         else
+          # TestLowLevelIVF.IVFRQ hangs on pytorch>=2.7, so left it as <2.5 for now.
           conda install -y -q "pytorch<2.5" -c pytorch
         fi
     - name: ROCm - Install dependencies

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           label: main
   linux-x86_64-GPU-packages-CUDA-12-4-0:
-    name: Linux x86_64 GPU packages (CUDA 12.4.0)
+    name: Linux x86_64 GPU packages (CUDA 12.6)
     runs-on: 4-core-ubuntu-gpu-t4
     env:
       CUDA_ARCHS: "70-real;72-real;75-real;80;86-real"
@@ -39,9 +39,9 @@ jobs:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         with:
           label: main
-          cuda: "12.4.0"
+          cuda: "12.6"
   linux-x86_64-GPU-CUVS-packages-CUDA12-4-0:
-    name: Linux x86_64 GPU w/ cuVS packages (CUDA 12.4.0)
+    name: Linux x86_64 GPU w/ cuVS packages (CUDA 12.6)
     runs-on: 4-core-ubuntu-gpu-t4
     env:
       CUDA_ARCHS: "70-real;72-real;75-real;80;86-real"
@@ -58,7 +58,7 @@ jobs:
         with:
           label: main
           cuvs: "ON"
-          cuda: "12.4.0"
+          cuda: "12.6"
   windows-x86_64-packages:
     name: Windows x86_64 packages
     runs-on: windows-2022

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           label: nightly
   linux-x86_64-GPU-CUDA-12-4-nightly:
-    name: Linux x86_64 GPU nightlies (CUDA 12.4.0)
+    name: Linux x86_64 GPU nightlies (CUDA 12.6)
     runs-on: 4-core-ubuntu-gpu-t4
     env:
       CUDA_ARCHS: "70-real;72-real;75-real;80;86-real"
@@ -36,9 +36,9 @@ jobs:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         with:
           label: nightly
-          cuda: "12.4.0"
+          cuda: "12.6"
   linux-x86_64-GPU-CUVS-CUDA12-4-0-nightly:
-    name: Linux x86_64 GPU w/ cuVS nightlies (CUDA 12.4.0)
+    name: Linux x86_64 GPU w/ cuVS nightlies (CUDA 12.6)
     runs-on: 4-core-ubuntu-gpu-t4
     env:
       CUDA_ARCHS: "70-real;72-real;75-real;80;86-real"
@@ -54,7 +54,7 @@ jobs:
         with:
           label: nightly
           cuvs: "ON"
-          cuda: "12.4.0"
+          cuda: "12.6"
   windows-x86_64-nightly:
     name: Windows x86_64 nightlies
     runs-on: windows-2022

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ $ conda install -c pytorch/label/nightly faiss-cpu
 # GPU(+CPU) version
 $ conda install -c pytorch/label/nightly -c nvidia faiss-gpu=1.12.0
 
-# GPU(+CPU) version with NVIDIA cuVS (package built with CUDA 12.4)
+# GPU(+CPU) version with NVIDIA cuVS (package built with CUDA 12.6)
 conda install -c pytorch -c rapidsai -c rapidsai-nightly -c conda-forge -c nvidia pytorch/label/nightly::faiss-gpu-cuvs 'cuda-version>=12.0,<=12.5'
 
 # GPU(+CPU) version with NVIDIA cuVS (package built with CUDA 11.8)

--- a/conda/faiss-gpu-cuvs/meta.yaml
+++ b/conda/faiss-gpu-cuvs/meta.yaml
@@ -6,9 +6,9 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG').lstrip('v') %}
 {% set suffix = "_nightly" if environ.get('PACKAGE_TYPE') == 'nightly' else "" %}
 {% set number = GIT_DESCRIBE_NUMBER %}
-{% set cuda_constraints=">=12.1,<12.5" %}
-{% set libcublas_constraints=">=12.1,<13" %}
-{% set cudart_constraints=">=12.4,<12.5" %}
+{% set cuda_constraints=">=12.6,<12.7" %}
+{% set libcublas_constraints=">=12.6,<12.7" %}
+{% set cudart_constraints=">=12.6,<12.7" %}
 
 package:
   name: faiss-pkg
@@ -47,8 +47,8 @@ outputs:
         - cmake >=3.30.4
         - make =4.2 # [not win]
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
-        - mkl =2023  # [x86_64]
-        - mkl-devel =2023  # [x86_64]
+        - mkl >=2024.2.2,<2025.0a0  # [x86_64]
+        - mkl-devel >=2024.2.2,<2025.0a0  # [x86_64]
         - cuda-toolkit {{ cudatoolkit }}
         - cuda-cudart {{ cudart_constraints }}
         - cuda-cudart-dev {{ cudart_constraints }}
@@ -58,13 +58,13 @@ outputs:
         - cuda-cudart-static_linux-64 {{ cudart_constraints }}  # [linux64]
       host:
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
-        - mkl =2023  # [x86_64]
+        - mkl >=2024.2.2,<2025.0a0  # [x86_64]
         - openblas =0.3.30 # [not x86_64]
         - libcuvs =25.08
         - cuda-version {{ cuda_constraints }}
       run:
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
-        - mkl =2023  # [x86_64]
+        - mkl >=2024.2.2,<2025.0a0  # [x86_64]
         - openblas =0.3.30 # [not x86_64]
         - cuda-cudart {{ cuda_constraints }}
         - libcublas {{ libcublas_constraints }}
@@ -95,16 +95,16 @@ outputs:
         - cmake >=3.26.4
         - make =4.2 # [not win]
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
-        - mkl =2023.0  # [x86_64]
+        - mkl >=2024.2.2,<2025.0a0  # [x86_64]
         - cuda-toolkit {{ cudatoolkit }}
       host:
-        - mkl =2023.0  # [x86_64]
+        - mkl >=2024.2.2,<2025.0a0  # [x86_64]
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
         - python {{ python }}
         - numpy >=2.0,<3.0
         - {{ pin_subpackage('libfaiss', exact=True) }}
       run:
-        - mkl =2023.0  # [x86_64]
+        - mkl >=2024.2.2,<2025.0a0  # [x86_64]
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
         - python {{ python }}
         - numpy >=2.0,<3.0
@@ -114,8 +114,7 @@ outputs:
       requires:
         - numpy >=2.0,<3.0
         - scipy
-        - pytorch >=2.7
-        - pytorch-cuda {{ cuda_constraints }}
+        - pytorch-gpu >=2.7
       commands:
         - python -X faulthandler -m unittest discover -v -s tests/ -p "test_*"
         - python -X faulthandler -m unittest discover -v -s tests/ -p "torch_*"

--- a/conda/faiss-gpu/meta.yaml
+++ b/conda/faiss-gpu/meta.yaml
@@ -6,16 +6,9 @@
 {% set version = environ.get('GIT_DESCRIBE_TAG').lstrip('v') %}
 {% set suffix = "_nightly" if environ.get('PACKAGE_TYPE') == 'nightly' else "" %}
 {% set number = GIT_DESCRIBE_NUMBER %}
-{% if cudatoolkit == '11.4.4' %}
-{% set cuda_constraints=">=11.4,<12" %}
-{% set libcublas_constraints=">=11.6,<12" %}
-{% elif cudatoolkit == '12.1.1' %}
-{% set cuda_constraints=">=12.1,<13" %}
-{% set libcublas_constraints=">=12.1,<13" %}
-{% elif cudatoolkit == '12.4.0' %}
-{% set cuda_constraints=">=12.4,<13" %}
-{% set libcublas_constraints=">=12.4,<13" %}
-{% endif %}
+{% set cuda_constraints=">=12.6,<12.7" %}
+{% set libcublas_constraints=">=12.6,<12.7" %}
+{% set cudart_constraints=">=12.6,<12.7" %}
 
 package:
   name: faiss-pkg
@@ -49,20 +42,19 @@ outputs:
         - FAISS_FLATTEN_CONDA_INCLUDES
     requirements:
       build:
-        - {{ compiler('cxx') }}
+        - {{ compiler('cxx') }} =12.4
         - sysroot_linux-64 =2.17 # [linux64]
         - llvm-openmp  # [osx]
         - cmake >=3.24.0
         - make =4.2 # [not win and not (osx and arm64)]
         - make =4.4 # [osx and arm64]
-        - mkl-devel =2023.0  # [x86_64]
+        - mkl-devel >=2024.2.2,<2025.0a0  # [x86_64]
         - cuda-toolkit {{ cudatoolkit }}
-        - gcc_linux-64 =11.2  # [cudatoolkit == '11.4.4']
       host:
-        - mkl =2023.0  # [x86_64]
+        - mkl >=2024.2.2,<2025.0a0  # [x86_64]
         - openblas =0.3.30 # [not x86_64]
       run:
-        - mkl =2023.0  # [x86_64]
+        - mkl >=2024.2.2,<2025.0a0  # [x86_64]
         - openblas =0.3.30 # [not x86_64]
         - cuda-cudart {{ cuda_constraints }}
         - libcublas {{ libcublas_constraints }}
@@ -84,7 +76,7 @@ outputs:
       string: "py{{ PY_VER }}_h{{ PKG_HASH }}_{{ number }}_cuda{{ cudatoolkit }}{{ suffix }}"
     requirements:
       build:
-        - {{ compiler('cxx') }}
+        - {{ compiler('cxx') }} =12.4
         - sysroot_linux-64 =2.17 # [linux64]
         - swig =4.0
         - cmake >=3.24.0
@@ -92,15 +84,15 @@ outputs:
         - make =4.4 # [osx and arm64]
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64 and not win]
         - cuda-toolkit {{ cudatoolkit }}
-        - mkl-devel =2023.0  # [x86_64]
+        - mkl-devel >=2024.2.2,<2025.0a0  # [x86_64]
       host:
-        - mkl =2023.0  # [x86_64]
+        - mkl >=2024.2.2,<2025.0a0  # [x86_64]
         - python {{ python }}
         - numpy >=2.0,<3.0
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64 and not win]
         - {{ pin_subpackage('libfaiss', exact=True) }}
       run:
-        - mkl =2023.0  # [x86_64]
+        - mkl >=2024.2.2,<2025.0a0  # [x86_64]
         - python {{ python }}
         - numpy >=2.0,<3.0
         - packaging
@@ -109,8 +101,7 @@ outputs:
       requires:
         - numpy >=2.0,<3.0
         - scipy
-        - pytorch >=2.7
-        - pytorch-cuda {{ cuda_constraints }}
+        - pytorch-gpu >=2.7
       commands:
         - python -X faulthandler -m unittest discover -v -s tests/ -p "test_*"
         - python -X faulthandler -m unittest discover -v -s tests/ -p "torch_*"


### PR DESCRIPTION
Differential Revision: D84193438
Nightly for GPU builds (cuvs and non-cuvs) is failing again after numpy2 upgrade.
- Fixed it by upgrading CUDA, using the right deps (pytorch-gpu instead of the deprecated pytorch-cuda), pinning pytorch >=2.7 for GPU builds, upgrading MKL
- SVE requires pytorch<2.5 for the testing flow, otherwise it times out for 1 test.

