### PR TITLE
Fix ARM64 compilation error in IndexRaBitQFastScan

### DIFF
--- a/faiss/IndexRaBitQFastScan.cpp
+++ b/faiss/IndexRaBitQFastScan.cpp
@@ -491,7 +491,7 @@ void RaBitQHeapHandler<C, with_id_map>::handle(
     // Compute loop bounds to avoid redundant bounds checking
     const size_t base_db_idx = this->j0 + b * 32;
     const size_t max_vectors = (base_db_idx < rabitq_index->ntotal)
-            ? std::min(size_t(32), rabitq_index->ntotal - base_db_idx)
+            ? std::min<size_t>(32, rabitq_index->ntotal - base_db_idx)
             : 0;
 
     // Process distances in batch


### PR DESCRIPTION
Summary:
Use explicit template parameter for std::min to resolve type mismatch on ARM64 platforms.

On ARM64 (macOS), idx_t is typically int64_t/long long. When subtracting size_t from idx_t, the result gets promoted to unsigned long long on ARM64, but remains unsigned long on x64. This causes std::min to fail template argument deduction on ARM64 because it receives conflicting types: size_t (unsigned long) and unsigned long long.

The fix uses std::min<size_t> with an explicit template parameter, which eliminates the need for type deduction and allows the compiler to implicitly convert both arguments to size_t. This is the idiomatic C++ solution for this pattern and adds zero runtime overhead.

Differential Revision: D84721816


