### PR TITLE
Replace static constexpr with inline constexpr in header

### DIFF
--- a/faiss/utils/hamming_distance/common.h
+++ b/faiss/utils/hamming_distance/common.h
@@ -30,8 +30,7 @@ inline int popcount64(uint64_t x) {
 // This table was moved from .cpp to .h file, because
 // otherwise it was causing compilation errors while trying to
 // compile swig modules on Windows.
-// todo for C++17: switch to 'inline constexpr'
-static constexpr uint8_t hamdis_tab_ham_bytes[256] = {
+inline constexpr uint8_t hamdis_tab_ham_bytes[256] = {
         0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4,
         2, 3, 3, 4, 3, 4, 4, 5, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
         2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 1, 2, 2, 3, 2, 3, 3, 4,


### PR DESCRIPTION
Summary:
Replace `static constexpr` with `inline constexpr` for the `hamdis_tab_ham_bytes` array in the header file to fix namespace-level static linkage issue.

Using `static` at namespace level in a header file causes a separate copy of the aggregate to appear in every compilation unit that includes the header, which is inefficient and violates best practices. The `inline constexpr` specifier (C++17) provides external linkage while ensuring only one definition exists across all translation units.

This change implements the TODO that was already documented in the code comments, as Faiss uses C++17 (confirmed in CMakeLists.txt). The table remains in the header file as required for SWIG compilation on Windows, but now uses the correct modern C++ approach.

Differential Revision: D84858704


