### PR TITLE
Fix IndexIVFRaBitQFastScan by overriding search_preassigned

### DIFF
--- a/faiss/IndexIVFRaBitQFastScan.cpp
+++ b/faiss/IndexIVFRaBitQFastScan.cpp
@@ -279,37 +279,34 @@ void IndexIVFRaBitQFastScan::compute_residual_LUT(
     }
 }
 
-void IndexIVFRaBitQFastScan::search(
+void IndexIVFRaBitQFastScan::search_preassigned(
         idx_t n,
         const float* x,
         idx_t k,
+        const idx_t* assign,
+        const float* centroid_dis,
         float* distances,
         idx_t* labels,
-        const SearchParameters* params_in) const {
+        bool store_pairs,
+        const IVFSearchParameters* params,
+        IndexIVFStats* stats) const {
     FAISS_THROW_IF_NOT(is_trained);
     FAISS_THROW_IF_NOT(k > 0);
+    FAISS_THROW_IF_NOT_MSG(
+            !store_pairs, "store_pairs not supported for RaBitQFastScan");
+    FAISS_THROW_IF_NOT_MSG(!stats, "stats not supported for this index");
 
-    // Parse parameters following parent class pattern
-    const IVFSearchParameters* params = nullptr;
-    if (params_in) {
-        params = dynamic_cast<const IVFSearchParameters*>(params_in);
-        FAISS_THROW_IF_NOT_MSG(
-                params, "IndexIVFFastScan params have incorrect type");
-    }
     size_t nprobe = this->nprobe;
     if (params) {
         FAISS_THROW_IF_NOT(params->max_codes == 0);
         nprobe = params->nprobe;
     }
 
-    // Create query factors storage and ProcessingContext
     std::vector<QueryFactorsData> query_factors_storage(n * nlist);
     FastScanDistancePostProcessing context;
     context.query_factors = query_factors_storage.data();
 
-    // Replicate search_preassigned behavior but with ProcessingContext:
-    // Create CoarseQuantized struct and call search_dispatch_implem directly
-    const CoarseQuantized cq = {nprobe, nullptr, nullptr};
+    const CoarseQuantized cq = {nprobe, centroid_dis, assign};
     search_dispatch_implem(n, x, k, distances, labels, cq, context, params);
 }
 

--- a/faiss/IndexIVFRaBitQFastScan.h
+++ b/faiss/IndexIVFRaBitQFastScan.h
@@ -138,13 +138,17 @@ struct IndexIVFRaBitQFastScan : IndexIVFFastScan {
             AlignedTable<float>& biases,
             const FastScanDistancePostProcessing& context) const override;
 
-    void search(
+    void search_preassigned(
             idx_t n,
             const float* x,
             idx_t k,
+            const idx_t* assign,
+            const float* centroid_dis,
             float* distances,
             idx_t* labels,
-            const SearchParameters* params = nullptr) const override;
+            bool store_pairs,
+            const IVFSearchParameters* params = nullptr,
+            IndexIVFStats* stats = nullptr) const override;
 
     /// Override to create RaBitQ-specific handlers
     SIMDResultHandlerToFloat* make_knn_handler(


### PR DESCRIPTION
Summary:
This diff fixes `IndexIVFRaBitQFastScan` to work correctly with `search_with_parameters` by changing from overriding `search()` to properly overriding `search_preassigned()`.

**Problem:**
`IndexIVFRaBitQFastScan` was incorrectly overriding `search()` method, which prevented the parent class (`IndexIVFFastScan`) from performing proper coarse quantization. This caused issues when using `faiss.search_with_parameters()`, as the index would not work correctly.

**Solution:**
- Removed the `search()` override from `IndexIVFRaBitQFastScan`
- Added proper `search_preassigned()` override instead
- The `search_preassigned()` implementation allocates proper `QueryFactorsData` storage (size `n * nlist`) required by RaBitQ's `compute_LUT` method
- Now the parent class's `search()` method handles coarse quantization, then calls our `search_preassigned()` with proper assignments

This follows the same pattern as `IndexIVFAdditiveQuantizerFastScan`, which also requires special context setup in `search_preassigned()`.

**Additional Changes:**
- Added `test_search_with_parameters()` test case in `test_rabitq.py` to verify the fix works correctly with `search_with_parameters`

Differential Revision: D84961631


