### PR TITLE
Fix IVFFlatPanorama bench

### DIFF
--- a/benchs/bench_ivf_flat_panorama.py
+++ b/benchs/bench_ivf_flat_panorama.py
@@ -38,7 +38,7 @@ def get_ivf_index(index):
     return index
 
 
-def eval_recall(index, name, nprobe_val):
+def eval_recall(index, nprobe_val):
     t0 = time.time()
     _, I = index.search(xq, k=k)
     t = time.time() - t0
@@ -71,7 +71,7 @@ def eval_and_plot(name, plot=True):
     print(f"======{name}")
     for nprobe in 1, 2, 4, 8, 16, 32, 64:
         ivf_index.nprobe = nprobe
-        recall, qps = eval_recall(index, name, nprobe)
+        recall, qps = eval_recall(index, nprobe)
         data.append((recall, qps))
 
     if plot:


### PR DESCRIPTION
This PR fixes a bug introduced while merging #4606. While the PR itself has `_, I = index.search(xq, k=k)` at line 44 of `benchs/bench_ivf_flat_panorama.py`, the code merged into main had `_, I = ivf_index.search(xq, k=k)`, causing a bug. Perhaps this bug was introduced as a result of the unused definition of `ivf_index` on line 42, which I also remove in this PR.

The bench now produces the intended output:
```
======IVF128,Flat
        nprobe   1, Recall@10: 0.145200, speed: 2.780188 ms/query
        nprobe   2, Recall@10: 0.261300, speed: 5.612059 ms/query
        nprobe   4, Recall@10: 0.440800, speed: 11.198325 ms/query
        nprobe   8, Recall@10: 0.647900, speed: 22.286867 ms/query
        nprobe  16, Recall@10: 0.879100, speed: 44.287742 ms/query
        nprobe  32, Recall@10: 0.975400, speed: 86.729102 ms/query
        nprobe  64, Recall@10: 0.986800, speed: 164.087180 ms/query
======PCA960,IVF128,FlatPanorama8
        nprobe   1, Recall@10: 0.144400, speed: 0.614665 ms/query
        nprobe   2, Recall@10: 0.260900, speed: 1.080409 ms/query
        nprobe   4, Recall@10: 0.439300, speed: 1.932697 ms/query
        nprobe   8, Recall@10: 0.647600, speed: 3.506942 ms/query
        nprobe  16, Recall@10: 0.878200, speed: 6.489344 ms/query
        nprobe  32, Recall@10: 0.976500, speed: 12.024698 ms/query
        nprobe  64, Recall@10: 0.986800, speed: 21.948482 ms/query
```
<img width="777" height="435" alt="bench_ivf_flat_panorama" src="https://github.com/user-attachments/assets/51f3ba93-0750-4ef2-a601-cfcb2746cd69" />

