### PR TITLE
Add immediate notification when autoclose label is applied

### DIFF
--- a/.github/workflows/autoclose.yml
+++ b/.github/workflows/autoclose.yml
@@ -2,9 +2,23 @@ name: Close Inactive Issues
 on:
   schedule:
     - cron: "30 1 * * *"
+  issues:
+    types: [labeled]
 
 jobs:
+  notify-on-label:
+    if: github.event_name == 'issues' && github.event.label.name == 'autoclose'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Comment on autoclose label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh issue comment ${{ github.event.issue.number }} --body "This issue has been marked for autoclose and will be closed after 14 days of inactivity."
+
   close-issues:
+    if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
Summary:
Add a new job that immediately notifies users when the "autoclose" label is applied to an issue. Previously, users would only see messages at 7 days (stale) and 14 days (close). Now they receive an immediate notification explaining the autoclose policy.

The workflow now has two jobs:
- `notify-on-label`: Triggers when "autoclose" label is added, posts immediate comment via GitHub CLI
- `close-issues`: Existing scheduled job (runs daily) that marks stale and closes inactive issues

This provides better user experience by setting clear expectations upfront about the 14-day inactivity policy.

Reviewed By: mnorris11

Differential Revision: D84967302


