### PR TITLE
Fix IndexIVFRaBitQFastScan nprobe handling in search_with_parameters

### DIFF
--- a/faiss/IndexIVFRaBitQFastScan.cpp
+++ b/faiss/IndexIVFRaBitQFastScan.cpp
@@ -320,7 +320,7 @@ void IndexIVFRaBitQFastScan::compute_LUT(
     FAISS_THROW_IF_NOT(is_trained);
     FAISS_THROW_IF_NOT(by_residual);
 
-    size_t nprobe = this->nprobe;
+    size_t nprobe = cq.nprobe;
 
     size_t dim12 = 16 * M;
 

--- a/faiss/IndexIVFRaBitQFastScan.h
+++ b/faiss/IndexIVFRaBitQFastScan.h
@@ -27,11 +27,6 @@ struct FastScanDistancePostProcessing;
 using rabitq_utils::FactorsData;
 using rabitq_utils::QueryFactorsData;
 
-struct IVFRaBitQFastScanSearchParameters : IVFSearchParameters {
-    uint8_t qb = 0;
-    bool centered = false;
-};
-
 /** Fast-scan version of IndexIVFRaBitQ that processes vectors in batches
  * using SIMD operations. Combines the inverted file structure of IVF
  * with RaBitQ's bit-level quantization and FastScan's batch processing.


### PR DESCRIPTION
Summary:
Fix a critical bug in IndexIVFRaBitQFastScan where compute_LUT was using the index's default nprobe value instead of the nprobe from the CoarseQuantized parameter. This caused incorrect lookup table computation when using search_with_parameters with a different nprobe than the index's default, resulting in severely degraded recall (0.019 vs 0.474 in benchmarks).

The bug manifested when:
1. search_with_parameters() was called with params->nprobe (e.g., 4)
2. But the index's default this->nprobe was different (e.g., 1)
3. compute_LUT() incorrectly used this->nprobe instead of cq.nprobe
4. This caused LUTs to be computed for only 1 list while search tried to access 4 lists

The fix changes compute_LUT to use cq.nprobe (line 323), matching the pattern used in all other FastScan implementations (IndexIVFPQFastScan, IndexIVFAdditiveQuantizerFastScan).

Also removed the unused IVFRaBitQFastScanSearchParameters struct which was redundant since the base IVFSearchParameters already provides all necessary fields (nprobe, quantizer_params, etc). The qb and centered parameters are properties of the index itself, not search parameters.

Updated test_rabitq.py to use standard IVFSearchParameters instead of the removed custom parameter type.

Differential Revision: D85113569


