### PR TITLE
Add getter/setter for balanced_bins in PCAMatrix C API issue #4617

### DIFF
--- a/c_api/VectorTransform_c.cpp
+++ b/c_api/VectorTransform_c.cpp
@@ -120,6 +120,10 @@ DEFINE_GETTER(PCAMatrix, float, eigen_power)
 
 DEFINE_GETTER(PCAMatrix, int, random_rotation)
 
+DEFINE_GETTER(PCAMatrix, int, balanced_bins)
+
+DEFINE_SETTER(PCAMatrix, int, balanced_bins)
+
 /*********************************************
  * ITQMatrix
  *********************************************/

--- a/c_api/VectorTransform_c.h
+++ b/c_api/VectorTransform_c.h
@@ -116,6 +116,12 @@ FAISS_DECLARE_GETTER(PCAMatrix, float, eigen_power)
 /// Getter for random_rotation
 FAISS_DECLARE_GETTER(PCAMatrix, int, random_rotation)
 
+/// Getter for balanced_bins
+FAISS_DECLARE_GETTER(PCAMatrix, int, balanced_bins)
+
+/// Setter for balanced_bins
+FAISS_DECLARE_SETTER(PCAMatrix, int, balanced_bins)
+
 FAISS_DECLARE_CLASS_INHERITED(ITQMatrix, VectorTransform)
 FAISS_DECLARE_DESTRUCTOR(ITQMatrix)
 


### PR DESCRIPTION
## Summary
Adds getter and setter for `balanced_bins` field in PCAMatrix through the C API.

## Motivation
Enables access to the `balanced_bins` parameter from language bindings (e.g., Rust).

Fixes #4617

## Changes
- Added `FAISS_DECLARE_GETTER` and `FAISS_DECLARE_SETTER` for `balanced_bins` in `c_api/VectorTransform_c.h`
- Added `DEFINE_GETTER` and `DEFINE_SETTER` implementations in `c_api/VectorTransform_c.cpp`

## Testing
- Code follows existing patterns in the C API
- No API changes to existing functionality