### PR TITLE
Fix autoclose workflow - add GH_REPO for immediate notification

### DIFF
--- a/.github/workflows/autoclose.yml
+++ b/.github/workflows/autoclose.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Comment on autoclose label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: gh issue comment ${{ github.event.issue.number }} --body "This issue has been marked for autoclose and will be closed after 14 days of inactivity."
 
   close-issues:


### PR DESCRIPTION
Summary:
The immediate notification in the autoclose workflow was not working because the GitHub CLI command `gh issue comment` requires the repository context to post comments. Without the `GH_REPO` environment variable, the command couldn't determine which repository to operate on, causing the notification to fail silently.

This change adds `GH_REPO: ${{ github.repository }}` to the environment variables in the notify-on-label job, which provides the necessary repository context for the GitHub CLI.

Reviewed By: mnorris11

Differential Revision: D85166050


