### PR TITLE
Optimize IVFRaBitQFastScan query factors: n*nlist to n*nprobe

### DIFF
--- a/faiss/IndexIVFFastScan.cpp
+++ b/faiss/IndexIVFFastScan.cpp
@@ -647,7 +647,7 @@ void IndexIVFFastScan::search_dispatch_implem(
                     // pointer
                     FastScanDistancePostProcessing thread_context = context;
                     if (thread_context.query_factors != nullptr) {
-                        thread_context.query_factors += i0 * nlist;
+                        thread_context.query_factors += i0 * nprobe;
                     }
 
                     std::unique_ptr<RH> handler(

--- a/faiss/impl/FastScanDistancePostProcessing.h
+++ b/faiss/impl/FastScanDistancePostProcessing.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 namespace faiss {
 
 // Forward declarations
@@ -27,6 +29,12 @@ struct FastScanDistancePostProcessing {
     /// This pointer should point to the beginning of the relevant
     /// QueryFactorsData subset for this context.
     rabitq_utils::QueryFactorsData* query_factors = nullptr;
+
+    /// The nprobe value used when allocating query_factors storage.
+    /// This is needed because the allocation size (n * nprobe) may use a
+    /// different nprobe than index->nprobe if search params override it.
+    /// Set to 0 to use index->nprobe as fallback.
+    size_t nprobe = 0;
 
     /// Default constructor - no processing
     FastScanDistancePostProcessing() = default;


### PR DESCRIPTION
Summary:
Reduce memory allocation for query factors from n*nlist to n*nprobe, providing 100x-1000x memory reduction for typical configurations.

## Problem
IndexIVFRaBitQFastScan was allocating query factors storage for all possible query-centroid combinations (n * nlist), even though only n * nprobe combinations are actually used during search. For typical parameters (nlist=10000, nprobe=10), this resulted in 1000x memory waste.

## Solution
Changed the indexing scheme from list_id-based to probe_rank-based:

**Before:**
- Allocation: `query_factors_storage(n * nlist)`
- Indexing: `storage_idx = query_id * nlist + list_id`

**After:**
- Allocation: `query_factors_storage(n * nprobe)`
- Indexing: `storage_idx = query_id * nprobe + probe_rank`

The probe_rank is obtained from the existing `probe_indices` vector that's already set via `set_list_context()` before scanning each inverted list.

## Changes
1. `IndexIVFRaBitQFastScan::search_preassigned`: Allocate n*nprobe instead of n*nlist
2. `IndexIVFRaBitQFastScan::compute_LUT`: Use compact indexing (ij directly)
3. `IndexIVFFastScan::search_dispatch_implem`: Update thread offset from i0*nlist to i0*nprobe
4. `IVFRaBitQHeapHandler::handle`: Retrieve probe_rank and compute storage_idx accordingly

## Correctness
- Thread-safe: Each (query, probe) pair has unique index during computation
- Thread-safe: Disjoint memory regions accessed during multi-threaded search
- No serialization impact: Query factors are runtime-only, never persisted
- Verified with all 35 RaBitQ tests passing

## Memory Impact
Example with n=1000, nlist=10000, nprobe=10:
- Before: 10,000,000 entries × 24 bytes = 240 MB
- After: 10,000 entries × 24 bytes = 240 KB
- **Reduction: 999x**

Differential Revision: D85778136


