### PR TITLE
Update GitHub workflow to use clang-format-21

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -17,11 +17,11 @@ jobs:
             sudo apt install -y lsb-release wget software-properties-common gnupg
             wget https://apt.llvm.org/llvm.sh
             chmod u+x llvm.sh
-            sudo ./llvm.sh 18
-            sudo apt-get install -y git-core clang-format-18
+            sudo ./llvm.sh 21
+            sudo apt-get install -y git-core clang-format-21
       - name: Verify clang-format
         run: |
-            git ls-files | grep -E  '\.(cpp|h|cu|cuh)$' | xargs clang-format-18 -i
+            git ls-files | grep -E  '\.(cpp|h|cu|cuh)$' | xargs clang-format-21 -i
             if git diff --quiet; then
               echo "Formatting OK!"
             else


### PR DESCRIPTION
Summary:
Update the GitHub Actions workflow to use clang-format-21 instead of clang-format-18 to match the recent codebase formatting change in D85317706.

The workflow was failing because it was using clang-format-18 to verify code formatting while the codebase is now formatted with clang-format-21, causing formatting mismatches and CI failures.

Updated three locations in the build-pull-request.yml workflow:
- llvm.sh installation script parameter (18 → 21)
- apt-get install package name (clang-format-18 → clang-format-21)
- clang-format command invocation (clang-format-18 → clang-format-21)

Reviewed By: juancarpio27, mnorris11

Differential Revision: D85783038


