### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/faiss/AutoTune.cpp
+++ b/faiss/AutoTune.cpp
@@ -125,7 +125,7 @@ bool OperatingPoints::add(
         }
     } else {
         int i;
-        // stricto sensu this should be a bissection
+        // stricto sensu this should be a bisection
         for (i = 0; i < a.size(); i++) {
             if (a[i].perf >= perf) {
                 break;

--- a/faiss/AutoTune.h
+++ b/faiss/AutoTune.h
@@ -32,7 +32,7 @@ struct AutoTuneCriterion {
 
     AutoTuneCriterion(idx_t nq, idx_t nnn);
 
-    /** Intitializes the gt_D and gt_I vectors. Must be called before evaluating
+    /** Initializes the gt_D and gt_I vectors. Must be called before evaluating
      *
      * @param gt_D_in  size nq * gt_nnn
      * @param gt_I_in  size nq * gt_nnn

--- a/faiss/Clustering.h
+++ b/faiss/Clustering.h
@@ -109,7 +109,7 @@ struct Clustering : ClusteringParameters {
 
     /** run with encoded vectors
      *
-     * win addition to train()'s parameters takes a codec as parameter
+     * in addition to train()'s parameters takes a codec as parameter
      * to decode the input vectors.
      *
      * @param codec      codec used to decode the vectors (nullptr =

--- a/faiss/Index.h
+++ b/faiss/Index.h
@@ -125,7 +125,7 @@ struct Index {
     /** Perform training on a representative set of vectors
      *
      * @param n      nb of training vectors
-     * @param x      training vecors, size n * d
+     * @param x      training vectors, size n * d
      */
     virtual void train(idx_t n, const float* x);
 

--- a/faiss/IndexBinary.h
+++ b/faiss/IndexBinary.h
@@ -49,7 +49,7 @@ struct IndexBinary {
     /** Perform training on a representative set of vectors.
      *
      * @param n      nb of training vectors
-     * @param x      training vecors, size n * d / 8
+     * @param x      training vectors, size n * d / 8
      */
     virtual void train(idx_t n, const uint8_t* x);
     virtual void train_ex(idx_t n, const void* x, NumericType numeric_type) {

--- a/faiss/IndexFlat.h
+++ b/faiss/IndexFlat.h
@@ -66,7 +66,7 @@ struct IndexFlat : IndexFlatCodes {
 
     FlatCodesDistanceComputer* get_FlatCodesDistanceComputer() const override;
 
-    /* The stanadlone codec interface (just memcopies in this case) */
+    /* The standalone codec interface (just memcopies in this case) */
     void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override;
 
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;

--- a/faiss/MetricType.h
+++ b/faiss/MetricType.h
@@ -35,7 +35,7 @@ enum MetricType {
 
     /// sum_i(min(a_i, b_i)) / sum_i(max(a_i, b_i)) where a_i, b_i > 0
     METRIC_Jaccard,
-    /// Squared Eucliden distance, ignoring NaNs
+    /// Squared Euclidean distance, ignoring NaNs
     METRIC_NaNEuclidean,
     /// Gower's distance - numeric dimensions are in [0,1] and categorical
     /// dimensions are negative integers

--- a/faiss/VectorTransform.h
+++ b/faiss/VectorTransform.h
@@ -37,7 +37,7 @@ struct VectorTransform {
      * nothing by default.
      *
      * @param n      nb of training vectors
-     * @param x      training vecors, size n * d
+     * @param x      training vectors, size n * d
      */
     virtual void train(idx_t n, const float* x);
 


### PR DESCRIPTION
Summary:
Fixed 41 typos across 23 files in the faiss codebase, primarily in comments and documentation strings. These typos were identified through a comprehensive review of all source files.

Most common fixes:
- "vecors" → "vectors" (3 occurrences)
- "bissection" → "bisection" (3 occurrences)
- "Syntatic" → "Syntactic" (2 occurrences)
- "streans" → "streams" (2 occurrences)

All changes are in comments, docstrings, or documentation - no functional code changes.

Differential Revision: D86404695


