### PR TITLE
Fix additional typos found in second review

### DIFF
--- a/faiss/impl/NNDescent.h
+++ b/faiss/impl/NNDescent.h
@@ -34,7 +34,7 @@ namespace faiss {
  *
  *  Dong, Wei, Charikar Moses, and Kai Li, WWW 2011
  *
- * This implmentation is heavily influenced by the efanna
+ * This implementation is heavily influenced by the efanna
  * implementation by Cong Fu and the KGraph library by Wei Dong
  * (https://github.com/ZJULearning/efanna_graph)
  * (https://github.com/aaalgo/kgraph)


### PR DESCRIPTION
Summary:
Fixed additional typos found during second comprehensive review:

1. **impl/NNDescent.h**: `implmentation` → `implementation`

Note: During the second review, additional typos were found in CHANGELOG.md that should be addressed in a follow-up:
- Multiple occurrences of `HSNW` → `HNSW`
- `nightily` → `nightly`
- `verbosoe` → `verbose`
- `separare` → `separate`
- `nterrupting` → `interrupting`

All changes are in comments and documentation - no functional code changes.

Differential Revision: D86474075


