### PR TITLE
Implement multi-bit RaBitQ quantization (nb_bits 2-9)

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -66,6 +66,7 @@ set(FAISS_SRC
   impl/ProductQuantizer.cpp
   impl/AdditiveQuantizer.cpp
   impl/RaBitQuantizer.cpp
+  impl/RaBitQuantizerMultiBit.cpp
   impl/RaBitQUtils.cpp
   impl/ResidualQuantizer.cpp
   impl/LocalSearchQuantizer.cpp
@@ -183,6 +184,7 @@ set(FAISS_HEADERS
   impl/ProductQuantizer.h
   impl/Quantizer.h
   impl/RaBitQuantizer.h
+  impl/RaBitQuantizerMultiBit.h
   impl/RaBitQUtils.h
   impl/ResidualQuantizer.h
   impl/ResultHandler.h

--- a/faiss/IndexIVFRaBitQ.h
+++ b/faiss/IndexIVFRaBitQ.h
@@ -35,7 +35,8 @@ struct IndexIVFRaBitQ : IndexIVF {
             const size_t d,
             const size_t nlist,
             MetricType metric = METRIC_L2,
-            bool own_invlists = true);
+            bool own_invlists = true,
+            uint8_t nb_bits = 1);
 
     IndexIVFRaBitQ();
 

--- a/faiss/IndexRaBitQ.cpp
+++ b/faiss/IndexRaBitQ.cpp
@@ -9,13 +9,18 @@
 
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/ResultHandler.h>
+#include <memory>
 
 namespace faiss {
 
+// Forward declaration from RaBitQuantizer.cpp
+struct RaBitQDistanceComputer;
+
 IndexRaBitQ::IndexRaBitQ() = default;
 
-IndexRaBitQ::IndexRaBitQ(idx_t d, MetricType metric)
-        : IndexFlatCodes(0, d, metric), rabitq(d, metric) {
+IndexRaBitQ::IndexRaBitQ(idx_t d, MetricType metric, uint8_t nb_bits_in)
+        : IndexFlatCodes(0, d, metric), rabitq(d, metric, nb_bits_in) {
+    // Update code size based on nb_bits
     code_size = rabitq.code_size;
 
     is_trained = false;
@@ -78,6 +83,7 @@ struct Run_search_with_dc_res {
 
     uint8_t qb = 0;
     bool centered = false;
+    uint8_t nb_bits = 1; // Number of bits per dimension
 
     template <class BlockResultHandler>
     void f(BlockResultHandler& res, const IndexRaBitQ* index, const float* xq) {
@@ -85,22 +91,70 @@ struct Run_search_with_dc_res {
         using SingleResultHandler =
                 typename BlockResultHandler::SingleResultHandler;
         const int d = index->d;
+        size_t ex_bits = nb_bits - 1;
 
-#pragma omp parallel // if (res.nq > 100)
+#pragma omp parallel
         {
-            std::unique_ptr<FlatCodesDistanceComputer> dc(
+            std::unique_ptr<FlatCodesDistanceComputer> dc_base(
                     index->get_quantized_distance_computer(qb, centered));
             SingleResultHandler resi(res);
 #pragma omp for
             for (int64_t q = 0; q < res.nq; q++) {
                 resi.begin(q);
-                dc->set_query(xq + d * q);
-                for (size_t i = 0; i < ntotal; i++) {
-                    if (res.is_in_selection(i)) {
-                        float dis = (*dc)(i);
-                        resi.add_result(dis, i);
+                dc_base->set_query(xq + d * q);
+
+                if (ex_bits == 0) {
+                    // 1-bit: Standard single-stage search
+                    for (size_t i = 0; i < ntotal; i++) {
+                        if (res.is_in_selection(i)) {
+                            float dis = (*dc_base)(i);
+                            resi.add_result(dis, i);
+                        }
+                    }
+                } else {
+                    // Multi-bit: Two-stage search with adaptive filtering
+                    // Note: Even with query quantization (qb > 0), ex-bits
+                    // distance computation uses the float query to maintain
+                    // consistency with encoding-time factor computation. See
+                    // RaBitQuantizer.cpp for details.
+                    auto* dc = dynamic_cast<RaBitQDistanceComputer*>(
+                            dc_base.get());
+                    FAISS_THROW_IF_NOT_MSG(
+                            dc != nullptr,
+                            "Failed to cast to RaBitQDistanceComputer for two-stage search");
+
+                    // Use appropriate comparison based on metric type
+                    bool is_similarity =
+                            is_similarity_metric(index->metric_type);
+
+                    for (size_t i = 0; i < ntotal; i++) {
+                        if (res.is_in_selection(i)) {
+                            const uint8_t* code =
+                                    index->codes.data() + i * index->code_size;
+
+                            // Stage 1: Compute 1-bit lower bound
+                            float lower_bound = dc->lower_bound_distance(code);
+
+                            // Stage 2: Adaptive filtering using threshold
+                            // For L2 (min-heap): filter if lower_bound <
+                            // resi.threshold For IP (max-heap): filter if
+                            // lower_bound > resi.threshold Note: Using
+                            // resi.threshold directly (not cached) enables more
+                            // aggressive filtering as the heap is updated
+                            bool should_compute_full = is_similarity
+                                    ? (lower_bound > resi.threshold)
+                                    : (lower_bound < resi.threshold);
+
+                            if (should_compute_full) {
+                                // Compute full multi-bit distance
+                                float dist_full =
+                                        dc->distance_to_code_full(code);
+                                resi.add_result(dist_full, i);
+                            }
+                        }
                     }
                 }
+
                 resi.end();
             }
         }
@@ -116,16 +170,25 @@ void IndexRaBitQ::search(
         float* distances,
         idx_t* labels,
         const SearchParameters* params_in) const {
-    const IDSelector* sel = (params_in != nullptr) ? params_in->sel : nullptr;
-    Run_search_with_dc_res r;
+    FAISS_THROW_IF_NOT(is_trained);
+
+    // Extract search parameters
+    uint8_t used_qb = qb;
+    bool used_centered = centered;
     if (auto params = dynamic_cast<const RaBitQSearchParameters*>(params_in)) {
-        r.qb = params->qb;
-        r.centered = params->centered;
-    } else {
-        r.qb = this->qb;
-        r.centered = this->centered;
+        used_qb = params->qb;
+        used_centered = params->centered;
     }
 
+    const IDSelector* sel = (params_in != nullptr) ? params_in->sel : nullptr;
+
+    // Set up functor with all necessary parameters
+    Run_search_with_dc_res r;
+    r.qb = used_qb;
+    r.centered = used_centered;
+    r.nb_bits = rabitq.nb_bits; // Pass multi-bit info to functor
+
+    // Use Faiss framework for all cases (single-stage and two-stage)
     dispatch_knn_ResultHandler(
             n, distances, labels, k, metric_type, sel, r, this, x);
 }

--- a/faiss/IndexRaBitQ.h
+++ b/faiss/IndexRaBitQ.h
@@ -32,7 +32,10 @@ struct IndexRaBitQ : IndexFlatCodes {
 
     IndexRaBitQ();
 
-    explicit IndexRaBitQ(idx_t d, MetricType metric = METRIC_L2);
+    explicit IndexRaBitQ(
+            idx_t d,
+            MetricType metric = METRIC_L2,
+            uint8_t nb_bits = 1);
 
     void train(idx_t n, const float* x) override;
 

--- a/faiss/impl/RaBitQuantizer.cpp
+++ b/faiss/impl/RaBitQuantizer.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/RaBitQUtils.h>
+#include <faiss/impl/RaBitQuantizerMultiBit.h>
 #include <faiss/utils/distances.h>
 #include <faiss/utils/rabitq_simd.h>
 #include <algorithm>
@@ -20,15 +21,45 @@
 namespace faiss {
 
 // Import shared utilities from RaBitQUtils
+using rabitq_utils::BaseFactorsData;
+using rabitq_utils::ExFactorsData;
 using rabitq_utils::FactorsData;
 using rabitq_utils::QueryFactorsData;
 
-static size_t get_code_size(const size_t d) {
-    return (d + 7) / 8 + sizeof(FactorsData);
+RaBitQuantizer::RaBitQuantizer(size_t d, MetricType metric, size_t nb_bits)
+        : Quantizer(d, 0), // code_size will be set below
+          metric_type{metric},
+          nb_bits{nb_bits} {
+    // Validate nb_bits range
+    FAISS_THROW_IF_NOT(nb_bits >= 1 && nb_bits <= 9);
+
+    // Set code_size using compute_code_size
+    code_size = compute_code_size(d, nb_bits);
 }
 
-RaBitQuantizer::RaBitQuantizer(size_t d, MetricType metric)
-        : Quantizer(d, get_code_size(d)), metric_type{metric} {}
+size_t RaBitQuantizer::compute_code_size(size_t d, size_t num_bits) const {
+    // Validate inputs
+    FAISS_THROW_IF_NOT(num_bits >= 1 && num_bits <= 9);
+
+    size_t ex_bits = num_bits - 1;
+
+    // Base: 1-bit codes + base factors
+    // Layout for 1-bit: [binary_code: (d+7)/8 bytes][BaseFactorsData: 8 bytes]
+    //   base_factors = or_minus_c_l2sqr (4) + dp_multiplier (4)
+    // Layout for multi-bit: [binary_code: (d+7)/8 bytes][FactorsData: 12 bytes]
+    //   factors = or_minus_c_l2sqr (4) + dp_multiplier (4) + f_error (4)
+    size_t base_size = (d + 7) / 8 +
+            (ex_bits == 0 ? sizeof(BaseFactorsData) : sizeof(FactorsData));
+
+    // Extra: ex-bit codes + ex factors (only if ex_bits > 0)
+    // Layout: [ex_code: (d*ex_bits+7)/8 bytes][ex_factors: 8 bytes]
+    size_t ex_size = 0;
+    if (ex_bits > 0) {
+        ex_size = (d * ex_bits + 7) / 8 + sizeof(ExFactorsData);
+    }
+
+    return base_size + ex_size;
+}
 
 void RaBitQuantizer::train(size_t n, const float* x) {
     // does nothing
@@ -54,23 +85,46 @@ void RaBitQuantizer::compute_codes_core(
         return;
     }
 
-    // compute codes
+    const size_t ex_bits = nb_bits - 1;
+
+    // Compute codes
 #pragma omp parallel for if (n > 1000)
     for (int64_t i = 0; i < n; i++) {
-        // the code
+        // Pointer to this vector's code
         uint8_t* code = codes + i * code_size;
-        FactorsData* fac = reinterpret_cast<FactorsData*>(code + (d + 7) / 8);
 
-        // cleanup it
-        if (code != nullptr) {
-            memset(code, 0, code_size);
-        }
+        // Clear code memory
+        memset(code, 0, code_size);
 
         const float* x_row = x + i * d;
 
+        // Pointer arithmetic for code layout:
+        // For 1-bit: [binary_code: (d+7)/8 bytes][BaseFactorsData: 8 bytes]
+        // For multi-bit: [binary_code: (d+7)/8 bytes][FactorsData: 12 bytes]
+        //                [ex_code: (d*ex_bits+7)/8 bytes][ex_factors: 8 bytes]
+        uint8_t* binary_code = code;
+
+        // Step 1: Compute 1-bit quantization and base factors
+        // Store residual for potential ex-bits quantization
+        std::vector<float> residual(d);
+
         // Use shared utilities for computing factors
-        *fac = rabitq_utils::compute_vector_factors(
+        FactorsData factors_data = rabitq_utils::compute_vector_factors(
                 x_row, d, centroid_in, metric_type);
+
+        // Write appropriate factors based on nb_bits
+        if (ex_bits == 0) {
+            // For 1-bit: write only BaseFactorsData (8 bytes)
+            BaseFactorsData* base_factors =
+                    reinterpret_cast<BaseFactorsData*>(code + (d + 7) / 8);
+            base_factors->or_minus_c_l2sqr = factors_data.or_minus_c_l2sqr;
+            base_factors->dp_multiplier = factors_data.dp_multiplier;
+        } else {
+            // For multi-bit: write full FactorsData (12 bytes)
+            FactorsData* full_factors =
+                    reinterpret_cast<FactorsData*>(code + (d + 7) / 8);
+            *full_factors = factors_data;
+        }
 
         // Pack bits into standard RaBitQ format
         for (size_t j = 0; j < d; j++) {
@@ -78,12 +132,33 @@ void RaBitQuantizer::compute_codes_core(
             const float centroid_val =
                     (centroid_in == nullptr) ? 0.0f : centroid_in[j];
             const float or_minus_c = x_val - centroid_val;
+            residual[j] = or_minus_c;
+
             const bool xb = (or_minus_c > 0.0f);
 
-            // store the output data
-            if (code != nullptr && xb) {
-                rabitq_utils::set_bit_standard(code, j);
+            // Store the 1-bit sign code
+            if (xb) {
+                rabitq_utils::set_bit_standard(binary_code, j);
             }
+        }
+
+        // Step 2: Compute ex-bits quantization (if nb_bits > 1)
+        if (ex_bits > 0) {
+            // Pointer to ex-bit code section
+            uint8_t* ex_code = code + (d + 7) / 8 + sizeof(FactorsData);
+            // Pointer to ex-factors section
+            ExFactorsData* ex_factors = reinterpret_cast<ExFactorsData*>(
+                    ex_code + (d * ex_bits + 7) / 8);
+
+            // Quantize residual to ex-bits (pass centroid for IP metric)
+            rabitq_multibit::quantize_ex_bits(
+                    residual.data(),
+                    d,
+                    nb_bits,
+                    ex_code,
+                    *ex_factors,
+                    metric_type,
+                    centroid_in);
         }
     }
 }
@@ -101,6 +176,7 @@ void RaBitQuantizer::decode_core(
     FAISS_ASSERT(x != nullptr);
 
     const float inv_d_sqrt = (d == 0) ? 1.0f : (1.0f / std::sqrt((float)d));
+    const size_t ex_bits = nb_bits - 1;
 
 #pragma omp parallel for if (n > 1000)
     for (int64_t i = 0; i < n; i++) {
@@ -108,10 +184,18 @@ void RaBitQuantizer::decode_core(
 
         // split the code into parts
         const uint8_t* binary_data = code;
-        const FactorsData* fac =
-                reinterpret_cast<const FactorsData*>(code + (d + 7) / 8);
 
+        // Cast to appropriate type based on nb_bits
+        // For 1-bit: use BaseFactorsData (8 bytes)
+        // For multi-bit: use FactorsData (12 bytes, but only first 8 bytes used
+        // for decode)
+        const BaseFactorsData* fac = (ex_bits == 0)
+                ? reinterpret_cast<const BaseFactorsData*>(code + (d + 7) / 8)
+                : reinterpret_cast<const FactorsData*>(code + (d + 7) / 8);
+
+        // this is the baseline code
         //
+        // compute <q,o> using floats
         for (size_t j = 0; j < d; j++) {
             // extract i-th bit
             const uint8_t masker = (1 << (j % 8));
@@ -124,51 +208,67 @@ void RaBitQuantizer::decode_core(
     }
 }
 
-struct RaBitDistanceComputer : FlatCodesDistanceComputer {
-    // dimensionality
-    size_t d = 0;
-    // a centroid to use
-    const float* centroid = nullptr;
+// Implementation of RaBitQDistanceComputer (declared in header)
 
-    // the metric
-    MetricType metric_type = MetricType::METRIC_L2;
+float RaBitQDistanceComputer::lower_bound_distance(const uint8_t* code) {
+    FAISS_ASSERT(code != nullptr);
 
-    RaBitDistanceComputer();
+    // Compute estimated distance using 1-bit codes
+    float est_distance = distance_to_code_1bit(code);
 
-    float symmetric_dis(idx_t i, idx_t j) override;
-};
+    // Extract f_error from the code
+    size_t size = (d + 7) / 8;
+    const FactorsData* base_fac =
+            reinterpret_cast<const FactorsData*>(code + size);
+    float f_error = base_fac->f_error;
 
-RaBitDistanceComputer::RaBitDistanceComputer() = default;
+    // Compute proper lower bound using RaBitQ error formula:
+    // lower_bound = est_distance - f_error * g_error
+    // This guarantees: lower_bound ≤ true_distance
+    float lower_bound = est_distance - (f_error * g_error);
 
-float RaBitDistanceComputer::symmetric_dis(idx_t i, idx_t j) {
-    FAISS_THROW_MSG("Not implemented");
+    // Distance cannot be negative
+    return std::max(0.0f, lower_bound);
 }
 
-struct RaBitDistanceComputerNotQ : RaBitDistanceComputer {
+namespace {
+
+struct RaBitQDistanceComputerNotQ : RaBitQDistanceComputer {
     // the rotated query (qr - c)
     std::vector<float> rotated_q;
     // some additional numbers for the query
     QueryFactorsData query_fac;
 
-    RaBitDistanceComputerNotQ();
+    RaBitQDistanceComputerNotQ();
 
-    float distance_to_code(const uint8_t* code) override;
+    // Compute distance using only 1-bit codes (fast)
+    float distance_to_code_1bit(const uint8_t* code) override;
+
+    // Compute full distance using 1-bit + ex-bits (accurate)
+    float distance_to_code_full(const uint8_t* code) override;
 
     void set_query(const float* x) override;
 };
 
-RaBitDistanceComputerNotQ::RaBitDistanceComputerNotQ() = default;
+RaBitQDistanceComputerNotQ::RaBitQDistanceComputerNotQ() = default;
 
-float RaBitDistanceComputerNotQ::distance_to_code(const uint8_t* code) {
+float RaBitQDistanceComputerNotQ::distance_to_code_1bit(const uint8_t* code) {
     FAISS_ASSERT(code != nullptr);
     FAISS_ASSERT(
             (metric_type == MetricType::METRIC_L2 ||
              metric_type == MetricType::METRIC_INNER_PRODUCT));
+    FAISS_ASSERT(rotated_q.size() == d);
 
     // split the code into parts
     const uint8_t* binary_data = code;
-    const FactorsData* fac =
-            reinterpret_cast<const FactorsData*>(code + (d + 7) / 8);
+
+    // Cast to appropriate type based on nb_bits
+    // For 1-bit: use BaseFactorsData (8 bytes)
+    // For multi-bit: use FactorsData (12 bytes) which includes f_error
+    size_t ex_bits = nb_bits - 1;
+    const BaseFactorsData* base_fac = (ex_bits == 0)
+            ? reinterpret_cast<const BaseFactorsData*>(code + (d + 7) / 8)
+            : reinterpret_cast<const FactorsData*>(code + (d + 7) / 8);
 
     // this is the baseline code
     //
@@ -177,48 +277,96 @@ float RaBitDistanceComputerNotQ::distance_to_code(const uint8_t* code) {
     // It was a willful decision (after the discussion) to not to pre-cache
     //   the sum of all bits, just in order to reduce the overhead per vector.
     uint64_t sum_q = 0;
-    for (size_t i = 0; i < d; i++) {
-        // extract i-th bit
-        const uint8_t masker = (1 << (i % 8));
-        const bool b_bit = ((binary_data[i / 8] & masker) == masker);
 
+    for (size_t i = 0; i < d; i++) {
+        // Extract i-th bit
+        bool bit = rabitq_utils::extract_bit_standard(binary_data, i);
         // accumulate dp
-        dot_qo += (b_bit) ? rotated_q[i] : 0;
+        dot_qo += bit ? rotated_q[i] : 0;
         // accumulate sum-of-bits
-        sum_q += (b_bit) ? 1 : 0;
+        sum_q += bit ? 1 : 0;
     }
 
-    float final_dot = 0;
-    // dot-product itself
-    final_dot += query_fac.c1 * dot_qo;
-    // normalizer coefficients
-    final_dot += query_fac.c2 * sum_q;
-    // normalizer coefficients
-    final_dot -= query_fac.c34;
-
-    // this is ||or - c||^2 - (IP ? ||or||^2 : 0)
-    const float or_c_l2sqr = fac->or_minus_c_l2sqr;
+    // Apply query factors
+    float final_dot =
+            query_fac.c1 * dot_qo + query_fac.c2 * sum_q - query_fac.c34;
 
     // pre_dist = ||or - c||^2 + ||qr - c||^2 -
     //     2 * ||or - c|| * ||qr - c|| * <q,o> - (IP ? ||or||^2 : 0)
-    const float pre_dist = or_c_l2sqr + query_fac.qr_to_c_L2sqr -
-            2 * fac->dp_multiplier * final_dot;
+    float pre_dist = base_fac->or_minus_c_l2sqr + query_fac.qr_to_c_L2sqr -
+            2 * base_fac->dp_multiplier * final_dot;
 
     if (metric_type == MetricType::METRIC_L2) {
         // ||or - q||^ 2
         return pre_dist;
     } else {
         // metric == MetricType::METRIC_INNER_PRODUCT
-
-        // this is ||q||^2
-        const float query_norm_sqr = query_fac.qr_norm_L2sqr;
-
-        // 2 * (or, q) = (||or - q||^2 - ||q||^2 - ||or||^2)
-        return -0.5f * (pre_dist - query_norm_sqr);
+        return -0.5f * (pre_dist - query_fac.qr_norm_L2sqr);
     }
 }
 
-void RaBitDistanceComputerNotQ::set_query(const float* x) {
+float RaBitQDistanceComputerNotQ::distance_to_code_full(const uint8_t* code) {
+    FAISS_ASSERT(code != nullptr);
+    FAISS_ASSERT(
+            (metric_type == MetricType::METRIC_L2 ||
+             metric_type == MetricType::METRIC_INNER_PRODUCT));
+    FAISS_ASSERT(rotated_q.size() == d);
+
+    size_t ex_bits = nb_bits - 1;
+
+    if (ex_bits == 0) {
+        // No ex-bits, just return 1-bit distance
+        return distance_to_code_1bit(code);
+    }
+
+    // Extract pointers to code sections
+    const uint8_t* binary_data = code;
+    size_t offset = (d + 7) / 8 + sizeof(FactorsData);
+    const uint8_t* ex_code = code + offset;
+    const ExFactorsData* ex_fac = reinterpret_cast<const ExFactorsData*>(
+            ex_code + (d * ex_bits + 7) / 8);
+
+    // Compute inner product with on-the-fly code extraction
+    // OPTIMIZATION: Extract codes during dot product loop instead of unpacking
+    // all codes first. This eliminates buffer allocation, reduces memory
+    // accesses, and improves cache locality (5-10x speedup expected).
+    float ex_ip = 0;
+    const float cb = -(static_cast<float>(1 << ex_bits) - 0.5f);
+
+    for (size_t i = 0; i < d; i++) {
+        // Get sign bit from 1-bit codes (0 or 1)
+        bool sign_bit = rabitq_utils::extract_bit_standard(binary_data, i);
+
+        // Extract magnitude code on-the-fly (no unpacking required)
+        int ex_code_val =
+                rabitq_utils::extract_code_inline(ex_code, i, ex_bits);
+
+        // Form total code: total_code = sign_bit * 2^ex_bits + ex_code
+        int total_code = (sign_bit ? 1 : 0) << ex_bits;
+        total_code += ex_code_val;
+
+        // Reconstruction: u_cb[i] = total_code[i] + cb
+        float reconstructed = static_cast<float>(total_code) + cb;
+
+        // Compute contribution to inner product
+        ex_ip += rotated_q[i] * reconstructed;
+    }
+
+    // Compute refined distance using ex-bits factors
+    // L2^2 = ||query||^2 + ||db||^2 - 2*dot(query,db)
+    //      = qr_to_c_L2sqr + f_add_ex + f_rescale_ex * ex_ip
+    float refined_dist = query_fac.qr_to_c_L2sqr + ex_fac->f_add_ex +
+            ex_fac->f_rescale_ex * ex_ip;
+
+    if (metric_type == MetricType::METRIC_L2) {
+        return refined_dist;
+    } else {
+        // 2 * (or, q) = (||or - q||^2 - ||q||^2 - ||or||^2)
+        return -0.5f * (refined_dist - query_fac.qr_norm_L2sqr);
+    }
+}
+
+void RaBitQDistanceComputerNotQ::set_query(const float* x) {
     FAISS_ASSERT(x != nullptr);
     FAISS_ASSERT(
             (metric_type == MetricType::METRIC_L2 ||
@@ -236,6 +384,10 @@ void RaBitDistanceComputerNotQ::set_query(const float* x) {
     for (size_t i = 0; i < d; i++) {
         rotated_q[i] = x[i] - ((centroid == nullptr) ? 0 : centroid[i]);
     }
+
+    // Compute g_error (query norm for lower bound computation)
+    // g_error = ||qr - c|| (L2 norm of rotated query)
+    g_error = std::sqrt(query_fac.qr_to_c_L2sqr);
 
     // compute some numbers
     const float inv_d = (d == 0) ? 1.0f : (1.0f / std::sqrt((float)d));
@@ -257,8 +409,10 @@ void RaBitDistanceComputerNotQ::set_query(const float* x) {
 }
 
 //
-struct RaBitDistanceComputerQ : RaBitDistanceComputer {
+struct RaBitQDistanceComputerQ : RaBitQDistanceComputer {
     // the rotated and quantized query (qr - c)
+    std::vector<float> rotated_q;
+    // the rotated and quantized query (qr - c) for fast 1-bit computation
     std::vector<uint8_t> rotated_qq;
     // we're using the proposed relayout-ed scheme from 3.3 that allows
     //    using popcounts for computing the distance.
@@ -272,16 +426,20 @@ struct RaBitDistanceComputerQ : RaBitDistanceComputer {
     // the smallest value divisible by 8 that is not smaller than dim
     size_t popcount_aligned_dim = 0;
 
-    RaBitDistanceComputerQ();
+    RaBitQDistanceComputerQ();
 
-    float distance_to_code(const uint8_t* code) override;
+    // Compute distance using only 1-bit codes (fast)
+    float distance_to_code_1bit(const uint8_t* code) override;
+
+    // Compute full distance using 1-bit + ex-bits (accurate)
+    float distance_to_code_full(const uint8_t* code) override;
 
     void set_query(const float* x) override;
 };
 
-RaBitDistanceComputerQ::RaBitDistanceComputerQ() = default;
+RaBitQDistanceComputerQ::RaBitQDistanceComputerQ() = default;
 
-float RaBitDistanceComputerQ::distance_to_code(const uint8_t* code) {
+float RaBitQDistanceComputerQ::distance_to_code_1bit(const uint8_t* code) {
     FAISS_ASSERT(code != nullptr);
     FAISS_ASSERT(
             (metric_type == MetricType::METRIC_L2 ||
@@ -290,21 +448,27 @@ float RaBitDistanceComputerQ::distance_to_code(const uint8_t* code) {
     // split the code into parts
     size_t size = (d + 7) / 8;
     const uint8_t* binary_data = code;
-    const FactorsData* fac = reinterpret_cast<const FactorsData*>(code + size);
+
+    // Cast to appropriate type based on nb_bits
+    // For 1-bit: use BaseFactorsData (8 bytes)
+    // For multi-bit: use FactorsData (12 bytes) which includes f_error
+    size_t ex_bits = nb_bits - 1;
+    const BaseFactorsData* base_fac = (ex_bits == 0)
+            ? reinterpret_cast<const BaseFactorsData*>(code + size)
+            : reinterpret_cast<const FactorsData*>(code + size);
 
     // this is ||or - c||^2 - (IP ? ||or||^2 : 0)
     float final_dot = 0;
     if (centered) {
         int64_t int_dot = ((1 << qb) - 1) * d;
+        // See RaBitDistanceComputerNotQ::distance_to_code() for baseline code.
         int_dot -= 2 *
                 rabitq::bitwise_xor_dot_product(
                            rearranged_rotated_qq.data(), binary_data, size, qb);
         final_dot += int_dot * query_fac.int_dot_scale;
     } else {
-        // See RaBitDistanceComputerNotQ::distance_to_code() for baseline code.
         auto dot_qo = rabitq::bitwise_and_dot_product(
                 rearranged_rotated_qq.data(), binary_data, size, qb);
-
         // It was a willful decision (after the discussion) to not to pre-cache
         // the sum of all bits, just in order to reduce the overhead per vector.
         // process 64-bit popcounts
@@ -317,32 +481,89 @@ float RaBitDistanceComputerQ::distance_to_code(const uint8_t* code) {
         final_dot -= query_fac.c34;
     }
 
-    // this is ||or - c||^2 - (IP ? ||or||^2 : 0)
-    const float or_c_l2sqr = fac->or_minus_c_l2sqr;
-
     // pre_dist = ||or - c||^2 + ||qr - c||^2 -
     //     2 * ||or - c|| * ||qr - c|| * <q,o> - (IP ? ||or||^2 : 0)
-    const float pre_dist = or_c_l2sqr + query_fac.qr_to_c_L2sqr -
-            2 * fac->dp_multiplier * final_dot;
+    const float pre_dist = base_fac->or_minus_c_l2sqr +
+            query_fac.qr_to_c_L2sqr - 2 * base_fac->dp_multiplier * final_dot;
 
     if (metric_type == MetricType::METRIC_L2) {
         // ||or - q||^ 2
         return pre_dist;
     } else {
         // metric == MetricType::METRIC_INNER_PRODUCT
-
-        // this is ||q||^2
-        const float query_norm_sqr = query_fac.qr_norm_L2sqr;
-
         // 2 * (or, q) = (||or - q||^2 - ||q||^2 - ||or||^2)
-        return -0.5f * (pre_dist - query_norm_sqr);
+        return -0.5f * (pre_dist - query_fac.qr_norm_L2sqr);
+    }
+}
+
+float RaBitQDistanceComputerQ::distance_to_code_full(const uint8_t* code) {
+    FAISS_ASSERT(code != nullptr);
+    FAISS_ASSERT(
+            (metric_type == MetricType::METRIC_L2 ||
+             metric_type == MetricType::METRIC_INNER_PRODUCT));
+    FAISS_ASSERT(rotated_q.size() == d);
+
+    size_t ex_bits = nb_bits - 1;
+
+    if (ex_bits == 0) {
+        // No ex-bits, just return 1-bit distance
+        return distance_to_code_1bit(code);
+    }
+
+    // Extract pointers to code sections
+    const uint8_t* binary_data = code;
+    size_t offset = (d + 7) / 8 + sizeof(FactorsData);
+    const uint8_t* ex_code = code + offset;
+    const ExFactorsData* ex_fac = reinterpret_cast<const ExFactorsData*>(
+            ex_code + (d * ex_bits + 7) / 8);
+
+    // Compute inner product with on-the-fly code extraction
+    // OPTIMIZATION: Extract codes during dot product loop instead of unpacking
+    // all codes first. This eliminates buffer allocation, reduces memory
+    // accesses, and improves cache locality (5-10x speedup expected).
+    float ex_ip = 0;
+    const float cb = -(static_cast<float>(1 << ex_bits) - 0.5f);
+
+    for (size_t i = 0; i < d; i++) {
+        // Get sign bit from 1-bit codes (0 or 1)
+        bool sign_bit = rabitq_utils::extract_bit_standard(binary_data, i);
+
+        // Extract magnitude code on-the-fly (no unpacking required)
+        int ex_code_val =
+                rabitq_utils::extract_code_inline(ex_code, i, ex_bits);
+
+        // Form total code: total_code = sign_bit * 2^ex_bits + ex_code
+        int total_code = (sign_bit ? 1 : 0) << ex_bits;
+        total_code += ex_code_val;
+
+        // Reconstruction: u_cb[i] = total_code[i] + cb
+        float reconstructed = static_cast<float>(total_code) + cb;
+
+        // Compute contribution to inner product using FLOAT query
+        // CRITICAL: Must use rotated_q (float) instead of rotated_qq
+        // (quantized) because ex_factors were precomputed during encoding using
+        // float residuals. Using the same precision at search time maintains
+        // encoding/search consistency.
+        ex_ip += rotated_q[i] * reconstructed;
+    }
+
+    // Compute refined distance using ex-bits factors
+    // L2^2 = ||query||^2 + ||db||^2 - 2*dot(query,db)
+    //      = qr_to_c_L2sqr + f_add_ex + f_rescale_ex * ex_ip
+    float refined_dist = query_fac.qr_to_c_L2sqr + ex_fac->f_add_ex +
+            ex_fac->f_rescale_ex * ex_ip;
+
+    if (metric_type == MetricType::METRIC_L2) {
+        return refined_dist;
+    } else {
+        return -0.5f * (refined_dist - query_fac.qr_norm_L2sqr);
     }
 }
 
 // Use shared constant from RaBitQUtils
 using rabitq_utils::Z_MAX_BY_QB;
 
-void RaBitDistanceComputerQ::set_query(const float* x) {
+void RaBitQDistanceComputerQ::set_query(const float* x) {
     FAISS_ASSERT(x != nullptr);
     FAISS_ASSERT(
             (metric_type == MetricType::METRIC_L2 ||
@@ -351,9 +572,14 @@ void RaBitDistanceComputerQ::set_query(const float* x) {
     FAISS_THROW_IF_NOT(qb > 0);
 
     // Use shared utilities for core query factor computation
-    std::vector<float> rotated_q;
+    // rotated_q is populated directly by compute_query_factors as an output
+    // parameter
     query_fac = rabitq_utils::compute_query_factors(
             x, d, centroid, qb, centered, metric_type, rotated_q, rotated_qq);
+
+    // Compute g_error (query norm for lower bound computation)
+    // g_error = ||qr - c|| (L2 norm of rotated query)
+    g_error = std::sqrt(query_fac.qr_to_c_L2sqr);
 
     // Rearrange the query vector for SIMD operations (RaBitQuantizer-specific)
     popcount_aligned_dim = ((d + 7) / 8) * 8;
@@ -371,24 +597,28 @@ void RaBitDistanceComputerQ::set_query(const float* x) {
     }
 }
 
+} // anonymous namespace
+
 FlatCodesDistanceComputer* RaBitQuantizer::get_distance_computer(
         uint8_t qb,
         const float* centroid_in,
         bool centered) const {
     if (qb == 0) {
-        auto dc = std::make_unique<RaBitDistanceComputerNotQ>();
+        auto dc = std::make_unique<RaBitQDistanceComputerNotQ>();
         dc->metric_type = metric_type;
         dc->d = d;
         dc->centroid = centroid_in;
+        dc->nb_bits = nb_bits;
 
         return dc.release();
     } else {
-        auto dc = std::make_unique<RaBitDistanceComputerQ>();
+        auto dc = std::make_unique<RaBitQDistanceComputerQ>();
         dc->metric_type = metric_type;
         dc->d = d;
         dc->centroid = centroid_in;
         dc->qb = qb;
         dc->centered = centered;
+        dc->nb_bits = nb_bits;
 
         return dc.release();
     }

--- a/faiss/impl/RaBitQuantizerMultiBit.cpp
+++ b/faiss/impl/RaBitQuantizerMultiBit.cpp
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NOTE: Parts of this implementation are adapted from:
+// RaBitQ-Library/include/rabitqlib/quantization/rabitq_impl.hpp
+// https://github.com/VectorDB-NTU/RaBitQ-Library
+
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/RaBitQUtils.h>
+#include <faiss/utils/distances.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <queue>
+#include <vector>
+
+namespace faiss {
+namespace rabitq_multibit {
+
+using rabitq_utils::ExFactorsData;
+using rabitq_utils::FactorsData;
+
+constexpr float kTightStart[9] =
+        {0.0f, 0.15f, 0.20f, 0.52f, 0.59f, 0.71f, 0.75f, 0.77f, 0.81f};
+
+constexpr double kEps = 1e-5;
+
+/**
+ * Compute optimal scaling factor for ex-bits quantization using priority
+ * queue-based search.
+ *
+ * This function finds the optimal scaling factor 't' that maximizes the
+ * inner product between the normalized quantized vector and the normalized
+ * absolute residual. The algorithm uses a priority queue to efficiently
+ * explore different quantization levels.
+ *
+ *
+ * @param o_abs Normalized absolute residual vector (must be positive, length
+ * d)
+ * @param d Dimensionality of the vector
+ * @param nb_bits Number of bits per dimension (2-9)
+ * @return Optimal scaling factor 't'
+ */
+float compute_optimal_scaling_factor(
+        const float* o_abs,
+        size_t d,
+        size_t nb_bits) {
+    const size_t ex_bits = nb_bits - 1;
+    FAISS_THROW_IF_NOT_MSG(
+            ex_bits >= 1 && ex_bits <= 8, "ex_bits must be in range [1, 8]");
+
+    const int kNEnum = 10;
+    const int max_code = (1 << ex_bits) - 1;
+
+    float max_o = *std::max_element(o_abs, o_abs + d);
+
+    // Determine search range [t_start, t_end]
+    float t_end = static_cast<float>(max_code + kNEnum) / max_o;
+    float t_start = t_end * kTightStart[ex_bits];
+
+    std::vector<float> inv_o_abs(d);
+    for (size_t i = 0; i < d; ++i) {
+        inv_o_abs[i] = 1.0f / o_abs[i];
+    }
+
+    std::vector<int> cur_o_bar(d);
+    float sqr_denominator = static_cast<float>(d) * 0.25f;
+    float numerator = 0.0f;
+
+    for (size_t i = 0; i < d; ++i) {
+        int cur = static_cast<int>((t_start * o_abs[i]) + kEps);
+        cur_o_bar[i] = cur;
+        sqr_denominator += static_cast<float>(cur * cur + cur);
+        numerator += (cur + 0.5f) * o_abs[i];
+    }
+
+    float inv_sqrt_denom = 1.0f / std::sqrt(sqr_denominator);
+
+    // Pair: (next_t, dimension_index)
+    // Maximum size is d (one entry per dimension), so reserve exactly d
+    std::vector<std::pair<float, size_t>> pq_storage;
+    pq_storage.reserve(d);
+    std::priority_queue<
+            std::pair<float, size_t>,
+            std::vector<std::pair<float, size_t>>,
+            std::greater<>>
+            next_t(std::greater<>(), std::move(pq_storage));
+
+    // Initialize queue with next quantization level for each dimension
+    for (size_t i = 0; i < d; ++i) {
+        float t_next = static_cast<float>(cur_o_bar[i] + 1) * inv_o_abs[i];
+        if (t_next < t_end) {
+            next_t.emplace(t_next, i);
+        }
+    }
+
+    float max_ip = 0.0f;
+    float t = 0.0f;
+
+    while (!next_t.empty()) {
+        float cur_t = next_t.top().first;
+        size_t update_id = next_t.top().second;
+        next_t.pop();
+
+        cur_o_bar[update_id]++;
+        int update_o_bar = cur_o_bar[update_id];
+
+        float delta = 2.0f * update_o_bar;
+        sqr_denominator += delta;
+        numerator += o_abs[update_id];
+
+        float old_denom = sqr_denominator - delta;
+        inv_sqrt_denom = inv_sqrt_denom *
+                (1.0f - 0.5f * delta / (old_denom + delta * 0.5f));
+
+        float cur_ip = numerator * inv_sqrt_denom;
+
+        if (cur_ip > max_ip) {
+            max_ip = cur_ip;
+            t = cur_t;
+        }
+
+        if (update_o_bar < max_code) {
+            float t_next =
+                    static_cast<float>(update_o_bar + 1) * inv_o_abs[update_id];
+            if (t_next < t_end) {
+                next_t.emplace(t_next, update_id);
+            }
+        }
+    }
+
+    return t;
+}
+
+/**
+ * Pack multi-bit codes from integer array to byte array.
+ *
+ * @param tmp_code Integer codes (length d), each value in [0, 2^ex_bits - 1]
+ * @param ex_code Output packed byte array
+ * @param d Dimensionality
+ * @param nb_bits Number of bits per dimension (2-9)
+ */
+void pack_multibit_codes(
+        const int* tmp_code,
+        uint8_t* ex_code,
+        size_t d,
+        size_t nb_bits) {
+    const size_t ex_bits = nb_bits - 1;
+    FAISS_THROW_IF_NOT_MSG(
+            ex_bits >= 1 && ex_bits <= 8, "ex_bits must be in range [1, 8]");
+
+    size_t total_bits = d * ex_bits;
+    size_t output_size = (total_bits + 7) / 8;
+    memset(ex_code, 0, output_size);
+
+    size_t bit_pos = 0;
+    for (size_t i = 0; i < d; i++) {
+        int code_value = tmp_code[i];
+
+        for (size_t bit = 0; bit < ex_bits; bit++) {
+            size_t byte_idx = bit_pos / 8;
+            size_t bit_idx = bit_pos % 8;
+
+            if (code_value & (1 << bit)) {
+                ex_code[byte_idx] |= (1 << bit_idx);
+            }
+
+            bit_pos++;
+        }
+    }
+}
+
+/**
+ * Compute ex-bits factors for distance computation.
+ *
+ * @param residual Original residual vector (data - centroid)
+ * @param centroid Centroid vector (can be nullptr for zero centroid)
+ * @param tmp_code Quantized ex-bit codes (before packing, after bit flipping)
+ * @param d Dimensionality
+ * @param ex_bits Number of extra bits
+ * @param norm L2 norm of residual
+ * @param ipnorm Unnormalized inner product between quantized and normalized
+ * residual
+ * @param ex_factors Output factors structure
+ * @param metric_type Distance metric (L2 or Inner Product)
+ */
+void compute_ex_factors(
+        const float* residual,
+        const float* centroid,
+        const int* tmp_code,
+        size_t d,
+        size_t ex_bits,
+        float norm,
+        double ipnorm,
+        ExFactorsData& ex_factors,
+        MetricType metric_type) {
+    FAISS_THROW_IF_NOT_MSG(
+            metric_type == MetricType::METRIC_L2 ||
+                    metric_type == MetricType::METRIC_INNER_PRODUCT,
+            "Unsupported metric type");
+
+    // Compute ipnorm_inv = 1 / ipnorm
+    float ipnorm_inv = static_cast<float>(1.0 / ipnorm);
+    if (!std::isnormal(ipnorm_inv)) {
+        ipnorm_inv = 1.0f;
+    }
+
+    // Reconstruct xu_cb from total_code
+    // total_code was formed from: total_code[i] = (sign << ex_bits) +
+    // ex_code[i] Reconstruction: xu_cb[i] = total_code[i] + cb
+    const float cb = -(static_cast<float>(1 << ex_bits) - 0.5f);
+    std::vector<float> xu_cb(d);
+    for (size_t i = 0; i < d; i++) {
+        xu_cb[i] = static_cast<float>(tmp_code[i]) + cb;
+    }
+
+    // Compute inner products needed for factors
+    float l2_sqr = norm * norm;
+    float ip_resi_xucb = fvec_inner_product(residual, xu_cb.data(), d);
+
+    // Compute factors
+    if (metric_type == MetricType::METRIC_L2) {
+        // For L2, no centroid correction needed in IVF setting
+        // because residual = x - centroid, distance computed in residual space
+        ex_factors.f_add_ex = l2_sqr;
+        ex_factors.f_rescale_ex = ipnorm_inv * -2.0f * norm;
+    } else {
+        // For IP, centroid correction is needed
+        float ip_resi_cent = 0;
+        if (centroid != nullptr) {
+            ip_resi_cent = fvec_inner_product(residual, centroid, d);
+        }
+
+        float ip_cent_xucb = 0;
+        if (centroid != nullptr) {
+            ip_cent_xucb = fvec_inner_product(centroid, xu_cb.data(), d);
+        }
+
+        // When ip_resi_xucb is zero, the correction term should be zero
+        float correction_term = 0.0f;
+        if (ip_resi_xucb != 0.0f) {
+            correction_term = l2_sqr * ip_cent_xucb / ip_resi_xucb;
+        }
+
+        ex_factors.f_add_ex = 1 - ip_resi_cent + correction_term;
+        ex_factors.f_rescale_ex = ipnorm_inv * -norm;
+    }
+}
+
+/**
+ * Quantize residual vector to ex-bits.
+ *
+ * This is the main quantization function that:
+ * 1. Normalizes the residual
+ * 2. Takes absolute value
+ * 3. Finds optimal scaling factor
+ * 4. Quantizes to ex_bits
+ * 5. Handles negative dimensions by flipping bits
+ * 6. Packs codes into byte array
+ * 7. Computes factors for distance computation
+ *
+ * @param residual Input residual vector (data - centroid), length d
+ * @param d Dimensionality
+ * @param nb_bits Number of bits per dimension (2-9)
+ * @param ex_code Output packed ex-bit codes
+ * @param ex_factors Output ex-bits factors
+ * @param metric_type Distance metric (L2 or Inner Product)
+ * @param centroid Optional centroid vector (needed for IP metric)
+ */
+void quantize_ex_bits(
+        const float* residual,
+        size_t d,
+        size_t nb_bits,
+        uint8_t* ex_code,
+        ExFactorsData& ex_factors,
+        MetricType metric_type,
+        const float* centroid) {
+    const size_t ex_bits = nb_bits - 1;
+    FAISS_THROW_IF_NOT_MSG(
+            ex_bits >= 1 && ex_bits <= 8, "ex_bits must be in range [1, 8]");
+    FAISS_THROW_IF_NOT_MSG(residual != nullptr, "residual cannot be null");
+    FAISS_THROW_IF_NOT_MSG(ex_code != nullptr, "ex_code cannot be null");
+
+    // Step 1: Compute L2 norm of residual
+    float norm_sqr = fvec_norm_L2sqr(residual, d);
+    float norm = std::sqrt(norm_sqr);
+
+    // Handle degenerate case
+    if (norm < 1e-10f) {
+        size_t code_size = (d * ex_bits + 7) / 8;
+        memset(ex_code, 0, code_size);
+        ex_factors.f_add_ex = 0.0f;
+        ex_factors.f_rescale_ex = 1.0f;
+        return;
+    }
+
+    // Step 2: Normalize residual
+    std::vector<float> normalized_residual(d);
+    for (size_t i = 0; i < d; i++) {
+        normalized_residual[i] = residual[i] / norm;
+    }
+
+    // Step 3: Take absolute value
+    std::vector<float> o_abs(d);
+    for (size_t i = 0; i < d; i++) {
+        o_abs[i] = std::abs(normalized_residual[i]);
+    }
+
+    // Step 4: Find optimal scaling factor
+    float t = compute_optimal_scaling_factor(o_abs.data(), d, nb_bits);
+
+    // Step 5: Quantize to ex_bits
+    std::vector<int> tmp_code(d);
+    double ipnorm = 0;
+    int max_code = (1 << ex_bits) - 1;
+
+    for (size_t i = 0; i < d; i++) {
+        tmp_code[i] = std::min(static_cast<int>(t * o_abs[i] + kEps), max_code);
+        // Compute unnormalized inner product
+        ipnorm += (tmp_code[i] + 0.5) * o_abs[i];
+    }
+
+    // Step 6: Handle negative dimensions (flip bits)
+    // For negative residuals, flip all bits: code' = ~code & max_code
+    for (size_t i = 0; i < d; i++) {
+        if (residual[i] < 0) {
+            tmp_code[i] = (~tmp_code[i]) & max_code;
+        }
+    }
+
+    // Step 7: Pack codes into byte array
+    pack_multibit_codes(tmp_code.data(), ex_code, d, nb_bits);
+
+    // Step 8: Compute factors for distance computation
+    // Reconstruct total_code for factor computation
+    std::vector<int> total_code(d);
+    for (size_t i = 0; i < d; i++) {
+        // Form total_code = (sign << ex_bits) + ex_code
+        bool sign_bit = (residual[i] >= 0);
+        total_code[i] = tmp_code[i] + ((sign_bit ? 1 : 0) << ex_bits);
+    }
+
+    // Compute ex-factors; centroid is needed for IP metric correction
+    compute_ex_factors(
+            residual,
+            centroid, // Pass centroid for IP metric factor computation
+            total_code.data(),
+            d,
+            ex_bits,
+            norm,
+            ipnorm,
+            ex_factors,
+            metric_type);
+}
+
+} // namespace rabitq_multibit
+} // namespace faiss

--- a/faiss/impl/RaBitQuantizerMultiBit.h
+++ b/faiss/impl/RaBitQuantizerMultiBit.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Reference:
+// "Practical and asymptotically optimal quantization of high-dimensional
+// vectors in euclidean space for approximate nearest neighbor search"
+// Jianyang Gao, Yutong Gou, Yuexuan Xu, Yongyi Yang, Cheng Long, Raymond
+// Chi-Wing Wong https://dl.acm.org/doi/pdf/10.1145/3725413
+//
+// Reference implementation: https://github.com/VectorDB-NTU/RaBitQ-Library
+// NOTE: Parts of this implementation are adapted from
+// rabitqlib/quantization/rabitq_impl.hpp in the above repository.
+
+#pragma once
+
+#include <faiss/MetricType.h>
+#include <faiss/impl/RaBitQUtils.h>
+#include <cstddef>
+#include <cstdint>
+
+namespace faiss {
+namespace rabitq_multibit {
+
+/**
+ * Compute optimal scaling factor for ex-bits quantization.
+ *
+ * Uses priority queue-based search to find the scaling factor that
+ * maximizes the inner product between quantized and original vectors.
+ *
+ * @param o_abs Normalized absolute residual vector (positive values)
+ * @param d Dimensionality
+ * @param nb_bits Number of bits per dimension (2-9)
+ * @return Optimal scaling factor 't'
+ */
+float compute_optimal_scaling_factor(
+        const float* o_abs,
+        size_t d,
+        size_t nb_bits);
+
+/**
+ * Pack multi-bit codes from integer array to byte array.
+ *
+ * @param tmp_code Integer codes (length d), values in [0, 2^ex_bits - 1]
+ * @param ex_code Output packed byte array
+ * @param d Dimensionality
+ * @param nb_bits Number of bits per dimension (2-9)
+ */
+void pack_multibit_codes(
+        const int* tmp_code,
+        uint8_t* ex_code,
+        size_t d,
+        size_t nb_bits);
+
+/**
+ * Compute ex-bits factors for distance computation.
+ *
+ * @param residual Original residual vector (data - centroid)
+ * @param centroid Centroid vector (can be nullptr for zero centroid)
+ * @param tmp_code Quantized ex-bit codes (unpacked integers)
+ * @param d Dimensionality
+ * @param ex_bits Number of extra bits
+ * @param norm L2 norm of residual
+ * @param ipnorm Unnormalized inner product
+ * @param ex_factors Output factors structure
+ * @param metric_type Distance metric (L2 or IP)
+ */
+void compute_ex_factors(
+        const float* residual,
+        const float* centroid,
+        const int* tmp_code,
+        size_t d,
+        size_t ex_bits,
+        float norm,
+        double ipnorm,
+        rabitq_utils::ExFactorsData& ex_factors,
+        MetricType metric_type);
+
+/**
+ * Main quantization function: quantize residual vector to ex-bits.
+ *
+ * Performs the complete multi-bit quantization pipeline:
+ * 1. Normalize residual
+ * 2. Take absolute value
+ * 3. Find optimal scaling factor
+ * 4. Quantize to ex_bits
+ * 5. Handle negative dimensions by bit flipping
+ * 6. Pack codes into byte array
+ * 7. Compute factors for distance computation
+ *
+ * @param residual Input residual vector (data - centroid), length d
+ * @param d Dimensionality
+ * @param nb_bits Number of bits per dimension (2-9)
+ * @param ex_code Output packed ex-bit codes
+ * @param ex_factors Output ex-bits factors
+ * @param metric_type Distance metric (L2 or Inner Product)
+ * @param centroid Optional centroid vector (needed for IP metric)
+ */
+void quantize_ex_bits(
+        const float* residual,
+        size_t d,
+        size_t nb_bits,
+        uint8_t* ex_code,
+        rabitq_utils::ExFactorsData& ex_factors,
+        MetricType metric_type,
+        const float* centroid = nullptr);
+
+} // namespace rabitq_multibit
+} // namespace faiss

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -607,11 +607,20 @@ ProductQuantizer* read_ProductQuantizer(IOReader* reader) {
     return pq;
 }
 
-static void read_RaBitQuantizer(RaBitQuantizer* rabitq, IOReader* f) {
+static void read_RaBitQuantizer(
+        RaBitQuantizer* rabitq,
+        IOReader* f,
+        bool multi_bit) {
     // don't care about rabitq->centroid
     READ1(rabitq->d);
     READ1(rabitq->code_size);
     READ1(rabitq->metric_type);
+
+    if (multi_bit) {
+        READ1(rabitq->nb_bits);
+    } else {
+        rabitq->nb_bits = 1;
+    }
 }
 
 void read_direct_map(DirectMap* dm, IOReader* f) {
@@ -1280,7 +1289,7 @@ Index* read_index(IOReader* f, int io_flags) {
     } else if (h == fourcc("Irfs")) {
         IndexRaBitQFastScan* idxqfs = new IndexRaBitQFastScan();
         read_index_header(idxqfs, f);
-        read_RaBitQuantizer(&idxqfs->rabitq, f);
+        read_RaBitQuantizer(&idxqfs->rabitq, f, false);
         READVECTOR(idxqfs->center);
         READ1(idxqfs->qb);
         READVECTOR(idxqfs->factors_storage);
@@ -1301,25 +1310,59 @@ Index* read_index(IOReader* f, int io_flags) {
     } else if (h == fourcc("Ixrq")) {
         IndexRaBitQ* idxq = new IndexRaBitQ();
         read_index_header(idxq, f);
-        read_RaBitQuantizer(&idxq->rabitq, f);
+        read_RaBitQuantizer(&idxq->rabitq, f, false);
         READVECTOR(idxq->codes);
         READVECTOR(idxq->center);
         READ1(idxq->qb);
+
+        // rabitq.nb_bits is already set to 1 by read_RaBitQuantizer
+        idxq->code_size = idxq->rabitq.code_size;
+        idx = idxq;
+    } else if (h == fourcc("Ixrr")) {
+        // Ixrr = multi-bit format (new)
+        IndexRaBitQ* idxq = new IndexRaBitQ();
+        read_index_header(idxq, f);
+        read_RaBitQuantizer(&idxq->rabitq, f, true); // Reads nb_bits from file
+        READVECTOR(idxq->codes);
+        READVECTOR(idxq->center);
+        READ1(idxq->qb);
+
         idxq->code_size = idxq->rabitq.code_size;
         idx = idxq;
     } else if (h == fourcc("Iwrq")) {
         IndexIVFRaBitQ* ivrq = new IndexIVFRaBitQ();
         read_ivf_header(ivrq, f);
-        read_RaBitQuantizer(&ivrq->rabitq, f);
+        read_RaBitQuantizer(&ivrq->rabitq, f, false);
         READ1(ivrq->code_size);
         READ1(ivrq->by_residual);
         READ1(ivrq->qb);
+
+        // rabitq.nb_bits is already set to 1 by read_RaBitQuantizer
+        // Update rabitq to match nb_bits
+        ivrq->rabitq.code_size =
+                ivrq->rabitq.compute_code_size(ivrq->d, ivrq->rabitq.nb_bits);
+        ivrq->code_size = ivrq->rabitq.code_size;
+        read_InvertedLists(ivrq, f, io_flags);
+        idx = ivrq;
+    } else if (h == fourcc("Iwrr")) {
+        // Iwrr = multi-bit format (new)
+        IndexIVFRaBitQ* ivrq = new IndexIVFRaBitQ();
+        read_ivf_header(ivrq, f);
+        read_RaBitQuantizer(&ivrq->rabitq, f, true); // Reads nb_bits from file
+        READ1(ivrq->code_size);
+        READ1(ivrq->by_residual);
+        READ1(ivrq->qb);
+
+        // Update rabitq to match nb_bits
+        ivrq->rabitq.code_size =
+                ivrq->rabitq.compute_code_size(ivrq->d, ivrq->rabitq.nb_bits);
+        ivrq->code_size = ivrq->rabitq.code_size;
         read_InvertedLists(ivrq, f, io_flags);
         idx = ivrq;
     } else if (h == fourcc("Iwrf")) {
         IndexIVFRaBitQFastScan* ivrqfs = new IndexIVFRaBitQFastScan();
         read_ivf_header(ivrqfs, f);
-        read_RaBitQuantizer(&ivrqfs->rabitq, f);
+        read_RaBitQuantizer(&ivrqfs->rabitq, f, false);
         READ1(ivrqfs->by_residual);
         READ1(ivrqfs->code_size);
         READ1(ivrqfs->bbs);

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -396,11 +396,18 @@ static void write_NNDescent(const NNDescent* nnd, IOWriter* f) {
     WRITEVECTOR(nnd->final_graph);
 }
 
-static void write_RaBitQuantizer(const RaBitQuantizer* rabitq, IOWriter* f) {
+// Write RaBitQuantizer for 1-bit format (backward compatible)
+static void write_RaBitQuantizer(
+        const RaBitQuantizer* rabitq,
+        IOWriter* f,
+        bool multi_bit) {
     // don't care about rabitq->centroid
     WRITE1(rabitq->d);
     WRITE1(rabitq->code_size);
     WRITE1(rabitq->metric_type);
+    if (multi_bit) {
+        WRITE1(rabitq->nb_bits);
+    }
 }
 
 static void write_direct_map(const DirectMap* dm, IOWriter* f) {
@@ -917,7 +924,7 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
         uint32_t h = fourcc("Irfs");
         WRITE1(h);
         write_index_header(idx, f);
-        write_RaBitQuantizer(&idxqfs->rabitq, f);
+        write_RaBitQuantizer(&idxqfs->rabitq, f, false);
         WRITEVECTOR(idxqfs->center);
         WRITE1(idxqfs->qb);
         WRITEVECTOR(idxqfs->factors_storage);
@@ -928,20 +935,36 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
         WRITEVECTOR(idxqfs->codes);
     } else if (
             const IndexRaBitQ* idxq = dynamic_cast<const IndexRaBitQ*>(idx)) {
-        uint32_t h = fourcc("Ixrq");
-        WRITE1(h);
-        write_index_header(idx, f);
-        write_RaBitQuantizer(&idxq->rabitq, f);
+        // Use different fourcc codes for 1-bit vs multi-bit
+        if (idxq->rabitq.nb_bits == 1) {
+            uint32_t h = fourcc("Ixrq"); // 1-bit (backward compatible)
+            WRITE1(h);
+            write_index_header(idx, f);
+            write_RaBitQuantizer(&idxq->rabitq, f, false);
+        } else {
+            uint32_t h = fourcc("Ixrr"); // multi-bit (new format)
+            WRITE1(h);
+            write_index_header(idx, f);
+            write_RaBitQuantizer(&idxq->rabitq, f, true);
+        }
         WRITEVECTOR(idxq->codes);
         WRITEVECTOR(idxq->center);
         WRITE1(idxq->qb);
     } else if (
             const IndexIVFRaBitQ* ivrq =
                     dynamic_cast<const IndexIVFRaBitQ*>(idx)) {
-        uint32_t h = fourcc("Iwrq");
-        WRITE1(h);
-        write_ivf_header(ivrq, f);
-        write_RaBitQuantizer(&ivrq->rabitq, f);
+        // Use different fourcc codes for 1-bit vs multi-bit
+        if (ivrq->rabitq.nb_bits == 1) {
+            uint32_t h = fourcc("Iwrq"); // 1-bit (backward compatible)
+            WRITE1(h);
+            write_ivf_header(ivrq, f);
+            write_RaBitQuantizer(&ivrq->rabitq, f, false);
+        } else {
+            uint32_t h = fourcc("Iwrr"); // multi-bit (new format)
+            WRITE1(h);
+            write_ivf_header(ivrq, f);
+            write_RaBitQuantizer(&ivrq->rabitq, f, true);
+        }
         WRITE1(ivrq->code_size);
         WRITE1(ivrq->by_residual);
         WRITE1(ivrq->qb);
@@ -952,7 +975,7 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
         uint32_t h = fourcc("Iwrf");
         WRITE1(h);
         write_ivf_header(ivrqfs, f);
-        write_RaBitQuantizer(&ivrqfs->rabitq, f);
+        write_RaBitQuantizer(&ivrqfs->rabitq, f, false);
         WRITE1(ivrqfs->by_residual);
         WRITE1(ivrqfs->code_size);
         WRITE1(ivrqfs->bbs);

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -457,8 +457,11 @@ IndexIVF* parse_IndexIVF(
         }
         return index_ivf;
     }
-    if (match(rabitq_pattern)) {
-        return new IndexIVFRaBitQ(get_q(), d, nlist, mt, own_il);
+    // IndexIVFRaBitQ with optional nb_bits (1-9)
+    // Accepts: "RaBitQ" (default 1-bit) or "RaBitQ{nb_bits}" (e.g., "RaBitQ4")
+    if (match("RaBitQ([0-9])?")) {
+        uint8_t nb_bits = sm[1].length() > 0 ? std::stoi(sm[1].str()) : 1;
+        return new IndexIVFRaBitQ(get_q(), d, nlist, mt, own_il, nb_bits);
     }
     if (match("RaBitQfs(_[0-9]+)?")) {
         int bbs = mres_to_int(sm[1], 32, 1);
@@ -697,9 +700,11 @@ Index* parse_other_indexes(
         }
     }
 
-    // IndexRaBitQ
-    if (match(rabitq_pattern)) {
-        return new IndexRaBitQ(d, metric);
+    // IndexRaBitQ with optional nb_bits (1-9)
+    // Accepts: "RaBitQ" (default 1-bit) or "RaBitQ{nb_bits}" (e.g., "RaBitQ4")
+    if (match("RaBitQ([0-9])?")) {
+        uint8_t nb_bits = sm[1].length() > 0 ? std::stoi(sm[1].str()) : 1;
+        return new IndexRaBitQ(d, metric, nb_bits);
     }
 
     // IndexRaBitQFastScan


### PR DESCRIPTION
Summary:
Extends RaBitQ quantization from 1-bit to support 2-9 bits per dimension, enabling flexible accuracy/memory trade-offs. Multi-bit RaBitQ achieves significantly higher recall than 1-bit (e.g., 4-bit: ~88% vs 1-bit: ~52% on benchmark datasets) with minimal performance overhead via two-stage search.

## Motivation

While 1-bit RaBitQ offers excellent compression, recall performance varies depending on dataset characteristics and query requirements. On some datasets, 1-bit recall may be sufficient, but on others, higher accuracy is needed. This diff adds multi-bit support (2-9 bits) to provide flexible accuracy/memory trade-offs, bridging the gap between 1-bit RaBitQ and higher-memory quantizers like PQ/SQ.

## Implementation

### Quantization Algorithm (`RaBitQuantizerMultiBit`)

Multi-bit encoding uses split representation:
- **1 sign bit**: Encodes residual sign (positive/negative)
- **ex_bits magnitude bits**: Encodes residual magnitude (0 to 2^ex_bits - 1)

For each vector:
1. Compute residual: `r = x - centroid`
2. Normalize and take absolute value: `o_abs = |r| / ||r||`
3. Find optimal scaling factor `t` via priority queue search (maximizes quantized/original inner product)
4. Quantize magnitudes: `ex_code[i] = min(⌊t * o_abs[i]⌋, 2^ex_bits - 1)`
5. Handle negative dimensions via bit flipping: `ex_code[i] = ~ex_code[i] & max_code` if `residual[i] < 0`
6. Pack into bytes and compute distance factors (`ExFactorsData`)

**Code Layout** (per vector):
```
[1-bit codes: (d+7)/8 bytes]
[Base factors: 12 bytes (or_minus_c_l2sqr, dp_multiplier, f_error)]
[Ex-bit codes: (d*ex_bits+7)/8 bytes]  // only if nb_bits > 1
[Ex factors: 8 bytes (f_add_ex, f_rescale_ex)]  // only if nb_bits > 1
```

### Two-Stage Search (`RaBitQDistanceComputer`)

Introduced new base class with three distance methods:
- `distance_to_code_1bit()`: Fast 1-bit estimate using sign bits only
- `lower_bound_distance()`: 1-bit estimate minus error bound (f_error * g_error)
- `distance_to_code_full()`: Accurate distance using all bits

**Search Strategy:**
- **1-bit** (nb_bits=1): Single-stage search using sign bits
- **Multi-bit** (nb_bits>1): Two-stage search with adaptive filtering
  1. Compute 1-bit lower bound for all candidates
  2. Filter candidates where lower_bound < current_threshold
  3. Compute full multi-bit distance only for promising candidates
  4. Update heap with refined distances

Applied in both `IndexRaBitQ::search()` and `IndexIVFRaBitQ::scan_codes()`.

### Index API Changes

**IndexRaBitQ / IndexIVFRaBitQ:**
```cpp
// Constructor now accepts nb_bits parameter (default=1 for backward compatibility)
IndexRaBitQ(idx_t d, MetricType metric = METRIC_L2, uint8_t nb_bits = 1);
IndexIVFRaBitQ(Index* quantizer, size_t d, size_t nlist,
               MetricType metric = METRIC_L2, bool own_invlists = true,
               uint8_t nb_bits = 1);

// New field
uint8_t nb_bits;  // Range: 1-9, validated in constructor
```

**Index Factory Syntax:**
```
"RaBitQ"          → 1-bit (backward compatible)
"RaBitQ2"         → 2-bit
"RaBitQ4"         → 4-bit
"RaBitQ8"         → 8-bit
"IVF16,RaBitQ"    → 1-bit IVF
"IVF16,RaBitQ4"   → 4-bit IVF
```

### Serialization

Updated `index_read.cpp` and `index_write.cpp` to persist `nb_bits` field. Maintains backward compatibility with existing 1-bit indexes.

## Performance Characteristics

**Memory Usage** (per vector, dimension d):
- **1-bit**: `(d+7)/8 + 12` bytes
  - 1-bit codes + base factors (FactorsData: 12 bytes)
- **2-bit**: `(d+7)/8 + 12 + (d+7)/8 + 8` bytes
  - 1-bit codes + base factors + 1-bit ex-codes + ex factors (ExFactorsData: 8 bytes)
- **4-bit**: `(d+7)/8 + 12 + (3*d+7)/8 + 8` bytes
  - 1-bit codes + base factors + 3-bit ex-codes + ex factors
- **8-bit**: `(d+7)/8 + 12 + (7*d+7)/8 + 8` bytes
  - 1-bit codes + base factors + 7-bit ex-codes + ex factors

**Example (d=128):**
- 1-bit: 28 bytes
- 2-bit: 52 bytes (1.86x)
- 4-bit: 84 bytes (3.0x)
- 8-bit: 148 bytes (5.3x)

**Recall @ 10** (measured on synthetic data, d=128, averaged across L2/IP metrics and qb values):
- 1-bit: ~52% recall
- 2-bit: ~74% recall (+42% relative improvement)
- 4-bit: ~88% recall (+68% relative improvement)
- 8-bit: ~95% recall (+81% relative improvement)

**Search Performance:**
- 1-bit: Single-stage, fastest
- Multi-bit: Two-stage with adaptive filtering, ~1.2-1.5x overhead vs 1-bit, significantly faster than full scan

## Files Changed

**New Files:**
- `impl/RaBitQuantizerMultiBit.{cpp,h}`: Multi-bit quantization algorithms

**Modified Core:**
- `impl/RaBitQuantizer.{cpp,h}`: Extended with nb_bits, two-stage distance computers
- `impl/RaBitQUtils.{cpp,h}`: Added ExFactorsData, f_error computation
- `IndexRaBitQ.{cpp,h}`: Added nb_bits field, two-stage search
- `IndexIVFRaBitQ.{cpp,h}`: Added nb_bits field, scan_codes override

**Factory & Serialization:**
- `index_factory.cpp`: Added "RaBitQ{nb_bits}" syntax parsing
- `impl/index_read.cpp`: Read nb_bits field
- `impl/index_write.cpp`: Write nb_bits field

**Tests:**
- `tests/test_rabitq.py`: Added 6 test classes, 78+ test methods
- `xplat.bzl`: Added RaBitQuantizerMultiBit to build

Differential Revision: D87190125


