### PR TITLE
Add copyright header to test_flat_l2_panorama.py

### DIFF
--- a/tests/test_flat_l2_panorama.py
+++ b/tests/test_flat_l2_panorama.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """
 Comprehensive test suite for IndexFlatL2Panorama.
 


### PR DESCRIPTION
Summary: Added the required Meta copyright header to the IndexFlatL2Panorama test file. The file was missing the standard copyright notice that should be present in all Meta source files.

Differential Revision: D87461145


