### PR TITLE
sve optimization for HNSW::MinimaxHeap::pop_min()

### DIFF
--- a/perf_tests/CMakeLists.txt
+++ b/perf_tests/CMakeLists.txt
@@ -18,14 +18,19 @@ FetchContent_MakeAvailable(
 
 find_package(Threads REQUIRED)
 find_package(OpenMP REQUIRED)
-find_package(gflags REQUIRED)
+find_package(gflags QUIET)
+if(NOT gflags_FOUND)
+    message(WARNING "gflags not found - perf_tests will be skipped. Install gflags to enable performance benchmarks.")
+    return()
+endif()
 
 add_library(faiss_perf_tests_utils
   utils.cpp
 )
 # `#include <faiss/perf_tests/utils.h>` or any other headers
+# Use CMAKE_SOURCE_DIR to get the root directory (where main CMakeLists.txt is)
 target_include_directories(faiss_perf_tests_utils PRIVATE
-   ${PROJECT_SOURCE_DIR}/../..)
+   ${CMAKE_SOURCE_DIR})
 
 include(../cmake/link_to_faiss_lib.cmake)
 
@@ -44,7 +49,8 @@ foreach(bench ${FAISS_PERF_TEST_SRC})
   link_to_faiss_lib(${bench_exec})
   target_link_libraries(${bench_exec} PRIVATE faiss_perf_tests_utils OpenMP::OpenMP_CXX benchmark::benchmark gflags)
   # `#include <faiss/perf_tests/utils.h>` or any other headers
+  # Use CMAKE_SOURCE_DIR to get the root directory (where main CMakeLists.txt is)
   target_include_directories(${bench_exec} PRIVATE
-   ${PROJECT_SOURCE_DIR}/../..)
+   ${CMAKE_SOURCE_DIR})
 
 endforeach()


### PR DESCRIPTION
1. sve optimization for HNSW::MinimaxHeap::pop_min()
2. Add prefetch for ids.data() and dis.data() to reduce memory latency

The unit test for pop_min() passed: 
$  ./faiss_test --gtest_filter=HNSW.Test_popmin*
WARNING clustering 1000 points to 40 centroids: please provide at least 1560 training points
Running main() from /home/scratch.lyou_gpu/arm/workspaces/faiss-main/build/_deps/googletest-src/googletest/src/gtest_main.cc
Note: Google Test filter = HNSW.Test_popmin*
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from HNSW
[ RUN      ] HNSW.Test_popmin
[       OK ] HNSW.Test_popmin (0 ms)
[ RUN      ] HNSW.Test_popmin_identical_distances
[       OK ] HNSW.Test_popmin_identical_distances (0 ms)
[ RUN      ] HNSW.Test_popmin_infinite_distances
[       OK ] HNSW.Test_popmin_infinite_distances (0 ms)
[----------] 3 tests from HNSW (0 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

Performance Result:
**Benchmark:** cuvs bench https://github.com/rapidsai/cuvs/tree/main/cpp/bench/ann
**datasets:** deep-96-image
**Threads No:** 1 and 8 

Single-Thread Result: (**Average  1.031x and up to 1.88X**)
========================================================================================================================
Speedup Analysis: Baseline vs Optimized
========================================================================================================================
Configuration                                      Baseline     Optimized    Speedup    Recall
------------------------------------------------------------------------------------------------------------------------
M16.efConstruction128.efSearch16                       0.1647ms     0.1643ms    1.002x  0.717
M16.efConstruction128.efSearch64                       0.2858ms     0.2829ms    1.010x  0.914
M16.efConstruction128.efSearch256                      0.7482ms     0.7220ms    1.036x  0.982
M16.efConstruction128.efSearch1024                     2.9258ms     2.6881ms    1.088x  0.996
M32.efConstruction128.efSearch16                       0.1812ms     0.1802ms    1.006x  0.784
M32.efConstruction128.efSearch64                       0.3297ms     0.3254ms    1.013x  0.940
M32.efConstruction128.efSearch256                      0.8822ms     0.8530ms    1.034x  0.990
M32.efConstruction128.efSearch1024                     3.3204ms     3.0752ms    1.080x  0.998
M32.efConstruction256.efSearch64                       0.3540ms     0.3498ms    1.012x  0.954
M32.efConstruction256.efSearch256                      0.9627ms     0.9392ms    1.025x  0.994
------------------------------------------------------------------------------------------------------------------------

8-Threads Result: (**Average 1.032x and up to 1.083x**)

========================================================================================================================
Speedup Analysis: Baseline vs Optimized
========================================================================================================================
Configuration                                      Baseline     Optimized    Speedup    Recall
------------------------------------------------------------------------------------------------------------------------
M16.efConstruction128.efSearch16                       0.0856ms     0.0855ms    1.001x  0.714
M16.efConstruction128.efSearch64                       0.2157ms     0.2128ms    1.014x  0.911
M16.efConstruction128.efSearch256                      0.7099ms     0.6857ms    1.035x  0.982
M16.efConstruction128.efSearch1024                     2.9916ms     2.7619ms    1.083x  0.997
M32.efConstruction128.efSearch16                       0.1047ms     0.1045ms    1.002x  0.773
M32.efConstruction128.efSearch64                       0.2664ms     0.2633ms    1.012x  0.940
M32.efConstruction128.efSearch256                      0.8598ms     0.8363ms    1.028x  0.990
M32.efConstruction128.efSearch1024                     3.4262ms     3.1977ms    1.071x  0.998
M32.efConstruction256.efSearch64                       0.2936ms     0.2911ms    1.008x  0.955
M32.efConstruction256.efSearch256                      0.9519ms     0.9282ms    1.026x  0.994
------------------------------------------------------------------------------------------------------------------------



