### PR TITLE
Fix deprecated this capture in faiss/gpu/GpuIcmEncoder.cu +1

### DIFF
--- a/faiss/gpu/GpuIcmEncoder.cu
+++ b/faiss/gpu/GpuIcmEncoder.cu
@@ -70,7 +70,7 @@ GpuIcmEncoder::GpuIcmEncoder(
 GpuIcmEncoder::~GpuIcmEncoder() {}
 
 void GpuIcmEncoder::set_binary_term() {
-    auto fn = [=](int idx, IcmEncoderImpl* encoder) {
+    auto fn = [lsq = lsq](int idx, IcmEncoderImpl* encoder) {
         encoder->setBinaryTerm(lsq->codebooks.data());
     };
     shards->runOnShards(fn);


### PR DESCRIPTION
Summary:
In the future LLVM will require that lambdas capture `this` explicitly. `-Wdeprecated-this-capture` checks for and enforces this now.

This diff adds an explicit `this` capture to a lambda to fix an issue that presents similarly to this:
```
   -> fbcode/path/to/my_file.cpp:66:47: error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-
Wdeprecated-this-capture]
   ->           detail::createIOWorkerProvider(evb, requestsRegistry_);
   ->                                               ^
   -> fbcode/path/to/my_file.cpp:61:30: note: add an explicit capture of 'this' to capture '*this' by reference
   ->   evb->runInEventBaseThread([=, self_weak = std::move(self_weak)]() {
   ->                              ^
   ->                               , this
```

Differential Revision: D88052068


