### PR TITLE
Add multi-bit support for IndexRaBitQFastScan

### DIFF
--- a/faiss/IndexFastScan.cpp
+++ b/faiss/IndexFastScan.cpp
@@ -199,7 +199,7 @@ void estimators_from_tables_generic(
 } // anonymous namespace
 
 // Default implementation of make_knn_handler with centralized fallback logic
-void* IndexFastScan::make_knn_handler(
+SIMDResultHandlerToFloat* IndexFastScan::make_knn_handler(
         bool is_max,
         int impl,
         idx_t n,

--- a/faiss/IndexFastScan.h
+++ b/faiss/IndexFastScan.h
@@ -15,13 +15,8 @@ namespace faiss {
 
 struct CodePacker;
 struct NormTableScaler;
-
-// Forward declarations for result handlers
-namespace simd_result_handlers {
-template <class C, bool with_id_map>
-struct ResultHandlerCompare;
-}
 struct IDSelector;
+struct SIMDResultHandlerToFloat;
 
 /** Fast scan version of IndexPQ and IndexAQ. Works for 4-bit PQ and AQ for now.
  *
@@ -141,10 +136,10 @@ struct IndexFastScan : Index {
      * @param distances    output distances array
      * @param labels       output labels array
      * @param sel          optional ID selector
-     * @param query_offset query offset for batch processing
+     * @param context      processing context for distance post-processing
      * @return             pointer to created handler (never returns nullptr)
      */
-    virtual void* make_knn_handler(
+    virtual SIMDResultHandlerToFloat* make_knn_handler(
             bool is_max,
             int impl,
             idx_t n,

--- a/faiss/IndexRaBitQFastScan.cpp
+++ b/faiss/IndexRaBitQFastScan.cpp
@@ -8,6 +8,7 @@
 #include <faiss/IndexRaBitQFastScan.h>
 #include <faiss/impl/FastScanDistancePostProcessing.h>
 #include <faiss/impl/RaBitQUtils.h>
+#include <faiss/impl/RaBitQuantizerMultiBit.h>
 #include <faiss/impl/pq4_fast_scan.h>
 #include <faiss/utils/utils.h>
 #include <algorithm>
@@ -19,15 +20,34 @@ static inline size_t roundup(size_t a, size_t b) {
     return (a + b - 1) / b * b;
 }
 
+size_t IndexRaBitQFastScan::compute_per_vector_storage_size() const {
+    const size_t ex_bits = rabitq.nb_bits - 1;
+
+    if (ex_bits == 0) {
+        // 1-bit: only BaseFactorsData
+        return sizeof(rabitq_utils::BaseFactorsData);
+    } else {
+        // Multi-bit: FactorsData + ExFactorsData + ex-codes
+        return sizeof(FactorsData) + sizeof(ExFactorsData) +
+                (d * ex_bits + 7) / 8;
+    }
+}
+
 IndexRaBitQFastScan::IndexRaBitQFastScan() = default;
 
-IndexRaBitQFastScan::IndexRaBitQFastScan(idx_t d, MetricType metric, int bbs)
-        : rabitq(d, metric) {
+IndexRaBitQFastScan::IndexRaBitQFastScan(
+        idx_t d,
+        MetricType metric,
+        int bbs,
+        uint8_t nb_bits)
+        : rabitq(d, metric, nb_bits) {
     // RaBitQ-specific validation
     FAISS_THROW_IF_NOT_MSG(d > 0, "Dimension must be positive");
     FAISS_THROW_IF_NOT_MSG(
             metric == METRIC_L2 || metric == METRIC_INNER_PRODUCT,
             "RaBitQ FastScan only supports L2 and Inner Product metrics");
+    FAISS_THROW_IF_NOT_MSG(
+            nb_bits >= 1 && nb_bits <= 9, "nb_bits must be between 1 and 9");
 
     // RaBitQ uses 1 bit per dimension packed into 4-bit FastScan sub-quantizers
     // Each FastScan sub-quantizer handles 4 RaBitQ dimensions
@@ -37,17 +57,15 @@ IndexRaBitQFastScan::IndexRaBitQFastScan(idx_t d, MetricType metric, int bbs)
     // init_fastscan will validate bbs % 32 == 0 and nbits_fastscan == 4
     init_fastscan(static_cast<int>(d), M_fastscan, nbits_fastscan, metric, bbs);
 
-    // Override code_size to include space for factors after bit patterns
-    // RaBitQ stores 1 bit per dimension, requiring (d + 7) / 8 bytes
-    const size_t bit_pattern_size = (d + 7) / 8;
-    code_size = bit_pattern_size + sizeof(FactorsData);
+    // Compute code_size directly using RaBitQuantizer
+    code_size = rabitq.compute_code_size(d, nb_bits);
 
     // Set RaBitQ-specific parameters
     qb = 8;
     center.resize(d, 0.0f);
 
-    // Pre-allocate storage vectors for efficiency
-    factors_storage.clear();
+    // Initialize empty flat storage
+    flat_storage.clear();
 }
 
 IndexRaBitQFastScan::IndexRaBitQFastScan(const IndexRaBitQ& orig, int bbs)
@@ -72,10 +90,7 @@ IndexRaBitQFastScan::IndexRaBitQFastScan(const IndexRaBitQ& orig, int bbs)
             orig.metric_type,
             bbs);
 
-    // Override code_size to include space for factors after bit patterns
-    // RaBitQ stores 1 bit per dimension, requiring (d + 7) / 8 bytes
-    const size_t bit_pattern_size = (orig.d + 7) / 8;
-    code_size = bit_pattern_size + sizeof(FactorsData);
+    code_size = rabitq.compute_code_size(d, rabitq.nb_bits);
 
     // Copy properties from original index
     ntotal = orig.ntotal;
@@ -88,23 +103,19 @@ IndexRaBitQFastScan::IndexRaBitQFastScan(const IndexRaBitQ& orig, int bbs)
 
     // If the original index has data, extract factors and pack codes
     if (ntotal > 0) {
-        // Allocate space for factors
-        factors_storage.resize(ntotal);
+        // Compute per-vector storage size for flat storage
+        const size_t storage_size = compute_per_vector_storage_size();
 
-        // Extract factors from original codes for each vector
-        const float* centroid_data = center.data();
+        // Allocate flat storage
+        flat_storage.resize(ntotal * storage_size);
 
-        // Use the original RaBitQ quantizer to decode and compute factors
-        std::vector<float> decoded_vectors(ntotal * orig.d);
-        orig.sa_decode(ntotal, orig.codes.data(), decoded_vectors.data());
-
+        // Copy factors directly from original codes
+        const size_t bit_pattern_size = (d + 7) / 8;
         for (idx_t i = 0; i < ntotal; i++) {
-            FactorsData& fac = factors_storage[i];
-            const float* x_row = decoded_vectors.data() + i * orig.d;
-
-            // Use shared utilities for computing factors
-            fac = rabitq_utils::compute_vector_factors(
-                    x_row, orig.d, centroid_data, orig.metric_type);
+            const uint8_t* orig_code = orig.codes.data() + i * orig.code_size;
+            const uint8_t* source_factors_ptr = orig_code + bit_pattern_size;
+            uint8_t* storage = flat_storage.data() + i * storage_size;
+            memcpy(storage, source_factors_ptr, storage_size);
         }
 
         // Convert RaBitQ bit format to FastScan 4-bit sub-quantizer format
@@ -191,15 +202,19 @@ void IndexRaBitQFastScan::add(idx_t n, const float* x) {
     AlignedTable<uint8_t> tmp_codes(n * code_size);
     compute_codes(tmp_codes.get(), n, x);
 
-    // Extract and store factors from embedded codes for handler access
+    const size_t storage_size = compute_per_vector_storage_size();
+    flat_storage.resize((ntotal + n) * storage_size);
+
+    // Populate flat storage (no sign bits copying needed!)
     const size_t bit_pattern_size = (d + 7) / 8;
-    factors_storage.resize(ntotal + n);
     for (idx_t i = 0; i < n; i++) {
         const uint8_t* code = tmp_codes.get() + i * code_size;
-        const uint8_t* factors_ptr = code + bit_pattern_size;
-        const FactorsData& embedded_factors =
-                *reinterpret_cast<const FactorsData*>(factors_ptr);
-        factors_storage[ntotal + i] = embedded_factors;
+        const idx_t vec_idx = ntotal + i;
+
+        // Copy factors data directly to flat storage (no reordering needed)
+        const uint8_t* source_factors_ptr = code + bit_pattern_size;
+        uint8_t* storage = flat_storage.data() + vec_idx * storage_size;
+        memcpy(storage, source_factors_ptr, storage_size);
     }
 
     // Resize main storage (same logic as parent)
@@ -239,6 +254,8 @@ void IndexRaBitQFastScan::compute_codes(uint8_t* codes, idx_t n, const float* x)
     // Hoist loop-invariant computations
     const float* centroid_data = center.data();
     const size_t bit_pattern_size = (d + 7) / 8;
+    const size_t ex_bits = rabitq.nb_bits - 1;
+    const size_t ex_code_size = (d * ex_bits + 7) / 8;
 
     memset(codes, 0, n * code_size);
 
@@ -247,25 +264,48 @@ void IndexRaBitQFastScan::compute_codes(uint8_t* codes, idx_t n, const float* x)
         uint8_t* const code = codes + i * code_size;
         const float* const x_row = x + i * d;
 
-        // Pack bits directly into FastScan format
+        // Compute residual once, reuse for both sign bits and ex-bits
+        std::vector<float> residual(d);
         for (size_t j = 0; j < d; j++) {
-            const float x_val = x_row[j];
             const float centroid_val = centroid_data ? centroid_data[j] : 0.0f;
-            const float or_minus_c = x_val - centroid_val;
-            const bool xb = (or_minus_c > 0.0f);
+            residual[j] = x_row[j] - centroid_val;
+        }
 
-            if (xb) {
+        // Pack sign bits directly into FastScan format using precomputed
+        // residual
+        for (size_t j = 0; j < d; j++) {
+            if (residual[j] > 0.0f) {
                 rabitq_utils::set_bit_fastscan(code, j);
             }
         }
 
-        // Calculate and append factors after the bit data
         FactorsData factors = rabitq_utils::compute_vector_factors(
-                x_row, d, centroid_data, metric_type);
+                x_row, d, centroid_data, metric_type, ex_bits > 0);
 
-        // Append factors at the end of the code
-        uint8_t* factors_ptr = code + bit_pattern_size;
-        *reinterpret_cast<FactorsData*>(factors_ptr) = factors;
+        if (ex_bits == 0) {
+            // 1-bit: store only BaseFactorsData (8 bytes)
+            memcpy(code + bit_pattern_size, &factors, sizeof(BaseFactorsData));
+        } else {
+            // Multi-bit: store full FactorsData (12 bytes)
+            memcpy(code + bit_pattern_size, &factors, sizeof(FactorsData));
+
+            // Add ex-codes and ExFactorsData using precomputed residual
+            uint8_t* ex_code = code + bit_pattern_size + sizeof(FactorsData);
+            ExFactorsData ex_factors_temp;
+
+            rabitq_multibit::quantize_ex_bits(
+                    residual.data(),
+                    d,
+                    rabitq.nb_bits,
+                    ex_code,
+                    ex_factors_temp,
+                    metric_type,
+                    centroid_data);
+
+            memcpy(ex_code + ex_code_size,
+                   &ex_factors_temp,
+                   sizeof(ExFactorsData));
+        }
     }
 }
 
@@ -300,7 +340,8 @@ void IndexRaBitQFastScan::compute_float_LUT(
                         rotated_qq);
 
         // Store query factors in context array if provided
-        if (context.query_factors) {
+        if (context.query_factors != nullptr) {
+            query_factors_data.rotated_q = rotated_q;
             context.query_factors[i] = query_factors_data;
         }
 
@@ -397,8 +438,9 @@ void IndexRaBitQFastScan::sa_decode(idx_t n, const uint8_t* bytes, float* x)
 
         // Extract factors directly from embedded codes
         const uint8_t* factors_ptr = code + bit_pattern_size;
-        const FactorsData& fac =
-                *reinterpret_cast<const FactorsData*>(factors_ptr);
+        const rabitq_utils::BaseFactorsData* fac =
+                reinterpret_cast<const rabitq_utils::BaseFactorsData*>(
+                        factors_ptr);
 
         for (size_t j = 0; j < d; j++) {
             // Use RaBitQUtils for consistent bit extraction
@@ -406,7 +448,7 @@ void IndexRaBitQFastScan::sa_decode(idx_t n, const uint8_t* bytes, float* x)
             float bit = bit_value ? 1.0f : 0.0f;
 
             // Compute the output using RaBitQ reconstruction formula
-            x[i * d + j] = (bit - 0.5f) * fac.dp_multiplier * 2 * inv_d_sqrt +
+            x[i * d + j] = (bit - 0.5f) * fac->dp_multiplier * 2 * inv_d_sqrt +
                     ((centroid_in == nullptr) ? 0 : centroid_in[j]);
         }
     }
@@ -446,14 +488,16 @@ RaBitQHeapHandler<C, with_id_map>::RaBitQHeapHandler(
         float* distances,
         int64_t* labels,
         const IDSelector* sel_in,
-        const FastScanDistancePostProcessing& ctx)
+        const FastScanDistancePostProcessing& ctx,
+        bool multi_bit)
         : RHC(nq_val, index->ntotal, sel_in),
           rabitq_index(index),
           heap_distances(distances),
           heap_labels(labels),
           nq(nq_val),
           k(k_val),
-          context(ctx) {
+          context(ctx),
+          is_multi_bit(multi_bit) {
     // Initialize heaps for all queries in constructor
     // This allows us to support direct normalizer assignment
 #pragma omp parallel for if (nq > 100)
@@ -480,7 +524,7 @@ void RaBitQHeapHandler<C, with_id_map>::handle(
 
     // Access query factors from query_factors pointer
     rabitq_utils::QueryFactorsData query_factors_data = {};
-    if (context.query_factors) {
+    if (context.query_factors != nullptr) {
         query_factors_data = context.query_factors[q];
     }
 
@@ -494,6 +538,9 @@ void RaBitQHeapHandler<C, with_id_map>::handle(
             ? std::min<size_t>(32, rabitq_index->ntotal - base_db_idx)
             : 0;
 
+    // Get storage size once
+    const size_t storage_size = rabitq_index->compute_per_vector_storage_size();
+
     // Process distances in batch
     for (size_t i = 0; i < max_vectors; i++) {
         const size_t db_idx = base_db_idx + i;
@@ -501,41 +548,58 @@ void RaBitQHeapHandler<C, with_id_map>::handle(
         // Normalize distance from LUT lookup
         const float normalized_distance = d32tab[i] * one_a + bias;
 
-        // Access factors from storage (populated from embedded codes during
-        // add())
-        const auto& db_factors = rabitq_index->factors_storage[db_idx];
+        // Access factors from flat storage
+        const uint8_t* base_ptr =
+                rabitq_index->flat_storage.data() + db_idx * storage_size;
 
-        float adjusted_distance;
+        if (is_multi_bit) {
+            const FactorsData& full_factors =
+                    *reinterpret_cast<const FactorsData*>(base_ptr);
 
-        if (rabitq_index->centered) {
-            // For centered mode: normalized_distance contains the raw XOR
-            // contribution. Apply the signed odd integer quantization formula:
-            // int_dot = ((1 << qb) - 1) * d - 2 * xor_dot_product
-            int64_t int_dot = ((1 << rabitq_index->qb) - 1) * rabitq_index->d;
-            int_dot -= 2 * static_cast<int64_t>(normalized_distance);
+            float dist_1bit = rabitq_utils::compute_1bit_adjusted_distance(
+                    normalized_distance,
+                    full_factors,
+                    query_factors_data,
+                    rabitq_index->centered,
+                    rabitq_index->qb,
+                    rabitq_index->d);
 
-            adjusted_distance = query_factors_data.qr_to_c_L2sqr +
-                    db_factors.or_minus_c_l2sqr -
-                    2 * db_factors.dp_multiplier * int_dot *
-                            query_factors_data.int_dot_scale;
+            float lower_bound = compute_lower_bound(dist_1bit, db_idx, q);
+
+            // Adaptive filtering: decide whether to compute full distance
+            const bool is_similarity = rabitq_index->metric_type ==
+                    MetricType::METRIC_INNER_PRODUCT;
+            bool should_refine = is_similarity
+                    ? (lower_bound > heap_dis[0])  // IP: keep if better
+                    : (lower_bound < heap_dis[0]); // L2: keep if better
+
+            if (should_refine) {
+                float dist_full = compute_full_multibit_distance(db_idx, q);
+
+                if (Cfloat::cmp(heap_dis[0], dist_full)) {
+                    heap_replace_top<Cfloat>(
+                            k, heap_dis, heap_ids, dist_full, db_idx);
+                }
+            }
         } else {
-            // For non-centered quantization: use traditional formula
-            float final_dot = normalized_distance - query_factors_data.c34;
-            adjusted_distance = db_factors.or_minus_c_l2sqr +
-                    query_factors_data.qr_to_c_L2sqr -
-                    2 * db_factors.dp_multiplier * final_dot;
-        }
+            const rabitq_utils::BaseFactorsData& db_factors =
+                    *reinterpret_cast<const rabitq_utils::BaseFactorsData*>(
+                            base_ptr);
 
-        // Apply inner product correction if needed
-        if (query_factors_data.qr_norm_L2sqr != 0.0f) {
-            adjusted_distance = -0.5f *
-                    (adjusted_distance - query_factors_data.qr_norm_L2sqr);
-        }
+            float adjusted_distance =
+                    rabitq_utils::compute_1bit_adjusted_distance(
+                            normalized_distance,
+                            db_factors,
+                            query_factors_data,
+                            rabitq_index->centered,
+                            rabitq_index->qb,
+                            rabitq_index->d);
 
-        // Add to heap if better than current worst
-        if (Cfloat::cmp(heap_dis[0], adjusted_distance)) {
-            heap_replace_top<Cfloat>(
-                    k, heap_dis, heap_ids, adjusted_distance, db_idx);
+            // Add to heap if better than current worst
+            if (Cfloat::cmp(heap_dis[0], adjusted_distance)) {
+                heap_replace_top<Cfloat>(
+                        k, heap_dis, heap_ids, adjusted_distance, db_idx);
+            }
         }
     }
 }
@@ -557,8 +621,71 @@ void RaBitQHeapHandler<C, with_id_map>::end() {
     }
 }
 
+template <class C, bool with_id_map>
+float RaBitQHeapHandler<C, with_id_map>::compute_lower_bound(
+        float dist_1bit,
+        size_t db_idx,
+        size_t q) const {
+    // Access f_error directly from FactorsData in flat storage
+    const size_t storage_size = rabitq_index->compute_per_vector_storage_size();
+    const uint8_t* base_ptr =
+            rabitq_index->flat_storage.data() + db_idx * storage_size;
+    const FactorsData& db_factors =
+            *reinterpret_cast<const FactorsData*>(base_ptr);
+    float f_error = db_factors.f_error;
+
+    // Get g_error from query factors (query-dependent error term)
+    float g_error = 0.0f;
+    if (context.query_factors != nullptr) {
+        g_error = context.query_factors[q].g_error;
+    }
+
+    // Compute error adjustment: f_error * g_error
+    float error_adjustment = f_error * g_error;
+
+    return dist_1bit - error_adjustment;
+}
+
+template <class C, bool with_id_map>
+float RaBitQHeapHandler<C, with_id_map>::compute_full_multibit_distance(
+        size_t db_idx,
+        size_t q) const {
+    const size_t ex_bits = rabitq_index->rabitq.nb_bits - 1;
+    const size_t dim = rabitq_index->d;
+
+    const size_t storage_size = rabitq_index->compute_per_vector_storage_size();
+    const uint8_t* base_ptr =
+            rabitq_index->flat_storage.data() + db_idx * storage_size;
+
+    const size_t ex_code_size = (dim * ex_bits + 7) / 8;
+    const uint8_t* ex_code = base_ptr + sizeof(FactorsData);
+    const ExFactorsData& ex_fac = *reinterpret_cast<const ExFactorsData*>(
+            base_ptr + sizeof(FactorsData) + ex_code_size);
+
+    // Get query factors reference (avoid copying)
+    const rabitq_utils::QueryFactorsData& query_factors =
+            context.query_factors[q];
+
+    // Get sign bits from FastScan packed format
+    std::vector<uint8_t> unpacked_code(rabitq_index->code_size);
+    CodePackerPQ4 packer(rabitq_index->M2, rabitq_index->bbs);
+    packer.unpack_1(rabitq_index->codes.get(), db_idx, unpacked_code.data());
+    const uint8_t* sign_bits = unpacked_code.data();
+
+    return rabitq_utils::compute_full_multibit_distance(
+            sign_bits,
+            ex_code,
+            ex_fac,
+            query_factors.rotated_q.data(),
+            query_factors.qr_to_c_L2sqr,
+            query_factors.qr_norm_L2sqr,
+            dim,
+            ex_bits,
+            rabitq_index->metric_type);
+}
+
 // Implementation of virtual make_knn_handler method
-void* IndexRaBitQFastScan::make_knn_handler(
+SIMDResultHandlerToFloat* IndexRaBitQFastScan::make_knn_handler(
         bool is_max,
         int /*impl*/,
         idx_t n,
@@ -568,19 +695,16 @@ void* IndexRaBitQFastScan::make_knn_handler(
         idx_t* labels,
         const IDSelector* sel,
         const FastScanDistancePostProcessing& context) const {
+    // Use runtime boolean for multi-bit mode
+    const bool multi_bit = rabitq.nb_bits > 1;
+
     if (is_max) {
         return new RaBitQHeapHandler<CMax<uint16_t, int>, false>(
-                this, n, k, distances, labels, sel, context);
+                this, n, k, distances, labels, sel, context, multi_bit);
     } else {
         return new RaBitQHeapHandler<CMin<uint16_t, int>, false>(
-                this, n, k, distances, labels, sel, context);
+                this, n, k, distances, labels, sel, context, multi_bit);
     }
 }
-
-// Explicit template instantiations for the required comparator types
-template struct RaBitQHeapHandler<CMin<uint16_t, int>, false>;
-template struct RaBitQHeapHandler<CMax<uint16_t, int>, false>;
-template struct RaBitQHeapHandler<CMin<uint16_t, int>, true>;
-template struct RaBitQHeapHandler<CMax<uint16_t, int>, true>;
 
 } // namespace faiss

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -617,8 +617,7 @@ ProductQuantizer* read_ProductQuantizer(IOReader* reader) {
 static void read_RaBitQuantizer(
         RaBitQuantizer* rabitq,
         IOReader* f,
-        bool multi_bit) {
-    // don't care about rabitq->centroid
+        bool multi_bit = true) {
     READ1(rabitq->d);
     READ1(rabitq->code_size);
     READ1(rabitq->metric_type);
@@ -1296,16 +1295,16 @@ Index* read_index(IOReader* f, int io_flags) {
     } else if (h == fourcc("Irfs")) {
         IndexRaBitQFastScan* idxqfs = new IndexRaBitQFastScan();
         read_index_header(idxqfs, f);
-        read_RaBitQuantizer(&idxqfs->rabitq, f, false);
+        read_RaBitQuantizer(&idxqfs->rabitq, f, true);
         READVECTOR(idxqfs->center);
         READ1(idxqfs->qb);
-        READVECTOR(idxqfs->factors_storage);
+        READVECTOR(idxqfs->flat_storage);
+
         READ1(idxqfs->bbs);
         READ1(idxqfs->ntotal2);
         READ1(idxqfs->M2);
         READ1(idxqfs->code_size);
 
-        // Need to initialize the FastScan base class fields
         const size_t M_fastscan = (idxqfs->d + 3) / 4;
         constexpr size_t nbits_fastscan = 4;
         idxqfs->M = M_fastscan;

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -407,8 +407,7 @@ static void write_NNDescent(const NNDescent* nnd, IOWriter* f) {
 static void write_RaBitQuantizer(
         const RaBitQuantizer* rabitq,
         IOWriter* f,
-        bool multi_bit) {
-    // don't care about rabitq->centroid
+        bool multi_bit = true) {
     WRITE1(rabitq->d);
     WRITE1(rabitq->code_size);
     WRITE1(rabitq->metric_type);
@@ -931,10 +930,10 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
         uint32_t h = fourcc("Irfs");
         WRITE1(h);
         write_index_header(idx, f);
-        write_RaBitQuantizer(&idxqfs->rabitq, f, false);
+        write_RaBitQuantizer(&idxqfs->rabitq, f);
         WRITEVECTOR(idxqfs->center);
         WRITE1(idxqfs->qb);
-        WRITEVECTOR(idxqfs->factors_storage);
+        WRITEVECTOR(idxqfs->flat_storage);
         WRITE1(idxqfs->bbs);
         WRITE1(idxqfs->ntotal2);
         WRITE1(idxqfs->M2);

--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -107,6 +107,12 @@ inline int __builtin_clzll(uint64_t x) {
 
 #define FAISS_ALWAYS_INLINE __forceinline
 
+// MSVC uses pragma pack instead of __attribute__((packed))
+// Use FAISS_PACK_STRUCTS_BEGIN/END to wrap packed structure definitions
+#define FAISS_PACKED
+#define FAISS_PACK_STRUCTS_BEGIN __pragma(pack(push, 1))
+#define FAISS_PACK_STRUCTS_END __pragma(pack(pop))
+
 #else
 /*******************************************************
  * Linux and OSX
@@ -119,9 +125,15 @@ inline int __builtin_clzll(uint64_t x) {
 // windows
 #ifdef SWIG
 #define ALIGNED(x)
+#define FAISS_PACKED
 #else
 #define ALIGNED(x) __attribute__((aligned(x)))
+#define FAISS_PACKED __attribute__((packed))
 #endif
+
+// On non-Windows, FAISS_PACKED handles packing, so these are no-ops
+#define FAISS_PACK_STRUCTS_BEGIN
+#define FAISS_PACK_STRUCTS_END
 
 #define FAISS_ALWAYS_INLINE __attribute__((always_inline)) inline
 

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -464,7 +464,7 @@ IndexIVF* parse_IndexIVF(
     }
     // IndexIVFRaBitQ with optional nb_bits (1-9)
     // Accepts: "RaBitQ" (default 1-bit) or "RaBitQ{nb_bits}" (e.g., "RaBitQ4")
-    if (match("RaBitQ([0-9])?")) {
+    if (match("RaBitQ([1-9])?")) {
         uint8_t nb_bits = sm[1].length() > 0 ? std::stoi(sm[1].str()) : 1;
         return new IndexIVFRaBitQ(get_q(), d, nlist, mt, own_il, nb_bits);
     }
@@ -810,15 +810,15 @@ Index* parse_other_indexes(
 
     // IndexRaBitQ with optional nb_bits (1-9)
     // Accepts: "RaBitQ" (default 1-bit) or "RaBitQ{nb_bits}" (e.g., "RaBitQ4")
-    if (match("RaBitQ([0-9])?")) {
+    if (match("RaBitQ([1-9])?")) {
         uint8_t nb_bits = sm[1].length() > 0 ? std::stoi(sm[1].str()) : 1;
         return new IndexRaBitQ(d, metric, nb_bits);
     }
 
-    // IndexRaBitQFastScan
-    if (match("RaBitQfs(_[0-9]+)?")) {
-        int bbs = mres_to_int(sm[1], 32, 1);
-        return new IndexRaBitQFastScan(d, metric, bbs);
+    if (match("RaBitQfs([1-9])?(_[0-9]+)?")) {
+        uint8_t nb_bits = sm[1].length() > 0 ? std::stoi(sm[1].str()) : 1;
+        int bbs = mres_to_int(sm[2], 32, 1);
+        return new IndexRaBitQFastScan(d, metric, bbs, nb_bits);
     }
 
     return nullptr;


### PR DESCRIPTION
Summary:
Extends IndexRaBitQFastScan to support multi-bit quantization (1-9 bits) while maintaining backward compatibility with existing 1-bit indexes. This unifies the API with IndexRaBitQ and enables higher precision quantization for improved recall.

Key improvements:
- Unified constructor pattern matching IndexRaBitQ with nb_bits parameter
- Backward compatible serialization using separate fourcc codes ("Irfs" for 1-bit, "Irfm" for multi-bit)
- Factory string support for multi-bit construction (e.g., "RaBitQfs4")

Differential Revision: D88495746


