### PR TITLE
Add multi-bit support for IndexIVFRaBitQFastScan

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -1447,7 +1447,7 @@ Index* read_index(IOReader* f, int io_flags) {
     else if (h == fourcc("Iwrf")) {
         IndexIVFRaBitQFastScan* ivrqfs = new IndexIVFRaBitQFastScan();
         read_ivf_header(ivrqfs, f);
-        read_RaBitQuantizer(&ivrqfs->rabitq, f, false);
+        read_RaBitQuantizer(&ivrqfs->rabitq, f);
         READ1(ivrqfs->by_residual);
         READ1(ivrqfs->code_size);
         READ1(ivrqfs->bbs);
@@ -1456,7 +1456,7 @@ Index* read_index(IOReader* f, int io_flags) {
         READ1(ivrqfs->implem);
         READ1(ivrqfs->qb);
         READ1(ivrqfs->centered);
-        READVECTOR(ivrqfs->factors_storage);
+        READVECTOR(ivrqfs->flat_storage);
 
         // Initialize FastScan base class fields
         const size_t M_fastscan = (ivrqfs->d + 3) / 4;

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -1063,7 +1063,7 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
         uint32_t h = fourcc("Iwrf");
         WRITE1(h);
         write_ivf_header(ivrqfs, f);
-        write_RaBitQuantizer(&ivrqfs->rabitq, f, false);
+        write_RaBitQuantizer(&ivrqfs->rabitq, f);
         WRITE1(ivrqfs->by_residual);
         WRITE1(ivrqfs->code_size);
         WRITE1(ivrqfs->bbs);
@@ -1072,7 +1072,7 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
         WRITE1(ivrqfs->implem);
         WRITE1(ivrqfs->qb);
         WRITE1(ivrqfs->centered);
-        WRITEVECTOR(ivrqfs->factors_storage);
+        WRITEVECTOR(ivrqfs->flat_storage);
         write_InvertedLists(ivrqfs->invlists, f);
     } else {
         FAISS_THROW_MSG("don't know how to serialize this type of index");

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -468,9 +468,15 @@ IndexIVF* parse_IndexIVF(
         uint8_t nb_bits = sm[1].length() > 0 ? std::stoi(sm[1].str()) : 1;
         return new IndexIVFRaBitQ(get_q(), d, nlist, mt, own_il, nb_bits);
     }
-    if (match("RaBitQfs(_[0-9]+)?")) {
-        int bbs = mres_to_int(sm[1], 32, 1);
-        return new IndexIVFRaBitQFastScan(get_q(), d, nlist, mt, bbs, own_il);
+    // Accepts: "RaBitQfs" (default 1-bit, batch size 32)
+    //          "RaBitQfs{nb_bits}" (e.g., "RaBitQfs4")
+    //          "RaBitQfs_64" (1-bit, batch size 64)
+    //          "RaBitQfs{nb_bits}_{bbs}" (e.g., "RaBitQfs4_64")
+    if (match("RaBitQfs([0-9])?(_[0-9]+)?")) {
+        uint8_t nb_bits = sm[1].length() > 0 ? std::stoi(sm[1].str()) : 1;
+        int bbs = mres_to_int(sm[2], 32, 1);
+        return new IndexIVFRaBitQFastScan(
+                get_q(), d, nlist, mt, bbs, own_il, nb_bits);
     }
     return nullptr;
 }


### PR DESCRIPTION
Summary:
Extends IndexIVFRaBitQFastScan to support multi-bit quantization (1-9 bits), complementing the flat IndexRaBitQFastScan multi-bit implementation. This enables higher precision quantization with IVF partitioning for improved recall on large-scale datasets while maintaining FastScan performance characteristics.

The implementation uses a two-stage search strategy: fast 1-bit SIMD filtering followed by accurate ex-bit refinement with error-bound-based candidate selection. Backward compatible serialization uses separate fourcc codes ("Iwrf" for 1-bit, "Iwrm" for multi-bit), and factory string support follows the same pattern as flat multi-bit: "IVF{nlist},RaBitQfs{nb_bits}".

Differential Revision: D88869280


