### PR TITLE
Enable cuVS in Faiss internally (not Github, that is already working)

### DIFF
--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -419,6 +419,7 @@ int64_t cast_cudastream_t_to_integer(hipStream_t x) {
 
 #else // FAISS_ENABLE_ROCM
 
+#ifdef FAISS_ENABLE_CUVS
 %shared_ptr(faiss::gpu::IVFPQBuildCagraConfig);
 %shared_ptr(faiss::gpu::IVFPQSearchCagraConfig);
 
@@ -428,6 +429,7 @@ int64_t cast_cudastream_t_to_integer(hipStream_t x) {
 #include <faiss/gpu/GpuIndexBinaryCagra.h>
 
 %}
+#endif // FAISS_ENABLE_CUVS
 
 typedef CUstream_st* cudaStream_t;
 


### PR DESCRIPTION
Summary:
`1.` Enables a new `faiss_gpu_cuvs` and `pyfaiss_gpu_cuvs` target.

Why a separate target? There are many targets that depend on faiss/gpu. They have errors because cuVS 25.06 requires:
- certain flags (we can't modify all of those targets to provide the flags; flags we specify in Faiss do not propagate that way)
- cuda 12.8 features


`2.` enables cuvs unit tests that previously were skipped or never enabled

`3.` adds the cuvs target to bento, so bento will always allow cuvs

Differential Revision: D89335077


