### PR TITLE
VisitedSet -> unordered_set if ntotal is large

### DIFF
--- a/benchs/bench_visited_table.cpp
+++ b/benchs/bench_visited_table.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <benchmark/benchmark.h>
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/VisitedTable.h>
+#include <faiss/utils/random.h>
+#include <omp.h>
+
+namespace faiss {
+
+// Benchmark VisitedTable with various combinations of index size and query
+// batch size, exercising both vector and hash set strategies.
+void bench_visited_table(benchmark::State& state) {
+    bool use_hashset = state.range(0);
+    size_t ntotal = static_cast<size_t>(state.range(1));
+    size_t batch_size = static_cast<size_t>(state.range(2));
+
+    size_t nq = omp_get_max_threads() * batch_size * 2;
+    std::uniform_int_distribution<size_t> randId(0, ntotal - 1);
+    constexpr size_t ndis = 1000;
+
+    size_t total_queries = 0;
+    for (auto _ : state) {
+        total_queries += nq;
+#pragma omp parallel
+        {
+            VisitedTable vt(ntotal, use_hashset);
+
+#pragma omp for schedule(static)
+            for (size_t q0 = 0; q0 < nq; q0 += batch_size) {
+                size_t q1 = std::min(q0 + batch_size, nq);
+                for (size_t q = q0; q < q1; ++q) {
+                    std::default_random_engine rng1(q);
+                    std::default_random_engine rng2(q);
+                    size_t added = 0;
+                    for (int i = 0; i < ndis; ++i) {
+                        auto id = randId(rng1);
+                        added += vt.set(id);
+                    }
+                    size_t other_visited = 0;
+                    for (int i = 0; i < ndis; ++i) {
+                        auto id = randId(rng2);
+                        other_visited += vt.get(randId(rng1));
+                        auto r = vt.get(id);
+                        FAISS_ASSERT(r);
+                        other_visited += vt.get(randId(rng1));
+                    }
+                    benchmark::DoNotOptimize(other_visited + added);
+                    vt.advance();
+                }
+            }
+        }
+    }
+    state.SetItemsProcessed(total_queries);
+}
+
+BENCHMARK(bench_visited_table)
+        ->ArgsProduct({
+                // use_hashset
+                {0, 1},
+                // ntotal
+                benchmark::CreateRange(1 << 10, 1 << 26, 4),
+                // batch_size
+                {1, 64},
+        });
+BENCHMARK_MAIN();
+
+} // namespace faiss

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -84,6 +84,7 @@ set(FAISS_SRC
   clone_index.cpp
   index_factory.cpp
   impl/AuxIndexStructures.cpp
+  impl/VisitedTable.cpp
   impl/ClusteringInitialization.cpp
   impl/CodePacker.cpp
   impl/IDSelector.cpp
@@ -207,6 +208,7 @@ set(FAISS_HEADERS
   index_io.h
   impl/AdditiveQuantizer.h
   impl/AuxIndexStructures.h
+  impl/VisitedTable.h
   impl/ClusteringInitialization.h
   impl/CodePacker.h
   impl/IDSelector.h

--- a/faiss/IndexBinaryHNSW.cpp
+++ b/faiss/IndexBinaryHNSW.cpp
@@ -22,6 +22,7 @@
 #include <faiss/impl/DistanceComputer.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/ResultHandler.h>
+#include <faiss/impl/VisitedTable.h>
 #include <faiss/utils/Heap.h>
 #include <faiss/utils/hamming.h>
 #include <faiss/utils/random.h>

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -27,6 +27,7 @@
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/ResultHandler.h>
+#include <faiss/impl/VisitedTable.h>
 #include <faiss/utils/random.h>
 #include <faiss/utils/sorting.h>
 
@@ -142,7 +143,7 @@ void hnsw_add_vertices(
 
 #pragma omp parallel if (i1 > i0 + 100)
             {
-                VisitedTable vt(ntotal);
+                VisitedTable vt(ntotal, hnsw.use_visited_hashset);
 
                 std::unique_ptr<DistanceComputer> dis(
                         storage_distance_computer(index_hnsw.storage));
@@ -265,7 +266,7 @@ void hnsw_search(
 
 #pragma omp parallel if (i1 - i0 > 1)
         {
-            VisitedTable vt(index->ntotal);
+            VisitedTable vt(index->ntotal, hnsw.use_visited_hashset);
             typename BlockResultHandler::SingleResultHandler res(bres);
 
             std::unique_ptr<DistanceComputer> dis(
@@ -436,7 +437,7 @@ void IndexHNSW::search_level_0(
         std::unique_ptr<DistanceComputer> qdis(
                 storage_distance_computer(storage));
         HNSWStats search_stats;
-        VisitedTable vt(ntotal);
+        VisitedTable vt(ntotal, hnsw.use_visited_hashset);
         RH::SingleResultHandler res(bres);
 
 #pragma omp for
@@ -524,7 +525,7 @@ void IndexHNSW::init_level_0_from_entry_points(
 
 #pragma omp parallel
     {
-        VisitedTable vt(ntotal);
+        VisitedTable vt(ntotal, hnsw.use_visited_hashset);
 
         std::unique_ptr<DistanceComputer> dis(
                 storage_distance_computer(storage));
@@ -875,7 +876,8 @@ void IndexHNSW2Level::search(
 
 #pragma omp parallel
         {
-            VisitedTable vt(ntotal);
+            // visited table (not hash set) for tri-state flags.
+            VisitedTable vt(ntotal, /*use_hashset=*/false);
             std::unique_ptr<DistanceComputer> dis(
                     storage_distance_computer(storage));
 

--- a/faiss/IndexHNSW.h
+++ b/faiss/IndexHNSW.h
@@ -9,9 +9,10 @@
 
 #pragma once
 
+#include <optional>
 #include <vector>
-#include "faiss/Index.h"
 
+#include <faiss/Index.h>
 #include <faiss/IndexFlat.h>
 #include <faiss/IndexPQ.h>
 #include <faiss/IndexScalarQuantizer.h>
@@ -47,6 +48,9 @@ struct IndexHNSW : Index {
     // IndexHNSWCagra to create a full base layer graph that is
     // used when GpuIndexCagra::copyFrom(IndexHNSWCagra*) is invoked.
     bool keep_max_size_level0 = false;
+
+    // See impl/VisitedTable.h.
+    std::optional<bool> use_visited_hashset;
 
     explicit IndexHNSW(int d = 0, int M = 32, MetricType metric = METRIC_L2);
     explicit IndexHNSW(Index* storage, int M = 32);

--- a/faiss/IndexNNDescent.cpp
+++ b/faiss/IndexNNDescent.cpp
@@ -19,6 +19,7 @@
 #include <faiss/IndexFlat.h>
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/VisitedTable.h>
 #include <faiss/utils/distances.h>
 
 extern "C" {

--- a/faiss/IndexNSG.cpp
+++ b/faiss/IndexNSG.cpp
@@ -16,6 +16,7 @@
 #include <faiss/IndexNNDescent.h>
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/VisitedTable.h>
 #include <faiss/utils/distances.h>
 
 namespace faiss {
@@ -74,7 +75,7 @@ void IndexNSG::search(
 
 #pragma omp parallel
         {
-            VisitedTable vt(ntotal);
+            VisitedTable vt(ntotal, nsg.use_visited_hashset);
 
             std::unique_ptr<DistanceComputer> dis(
                     storage_distance_computer(storage));

--- a/faiss/IndexNSG.h
+++ b/faiss/IndexNSG.h
@@ -9,8 +9,6 @@
 
 #pragma once
 
-#include <vector>
-
 #include <faiss/IndexFlat.h>
 #include <faiss/IndexNNDescent.h>
 #include <faiss/IndexPQ.h>

--- a/faiss/impl/AuxIndexStructures.h
+++ b/faiss/impl/AuxIndexStructures.h
@@ -169,34 +169,6 @@ struct TimeoutCallback : InterruptCallback {
     static void reset(double timeout_in_seconds);
 };
 
-/// set implementation optimized for fast access.
-struct VisitedTable {
-    std::vector<uint8_t> visited;
-    uint8_t visno;
-
-    explicit VisitedTable(int size) : visited(size), visno(1) {}
-
-    /// set flag #no to true
-    void set(int no) {
-        visited[no] = visno;
-    }
-
-    /// get flag #no
-    bool get(int no) const {
-        return visited[no] == visno;
-    }
-
-    /// reset all flags to false
-    void advance() {
-        visno++;
-        if (visno == 250) {
-            // 250 rather than 255 because sometimes we use visno and visno+1
-            memset(visited.data(), 0, sizeof(visited[0]) * visited.size());
-            visno = 1;
-        }
-    }
-};
-
 } // namespace faiss
 
 #endif

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -11,11 +11,10 @@
 
 #include <faiss/IndexHNSW.h>
 
-#include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/DistanceComputer.h>
 #include <faiss/impl/IDSelector.h>
 #include <faiss/impl/ResultHandler.h>
-#include <faiss/utils/prefetch.h>
+#include <faiss/impl/VisitedTable.h>
 
 #ifdef __AVX2__
 #include <immintrin.h>
@@ -407,10 +406,9 @@ void search_neighbors_to_add(
                 if (nodeId < 0) {
                     break;
                 }
-                if (vt.get(nodeId)) {
+                if (!vt.set(nodeId)) {
                     continue;
                 }
-                vt.set(nodeId);
 
                 float dis = qdis(nodeId);
                 NodeDistFarther evE1(dis, nodeId);
@@ -448,10 +446,9 @@ void search_neighbors_to_add(
                 if (nodeId < 0) {
                     break;
                 }
-                if (vt.get(nodeId)) {
+                if (!vt.set(nodeId)) {
                     continue;
                 }
-                vt.set(nodeId);
 
                 buffered_ids[n_buffered] = nodeId;
                 n_buffered += 1;
@@ -675,7 +672,7 @@ int search_from_candidates(
                 break;
             }
 
-            prefetch_L2(vt.visited.data() + v1);
+            vt.prefetch(v1);
             jmax += 1;
         }
 
@@ -699,10 +696,8 @@ int search_from_candidates(
         for (size_t j = begin; j < jmax; j++) {
             int v1 = hnsw.neighbors[j];
 
-            bool vget = vt.get(v1);
-            vt.set(v1);
             saved_j[counter] = v1;
-            counter += vget ? 0 : 1;
+            counter += vt.set(v1) ? 1 : 0;
 
             if (counter == 4) {
                 float dis[4];
@@ -842,9 +837,7 @@ int search_from_candidates_panorama(
                     query_norm_sq + cum_sums_v1[0] * cum_sums_v1[0];
 
             bool is_selected = !sel || sel->is_member(v1);
-            initial_size += is_selected && !vt.get(v1) ? 1 : 0;
-
-            vt.set(v1);
+            initial_size += is_selected && vt.set(v1) ? 1 : 0;
         }
 
         size_t batch_size = initial_size;
@@ -1032,7 +1025,7 @@ std::priority_queue<HNSW::Node> search_from_candidate_unbounded(
                 break;
             }
 
-            prefetch_L2(vt->visited.data() + v1);
+            vt->prefetch(v1);
             jmax += 1;
         }
 
@@ -1054,10 +1047,8 @@ std::priority_queue<HNSW::Node> search_from_candidate_unbounded(
         for (size_t j = begin; j < jmax; j++) {
             int v1 = hnsw.neighbors[j];
 
-            bool vget = vt->get(v1);
-            vt->set(v1);
             saved_j[counter] = v1;
-            counter += vget ? 0 : 1;
+            counter += vt->set(v1) ? 1 : 0;
 
             if (counter == 4) {
                 float dis[4];

--- a/faiss/impl/HNSW.h
+++ b/faiss/impl/HNSW.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <optional>
 #include <queue>
 #include <vector>
 
@@ -150,6 +151,9 @@ struct HNSW {
 
     /// use Panorama progressive pruning in search
     bool is_panorama = false;
+
+    // See impl/VisitedTable.h.
+    std::optional<bool> use_visited_hashset;
 
     // methods that initialize the tree sizes
 

--- a/faiss/impl/NNDescent.cpp
+++ b/faiss/impl/NNDescent.cpp
@@ -10,10 +10,10 @@
 #include <faiss/impl/NNDescent.h>
 
 #include <mutex>
-#include <string>
 
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/DistanceComputer.h>
+#include <faiss/impl/VisitedTable.h>
 
 namespace faiss {
 

--- a/faiss/impl/NSG.cpp
+++ b/faiss/impl/NSG.cpp
@@ -13,6 +13,7 @@
 #include <stack>
 
 #include <faiss/impl/DistanceComputer.h>
+#include <faiss/impl/VisitedTable.h>
 
 namespace faiss {
 
@@ -233,7 +234,7 @@ void NSG::init_graph(Index* storage, const nsg::Graph<idx_t>& knn_graph) {
     std::unique_ptr<DistanceComputer> dis(storage_distance_computer(storage));
 
     dis->set_query(center.get());
-    VisitedTable vt(ntotal);
+    VisitedTable vt(ntotal, use_visited_hashset);
 
     // Do not collect the visited nodes
     search_on_graph<false>(knn_graph, *dis, vt, ep, L, retset, tmpset);
@@ -341,7 +342,7 @@ void NSG::link(
         std::vector<Node> pool;
         std::vector<Neighbor> tmp;
 
-        VisitedTable vt(ntotal);
+        VisitedTable vt(ntotal, use_visited_hashset);
         std::unique_ptr<DistanceComputer> dis(
                 storage_distance_computer(storage));
 
@@ -513,8 +514,8 @@ void NSG::add_reverse_links(
 
 int NSG::tree_grow(Index* storage, std::vector<int>& degrees) {
     int root = enterpoint;
-    VisitedTable vt(ntotal);
-    VisitedTable vt2(ntotal);
+    VisitedTable vt(ntotal, use_visited_hashset);
+    VisitedTable vt2(ntotal, use_visited_hashset);
 
     int num_attached = 0;
     int cnt = 0;

--- a/faiss/impl/NSG.h
+++ b/faiss/impl/NSG.h
@@ -9,12 +9,12 @@
 
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <vector>
 
 #include <omp.h>
 
 #include <faiss/Index.h>
-#include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/Heap.h>
 #include <faiss/utils/random.h>
@@ -38,6 +38,7 @@ namespace faiss {
  */
 
 struct DistanceComputer; // from AuxIndexStructures
+struct VisitedTable;
 
 namespace nsg {
 
@@ -121,6 +122,9 @@ struct NSG {
 
     // search-time parameters
     int search_L = 16; ///< length of the search path
+
+    // See impl/VisitedTable.h.
+    std::optional<bool> use_visited_hashset;
 
     int enterpoint; ///< enterpoint
 

--- a/faiss/impl/VisitedTable.cpp
+++ b/faiss/impl/VisitedTable.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <faiss/impl/VisitedTable.h>
+
+#include <cstring>
+
+namespace faiss {
+
+// The vector strategy is faster for get()/set(), but O(size) to initialize.
+// advance() is O(1) except every 250 calls, which are O(size).
+// The hash set strategy is a constant factor slower for get()/set(),
+// but O(1) to construct and O(visits) to advance.
+// A size of ~1M seems to be the threshold where the hash set wins.
+size_t visited_table_hashset_threshold = 500000;
+
+VisitedTable::VisitedTable(size_t size, std::optional<bool> use_hashset)
+        : visno(use_hashset.value_or(size >= visited_table_hashset_threshold)
+                        ? 0
+                        : 1) {
+    if (visno != 0) {
+        visited.resize(size, 0);
+    }
+}
+
+void VisitedTable::advance() {
+    if (visno == 0) {
+        visited_set.clear();
+    } else if (visno < 254) {
+        // 254 rather than 255 because sometimes we use visno and visno+1
+        ++visno;
+    } else {
+        memset(visited.data(), 0, sizeof(visited[0]) * visited.size());
+        visno = 1;
+    }
+}
+
+} // namespace faiss

--- a/faiss/impl/VisitedTable.h
+++ b/faiss/impl/VisitedTable.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef FAISS_VISITED_TABLE_H
+#define FAISS_VISITED_TABLE_H
+
+#include <stdint.h>
+
+#include <optional>
+#include <unordered_set>
+#include <vector>
+
+#include <faiss/impl/platform_macros.h>
+#include <faiss/utils/prefetch.h>
+
+namespace faiss {
+
+FAISS_API extern size_t visited_table_hashset_threshold;
+
+/// A fast, reusable Visited Set for graph search algorithms.
+struct VisitedTable {
+    std::vector<uint8_t> visited;
+    std::unordered_set<size_t> visited_set;
+    uint8_t visno; // 0 if using visited_set, 1..250 if using vector.
+
+    // If use_hashset is nullopt, the use of a hashset will be determined by
+    // size >= visited_table_hashset_threshold.
+    explicit VisitedTable(
+            size_t size,
+            std::optional<bool> use_hashset = std::nullopt);
+
+    /// set flag #no to true, return whether this changed it.
+    bool set(size_t no) {
+        if (visno == 0) {
+            return visited_set.insert(no).second;
+        } else if (visited[no] == visno) {
+            return false;
+        } else {
+            visited[no] = visno;
+            return true;
+        }
+    }
+
+    /// get flag #no
+    bool get(size_t no) const {
+        if (visno == 0) {
+            return visited_set.count(no) != 0;
+        } else {
+            return visited[no] == visno;
+        }
+    }
+
+    void prefetch(size_t no) const {
+        if (visno != 0) {
+            prefetch_L2(&visited[no]);
+        }
+    }
+
+    /// reset all flags to false
+    void advance();
+};
+
+} // namespace faiss
+
+#endif

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -166,6 +166,7 @@ typedef uint64_t size_t;
 #include <faiss/utils/AlignedTable.h>
 #include <faiss/utils/partitioning.h>
 #include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/VisitedTable.h>
 #include <faiss/impl/IDSelector.h>
 #include <faiss/impl/DistanceComputer.h>
 #include <faiss/impl/AdditiveQuantizer.h>
@@ -658,6 +659,7 @@ struct faiss::simd16uint16 {};
 %ignore faiss::InterruptCallback::lock;
 
 %include <faiss/impl/AuxIndexStructures.h>
+%include <faiss/impl/VisitedTable.h>
 %include <faiss/impl/IDSelector.h>
 
 %include  <faiss/IndexIDMap.h>

--- a/perf_tests/bench_hnsw.py
+++ b/perf_tests/bench_hnsw.py
@@ -72,8 +72,13 @@ def run_on_dataset(
     k = 10
     # pyre-ignore[16]: Module `faiss` has no attribute `omp_set_num_threads`.
     faiss.omp_set_num_threads(num_threads)
-    index = faiss.IndexHNSWFlat(d, M)
-    index.hnsw.efConstruction = efConstruction  # default
+    if M == 0:
+        index = faiss.IndexFlatL2(d)
+    else:
+        index = faiss.IndexHNSWFlat(d, M)
+        index.hnsw.efConstruction = efConstruction  # default
+        index.hnsw.efSearch = efSearch
+        index.hnsw.search_bounded_queue = search_bounded_queue
     with timed_execution() as t:
         for _ in range(num_add_iterations):
             index.add(xb)
@@ -82,8 +87,6 @@ def run_on_dataset(
     counters["nb"] = nb
     counters["num_add_iterations"] = num_add_iterations
 
-    index.hnsw.efSearch = efSearch
-    index.hnsw.search_bounded_queue = search_bounded_queue
     with timed_execution() as t:
         for _ in range(num_search_iterations):
             D, I = index.search(xq, k)

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -16,6 +16,7 @@
 #include <faiss/IndexHNSW.h>
 #include <faiss/impl/HNSW.h>
 #include <faiss/impl/ResultHandler.h>
+#include <faiss/impl/VisitedTable.h>
 #include <faiss/utils/random.h>
 
 int reference_pop_min(faiss::HNSW::MinimaxHeap& heap, float* vmin_out) {


### PR DESCRIPTION
Summary:
`VisitedTable` accounts for a huge portion of `HNSW::search()` for unbatched searches of large indices.

As demonstrated in the benchmarks shown below, the vector-based implementation is much faster for smaller `ntotal` values, but at ~2M and above, it becomes slower, often significantly so. E.g.: At 64M slots, without batching, a workload of 1000 `set()`/`get()`s is >100x slower. Even with batching, this workload is still 3x slower with vectors.

This is a very likely explanation for the poor performance of HNSW in a 2023 USearch blog post (https://www.unum.cloud/blog/2023-11-07-scaling-vector-search-with-intel), which shows the same high throughput below 1M docs, and the same O(n) slowdown as the size grows beyond >2M:

Differential Revision: D89515309


