### PR TITLE
Add early stopping to k-means clustering

### DIFF
--- a/faiss/Clustering.cpp
+++ b/faiss/Clustering.cpp
@@ -562,6 +562,22 @@ void Clustering::train_encoded(
 
             index.add(k, centroids.data());
             InterruptCallback::check();
+
+            // Early stopping: if objective didn't change, we've converged.
+            // Safe to access iteration_stats[size - 2] because we push_back
+            // above, so size >= i + 1, and when i > 0 we have size >= 2.
+            if (i > 0) {
+                float prev_obj =
+                        iteration_stats[iteration_stats.size() - 2].obj;
+                if (obj == prev_obj) {
+                    if (verbose) {
+                        printf("\n  Converged at iteration %d: "
+                               "objective did not change\n",
+                               i);
+                    }
+                    break;
+                }
+            }
         }
 
         if (verbose) {

--- a/tests/test_callback.cpp
+++ b/tests/test_callback.cpp
@@ -14,9 +14,9 @@
 #include <faiss/utils/random.h>
 
 TEST(TestCallback, timeout) {
-    int n = 1000;
-    int k = 100;
-    int d = 128;
+    int n = 1000000;
+    int k = 10000;
+    int d = 384;
     int niter = 1000000000;
     int seed = 42;
 

--- a/tests/test_callback_py.py
+++ b/tests/test_callback_py.py
@@ -13,9 +13,9 @@ class TestCallbackPy(unittest.TestCase):
         super().setUp()
 
     def test_timeout(self) -> None:
-        n = 1000
-        k = 100
-        d = 128
+        n = 1000000
+        k = 10000
+        d = 384
         niter = 1_000_000_000
 
         x = np.random.rand(n, d).astype('float32')

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -296,3 +296,23 @@ class TestClustering1D(unittest.TestCase):
         faiss.smawk(nrows, ncols, sp(A), sp(argmins))
         argmins_ref = np.argmin(A, axis=1)
         assert np.array_equal(argmins, argmins_ref)
+
+
+class TestEarlyStopping(unittest.TestCase):
+
+    def test_early_stopping_convergence(self):
+        d = 32
+        n = 1000
+        k = 10
+        max_iter = 1000
+
+        rs = np.random.RandomState(42)
+        x = rs.uniform(size=(n, d)).astype('float32')
+
+        clus = faiss.Clustering(d, k)
+        clus.niter = max_iter
+        index = faiss.IndexFlatL2(d)
+        clus.train(x, index)
+
+        num_iterations = clus.iteration_stats.size()
+        self.assertLess(num_iterations, max_iter)


### PR DESCRIPTION
Summary: K-means clustering now stops early when the objective function converges, avoiding unnecessary iterations when niter is set to a high value as a safeguard. This prevents wasted computation when convergence happens well before the maximum iteration limit.

Differential Revision: D89748242


