### PR TITLE
Reduce memory usage in timeout callback tests

### DIFF
--- a/tests/test_callback.cpp
+++ b/tests/test_callback.cpp
@@ -14,9 +14,9 @@
 #include <faiss/utils/random.h>
 
 TEST(TestCallback, timeout) {
-    int n = 1000000;
-    int k = 10000;
-    int d = 384;
+    int n = 20000;
+    int k = 5000;
+    int d = 128;
     int niter = 1000000000;
     int seed = 42;
 

--- a/tests/test_callback_py.py
+++ b/tests/test_callback_py.py
@@ -13,9 +13,9 @@ class TestCallbackPy(unittest.TestCase):
         super().setUp()
 
     def test_timeout(self) -> None:
-        n = 1000000
-        k = 10000
-        d = 384
+        n = 20000
+        k = 5000
+        d = 128
         niter = 1_000_000_000
 
         x = np.random.rand(n, d).astype('float32')


### PR DESCRIPTION
Summary: Reduce test dataset size to use ~13 MB instead of ~1.5 GB while maintaining enough computational complexity to trigger the 10ms timeout before early stopping can converge.

Differential Revision: D90128255


