### PR TITLE
Fix multi-bit RaBitQ IP metric filtering and f_add_ex computation

### DIFF
--- a/faiss/IndexIVFRaBitQFastScan.h
+++ b/faiss/IndexIVFRaBitQFastScan.h
@@ -236,16 +236,6 @@ struct IndexIVFRaBitQFastScan : IndexIVFFastScan {
                 size_t local_q,
                 size_t global_q,
                 size_t local_offset) const;
-
-        /// Compute lower bound using 1-bit distance and error bound (multi-bit
-        /// only)
-        /// @param local_q Batch-local query index (for probe_indices access)
-        /// @param global_q Global query index (for storage indexing)
-        float compute_lower_bound(
-                float dist_1bit,
-                size_t db_idx,
-                size_t local_q,
-                size_t global_q) const;
     };
 };
 

--- a/faiss/IndexRaBitQFastScan.cpp
+++ b/faiss/IndexRaBitQFastScan.cpp
@@ -578,14 +578,16 @@ void RaBitQHeapHandler<C, with_id_map>::handle(
                     rabitq_index->qb,
                     rabitq_index->d);
 
-            float lower_bound = compute_lower_bound(dist_1bit, db_idx, q);
-
             // Adaptive filtering: decide whether to compute full distance
             const bool is_similarity = rabitq_index->metric_type ==
                     MetricType::METRIC_INNER_PRODUCT;
-            bool should_refine = is_similarity
-                    ? (lower_bound > heap_dis[0])  // IP: keep if better
-                    : (lower_bound < heap_dis[0]); // L2: keep if better
+            bool should_refine = rabitq_utils::should_refine_candidate(
+                    dist_1bit,
+                    full_factors.f_error,
+                    context.query_factors ? context.query_factors[q].g_error
+                                          : 0.0f,
+                    heap_dis[0],
+                    is_similarity);
 
             if (should_refine) {
                 local_multibit_evaluations++;

--- a/faiss/impl/RaBitQuantizer.cpp
+++ b/faiss/impl/RaBitQuantizer.cpp
@@ -215,29 +215,6 @@ void RaBitQuantizer::decode_core(
     }
 }
 
-// Implementation of RaBitQDistanceComputer (declared in header)
-
-float RaBitQDistanceComputer::lower_bound_distance(const uint8_t* code) {
-    FAISS_ASSERT(code != nullptr);
-
-    // Compute estimated distance using 1-bit codes
-    float est_distance = distance_to_code_1bit(code);
-
-    // Extract f_error from the code
-    size_t size = (d + 7) / 8;
-    const SignBitFactorsWithError* base_fac =
-            reinterpret_cast<const SignBitFactorsWithError*>(code + size);
-    float f_error = base_fac->f_error;
-
-    // Compute proper lower bound using RaBitQ error formula:
-    // lower_bound = est_distance - f_error * g_error
-    // This guarantees: lower_bound ≤ true_distance
-    float lower_bound = est_distance - (f_error * g_error);
-
-    // Distance cannot be negative
-    return std::max(0.0f, lower_bound);
-}
-
 namespace {
 
 struct RaBitQDistanceComputerNotQ : RaBitQDistanceComputer {

--- a/faiss/impl/RaBitQuantizer.h
+++ b/faiss/impl/RaBitQuantizer.h
@@ -103,10 +103,8 @@ struct RaBitQuantizer : Quantizer {
 //
 // 1. distance_to_code_1bit() - Fast 1-bit filtering using only sign bits
 // 2. distance_to_code_full() - Accurate multi-bit refinement using all bits
-// 3. lower_bound_distance() - Error-bounded adaptive filtering
-//                              (based on 1-bit estimator)
 //
-// These three methods implement RaBitQ's two-stage search pattern and are
+// These methods implement RaBitQ's two-stage search pattern and are
 // shared between the quantized (Q) and non-quantized (NotQ) query variants.
 // The intermediate class allows two-stage search code to work with both
 // variants via a single dynamic_cast.
@@ -116,8 +114,8 @@ struct RaBitQDistanceComputer : FlatCodesDistanceComputer {
     MetricType metric_type = MetricType::METRIC_L2;
     size_t nb_bits = 1;
 
-    // Query norm for lower bound computation (g_error in rabitq-library)
-    // This is the L2 norm of the rotated query: ||query - centroid||
+    // Query error factor for bound computation (g_error in rabitq-library)
+    // Used with f_error to compute error bounds for two-stage filtering
     float g_error = 0.0f;
 
     float symmetric_dis(idx_t /*i*/, idx_t /*j*/) override {
@@ -130,11 +128,6 @@ struct RaBitQDistanceComputer : FlatCodesDistanceComputer {
 
     // Compute full multi-bit distance (accurate)
     virtual float distance_to_code_full(const uint8_t* code) = 0;
-
-    // Compute lower bound of distance using error bounds
-    // Guarantees: actual_distance >= lower_bound_distance
-    // Used for adaptive filtering in two-stage search
-    virtual float lower_bound_distance(const uint8_t* code);
 
     // Override from FlatCodesDistanceComputer
     // Delegates to distance_to_code_full() for multi-bit distance computation

--- a/faiss/impl/RaBitQuantizerMultiBit.h
+++ b/faiss/impl/RaBitQuantizerMultiBit.h
@@ -60,9 +60,7 @@ void pack_multibit_codes(
  *
  * @param residual Original residual vector (data - centroid)
  * @param centroid Centroid vector (can be nullptr for zero centroid)
- * @param tmp_code Quantized ex-bit codes (unpacked integers)
  * @param d Dimensionality
- * @param ex_bits Number of extra bits
  * @param norm L2 norm of residual
  * @param ipnorm Unnormalized inner product
  * @param ex_factors Output factors structure
@@ -71,9 +69,7 @@ void pack_multibit_codes(
 void compute_ex_factors(
         const float* residual,
         const float* centroid,
-        const int* tmp_code,
         size_t d,
-        size_t ex_bits,
         float norm,
         double ipnorm,
         rabitq_utils::ExtraBitsFactors& ex_factors,


### PR DESCRIPTION
Summary:
This diff fixes two bugs in the multi-bit RaBitQ implementation for the Inner Product (IP) metric.

**Bug 1: Incorrect f_add_ex computation for IP metric**

The multi-bit distance formula computes:
```
raw = ||q-c||² + f_add_ex + f_rescale_ex × ex_ip
```

For IP metric, this raw distance is converted to inner product via:
```
dist_IP = -0.5 × (raw - ||q||²)
```

For this to correctly compute ⟨q, x⟩, we need `raw = ||q-x||² - ||x||²`. Since the L2-style computation gives `||q-x||² ≈ ||q-c||² + ||x-c||² - 2⟨q-c, x-c⟩`, we require:
```
f_add_ex = ||x-c||² - ||x||²
```

The old code was computing an incorrect correction term. The fix now correctly computes `f_add_ex = l2_sqr - or_L2sqr` where `l2_sqr = ||x-c||²` and `or_L2sqr = ||x||²`, matching the 1-bit formula's `or_minus_c_l2sqr` for IP metric.

**Bug 2: Incorrect filtering logic for IP metric in two-stage search**

The two-stage search uses error bounds to filter candidates:
- For L2 (min-heap): `lower_bound = est_distance - f_error × g_error`
- For IP (max-heap): `upper_bound = est_distance + f_error × g_error`

The old code incorrectly used `lower_bound` for IP filtering. For IP where higher values are better, using lower_bound meant we were incorrectly skipping promising candidates. The fix now uses `upper_bound` for IP, ensuring we only skip candidates whose best possible distance can't beat the current heap threshold.

**Code consolidation:**
Added `should_refine_candidate()` helper in `RaBitQUtils.h` to consolidate filtering logic across all four RaBitQ index implementations.

Differential Revision: D90550577


