### PR TITLE
Change default qb from 0 to 4 in RaBitQ indexes

### DIFF
--- a/faiss/IndexIVFRaBitQ.h
+++ b/faiss/IndexIVFRaBitQ.h
@@ -19,7 +19,7 @@
 namespace faiss {
 
 struct IVFRaBitQSearchParameters : IVFSearchParameters {
-    uint8_t qb = 0;
+    uint8_t qb = 4;
     bool centered = false;
 };
 
@@ -29,7 +29,7 @@ struct IndexIVFRaBitQ : IndexIVF {
 
     // the default number of bits to quantize a query with.
     // use '0' to disable quantization and use raw fp32 values.
-    uint8_t qb = 0;
+    uint8_t qb = 4;
 
     IndexIVFRaBitQ(
             Index* quantizer,

--- a/faiss/IndexRaBitQ.h
+++ b/faiss/IndexRaBitQ.h
@@ -14,7 +14,7 @@
 namespace faiss {
 
 struct RaBitQSearchParameters : SearchParameters {
-    uint8_t qb = 0;
+    uint8_t qb = 4;
     bool centered = false;
 };
 
@@ -26,7 +26,7 @@ struct IndexRaBitQ : IndexFlatCodes {
 
     // the default number of bits to quantize a query with.
     // use '0' to disable quantization and use raw fp32 values.
-    uint8_t qb = 0;
+    uint8_t qb = 4;
 
     // quantize the query with a zero-centered scalar quantizer.
     bool centered = false;


### PR DESCRIPTION
Summary: Enable query quantization by default for RaBitQ indexes instead of using raw fp32 values. A qb value of 4 provides a good balance between search performance and accuracy.

Differential Revision: D90704860


