### PR TITLE
Add InvertedListScanner support for IndexIVFRaBitQFastScan

### DIFF
--- a/faiss/IndexIVFRaBitQFastScan.h
+++ b/faiss/IndexIVFRaBitQFastScan.h
@@ -166,6 +166,13 @@ struct IndexIVFRaBitQFastScan : IndexIVFFastScan {
             const FastScanDistancePostProcessing& context,
             const float* normalizers = nullptr) const override;
 
+    /// Get an InvertedListScanner for single-query scanning.
+    /// This provides compatibility with the standard IVF search interface
+    InvertedListScanner* get_InvertedListScanner(
+            bool store_pairs = false,
+            const IDSelector* sel = nullptr,
+            const IVFSearchParameters* params = nullptr) const override;
+
     /** SIMD result handler for IndexIVFRaBitQFastScan that applies
      * RaBitQ-specific distance corrections during batch processing.
      *
@@ -197,6 +204,7 @@ struct IndexIVFRaBitQFastScan : IndexIVFFastScan {
         const FastScanDistancePostProcessing*
                 context;        // Processing context with query factors
         const bool is_multibit; // Whether to use multi-bit two-stage search
+        size_t nup = 0;         // Number of heap updates
 
         // Use float-based comparator for heap operations
         using Cfloat = typename std::conditional<
@@ -223,6 +231,10 @@ struct IndexIVFRaBitQFastScan : IndexIVFFastScan {
         void begin(const float* norms) override;
 
         void end() override;
+
+        size_t num_updates() override {
+            return nup;
+        }
 
        private:
         /// Compute full multi-bit distance for a candidate vector (multi-bit


### PR DESCRIPTION
Summary:
This enables IndexIVFRaBitQFastScan to work with the standard IVF search interface by implementing the InvertedListScanner pattern. The scanner follows the same design as IVFPQFastScanScanner - processing one query at a time with SIMD-optimized distance computation via pq4_accumulate_loop, while applying RaBitQ-specific distance corrections through the IVFRaBitQHeapHandler.

This is needed for compatibility with low-level IVF APIs that use scanners directly, and for use cases requiring fine-grained control over inverted list scanning.

Differential Revision: D90634862


