### PR TITLE
generic result handlers for most indexes

### DIFF
--- a/faiss/Index.cpp
+++ b/faiss/Index.cpp
@@ -115,6 +115,10 @@ void Index::search_subset(
     FAISS_THROW_MSG("search_subset not implemented for this type of index");
 }
 
+void Index::search1(const float*, ResultHandler&, SearchParameters*) const {
+    FAISS_THROW_MSG("search1 not implemented for this type of index");
+}
+
 void Index::compute_residual(const float* x, float* residual, idx_t key) const {
     reconstruct(key, residual);
     for (size_t i = 0; i < d; i++) {

--- a/faiss/Index.h
+++ b/faiss/Index.h
@@ -14,7 +14,6 @@
 #include <faiss/impl/FaissAssert.h>
 
 #include <cstdio>
-#include <sstream>
 
 #define FAISS_VERSION_MAJOR 1
 #define FAISS_VERSION_MINOR 13
@@ -55,6 +54,9 @@ namespace faiss {
 struct IDSelector;
 struct RangeSearchResult;
 struct DistanceComputer;
+template <typename T, typename TI>
+struct ResultHandlerUnordered;
+using ResultHandler = ResultHandlerUnordered<float, idx_t>;
 
 enum NumericType {
     Float32,
@@ -215,6 +217,12 @@ struct Index {
             FAISS_THROW_MSG("Index::search: unsupported numeric type");
         }
     }
+
+    /** search one vector with a custom result handler */
+    virtual void search1(
+            const float* x,
+            ResultHandler& handler,
+            SearchParameters* params = nullptr) const;
 
     /** query n vectors of dimension d to the index.
      *

--- a/faiss/IndexBinary.cpp
+++ b/faiss/IndexBinary.cpp
@@ -12,6 +12,7 @@
 
 #include <cinttypes>
 #include <cstring>
+#include <typeinfo>
 
 namespace faiss {
 

--- a/faiss/IndexFlatCodes.h
+++ b/faiss/IndexFlatCodes.h
@@ -55,7 +55,8 @@ struct IndexFlatCodes : Index {
         return get_FlatCodesDistanceComputer();
     }
 
-    /** Search implemented by decoding */
+    /** Search implemented by decoding (most index types will have a faster
+     * implementation) */
     void search(
             idx_t n,
             const float* x,
@@ -70,6 +71,11 @@ struct IndexFlatCodes : Index {
             float radius,
             RangeSearchResult* result,
             const SearchParameters* params = nullptr) const override;
+
+    virtual void search1(
+            const float* x,
+            ResultHandler& handler,
+            SearchParameters* params = nullptr) const override;
 
     // returns a new instance of a CodePacker
     CodePacker* get_CodePacker() const;

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -333,6 +333,14 @@ void IndexHNSW::range_search(
     }
 }
 
+void IndexHNSW::search1(
+        const float* x,
+        ResultHandler& handler,
+        SearchParameters* params) const {
+    SingleQueryBlockResultHandler<HNSW::C, false> bres(handler);
+    hnsw_search(this, 1, x, bres, params);
+}
+
 void IndexHNSW::add(idx_t n, const float* x) {
     FAISS_THROW_IF_NOT_MSG(
             storage,

--- a/faiss/IndexHNSW.h
+++ b/faiss/IndexHNSW.h
@@ -74,6 +74,12 @@ struct IndexHNSW : Index {
             RangeSearchResult* result,
             const SearchParameters* params = nullptr) const override;
 
+    /** search one vector with a custom result handler */
+    void search1(
+            const float* x,
+            ResultHandler& handler,
+            SearchParameters* params = nullptr) const override;
+
     void reconstruct(idx_t key, float* recons) const override;
 
     void reset() override;

--- a/faiss/IndexIDMap.cpp
+++ b/faiss/IndexIDMap.cpp
@@ -12,7 +12,7 @@
 #include <cinttypes>
 #include <cstdint>
 #include <cstdio>
-#include "faiss/Index.h"
+#include <stdexcept>
 
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>

--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -11,9 +11,6 @@
 #define FAISS_INDEX_IVF_H
 
 #include <stdint.h>
-#include <memory>
-#include <unordered_map>
-#include <vector>
 
 #include <faiss/Clustering.h>
 #include <faiss/Index.h>
@@ -325,6 +322,12 @@ struct IndexIVF : Index, IndexIVFInterface {
             RangeSearchResult* result,
             const SearchParameters* params = nullptr) const override;
 
+    /** search one vector with a custom result handler */
+    void search1(
+            const float* x,
+            ResultHandler& handler,
+            SearchParameters* params = nullptr) const override;
+
     /** Get a scanner for this index (store_pairs means ignore labels)
      *
      * The default search implementation uses this to compute the distances.
@@ -492,7 +495,7 @@ struct InvertedListScanner {
     virtual void set_query(const float* query_vector) = 0;
 
     /// following codes come from this inverted list
-    virtual void set_list(idx_t list_no, float coarse_dis) = 0;
+    virtual void set_list(idx_t list_no, float coarse_dis);
 
     /// compute a single query-to-code distance
     virtual float distance_to_code(const uint8_t* code) const = 0;
@@ -542,6 +545,13 @@ struct InvertedListScanner {
             float radius,
             RangeQueryResult& result,
             size_t& list_size) const;
+
+    // accumulate results with a ResultHandler
+    virtual size_t scan_codes(
+            size_t n,
+            const uint8_t* codes,
+            const idx_t* ids,
+            ResultHandler& handler) const;
 
     virtual ~InvertedListScanner() {}
 };

--- a/faiss/IndexIVFFlat.cpp
+++ b/faiss/IndexIVFFlat.cpp
@@ -170,53 +170,9 @@ struct IVFFlatScanner : InvertedListScanner {
         this->list_no = list_no;
     }
 
-    float distance_to_code(const uint8_t* code) const override {
+    float distance_to_code(const uint8_t* code) const final {
         const float* yj = (float*)code;
         return vd(xi, yj);
-    }
-
-    size_t scan_codes(
-            size_t list_size,
-            const uint8_t* codes,
-            const idx_t* ids,
-            float* simi,
-            idx_t* idxi,
-            size_t k) const override {
-        const float* list_vecs = (const float*)codes;
-        size_t nup = 0;
-        for (size_t j = 0; j < list_size; j++) {
-            const float* yj = list_vecs + vd.d * j;
-            if (use_sel && !sel->is_member(ids[j])) {
-                continue;
-            }
-            float dis = vd(xi, yj);
-            if (C::cmp(simi[0], dis)) {
-                int64_t id = store_pairs ? lo_build(list_no, j) : ids[j];
-                heap_replace_top<C>(k, simi, idxi, dis, id);
-                nup++;
-            }
-        }
-        return nup;
-    }
-
-    void scan_codes_range(
-            size_t list_size,
-            const uint8_t* codes,
-            const idx_t* ids,
-            float radius,
-            RangeQueryResult& res) const override {
-        const float* list_vecs = (const float*)codes;
-        for (size_t j = 0; j < list_size; j++) {
-            const float* yj = list_vecs + vd.d * j;
-            if (use_sel && !sel->is_member(ids[j])) {
-                continue;
-            }
-            float dis = vd(xi, yj);
-            if (C::cmp(radius, dis)) {
-                int64_t id = store_pairs ? lo_build(list_no, j) : ids[j];
-                res.add(dis, id);
-            }
-        }
     }
 };
 

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -25,13 +25,11 @@
 
 #include <faiss/utils/hamming.h>
 
-#include <faiss/impl/FaissAssert.h>
-
 #include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/IDSelector.h>
-
 #include <faiss/impl/ProductQuantizer.h>
-
+#include <faiss/impl/ResultHandler.h>
 #include <faiss/impl/code_distance/code_distance.h>
 
 namespace faiss {
@@ -762,52 +760,31 @@ struct QueryTables {
     }
 };
 
-// This way of handling the selector is not optimal since all distances
-// are computed even if the id would filter it out.
 template <class C, bool use_sel>
-struct KnnSearchResults {
-    idx_t key;
+struct WrappedSearchResult {
+    ResultHandler& res;
+    size_t nup = 0;
+    idx_t list_no;
+
     const idx_t* ids;
     const IDSelector* sel;
 
-    // heap params
-    size_t k;
-    float* heap_sim;
-    idx_t* heap_ids;
-
-    size_t nup;
+    WrappedSearchResult(
+            idx_t list_no,
+            const idx_t* ids,
+            const IDSelector* sel,
+            ResultHandler& res)
+            : res(res), list_no(list_no), ids(ids), sel(sel) {}
 
     inline bool skip_entry(idx_t j) {
         return use_sel && !sel->is_member(ids[j]);
     }
 
     inline void add(idx_t j, float dis) {
-        if (C::cmp(heap_sim[0], dis)) {
-            idx_t id = ids ? ids[j] : lo_build(key, j);
-            heap_replace_top<C>(k, heap_sim, heap_ids, dis, id);
+        if (C::cmp(res.threshold, dis)) {
+            idx_t id = ids ? ids[j] : lo_build(this->list_no, j);
+            res.add_result(dis, id);
             nup++;
-        }
-    }
-};
-
-template <class C, bool use_sel>
-struct RangeSearchResults {
-    idx_t key;
-    const idx_t* ids;
-    const IDSelector* sel;
-
-    // wrapped result structure
-    float radius;
-    RangeQueryResult& rres;
-
-    inline bool skip_entry(idx_t j) {
-        return use_sel && !sel->is_member(ids[j]);
-    }
-
-    inline void add(idx_t j, float dis) {
-        if (C::cmp(radius, dis)) {
-            idx_t id = ids ? ids[j] : lo_build(key, j);
-            rres.add(dis, id);
         }
     }
 };
@@ -1239,17 +1216,12 @@ struct IVFPQScanner : IVFPQScannerT<idx_t, METRIC_TYPE, PQDecoder>,
             size_t ncode,
             const uint8_t* codes,
             const idx_t* ids,
-            float* heap_sim,
-            idx_t* heap_ids,
-            size_t k) const override {
-        KnnSearchResults<C, use_sel> res = {
-                /* key */ this->key,
-                /* ids */ this->store_pairs ? nullptr : ids,
-                /* sel */ this->sel,
-                /* k */ k,
-                /* heap_sim */ heap_sim,
-                /* heap_ids */ heap_ids,
-                /* nup */ 0};
+            ResultHandler& handler) const override {
+        WrappedSearchResult<C, use_sel> res(
+                this->key,
+                this->store_pairs ? nullptr : ids,
+                this->sel,
+                handler);
 
         if (this->polysemous_ht > 0) {
             assert(precompute_mode == 2);
@@ -1264,33 +1236,6 @@ struct IVFPQScanner : IVFPQScannerT<idx_t, METRIC_TYPE, PQDecoder>,
             FAISS_THROW_MSG("bad precomp mode");
         }
         return res.nup;
-    }
-
-    void scan_codes_range(
-            size_t ncode,
-            const uint8_t* codes,
-            const idx_t* ids,
-            float radius,
-            RangeQueryResult& rres) const override {
-        RangeSearchResults<C, use_sel> res = {
-                /* key */ this->key,
-                /* ids */ this->store_pairs ? nullptr : ids,
-                /* sel */ this->sel,
-                /* radius */ radius,
-                /* rres */ rres};
-
-        if (this->polysemous_ht > 0) {
-            assert(precompute_mode == 2);
-            this->scan_list_polysemous(ncode, codes, res);
-        } else if (precompute_mode == 2) {
-            this->scan_list_with_table(ncode, codes, res);
-        } else if (precompute_mode == 1) {
-            this->scan_list_with_pointer(ncode, codes, res);
-        } else if (precompute_mode == 0) {
-            this->scan_on_the_fly_dist(ncode, codes, res);
-        } else {
-            FAISS_THROW_MSG("bad precomp mode");
-        }
     }
 };
 

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -616,7 +616,7 @@ static inline void extract_search_params(
 int search_from_candidates(
         const HNSW& hnsw,
         DistanceComputer& qdis,
-        ResultHandler<C>& res,
+        ResultHandler& res,
         MinimaxHeap& candidates,
         VisitedTable& vt,
         HNSWStats& stats,
@@ -755,7 +755,7 @@ int search_from_candidates_panorama(
         const HNSW& hnsw,
         const IndexHNSW* index,
         DistanceComputer& qdis,
-        ResultHandler<C>& res,
+        ResultHandler& res,
         MinimaxHeap& candidates,
         VisitedTable& vt,
         HNSWStats& stats,
@@ -1182,7 +1182,7 @@ using Node = HNSW::Node;
 using C = HNSW::C;
 
 // just used as a lower bound for the minmaxheap, but it is set for heap search
-int extract_k_from_ResultHandler(ResultHandler<C>& res) {
+int extract_k_from_ResultHandler(ResultHandler& res) {
     using RH = HeapBlockResultHandler<C>;
     if (auto hres = dynamic_cast<RH::SingleResultHandler*>(&res)) {
         return hres->k;
@@ -1195,7 +1195,7 @@ int extract_k_from_ResultHandler(ResultHandler<C>& res) {
 HNSWStats HNSW::search(
         DistanceComputer& qdis,
         const IndexHNSW* index,
-        ResultHandler<C>& res,
+        ResultHandler& res,
         VisitedTable& vt,
         const SearchParameters* params) const {
     HNSWStats stats;
@@ -1272,7 +1272,7 @@ HNSWStats HNSW::search(
 
 void HNSW::search_level_0(
         DistanceComputer& qdis,
-        ResultHandler<C>& res,
+        ResultHandler& res,
         idx_t nprobe,
         const storage_idx_t* nearest_i,
         const float* nearest_d,

--- a/faiss/impl/HNSW.h
+++ b/faiss/impl/HNSW.h
@@ -45,8 +45,6 @@ struct IndexHNSWFlatPanorama;
 struct VisitedTable;
 struct DistanceComputer; // from AuxIndexStructures
 struct HNSWStats;
-template <class C>
-struct ResultHandler;
 
 struct SearchParametersHNSW : SearchParameters {
     int efSearch = 16;
@@ -212,14 +210,14 @@ struct HNSW {
     HNSWStats search(
             DistanceComputer& qdis,
             const IndexHNSW* index,
-            ResultHandler<C>& res,
+            ResultHandler& res,
             VisitedTable& vt,
             const SearchParameters* params = nullptr) const;
 
     /// search only in level 0 from a given vertex
     void search_level_0(
             DistanceComputer& qdis,
-            ResultHandler<C>& res,
+            ResultHandler& res,
             idx_t nprobe,
             const storage_idx_t* nearest_i,
             const float* nearest_d,
@@ -272,7 +270,7 @@ FAISS_API extern HNSWStats hnsw_stats;
 int search_from_candidates(
         const HNSW& hnsw,
         DistanceComputer& qdis,
-        ResultHandler<HNSW::C>& res,
+        ResultHandler& res,
         HNSW::MinimaxHeap& candidates,
         VisitedTable& vt,
         HNSWStats& stats,
@@ -288,7 +286,7 @@ int search_from_candidates_panorama(
         const HNSW& hnsw,
         const IndexHNSW* index,
         DistanceComputer& qdis,
-        ResultHandler<HNSW::C>& res,
+        ResultHandler& res,
         HNSW::MinimaxHeap& candidates,
         VisitedTable& vt,
         HNSWStats& stats,

--- a/faiss/impl/ResultHandler.h
+++ b/faiss/impl/ResultHandler.h
@@ -12,15 +12,41 @@
 #pragma once
 
 #include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/FaissException.h>
 #include <faiss/impl/IDSelector.h>
 #include <faiss/utils/Heap.h>
 #include <faiss/utils/partitioning.h>
-
 #include <algorithm>
 #include <iostream>
 
 namespace faiss {
+
+/* result handlers for a single query */
+
+template <typename T, typename TI>
+struct ResultHandlerUnordered {
+    // if not better than threshold, then not necessary to call add_result
+    T threshold{};
+
+    // return whether threshold was updated
+    virtual bool add_result(T dis, TI idx) = 0;
+
+    virtual ~ResultHandlerUnordered() {}
+};
+
+// handler for a single query
+template <class C>
+struct ResultHandlerT : ResultHandlerUnordered<typename C::T, typename C::TI> {
+    ResultHandlerT() {
+        this->threshold = C::neutral();
+    }
+
+    virtual ~ResultHandlerT() {}
+};
+
+// generic handler for searching in float indexes
+using ResultHandler = ResultHandlerUnordered<float, idx_t>;
 
 /*****************************************************************
  * The classes below are intended to be used as template arguments
@@ -67,16 +93,46 @@ struct BlockResultHandler {
     }
 };
 
-// handler for a single query
-template <class C>
-struct ResultHandler {
-    // if not better than threshold, then not necessary to call add_result
-    typename C::T threshold = C::neutral();
+/*****************************************************************
+ * Convenience classes for float Indexes
+ *****************************************************************/
 
-    // return whether threshold was updated
-    virtual bool add_result(typename C::T dis, typename C::TI idx) = 0;
+// fake BlockResultHandler for a single query
+template <class C, bool use_sel>
+struct SingleQueryBlockResultHandler : BlockResultHandler<C, use_sel> {
+    using T = typename C::T;
+    using TI = typename C::TI;
+    using BlockResultHandler<C, use_sel>::i0;
+    using BlockResultHandler<C, use_sel>::i1;
 
-    virtual ~ResultHandler() {}
+    ResultHandler& the_handler;
+
+    explicit SingleQueryBlockResultHandler(
+            ResultHandler& the_handler,
+            const IDSelector* sel = nullptr)
+            : BlockResultHandler<C, use_sel>(1, sel),
+              the_handler(the_handler) {}
+
+    struct SingleResultHandler : ResultHandlerT<C> {
+        ResultHandler& the_handler;
+        using ResultHandlerT<C>::threshold;
+
+        explicit SingleResultHandler(SingleQueryBlockResultHandler& hr)
+                : the_handler(hr.the_handler) {}
+
+        /// begin results for query # i
+        void begin(const size_t qid) {
+            assert(qid == 0);
+        }
+
+        /// add one result for query i
+        bool add_result(T dis, TI idx) final {
+            return the_handler.add_result(dis, idx);
+        }
+
+        /// series of results for query i is done
+        void end() {}
+    };
 };
 
 /*****************************************************************
@@ -127,9 +183,9 @@ struct Top1BlockResultHandler : TopkBlockResultHandler<C, use_sel> {
             : TopkBlockResultHandler<C, use_sel>(nq, dis_tab, ids_tab, 1, sel) {
     }
 
-    struct SingleResultHandler : ResultHandler<C> {
+    struct SingleResultHandler : ResultHandlerT<C> {
         Top1BlockResultHandler& hr;
-        using ResultHandler<C>::threshold;
+        using ResultHandlerT<C>::threshold;
 
         TI min_idx;
         size_t current_idx = 0;
@@ -205,6 +261,34 @@ struct Top1BlockResultHandler : TopkBlockResultHandler<C, use_sel> {
  *****************************************************************/
 
 template <class C, bool use_sel = false>
+struct HeapResultHandler : ResultHandlerT<C> {
+    using T = typename C::T;
+    using TI = typename C::TI;
+    using ResultHandlerT<C>::threshold;
+    size_t k;
+
+    T* heap_dis;
+    TI* heap_ids;
+
+    HeapResultHandler(size_t k, T* heap_dis, TI* heap_ids)
+            : k(k), heap_dis(heap_dis), heap_ids(heap_ids) {
+        if (heap_dis) {
+            this->threshold = heap_dis[0];
+        }
+    }
+
+    /// add one result for query i
+    bool add_result(T dis, TI idx) final {
+        if (C::cmp(threshold, dis)) {
+            heap_replace_top<C>(k, heap_dis, heap_ids, dis, idx);
+            threshold = heap_dis[0];
+            return true;
+        }
+        return false;
+    }
+};
+
+template <class C, bool use_sel = false>
 struct HeapBlockResultHandler : TopkBlockResultHandler<C, use_sel> {
     using T = typename C::T;
     using TI = typename C::TI;
@@ -220,43 +304,30 @@ struct HeapBlockResultHandler : TopkBlockResultHandler<C, use_sel> {
             const IDSelector* sel = nullptr)
             : TopkBlockResultHandler<C, use_sel>(nq, dis_tab, ids_tab, k, sel) {
     }
+
     /******************************************************
      * API for 1 result at a time (each SingleResultHandler is
      * called from 1 thread)
      */
 
-    struct SingleResultHandler : ResultHandler<C> {
+    struct SingleResultHandler : HeapResultHandler<C, use_sel> {
         HeapBlockResultHandler& hr;
-        using ResultHandler<C>::threshold;
-        size_t k;
-
-        T* heap_dis;
-        TI* heap_ids;
 
         explicit SingleResultHandler(HeapBlockResultHandler& hr)
-                : hr(hr), k(hr.k) {}
+                : HeapResultHandler<C, use_sel>(hr.k, nullptr, nullptr),
+                  hr(hr) {}
 
         /// begin results for query # i
         void begin(size_t i) {
-            heap_dis = hr.dis_tab + i * k;
-            heap_ids = hr.ids_tab + i * k;
-            heap_heapify<C>(k, heap_dis, heap_ids);
-            threshold = heap_dis[0];
-        }
-
-        /// add one result for query i
-        bool add_result(T dis, TI idx) final {
-            if (C::cmp(threshold, dis)) {
-                heap_replace_top<C>(k, heap_dis, heap_ids, dis, idx);
-                threshold = heap_dis[0];
-                return true;
-            }
-            return false;
+            this->heap_dis = hr.dis_tab + i * this->k;
+            this->heap_ids = hr.ids_tab + i * this->k;
+            heap_heapify<C>(this->k, this->heap_dis, this->heap_ids);
+            this->threshold = this->heap_dis[0];
         }
 
         /// series of results for query i is done
         void end() {
-            heap_reorder<C>(k, heap_dis, heap_ids);
+            heap_reorder<C>(this->k, this->heap_dis, this->heap_ids);
         }
     };
 
@@ -312,10 +383,10 @@ struct HeapBlockResultHandler : TopkBlockResultHandler<C, use_sel> {
 
 /// Reservoir for a single query
 template <class C>
-struct ReservoirTopN : ResultHandler<C> {
+struct ReservoirTopN : ResultHandlerT<C> {
     using T = typename C::T;
     using TI = typename C::TI;
-    using ResultHandler<C>::threshold;
+    using ResultHandlerT<C>::threshold;
 
     T* vals;
     TI* ids;
@@ -489,6 +560,27 @@ struct ReservoirBlockResultHandler : TopkBlockResultHandler<C, use_sel> {
  *****************************************************************/
 
 template <class C, bool use_sel = false>
+struct RangeResultHandler : ResultHandlerT<C> {
+    using T = typename C::T;
+    using TI = typename C::TI;
+    using ResultHandlerT<C>::threshold;
+
+    RangeQueryResult* qr = nullptr;
+
+    RangeResultHandler(RangeQueryResult* qr, T threshold) : qr(qr) {
+        this->threshold = threshold;
+    }
+
+    /// add one result for query i
+    bool add_result(T dis, TI idx) final {
+        if (C::cmp(threshold, dis)) {
+            qr->add(dis, idx);
+        }
+        return false;
+    }
+};
+
+template <class C, bool use_sel = false>
 struct RangeSearchBlockResultHandler : BlockResultHandler<C, use_sel> {
     using T = typename C::T;
     using TI = typename C::TI;
@@ -511,28 +603,17 @@ struct RangeSearchBlockResultHandler : BlockResultHandler<C, use_sel> {
      * called from 1 thread)
      ******************************************************/
 
-    struct SingleResultHandler : ResultHandler<C> {
+    struct SingleResultHandler : RangeResultHandler<C> {
         // almost the same interface as RangeSearchResultHandler
-        using ResultHandler<C>::threshold;
+        using ResultHandlerT<C>::threshold;
         RangeSearchPartialResult pres;
-        RangeQueryResult* qr = nullptr;
 
         explicit SingleResultHandler(RangeSearchBlockResultHandler& rh)
-                : pres(rh.res) {
-            threshold = rh.radius;
-        }
+                : RangeResultHandler<C>(nullptr, rh.radius), pres(rh.res) {}
 
         /// begin results for query # i
         void begin(size_t i) {
-            qr = &pres.new_result(i);
-        }
-
-        /// add one result for query i
-        bool add_result(T dis, TI idx) final {
-            if (C::cmp(threshold, dis)) {
-                qr->add(dis, idx);
-            }
-            return false;
+            this->qr = &pres.new_result(i);
         }
 
         /// series of results for query i is done

--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -2161,50 +2161,6 @@ struct IVFSQScannerIP : InvertedListScanner {
     float distance_to_code(const uint8_t* code) const final {
         return accu0 + dc.query_to_code(code);
     }
-
-    size_t scan_codes(
-            size_t list_size,
-            const uint8_t* codes,
-            const idx_t* ids,
-            float* simi,
-            idx_t* idxi,
-            size_t k) const override {
-        size_t nup = 0;
-
-        for (size_t j = 0; j < list_size; j++, codes += code_size) {
-            if (use_sel && !sel->is_member(use_sel == 1 ? ids[j] : j)) {
-                continue;
-            }
-
-            float accu = accu0 + dc.query_to_code(codes);
-
-            if (accu > simi[0]) {
-                int64_t id = store_pairs ? (list_no << 32 | j) : ids[j];
-                minheap_replace_top(k, simi, idxi, accu, id);
-                nup++;
-            }
-        }
-        return nup;
-    }
-
-    void scan_codes_range(
-            size_t list_size,
-            const uint8_t* codes,
-            const idx_t* ids,
-            float radius,
-            RangeQueryResult& res) const override {
-        for (size_t j = 0; j < list_size; j++, codes += code_size) {
-            if (use_sel && !sel->is_member(use_sel == 1 ? ids[j] : j)) {
-                continue;
-            }
-
-            float accu = accu0 + dc.query_to_code(codes);
-            if (accu > radius) {
-                int64_t id = store_pairs ? (list_no << 32 | j) : ids[j];
-                res.add(accu, id);
-            }
-        }
-    }
 };
 
 /* use_sel = 0: don't check selector
@@ -2259,49 +2215,6 @@ struct IVFSQScannerL2 : InvertedListScanner {
 
     float distance_to_code(const uint8_t* code) const final {
         return dc.query_to_code(code);
-    }
-
-    size_t scan_codes(
-            size_t list_size,
-            const uint8_t* codes,
-            const idx_t* ids,
-            float* simi,
-            idx_t* idxi,
-            size_t k) const override {
-        size_t nup = 0;
-        for (size_t j = 0; j < list_size; j++, codes += code_size) {
-            if (use_sel && !sel->is_member(use_sel == 1 ? ids[j] : j)) {
-                continue;
-            }
-
-            float dis = dc.query_to_code(codes);
-
-            if (dis < simi[0]) {
-                int64_t id = store_pairs ? (list_no << 32 | j) : ids[j];
-                maxheap_replace_top(k, simi, idxi, dis, id);
-                nup++;
-            }
-        }
-        return nup;
-    }
-
-    void scan_codes_range(
-            size_t list_size,
-            const uint8_t* codes,
-            const idx_t* ids,
-            float radius,
-            RangeQueryResult& res) const override {
-        for (size_t j = 0; j < list_size; j++, codes += code_size) {
-            if (use_sel && !sel->is_member(use_sel == 1 ? ids[j] : j)) {
-                continue;
-            }
-
-            float dis = dc.query_to_code(codes);
-            if (dis < radius) {
-                int64_t id = store_pairs ? (list_no << 32 | j) : ids[j];
-                res.add(dis, id);
-            }
-        }
     }
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ set(FAISS_TEST_SRC
   test_hamming.cpp
   test_mmap.cpp
   test_zerocopy.cpp
+  test_custom_result_handler.cpp
 )
 
 if(FAISS_ENABLE_SVS)

--- a/tests/test_custom_result_handler.cpp
+++ b/tests/test_custom_result_handler.cpp
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <faiss/AutoTune.h>
+#include <faiss/IndexIVF.h>
+#include <faiss/impl/ResultHandler.h>
+#include <faiss/index_factory.h>
+#include <faiss/utils/random.h>
+
+using namespace faiss;
+
+/** A ResultHandler that just collects all results that presented to it. */
+struct CollectAllResultHandler : ResultHandler {
+    std::vector<float> D;
+    std::vector<idx_t> I;
+
+    bool add_result(float distance, idx_t i) override {
+        // we never change the default threshold so that all results pass
+        D.push_back(distance);
+        I.push_back(i);
+        return true;
+    }
+
+    // Sort results by distance and return the top k
+    void get_top_k(
+            size_t top_k,
+            std::vector<float>& out_D,
+            std::vector<idx_t>& out_I,
+            bool is_max) const {
+        size_t n_results = D.size();
+
+        // Create indices for sorting
+        std::vector<size_t> indices(n_results);
+        for (size_t i = 0; i < n_results; i++) {
+            indices[i] = i;
+        }
+
+        // Make local copies for lambda capture
+        const std::vector<float>& distances = D;
+
+        // Sort by distance (ascending for L2, descending for IP)
+        if (is_max) {
+            std::sort(
+                    indices.begin(),
+                    indices.end(),
+                    [&distances](size_t a, size_t b) {
+                        return distances[a] > distances[b];
+                    });
+        } else {
+            std::sort(
+                    indices.begin(),
+                    indices.end(),
+                    [&distances](size_t a, size_t b) {
+                        return distances[a] < distances[b];
+                    });
+        }
+
+        // Take top k
+        size_t n_out = std::min(top_k, n_results);
+        out_D.resize(n_out);
+        out_I.resize(n_out);
+        for (size_t i = 0; i < n_out; i++) {
+            out_D[i] = D[indices[i]];
+            out_I[i] = I[indices[i]];
+        }
+    }
+};
+
+namespace {
+
+// dimension of the vectors to index
+constexpr int d = 64;
+
+// nb of training vectors
+constexpr size_t nt = 5000;
+
+// size of the database
+constexpr size_t nb = 2000;
+
+// nb of queries
+constexpr size_t nq = 100;
+
+// k for search
+constexpr int k = 10;
+
+/**
+ * Generate smooth random data using Faiss's rand_smooth_vectors.
+ * This produces data with intrinsic dimensionality ~10 that is harder to
+ * index than a subspace but easier than uniform random data.
+ */
+std::vector<float> make_smooth_data(size_t n, int64_t seed) {
+    std::vector<float> data(n * d);
+    rand_smooth_vectors(n, d, data.data(), seed);
+    return data;
+}
+
+/**
+ * Test helper: trains an index, adds data, and performs a search using
+ * both the standard search method and the custom handler search1 method.
+ * Compares the results to ensure they match.
+ */
+void test_index(
+        const char* index_key,
+        MetricType metric,
+        double min_match_ratio = 1.0) {
+    // Create index using factory
+    std::unique_ptr<Index> index(index_factory(d, index_key, metric));
+    ASSERT_NE(index, nullptr) << "Failed to create IVF index for " << index_key;
+
+    // Generate smooth random data for training and database
+    auto xt = make_smooth_data(nt, 1234);
+    auto xb = make_smooth_data(nb, 4567);
+    auto xq = make_smooth_data(nq, 7890);
+
+    // Train the index
+    index->train(nt, xt.data());
+
+    // Add database vectors
+    index->add(nb, xb.data());
+
+    // Set nprobe for IVF indexes
+    if (IndexIVF* index_ivf = dynamic_cast<IndexIVF*>(index.get())) {
+        index_ivf->nprobe = 4;
+    }
+
+    // Perform reference search using standard search method
+    std::vector<idx_t> Iref(nq * k);
+    std::vector<float> Dref(nq * k);
+    index->search(nq, xq.data(), k, Dref.data(), Iref.data());
+
+    // For IP metric, we need to sort in descending order
+    bool is_max = (metric == METRIC_INNER_PRODUCT);
+
+    // Now test search1 with custom handler for each query
+    for (size_t q = 0; q < nq; q++) {
+        CollectAllResultHandler handler;
+        // Set threshold to collect all results
+        // For L2: use max float (condition: threshold > distance)
+        // For IP: use min float (condition: threshold < distance)
+        if (is_max) {
+            handler.threshold = -std::numeric_limits<float>::max();
+        } else {
+            handler.threshold = std::numeric_limits<float>::max();
+        }
+        index->search1(xq.data() + q * d, handler);
+
+        // Sort the handler results and get top k
+        std::vector<float> D_handler;
+        std::vector<idx_t> I_handler;
+        handler.get_top_k(k, D_handler, I_handler, is_max);
+
+        // Compare with reference results for this query using set comparison
+        const idx_t* Iref_q = Iref.data() + q * k;
+
+        // Create sets of IDs for comparison
+        std::unordered_set<idx_t> ref_set(Iref_q, Iref_q + k);
+        std::unordered_set<idx_t> handler_set(
+                I_handler.begin(), I_handler.end());
+
+        // Count how many results from handler are in the reference set
+        int matches = 0;
+        for (idx_t id : handler_set) {
+            if (ref_set.count(id) > 0) {
+                matches++;
+            }
+        }
+
+        // Check that matches meet the minimum threshold
+        EXPECT_GE(matches, static_cast<int>(k * min_match_ratio))
+                << "Query " << q << ": expected at least "
+                << static_cast<int>(k * min_match_ratio) << " matches, got "
+                << matches;
+    }
+}
+
+/*************************************************************
+ * Test cases for different IVF index types
+ *************************************************************/
+
+TEST(TestIndexTypes, IVFFlat_L2) {
+    test_index("IVF32,Flat", METRIC_L2);
+}
+
+TEST(TestIndexTypes, IVFFlat_IP) {
+    test_index("IVF32,Flat", METRIC_INNER_PRODUCT);
+}
+
+TEST(TestIndexTypes, IVFPQ_L2) {
+    test_index("IVF32,PQ8np", METRIC_L2);
+}
+
+TEST(TestIndexTypes, IVFPQ_IP) {
+    test_index("IVF32,PQ8np", METRIC_INNER_PRODUCT);
+}
+
+TEST(TestIndexTypes, IVFSQ_L2) {
+    test_index("IVF32,SQ8", METRIC_L2);
+}
+
+TEST(TestIndexTypes, IVFRaBitQ_IP) {
+    test_index("IVF32,RaBitQ", METRIC_INNER_PRODUCT);
+}
+
+TEST(TestIndexTypes, IVFRaBitQ4_L2) {
+    // RaBitQ4 does a topk per invlist, so not exactly the same as top over all
+    test_index("IVF32,RaBitQ4", METRIC_L2, 0.8);
+}
+
+TEST(TestIndexTypes, IVFRaBitQ4_IP) {
+    // RaBitQ4 does a topk per invlist, so not exactly the same as top over all
+    test_index("IVF32,RaBitQ4", METRIC_INNER_PRODUCT, 0.8);
+}
+
+TEST(TestIndexTypes, HNSW) {
+    test_index("HNSW32,Flat", METRIC_L2);
+}
+
+TEST(TestIndexTypes, SQ8) {
+    test_index("SQ8", METRIC_L2);
+}
+
+} // namespace

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -249,7 +249,7 @@ class HNSWTest : public testing::Test {
 int reference_search_from_candidates(
         const faiss::HNSW& hnsw,
         faiss::DistanceComputer& qdis,
-        faiss::ResultHandler<faiss::HNSW::C>& res,
+        faiss::ResultHandler& res,
         faiss::HNSW::MinimaxHeap& candidates,
         faiss::VisitedTable& vt,
         faiss::HNSWStats& stats,

--- a/tests/test_index_accuracy.py
+++ b/tests/test_index_accuracy.py
@@ -374,8 +374,8 @@ class TestSQByte(unittest.TestCase):
         index.add(xb)
         D, I = index.search(xq, 10)
 
-        assert np.all(I == Iref)
-        assert np.all(D == Dref)
+        np.testing.assert_array_equal(D, Dref)
+        np.testing.assert_array_equal(I, Iref)
 
     def test_8bit_direct(self):
         for quantizer in faiss.ScalarQuantizer.QT_8bit_direct, faiss.ScalarQuantizer.QT_8bit_direct_signed:


### PR DESCRIPTION
Summary:
Some search functions require special handling on the search resutls. For example collecting resutls from diverse groups.

In order to support this, we re-purpose the ResultHandler object to offer an arbitrary callback whenever a new vector should be taken in consideration.

Many indexes did already have such a callback, but in non-uniform formats. This diff consolidates these diverse implementations. This is especially the case for the InvertedListScanner that is now implemented on top of that.

Most indexes now get a `search1` that searches one query vector and takes a ResultCollector as input. This is the object that can be used a a callback to do specific handling on the results.

The current impleentatoin of search1 may not be perfectly optimized, especially for IndexFlatCodes indexes. Another todo is to support BlockResultHandlers to allow multiple queries at a time.

Differential Revision: D91003349


