### PR TITLE
Address review comments on SQ correctness tests

### DIFF
--- a/tests/test_scalar_quantizer_correctness.py
+++ b/tests/test_scalar_quantizer_correctness.py
@@ -10,14 +10,15 @@ import numpy as np
 import faiss
 import unittest
 
+from faiss.contrib.datasets import SyntheticDataset
+
 
 class TestScalarQuantizerEncodeDecode(unittest.TestCase):
 
     def setUp(self):
         self.d = 32
-        self.n = 1000
-        np.random.seed(42)
-        self.xb = np.random.random((self.n, self.d)).astype('float32')
+        self.ds = SyntheticDataset(d=self.d, nt=0, nb=1000, nq=0, seed=42)
+        self.xb = self.ds.get_database()
 
     def do_encode_decode(self, qtype, max_err):
         sq = faiss.ScalarQuantizer(self.d, qtype)
@@ -45,9 +46,9 @@ class TestScalarQuantizerSearch(unittest.TestCase):
 
     def setUp(self):
         self.d = 32
-        np.random.seed(42)
-        self.xb = np.random.random((10000, self.d)).astype('float32')
-        self.xq = np.random.random((100, self.d)).astype('float32')
+        self.ds = SyntheticDataset(d=self.d, nt=0, nb=10000, nq=100, seed=42)
+        self.xb = self.ds.get_database()
+        self.xq = self.ds.get_queries()
 
     def do_search(self, factory_str, min_recall):
         index_gt = faiss.IndexFlatL2(self.d)
@@ -73,9 +74,9 @@ class TestScalarQuantizerDistances(unittest.TestCase):
 
     def test_distance_matches_reconstruct(self):
         d = 32
-        np.random.seed(42)
-        x = np.random.random((1, d)).astype('float32')
-        xb = np.random.random((100, d)).astype('float32')
+        ds = SyntheticDataset(d=d, nt=0, nb=100, nq=1, seed=42)
+        x = ds.get_queries()
+        xb = ds.get_database()
 
         index = faiss.index_factory(d, 'SQ8')
         index.train(xb)
@@ -109,50 +110,42 @@ class TestScalarQuantizerEdgeCases(unittest.TestCase):
         D, _ = index.search(np.ones((1, d), dtype='float32') * 0.5, 10)
         self.assertTrue(np.allclose(D, 0, atol=1e-3))
 
-    def test_d1(self):
-        d = 1
-        np.random.seed(42)
-        xb = np.random.random((100, d)).astype('float32')
-        index = faiss.index_factory(d, 'SQ8')
-        index.train(xb)
-        index.add(xb)
-        D, I = index.search(np.array([[0.5]], dtype='float32'), 10)
-        self.assertEqual(D.shape, (1, 10))
-        self.assertEqual(I.shape, (1, 10))
-
-    def test_d1024(self):
-        d = 1024
-        np.random.seed(42)
-        xb = np.random.random((100, d)).astype('float32')
-        index = faiss.index_factory(d, 'SQ8')
-        index.train(xb)
-        index.add(xb)
-        xq = np.random.random((10, d)).astype('float32')
-        D, I = index.search(xq, 10)
-        self.assertEqual(D.shape, (10, 10))
-        self.assertEqual(I.shape, (10, 10))
+    def test_extreme_dims(self):
+        """Test extreme dimension values (very small and very large)."""
+        for d in [1, 1024]:
+            with self.subTest(d=d):
+                ds = SyntheticDataset(d=d, nt=0, nb=100, nq=10, seed=42)
+                xb = ds.get_database()
+                xq = ds.get_queries()
+                index = faiss.index_factory(d, 'SQ8')
+                index.train(xb)
+                index.add(xb)
+                D, I = index.search(xq, 10)
+                self.assertEqual(D.shape, (10, 10))
+                self.assertEqual(I.shape, (10, 10))
 
     def test_non_simd_dims(self):
-        # dimensions not aligned to SIMD width (8/16)
-        np.random.seed(42)
+        """Test dimensions not aligned to SIMD width (8/16)."""
         for d in [7, 9, 15, 17, 31, 33, 63, 65]:
-            xb = np.random.random((100, d)).astype('float32')
-            index = faiss.index_factory(d, 'SQ8')
-            index.train(xb)
-            index.add(xb)
-            xq = np.random.random((5, d)).astype('float32')
-            D, I = index.search(xq, 10)
-            self.assertEqual(D.shape, (5, 10))
-            self.assertEqual(I.shape, (5, 10))
+            with self.subTest(d=d):
+                ds = SyntheticDataset(d=d, nt=0, nb=100, nq=5, seed=42)
+                xb = ds.get_database()
+                xq = ds.get_queries()
+                index = faiss.index_factory(d, 'SQ8')
+                index.train(xb)
+                index.add(xb)
+                D, I = index.search(xq, 10)
+                self.assertEqual(D.shape, (5, 10))
+                self.assertEqual(I.shape, (5, 10))
 
 
 class TestScalarQuantizerIP(unittest.TestCase):
 
     def test_inner_product(self):
         d = 32
-        np.random.seed(42)
-        xb = np.random.random((1000, d)).astype('float32')
-        xq = np.random.random((10, d)).astype('float32')
+        ds = SyntheticDataset(d=d, nt=0, nb=1000, nq=10, seed=42)
+        xb = ds.get_database().copy()
+        xq = ds.get_queries().copy()
         faiss.normalize_L2(xb)
         faiss.normalize_L2(xq)
 
@@ -163,4 +156,4 @@ class TestScalarQuantizerIP(unittest.TestCase):
 
         # normalized vectors: max IP should be close to 1
         self.assertTrue(np.all(D[:, 0] <= 1.1))
-        self.assertTrue(np.all(D[:, 0] >= 0.8))
+        self.assertTrue(np.all(D[:, 0] >= 0.5))


### PR DESCRIPTION
Summary:
Follow-up to D91104886 addressing Matthijs's review comments:

1. Use SyntheticDataset from faiss.contrib.datasets instead of manual
   np.random.random() calls throughout the tests

2. Factorize test_d1 and test_d1024 into a single test_extreme_dims
   test that iterates over both dimensions with subTest

3. Use self.subTest() in test_non_simd_dims for finer error granularity
   so each dimension reports as a separate subtest

Also moved the test to py_tests_with_contrib in BUCK since it now
depends on faiss.contrib.

Differential Revision: D91560577


