### PR TITLE
SIMDConfig object + SIMD detections (#4552)

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -105,6 +105,7 @@ set(FAISS_SRC
   utils/random.cpp
   utils/sorting.cpp
   utils/utils.cpp
+  utils/simd_levels.cpp
   utils/distances_fused/avx512.cpp
   utils/distances_fused/distances_fused.cpp
   utils/distances_fused/simdlib_based.cpp
@@ -259,6 +260,7 @@ set(FAISS_HEADERS
   utils/simdlib_neon.h
   utils/simdlib_ppc64.h
   utils/utils.h
+  utils/simd_levels.h
   utils/distances_fused/avx512.h
   utils/distances_fused/distances_fused.h
   utils/distances_fused/simdlib_based.h

--- a/faiss/impl/FaissAssert.h
+++ b/faiss/impl/FaissAssert.h
@@ -69,7 +69,7 @@
 
 #define FAISS_THROW_MSG(MSG)                                   \
     do {                                                       \
-        throw faiss::FaissException(                           \
+        throw ::faiss::FaissException(                         \
                 MSG, __PRETTY_FUNCTION__, __FILE__, __LINE__); \
     } while (false)
 
@@ -79,7 +79,7 @@
         int __size = snprintf(nullptr, 0, FMT, __VA_ARGS__);   \
         __s.resize(__size + 1);                                \
         snprintf(&__s[0], __s.size(), FMT, __VA_ARGS__);       \
-        throw faiss::FaissException(                           \
+        throw ::faiss::FaissException(                         \
                 __s, __PRETTY_FUNCTION__, __FILE__, __LINE__); \
     } while (false)
 

--- a/faiss/impl/simd_dispatch.h
+++ b/faiss/impl/simd_dispatch.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+/**
+ * @file simd_dispatch.h
+ * @brief Internal dispatch macros for SIMD level selection.
+ *
+ * This is a PRIVATE header - do not include in public APIs or user code.
+ * Only faiss internal .cpp files should include this header.
+ *
+ * For the public API (SIMDLevel enum, SIMDConfig class), use:
+ *   #include <faiss/utils/simd_levels.h>
+ */
+
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/utils/simd_levels.h>
+
+namespace faiss {
+
+/*********************** x86 SIMD dispatch cases */
+
+#ifdef COMPILE_SIMD_AVX2
+#define DISPATCH_SIMDLevel_AVX2(f, ...) \
+    case SIMDLevel::AVX2:               \
+        return f<SIMDLevel::AVX2>(__VA_ARGS__)
+#else
+#define DISPATCH_SIMDLevel_AVX2(f, ...)
+#endif
+
+#ifdef COMPILE_SIMD_AVX512
+#define DISPATCH_SIMDLevel_AVX512(f, ...) \
+    case SIMDLevel::AVX512:               \
+        return f<SIMDLevel::AVX512>(__VA_ARGS__)
+#else
+#define DISPATCH_SIMDLevel_AVX512(f, ...)
+#endif
+
+#ifdef COMPILE_SIMD_AVX512_SPR
+#define DISPATCH_SIMDLevel_AVX512_SPR(f, ...) \
+    case SIMDLevel::AVX512_SPR:               \
+        return f<SIMDLevel::AVX512_SPR>(__VA_ARGS__)
+#else
+#define DISPATCH_SIMDLevel_AVX512_SPR(f, ...)
+#endif
+
+/*********************** ARM SIMD dispatch cases */
+
+#ifdef COMPILE_SIMD_ARM_NEON
+#define DISPATCH_SIMDLevel_ARM_NEON(f, ...) \
+    case SIMDLevel::ARM_NEON:               \
+        return f<SIMDLevel::ARM_NEON>(__VA_ARGS__)
+#else
+#define DISPATCH_SIMDLevel_ARM_NEON(f, ...)
+#endif
+
+/*********************** Main dispatch macro */
+
+#ifdef FAISS_ENABLE_DD
+
+// DD mode: runtime dispatch based on SIMDConfig::level
+#define DISPATCH_SIMDLevel(f, ...)                         \
+    switch (SIMDConfig::level) {                           \
+        case SIMDLevel::NONE:                              \
+            return f<SIMDLevel::NONE>(__VA_ARGS__);        \
+            DISPATCH_SIMDLevel_AVX2(f, __VA_ARGS__);       \
+            DISPATCH_SIMDLevel_AVX512(f, __VA_ARGS__);     \
+            DISPATCH_SIMDLevel_AVX512_SPR(f, __VA_ARGS__); \
+            DISPATCH_SIMDLevel_ARM_NEON(f, __VA_ARGS__);   \
+        default:                                           \
+            FAISS_THROW_MSG("Invalid SIMD level");         \
+    }
+
+#else // Static mode
+
+// Static mode: direct call to compiled-in SIMD level (no runtime switch)
+#if defined(COMPILE_SIMD_AVX512_SPR)
+#define DISPATCH_SIMDLevel(f, ...) return f<SIMDLevel::AVX512_SPR>(__VA_ARGS__)
+#elif defined(COMPILE_SIMD_AVX512)
+#define DISPATCH_SIMDLevel(f, ...) return f<SIMDLevel::AVX512>(__VA_ARGS__)
+#elif defined(COMPILE_SIMD_AVX2)
+#define DISPATCH_SIMDLevel(f, ...) return f<SIMDLevel::AVX2>(__VA_ARGS__)
+#elif defined(COMPILE_SIMD_ARM_NEON)
+#define DISPATCH_SIMDLevel(f, ...) return f<SIMDLevel::ARM_NEON>(__VA_ARGS__)
+#else
+#define DISPATCH_SIMDLevel(f, ...) return f<SIMDLevel::NONE>(__VA_ARGS__)
+#endif
+
+#endif // FAISS_ENABLE_DD
+
+} // namespace faiss

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -153,6 +153,11 @@ typedef uint64_t size_t;
 #include <faiss/IVFlib.h>
 #include <faiss/utils/utils.h>
 
+// For DD builds, we need the function declaration.
+// Note: We always declare it here for the C++ compiler since faiss_dd exports it.
+// The SWIG interface section below controls whether Python can call it.
+#include <faiss/utils/simd_levels.h>
+
 #include <faiss/utils/sorting.h>
 #include <faiss/utils/distances.h>
 #include <faiss/utils/extra_distances.h>
@@ -478,6 +483,8 @@ void gpu_sync_all_devices()
 %include  <faiss/utils/utils.h>
 %template(CombinerRangeKNNfloat) faiss::CombinerRangeKNN<float>;
 %template(CombinerRangeKNNint16) faiss::CombinerRangeKNN<int16_t>;
+
+%include  <faiss/utils/simd_levels.h>
 
 %include  <faiss/utils/distances.h>
 %include  <faiss/utils/random.h>

--- a/faiss/utils/simd_levels.cpp
+++ b/faiss/utils/simd_levels.cpp
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <faiss/utils/simd_levels.h>
+
+#include <cstdlib>
+
+#include <faiss/impl/FaissAssert.h>
+
+namespace faiss {
+
+// Static member definitions - used in both DD and static modes
+SIMDLevel SIMDConfig::level = SIMDLevel::NONE;
+
+// Bitmask of supported SIMD levels (1 << SIMDLevel)
+uint64_t SIMDConfig::supported_simd_levels = 0;
+
+#ifdef FAISS_ENABLE_DD
+
+// =============================================================================
+// Dynamic Dispatch (DD) mode implementation
+// =============================================================================
+
+// Static initializer to run constructor at load time
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+static SIMDConfig simd_config_initializer;
+
+SIMDConfig::SIMDConfig(const char** faiss_simd_level_env) {
+    // Support dependency injection for testing
+    const char* env_var = faiss_simd_level_env ? *faiss_simd_level_env
+                                               : getenv("FAISS_SIMD_LEVEL");
+
+    if (!env_var) {
+        level = auto_detect_simd_level();
+    } else {
+        level = to_simd_level(env_var);
+        supported_simd_levels = (1 << static_cast<int>(level));
+    }
+    supported_simd_levels |= (1 << static_cast<int>(SIMDLevel::NONE));
+}
+
+void SIMDConfig::set_level(SIMDLevel l) {
+    if (!is_simd_level_available(l)) {
+        FAISS_THROW_FMT(
+                "SIMDConfig::set_level: level %s is not available",
+                to_string(l).c_str());
+    }
+    level = l;
+}
+
+SIMDLevel SIMDConfig::get_level() {
+    return level;
+}
+
+std::string SIMDConfig::get_level_name() {
+    return to_string(level);
+}
+
+bool SIMDConfig::is_simd_level_available(SIMDLevel l) {
+    return (supported_simd_levels & (1 << static_cast<int>(l))) != 0;
+}
+
+SIMDLevel SIMDConfig::auto_detect_simd_level() {
+    SIMDLevel detected_level = SIMDLevel::NONE;
+
+#if defined(__x86_64__) && \
+        (defined(COMPILE_SIMD_AVX2) || defined(COMPILE_SIMD_AVX512))
+    unsigned int eax, ebx, ecx, edx;
+
+    eax = 1;
+    ecx = 0;
+    asm volatile("cpuid"
+                 : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx)
+                 : "a"(eax), "c"(ecx));
+
+    bool has_avx = (ecx & (1 << 28)) != 0;
+
+    bool has_xsave_osxsave =
+            (ecx & ((1 << 26) | (1 << 27))) == ((1 << 26) | (1 << 27));
+
+    bool avx_supported = false;
+    if (has_avx && has_xsave_osxsave) {
+        unsigned int xcr0;
+        asm volatile("xgetbv" : "=a"(xcr0), "=d"(edx) : "c"(0));
+        avx_supported = (xcr0 & 6) == 6;
+    }
+
+    if (avx_supported) {
+        eax = 7;
+        ecx = 0;
+        asm volatile("cpuid"
+                     : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx)
+                     : "a"(eax), "c"(ecx));
+
+        unsigned int xcr0;
+        asm volatile("xgetbv" : "=a"(xcr0), "=d"(edx) : "c"(0));
+
+#if defined(COMPILE_SIMD_AVX2) || defined(COMPILE_SIMD_AVX512)
+        bool has_avx2 = (ebx & (1 << 5)) != 0;
+        if (has_avx2) {
+            supported_simd_levels |= (1 << static_cast<int>(SIMDLevel::AVX2));
+            detected_level = SIMDLevel::AVX2;
+        }
+
+#if defined(COMPILE_SIMD_AVX512)
+        bool cpu_has_avx512f = (ebx & (1 << 16)) != 0;
+        bool os_supports_avx512 = (xcr0 & 0xE0) == 0xE0;
+        bool has_avx512f = cpu_has_avx512f && os_supports_avx512;
+        if (has_avx512f) {
+            bool has_avx512cd = (ebx & (1 << 28)) != 0;
+            bool has_avx512vl = (ebx & (1 << 31)) != 0;
+            bool has_avx512dq = (ebx & (1 << 17)) != 0;
+            bool has_avx512bw = (ebx & (1 << 30)) != 0;
+            if (has_avx512bw && has_avx512cd && has_avx512vl && has_avx512dq) {
+                detected_level = SIMDLevel::AVX512;
+                supported_simd_levels |=
+                        (1 << static_cast<int>(SIMDLevel::AVX512));
+
+#if defined(COMPILE_SIMD_AVX512_SPR)
+                // Check for Sapphire Rapids features (AVX512_BF16)
+                // CPUID EAX=7, ECX=1: EAX bit 5 = AVX512_BF16
+                unsigned int eax1, ebx1, ecx1, edx1;
+                eax1 = 7;
+                ecx1 = 1;
+                asm volatile("cpuid"
+                             : "=a"(eax1), "=b"(ebx1), "=c"(ecx1), "=d"(edx1)
+                             : "a"(eax1), "c"(ecx1));
+                bool has_avx512_bf16 = (eax1 & (1 << 5)) != 0;
+                if (has_avx512_bf16) {
+                    detected_level = SIMDLevel::AVX512_SPR;
+                    supported_simd_levels |=
+                            (1 << static_cast<int>(SIMDLevel::AVX512_SPR));
+                }
+#endif // defined(COMPILE_SIMD_AVX512_SPR)
+            }
+        }
+#endif // defined(COMPILE_SIMD_AVX512)
+#endif // defined(COMPILE_SIMD_AVX2) || defined(COMPILE_SIMD_AVX512)
+    }
+#endif // defined(__x86_64__) && ...
+
+#if defined(__aarch64__) && defined(__ARM_NEON) && \
+        defined(COMPILE_SIMD_ARM_NEON)
+    // ARM NEON is standard on aarch64
+    supported_simd_levels |= (1 << static_cast<int>(SIMDLevel::ARM_NEON));
+    detected_level = SIMDLevel::ARM_NEON;
+#endif
+
+    return detected_level;
+}
+
+// Include private header for DISPATCH_SIMDLevel macro
+#include <faiss/impl/simd_dispatch.h>
+
+namespace {
+
+template <SIMDLevel Level>
+SIMDLevel get_dispatched_level_impl() {
+    return Level;
+}
+
+} // namespace
+
+SIMDLevel SIMDConfig::get_dispatched_level() {
+    DISPATCH_SIMDLevel(get_dispatched_level_impl);
+}
+
+#else // Static mode
+
+// =============================================================================
+// Static mode implementation
+// =============================================================================
+
+// Static initializer to set up the single supported level
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+static SIMDConfig simd_config_initializer;
+
+SIMDConfig::SIMDConfig(const char** /* faiss_simd_level_env */) {
+    // In static mode, the level is fixed at compile time
+    level = auto_detect_simd_level();
+    supported_simd_levels = (1 << static_cast<int>(level));
+}
+
+void SIMDConfig::set_level(SIMDLevel l) {
+    if (!is_simd_level_available(l)) {
+        FAISS_THROW_FMT(
+                "SIMDConfig::set_level: level %s is not available "
+                "(static build only supports %s)",
+                to_string(l).c_str(),
+                to_string(level).c_str());
+    }
+    // In static mode, setting to the same level is a no-op
+    level = l;
+}
+
+SIMDLevel SIMDConfig::get_level() {
+    return level;
+}
+
+std::string SIMDConfig::get_level_name() {
+    return to_string(level);
+}
+
+bool SIMDConfig::is_simd_level_available(SIMDLevel l) {
+    return (supported_simd_levels & (1 << static_cast<int>(l))) != 0;
+}
+
+SIMDLevel SIMDConfig::auto_detect_simd_level() {
+    // In static mode, return the compiled-in level
+#if defined(COMPILE_SIMD_AVX512_SPR)
+    return SIMDLevel::AVX512_SPR;
+#elif defined(COMPILE_SIMD_AVX512)
+    return SIMDLevel::AVX512;
+#elif defined(COMPILE_SIMD_AVX2)
+    return SIMDLevel::AVX2;
+#elif defined(COMPILE_SIMD_ARM_NEON)
+    return SIMDLevel::ARM_NEON;
+#else
+    return SIMDLevel::NONE;
+#endif
+}
+
+SIMDLevel SIMDConfig::get_dispatched_level() {
+    // In static mode, just return the current level (no dispatch)
+    return get_level();
+}
+
+#endif // FAISS_ENABLE_DD
+
+// =============================================================================
+// Common functions (both modes)
+// =============================================================================
+
+std::string to_string(SIMDLevel level) {
+    switch (level) {
+        case SIMDLevel::NONE:
+            return "NONE";
+        case SIMDLevel::AVX2:
+            return "AVX2";
+        case SIMDLevel::AVX512:
+            return "AVX512";
+        case SIMDLevel::AVX512_SPR:
+            return "AVX512_SPR";
+        case SIMDLevel::ARM_NEON:
+            return "ARM_NEON";
+        case SIMDLevel::COUNT:
+        default:
+            throw FaissException("Invalid SIMDLevel");
+    }
+}
+
+SIMDLevel to_simd_level(const std::string& level_str) {
+    if (level_str == "NONE") {
+        return SIMDLevel::NONE;
+    }
+    if (level_str == "AVX2") {
+        return SIMDLevel::AVX2;
+    }
+    if (level_str == "AVX512") {
+        return SIMDLevel::AVX512;
+    }
+    if (level_str == "AVX512_SPR") {
+        return SIMDLevel::AVX512_SPR;
+    }
+    if (level_str == "ARM_NEON") {
+        return SIMDLevel::ARM_NEON;
+    }
+
+    throw FaissException("Invalid SIMD level string: " + level_str);
+}
+
+} // namespace faiss

--- a/faiss/utils/simd_levels.h
+++ b/faiss/utils/simd_levels.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include <faiss/impl/platform_macros.h>
+
+namespace faiss {
+
+#define COMPILE_SIMD_NONE
+
+enum class SIMDLevel {
+    NONE,
+    // x86
+    AVX2,
+    AVX512,
+    AVX512_SPR, // Sapphire Rapids: AVX512 + BF16 + FP16 + VNNI
+    // arm & aarch64
+    ARM_NEON,
+
+    COUNT
+};
+
+/// Convert SIMDLevel to string. Throws FaissException for invalid level.
+std::string to_string(SIMDLevel level);
+
+/// Parse string to SIMDLevel. Throws FaissException for invalid strings.
+SIMDLevel to_simd_level(const std::string& level_str);
+
+/**
+ * Current SIMD configuration.
+ *
+ * This class provides a uniform API for querying and setting the SIMD level,
+ * regardless of whether faiss was built with Dynamic Dispatch (DD) or static
+ * SIMD selection.
+ *
+ * In DD mode:
+ *   - get_level() returns the runtime-detected or user-set level
+ *   - set_level() changes the runtime level (if level is supported)
+ *   - supported_simd_levels() returns bitmask of all compiled-in levels
+ *
+ * In static mode:
+ *   - get_level() returns the compiled-in level
+ *   - set_level() succeeds only if level matches compiled-in level
+ *   - supported_simd_levels() returns bitmask with single level
+ */
+struct FAISS_API SIMDConfig {
+    static SIMDLevel level;
+
+    /// Returns bitmask of supported SIMD levels (1 << SIMDLevel).
+    static uint64_t supported_simd_levels;
+
+    static SIMDLevel auto_detect_simd_level();
+
+    SIMDConfig(const char** faiss_simd_level_env = nullptr);
+
+    /// Set the SIMD level. Throws FaissException if level is not supported.
+    static void set_level(SIMDLevel level);
+    static SIMDLevel get_level();
+    static std::string get_level_name();
+
+    /// Check if a SIMD level is available (compiled in).
+    static bool is_simd_level_available(SIMDLevel level);
+
+    /// Returns the SIMD level via the dispatch mechanism.
+    /// In DD mode, uses DISPATCH_SIMDLevel internally.
+    /// In static mode, returns the compiled-in level.
+    /// Useful for verification: get_level() == get_dispatched_level()
+    static SIMDLevel get_dispatched_level();
+};
+
+} // namespace faiss

--- a/faiss/utils/utils.cpp
+++ b/faiss/utils/utils.cpp
@@ -8,6 +8,7 @@
 // -*- c++ -*-
 
 #include <faiss/Index.h>
+#include <faiss/utils/simd_levels.h>
 #include <faiss/utils/utils.h>
 
 #include <cassert>
@@ -115,16 +116,22 @@ std::string get_compile_options() {
     options += "OPTIMIZE ";
 #endif
 
-#ifdef __AVX512F__
-    options += "AVX512 ";
-#elif defined(__AVX2__)
-    options += "AVX2 ";
-#elif defined(__ARM_FEATURE_SVE)
-    options += "SVE NEON ";
-#elif defined(__aarch64__)
-    options += "NEON ";
+#ifdef FAISS_ENABLE_DD
+    // Dynamic Dispatch mode: report DD and all available SIMD levels
+    options += "DD ";
+    int supported = SIMDConfig::supported_simd_levels;
+    for (int i = 0; i < static_cast<int>(SIMDLevel::COUNT); ++i) {
+        auto level = static_cast<SIMDLevel>(i);
+        if ((supported & (1 << i)) && level != SIMDLevel::NONE) {
+            options += to_string(level) + " ";
+        }
+    }
 #else
-    options += "GENERIC ";
+    // Static mode: report the compiled-in SIMD level
+    SIMDLevel level = SIMDConfig::get_level();
+    if (level != SIMDLevel::NONE) {
+        options += to_string(level) + " ";
+    }
 #endif
 
 #ifdef FAISS_ENABLE_SVS

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,32 @@ if(FAISS_ENABLE_SVS)
   list(APPEND FAISS_TEST_SRC test_svs.cpp)
 endif()
 
+# DD-only tests: require Dynamic Dispatch (SIMDConfig)
+if(FAISS_OPT_LEVEL STREQUAL "dd")
+  list(APPEND FAISS_TEST_SRC
+    test_simd_levels.cpp
+    test_simd_levels_x86_avx2.cpp
+    test_simd_levels_x86_avx512.cpp
+  )
+  # Set SIMD compile flags per file (cross-platform)
+  if(NOT WIN32)
+    set_source_files_properties(test_simd_levels_x86_avx2.cpp
+      PROPERTIES COMPILE_OPTIONS "-mavx2;-mfma;-mf16c;-mpopcnt"
+    )
+    set_source_files_properties(test_simd_levels_x86_avx512.cpp
+      PROPERTIES COMPILE_OPTIONS "-mavx2;-mfma;-mf16c;-mpopcnt;-mavx512f;-mavx512cd;-mavx512vl;-mavx512dq;-mavx512bw"
+    )
+  else()
+    # MSVC
+    set_source_files_properties(test_simd_levels_x86_avx2.cpp
+      PROPERTIES COMPILE_OPTIONS "/arch:AVX2"
+    )
+    set_source_files_properties(test_simd_levels_x86_avx512.cpp
+      PROPERTIES COMPILE_OPTIONS "/arch:AVX512"
+    )
+  endif()
+endif()
+
 add_executable(faiss_test ${FAISS_TEST_SRC})
 
 if(FAISS_ENABLE_SVS)

--- a/tests/test_fast_scan.py
+++ b/tests/test_fast_scan.py
@@ -41,12 +41,16 @@ class TestSearch(unittest.TestCase):
     # hopefully the jitter in executtion time will not produce
     # too many spurious test failures. Unoptimized timings are
     # not exploitable, hence the flag test on that as well.
+    # TODO(DD): Add DD dispatch to fast_scan (pq4_fast_scan.cpp) and remove
+    # the "DD" exclusion below. Currently fast_scan is compiled with SSE4-only
+    # flags in DD mode, so it doesn't benefit from AVX2/AVX512 SIMD.
     @unittest.skipUnless(
         ('AVX2' in faiss.get_compile_options() or
         'AVX512' in faiss.get_compile_options() or
         'NEON' in faiss.get_compile_options()) and
-        "OPTIMIZE" in faiss.get_compile_options(),
-        "only test while building with avx2 or neon")
+        "OPTIMIZE" in faiss.get_compile_options() and
+        "DD" not in faiss.get_compile_options(),
+        "only test in static mode with avx2 or neon (DD lacks fast_scan dispatch)")
     def test_PQ4_speed(self):
         ds  = datasets.SyntheticDataset(32, 2000, 5000, 1000)
         xt = ds.get_train()

--- a/tests/test_simd_dispatch.py
+++ b/tests/test_simd_dispatch.py
@@ -1,0 +1,130 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Tests for Dynamic Dispatch (DD) SIMD level selection.
+
+These tests verify that FAISS_SIMD_LEVEL environment variable correctly
+controls which SIMD implementation is used at runtime.
+
+NOTE: These tests only work with DD builds (FAISS_ENABLE_DD).
+In static builds, the SIMD level is fixed at compile time.
+"""
+
+import os
+import subprocess
+import sys
+import unittest
+
+
+def get_available_simd_levels():
+    """
+    Returns SIMD levels that are available on the current platform.
+    NONE is always available. Others depend on architecture.
+    """
+    import platform
+    arch = platform.machine().lower()
+
+    # SIMDLevel enum names
+    levels = ["NONE"]
+
+    if arch in ("x86_64", "amd64"):
+        levels.extend(["AVX2", "AVX512"])
+        # AVX512_SPR is typically not enabled in DD builds
+    elif arch in ("aarch64", "arm64"):
+        levels.append("ARM_NEON")
+
+    return levels
+
+
+class TestSIMDDispatch(unittest.TestCase):
+    """Tests for SIMD dispatch via FAISS_SIMD_LEVEL environment variable."""
+
+    def test_dispatch_function_exists(self):
+        """Verify SIMDConfig.get_dispatched_level() is available."""
+        try:
+            import faiss
+        except ImportError:
+            self.skipTest("faiss not available")
+
+        # Method should exist on SIMDConfig
+        self.assertTrue(hasattr(faiss.SIMDConfig, 'get_dispatched_level'))
+
+        # Should return a value (SIMDLevel enum)
+        result = faiss.SIMDConfig.get_dispatched_level()
+        # In SWIG, enum values are integers
+        self.assertIsNotNone(result)
+
+    def test_get_level_equals_get_dispatched_level(self):
+        """Verify get_level() and get_dispatched_level() return the same value."""
+        try:
+            import faiss
+        except ImportError:
+            self.skipTest("faiss not available")
+
+        level = faiss.SIMDConfig.get_level()
+        dispatched = faiss.SIMDConfig.get_dispatched_level()
+        self.assertEqual(level, dispatched)
+
+    def test_dispatch_with_env_var(self):
+        """
+        Test that FAISS_SIMD_LEVEL controls dispatch.
+
+        Runs faiss in subprocesses with different SIMD levels and verifies
+        that get_dispatched_level() returns the expected value.
+        """
+        # Only run in DD mode
+        try:
+            import faiss
+            if "DD" not in faiss.get_compile_options():
+                self.skipTest("Not a DD build - SIMD level is fixed at compile time")
+        except ImportError:
+            self.skipTest("faiss not available")
+
+        levels = get_available_simd_levels()
+
+        # Get the PYTHONPATH that includes faiss module
+        python_path = os.pathsep.join(sys.path)
+
+        for level_name in levels:
+            with self.subTest(level=level_name):
+                # Run a subprocess with FAISS_SIMD_LEVEL set
+                env = os.environ.copy()
+                env["FAISS_SIMD_LEVEL"] = level_name
+                env["PYTHONPATH"] = python_path
+
+                script = f'''
+import faiss
+level = faiss.SIMDConfig.get_level()
+dispatched = faiss.SIMDConfig.get_dispatched_level()
+level_name = faiss.SIMDConfig.get_level_name()
+
+# Verify dispatch matches
+if level != dispatched:
+    print(f"FAIL: get_level() != get_dispatched_level()")
+    exit(1)
+
+# Verify it's the expected level
+if level_name != "{level_name}":
+    print(f"FAIL: expected {level_name}, got {{level_name}}")
+    exit(1)
+
+print(f"OK: SIMD level {level_name} dispatched correctly")
+'''
+                result = subprocess.run(
+                    [sys.executable, "-c", script],
+                    env=env,
+                    capture_output=True,
+                    text=True
+                )
+
+                self.assertEqual(
+                    result.returncode, 0,
+                    f"Failed for {level_name}: {result.stdout} {result.stderr}"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_simd_levels.cpp
+++ b/tests/test_simd_levels.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Core SIMDConfig API tests - works in both static and DD modes.
+// Hardware execution tests (DD-only) are in separate files:
+// - test_simd_levels_x86_avx2.cpp (compiled with AVX2 flags)
+// - test_simd_levels_x86_avx512.cpp (compiled with AVX512 flags)
+
+#include <gtest/gtest.h>
+
+#include <faiss/impl/FaissException.h>
+#include <faiss/utils/simd_levels.h>
+#include <faiss/utils/utils.h>
+
+// Helper to check if we're in DD mode
+static bool is_dd_mode() {
+    return faiss::get_compile_options().find("DD") != std::string::npos;
+}
+
+TEST(SIMDConfig, get_level_returns_valid_level) {
+    // Works in both static and DD modes
+    faiss::SIMDLevel level = faiss::SIMDConfig::get_level();
+    EXPECT_NE(level, faiss::SIMDLevel::COUNT);
+    EXPECT_GE(static_cast<int>(level), 0);
+    EXPECT_LT(
+            static_cast<int>(level), static_cast<int>(faiss::SIMDLevel::COUNT));
+}
+
+TEST(SIMDConfig, supported_simd_levels_not_empty) {
+    // Works in both static and DD modes
+    // Current level should always be in supported levels
+    EXPECT_TRUE(
+            faiss::SIMDConfig::is_simd_level_available(
+                    faiss::SIMDConfig::get_level()));
+}
+
+TEST(SIMDConfig, set_level_to_supported_level_succeeds) {
+    // Works in both static and DD modes
+    faiss::SIMDLevel original_level = faiss::SIMDConfig::get_level();
+
+    // Setting to any supported level should succeed
+    for (int i = 0; i < static_cast<int>(faiss::SIMDLevel::COUNT); ++i) {
+        auto level = static_cast<faiss::SIMDLevel>(i);
+        if (faiss::SIMDConfig::is_simd_level_available(level)) {
+            EXPECT_NO_THROW(faiss::SIMDConfig::set_level(level))
+                    << "set_level(" << faiss::to_string(level)
+                    << ") should succeed";
+            EXPECT_EQ(faiss::SIMDConfig::get_level(), level);
+        }
+    }
+
+    // Restore original level
+    faiss::SIMDConfig::set_level(original_level);
+}
+
+TEST(SIMDConfig, set_level_to_unsupported_level_throws) {
+    // Works in both static and DD modes
+    // Find a level that's NOT supported
+    faiss::SIMDLevel unsupported = faiss::SIMDLevel::COUNT;
+    for (int i = 0; i < static_cast<int>(faiss::SIMDLevel::COUNT); ++i) {
+        auto level = static_cast<faiss::SIMDLevel>(i);
+        if (!faiss::SIMDConfig::is_simd_level_available(level)) {
+            unsupported = level;
+            break;
+        }
+    }
+
+    if (unsupported != faiss::SIMDLevel::COUNT) {
+        EXPECT_THROW(
+                faiss::SIMDConfig::set_level(unsupported),
+                faiss::FaissException)
+                << "set_level(" << faiss::to_string(unsupported)
+                << ") should throw";
+    }
+}
+
+TEST(SIMDConfig, static_mode_has_single_level) {
+    // Static mode should have exactly 1 level: the compiled-in level
+    if (is_dd_mode()) {
+        GTEST_SKIP() << "DD build - has multiple levels";
+    }
+
+    int count = 0;
+    for (int i = 0; i < static_cast<int>(faiss::SIMDLevel::COUNT); ++i) {
+        if (faiss::SIMDConfig::is_simd_level_available(
+                    static_cast<faiss::SIMDLevel>(i))) {
+            ++count;
+        }
+    }
+    EXPECT_EQ(count, 1)
+            << "Static mode should have exactly 1 level (compiled-in)";
+}
+
+TEST(SIMDConfig, get_level_name_matches_level) {
+    // Works in both static and DD modes
+    faiss::SIMDLevel level = faiss::SIMDConfig::get_level();
+    std::string name = faiss::SIMDConfig::get_level_name();
+    std::string expected = faiss::to_string(level);
+    EXPECT_EQ(name, expected);
+}
+
+TEST(SIMDConfig, get_dispatched_level_matches_get_level) {
+    // Works in both static and DD modes
+    // Verifies that dispatch mechanism returns the same level as get_level()
+    faiss::SIMDLevel level = faiss::SIMDConfig::get_level();
+    faiss::SIMDLevel dispatched = faiss::SIMDConfig::get_dispatched_level();
+    EXPECT_EQ(level, dispatched)
+            << "get_level() returned " << faiss::to_string(level)
+            << " but get_dispatched_level() returned "
+            << faiss::to_string(dispatched);
+}
+
+TEST(SIMDLevel, to_string_all_levels) {
+    EXPECT_EQ("NONE", faiss::to_string(faiss::SIMDLevel::NONE));
+    EXPECT_EQ("AVX2", faiss::to_string(faiss::SIMDLevel::AVX2));
+    EXPECT_EQ("AVX512", faiss::to_string(faiss::SIMDLevel::AVX512));
+    EXPECT_EQ("AVX512_SPR", faiss::to_string(faiss::SIMDLevel::AVX512_SPR));
+    EXPECT_EQ("ARM_NEON", faiss::to_string(faiss::SIMDLevel::ARM_NEON));
+
+    // COUNT should throw
+    EXPECT_THROW(
+            faiss::to_string(faiss::SIMDLevel::COUNT), faiss::FaissException);
+}
+
+TEST(SIMDLevel, to_simd_level_all_strings) {
+    EXPECT_EQ(faiss::SIMDLevel::NONE, faiss::to_simd_level("NONE"));
+    EXPECT_EQ(faiss::SIMDLevel::AVX2, faiss::to_simd_level("AVX2"));
+    EXPECT_EQ(faiss::SIMDLevel::AVX512, faiss::to_simd_level("AVX512"));
+    EXPECT_EQ(faiss::SIMDLevel::AVX512_SPR, faiss::to_simd_level("AVX512_SPR"));
+    EXPECT_EQ(faiss::SIMDLevel::ARM_NEON, faiss::to_simd_level("ARM_NEON"));
+
+    // Invalid strings should throw
+    EXPECT_THROW(faiss::to_simd_level("INVALID"), faiss::FaissException);
+    EXPECT_THROW(faiss::to_simd_level(""), faiss::FaissException);
+}
+
+TEST(SIMDConfig, modern_hardware_has_simd_support) {
+    // In DD mode, verify modern hardware detects SIMD support
+    if (!is_dd_mode()) {
+        GTEST_SKIP() << "Static build - level is fixed at compile time";
+    }
+
+    faiss::SIMDLevel detected = faiss::SIMDConfig::auto_detect_simd_level();
+
+#if defined(__x86_64__) || defined(_M_X64)
+    // All modern x86_64 machines (Haswell 2013+) support at least AVX2
+    EXPECT_NE(detected, faiss::SIMDLevel::NONE)
+            << "x86_64 machines should support at least AVX2";
+#elif defined(__aarch64__) || defined(_M_ARM64)
+    // NEON is mandatory on aarch64
+    EXPECT_NE(detected, faiss::SIMDLevel::NONE)
+            << "ARM64 machines should support at least NEON";
+#endif
+}
+
+TEST(CompileOptions, lists_expected_levels) {
+    std::string options = faiss::get_compile_options();
+
+    // All supported levels (except NONE) should be in compile options
+    for (int i = 0; i < static_cast<int>(faiss::SIMDLevel::COUNT); ++i) {
+        auto level = static_cast<faiss::SIMDLevel>(i);
+        if (!faiss::SIMDConfig::is_simd_level_available(level)) {
+            continue;
+        }
+        if (level == faiss::SIMDLevel::NONE) {
+            continue; // NONE is not reported in options
+        }
+        std::string name = faiss::to_string(level);
+        EXPECT_NE(options.find(name), std::string::npos)
+                << "Supported level " << name
+                << " should be in compile options: " << options;
+    }
+
+    // DD mode should have "DD" marker
+    if (is_dd_mode()) {
+        EXPECT_NE(options.find("DD"), std::string::npos)
+                << "DD mode should have 'DD' in compile options: " << options;
+    }
+}

--- a/tests/test_simd_levels_x86_avx2.cpp
+++ b/tests/test_simd_levels_x86_avx2.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// AVX2 hardware execution tests - this file is compiled with AVX2 flags.
+// Verifies that AVX2 instructions execute correctly when SIMDConfig reports
+// AVX2 support.
+
+#if defined(__x86_64__) || defined(_M_X64)
+
+#include <gtest/gtest.h>
+#include <immintrin.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <vector>
+
+#include <faiss/utils/simd_levels.h>
+
+namespace {
+
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+static jmp_buf jmpbuf;
+
+[[noreturn]] static void sigill_handler(int /* sig */) {
+    longjmp(jmpbuf, 1);
+}
+
+std::pair<bool, std::vector<int>> try_execute_avx2(std::vector<int> (*func)()) {
+    signal(SIGILL, sigill_handler);
+    if (setjmp(jmpbuf) == 0) {
+        auto result = func();
+        signal(SIGILL, SIG_DFL);
+        return std::make_pair(true, result);
+    } else {
+        signal(SIGILL, SIG_DFL);
+        return std::make_pair(false, std::vector<int>());
+    }
+}
+
+std::vector<int> run_avx2_computation() {
+    alignas(32) int result[8];
+    alignas(32) int input1[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+    alignas(32) int input2[8] = {8, 7, 6, 5, 4, 3, 2, 1};
+
+    __m256i vec1 = _mm256_load_si256(reinterpret_cast<__m256i*>(input1));
+    __m256i vec2 = _mm256_load_si256(reinterpret_cast<__m256i*>(input2));
+    __m256i vec_result = _mm256_add_epi32(vec1, vec2);
+    _mm256_store_si256(reinterpret_cast<__m256i*>(result), vec_result);
+
+    return {result, result + 8};
+}
+
+} // namespace
+
+TEST(SIMDConfig, successful_avx2_execution_on_x86arch) {
+    if (faiss::SIMDConfig::is_simd_level_available(faiss::SIMDLevel::AVX2)) {
+        auto actual_result = try_execute_avx2(run_avx2_computation);
+        EXPECT_TRUE(actual_result.first);
+        auto expected_result_vector = std::vector<int>(8, 9);
+        EXPECT_EQ(actual_result.second, expected_result_vector);
+    }
+}
+
+TEST(SIMDConfig, on_avx512f_supported_we_should_have_avx2_support_as_well) {
+    if (faiss::SIMDConfig::is_simd_level_available(faiss::SIMDLevel::AVX512)) {
+        EXPECT_TRUE(
+                faiss::SIMDConfig::is_simd_level_available(
+                        faiss::SIMDLevel::AVX2));
+    }
+}
+
+#endif // defined(__x86_64__) || defined(_M_X64)

--- a/tests/test_simd_levels_x86_avx512.cpp
+++ b/tests/test_simd_levels_x86_avx512.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// AVX512 hardware execution tests - this file is compiled with AVX512 flags.
+// Verifies that AVX512 instructions execute correctly when SIMDConfig reports
+// AVX512 support.
+
+#if defined(__x86_64__) || defined(_M_X64)
+
+#include <gtest/gtest.h>
+#include <immintrin.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <vector>
+
+#include <faiss/utils/simd_levels.h>
+
+namespace {
+
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+static jmp_buf jmpbuf;
+
+[[noreturn]] static void sigill_handler(int /* sig */) {
+    longjmp(jmpbuf, 1);
+}
+
+std::pair<bool, std::vector<int>> try_execute_avx512(
+        std::vector<int> (*func)()) {
+    signal(SIGILL, sigill_handler);
+    if (setjmp(jmpbuf) == 0) {
+        auto result = func();
+        signal(SIGILL, SIG_DFL);
+        return std::make_pair(true, result);
+    } else {
+        signal(SIGILL, SIG_DFL);
+        return std::make_pair(false, std::vector<int>());
+    }
+}
+
+std::vector<int> run_avx512f_computation() {
+    alignas(64) long long result[8];
+    alignas(64) long long input1[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+    alignas(64) long long input2[8] = {8, 7, 6, 5, 4, 3, 2, 1};
+
+    __m512i vec1 = _mm512_load_si512(reinterpret_cast<const __m512i*>(input1));
+    __m512i vec2 = _mm512_load_si512(reinterpret_cast<const __m512i*>(input2));
+    __m512i vec_result = _mm512_add_epi64(vec1, vec2);
+    _mm512_store_si512(reinterpret_cast<__m512i*>(result), vec_result);
+
+    return {result, result + 8};
+}
+
+std::vector<int> run_avx512cd_computation() {
+    run_avx512f_computation();
+
+    __m512i indices = _mm512_set_epi32(
+            15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+    __m512i conflict_mask = _mm512_conflict_epi32(indices);
+
+    alignas(64) int mask_array[16];
+    _mm512_store_epi32(mask_array, conflict_mask);
+
+    return std::vector<int>();
+}
+
+std::vector<int> run_avx512vl_computation() {
+    run_avx512f_computation();
+
+    __m256i vec1 = _mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0);
+    __m256i vec2 = _mm256_set_epi32(0, 1, 2, 3, 4, 5, 6, 7);
+    __m256i result = _mm256_add_epi32(vec1, vec2);
+    alignas(32) int result_array[8];
+    _mm256_store_si256(reinterpret_cast<__m256i*>(result_array), result);
+
+    return std::vector<int>(result_array, result_array + 8);
+}
+
+std::vector<int> run_avx512dq_computation() {
+    run_avx512f_computation();
+
+    __m512i vec1 = _mm512_set_epi64(7, 6, 5, 4, 3, 2, 1, 0);
+    __m512i vec2 = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
+    __m512i result = _mm512_add_epi64(vec1, vec2);
+
+    alignas(64) long long result_array[8];
+    _mm512_store_si512(result_array, result);
+
+    return std::vector<int>(result_array, result_array + 8);
+}
+
+std::vector<int> run_avx512bw_computation() {
+    run_avx512f_computation();
+
+    std::vector<int8_t> input1(64, 0);
+    __m512i vec1 =
+            _mm512_loadu_si512(reinterpret_cast<const void*>(input1.data()));
+    std::vector<int8_t> input2(64, 7);
+    __m512i vec2 =
+            _mm512_loadu_si512(reinterpret_cast<const void*>(input2.data()));
+    __m512i result = _mm512_add_epi8(vec1, vec2);
+
+    alignas(64) int8_t result_array[64];
+    _mm512_storeu_si512(reinterpret_cast<__m512i*>(result_array), result);
+
+    return std::vector<int>(result_array, result_array + 64);
+}
+
+} // namespace
+
+TEST(SIMDConfig, successful_avx512f_execution_on_x86arch) {
+    if (faiss::SIMDConfig::is_simd_level_available(faiss::SIMDLevel::AVX512)) {
+        auto actual_result = try_execute_avx512(run_avx512f_computation);
+        EXPECT_TRUE(actual_result.first);
+        auto expected_result_vector = std::vector<int>(8, 9);
+        EXPECT_EQ(actual_result.second, expected_result_vector);
+    }
+}
+
+TEST(SIMDConfig, successful_avx512cd_execution_on_x86arch) {
+    if (faiss::SIMDConfig::is_simd_level_available(faiss::SIMDLevel::AVX512)) {
+        auto actual = try_execute_avx512(run_avx512cd_computation);
+        EXPECT_TRUE(actual.first);
+    }
+}
+
+TEST(SIMDConfig, successful_avx512vl_execution_on_x86arch) {
+    if (faiss::SIMDConfig::is_simd_level_available(faiss::SIMDLevel::AVX512)) {
+        auto actual = try_execute_avx512(run_avx512vl_computation);
+        EXPECT_TRUE(actual.first);
+        EXPECT_EQ(actual.second, std::vector<int>(8, 7));
+    }
+}
+
+TEST(SIMDConfig, successful_avx512dq_execution_on_x86arch) {
+    if (faiss::SIMDConfig::is_simd_level_available(faiss::SIMDLevel::AVX512)) {
+        auto actual = try_execute_avx512(run_avx512dq_computation);
+        EXPECT_TRUE(actual.first);
+        EXPECT_EQ(actual.second, std::vector<int>(8, 7));
+    }
+}
+
+TEST(SIMDConfig, successful_avx512bw_execution_on_x86arch) {
+    if (faiss::SIMDConfig::is_simd_level_available(faiss::SIMDLevel::AVX512)) {
+        auto actual = try_execute_avx512(run_avx512bw_computation);
+        EXPECT_TRUE(actual.first);
+        EXPECT_EQ(actual.second, std::vector<int>(64, 7));
+    }
+}
+
+#endif // defined(__x86_64__) || defined(_M_X64)


### PR DESCRIPTION
Summary:

Implementation of:
- `SIMDLevel` that can be used as a template parameter to differentiate implementations 
- `SIMDConfig` object that defines what is the enabled SIMDLevel

in the TARGETS all SIMD code is disabled by default.

Reviewed By: mnorris11

Differential Revision: D72937710


