### PR TITLE
inline scanning code for fast distance computations

### DIFF
--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// -*- c++ -*-
-
 #include <faiss/IndexIVF.h>
 
 #include <omp.h>
@@ -28,6 +26,7 @@
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/IDSelector.h>
 #include <faiss/impl/ResultHandler.h>
+#include <faiss/impl/expanded_scanners.h>
 
 namespace faiss {
 
@@ -1345,81 +1344,14 @@ IndexIVFStats indexIVF_stats;
  * InvertedListScanner
  *************************************************************************/
 
-namespace {
-
-template <typename C, bool store_pairs, bool use_sel>
-size_t run_scan_codes1(
-        const InvertedListScanner& scanner,
-        size_t list_size,
-        const uint8_t* codes,
-        const idx_t* ids,
-        ResultHandler& handler) {
-    size_t nup = 0;
-    size_t list_no = scanner.list_no;
-    size_t code_size = scanner.code_size;
-    const IDSelector* sel = scanner.sel;
-    for (size_t j = 0; j < list_size; j++) {
-        if (use_sel) {
-            int64_t id = store_pairs ? lo_build(list_no, j) : ids[j];
-            // skip code without computing distance
-            if (!sel->is_member(id)) {
-                codes += code_size;
-                continue;
-            }
-        }
-
-        float dis = scanner.distance_to_code(codes);
-        if (C::cmp(handler.threshold, dis)) {
-            int64_t id = store_pairs ? lo_build(list_no, j) : ids[j];
-            handler.add_result(dis, id);
-            nup++;
-        }
-        codes += code_size;
-    }
-
-    return nup;
-}
-
-template <bool store_pairs, bool use_sel>
-size_t run_scan_codes(
-        const InvertedListScanner& scanner,
-        size_t list_size,
-        const uint8_t* codes,
-        const idx_t* ids,
-        ResultHandler& handler) {
-    if (scanner.keep_max) {
-        return run_scan_codes1<CMin<float, idx_t>, store_pairs, use_sel>(
-                scanner, list_size, codes, ids, handler);
-    } else {
-        return run_scan_codes1<CMax<float, idx_t>, store_pairs, use_sel>(
-                scanner, list_size, codes, ids, handler);
-    }
-}
-
-} // anonymous namespace
+// this gets expanded in expanded_scanners
 
 size_t InvertedListScanner::scan_codes(
         size_t list_size,
         const uint8_t* codes,
         const idx_t* ids,
         ResultHandler& handler) const {
-    if (sel == nullptr) {
-        if (store_pairs) {
-            return run_scan_codes<true, false>(
-                    *this, list_size, codes, ids, handler);
-        } else {
-            return run_scan_codes<false, false>(
-                    *this, list_size, codes, ids, handler);
-        }
-    } else {
-        if (store_pairs) {
-            return run_scan_codes<true, true>(
-                    *this, list_size, codes, ids, handler);
-        } else {
-            return run_scan_codes<false, true>(
-                    *this, list_size, codes, ids, handler);
-        }
-    }
+    return run_scan_codes(*this, list_size, codes, ids, handler);
 }
 
 void InvertedListScanner::set_list(idx_t list_no_in, float /* coarse_dis */) {

--- a/faiss/IndexIVFFlat.cpp
+++ b/faiss/IndexIVFFlat.cpp
@@ -21,6 +21,7 @@
 #include <faiss/impl/IDSelector.h>
 
 #include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/expanded_scanners.h>
 #include <faiss/utils/distances.h>
 #include <faiss/utils/extra_distances.h>
 #include <faiss/utils/utils.h>
@@ -147,7 +148,7 @@ void IndexIVFFlat::sa_decode(idx_t n, const uint8_t* bytes, float* x) const {
 
 namespace {
 
-template <typename VectorDistance, bool use_sel>
+template <typename VectorDistance>
 struct IVFFlatScanner : InvertedListScanner {
     VectorDistance vd;
     using C = typename VectorDistance::C;
@@ -174,6 +175,15 @@ struct IVFFlatScanner : InvertedListScanner {
         const float* yj = (float*)code;
         return vd(xi, yj);
     }
+
+    // redefining the scan_codes allows to inline the distance_to_code
+    size_t scan_codes(
+            size_t list_size,
+            const uint8_t* codes,
+            const idx_t* ids,
+            ResultHandler& handler) const {
+        return run_scan_codes_fix_C<C>(*this, list_size, codes, ids, handler);
+    }
 };
 
 struct Run_get_InvertedListScanner {
@@ -185,11 +195,7 @@ struct Run_get_InvertedListScanner {
             const IndexIVFFlat* ivf,
             bool store_pairs,
             const IDSelector* sel) {
-        if (sel) {
-            return new IVFFlatScanner<VD, true>(vd, store_pairs, sel);
-        } else {
-            return new IVFFlatScanner<VD, false>(vd, store_pairs, sel);
-        }
+        return new IVFFlatScanner<VD>(vd, store_pairs, sel);
     }
 };
 

--- a/faiss/impl/expanded_scanners.h
+++ b/faiss/impl/expanded_scanners.h
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdio>
+
+#include <faiss/IndexIVF.h>
+#include <faiss/impl/ResultHandler.h>
+
+/* This is the inner loop of the inverted list scanners. The default version
+ * that is defined in IndexIVF.cpp works fine but it cannot inline the distance
+ * computation code by calling one or another of the run_scan_codes_* variants
+ * with the exact ScannerType and by setting distance_to_code to be a final
+ * function, the code can be inlined. The speed difference matters for very
+ * small distance computations (eg. SQ or Flat) */
+
+namespace faiss {
+
+namespace {
+
+template <class ScannerType, typename C, bool store_pairs, bool use_sel>
+size_t run_scan_codes1(
+        const ScannerType& scanner,
+        size_t list_size,
+        const uint8_t* codes,
+        const idx_t* ids,
+        ResultHandler& handler) {
+    size_t nup = 0;
+    size_t list_no = scanner.list_no;
+    size_t code_size = scanner.code_size;
+    const IDSelector* sel = scanner.sel;
+    float threshold = handler.threshold;
+    for (size_t j = 0; j < list_size; j++) {
+        if (use_sel) {
+            int64_t id = store_pairs ? lo_build(list_no, j) : ids[j];
+            // skip code without computing distance
+            if (!sel->is_member(id)) {
+                codes += code_size;
+                continue;
+            }
+        }
+
+        float dis = scanner.distance_to_code(codes); // will be inlined if final
+        if (C::cmp(threshold, dis)) {
+            int64_t id = store_pairs ? lo_build(list_no, j) : ids[j];
+            handler.add_result(dis, id);
+            threshold = handler.threshold;
+            nup++;
+        }
+        codes += code_size;
+    }
+
+    return nup;
+}
+
+/*****************************************************************************
+ * The following functions dispatch runtime parameters to templates, with
+ * possibly some already-fixed templates.
+ */
+
+template <bool store_pairs, bool use_sel, class ScannerType>
+size_t run_scan_codes_fix_store_pairs_fix_use_sel(
+        const ScannerType& scanner,
+        size_t list_size,
+        const uint8_t* codes,
+        const idx_t* ids,
+        ResultHandler& handler) {
+    if (scanner.keep_max) {
+        return run_scan_codes1<
+                ScannerType,
+                CMin<float, idx_t>,
+                store_pairs,
+                use_sel>(scanner, list_size, codes, ids, handler);
+    } else {
+        return run_scan_codes1<
+                ScannerType,
+                CMax<float, idx_t>,
+                store_pairs,
+                use_sel>(scanner, list_size, codes, ids, handler);
+    }
+}
+
+template <class C, bool use_sel, class ScannerType>
+size_t run_scan_codes_fix_C_fix_use_sel(
+        const ScannerType& scanner,
+        size_t list_size,
+        const uint8_t* codes,
+        const idx_t* ids,
+        ResultHandler& handler) {
+    if (scanner.store_pairs) {
+        return run_scan_codes1<ScannerType, C, true, use_sel>(
+                scanner, list_size, codes, ids, handler);
+    } else {
+        return run_scan_codes1<ScannerType, C, false, use_sel>(
+                scanner, list_size, codes, ids, handler);
+    }
+}
+
+template <class C, class ScannerType>
+size_t run_scan_codes_fix_C(
+        const ScannerType& scanner,
+        size_t list_size,
+        const uint8_t* codes,
+        const idx_t* ids,
+        ResultHandler& handler) {
+    if (scanner.sel) {
+        if (scanner.store_pairs) {
+            return run_scan_codes1<ScannerType, C, true, true>(
+                    scanner, list_size, codes, ids, handler);
+        } else {
+            return run_scan_codes1<ScannerType, C, false, true>(
+                    scanner, list_size, codes, ids, handler);
+        }
+    } else {
+        if (scanner.store_pairs) {
+            return run_scan_codes1<ScannerType, C, true, false>(
+                    scanner, list_size, codes, ids, handler);
+        } else {
+            return run_scan_codes1<ScannerType, C, false, false>(
+                    scanner, list_size, codes, ids, handler);
+        }
+    }
+}
+
+template <class ScannerType>
+size_t run_scan_codes(
+        const ScannerType& scanner,
+        size_t list_size,
+        const uint8_t* codes,
+        const idx_t* ids,
+        ResultHandler& handler) {
+    if (scanner.sel == nullptr) {
+        if (scanner.store_pairs) {
+            return run_scan_codes_fix_store_pairs_fix_use_sel<true, false>(
+                    scanner, list_size, codes, ids, handler);
+        } else {
+            return run_scan_codes_fix_store_pairs_fix_use_sel<false, false>(
+                    scanner, list_size, codes, ids, handler);
+        }
+    } else {
+        if (scanner.store_pairs) {
+            return run_scan_codes_fix_store_pairs_fix_use_sel<true, true>(
+                    scanner, list_size, codes, ids, handler);
+        } else {
+            return run_scan_codes_fix_store_pairs_fix_use_sel<false, true>(
+                    scanner, list_size, codes, ids, handler);
+        }
+    }
+}
+
+} // anonymous namespace
+
+} // namespace faiss


### PR DESCRIPTION
Summary:
After the ResultHandler diff landed there was a 1% performance regression on some critical codepath.

It seems plausible that this regression was caused because the inner loop of the scanning code calls 2 virtual functions:
- distance_to_code to compute a code distance
- add_result to update the result structure whenever a better restlt is found

It is probably the distance_to_code function that is the culprit because it is called for *all* the codes, when distance_to_code is called only if a better rresult is found.

What this diff changes is that the scanning code is made available to the InvertedListScanner implementation so that the distance computation inlining can happen.

This is applied to IndexIVFScalarQuantizer, IndexIVFFlat and IndexIVFRabitQ (it turns out that this one has a virtual function call inside its ditance_to_code so this update is unlikely to be significant).

Reviewed By: junjieqi

Differential Revision: D91830227


