### PR TITLE
Fix OSX arm64 nightly by disabling hidden visibility on macOS

### DIFF
--- a/faiss/python/CMakeLists.txt
+++ b/faiss/python/CMakeLists.txt
@@ -114,11 +114,11 @@ swig_add_library(swigfaiss
   SOURCES swigfaiss.swig
 )
 
-if(TARGET swigfaiss)
-    set_target_properties(swigfaiss PROPERTIES
-        CXX_VISIBILITY_PRESET hidden
-        VISIBILITY_INLINES_HIDDEN ON
-    )
+if(TARGET swigfaiss AND NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  set_target_properties(swigfaiss PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
+  )
 endif()
 
 set_property(TARGET swigfaiss PROPERTY SWIG_COMPILE_OPTIONS -doxygen)


### PR DESCRIPTION
Summary:
Hidden symbol visibility breaks SWIG's dynamic_cast on macOS because RTTI typeinfo symbols are not shared across dylib boundaries. This causes downcast_index() to return generic Index objects instead of specific derived types, resulting in AttributeError failures in tests.

Linux and Windows handle RTTI differently and work correctly with hidden visibility.

Differential Revision: D92076961


