### PR TITLE
Fix string-conversion issue in faiss/invlists/OnDiskInvertedLists.cpp +5

### DIFF
--- a/faiss/invlists/OnDiskInvertedLists.cpp
+++ b/faiss/invlists/OnDiskInvertedLists.cpp
@@ -314,7 +314,7 @@ void OnDiskInvertedLists::update_totsize(size_t new_size) {
             slots.push_back(Slot(totsize, new_size - totsize));
         }
     } else {
-        assert(!"not implemented");
+        assert(false && "not implemented");
     }
 
     totsize = new_size;

--- a/faiss/utils/partitioning.cpp
+++ b/faiss/utils/partitioning.cpp
@@ -627,7 +627,7 @@ uint16_t simd_partition_fuzzy_with_bounds_histogram(
             n_lt = sum_below - hist[i];
             n_gt = n - sum_below;
         } else {
-            assert(!"not implemented");
+            assert(false && "not implemented");
         }
 
         IFV printf(

--- a/tests/test_dealloc_invlists.cpp
+++ b/tests/test_dealloc_invlists.cpp
@@ -109,17 +109,17 @@ struct EncapsulateInvertedLists : InvertedLists {
     }
 
     size_t add_entries(size_t, size_t, const idx_t*, const uint8_t*) override {
-        assert(!"not implemented");
+        assert(false && "not implemented");
         return 0;
     }
 
     void update_entries(size_t, size_t, size_t, const idx_t*, const uint8_t*)
             override {
-        assert(!"not implemented");
+        assert(false && "not implemented");
     }
 
     void resize(size_t, size_t) override {
-        assert(!"not implemented");
+        assert(false && "not implemented");
     }
 
     ~EncapsulateInvertedLists() override {}


### PR DESCRIPTION
Summary:
This could is triggering `-Wstring-conversion`, which presents as:
```
warning: implicit conversion turns string literal into bool: A to B
```
This is often a bug and what was intended. The most frequent cause is the code was:
```
void foo(bool) { ... }
void foo(std::string) { ... }
foo("this gets interpreted as a bool");
```

It is also possible the issue is innocuous as part of an assert:
```
assert(!"this string is true, so the assertion is false");
EXPECT_FALSE("this string is true, so the expect fails");
```
in these cases the use is to "cute", so we modify the code to make it more obvious.
```
assert(false && "the compiler recognizes and doesn't complain about this pattern");
FAIL() << "much more obvious";
```

Reviewed By: mdouze

Differential Revision: D92013578


