### PR TITLE
Fix string-conversion issue in faiss/impl/lattice_Zn.cpp +1

### DIFF
--- a/faiss/impl/lattice_Zn.cpp
+++ b/faiss/impl/lattice_Zn.cpp
@@ -490,7 +490,7 @@ ZnSphereCodecRec::ZnSphereCodecRec(int dim, int r2)
     while (dim > (1 << log2_dim)) {
         log2_dim++;
     }
-    assert(dim == (1 << log2_dim) || !"dimension must be a power of 2");
+    assert(dim == (1 << log2_dim) && "dimension must be a power of 2");
 
     all_nv.resize((log2_dim + 1) * (r2 + 1));
     all_nv_cum.resize((log2_dim + 1) * (r2 + 1) * (r2 + 1));


### PR DESCRIPTION
Summary:
This could is triggering `-Wstring-conversion`, which presents as:
```
warning: implicit conversion turns string literal into bool: A to B
```
This is often a bug and what was intended. The most frequent cause is the code was:
```
void foo(bool) { ... }
void foo(std::string) { ... }
foo("this gets interpreted as a bool");
```

It is also possible the issue is innocuous as part of an assert:
```
assert(!"this string is true, so the assertion is false");
EXPECT_FALSE("this string is true, so the expect fails");
```
in these cases the use is to "cute", so we modify the code to make it more obvious.
```
assert(false && "the compiler recognizes and doesn't complain about this pattern");
FAIL() << "much more obvious";
```

Differential Revision: D92528311


