### PR TITLE
Add post_init_hook call to Python __init__

### DIFF
--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -357,3 +357,9 @@ class TimeoutGuard:
 
     def __exit__(self, exc_type, exc_value, traceback):
         PythonInterruptCallback.reset()
+
+
+try:
+    post_init_hook()
+except NameError:
+    pass


### PR DESCRIPTION
Summary: Describes it as a generic extensibility point for platform-specific customizations after class wrappers run, with the NameError guard for safety.

Differential Revision: D92715368


