### PR TITLE
put dispatch one level above

### DIFF
--- a/faiss/IVFlib.cpp
+++ b/faiss/IVFlib.cpp
@@ -18,8 +18,9 @@
 #include <faiss/MetaIndexes.h>
 #include <faiss/clone_index.h>
 #include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/simd_dispatch.h>
 #include <faiss/index_io.h>
-#include <faiss/utils/distances_dispatch.h>
+#include <faiss/utils/distances.h>
 #include <faiss/utils/hamming.h>
 #include <faiss/utils/utils.h>
 
@@ -512,39 +513,41 @@ void ivf_residual_add_from_flat_codes(
     const ResidualQuantizer& rq = index->rq;
 
     // populate inverted lists
-#pragma omp parallel if (nb > 10000)
-    {
-        std::vector<uint8_t> tmp_code(index->code_size);
-        std::vector<float> tmp(rq.d);
-        int nt = omp_get_num_threads();
-        int rank = omp_get_thread_num();
+    with_simd_level([&]<SIMDLevel SL>() {
+#pragma omp parallel
+        {
+            std::vector<uint8_t> tmp_code(index->rq.code_size);
+            std::vector<float> tmp(rq.d);
+            int nt = omp_get_num_threads();
+            int rank = omp_get_thread_num();
 
 #pragma omp for
-        for (idx_t i = 0; i < nb; i++) {
-            const uint8_t* code = &raw_codes[i * code_size];
-            BitstringReader rd(code, code_size);
-            idx_t list_no = rd.read(rcq->rq.tot_bits);
+            for (idx_t i = 0; i < nb; i++) {
+                const uint8_t* code = &raw_codes[i * code_size];
+                BitstringReader rd(code, code_size);
+                idx_t list_no = rd.read(rcq->rq.tot_bits);
 
-            if (list_no % nt ==
-                rank) { // each thread takes care of 1/nt of the invlists
-                // copy AQ indexes one by one
-                BitstringWriter wr(tmp_code.data(), tmp_code.size());
-                for (int j = 0; j < rq.M; j++) {
-                    int nbit = rq.nbits[j];
-                    wr.write(rd.read(nbit), nbit);
+                if (list_no % nt ==
+                    rank) { // each thread takes care of 1/nt of the invlists
+                    // copy AQ indexes one by one
+                    BitstringWriter wr(tmp_code.data(), tmp_code.size());
+                    for (int j = 0; j < rq.M; j++) {
+                        int nbit = rq.nbits[j];
+                        wr.write(rd.read(nbit), nbit);
+                    }
+                    // we need to recompute the norm
+                    // decode first, does not use the norm component, so that's
+                    // ok
+                    index->rq.decode(tmp_code.data(), tmp.data(), 1);
+                    float norm = fvec_norm_L2sqr<SL>(tmp.data(), rq.d);
+                    wr.write(rq.encode_norm(norm), rq.norm_bits);
+
+                    // add code to the inverted list
+                    invlists.add_entry(list_no, i, tmp_code.data());
                 }
-                // we need to recompute the norm
-                // decode first, does not use the norm component, so that's
-                // ok
-                index->rq.decode(tmp_code.data(), tmp.data(), 1);
-                float norm = fvec_norm_L2sqr_dispatch(tmp.data(), rq.d);
-                wr.write(rq.encode_norm(norm), rq.norm_bits);
-
-                // add code to the inverted list
-                invlists.add_entry(list_no, i, tmp_code.data());
             }
         }
-    }
+    });
     index->ntotal += nb;
 }
 

--- a/faiss/Index.cpp
+++ b/faiss/Index.cpp
@@ -12,7 +12,7 @@
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/DistanceComputer.h>
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/utils/distances_dispatch.h>
+#include <faiss/utils/distances.h>
 
 #include <cstring>
 
@@ -169,13 +169,13 @@ struct GenericDistanceComputer : DistanceComputer {
 
     float operator()(idx_t i) override {
         storage.reconstruct(i, buf.data());
-        return fvec_L2sqr_dispatch(q, buf.data(), d);
+        return fvec_L2sqr(q, buf.data(), d);
     }
 
     float symmetric_dis(idx_t i, idx_t j) override {
         storage.reconstruct(i, buf.data());
         storage.reconstruct(j, buf.data() + d);
-        return fvec_L2sqr_dispatch(buf.data() + d, buf.data(), d);
+        return fvec_L2sqr(buf.data() + d, buf.data(), d);
     }
 
     void set_query(const float* x) override {

--- a/faiss/Index2Layer.cpp
+++ b/faiss/Index2Layer.cpp
@@ -24,7 +24,7 @@
 #include <faiss/IndexFlat.h>
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/utils/distances_dispatch.h>
+#include <faiss/utils/distances.h>
 #include <faiss/utils/utils.h>
 
 namespace faiss {
@@ -152,7 +152,7 @@ struct Distance2Level : DistanceComputer {
     float symmetric_dis(idx_t i, idx_t j) override {
         storage.reconstruct(i, buf.data());
         storage.reconstruct(j, buf.data() + d);
-        return fvec_L2sqr_dispatch(buf.data() + d, buf.data(), d);
+        return fvec_L2sqr(buf.data() + d, buf.data(), d);
     }
 
     void set_query(const float* x) override {

--- a/faiss/IndexAdditiveQuantizer.cpp
+++ b/faiss/IndexAdditiveQuantizer.cpp
@@ -8,13 +8,11 @@
 #include <faiss/IndexAdditiveQuantizer.h>
 
 #include <algorithm>
-#include <cmath>
 #include <cstring>
 
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/ResidualQuantizer.h>
 #include <faiss/impl/ResultHandler.h>
-#include <faiss/utils/distances_dispatch.h>
 #include <faiss/utils/extra_distances.h>
 
 namespace faiss {
@@ -92,7 +90,7 @@ struct AQDistanceComputerLUT : FlatCodesDistanceComputer {
         if (is_IP) {
             bias = 0;
         } else {
-            bias = fvec_norm_L2sqr_dispatch(x, d);
+            bias = fvec_norm_L2sqr(x, d);
         }
     }
 
@@ -100,7 +98,7 @@ struct AQDistanceComputerLUT : FlatCodesDistanceComputer {
         float* tmp = LUT.data();
         aq.decode(codes + i * d, tmp, 1);
         aq.decode(codes + j * d, tmp + d, 1);
-        return fvec_L2sqr_dispatch(tmp, tmp + d, d);
+        return fvec_L2sqr(tmp, tmp + d, d);
     }
 
     float distance_to_code(const uint8_t* code) final {
@@ -173,7 +171,7 @@ void search_with_LUT(
         float bias = 0;
         if (!is_IP) { // the LUT function returns ||y||^2 - 2 * <x, y>, need to
                       // add ||x||^2
-            bias = fvec_norm_L2sqr_dispatch(xq + q * d, d);
+            bias = fvec_norm_L2sqr(xq + q * d, d);
         }
         for (size_t i = 0; i < ntotal; i++) {
             float dis = aq.compute_1_distance_LUT<is_IP, st>(
@@ -184,22 +182,46 @@ void search_with_LUT(
     }
 }
 
+struct Run_search_with_decompress {
+    const IndexAdditiveQuantizer& iaq;
+    const float* xq;
+    idx_t n;
+    idx_t k;
+    float* distances;
+    idx_t* labels;
+    using T = void;
+
+    template <class VD>
+    void f(VD vd) {
+        if constexpr (VD::is_similarity) {
+            HeapBlockResultHandler<CMin<float, idx_t>> rh(
+                    n, distances, labels, k);
+            search_with_decompress(iaq, xq, vd, rh);
+        } else {
+            HeapBlockResultHandler<CMax<float, idx_t>> rh(
+                    n, distances, labels, k);
+            search_with_decompress(iaq, xq, vd, rh);
+        }
+    }
+};
+
+struct Run_new_AQDistanceComputerDecompress {
+    const IndexAdditiveQuantizer& iaq;
+    using T = FlatCodesDistanceComputer*;
+
+    template <class VD>
+    T f(VD vd) {
+        return new AQDistanceComputerDecompress<VD>(iaq, vd);
+    }
+};
+
 } // anonymous namespace
 
 FlatCodesDistanceComputer* IndexAdditiveQuantizer::
         get_FlatCodesDistanceComputer() const {
     if (aq->search_type == AdditiveQuantizer::ST_decompress) {
-        if (metric_type == METRIC_L2) {
-            using VD = VectorDistance<METRIC_L2>;
-            VD vd = {size_t(d), metric_arg};
-            return new AQDistanceComputerDecompress<VD>(*this, vd);
-        } else if (metric_type == METRIC_INNER_PRODUCT) {
-            using VD = VectorDistance<METRIC_INNER_PRODUCT>;
-            VD vd = {size_t(d), metric_arg};
-            return new AQDistanceComputerDecompress<VD>(*this, vd);
-        } else {
-            FAISS_THROW_MSG("unsupported metric");
-        }
+        Run_new_AQDistanceComputerDecompress consumer{*this};
+        return dispatch_VectorDistance(d, metric_type, metric_arg, consumer);
     } else {
         if (metric_type == METRIC_INNER_PRODUCT) {
             return new AQDistanceComputerLUT<
@@ -242,17 +264,8 @@ void IndexAdditiveQuantizer::search(
             !params, "search params not supported for this index");
 
     if (aq->search_type == AdditiveQuantizer::ST_decompress) {
-        if (metric_type == METRIC_L2) {
-            using VD = VectorDistance<METRIC_L2>;
-            VD vd = {size_t(d), metric_arg};
-            HeapBlockResultHandler<VD::C> rh(n, distances, labels, k);
-            search_with_decompress(*this, x, vd, rh);
-        } else if (metric_type == METRIC_INNER_PRODUCT) {
-            using VD = VectorDistance<METRIC_INNER_PRODUCT>;
-            VD vd = {size_t(d), metric_arg};
-            HeapBlockResultHandler<VD::C> rh(n, distances, labels, k);
-            search_with_decompress(*this, x, vd, rh);
-        }
+        Run_search_with_decompress consumer{*this, x, n, k, distances, labels};
+        dispatch_VectorDistance(d, metric_type, metric_arg, consumer);
     } else {
         if (metric_type == METRIC_INNER_PRODUCT) {
             HeapBlockResultHandler<CMin<float, idx_t>> rh(

--- a/faiss/IndexIVFAdditiveQuantizer.cpp
+++ b/faiss/IndexIVFAdditiveQuantizer.cpp
@@ -14,7 +14,7 @@
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/ResidualQuantizer.h>
 #include <faiss/impl/ResultHandler.h>
-#include <faiss/utils/distances_dispatch.h>
+#include <faiss/utils/distances.h>
 #include <faiss/utils/extra_distances.h>
 
 namespace faiss {
@@ -225,9 +225,8 @@ struct AQInvertedListScannerDecompress : AQInvertedListScanner {
         FAISS_ASSERT(q);
         FAISS_ASSERT(b.data());
 
-        return is_IP
-                ? coarse_dis + fvec_inner_product_dispatch(q, b.data(), aq.d)
-                : fvec_L2sqr_dispatch(q, b.data(), aq.d);
+        return is_IP ? coarse_dis + fvec_inner_product(q, b.data(), aq.d)
+                     : fvec_L2sqr(q, b.data(), aq.d);
     }
 
     ~AQInvertedListScannerDecompress() override = default;
@@ -251,7 +250,7 @@ struct AQInvertedListScannerLUT : AQInvertedListScanner {
     void set_query(const float* query_vector) override {
         AQInvertedListScanner::set_query(query_vector);
         if (!is_IP && !ia.by_residual) {
-            distance_bias = fvec_norm_L2sqr_dispatch(query_vector, ia.d);
+            distance_bias = fvec_norm_L2sqr(query_vector, ia.d);
         }
     }
 

--- a/faiss/IndexIVFAdditiveQuantizerFastScan.h
+++ b/faiss/IndexIVFAdditiveQuantizerFastScan.h
@@ -37,13 +37,13 @@ namespace faiss {
 struct IndexIVFAdditiveQuantizerFastScan : IndexIVFFastScan {
     using Search_type_t = AdditiveQuantizer::Search_type_t;
 
-    AdditiveQuantizer* aq;
+    AdditiveQuantizer* aq{};
 
     bool rescale_norm = false;
     int norm_scale = 1;
 
     // max number of training vectors
-    size_t max_train_points;
+    size_t max_train_points{};
 
     IndexIVFAdditiveQuantizerFastScan(
             Index* quantizer,

--- a/faiss/IndexIVFPQR.cpp
+++ b/faiss/IndexIVFPQR.cpp
@@ -11,8 +11,9 @@
 
 #include <cinttypes>
 
+#include <faiss/impl/simd_dispatch.h>
 #include <faiss/utils/Heap.h>
-#include <faiss/utils/distances_dispatch.h>
+#include <faiss/utils/distances.h>
 #include <faiss/utils/utils.h>
 
 #include <faiss/impl/FaissAssert.h>
@@ -128,7 +129,7 @@ void IndexIVFPQR::search_preassigned(
         IndexIVFStats* stats) const {
     uint64_t t0;
     TIC;
-    size_t k_coarse = long(k * k_factor);
+    size_t k_coarse = long((size_t)k * k_factor);
     std::unique_ptr<idx_t[]> coarse_labels(new idx_t[k_coarse * n]);
     {
         // query with quantizer levels 1 and 2.
@@ -196,8 +197,7 @@ void IndexIVFPQR::search_preassigned(
                         &refine_codes[id * refine_pq.code_size],
                         residual_1.get());
 
-                float dis =
-                        fvec_L2sqr_dispatch(residual_1.get(), residual_2, d);
+                float dis = fvec_L2sqr(residual_1.get(), residual_2, d);
 
                 if (dis < heap_sim[0]) {
                     idx_t id_or_pair = store_pairs ? sl : id;

--- a/faiss/IndexIVFRaBitQFastScan.cpp
+++ b/faiss/IndexIVFRaBitQFastScan.cpp
@@ -19,7 +19,7 @@
 #include <faiss/impl/pq4_fast_scan.h>
 #include <faiss/impl/simd_result_handlers.h>
 #include <faiss/invlists/BlockInvertedLists.h>
-#include <faiss/utils/distances_dispatch.h>
+#include <faiss/utils/distances.h>
 #include <faiss/utils/utils.h>
 
 namespace faiss {
@@ -276,8 +276,7 @@ void IndexIVFRaBitQFastScan::compute_residual_LUT(
     // Override query norm for inner product if original query is provided
     if (metric_type == MetricType::METRIC_INNER_PRODUCT &&
         original_query != nullptr) {
-        query_factors.qr_norm_L2sqr =
-                fvec_norm_L2sqr_dispatch(original_query, d);
+        query_factors.qr_norm_L2sqr = fvec_norm_L2sqr(original_query, d);
     }
 
     const size_t ex_bits = rabitq.nb_bits - 1;

--- a/faiss/IndexLattice.cpp
+++ b/faiss/IndexLattice.cpp
@@ -9,7 +9,8 @@
 
 #include <faiss/IndexLattice.h>
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/utils/distances_dispatch.h>
+#include <faiss/impl/simd_dispatch.h>
+#include <faiss/utils/distances.h>
 #include <faiss/utils/hamming.h> // for the bitstring routines
 
 namespace faiss {
@@ -44,17 +45,19 @@ void IndexLattice::train(idx_t n, const float* x) {
         maxs[sq] = -1;
     }
 
-    for (idx_t i = 0; i < n; i++) {
-        for (int sq = 0; sq < nsq; sq++) {
-            float norm2 = fvec_norm_L2sqr_dispatch(x + i * d + sq * dsq, dsq);
-            if (norm2 > maxs[sq]) {
-                maxs[sq] = norm2;
-            }
-            if (norm2 < mins[sq]) {
-                mins[sq] = norm2;
+    with_simd_level([&]<SIMDLevel SL>() {
+        for (idx_t i = 0; i < n; i++) {
+            for (int sq = 0; sq < nsq; sq++) {
+                float norm2 = fvec_norm_L2sqr<SL>(x + i * d + sq * dsq, dsq);
+                if (norm2 > maxs[sq]) {
+                    maxs[sq] = norm2;
+                }
+                if (norm2 < mins[sq]) {
+                    mins[sq] = norm2;
+                }
             }
         }
-    }
+    });
 
     for (int sq = 0; sq < nsq; sq++) {
         mins[sq] = sqrtf(mins[sq]);
@@ -74,24 +77,26 @@ void IndexLattice::sa_encode(idx_t n, const float* x, uint8_t* codes) const {
     const float* maxs = mins + nsq;
     int64_t sc = int64_t(1) << scale_nbit;
 
+    with_simd_level([&]<SIMDLevel SL>() {
 #pragma omp parallel for
-    for (idx_t i = 0; i < n; i++) {
-        BitstringWriter wr(codes + i * code_size, code_size);
-        const float* xi = x + i * d;
-        for (int j = 0; j < nsq; j++) {
-            float nj = (sqrtf(fvec_norm_L2sqr_dispatch(xi, dsq)) - mins[j]) *
-                    sc / (maxs[j] - mins[j]);
-            if (nj < 0) {
-                nj = 0;
+        for (idx_t i = 0; i < n; i++) {
+            BitstringWriter wr(codes + i * code_size, code_size);
+            const float* xi = x + i * d;
+            for (int j = 0; j < nsq; j++) {
+                float nj = (sqrtf(fvec_norm_L2sqr<SL>(xi, dsq)) - mins[j]) *
+                        sc / (maxs[j] - mins[j]);
+                if (nj < 0) {
+                    nj = 0;
+                }
+                if (nj >= sc) {
+                    nj = sc - 1;
+                }
+                wr.write((int64_t)nj, scale_nbit);
+                wr.write(zn_sphere_codec.encode(xi), lattice_nbit);
+                xi += dsq;
             }
-            if (nj >= sc) {
-                nj = sc - 1;
-            }
-            wr.write((int64_t)nj, scale_nbit);
-            wr.write(zn_sphere_codec.encode(xi), lattice_nbit);
-            xi += dsq;
         }
-    }
+    });
 }
 
 void IndexLattice::sa_decode(idx_t n, const uint8_t* codes, float* x) const {

--- a/faiss/VectorTransform.cpp
+++ b/faiss/VectorTransform.cpp
@@ -18,7 +18,6 @@
 #include <faiss/IndexPQ.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/distances.h>
-#include <faiss/utils/distances_dispatch.h>
 #include <faiss/utils/random.h>
 #include <faiss/utils/utils.h>
 
@@ -1106,8 +1105,7 @@ void OPQMatrix::train(idx_t n, const float* x_in) {
         }
         pq_regular.decode(codes.data(), pq_recons.data(), n);
 
-        float pq_err =
-                fvec_L2sqr_dispatch(pq_recons.data(), xproj.data(), n * d2) / n;
+        float pq_err = fvec_L2sqr(pq_recons.data(), xproj.data(), n * d2) / n;
 
         if (verbose)
             printf("    Iteration %d (%d PQ iterations):"

--- a/faiss/impl/AdditiveQuantizer.cpp
+++ b/faiss/impl/AdditiveQuantizer.cpp
@@ -21,9 +21,9 @@
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/LocalSearchQuantizer.h>
 #include <faiss/impl/ResidualQuantizer.h>
+#include <faiss/impl/simd_dispatch.h>
 #include <faiss/utils/Heap.h>
 #include <faiss/utils/distances.h>
-#include <faiss/utils/distances_dispatch.h>
 #include <faiss/utils/hamming.h>
 
 extern "C" {
@@ -349,15 +349,17 @@ AdditiveQuantizer::~AdditiveQuantizer() {}
 void AdditiveQuantizer::compute_centroid_norms(float* norms) const {
     size_t ntotal = (size_t)1 << tot_bits;
     // TODO: make tree of partial sums
+    with_simd_level([&]<SIMDLevel SL>() {
 #pragma omp parallel
-    {
-        std::vector<float> tmp(d);
+        {
+            std::vector<float> tmp(d);
 #pragma omp for
-        for (int64_t i = 0; i < ntotal; i++) {
-            decode_64bit(i, tmp.data());
-            norms[i] = fvec_norm_L2sqr_dispatch(tmp.data(), d);
+            for (int64_t i = 0; i < ntotal; i++) {
+                decode_64bit(i, tmp.data());
+                norms[i] = fvec_norm_L2sqr<SL>(tmp.data(), d);
+            }
         }
-    }
+    });
 }
 
 void AdditiveQuantizer::decode_64bit(idx_t bits, float* xi) const {

--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -19,8 +19,8 @@
 #include <faiss/IndexFlat.h>
 #include <faiss/VectorTransform.h>
 #include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/simd_dispatch.h>
 #include <faiss/utils/distances.h>
-#include <faiss/utils/distances_dispatch.h>
 
 extern "C" {
 
@@ -202,8 +202,10 @@ void ProductQuantizer::train(size_t n, const float* x) {
     }
 }
 
-template <class PQEncoder>
-void compute_code(const ProductQuantizer& pq, const float* x, uint8_t* code) {
+namespace {
+
+template <class PQEncoder, SIMDLevel SL>
+void compute_1_code(const ProductQuantizer& pq, const float* x, uint8_t* code) {
     std::vector<float> distances(pq.ksub);
 
     // It seems to be meaningless to allocate std::vector<float> distances.
@@ -249,7 +251,7 @@ void compute_code(const ProductQuantizer& pq, const float* x, uint8_t* code) {
         uint64_t idxm = 0;
         if (pq.transposed_centroids.empty()) {
             // the regular version
-            idxm = fvec_L2sqr_ny_nearest_dispatch(
+            idxm = fvec_L2sqr_ny_nearest<SL>(
                     distances.data(),
                     xsub,
                     pq.get_centroids(m, 0),
@@ -257,7 +259,7 @@ void compute_code(const ProductQuantizer& pq, const float* x, uint8_t* code) {
                     pq.ksub);
         } else {
             // transposed centroids are available, use'em
-            idxm = fvec_L2sqr_ny_nearest_y_transposed_dispatch(
+            idxm = fvec_L2sqr_ny_nearest_y_transposed<SL>(
                     distances.data(),
                     xsub,
                     pq.transposed_centroids.data() + m * pq.ksub,
@@ -271,20 +273,24 @@ void compute_code(const ProductQuantizer& pq, const float* x, uint8_t* code) {
     }
 }
 
+} // namespace
+
 void ProductQuantizer::compute_code(const float* x, uint8_t* code) const {
-    switch (nbits) {
-        case 8:
-            faiss::compute_code<PQEncoder8>(*this, x, code);
-            break;
+    with_simd_level([&]<SIMDLevel SL>() {
+        switch (nbits) {
+            case 8:
+                compute_1_code<PQEncoder8, SL>(*this, x, code);
+                break;
 
-        case 16:
-            faiss::compute_code<PQEncoder16>(*this, x, code);
-            break;
+            case 16:
+                compute_1_code<PQEncoder16, SL>(*this, x, code);
+                break;
 
-        default:
-            faiss::compute_code<PQEncoderGeneric>(*this, x, code);
-            break;
-    }
+            default:
+                compute_1_code<PQEncoderGeneric, SL>(*this, x, code);
+                break;
+        }
+    }); // with_simd_level
 }
 
 template <class PQDecoder>
@@ -429,44 +435,46 @@ void ProductQuantizer::compute_codes(const float* x, uint8_t* codes, size_t n)
 
 void ProductQuantizer::compute_distance_table(const float* x, float* dis_table)
         const {
-    if (transposed_centroids.empty()) {
-        // use regular version
+    with_simd_level([&]<SIMDLevel SL>() {
+        if (transposed_centroids.empty()) {
+            // use regular version
+            for (size_t m = 0; m < M; m++) {
+                fvec_L2sqr_ny<SL>(
+                        dis_table + m * ksub,
+                        x + m * dsub,
+                        get_centroids(m, 0),
+                        dsub,
+                        ksub);
+            }
+        } else {
+            // transposed centroids are available, use'em
+            for (size_t m = 0; m < M; m++) {
+                fvec_L2sqr_ny_transposed<SL>(
+                        dis_table + m * ksub,
+                        x + m * dsub,
+                        transposed_centroids.data() + m * ksub,
+                        centroids_sq_lengths.data() + m * ksub,
+                        dsub,
+                        M * ksub,
+                        ksub);
+            }
+        }
+    });
+}
+
+void ProductQuantizer::compute_inner_prod_table(
+        const float* x,
+        float* dis_table) const {
+    with_simd_level([&]<SIMDLevel SL>() {
         for (size_t m = 0; m < M; m++) {
-            fvec_L2sqr_ny_dispatch(
+            fvec_inner_products_ny<SL>(
                     dis_table + m * ksub,
                     x + m * dsub,
                     get_centroids(m, 0),
                     dsub,
                     ksub);
         }
-    } else {
-        // transposed centroids are available, use'em
-        for (size_t m = 0; m < M; m++) {
-            fvec_L2sqr_ny_transposed_dispatch(
-                    dis_table + m * ksub,
-                    x + m * dsub,
-                    transposed_centroids.data() + m * ksub,
-                    centroids_sq_lengths.data() + m * ksub,
-                    dsub,
-                    M * ksub,
-                    ksub);
-        }
-    }
-}
-
-void ProductQuantizer::compute_inner_prod_table(
-        const float* x,
-        float* dis_table) const {
-    size_t m;
-
-    for (m = 0; m < M; m++) {
-        fvec_inner_products_ny_dispatch(
-                dis_table + m * ksub,
-                x + m * dsub,
-                get_centroids(m, 0),
-                dsub,
-                ksub);
-    }
+    });
 }
 
 void ProductQuantizer::compute_distance_tables(
@@ -786,18 +794,19 @@ void ProductQuantizer::compute_sdc_table() {
     sdc_table.resize(M * ksub * ksub);
 
     if (dsub < 4) {
+        with_simd_level([&]<SIMDLevel SL>() {
 #pragma omp parallel for
-        for (int mk = 0; mk < M * ksub; mk++) {
-            // allow omp to schedule in a more fine-grained way
-            // `collapse` is not supported in OpenMP 2.x
-            int m = mk / ksub;
-            int k = mk % ksub;
-            const float* cents = centroids.data() + m * ksub * dsub;
-            const float* centi = cents + k * dsub;
-            float* dis_tab = sdc_table.data() + m * ksub * ksub;
-            fvec_L2sqr_ny_dispatch(
-                    dis_tab + k * ksub, centi, cents, dsub, ksub);
-        }
+            for (int mk = 0; mk < M * ksub; mk++) {
+                // allow omp to schedule in a more fine-grained way
+                // `collapse` is not supported in OpenMP 2.x
+                int m = mk / ksub;
+                int k = mk % ksub;
+                const float* cents = centroids.data() + m * ksub * dsub;
+                const float* centi = cents + k * dsub;
+                float* dis_tab = sdc_table.data() + m * ksub * ksub;
+                fvec_L2sqr_ny<SL>(dis_tab + k * ksub, centi, cents, dsub, ksub);
+            }
+        });
     } else {
         // NOTE: it would disable the omp loop in pairwise_L2sqr
         // but still accelerate especially when M >= 4

--- a/faiss/impl/RaBitQUtils.cpp
+++ b/faiss/impl/RaBitQUtils.cpp
@@ -8,7 +8,7 @@
 #include <faiss/impl/RaBitQUtils.h>
 
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/utils/distances_dispatch.h>
+#include <faiss/utils/distances.h>
 #include <algorithm>
 #include <cmath>
 #include <limits>
@@ -156,9 +156,9 @@ QueryFactorsData compute_query_factors(
 
     // Compute distance from query to centroid
     if (centroid != nullptr) {
-        query_factors.qr_to_c_L2sqr = fvec_L2sqr_dispatch(query, centroid, d);
+        query_factors.qr_to_c_L2sqr = fvec_L2sqr(query, centroid, d);
     } else {
-        query_factors.qr_to_c_L2sqr = fvec_norm_L2sqr_dispatch(query, d);
+        query_factors.qr_to_c_L2sqr = fvec_norm_L2sqr(query, d);
     }
     query_factors.g_error = std::sqrt(query_factors.qr_to_c_L2sqr);
 
@@ -243,7 +243,7 @@ QueryFactorsData compute_query_factors(
     // Compute query norm for inner product metric
     query_factors.qr_norm_L2sqr = 0.0f;
     if (metric_type == MetricType::METRIC_INNER_PRODUCT) {
-        query_factors.qr_norm_L2sqr = fvec_norm_L2sqr_dispatch(query, d);
+        query_factors.qr_norm_L2sqr = fvec_norm_L2sqr(query, d);
     }
 
     return query_factors;

--- a/faiss/impl/RaBitQuantizer.cpp
+++ b/faiss/impl/RaBitQuantizer.cpp
@@ -10,8 +10,9 @@
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/RaBitQUtils.h>
 #include <faiss/impl/RaBitQuantizerMultiBit.h>
-#include <faiss/utils/distances_dispatch.h>
+#include <faiss/utils/distances.h>
 #include <faiss/utils/rabitq_simd.h>
+
 #include <algorithm>
 #include <cmath>
 #include <cstring>
@@ -334,9 +335,9 @@ void RaBitQDistanceComputerNotQ::set_query(const float* x) {
 
     // compute the distance from the query to the centroid
     if (centroid != nullptr) {
-        query_fac.qr_to_c_L2sqr = fvec_L2sqr_dispatch(x, centroid, d);
+        query_fac.qr_to_c_L2sqr = fvec_L2sqr(x, centroid, d);
     } else {
-        query_fac.qr_to_c_L2sqr = fvec_norm_L2sqr_dispatch(x, d);
+        query_fac.qr_to_c_L2sqr = fvec_norm_L2sqr(x, d);
     }
 
     // subtract c, obtain P^(-1)(qr - c)
@@ -364,7 +365,7 @@ void RaBitQDistanceComputerNotQ::set_query(const float* x) {
 
     if (metric_type == MetricType::METRIC_INNER_PRODUCT) {
         // precompute if needed
-        query_fac.qr_norm_L2sqr = fvec_norm_L2sqr_dispatch(x, d);
+        query_fac.qr_norm_L2sqr = fvec_norm_L2sqr(x, d);
     }
 }
 

--- a/faiss/impl/RaBitQuantizerMultiBit.cpp
+++ b/faiss/impl/RaBitQuantizerMultiBit.cpp
@@ -11,7 +11,7 @@
 
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/RaBitQUtils.h>
-#include <faiss/utils/distances_dispatch.h>
+#include <faiss/utils/distances.h>
 
 #include <algorithm>
 #include <cmath>
@@ -273,7 +273,7 @@ void quantize_ex_bits(
     FAISS_THROW_IF_NOT_MSG(ex_code != nullptr, "ex_code cannot be null");
 
     // Step 1: Compute L2 norm of residual
-    float norm_sqr = fvec_norm_L2sqr_dispatch(residual, d);
+    float norm_sqr = fvec_norm_L2sqr(residual, d);
     float norm = std::sqrt(norm_sqr);
 
     // Handle degenerate case

--- a/faiss/impl/ResidualQuantizer.cpp
+++ b/faiss/impl/ResidualQuantizer.cpp
@@ -18,7 +18,8 @@
 #include <faiss/VectorTransform.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/residual_quantizer_encode_steps.h>
-#include <faiss/utils/distances_dispatch.h>
+#include <faiss/impl/simd_dispatch.h>
+#include <faiss/utils/distances.h>
 #include <faiss/utils/hamming.h>
 #include <faiss/utils/utils.h>
 
@@ -274,10 +275,12 @@ void ResidualQuantizer::train(size_t n, const float* x) {
     // find min and max norms
     std::vector<float> norms(n);
 
-    for (size_t i = 0; i < n; i++) {
-        norms[i] = fvec_L2sqr_dispatch(
-                x + i * d, residuals.data() + i * cur_beam_size * d, d);
-    }
+    with_simd_level([&]<SIMDLevel SL>() {
+        for (size_t i = 0; i < n; i++) {
+            norms[i] = fvec_L2sqr<SL>(
+                    x + i * d, residuals.data() + i * cur_beam_size * d, d);
+        }
+    });
 
     // fvec_norms_L2sqr(norms.data(), x, d, n);
     train_norm(n, norms.data());
@@ -301,7 +304,7 @@ float ResidualQuantizer::retrain_AQ_codebook(size_t n, const float* x) {
     {
         std::vector<float> x_recons(n * d);
         decode(codes.data(), x_recons.data(), n);
-        input_recons_error = fvec_L2sqr_dispatch(x, x_recons.data(), n * d);
+        input_recons_error = fvec_L2sqr(x, x_recons.data(), n * d);
         if (verbose) {
             printf("  input quantization error %g\n", input_recons_error);
         }
@@ -393,11 +396,13 @@ float ResidualQuantizer::retrain_AQ_codebook(size_t n, const float* x) {
     }
 
     float output_recons_error = 0;
-    for (size_t j = 0; j < d; j++) {
-        output_recons_error += fvec_norm_L2sqr_dispatch(
-                xt.data() + total_codebook_size + n * j,
-                n - total_codebook_size);
-    }
+    with_simd_level([&]<SIMDLevel SL>() {
+        for (size_t j = 0; j < d; j++) {
+            output_recons_error += fvec_norm_L2sqr<SL>(
+                    xt.data() + total_codebook_size + n * j,
+                    n - total_codebook_size);
+        }
+    });
     if (verbose) {
         printf("  output quantization error %g\n", output_recons_error);
     }

--- a/faiss/utils/extra_distances-inl.h
+++ b/faiss/utils/extra_distances-inl.h
@@ -12,188 +12,200 @@
 
 #include <faiss/MetricType.h>
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/utils/distances_dispatch.h>
+#include <faiss/impl/simd_dispatch.h>
+#include <faiss/utils/distances.h>
 #include <cmath>
 #include <type_traits>
 
 namespace faiss {
 
+/***************************************************************************
+ * VectorDistance base class - contains common data members and type defs
+ **************************************************************************/
+
 template <MetricType mt>
-struct VectorDistance {
+struct VectorDistanceBase {
     size_t d;
     float metric_arg;
     static constexpr MetricType metric = mt;
     static constexpr bool is_similarity = is_similarity_metric(mt);
 
-    inline float operator()(const float* x, const float* y) const;
-
-    // heap template to use for this type of metric
     using C = typename std::conditional<
             is_similarity_metric(mt),
             CMin<float, int64_t>,
             CMax<float, int64_t>>::type;
 };
 
-template <>
-inline float VectorDistance<METRIC_L2>::operator()(
-        const float* x,
-        const float* y) const {
-    return fvec_L2sqr_dispatch(x, y, d);
-}
+/***************************************************************************
+ * VectorDistance struct template - specializations for each metric type
+ **************************************************************************/
+
+template <MetricType mt, SIMDLevel level>
+struct VectorDistance : VectorDistanceBase<mt> {
+    inline float operator()(const float* x, const float* y) const;
+};
+
+template <SIMDLevel level>
+struct VectorDistance<METRIC_L2, level> : VectorDistanceBase<METRIC_L2> {
+    inline float operator()(const float* x, const float* y) const {
+        return fvec_L2sqr<level>(x, y, this->d);
+    }
+};
+
+template <SIMDLevel level>
+struct VectorDistance<METRIC_INNER_PRODUCT, level>
+        : VectorDistanceBase<METRIC_INNER_PRODUCT> {
+    inline float operator()(const float* x, const float* y) const {
+        return fvec_inner_product<level>(x, y, this->d);
+    }
+};
+
+template <SIMDLevel level>
+struct VectorDistance<METRIC_L1, level> : VectorDistanceBase<METRIC_L1> {
+    inline float operator()(const float* x, const float* y) const {
+        return fvec_L1<level>(x, y, this->d);
+    }
+};
+
+template <SIMDLevel level>
+struct VectorDistance<METRIC_Linf, level> : VectorDistanceBase<METRIC_Linf> {
+    inline float operator()(const float* x, const float* y) const {
+        return fvec_Linf<level>(x, y, this->d);
+    }
+};
 
 template <>
-inline float VectorDistance<METRIC_INNER_PRODUCT>::operator()(
-        const float* x,
-        const float* y) const {
-    return fvec_inner_product_dispatch(x, y, d);
-}
-
-template <>
-inline float VectorDistance<METRIC_L1>::operator()(
-        const float* x,
-        const float* y) const {
-    return fvec_L1_dispatch(x, y, d);
-}
-
-template <>
-inline float VectorDistance<METRIC_Linf>::operator()(
-        const float* x,
-        const float* y) const {
-    return fvec_Linf_dispatch(x, y, d);
-    /*
-        float vmax = 0;
-        for (size_t i = 0; i < d; i++) {
-            float diff = fabs (x[i] - y[i]);
-            if (diff > vmax) vmax = diff;
+struct VectorDistance<METRIC_Lp, SIMDLevel::NONE>
+        : VectorDistanceBase<METRIC_Lp> {
+    inline float operator()(const float* x, const float* y) const {
+        float accu = 0;
+        for (size_t i = 0; i < this->d; i++) {
+            float diff = fabs(x[i] - y[i]);
+            accu += powf(diff, this->metric_arg);
         }
-     return vmax;*/
-}
-
-template <>
-inline float VectorDistance<METRIC_Lp>::operator()(
-        const float* x,
-        const float* y) const {
-    float accu = 0;
-    for (size_t i = 0; i < d; i++) {
-        float diff = fabs(x[i] - y[i]);
-        accu += powf(diff, metric_arg);
+        return accu;
     }
-    return accu;
-}
+};
 
 template <>
-inline float VectorDistance<METRIC_Canberra>::operator()(
-        const float* x,
-        const float* y) const {
-    float accu = 0;
-    for (size_t i = 0; i < d; i++) {
-        float xi = x[i], yi = y[i];
-        accu += fabs(xi - yi) / (fabs(xi) + fabs(yi));
-    }
-    return accu;
-}
-
-template <>
-inline float VectorDistance<METRIC_BrayCurtis>::operator()(
-        const float* x,
-        const float* y) const {
-    float accu_num = 0, accu_den = 0;
-    for (size_t i = 0; i < d; i++) {
-        float xi = x[i], yi = y[i];
-        accu_num += fabs(xi - yi);
-        accu_den += fabs(xi + yi);
-    }
-    return accu_num / accu_den;
-}
-
-template <>
-inline float VectorDistance<METRIC_JensenShannon>::operator()(
-        const float* x,
-        const float* y) const {
-    float accu = 0;
-    for (size_t i = 0; i < d; i++) {
-        float xi = x[i], yi = y[i];
-        float mi = 0.5 * (xi + yi);
-        float kl1 = -xi * log(mi / xi);
-        float kl2 = -yi * log(mi / yi);
-        accu += kl1 + kl2;
-    }
-    return 0.5 * accu;
-}
-
-template <>
-inline float VectorDistance<METRIC_Jaccard>::operator()(
-        const float* x,
-        const float* y) const {
-    // WARNING: this distance is defined only for positive input vectors.
-    // Providing vectors with negative values would lead to incorrect results.
-    float accu_num = 0, accu_den = 0;
-    for (size_t i = 0; i < d; i++) {
-        accu_num += fmin(x[i], y[i]);
-        accu_den += fmax(x[i], y[i]);
-    }
-    return accu_num / accu_den;
-}
-
-template <>
-inline float VectorDistance<METRIC_NaNEuclidean>::operator()(
-        const float* x,
-        const float* y) const {
-    // https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise.nan_euclidean_distances.html
-    float accu = 0;
-    size_t present = 0;
-    for (size_t i = 0; i < d; i++) {
-        if (!std::isnan(x[i]) && !std::isnan(y[i])) {
-            float diff = x[i] - y[i];
-            accu += diff * diff;
-            present++;
+struct VectorDistance<METRIC_Canberra, SIMDLevel::NONE>
+        : VectorDistanceBase<METRIC_Canberra> {
+    inline float operator()(const float* x, const float* y) const {
+        float accu = 0;
+        for (size_t i = 0; i < this->d; i++) {
+            float xi = x[i], yi = y[i];
+            accu += fabs(xi - yi) / (fabs(xi) + fabs(yi));
         }
+        return accu;
     }
-    if (present == 0) {
-        return NAN;
-    }
-    return float(d) / float(present) * accu;
-}
+};
 
 template <>
-inline float VectorDistance<METRIC_GOWER>::operator()(
-        const float* x,
-        const float* y) const {
-    float accu = 0;
-    size_t valid_dims = 0;
-
-    for (size_t i = 0; i < d; i++) {
-        if (std::isnan(x[i]) || std::isnan(y[i])) {
-            continue;
+struct VectorDistance<METRIC_BrayCurtis, SIMDLevel::NONE>
+        : VectorDistanceBase<METRIC_BrayCurtis> {
+    inline float operator()(const float* x, const float* y) const {
+        float accu_num = 0, accu_den = 0;
+        for (size_t i = 0; i < this->d; i++) {
+            float xi = x[i], yi = y[i];
+            accu_num += fabs(xi - yi);
+            accu_den += fabs(xi + yi);
         }
+        return accu_num / accu_den;
+    }
+};
 
-        if (x[i] >= 0 && y[i] >= 0) {
-            if (x[i] > 1 || y[i] > 1) {
+template <>
+struct VectorDistance<METRIC_JensenShannon, SIMDLevel::NONE>
+        : VectorDistanceBase<METRIC_JensenShannon> {
+    inline float operator()(const float* x, const float* y) const {
+        float accu = 0;
+        for (size_t i = 0; i < this->d; i++) {
+            float xi = x[i], yi = y[i];
+            float mi = 0.5 * (xi + yi);
+            float kl1 = -xi * log(mi / xi);
+            float kl2 = -yi * log(mi / yi);
+            accu += kl1 + kl2;
+        }
+        return 0.5 * accu;
+    }
+};
+
+template <>
+struct VectorDistance<METRIC_Jaccard, SIMDLevel::NONE>
+        : VectorDistanceBase<METRIC_Jaccard> {
+    inline float operator()(const float* x, const float* y) const {
+        // WARNING: this distance is defined only for positive input vectors.
+        // Providing vectors with negative values would lead to incorrect
+        // results.
+        float accu_num = 0, accu_den = 0;
+        for (size_t i = 0; i < this->d; i++) {
+            accu_num += fmin(x[i], y[i]);
+            accu_den += fmax(x[i], y[i]);
+        }
+        return accu_num / accu_den;
+    }
+};
+
+template <>
+struct VectorDistance<METRIC_NaNEuclidean, SIMDLevel::NONE>
+        : VectorDistanceBase<METRIC_NaNEuclidean> {
+    inline float operator()(const float* x, const float* y) const {
+        // https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise.nan_euclidean_distances.html
+        float accu = 0;
+        size_t present = 0;
+        for (size_t i = 0; i < this->d; i++) {
+            if (!std::isnan(x[i]) && !std::isnan(y[i])) {
+                float diff = x[i] - y[i];
+                accu += diff * diff;
+                present++;
+            }
+        }
+        if (present == 0) {
+            return NAN;
+        }
+        return float(this->d) / float(present) * accu;
+    }
+};
+
+template <>
+struct VectorDistance<METRIC_GOWER, SIMDLevel::NONE>
+        : VectorDistanceBase<METRIC_GOWER> {
+    inline float operator()(const float* x, const float* y) const {
+        float accu = 0;
+        size_t valid_dims = 0;
+
+        for (size_t i = 0; i < this->d; i++) {
+            if (std::isnan(x[i]) || std::isnan(y[i])) {
+                continue;
+            }
+
+            if (x[i] >= 0 && y[i] >= 0) {
+                if (x[i] > 1 || y[i] > 1) {
+                    return std::numeric_limits<float>::quiet_NaN();
+                }
+                accu += fabs(x[i] - y[i]);
+            } else if (x[i] < 0 && y[i] < 0) {
+                accu += float(int(x[i] != y[i]));
+            } else {
                 return std::numeric_limits<float>::quiet_NaN();
             }
-            // Numeric dimensions are in [0,1]
-            accu += fabs(x[i] - y[i]);
-        } else if (x[i] < 0 && y[i] < 0) {
-            // Categorical dimensions are negative values
-            accu += float(int(x[i] != y[i]));
-        } else {
-            // Invalid representation
+            valid_dims++;
+        }
+
+        if (valid_dims == 0) {
             return std::numeric_limits<float>::quiet_NaN();
         }
-        valid_dims++;
+        return accu / valid_dims;
     }
-
-    if (valid_dims == 0) {
-        return std::numeric_limits<float>::quiet_NaN();
-    }
-    return accu / valid_dims;
-}
+};
 
 /***************************************************************************
  * Dispatching function that takes a metric type and a consumer object
  * the consumer object should contain a return type T and a operation template
- * function f() that is called to perform the operation. The first argument
- * of the function is the VectorDistance object. The rest are passed in as is.
+ * function f() that is called to perform the operation.
+ *
+ * The first argument of the function is the VectorDistance object. The rest
+ * are passed in as is. The object also dispatches to the current SIMD level.
  **************************************************************************/
 
 template <class Consumer, class... Types>
@@ -203,27 +215,21 @@ typename Consumer::T dispatch_VectorDistance(
         float metric_arg,
         Consumer& consumer,
         Types... args) {
-    switch (metric) {
-#define DISPATCH_VD(mt)                                              \
-    case mt: {                                                       \
-        VectorDistance<mt> vd = {d, metric_arg};                     \
-        return consumer.template f<VectorDistance<mt>>(vd, args...); \
-    }
-        DISPATCH_VD(METRIC_INNER_PRODUCT);
-        DISPATCH_VD(METRIC_L2);
-        DISPATCH_VD(METRIC_L1);
-        DISPATCH_VD(METRIC_Linf);
-        DISPATCH_VD(METRIC_Lp);
-        DISPATCH_VD(METRIC_Canberra);
-        DISPATCH_VD(METRIC_BrayCurtis);
-        DISPATCH_VD(METRIC_JensenShannon);
-        DISPATCH_VD(METRIC_Jaccard);
-        DISPATCH_VD(METRIC_NaNEuclidean);
-        DISPATCH_VD(METRIC_GOWER);
-        default:
-            FAISS_THROW_FMT("Invalid metric %d", metric);
-    }
-#undef DISPATCH_VD
+    auto dispatch_metric = [&]<MetricType mt>() {
+        auto call = [&]<SIMDLevel level>() {
+            VectorDistance<mt, level> vd = {d, metric_arg};
+            return consumer.template f<VectorDistance<mt, level>>(vd, args...);
+        };
+
+        constexpr bool has_simd = mt == METRIC_INNER_PRODUCT ||
+                mt == METRIC_L2 || mt == METRIC_L1 || mt == METRIC_Linf;
+        if constexpr (!has_simd) {
+            return call.template operator()<SIMDLevel::NONE>();
+        } else {
+            DISPATCH_SIMDLevel(call.template operator());
+        }
+    };
+    return with_metric_type(metric, dispatch_metric);
 }
 
 } // namespace faiss


### PR DESCRIPTION
Summary:
Dynamic dispatching will be performed when fvec_L2sqr is called. This is problematic for tight loops.
This diff moves the dispatching one level above in the calling code to avoid this pitfall.


In particular, the VectorDistance dispatcher now takes not only the metric type into account but also the SIMD level. The consequence is that there should be no degradation for IVFFlat.

Reviewed By: algoriddle

Differential Revision: D92966745


