### PR TITLE
resulthandlers with AVX512

### DIFF
--- a/benchs/avx512_result_handlers/bench_avx512_result_handler.cpp
+++ b/benchs/avx512_result_handlers/bench_avx512_result_handler.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "faiss_avx512_result_handler.h"
+
+#include <faiss/IndexIVF.h>
+#include <faiss/index_factory.h>
+#include <faiss/utils/random.h>
+#include <faiss/utils/utils.h>
+#include <omp.h>
+
+#include <cstdio>
+#include <memory>
+#include <vector>
+
+using namespace faiss;
+
+// Parameters
+constexpr int d = 64;          // dimension
+constexpr size_t nb = 1000000; // database size
+constexpr size_t nt = 10000;   // training size
+constexpr size_t nq = 100;     // number of queries
+constexpr int nrun = 5;        // number of timing runs
+
+int main() {
+    // Use single OpenMP thread
+
+    printf("Generating nt=%zu nb=%zu nq=%zu vectors of dimension %d\n",
+           nt,
+           nb,
+           nq,
+           d);
+    std::vector<float> xt(nt * d), xb(nb * d), xq(nq * d);
+    rand_smooth_vectors(nt, d, xt.data(), 1234);
+    rand_smooth_vectors(nb, d, xb.data(), 4567);
+    rand_smooth_vectors(nq, d, xq.data(), 7890);
+
+    // Build IVF1024,Flat index
+    printf("Building IVF1024,Flat index...\n");
+    std::unique_ptr<Index> index(index_factory(d, "IVF1024,Flat", METRIC_L2));
+
+    printf("Training index...\n");
+    index->train(nt, xt.data());
+
+    printf("Adding %zu vectors to index...\n", nb);
+    index->add(nb, xb.data());
+
+    // Set nprobe for IVF index
+    IndexIVF* index_ivf = dynamic_cast<IndexIVF*>(index.get());
+    if (index_ivf) {
+    }
+    omp_set_num_threads(1);
+
+    // Test with varying k values
+    std::vector<size_t> k_values = {1, 10, 20, 50, 100, 200, 500, 1000};
+    std::vector<size_t> nprobe_values = {1, 2, 4, 8, 16, 64};
+
+    printf("\nBenchmarking with %d OpenMP thread(s), %d runs per config\n",
+           omp_get_max_threads(),
+           nrun);
+    printf("%-8s %15s %15s %10s\n",
+           "k",
+           "baseline(ms)",
+           "avx512(ms)",
+           "speedup");
+    printf("------------------------------------------------------------\n");
+
+    for (size_t nprobe : nprobe_values) {
+        index_ivf->nprobe = nprobe;
+        printf("============ nprobe=%zu ===========\n", nprobe);
+        for (size_t k : k_values) {
+            std::vector<float> D_ref(nq * k);
+            std::vector<idx_t> I_ref(nq * k);
+            std::vector<float> D_avx(nq * k);
+            std::vector<idx_t> I_avx(nq * k);
+
+            // Warmup
+            index->search(nq, xq.data(), k, D_ref.data(), I_ref.data());
+
+            // Benchmark baseline search
+            double t0 = getmillisecs();
+            for (int run = 0; run < nrun; run++) {
+                for (size_t q = 0; q < nq; q++) {
+                    index->search(
+                            1,
+                            xq.data() + q * d,
+                            k,
+                            D_ref.data() + q * k,
+                            I_ref.data() + q * k);
+                }
+            }
+            double baseline_time = (getmillisecs() - t0) / nrun;
+
+            // Warmup AVX512 handler
+            ReservoirResultHandlerAVX512 handler(k);
+            for (size_t q = 0; q < nq; q++) {
+                handler.begin();
+                index->search1(xq.data() + q * d, handler);
+                handler.end(D_avx.data() + q * k, I_avx.data() + q * k);
+            }
+
+            // Benchmark AVX512 result handler
+            t0 = getmillisecs();
+            for (int run = 0; run < nrun; run++) {
+                for (size_t q = 0; q < nq; q++) {
+                    handler.begin();
+                    index->search1(xq.data() + q * d, handler);
+                    handler.end(D_avx.data() + q * k, I_avx.data() + q * k);
+                }
+            }
+            double avx512_time = (getmillisecs() - t0) / nrun;
+
+            double speedup = baseline_time / avx512_time;
+            printf("%-8zu %15.3f %15.3f %10.2fx\n",
+                   k,
+                   baseline_time,
+                   avx512_time,
+                   speedup);
+        }
+    }
+
+    return 0;
+}

--- a/benchs/avx512_result_handlers/faiss_avx512_result_handler.h
+++ b/benchs/avx512_result_handlers/faiss_avx512_result_handler.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/ResultHandler.h>
+#include <immintrin.h>
+#include "partition.h"
+
+#include <algorithm>
+#include <vector>
+
+namespace faiss {
+
+/**
+ * AVX-512 optimized reservoir result handler for top-k selection.
+ *
+ * This handler collects results one by one and uses the AVX-512
+ * optimized partition algorithm when compaction is needed.
+ *
+ * Handles distances where lower is better (e.g., L2 distance).
+ * Keeps the k smallest distances.
+ *
+ * Usage:
+ *   ReservoirResultHandlerAVX512 handler(k);
+ *   for (size_t q = 0; q < nq; q++) {
+ *       handler.begin();
+ *       index->search1(xq + q * d, handler);
+ *       handler.end(D + q * k, I + q * k);
+ *   }
+ */
+struct ReservoirResultHandlerAVX512 : ResultHandler {
+    // total size (rounded up to multiple of 16)
+    size_t capacity;
+    // number we want to keep
+    size_t k;
+    // number currently stored
+    size_t n;
+
+    // Storage arrays
+    std::vector<float> vals;
+    std::vector<int32_t> idxs;
+
+    /**
+     * Constructor
+     * @param k           Number of results to keep
+     * @param capacity_in Optional capacity for reservoir (default: 2*k rounded
+     * up to 16)
+     */
+    explicit ReservoirResultHandlerAVX512(size_t k, size_t capacity_in = 0)
+            : k(k) {
+        capacity = capacity_in > 0 ? capacity_in : 2 * k;
+        if (capacity < k + 16) {
+            capacity = k + 16;
+        }
+        capacity = (capacity + 15) & ~15; // Round up to multiple of 16
+        vals.resize(capacity);
+        idxs.resize(capacity);
+        begin();
+    }
+
+    /**
+     * Begin a new query. Resets the handler state.
+     */
+    void begin() {
+        n = 0;
+        threshold = HUGE_VALF;
+    }
+
+    /**
+     * Compact the reservoir by partitioning to keep only k smallest elements.
+     */
+    void compact() {
+        assert(n >= k);
+        // argpartition(n, ..., n-k) puts (n-k) largest at [k, n), leaving k
+        // smallest at [0, k)
+        argpartition(n, vals.data(), idxs.data(), n - k);
+        // threshold is max of k smallest values
+        threshold = *std::max_element(vals.data(), vals.data() + k);
+        n = k;
+    }
+
+    /**
+     * Add one result.
+     * Checks that the idx fits in 32 bits.
+     *
+     * @param dis  Distance value (lower is better)
+     * @param idx  64-bit index (must fit in 32 bits)
+     * @return true if threshold was updated
+     */
+    bool add_result(float dis, idx_t idx) override {
+        FAISS_THROW_IF_NOT_MSG(idx >> 32 == 0, "Index does not fit in 32 bits");
+
+        // Early threshold check: reject if dis >= threshold
+        if (dis >= threshold) {
+            return false;
+        }
+
+        if (n == capacity) {
+            compact();
+            if (dis >= threshold) {
+                return false;
+            }
+        }
+
+        float old_threshold = threshold;
+        vals[n] = dis;
+        idxs[n] = static_cast<int32_t>(idx);
+        n++;
+
+        return threshold != old_threshold;
+    }
+
+    /**
+     * Finalize results: sort the reservoir and copy to output arrays.
+     * Results are sorted with smallest distances first.
+     *
+     * @param heap_dis  Output array for distances (size k)
+     * @param heap_ids  Output array for ids (size k)
+     */
+    void end(float* heap_dis, idx_t* heap_ids) {
+        // Sort the reservoir (ascending order)
+        if (n > 0) {
+            argsort(n, vals.data(), idxs.data());
+        }
+
+        // Copy results to output (up to k elements)
+        size_t n_results = std::min(n, k);
+        for (size_t i = 0; i < n_results; i++) {
+            heap_dis[i] = vals[i];
+            heap_ids[i] = static_cast<idx_t>(idxs[i]);
+        }
+
+        // Fill remaining slots with neutral values
+        for (size_t i = n_results; i < k; i++) {
+            heap_dis[i] = HUGE_VALF;
+            heap_ids[i] = -1;
+        }
+    }
+};
+
+} // namespace faiss

--- a/benchs/avx512_result_handlers/partition.cpp
+++ b/benchs/avx512_result_handlers/partition.cpp
@@ -1,0 +1,603 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "partition.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+#include <immintrin.h>
+
+// Set to 1 to enable debug output
+#define DEBUG_PARTITION 0
+
+namespace {
+
+// Scalar Hoare partition - used for small arrays and as reference
+size_t scalar_partition(float* vals, int32_t* idxs, size_t n, float pivot) {
+    float* left = vals;
+    float* right = vals + n - 1;
+    int32_t* left_idx = idxs;
+    int32_t* right_idx = idxs + n - 1;
+
+    while (true) {
+        while (left <= right && *left < pivot) {
+            left++;
+            left_idx++;
+        }
+        while (left <= right && *right >= pivot) {
+            right--;
+            right_idx--;
+        }
+        if (left >= right) {
+            break;
+        }
+        std::swap(*left, *right);
+        std::swap(*left_idx, *right_idx);
+        left++;
+        left_idx++;
+        right--;
+        right_idx--;
+    }
+    return left - vals;
+}
+
+constexpr int B = 16; // AVX-512 processes 16 floats at a time
+
+// simple full buffer (after loading)
+struct KVBufferB {
+    __m512 val;
+    __m512i idx;
+    static constexpr uint32_t nval = B; // always full
+};
+
+struct KVPartialBuffer {
+    __m512 val;
+    __m512i idx;
+    uint32_t nval = 0; // number of values, size <= B
+};
+
+struct PartialBuffer2B {
+    KVBufferB b0;
+    KVBufferB b1;
+    uint32_t nval = 0; // number of values, size <= 2 * B
+
+    // Append a buffer (KVBufferB or KVPartialBuffer) to this 2B buffer
+    template <typename BufferT>
+    inline void append(const BufferT& partial) {
+        const uint32_t partial_nval = partial.nval;
+
+        if (nval == 0) {
+            b0.val = partial.val;
+            b0.idx = partial.idx;
+            nval = partial_nval;
+        } else if (nval + partial_nval <= B) {
+            // Merge into b0: shift existing and add new
+            // Use compress store and load to merge
+            __mmask16 mask_new = ((1u << partial_nval) - 1) << nval;
+
+            // Expand partial to start at position nval
+            b0.val = _mm512_mask_expand_ps(b0.val, mask_new, partial.val);
+            b0.idx = _mm512_mask_expand_epi32(b0.idx, mask_new, partial.idx);
+            nval += partial_nval;
+        } else if (nval <= B) {
+            // Need to split between b0 and b1
+            uint32_t space_in_b0 = B - nval;
+
+            if (space_in_b0 > 0) {
+                // Fill remaining space in b0
+                __mmask16 mask_fill = ((1u << space_in_b0) - 1) << nval;
+                b0.val = _mm512_mask_expand_ps(b0.val, mask_fill, partial.val);
+                b0.idx = _mm512_mask_expand_epi32(
+                        b0.idx, mask_fill, partial.idx);
+            }
+
+            // Put the rest in b1
+            uint32_t remaining = partial_nval - space_in_b0;
+            if (remaining > 0) {
+                // Compress out the first space_in_b0 elements from partial
+                __mmask16 mask_rest = ((1u << remaining) - 1) << space_in_b0;
+                b1.val = _mm512_maskz_compress_ps(mask_rest, partial.val);
+                b1.idx = _mm512_maskz_compress_epi32(mask_rest, partial.idx);
+            }
+            nval = B + remaining;
+        } else {
+            // nval > B, append to b1
+            uint32_t pos_in_b1 = nval - B;
+            __mmask16 mask_new = ((1u << partial_nval) - 1) << pos_in_b1;
+            b1.val = _mm512_mask_expand_ps(b1.val, mask_new, partial.val);
+            b1.idx = _mm512_mask_expand_epi32(b1.idx, mask_new, partial.idx);
+            nval += partial_nval;
+        }
+    }
+
+    // Extract the first B elements, shifting the rest
+    inline KVBufferB pop_front_B() {
+        assert(nval >= B);
+        KVBufferB ret = b0;
+        b0 = b1;
+        nval -= B;
+        return ret;
+    }
+};
+
+size_t partition_avx512(
+        float* __restrict__ vals,
+        int32_t* __restrict__ idxs,
+        size_t n,
+        float pivot) {
+    if (n < B) {
+        return scalar_partition(vals, idxs, n, pivot);
+    }
+
+    __m512 pivot_vec = _mm512_set1_ps(pivot);
+
+    PartialBuffer2B buffer_left;
+    buffer_left.nval = 0;
+    PartialBuffer2B buffer_right;
+    buffer_right.nval = 0;
+
+    auto load = [vals, idxs](size_t i) {
+        KVBufferB ret;
+        ret.val = _mm512_loadu_ps(vals + i);
+        ret.idx = _mm512_loadu_epi32(idxs + i);
+        return ret;
+    };
+
+    auto store = [vals, idxs](size_t i, const KVBufferB& x) {
+        _mm512_storeu_ps(vals + i, x.val);
+        _mm512_storeu_epi32(idxs + i, x.idx);
+    };
+
+    auto partial_load = [vals, idxs](size_t addr, size_t count) {
+        KVPartialBuffer ret;
+        ret.nval = count;
+        if (count == 0) {
+            return ret;
+        }
+        __mmask16 mask = (1u << count) - 1;
+        ret.val = _mm512_maskz_loadu_ps(mask, vals + addr);
+        ret.idx = _mm512_maskz_loadu_epi32(mask, idxs + addr);
+        return ret;
+    };
+
+    auto partial_store = [vals, idxs](size_t addr, const KVPartialBuffer& buf) {
+        if (buf.nval == 0) {
+            return;
+        }
+        __mmask16 mask = (1u << buf.nval) - 1;
+        _mm512_mask_storeu_ps(vals + addr, mask, buf.val);
+        _mm512_mask_storeu_epi32(idxs + addr, mask, buf.idx);
+    };
+
+    // Partition a block into left/right buffers based on pivot comparison
+    auto fill_buffers = [&](const KVBufferB& x) {
+        __mmask16 mask_lt = _mm512_cmp_ps_mask(x.val, pivot_vec, _CMP_LT_OS);
+        __mmask16 mask_ge = ~mask_lt;
+
+        KVPartialBuffer left_part;
+        left_part.val = _mm512_maskz_compress_ps(mask_lt, x.val);
+        left_part.idx = _mm512_maskz_compress_epi32(mask_lt, x.idx);
+        left_part.nval = _mm_popcnt_u32(mask_lt);
+
+        KVPartialBuffer right_part;
+        right_part.val = _mm512_maskz_compress_ps(mask_ge, x.val);
+        right_part.idx = _mm512_maskz_compress_epi32(mask_ge, x.idx);
+        right_part.nval = _mm_popcnt_u32(mask_ge);
+
+        buffer_left.append(left_part);
+        buffer_right.append(right_part);
+    };
+
+    // Same for partial buffer
+    auto fill_buffers_partial = [&](const KVPartialBuffer& x) {
+        if (x.nval == 0) {
+            return;
+        }
+
+        __mmask16 valid_mask = (1u << x.nval) - 1;
+        __mmask16 mask_lt =
+                _mm512_cmp_ps_mask(x.val, pivot_vec, _CMP_LT_OS) & valid_mask;
+        __mmask16 mask_ge = (~mask_lt) & valid_mask;
+
+        KVPartialBuffer left_part;
+        left_part.val = _mm512_maskz_compress_ps(mask_lt, x.val);
+        left_part.idx = _mm512_maskz_compress_epi32(mask_lt, x.idx);
+        left_part.nval = _mm_popcnt_u32(mask_lt);
+
+        KVPartialBuffer right_part;
+        right_part.val = _mm512_maskz_compress_ps(mask_ge, x.val);
+        right_part.idx = _mm512_maskz_compress_epi32(mask_ge, x.idx);
+        right_part.nval = _mm_popcnt_u32(mask_ge);
+
+        buffer_left.append(left_part);
+        buffer_right.append(right_part);
+    };
+
+    size_t left_ptr = 0;
+    size_t right_ptr = n;
+    KVPartialBuffer x_partial;
+    x_partial.nval = 0;
+
+    if (n >= 2 * B) {
+        // Initialization: load first and last blocks
+        KVBufferB x = load(left_ptr);
+        fill_buffers(x);
+
+        x = load(right_ptr - B);
+        fill_buffers(x);
+
+        // Main loop
+        while (left_ptr + 3 * B <= right_ptr) {
+            assert(buffer_left.nval <= 2 * B);
+            assert(buffer_right.nval <= 2 * B);
+            assert(buffer_left.nval + buffer_right.nval == 2 * B);
+
+            if (buffer_left.nval >= B) {
+                KVBufferB to_store = buffer_left.pop_front_B();
+                store(left_ptr, to_store);
+                left_ptr += B;
+                x = load(left_ptr);
+                fill_buffers(x);
+            } else {
+                assert(buffer_right.nval >= B);
+                KVBufferB to_store = buffer_right.pop_front_B();
+                store(right_ptr - B, to_store);
+                right_ptr -= B;
+                x = load(right_ptr - B);
+                fill_buffers(x);
+            }
+        }
+
+        // Load remaining data (size < B)
+        assert(left_ptr + B <= right_ptr - B);
+        size_t remaining = right_ptr - left_ptr - 2 * B;
+        x_partial = partial_load(left_ptr + B, remaining);
+
+        // Make room by flushing full buffers
+        if (buffer_left.nval >= B) {
+            KVBufferB to_store = buffer_left.pop_front_B();
+            store(left_ptr, to_store);
+            left_ptr += B;
+        }
+        if (buffer_right.nval >= B) {
+            KVBufferB to_store = buffer_right.pop_front_B();
+            store(right_ptr - B, to_store);
+            right_ptr -= B;
+        }
+
+    } else if (n >= B) {
+        // Load a single full batch and a partial batch
+        KVBufferB x = load(0);
+        fill_buffers(x);
+        x_partial = partial_load(B, n - B);
+    } else { // for completeness, was handled by scalar code
+        // n < B: load a partial batch
+        x_partial = partial_load(0, n);
+    }
+
+    // Process remaining partial data
+    fill_buffers_partial(x_partial);
+
+    // Write out the left buffer
+    if (buffer_left.nval >= B) {
+        KVBufferB to_store = buffer_left.pop_front_B();
+        store(left_ptr, to_store);
+        left_ptr += B;
+    }
+
+    // Write partial left buffer
+    KVPartialBuffer left_remainder;
+    left_remainder.val = buffer_left.b0.val;
+    left_remainder.idx = buffer_left.b0.idx;
+    left_remainder.nval = buffer_left.nval;
+    partial_store(left_ptr, left_remainder);
+    left_ptr += left_remainder.nval;
+
+    // Remember partition point
+    size_t ret = left_ptr;
+
+    // Write out the right buffer
+    if (buffer_right.nval >= B) {
+        KVBufferB to_store = buffer_right.pop_front_B();
+        store(left_ptr, to_store);
+        left_ptr += B;
+    }
+
+    // Write partial right buffer
+    KVPartialBuffer right_remainder;
+    right_remainder.val = buffer_right.b0.val;
+    right_remainder.idx = buffer_right.b0.idx;
+    right_remainder.nval = buffer_right.nval;
+    partial_store(left_ptr, right_remainder);
+    left_ptr += right_remainder.nval;
+
+    assert(left_ptr == right_ptr);
+
+    return ret;
+}
+
+// Median of three for pivot selection
+inline float median3(float a, float b, float c) {
+    return std::max(std::min(a, b), std::min(std::max(a, b), c));
+}
+
+// Heap-based selection fallback for worst-case protection
+void heap_select_largest_k(float* vals, int32_t* idxs, size_t n, size_t k) {
+    // Build min-heap of first k elements
+    auto cmp = [&vals](size_t a, size_t b) { return vals[a] > vals[b]; };
+
+    std::vector<size_t> heap_idx(k);
+    std::iota(heap_idx.begin(), heap_idx.end(), 0);
+    std::make_heap(heap_idx.begin(), heap_idx.end(), cmp);
+
+    // Process remaining elements
+    for (size_t i = k; i < n; i++) {
+        if (vals[i] > vals[heap_idx[0]]) {
+            std::pop_heap(heap_idx.begin(), heap_idx.end(), cmp);
+            heap_idx[k - 1] = i;
+            std::push_heap(heap_idx.begin(), heap_idx.end(), cmp);
+        }
+    }
+
+    // Rearrange so top-k are at the end
+    std::vector<float> tmp_vals(n);
+    std::vector<int32_t> tmp_idxs(n);
+    std::copy(vals, vals + n, tmp_vals.begin());
+    std::copy(idxs, idxs + n, tmp_idxs.begin());
+
+    // Mark which indices are in top-k
+    std::vector<bool> in_topk(n, false);
+    for (size_t i = 0; i < k; i++) {
+        in_topk[heap_idx[i]] = true;
+    }
+
+    // Write non-top-k to front, top-k to back
+    size_t front = 0, back = n - k;
+    for (size_t i = 0; i < n; i++) {
+        if (in_topk[i]) {
+            vals[back] = tmp_vals[i];
+            idxs[back] = tmp_idxs[i];
+            back++;
+        } else {
+            vals[front] = tmp_vals[i];
+            idxs[front] = tmp_idxs[i];
+            front++;
+        }
+    }
+}
+
+// Introselect: quickselect with depth limit and heap fallback
+void introselect_avx512(
+        float* vals,
+        int32_t* idxs,
+        size_t n,
+        size_t k,
+        int depth_limit) {
+    while (n > 1) {
+        if (depth_limit == 0) {
+            // Fall back to heap selection to guarantee O(n log n)
+            heap_select_largest_k(vals, idxs, n, k);
+            return;
+        }
+        depth_limit--;
+
+        // Select pivot using median-of-three
+        float pivot = median3(vals[0], vals[n / 2], vals[n - 1]);
+
+        // Partition around pivot
+        size_t left_size = partition_avx512(vals, idxs, n, pivot);
+        size_t right_size = n - left_size;
+
+        // Determine which partition contains the k-th largest element
+        // We want the k largest at positions [n-k, n)
+        // So we need (n - k) elements in the "less than" partition
+
+        if (left_size == n || right_size == n) {
+            // All elements equal to pivot or bad pivot - use different strategy
+            float new_pivot = pivot;
+            for (size_t i = 0; i < n; i++) {
+                if (vals[i] != pivot) {
+                    new_pivot = (vals[i] + pivot) / 2.0f;
+                    break;
+                }
+            }
+            if (new_pivot == pivot) {
+                // All elements are equal, nothing to do
+                return;
+            }
+            pivot = new_pivot;
+            left_size = partition_avx512(vals, idxs, n, pivot);
+            right_size = n - left_size;
+        }
+
+        size_t target_left = n - k; // How many elements should be on the left
+
+        if (left_size == target_left) {
+            // Perfect partition - done!
+            return;
+        } else if (left_size < target_left) {
+            // Need more elements on the left side
+            // Recurse on the right partition to find more elements for left
+            size_t need_from_right = target_left - left_size;
+            introselect_avx512(
+                    vals + left_size,
+                    idxs + left_size,
+                    right_size,
+                    right_size - need_from_right,
+                    depth_limit);
+            return;
+        } else {
+            // Too many elements on left side, recurse on left partition
+            n = left_size;
+            k = k - right_size; // Adjust k since we're dropping right_size
+                                // elements
+        }
+    }
+}
+
+} // anonymous namespace
+
+void argpartition(size_t n, float* val, int32_t* idx, size_t k) {
+    assert(k <= n);
+
+    if (k == 0 || k == n) {
+        return;
+    }
+
+    // Depth limit for introselect: 2 * log2(n) iterations before heap fallback
+    int depth_limit = 2 * (32 - __builtin_clz((uint32_t)n));
+
+    // Run introselect to partition so k largest are at positions [n-k, n)
+    introselect_avx512(val, idx, n, k, depth_limit);
+}
+
+/*****************************************
+ *
+ */
+
+KVBufferB flip_with_step(KVBufferB a, int log2_p) {
+    KVBufferB ret;
+    switch (log2_p) {
+        case 0:
+            // p=1: swap adjacent elements (0,1), (2,3), etc.
+            ret.val = _mm512_shuffle_ps(a.val, a.val, 0b10110001);
+            ret.idx = _mm512_shuffle_epi32(a.idx, _MM_PERM_CDAB);
+            break;
+        case 1:
+            // p=2: swap pairs (0,1)<->(2,3), (4,5)<->(6,7), etc.
+            ret.val = _mm512_shuffle_ps(a.val, a.val, 0b01001110);
+            ret.idx = _mm512_shuffle_epi32(a.idx, _MM_PERM_BADC);
+            break;
+        case 2:
+            // p=4: swap 128-bit lanes within each 256-bit half
+            ret.val = _mm512_shuffle_f32x4(a.val, a.val, 0b10110001);
+            ret.idx = _mm512_shuffle_i32x4(a.idx, a.idx, 0b10110001);
+            break;
+        case 3:
+            // p=8: swap 256-bit halves
+            ret.val = _mm512_shuffle_f32x4(a.val, a.val, 0b01001110);
+            ret.idx = _mm512_shuffle_i32x4(a.idx, a.idx, 0b01001110);
+            break;
+        default:
+            assert(false);
+    }
+    return ret;
+}
+
+__mmask16 mask_with_step(int step) {
+    switch (step) {
+        case 0:
+            return 0xAAAA;
+        case 1:
+            return 0xCCCC;
+        case 2:
+            return 0xF0F0;
+        case 3:
+            return 0xFF00;
+        case 4:
+            return 0x0000;
+        default:
+            assert(false);
+    }
+    return 0;
+}
+
+KVBufferB bitonic_merge(KVBufferB tab, int step, int stepk) {
+    KVBufferB inv_tab = flip_with_step(tab, step);
+    __mmask16 mask = _mm512_cmp_ps_mask(tab.val, inv_tab.val, _CMP_GT_OQ);
+    __mmask16 eq_mask = _mm512_cmp_ps_mask(tab.val, inv_tab.val, _CMP_EQ_OQ);
+    mask ^= mask_with_step(step) ^ mask_with_step(stepk);
+    // When values are equal, don't swap - prevents index duplication
+    mask &= ~eq_mask;
+    KVBufferB res;
+    res.val = _mm512_mask_blend_ps(mask, tab.val, inv_tab.val);
+    res.idx = _mm512_mask_blend_epi32(mask, tab.idx, inv_tab.idx);
+    return res;
+}
+
+KVBufferB bitonic_sort(KVBufferB tab) {
+    for (int stepk = 1; stepk < 5; stepk++) {
+        for (int step = stepk - 1; step >= 0; step--) {
+            tab = bitonic_merge(tab, step, stepk);
+        }
+    }
+    return tab;
+}
+
+void argsort(size_t n, float* val, int32_t* idx) {
+    if (n <= 1) {
+        return;
+    }
+
+    if (n <= B) {
+        // Use bitonic sort for small arrays (<=16 elements)
+        // Load data into KVBufferB, padding with max float values
+        KVBufferB buf;
+        if (n == B) {
+            buf.val = _mm512_loadu_ps(val);
+            buf.idx = _mm512_loadu_epi32(idx);
+        } else {
+            // Partial load: fill unused slots with max float to push them to
+            // end
+            __mmask16 mask = (1u << n) - 1;
+            buf.val = _mm512_mask_loadu_ps(
+                    _mm512_set1_ps(std::numeric_limits<float>::max()),
+                    mask,
+                    val);
+            buf.idx = _mm512_mask_loadu_epi32(_mm512_set1_epi32(-1), mask, idx);
+        }
+
+        buf = bitonic_sort(buf);
+
+        // Store back only the valid elements
+        if (n == B) {
+            _mm512_storeu_ps(val, buf.val);
+            _mm512_storeu_epi32(idx, buf.idx);
+        } else {
+            __mmask16 mask = (1u << n) - 1;
+            _mm512_mask_storeu_ps(val, mask, buf.val);
+            _mm512_mask_storeu_epi32(idx, mask, buf.idx);
+        }
+        return;
+    }
+
+    // Use quicksort with partition_avx512 for larger arrays
+    // Select pivot using median-of-three
+    float pivot = median3(val[0], val[n / 2], val[n - 1]);
+
+    // Partition around pivot
+    size_t left_size = partition_avx512(val, idx, n, pivot);
+
+    // Handle degenerate case where all elements are equal to pivot
+    if (left_size == 0 || left_size == n) {
+        // Find a different pivot
+        float new_pivot = pivot;
+        for (size_t i = 0; i < n; i++) {
+            if (val[i] != pivot) {
+                new_pivot = (val[i] + pivot) / 2.0f;
+                break;
+            }
+        }
+        if (new_pivot == pivot) {
+            // All elements are equal, already sorted
+            return;
+        }
+        left_size = partition_avx512(val, idx, n, new_pivot);
+    }
+
+    // Recursively sort both partitions
+    argsort(left_size, val, idx);
+    argsort(n - left_size, val + left_size, idx + left_size);
+}

--- a/benchs/avx512_result_handlers/partition.h
+++ b/benchs/avx512_result_handlers/partition.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+/**
+ * AVX-512 SIMD argpartition implementation
+ * Inspired by NumPy's x86-simd-sort / introselect
+ *
+ * Partitions indices such that the k largest elements' indices are at positions
+ * [n-k, n) Uses introselect (quickselect with heap fallback) with
+ * SIMD-optimized partition
+ *
+ * @param n     Number of elements (must be multiple of 16)
+ * @param val   Array of values (modified in place)
+ * @param idx   Array of indices (modified in place)
+ * @param k     Number of largest elements to partition
+ *
+ * After calling, the k largest elements will be at positions [n-k, n) in both
+ * arrays. The relative order within each partition is undefined.
+ */
+void argpartition(size_t n, float* val, int32_t* idx, size_t k);
+
+/**
+ * AVX-512 optimized argsort implementation
+ * Uses quicksort with SIMD-optimized partition for large arrays (>16 elements)
+ * and bitonic sort for small arrays (<=16 elements)
+ *
+ * @param n     Number of elements
+ * @param val   Array of values (modified in place, sorted in ascending order)
+ * @param idx   Array of indices (modified in place, reordered with values)
+ */
+void argsort(size_t n, float* val, int32_t* idx);

--- a/benchs/avx512_result_handlers/test_bitonic.cpp
+++ b/benchs/avx512_result_handlers/test_bitonic.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <immintrin.h>
+#include <algorithm>
+#include <cassert>
+#include <cstdio>
+#include <numeric>
+#include <random>
+
+__m512 flip_with_step(__m512 a, int log2_p) {
+    switch (log2_p) {
+        case 0:
+            // p=1: swap adjacent elements (0,1), (2,3), etc.
+            // [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] ->
+            // [1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14]
+            return _mm512_shuffle_ps(a, a, 0b10110001);
+        case 1:
+            // p=2: swap pairs (0,1)<->(2,3), (4,5)<->(6,7), etc.
+            // [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] ->
+            // [2,3,0,1,6,7,4,5,10,11,8,9,14,15,12,13]
+            return _mm512_shuffle_ps(a, a, 0b01001110);
+        case 2:
+            // p=4: swap 128-bit lanes within each 256-bit half
+            // [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] ->
+            // [4,5,6,7,0,1,2,3,12,13,14,15,8,9,10,11]
+            return _mm512_shuffle_f32x4(a, a, 0b10110001);
+        case 3:
+            // p=8: swap 256-bit halves
+            // [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] ->
+            // [8,9,10,11,12,13,14,15,0,1,2,3,4,5,6,7]
+            return _mm512_shuffle_f32x4(a, a, 0b01001110);
+        default:
+            assert(false);
+            return a; // keep some compilers happy
+    }
+}
+
+__mmask16 mask_with_step(int step) {
+    switch (step) {
+        case 0:
+            return 0xAAAA;
+        case 1:
+            return 0xCCCC;
+        case 2:
+            return 0xF0F0;
+        case 3:
+            return 0xFF00;
+        case 4:
+            return 0x0000;
+        default:
+            assert(false);
+            return 0; // keep some compilers happy
+    }
+}
+
+__m512 bitonic_merge(__m512 tab, int step, int stepk) {
+    __m512 inv_tab = flip_with_step(tab, step);
+    __mmask16 mask = _mm512_cmp_ps_mask(tab, inv_tab, _CMP_GT_OQ);
+
+    // for distinct values, the mask is ok, but for others we should make sure
+    // there is one 0 and one 1 per pair, so force
+    //    mask[i ^ (1<<step)] = 1 - mask[i]
+    mask &= ~mask_with_step(step);
+    mask |= (mask & mask_with_step(step)) << step;
+
+    mask ^= mask_with_step(step) ^ mask_with_step(stepk);
+    return _mm512_mask_blend_ps(mask, tab, inv_tab);
+}
+
+__m512 bitonic_sort(__m512 tab) {
+    for (int stepk = 1; stepk < 5; stepk++) {
+        for (int step = stepk - 1; step >= 0; step--) {
+            tab = bitonic_merge(tab, step, stepk);
+        }
+    }
+    return tab;
+}
+
+int main() {
+    // Generate a random permutation of 0..15
+    float values[16];
+    std::iota(values, values + 16, 0.0f);
+    std::mt19937 rng(1234);
+    std::shuffle(values, values + 16, rng);
+
+    printf("Input:  ");
+    for (int i = 0; i < 16; i++) {
+        printf("%2.0f ", values[i]);
+    }
+    printf("\n");
+
+    // Load into __m512 and sort
+    __m512 vec = _mm512_loadu_ps(values);
+    vec = bitonic_sort(vec);
+
+    // Store and display result
+    float result[16];
+    _mm512_storeu_ps(result, vec);
+
+    printf("Output: ");
+    for (int i = 0; i < 16; i++) {
+        printf("%2.0f ", result[i]);
+    }
+    printf("\n");
+
+    return 0;
+}

--- a/benchs/avx512_result_handlers/test_bitonic.py
+++ b/benchs/avx512_result_handlers/test_bitonic.py
@@ -1,0 +1,85 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import numpy as np
+
+
+def squaresig(n, period):
+    if n == period:
+        return np.zeros(n, dtype=bool)
+    ret = np.zeros(n, dtype=bool).reshape(-1, 2, period)
+    ret[:, 1, :] = True
+    return ret.ravel()
+
+
+def bitonic_merge_2(tab, step, stepk):
+    tr = tab.reshape(-1, 2, step // 2)
+    tc = tr.copy()
+    # print(tc)
+    mask = tr[:, 0, :] < tr[:, 1, :]
+    flip_mask = squaresig(mask.shape[0], stepk // step)
+    mask ^= flip_mask[:, None]
+    # print(mask)
+    # print(mask)
+    # print(f"{n=} {step=} {stepk=}, {flip_mask.astype(int)}")
+    tr[:, 0, :] = np.where(mask, tc[:, 0, :], tc[:, 1, :])
+    tr[:, 1, :] = np.where(mask, tc[:, 1, :], tc[:, 0, :])
+    # print(tr)
+
+
+def bitonic_merge_rev(tab, res, step, stepk):
+    n = len(tab)
+    inv_tab = np.array([tab[i ^ (step // 2)] for i in range(n)])
+    mask = np.ones(n, dtype=int)
+    mask[:] = 2
+    mask[res == tab] = 0
+    mask[res == inv_tab] = 1
+    cmp = tab > inv_tab
+    mask ^= cmp.astype(int)
+    flip_mask = np.array(
+        [((i // (step // 2)) & 1) ^ (i // (stepk) & 1) for i in range(n)]
+    )
+    mask ^= flip_mask.astype(int)
+    # flip_mask = np.array([(i % (stepk * 2) < stepk) for i in range(n)])
+    # mask ^= flip_mask
+    print(f"{n=:2} {step=:2} {stepk=:2}, A {mask}")
+    # print(f"{n=:2} {step=:2} {stepk=:2}, B {flip_mask.astype(int)}")
+
+
+def bitonic_merge_3(tab, step, stepk):
+    n = len(tab)
+    inv_tab = np.array([tab[i ^ (step // 2)] for i in range(n)])
+    mask = tab > inv_tab
+    flip_mask = np.array(
+        [((i // (step // 2)) & 1) ^ (i // (stepk) & 1) for i in range(n)]
+    )
+    mask ^= flip_mask.astype(bool)
+    print(f"{n=:2} {step=:2} {stepk=:2}, {mask.astype(int)}")
+    tab[:] = np.where(mask, inv_tab, tab)
+
+
+log_n = 4
+rs = np.random.RandomState(1234)
+tab = rs.permutation(1 << log_n)
+print(tab)
+
+for stepk in range(1, log_n + 1):
+    for step in range(stepk, 0, -1):
+        bitonic_merge_3(tab, 2**step, 2**stepk)
+        print(tab)
+
+if False:
+    log_n = 5
+    rs = np.random.RandomState(1234)
+
+    for _ in range(10):
+        tab = rs.permutation(1 << log_n)
+        print(tab)
+
+        for stepk in range(1, log_n + 1):
+            for step in range(stepk, 0, -1):
+                tab0 = tab.copy()
+                bitonic_merge_3(tab, 2**step, 2**stepk)
+                bitonic_merge_rev(tab0, tab, 2**step, 2**stepk)

--- a/benchs/avx512_result_handlers/test_partition.cpp
+++ b/benchs/avx512_result_handlers/test_partition.cpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include "partition.h"
+
+#include <algorithm>
+#include <numeric>
+#include <random>
+#include <vector>
+
+TEST(ArgsortTest, SortsCorrectly) {
+    std::mt19937 rng(12345);
+
+    for (int trial = 0; trial < 100; trial++) {
+        // Generate random size between 1 and 1000
+        std::uniform_int_distribution<size_t> size_dist(1, 1000);
+        size_t n = size_dist(rng);
+
+        std::vector<float> vals(n);
+        std::vector<int32_t> idxs(n);
+
+        // Generate random float values
+        std::uniform_real_distribution<float> val_dist(-1e6f, 1e6f);
+        for (size_t i = 0; i < n; i++) {
+            vals[i] = val_dist(rng);
+        }
+
+        // Generate distinct random IDs by shuffling a sequence
+        std::iota(idxs.begin(), idxs.end(), 0);
+        std::shuffle(idxs.begin(), idxs.end(), rng);
+
+        // Make copies for reference
+        std::vector<std::pair<float, int32_t>> ref_pairs(n);
+        for (size_t i = 0; i < n; i++) {
+            ref_pairs[i] = {vals[i], idxs[i]};
+        }
+
+        // Sort using our implementation
+        argsort(n, vals.data(), idxs.data());
+
+        // Sort reference using std::sort
+        std::sort(
+                ref_pairs.begin(),
+                ref_pairs.end(),
+                [](const auto& a, const auto& b) { return a.first < b.first; });
+
+        // Check that values are sorted correctly
+        for (size_t i = 0; i < n; i++) {
+            EXPECT_EQ(vals[i], ref_pairs[i].first)
+                    << "Trial " << trial << ": Value mismatch at index " << i
+                    << " for n=" << n;
+            EXPECT_EQ(idxs[i], ref_pairs[i].second)
+                    << "Trial " << trial << ": Index mismatch at index " << i
+                    << " for n=" << n;
+        }
+    }
+}
+
+TEST(ArgsortTest, SortsWithCollisions) {
+    std::mt19937 rng(99999);
+
+    for (int trial = 0; trial < 100; trial++) {
+        // Generate random size between 1 and 1000
+        std::uniform_int_distribution<size_t> size_dist(1, 1000);
+        size_t n = size_dist(rng);
+
+        std::vector<float> vals(n);
+        std::vector<int32_t> idxs(n);
+
+        // Generate integer values between 0 and 20 (many collisions)
+        std::uniform_int_distribution<int> val_dist(0, 20);
+        for (size_t i = 0; i < n; i++) {
+            vals[i] = static_cast<float>(val_dist(rng));
+        }
+
+        // Generate distinct random IDs by shuffling a sequence
+        std::iota(idxs.begin(), idxs.end(), 0);
+        std::shuffle(idxs.begin(), idxs.end(), rng);
+
+        // Save original idx array for validation
+        std::vector<int32_t> original_idxs = idxs;
+
+        // Sort using our implementation
+        argsort(n, vals.data(), idxs.data());
+
+        // Check that values are sorted in ascending order
+        for (size_t i = 1; i < n; i++) {
+            EXPECT_LE(vals[i - 1], vals[i])
+                    << "Trial " << trial << ": Values not sorted at index " << i
+                    << " for n=" << n << " (vals[" << i - 1
+                    << "]=" << vals[i - 1] << ", vals[" << i << "]=" << vals[i]
+                    << ")";
+        }
+
+        // Check that all original IDs are present (idx array is a permutation)
+        std::vector<int32_t> sorted_original = original_idxs;
+        std::vector<int32_t> sorted_result = idxs;
+        std::sort(sorted_original.begin(), sorted_original.end());
+        std::sort(sorted_result.begin(), sorted_result.end());
+        EXPECT_EQ(sorted_result, sorted_original)
+                << "Trial " << trial
+                << ": Result IDs don't match original IDs for n=" << n;
+    }
+}
+
+TEST(ArgpartitionTest, PartitionsCorrectly) {
+    std::mt19937 rng(54321);
+
+    for (int trial = 0; trial < 100; trial++) {
+        // Generate random size between 1 and 1000
+        std::uniform_int_distribution<size_t> size_dist(1, 1000);
+        size_t n = size_dist(rng);
+
+        // Generate random k between 1 and n
+        std::uniform_int_distribution<size_t> k_dist(1, n);
+        size_t k = k_dist(rng);
+
+        std::vector<float> vals(n);
+        std::vector<int32_t> idxs(n);
+
+        // Generate random float values
+        std::uniform_real_distribution<float> val_dist(-1e6f, 1e6f);
+        for (size_t i = 0; i < n; i++) {
+            vals[i] = val_dist(rng);
+        }
+
+        // Generate distinct random IDs
+        std::iota(idxs.begin(), idxs.end(), 0);
+        std::shuffle(idxs.begin(), idxs.end(), rng);
+
+        // Make copies for reference
+        std::vector<std::pair<float, int32_t>> ref_pairs(n);
+        for (size_t i = 0; i < n; i++) {
+            ref_pairs[i] = {vals[i], idxs[i]};
+        }
+
+        // Partition using our implementation
+        argpartition(n, vals.data(), idxs.data(), k);
+
+        // Use std::nth_element on reference
+        std::nth_element(
+                ref_pairs.begin(),
+                ref_pairs.begin() + (n - k),
+                ref_pairs.end(),
+                [](const auto& a, const auto& b) { return a.first < b.first; });
+
+        // Collect the k largest values from our result (sorted)
+        std::vector<float> our_topk(vals.begin() + (n - k), vals.end());
+        std::sort(our_topk.begin(), our_topk.end());
+
+        // Collect the k largest values from reference (sorted)
+        std::vector<float> ref_topk;
+        for (size_t i = n - k; i < n; i++) {
+            ref_topk.push_back(ref_pairs[i].first);
+        }
+        std::sort(ref_topk.begin(), ref_topk.end());
+
+        // Check that we have the same k largest values
+        ASSERT_EQ(our_topk.size(), ref_topk.size());
+        for (size_t i = 0; i < k; i++) {
+            EXPECT_EQ(our_topk[i], ref_topk[i])
+                    << "Trial " << trial << ": Top-k mismatch at index " << i
+                    << " for n=" << n << ", k=" << k;
+        }
+    }
+}


### PR DESCRIPTION
Summary:
Implementation of result handlers with AVX512.
This diff introduces parittioning code optimized using AVX512 compression primitives. This enables implementing in-register parition and sort.

This does speed up search, especially for large k and small nprobe:

https://www.internalfb.com/phabricator/paste/view/P2175597887

Currently keeping this as a separate code, waiting for the SIMD infrastructure to stabilize

Reviewed By: algoriddle

Differential Revision: D92663660


