### PR TITLE
Fix CMake/Buck build discrepancies

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -203,6 +203,7 @@ set(FAISS_HEADERS
   VectorTransform.h
   clone_index.h
   index_factory.h
+  factory_tools.h
   index_io.h
   impl/AdditiveQuantizer.h
   impl/AuxIndexStructures.h
@@ -233,6 +234,7 @@ set(FAISS_HEADERS
   impl/ResidualQuantizer.h
   impl/ResultHandler.h
   impl/ScalarQuantizer.h
+  impl/expanded_scanners.h
   impl/scalar_quantizer/codecs.h
   impl/scalar_quantizer/distance_computers.h
   impl/scalar_quantizer/quantizers.h
@@ -243,6 +245,7 @@ set(FAISS_HEADERS
   impl/index_read_utils.h
   impl/io.h
   impl/io_macros.h
+  impl/mapped_io.h
   impl/kmeans1d.h
   impl/lattice_Zn.h
   impl/platform_macros.h
@@ -280,6 +283,7 @@ set(FAISS_HEADERS
   utils/partitioning.h
   utils/prefetch.h
   utils/quantize_lut.h
+  utils/rabitq_simd.h
   utils/random.h
   utils/sorting.h
   utils/simdlib.h
@@ -307,6 +311,7 @@ set(FAISS_HEADERS
   utils/hamming_distance/avx2-inl.h
   utils/hamming_distance/avx512-inl.h
   utils/simd_impl/distances_autovec-inl.h
+  utils/simd_impl/distances_sse-inl.h
 )
 
 if(FAISS_ENABLE_SVS)


### PR DESCRIPTION
Summary:
1. CMakeLists.txt: Add 5 headers present in Buck's header_files() but missing from CMake's FAISS_HEADERS. Without these, open-source CMake builds may fail to install the headers, causing downstream compile errors for users who include them: factory_tools.h, impl/expanded_scanners.h, impl/mapped_io.h, utils/rabitq_simd.h, utils/simd_impl/distances_sse-inl.h.

2. xplat.bzl: Remove duplicate definitions of get_arch_compiler_flags() and get_arch_preprocessor_flags(). The second definitions silently shadow the first in Starlark. They happen to be identical, but the duplicates are dead code that adds confusion.

3. simd_dispatch.bzl: Enable ARM_SVE in dispatch_config. CMake DD builds on aarch64 already compile SVE sources and define COMPILE_SIMD_ARM_SVE, and OSS CI tests this on every PR (linux-arm64-DD-cmake on Graviton). Buck DD had SVE disabled despite the full infrastructure being wired up (source files, compiler flags, preprocessor flags), causing a silent divergence between the two build systems.

Differential Revision: D93199230


