### PR TITLE
Deploy std::unique_ptr<> in index_read.cpp for exception safety

### DIFF
--- a/faiss/impl/index_read_utils.h
+++ b/faiss/impl/index_read_utils.h
@@ -19,7 +19,6 @@ namespace faiss {
 struct ProductQuantizer;
 struct ScalarQuantizer;
 
-void read_index_header(Index* idx, IOReader* f);
 void read_direct_map(DirectMap* dm, IOReader* f);
 void read_ivf_header(
         IndexIVF* ivf,

--- a/faiss/index_io.h
+++ b/faiss/index_io.h
@@ -11,13 +11,17 @@
 #define FAISS_INDEX_IO_H
 
 #include <cstdio>
+#include <memory>
 
 /** I/O functions can read/write to a filename, a file handle or to an
  * object that abstracts the medium.
  *
- * The read functions return objects that should be deallocated with
- * delete. All references within these objects are owned by the
- * object.
+ * The read functions come in two forms:
+ * - read_*_up() returns a std::unique_ptr that owns the result.
+ * - read_*() returns a raw pointer for backward compatibility.
+ *   The caller is responsible for deleting the returned object.
+ *
+ * All references within these objects are owned by the object.
  */
 
 namespace faiss {
@@ -68,9 +72,21 @@ Index* read_index(const char* fname, int io_flags = 0);
 Index* read_index(FILE* f, int io_flags = 0);
 Index* read_index(IOReader* reader, int io_flags = 0);
 
+std::unique_ptr<Index> read_index_up(const char* fname, int io_flags = 0);
+std::unique_ptr<Index> read_index_up(FILE* f, int io_flags = 0);
+std::unique_ptr<Index> read_index_up(IOReader* reader, int io_flags = 0);
+
 IndexBinary* read_index_binary(const char* fname, int io_flags = 0);
 IndexBinary* read_index_binary(FILE* f, int io_flags = 0);
 IndexBinary* read_index_binary(IOReader* reader, int io_flags = 0);
+
+std::unique_ptr<IndexBinary> read_index_binary_up(
+        const char* fname,
+        int io_flags = 0);
+std::unique_ptr<IndexBinary> read_index_binary_up(FILE* f, int io_flags = 0);
+std::unique_ptr<IndexBinary> read_index_binary_up(
+        IOReader* reader,
+        int io_flags = 0);
 
 void write_VectorTransform(const VectorTransform* vt, const char* fname);
 void write_VectorTransform(const VectorTransform* vt, IOWriter* f);
@@ -78,14 +94,24 @@ void write_VectorTransform(const VectorTransform* vt, IOWriter* f);
 VectorTransform* read_VectorTransform(const char* fname);
 VectorTransform* read_VectorTransform(IOReader* f);
 
+std::unique_ptr<VectorTransform> read_VectorTransform_up(const char* fname);
+std::unique_ptr<VectorTransform> read_VectorTransform_up(IOReader* f);
+
 ProductQuantizer* read_ProductQuantizer(const char* fname);
 ProductQuantizer* read_ProductQuantizer(IOReader* reader);
+
+std::unique_ptr<ProductQuantizer> read_ProductQuantizer_up(const char* fname);
+std::unique_ptr<ProductQuantizer> read_ProductQuantizer_up(IOReader* reader);
 
 void write_ProductQuantizer(const ProductQuantizer* pq, const char* fname);
 void write_ProductQuantizer(const ProductQuantizer* pq, IOWriter* f);
 
 void write_InvertedLists(const InvertedLists* ils, IOWriter* f);
 InvertedLists* read_InvertedLists(IOReader* reader, int io_flags = 0);
+
+std::unique_ptr<InvertedLists> read_InvertedLists_up(
+        IOReader* reader,
+        int io_flags = 0);
 
 } // namespace faiss
 

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -941,6 +941,14 @@ faiss::Quantizer * downcast_Quantizer (faiss::Quantizer *aq)
 }
 %}
 
+// SWIG cannot handle std::unique_ptr return types; the raw-pointer
+// versions (already annotated with %newobject) are sufficient.
+%ignore faiss::read_index_up;
+%ignore faiss::read_index_binary_up;
+%ignore faiss::read_VectorTransform_up;
+%ignore faiss::read_ProductQuantizer_up;
+%ignore faiss::read_InvertedLists_up;
+
 %include  <faiss/index_io.h>
 %include  <faiss/clone_index.h>
 %newobject index_factory;


### PR DESCRIPTION
Summary:
Convert all allocations in faiss/impl/index_read.cpp to std::unique_ptr<>
so that exceptions thrown during deserialization do not leak memory.

The conversion is mostly mechanical in nature except that it includes
std::unique_ptr<> versions of the public API to faciliate future adoption
of this approach to exception safety in calling contexts.

NOTE: This covers the most obvious exception related memory leaks, but
additional auditing and testing may find others. These will be addressed in
a separate commit.

Differential Revision: D93139218


