### PR TITLE
Harden deserialization against integer overflow and buffer overflows

### DIFF
--- a/faiss/impl/AdditiveQuantizer.cpp
+++ b/faiss/impl/AdditiveQuantizer.cpp
@@ -67,8 +67,10 @@ void AdditiveQuantizer::set_derived_values() {
     codebook_offsets.resize(M + 1, 0);
     for (int i = 0; i < M; i++) {
         int nbit = nbits[i];
-        size_t k = 1 << nbit;
-        codebook_offsets[i + 1] = codebook_offsets[i] + k;
+        FAISS_CHECK_RANGE(nbit, 0, 31);
+        size_t k = (size_t)1 << nbit;
+        codebook_offsets[i + 1] =
+                add_no_overflow(codebook_offsets[i], k, "codebook_offsets");
         tot_bits += nbit;
         if (nbit != 0) {
             only_8bit = false;
@@ -154,12 +156,24 @@ void AdditiveQuantizer::train_norm(size_t n, const float* norms) {
 
 void AdditiveQuantizer::compute_codebook_tables() {
     centroid_norms.resize(total_codebook_size);
+    FAISS_THROW_IF_NOT_FMT(
+            codebooks.size() >=
+                    mul_no_overflow(
+                            total_codebook_size, d, "codebooks validation"),
+            "codebooks size %zd too small for total_codebook_size=%zd * d=%zd",
+            codebooks.size(),
+            total_codebook_size,
+            d);
     fvec_norms_L2sqr(
             centroid_norms.data(), codebooks.data(), d, total_codebook_size);
     size_t cross_table_size = 0;
     for (int m = 0; m < M; m++) {
+        FAISS_CHECK_RANGE(nbits[m], 0, 31);
         size_t K = (size_t)1 << nbits[m];
-        cross_table_size += K * codebook_offsets[m];
+        size_t product =
+                mul_no_overflow(K, codebook_offsets[m], "cross_table_size");
+        cross_table_size = add_no_overflow(
+                cross_table_size, product, "cross_table_size accumulation");
     }
     codebook_cross_products.resize(cross_table_size);
     size_t ofs = 0;
@@ -168,7 +182,16 @@ void AdditiveQuantizer::compute_codebook_tables() {
         FINTEGER kk = codebook_offsets[m];
         FINTEGER di = d;
         float zero = 0, one = 1;
-        assert(ofs + ki * kk <= cross_table_size);
+        size_t step_size = (size_t)ki * (size_t)kk;
+        FAISS_THROW_IF_NOT_FMT(
+                add_no_overflow(ofs, step_size, "cross product table offset") <=
+                        cross_table_size,
+                "cross product table overflow at step %d: "
+                "%zd + %zd > %zd",
+                m,
+                ofs,
+                step_size,
+                cross_table_size);
         sgemm_("Transposed",
                "Not transposed",
                &ki,
@@ -182,7 +205,7 @@ void AdditiveQuantizer::compute_codebook_tables() {
                &zero,
                codebook_cross_products.data() + ofs,
                &ki);
-        ofs += ki * kk;
+        ofs += step_size;
     }
 }
 

--- a/faiss/impl/FaissAssert.h
+++ b/faiss/impl/FaissAssert.h
@@ -12,6 +12,7 @@
 
 #include <faiss/impl/FaissException.h>
 #include <faiss/impl/platform_macros.h>
+#include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
 #include <string>
@@ -109,5 +110,62 @@
             FAISS_THROW_FMT("Error: '%s' failed: " FMT, #X, __VA_ARGS__); \
         }                                                                 \
     } while (false)
+
+///
+/// Safe arithmetic
+///
+
+#include <limits>
+
+namespace faiss {
+
+/// Multiplication that throws on overflow instead of wrapping
+inline size_t mul_no_overflow(size_t a, size_t b, const char* context) {
+    if (a != 0 && b > (std::numeric_limits<size_t>::max)() / a) {
+        FAISS_THROW_FMT("integer overflow in %s: %zu * %zu", context, a, b);
+    }
+    return a * b;
+}
+
+/// Addition that throws on overflow instead of wrapping
+inline size_t add_no_overflow(size_t a, size_t b, const char* context) {
+    if (a > (std::numeric_limits<size_t>::max)() - b) {
+        FAISS_THROW_FMT("integer overflow in %s: %zu + %zu", context, a, b);
+    }
+    return a + b;
+}
+
+} // namespace faiss
+
+///
+/// Bounds checking
+///
+
+/// Check that val is in half-open range [lo, hi). Throws with the
+/// stringified expression, its value, and the bounds on failure.
+#define FAISS_CHECK_RANGE(val, lo, hi)                                         \
+    FAISS_THROW_IF_NOT_FMT(                                                    \
+            (int64_t)(val) >= (int64_t)(lo) && (int64_t)(val) < (int64_t)(hi), \
+            "%s (= %" PRId64 ") out of range [%" PRId64 ", %" PRId64 ")",      \
+            #val,                                                              \
+            (int64_t)(val),                                                    \
+            (int64_t)(lo),                                                     \
+            (int64_t)(hi))
+
+/// Debug-only variant of FAISS_CHECK_RANGE. Aborts in debug builds
+/// (when NDEBUG is not defined); compiled out in release builds to
+/// avoid overhead in hot paths.
+#ifndef NDEBUG
+#define FAISS_CHECK_RANGE_DEBUG(val, lo, hi)                                   \
+    FAISS_ASSERT_FMT(                                                          \
+            (int64_t)(val) >= (int64_t)(lo) && (int64_t)(val) < (int64_t)(hi), \
+            "%s (= %" PRId64 ") out of range [%" PRId64 ", %" PRId64 ")",      \
+            #val,                                                              \
+            (int64_t)(val),                                                    \
+            (int64_t)(lo),                                                     \
+            (int64_t)(hi))
+#else
+#define FAISS_CHECK_RANGE_DEBUG(val, lo, hi) ((void)0)
+#endif
 
 #endif

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -7,6 +7,7 @@
 
 #include <faiss/impl/HNSW.h>
 
+#include <cinttypes>
 #include <cstddef>
 
 #include <faiss/IndexHNSW.h>
@@ -44,11 +45,15 @@ void HNSW::set_nb_neighbors(int level_no, int n) {
 }
 
 int HNSW::cum_nb_neighbors(int layer_no) const {
+    FAISS_CHECK_RANGE_DEBUG(layer_no, 0, (int)cum_nneighbor_per_level.size());
     return cum_nneighbor_per_level[layer_no];
 }
 
 void HNSW::neighbor_range(idx_t no, int layer_no, size_t* begin, size_t* end)
         const {
+    FAISS_CHECK_RANGE_DEBUG(no, 0, (idx_t)offsets.size());
+    FAISS_CHECK_RANGE_DEBUG(
+            layer_no, 0, (int)cum_nneighbor_per_level.size() - 1);
     size_t o = offsets[no];
     *begin = o + cum_nb_neighbors(layer_no);
     *end = o + cum_nb_neighbors(layer_no + 1);

--- a/faiss/impl/NSG.h
+++ b/faiss/impl/NSG.h
@@ -66,12 +66,14 @@ struct Graph {
     // construct an empty graph
     // NOTE: the newly allocated data needs to be destroyed at destruction time
     Graph(int N, int K) : K(K), N(N), own_fields(true) {
-        data = new node_t[N * K];
+        size_t total = faiss::mul_no_overflow(
+                (size_t)N, (size_t)K, "Graph allocation");
+        data = new node_t[total];
     }
 
     // copy constructor
     Graph(const Graph& g) : Graph(g.N, g.K) {
-        memcpy(data, g.data, N * K * sizeof(node_t));
+        memcpy(data, g.data, (size_t)N * (size_t)K * sizeof(node_t));
     }
 
     // release the allocated memory if needed
@@ -83,21 +85,25 @@ struct Graph {
 
     // access the j-th neighbor of node i
     inline node_t at(int i, int j) const {
-        return data[i * K + j];
+        FAISS_CHECK_RANGE_DEBUG(i, 0, N);
+        FAISS_CHECK_RANGE_DEBUG(j, 0, K);
+        return data[(size_t)i * K + j];
     }
 
     // access the j-th neighbor of node i by reference
     inline node_t& at(int i, int j) {
-        return data[i * K + j];
+        FAISS_CHECK_RANGE_DEBUG(i, 0, N);
+        FAISS_CHECK_RANGE_DEBUG(j, 0, K);
+        return data[(size_t)i * K + j];
     }
 
     // get all neighbors of node i (used during search only)
     virtual size_t get_neighbors(int i, node_t* neighbors) const {
         for (int j = 0; j < K; j++) {
-            if (data[i * K + j] < 0) {
+            if (data[(size_t)i * K + j] < 0) {
                 return j;
             }
-            neighbors[j] = data[i * K + j];
+            neighbors[j] = data[(size_t)i * K + j];
         }
         return K;
     }


### PR DESCRIPTION
Summary:
Changes across five files to strengthen protection against malicious index contents:

FaissAssert.h: Add faiss::safe_mul() for overflow-checked size_t multiplication, shared across deserialization code.

index_read.cpp: Use safe_mul() for overflow-checked size computations in ArrayInvertedLists, binary hash, and NSG graph allocation. Fix NSG graph allocation to use R+1 columns (matching the read loop). Add even-size checks for step-2 loops in sparse inverted lists and IVFFlatDedup. Add non-negative checks for deserialized int fields (d, ntotal).

NSG.h: Use safe_mul() in Graph constructor allocation, bounds-checked mutable at(), size_t casts in all data indexing.

AdditiveQuantizer.cpp: Overflow checks in set_derived_values() for nbits/codebook_offsets, and in compute_codebook_tables() for cross_table_size accumulation and sgemm bounds.

HNSW.cpp: Bounds checks in cum_nb_neighbors() and neighbor_range() to prevent OOB access via deserialized offsets/levels when add() or search() is called post-load.

Reviewed By: junjieqi

Differential Revision: D92907607


