### PR TITLE
Add conda-forge channel to INSTALL.md install commands

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,10 +12,10 @@ To install the latest stable release:
 
 ``` shell
 # CPU-only version
-$ conda install -c pytorch faiss-cpu=1.13.2
+$ conda install -c pytorch -c conda-forge faiss-cpu=1.13.2
 
 # GPU(+CPU) version
-$ conda install -c pytorch -c nvidia faiss-gpu=1.13.2
+$ conda install -c pytorch -c nvidia -c conda-forge faiss-gpu=1.13.2
 
 # GPU(+CPU) version with NVIDIA cuVS
 $ conda install -c pytorch -c nvidia -c rapidsai -c conda-forge libnvjitlink faiss-gpu-cuvs=1.13.2
@@ -23,7 +23,9 @@ $ conda install -c pytorch -c nvidia -c rapidsai -c conda-forge libnvjitlink fai
 # GPU(+CPU) version using AMD ROCm not yet available
 ```
 
-For faiss-gpu, the nvidia channel is required for CUDA, which is not published in the main anaconda channel.
+The conda-forge channel is required for up-to-date dependencies (MKL on x86-64, OpenBLAS on ARM), which are not regularly updated in the default Anaconda channel.
+
+For faiss-gpu, the nvidia channel is additionally required for CUDA, which is not published in the main anaconda channel.
 
 For faiss-gpu-cuvs, the rapidsai, conda-forge and nvidia channels are required.
 
@@ -31,10 +33,10 @@ Nightly pre-release packages can be installed as follows:
 
 ``` shell
 # CPU-only version
-$ conda install -c pytorch/label/nightly faiss-cpu
+$ conda install -c pytorch/label/nightly -c conda-forge faiss-cpu
 
 # GPU(+CPU) version
-$ conda install -c pytorch/label/nightly -c nvidia faiss-gpu=1.13.2
+$ conda install -c pytorch/label/nightly -c nvidia -c conda-forge faiss-gpu=1.13.2
 
 # GPU(+CPU) version with NVIDIA cuVS (package built with CUDA 12.6)
 conda install -c pytorch -c rapidsai -c rapidsai-nightly -c conda-forge -c nvidia pytorch/label/nightly::faiss-gpu-cuvs 'cuda-version=12.6'


### PR DESCRIPTION
Summary:
Users following the conda install instructions for faiss-cpu and faiss-gpu hit LibMambaUnsatisfiableError because the default Anaconda channel does not carry up-to-date builds of dependencies like MKL (x86-64) and libopenblas (ARM/osx-arm64). The conda-forge channel has these packages but was only included in the faiss-gpu-cuvs command, not the faiss-cpu or faiss-gpu commands.

Added `-c conda-forge` to all four affected install commands (stable and nightly for both faiss-cpu and faiss-gpu), and added an explanatory note about why the channel is needed.

Differential Revision: D93809073


