### PR TITLE
Make dispatch_VectorDistance more compact

### DIFF
--- a/faiss/IndexAdditiveQuantizer.cpp
+++ b/faiss/IndexAdditiveQuantizer.cpp
@@ -182,46 +182,19 @@ void search_with_LUT(
     }
 }
 
-struct Run_search_with_decompress {
-    const IndexAdditiveQuantizer& iaq;
-    const float* xq;
-    idx_t n;
-    idx_t k;
-    float* distances;
-    idx_t* labels;
-    using T = void;
-
-    template <class VD>
-    void f(VD vd) {
-        if constexpr (VD::is_similarity) {
-            HeapBlockResultHandler<CMin<float, idx_t>> rh(
-                    n, distances, labels, k);
-            search_with_decompress(iaq, xq, vd, rh);
-        } else {
-            HeapBlockResultHandler<CMax<float, idx_t>> rh(
-                    n, distances, labels, k);
-            search_with_decompress(iaq, xq, vd, rh);
-        }
-    }
-};
-
-struct Run_new_AQDistanceComputerDecompress {
-    const IndexAdditiveQuantizer& iaq;
-    using T = FlatCodesDistanceComputer*;
-
-    template <class VD>
-    T f(VD vd) {
-        return new AQDistanceComputerDecompress<VD>(iaq, vd);
-    }
-};
-
 } // anonymous namespace
 
 FlatCodesDistanceComputer* IndexAdditiveQuantizer::
         get_FlatCodesDistanceComputer() const {
     if (aq->search_type == AdditiveQuantizer::ST_decompress) {
-        Run_new_AQDistanceComputerDecompress consumer{*this};
-        return dispatch_VectorDistance(d, metric_type, metric_arg, consumer);
+        return with_VectorDistance(
+                d,
+                metric_type,
+                metric_arg,
+                [&](auto vd) -> FlatCodesDistanceComputer* {
+                    return new AQDistanceComputerDecompress<decltype(vd)>(
+                            *this, vd);
+                });
     } else {
         if (metric_type == METRIC_INNER_PRODUCT) {
             return new AQDistanceComputerLUT<
@@ -264,8 +237,17 @@ void IndexAdditiveQuantizer::search(
             !params, "search params not supported for this index");
 
     if (aq->search_type == AdditiveQuantizer::ST_decompress) {
-        Run_search_with_decompress consumer{*this, x, n, k, distances, labels};
-        dispatch_VectorDistance(d, metric_type, metric_arg, consumer);
+        with_VectorDistance(d, metric_type, metric_arg, [&](auto vd) {
+            if constexpr (decltype(vd)::is_similarity) {
+                HeapBlockResultHandler<CMin<float, idx_t>> rh(
+                        n, distances, labels, k);
+                search_with_decompress(*this, x, vd, rh);
+            } else {
+                HeapBlockResultHandler<CMax<float, idx_t>> rh(
+                        n, distances, labels, k);
+                search_with_decompress(*this, x, vd, rh);
+            }
+        });
     } else {
         if (metric_type == METRIC_INNER_PRODUCT) {
             HeapBlockResultHandler<CMin<float, idx_t>> rh(

--- a/faiss/IndexIVFFlat.cpp
+++ b/faiss/IndexIVFFlat.cpp
@@ -185,28 +185,16 @@ struct IVFFlatScanner : InvertedListScanner {
     }
 };
 
-struct Run_get_InvertedListScanner {
-    using T = InvertedListScanner*;
-
-    template <class VD>
-    InvertedListScanner* f(
-            VD& vd,
-            const IndexIVFFlat* ivf,
-            bool store_pairs,
-            const IDSelector* sel) {
-        return new IVFFlatScanner<VD>(vd, store_pairs, sel);
-    }
-};
-
 } // anonymous namespace
 
 InvertedListScanner* IndexIVFFlat::get_InvertedListScanner(
         bool store_pairs,
         const IDSelector* sel,
         const IVFSearchParameters*) const {
-    Run_get_InvertedListScanner run;
-    return dispatch_VectorDistance(
-            d, metric_type, metric_arg, run, this, store_pairs, sel);
+    return with_VectorDistance(
+            d, metric_type, metric_arg, [&](auto vd) -> InvertedListScanner* {
+                return new IVFFlatScanner<decltype(vd)>(vd, store_pairs, sel);
+            });
 }
 
 void IndexIVFFlat::reconstruct_from_offset(

--- a/faiss/IndexIVFFlatPanorama.cpp
+++ b/faiss/IndexIVFFlatPanorama.cpp
@@ -143,41 +143,28 @@ struct IVFFlatScannerPanorama : InvertedListScanner {
     }
 };
 
-struct Run_get_InvertedListScanner {
-    using T = InvertedListScanner*;
-
-    template <class VD>
-    InvertedListScanner* f(
-            VD& vd,
-            const IndexIVFFlatPanorama* ivf,
-            bool store_pairs,
-            const IDSelector* sel) {
-        // Safely cast to ArrayInvertedListsPanorama to access cumulative sums.
-        const ArrayInvertedListsPanorama* storage =
-                dynamic_cast<const ArrayInvertedListsPanorama*>(ivf->invlists);
-        FAISS_THROW_IF_NOT_MSG(
-                storage,
-                "IndexIVFFlatPanorama requires ArrayInvertedListsPanorama");
-
-        if (sel) {
-            return new IVFFlatScannerPanorama<VD, true>(
-                    vd, storage, store_pairs, sel);
-        } else {
-            return new IVFFlatScannerPanorama<VD, false>(
-                    vd, storage, store_pairs, sel);
-        }
-    }
-};
-
 } // anonymous namespace
 
 InvertedListScanner* IndexIVFFlatPanorama::get_InvertedListScanner(
         bool store_pairs,
         const IDSelector* sel,
         const IVFSearchParameters*) const {
-    Run_get_InvertedListScanner run;
-    return dispatch_VectorDistance(
-            d, metric_type, metric_arg, run, this, store_pairs, sel);
+    const ArrayInvertedListsPanorama* storage =
+            dynamic_cast<const ArrayInvertedListsPanorama*>(invlists);
+    FAISS_THROW_IF_NOT_MSG(
+            storage,
+            "IndexIVFFlatPanorama requires ArrayInvertedListsPanorama");
+
+    return with_VectorDistance(
+            d, metric_type, metric_arg, [&](auto vd) -> InvertedListScanner* {
+                if (sel) {
+                    return new IVFFlatScannerPanorama<decltype(vd), true>(
+                            vd, storage, store_pairs, sel);
+                } else {
+                    return new IVFFlatScannerPanorama<decltype(vd), false>(
+                            vd, storage, store_pairs, sel);
+                }
+            });
 }
 
 void IndexIVFFlatPanorama::reconstruct_from_offset(

--- a/faiss/utils/extra_distances.cpp
+++ b/faiss/utils/extra_distances.cpp
@@ -11,7 +11,6 @@
 
 #include <omp.h>
 #include <algorithm>
-#include <cmath>
 
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/DistanceComputer.h>
@@ -25,81 +24,6 @@ namespace faiss {
  ***************************************************************************/
 
 namespace {
-
-struct Run_pairwise_extra_distances {
-    using T = void;
-
-    template <class VD>
-    void f(VD vd,
-           int64_t nq,
-           const float* xq,
-           int64_t nb,
-           const float* xb,
-           float* dis,
-           int64_t ldq,
-           int64_t ldb,
-           int64_t ldd) {
-#pragma omp parallel for if (nq > 10)
-        for (int64_t i = 0; i < nq; i++) {
-            const float* xqi = xq + i * ldq;
-            const float* xbj = xb;
-            float* disi = dis + ldd * i;
-
-            for (int64_t j = 0; j < nb; j++) {
-                disi[j] = vd(xqi, xbj);
-                xbj += ldb;
-            }
-        }
-    }
-};
-
-struct Run_knn_extra_metrics {
-    using T = void;
-    template <class VD>
-    void f(VD vd,
-           const float* x,
-           const float* y,
-           size_t nx,
-           size_t ny,
-           size_t k,
-           float* distances,
-           int64_t* labels,
-           const IDSelector* sel = nullptr) {
-        size_t d = vd.d;
-        using C = typename VD::C;
-        size_t check_period = InterruptCallback::get_period_hint(ny * d);
-        check_period *= omp_get_max_threads();
-
-        for (size_t i0 = 0; i0 < nx; i0 += check_period) {
-            size_t i1 = std::min(i0 + check_period, nx);
-
-#pragma omp parallel for
-            for (int64_t i = i0; i < i1; i++) {
-                const float* x_i = x + i * d;
-                const float* y_j = y;
-                size_t j;
-                float* simi = distances + k * i;
-                int64_t* idxi = labels + k * i;
-
-                // maxheap_heapify(k, simi, idxi);
-                heap_heapify<C>(k, simi, idxi);
-                for (j = 0; j < ny; j++) {
-                    if (!sel || sel->is_member(j)) {
-                        float disij = vd(x_i, y_j);
-
-                        if (C::cmp(simi[0], disij)) {
-                            heap_replace_top<C>(k, simi, idxi, disij, j);
-                        }
-                    }
-                    y_j += d;
-                }
-                // maxheap_reorder(k, simi, idxi);
-                heap_reorder<C>(k, simi, idxi);
-            }
-            InterruptCallback::check();
-        }
-    }
-};
 
 template <class VD>
 struct ExtraDistanceComputer : FlatCodesDistanceComputer {
@@ -132,19 +56,6 @@ struct ExtraDistanceComputer : FlatCodesDistanceComputer {
     }
 };
 
-struct Run_get_distance_computer {
-    using T = FlatCodesDistanceComputer*;
-
-    template <class VD>
-    FlatCodesDistanceComputer* f(
-            VD vd,
-            const float* xb,
-            size_t nb,
-            const float* q = nullptr) {
-        return new ExtraDistanceComputer<VD>(vd, xb, nb, q);
-    }
-};
-
 } // anonymous namespace
 
 void pairwise_extra_distances(
@@ -172,9 +83,19 @@ void pairwise_extra_distances(
         ldd = nb;
     }
 
-    Run_pairwise_extra_distances run;
-    dispatch_VectorDistance(
-            d, mt, metric_arg, run, nq, xq, nb, xb, dis, ldq, ldb, ldd);
+    with_VectorDistance(d, mt, metric_arg, [&](auto vd) {
+#pragma omp parallel for if (nq > 10)
+        for (int64_t i = 0; i < nq; i++) {
+            const float* xqi = xq + i * ldq;
+            const float* xbj = xb;
+            float* disi = dis + ldd * i;
+
+            for (int64_t j = 0; j < nb; j++) {
+                disi[j] = vd(xqi, xbj);
+                xbj += ldb;
+            }
+        }
+    });
 }
 
 void knn_extra_metrics(
@@ -189,9 +110,38 @@ void knn_extra_metrics(
         float* distances,
         int64_t* indexes,
         const IDSelector* sel) {
-    Run_knn_extra_metrics run;
-    dispatch_VectorDistance(
-            d, mt, metric_arg, run, x, y, nx, ny, k, distances, indexes, sel);
+    with_VectorDistance(d, mt, metric_arg, [&](auto vd) {
+        using C = typename decltype(vd)::C;
+        size_t check_period = InterruptCallback::get_period_hint(ny * d);
+        check_period *= omp_get_max_threads();
+
+        for (size_t i0 = 0; i0 < nx; i0 += check_period) {
+            size_t i1 = std::min(i0 + check_period, nx);
+
+#pragma omp parallel for
+            for (int64_t i = i0; i < i1; i++) {
+                const float* x_i = x + i * d;
+                const float* y_j = y;
+                size_t j;
+                float* simi = distances + k * i;
+                int64_t* idxi = indexes + k * i;
+
+                heap_heapify<C>(k, simi, idxi);
+                for (j = 0; j < ny; j++) {
+                    if (!sel || sel->is_member(j)) {
+                        float disij = vd(x_i, y_j);
+
+                        if (C::cmp(simi[0], disij)) {
+                            heap_replace_top<C>(k, simi, idxi, disij, j);
+                        }
+                    }
+                    y_j += d;
+                }
+                heap_reorder<C>(k, simi, idxi);
+            }
+            InterruptCallback::check();
+        }
+    });
 }
 
 FlatCodesDistanceComputer* get_extra_distance_computer(
@@ -200,8 +150,10 @@ FlatCodesDistanceComputer* get_extra_distance_computer(
         float metric_arg,
         size_t nb,
         const float* xb) {
-    Run_get_distance_computer run;
-    return dispatch_VectorDistance(d, mt, metric_arg, run, xb, nb);
+    return with_VectorDistance(
+            d, mt, metric_arg, [&](auto vd) -> FlatCodesDistanceComputer* {
+                return new ExtraDistanceComputer<decltype(vd)>(vd, xb, nb);
+            });
 }
 
 } // namespace faiss


### PR DESCRIPTION
Summary:
The dispatch_VectorDistance was used to dispatch vector distance computations based on a runtime parameters.
We replace this with with_VectorDistance, that avoids creating a class whose sole purpose is to have a templatized function.
Instead we use templatized lambdas.
This makes the code more compact and reduces the visual imbrications (at the cost of some nifty C++20 syntax)

Differential Revision: D93883106


