### PR TITLE
Catch attempts to deserialize undefined MetricTypes

### DIFF
--- a/faiss/MetricType.h
+++ b/faiss/MetricType.h
@@ -14,6 +14,8 @@
 #include <cstdio>
 #include <cstdlib>
 
+#include <faiss/impl/FaissAssert.h>
+
 namespace faiss {
 
 /// The metric space for vector comparison for Faiss indices and algorithms.
@@ -21,6 +23,8 @@ namespace faiss {
 /// Most algorithms support both inner product and L2, with the flat
 /// (brute-force) indices supporting additional metric types for vector
 /// comparison.
+///
+/// NOTE: when adding or removing values, update metric_type_from_int() below.
 enum MetricType {
     METRIC_INNER_PRODUCT = 0, ///< maximum inner product search
     METRIC_L2 = 1,            ///< squared L2 search
@@ -51,6 +55,17 @@ using idx_t = int64_t;
 constexpr bool is_similarity_metric(MetricType metric_type) {
     return ((metric_type == METRIC_INNER_PRODUCT) ||
             (metric_type == METRIC_Jaccard));
+}
+
+/// Convert an integer to MetricType with range validation.
+/// Throws FaissException if the value is not a valid MetricType.
+inline MetricType metric_type_from_int(int x) {
+    FAISS_THROW_IF_NOT_FMT(
+            (x >= METRIC_INNER_PRODUCT && x <= METRIC_Lp) ||
+                    (x >= METRIC_Canberra && x <= METRIC_GOWER),
+            "invalid metric type %d",
+            x);
+    return static_cast<MetricType>(x);
 }
 
 } // namespace faiss

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -218,7 +218,9 @@ static void read_index_header(Index& idx, IOReader* f) {
     READ1(dummy);
     READ1(dummy);
     READ1(idx.is_trained);
-    READ1(idx.metric_type);
+    int metric_type_int;
+    READ1(metric_type_int);
+    idx.metric_type = metric_type_from_int(metric_type_int);
     if (idx.metric_type > 1) {
         READ1(idx.metric_arg);
     }
@@ -786,7 +788,9 @@ static void read_RaBitQuantizer(
         bool multi_bit = true) {
     READ1(rabitq.d);
     READ1(rabitq.code_size);
-    READ1(rabitq.metric_type);
+    int metric_type_int;
+    READ1(metric_type_int);
+    rabitq.metric_type = metric_type_from_int(metric_type_int);
 
     if (multi_bit) {
         READ1(rabitq.nb_bits);
@@ -1740,7 +1744,9 @@ static void read_index_binary_header(IndexBinary& idx, IOReader* f) {
     READ1(idx.code_size);
     READ1(idx.ntotal);
     READ1(idx.is_trained);
-    READ1(idx.metric_type);
+    int metric_type_int;
+    READ1(metric_type_int);
+    idx.metric_type = metric_type_from_int(metric_type_int);
     FAISS_THROW_IF_NOT_FMT(
             idx.d >= 0, "invalid binary index dimension %d", idx.d);
     FAISS_THROW_IF_NOT_FMT(


### PR DESCRIPTION
Summary:
Casting an int to an undefined enum value is undefined behavior
in C++. When deserializing indexes, explicitly validate MetricType
and throw an exception if it is not a defined value.

Differential Revision: D93898294


