### PR TITLE
Validate n_levels > 0 in Panorama

### DIFF
--- a/faiss/impl/Panorama.cpp
+++ b/faiss/impl/Panorama.cpp
@@ -11,6 +11,8 @@
 #include <cmath>
 #include <cstring>
 
+#include <faiss/impl/FaissAssert.h>
+
 namespace faiss {
 
 namespace {
@@ -58,6 +60,7 @@ Panorama::Panorama(size_t code_size, size_t n_levels, size_t batch_size)
 }
 
 void Panorama::set_derived_values() {
+    FAISS_THROW_IF_NOT_MSG(n_levels > 0, "Panorama: n_levels must be > 0");
     this->d = code_size / sizeof(float);
     this->level_width_floats = ((d + n_levels - 1) / n_levels);
     this->level_width = this->level_width_floats * sizeof(float);

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -906,6 +906,7 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         size_t n_levels, batch_size;
         READ1(d);
         READ1(n_levels);
+        FAISS_THROW_IF_NOT_FMT(n_levels > 0, "invalid n_levels %zd", n_levels);
         READ1(batch_size);
         std::unique_ptr<IndexFlatPanorama> idxp;
         if (h == fourcc("IxFP")) {


### PR DESCRIPTION
Summary: Add n_levels > 0 check in Panorama::set_derived_values() to prevent division by zero, and validate n_levels during deserialization.

Reviewed By: mdouze

Differential Revision: D93670703


