### PR TITLE
ScalarQuantizer: refactor SIMDWIDTH int → SIMDLevel enum

### DIFF
--- a/faiss/impl/scalar_quantizer/distance_computers.h
+++ b/faiss/impl/scalar_quantizer/distance_computers.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <faiss/impl/ScalarQuantizer.h>
+#include <faiss/utils/simd_levels.h>
 #include <faiss/utils/simdlib.h>
 
 namespace faiss {
@@ -21,11 +22,11 @@ using SQDistanceComputer = ScalarQuantizer::SQDistanceComputer;
  * code-to-vector or code-to-code comparisons
  *******************************************************************/
 
-template <class Quantizer, class Similarity, int SIMDWIDTH>
+template <class Quantizer, class Similarity, SIMDLevel SL>
 struct DCTemplate : SQDistanceComputer {};
 
 template <class Quantizer, class Similarity>
-struct DCTemplate<Quantizer, Similarity, 1> : SQDistanceComputer {
+struct DCTemplate<Quantizer, Similarity, SIMDLevel::NONE> : SQDistanceComputer {
     using Sim = Similarity;
 
     Quantizer quant;
@@ -72,7 +73,7 @@ struct DCTemplate<Quantizer, Similarity, 1> : SQDistanceComputer {
 #if defined(USE_AVX512_F16C)
 
 template <class Quantizer, class Similarity>
-struct DCTemplate<Quantizer, Similarity, 16>
+struct DCTemplate<Quantizer, Similarity, SIMDLevel::AVX512>
         : SQDistanceComputer { // Update to handle 16 lanes
     using Sim = Similarity;
 
@@ -117,10 +118,65 @@ struct DCTemplate<Quantizer, Similarity, 16>
     }
 };
 
-#elif defined(USE_F16C) || defined(USE_NEON)
+#endif
+
+#if defined(USE_F16C)
 
 template <class Quantizer, class Similarity>
-struct DCTemplate<Quantizer, Similarity, 8> : SQDistanceComputer {
+struct DCTemplate<Quantizer, Similarity, SIMDLevel::AVX2> : SQDistanceComputer {
+    using Sim = Similarity;
+
+    Quantizer quant;
+
+    DCTemplate(size_t d, const std::vector<float>& trained)
+            : quant(d, trained) {}
+
+    float compute_distance(const float* x, const uint8_t* code) const {
+        Similarity sim(x);
+        sim.begin_8();
+        for (size_t i = 0; i < quant.d; i += 8) {
+            simd8float32 xi =
+                    quant.reconstruct_8_components(code, static_cast<int>(i));
+            sim.add_8_components(xi);
+        }
+        return sim.result_8();
+    }
+
+    float compute_code_distance(const uint8_t* code1, const uint8_t* code2)
+            const {
+        Similarity sim(nullptr);
+        sim.begin_8();
+        for (size_t i = 0; i < quant.d; i += 8) {
+            simd8float32 x1 =
+                    quant.reconstruct_8_components(code1, static_cast<int>(i));
+            simd8float32 x2 =
+                    quant.reconstruct_8_components(code2, static_cast<int>(i));
+            sim.add_8_components_2(x1, x2);
+        }
+        return sim.result_8();
+    }
+
+    void set_query(const float* x) final {
+        q = x;
+    }
+
+    float symmetric_dis(idx_t i, idx_t j) override {
+        return compute_code_distance(
+                codes + i * code_size, codes + j * code_size);
+    }
+
+    float query_to_code(const uint8_t* code) const final {
+        return compute_distance(q, code);
+    }
+};
+
+#endif
+
+#ifdef USE_NEON
+
+template <class Quantizer, class Similarity>
+struct DCTemplate<Quantizer, Similarity, SIMDLevel::ARM_NEON>
+        : SQDistanceComputer {
     using Sim = Similarity;
 
     Quantizer quant;
@@ -173,11 +229,11 @@ struct DCTemplate<Quantizer, Similarity, 8> : SQDistanceComputer {
  * DistanceComputerByte: computes distances in the integer domain
  *******************************************************************/
 
-template <class Similarity, int SIMDWIDTH>
+template <class Similarity, SIMDLevel SL>
 struct DistanceComputerByte : SQDistanceComputer {};
 
 template <class Similarity>
-struct DistanceComputerByte<Similarity, 1> : SQDistanceComputer {
+struct DistanceComputerByte<Similarity, SIMDLevel::NONE> : SQDistanceComputer {
     using Sim = Similarity;
 
     int d;
@@ -223,7 +279,8 @@ struct DistanceComputerByte<Similarity, 1> : SQDistanceComputer {
 #if defined(__AVX512F__)
 
 template <class Similarity>
-struct DistanceComputerByte<Similarity, 16> : SQDistanceComputer {
+struct DistanceComputerByte<Similarity, SIMDLevel::AVX512>
+        : SQDistanceComputer {
     using Sim = Similarity;
 
     int d;
@@ -276,7 +333,7 @@ struct DistanceComputerByte<Similarity, 16> : SQDistanceComputer {
 #elif defined(__AVX2__)
 
 template <class Similarity>
-struct DistanceComputerByte<Similarity, 8> : SQDistanceComputer {
+struct DistanceComputerByte<Similarity, SIMDLevel::AVX2> : SQDistanceComputer {
     using Sim = Similarity;
 
     int d;
@@ -341,7 +398,8 @@ struct DistanceComputerByte<Similarity, 8> : SQDistanceComputer {
 #ifdef USE_NEON
 
 template <class Similarity>
-struct DistanceComputerByte<Similarity, 8> : SQDistanceComputer {
+struct DistanceComputerByte<Similarity, SIMDLevel::ARM_NEON>
+        : SQDistanceComputer {
     using Sim = Similarity;
 
     int d;

--- a/faiss/impl/scalar_quantizer/quantizers.h
+++ b/faiss/impl/scalar_quantizer/quantizers.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <faiss/impl/ScalarQuantizer.h>
+#include <faiss/utils/simd_levels.h>
 #include <faiss/utils/simdlib.h>
 
 namespace faiss {
@@ -21,12 +22,14 @@ namespace scalar_quantizer {
 
 enum class QuantizerTemplateScaling { UNIFORM = 0, NON_UNIFORM = 1 };
 
-template <class Codec, QuantizerTemplateScaling SCALING, int SIMD>
+template <class Codec, QuantizerTemplateScaling SCALING, SIMDLevel SL>
 struct QuantizerTemplate {};
 
 template <class Codec>
-struct QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 1>
-        : ScalarQuantizer::SQuantizer {
+struct QuantizerTemplate<
+        Codec,
+        QuantizerTemplateScaling::UNIFORM,
+        SIMDLevel::NONE> : ScalarQuantizer::SQuantizer {
     const size_t d;
     const float vmin, vdiff;
 
@@ -67,12 +70,19 @@ struct QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 1>
 #if defined(__AVX512F__)
 
 template <class Codec>
-struct QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 16>
-        : QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 1> {
+struct QuantizerTemplate<
+        Codec,
+        QuantizerTemplateScaling::UNIFORM,
+        SIMDLevel::AVX512>
+        : QuantizerTemplate<
+                  Codec,
+                  QuantizerTemplateScaling::UNIFORM,
+                  SIMDLevel::NONE> {
     QuantizerTemplate(size_t d, const std::vector<float>& trained)
-            : QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 1>(
-                      d,
-                      trained) {}
+            : QuantizerTemplate<
+                      Codec,
+                      QuantizerTemplateScaling::UNIFORM,
+                      SIMDLevel::NONE>(d, trained) {}
 
     FAISS_ALWAYS_INLINE simd16float32
     reconstruct_16_components(const uint8_t* code, int i) const {
@@ -85,12 +95,19 @@ struct QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 16>
 #elif defined(__AVX2__)
 
 template <class Codec>
-struct QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 8>
-        : QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 1> {
+struct QuantizerTemplate<
+        Codec,
+        QuantizerTemplateScaling::UNIFORM,
+        SIMDLevel::AVX2>
+        : QuantizerTemplate<
+                  Codec,
+                  QuantizerTemplateScaling::UNIFORM,
+                  SIMDLevel::NONE> {
     QuantizerTemplate(size_t d, const std::vector<float>& trained)
-            : QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 1>(
-                      d,
-                      trained) {}
+            : QuantizerTemplate<
+                      Codec,
+                      QuantizerTemplateScaling::UNIFORM,
+                      SIMDLevel::NONE>(d, trained) {}
 
     FAISS_ALWAYS_INLINE simd8float32
     reconstruct_8_components(const uint8_t* code, int i) const {
@@ -105,12 +122,19 @@ struct QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 8>
 #ifdef USE_NEON
 
 template <class Codec>
-struct QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 8>
-        : QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 1> {
+struct QuantizerTemplate<
+        Codec,
+        QuantizerTemplateScaling::UNIFORM,
+        SIMDLevel::ARM_NEON>
+        : QuantizerTemplate<
+                  Codec,
+                  QuantizerTemplateScaling::UNIFORM,
+                  SIMDLevel::NONE> {
     QuantizerTemplate(size_t d, const std::vector<float>& trained)
-            : QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 1>(
-                      d,
-                      trained) {}
+            : QuantizerTemplate<
+                      Codec,
+                      QuantizerTemplateScaling::UNIFORM,
+                      SIMDLevel::NONE>(d, trained) {}
 
     FAISS_ALWAYS_INLINE simd8float32
     reconstruct_8_components(const uint8_t* code, int i) const {
@@ -131,8 +155,10 @@ struct QuantizerTemplate<Codec, QuantizerTemplateScaling::UNIFORM, 8>
 #endif
 
 template <class Codec>
-struct QuantizerTemplate<Codec, QuantizerTemplateScaling::NON_UNIFORM, 1>
-        : ScalarQuantizer::SQuantizer {
+struct QuantizerTemplate<
+        Codec,
+        QuantizerTemplateScaling::NON_UNIFORM,
+        SIMDLevel::NONE> : ScalarQuantizer::SQuantizer {
     const size_t d;
     const float *vmin, *vdiff;
 
@@ -173,13 +199,19 @@ struct QuantizerTemplate<Codec, QuantizerTemplateScaling::NON_UNIFORM, 1>
 #if defined(__AVX512F__)
 
 template <class Codec>
-struct QuantizerTemplate<Codec, QuantizerTemplateScaling::NON_UNIFORM, 16>
-        : QuantizerTemplate<Codec, QuantizerTemplateScaling::NON_UNIFORM, 1> {
+struct QuantizerTemplate<
+        Codec,
+        QuantizerTemplateScaling::NON_UNIFORM,
+        SIMDLevel::AVX512>
+        : QuantizerTemplate<
+                  Codec,
+                  QuantizerTemplateScaling::NON_UNIFORM,
+                  SIMDLevel::NONE> {
     QuantizerTemplate(size_t d, const std::vector<float>& trained)
             : QuantizerTemplate<
                       Codec,
                       QuantizerTemplateScaling::NON_UNIFORM,
-                      1>(d, trained) {}
+                      SIMDLevel::NONE>(d, trained) {}
 
     FAISS_ALWAYS_INLINE simd16float32
     reconstruct_16_components(const uint8_t* code, int i) const {
@@ -194,13 +226,19 @@ struct QuantizerTemplate<Codec, QuantizerTemplateScaling::NON_UNIFORM, 16>
 #elif defined(__AVX2__)
 
 template <class Codec>
-struct QuantizerTemplate<Codec, QuantizerTemplateScaling::NON_UNIFORM, 8>
-        : QuantizerTemplate<Codec, QuantizerTemplateScaling::NON_UNIFORM, 1> {
+struct QuantizerTemplate<
+        Codec,
+        QuantizerTemplateScaling::NON_UNIFORM,
+        SIMDLevel::AVX2>
+        : QuantizerTemplate<
+                  Codec,
+                  QuantizerTemplateScaling::NON_UNIFORM,
+                  SIMDLevel::NONE> {
     QuantizerTemplate(size_t d, const std::vector<float>& trained)
             : QuantizerTemplate<
                       Codec,
                       QuantizerTemplateScaling::NON_UNIFORM,
-                      1>(d, trained) {}
+                      SIMDLevel::NONE>(d, trained) {}
 
     FAISS_ALWAYS_INLINE simd8float32
     reconstruct_8_components(const uint8_t* code, int i) const {
@@ -217,13 +255,19 @@ struct QuantizerTemplate<Codec, QuantizerTemplateScaling::NON_UNIFORM, 8>
 #ifdef USE_NEON
 
 template <class Codec>
-struct QuantizerTemplate<Codec, QuantizerTemplateScaling::NON_UNIFORM, 8>
-        : QuantizerTemplate<Codec, QuantizerTemplateScaling::NON_UNIFORM, 1> {
+struct QuantizerTemplate<
+        Codec,
+        QuantizerTemplateScaling::NON_UNIFORM,
+        SIMDLevel::ARM_NEON>
+        : QuantizerTemplate<
+                  Codec,
+                  QuantizerTemplateScaling::NON_UNIFORM,
+                  SIMDLevel::NONE> {
     QuantizerTemplate(size_t d, const std::vector<float>& trained)
             : QuantizerTemplate<
                       Codec,
                       QuantizerTemplateScaling::NON_UNIFORM,
-                      1>(d, trained) {}
+                      SIMDLevel::NONE>(d, trained) {}
 
     FAISS_ALWAYS_INLINE simd8float32
     reconstruct_8_components(const uint8_t* code, int i) const {
@@ -245,11 +289,11 @@ struct QuantizerTemplate<Codec, QuantizerTemplateScaling::NON_UNIFORM, 8>
  * FP16 quantizer
  *******************************************************************/
 
-template <int SIMDWIDTH>
+template <SIMDLevel SL>
 struct QuantizerFP16 {};
 
 template <>
-struct QuantizerFP16<1> : ScalarQuantizer::SQuantizer {
+struct QuantizerFP16<SIMDLevel::NONE> : ScalarQuantizer::SQuantizer {
     const size_t d;
 
     QuantizerFP16(size_t d, const std::vector<float>& /* unused */) : d(d) {}
@@ -276,9 +320,9 @@ struct QuantizerFP16<1> : ScalarQuantizer::SQuantizer {
 #if defined(USE_AVX512_F16C)
 
 template <>
-struct QuantizerFP16<16> : QuantizerFP16<1> {
+struct QuantizerFP16<SIMDLevel::AVX512> : QuantizerFP16<SIMDLevel::NONE> {
     QuantizerFP16(size_t d, const std::vector<float>& trained)
-            : QuantizerFP16<1>(d, trained) {}
+            : QuantizerFP16<SIMDLevel::NONE>(d, trained) {}
 
     FAISS_ALWAYS_INLINE simd16float32
     reconstruct_16_components(const uint8_t* code, int i) const {
@@ -292,9 +336,9 @@ struct QuantizerFP16<16> : QuantizerFP16<1> {
 #if defined(USE_F16C)
 
 template <>
-struct QuantizerFP16<8> : QuantizerFP16<1> {
+struct QuantizerFP16<SIMDLevel::AVX2> : QuantizerFP16<SIMDLevel::NONE> {
     QuantizerFP16(size_t d, const std::vector<float>& trained)
-            : QuantizerFP16<1>(d, trained) {}
+            : QuantizerFP16<SIMDLevel::NONE>(d, trained) {}
 
     FAISS_ALWAYS_INLINE simd8float32
     reconstruct_8_components(const uint8_t* code, int i) const {
@@ -308,9 +352,9 @@ struct QuantizerFP16<8> : QuantizerFP16<1> {
 #ifdef USE_NEON
 
 template <>
-struct QuantizerFP16<8> : QuantizerFP16<1> {
+struct QuantizerFP16<SIMDLevel::ARM_NEON> : QuantizerFP16<SIMDLevel::NONE> {
     QuantizerFP16(size_t d, const std::vector<float>& trained)
-            : QuantizerFP16<1>(d, trained) {}
+            : QuantizerFP16<SIMDLevel::NONE>(d, trained) {}
 
     FAISS_ALWAYS_INLINE simd8float32
     reconstruct_8_components(const uint8_t* code, int i) const {
@@ -326,11 +370,11 @@ struct QuantizerFP16<8> : QuantizerFP16<1> {
  * BF16 quantizer
  *******************************************************************/
 
-template <int SIMDWIDTH>
+template <SIMDLevel SL>
 struct QuantizerBF16 {};
 
 template <>
-struct QuantizerBF16<1> : ScalarQuantizer::SQuantizer {
+struct QuantizerBF16<SIMDLevel::NONE> : ScalarQuantizer::SQuantizer {
     const size_t d;
 
     QuantizerBF16(size_t d, const std::vector<float>& /* unused */) : d(d) {}
@@ -357,9 +401,9 @@ struct QuantizerBF16<1> : ScalarQuantizer::SQuantizer {
 #if defined(__AVX512F__)
 
 template <>
-struct QuantizerBF16<16> : QuantizerBF16<1> {
+struct QuantizerBF16<SIMDLevel::AVX512> : QuantizerBF16<SIMDLevel::NONE> {
     QuantizerBF16(size_t d, const std::vector<float>& trained)
-            : QuantizerBF16<1>(d, trained) {}
+            : QuantizerBF16<SIMDLevel::NONE>(d, trained) {}
     FAISS_ALWAYS_INLINE simd16float32
     reconstruct_16_components(const uint8_t* code, int i) const {
         __m256i code_256i = _mm256_loadu_si256((const __m256i*)(code + 2 * i));
@@ -372,9 +416,9 @@ struct QuantizerBF16<16> : QuantizerBF16<1> {
 #elif defined(__AVX2__)
 
 template <>
-struct QuantizerBF16<8> : QuantizerBF16<1> {
+struct QuantizerBF16<SIMDLevel::AVX2> : QuantizerBF16<SIMDLevel::NONE> {
     QuantizerBF16(size_t d, const std::vector<float>& trained)
-            : QuantizerBF16<1>(d, trained) {}
+            : QuantizerBF16<SIMDLevel::NONE>(d, trained) {}
 
     FAISS_ALWAYS_INLINE simd8float32
     reconstruct_8_components(const uint8_t* code, int i) const {
@@ -390,9 +434,9 @@ struct QuantizerBF16<8> : QuantizerBF16<1> {
 #ifdef USE_NEON
 
 template <>
-struct QuantizerBF16<8> : QuantizerBF16<1> {
+struct QuantizerBF16<SIMDLevel::ARM_NEON> : QuantizerBF16<SIMDLevel::NONE> {
     QuantizerBF16(size_t d, const std::vector<float>& trained)
-            : QuantizerBF16<1>(d, trained) {}
+            : QuantizerBF16<SIMDLevel::NONE>(d, trained) {}
 
     FAISS_ALWAYS_INLINE simd8float32
     reconstruct_8_components(const uint8_t* code, int i) const {
@@ -410,11 +454,11 @@ struct QuantizerBF16<8> : QuantizerBF16<1> {
  * 8bit_direct quantizer
  *******************************************************************/
 
-template <int SIMDWIDTH>
+template <SIMDLevel SL>
 struct Quantizer8bitDirect {};
 
 template <>
-struct Quantizer8bitDirect<1> : ScalarQuantizer::SQuantizer {
+struct Quantizer8bitDirect<SIMDLevel::NONE> : ScalarQuantizer::SQuantizer {
     const size_t d;
 
     Quantizer8bitDirect(size_t d, const std::vector<float>& /* unused */)
@@ -442,9 +486,10 @@ struct Quantizer8bitDirect<1> : ScalarQuantizer::SQuantizer {
 #if defined(__AVX512F__)
 
 template <>
-struct Quantizer8bitDirect<16> : Quantizer8bitDirect<1> {
+struct Quantizer8bitDirect<SIMDLevel::AVX512>
+        : Quantizer8bitDirect<SIMDLevel::NONE> {
     Quantizer8bitDirect(size_t d, const std::vector<float>& trained)
-            : Quantizer8bitDirect<1>(d, trained) {}
+            : Quantizer8bitDirect<SIMDLevel::NONE>(d, trained) {}
 
     FAISS_ALWAYS_INLINE simd16float32
     reconstruct_16_components(const uint8_t* code, int i) const {
@@ -457,9 +502,10 @@ struct Quantizer8bitDirect<16> : Quantizer8bitDirect<1> {
 #elif defined(__AVX2__)
 
 template <>
-struct Quantizer8bitDirect<8> : Quantizer8bitDirect<1> {
+struct Quantizer8bitDirect<SIMDLevel::AVX2>
+        : Quantizer8bitDirect<SIMDLevel::NONE> {
     Quantizer8bitDirect(size_t d, const std::vector<float>& trained)
-            : Quantizer8bitDirect<1>(d, trained) {}
+            : Quantizer8bitDirect<SIMDLevel::NONE>(d, trained) {}
 
     FAISS_ALWAYS_INLINE simd8float32
     reconstruct_8_components(const uint8_t* code, int i) const {
@@ -474,9 +520,10 @@ struct Quantizer8bitDirect<8> : Quantizer8bitDirect<1> {
 #ifdef USE_NEON
 
 template <>
-struct Quantizer8bitDirect<8> : Quantizer8bitDirect<1> {
+struct Quantizer8bitDirect<SIMDLevel::ARM_NEON>
+        : Quantizer8bitDirect<SIMDLevel::NONE> {
     Quantizer8bitDirect(size_t d, const std::vector<float>& trained)
-            : Quantizer8bitDirect<1>(d, trained) {}
+            : Quantizer8bitDirect<SIMDLevel::NONE>(d, trained) {}
 
     FAISS_ALWAYS_INLINE simd8float32
     reconstruct_8_components(const uint8_t* code, int i) const {
@@ -498,11 +545,12 @@ struct Quantizer8bitDirect<8> : Quantizer8bitDirect<1> {
  * 8bit_direct_signed quantizer
  *******************************************************************/
 
-template <int SIMDWIDTH>
+template <SIMDLevel SL>
 struct Quantizer8bitDirectSigned {};
 
 template <>
-struct Quantizer8bitDirectSigned<1> : ScalarQuantizer::SQuantizer {
+struct Quantizer8bitDirectSigned<SIMDLevel::NONE>
+        : ScalarQuantizer::SQuantizer {
     const size_t d;
 
     Quantizer8bitDirectSigned(size_t d, const std::vector<float>& /* unused */)
@@ -530,9 +578,10 @@ struct Quantizer8bitDirectSigned<1> : ScalarQuantizer::SQuantizer {
 #if defined(__AVX512F__)
 
 template <>
-struct Quantizer8bitDirectSigned<16> : Quantizer8bitDirectSigned<1> {
+struct Quantizer8bitDirectSigned<SIMDLevel::AVX512>
+        : Quantizer8bitDirectSigned<SIMDLevel::NONE> {
     Quantizer8bitDirectSigned(size_t d, const std::vector<float>& trained)
-            : Quantizer8bitDirectSigned<1>(d, trained) {}
+            : Quantizer8bitDirectSigned<SIMDLevel::NONE>(d, trained) {}
 
     FAISS_ALWAYS_INLINE simd16float32
     reconstruct_16_components(const uint8_t* code, int i) const {
@@ -547,9 +596,10 @@ struct Quantizer8bitDirectSigned<16> : Quantizer8bitDirectSigned<1> {
 #elif defined(__AVX2__)
 
 template <>
-struct Quantizer8bitDirectSigned<8> : Quantizer8bitDirectSigned<1> {
+struct Quantizer8bitDirectSigned<SIMDLevel::AVX2>
+        : Quantizer8bitDirectSigned<SIMDLevel::NONE> {
     Quantizer8bitDirectSigned(size_t d, const std::vector<float>& trained)
-            : Quantizer8bitDirectSigned<1>(d, trained) {}
+            : Quantizer8bitDirectSigned<SIMDLevel::NONE>(d, trained) {}
 
     FAISS_ALWAYS_INLINE simd8float32
     reconstruct_8_components(const uint8_t* code, int i) const {
@@ -566,9 +616,10 @@ struct Quantizer8bitDirectSigned<8> : Quantizer8bitDirectSigned<1> {
 #ifdef USE_NEON
 
 template <>
-struct Quantizer8bitDirectSigned<8> : Quantizer8bitDirectSigned<1> {
+struct Quantizer8bitDirectSigned<SIMDLevel::ARM_NEON>
+        : Quantizer8bitDirectSigned<SIMDLevel::NONE> {
     Quantizer8bitDirectSigned(size_t d, const std::vector<float>& trained)
-            : Quantizer8bitDirectSigned<1>(d, trained) {}
+            : Quantizer8bitDirectSigned<SIMDLevel::NONE>(d, trained) {}
 
     FAISS_ALWAYS_INLINE simd8float32
     reconstruct_8_components(const uint8_t* code, int i) const {

--- a/faiss/impl/scalar_quantizer/similarities.h
+++ b/faiss/impl/scalar_quantizer/similarities.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <faiss/impl/ScalarQuantizer.h>
+#include <faiss/utils/simd_levels.h>
 #include <faiss/utils/simdlib.h>
 
 namespace faiss {
@@ -20,12 +21,13 @@ namespace scalar_quantizer {
  * an accumulator.
  */
 
-template <int SIMDWIDTH>
+template <SIMDLevel SL>
 struct SimilarityL2 {};
 
 template <>
-struct SimilarityL2<1> {
+struct SimilarityL2<SIMDLevel::NONE> {
     static constexpr int simdwidth = 1;
+    static constexpr SIMDLevel simd_level = SIMDLevel::NONE;
     static constexpr MetricType metric_type = METRIC_L2;
 
     const float *y, *yi;
@@ -59,8 +61,9 @@ struct SimilarityL2<1> {
 #if defined(__AVX512F__)
 
 template <>
-struct SimilarityL2<16> {
+struct SimilarityL2<SIMDLevel::AVX512> {
     static constexpr int simdwidth = 16;
+    static constexpr SIMDLevel simd_level = SIMDLevel::AVX512;
     static constexpr MetricType metric_type = METRIC_L2;
 
     const float *y, *yi;
@@ -96,8 +99,9 @@ struct SimilarityL2<16> {
 #elif defined(__AVX2__)
 
 template <>
-struct SimilarityL2<8> {
+struct SimilarityL2<SIMDLevel::AVX2> {
     static constexpr int simdwidth = 8;
+    static constexpr SIMDLevel simd_level = SIMDLevel::AVX2;
     static constexpr MetricType metric_type = METRIC_L2;
 
     const float *y, *yi;
@@ -140,8 +144,9 @@ struct SimilarityL2<8> {
 
 #ifdef USE_NEON
 template <>
-struct SimilarityL2<8> {
+struct SimilarityL2<SIMDLevel::ARM_NEON> {
     static constexpr int simdwidth = 8;
+    static constexpr SIMDLevel simd_level = SIMDLevel::ARM_NEON;
     static constexpr MetricType metric_type = METRIC_L2;
 
     const float *y, *yi;
@@ -190,12 +195,13 @@ struct SimilarityL2<8> {
 };
 #endif
 
-template <int SIMDWIDTH>
+template <SIMDLevel SL>
 struct SimilarityIP {};
 
 template <>
-struct SimilarityIP<1> {
+struct SimilarityIP<SIMDLevel::NONE> {
     static constexpr int simdwidth = 1;
+    static constexpr SIMDLevel simd_level = SIMDLevel::NONE;
     static constexpr MetricType metric_type = METRIC_INNER_PRODUCT;
     const float *y, *yi;
 
@@ -224,8 +230,9 @@ struct SimilarityIP<1> {
 #if defined(__AVX512F__)
 
 template <>
-struct SimilarityIP<16> {
+struct SimilarityIP<SIMDLevel::AVX512> {
     static constexpr int simdwidth = 16;
+    static constexpr SIMDLevel simd_level = SIMDLevel::AVX512;
     static constexpr MetricType metric_type = METRIC_INNER_PRODUCT;
 
     const float *y, *yi;
@@ -262,8 +269,9 @@ struct SimilarityIP<16> {
 #elif defined(__AVX2__)
 
 template <>
-struct SimilarityIP<8> {
+struct SimilarityIP<SIMDLevel::AVX2> {
     static constexpr int simdwidth = 8;
+    static constexpr SIMDLevel simd_level = SIMDLevel::AVX2;
     static constexpr MetricType metric_type = METRIC_INNER_PRODUCT;
 
     const float *y, *yi;
@@ -307,8 +315,9 @@ struct SimilarityIP<8> {
 #ifdef USE_NEON
 
 template <>
-struct SimilarityIP<8> {
+struct SimilarityIP<SIMDLevel::ARM_NEON> {
     static constexpr int simdwidth = 8;
+    static constexpr SIMDLevel simd_level = SIMDLevel::ARM_NEON;
     static constexpr MetricType metric_type = METRIC_INNER_PRODUCT;
 
     const float *y, *yi;

--- a/faiss/utils/simd_levels.h
+++ b/faiss/utils/simd_levels.h
@@ -29,6 +29,17 @@ enum class SIMDLevel {
     COUNT
 };
 
+/// Number of float32 lanes for a given SIMD level.
+template <SIMDLevel SL>
+constexpr int simd_width() {
+    if constexpr (SL == SIMDLevel::AVX512 || SL == SIMDLevel::AVX512_SPR)
+        return 16;
+    else if constexpr (SL == SIMDLevel::AVX2 || SL == SIMDLevel::ARM_NEON)
+        return 8;
+    else
+        return 1;
+}
+
 /// Convert SIMDLevel to string. Throws FaissException for invalid level.
 std::string to_string(SIMDLevel level);
 


### PR DESCRIPTION
Summary:
Pure type-system refactor — no behavioral change.

Convert the ScalarQuantizer template parameter from `int SIMDWIDTH`
(1/8/16) to `SIMDLevel SL` (NONE/AVX2/AVX512/ARM_NEON) across
quantizers.h, similarities.h, distance_computers.h, and
ScalarQuantizer.cpp.

Key changes:
- Primary templates: `int SIMD` → `SIMDLevel SL`
- Specializations: `<1>` → `<SIMDLevel::NONE>`, `<8>` → AVX2/ARM_NEON,
  `<16>` → AVX512
- Add `static constexpr SIMDLevel simd_level` to Similarity structs
- Split combined `USE_F16C || USE_NEON` guards into separate blocks
  for distinct SIMDLevel values (AVX2 vs ARM_NEON)
- Add `simd_width<SL>()` constexpr helper for future use

Prepares for per-SIMD .cpp file splitting in the next diff.

Differential Revision: D94375444


