### PR TITLE
Temporarily disable RaBitQ FastScan from backward compatibility test

### DIFF
--- a/tests/index_io_backward_compatibility/common_io.py
+++ b/tests/index_io_backward_compatibility/common_io.py
@@ -38,14 +38,19 @@ INDEX_TYPES = [
     "RaBitQ",  # regular
     "IVF256,RaBitQ",  # IVF
     "IVF256,RaBitQ4",  # IVF multibit
-    "RaBitQfs",  # FS
-    "RaBitQfs_64",  # FS, batch size 64
-    "IVF256,RaBitQfs",  # IVF FS
-    "IVF256,RaBitQfs_64",  # IVF FS, batch size 64
-    "RaBitQfs6",  # multibit FS
-    "RaBitQfs4_64",  # multibit FS, batch size 64
-    "IVF256,RaBitQfs3",  # IVF FS multibit
-    "IVF256,RaBitQfs7_64",  # IVF FS multibit, batch size 64
+    # RaBitQ FastScan indexes are temporarily disabled because D93538118
+    # changed the serialization format (fourcc "Irfs"->"Irfn", "Iwrf"->"Iwrn")
+    # by embedding auxiliary data directly into SIMD blocks. The conda
+    # faiss-cpu=1.13.2 reader does not understand the new format.
+    # Re-enable these once a new conda release includes the new format.
+    # "RaBitQfs",  # FS
+    # "RaBitQfs_64",  # FS, batch size 64
+    # "IVF256,RaBitQfs",  # IVF FS
+    # "IVF256,RaBitQfs_64",  # IVF FS, batch size 64
+    # "RaBitQfs6",  # multibit FS
+    # "RaBitQfs4_64",  # multibit FS, batch size 64
+    # "IVF256,RaBitQfs3",  # IVF FS multibit
+    # "IVF256,RaBitQfs7_64",  # IVF FS multibit, batch size 64
     # HNSW indexes
     "HNSW32",
     "HNSW32_SQ8",


### PR DESCRIPTION
Summary:
D93538118 changed the RaBitQ FastScan serialization format by embedding auxiliary data directly into SIMD blocks (fourcc "Irfs"->"Irfn" for non-IVF, "Iwrf"->"Iwrn" for IVF). The conda faiss-cpu=1.13.2 reader used in the GitHub Actions backward compatibility test does not understand the new format, causing the "CMake Write -> Conda Read" test to fail with malformed fourcc errors.

Temporarily comment out all 8 RaBitQ FastScan index types from the test until a new conda release includes the new format, at which point they should be re-enabled and the conda version bumped (following the pattern from D89523639).

Differential Revision: D94432870


