### PR TITLE
OMP build diagnostics (#4842)

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -156,6 +156,7 @@ set(FAISS_SRC
   utils/simd_levels.cpp
   utils/distances_fused/distances_fused.cpp
   factory_tools.cpp
+  # build.cpp excluded due to build errors on Windows
 )
 
 if(FAISS_ENABLE_SVS)

--- a/faiss/build.cpp
+++ b/faiss/build.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "faiss/build.h"
+
+namespace faiss {
+
+bool has_omp() {
+    int omp = 1;
+    // Detect whether OpenMP is enabled by using the 'max' reduction to render
+    // the below assignment a no-op. This works:
+    //  1) without starting any threads
+    //  2) irrespective of the current thread limit
+#pragma omp parallel reduction(max : omp) num_threads(1)
+    omp = 0;
+    return omp != 0;
+}
+
+} // namespace faiss

--- a/faiss/build.h
+++ b/faiss/build.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace faiss {
+
+// Returns true iff `faiss` was compiled with non-mocked OpenMP support.
+bool has_omp();
+
+} // namespace faiss


### PR DESCRIPTION
Summary:

Some tools which depend on FAISS recently became much slower because they were accidentally changed to depend on `faiss:faiss_no_multithreading` instead of `faiss:faiss`.

This adds `faiss::has_omp()`, which returns true if a `#pragma omp parallel` region had any effect through the use of a `reduction(max)` which would otherwise be stripped out.

Note:
1. Compile-time check is not sufficient, as the `faiss_no_multithreading` and/or `faiss_omp_mock` targets control whether the `faiss/*.cpp` implementations have effective `#pragma omp` blocks.
2. Depending on the BUCK build mode, a `cpp_binary` which depends on `faiss:faiss_no_multithreading` and `faiss:faiss` *may or may not* link to implementations with OpenMP support.

Reviewed By: subhadeepkaran

Differential Revision: D94394555
