### PR TITLE
removed conda-forge install documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,31 +52,6 @@ conda activate faiss_1.8.0
 conda install -c pytorch -c nvidia faiss-gpu=1.8.0 pytorch=*=*cuda* pytorch-cuda=11 numpy
 ```
 
-## Installing from conda-forge
-
-Faiss is also being packaged by [conda-forge](https://conda-forge.org/), the
-community-driven packaging ecosystem for conda. The packaging effort is
-collaborating with the Faiss team to ensure high-quality package builds.
-
-Due to the comprehensive infrastructure of conda-forge, it may even happen that
-certain build combinations are supported in conda-forge that are not available
-through the pytorch channel. To install, use
-
-``` shell
-# CPU version
-$ conda install -c conda-forge faiss-cpu
-
-# GPU version
-$ conda install -c conda-forge faiss-gpu
-
-# NVIDIA cuVS and AMD ROCm version not yet available
-```
-
-You can tell which channel your conda packages come from by using `conda list`.
-If you are having problems using a package built by conda-forge, please raise
-an [issue](https://github.com/conda-forge/faiss-split-feedstock/issues) on the
-conda-forge package "feedstock".
-
 # Building from source
 
 Faiss can be built from source using CMake.


### PR DESCRIPTION
The last build pushed to conda-forge was 1.9 in December 2024. Removing the instructions in INSTALL.md for now on using conda-forge to not be misleading.