### PR TITLE
HNSW: add prune_headroom to avoid O(n^2) pruning/locking, headroom test (#4847)

### DIFF
--- a/benchs/README.md
+++ b/benchs/README.md
@@ -348,6 +348,7 @@ Certain tests / benchmarks might be outdated.
 * bench_hamming_computer.cpp - specialized implementations for Hamming distance computations
 * bench_heap_replace.cpp - benchmarks different implementations of certain calls for a Heap data structure
 * bench_hnsw.py - benchmarks HNSW in combination with other ones for SIFT1M dataset
+* bench_hnsw_prune_headroom.py - benchmarks HNSW prune_headroom recall and build time impact
 * bench_index_flat.py - benchmarks IndexFlatL2 on a synthetic dataset
 * bench_index_pq.py - benchmarks PQ on SIFT1M dataset
 * bench_ivf_fastscan_single_query.py - benchmarks a single query for different nprobe levels for IVF{nlist},PQ{M}x4fs on BIGANN dataset

--- a/benchs/bench_hnsw_prune_headroom.py
+++ b/benchs/bench_hnsw_prune_headroom.py
@@ -1,0 +1,234 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Benchmark script for testing HNSW prune_headroom recall impact.
+
+Compares recall and build time between different prune_headroom values.
+Default comparison is between:
+- Baseline: prune_headroom = 0.0 (original behavior, no headroom)
+- With headroom: prune_headroom = 0.2 (proposed default)
+
+Usage:
+    python bench_hnsw_prune_headroom.py
+    python bench_hnsw_prune_headroom.py --nb 100000 --d 256
+    python bench_hnsw_prune_headroom.py --headroom_values 0.0 0.1 0.2 0.3
+"""
+
+import argparse
+import time
+
+import faiss
+
+try:
+    from faiss.contrib.datasets_fb import DatasetSIFT1M
+except ImportError:
+    from faiss.contrib.datasets import DatasetSIFT1M
+
+from faiss.contrib.datasets import SyntheticDataset
+
+
+def compute_recall(I, gt, k):
+    """Compute recall@k given search results I and ground truth gt."""
+    nq = gt.shape[0]
+    return faiss.eval_intersection(I[:, :k], gt[:, :k]) / (nq * k)
+
+
+def build_hnsw_index(d, m, xb, ef_construction, prune_headroom):
+    """Build an HNSW index with the specified configuration."""
+    index = faiss.IndexHNSWSQ(d, faiss.ScalarQuantizer.QT_4bit, m)
+    index.hnsw.efConstruction = ef_construction
+    index.hnsw.prune_headroom = prune_headroom
+
+    index.train(xb)
+    start_time = time.time()
+    index.add(xb)
+    build_time = time.time() - start_time
+
+    return index, build_time
+
+
+def run_benchmark(
+    d=384,
+    m=32,
+    nb=50000,
+    nq=1000,
+    reps=3,
+    ef_construction=40,
+    ef_search_values=None,
+    k_values=None,
+    headroom_values=None,
+    use_sift1m=False,
+):
+    """
+    Run the prune_headroom recall benchmark.
+
+    Args:
+        d: Dimension of vectors
+        nb: Number of base vectors
+        nq: Number of query vectors
+        ef_construction: efConstruction parameter for HNSW
+        ef_search_values: List of efSearch values to test
+        k_values: List of k values for recall@k
+        headroom_values: List of prune_headroom values to compare
+        use_sift1m: Use SIFT1M dataset instead of synthetic
+
+    Returns:
+        Dictionary containing benchmark results
+    """
+    if ef_search_values is None:
+        ef_search_values = [16, 32, 64, 128, 256]
+    if k_values is None:
+        k_values = [1, 10]
+    if headroom_values is None:
+        headroom_values = [0.0, 0.2]
+
+    if use_sift1m:
+        print("Loading SIFT1M dataset")
+        ds = DatasetSIFT1M()
+        xb = ds.get_database()
+        xq = ds.get_queries()
+        d = xb.shape[1]
+        nb = xb.shape[0]
+        nq = xq.shape[0]
+    else:
+        print(f"Generating synthetic dataset: d={d}, nb={nb}, nq={nq}")
+        ds = SyntheticDataset(d=d, nt=0, nb=nb, nq=nq)
+        xb = ds.get_database()
+        xq = ds.get_queries()
+
+    max_k = max(k_values)
+    print(f"Computing ground truth for k={max_k}")
+    gt = ds.get_groundtruth(k=max_k)
+
+    results = {"build_times": {}, "ndis_search": {}, "recalls": {}}
+
+    for headroom in headroom_values:
+        for rep in range(reps):
+            index, build_time = build_hnsw_index(
+                d, m, xb, ef_construction, headroom)
+            results["build_times"][headroom] = build_time
+
+            faiss.cvar.hnsw_stats.reset()
+            row = {}
+            results["recalls"][(headroom, rep)] = row
+            for ef_search in ef_search_values:
+                index.hnsw.efSearch = ef_search
+                _, I = index.search(xq, max_k)
+
+                col = {}
+                row[ef_search] = col
+                for k in k_values:
+                    recall = compute_recall(I, gt, k)
+                    col[k] = recall
+            ndis_search = faiss.cvar.hnsw_stats.ndis / nq
+            results["ndis_search"][headroom] = ndis_search
+            print(
+                f"HNSW{m}(prune_headroom={headroom:4.2f}): "
+                f"{build_time=:4.2f}s, {ndis_search=:5.1f}"
+            )
+
+    print_results_table(results, ef_search_values, k_values, headroom_values)
+    return results
+
+
+def print_results_table(results, ef_search_values, k_values, headroom_values):
+
+    for k in k_values:
+        header_parts = [f"{k=:2}  "]
+        for ef_search in ef_search_values:
+            header_parts.append(f"ef={ef_search:3}")
+        header = " | ".join(header_parts)
+
+        print(f"\n{header}")
+        print("-" * len(header))
+        for (h, _), row in results["recalls"].items():
+            row_parts = [f"h={h:4.2f}"]
+            for ef_search in ef_search_values:
+                recall = row[ef_search][k]
+                row_parts.append(f"{recall:6.4f}")
+            print(" | ".join(row_parts))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="HNSW prune_headroom recall and build time benchmark"
+    )
+    parser.add_argument(
+        "--d",
+        type=int,
+        default=128,
+        help="Dimension of vectors (default: 128)",
+    )
+    parser.add_argument(
+        "--m",
+        type=int,
+        default=32,
+        help="Node degree (M, default: 32)",
+    )
+    parser.add_argument(
+        "--nb",
+        type=int,
+        default=50000,
+        help="Number of base vectors (default: 50000)",
+    )
+    parser.add_argument(
+        "--nq",
+        type=int,
+        default=10000,
+        help="Number of query vectors (default: 10000)",
+    )
+    parser.add_argument(
+        "--ef_construction",
+        type=int,
+        default=40,
+        help="efConstruction parameter (default: 40)",
+    )
+    parser.add_argument(
+        "--ef_search",
+        type=int,
+        nargs="+",
+        default=[16, 32, 64, 128, 256],
+        help="efSearch values to test (default: 16 32 64 128 256)",
+    )
+    parser.add_argument(
+        "--k",
+        type=int,
+        nargs="+",
+        default=[1, 10],
+        help="k values for recall@k (default: 1 10)",
+    )
+    parser.add_argument(
+        "--headroom_values",
+        type=float,
+        nargs="+",
+        default=[0.0, 0.04, 0.08, 0.12, 0.16, 0.20],
+        help="prune_headroom values to compare (default: 0.0 0.2)",
+    )
+    parser.add_argument(
+        "--reps",
+        type=int,
+        default=3,
+        help="Number of repetitions (default: 3)",
+    )
+    parser.add_argument(
+        "--sift1m",
+        action="store_true",
+        help="Use SIFT1M dataset instead of synthetic",
+    )
+    args = parser.parse_args()
+
+    run_benchmark(
+        d=args.d,
+        m=args.m,
+        nb=args.nb,
+        nq=args.nq,
+        reps=args.reps,
+        ef_construction=args.ef_construction,
+        ef_search_values=args.ef_search,
+        k_values=args.k,
+        headroom_values=args.headroom_values,
+        use_sift1m=args.sift1m,
+    )

--- a/faiss/AutoTune.cpp
+++ b/faiss/AutoTune.cpp
@@ -574,6 +574,13 @@ void ParameterSpace::set_index_parameter(
         }
     }
 
+    if (name == "prune_headroom") {
+        if (DC(IndexHNSW)) {
+            ix->hnsw.prune_headroom = val;
+            return;
+        }
+    }
+
     if (name == "efConstruction") {
         if (DC(IndexHNSW)) {
             ix->hnsw.efConstruction = int(val);

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -240,7 +240,7 @@ void HNSW::shrink_neighbor_list(
         DistanceComputer& qdis,
         std::priority_queue<NodeDistFarther>& input,
         std::vector<NodeDistFarther>& output,
-        int max_size,
+        size_t max_size,
         bool keep_max_size_level0) {
     // This prevents number of neighbors at
     // level 0 from being shrunk to less than 2 * M.
@@ -293,7 +293,7 @@ using NodeDistFarther = HNSW::NodeDistFarther;
 void shrink_neighbor_list(
         DistanceComputer& qdis,
         std::priority_queue<NodeDistCloser>& resultSet1,
-        int max_size,
+        size_t max_size,
         bool keep_max_size_level0 = false) {
     if (resultSet1.size() < max_size) {
         return;
@@ -348,7 +348,9 @@ void add_link(
         resultSet.emplace(qdis.symmetric_dis(src, neigh), neigh);
     }
 
-    shrink_neighbor_list(qdis, resultSet, end - begin, keep_max_size_level0);
+    size_t max_size = end - begin;
+    max_size -= max_size * std::clamp(hnsw.prune_headroom, 0.0f, 0.5f);
+    shrink_neighbor_list(qdis, resultSet, max_size, keep_max_size_level0);
 
     // ...and back
     size_t i = begin;

--- a/faiss/impl/HNSW.h
+++ b/faiss/impl/HNSW.h
@@ -142,6 +142,10 @@ struct HNSW {
     /// expansion factor at search time
     int efSearch = 16;
 
+    /// when pruning, leave room for more neighbors to avoid O(n^2)
+    /// costs and lock contention on frequently-pruned nodes.
+    float prune_headroom = 0.2f;
+
     /// during search: do we check whether the next best distance is good
     /// enough?
     bool check_relative_distance = true;
@@ -241,7 +245,7 @@ struct HNSW {
             DistanceComputer& qdis,
             std::priority_queue<NodeDistFarther>& input,
             std::vector<NodeDistFarther>& output,
-            int max_size,
+            size_t max_size,
             bool keep_max_size_level0 = false);
 
     void permute_entries(const idx_t* map);


### PR DESCRIPTION
Summary:

Particularly when building large graphs (10M+), insertion performance often plummets in the presence of highly contended nodes. More time is spent doing repeated `O(d*M^2)` pruning, and more time is spent waiting for locks:

```name=Before
 [6.2%] +624,960 vecs / +10.1s = +62,165 vecs/s
[12.5%] +625,152 vecs /  +8.3s = +75,316 vecs/s
[18.8%] +625,152 vecs /  +8.0s = +78,244 vecs/s
[25.0%] +625,152 vecs /  +8.6s = +72,813 vecs/s
[31.3%] +625,024 vecs /  +8.6s = +72,796 vecs/s
[37.5%] +624,960 vecs /  +9.2s = +68,038 vecs/s
[43.8%] +624,960 vecs /  +9.9s = +63,074 vecs/s
[50.0%] +624,960 vecs /  +9.3s = +67,249 vecs/s
[56.3%] +624,960 vecs /  +9.6s = +64,865 vecs/s
[62.5%] +624,960 vecs /  +9.8s = +63,622 vecs/s
[68.8%] +624,960 vecs / +10.1s = +62,016 vecs/s
[75.0%] +624,960 vecs / +10.3s = +60,543 vecs/s
[81.3%] +624,960 vecs / +23.3s = +26,858 vecs/s
[87.5%] +624,960 vecs / +12.0s = +51,891 vecs/s
[93.8%] +624,960 vecs / +11.4s = +55,053 vecs/s
[100.%] +624,960 vecs / +11.9s = +52,318 vecs/s
[done] 10,000,000 vecs / 177.9s = 56,220 vecs/s average
```

By providing a bit more headroom, much useful time is spent actually constructing the graph, leading to
```name=After
Building IDMap,HNSW64 with 192 threads...
[ 6.2%] +624,960 vecs / +4.0s = +154,359 vecs/s
[12.5%] +625,152 vecs / +3.9s = +159,162 vecs/s
[18.8%] +625,152 vecs / +4.2s = +150,183 vecs/s
[25.0%] +625,152 vecs / +4.8s = +130,363 vecs/s
[31.3%] +625,024 vecs / +5.3s = +118,817 vecs/s
[37.5%] +624,960 vecs / +4.7s = +133,585 vecs/s
[43.8%] +624,960 vecs / +5.5s = +113,630 vecs/s
[50.0%] +624,960 vecs / +4.8s = +131,124 vecs/s
[56.3%] +624,960 vecs / +4.8s = +129,847 vecs/s
[62.5%] +624,960 vecs / +5.0s = +124,726 vecs/s
[68.8%] +624,960 vecs / +5.3s = +117,075 vecs/s
[75.0%] +624,960 vecs / +5.3s = +118,652 vecs/s
[81.3%] +624,960 vecs / +8.1s =  +77,497 vecs/s
[87.5%] +624,960 vecs / +6.3s =  +99,823 vecs/s
[93.8%] +624,960 vecs / +6.0s = +103,604 vecs/s
[100.%] +624,960 vecs / +5.9s = +106,680 vecs/s
[done] 10,000,000 vecs / 89.9s = 111,278 vecs/s average
```

The increased pruning has minimal effect on recall, particularly with the default value of `prune_headroom = 0.2`.

Reviewed By: mdouze

Differential Revision: D94442964
