### PR TITLE
Strengthen roundtrip tests by doing serialization after deserialization

### DIFF
--- a/tests/test_binary_hashindex.py
+++ b/tests/test_binary_hashindex.py
@@ -166,6 +166,13 @@ class TestKnn(unittest.TestCase):
             np.testing.assert_array_equal(Inew, I2)
             np.testing.assert_array_equal(Dnew, D2)
 
+            # Verify deserialized index is serializable again
+            index3 = faiss.deserialize_index_binary(
+                faiss.serialize_index_binary(index2))
+            D3, I3 = index3.search(xq, k)
+            np.testing.assert_array_equal(Inew, I3)
+            np.testing.assert_array_equal(Dnew, D3)
+
         self.assertGreater(3, abs(nfound[(0, 7)] - nfound[(1, 7)]))
         self.assertGreater(nfound[(3, 7)], nfound[(1, 7)])
         self.assertGreater(nfound[(5, 7)], nfound[(3, 7)])

--- a/tests/test_binary_io.py
+++ b/tests/test_binary_io.py
@@ -42,6 +42,13 @@ class TestBinaryFlat(unittest.TestCase):
         assert (I2 == I).all()
         assert (D2 == D).all()
 
+        # Verify deserialized index is serializable again
+        index3 = faiss.deserialize_index_binary(
+            faiss.serialize_index_binary(index2))
+        D3, I3 = index3.search(self.xq, 3)
+        assert (I3 == I).all()
+        assert (D3 == D).all()
+
 
 class TestBinaryIVF(unittest.TestCase):
 
@@ -72,6 +79,13 @@ class TestBinaryIVF(unittest.TestCase):
         assert (I2 == I).all()
         assert (D2 == D).all()
 
+        # Verify deserialized index is serializable again
+        index3 = faiss.deserialize_index_binary(
+            faiss.serialize_index_binary(index2))
+        D3, I3 = index3.search(self.xq, 3)
+        assert (I3 == I).all()
+        assert (D3 == D).all()
+
 
 class TestObjectOwnership(unittest.TestCase):
 
@@ -94,6 +108,11 @@ class TestObjectOwnership(unittest.TestCase):
         index2 = faiss.deserialize_index_binary(faiss.serialize_index_binary(index))
 
         assert index2.thisown
+
+        # Verify deserialized index is serializable again
+        index3 = faiss.deserialize_index_binary(
+            faiss.serialize_index_binary(index2))
+        assert index3.thisown
 
 
 class TestBinaryFromFloat(unittest.TestCase):
@@ -121,6 +140,13 @@ class TestBinaryFromFloat(unittest.TestCase):
         assert (I2 == I).all()
         assert (D2 == D).all()
 
+        # Verify deserialized index is serializable again
+        index3 = faiss.deserialize_index_binary(
+            faiss.serialize_index_binary(index2))
+        D3, I3 = index3.search(self.xq, 3)
+        assert (I3 == I).all()
+        assert (D3 == D).all()
+
 class TestBinaryHNSW(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
@@ -146,6 +172,13 @@ class TestBinaryHNSW(unittest.TestCase):
         assert (I2 == I).all()
         assert (D2 == D).all()
 
+        # Verify deserialized index is serializable again
+        index3 = faiss.deserialize_index_binary(
+            faiss.serialize_index_binary(index2))
+        D3, I3 = index3.search(self.xq, 3)
+        assert (I3 == I).all()
+        assert (D3 == D).all()
+
     def test_ivf_hnsw(self):
         d = self.xq.shape[1] * 8
 
@@ -157,9 +190,16 @@ class TestBinaryHNSW(unittest.TestCase):
         index.add(self.xb)
         D, I = index.search(self.xq, 3)
 
-        index2 = faiss.deserialize_index_binary(faiss.serialize_index_binary(index)) 
-        
+        index2 = faiss.deserialize_index_binary(faiss.serialize_index_binary(index))
+
         D2, I2 = index2.search(self.xq, 3)
 
         assert (I2 == I).all()
         assert (D2 == D).all()
+
+        # Verify deserialized index is serializable again
+        index3 = faiss.deserialize_index_binary(
+            faiss.serialize_index_binary(index2))
+        D3, I3 = index3.search(self.xq, 3)
+        assert (I3 == I).all()
+        assert (D3 == D).all()

--- a/tests/test_index_composite.py
+++ b/tests/test_index_composite.py
@@ -202,6 +202,11 @@ class TestRemove(unittest.TestCase):
         else:
             assert False, 'should have raised an exception'
 
+        # Verify deserialized index is serializable again
+        index2 = faiss.deserialize_index_binary(
+            faiss.serialize_index_binary(index))
+        assert index2.reconstruct(1004)[0] == 104
+
 
 class TestRangeSearch(unittest.TestCase):
 
@@ -466,6 +471,11 @@ class TestIVFFlatDedup(unittest.TestCase):
         Dst, Ist = index_st.search(xq, 20)
 
         check_ref_knn_with_draws(Dnew, Inew, Dst, Ist)
+
+        # Verify deserialized index is serializable again
+        index_st2 = faiss.deserialize_index(faiss.serialize_index(index_st))
+        Dst2, Ist2 = index_st2.search(xq, 20)
+        check_ref_knn_with_draws(Dnew, Inew, Dst2, Ist2)
 
         # test remove
         toremove = np.hstack((np.arange(3, 1000, 5), np.arange(850, 950)))
@@ -811,6 +821,12 @@ class TestIndependentQuantizer(unittest.TestCase):
 
         np.testing.assert_array_equal(Dnew, D2)
         np.testing.assert_array_equal(Inew, I2)
+
+        # Verify deserialized index is serializable again
+        index3 = faiss.deserialize_index(faiss.serialize_index(index2))
+        D3, I3 = index3.search(ds.get_queries(), 10)
+        np.testing.assert_array_equal(Dnew, D3)
+        np.testing.assert_array_equal(Inew, I3)
 
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -276,6 +276,15 @@ class TestPickle(unittest.TestCase):
         np.testing.assert_array_equal(Iref, Inew)
         np.testing.assert_array_equal(Dref, Dnew)
 
+        # Verify deserialized index is serializable again
+        buf2 = io.BytesIO()
+        pickle.dump(index2, buf2)
+        buf2.seek(0)
+        index3 = pickle.load(buf2)
+        Dnew3, Inew3 = index3.search(xq, 4)
+        np.testing.assert_array_equal(Iref, Inew3)
+        np.testing.assert_array_equal(Dref, Dnew3)
+
     def test_flat(self):
         self.dump_load_factory("Flat")
 
@@ -311,6 +320,19 @@ class Test_IO_VectorTransform(unittest.TestCase):
             assert vt.d_in == index.vt.d_in
             assert vt.d_out == index.vt.d_out
             assert vt.is_trained
+
+            # Verify deserialized VectorTransform is serializable again
+            fd2, fname2 = tempfile.mkstemp()
+            os.close(fd2)
+            try:
+                faiss.write_VectorTransform(vt, fname2)
+                vt2 = faiss.read_VectorTransform(fname2)
+                assert vt2.d_in == index.vt.d_in
+                assert vt2.d_out == index.vt.d_out
+                assert vt2.is_trained
+            finally:
+                if os.path.exists(fname2):
+                    os.unlink(fname2)
 
         finally:
             if os.path.exists(fname):
@@ -372,6 +394,22 @@ class Test_IO_PQ(unittest.TestCase):
             faiss.vector_to_array(read_pq.centroids)
         )
 
+        # Verify deserialized PQ is serializable again
+        fd2, fname2 = tempfile.mkstemp()
+        os.close(fd2)
+        try:
+            faiss.write_ProductQuantizer(read_pq, fname2)
+            read_pq2 = faiss.read_ProductQuantizer(fname2)
+        finally:
+            if os.path.exists(fname2):
+                os.unlink(fname2)
+        self.assertEqual(index.pq.M, read_pq2.M)
+        self.assertEqual(index.pq.nbits, read_pq2.nbits)
+        np.testing.assert_array_equal(
+            faiss.vector_to_array(index.pq.centroids),
+            faiss.vector_to_array(read_pq2.centroids)
+        )
+
 
 
 class Test_IO_IndexLSH(unittest.TestCase):
@@ -407,6 +445,13 @@ class Test_IO_IndexLSH(unittest.TestCase):
 
             np.testing.assert_array_equal(D, D_read)
             np.testing.assert_array_equal(I, I_read)
+
+            # Verify deserialized index is serializable again
+            data3 = faiss.serialize_index(read_index_lsh)
+            index3 = faiss.deserialize_index(data3)
+            D3, I3 = index3.search(xq, 10)
+            np.testing.assert_array_equal(D, D3)
+            np.testing.assert_array_equal(I, I3)
 
         finally:
             if os.path.exists(fname):
@@ -446,6 +491,13 @@ class Test_IO_IndexIVFSpectralHash(unittest.TestCase):
             np.testing.assert_array_equal(D, D_read)
             np.testing.assert_array_equal(I, I_read)
 
+            # Verify deserialized index is serializable again
+            data3 = faiss.serialize_index(read_index)
+            index3 = faiss.deserialize_index(data3)
+            D3, I3 = index3.search(xq, 10)
+            np.testing.assert_array_equal(D, D3)
+            np.testing.assert_array_equal(I, I3)
+
         finally:
             if os.path.exists(fname):
                 os.unlink(fname)
@@ -478,6 +530,13 @@ class TestIVFPQRead(unittest.TestCase):
             codes_a = index_a.sa_encode(xq)
             codes_b = index_b.sa_encode(xq)
             np.testing.assert_array_equal(codes_a, codes_b)
+
+            # Verify deserialized indexes are serializable again
+            data3 = faiss.serialize_index(index_a)
+            index3 = faiss.deserialize_index(data3)
+            D3, I3 = index3.search(xq, 10)
+            np.testing.assert_array_equal(Da, D3)
+            np.testing.assert_array_equal(Ia, I3)
 
         finally:
             if os.path.exists(fname):
@@ -532,6 +591,13 @@ class TestIOFlatMMap(unittest.TestCase):
         Dnew, Inew = index2.search(xq, 10)
         np.testing.assert_array_equal(Iref, Inew)
         np.testing.assert_array_equal(Dref, Dnew)
+
+        # Verify deserialized index is serializable again
+        data3 = faiss.serialize_index(index2)
+        index3 = faiss.deserialize_index(data3)
+        Dnew3, Inew3 = index3.search(xq, 10)
+        np.testing.assert_array_equal(Iref, Inew3)
+        np.testing.assert_array_equal(Dref, Dnew3)
 
 
 class TestIORoundTrip(unittest.TestCase):

--- a/tests/test_rabitq.py
+++ b/tests/test_rabitq.py
@@ -595,6 +595,13 @@ def do_test_serde(description):
     np.testing.assert_equal(Dref, Dnew)
     np.testing.assert_equal(Iref, Inew)
 
+    # Verify deserialized index is serializable again
+    b2 = faiss.serialize_index(index2)
+    index3 = faiss.deserialize_index(b2)
+    Dnew3, Inew3 = index3.search(ds.get_queries(), 10)
+    np.testing.assert_equal(Dref, Dnew3)
+    np.testing.assert_equal(Iref, Inew3)
+
 
 class TestMultiBitRaBitQ(unittest.TestCase):
     """Consolidated tests for multi-bit RaBitQ.
@@ -769,6 +776,15 @@ class TestMultiBitRaBitQ(unittest.TestCase):
                         np.testing.assert_array_equal(I1, I2)
                         np.testing.assert_allclose(D1, D2, rtol=1e-5)
 
+                        # Verify deserialized index is serializable again
+                        index_bytes2 = faiss.serialize_index(index2)
+                        index3 = faiss.deserialize_index(index_bytes2)
+                        D3, I3 = index3.search(
+                            ds.get_queries(), 5, params=params
+                        )
+                        np.testing.assert_array_equal(I1, I3)
+                        np.testing.assert_allclose(D1, D3, rtol=1e-5)
+
     # ==================== IVF Tests ====================
 
     def test_ivf_basic_operations(self):
@@ -856,6 +872,15 @@ class TestMultiBitRaBitQ(unittest.TestCase):
 
                         np.testing.assert_array_equal(I1, I2)
                         np.testing.assert_allclose(D1, D2, rtol=1e-5)
+
+                        # Verify deserialized index is serializable again
+                        index_bytes2 = faiss.serialize_index(index2)
+                        index3 = faiss.deserialize_index(index_bytes2)
+                        D3, I3 = index3.search(
+                            ds.get_queries(), 5, params=params
+                        )
+                        np.testing.assert_array_equal(I1, I3)
+                        np.testing.assert_allclose(D1, D3, rtol=1e-5)
 
     # ==================== Query Quantization Tests ====================
 

--- a/tests/test_rabitq_fastscan.py
+++ b/tests/test_rabitq_fastscan.py
@@ -179,6 +179,15 @@ class TestRaBitQFastScan(unittest.TestCase):
                     np.testing.assert_array_equal(Dref, Dnew)
                     np.testing.assert_array_equal(Iref, Inew)
 
+                # Verify deserialized index is serializable again
+                b2 = faiss.serialize_index(index2)
+                index3 = faiss.deserialize_index(b2)
+                if use_ivf:
+                    index3.nprobe = self.NPROBE
+                Dnew3, Inew3 = index3.search(ds.get_queries(), 10)
+                np.testing.assert_array_equal(Dref, Dnew3)
+                np.testing.assert_array_equal(Iref, Inew3)
+
     # ==================== Memory Management Tests ====================
 
     def test_memory_management(self):
@@ -754,6 +763,14 @@ class TestMultiBitRaBitQFastScan(unittest.TestCase):
                         np.testing.assert_array_equal(I1, I2)
                         np.testing.assert_allclose(D1, D2, rtol=1e-5)
 
+                        # Verify deserialized index is serializable again
+                        index_bytes2 = faiss.serialize_index(index2)
+                        index3 = faiss.deserialize_index(index_bytes2)
+                        index3.qb = qb
+                        D3, I3 = index3.search(ds.get_queries(), 5)
+                        np.testing.assert_array_equal(I1, I3)
+                        np.testing.assert_allclose(D1, D3, rtol=1e-5)
+
     def test_ivf_serialization(self):
         """Test IVF serialization preserves results."""
         ds = datasets.SyntheticDataset(64, 1000, 500, 20)
@@ -778,6 +795,13 @@ class TestMultiBitRaBitQFastScan(unittest.TestCase):
                     self.assertEqual(index2.rabitq.nb_bits, nb_bits)
                     np.testing.assert_array_equal(I1, I2)
                     np.testing.assert_allclose(D1, D2, rtol=1e-5)
+
+                    # Verify deserialized index is serializable again
+                    index_bytes2 = faiss.serialize_index(index2)
+                    index3 = faiss.deserialize_index(index_bytes2)
+                    D3, I3 = index3.search(ds.get_queries(), 10)
+                    np.testing.assert_array_equal(I1, I3)
+                    np.testing.assert_allclose(D1, D3, rtol=1e-5)
 
     # ==================== Reconstruction Tests ====================
 

--- a/tests/test_standalone_codec.py
+++ b/tests/test_standalone_codec.py
@@ -121,6 +121,12 @@ class TestIndexEquiv(unittest.TestCase):
         self.assertTrue(np.all(code_new == code_ref))
         self.assertTrue(np.all(x_recons_new == x_recons_ref))
 
+        # Verify deserialized index is serializable again
+        codec_new_3 = faiss.deserialize_index(
+            faiss.serialize_index(codec_new_2))
+        code_new_3 = codec_new_3.sa_encode(x)
+        self.assertTrue(np.all(code_new_3 == code_ref))
+
     def test_IVFPQ(self):
         self.do_test("IVF512,PQ6np", "Residual512,PQ6")
 
@@ -165,6 +171,13 @@ class TestAccuracy(unittest.TestCase):
             codes = codec2.sa_encode(x)
             x3 = codec2.sa_decode(codes)
             self.assertTrue(np.all(x2 == x3))
+
+            # Verify deserialized index is serializable again
+            codec3 = faiss.deserialize_index(
+                faiss.serialize_index(codec2))
+            codes3 = codec3.sa_encode(x)
+            x4 = codec3.sa_decode(codes3)
+            self.assertTrue(np.all(x2 == x4))
 
     def test_SQ(self):
         self.compare_accuracy('SQ4', 'SQ8')

--- a/tests/test_swig_wrapper.py
+++ b/tests/test_swig_wrapper.py
@@ -49,6 +49,12 @@ class TestSWIGWrap(unittest.TestCase):
 
         assert isinstance(index2, faiss.IndexRefineFlat)
 
+        # Verify deserialized index is serializable again
+        index3 = faiss.deserialize_index(
+            faiss.serialize_index(index2)
+        )
+        assert isinstance(index3, faiss.IndexRefineFlat)
+
     def do_test_array_type(self, dtype):
         """ tests swig_ptr and rev_swig_ptr for this type of array """
         a = np.arange(12).astype(dtype)


### PR DESCRIPTION
Summary: Roundtrip tests only test serialize -> deserialize. They should also test the deserialize -> serialize sequence.

Reviewed By: mdouze

Differential Revision: D93678044


