### PR TITLE
add hadamard transformation as an index for  IVF

### DIFF
--- a/benchs/bench_fwht.py
+++ b/benchs/bench_fwht.py
@@ -1,0 +1,90 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Benchmark HadamardRotation (HD3 FWHT) vs RandomRotationMatrix (BLAS sgemm).
+
+Measures:
+  1. Speed: wall-clock time for transform.apply(x)
+  2. Recall@1: nearest-neighbor recall after pre-transform + Flat index
+"""
+
+import faiss
+import numpy as np
+import time
+
+n = 10000
+nq = 200
+n_trials = 15
+
+print(f'n={n} vectors, nq={nq} queries, {n_trials} speed trials')
+
+# --- Speed benchmark ---
+print('\n=== Speed ===')
+print(f'{"dim":>6s}  {"HR (ms)":>10s}  {"RRM (ms)":>10s}  {"speedup":>8s}')
+print('-' * 42)
+
+dims = [64, 128, 256, 384, 512, 768, 1024, 1536, 2048, 3072, 4096, 6144, 8192]
+for d in dims:
+    np.random.seed(42)
+    x = np.random.randn(n, d).astype('float32')
+
+    hr = faiss.HadamardRotation(d, 42)
+    hr.apply(x[:100])  # warmup
+    times_hr = []
+    for _ in range(n_trials):
+        t0 = time.perf_counter()
+        hr.apply(x)
+        t1 = time.perf_counter()
+        times_hr.append((t1 - t0) * 1000)
+    hr_ms = sorted(times_hr)[1]
+
+    rr = faiss.RandomRotationMatrix(d, d)
+    rr.train(x[:100])
+    rr.apply(x[:100])  # warmup
+    times_rr = []
+    for _ in range(n_trials):
+        t0 = time.perf_counter()
+        rr.apply(x)
+        t1 = time.perf_counter()
+        times_rr.append((t1 - t0) * 1000)
+    rr_ms = sorted(times_rr)[1]
+
+    speedup = rr_ms / hr_ms
+    print(f'{d:6d}  {hr_ms:10.2f}  {rr_ms:10.2f}  {speedup:7.1f}x')
+
+# --- Recall benchmark with IVF (where rotation actually matters) ---
+print(f'\n=== Recall@1 with IVF (L2, n={n}, nq={nq}, k=1) ===')
+print(f'{"dim":>6s}  {"HR R@1":>8s}  {"RRM R@1":>8s}  {"none R@1":>8s}')
+print('-' * 40)
+
+for d in [64, 128, 256, 768, 1024, 2048, 4096]:
+    np.random.seed(42)
+    xb = np.random.randn(n, d).astype('float32')
+    xq = np.random.randn(nq, d).astype('float32')
+
+    # Ground truth (brute force, no transform)
+    gt_index = faiss.IndexFlatL2(d)
+    gt_index.add(xb)
+    _, gt_I = gt_index.search(xq, 1)
+
+    nlist = 64
+    recalls = {}
+    for label, factory_str in [
+        ('HR', f'HR,IVF{nlist},Flat'),
+        ('RRM', f'RR,IVF{nlist},Flat'),
+        ('none', f'IVF{nlist},Flat'),
+    ]:
+        index = faiss.index_factory(d, factory_str)
+        index.train(xb)
+        index.add(xb)
+        faiss.extract_index_ivf(index).nprobe = 8
+        _, I = index.search(xq, 1)
+        recall = (I[:, 0] == gt_I[:, 0]).mean()
+        recalls[label] = recall
+
+    print(
+        f'{d:6d}  {recalls["HR"]:8.4f}'
+        f'  {recalls["RRM"]:8.4f}  {recalls["none"]:8.4f}'
+    )

--- a/faiss/VectorTransform.cpp
+++ b/faiss/VectorTransform.cpp
@@ -353,6 +353,126 @@ void RandomRotationMatrix::train(idx_t /*n*/, const float* /*x*/) {
 }
 
 /*********************************************
+ * HadamardRotation
+ *********************************************/
+
+// In-place Fast Walsh-Hadamard Transform. n must be a power of 2.
+// Applies the unnormalized Hadamard butterfly: O(n log n) add/sub, no
+// multiplies.
+static void fwht_inplace(float* buf, size_t n) {
+    for (size_t step = 1; step < n; step *= 2) {
+        for (size_t i = 0; i < n; i += step * 2) {
+            for (size_t j = i; j < i + step; j++) {
+                float a = buf[j];
+                float b = buf[j + step];
+                buf[j] = a + b;
+                buf[j + step] = a - b;
+            }
+        }
+    }
+}
+
+// Smallest power of 2 >= n.
+static int next_power_of_2(int n) {
+    int p = 1;
+    while (p < n) {
+        p *= 2;
+    }
+    return p;
+}
+
+// Generate three sign-flip vectors from the given seed.
+static void generate_signs(
+        uint32_t seed,
+        size_t p,
+        std::vector<float>& s1,
+        std::vector<float>& s2,
+        std::vector<float>& s3) {
+    FAISS_THROW_IF_NOT(p > 0);
+    SplitMix64RandomGenerator rng(seed);
+    s1.resize(p);
+    s2.resize(p);
+    s3.resize(p);
+    for (size_t j = 0; j < p; j++) {
+        s1[j] = (rng.rand_int(2) == 0) ? -1.0f : 1.0f;
+    }
+    for (size_t j = 0; j < p; j++) {
+        s2[j] = (rng.rand_int(2) == 0) ? -1.0f : 1.0f;
+    }
+    for (size_t j = 0; j < p; j++) {
+        s3[j] = (rng.rand_int(2) == 0) ? -1.0f : 1.0f;
+    }
+}
+
+HadamardRotation::HadamardRotation(int d, uint32_t seed_in)
+        : VectorTransform(d, next_power_of_2(d)), seed(seed_in) {
+    init(seed_in);
+}
+
+void HadamardRotation::init(uint32_t seed_in) {
+    seed = seed_in;
+    is_trained = true;
+    generate_signs(seed, d_out, signs1, signs2, signs3);
+}
+
+void HadamardRotation::train(idx_t, const float*) {
+    init(seed != 0 ? seed : 12345);
+}
+
+void HadamardRotation::apply_noalloc(idx_t n, const float* x, float* xt) const {
+    FAISS_THROW_IF_NOT_MSG(is_trained, "Transformation not trained yet");
+
+    size_t d = d_in;
+    size_t p = d_out;
+    FAISS_THROW_IF_NOT(signs1.size() == p);
+    FAISS_THROW_IF_NOT(signs2.size() == p);
+    FAISS_THROW_IF_NOT(signs3.size() == p);
+
+    // Each unnormalized FWHT scales norms by sqrt(p).
+    // Three rounds scale by p^(3/2). Normalize once at the end.
+    float total_scale = 1.0f / (p * std::sqrt(static_cast<float>(p)));
+
+#pragma omp parallel for schedule(dynamic)
+    for (idx_t i = 0; i < n; i++) {
+        const float* xi = x + i * d;
+        float* xo = xt + i * p;
+
+        // Round 1: copy + zero-pad + sign-flip + FWHT
+        for (size_t j = 0; j < d; j++) {
+            xo[j] = xi[j] * signs1[j];
+        }
+        for (size_t j = d; j < p; j++) {
+            xo[j] = 0.0f;
+        }
+        fwht_inplace(xo, p);
+
+        // Round 2: sign-flip + FWHT
+        for (size_t j = 0; j < p; j++) {
+            xo[j] *= signs2[j];
+        }
+        fwht_inplace(xo, p);
+
+        // Round 3: sign-flip + FWHT + normalize
+        for (size_t j = 0; j < p; j++) {
+            xo[j] *= signs3[j];
+        }
+        fwht_inplace(xo, p);
+
+        for (size_t j = 0; j < p; j++) {
+            xo[j] *= total_scale;
+        }
+    }
+}
+
+void HadamardRotation::check_identical(const VectorTransform& other) const {
+    auto* hr = dynamic_cast<const HadamardRotation*>(&other);
+    FAISS_THROW_IF_NOT(hr);
+    FAISS_THROW_IF_NOT(d_in == hr->d_in);
+    FAISS_THROW_IF_NOT(d_out == hr->d_out);
+    FAISS_THROW_IF_NOT(seed == hr->seed);
+}
+
+/*********************************************
  * PCAMatrix
  *********************************************/
 

--- a/faiss/VectorTransform.h
+++ b/faiss/VectorTransform.h
@@ -126,6 +126,29 @@ struct RandomRotationMatrix : LinearTransform {
     RandomRotationMatrix() {}
 };
 
+/** Three rounds of random sign-flip + Fast Walsh-Hadamard Transform.
+ * Produces a pseudo-random rotation in O(d log d) time.
+ * d_out is the smallest power of 2 >= d_in (zero-padded as needed).
+ */
+struct HadamardRotation : VectorTransform {
+    uint32_t seed{};
+
+    /// Sign-flip vectors, each of size d_out, generated from seed.
+    std::vector<float> signs1, signs2, signs3;
+
+    explicit HadamardRotation(int d, uint32_t seed = 12345);
+
+    void init(uint32_t seed_in);
+
+    void train(idx_t n, const float* x) override;
+
+    void apply_noalloc(idx_t n, const float* x, float* xt) const override;
+
+    void check_identical(const VectorTransform& other) const override;
+
+    HadamardRotation() {}
+};
+
 /** Applies a principal component analysis on a set of vectors,
  *  with optionally whitening and random rotation. */
 struct PCAMatrix : LinearTransform {

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -304,6 +304,10 @@ std::unique_ptr<VectorTransform> read_VectorTransform_up(IOReader* f) {
             itqt->pca_then_itq = *pi;
         }
         vt = std::move(itqt);
+    } else if (h == fourcc("HRot")) {
+        auto hr = std::make_unique<HadamardRotation>();
+        READ1(hr->seed);
+        vt = std::move(hr);
     } else {
         FAISS_THROW_FMT(
                 "fourcc %ud (\"%s\") not recognized in %s",
@@ -314,6 +318,10 @@ std::unique_ptr<VectorTransform> read_VectorTransform_up(IOReader* f) {
     READ1(vt->d_in);
     READ1(vt->d_out);
     READ1(vt->is_trained);
+    if (h == fourcc("HRot")) {
+        auto* hr = dynamic_cast<HadamardRotation*>(vt.get());
+        hr->init(hr->seed);
+    }
     return vt;
 }
 

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -105,7 +105,14 @@ static void write_index_header(const Index* idx, IOWriter* f) {
 }
 
 void write_VectorTransform(const VectorTransform* vt, IOWriter* f) {
-    if (const LinearTransform* lt = dynamic_cast<const LinearTransform*>(vt)) {
+    if (const HadamardRotation* hr =
+                dynamic_cast<const HadamardRotation*>(vt)) {
+        uint32_t h = fourcc("HRot");
+        WRITE1(h);
+        WRITE1(hr->seed);
+    } else if (
+            const LinearTransform* lt =
+                    dynamic_cast<const LinearTransform*>(vt)) {
         if (dynamic_cast<const RandomRotationMatrix*>(lt)) {
             uint32_t h = fourcc("rrot");
             WRITE1(h);

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -220,6 +220,9 @@ VectorTransform* parse_VectorTransform(const std::string& description, int d) {
     if (match("RR([0-9]+)?")) {
         return new RandomRotationMatrix(d, mres_to_int(sm[1], d));
     }
+    if (match("HR([0-9]+)?")) {
+        return new HadamardRotation(d, mres_to_int(sm[1], 12345));
+    }
     if (match("ITQ([0-9]+)?")) {
         return new ITQTransform(d, mres_to_int(sm[1], d), sm[1].length() > 0);
     }

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -873,6 +873,7 @@ struct faiss::simd16uint16 {};
     DOWNCAST (OPQMatrix)
     DOWNCAST (PCAMatrix)
     DOWNCAST (ITQMatrix)
+    DOWNCAST (HadamardRotation)
     DOWNCAST (RandomRotationMatrix)
     DOWNCAST (LinearTransform)
     DOWNCAST (NormalizationTransform)

--- a/tests/test_build_blocks.py
+++ b/tests/test_build_blocks.py
@@ -80,6 +80,82 @@ class TestMapLong2Long(unittest.TestCase):
         assert m.search(12343) == -1
 
 
+class TestHadamardRotation(unittest.TestCase):
+
+    def test_shape(self):
+        d = 128
+        n = 100
+        np.random.seed(123)
+        x = np.random.randn(n, d).astype('float32')
+
+        fr = faiss.HadamardRotation(d)
+        y = fr.apply(x)
+        # d=128 is a power of 2, so d_out == d_in
+        self.assertEqual(y.shape, (n, d))
+
+    def test_non_power_of_2(self):
+        """Non-power-of-2 dimensions are zero-padded to next power of 2."""
+        cases = {192: 256, 384: 512, 768: 1024, 1536: 2048}
+        for d, expected_out in cases.items():
+            np.random.seed(42)
+            x = np.random.randn(20, d).astype('float32')
+            fr = faiss.HadamardRotation(d)
+            self.assertEqual(fr.d_out, expected_out)
+            y = fr.apply(x)
+            self.assertEqual(y.shape, (20, expected_out))
+            # output should be finite and non-trivial
+            self.assertTrue(np.all(np.isfinite(y)))
+            self.assertFalse(np.allclose(y, 0))
+
+    def test_deterministic(self):
+        d = 64
+        n = 20
+        np.random.seed(789)
+        x = np.random.randn(n, d).astype('float32')
+
+        fr1 = faiss.HadamardRotation(d, 42)
+        fr2 = faiss.HadamardRotation(d, 42)
+        y1 = fr1.apply(x)
+        y2 = fr2.apply(x)
+        np.testing.assert_array_equal(y1, y2)
+
+    def test_different_seeds(self):
+        d = 64
+        n = 20
+        np.random.seed(101)
+        x = np.random.randn(n, d).astype('float32')
+
+        fr1 = faiss.HadamardRotation(d, 1)
+        fr2 = faiss.HadamardRotation(d, 2)
+        y1 = fr1.apply(x)
+        y2 = fr2.apply(x)
+        self.assertFalse(np.allclose(y1, y2))
+
+    def test_norm_preservation_power_of_2(self):
+        """Hadamard transform preserves L2 norms for power-of-2 dims."""
+        d = 256
+        np.random.seed(42)
+        x = np.random.randn(100, d).astype('float32')
+        fr = faiss.HadamardRotation(d)
+        y = fr.apply(x)
+        norms_in = np.linalg.norm(x, axis=1)
+        norms_out = np.linalg.norm(y, axis=1)
+        np.testing.assert_allclose(norms_in, norms_out, rtol=1e-4)
+
+    def test_index_factory(self):
+        d = 64
+        n = 500
+        np.random.seed(202)
+        x = np.random.randn(n, d).astype('float32')
+
+        index = faiss.index_factory(d, "HR,Flat")
+        index.train(x)
+        index.add(x)
+        D, I = index.search(x[:5], 5)
+        # first result for each query should be itself
+        np.testing.assert_array_equal(I[:, 0], np.arange(5))
+
+
 class TestOrthogonalReconstruct(unittest.TestCase):
 
     def test_recons_orthonormal(self):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -651,6 +651,39 @@ class TestIORoundTrip(unittest.TestCase):
         out = pca2.apply(xq)
         np.testing.assert_array_equal(ref, out)
 
+    def test_vector_transform_hadamard_rotation(self):
+        """HadamardRotation VectorTransform write/read round-trip."""
+        xt, _, xq = get_dataset_2(d, nt, nb, nq)
+        fr = faiss.HadamardRotation(d, 42)
+
+        writer = faiss.VectorIOWriter()
+        faiss.write_VectorTransform(fr, writer)
+
+        reader = faiss.VectorIOReader()
+        faiss.copy_array_to_vector(
+            np.array(faiss.vector_to_array(writer.data)), reader.data)
+        fr2 = faiss.read_VectorTransform(reader)
+
+        self.assertEqual(fr2.d_in, d)
+        self.assertEqual(fr2.d_out, d)
+
+        ref = fr.apply(xq)
+        out = fr2.apply(xq)
+        np.testing.assert_array_equal(ref, out)
+
+    def test_index_pretransform_hadamard_rotation(self):
+        """Full index with HadamardRotation pre-transform round-trip."""
+        xt, xb, xq = get_dataset_2(d, nt, nb, nq)
+        index = faiss.index_factory(d, "HR,Flat")
+        index.train(xt)
+        index.add(xb)
+        Dref, Iref = index.search(xq, 5)
+
+        index2 = faiss.deserialize_index(faiss.serialize_index(index))
+        D2, I2 = index2.search(xq, 5)
+        np.testing.assert_array_equal(Iref, I2)
+        np.testing.assert_array_equal(Dref, D2)
+
     def test_null_index(self):
         """Serializing None / null index round-trips to None."""
         writer = faiss.VectorIOWriter()


### PR DESCRIPTION
Summary:
Using a Hadamard transformation is very similar to using a random rotation matrix, but we can calculate it in `d log d` time instead of `d ^ 2`. I initially started exploring this using a fast fourier transform which does outperform a random rotation, but a Hadamard transformation has the same computation complexity as FFT and in practice it is much easier to implement. Also because it is an orthonormal transformation, the recall is identical to a random rotation matrix.

I added a benchmark to compare both.

Differential Revision: D94658424


