### PR TITLE
Increment to next release, v1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.14.1] - 2026-03-04
+
+Added
+- 5cf2c4203f0e52f67504f154ae4dbea84906bc1f Expose IndexBinaryFlat to the C API. (#4834)
+- db9ba35118d5230f92d466e17e19f5019ff8601d add hadamard transformation as an index for IVF (#4856)
+
+Changed
+- d2f8d3514003986ec9ed37c9b29d70818ccf686a removed conda-forge install documentation (#4843)
+- c90c9dc544a8a82108d6499d7fafb3c3dc6fda2f Update python to include 3.13 and 3.14 (#4859)
+- 8af77fe730f141d58fa7b0de8d3a33663e8c4b23 SIMD-optimize multi-bit RaBitQ inner product (#4850)
+- ccc934f58660f42da677d5c253b550e61b153d5f ScalarQuantizer: split SIMD specializations into per-SIMD TUs + DD dispatch (#4839)
+
+Fixed
+- 28f79bd98efcb00c2bbf50a7eb30abc507ae49b6 Fix SWIG 4.4 multi-phase init: replace import_array() with import_array1(-1) (#4846)
+
+
 ## [1.14.0] - 2026-03-02
 
 Added
@@ -906,7 +922,13 @@ by conda install -c pytorch faiss-gpu cudatoolkit=10.0.
 - C bindings.
 - Extended tutorial to GPU indices.
 
-[Unreleased]: https://github.com/facebookresearch/faiss/compare/v1.11.0...HEAD
+[Unreleased]: https://github.com/facebookresearch/faiss/compare/v1.14.1...HEAD
+[1.14.1]: https://github.com/facebookresearch/faiss/compare/v1.14.0...v1.14.1
+[1.14.0]: https://github.com/facebookresearch/faiss/compare/v1.13.2...v1.14.0
+[1.13.2]: https://github.com/facebookresearch/faiss/compare/v1.13.1...v1.13.2
+[1.13.1]: https://github.com/facebookresearch/faiss/compare/v1.13.0...v1.13.1
+[1.13.0]: https://github.com/facebookresearch/faiss/compare/v1.12.0...v1.13.0
+[1.12.0]: https://github.com/facebookresearch/faiss/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/facebookresearch/faiss/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/facebookresearch/faiss/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/facebookresearch/faiss/compare/v1.8.0...v1.9.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if(FAISS_ENABLE_CUVS)
 endif()
 
 project(faiss
-  VERSION 1.14.0
+  VERSION 1.14.1
   DESCRIPTION "A library for efficient similarity search and clustering of dense vectors."
   HOMEPAGE_URL "https://github.com/facebookresearch/faiss"
   LANGUAGES ${FAISS_LANGUAGES})

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,13 +12,13 @@ To install the latest stable release:
 
 ``` shell
 # CPU-only version
-$ conda install -c pytorch -c conda-forge faiss-cpu=1.14.0
+$ conda install -c pytorch -c conda-forge faiss-cpu=1.14.1
 
 # GPU(+CPU) version
-$ conda install -c pytorch -c nvidia -c conda-forge faiss-gpu=1.14.0
+$ conda install -c pytorch -c nvidia -c conda-forge faiss-gpu=1.14.1
 
 # GPU(+CPU) version with NVIDIA cuVS
-$ conda install -c pytorch -c nvidia -c rapidsai -c conda-forge libnvjitlink faiss-gpu-cuvs=1.14.0
+$ conda install -c pytorch -c nvidia -c rapidsai -c conda-forge libnvjitlink faiss-gpu-cuvs=1.14.1
 
 # GPU(+CPU) version using AMD ROCm not yet available
 ```
@@ -36,7 +36,7 @@ Nightly pre-release packages can be installed as follows:
 $ conda install -c pytorch/label/nightly -c conda-forge faiss-cpu
 
 # GPU(+CPU) version
-$ conda install -c pytorch/label/nightly -c nvidia -c conda-forge faiss-gpu=1.14.0
+$ conda install -c pytorch/label/nightly -c nvidia -c conda-forge faiss-gpu=1.14.1
 
 # GPU(+CPU) version with NVIDIA cuVS (package built with CUDA 12.6)
 conda install -c pytorch -c rapidsai -c rapidsai-nightly -c conda-forge -c nvidia pytorch/label/nightly::faiss-gpu-cuvs 'cuda-version=12.6'

--- a/faiss/Index.h
+++ b/faiss/Index.h
@@ -16,8 +16,8 @@
 #include <cstdio>
 
 #define FAISS_VERSION_MAJOR 1
-#define FAISS_VERSION_MINOR 13
-#define FAISS_VERSION_PATCH 2
+#define FAISS_VERSION_MINOR 14
+#define FAISS_VERSION_PATCH 1
 
 // Macro to combine the version components into a single string
 #ifndef FAISS_STRINGIFY

--- a/faiss/python/setup.py
+++ b/faiss/python/setup.py
@@ -114,7 +114,7 @@ are implemented on the GPU. It is developed by Facebook AI Research.
 """
 setup(
     name="faiss",
-    version="1.14.0",
+    version="1.14.1",
     description="A library for efficient similarity search and clustering of dense vectors",
     long_description=long_description,
     long_description_content_type="text/plain",


### PR DESCRIPTION
need new version to include Python 3.14 change so we can fix the backwards compatibility tests

## Summary
- Increment version to 1.14.1
- Update CHANGELOG.md with 7 commits since v1.14.0
- Bump version in CMakeLists.txt, setup.py, Index.h, INSTALL.md
- Update backward compatibility test to use faiss-cpu=1.14.1
- Fix 6 missing CHANGELOG comparison links (1.12.0–1.14.0)

## Test plan
- [ ] CI passes
- [ ] Backward compatibility test uses correct version
- [ ] CHANGELOG entries are correctly categorized