### PR TITLE
Improve exception safety for the 'own_fields'/allocation pattern

### DIFF
--- a/faiss/IndexBinaryHNSW.cpp
+++ b/faiss/IndexBinaryHNSW.cpp
@@ -172,19 +172,14 @@ IndexBinaryHNSW::IndexBinaryHNSW() {
     is_trained = true;
 }
 
-IndexBinaryHNSW::IndexBinaryHNSW(int d, int M)
-        : IndexBinary(d),
-          hnsw(M),
-          own_fields(true),
-          storage(new IndexBinaryFlat(d)) {
+IndexBinaryHNSW::IndexBinaryHNSW(int d, int M) : IndexBinary(d), hnsw(M) {
+    storage = std::make_unique<IndexBinaryFlat>(d).release();
+    own_fields = true;
     is_trained = true;
 }
 
 IndexBinaryHNSW::IndexBinaryHNSW(IndexBinary* storage, int M)
-        : IndexBinary(storage->d),
-          hnsw(M),
-          own_fields(false),
-          storage(storage) {
+        : IndexBinary(storage->d), hnsw(M), storage(storage) {
     is_trained = true;
 }
 

--- a/faiss/IndexBinaryHNSW.h
+++ b/faiss/IndexBinaryHNSW.h
@@ -25,8 +25,8 @@ struct IndexBinaryHNSW : IndexBinary {
     HNSW hnsw;
 
     // the sequential storage
-    bool own_fields;
-    IndexBinary* storage;
+    bool own_fields = false;
+    IndexBinary* storage = nullptr;
 
     // When set to false, level 0 in the knn graph is not initialized.
     // This option is used by GpuIndexBinaryCagra::copyTo(IndexBinaryHNSW*)

--- a/faiss/IndexBinaryHash.cpp
+++ b/faiss/IndexBinaryHash.cpp
@@ -11,6 +11,7 @@
 
 #include <cinttypes>
 #include <cstdio>
+#include <memory>
 #include <unordered_set>
 
 #include <faiss/utils/hamming.h>
@@ -286,18 +287,14 @@ IndexBinaryHashStats indexBinaryHash_stats;
  ******************************************************/
 
 IndexBinaryMultiHash::IndexBinaryMultiHash(int d, int nhash, int b)
-        : IndexBinary(d),
-          storage(new IndexBinaryFlat(d)),
-          own_fields(true),
-          maps(nhash),
-          nhash(nhash),
-          b(b),
-          nflip(0) {
+        : IndexBinary(d), maps(nhash), nhash(nhash), b(b), nflip(0) {
     FAISS_THROW_IF_NOT(nhash * b <= d);
+    storage = std::make_unique<IndexBinaryFlat>(d).release();
+    own_fields = true;
 }
 
 IndexBinaryMultiHash::IndexBinaryMultiHash()
-        : storage(nullptr), own_fields(true), nhash(0), b(0), nflip(0) {}
+        : storage(nullptr), nhash(0), b(0), nflip(0) {}
 
 IndexBinaryMultiHash::~IndexBinaryMultiHash() {
     if (own_fields) {

--- a/faiss/IndexBinaryHash.h
+++ b/faiss/IndexBinaryHash.h
@@ -82,8 +82,8 @@ FAISS_API extern IndexBinaryHashStats indexBinaryHash_stats;
 /** just uses the b first bits as a hash value */
 struct IndexBinaryMultiHash : IndexBinary {
     // where the vectors are actually stored
-    IndexBinaryFlat* storage;
-    bool own_fields;
+    IndexBinaryFlat* storage = nullptr;
+    bool own_fields = false;
 
     // maps hash values to the ids that hash to them
     using Map = std::unordered_map<idx_t, std::vector<idx_t>>;

--- a/faiss/IndexIVFSpectralHash.cpp
+++ b/faiss/IndexIVFSpectralHash.cpp
@@ -38,9 +38,10 @@ IndexIVFSpectralHash::IndexIVFSpectralHash(
                   own_invlists),
           nbit(nbit),
           period(period) {
-    RandomRotationMatrix* rr = new RandomRotationMatrix(d, nbit);
+    auto rr = std::make_unique<RandomRotationMatrix>(d, nbit);
     rr->init(1234);
-    vt = rr;
+    vt = rr.release();
+    own_fields = true;
     is_trained = false;
     by_residual = false;
 }

--- a/faiss/IndexIVFSpectralHash.h
+++ b/faiss/IndexIVFSpectralHash.h
@@ -32,7 +32,7 @@ struct IndexIVFSpectralHash : IndexIVF {
     /// transformation from d to nbit dim
     VectorTransform* vt = nullptr;
     /// own the vt
-    bool own_fields = true;
+    bool own_fields = false;
 
     /// nb of bits of the binary signature
     int nbit = 0;

--- a/faiss/IndexNNDescent.h
+++ b/faiss/IndexNNDescent.h
@@ -30,8 +30,8 @@ struct IndexNNDescent : Index {
     NNDescent nndescent;
 
     // the sequential storage
-    bool own_fields;
-    Index* storage;
+    bool own_fields = false;
+    Index* storage = nullptr;
 
     explicit IndexNNDescent(
             int d = 0,

--- a/faiss/IndexPQ.h
+++ b/faiss/IndexPQ.h
@@ -169,7 +169,7 @@ FAISS_API extern int multi_index_quantizer_search_bs;
 struct MultiIndexQuantizer2 : MultiIndexQuantizer {
     /// M Indexes on d / M dimensions
     std::vector<Index*> assign_indexes;
-    bool own_fields;
+    bool own_fields = false;
 
     MultiIndexQuantizer2(int d, size_t M, size_t nbits, Index** indexes);
 

--- a/faiss/IndexPreTransform.h
+++ b/faiss/IndexPreTransform.h
@@ -26,7 +26,7 @@ struct IndexPreTransform : Index {
     std::vector<VectorTransform*> chain; ///! chain of transforms
     Index* index;                        ///! the sub-index
 
-    bool own_fields; ///! whether pointers are deleted in destructor
+    bool own_fields = false; ///! whether pointers are deleted in destructor
 
     explicit IndexPreTransform(Index* index);
 

--- a/faiss/IndexRefine.h
+++ b/faiss/IndexRefine.h
@@ -28,8 +28,8 @@ struct IndexRefine : Index {
     /// refinement index
     Index* refine_index;
 
-    bool own_fields;       ///< should the base index be deallocated?
-    bool own_refine_index; ///< same with the refinement index
+    bool own_fields = false;       ///< should the base index be deallocated?
+    bool own_refine_index = false; ///< same with the refinement index
 
     /// factor between k requested in search and the k requested from
     /// the base_index (should be >= 1)

--- a/faiss/IndexRowwiseMinMax.h
+++ b/faiss/IndexRowwiseMinMax.h
@@ -43,7 +43,7 @@ struct IndexRowwiseMinMaxBase : Index {
     Index* index;
 
     /// whether the subindex needs to be freed in the destructor.
-    bool own_fields;
+    bool own_fields = false;
 
     explicit IndexRowwiseMinMaxBase(Index* index);
 

--- a/faiss/MetaIndexes.h
+++ b/faiss/MetaIndexes.h
@@ -22,7 +22,7 @@ namespace faiss {
  * used to distribute a MultiIndexQuantizer
  */
 struct IndexSplitVectors : Index {
-    bool own_fields;
+    bool own_fields = false;
     bool threaded;
     std::vector<Index*> sub_indexes;
     idx_t sum_d; /// sum of dimensions seen so far


### PR DESCRIPTION
Summary:
FAISS index data structures use C compatible types and thus cannot
embed RAII types like std::unique_ptr to trivially ensure exception
safety. For this reason, allocations within constructors must be performed
within the body of constructors where RAII types and other exception
handling tools are available.

This diff makes a pass through the index types to clean up the
"own_fields" allocation pattern. "own_fields" and the pointer it guards
are now both initialized to safe (false/nullptr) values at the definition
site and only updated within the constructor body when further exceptions
in the constructor are no longer possible. This also fixes a few cases
where these fields had indeterminent state or actually wrong state when
an exception is thrown.

There are a few cases that perform the strange looking operation
'std::make_unique().release()'. This is functionally equivalent to just
calling new, but hopefully encourages the continued use of std::unique_ptr
should the constructor logic change to introduce vectors for exceptions to
be thrown.

Differential Revision: D95294213


