### PR TITLE
Add defaulted SIMDLevel template parameter to handler and scaler types

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -117,9 +117,9 @@ set(FAISS_SRC
   impl/kmeans1d.cpp
   impl/lattice_Zn.cpp
   impl/mapped_io.cpp
-  impl/pq4_fast_scan.cpp
-  impl/pq4_fast_scan_search_1.cpp
-  impl/pq4_fast_scan_search_qbs.cpp
+  impl/fast_scan/pq4_fast_scan.cpp
+  impl/fast_scan/pq4_fast_scan_search_1.cpp
+  impl/fast_scan/pq4_fast_scan_search_qbs.cpp
   impl/residual_quantizer_encode_steps.cpp
   impl/zerocopy_io.cpp
   impl/NNDescent.cpp
@@ -227,8 +227,8 @@ set(FAISS_HEADERS
   impl/HNSW.h
   impl/LocalSearchQuantizer.h
   impl/ProductAdditiveQuantizer.h
-  impl/LookupTableScaler.h
-  impl/FastScanDistancePostProcessing.h
+  impl/fast_scan/LookupTableScaler.h
+  impl/fast_scan/FastScanDistancePostProcessing.h
   impl/maybe_owned_vector.h
   impl/NNDescent.h
   impl/NSG.h
@@ -262,10 +262,10 @@ set(FAISS_HEADERS
   impl/kmeans1d.h
   impl/lattice_Zn.h
   impl/platform_macros.h
-  impl/pq4_fast_scan.h
+  impl/fast_scan/pq4_fast_scan.h
   impl/residual_quantizer_encode_steps.h
   impl/simd_dispatch.h
-  impl/simd_result_handlers.h
+  impl/fast_scan/simd_result_handlers.h
   impl/zerocopy_io.h
   utils/pq_code_distance.h
   impl/pq_code_distance/pq_code_distance-inl.h

--- a/faiss/IndexAdditiveQuantizerFastScan.cpp
+++ b/faiss/IndexAdditiveQuantizerFastScan.cpp
@@ -11,11 +11,10 @@
 #include <memory>
 
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/impl/FastScanDistancePostProcessing.h>
 #include <faiss/impl/LocalSearchQuantizer.h>
-#include <faiss/impl/LookupTableScaler.h>
 #include <faiss/impl/ResidualQuantizer.h>
-#include <faiss/impl/pq4_fast_scan.h>
+#include <faiss/impl/fast_scan/FastScanDistancePostProcessing.h>
+#include <faiss/impl/fast_scan/pq4_fast_scan.h>
 #include <faiss/utils/quantize_lut.h>
 #include <faiss/utils/utils.h>
 
@@ -202,9 +201,8 @@ void IndexAdditiveQuantizerFastScan::search(
         return;
     }
 
-    NormTableScaler scaler(norm_scale);
     FastScanDistancePostProcessing context;
-    context.norm_scaler = &scaler;
+    context.pq2x4_scale = norm_scale;
     if (metric_type == METRIC_L2) {
         search_dispatch_implem<true>(n, x, k, distances, labels, context);
     } else {

--- a/faiss/IndexFastScan.cpp
+++ b/faiss/IndexFastScan.cpp
@@ -13,12 +13,11 @@
 
 #include <faiss/impl/CodePacker.h>
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/impl/FastScanDistancePostProcessing.h>
 #include <faiss/impl/IDSelector.h>
-#include <faiss/impl/LookupTableScaler.h>
 #include <faiss/impl/RaBitQUtils.h>
-#include <faiss/impl/pq4_fast_scan.h>
-#include <faiss/impl/simd_result_handlers.h>
+#include <faiss/impl/fast_scan/FastScanDistancePostProcessing.h>
+#include <faiss/impl/fast_scan/pq4_fast_scan.h>
+#include <faiss/impl/fast_scan/simd_result_handlers.h>
 #include <faiss/utils/hamming.h>
 #include <faiss/utils/quantize_lut.h>
 #include <faiss/utils/utils.h>
@@ -187,7 +186,7 @@ void estimators_from_tables_generic(
         BitstringReader bsr(codes + j * index.code_size, index.code_size);
         accu_t dis = 0;
         const dis_t* dt = dis_table;
-        int nscale = context.norm_scaler ? context.norm_scaler->nscale : 0;
+        int nscale = context.pq2x4_scale ? 2 : 0;
 
         for (size_t m = 0; m < index.M - nscale; m++) {
             uint64_t c = bsr.read(index.nbits);
@@ -195,10 +194,10 @@ void estimators_from_tables_generic(
             dt += index.ksub;
         }
 
-        if (nscale && context.norm_scaler) {
+        if (nscale) {
             for (size_t m = 0; m < nscale; m++) {
                 uint64_t c = bsr.read(index.nbits);
-                dis += context.norm_scaler->scale_one(dt[c]);
+                dis += dt[c] * context.pq2x4_scale;
                 dt += index.ksub;
             }
         }
@@ -545,7 +544,7 @@ void IndexFastScan::search_implem_12(
                 codes.get(),
                 LUT.get(),
                 *handler.get(),
-                context.norm_scaler,
+                context.pq2x4_scale,
                 get_block_stride());
     }
     if (!(skip & 8)) {
@@ -629,7 +628,7 @@ void IndexFastScan::search_implem_14(
                 codes.get(),
                 LUT.get(),
                 *handler.get(),
-                context.norm_scaler,
+                context.pq2x4_scale,
                 get_block_stride());
     }
     if (!(skip & 8)) {

--- a/faiss/IndexFastScan.h
+++ b/faiss/IndexFastScan.h
@@ -8,13 +8,12 @@
 #pragma once
 
 #include <faiss/Index.h>
-#include <faiss/impl/FastScanDistancePostProcessing.h>
+#include <faiss/impl/fast_scan/FastScanDistancePostProcessing.h>
 #include <faiss/utils/AlignedTable.h>
 
 namespace faiss {
 
 struct CodePacker;
-struct NormTableScaler;
 struct IDSelector;
 struct SIMDResultHandlerToFloat;
 

--- a/faiss/IndexIVFAdditiveQuantizerFastScan.cpp
+++ b/faiss/IndexIVFAdditiveQuantizerFastScan.cpp
@@ -14,9 +14,8 @@
 
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/impl/FastScanDistancePostProcessing.h>
-#include <faiss/impl/LookupTableScaler.h>
-#include <faiss/impl/pq4_fast_scan.h>
+#include <faiss/impl/fast_scan/FastScanDistancePostProcessing.h>
+#include <faiss/impl/fast_scan/pq4_fast_scan.h>
 #include <faiss/impl/simd_dispatch.h>
 #include <faiss/invlists/BlockInvertedLists.h>
 #include <faiss/utils/distances.h>
@@ -317,9 +316,8 @@ void IndexIVFAdditiveQuantizerFastScan::search(
         return;
     }
 
-    NormTableScaler scaler(norm_scale);
     FastScanDistancePostProcessing context;
-    context.norm_scaler = &scaler;
+    context.pq2x4_scale = norm_scale;
     IndexIVFFastScan::CoarseQuantized cq{nprobe};
     search_dispatch_implem(n, x, k, distances, labels, cq, context);
 }

--- a/faiss/IndexIVFAdditiveQuantizerFastScan.h
+++ b/faiss/IndexIVFAdditiveQuantizerFastScan.h
@@ -12,8 +12,8 @@
 #include <faiss/IndexIVFAdditiveQuantizer.h>
 #include <faiss/IndexIVFFastScan.h>
 #include <faiss/impl/AdditiveQuantizer.h>
-#include <faiss/impl/FastScanDistancePostProcessing.h>
 #include <faiss/impl/ProductAdditiveQuantizer.h>
+#include <faiss/impl/fast_scan/FastScanDistancePostProcessing.h>
 #include <faiss/utils/AlignedTable.h>
 
 namespace faiss {

--- a/faiss/IndexIVFFastScan.cpp
+++ b/faiss/IndexIVFFastScan.cpp
@@ -17,11 +17,10 @@
 #include <faiss/IndexIVFPQ.h>
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/impl/FastScanDistancePostProcessing.h>
-#include <faiss/impl/LookupTableScaler.h>
 #include <faiss/impl/RaBitQUtils.h>
-#include <faiss/impl/pq4_fast_scan.h>
-#include <faiss/impl/simd_result_handlers.h>
+#include <faiss/impl/fast_scan/FastScanDistancePostProcessing.h>
+#include <faiss/impl/fast_scan/pq4_fast_scan.h>
+#include <faiss/impl/fast_scan/simd_result_handlers.h>
 #include <faiss/invlists/BlockInvertedLists.h>
 #include <faiss/utils/hamming.h>
 #include <faiss/utils/quantize_lut.h>
@@ -239,7 +238,7 @@ void estimators_from_tables_generic(
         int64_t* heap_ids,
         const FastScanDistancePostProcessing& context) {
     using accu_t = typename C::T;
-    size_t nscale = context.norm_scaler ? context.norm_scaler->nscale : 0;
+    size_t nscale = context.pq2x4_scale ? 2 : 0;
     for (size_t j = 0; j < ncodes; ++j) {
         BitstringReader bsr(codes + j * index.code_size, index.code_size);
         accu_t dis = bias;
@@ -251,10 +250,10 @@ void estimators_from_tables_generic(
             dt += index.ksub;
         }
 
-        if (context.norm_scaler) {
+        if (nscale) {
             for (size_t m = 0; m < nscale; m++) {
                 uint64_t c = bsr.read(index.nbits);
-                dis += context.norm_scaler->scale_one(dt[c]);
+                dis += dt[c] * context.pq2x4_scale;
                 dt += index.ksub;
             }
         }
@@ -1031,7 +1030,7 @@ void IndexIVFFastScan::search_implem_10(
                     codes.get(),
                     LUT,
                     handler,
-                    context.norm_scaler,
+                    context.pq2x4_scale,
                     get_block_stride());
 
             ndis += ls;
@@ -1183,7 +1182,7 @@ void IndexIVFFastScan::search_implem_12(
                 codes.get(),
                 LUT.get(),
                 handler,
-                context.norm_scaler,
+                context.pq2x4_scale,
                 get_block_stride());
         // prepare for next loop
         i0 = i1;
@@ -1407,7 +1406,7 @@ void IndexIVFFastScan::search_implem_14(
                     codes.get(),
                     LUT.get(),
                     *handler.get(),
-                    context.norm_scaler,
+                    context.pq2x4_scale,
                     get_block_stride());
         }
 

--- a/faiss/IndexIVFFastScan.h
+++ b/faiss/IndexIVFFastScan.h
@@ -8,12 +8,11 @@
 #pragma once
 
 #include <faiss/IndexIVF.h>
-#include <faiss/impl/FastScanDistancePostProcessing.h>
+#include <faiss/impl/fast_scan/FastScanDistancePostProcessing.h>
 #include <faiss/utils/AlignedTable.h>
 
 namespace faiss {
 
-struct NormTableScaler;
 struct SIMDResultHandlerToFloat;
 struct Quantizer;
 

--- a/faiss/IndexIVFPQFastScan.cpp
+++ b/faiss/IndexIVFPQFastScan.cpp
@@ -22,8 +22,8 @@
 
 #include <faiss/invlists/BlockInvertedLists.h>
 
-#include <faiss/impl/pq4_fast_scan.h>
-#include <faiss/impl/simd_result_handlers.h>
+#include <faiss/impl/fast_scan/pq4_fast_scan.h>
+#include <faiss/impl/fast_scan/simd_result_handlers.h>
 
 namespace faiss {
 
@@ -419,7 +419,7 @@ struct IVFPQFastScanScanner : InvertedListScanner {
                 codes,
                 LUT,
                 *handler,
-                nullptr,
+                0,
                 index.get_block_stride());
 
         // The handler is for the results of this iteration.

--- a/faiss/IndexIVFRaBitQFastScan.cpp
+++ b/faiss/IndexIVFRaBitQFastScan.cpp
@@ -14,11 +14,11 @@
 
 #include <faiss/impl/CodePackerRaBitQ.h>
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/impl/FastScanDistancePostProcessing.h>
 #include <faiss/impl/RaBitQUtils.h>
 #include <faiss/impl/RaBitQuantizerMultiBit.h>
-#include <faiss/impl/pq4_fast_scan.h>
-#include <faiss/impl/simd_result_handlers.h>
+#include <faiss/impl/fast_scan/FastScanDistancePostProcessing.h>
+#include <faiss/impl/fast_scan/pq4_fast_scan.h>
+#include <faiss/impl/fast_scan/simd_result_handlers.h>
 #include <faiss/invlists/BlockInvertedLists.h>
 #include <faiss/utils/distances.h>
 #include <faiss/utils/utils.h>
@@ -938,7 +938,7 @@ struct IVFRaBitQFastScanScanner : InvertedListScanner {
                 codes,
                 LUT,
                 *handler,
-                nullptr,
+                0,
                 index.get_block_stride());
 
         // Combine results across iterations

--- a/faiss/IndexIVFRaBitQFastScan.h
+++ b/faiss/IndexIVFRaBitQFastScan.h
@@ -16,7 +16,7 @@
 #include <faiss/impl/RaBitQStats.h>
 #include <faiss/impl/RaBitQUtils.h>
 #include <faiss/impl/RaBitQuantizer.h>
-#include <faiss/impl/simd_result_handlers.h>
+#include <faiss/impl/fast_scan/simd_result_handlers.h>
 #include <faiss/utils/AlignedTable.h>
 #include <faiss/utils/Heap.h>
 

--- a/faiss/IndexPQFastScan.cpp
+++ b/faiss/IndexPQFastScan.cpp
@@ -9,8 +9,8 @@
 
 #include <memory>
 
-#include <faiss/impl/FastScanDistancePostProcessing.h>
-#include <faiss/impl/pq4_fast_scan.h>
+#include <faiss/impl/fast_scan/FastScanDistancePostProcessing.h>
+#include <faiss/impl/fast_scan/pq4_fast_scan.h>
 #include <faiss/utils/utils.h>
 
 namespace faiss {

--- a/faiss/IndexRaBitQFastScan.cpp
+++ b/faiss/IndexRaBitQFastScan.cpp
@@ -7,10 +7,10 @@
 
 #include <faiss/IndexRaBitQFastScan.h>
 #include <faiss/impl/CodePackerRaBitQ.h>
-#include <faiss/impl/FastScanDistancePostProcessing.h>
 #include <faiss/impl/RaBitQUtils.h>
 #include <faiss/impl/RaBitQuantizerMultiBit.h>
-#include <faiss/impl/pq4_fast_scan.h>
+#include <faiss/impl/fast_scan/FastScanDistancePostProcessing.h>
+#include <faiss/impl/fast_scan/pq4_fast_scan.h>
 #include <faiss/utils/utils.h>
 #include <algorithm>
 #include <cmath>

--- a/faiss/IndexRaBitQFastScan.h
+++ b/faiss/IndexRaBitQFastScan.h
@@ -15,7 +15,7 @@
 #include <faiss/impl/RaBitQStats.h>
 #include <faiss/impl/RaBitQUtils.h>
 #include <faiss/impl/RaBitQuantizer.h>
-#include <faiss/impl/simd_result_handlers.h>
+#include <faiss/impl/fast_scan/simd_result_handlers.h>
 #include <faiss/impl/simdlib/simdlib_dispatch.h>
 #include <faiss/utils/Heap.h>
 

--- a/faiss/impl/CodePackerRaBitQ.cpp
+++ b/faiss/impl/CodePackerRaBitQ.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <faiss/impl/CodePackerRaBitQ.h>
-#include <faiss/impl/pq4_fast_scan.h>
+#include <faiss/impl/fast_scan/pq4_fast_scan.h>
 
 #include <cstring>
 

--- a/faiss/impl/fast_scan/FastScanDistancePostProcessing.h
+++ b/faiss/impl/fast_scan/FastScanDistancePostProcessing.h
@@ -11,9 +11,6 @@
 
 namespace faiss {
 
-// Forward declarations
-struct NormTableScaler;
-
 namespace rabitq_utils {
 struct QueryFactorsData;
 }
@@ -22,8 +19,10 @@ struct QueryFactorsData;
  * Simple context object that holds processors for FastScan operations.
  * */
 struct FastScanDistancePostProcessing {
-    /// Norm scaling processor for Additive Quantizers (nullptr if not needed)
-    const NormTableScaler* norm_scaler = nullptr;
+    /// Norm scaling processor for Additive Quantizers.
+    /// The scale is encoded in a 2x4 bit PQ table, then scaled by this int.
+    /// Set to 0 if unused.
+    int pq2x4_scale = 0;
 
     /// Query factors data pointer for RaBitQ (nullptr if not needed)
     /// This pointer should point to the beginning of the relevant
@@ -41,7 +40,7 @@ struct FastScanDistancePostProcessing {
 
     /// Check if norm scaling is enabled
     bool has_norm_scaling() const {
-        return norm_scaler != nullptr;
+        return pq2x4_scale != 0;
     }
 
     /// Check if query factors processing is enabled

--- a/faiss/impl/fast_scan/LookupTableScaler.h
+++ b/faiss/impl/fast_scan/LookupTableScaler.h
@@ -20,8 +20,14 @@
 namespace faiss {
 
 /// no-op handler
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
 struct DummyScaler {
     static constexpr int nscale = 0;
+    static constexpr SIMDLevel SL256 = simd256_level_selector<SL>::value;
+    using simd32uint8 = simd32uint8_tpl<SL256>;
+    using simd16uint16 = simd16uint16_tpl<SL256>;
+    using simd64uint8 = simd64uint8_tpl<SL>;
+    using simd32uint16 = simd32uint16_tpl<SL>;
 
     inline simd32uint8 lookup(const simd32uint8&, const simd32uint8&) const {
         FAISS_THROW_MSG("DummyScaler::lookup should not be called.");
@@ -38,7 +44,6 @@ struct DummyScaler {
         return simd16uint16(0);
     }
 
-#ifdef __AVX512F__
     inline simd64uint8 lookup(const simd64uint8&, const simd64uint8&) const {
         FAISS_THROW_MSG("DummyScaler::lookup should not be called.");
         return simd64uint8(0);
@@ -53,7 +58,6 @@ struct DummyScaler {
         FAISS_THROW_MSG("DummyScaler::scale_hi should not be called.");
         return simd32uint16(0);
     }
-#endif
 
     template <class dist_t>
     inline dist_t scale_one(const dist_t&) const {
@@ -64,8 +68,15 @@ struct DummyScaler {
 
 /// consumes 2x4 bits to encode a norm as a scalar additive quantizer
 /// the norm is scaled because its range is larger than other components
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
 struct NormTableScaler {
     static constexpr int nscale = 2;
+    static constexpr SIMDLevel SL256 = simd256_level_selector<SL>::value;
+    using simd32uint8 = simd32uint8_tpl<SL256>;
+    using simd16uint16 = simd16uint16_tpl<SL256>;
+    using simd64uint8 = simd64uint8_tpl<SL>;
+    using simd32uint16 = simd32uint16_tpl<SL>;
+
     int scale_int;
     simd16uint16 scale_simd;
 
@@ -84,7 +95,6 @@ struct NormTableScaler {
         return (simd16uint16(res) >> 8) * scale_simd;
     }
 
-#ifdef __AVX512F__
     inline simd64uint8 lookup(const simd64uint8& lut, const simd64uint8& c)
             const {
         return lut.lookup_4_lanes(c);
@@ -99,7 +109,6 @@ struct NormTableScaler {
         auto scale_simd_wide = simd32uint16(scale_simd, scale_simd);
         return (simd32uint16(res) >> 8) * scale_simd_wide;
     }
-#endif
 
     // for non-SIMD implem 2, 3, 4
     template <class dist_t>

--- a/faiss/impl/fast_scan/pq4_fast_scan.cpp
+++ b/faiss/impl/fast_scan/pq4_fast_scan.cpp
@@ -6,8 +6,8 @@
  */
 
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/impl/pq4_fast_scan.h>
-#include <faiss/impl/simd_result_handlers.h>
+#include <faiss/impl/fast_scan/pq4_fast_scan.h>
+#include <faiss/impl/fast_scan/simd_result_handlers.h>
 
 #include <array>
 

--- a/faiss/impl/fast_scan/pq4_fast_scan.h
+++ b/faiss/impl/fast_scan/pq4_fast_scan.h
@@ -24,7 +24,6 @@
 
 namespace faiss {
 
-struct NormTableScaler;
 struct SIMDResultHandler;
 
 /** Pack codes for consumption by the SIMD kernels.
@@ -139,7 +138,7 @@ void pq4_accumulate_loop(
         const uint8_t* codes,
         const uint8_t* LUT,
         SIMDResultHandler& res,
-        const NormTableScaler* scaler,
+        int pq2x4_scale,
         size_t block_stride);
 
 /* qbs versions, supported only for bbs=32.
@@ -190,7 +189,7 @@ int pq4_pack_LUT_qbs_q_map(
  * @param codes   encoded database vectors (packed)
  * @param LUT     look-up table (packed)
  * @param res     call-back for the results
- * @param scaler  scaler to scale the encoded norm
+ * @param pq2x4_scale  scaler to scale the encoded norm
  * @param block_stride  stride in bytes between consecutive blocks.
  */
 void pq4_accumulate_loop_qbs(
@@ -200,7 +199,7 @@ void pq4_accumulate_loop_qbs(
         const uint8_t* codes,
         const uint8_t* LUT,
         SIMDResultHandler& res,
-        const NormTableScaler* scaler,
+        int pq2x4_scale,
         size_t block_stride);
 
 /** Wrapper of pq4_accumulate_loop_qbs using simple StoreResultHandler

--- a/faiss/impl/fast_scan/pq4_fast_scan_search_1.cpp
+++ b/faiss/impl/fast_scan/pq4_fast_scan_search_1.cpp
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <faiss/impl/pq4_fast_scan.h>
+#include <faiss/impl/fast_scan/pq4_fast_scan.h>
 
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/impl/LookupTableScaler.h>
-#include <faiss/impl/simd_result_handlers.h>
+#include <faiss/impl/fast_scan/LookupTableScaler.h>
+#include <faiss/impl/fast_scan/simd_result_handlers.h>
 
 namespace faiss {
 
@@ -182,33 +182,18 @@ void pq4_accumulate_loop_fixed_handler(
         const uint8_t* codes,
         const uint8_t* LUT,
         ResultHandler& res,
-        const NormTableScaler* scaler,
+        int pq2x4_scale,
         size_t block_stride) {
-    if (scaler) {
+    if (pq2x4_scale) {
+        NormTableScaler<> scaler(pq2x4_scale);
         pq4_accumulate_loop_fixed_scaler(
-                nq, nb, bbs, nsq, codes, LUT, res, *scaler, block_stride);
+                nq, nb, bbs, nsq, codes, LUT, res, scaler, block_stride);
     } else {
-        DummyScaler dscaler;
+        DummyScaler<> dscaler;
         pq4_accumulate_loop_fixed_scaler(
                 nq, nb, bbs, nsq, codes, LUT, res, dscaler, block_stride);
     }
 }
-
-struct Run_pq4_accumulate_loop {
-    template <class ResultHandler>
-    void f(ResultHandler& res,
-           int nq,
-           size_t nb,
-           int bbs,
-           int nsq,
-           const uint8_t* codes,
-           const uint8_t* LUT,
-           const NormTableScaler* scaler,
-           size_t block_stride) {
-        pq4_accumulate_loop_fixed_handler(
-                nq, nb, bbs, nsq, codes, LUT, res, scaler, block_stride);
-    }
-};
 
 } // anonymous namespace
 
@@ -220,11 +205,20 @@ void pq4_accumulate_loop(
         const uint8_t* codes,
         const uint8_t* LUT,
         SIMDResultHandler& res,
-        const NormTableScaler* scaler,
+        int pq2x4_scale,
         size_t block_stride) {
-    Run_pq4_accumulate_loop consumer;
-    dispatch_SIMDResultHandler(
-            res, consumer, nq, nb, bbs, nsq, codes, LUT, scaler, block_stride);
+    with_SIMDResultHandler(res, [&](auto& handler) {
+        pq4_accumulate_loop_fixed_handler(
+                nq,
+                nb,
+                bbs,
+                nsq,
+                codes,
+                LUT,
+                handler,
+                pq2x4_scale,
+                block_stride);
+    });
 }
 
 } // namespace faiss

--- a/faiss/impl/fast_scan/pq4_fast_scan_search_qbs.cpp
+++ b/faiss/impl/fast_scan/pq4_fast_scan_search_qbs.cpp
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <faiss/impl/pq4_fast_scan.h>
+#include <faiss/impl/fast_scan/pq4_fast_scan.h>
 
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/impl/LookupTableScaler.h>
-#include <faiss/impl/simd_result_handlers.h>
+#include <faiss/impl/fast_scan/LookupTableScaler.h>
+#include <faiss/impl/fast_scan/simd_result_handlers.h>
 
 namespace faiss {
 
@@ -723,27 +723,6 @@ void pq4_accumulate_loop_qbs_fixed_scaler(
     }
 }
 
-struct Run_pq4_accumulate_loop_qbs {
-    template <class ResultHandler>
-    void f(ResultHandler& res,
-           int qbs,
-           size_t nb,
-           int nsq,
-           const uint8_t* codes,
-           const uint8_t* LUT,
-           const NormTableScaler* scaler,
-           size_t block_stride) {
-        if (scaler) {
-            pq4_accumulate_loop_qbs_fixed_scaler(
-                    qbs, nb, nsq, codes, LUT, res, *scaler, block_stride);
-        } else {
-            DummyScaler dummy;
-            pq4_accumulate_loop_qbs_fixed_scaler(
-                    qbs, nb, nsq, codes, LUT, res, dummy, block_stride);
-        }
-    }
-};
-
 } // namespace
 
 void pq4_accumulate_loop_qbs(
@@ -753,11 +732,19 @@ void pq4_accumulate_loop_qbs(
         const uint8_t* codes,
         const uint8_t* LUT,
         SIMDResultHandler& res,
-        const NormTableScaler* scaler,
+        int pq2x4_scale,
         size_t block_stride) {
-    Run_pq4_accumulate_loop_qbs consumer;
-    dispatch_SIMDResultHandler(
-            res, consumer, qbs, nb, nsq, codes, LUT, scaler, block_stride);
+    with_SIMDResultHandler(res, [&](auto& handler) {
+        if (pq2x4_scale) {
+            NormTableScaler<> scaler(pq2x4_scale);
+            pq4_accumulate_loop_qbs_fixed_scaler(
+                    qbs, nb, nsq, codes, LUT, handler, scaler, block_stride);
+        } else {
+            DummyScaler<> dummy;
+            pq4_accumulate_loop_qbs_fixed_scaler(
+                    qbs, nb, nsq, codes, LUT, handler, dummy, block_stride);
+        }
+    });
 }
 
 /***************************************************************
@@ -783,8 +770,8 @@ void accumulate_to_mem(
         const uint8_t* LUT,
         uint16_t* accu) {
     FAISS_THROW_IF_NOT(ntotal2 % 32 == 0);
-    StoreResultHandler handler(accu, ntotal2);
-    DummyScaler scaler;
+    StoreResultHandler<> handler(accu, ntotal2);
+    DummyScaler<> scaler;
     accumulate(nq, ntotal2, nsq, codes, LUT, handler, scaler, 32 * nsq / 2);
 }
 

--- a/faiss/impl/fast_scan/simd_result_handlers.h
+++ b/faiss/impl/fast_scan/simd_result_handlers.h
@@ -101,7 +101,11 @@ namespace simd_result_handlers {
 
 /** Dummy structure that just computes a checksum on results
  * (to avoid the computation to be optimized away) */
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
 struct DummyResultHandler : SIMDResultHandler {
+    static constexpr SIMDLevel SL256 = simd256_level_selector<SL>::value;
+    using simd16uint16 = simd16uint16_tpl<SL256>;
+
     size_t cs = 0;
 
     void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
@@ -117,7 +121,11 @@ struct DummyResultHandler : SIMDResultHandler {
  *
  * j0 is the current upper-left block of the matrix
  */
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
 struct StoreResultHandler : SIMDResultHandler {
+    static constexpr SIMDLevel SL256 = simd256_level_selector<SL>::value;
+    using simd16uint16 = simd16uint16_tpl<SL256>;
+
     uint16_t* data;
     size_t ld; // total number of columns
     size_t i0 = 0;
@@ -138,8 +146,11 @@ struct StoreResultHandler : SIMDResultHandler {
 };
 
 /** stores results in fixed-size matrix. */
-template <int NQ, int BB>
+template <int NQ, int BB, SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
 struct FixedStorageHandler : SIMDResultHandler {
+    static constexpr SIMDLevel SL256 = simd256_level_selector<SL>::value;
+    using simd16uint16 = simd16uint16_tpl<SL256>;
+
     simd16uint16 dis[NQ][BB];
     int i0 = 0;
 
@@ -166,9 +177,11 @@ struct FixedStorageHandler : SIMDResultHandler {
 };
 
 /** Result handler that compares distances to check if they need to be kept */
-template <class C, bool with_id_map>
+template <class C, bool with_id_map, SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
 struct ResultHandlerCompare : SIMDResultHandlerToFloat {
     using TI = typename C::TI;
+    static constexpr SIMDLevel SL256 = simd256_level_selector<SL>::value;
+    using simd16uint16 = simd16uint16_tpl<SL256>;
 
     bool disable = false;
 
@@ -248,12 +261,16 @@ struct ResultHandlerCompare : SIMDResultHandlerToFloat {
 };
 
 /** Special version for k=1 */
-template <class C, bool with_id_map = false>
-struct SingleResultHandler : ResultHandlerCompare<C, with_id_map> {
+template <
+        class C,
+        bool with_id_map = false,
+        SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
+struct SingleResultHandler : ResultHandlerCompare<C, with_id_map, SL> {
     using T = typename C::T;
     using TI = typename C::TI;
-    using RHC = ResultHandlerCompare<C, with_id_map>;
+    using RHC = ResultHandlerCompare<C, with_id_map, SL>;
     using RHC::normalizers;
+    using typename RHC::simd16uint16;
 
     std::vector<int16_t> idis;
     float* dis;
@@ -330,12 +347,16 @@ struct SingleResultHandler : ResultHandlerCompare<C, with_id_map> {
 };
 
 /** Structure that collects results in a min- or max-heap */
-template <class C, bool with_id_map = false>
-struct HeapHandler : ResultHandlerCompare<C, with_id_map> {
+template <
+        class C,
+        bool with_id_map = false,
+        SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
+struct HeapHandler : ResultHandlerCompare<C, with_id_map, SL> {
     using T = typename C::T;
     using TI = typename C::TI;
-    using RHC = ResultHandlerCompare<C, with_id_map>;
+    using RHC = ResultHandlerCompare<C, with_id_map, SL>;
     using RHC::normalizers;
+    using typename RHC::simd16uint16;
 
     std::vector<uint16_t> idis;
     std::vector<TI> iids;
@@ -461,12 +482,16 @@ struct HeapHandler : ResultHandlerCompare<C, with_id_map> {
  * reached. Then a partition sort is used to update the threshold. */
 
 /** Handler built from several ReservoirTopN (one per query) */
-template <class C, bool with_id_map = false>
-struct ReservoirHandler : ResultHandlerCompare<C, with_id_map> {
+template <
+        class C,
+        bool with_id_map = false,
+        SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
+struct ReservoirHandler : ResultHandlerCompare<C, with_id_map, SL> {
     using T = typename C::T;
     using TI = typename C::TI;
-    using RHC = ResultHandlerCompare<C, with_id_map>;
+    using RHC = ResultHandlerCompare<C, with_id_map, SL>;
     using RHC::normalizers;
+    using typename RHC::simd16uint16;
 
     size_t capacity; // rounded up to multiple of 16
 
@@ -584,13 +609,17 @@ struct ReservoirHandler : ResultHandlerCompare<C, with_id_map> {
  * have to be scaled using the scaler.
  */
 
-template <class C, bool with_id_map = false>
-struct RangeHandler : ResultHandlerCompare<C, with_id_map> {
+template <
+        class C,
+        bool with_id_map = false,
+        SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
+struct RangeHandler : ResultHandlerCompare<C, with_id_map, SL> {
     using T = typename C::T;
     using TI = typename C::TI;
-    using RHC = ResultHandlerCompare<C, with_id_map>;
+    using RHC = ResultHandlerCompare<C, with_id_map, SL>;
     using RHC::normalizers;
     using RHC::nq;
+    using typename RHC::simd16uint16;
 
     RangeSearchResult& rres;
     float radius;
@@ -690,11 +719,14 @@ struct RangeHandler : ResultHandlerCompare<C, with_id_map> {
 #ifndef SWIG
 
 // handler for a subset of queries
-template <class C, bool with_id_map = false>
-struct PartialRangeHandler : RangeHandler<C, with_id_map> {
+template <
+        class C,
+        bool with_id_map = false,
+        SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
+struct PartialRangeHandler : RangeHandler<C, with_id_map, SL> {
     using T = typename C::T;
     using TI = typename C::TI;
-    using RHC = RangeHandler<C, with_id_map>;
+    using RHC = RangeHandler<C, with_id_map, SL>;
     using RHC::normalizers;
     using RHC::nq, RHC::q0, RHC::triplets, RHC::n_per_query;
 
@@ -707,7 +739,11 @@ struct PartialRangeHandler : RangeHandler<C, with_id_map> {
             size_t q0,
             size_t q1,
             const IDSelector* sel_in)
-            : RangeHandler<C, with_id_map>(*pres.res, radius, ntotal, sel_in),
+            : RangeHandler<C, with_id_map, SL>(
+                      *pres.res,
+                      radius,
+                      ntotal,
+                      sel_in),
               pres(pres) {
         nq = q1 - q0;
         this->q0 = q0;
@@ -752,75 +788,65 @@ struct PartialRangeHandler : RangeHandler<C, with_id_map> {
 #endif
 
 /********************************************************************************
- * Dynamic dispatching function. The consumer should have a templatized method f
- * that will be replaced with the actual SIMDResultHandler that is determined
- * dynamically.
+ * Dynamic dispatching function. Calls a lambda with the concrete
+ * SIMDResultHandler type, determined at runtime via dynamic_cast.
+ *
+ * Usage:
+ *   with_SIMDResultHandler(res, [&](auto& handler) {
+ *       // handler has the concrete type (HeapHandler, ReservoirHandler, etc.)
+ *       kernel(handler, ...);
+ *   });
  */
 
-template <class C, bool W, class Consumer, class... Types>
-void dispatch_SIMDResultHandler_fixedCW(
-        SIMDResultHandler& res,
-        Consumer& consumer,
-        Types... args) {
-    if (auto resh_sh = dynamic_cast<SingleResultHandler<C, W>*>(&res)) {
-        consumer.template f<SingleResultHandler<C, W>>(*resh_sh, args...);
-    } else if (auto resh_hh = dynamic_cast<HeapHandler<C, W>*>(&res)) {
-        consumer.template f<HeapHandler<C, W>>(*resh_hh, args...);
-    } else if (auto resh_rh = dynamic_cast<ReservoirHandler<C, W>*>(&res)) {
-        consumer.template f<ReservoirHandler<C, W>>(*resh_rh, args...);
-    } else { // generic handler -- will not be inlined
-        FAISS_THROW_IF_NOT_FMT(
-                simd_result_handlers_accept_virtual,
-                "Running virtual handler for %s",
-                typeid(res).name());
-        consumer.template f<SIMDResultHandler>(res, args...);
-    }
-}
+template <class Lambda>
+void with_SIMDResultHandler(SIMDResultHandler& res, Lambda&& lambda) {
+    auto fixedCW = [&]<class C, bool W>() {
+        if (auto resh = dynamic_cast<SingleResultHandler<C, W>*>(&res)) {
+            lambda(*resh);
+        } else if (auto resh = dynamic_cast<HeapHandler<C, W>*>(&res)) {
+            lambda(*resh);
+        } else if (auto resh = dynamic_cast<ReservoirHandler<C, W>*>(&res)) {
+            lambda(*resh);
+        } else { // generic handler -- will not be inlined
+            FAISS_THROW_IF_NOT_FMT(
+                    simd_result_handlers_accept_virtual,
+                    "Running virtual handler for %s",
+                    typeid(res).name());
+            lambda(res);
+        }
+    };
 
-template <class C, class Consumer, class... Types>
-void dispatch_SIMDResultHandler_fixedC(
-        SIMDResultHandler& res,
-        Consumer& consumer,
-        Types... args) {
-    if (res.with_fields) {
-        dispatch_SIMDResultHandler_fixedCW<C, true>(res, consumer, args...);
-    } else {
-        dispatch_SIMDResultHandler_fixedCW<C, false>(res, consumer, args...);
-    }
-}
+    auto fixedC = [&]<class C>() {
+        if (res.with_fields) {
+            fixedCW.template operator()<C, true>();
+        } else {
+            fixedCW.template operator()<C, false>();
+        }
+    };
 
-template <class Consumer, class... Types>
-void dispatch_SIMDResultHandler(
-        SIMDResultHandler& res,
-        Consumer& consumer,
-        Types... args) {
     if (res.sizeof_ids == 0) {
-        if (auto resh = dynamic_cast<StoreResultHandler*>(&res)) {
-            consumer.template f<StoreResultHandler>(*resh, args...);
-        } else if (auto resh_2 = dynamic_cast<DummyResultHandler*>(&res)) {
-            consumer.template f<DummyResultHandler>(*resh_2, args...);
+        if (auto resh = dynamic_cast<StoreResultHandler<>*>(&res)) {
+            lambda(*resh);
+        } else if (auto resh = dynamic_cast<DummyResultHandler<>*>(&res)) {
+            lambda(*resh);
         } else { // generic path
             FAISS_THROW_IF_NOT_FMT(
                     simd_result_handlers_accept_virtual,
                     "Running virtual handler for %s",
                     typeid(res).name());
-            consumer.template f<SIMDResultHandler>(res, args...);
+            lambda(res);
         }
     } else if (res.sizeof_ids == sizeof(int)) {
         if (res.is_CMax) {
-            dispatch_SIMDResultHandler_fixedC<CMax<uint16_t, int>>(
-                    res, consumer, args...);
+            fixedC.template operator()<CMax<uint16_t, int>>();
         } else {
-            dispatch_SIMDResultHandler_fixedC<CMin<uint16_t, int>>(
-                    res, consumer, args...);
+            fixedC.template operator()<CMin<uint16_t, int>>();
         }
     } else if (res.sizeof_ids == sizeof(int64_t)) {
         if (res.is_CMax) {
-            dispatch_SIMDResultHandler_fixedC<CMax<uint16_t, int64_t>>(
-                    res, consumer, args...);
+            fixedC.template operator()<CMax<uint16_t, int64_t>>();
         } else {
-            dispatch_SIMDResultHandler_fixedC<CMin<uint16_t, int64_t>>(
-                    res, consumer, args...);
+            fixedC.template operator()<CMin<uint16_t, int64_t>>();
         }
     } else {
         FAISS_THROW_FMT("Unknown id size %d", res.sizeof_ids);

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -105,9 +105,9 @@ typedef uint64_t size_t;
 #include <faiss/IndexFastScan.h>
 #include <faiss/IndexAdditiveQuantizerFastScan.h>
 #include <faiss/IndexPQFastScan.h>
-#include <faiss/impl/FastScanDistancePostProcessing.h>
+#include <faiss/impl/fast_scan/FastScanDistancePostProcessing.h>
 #include <faiss/impl/simdlib/simdlib_dispatch.h>
-#include <faiss/impl/simd_result_handlers.h>
+#include <faiss/impl/fast_scan/simd_result_handlers.h>
 
 #include <faiss/IndexIVFFastScan.h>
 #include <faiss/IndexIVFAdditiveQuantizerFastScan.h>
@@ -597,7 +597,7 @@ void gpu_sync_all_devices()
 %include  <faiss/IndexIVFPQR.h>
 %include  <faiss/Index2Layer.h>
 
-%include  <faiss/impl/FastScanDistancePostProcessing.h>
+%include  <faiss/impl/fast_scan/FastScanDistancePostProcessing.h>
 
 // Ignore make_knn_handler methods — they return SIMDResultHandlerToFloat*
 // which is an internal SIMD type not exposed to Python.
@@ -613,7 +613,7 @@ void gpu_sync_all_devices()
 // NOTE(matthijs) simd_result_handlers.h uses simd16uint16 which is now a
 // class template. SWIG cannot handle this, and the Python API doesn't need
 // the internal SIMD handler types.
-// %include  <faiss/impl/simd_result_handlers.h>
+// %include  <faiss/impl/fast_scan/simd_result_handlers.h>
 %include  <faiss/IndexIVFFastScan.h>
 %include  <faiss/IndexIVFAdditiveQuantizerFastScan.h>
 %include  <faiss/IndexIVFIndependentQuantizer.h>

--- a/tests/test_pq_encoding.cpp
+++ b/tests/test_pq_encoding.cpp
@@ -13,7 +13,7 @@
 
 #include <faiss/IndexPQFastScan.h>
 #include <faiss/impl/ProductQuantizer.h>
-#include <faiss/impl/pq4_fast_scan.h>
+#include <faiss/impl/fast_scan/pq4_fast_scan.h>
 
 namespace {
 

--- a/tests/test_pqfs_unaligned.cpp
+++ b/tests/test_pqfs_unaligned.cpp
@@ -12,7 +12,7 @@
 #include <vector>
 
 #include <faiss/IndexIVF.h>
-#include <faiss/impl/pq4_fast_scan.h>
+#include <faiss/impl/fast_scan/pq4_fast_scan.h>
 #include <faiss/utils/AlignedTable.h>
 #include <faiss/utils/random.h>
 


### PR DESCRIPTION
Summary:
Templatize the result handler hierarchy and scaler types on SIMDLevel SL,
defaulted to SINGLE_SIMD_LEVEL_256. This allows per-SIMD TUs to instantiate
handlers and scalers with explicit SIMD levels (e.g., AVX2) for native
dispatch.

Result handlers: ResultHandlerCompare, SingleResultHandler, HeapHandler,
ReservoirHandler, RangeHandler, PartialRangeHandler — all gain SL parameter.

Scalers: DummyScaler templatized on SL. 512-bit methods use SL directly
(removing #ifdef __AVX512F__ guard — safe because template bodies only
instantiated when called). NormTableScaler stays non-template (public API).

FixedStorageHandler: add SL parameter, remove SIMDResultHandler base class
(never used polymorphically), remove final/virtual.

Pure refactor. All existing callers use defaults and compile unchanged.

Differential Revision: D95392149


