### PR TITLE
Upgrade to C++20 for CUVS (#4881)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,11 +53,7 @@ project(faiss
   LANGUAGES ${FAISS_LANGUAGES})
 include(GNUInstallDirs)
 
-if(FAISS_ENABLE_CUVS)
-  set(CMAKE_CXX_STANDARD 17)
-else()
-  set(CMAKE_CXX_STANDARD 20)
-endif()
+set(CMAKE_CXX_STANDARD 20)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -61,7 +61,7 @@ found to run on other platforms as well, see
 [other platforms](https://github.com/facebookresearch/faiss/wiki/Related-projects#bindings-to-other-languages-and-porting-to-other-platforms).
 
 The basic requirements are:
-- a C++17 compiler (with OpenMP support version 2 or higher),
+- a C++20 compiler (with OpenMP support version 2 or higher),
 - a BLAS implementation (on Intel machines we strongly recommend using Intel MKL for best
 performance).
 

--- a/faiss/python/CMakeLists.txt
+++ b/faiss/python/CMakeLists.txt
@@ -10,11 +10,7 @@ project(pyfaiss
   HOMEPAGE_URL "https://github.com/facebookresearch/faiss"
   LANGUAGES CXX)
 
-if(FAISS_ENABLE_CUVS)
-  set(CMAKE_CXX_STANDARD 17)
-else()
-  set(CMAKE_CXX_STANDARD 20)
-endif()
+set(CMAKE_CXX_STANDARD 20)
 
 find_package(SWIG REQUIRED COMPONENTS python)
 include(${SWIG_USE_FILE})


### PR DESCRIPTION
Summary:

Upgrades Faiss CUVS builds from C++17 to C++20. CUVS was updated from 25.10 to 26.02, which includes C++20 support (tracked in https://github.com/rapidsai/cuvs/issues/1659).

Changes:
- Remove the C++17 exception for CUVS in both `public_tld/CMakeLists.txt` and `python/CMakeLists.txt`, making C++20 unconditional across all platforms
- Update INSTALL.md to reflect the new cuVS version and C++20 compiler requirement

Differential Revision: D95573957


