### PR TITLE
Fix cloning for IVFFlatPanorama

### DIFF
--- a/faiss/clone_index.cpp
+++ b/faiss/clone_index.cpp
@@ -102,8 +102,8 @@ IndexIVF* Cloner::clone_IndexIVF(const IndexIVF* ivf) {
     TRYCLONE(IndexIVFRaBitQ, ivf)
 
     TRYCLONE(IndexIVFFlatDedup, ivf)
-    TRYCLONE(IndexIVFFlat, ivf)
     TRYCLONE(IndexIVFFlatPanorama, ivf)
+    TRYCLONE(IndexIVFFlat, ivf)
 
     TRYCLONE(IndexIVFSpectralHash, ivf)
 

--- a/tests/test_ivflib.py
+++ b/tests/test_ivflib.py
@@ -440,3 +440,32 @@ class TestIvfSharding(unittest.TestCase):
         )
         self.verify_sharded_ivf_indexes(
             template, xb, shard_count, self.custom_sharding_function)
+
+    def test_save_index_shards_by_centroids_panorama(self):
+        """Test sharding for IndexIVFFlatPanorama."""
+        xb = np.random.rand(self.nb, self.d).astype('float32')
+        quantizer = faiss.IndexFlatL2(self.d)
+        n_levels = 4
+        index = faiss.IndexIVFFlatPanorama(
+            quantizer, self.d, self.nlist, n_levels)
+        shard_count = 5
+
+        index.quantizer.add(xb)
+
+        template = str(random.randint(0, 100000)) + "shard.%d.panorama.index"
+        faiss.shard_ivf_index_centroids(
+            index,
+            shard_count,
+            template,
+            None,
+            True
+        )
+
+        # Verify shards are IndexIVFFlatPanorama after read-back
+        for i in range(shard_count):
+            fname = template % i
+            shard = faiss.read_index(fname)
+            self.assertIsInstance(shard, faiss.IndexIVFFlatPanorama)
+
+        self.verify_sharded_ivf_indexes(
+            template, xb, shard_count, self.default_sharding_function)


### PR DESCRIPTION
Summary: Has to be checked before IVFFlat, otherwise deserialize will give an IVFFlat rather than IVFFlatPanorama.

Differential Revision: D95647196


