### PR TITLE
Partial Optimization for IVFPQ

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -32,10 +32,14 @@ set(FAISS_SIMD_NEON_SRC
   impl/fast_scan/impl-neon.cpp
   impl/scalar_quantizer/sq-neon.cpp
   impl/approx_topk/neon.cpp
+  impl/ProductQuantizer-neon.cpp
+  impl/pq_code_distance/pq_code_distance-neon.cpp
   utils/simd_impl/distances_aarch64.cpp
+  utils/simd_impl/distances_neon.cpp
   utils/simd_impl/partitioning_neon.cpp
   utils/distances_fused/simdlib_based_neon.cpp
   utils/simd_impl/rabitq_neon.cpp
+  utils/simd_impl/matrix_transpose_neon.cpp
 )
 set(FAISS_SIMD_SVE_SRC
   impl/pq_code_distance/pq_code_distance-sve.cpp
@@ -489,6 +493,11 @@ endif()
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64|arm64|ARM64)")
   target_compile_definitions(faiss PRIVATE COMPILE_SIMD_ARM_NEON)
   target_sources(faiss PRIVATE ${FAISS_SIMD_NEON_SRC})
+  # ProductQuantizer-neon.cpp uses vdotq_s32 which requires ARMv8.2-a+dotprod
+  set_source_files_properties(impl/ProductQuantizer-neon.cpp
+    TARGET_DIRECTORY faiss
+    PROPERTIES COMPILE_OPTIONS "-march=armv8.2-a+dotprod"
+  )
 endif()
 
 if(FAISS_ENABLE_SVS)

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -33,6 +33,29 @@
 
 namespace faiss {
 
+#ifdef COMPILE_SIMD_ARM_NEON
+namespace pq_code_distance {
+// Forward declarations for NEON batch functions
+void pq_code_distance_batch(
+        size_t M,
+        size_t nbits,
+        size_t ncode,
+        const uint8_t* codes,
+        const float* sim_table,
+        float* dis,
+        float dis0);
+
+void pq_code_distance_batch_by_idx(
+        size_t M,
+        size_t ncode,
+        const uint8_t* codes,
+        const float* sim_table,
+        float* dis,
+        float dis0,
+        const size_t* idx);
+} // namespace pq_code_distance
+#endif
+
 /*****************************************
  * IndexIVFPQ implementation
  ******************************************/
@@ -814,6 +837,8 @@ struct IVFPQScannerT : QueryTables {
     }
 
     float dis0;
+    mutable std::vector<float> dis_buffer;
+    mutable std::vector<size_t> idx_buffer;
 
     void init_list(idx_t list_no, float coarse_dis_in, int mode) {
         this->key = list_no;
@@ -926,6 +951,59 @@ struct IVFPQScannerT : QueryTables {
                                 sim_table,
                                 codes + saved_j[2] * pq.code_size);
             res.add(saved_j[2], dis);
+        }
+    }
+
+    /// Batch version using pq_code_distance_batch for ARM_NEON optimization
+    template <class SearchResultType>
+    void scan_list_with_table_batch(
+            size_t ncode,
+            const uint8_t* codes,
+            SearchResultType& res) const {
+        if (dis_buffer.size() < ncode) {
+            dis_buffer.resize(ncode);
+        }
+
+        pq_code_distance::pq_code_distance_batch(
+                pq.M, pq.nbits, ncode, codes, sim_table, dis_buffer.data(), dis0);
+
+        for (size_t j = 0; j < ncode; j++) {
+            if (!res.skip_entry(j)) {
+                res.add(j, dis_buffer[j]);
+            }
+        }
+    }
+
+    /// Batch version with IDSelector pre-filtering for ARM_NEON optimization.
+    template <class SearchResultType>
+    void scan_list_with_table_batch_sel(
+            size_t ncode,
+            const uint8_t* codes,
+            SearchResultType& res) const {
+        // Build index list of passing entries
+        if (idx_buffer.size() < ncode) {
+            idx_buffer.resize(ncode);
+        }
+        size_t npass = 0;
+        for (size_t i = 0; i < ncode; i++) {
+            if (!res.skip_entry(i)) {
+                idx_buffer[npass++] = i;
+            }
+        }
+        if (npass == 0) {
+            return;
+        }
+        if (dis_buffer.size() < npass) {
+            dis_buffer.resize(npass);
+        }
+        // Compute distances only for passing entries
+        for (size_t j = 0; j < npass; j++) {
+            dis_buffer[j] = pq_code_distance_single(
+                    pq.M, pq.nbits, sim_table,
+                    codes + idx_buffer[j] * pq.code_size) + dis0;
+        }
+        for (size_t j = 0; j < npass; j++) {
+            res.add(idx_buffer[j], dis_buffer[j]);
         }
     }
 
@@ -1237,7 +1315,21 @@ struct IVFPQScanner : IVFPQScannerT<idx_t, METRIC_TYPE, PQCodeDist>,
             FAISS_THROW_IF_NOT(precompute_mode == 2);
             this->scan_list_polysemous(ncode, codes, res);
         } else if (precompute_mode == 2) {
+#ifdef COMPILE_SIMD_ARM_NEON
+            if (SIMDConfig::level == SIMDLevel::ARM_NEON && this->pq.nbits == 8) {
+                if constexpr (use_sel) {
+                    // ARM_NEON + IDSelector: pre-filter then batch compute
+                    this->scan_list_with_table_batch_sel(ncode, codes, res);
+                } else {
+                    // ARM_NEON, no IDSelector: full batch compute
+                    this->scan_list_with_table_batch(ncode, codes, res);
+                }
+            } else {
+                this->scan_list_with_table(ncode, codes, res);
+            }
+#else
             this->scan_list_with_table(ncode, codes, res);
+#endif
         } else if (precompute_mode == 1) {
             this->scan_list_with_pointer(ncode, codes, res);
         } else if (precompute_mode == 0) {

--- a/faiss/impl/ProductQuantizer-neon.cpp
+++ b/faiss/impl/ProductQuantizer-neon.cpp
@@ -1,0 +1,637 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Copyright (c) Huawei Technologies Co., Ltd.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NEON-optimized ProductQuantizer distance table computation.
+// precision=0 (FP32): block-transposed fp32 + continuous_transpose kernels
+// precision=1 (INT8): quantized int8 centroids + int8 dot-product kernels
+// precision=2 (FP16): quantized fp16 centroids + fp16 kernels
+
+#ifdef COMPILE_SIMD_ARM_NEON
+
+#include <arm_neon.h>
+#include <cstring>
+#include <vector>
+
+#include <faiss/impl/ProductQuantizer.h>
+#include <faiss/impl/FaissAssert.h>
+
+namespace faiss {
+void matrix_block_transpose_neon(
+        const uint32_t* src,
+        size_t ny,
+        size_t dim,
+        size_t blocksize,
+        uint32_t* block);
+} // namespace faiss
+
+namespace faiss {
+
+// blocksize == 16
+static void ip_continuous_transpose_16(
+        float* dis,
+        const float* x,
+        const float* y,
+        size_t dsub) {
+    float32x4_t res[4];
+    float32x4_t q = vdupq_n_f32(x[0]);
+    res[0] = vmulq_f32(vld1q_f32(y), q);
+    res[1] = vmulq_f32(vld1q_f32(y + 4), q);
+    res[2] = vmulq_f32(vld1q_f32(y + 8), q);
+    res[3] = vmulq_f32(vld1q_f32(y + 12), q);
+    for (size_t i = 1; i < dsub; ++i) {
+        q = vdupq_n_f32(x[i]);
+        res[0] = vmlaq_f32(res[0], vld1q_f32(y + 16 * i), q);
+        res[1] = vmlaq_f32(res[1], vld1q_f32(y + 16 * i + 4), q);
+        res[2] = vmlaq_f32(res[2], vld1q_f32(y + 16 * i + 8), q);
+        res[3] = vmlaq_f32(res[3], vld1q_f32(y + 16 * i + 12), q);
+    }
+    vst1q_f32(dis, res[0]);
+    vst1q_f32(dis + 4, res[1]);
+    vst1q_f32(dis + 8, res[2]);
+    vst1q_f32(dis + 12, res[3]);
+}
+
+// blocksize == 32
+static void ip_continuous_transpose_32(
+        float* dis,
+        const float* x,
+        const float* y,
+        size_t dsub) {
+    float32x4_t res[8];
+    float32x4_t q = vdupq_n_f32(x[0]);
+    for (int j = 0; j < 8; j++) {
+        res[j] = vmulq_f32(vld1q_f32(y + j * 4), q);
+    }
+    for (size_t i = 1; i < dsub; ++i) {
+        q = vdupq_n_f32(x[i]);
+        for (int j = 0; j < 8; j++) {
+            res[j] = vmlaq_f32(res[j], vld1q_f32(y + 32 * i + j * 4), q);
+        }
+    }
+    for (int j = 0; j < 8; j++) {
+        vst1q_f32(dis + j * 4, res[j]);
+    }
+}
+
+// blocksize == 64
+static void ip_continuous_transpose_64(
+        float* dis,
+        const float* x,
+        const float* y,
+        size_t dsub) {
+    float32x4_t res[16];
+    float32x4_t q = vdupq_n_f32(x[0]);
+    for (int j = 0; j < 16; j++) {
+        res[j] = vmulq_f32(vld1q_f32(y + j * 4), q);
+    }
+    for (size_t i = 1; i < dsub; ++i) {
+        q = vdupq_n_f32(x[i]);
+        for (int j = 0; j < 16; j++) {
+            res[j] = vmlaq_f32(res[j], vld1q_f32(y + 64 * i + j * 4), q);
+        }
+    }
+    for (int j = 0; j < 16; j++) {
+        vst1q_f32(dis + j * 4, res[j]);
+    }
+}
+
+// blocksize == 16, computes ||centroid[j] - x||^2 for j=0..15
+static void l2_continuous_transpose_16(
+        float* dis,
+        const float* x,
+        const float* y,
+        size_t dsub) {
+    // Initialize with (y[j][0] - x[0])^2 for j=0..15
+    float32x4_t q0 = vdupq_n_f32(x[0]);
+    float32x4_t d0 = vsubq_f32(vld1q_f32(y), q0);
+    float32x4_t d1 = vsubq_f32(vld1q_f32(y + 4), q0);
+    float32x4_t d2 = vsubq_f32(vld1q_f32(y + 8), q0);
+    float32x4_t d3 = vsubq_f32(vld1q_f32(y + 12), q0);
+    float32x4_t res0 = vmulq_f32(d0, d0);
+    float32x4_t res1 = vmulq_f32(d1, d1);
+    float32x4_t res2 = vmulq_f32(d2, d2);
+    float32x4_t res3 = vmulq_f32(d3, d3);
+    for (size_t i = 1; i < dsub; ++i) {
+        q0 = vdupq_n_f32(x[i]);
+        d0 = vsubq_f32(vld1q_f32(y + 16 * i), q0);
+        d1 = vsubq_f32(vld1q_f32(y + 16 * i + 4), q0);
+        d2 = vsubq_f32(vld1q_f32(y + 16 * i + 8), q0);
+        d3 = vsubq_f32(vld1q_f32(y + 16 * i + 12), q0);
+        res0 = vmlaq_f32(res0, d0, d0);
+        res1 = vmlaq_f32(res1, d1, d1);
+        res2 = vmlaq_f32(res2, d2, d2);
+        res3 = vmlaq_f32(res3, d3, d3);
+    }
+    vst1q_f32(dis, res0);
+    vst1q_f32(dis + 4, res1);
+    vst1q_f32(dis + 8, res2);
+    vst1q_f32(dis + 12, res3);
+}
+
+// blocksize == 32
+static void l2_continuous_transpose_32(
+        float* dis,
+        const float* x,
+        const float* y,
+        size_t dsub) {
+    float32x4_t res[8];
+    float32x4_t q = vdupq_n_f32(x[0]);
+    for (int j = 0; j < 8; j++) {
+        float32x4_t d = vsubq_f32(vld1q_f32(y + j * 4), q);
+        res[j] = vmulq_f32(d, d);
+    }
+    for (size_t i = 1; i < dsub; ++i) {
+        q = vdupq_n_f32(x[i]);
+        for (int j = 0; j < 8; j++) {
+            float32x4_t d = vsubq_f32(vld1q_f32(y + 32 * i + j * 4), q);
+            res[j] = vmlaq_f32(res[j], d, d);
+        }
+    }
+    for (int j = 0; j < 8; j++) {
+        vst1q_f32(dis + j * 4, res[j]);
+    }
+}
+
+// blocksize == 64
+static void l2_continuous_transpose_64(
+        float* dis,
+        const float* x,
+        const float* y,
+        size_t dsub) {
+    float32x4_t res[16];
+    float32x4_t q = vdupq_n_f32(x[0]);
+    for (int j = 0; j < 16; j++) {
+        float32x4_t d = vsubq_f32(vld1q_f32(y + j * 4), q);
+        res[j] = vmulq_f32(d, d);
+    }
+    for (size_t i = 1; i < dsub; ++i) {
+        q = vdupq_n_f32(x[i]);
+        for (int j = 0; j < 16; j++) {
+            float32x4_t d = vsubq_f32(vld1q_f32(y + 64 * i + j * 4), q);
+            res[j] = vmlaq_f32(res[j], d, d);
+        }
+    }
+    for (int j = 0; j < 16; j++) {
+        vst1q_f32(dis + j * 4, res[j]);
+    }
+}
+
+static void compute_inner_prod_table_neon(
+        size_t M,
+        size_t ksub,
+        size_t dsub,
+        const float* x,          // query, shape (M, dsub)
+        const float* y,          // NEON transposed centroids, layout per subq: (dsub, ceil_ksub)
+        size_t ceil_ksub,        // ksub rounded up to blocksize
+        size_t blocksize,        // 16, 32, or 64
+        float* dis) {            // output, shape (M, ksub)
+    const size_t left = ksub & (blocksize - 1);
+    const float* yp = y;
+
+    for (size_t m = 0; m < M; m++) {
+        float* disp = dis + m * ksub;
+        const float* xp = x + m * dsub;
+
+        if (blocksize == 64) {
+            if (left) {
+                float tmp[64];
+                size_t i = 0;
+                for (; i + 64 <= ksub; i += 64) {
+                    ip_continuous_transpose_64(disp + i, xp, yp + i * dsub, dsub);
+                }
+                ip_continuous_transpose_64(tmp, xp, yp + i * dsub, dsub);
+                std::memcpy(disp + i, tmp, left * sizeof(float));
+            } else {
+                for (size_t i = 0; i < ksub; i += 64) {
+                    ip_continuous_transpose_64(disp + i, xp, yp + i * dsub, dsub);
+                }
+            }
+        } else if (blocksize == 32) {
+            if (left) {
+                float tmp[32];
+                size_t i = 0;
+                for (; i + 32 <= ksub; i += 32) {
+                    ip_continuous_transpose_32(disp + i, xp, yp + i * dsub, dsub);
+                }
+                ip_continuous_transpose_32(tmp, xp, yp + i * dsub, dsub);
+                std::memcpy(disp + i, tmp, left * sizeof(float));
+            } else {
+                for (size_t i = 0; i < ksub; i += 32) {
+                    ip_continuous_transpose_32(disp + i, xp, yp + i * dsub, dsub);
+                }
+            }
+        } else { // blocksize == 16
+            if (left) {
+                float tmp[16];
+                size_t i = 0;
+                for (; i + 16 <= ksub; i += 16) {
+                    ip_continuous_transpose_16(disp + i, xp, yp + i * dsub, dsub);
+                }
+                ip_continuous_transpose_16(tmp, xp, yp + i * dsub, dsub);
+                std::memcpy(disp + i, tmp, left * sizeof(float));
+            } else {
+                for (size_t i = 0; i < ksub; i += 16) {
+                    ip_continuous_transpose_16(disp + i, xp, yp + i * dsub, dsub);
+                }
+            }
+        }
+        yp += ceil_ksub * dsub;
+    }
+}
+
+static void compute_distance_table_neon(
+        size_t M,
+        size_t ksub,
+        size_t dsub,
+        const float* x,          // query, shape (M, dsub)
+        const float* y,          // NEON transposed centroids
+        size_t ceil_ksub,
+        size_t blocksize,
+        float* dis) {
+    const size_t left = ksub & (blocksize - 1);
+    const float* yp = y;
+
+    for (size_t m = 0; m < M; m++) {
+        float* disp = dis + m * ksub;
+        const float* xp = x + m * dsub;
+
+        if (blocksize == 64) {
+            if (left) {
+                float tmp[64];
+                size_t i = 0;
+                for (; i + 64 <= ksub; i += 64) {
+                    l2_continuous_transpose_64(disp + i, xp, yp + i * dsub, dsub);
+                }
+                l2_continuous_transpose_64(tmp, xp, yp + i * dsub, dsub);
+                std::memcpy(disp + i, tmp, left * sizeof(float));
+            } else {
+                for (size_t i = 0; i < ksub; i += 64) {
+                    l2_continuous_transpose_64(disp + i, xp, yp + i * dsub, dsub);
+                }
+            }
+        } else if (blocksize == 32) {
+            if (left) {
+                float tmp[32];
+                size_t i = 0;
+                for (; i + 32 <= ksub; i += 32) {
+                    l2_continuous_transpose_32(disp + i, xp, yp + i * dsub, dsub);
+                }
+                l2_continuous_transpose_32(tmp, xp, yp + i * dsub, dsub);
+                std::memcpy(disp + i, tmp, left * sizeof(float));
+            } else {
+                for (size_t i = 0; i < ksub; i += 32) {
+                    l2_continuous_transpose_32(disp + i, xp, yp + i * dsub, dsub);
+                }
+            }
+        } else { // blocksize == 16
+            if (left) {
+                float tmp[16];
+                size_t i = 0;
+                for (; i + 16 <= ksub; i += 16) {
+                    l2_continuous_transpose_16(disp + i, xp, yp + i * dsub, dsub);
+                }
+                l2_continuous_transpose_16(tmp, xp, yp + i * dsub, dsub);
+                std::memcpy(disp + i, tmp, left * sizeof(float));
+            } else {
+                for (size_t i = 0; i < ksub; i += 16) {
+                    l2_continuous_transpose_16(disp + i, xp, yp + i * dsub, dsub);
+                }
+            }
+        }
+        yp += ceil_ksub * dsub;
+    }
+}
+
+void ProductQuantizer::initialize_neon_transposed_centroids(
+        size_t blocksize,
+        int precision_mode) {
+    FAISS_THROW_IF_NOT_MSG(!centroids.empty(), "centroids must be set first");
+
+    using Precision = NeonTransposedCentroids::Precision;
+
+    // Clear all storage first
+    neon_transposed.data.clear();
+    neon_transposed.data_f16.clear();
+    neon_transposed.data_u8.clear();
+
+    if (precision_mode == 0) {
+        // FP32: block-transpose centroids for continuous_transpose kernels.
+        // Output layout per subquantizer: (num_blocks, dsub, blocksize)
+        // i.e. matrix_block_transpose_neon output for (ksub, dsub) input.
+        FAISS_THROW_IF_NOT_MSG(
+                blocksize == 16 || blocksize == 32 || blocksize == 64,
+                "blocksize must be 16, 32, or 64");
+        const size_t ceil_ksub = (ksub + blocksize - 1) & ~(blocksize - 1);
+        neon_transposed.precision = Precision::FP32;
+        neon_transposed.blocksize = blocksize;
+        neon_transposed.ceil_ksub = ceil_ksub;
+        // Total: M * ceil_ksub * dsub floats
+        neon_transposed.data.resize(M * ceil_ksub * dsub, 0.0f);
+        for (size_t m = 0; m < M; m++) {
+            matrix_block_transpose_neon(
+                    reinterpret_cast<const uint32_t*>(get_centroids(m, 0)),
+                    ksub,
+                    dsub,
+                    blocksize,
+                    reinterpret_cast<uint32_t*>(
+                            neon_transposed.data.data() +
+                            m * ceil_ksub * dsub));
+        }
+    } else if (precision_mode == 1) {
+        // INT8: quantize centroids to uint8 (L2) or int8 (IP).
+        // Layout: (M, ksub, dsub) uint8 — same as original centroids, just quantized.
+        // Query will be quantized on-the-fly at search time.
+        neon_transposed.precision = Precision::INT8;
+        neon_transposed.blocksize = 0;
+        neon_transposed.ceil_ksub = 0;
+        const size_t total = M * ksub * dsub;
+        neon_transposed.data_u8.resize(total);
+        // Quantize: map float to uint8 via round-to-nearest, clamp [0,255]
+        // Uses same approach as krl quant_u8: vcvtaq_u32_f32 + narrow
+        const float* src = centroids.data();
+        uint8_t* dst = neon_transposed.data_u8.data();
+        size_t i = 0;
+        for (; i + 16 <= total; i += 16) {
+            float32x4_t a0 = vld1q_f32(src + i);
+            float32x4_t a1 = vld1q_f32(src + i + 4);
+            float32x4_t a2 = vld1q_f32(src + i + 8);
+            float32x4_t a3 = vld1q_f32(src + i + 12);
+            uint32x4_t u0 = vcvtaq_u32_f32(a0);
+            uint32x4_t u1 = vcvtaq_u32_f32(a1);
+            uint32x4_t u2 = vcvtaq_u32_f32(a2);
+            uint32x4_t u3 = vcvtaq_u32_f32(a3);
+            uint16x8_t s01 = vcombine_u16(vqmovn_u32(u0), vqmovn_u32(u1));
+            uint16x8_t s23 = vcombine_u16(vqmovn_u32(u2), vqmovn_u32(u3));
+            uint8x16_t b = vcombine_u8(vqmovn_u16(s01), vqmovn_u16(s23));
+            vst1q_u8(dst + i, b);
+        }
+        for (; i < total; i++) {
+            float v = src[i];
+            dst[i] = (v < 0.f) ? 0 : (v > 255.f) ? 255 : (uint8_t)(v + 0.5f);
+        }
+    } else {
+        // FP16: quantize centroids to float16.
+        // Layout: (M, ksub, dsub) uint16 — same as original centroids, just quantized.
+        neon_transposed.precision = Precision::FP16;
+        neon_transposed.blocksize = 0;
+        neon_transposed.ceil_ksub = 0;
+        const size_t total = M * ksub * dsub;
+        neon_transposed.data_f16.resize(total);
+        const float* src = centroids.data();
+        uint16_t* dst = neon_transposed.data_f16.data();
+        size_t i = 0;
+        for (; i + 16 <= total; i += 16) {
+            float32x4_t a0 = vld1q_f32(src + i);
+            float32x4_t a1 = vld1q_f32(src + i + 4);
+            float32x4_t a2 = vld1q_f32(src + i + 8);
+            float32x4_t a3 = vld1q_f32(src + i + 12);
+            vst1_u16(dst + i,      vreinterpret_u16_f16(vcvt_f16_f32(a0)));
+            vst1_u16(dst + i + 4,  vreinterpret_u16_f16(vcvt_f16_f32(a1)));
+            vst1_u16(dst + i + 8,  vreinterpret_u16_f16(vcvt_f16_f32(a2)));
+            vst1_u16(dst + i + 12, vreinterpret_u16_f16(vcvt_f16_f32(a3)));
+        }
+        for (; i < total; i++) {
+            float16x4_t tmp = vcvt_f16_f32(vdupq_n_f32(src[i]));
+            vst1_lane_u16(dst + i, vreinterpret_u16_f16(tmp), 0);
+        }
+    }
+}
+
+static float ip_f16_scalar(
+        const float16_t* qx,
+        const float16_t* cy,
+        size_t dsub) {
+    float32x4_t acc = vdupq_n_f32(0.f);
+    size_t i = 0;
+    for (; i + 4 <= dsub; i += 4) {
+        float32x4_t xv = vcvt_f32_f16(vld1_f16(qx + i));
+        float32x4_t yv = vcvt_f32_f16(vld1_f16(cy + i));
+        acc = vmlaq_f32(acc, xv, yv);
+    }
+    float res = vaddvq_f32(acc);
+    for (; i < dsub; i++) {
+        res += (float)qx[i] * (float)cy[i];
+    }
+    return res;
+}
+
+// FP16 L2sqr: ||qx - cy||^2 in fp16 arithmetic, result float.
+static float l2_f16_scalar(
+        const float16_t* qx,
+        const float16_t* cy,
+        size_t dsub) {
+    float32x4_t acc = vdupq_n_f32(0.f);
+    size_t i = 0;
+    for (; i + 4 <= dsub; i += 4) {
+        float32x4_t xv = vcvt_f32_f16(vld1_f16(qx + i));
+        float32x4_t yv = vcvt_f32_f16(vld1_f16(cy + i));
+        float32x4_t dv = vsubq_f32(xv, yv);
+        acc = vmlaq_f32(acc, dv, dv);
+    }
+    float res = vaddvq_f32(acc);
+    for (; i < dsub; i++) {
+        float d = (float)qx[i] - (float)cy[i];
+        res += d * d;
+    }
+    return res;
+}
+
+// INT8 inner product: one int8 query subvector vs one uint8 centroid subvector.
+static int32_t ip_u8s8_scalar(
+        const int8_t* qx,
+        const uint8_t* cy,
+        size_t dsub) {
+    int32x4_t acc = vdupq_n_s32(0);
+    size_t i = 0;
+    for (; i + 16 <= dsub; i += 16) {
+        int8x16_t xv = vld1q_s8(qx + i);
+        // Reinterpret uint8 centroid as int8 for dot product
+        int8x16_t yv = vreinterpretq_s8_u8(vld1q_u8(cy + i));
+        acc = vdotq_s32(acc, xv, yv);
+    }
+    int32_t res = vaddvq_s32(acc);
+    for (; i < dsub; i++) {
+        res += (int32_t)qx[i] * (int32_t)(int8_t)cy[i];
+    }
+    return res;
+}
+
+// INT8 L2sqr: ||qx - cy||^2 with uint8 operands, result uint32.
+static uint32_t l2_u8_scalar(
+        const uint8_t* qx,
+        const uint8_t* cy,
+        size_t dsub) {
+    uint32x4_t acc = vdupq_n_u32(0);
+    size_t i = 0;
+    for (; i + 16 <= dsub; i += 16) {
+        uint8x16_t xv = vld1q_u8(qx + i);
+        uint8x16_t yv = vld1q_u8(cy + i);
+        uint8x16_t dv = vabdq_u8(xv, yv);
+        acc = vdotq_u32(acc, dv, dv);
+    }
+    uint32_t res = vaddvq_u32(acc);
+    for (; i < dsub; i++) {
+        int32_t d = (int32_t)qx[i] - (int32_t)cy[i];
+        res += (uint32_t)(d * d);
+    }
+    return res;
+}
+
+void pq_compute_inner_prod_table_neon(
+        const ProductQuantizer& pq,
+        const float* x,
+        float* dis_table) {
+    using Precision = ProductQuantizer::NeonTransposedCentroids::Precision;
+    const auto& nt = pq.neon_transposed;
+
+    if (nt.precision == Precision::FP32) {
+        // Block-transposed fp32 path — highest accuracy, uses continuous_transpose kernels
+        compute_inner_prod_table_neon(
+                pq.M,
+                pq.ksub,
+                pq.dsub,
+                x,
+                nt.data.data(),
+                nt.ceil_ksub,
+                nt.blocksize,
+                dis_table);
+    } else if (nt.precision == Precision::FP16) {
+        // FP16 path: quantize query x on-the-fly, compute IP vs fp16 centroids.
+        std::vector<float16_t> qx_f16(pq.M * pq.dsub);
+        // quant_f16: convert fp32 query to fp16
+        size_t total_q = pq.M * pq.dsub;
+        size_t qi = 0;
+        for (; qi + 4 <= total_q; qi += 4) {
+            vst1_f16(qx_f16.data() + qi, vcvt_f16_f32(vld1q_f32(x + qi)));
+        }
+        for (; qi < total_q; qi++) {
+            float16x4_t tmp = vcvt_f16_f32(vdupq_n_f32(x[qi]));
+            vst1_lane_f16(qx_f16.data() + qi, tmp, 0);
+        }
+        const float16_t* cy = reinterpret_cast<const float16_t*>(nt.data_f16.data());
+        for (size_t m = 0; m < pq.M; m++) {
+            const float16_t* qxm = qx_f16.data() + m * pq.dsub;
+            const float16_t* cym = cy + m * pq.ksub * pq.dsub;
+            float* disp = dis_table + m * pq.ksub;
+            for (size_t k = 0; k < pq.ksub; k++) {
+                disp[k] = ip_f16_scalar(qxm, cym + k * pq.dsub, pq.dsub);
+            }
+        }
+    } else {
+        // INT8 path: quantize query x to int8 on-the-fly, compute IP vs uint8 centroids.
+        std::vector<int8_t> qx_s8(pq.M * pq.dsub);
+        // quant_s8: vcvtaq_s32_f32 + narrow to int8
+        size_t total_q = pq.M * pq.dsub;
+        size_t qi = 0;
+        for (; qi + 16 <= total_q; qi += 16) {
+            float32x4_t a0 = vld1q_f32(x + qi);
+            float32x4_t a1 = vld1q_f32(x + qi + 4);
+            float32x4_t a2 = vld1q_f32(x + qi + 8);
+            float32x4_t a3 = vld1q_f32(x + qi + 12);
+            int32x4_t i0 = vcvtaq_s32_f32(a0);
+            int32x4_t i1 = vcvtaq_s32_f32(a1);
+            int32x4_t i2 = vcvtaq_s32_f32(a2);
+            int32x4_t i3 = vcvtaq_s32_f32(a3);
+            int16x8_t s01 = vcombine_s16(vqmovn_s32(i0), vqmovn_s32(i1));
+            int16x8_t s23 = vcombine_s16(vqmovn_s32(i2), vqmovn_s32(i3));
+            int8x16_t b = vcombine_s8(vqmovn_s16(s01), vqmovn_s16(s23));
+            vst1q_s8(qx_s8.data() + qi, b);
+        }
+        for (; qi < total_q; qi++) {
+            float v = x[qi];
+            qx_s8[qi] = (v < -128.f) ? -128 : (v > 127.f) ? 127 : (int8_t)(v + (v >= 0.f ? 0.5f : -0.5f));
+        }
+        const uint8_t* cy = nt.data_u8.data();
+        for (size_t m = 0; m < pq.M; m++) {
+            const int8_t* qxm = qx_s8.data() + m * pq.dsub;
+            const uint8_t* cym = cy + m * pq.ksub * pq.dsub;
+            float* disp = dis_table + m * pq.ksub;
+            for (size_t k = 0; k < pq.ksub; k++) {
+                disp[k] = (float)ip_u8s8_scalar(qxm, cym + k * pq.dsub, pq.dsub);
+            }
+        }
+    }
+}
+
+void pq_compute_distance_table_neon(
+        const ProductQuantizer& pq,
+        const float* x,
+        float* dis_table) {
+    using Precision = ProductQuantizer::NeonTransposedCentroids::Precision;
+    const auto& nt = pq.neon_transposed;
+
+    if (nt.precision == Precision::FP32) {
+        // Block-transposed fp32 path
+        compute_distance_table_neon(
+                pq.M,
+                pq.ksub,
+                pq.dsub,
+                x,
+                nt.data.data(),
+                nt.ceil_ksub,
+                nt.blocksize,
+                dis_table);
+    } else if (nt.precision == Precision::FP16) {
+        // FP16 path: quantize query, compute L2sqr vs fp16 centroids.
+        std::vector<float16_t> qx_f16(pq.M * pq.dsub);
+        size_t total_q = pq.M * pq.dsub;
+        size_t qi = 0;
+        for (; qi + 4 <= total_q; qi += 4) {
+            vst1_f16(qx_f16.data() + qi, vcvt_f16_f32(vld1q_f32(x + qi)));
+        }
+        for (; qi < total_q; qi++) {
+            float16x4_t tmp = vcvt_f16_f32(vdupq_n_f32(x[qi]));
+            vst1_lane_f16(qx_f16.data() + qi, tmp, 0);
+        }
+        const float16_t* cy = reinterpret_cast<const float16_t*>(nt.data_f16.data());
+        for (size_t m = 0; m < pq.M; m++) {
+            const float16_t* qxm = qx_f16.data() + m * pq.dsub;
+            const float16_t* cym = cy + m * pq.ksub * pq.dsub;
+            float* disp = dis_table + m * pq.ksub;
+            for (size_t k = 0; k < pq.ksub; k++) {
+                disp[k] = l2_f16_scalar(qxm, cym + k * pq.dsub, pq.dsub);
+            }
+        }
+    } else {
+        // INT8 path: quantize query to uint8, compute L2sqr vs uint8 centroids.
+        std::vector<uint8_t> qx_u8(pq.M * pq.dsub);
+        size_t total_q = pq.M * pq.dsub;
+        size_t qi = 0;
+        for (; qi + 16 <= total_q; qi += 16) {
+            float32x4_t a0 = vld1q_f32(x + qi);
+            float32x4_t a1 = vld1q_f32(x + qi + 4);
+            float32x4_t a2 = vld1q_f32(x + qi + 8);
+            float32x4_t a3 = vld1q_f32(x + qi + 12);
+            uint32x4_t u0 = vcvtaq_u32_f32(a0);
+            uint32x4_t u1 = vcvtaq_u32_f32(a1);
+            uint32x4_t u2 = vcvtaq_u32_f32(a2);
+            uint32x4_t u3 = vcvtaq_u32_f32(a3);
+            uint16x8_t s01 = vcombine_u16(vqmovn_u32(u0), vqmovn_u32(u1));
+            uint16x8_t s23 = vcombine_u16(vqmovn_u32(u2), vqmovn_u32(u3));
+            uint8x16_t b = vcombine_u8(vqmovn_u16(s01), vqmovn_u16(s23));
+            vst1q_u8(qx_u8.data() + qi, b);
+        }
+        for (; qi < total_q; qi++) {
+            float v = x[qi];
+            qx_u8[qi] = (v < 0.f) ? 0 : (v > 255.f) ? 255 : (uint8_t)(v + 0.5f);
+        }
+        const uint8_t* cy = nt.data_u8.data();
+        for (size_t m = 0; m < pq.M; m++) {
+            const uint8_t* qxm = qx_u8.data() + m * pq.dsub;
+            const uint8_t* cym = cy + m * pq.ksub * pq.dsub;
+            float* disp = dis_table + m * pq.ksub;
+            for (size_t k = 0; k < pq.ksub; k++) {
+                disp[k] = (float)l2_u8_scalar(qxm, cym + k * pq.dsub, pq.dsub);
+            }
+        }
+    }
+}
+
+} // namespace faiss
+
+#endif // COMPILE_SIMD_ARM_NEON

--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -44,6 +44,19 @@ int sgemm_(
 
 namespace faiss {
 
+#ifdef COMPILE_SIMD_ARM_NEON
+// Forward declarations for NEON-optimized functions defined in ProductQuantizer-neon.cpp
+void pq_compute_distance_table_neon(
+        const ProductQuantizer& pq,
+        const float* x,
+        float* dis_table);
+
+void pq_compute_inner_prod_table_neon(
+        const ProductQuantizer& pq,
+        const float* x,
+        float* dis_table);
+#endif
+
 /*********************************************
  * PQ implementation
  *********************************************/
@@ -439,6 +452,13 @@ void ProductQuantizer::compute_codes(const float* x, uint8_t* codes, size_t n)
 
 void ProductQuantizer::compute_distance_table(const float* x, float* dis_table)
         const {
+#ifdef COMPILE_SIMD_ARM_NEON
+    if (!neon_transposed.data.empty() || !neon_transposed.data_f16.empty() ||
+        !neon_transposed.data_u8.empty()) {
+        pq_compute_distance_table_neon(*this, x, dis_table);
+        return;
+    }
+#endif // COMPILE_SIMD_ARM_NEON
     with_simd_level([&]<SIMDLevel SL>() {
         if (transposed_centroids.empty()) {
             // use regular version
@@ -469,6 +489,13 @@ void ProductQuantizer::compute_distance_table(const float* x, float* dis_table)
 void ProductQuantizer::compute_inner_prod_table(
         const float* x,
         float* dis_table) const {
+#ifdef COMPILE_SIMD_ARM_NEON
+    if (!neon_transposed.data.empty() || !neon_transposed.data_f16.empty() ||
+        !neon_transposed.data_u8.empty()) {
+        pq_compute_inner_prod_table_neon(*this, x, dis_table);
+        return;
+    }
+#endif // COMPILE_SIMD_ARM_NEON
     with_simd_level([&]<SIMDLevel SL>() {
         for (size_t m = 0; m < M; m++) {
             fvec_inner_products_ny<SL>(

--- a/faiss/impl/ProductQuantizer.h
+++ b/faiss/impl/ProductQuantizer.h
@@ -63,6 +63,35 @@ struct ProductQuantizer : Quantizer {
     /// Layout: (M, ksub)
     std::vector<float> centroids_sq_lengths;
 
+    /// NEON optimized centroid storage for PQ distance table computation.
+    /// Supports three precision modes selectable at initialization time.
+    /// On non-aarch64 platforms, data vectors remain empty and are never used.
+    struct NeonTransposedCentroids {
+        /// Precision mode:
+        ///   FP32: block-transposed fp32, layout (num_blocks, dsub, blocksize) per subq
+        ///   FP16: quantized fp16, layout (M, ksub, dsub) — no transpose
+        ///   INT8: quantized int8, layout (M, ksub, dsub) — no transpose
+        enum class Precision { FP32, FP16, INT8 };
+
+        Precision precision = Precision::FP32;
+        size_t blocksize = 64;  ///< 16, 32, or 64 (only used for FP32)
+        size_t ceil_ksub = 0;   ///< ksub rounded up to blocksize (only used for FP32)
+
+        std::vector<float> data;    ///< FP32 block-transposed: M * ceil_ksub * dsub floats
+        std::vector<uint16_t> data_f16; ///< FP16 quantized: M * ksub * dsub uint16_t
+        std::vector<uint8_t> data_u8;   ///< INT8 quantized: M * ksub * dsub uint8_t
+    };
+    NeonTransposedCentroids neon_transposed;
+
+    /// Initialize NEON optimized centroid storage.
+    /// precision: 0=fp32 (block-transpose, default), 1=int8, 2=fp16
+    /// blocksize: 16, 32, or 64 (only relevant for fp32 precision)
+    /// Call after centroids are set (e.g. after train or index load).
+    /// No-op on non-aarch64 platforms.
+    void initialize_neon_transposed_centroids(
+            size_t blocksize = 64,
+            int precision = 0);
+
     /// return the centroids associated with subvector m
     float* get_centroids(size_t m, size_t i) {
         return &centroids[(m * ksub + i) * dsub];

--- a/faiss/impl/pq_code_distance/pq_code_distance-generic.cpp
+++ b/faiss/impl/pq_code_distance/pq_code_distance-generic.cpp
@@ -59,49 +59,6 @@ void pq_code_distance_four_impl<SIMDLevel::NONE>(
             result3);
 }
 
-#ifdef COMPILE_SIMD_ARM_NEON
-// ARM_NEON: No NEON-optimized PQ code distance exists. Use scalar.
-
-// NOLINTNEXTLINE(facebook-hte-MisplacedTemplateSpecialization)
-template <>
-float pq_code_distance_single_impl<SIMDLevel::ARM_NEON>(
-        size_t M,
-        size_t nbits,
-        const float* sim_table,
-        const uint8_t* code) {
-    return PQCodeDistanceScalar<PQDecoder8>::distance_single_code(
-            M, nbits, sim_table, code);
-}
-
-// NOLINTNEXTLINE(facebook-hte-MisplacedTemplateSpecialization)
-template <>
-void pq_code_distance_four_impl<SIMDLevel::ARM_NEON>(
-        size_t M,
-        size_t nbits,
-        const float* sim_table,
-        const uint8_t* __restrict code0,
-        const uint8_t* __restrict code1,
-        const uint8_t* __restrict code2,
-        const uint8_t* __restrict code3,
-        float& result0,
-        float& result1,
-        float& result2,
-        float& result3) {
-    PQCodeDistanceScalar<PQDecoder8>::distance_four_codes(
-            M,
-            nbits,
-            sim_table,
-            code0,
-            code1,
-            code2,
-            code3,
-            result0,
-            result1,
-            result2,
-            result3);
-}
-#endif // COMPILE_SIMD_ARM_NEON
-
 float pq_code_distance_single(
         size_t M,
         size_t nbits,

--- a/faiss/impl/pq_code_distance/pq_code_distance-neon.cpp
+++ b/faiss/impl/pq_code_distance/pq_code_distance-neon.cpp
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Copyright (c) Huawei Technologies Co., Ltd.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifdef COMPILE_SIMD_ARM_NEON
+
+#include <arm_neon.h>
+
+#include <faiss/impl/pq_code_distance/pq_code_distance-inl.h>
+
+namespace {
+
+inline float distance_single_code_neon(
+        const size_t M,
+        const float* sim_table,
+        const uint8_t* code) {
+    const float* tab = sim_table;
+    float result = 0;
+
+    for (size_t m = 0; m < M; m++) {
+        result += tab[*(code + m)];
+        tab += 256;
+    }
+
+    return result;
+}
+
+inline void distance_four_codes_neon(
+        const size_t M,
+        const float* sim_table,
+        const uint8_t* __restrict code0,
+        const uint8_t* __restrict code1,
+        const uint8_t* __restrict code2,
+        const uint8_t* __restrict code3,
+        float& result0,
+        float& result1,
+        float& result2,
+        float& result3) {
+    const float* tab = sim_table;
+    float32x4_t res = vdupq_n_f32(0.0f);
+
+    for (size_t m = 0; m < M; m++) {
+        const float32x4_t neon_result = {
+            tab[*(code0 + m)],
+            tab[*(code1 + m)],
+            tab[*(code2 + m)],
+            tab[*(code3 + m)]};
+        tab += 256;
+        res = vaddq_f32(res, neon_result);
+    }
+
+    float results[4];
+    vst1q_f32(results, res);
+    result0 = results[0];
+    result1 = results[1];
+    result2 = results[2];
+    result3 = results[3];
+}
+
+inline void distance_two_codes_n8(
+        const size_t M,
+        const float* sim_table,
+        const uint8_t* __restrict codes,
+        float* result,
+        const float dis) {
+    const float* tab = sim_table;
+    float result0 = dis;
+    float result1 = dis;
+
+    for (size_t m = 0; m < M; m++) {
+        result0 += tab[*(codes + m)];
+        result1 += tab[*(codes + M + m)];
+        tab += 256;
+    }
+    result[0] = result0;
+    result[1] = result1;
+}
+
+inline void distance_four_codes_n8(
+        const size_t M,
+        const float* sim_table,
+        const uint8_t* __restrict codes,
+        float* result,
+        const float dis) {
+    const float* tab = sim_table;
+    float32x4_t res = vdupq_n_f32(dis);
+
+    for (size_t m = 0; m < M; m++) {
+        const float32x4_t neon_result = {
+            tab[*(codes + m)],
+            tab[*(codes + M + m)],
+            tab[*(codes + 2 * M + m)],
+            tab[*(codes + 3 * M + m)]};
+        tab += 256;
+        res = vaddq_f32(res, neon_result);
+    }
+    vst1q_f32(result, res);
+}
+
+inline void distance_codes_n8_simd8(
+        const size_t M,
+        const float* sim_table,
+        const uint8_t* __restrict codes,
+        float* result,
+        const float dis) {
+    const float* tab = sim_table;
+    float32x4_t neon_result0 = vdupq_n_f32(dis);
+    float32x4_t neon_result1 = vdupq_n_f32(dis);
+    for (size_t m = 0; m < M; m++) {
+        const float32x4_t neon_single_dim0 = {
+            tab[*(codes + m)],
+            tab[*(codes + M + m)],
+            tab[*(codes + 2 * M + m)],
+            tab[*(codes + 3 * M + m)]};
+        const float32x4_t neon_single_dim1 = {
+            tab[*(codes + 4 * M + m)],
+            tab[*(codes + 5 * M + m)],
+            tab[*(codes + 6 * M + m)],
+            tab[*(codes + 7 * M + m)]};
+        tab += 256;
+        neon_result0 = vaddq_f32(neon_result0, neon_single_dim0);
+        neon_result1 = vaddq_f32(neon_result1, neon_single_dim1);
+    }
+    vst1q_f32(result, neon_result0);
+    vst1q_f32(result + 4, neon_result1);
+}
+
+} // namespace
+
+namespace faiss {
+namespace pq_code_distance {
+
+template <>
+float pq_code_distance_single_impl<SIMDLevel::ARM_NEON>(
+        size_t M,
+        size_t nbits,
+        const float* sim_table,
+        const uint8_t* code) {
+    if (nbits == 8) {
+        return distance_single_code_neon(M, sim_table, code);
+    }
+
+    // Fallback for non-8bit
+    const size_t ksub = 1 << nbits;
+    const float* tab = sim_table;
+    float result = 0;
+    for (size_t m = 0; m < M; m++) {
+        result += tab[code[m]];
+        tab += ksub;
+    }
+    return result;
+}
+
+template <>
+void pq_code_distance_four_impl<SIMDLevel::ARM_NEON>(
+        size_t M,
+        size_t nbits,
+        const float* sim_table,
+        const uint8_t* __restrict code0,
+        const uint8_t* __restrict code1,
+        const uint8_t* __restrict code2,
+        const uint8_t* __restrict code3,
+        float& result0,
+        float& result1,
+        float& result2,
+        float& result3) {
+    if (nbits == 8) {
+        distance_four_codes_neon(
+                M, sim_table, code0, code1, code2, code3,
+                result0, result1, result2, result3);
+        return;
+    }
+
+    // Fallback for non-8bit
+    const size_t ksub = 1 << nbits;
+    const float* tab = sim_table;
+    result0 = result1 = result2 = result3 = 0;
+    for (size_t m = 0; m < M; m++) {
+        result0 += tab[code0[m]];
+        result1 += tab[code1[m]];
+        result2 += tab[code2[m]];
+        result3 += tab[code3[m]];
+        tab += ksub;
+    }
+}
+
+void pq_code_distance_batch_neon(
+        const size_t M,
+        const size_t ncode,
+        const uint8_t* codes,
+        const float* sim_table,
+        float* dis,
+        const float dis0) {
+    size_t j = 0;
+    for (; j + 8 <= ncode; j += 8) {
+        distance_codes_n8_simd8(M, sim_table, codes + j * M, dis + j, dis0);
+    }
+    if (ncode & 4) {
+        distance_four_codes_n8(M, sim_table, codes + j * M, dis + j, dis0);
+        j += 4;
+    }
+    if (ncode & 2) {
+        distance_two_codes_n8(M, sim_table, codes + j * M, dis + j, dis0);
+        j += 2;
+    }
+    if (ncode & 1) {
+        dis[ncode - 1] = distance_single_code_neon(M, sim_table, codes + (ncode - 1) * M) + dis0;
+    }
+}
+
+void pq_code_distance_batch(
+        size_t M,
+        size_t nbits,
+        size_t ncode,
+        const uint8_t* codes,
+        const float* sim_table,
+        float* dis,
+        float dis0) {
+    if (nbits == 8) {
+        pq_code_distance_batch_neon(M, ncode, codes, sim_table, dis, dis0);
+        return;
+    }
+
+    // Fallback for non-8bit
+    for (size_t i = 0; i < ncode; i++) {
+        dis[i] = pq_code_distance_single_impl<SIMDLevel::ARM_NEON>(
+                M, nbits, sim_table, codes + i * M) + dis0;
+    }
+}
+
+void pq_code_distance_batch_by_idx(
+        size_t M,
+        size_t ncode,
+        const uint8_t* codes,
+        const float* sim_table,
+        float* dis,
+        float dis0,
+        const size_t* idx) {
+    for (size_t j = 0; j < ncode; j++) {
+        dis[j] = distance_single_code_neon(M, sim_table, codes + idx[j] * M) + dis0;
+    }
+}
+
+} // namespace pq_code_distance
+} // namespace faiss
+
+#endif // COMPILE_SIMD_ARM_NEON

--- a/faiss/utils/simd_impl/distances_aarch64.cpp
+++ b/faiss/utils/simd_impl/distances_aarch64.cpp
@@ -56,26 +56,6 @@ void fvec_L2sqr_ny_transposed<SIMDLevel::ARM_NEON>(
 }
 
 template <>
-void fvec_inner_products_ny<SIMDLevel::ARM_NEON>(
-        float* dis,
-        const float* x,
-        const float* y,
-        size_t d,
-        size_t ny) {
-    fvec_inner_products_ny<SIMDLevel::NONE>(dis, x, y, d, ny);
-}
-
-template <>
-void fvec_L2sqr_ny<SIMDLevel::ARM_NEON>(
-        float* dis,
-        const float* x,
-        const float* y,
-        size_t d,
-        size_t ny) {
-    fvec_L2sqr_ny<SIMDLevel::NONE>(dis, x, y, d, ny);
-}
-
-template <>
 size_t fvec_L2sqr_ny_nearest<SIMDLevel::ARM_NEON>(
         float* distances_tmp_buffer,
         const float* x,

--- a/faiss/utils/simd_impl/distances_neon.cpp
+++ b/faiss/utils/simd_impl/distances_neon.cpp
@@ -1,0 +1,1447 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Copyright (c) Huawei Technologies Co., Ltd.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NEON-optimized distance computations
+
+#ifdef COMPILE_SIMD_ARM_NEON
+
+#include <arm_neon.h>
+#include <faiss/utils/distances.h>
+
+namespace faiss {
+
+static inline float fvec_L2sqr_neon(const float* x, const float* y, size_t d) {
+    constexpr size_t single_round = 4;
+    constexpr size_t multi_round = 16;
+    size_t i;
+    float res;
+
+    if (d >= multi_round) {
+        __builtin_prefetch(x + multi_round, 0, 0);
+        __builtin_prefetch(y + multi_round, 0, 0);
+        float32x4_t x8_0 = vld1q_f32(x);
+        float32x4_t x8_1 = vld1q_f32(x + 4);
+        float32x4_t x8_2 = vld1q_f32(x + 8);
+        float32x4_t x8_3 = vld1q_f32(x + 12);
+
+        float32x4_t y8_0 = vld1q_f32(y);
+        float32x4_t y8_1 = vld1q_f32(y + 4);
+        float32x4_t y8_2 = vld1q_f32(y + 8);
+        float32x4_t y8_3 = vld1q_f32(y + 12);
+
+        float32x4_t d8_0 = vsubq_f32(x8_0, y8_0);
+        d8_0 = vmulq_f32(d8_0, d8_0);
+        float32x4_t d8_1 = vsubq_f32(x8_1, y8_1);
+        d8_1 = vmulq_f32(d8_1, d8_1);
+        float32x4_t d8_2 = vsubq_f32(x8_2, y8_2);
+        d8_2 = vmulq_f32(d8_2, d8_2);
+        float32x4_t d8_3 = vsubq_f32(x8_3, y8_3);
+        d8_3 = vmulq_f32(d8_3, d8_3);
+
+        for (i = multi_round; i <= d - multi_round; i += multi_round) {
+            __builtin_prefetch(x + i + multi_round, 0, 0);
+            __builtin_prefetch(y + i + multi_round, 0, 0);
+            x8_0 = vld1q_f32(x + i);
+            y8_0 = vld1q_f32(y + i);
+            const float32x4_t q8_0 = vsubq_f32(x8_0, y8_0);
+            d8_0 = vmlaq_f32(d8_0, q8_0, q8_0);
+
+            x8_1 = vld1q_f32(x + i + 4);
+            y8_1 = vld1q_f32(y + i + 4);
+            const float32x4_t q8_1 = vsubq_f32(x8_1, y8_1);
+            d8_1 = vmlaq_f32(d8_1, q8_1, q8_1);
+
+            x8_2 = vld1q_f32(x + i + 8);
+            y8_2 = vld1q_f32(y + i + 8);
+            const float32x4_t q8_2 = vsubq_f32(x8_2, y8_2);
+            d8_2 = vmlaq_f32(d8_2, q8_2, q8_2);
+
+            x8_3 = vld1q_f32(x + i + 12);
+            y8_3 = vld1q_f32(y + i + 12);
+            const float32x4_t q8_3 = vsubq_f32(x8_3, y8_3);
+            d8_3 = vmlaq_f32(d8_3, q8_3, q8_3);
+        }
+
+        for (; i <= d - single_round; i += single_round) {
+            x8_0 = vld1q_f32(x + i);
+            y8_0 = vld1q_f32(y + i);
+            const float32x4_t q8_0 = vsubq_f32(x8_0, y8_0);
+            d8_0 = vmlaq_f32(d8_0, q8_0, q8_0);
+        }
+
+        d8_0 = vaddq_f32(d8_0, d8_1);
+        d8_2 = vaddq_f32(d8_2, d8_3);
+        d8_0 = vaddq_f32(d8_0, d8_2);
+        res = vaddvq_f32(d8_0);
+    } else if (d >= single_round) {
+        float32x4_t x8_0 = vld1q_f32(x);
+        float32x4_t y8_0 = vld1q_f32(y);
+
+        float32x4_t d8_0 = vsubq_f32(x8_0, y8_0);
+        d8_0 = vmulq_f32(d8_0, d8_0);
+        for (i = single_round; i <= d - single_round; i += single_round) {
+            x8_0 = vld1q_f32(x + i);
+            y8_0 = vld1q_f32(y + i);
+            const float32x4_t q8_0 = vsubq_f32(x8_0, y8_0);
+            d8_0 = vmlaq_f32(d8_0, q8_0, q8_0);
+        }
+        res = vaddvq_f32(d8_0);
+    } else {
+        res = 0;
+        i = 0;
+    }
+
+    for (; i < d; i++) {
+        const float tmp = x[i] - y[i];
+        res += tmp * tmp;
+    }
+    return res;
+}
+
+static inline float fvec_inner_product_neon(const float* x, const float* y, size_t d) {
+    size_t i;
+    float res;
+    constexpr size_t single_round = 16;
+
+    if (d >= single_round) {
+        float32x4_t x8_0 = vld1q_f32(x);
+        float32x4_t x8_1 = vld1q_f32(x + 4);
+        float32x4_t x8_2 = vld1q_f32(x + 8);
+        float32x4_t x8_3 = vld1q_f32(x + 12);
+
+        float32x4_t y8_0 = vld1q_f32(y);
+        float32x4_t y8_1 = vld1q_f32(y + 4);
+        float32x4_t y8_2 = vld1q_f32(y + 8);
+        float32x4_t y8_3 = vld1q_f32(y + 12);
+
+        float32x4_t d8_0 = vmulq_f32(x8_0, y8_0);
+        float32x4_t d8_1 = vmulq_f32(x8_1, y8_1);
+        float32x4_t d8_2 = vmulq_f32(x8_2, y8_2);
+        float32x4_t d8_3 = vmulq_f32(x8_3, y8_3);
+
+        for (i = single_round; i <= d - single_round; i += single_round) {
+            x8_0 = vld1q_f32(x + i);
+            y8_0 = vld1q_f32(y + i);
+            d8_0 = vmlaq_f32(d8_0, x8_0, y8_0);
+
+            x8_1 = vld1q_f32(x + i + 4);
+            y8_1 = vld1q_f32(y + i + 4);
+            d8_1 = vmlaq_f32(d8_1, x8_1, y8_1);
+
+            x8_2 = vld1q_f32(x + i + 8);
+            y8_2 = vld1q_f32(y + i + 8);
+            d8_2 = vmlaq_f32(d8_2, x8_2, y8_2);
+
+            x8_3 = vld1q_f32(x + i + 12);
+            y8_3 = vld1q_f32(y + i + 12);
+            d8_3 = vmlaq_f32(d8_3, x8_3, y8_3);
+        }
+
+        d8_0 = vaddq_f32(d8_0, d8_1);
+        d8_2 = vaddq_f32(d8_2, d8_3);
+        d8_0 = vaddq_f32(d8_0, d8_2);
+        res = vaddvq_f32(d8_0);
+    } else {
+        i = 0;
+        res = 0;
+    }
+
+    for (; i < d; i++) {
+        const float tmp = x[i] * y[i];
+        res += tmp;
+    }
+    return res;
+}
+
+static inline void fvec_L2sqr_batch2_neon(const float* x, const float* y, size_t d, float* dis) {
+    size_t i;
+    constexpr size_t single_round = 8;
+
+    if (d >= single_round) {
+        float32x4_t x_0 = vld1q_f32(x);
+        float32x4_t x_1 = vld1q_f32(x + 4);
+
+        float32x4_t y0_0 = vld1q_f32(y);
+        float32x4_t y0_1 = vld1q_f32(y + 4);
+        float32x4_t y1_0 = vld1q_f32(y + d);
+        float32x4_t y1_1 = vld1q_f32(y + d + 4);
+
+        float32x4_t d0_0 = vsubq_f32(x_0, y0_0);
+        d0_0 = vmulq_f32(d0_0, d0_0);
+        float32x4_t d0_1 = vsubq_f32(x_1, y0_1);
+        d0_1 = vmulq_f32(d0_1, d0_1);
+        float32x4_t d1_0 = vsubq_f32(x_0, y1_0);
+        d1_0 = vmulq_f32(d1_0, d1_0);
+        float32x4_t d1_1 = vsubq_f32(x_1, y1_1);
+        d1_1 = vmulq_f32(d1_1, d1_1);
+
+        for (i = single_round; i <= d - single_round; i += single_round) {
+            x_0 = vld1q_f32(x + i);
+            y0_0 = vld1q_f32(y + i);
+            y1_0 = vld1q_f32(y + d + i);
+            const float32x4_t q0_0 = vsubq_f32(x_0, y0_0);
+            const float32x4_t q1_0 = vsubq_f32(x_0, y1_0);
+            d0_0 = vmlaq_f32(d0_0, q0_0, q0_0);
+            d1_0 = vmlaq_f32(d1_0, q1_0, q1_0);
+
+            x_1 = vld1q_f32(x + i + 4);
+            y0_1 = vld1q_f32(y + i + 4);
+            y1_1 = vld1q_f32(y + d + i + 4);
+            const float32x4_t q0_1 = vsubq_f32(x_1, y0_1);
+            const float32x4_t q1_1 = vsubq_f32(x_1, y1_1);
+            d0_1 = vmlaq_f32(d0_1, q0_1, q0_1);
+            d1_1 = vmlaq_f32(d1_1, q1_1, q1_1);
+        }
+
+        d0_0 = vaddq_f32(d0_0, d0_1);
+        d1_0 = vaddq_f32(d1_0, d1_1);
+        dis[0] = vaddvq_f32(d0_0);
+        dis[1] = vaddvq_f32(d1_0);
+    } else {
+        dis[0] = 0;
+        dis[1] = 0;
+        i = 0;
+    }
+
+    for (; i < d; i++) {
+        const float tmp0 = x[i] - *(y + i);
+        const float tmp1 = x[i] - *(y + d + i);
+        dis[0] += tmp0 * tmp0;
+        dis[1] += tmp1 * tmp1;
+    }
+}
+
+static inline void fvec_L2sqr_batch4_neon(const float* x, const float* y, size_t d, float* dis) {
+    constexpr size_t single_round = 4;
+    size_t i;
+    if (d >= single_round) {
+        float32x4_t b = vld1q_f32(x);
+
+        float32x4_t q0 = vld1q_f32(y);
+        float32x4_t q1 = vld1q_f32(y + d);
+        float32x4_t q2 = vld1q_f32(y + 2 * d);
+        float32x4_t q3 = vld1q_f32(y + 3 * d);
+
+        q0 = vsubq_f32(q0, b);
+        q1 = vsubq_f32(q1, b);
+        q2 = vsubq_f32(q2, b);
+        q3 = vsubq_f32(q3, b);
+
+        float32x4_t res0 = vmulq_f32(q0, q0);
+        float32x4_t res1 = vmulq_f32(q1, q1);
+        float32x4_t res2 = vmulq_f32(q2, q2);
+        float32x4_t res3 = vmulq_f32(q3, q3);
+
+        for (i = single_round; i <= d - single_round; i += single_round) {
+            b = vld1q_f32(x + i);
+
+            q0 = vld1q_f32(y + i);
+            q1 = vld1q_f32(y + d + i);
+            q2 = vld1q_f32(y + 2 * d + i);
+            q3 = vld1q_f32(y + 3 * d + i);
+
+            q0 = vsubq_f32(q0, b);
+            q1 = vsubq_f32(q1, b);
+            q2 = vsubq_f32(q2, b);
+            q3 = vsubq_f32(q3, b);
+
+            res0 = vmlaq_f32(res0, q0, q0);
+            res1 = vmlaq_f32(res1, q1, q1);
+            res2 = vmlaq_f32(res2, q2, q2);
+            res3 = vmlaq_f32(res3, q3, q3);
+        }
+        dis[0] = vaddvq_f32(res0);
+        dis[1] = vaddvq_f32(res1);
+        dis[2] = vaddvq_f32(res2);
+        dis[3] = vaddvq_f32(res3);
+    } else {
+        for (int i = 0; i < 4; i++) {
+            dis[i] = 0.0f;
+        }
+        i = 0;
+    }
+    if (d > i) {
+        float q0 = x[i] - *(y + i);
+        float q1 = x[i] - *(y + d + i);
+        float q2 = x[i] - *(y + 2 * d + i);
+        float q3 = x[i] - *(y + 3 * d + i);
+        float d0 = q0 * q0;
+        float d1 = q1 * q1;
+        float d2 = q2 * q2;
+        float d3 = q3 * q3;
+        for (i++; i < d; ++i) {
+            float q0 = x[i] - *(y + i);
+            float q1 = x[i] - *(y + d + i);
+            float q2 = x[i] - *(y + 2 * d + i);
+            float q3 = x[i] - *(y + 3 * d + i);
+            d0 += q0 * q0;
+            d1 += q1 * q1;
+            d2 += q2 * q2;
+            d3 += q3 * q3;
+        }
+        dis[0] += d0;
+        dis[1] += d1;
+        dis[2] += d2;
+        dis[3] += d3;
+    }
+}
+
+static inline void fvec_inner_product_batch2_neon(const float* x, const float* y, size_t d, float* dis) {
+    size_t i;
+    constexpr size_t single_round = 8;
+
+    if (d >= single_round) {
+        float32x4_t x_0 = vld1q_f32(x);
+        float32x4_t x_1 = vld1q_f32(x + 4);
+
+        float32x4_t y0_0 = vld1q_f32(y);
+        float32x4_t y0_1 = vld1q_f32(y + 4);
+        float32x4_t y1_0 = vld1q_f32(y + d);
+        float32x4_t y1_1 = vld1q_f32(y + d + 4);
+
+        float32x4_t d0_0 = vmulq_f32(x_0, y0_0);
+        float32x4_t d0_1 = vmulq_f32(x_1, y0_1);
+        float32x4_t d1_0 = vmulq_f32(x_0, y1_0);
+        float32x4_t d1_1 = vmulq_f32(x_1, y1_1);
+
+        for (i = single_round; i <= d - single_round; i += single_round) {
+            x_0 = vld1q_f32(x + i);
+            y0_0 = vld1q_f32(y + i);
+            y1_0 = vld1q_f32(y + d + i);
+            d0_0 = vmlaq_f32(d0_0, x_0, y0_0);
+            d1_0 = vmlaq_f32(d1_0, x_0, y1_0);
+
+            x_1 = vld1q_f32(x + i + 4);
+            y0_1 = vld1q_f32(y + i + 4);
+            y1_1 = vld1q_f32(y + d + i + 4);
+            d0_1 = vmlaq_f32(d0_1, x_1, y0_1);
+            d1_1 = vmlaq_f32(d1_1, x_1, y1_1);
+        }
+
+        d0_0 = vaddq_f32(d0_0, d0_1);
+        d1_0 = vaddq_f32(d1_0, d1_1);
+        dis[0] = vaddvq_f32(d0_0);
+        dis[1] = vaddvq_f32(d1_0);
+    } else {
+        dis[0] = 0;
+        dis[1] = 0;
+        i = 0;
+    }
+
+    for (; i < d; i++) {
+        const float tmp0 = x[i] * *(y + i);
+        const float tmp1 = x[i] * *(y + d + i);
+        dis[0] += tmp0;
+        dis[1] += tmp1;
+    }
+}
+
+static inline void fvec_inner_product_batch4_neon(const float* x, const float* y, size_t d, float* dis) {
+    size_t i;
+    constexpr size_t single_round = 4;
+
+    if (d >= single_round) {
+        float32x4_t neon_query = vld1q_f32(x);
+        float32x4_t neon_base1 = vld1q_f32(y);
+        float32x4_t neon_base2 = vld1q_f32(y + d);
+        float32x4_t neon_base3 = vld1q_f32(y + 2 * d);
+        float32x4_t neon_base4 = vld1q_f32(y + 3 * d);
+
+        float32x4_t neon_res1 = vmulq_f32(neon_base1, neon_query);
+        float32x4_t neon_res2 = vmulq_f32(neon_base2, neon_query);
+        float32x4_t neon_res3 = vmulq_f32(neon_base3, neon_query);
+        float32x4_t neon_res4 = vmulq_f32(neon_base4, neon_query);
+
+        for (i = single_round; i <= d - single_round; i += single_round) {
+            neon_query = vld1q_f32(x + i);
+            neon_base1 = vld1q_f32(y + i);
+            neon_base2 = vld1q_f32(y + d + i);
+            neon_base3 = vld1q_f32(y + 2 * d + i);
+            neon_base4 = vld1q_f32(y + 3 * d + i);
+
+            neon_res1 = vmlaq_f32(neon_res1, neon_base1, neon_query);
+            neon_res2 = vmlaq_f32(neon_res2, neon_base2, neon_query);
+            neon_res3 = vmlaq_f32(neon_res3, neon_base3, neon_query);
+            neon_res4 = vmlaq_f32(neon_res4, neon_base4, neon_query);
+        }
+        dis[0] = vaddvq_f32(neon_res1);
+        dis[1] = vaddvq_f32(neon_res2);
+        dis[2] = vaddvq_f32(neon_res3);
+        dis[3] = vaddvq_f32(neon_res4);
+    } else {
+        for (int i = 0; i < 4; i++) {
+            dis[i] = 0.0f;
+        }
+        i = 0;
+    }
+    if (i < d) {
+        float d0 = x[i] * *(y + i);
+        float d1 = x[i] * *(y + d + i);
+        float d2 = x[i] * *(y + 2 * d + i);
+        float d3 = x[i] * *(y + 3 * d + i);
+
+        for (i++; i < d; ++i) {
+            d0 += x[i] * *(y + i);
+            d1 += x[i] * *(y + d + i);
+            d2 += x[i] * *(y + 2 * d + i);
+            d3 += x[i] * *(y + 3 * d + i);
+        }
+
+        dis[0] += d0;
+        dis[1] += d1;
+        dis[2] += d2;
+        dis[3] += d3;
+    }
+}
+
+static inline void fvec_L2sqr_batch8_neon(const float* x, const float* y, size_t d, float* dis) {
+    size_t i;
+    constexpr size_t single_round = 4;
+    if (d >= single_round) {
+        float32x4_t neon_query = vld1q_f32(x);
+
+        float32x4_t neon_base1 = vld1q_f32(y);
+        float32x4_t neon_base2 = vld1q_f32(y + d);
+        float32x4_t neon_base3 = vld1q_f32(y + 2 * d);
+        float32x4_t neon_base4 = vld1q_f32(y + 3 * d);
+        float32x4_t neon_base5 = vld1q_f32(y + 4 * d);
+        float32x4_t neon_base6 = vld1q_f32(y + 5 * d);
+        float32x4_t neon_base7 = vld1q_f32(y + 6 * d);
+        float32x4_t neon_base8 = vld1q_f32(y + 7 * d);
+
+        neon_base1 = vsubq_f32(neon_base1, neon_query);
+        neon_base2 = vsubq_f32(neon_base2, neon_query);
+        neon_base3 = vsubq_f32(neon_base3, neon_query);
+        neon_base4 = vsubq_f32(neon_base4, neon_query);
+        neon_base5 = vsubq_f32(neon_base5, neon_query);
+        neon_base6 = vsubq_f32(neon_base6, neon_query);
+        neon_base7 = vsubq_f32(neon_base7, neon_query);
+        neon_base8 = vsubq_f32(neon_base8, neon_query);
+
+        float32x4_t neon_res1 = vmulq_f32(neon_base1, neon_base1);
+        float32x4_t neon_res2 = vmulq_f32(neon_base2, neon_base2);
+        float32x4_t neon_res3 = vmulq_f32(neon_base3, neon_base3);
+        float32x4_t neon_res4 = vmulq_f32(neon_base4, neon_base4);
+        float32x4_t neon_res5 = vmulq_f32(neon_base5, neon_base5);
+        float32x4_t neon_res6 = vmulq_f32(neon_base6, neon_base6);
+        float32x4_t neon_res7 = vmulq_f32(neon_base7, neon_base7);
+        float32x4_t neon_res8 = vmulq_f32(neon_base8, neon_base8);
+
+        for (i = single_round; i <= d - single_round; i += single_round) {
+            neon_query = vld1q_f32(x + i);
+
+            neon_base1 = vld1q_f32(y + i);
+            neon_base2 = vld1q_f32(y + d + i);
+            neon_base3 = vld1q_f32(y + 2 * d + i);
+            neon_base4 = vld1q_f32(y + 3 * d + i);
+            neon_base5 = vld1q_f32(y + 4 * d + i);
+            neon_base6 = vld1q_f32(y + 5 * d + i);
+            neon_base7 = vld1q_f32(y + 6 * d + i);
+            neon_base8 = vld1q_f32(y + 7 * d + i);
+
+            neon_base1 = vsubq_f32(neon_base1, neon_query);
+            neon_base2 = vsubq_f32(neon_base2, neon_query);
+            neon_base3 = vsubq_f32(neon_base3, neon_query);
+            neon_base4 = vsubq_f32(neon_base4, neon_query);
+            neon_base5 = vsubq_f32(neon_base5, neon_query);
+            neon_base6 = vsubq_f32(neon_base6, neon_query);
+            neon_base7 = vsubq_f32(neon_base7, neon_query);
+            neon_base8 = vsubq_f32(neon_base8, neon_query);
+
+            neon_res1 = vmlaq_f32(neon_res1, neon_base1, neon_base1);
+            neon_res2 = vmlaq_f32(neon_res2, neon_base2, neon_base2);
+            neon_res3 = vmlaq_f32(neon_res3, neon_base3, neon_base3);
+            neon_res4 = vmlaq_f32(neon_res4, neon_base4, neon_base4);
+            neon_res5 = vmlaq_f32(neon_res5, neon_base5, neon_base5);
+            neon_res6 = vmlaq_f32(neon_res6, neon_base6, neon_base6);
+            neon_res7 = vmlaq_f32(neon_res7, neon_base7, neon_base7);
+            neon_res8 = vmlaq_f32(neon_res8, neon_base8, neon_base8);
+        }
+        dis[0] = vaddvq_f32(neon_res1);
+        dis[1] = vaddvq_f32(neon_res2);
+        dis[2] = vaddvq_f32(neon_res3);
+        dis[3] = vaddvq_f32(neon_res4);
+        dis[4] = vaddvq_f32(neon_res5);
+        dis[5] = vaddvq_f32(neon_res6);
+        dis[6] = vaddvq_f32(neon_res7);
+        dis[7] = vaddvq_f32(neon_res8);
+    } else {
+        for (int i = 0; i < 8; i++) {
+            dis[i] = 0.0f;
+        }
+        i = 0;
+    }
+    if (i < d) {
+        float q0 = x[i] - *(y + i);
+        float q1 = x[i] - *(y + d + i);
+        float q2 = x[i] - *(y + 2 * d + i);
+        float q3 = x[i] - *(y + 3 * d + i);
+        float q4 = x[i] - *(y + 4 * d + i);
+        float q5 = x[i] - *(y + 5 * d + i);
+        float q6 = x[i] - *(y + 6 * d + i);
+        float q7 = x[i] - *(y + 7 * d + i);
+        float d0 = q0 * q0;
+        float d1 = q1 * q1;
+        float d2 = q2 * q2;
+        float d3 = q3 * q3;
+        float d4 = q4 * q4;
+        float d5 = q5 * q5;
+        float d6 = q6 * q6;
+        float d7 = q7 * q7;
+        for (i++; i < d; ++i) {
+            q0 = x[i] - *(y + i);
+            q1 = x[i] - *(y + d + i);
+            q2 = x[i] - *(y + 2 * d + i);
+            q3 = x[i] - *(y + 3 * d + i);
+            q4 = x[i] - *(y + 4 * d + i);
+            q5 = x[i] - *(y + 5 * d + i);
+            q6 = x[i] - *(y + 6 * d + i);
+            q7 = x[i] - *(y + 7 * d + i);
+            d0 += q0 * q0;
+            d1 += q1 * q1;
+            d2 += q2 * q2;
+            d3 += q3 * q3;
+            d4 += q4 * q4;
+            d5 += q5 * q5;
+            d6 += q6 * q6;
+            d7 += q7 * q7;
+        }
+        dis[0] += d0;
+        dis[1] += d1;
+        dis[2] += d2;
+        dis[3] += d3;
+        dis[4] += d4;
+        dis[5] += d5;
+        dis[6] += d6;
+        dis[7] += d7;
+    }
+}
+
+static inline void fvec_inner_product_batch8_neon(const float* x, const float* y, size_t d, float* dis) {
+    size_t i;
+    constexpr size_t single_round = 4;
+
+    if (d >= single_round) {
+        float32x4_t neon_query = vld1q_f32(x);
+        float32x4_t neon_base1 = vld1q_f32(y);
+        float32x4_t neon_base2 = vld1q_f32(y + d);
+        float32x4_t neon_base3 = vld1q_f32(y + 2 * d);
+        float32x4_t neon_base4 = vld1q_f32(y + 3 * d);
+        float32x4_t neon_base5 = vld1q_f32(y + 4 * d);
+        float32x4_t neon_base6 = vld1q_f32(y + 5 * d);
+        float32x4_t neon_base7 = vld1q_f32(y + 6 * d);
+        float32x4_t neon_base8 = vld1q_f32(y + 7 * d);
+
+        float32x4_t neon_res1 = vmulq_f32(neon_base1, neon_query);
+        float32x4_t neon_res2 = vmulq_f32(neon_base2, neon_query);
+        float32x4_t neon_res3 = vmulq_f32(neon_base3, neon_query);
+        float32x4_t neon_res4 = vmulq_f32(neon_base4, neon_query);
+        float32x4_t neon_res5 = vmulq_f32(neon_base5, neon_query);
+        float32x4_t neon_res6 = vmulq_f32(neon_base6, neon_query);
+        float32x4_t neon_res7 = vmulq_f32(neon_base7, neon_query);
+        float32x4_t neon_res8 = vmulq_f32(neon_base8, neon_query);
+
+        for (i = single_round; i <= d - single_round; i += single_round) {
+            neon_query = vld1q_f32(x + i);
+            neon_base1 = vld1q_f32(y + i);
+            neon_base2 = vld1q_f32(y + d + i);
+            neon_base3 = vld1q_f32(y + 2 * d + i);
+            neon_base4 = vld1q_f32(y + 3 * d + i);
+            neon_base5 = vld1q_f32(y + 4 * d + i);
+            neon_base6 = vld1q_f32(y + 5 * d + i);
+            neon_base7 = vld1q_f32(y + 6 * d + i);
+            neon_base8 = vld1q_f32(y + 7 * d + i);
+
+            neon_res1 = vmlaq_f32(neon_res1, neon_base1, neon_query);
+            neon_res2 = vmlaq_f32(neon_res2, neon_base2, neon_query);
+            neon_res3 = vmlaq_f32(neon_res3, neon_base3, neon_query);
+            neon_res4 = vmlaq_f32(neon_res4, neon_base4, neon_query);
+            neon_res5 = vmlaq_f32(neon_res5, neon_base5, neon_query);
+            neon_res6 = vmlaq_f32(neon_res6, neon_base6, neon_query);
+            neon_res7 = vmlaq_f32(neon_res7, neon_base7, neon_query);
+            neon_res8 = vmlaq_f32(neon_res8, neon_base8, neon_query);
+        }
+
+        dis[0] = vaddvq_f32(neon_res1);
+        dis[1] = vaddvq_f32(neon_res2);
+        dis[2] = vaddvq_f32(neon_res3);
+        dis[3] = vaddvq_f32(neon_res4);
+        dis[4] = vaddvq_f32(neon_res5);
+        dis[5] = vaddvq_f32(neon_res6);
+        dis[6] = vaddvq_f32(neon_res7);
+        dis[7] = vaddvq_f32(neon_res8);
+    } else {
+        for (int i = 0; i < 8; i++) {
+            dis[i] = 0.0f;
+        }
+        i = 0;
+    }
+    if (i < d) {
+        float d0 = x[i] * *(y + i);
+        float d1 = x[i] * *(y + d + i);
+        float d2 = x[i] * *(y + 2 * d + i);
+        float d3 = x[i] * *(y + 3 * d + i);
+        float d4 = x[i] * *(y + 4 * d + i);
+        float d5 = x[i] * *(y + 5 * d + i);
+        float d6 = x[i] * *(y + 6 * d + i);
+        float d7 = x[i] * *(y + 7 * d + i);
+
+        for (i++; i < d; ++i) {
+            d0 += x[i] * *(y + i);
+            d1 += x[i] * *(y + d + i);
+            d2 += x[i] * *(y + 2 * d + i);
+            d3 += x[i] * *(y + 3 * d + i);
+            d4 += x[i] * *(y + 4 * d + i);
+            d5 += x[i] * *(y + 5 * d + i);
+            d6 += x[i] * *(y + 6 * d + i);
+            d7 += x[i] * *(y + 7 * d + i);
+        }
+
+        dis[0] += d0;
+        dis[1] += d1;
+        dis[2] += d2;
+        dis[3] += d3;
+        dis[4] += d4;
+        dis[5] += d5;
+        dis[6] += d6;
+        dis[7] += d7;
+    }
+}
+
+static inline void fvec_L2sqr_batch24_neon(const float* x, const float* y, size_t d, float* dis) {
+    size_t i;
+    constexpr size_t single_round = 4;
+    if (d >= single_round) {
+        float32x4_t neon_query = vld1q_f32(x);
+        float32x4_t neon_base1 = vld1q_f32(y);
+        float32x4_t neon_base2 = vld1q_f32(y + d);
+        float32x4_t neon_base3 = vld1q_f32(y + 2 * d);
+        float32x4_t neon_base4 = vld1q_f32(y + 3 * d);
+        neon_base1 = vsubq_f32(neon_base1, neon_query);
+        neon_base2 = vsubq_f32(neon_base2, neon_query);
+        neon_base3 = vsubq_f32(neon_base3, neon_query);
+        neon_base4 = vsubq_f32(neon_base4, neon_query);
+        float32x4_t neon_res1 = vmulq_f32(neon_base1, neon_base1);
+        float32x4_t neon_res2 = vmulq_f32(neon_base2, neon_base2);
+        float32x4_t neon_res3 = vmulq_f32(neon_base3, neon_base3);
+        float32x4_t neon_res4 = vmulq_f32(neon_base4, neon_base4);
+
+        neon_base1 = vld1q_f32(y + 4 * d);
+        neon_base2 = vld1q_f32(y + 5 * d);
+        neon_base3 = vld1q_f32(y + 6 * d);
+        neon_base4 = vld1q_f32(y + 7 * d);
+        neon_base1 = vsubq_f32(neon_base1, neon_query);
+        neon_base2 = vsubq_f32(neon_base2, neon_query);
+        neon_base3 = vsubq_f32(neon_base3, neon_query);
+        neon_base4 = vsubq_f32(neon_base4, neon_query);
+        float32x4_t neon_res5 = vmulq_f32(neon_base1, neon_base1);
+        float32x4_t neon_res6 = vmulq_f32(neon_base2, neon_base2);
+        float32x4_t neon_res7 = vmulq_f32(neon_base3, neon_base3);
+        float32x4_t neon_res8 = vmulq_f32(neon_base4, neon_base4);
+
+        neon_base1 = vld1q_f32(y + 8 * d);
+        neon_base2 = vld1q_f32(y + 9 * d);
+        neon_base3 = vld1q_f32(y + 10 * d);
+        neon_base4 = vld1q_f32(y + 11 * d);
+        neon_base1 = vsubq_f32(neon_base1, neon_query);
+        neon_base2 = vsubq_f32(neon_base2, neon_query);
+        neon_base3 = vsubq_f32(neon_base3, neon_query);
+        neon_base4 = vsubq_f32(neon_base4, neon_query);
+        float32x4_t neon_res9 = vmulq_f32(neon_base1, neon_base1);
+        float32x4_t neon_res10 = vmulq_f32(neon_base2, neon_base2);
+        float32x4_t neon_res11 = vmulq_f32(neon_base3, neon_base3);
+        float32x4_t neon_res12 = vmulq_f32(neon_base4, neon_base4);
+
+        neon_base1 = vld1q_f32(y + 12 * d);
+        neon_base2 = vld1q_f32(y + 13 * d);
+        neon_base3 = vld1q_f32(y + 14 * d);
+        neon_base4 = vld1q_f32(y + 15 * d);
+        neon_base1 = vsubq_f32(neon_base1, neon_query);
+        neon_base2 = vsubq_f32(neon_base2, neon_query);
+        neon_base3 = vsubq_f32(neon_base3, neon_query);
+        neon_base4 = vsubq_f32(neon_base4, neon_query);
+        float32x4_t neon_res13 = vmulq_f32(neon_base1, neon_base1);
+        float32x4_t neon_res14 = vmulq_f32(neon_base2, neon_base2);
+        float32x4_t neon_res15 = vmulq_f32(neon_base3, neon_base3);
+        float32x4_t neon_res16 = vmulq_f32(neon_base4, neon_base4);
+
+        neon_base1 = vld1q_f32(y + 16 * d);
+        neon_base2 = vld1q_f32(y + 17 * d);
+        neon_base3 = vld1q_f32(y + 18 * d);
+        neon_base4 = vld1q_f32(y + 19 * d);
+        neon_base1 = vsubq_f32(neon_base1, neon_query);
+        neon_base2 = vsubq_f32(neon_base2, neon_query);
+        neon_base3 = vsubq_f32(neon_base3, neon_query);
+        neon_base4 = vsubq_f32(neon_base4, neon_query);
+        float32x4_t neon_res17 = vmulq_f32(neon_base1, neon_base1);
+        float32x4_t neon_res18 = vmulq_f32(neon_base2, neon_base2);
+        float32x4_t neon_res19 = vmulq_f32(neon_base3, neon_base3);
+        float32x4_t neon_res20 = vmulq_f32(neon_base4, neon_base4);
+
+        neon_base1 = vld1q_f32(y + 20 * d);
+        neon_base2 = vld1q_f32(y + 21 * d);
+        neon_base3 = vld1q_f32(y + 22 * d);
+        neon_base4 = vld1q_f32(y + 23 * d);
+        neon_base1 = vsubq_f32(neon_base1, neon_query);
+        neon_base2 = vsubq_f32(neon_base2, neon_query);
+        neon_base3 = vsubq_f32(neon_base3, neon_query);
+        neon_base4 = vsubq_f32(neon_base4, neon_query);
+        float32x4_t neon_res21 = vmulq_f32(neon_base1, neon_base1);
+        float32x4_t neon_res22 = vmulq_f32(neon_base2, neon_base2);
+        float32x4_t neon_res23 = vmulq_f32(neon_base3, neon_base3);
+        float32x4_t neon_res24 = vmulq_f32(neon_base4, neon_base4);
+        for (i = single_round; i <= d - single_round; i += single_round) {
+            neon_query = vld1q_f32(x + i);
+            neon_base1 = vld1q_f32(y + i);
+            neon_base2 = vld1q_f32(y + d + i);
+            neon_base3 = vld1q_f32(y + 2 * d + i);
+            neon_base4 = vld1q_f32(y + 3 * d + i);
+            neon_base1 = vsubq_f32(neon_base1, neon_query);
+            neon_base2 = vsubq_f32(neon_base2, neon_query);
+            neon_base3 = vsubq_f32(neon_base3, neon_query);
+            neon_base4 = vsubq_f32(neon_base4, neon_query);
+            neon_res1 = vmlaq_f32(neon_res1, neon_base1, neon_base1);
+            neon_res2 = vmlaq_f32(neon_res2, neon_base2, neon_base2);
+            neon_res3 = vmlaq_f32(neon_res3, neon_base3, neon_base3);
+            neon_res4 = vmlaq_f32(neon_res4, neon_base4, neon_base4);
+
+            neon_base1 = vld1q_f32(y + 4 * d + i);
+            neon_base2 = vld1q_f32(y + 5 * d + i);
+            neon_base3 = vld1q_f32(y + 6 * d + i);
+            neon_base4 = vld1q_f32(y + 7 * d + i);
+            neon_base1 = vsubq_f32(neon_base1, neon_query);
+            neon_base2 = vsubq_f32(neon_base2, neon_query);
+            neon_base3 = vsubq_f32(neon_base3, neon_query);
+            neon_base4 = vsubq_f32(neon_base4, neon_query);
+            neon_res5 = vmlaq_f32(neon_res5, neon_base1, neon_base1);
+            neon_res6 = vmlaq_f32(neon_res6, neon_base2, neon_base2);
+            neon_res7 = vmlaq_f32(neon_res7, neon_base3, neon_base3);
+            neon_res8 = vmlaq_f32(neon_res8, neon_base4, neon_base4);
+
+            neon_base1 = vld1q_f32(y + 8 * d + i);
+            neon_base2 = vld1q_f32(y + 9 * d + i);
+            neon_base3 = vld1q_f32(y + 10 * d + i);
+            neon_base4 = vld1q_f32(y + 11 * d + i);
+            neon_base1 = vsubq_f32(neon_base1, neon_query);
+            neon_base2 = vsubq_f32(neon_base2, neon_query);
+            neon_base3 = vsubq_f32(neon_base3, neon_query);
+            neon_base4 = vsubq_f32(neon_base4, neon_query);
+            neon_res9 = vmlaq_f32(neon_res9, neon_base1, neon_base1);
+            neon_res10 = vmlaq_f32(neon_res10, neon_base2, neon_base2);
+            neon_res11 = vmlaq_f32(neon_res11, neon_base3, neon_base3);
+            neon_res12 = vmlaq_f32(neon_res12, neon_base4, neon_base4);
+
+            neon_base1 = vld1q_f32(y + 12 * d + i);
+            neon_base2 = vld1q_f32(y + 13 * d + i);
+            neon_base3 = vld1q_f32(y + 14 * d + i);
+            neon_base4 = vld1q_f32(y + 15 * d + i);
+            neon_base1 = vsubq_f32(neon_base1, neon_query);
+            neon_base2 = vsubq_f32(neon_base2, neon_query);
+            neon_base3 = vsubq_f32(neon_base3, neon_query);
+            neon_base4 = vsubq_f32(neon_base4, neon_query);
+            neon_res13 = vmlaq_f32(neon_res13, neon_base1, neon_base1);
+            neon_res14 = vmlaq_f32(neon_res14, neon_base2, neon_base2);
+            neon_res15 = vmlaq_f32(neon_res15, neon_base3, neon_base3);
+            neon_res16 = vmlaq_f32(neon_res16, neon_base4, neon_base4);
+
+            neon_base1 = vld1q_f32(y + 16 * d + i);
+            neon_base2 = vld1q_f32(y + 17 * d + i);
+            neon_base3 = vld1q_f32(y + 18 * d + i);
+            neon_base4 = vld1q_f32(y + 19 * d + i);
+            neon_base1 = vsubq_f32(neon_base1, neon_query);
+            neon_base2 = vsubq_f32(neon_base2, neon_query);
+            neon_base3 = vsubq_f32(neon_base3, neon_query);
+            neon_base4 = vsubq_f32(neon_base4, neon_query);
+            neon_res17 = vmlaq_f32(neon_res17, neon_base1, neon_base1);
+            neon_res18 = vmlaq_f32(neon_res18, neon_base2, neon_base2);
+            neon_res19 = vmlaq_f32(neon_res19, neon_base3, neon_base3);
+            neon_res20 = vmlaq_f32(neon_res20, neon_base4, neon_base4);
+
+            neon_base1 = vld1q_f32(y + 20 * d + i);
+            neon_base2 = vld1q_f32(y + 21 * d + i);
+            neon_base3 = vld1q_f32(y + 22 * d + i);
+            neon_base4 = vld1q_f32(y + 23 * d + i);
+            neon_base1 = vsubq_f32(neon_base1, neon_query);
+            neon_base2 = vsubq_f32(neon_base2, neon_query);
+            neon_base3 = vsubq_f32(neon_base3, neon_query);
+            neon_base4 = vsubq_f32(neon_base4, neon_query);
+            neon_res21 = vmlaq_f32(neon_res21, neon_base1, neon_base1);
+            neon_res22 = vmlaq_f32(neon_res22, neon_base2, neon_base2);
+            neon_res23 = vmlaq_f32(neon_res23, neon_base3, neon_base3);
+            neon_res24 = vmlaq_f32(neon_res24, neon_base4, neon_base4);
+        }
+        dis[0] = vaddvq_f32(neon_res1);
+        dis[1] = vaddvq_f32(neon_res2);
+        dis[2] = vaddvq_f32(neon_res3);
+        dis[3] = vaddvq_f32(neon_res4);
+        dis[4] = vaddvq_f32(neon_res5);
+        dis[5] = vaddvq_f32(neon_res6);
+        dis[6] = vaddvq_f32(neon_res7);
+        dis[7] = vaddvq_f32(neon_res8);
+        dis[8] = vaddvq_f32(neon_res9);
+        dis[9] = vaddvq_f32(neon_res10);
+        dis[10] = vaddvq_f32(neon_res11);
+        dis[11] = vaddvq_f32(neon_res12);
+        dis[12] = vaddvq_f32(neon_res13);
+        dis[13] = vaddvq_f32(neon_res14);
+        dis[14] = vaddvq_f32(neon_res15);
+        dis[15] = vaddvq_f32(neon_res16);
+        dis[16] = vaddvq_f32(neon_res17);
+        dis[17] = vaddvq_f32(neon_res18);
+        dis[18] = vaddvq_f32(neon_res19);
+        dis[19] = vaddvq_f32(neon_res20);
+        dis[20] = vaddvq_f32(neon_res21);
+        dis[21] = vaddvq_f32(neon_res22);
+        dis[22] = vaddvq_f32(neon_res23);
+        dis[23] = vaddvq_f32(neon_res24);
+    } else {
+        for (int j = 0; j < 24; j++) {
+            dis[j] = 0.0f;
+        }
+        i = 0;
+    }
+    if (i < d) {
+        float q0 = x[i] - *(y + i);
+        float q1 = x[i] - *(y + d + i);
+        float q2 = x[i] - *(y + 2 * d + i);
+        float q3 = x[i] - *(y + 3 * d + i);
+        float q4 = x[i] - *(y + 4 * d + i);
+        float q5 = x[i] - *(y + 5 * d + i);
+        float q6 = x[i] - *(y + 6 * d + i);
+        float q7 = x[i] - *(y + 7 * d + i);
+        float d0 = q0 * q0;
+        float d1 = q1 * q1;
+        float d2 = q2 * q2;
+        float d3 = q3 * q3;
+        float d4 = q4 * q4;
+        float d5 = q5 * q5;
+        float d6 = q6 * q6;
+        float d7 = q7 * q7;
+        q0 = x[i] - *(y + 8 * d + i);
+        q1 = x[i] - *(y + 9 * d + i);
+        q2 = x[i] - *(y + 10 * d + i);
+        q3 = x[i] - *(y + 11 * d + i);
+        q4 = x[i] - *(y + 12 * d + i);
+        q5 = x[i] - *(y + 13 * d + i);
+        q6 = x[i] - *(y + 14 * d + i);
+        q7 = x[i] - *(y + 15 * d + i);
+        float d8 = q0 * q0;
+        float d9 = q1 * q1;
+        float d10 = q2 * q2;
+        float d11 = q3 * q3;
+        float d12 = q4 * q4;
+        float d13 = q5 * q5;
+        float d14 = q6 * q6;
+        float d15 = q7 * q7;
+        q0 = x[i] - *(y + 16 * d + i);
+        q1 = x[i] - *(y + 17 * d + i);
+        q2 = x[i] - *(y + 18 * d + i);
+        q3 = x[i] - *(y + 19 * d + i);
+        q4 = x[i] - *(y + 20 * d + i);
+        q5 = x[i] - *(y + 21 * d + i);
+        q6 = x[i] - *(y + 22 * d + i);
+        q7 = x[i] - *(y + 23 * d + i);
+        float d16 = q0 * q0;
+        float d17 = q1 * q1;
+        float d18 = q2 * q2;
+        float d19 = q3 * q3;
+        float d20 = q4 * q4;
+        float d21 = q5 * q5;
+        float d22 = q6 * q6;
+        float d23 = q7 * q7;
+        for (i++; i < d; ++i) {
+            q0 = x[i] - *(y + i);
+            q1 = x[i] - *(y + d + i);
+            q2 = x[i] - *(y + 2 * d + i);
+            q3 = x[i] - *(y + 3 * d + i);
+            q4 = x[i] - *(y + 4 * d + i);
+            q5 = x[i] - *(y + 5 * d + i);
+            q6 = x[i] - *(y + 6 * d + i);
+            q7 = x[i] - *(y + 7 * d + i);
+            d0 += q0 * q0;
+            d1 += q1 * q1;
+            d2 += q2 * q2;
+            d3 += q3 * q3;
+            d4 += q4 * q4;
+            d5 += q5 * q5;
+            d6 += q6 * q6;
+            d7 += q7 * q7;
+            q0 = x[i] - *(y + 8 * d + i);
+            q1 = x[i] - *(y + 9 * d + i);
+            q2 = x[i] - *(y + 10 * d + i);
+            q3 = x[i] - *(y + 11 * d + i);
+            q4 = x[i] - *(y + 12 * d + i);
+            q5 = x[i] - *(y + 13 * d + i);
+            q6 = x[i] - *(y + 14 * d + i);
+            q7 = x[i] - *(y + 15 * d + i);
+            d8 += q0 * q0;
+            d9 += q1 * q1;
+            d10 += q2 * q2;
+            d11 += q3 * q3;
+            d12 += q4 * q4;
+            d13 += q5 * q5;
+            d14 += q6 * q6;
+            d15 += q7 * q7;
+            q0 = x[i] - *(y + 16 * d + i);
+            q1 = x[i] - *(y + 17 * d + i);
+            q2 = x[i] - *(y + 18 * d + i);
+            q3 = x[i] - *(y + 19 * d + i);
+            q4 = x[i] - *(y + 20 * d + i);
+            q5 = x[i] - *(y + 21 * d + i);
+            q6 = x[i] - *(y + 22 * d + i);
+            q7 = x[i] - *(y + 23 * d + i);
+            d16 += q0 * q0;
+            d17 += q1 * q1;
+            d18 += q2 * q2;
+            d19 += q3 * q3;
+            d20 += q4 * q4;
+            d21 += q5 * q5;
+            d22 += q6 * q6;
+            d23 += q7 * q7;
+        }
+        dis[0] += d0;
+        dis[1] += d1;
+        dis[2] += d2;
+        dis[3] += d3;
+        dis[4] += d4;
+        dis[5] += d5;
+        dis[6] += d6;
+        dis[7] += d7;
+        dis[8] += d8;
+        dis[9] += d9;
+        dis[10] += d10;
+        dis[11] += d11;
+        dis[12] += d12;
+        dis[13] += d13;
+        dis[14] += d14;
+        dis[15] += d15;
+        dis[16] += d16;
+        dis[17] += d17;
+        dis[18] += d18;
+        dis[19] += d19;
+        dis[20] += d20;
+        dis[21] += d21;
+        dis[22] += d22;
+        dis[23] += d23;
+    }
+}
+
+static inline void fvec_L2sqr_batch16_neon(const float* x, const float* y, size_t d, float* dis) {
+    size_t i;
+    constexpr size_t single_round = 4;
+    if (d >= single_round) {
+        float32x4_t neon_query = vld1q_f32(x);
+
+        float32x4_t neon_base1 = vld1q_f32(y);
+        float32x4_t neon_base2 = vld1q_f32(y + d);
+        float32x4_t neon_base3 = vld1q_f32(y + 2 * d);
+        float32x4_t neon_base4 = vld1q_f32(y + 3 * d);
+        float32x4_t neon_base5 = vld1q_f32(y + 4 * d);
+        float32x4_t neon_base6 = vld1q_f32(y + 5 * d);
+        float32x4_t neon_base7 = vld1q_f32(y + 6 * d);
+        float32x4_t neon_base8 = vld1q_f32(y + 7 * d);
+
+        neon_base1 = vsubq_f32(neon_base1, neon_query);
+        neon_base2 = vsubq_f32(neon_base2, neon_query);
+        neon_base3 = vsubq_f32(neon_base3, neon_query);
+        neon_base4 = vsubq_f32(neon_base4, neon_query);
+        neon_base5 = vsubq_f32(neon_base5, neon_query);
+        neon_base6 = vsubq_f32(neon_base6, neon_query);
+        neon_base7 = vsubq_f32(neon_base7, neon_query);
+        neon_base8 = vsubq_f32(neon_base8, neon_query);
+
+        float32x4_t neon_res1 = vmulq_f32(neon_base1, neon_base1);
+        float32x4_t neon_res2 = vmulq_f32(neon_base2, neon_base2);
+        float32x4_t neon_res3 = vmulq_f32(neon_base3, neon_base3);
+        float32x4_t neon_res4 = vmulq_f32(neon_base4, neon_base4);
+        float32x4_t neon_res5 = vmulq_f32(neon_base5, neon_base5);
+        float32x4_t neon_res6 = vmulq_f32(neon_base6, neon_base6);
+        float32x4_t neon_res7 = vmulq_f32(neon_base7, neon_base7);
+        float32x4_t neon_res8 = vmulq_f32(neon_base8, neon_base8);
+
+        neon_base1 = vld1q_f32(y + 8 * d);
+        neon_base2 = vld1q_f32(y + 9 * d);
+        neon_base3 = vld1q_f32(y + 10 * d);
+        neon_base4 = vld1q_f32(y + 11 * d);
+        neon_base5 = vld1q_f32(y + 12 * d);
+        neon_base6 = vld1q_f32(y + 13 * d);
+        neon_base7 = vld1q_f32(y + 14 * d);
+        neon_base8 = vld1q_f32(y + 15 * d);
+
+        neon_base1 = vsubq_f32(neon_base1, neon_query);
+        neon_base2 = vsubq_f32(neon_base2, neon_query);
+        neon_base3 = vsubq_f32(neon_base3, neon_query);
+        neon_base4 = vsubq_f32(neon_base4, neon_query);
+        neon_base5 = vsubq_f32(neon_base5, neon_query);
+        neon_base6 = vsubq_f32(neon_base6, neon_query);
+        neon_base7 = vsubq_f32(neon_base7, neon_query);
+        neon_base8 = vsubq_f32(neon_base8, neon_query);
+
+        float32x4_t neon_res9 = vmulq_f32(neon_base1, neon_base1);
+        float32x4_t neon_res10 = vmulq_f32(neon_base2, neon_base2);
+        float32x4_t neon_res11 = vmulq_f32(neon_base3, neon_base3);
+        float32x4_t neon_res12 = vmulq_f32(neon_base4, neon_base4);
+        float32x4_t neon_res13 = vmulq_f32(neon_base5, neon_base5);
+        float32x4_t neon_res14 = vmulq_f32(neon_base6, neon_base6);
+        float32x4_t neon_res15 = vmulq_f32(neon_base7, neon_base7);
+        float32x4_t neon_res16 = vmulq_f32(neon_base8, neon_base8);
+
+        for (i = single_round; i <= d - single_round; i += single_round) {
+            neon_query = vld1q_f32(x + i);
+            neon_base1 = vld1q_f32(y + i);
+            neon_base2 = vld1q_f32(y + d + i);
+            neon_base3 = vld1q_f32(y + 2 * d + i);
+            neon_base4 = vld1q_f32(y + 3 * d + i);
+            neon_base5 = vld1q_f32(y + 4 * d + i);
+            neon_base6 = vld1q_f32(y + 5 * d + i);
+            neon_base7 = vld1q_f32(y + 6 * d + i);
+            neon_base8 = vld1q_f32(y + 7 * d + i);
+
+            neon_base1 = vsubq_f32(neon_base1, neon_query);
+            neon_base2 = vsubq_f32(neon_base2, neon_query);
+            neon_base3 = vsubq_f32(neon_base3, neon_query);
+            neon_base4 = vsubq_f32(neon_base4, neon_query);
+            neon_base5 = vsubq_f32(neon_base5, neon_query);
+            neon_base6 = vsubq_f32(neon_base6, neon_query);
+            neon_base7 = vsubq_f32(neon_base7, neon_query);
+            neon_base8 = vsubq_f32(neon_base8, neon_query);
+
+            neon_res1 = vmlaq_f32(neon_res1, neon_base1, neon_base1);
+            neon_res2 = vmlaq_f32(neon_res2, neon_base2, neon_base2);
+            neon_res3 = vmlaq_f32(neon_res3, neon_base3, neon_base3);
+            neon_res4 = vmlaq_f32(neon_res4, neon_base4, neon_base4);
+            neon_res5 = vmlaq_f32(neon_res5, neon_base5, neon_base5);
+            neon_res6 = vmlaq_f32(neon_res6, neon_base6, neon_base6);
+            neon_res7 = vmlaq_f32(neon_res7, neon_base7, neon_base7);
+            neon_res8 = vmlaq_f32(neon_res8, neon_base8, neon_base8);
+
+            neon_base1 = vld1q_f32(y + 8 * d + i);
+            neon_base2 = vld1q_f32(y + 9 * d + i);
+            neon_base3 = vld1q_f32(y + 10 * d + i);
+            neon_base4 = vld1q_f32(y + 11 * d + i);
+            neon_base5 = vld1q_f32(y + 12 * d + i);
+            neon_base6 = vld1q_f32(y + 13 * d + i);
+            neon_base7 = vld1q_f32(y + 14 * d + i);
+            neon_base8 = vld1q_f32(y + 15 * d + i);
+
+            neon_base1 = vsubq_f32(neon_base1, neon_query);
+            neon_base2 = vsubq_f32(neon_base2, neon_query);
+            neon_base3 = vsubq_f32(neon_base3, neon_query);
+            neon_base4 = vsubq_f32(neon_base4, neon_query);
+            neon_base5 = vsubq_f32(neon_base5, neon_query);
+            neon_base6 = vsubq_f32(neon_base6, neon_query);
+            neon_base7 = vsubq_f32(neon_base7, neon_query);
+            neon_base8 = vsubq_f32(neon_base8, neon_query);
+
+            neon_res9 = vmlaq_f32(neon_res9, neon_base1, neon_base1);
+            neon_res10 = vmlaq_f32(neon_res10, neon_base2, neon_base2);
+            neon_res11 = vmlaq_f32(neon_res11, neon_base3, neon_base3);
+            neon_res12 = vmlaq_f32(neon_res12, neon_base4, neon_base4);
+            neon_res13 = vmlaq_f32(neon_res13, neon_base5, neon_base5);
+            neon_res14 = vmlaq_f32(neon_res14, neon_base6, neon_base6);
+            neon_res15 = vmlaq_f32(neon_res15, neon_base7, neon_base7);
+            neon_res16 = vmlaq_f32(neon_res16, neon_base8, neon_base8);
+        }
+        dis[0] = vaddvq_f32(neon_res1);
+        dis[1] = vaddvq_f32(neon_res2);
+        dis[2] = vaddvq_f32(neon_res3);
+        dis[3] = vaddvq_f32(neon_res4);
+        dis[4] = vaddvq_f32(neon_res5);
+        dis[5] = vaddvq_f32(neon_res6);
+        dis[6] = vaddvq_f32(neon_res7);
+        dis[7] = vaddvq_f32(neon_res8);
+        dis[8] = vaddvq_f32(neon_res9);
+        dis[9] = vaddvq_f32(neon_res10);
+        dis[10] = vaddvq_f32(neon_res11);
+        dis[11] = vaddvq_f32(neon_res12);
+        dis[12] = vaddvq_f32(neon_res13);
+        dis[13] = vaddvq_f32(neon_res14);
+        dis[14] = vaddvq_f32(neon_res15);
+        dis[15] = vaddvq_f32(neon_res16);
+    } else {
+        for (int j = 0; j < 16; j++) {
+            dis[j] = 0.0f;
+        }
+        i = 0;
+    }
+    if (i < d) {
+        float q0 = x[i] - *(y + i);
+        float q1 = x[i] - *(y + d + i);
+        float q2 = x[i] - *(y + 2 * d + i);
+        float q3 = x[i] - *(y + 3 * d + i);
+        float q4 = x[i] - *(y + 4 * d + i);
+        float q5 = x[i] - *(y + 5 * d + i);
+        float q6 = x[i] - *(y + 6 * d + i);
+        float q7 = x[i] - *(y + 7 * d + i);
+        float d0 = q0 * q0;
+        float d1 = q1 * q1;
+        float d2 = q2 * q2;
+        float d3 = q3 * q3;
+        float d4 = q4 * q4;
+        float d5 = q5 * q5;
+        float d6 = q6 * q6;
+        float d7 = q7 * q7;
+        float q8 = x[i] - *(y + 8 * d + i);
+        float q9 = x[i] - *(y + 9 * d + i);
+        float q10 = x[i] - *(y + 10 * d + i);
+        float q11 = x[i] - *(y + 11 * d + i);
+        float q12 = x[i] - *(y + 12 * d + i);
+        float q13 = x[i] - *(y + 13 * d + i);
+        float q14 = x[i] - *(y + 14 * d + i);
+        float q15 = x[i] - *(y + 15 * d + i);
+        float d8 = q8 * q8;
+        float d9 = q9 * q9;
+        float d10 = q10 * q10;
+        float d11 = q11 * q11;
+        float d12 = q12 * q12;
+        float d13 = q13 * q13;
+        float d14 = q14 * q14;
+        float d15 = q15 * q15;
+        for (i++; i < d; ++i) {
+            q0 = x[i] - *(y + i);
+            q1 = x[i] - *(y + d + i);
+            q2 = x[i] - *(y + 2 * d + i);
+            q3 = x[i] - *(y + 3 * d + i);
+            q4 = x[i] - *(y + 4 * d + i);
+            q5 = x[i] - *(y + 5 * d + i);
+            q6 = x[i] - *(y + 6 * d + i);
+            q7 = x[i] - *(y + 7 * d + i);
+            d0 += q0 * q0;
+            d1 += q1 * q1;
+            d2 += q2 * q2;
+            d3 += q3 * q3;
+            d4 += q4 * q4;
+            d5 += q5 * q5;
+            d6 += q6 * q6;
+            d7 += q7 * q7;
+            q8 = x[i] - *(y + 8 * d + i);
+            q9 = x[i] - *(y + 9 * d + i);
+            q10 = x[i] - *(y + 10 * d + i);
+            q11 = x[i] - *(y + 11 * d + i);
+            q12 = x[i] - *(y + 12 * d + i);
+            q13 = x[i] - *(y + 13 * d + i);
+            q14 = x[i] - *(y + 14 * d + i);
+            q15 = x[i] - *(y + 15 * d + i);
+            d8 += q8 * q8;
+            d9 += q9 * q9;
+            d10 += q10 * q10;
+            d11 += q11 * q11;
+            d12 += q12 * q12;
+            d13 += q13 * q13;
+            d14 += q14 * q14;
+            d15 += q15 * q15;
+        }
+        dis[0] += d0;
+        dis[1] += d1;
+        dis[2] += d2;
+        dis[3] += d3;
+        dis[4] += d4;
+        dis[5] += d5;
+        dis[6] += d6;
+        dis[7] += d7;
+        dis[8] += d8;
+        dis[9] += d9;
+        dis[10] += d10;
+        dis[11] += d11;
+        dis[12] += d12;
+        dis[13] += d13;
+        dis[14] += d14;
+        dis[15] += d15;
+    }
+}
+
+// Template specializations for Faiss distance functions
+template <>
+void fvec_L2sqr_ny<SIMDLevel::ARM_NEON>(
+        float* dis,
+        const float* x,
+        const float* y,
+        size_t d,
+        size_t ny) {
+    size_t i = 0;
+    for (; i + 24 <= ny; i += 24) {
+        fvec_L2sqr_batch24_neon(x, y + i * d, d, dis + i);
+    }
+    if (i + 16 <= ny) {
+        fvec_L2sqr_batch16_neon(x, y + i * d, d, dis + i);
+        i += 16;
+    } else if (i + 8 <= ny) {
+        fvec_L2sqr_batch8_neon(x, y + i * d, d, dis + i);
+        i += 8;
+    }
+    if (ny & 4) {
+        fvec_L2sqr_batch4_neon(x, y + i * d, d, dis + i);
+        i += 4;
+    }
+    if (ny & 2) {
+        fvec_L2sqr_batch2_neon(x, y + i * d, d, dis + i);
+        i += 2;
+    }
+    if (ny & 1) {
+        dis[ny - 1] = fvec_L2sqr_neon(x, y + (ny - 1) * d, d);
+    }
+}
+
+static inline void fvec_inner_product_batch16_neon(const float* x, const float* y, size_t d, float* dis) {
+    size_t i;
+    constexpr size_t single_round = 4;
+
+    if (d >= single_round) {
+        float32x4_t neon_query = vld1q_f32(x);
+        float32x4_t neon_base1 = vld1q_f32(y);
+        float32x4_t neon_base2 = vld1q_f32(y + d);
+        float32x4_t neon_base3 = vld1q_f32(y + 2 * d);
+        float32x4_t neon_base4 = vld1q_f32(y + 3 * d);
+        float32x4_t neon_base5 = vld1q_f32(y + 4 * d);
+        float32x4_t neon_base6 = vld1q_f32(y + 5 * d);
+        float32x4_t neon_base7 = vld1q_f32(y + 6 * d);
+        float32x4_t neon_base8 = vld1q_f32(y + 7 * d);
+
+        float32x4_t neon_res1 = vmulq_f32(neon_base1, neon_query);
+        float32x4_t neon_res2 = vmulq_f32(neon_base2, neon_query);
+        float32x4_t neon_res3 = vmulq_f32(neon_base3, neon_query);
+        float32x4_t neon_res4 = vmulq_f32(neon_base4, neon_query);
+        float32x4_t neon_res5 = vmulq_f32(neon_base5, neon_query);
+        float32x4_t neon_res6 = vmulq_f32(neon_base6, neon_query);
+        float32x4_t neon_res7 = vmulq_f32(neon_base7, neon_query);
+        float32x4_t neon_res8 = vmulq_f32(neon_base8, neon_query);
+
+        neon_base1 = vld1q_f32(y + 8 * d);
+        neon_base2 = vld1q_f32(y + 9 * d);
+        neon_base3 = vld1q_f32(y + 10 * d);
+        neon_base4 = vld1q_f32(y + 11 * d);
+        neon_base5 = vld1q_f32(y + 12 * d);
+        neon_base6 = vld1q_f32(y + 13 * d);
+        neon_base7 = vld1q_f32(y + 14 * d);
+        neon_base8 = vld1q_f32(y + 15 * d);
+
+        float32x4_t neon_res9 = vmulq_f32(neon_base1, neon_query);
+        float32x4_t neon_res10 = vmulq_f32(neon_base2, neon_query);
+        float32x4_t neon_res11 = vmulq_f32(neon_base3, neon_query);
+        float32x4_t neon_res12 = vmulq_f32(neon_base4, neon_query);
+        float32x4_t neon_res13 = vmulq_f32(neon_base5, neon_query);
+        float32x4_t neon_res14 = vmulq_f32(neon_base6, neon_query);
+        float32x4_t neon_res15 = vmulq_f32(neon_base7, neon_query);
+        float32x4_t neon_res16 = vmulq_f32(neon_base8, neon_query);
+
+        for (i = single_round; i <= d - single_round; i += single_round) {
+            neon_query = vld1q_f32(x + i);
+            neon_base1 = vld1q_f32(y + i);
+            neon_base2 = vld1q_f32(y + d + i);
+            neon_base3 = vld1q_f32(y + 2 * d + i);
+            neon_base4 = vld1q_f32(y + 3 * d + i);
+            neon_base5 = vld1q_f32(y + 4 * d + i);
+            neon_base6 = vld1q_f32(y + 5 * d + i);
+            neon_base7 = vld1q_f32(y + 6 * d + i);
+            neon_base8 = vld1q_f32(y + 7 * d + i);
+
+            neon_res1 = vmlaq_f32(neon_res1, neon_base1, neon_query);
+            neon_res2 = vmlaq_f32(neon_res2, neon_base2, neon_query);
+            neon_res3 = vmlaq_f32(neon_res3, neon_base3, neon_query);
+            neon_res4 = vmlaq_f32(neon_res4, neon_base4, neon_query);
+            neon_res5 = vmlaq_f32(neon_res5, neon_base5, neon_query);
+            neon_res6 = vmlaq_f32(neon_res6, neon_base6, neon_query);
+            neon_res7 = vmlaq_f32(neon_res7, neon_base7, neon_query);
+            neon_res8 = vmlaq_f32(neon_res8, neon_base8, neon_query);
+
+            neon_base1 = vld1q_f32(y + 8 * d + i);
+            neon_base2 = vld1q_f32(y + 9 * d + i);
+            neon_base3 = vld1q_f32(y + 10 * d + i);
+            neon_base4 = vld1q_f32(y + 11 * d + i);
+            neon_base5 = vld1q_f32(y + 12 * d + i);
+            neon_base6 = vld1q_f32(y + 13 * d + i);
+            neon_base7 = vld1q_f32(y + 14 * d + i);
+            neon_base8 = vld1q_f32(y + 15 * d + i);
+
+            neon_res9 = vmlaq_f32(neon_res9, neon_base1, neon_query);
+            neon_res10 = vmlaq_f32(neon_res10, neon_base2, neon_query);
+            neon_res11 = vmlaq_f32(neon_res11, neon_base3, neon_query);
+            neon_res12 = vmlaq_f32(neon_res12, neon_base4, neon_query);
+            neon_res13 = vmlaq_f32(neon_res13, neon_base5, neon_query);
+            neon_res14 = vmlaq_f32(neon_res14, neon_base6, neon_query);
+            neon_res15 = vmlaq_f32(neon_res15, neon_base7, neon_query);
+            neon_res16 = vmlaq_f32(neon_res16, neon_base8, neon_query);
+        }
+
+        dis[0] = vaddvq_f32(neon_res1);
+        dis[1] = vaddvq_f32(neon_res2);
+        dis[2] = vaddvq_f32(neon_res3);
+        dis[3] = vaddvq_f32(neon_res4);
+        dis[4] = vaddvq_f32(neon_res5);
+        dis[5] = vaddvq_f32(neon_res6);
+        dis[6] = vaddvq_f32(neon_res7);
+        dis[7] = vaddvq_f32(neon_res8);
+        dis[8] = vaddvq_f32(neon_res9);
+        dis[9] = vaddvq_f32(neon_res10);
+        dis[10] = vaddvq_f32(neon_res11);
+        dis[11] = vaddvq_f32(neon_res12);
+        dis[12] = vaddvq_f32(neon_res13);
+        dis[13] = vaddvq_f32(neon_res14);
+        dis[14] = vaddvq_f32(neon_res15);
+        dis[15] = vaddvq_f32(neon_res16);
+    } else {
+        for (int j = 0; j < 16; j++) {
+            dis[j] = 0.0f;
+        }
+        i = 0;
+    }
+    if (i < d) {
+        float d0 = x[i] * *(y + i);
+        float d1 = x[i] * *(y + d + i);
+        float d2 = x[i] * *(y + 2 * d + i);
+        float d3 = x[i] * *(y + 3 * d + i);
+        float d4 = x[i] * *(y + 4 * d + i);
+        float d5 = x[i] * *(y + 5 * d + i);
+        float d6 = x[i] * *(y + 6 * d + i);
+        float d7 = x[i] * *(y + 7 * d + i);
+        float d8 = x[i] * *(y + 8 * d + i);
+        float d9 = x[i] * *(y + 9 * d + i);
+        float d10 = x[i] * *(y + 10 * d + i);
+        float d11 = x[i] * *(y + 11 * d + i);
+        float d12 = x[i] * *(y + 12 * d + i);
+        float d13 = x[i] * *(y + 13 * d + i);
+        float d14 = x[i] * *(y + 14 * d + i);
+        float d15 = x[i] * *(y + 15 * d + i);
+
+        for (i++; i < d; ++i) {
+            d0 += x[i] * *(y + i);
+            d1 += x[i] * *(y + d + i);
+            d2 += x[i] * *(y + 2 * d + i);
+            d3 += x[i] * *(y + 3 * d + i);
+            d4 += x[i] * *(y + 4 * d + i);
+            d5 += x[i] * *(y + 5 * d + i);
+            d6 += x[i] * *(y + 6 * d + i);
+            d7 += x[i] * *(y + 7 * d + i);
+            d8 += x[i] * *(y + 8 * d + i);
+            d9 += x[i] * *(y + 9 * d + i);
+            d10 += x[i] * *(y + 10 * d + i);
+            d11 += x[i] * *(y + 11 * d + i);
+            d12 += x[i] * *(y + 12 * d + i);
+            d13 += x[i] * *(y + 13 * d + i);
+            d14 += x[i] * *(y + 14 * d + i);
+            d15 += x[i] * *(y + 15 * d + i);
+        }
+
+        dis[0] += d0;
+        dis[1] += d1;
+        dis[2] += d2;
+        dis[3] += d3;
+        dis[4] += d4;
+        dis[5] += d5;
+        dis[6] += d6;
+        dis[7] += d7;
+        dis[8] += d8;
+        dis[9] += d9;
+        dis[10] += d10;
+        dis[11] += d11;
+        dis[12] += d12;
+        dis[13] += d13;
+        dis[14] += d14;
+        dis[15] += d15;
+    }
+}
+
+template <>
+void fvec_inner_products_ny<SIMDLevel::ARM_NEON>(
+        float* dis,
+        const float* x,
+        const float* y,
+        size_t d,
+        size_t ny) {
+    size_t i = 0;
+    for (; i + 16 <= ny; i += 16) {
+        fvec_inner_product_batch16_neon(x, y + i * d, d, dis + i);
+    }
+    if (ny & 8) {
+        fvec_inner_product_batch8_neon(x, y + i * d, d, dis + i);
+        i += 8;
+    }
+    if (ny & 4) {
+        fvec_inner_product_batch4_neon(x, y + i * d, d, dis + i);
+        i += 4;
+    }
+    if (ny & 2) {
+        fvec_inner_product_batch2_neon(x, y + i * d, d, dis + i);
+        i += 2;
+    }
+    if (ny & 1) {
+        dis[ny - 1] = fvec_inner_product_neon(x, y + (ny - 1) * d, d);
+    }
+}
+
+// Continuous transpose kernels for PQ precomputed tables
+
+static void inner_product_continuous_transpose_16_neon(
+        float* dis,
+        const float* x,
+        const float* y,
+        size_t d) {
+    float32x4_t res[4];
+    float32x4_t q = vdupq_n_f32(x[0]);
+    res[0] = vmulq_f32(vld1q_f32(y), q);
+    res[1] = vmulq_f32(vld1q_f32(y + 4), q);
+    res[2] = vmulq_f32(vld1q_f32(y + 8), q);
+    res[3] = vmulq_f32(vld1q_f32(y + 12), q);
+    for (size_t i = 1; i < d; ++i) {
+        q = vdupq_n_f32(x[i]);
+        res[0] = vmlaq_f32(res[0], vld1q_f32(y + 16 * i), q);
+        res[1] = vmlaq_f32(res[1], vld1q_f32(y + 16 * i + 4), q);
+        res[2] = vmlaq_f32(res[2], vld1q_f32(y + 16 * i + 8), q);
+        res[3] = vmlaq_f32(res[3], vld1q_f32(y + 16 * i + 12), q);
+    }
+    vst1q_f32(dis, res[0]);
+    vst1q_f32(dis + 4, res[1]);
+    vst1q_f32(dis + 8, res[2]);
+    vst1q_f32(dis + 12, res[3]);
+}
+
+static void inner_product_continuous_transpose_32_neon(
+        float* dis,
+        const float* x,
+        const float* y,
+        size_t d) {
+    float32x4_t res[8];
+    float32x4_t q = vdupq_n_f32(x[0]);
+    for (int j = 0; j < 8; j++) {
+        res[j] = vmulq_f32(vld1q_f32(y + j * 4), q);
+    }
+    for (size_t i = 1; i < d; ++i) {
+        q = vdupq_n_f32(x[i]);
+        for (int j = 0; j < 8; j++) {
+            res[j] = vmlaq_f32(res[j], vld1q_f32(y + 32 * i + j * 4), q);
+        }
+    }
+    for (int j = 0; j < 8; j++) {
+        vst1q_f32(dis + j * 4, res[j]);
+    }
+}
+
+static void inner_product_continuous_transpose_64_neon(
+        float* dis,
+        const float* x,
+        const float* y,
+        size_t d) {
+    float32x4_t res[16];
+    float32x4_t q = vdupq_n_f32(x[0]);
+    for (int j = 0; j < 16; j++) {
+        res[j] = vmulq_f32(vld1q_f32(y + j * 4), q);
+    }
+    for (size_t i = 1; i < d; ++i) {
+        q = vdupq_n_f32(x[i]);
+        for (int j = 0; j < 16; j++) {
+            res[j] = vmlaq_f32(res[j], vld1q_f32(y + 64 * i + j * 4), q);
+        }
+    }
+    for (int j = 0; j < 16; j++) {
+        vst1q_f32(dis + j * 4, res[j]);
+    }
+}
+
+} // namespace faiss
+
+#endif // COMPILE_SIMD_ARM_NEON

--- a/faiss/utils/simd_impl/matrix_transpose_neon.cpp
+++ b/faiss/utils/simd_impl/matrix_transpose_neon.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Copyright (c) Huawei Technologies Co., Ltd.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// NEON-optimized matrix block transpose
+
+#ifdef COMPILE_SIMD_ARM_NEON
+
+#include <arm_neon.h>
+#include <cstring>
+
+namespace faiss {
+
+// Migrated from krl_matrix_block_transpose_kernel
+static void matrix_block_transpose_kernel_neon(
+        const uint32_t* src,
+        size_t dim,
+        size_t blocksize,
+        uint32_t* block) {
+    uint32x4_t matrix[16];
+    uint64x2_t tmp[4];
+    for (size_t i = 0; i < blocksize; i += 16) {
+        for (size_t j = 0; j < 16; j += 4) {
+            matrix[j] = vld1q_u32(src + (i + j) * dim);
+            matrix[j + 1] = vld1q_u32(src + (i + j + 1) * dim);
+            matrix[j + 2] = vld1q_u32(src + (i + j + 2) * dim);
+            matrix[j + 3] = vld1q_u32(src + (i + j + 3) * dim);
+            tmp[0] = vreinterpretq_u64_u32(vtrn1q_u32(matrix[j], matrix[j + 1]));
+            tmp[1] = vreinterpretq_u64_u32(vtrn2q_u32(matrix[j], matrix[j + 1]));
+            tmp[2] = vreinterpretq_u64_u32(vtrn1q_u32(matrix[j + 2], matrix[j + 3]));
+            tmp[3] = vreinterpretq_u64_u32(vtrn2q_u32(matrix[j + 2], matrix[j + 3]));
+            matrix[j] = vreinterpretq_u32_u64(vtrn1q_u64(tmp[0], tmp[2]));
+            matrix[j + 1] = vreinterpretq_u32_u64(vtrn1q_u64(tmp[1], tmp[3]));
+            matrix[j + 2] = vreinterpretq_u32_u64(vtrn2q_u64(tmp[0], tmp[2]));
+            matrix[j + 3] = vreinterpretq_u32_u64(vtrn2q_u64(tmp[1], tmp[3]));
+        }
+        vst1q_u32(block + i, matrix[0]);
+        vst1q_u32(block + i + 4, matrix[4]);
+        vst1q_u32(block + i + 8, matrix[8]);
+        vst1q_u32(block + i + 12, matrix[12]);
+        vst1q_u32(block + i + blocksize, matrix[1]);
+        vst1q_u32(block + i + blocksize + 4, matrix[5]);
+        vst1q_u32(block + i + blocksize + 8, matrix[9]);
+        vst1q_u32(block + i + blocksize + 12, matrix[13]);
+        vst1q_u32(block + i + 2 * blocksize, matrix[2]);
+        vst1q_u32(block + i + 2 * blocksize + 4, matrix[6]);
+        vst1q_u32(block + i + 2 * blocksize + 8, matrix[10]);
+        vst1q_u32(block + i + 2 * blocksize + 12, matrix[14]);
+        vst1q_u32(block + i + 3 * blocksize, matrix[3]);
+        vst1q_u32(block + i + 3 * blocksize + 4, matrix[7]);
+        vst1q_u32(block + i + 3 * blocksize + 8, matrix[11]);
+        vst1q_u32(block + i + 3 * blocksize + 12, matrix[15]);
+    }
+}
+
+// Migrated from krl_matrix_block_transpose
+void matrix_block_transpose_neon(
+        const uint32_t* src,
+        size_t ny,
+        size_t dim,
+        size_t blocksize,
+        uint32_t* block) {
+    size_t i = 0;
+    size_t bid = 0;
+    for (; i + blocksize <= ny; i += blocksize) {
+        size_t d = 0;
+        for (; d + 4 <= dim; d += 4) {
+            matrix_block_transpose_kernel_neon(
+                    src + i * dim + d, dim, blocksize, block + bid);
+            bid += 4 * blocksize;
+        }
+        for (; d < dim; ++d) {
+            for (size_t j = 0; j < blocksize; ++j) {
+                block[bid + j] = src[(i + j) * dim + d];
+            }
+            bid += blocksize;
+        }
+    }
+    if (i < ny) {
+        const size_t left = ny - i;
+        for (size_t d = 0; d < dim; ++d) {
+            for (size_t j = 0; j < left; ++j) {
+                block[bid + j] = src[(i + j) * dim + d];
+            }
+            std::memset(block + bid + left, 0, (blocksize - left) * sizeof(uint32_t));
+            bid += blocksize;
+        }
+    }
+}
+
+} // namespace faiss
+
+#endif // COMPILE_SIMD_ARM_NEON


### PR DESCRIPTION
## Summary

This PR introduces ARM NEON optimizations for IVFPQ index, focusing on 8-bit lookup table operations and distance computations.

## Changes

- Optimized 8-bit LUT (lookup table) construction and distance calculation
- Implemented algorithmic improvements combined with NEON intrinsics
- All core optimization code is placed under `faiss/sra_krl/` for clear organization

## Design Decisions

- Code is organized in a separate directory (`faiss/sra_krl/`) to keep the file structure clean and facilitate initial code review
- Guarded by `__aarch64__` macro, no impact on x86 builds
- Functionally equivalent to the original implementation (no changes to index format or search results)

## Testing

- Passed FAISS built-in unit tests on AArch64 platform
- Benchmark results show noticeable performance improvements on ARM servers

## Notes

We understand that naming conventions and NEON code placement may need adjustments to align with the ongoing SIMD restructuring. We are happy to collaborate with maintainers to refine the code structure as needed.

If this contribution is well-received, we have additional optimizations for HNSW, Refine, and FastScan ready for follow-up PRs.