### PR TITLE
Additional binary index input validation

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -1901,6 +1901,18 @@ static void read_binary_hash_invlists(
     READ1(sz);
     int il_nbit = 0;
     READ1(il_nbit);
+    FAISS_THROW_IF_NOT_FMT(
+            il_nbit >= 0,
+            "invalid binary hash invlists il_nbit=%d (must be >= 0)",
+            il_nbit);
+    if (sz > 0) {
+        FAISS_THROW_IF_NOT_FMT(
+                il_nbit > 0,
+                "invalid binary hash invlists il_nbit=%d for sz=%zd "
+                "(must be > 0 when entries exist)",
+                il_nbit,
+                sz);
+    }
     // buffer for bitstrings
     size_t bits_per_entry = (size_t)b + (size_t)il_nbit;
     size_t total_bits =
@@ -2013,6 +2025,10 @@ std::unique_ptr<IndexBinary> read_index_binary_up(IOReader* f, int io_flags) {
         auto idxh = std::make_unique<IndexBinaryHash>();
         read_index_binary_header(*idxh, f);
         READ1(idxh->b);
+        FAISS_THROW_IF_NOT_FMT(
+                idxh->b > 0,
+                "invalid IndexBinaryHash b=%d (must be > 0)",
+                idxh->b);
         READ1(idxh->nflip);
         read_binary_hash_invlists(idxh->invlists, idxh->b, f);
         idx = std::move(idxh);

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -439,3 +439,54 @@ TEST(ReadIndexDeserialize, BinaryHashEmptyInvlistBuffer) {
 
     expect_binary_read_throws_with(buf, "binary hash invlists");
 }
+
+// -----------------------------------------------------------------------
+// Test: IndexBinaryHash with b=0 triggers the b > 0 validation.
+// Without this check, BitstringReader::read(0) would silently produce
+// garbage hash values on every inverted-list entry.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, BinaryHashBZero) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IBHh");
+    push_binary_index_header(buf, /*d=*/16, /*ntotal=*/0);
+    push_val<int>(buf, 0); // b = 0 (invalid)
+
+    expect_binary_read_throws_with(buf, "IndexBinaryHash b=");
+}
+
+// -----------------------------------------------------------------------
+// Test: read_binary_hash_invlists with negative il_nbit triggers the
+// il_nbit >= 0 validation.  Without this check, the negative value would
+// wrap to a huge size_t in the bits-per-entry calculation, causing an
+// out-of-bounds read in BitstringReader.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, BinaryHashNegativeIlNbit) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IBHh");
+    push_binary_index_header(buf, /*d=*/16, /*ntotal=*/0);
+    push_val<int>(buf, 4); // b
+    push_val<int>(buf, 0); // nflip
+    // read_binary_hash_invlists fields:
+    push_val<size_t>(buf, size_t(0)); // sz = 0
+    push_val<int>(buf, -1);           // il_nbit = -1 (invalid)
+
+    expect_binary_read_throws_with(buf, "il_nbit=");
+}
+
+// -----------------------------------------------------------------------
+// Test: read_binary_hash_invlists with il_nbit=0 but sz > 0 triggers
+// the il_nbit > 0 validation.  Without this check, every inverted-list
+// size would silently read as 0, corrupting the deserialized index.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, BinaryHashIlNbitZeroWithEntries) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IBHh");
+    push_binary_index_header(buf, /*d=*/16, /*ntotal=*/0);
+    push_val<int>(buf, 4); // b
+    push_val<int>(buf, 0); // nflip
+    // read_binary_hash_invlists fields:
+    push_val<size_t>(buf, size_t(1)); // sz = 1 (non-zero)
+    push_val<int>(buf, 0);            // il_nbit = 0 (invalid when sz > 0)
+
+    expect_binary_read_throws_with(buf, "il_nbit=");
+}


### PR DESCRIPTION
Summary:
- read_binary_hash_invlists(): Protect against negative values that cause
   out of bounds reads after conversion from int to size_t.
 - read_binary_hash_invlists() and read_index_binary_up(): Prevent silent
   corruption of the deserialized index by ensuring BitstringReader::read()
   has a valid, positive value for nbit.

Reviewed By: mnorris11

Differential Revision: D95839908


