### PR TITLE
Refactor binary HNSW stats to use OpenMP reduction instead of destructor sync (#4910)

### DIFF
--- a/faiss/IndexBinaryHNSW.cpp
+++ b/faiss/IndexBinaryHNSW.cpp
@@ -217,13 +217,15 @@ void IndexBinaryHNSW::search(
     using RH = HeapBlockResultHandler<HNSW::C>;
     RH bres(n, distances_f, labels, k);
 
+    size_t n1 = 0, n2 = 0, ndis = 0, nhops = 0;
+
 #pragma omp parallel
     {
         VisitedTable vt(ntotal);
         std::unique_ptr<DistanceComputer> dis(get_distance_computer());
         RH::SingleResultHandler res(bres);
 
-#pragma omp for
+#pragma omp for reduction(+ : n1, n2, ndis, nhops)
         for (idx_t i = 0; i < n; i++) {
             res.begin(i);
             dis->set_query((float*)(x + i * code_size));
@@ -231,10 +233,16 @@ void IndexBinaryHNSW::search(
             // as the index parameter. This state does not get used in the
             // search function, as it is merely there to to enable Panorama
             // execution for IndexHNSWFlatPanorama.
-            hnsw.search(*dis, nullptr, res, vt, params_in);
+            HNSWStats stats = hnsw.search(*dis, nullptr, res, vt, params_in);
+            n1 += stats.n1;
+            n2 += stats.n2;
+            ndis += stats.ndis;
+            nhops += stats.nhops;
             res.end();
         }
     }
+
+    hnsw_stats.combine({n1, n2, ndis, nhops});
 
 #pragma omp parallel for
     for (int i = 0; i < n * k; ++i) {
@@ -267,11 +275,9 @@ template <class HammingComputer>
 struct FlatHammingDis : DistanceComputer {
     const int code_size;
     const uint8_t* b;
-    size_t ndis;
     HammingComputer hc;
 
     float operator()(idx_t i) override {
-        ndis++;
         return hc.hamming(b + i * code_size);
     }
 
@@ -281,20 +287,12 @@ struct FlatHammingDis : DistanceComputer {
     }
 
     explicit FlatHammingDis(const IndexBinaryFlat& storage)
-            : code_size(storage.code_size),
-              b(storage.xb.data()),
-              ndis(0),
-              hc() {}
+            : code_size(storage.code_size), b(storage.xb.data()), hc() {}
 
     // NOTE: Pointers are cast from float in order to reuse the floating-point
     //   DistanceComputer.
     void set_query(const float* x) override {
         hc.set((uint8_t*)x, code_size);
-    }
-
-    ~FlatHammingDis() override {
-#pragma omp atomic
-        hnsw_stats.ndis += ndis;
     }
 };
 
@@ -404,6 +402,10 @@ void IndexBinaryHNSWCagra::search(
                         params);
 
                 res.end();
+            }
+#pragma omp critical
+            {
+                hnsw_stats.combine(search_stats);
             }
         }
 


### PR DESCRIPTION
Summary:

## Problem

Follow-up to the previous fix (replacing `#pragma omp critical` with `#pragma omp atomic` in `FlatHammingDis::~FlatHammingDis`). This commit implements the architecturally correct fix by matching the pattern already used in the float HNSW path (`IndexHNSW.cpp`).

The previous approach had two issues:
1. Stats accumulation in a destructor is fragile — the timing and frequency of destructor calls depends on the caller's object lifetime management, not on the search algorithm
2. `FlatHammingDis` maintained a redundant `ndis` counter (incremented on every `operator()` call) that duplicated what `HNSW::search()` already tracks internally via its returned `HNSWStats`

## Changes

### `IndexBinaryHNSW::search()` — use `#pragma omp for reduction`
- Capture the `HNSWStats` returned by `hnsw.search()` per query
- Accumulate `n1, n2, ndis, nhops` via `#pragma omp for reduction(+: ...)`, which uses lock-free per-thread copies merged at barrier — zero contention
- Call `hnsw_stats.combine()` once, single-threaded, after the parallel region
- This exactly matches the pattern in `hnsw_search()` in `IndexHNSW.cpp` (lines 259-291)

### `FlatHammingDis` — remove stats accumulation entirely
- Remove `size_t ndis` field (redundant with `HNSW::search()` internal tracking)
- Remove `ndis++` from `operator()` (eliminates per-distance-computation overhead)
- Remove destructor (no stats to accumulate → no sync needed)

### `IndexBinaryHNSWCagra::search()` — fix missing stats aggregation
- The `base_level_only` path's second parallel block (`search_level_0`) accumulated stats into a per-thread `HNSWStats search_stats` but never aggregated it into `hnsw_stats` — this was a pre-existing bug where stats were silently lost
- Added `#pragma omp critical { hnsw_stats.combine(search_stats); }` once per thread at the end of the parallel block, matching `IndexHNSW::search_level_0_wrapper()` (line 461)

## Performance Impact
- **Zero lock contention** in the main `IndexBinaryHNSW::search()` path (reduction is lock-free)
- Removes per-distance-computation `ndis++` overhead from `FlatHammingDis::operator()`
- `IndexBinaryHNSWCagra` path: `#pragma omp critical` once per thread (acceptable, matches float HNSW)
- No change to search results — only stats accumulation mechanism changes

Reviewed By: mnorris11

Differential Revision: D95911440
