### PR TITLE
Fix windows nightly by changing unsigned int to int in loop variable

### DIFF
--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -151,7 +151,7 @@ static std::unique_ptr<float[]> compute_residuals(
     std::unique_ptr<float[]> residuals(new float[n * d]);
     // Parallelize with OpenMP (each iteration is independent)
 #pragma omp parallel for if (n > 1000)
-    for (size_t i = 0; i < n; i++) {
+    for (int i = 0; i < n; i++) {
         if (list_nos[i] < 0)
             memset(residuals.get() + i * d, 0, sizeof(float) * d);
         else


### PR DESCRIPTION
Summary:
broken windows nightly: https://github.com/facebookresearch/faiss/actions/runs/22989535577/job/66816016470

problem:
```
  MSVC's OpenMP implementation (which only supports OpenMP 2.0) requires that loop variables in #pragma omp parallel for have a
  signed integer type (e.g., int, int64_t). The variable i at line 154 is likely declared as size_t (which is unsigned).
```

solution:
```
change to int from unsigned int
```

Differential Revision: D96323249


