### PR TITLE
Validate id_map size matches ntotal in IndexBinaryIDMap deserialization (#4917)

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -2081,6 +2081,7 @@ std::unique_ptr<IndexBinary> read_index_binary_up(IOReader* f, int io_flags) {
         idxmap->index = read_index_binary(f, io_flags);
         idxmap->own_fields = true;
         READVECTOR(idxmap->id_map);
+        FAISS_THROW_IF_NOT(idxmap->id_map.size() == idxmap->ntotal);
         if (is_map2) {
             static_cast<IndexBinaryIDMap2*>(idxmap.get())->construct_rev_map();
         }

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -642,3 +642,28 @@ TEST(ReadIndexDeserialize, BinaryMultiHashMapIlszExceedsNtotal) {
 
     expect_binary_read_throws_with(buf, "would exceed ntotal");
 }
+
+// -----------------------------------------------------------------------
+// Test: IndexBinaryIDMap ("IBMp") with id_map size != ntotal.  Without
+// the check, construct_rev_map (IBM2) or subsequent search operations
+// would use an inconsistent ID mapping.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, BinaryIDMapIdMapSizeMismatch) {
+    // Outer IBMp header has ntotal=2, but the id_map vector has 5
+    // entries.  The check on id_map.size() == ntotal must reject this.
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IBMp");
+    push_binary_index_header(buf, /*d=*/16, /*ntotal=*/2);
+
+    // Nested IBxF storage with ntotal=2 (matches outer header).
+    push_fourcc(buf, "IBxF");
+    push_binary_index_header(buf, /*d=*/16, /*ntotal=*/2);
+    std::vector<uint8_t> xb(2 * 2, 0); // ntotal * code_size
+    push_vector<uint8_t>(buf, xb);
+
+    // id_map with 5 entries (mismatches ntotal=2).
+    std::vector<int64_t> id_map = {10, 20, 30, 40, 50};
+    push_vector<int64_t>(buf, id_map);
+
+    expect_binary_read_throws_with(buf, "id_map");
+}


### PR DESCRIPTION
Summary:

Add a check in the `IBMp`/`IBM2` deserialization path that rejects
input where `id_map.size() != ntotal`.  Without this validation,
a crafted index with a mismatched `id_map` would silently deserialize,
and subsequent `search()` or `reconstruct()` calls would use an
inconsistent ID mapping.  For `IndexBinaryIDMap2`, the downstream
`construct_rev_map()` call would also build a corrupted reverse map.

Reviewed By: mnorris11

Differential Revision: D96333421
