### PR TITLE
Fix MSVC OpenMP build: use idx_t instead of size_t in parallel for loop

### DIFF
--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -151,7 +151,7 @@ static std::unique_ptr<float[]> compute_residuals(
     std::unique_ptr<float[]> residuals(new float[n * d]);
     // Parallelize with OpenMP (each iteration is independent)
 #pragma omp parallel for if (n > 1000)
-    for (size_t i = 0; i < n; i++) {
+    for (idx_t i = 0; i < n; i++) {
         if (list_nos[i] < 0)
             memset(residuals.get() + i * d, 0, sizeof(float) * d);
         else


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #4918

MSVC's OpenMP 2.0 implementation requires signed integral loop variables
(error C3016). The loop variable in compute_residuals was declared as
size_t (unsigned), causing the Windows nightly conda build to fail.

Change it to idx_t (int64_t), which is signed and consistent with the
rest of the FAISS codebase. See D23234967 for historical precedent.

Introduced by D86234690 (PR #4654).

Differential Revision: [D96355226](https://our.internmc.facebook.com/intern/diff/D96355226/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D96355226/)!