### PR TITLE
Re-enable backwards compatibility tests for rabitq now that 1.14.1 released

### DIFF
--- a/tests/index_io_backward_compatibility/cmake_conda_io_utils.py
+++ b/tests/index_io_backward_compatibility/cmake_conda_io_utils.py
@@ -38,19 +38,14 @@ INDEX_TYPES = [
     "RaBitQ",  # regular
     "IVF256,RaBitQ",  # IVF
     "IVF256,RaBitQ4",  # IVF multibit
-    # RaBitQ FastScan indexes are temporarily disabled because D93538118
-    # changed the serialization format (fourcc "Irfs"->"Irfn", "Iwrf"->"Iwrn")
-    # by embedding auxiliary data directly into SIMD blocks. The conda
-    # faiss-cpu=1.14.0 reader does not understand the new format.
-    # Re-enable these once a new conda release includes the new format.
-    # "RaBitQfs",  # FS
-    # "RaBitQfs_64",  # FS, batch size 64
-    # "IVF256,RaBitQfs",  # IVF FS
-    # "IVF256,RaBitQfs_64",  # IVF FS, batch size 64
-    # "RaBitQfs6",  # multibit FS
-    # "RaBitQfs4_64",  # multibit FS, batch size 64
-    # "IVF256,RaBitQfs3",  # IVF FS multibit
-    # "IVF256,RaBitQfs7_64",  # IVF FS multibit, batch size 64
+    "RaBitQfs",  # FS
+    "RaBitQfs_64",  # FS, batch size 64
+    "IVF256,RaBitQfs",  # IVF FS
+    "IVF256,RaBitQfs_64",  # IVF FS, batch size 64
+    "RaBitQfs6",  # multibit FS
+    "RaBitQfs4_64",  # multibit FS, batch size 64
+    "IVF256,RaBitQfs3",  # IVF FS multibit
+    "IVF256,RaBitQfs7_64",  # IVF FS multibit, batch size 64
     # HNSW indexes
     "HNSW32",
     "HNSW32_SQ8",


### PR DESCRIPTION
Summary: Re enable

Differential Revision: D96502381


