### PR TITLE
introduce `SingleQueryResultCollectHandler`

### DIFF
--- a/faiss/impl/fast_scan/accumulate_loops.h
+++ b/faiss/impl/fast_scan/accumulate_loops.h
@@ -57,12 +57,17 @@ void accumulate_fixed_blocks(
         const Scaler& scaler,
         size_t block_stride) {
     constexpr int bbs = 32 * BB;
-    for (size_t j0 = 0; j0 < nb; j0 += bbs) {
+    for (size_t j0 = 0; j0 < nb; j0 += bbs, codes += block_stride) {
+        res.set_block_origin(0, j0);
+        if constexpr (has_sel_member_v<ResultHandler>) {
+            if (whether_all_vectors_filtered_out(
+                        res, std::min<size_t>(bbs, res.ntotal - j0)))
+                continue;
+        }
+
         FixedStorageHandler<NQ, 2 * BB> res2;
         kernel_accumulate_block<NQ, BB>(nsq, codes, LUT, res2, scaler);
-        res.set_block_origin(0, j0);
         res2.to_other_handler(res);
-        codes += block_stride;
     }
 }
 
@@ -123,7 +128,14 @@ void accumulate_q_4step_256(
     constexpr int Q4 = (QBS >> 12) & 15;
     constexpr int SQ = Q1 + Q2 + Q3 + Q4;
 
-    for (size_t j0 = 0; j0 < ntotal2; j0 += 32) {
+    for (size_t j0 = 0; j0 < ntotal2; j0 += 32, codes += block_stride) {
+        res.set_block_origin(0, j0);
+        if constexpr (has_sel_member_v<ResultHandler>) {
+            if (whether_all_vectors_filtered_out(
+                        res, std::min<size_t>(32, res.ntotal - j0)))
+                continue;
+        }
+
         FixedStorageHandler<SQ, 2> res2;
         const uint8_t* LUT = LUT0;
         pq4_kernel_qbs_256<Q1>(nsq, codes, LUT, res2, scaler);
@@ -142,9 +154,7 @@ void accumulate_q_4step_256(
             res2.set_block_origin(Q1 + Q2 + Q3, 0);
             pq4_kernel_qbs_256<Q4>(nsq, codes, LUT, res2, scaler);
         }
-        res.set_block_origin(0, j0);
         res2.to_other_handler(res);
-        codes += block_stride;
     }
 }
 
@@ -195,7 +205,14 @@ void pq4_accumulate_loop_qbs_fixed_scaler_256(
     }
 
     // Default: qbs not known at compile time
-    for (size_t j0 = 0; j0 < ntotal2; j0 += 32) {
+    for (size_t j0 = 0; j0 < ntotal2; j0 += 32, codes += block_stride) {
+        res.set_block_origin(0, j0);
+        if constexpr (has_sel_member_v<ResultHandler>) {
+            if (whether_all_vectors_filtered_out(
+                        res, std::min<size_t>(32, res.ntotal - j0)))
+                continue;
+        }
+
         const uint8_t* LUT = LUT0;
         int qi = qbs;
         int i0 = 0;
@@ -219,7 +236,6 @@ void pq4_accumulate_loop_qbs_fixed_scaler_256(
             i0 += nq;
             LUT += nq * nsq * 16;
         }
-        codes += block_stride;
     }
 }
 

--- a/faiss/impl/fast_scan/decompose_qbs.h
+++ b/faiss/impl/fast_scan/decompose_qbs.h
@@ -52,7 +52,14 @@ void accumulate_q_4step(
     constexpr int Q4 = (QBS >> 12) & 15;
     constexpr int SQ = Q1 + Q2 + Q3 + Q4;
 
-    for (size_t j0 = 0; j0 < ntotal2; j0 += 32) {
+    for (size_t j0 = 0; j0 < ntotal2; j0 += 32, codes += block_stride) {
+        res.set_block_origin(0, j0);
+        if constexpr (has_sel_member_v<ResultHandler>) {
+            if (whether_all_vectors_filtered_out(
+                        res, std::min<size_t>(32, res.ntotal - j0)))
+                continue;
+        }
+
         FixedStorageHandler<SQ, 2> res2;
         const uint8_t* LUT = LUT0;
         kernel_accumulate_block<Q1>(nsq, codes, LUT, res2, scaler);
@@ -71,9 +78,7 @@ void accumulate_q_4step(
             res2.set_block_origin(Q1 + Q2 + Q3, 0);
             kernel_accumulate_block<Q4>(nsq, codes, LUT, res2, scaler);
         }
-        res.set_block_origin(0, j0);
         res2.to_other_handler(res);
-        codes += block_stride;
     }
 }
 
@@ -86,11 +91,16 @@ void kernel_accumulate_block_loop(
         ResultHandler& res,
         const Scaler& scaler,
         size_t block_stride) {
-    for (size_t j0 = 0; j0 < ntotal2; j0 += 32) {
+    for (size_t j0 = 0; j0 < ntotal2; j0 += 32, codes += block_stride) {
         res.set_block_origin(0, j0);
+        if constexpr (has_sel_member_v<ResultHandler>) {
+            if (whether_all_vectors_filtered_out(
+                        res, std::min<size_t>(32, res.ntotal - j0)))
+                continue;
+        }
+
         kernel_accumulate_block<NQ, ResultHandler>(
                 nsq, codes, LUT, res, scaler);
-        codes += block_stride;
     }
 }
 
@@ -173,7 +183,14 @@ void pq4_accumulate_loop_qbs_fixed_scaler(
     }
 
     // default implementation where qbs is not known at compile time
-    for (size_t j0 = 0; j0 < ntotal2; j0 += 32) {
+    for (size_t j0 = 0; j0 < ntotal2; j0 += 32, codes += block_stride) {
+        res.set_block_origin(0, j0);
+        if constexpr (has_sel_member_v<ResultHandler>) {
+            if (whether_all_vectors_filtered_out(
+                        res, std::min<size_t>(32, res.ntotal - j0)))
+                continue;
+        }
+
         const uint8_t* LUT = LUT0;
         int qi = qbs;
         int i0 = 0;
@@ -198,7 +215,6 @@ void pq4_accumulate_loop_qbs_fixed_scaler(
             i0 += nq;
             LUT += nq * nsq * 16;
         }
-        codes += block_stride;
     }
 }
 

--- a/faiss/impl/fast_scan/simd_result_handlers.h
+++ b/faiss/impl/fast_scan/simd_result_handlers.h
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include <faiss/impl/simdlib/simdlib_dispatch.h>
@@ -26,11 +27,50 @@
 
 namespace faiss {
 
+namespace {
+
+// a helper that checks whether a ResultHandler has a .sel member
+template <typename T, typename = void>
+struct has_sel_member : std::false_type {};
+template <typename T>
+struct has_sel_member<T, std::void_t<decltype(T::sel)>> : std::true_type {};
+template <typename T>
+inline constexpr bool has_sel_member_v = has_sel_member<T>::value;
+
+/// Check if all vectors in a block are filtered out by the IDSelector.
+/// Returns true if the block should be skipped (all vectors filtered).
+/// Requires set_block_origin() to have been called before this.
+/// Compiles to nothing (returns false) when ResultHandler has no sel member.
+template <class ResultHandler>
+inline bool whether_all_vectors_filtered_out(
+        ResultHandler& res,
+        size_t block_size) {
+    if constexpr (has_sel_member_v<ResultHandler>) {
+        if (res.sel != nullptr) {
+            for (size_t jj = 0; jj < block_size; jj++) {
+                if (res.sel->is_member(res.adjust_id(0, jj))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
 struct SIMDResultHandler {
     // used to dispatch templates
     bool is_CMax = false;
     uint8_t sizeof_ids = 0;
     bool with_fields = false;
+
+    // the number of elements that were successfully processed up to date,
+    //   for example, hitting the threshold for the range search.
+    // the variable is used to track whether an early stop condition
+    //   should be hit due to having zero search progress.
+    size_t in_range_num = 0;
 
     /**  called when 32 distances are computed and provided in two
      *   simd16uint16. (q, b) indicate which entry it is
@@ -59,17 +99,26 @@ struct SIMDResultHandlerToFloat : SIMDResultHandler {
             nullptr; // table of biases to add to each query (for IVF L2 search)
     const float* normalizers = nullptr; // size 2 * nq, to convert
 
+    size_t scan_cnt = 0; // scanned vector number (except filtered)
+
     SIMDResultHandlerToFloat(size_t nq, size_t ntotal)
             : nq(nq), ntotal(ntotal) {}
 
     virtual void begin(const float* norms) {
         normalizers = norms;
+        scan_cnt = 0;
     }
 
     // called at end of search to convert int16 distances to float, before
     // normalizers are deallocated
     virtual void end() {
         normalizers = nullptr;
+        scan_cnt = 0;
+    }
+
+    // Get the number of scanned vectors
+    size_t count_scanned_rows() {
+        return scan_cnt;
     }
 
     // Number of updates made to the underlying data structure.
@@ -312,10 +361,13 @@ struct SingleResultHandler : ResultHandlerCompare<C, with_id_map, SL> {
                 auto real_idx = this->adjust_id(b, j);
                 lt_mask -= 1 << j;
                 if (this->sel->is_member(real_idx)) {
+                    this->scan_cnt++;
                     T d = d32tab[j];
                     if (C::cmp(idis[q], d)) {
                         idis[q] = d;
                         ids[q] = real_idx;
+
+                        this->in_range_num++;
                     }
                 }
             }
@@ -324,10 +376,13 @@ struct SingleResultHandler : ResultHandlerCompare<C, with_id_map, SL> {
                 // find first non-zero
                 int j = __builtin_ctz(lt_mask);
                 lt_mask -= 1 << j;
+                this->scan_cnt++;
                 T d = d32tab[j];
                 if (C::cmp(idis[q], d)) {
                     idis[q] = d;
                     ids[q] = this->adjust_id(b, j);
+
+                    this->in_range_num++;
                 }
             }
         }
@@ -343,6 +398,7 @@ struct SingleResultHandler : ResultHandlerCompare<C, with_id_map, SL> {
                 dis[q] = b + idis[q] * one_a;
             }
         }
+        this->scan_cnt = 0;
     }
 };
 
@@ -428,11 +484,14 @@ struct HeapHandler : ResultHandlerCompare<C, with_id_map, SL> {
                 auto real_idx = this->adjust_id(b, j);
                 lt_mask -= 1 << j;
                 if (this->sel->is_member(real_idx)) {
+                    this->scan_cnt++;
                     T dis_for_j = d32tab[j];
                     if (C::cmp(heap_dis[0], dis_for_j)) {
                         heap_replace_top<C>(
                                 k, heap_dis, heap_ids, dis_for_j, real_idx);
                         nup++;
+
+                        this->in_range_num++;
                     }
                 }
             }
@@ -441,11 +500,14 @@ struct HeapHandler : ResultHandlerCompare<C, with_id_map, SL> {
                 // find first non-zero
                 int j = __builtin_ctz(lt_mask);
                 lt_mask -= 1 << j;
+                this->scan_cnt++;
                 T dis_for_j = d32tab[j];
                 if (C::cmp(heap_dis[0], dis_for_j)) {
                     int64_t idx = this->adjust_id(b, j);
                     heap_replace_top<C>(k, heap_dis, heap_ids, dis_for_j, idx);
                     nup++;
+
+                    this->in_range_num++;
                 }
             }
         }
@@ -469,6 +531,7 @@ struct HeapHandler : ResultHandlerCompare<C, with_id_map, SL> {
                 heap_ids[j] = heap_ids_in[j];
             }
         }
+        this->scan_cnt = 0;
     }
 
     size_t num_updates() override {
@@ -550,8 +613,11 @@ struct ReservoirHandler : ResultHandlerCompare<C, with_id_map, SL> {
                 auto real_idx = this->adjust_id(b, j);
                 lt_mask -= 1 << j;
                 if (this->sel->is_member(real_idx)) {
+                    this->scan_cnt++;
                     T dis_for_j = d32tab[j];
                     res.add(dis_for_j, real_idx);
+
+                    this->in_range_num++;
                 }
             }
         } else {
@@ -560,7 +626,10 @@ struct ReservoirHandler : ResultHandlerCompare<C, with_id_map, SL> {
                 int j = __builtin_ctz(lt_mask);
                 lt_mask -= 1 << j;
                 T dis_for_j = d32tab[j];
+                this->scan_cnt++;
                 res.add(dis_for_j, this->adjust_id(b, j));
+
+                this->in_range_num++;
             }
         }
     }
@@ -602,6 +671,7 @@ struct ReservoirHandler : ResultHandlerCompare<C, with_id_map, SL> {
             // possibly add empty results
             heap_heapify<Cf>(n - res.i, heap_dis + res.i, heap_ids + res.i);
         }
+        this->scan_cnt = 0;
     }
 };
 
@@ -680,6 +750,8 @@ struct RangeHandler : ResultHandlerCompare<C, with_id_map, SL> {
                     T dis = d32tab[j];
                     n_per_query[q]++;
                     triplets.push_back({idx_t(q + q0), real_idx, dis});
+
+                    this->in_range_num++;
                 }
             }
         } else {
@@ -690,6 +762,8 @@ struct RangeHandler : ResultHandlerCompare<C, with_id_map, SL> {
                 T dis = d32tab[j];
                 n_per_query[q]++;
                 triplets.push_back({idx_t(q + q0), this->adjust_id(b, j), dis});
+
+                this->in_range_num++;
             }
         }
     }
@@ -785,6 +859,93 @@ struct PartialRangeHandler : RangeHandler<C, with_id_map, SL> {
     }
 };
 
+/** Handler that collects all matching results for a single query.
+ *
+ * Unlike HeapHandler/ReservoirHandler which maintain a top-k structure,
+ * this handler appends every result that passes the threshold to a
+ * vector of (distance, id) pairs. Useful for exhaustive collection
+ * (e.g., "return all" searches) in the fast_scan SIMD path.
+ */
+template <
+        class C,
+        bool with_id_map = false,
+        SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
+struct SingleQueryResultCollectHandler
+        : ResultHandlerCompare<C, with_id_map, SL> {
+    using T = typename C::T;
+    using TI = typename C::TI;
+    using RHC = ResultHandlerCompare<C, with_id_map, SL>;
+    using RHC::normalizers;
+    using simd16uint16 = typename RHC::simd16uint16;
+
+    // Store as float (not T=uint16_t) since end() applies normalizer scaling
+    std::vector<std::pair<TI, float>>& collect;
+    const int q_id = 0;
+
+    SingleQueryResultCollectHandler(
+            std::vector<std::pair<TI, float>>& res,
+            size_t ntotal,
+            const IDSelector* sel_in)
+            : RHC(1, ntotal, sel_in), collect(res) {
+        this->q_map = &q_id;
+    }
+
+    void begin(const float* norms) override {
+        normalizers = norms;
+    }
+
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
+        if (this->disable) {
+            return;
+        }
+
+        this->adjust_with_origin(q, d0, d1);
+
+        uint32_t lt_mask = this->get_lt_mask(C::neutral(), b, d0, d1);
+
+        if (!lt_mask) {
+            return;
+        }
+
+        ALIGNED(32) uint16_t d32tab[32];
+        d0.store(d32tab);
+        d1.store(d32tab + 16);
+
+        if (this->sel != nullptr) {
+            while (lt_mask) {
+                int j = __builtin_ctz(lt_mask);
+                auto real_idx = this->adjust_id(b, j);
+                lt_mask -= 1 << j;
+                if (this->sel->is_member(real_idx)) {
+                    T dis = d32tab[j];
+                    collect.emplace_back(real_idx, dis);
+                    this->in_range_num++;
+                }
+            }
+        } else {
+            while (lt_mask) {
+                int j = __builtin_ctz(lt_mask);
+                lt_mask -= 1 << j;
+                T dis = d32tab[j];
+                int64_t idx = this->adjust_id(b, j);
+                collect.emplace_back(idx, dis);
+                this->in_range_num++;
+            }
+        }
+    }
+
+    void end() override {
+        if (normalizers) {
+            float one_a = 1 / normalizers[0];
+            float b = normalizers[1];
+            for (size_t i = 0; i < collect.size(); i++) {
+                collect[i].second = collect[i].second * one_a + b;
+            }
+        }
+        this->scan_cnt = 0;
+    }
+};
+
 #endif
 
 /********************************************************************************
@@ -806,6 +967,11 @@ void with_SIMDResultHandler(SIMDResultHandler& res, Lambda&& lambda) {
         } else if (auto resh = dynamic_cast<HeapHandler<C, W>*>(&res)) {
             lambda(*resh);
         } else if (auto resh = dynamic_cast<ReservoirHandler<C, W>*>(&res)) {
+            lambda(*resh);
+        } else if (
+                auto resh =
+                        dynamic_cast<SingleQueryResultCollectHandler<C, W>*>(
+                                &res)) {
             lambda(*resh);
         } else { // generic handler -- will not be inlined
             FAISS_THROW_IF_NOT_FMT(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,8 @@ set(FAISS_TEST_SRC
   test_scalar_quantizer.cpp
   test_factory_tools.cpp
   test_custom_result_handler.cpp
+  test_fastscan_filter.cpp
+  test_single_query_collect_handler.cpp
   # These tests work in both static and DD modes (uniform SIMDConfig API)
   test_distances_simd.cpp
   test_simd_levels.cpp

--- a/tests/test_fastscan_filter.cpp
+++ b/tests/test_fastscan_filter.cpp
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <faiss/IndexFlat.h>
+#include <faiss/IndexIVFPQFastScan.h>
+#include <faiss/impl/IDSelector.h>
+#include <faiss/index_factory.h>
+#include <faiss/utils/random.h>
+
+using namespace faiss;
+
+namespace {
+
+constexpr int d = 32;
+constexpr size_t nt = 5000;
+constexpr size_t nb = 1000;
+constexpr size_t nq = 20;
+
+std::vector<float> make_data(size_t n, int64_t seed) {
+    std::vector<float> data(n * d);
+    rand_smooth_vectors(n, d, data.data(), seed);
+    return data;
+}
+
+/*************************************************************
+ * Helper: test filtered search on a fastscan IVF index.
+ *
+ * Primary check: every returned ID is in the allowed set.
+ * Secondary check: results have reasonable overlap with Flat
+ * baseline (loose threshold since PQ is approximate).
+ *************************************************************/
+
+void test_filtered_search(
+        const char* fs_index_key,
+        MetricType metric,
+        const size_t k,
+        IDSelector& sel,
+        const std::unordered_set<idx_t>& allowed_ids,
+        const size_t db_size = nb) {
+    auto xt = make_data(nt, 1234);
+    auto xb = make_data(db_size, 4567);
+    auto xq = make_data(nq, 7890);
+
+    // Build fastscan index
+    std::unique_ptr<Index> fs_index(index_factory(d, fs_index_key, metric));
+    fs_index->train(nt, xt.data());
+    fs_index->add(db_size, xb.data());
+
+    // Search fastscan with selector
+    SearchParametersIVF params;
+    params.sel = &sel;
+    params.nprobe = 8;
+
+    std::vector<float> Dfs(nq * k);
+    std::vector<idx_t> Ifs(nq * k);
+
+    fs_index->search(nq, xq.data(), k, Dfs.data(), Ifs.data(), &params);
+
+    // Primary check: all results are in the allowed set (or -1)
+    for (size_t i = 0; i < nq * k; i++) {
+        if (Ifs[i] >= 0) {
+            EXPECT_TRUE(allowed_ids.count(Ifs[i]) > 0)
+                    << "Fastscan returned id " << Ifs[i]
+                    << " which is not in the allowed set";
+        }
+    }
+
+    // Secondary check: if allowed set is large enough, we should get
+    // some valid results (not all -1)
+    if (allowed_ids.size() > k) {
+        size_t valid_count = 0;
+        for (size_t i = 0; i < nq * k; i++) {
+            if (Ifs[i] >= 0)
+                valid_count++;
+        }
+        EXPECT_GT(valid_count, 0) << "Expected some valid results";
+    }
+}
+
+/*************************************************************
+ * Test: IDSelectorBatch with fastscan (batch of allowed IDs)
+ *************************************************************/
+
+// Both tests are needed, because one tests CMax,
+//   and another tests CMin.
+
+TEST(TestFastScanFilter, IVFPQfs_Batch_L2) {
+    std::vector<idx_t> subset;
+    for (idx_t i = 0; i < nb; i += 3) { // ~333 out of 1000
+        subset.push_back(i);
+    }
+
+    std::unordered_set<idx_t> allowed(subset.begin(), subset.end());
+    IDSelectorBatch sel(subset.size(), subset.data());
+
+    test_filtered_search("IVF32,PQ4x4fs", METRIC_L2, 10, sel, allowed);
+}
+
+TEST(TestFastScanFilter, IVFPQfs_Batch_IP) {
+    std::vector<idx_t> subset;
+    for (idx_t i = 0; i < nb; i += 3) {
+        subset.push_back(i);
+    }
+
+    std::unordered_set<idx_t> allowed(subset.begin(), subset.end());
+    IDSelectorBatch sel(subset.size(), subset.data());
+
+    test_filtered_search(
+            "IVF32,PQ4x4fs", METRIC_INNER_PRODUCT, 10, sel, allowed);
+}
+
+/*************************************************************
+ * Test: k=1 (SingleResultHandler path) and k=40 (ReservoirHandler)
+ *************************************************************/
+
+TEST(TestFastScanFilter, IVFPQfs_K1) {
+    std::vector<idx_t> subset;
+    for (idx_t i = 0; i < nb; i += 2) {
+        subset.push_back(i);
+    }
+
+    std::unordered_set<idx_t> allowed(subset.begin(), subset.end());
+    IDSelectorBatch sel(subset.size(), subset.data());
+
+    test_filtered_search("IVF32,PQ4x4fs", METRIC_L2, 1, sel, allowed);
+}
+
+TEST(TestFastScanFilter, IVFPQfs_K40) {
+    std::vector<idx_t> subset;
+    for (idx_t i = 0; i < nb; i += 2) {
+        subset.push_back(i);
+    }
+
+    std::unordered_set<idx_t> allowed(subset.begin(), subset.end());
+    IDSelectorBatch sel(subset.size(), subset.data());
+
+    test_filtered_search("IVF32,PQ4x4fs", METRIC_L2, 40, sel, allowed);
+}
+
+/*************************************************************
+ * Test: IDSelectorNot that excludes entire blocks (IDs 0-31, 64-95, etc.)
+ * This specifically tests the block-skip optimization.
+ *************************************************************/
+
+TEST(TestFastScanFilter, BlockSkip_WholeBlocks) {
+    // Exclude blocks 0 (ids 0-31) and 2 (ids 64-95)
+    std::vector<idx_t> excluded;
+    for (idx_t i = 0; i < 32; i++) {
+        excluded.push_back(i);
+    }
+    for (idx_t i = 64; i < 96; i++) {
+        excluded.push_back(i);
+    }
+
+    // Allowed = everything NOT in excluded
+    std::unordered_set<idx_t> allowed;
+    std::unordered_set<idx_t> excluded_set(excluded.begin(), excluded.end());
+    for (idx_t i = 0; i < nb; i++) {
+        if (excluded_set.count(i) == 0) {
+            allowed.insert(i);
+        }
+    }
+
+    IDSelectorBatch inner_sel(excluded.size(), excluded.data());
+    IDSelectorNot sel(&inner_sel);
+
+    test_filtered_search("IVF32,PQ4x4fs", METRIC_L2, 10, sel, allowed);
+}
+
+/*************************************************************
+ * Test: Partial block filtering (exclude some IDs within a block)
+ *************************************************************/
+
+TEST(TestFastScanFilter, BlockSkip_PartialBlock) {
+    // Exclude only a few IDs from the first block (0-31)
+    std::vector<idx_t> excluded = {5, 10, 20, 31};
+    std::unordered_set<idx_t> excluded_set(excluded.begin(), excluded.end());
+
+    std::unordered_set<idx_t> allowed;
+    for (idx_t i = 0; i < nb; i++) {
+        if (excluded_set.count(i) == 0) {
+            allowed.insert(i);
+        }
+    }
+
+    IDSelectorBatch inner_sel(excluded.size(), excluded.data());
+    IDSelectorNot sel(&inner_sel);
+
+    test_filtered_search("IVF32,PQ4x4fs", METRIC_L2, 10, sel, allowed);
+}
+
+/*************************************************************
+ * Test: Empty selector (nothing accepted) -> all results -1
+ *************************************************************/
+
+TEST(TestFastScanFilter, EmptySelector) {
+    auto xt = make_data(nt, 1234);
+    auto xb = make_data(nb, 4567);
+    auto xq = make_data(nq, 7890);
+
+    std::unique_ptr<Index> index(index_factory(d, "IVF32,PQ4x4fs", METRIC_L2));
+    index->train(nt, xt.data());
+    index->add(nb, xb.data());
+
+    // Empty batch selector: accepts nothing
+    std::vector<idx_t> empty_subset;
+    IDSelectorBatch sel(0, empty_subset.data());
+
+    size_t k = 10;
+    std::vector<float> D(nq * k);
+    std::vector<idx_t> I(nq * k);
+
+    SearchParametersIVF params;
+    params.sel = &sel;
+    params.nprobe = 4;
+    index->search(nq, xq.data(), k, D.data(), I.data(), &params);
+
+    // All results should be -1 (nothing matches)
+    for (size_t i = 0; i < nq * k; i++) {
+        EXPECT_EQ(I[i], -1)
+                << "Expected -1 at position " << i << " but got " << I[i];
+    }
+}
+
+/*************************************************************
+ * Test: ntotal not a multiple of 32
+ * Tests the min(32, ntotal - j0) boundary in block-skip check.
+ *************************************************************/
+
+TEST(TestFastScanFilter, NonAlignedNtotal_50) {
+    std::vector<idx_t> subset;
+    for (idx_t i = 0; i < 50; i += 2) {
+        subset.push_back(i);
+    }
+
+    std::unordered_set<idx_t> allowed(subset.begin(), subset.end());
+    IDSelectorBatch sel(subset.size(), subset.data());
+
+    test_filtered_search("IVF32,PQ4x4fs", METRIC_L2, 10, sel, allowed, 50);
+}
+
+TEST(TestFastScanFilter, NonAlignedNtotal_77) {
+    std::vector<idx_t> subset;
+    for (idx_t i = 0; i < 77; i += 2) {
+        subset.push_back(i);
+    }
+
+    std::unordered_set<idx_t> allowed(subset.begin(), subset.end());
+    IDSelectorBatch sel(subset.size(), subset.data());
+
+    test_filtered_search("IVF32,PQ4x4fs", METRIC_L2, 10, sel, allowed, 77);
+}
+
+TEST(TestFastScanFilter, NonAlignedNtotal_150) {
+    std::vector<idx_t> subset;
+    for (idx_t i = 0; i < 150; i += 3) {
+        subset.push_back(i);
+    }
+
+    std::unordered_set<idx_t> allowed(subset.begin(), subset.end());
+    IDSelectorBatch sel(subset.size(), subset.data());
+
+    test_filtered_search("IVF32,PQ4x4fs", METRIC_L2, 10, sel, allowed, 150);
+}
+
+/*************************************************************
+ * Test: IDSelectorRange with fastscan
+ *************************************************************/
+
+TEST(TestFastScanFilter, IVFPQfs_Range) {
+    std::unordered_set<idx_t> allowed;
+    for (idx_t i = 100; i < 500; i++) {
+        allowed.insert(i);
+    }
+
+    IDSelectorRange sel(100, 500);
+
+    test_filtered_search("IVF32,PQ4x4fs", METRIC_L2, 10, sel, allowed);
+}
+
+/*************************************************************
+ * Test: Heavy filtering (>90% excluded) - block-skip should
+ * skip most blocks entirely.
+ *************************************************************/
+
+TEST(TestFastScanFilter, HeavyFiltering) {
+    // Allow only ~5% of vectors
+    std::vector<idx_t> subset;
+    for (idx_t i = 0; i < nb; i += 20) {
+        subset.push_back(i);
+    }
+
+    std::unordered_set<idx_t> allowed(subset.begin(), subset.end());
+    IDSelectorBatch sel(subset.size(), subset.data());
+
+    test_filtered_search("IVF32,PQ4x4fs", METRIC_L2, 10, sel, allowed);
+}
+
+} // namespace

--- a/tests/test_fastscan_filter.py
+++ b/tests/test_fastscan_filter.py
@@ -1,0 +1,340 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import numpy as np
+import faiss
+
+from faiss.contrib import datasets
+
+faiss.omp_set_num_threads(4)
+
+
+class TestFastScanFiltering(unittest.TestCase):
+    """
+    Test IDSelector filtering on IVF fast_scan indexes.
+
+    The PR adds block-skip filtering to the fast_scan accumulate loops:
+    before processing each 32-vector block, it checks if all vectors
+    in the block are filtered out by the IDSelector, and skips the
+    block entirely if so.
+
+    These tests verify that filtered results only contain allowed IDs.
+    Only IVF-based fastscan indexes support SearchParameters with sel.
+    """
+
+    def do_test_filter(
+        self,
+        index_key,
+        id_selector_type="batch",
+        mt=faiss.METRIC_L2,
+        k=10,
+        nb=1000,
+    ):
+        """
+        Build a fastscan IVF index and search with IDSelector filtering.
+        Verify all returned results are in the allowed set.
+        """
+        d = 32
+        ds = datasets.SyntheticDataset(d, 2000, nb, 20, metric=mt)
+
+        index = faiss.index_factory(d, index_key, mt)
+        index.train(ds.get_train())
+        index.add(ds.get_database())
+
+        # Create selector and allowed set
+        rs = np.random.RandomState(123)
+        if id_selector_type == "batch":
+            subset = rs.choice(nb, nb // 3, replace=False).astype("int64")
+            sel = faiss.IDSelectorBatch(subset)
+            allowed = set(subset.tolist())
+        elif id_selector_type == "range":
+            lo, hi = nb // 4, 3 * nb // 4
+            sel = faiss.IDSelectorRange(lo, hi)
+            allowed = set(range(lo, hi))
+        elif id_selector_type == "not_batch":
+            # Exclude entire 32-vector blocks to test block-skip
+            excluded = np.concatenate([
+                np.arange(0, 32, dtype="int64"),
+                np.arange(64, 96, dtype="int64"),
+            ])
+            inner_sel = faiss.IDSelectorBatch(excluded)
+            sel = faiss.IDSelectorNot(inner_sel)
+            allowed = set(i for i in range(nb) if i not in excluded)
+        elif id_selector_type == "partial_batch":
+            # Exclude a few IDs within a single block (not a whole block)
+            excluded = np.array([5, 10, 20, 31], dtype="int64")
+            inner_sel = faiss.IDSelectorBatch(excluded)
+            sel = faiss.IDSelectorNot(inner_sel)
+            allowed = set(i for i in range(nb) if i not in excluded)
+        elif id_selector_type == "empty":
+            sel = faiss.IDSelectorBatch(np.array([], dtype="int64"))
+            allowed = set()
+        else:
+            raise ValueError(f"Unknown selector type: {id_selector_type}")
+
+        params = faiss.SearchParametersIVF(sel=sel, nprobe=8)
+        Dfs, Ifs = index.search(ds.get_queries(), k, params=params)
+
+        # Check: all results are in the allowed set or -1
+        for q in range(ds.nq):
+            for j in range(k):
+                idx = int(Ifs[q, j])
+                if idx >= 0:
+                    self.assertIn(
+                        idx, allowed,
+                        f"Query {q}, rank {j}: got id {idx} not in allowed set"
+                    )
+
+        # If allowed set is large enough, expect some valid results
+        if len(allowed) > k:
+            valid = np.sum(Ifs >= 0)
+            self.assertGreater(
+                valid, 0, "Expected some valid results"
+            )
+
+        return Ifs
+
+    # ------- IVFPQFastScan tests -------
+
+    def test_IVFPQfs_batch_L2(self):
+        self.do_test_filter("IVF32,PQ4x4fs", "batch", faiss.METRIC_L2)
+
+    def test_IVFPQfs_batch_IP(self):
+        self.do_test_filter(
+            "IVF32,PQ4x4fs", "batch", faiss.METRIC_INNER_PRODUCT
+        )
+
+    def test_IVFPQfs_range(self):
+        self.do_test_filter("IVF32,PQ4x4fs", "range")
+
+    def test_IVFPQfs_not_batch(self):
+        """IDSelectorNot excluding whole blocks -> block-skip path"""
+        self.do_test_filter("IVF32,PQ4x4fs", "not_batch")
+
+    def test_IVFPQfs_partial_batch(self):
+        """IDSelectorNot excluding a few IDs within a block"""
+        self.do_test_filter("IVF32,PQ4x4fs", "partial_batch")
+
+    def test_IVFPQfs_empty_selector(self):
+        """Empty selector accepts nothing -> all results -1"""
+        Ifs = self.do_test_filter("IVF32,PQ4x4fs", "empty")
+        np.testing.assert_array_equal(Ifs, -1)
+
+    # ------- Different k values (different handler paths) -------
+
+    def test_IVFPQfs_k1(self):
+        """k=1 -> SingleResultHandler path"""
+        self.do_test_filter("IVF32,PQ4x4fs", "batch", k=1)
+
+    def test_IVFPQfs_k40(self):
+        """k=40 -> ReservoirHandler path"""
+        self.do_test_filter("IVF32,PQ4x4fs", "batch", k=40)
+
+    # ------- Non-aligned ntotal -------
+
+    def test_IVFPQfs_ntotal_50(self):
+        """ntotal=50, not a multiple of 32"""
+        self.do_test_filter("IVF32,PQ4x4fs", "batch", nb=50)
+
+    def test_IVFPQfs_ntotal_77(self):
+        """ntotal=77, partial last block"""
+        self.do_test_filter("IVF32,PQ4x4fs", "batch", nb=77)
+
+    def test_IVFPQfs_ntotal_150(self):
+        """ntotal=150, not a multiple of 32"""
+        self.do_test_filter("IVF32,PQ4x4fs", "batch", nb=150)
+
+
+class TestBlockSkipConsistency(unittest.TestCase):
+    """
+    Test that block-skip filtering produces consistent results
+    across different filter configurations on fastscan IVF indexes.
+    """
+
+    def test_consistency_with_ivfpq(self):
+        """
+        Compare IVFPQFastScan filtered results with IVFPQ (non-fastscan)
+        filtered results. Both should only return allowed IDs.
+        """
+        d = 32
+        ds = datasets.SyntheticDataset(d, 2000, 500, 20)
+
+        rs = np.random.RandomState(42)
+        subset = rs.choice(500, 150, replace=False).astype("int64")
+        sel = faiss.IDSelectorBatch(subset)
+        allowed = set(subset.tolist())
+
+        # FastScan index
+        index_fs = faiss.index_factory(d, "IVF32,PQ4x4fs")
+        index_fs.train(ds.get_train())
+        index_fs.add(ds.get_database())
+
+        # Non-fastscan PQ index
+        index_pq = faiss.index_factory(d, "IVF32,PQ4x4np")
+        index_pq.train(ds.get_train())
+        index_pq.add(ds.get_database())
+
+        k = 10
+        params = faiss.SearchParametersIVF(sel=sel, nprobe=8)
+
+        Dfs, Ifs = index_fs.search(ds.get_queries(), k, params=params)
+        Dpq, Ipq = index_pq.search(ds.get_queries(), k, params=params)
+
+        # Both should only return allowed IDs
+        for q in range(ds.nq):
+            for j in range(k):
+                if Ifs[q, j] >= 0:
+                    self.assertIn(int(Ifs[q, j]), allowed)
+                if Ipq[q, j] >= 0:
+                    self.assertIn(int(Ipq[q, j]), allowed)
+
+    def test_blockskip_consistency_with_ivfpq(self):
+        """
+        Compare IVFPQFastScan vs IVFPQ (non-fastscan) when using
+        IDSelectorNot that excludes entire 32-vector blocks.
+        This specifically validates the block-skip optimization
+        against a baseline that doesn't have block-skip logic.
+        """
+        d = 32
+        nb = 500
+        ds = datasets.SyntheticDataset(d, 2000, nb, 20)
+
+        # Exclude entire blocks: IDs 0-31 and 64-95
+        excluded = np.concatenate([
+            np.arange(0, 32, dtype="int64"),
+            np.arange(64, 96, dtype="int64"),
+        ])
+        inner_sel = faiss.IDSelectorBatch(excluded)
+        sel = faiss.IDSelectorNot(inner_sel)
+        allowed = set(i for i in range(nb) if i not in excluded)
+
+        # FastScan index
+        index_fs = faiss.index_factory(d, "IVF32,PQ4x4fs")
+        index_fs.train(ds.get_train())
+        index_fs.add(ds.get_database())
+
+        # Non-fastscan PQ index (no block-skip logic)
+        index_pq = faiss.index_factory(d, "IVF32,PQ4x4np")
+        index_pq.train(ds.get_train())
+        index_pq.add(ds.get_database())
+
+        k = 10
+        params = faiss.SearchParametersIVF(sel=sel, nprobe=8)
+
+        Dfs, Ifs = index_fs.search(ds.get_queries(), k, params=params)
+        Dpq, Ipq = index_pq.search(ds.get_queries(), k, params=params)
+
+        # Both should only return allowed IDs
+        for q in range(ds.nq):
+            for j in range(k):
+                if Ifs[q, j] >= 0:
+                    self.assertIn(int(Ifs[q, j]), allowed,
+                        f"FastScan q={q} j={j}: id {Ifs[q, j]} is excluded")
+                if Ipq[q, j] >= 0:
+                    self.assertIn(int(Ipq[q, j]), allowed,
+                        f"IVFPQ q={q} j={j}: id {Ipq[q, j]} is excluded")
+
+    def test_partial_vs_whole_block_filter(self):
+        """
+        Excluding the same set of IDs via two identical IDSelectorNot
+        configurations should produce identical results.
+        """
+        d = 32
+        ds = datasets.SyntheticDataset(d, 2000, 200, 10)
+
+        index = faiss.index_factory(d, "IVF32,PQ4x4fs")
+        index.train(ds.get_train())
+        index.add(ds.get_database())
+
+        # Exclude the first 32 elements (whole block)
+        excluded = np.arange(0, 32, dtype="int64")
+        sel1 = faiss.IDSelectorNot(faiss.IDSelectorBatch(excluded))
+        sel2 = faiss.IDSelectorNot(faiss.IDSelectorBatch(excluded))
+
+        k = 10
+        params1 = faiss.SearchParametersIVF(sel=sel1, nprobe=8)
+        params2 = faiss.SearchParametersIVF(sel=sel2, nprobe=8)
+
+        D1, I1 = index.search(ds.get_queries(), k, params=params1)
+        D2, I2 = index.search(ds.get_queries(), k, params=params2)
+
+        # Results should be identical
+        np.testing.assert_array_equal(I1, I2)
+        np.testing.assert_array_almost_equal(D1, D2, decimal=5)
+
+    def test_heavy_filtering(self):
+        """
+        With >90% of vectors filtered, block-skip should skip most blocks.
+        Verify correctness under heavy filtering.
+        """
+        d = 32
+        ds = datasets.SyntheticDataset(d, 2000, 1000, 20)
+
+        index = faiss.index_factory(d, "IVF32,PQ4x4fs")
+        index.train(ds.get_train())
+        index.add(ds.get_database())
+
+        # Allow only ~5% of vectors
+        rs = np.random.RandomState(99)
+        subset = rs.choice(1000, 50, replace=False).astype("int64")
+        sel = faiss.IDSelectorBatch(subset)
+        allowed = set(subset.tolist())
+
+        k = 10
+        params = faiss.SearchParametersIVF(sel=sel, nprobe=16)
+        Dfs, Ifs = index.search(ds.get_queries(), k, params=params)
+
+        # All fastscan results must be in allowed set
+        for q in range(ds.nq):
+            for j in range(k):
+                idx = int(Ifs[q, j])
+                if idx >= 0:
+                    self.assertIn(idx, allowed)
+
+
+class TestFastScanRangeSearchFilter(unittest.TestCase):
+    """Test range_search with IDSelector on fastscan IVF indexes."""
+
+    def test_range_search_filtered(self):
+        """Range search with IDSelector should only return allowed IDs."""
+        d = 32
+        ds = datasets.SyntheticDataset(d, 2000, 500, 10)
+
+        index = faiss.index_factory(d, "IVF32,PQ4x4fs")
+        index.train(ds.get_train())
+        index.add(ds.get_database())
+
+        # Unfiltered range search to find a reasonable radius
+        Dref, _ = index.search(ds.get_queries(), 10)
+        radius = float(Dref.max()) * 1.5
+
+        rs = np.random.RandomState(123)
+        subset = rs.choice(500, 150, replace=False).astype("int64")
+        sel = faiss.IDSelectorBatch(subset)
+        allowed = set(subset.tolist())
+
+        params = faiss.SearchParametersIVF(sel=sel, nprobe=8)
+
+        try:
+            lims, D, I = index.range_search(
+                ds.get_queries(), radius, params=params
+            )
+
+            # All returned IDs should be in the allowed set
+            for idx in I:
+                if idx >= 0:
+                    self.assertIn(
+                        int(idx), allowed,
+                        f"Range search returned id {idx} not in allowed set"
+                    )
+        except RuntimeError:
+            # range_search may not be supported for all fastscan variants
+            pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_single_query_collect_handler.cpp
+++ b/tests/test_single_query_collect_handler.cpp
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * Tests for SingleQueryResultCollectHandler.
+ *
+ * Drives the handler through the actual fast_scan accumulate loop
+ * by building an IndexPQFastScan, computing its quantized LUT,
+ * and calling pq4_accumulate_loop_qbs_fixed_scaler_256 directly.
+ */
+
+#include <algorithm>
+#include <memory>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <faiss/IndexPQFastScan.h>
+#include <faiss/impl/IDSelector.h>
+#include <faiss/impl/fast_scan/accumulate_loops.h>
+#include <faiss/impl/fast_scan/simd_result_handlers.h>
+#include <faiss/utils/random.h>
+
+using namespace faiss;
+using namespace faiss::simd_result_handlers;
+
+namespace {
+
+constexpr int d = 32;
+constexpr size_t nt = 5000;
+constexpr size_t nb = 200;
+
+std::vector<float> make_data(size_t n, int64_t seed) {
+    std::vector<float> data(n * d);
+    rand_smooth_vectors(n, d, data.data(), seed);
+    return data;
+}
+
+/// Build, train and populate an IndexPQFastScan with bbs=32.
+std::unique_ptr<IndexPQFastScan> make_index(size_t db_size = nb) {
+    auto index = std::make_unique<IndexPQFastScan>(d, 4, 4, METRIC_L2, 32);
+    auto xt = make_data(nt, 1234);
+    index->train(nt, xt.data());
+    auto xb = make_data(db_size, 4567);
+    index->add(db_size, xb.data());
+    return index;
+}
+
+/// The following code relies on 1 query, because
+///   SingleQueryResultCollectHandler is hardcoded to use
+///   only 1 query.
+
+/// Run the collect handler through the real accumulate loop for one query.
+/// Returns collected (id, distance) pairs.
+std::vector<std::pair<int64_t, float>> run_collect_handler(
+        const IndexPQFastScan& index,
+        const float* query,
+        const IDSelector* sel) {
+    // CMax = L2 metric (keep the largest threshold, collect distances below it)
+    using C = CMax<uint16_t, int64_t>;
+
+    // 1. Compute quantized LUT + normalizers for 1 query
+    size_t dim12 = index.ksub * index.M2;
+    AlignedTable<uint8_t> quantized_dis_tables(dim12);
+    float normalizers[2];
+
+    FastScanDistancePostProcessing context{};
+    index.compute_quantized_LUT(
+            1, query, quantized_dis_tables.get(), normalizers, context);
+
+    // 2. Pack the LUT
+    int qbs = pq4_preferred_qbs(1);
+    AlignedTable<uint8_t> LUT(dim12);
+    pq4_pack_LUT_qbs(qbs, index.M2, quantized_dis_tables.get(), LUT.get());
+
+    // 3. Create the handler
+    std::vector<std::pair<int64_t, float>> results;
+    SingleQueryResultCollectHandler<C, false> handler(
+            results, index.ntotal, sel);
+
+    // 4. Begin + set normalizers
+    handler.begin(normalizers);
+
+    // 5. Run the accumulate loop
+    DummyScaler<> scaler;
+    pq4_accumulate_loop_qbs_fixed_scaler_256(
+            qbs,
+            index.ntotal2,
+            index.M2,
+            index.codes.get(),
+            LUT.get(),
+            handler,
+            scaler,
+            index.get_block_stride());
+
+    // 6. End (applies normalizer scaling)
+    handler.end();
+
+    return results;
+}
+
+/*************************************************************
+ * Test: handler collects results and count matches expectation
+ *************************************************************/
+
+TEST(TestSingleQueryCollectHandler, BasicResultCount) {
+    auto index = make_index();
+    auto xq = make_data(1, 7890);
+
+    auto results = run_collect_handler(*index, xq.data(), nullptr);
+
+    // Without any selector, the handler should collect all nb vectors
+    // (CMax::neutral() = uint16_max, so every distance passes)
+    EXPECT_EQ(results.size(), nb)
+            << "Expected " << nb << " results, got " << results.size();
+
+    // Each result should have a valid ID in [0, nb)
+    for (auto& [id, dist] : results) {
+        EXPECT_GE(id, 0);
+        EXPECT_LT(id, static_cast<int64_t>(nb));
+    }
+
+    // IDs should be unique
+    std::unordered_set<int64_t> id_set;
+    for (auto& [id, dist] : results) {
+        id_set.insert(id);
+    }
+    EXPECT_EQ(id_set.size(), nb) << "Expected unique IDs, got duplicates";
+}
+
+/*************************************************************
+ * Test: handler with IDSelector only returns allowed IDs
+ *************************************************************/
+
+TEST(TestSingleQueryCollectHandler, WithIDSelector) {
+    auto index = make_index();
+    auto xq = make_data(1, 7890);
+
+    // Allow only even IDs
+    std::vector<idx_t> subset;
+    for (idx_t i = 0; i < static_cast<idx_t>(nb); i += 2) {
+        subset.push_back(i);
+    }
+    std::unordered_set<int64_t> allowed(subset.begin(), subset.end());
+    IDSelectorBatch sel(subset.size(), subset.data());
+
+    auto results = run_collect_handler(*index, xq.data(), &sel);
+
+    // Should collect exactly the allowed IDs (nb/2)
+    EXPECT_EQ(results.size(), nb / 2)
+            << "Expected " << nb / 2 << " results, got " << results.size();
+
+    // Every result must be in the allowed set
+    for (auto& [id, dist] : results) {
+        EXPECT_TRUE(allowed.count(id) > 0)
+                << "Got id " << id << " which is not in the allowed set";
+    }
+}
+
+/*************************************************************
+ * Test: empty selector -> no results
+ *************************************************************/
+
+TEST(TestSingleQueryCollectHandler, EmptySelector) {
+    auto index = make_index();
+    auto xq = make_data(1, 7890);
+
+    // Empty batch = accept nothing
+    IDSelectorBatch sel(0, nullptr);
+
+    auto results = run_collect_handler(*index, xq.data(), &sel);
+
+    EXPECT_EQ(results.size(), 0)
+            << "Expected 0 results with empty selector, got " << results.size();
+}
+
+/*************************************************************
+ * Test: results are consistent with normal search
+ *
+ * The top-k from a normal search should be a subset of the
+ * collected results (since the handler collects everything).
+ *************************************************************/
+
+TEST(TestSingleQueryCollectHandler, ConsistentWithSearch) {
+    auto index = make_index();
+    auto xq = make_data(1, 7890);
+
+    // Normal top-10 search
+    int k = 10;
+    std::vector<float> Dref(k);
+    std::vector<idx_t> Iref(k);
+    index->search(1, xq.data(), k, Dref.data(), Iref.data());
+
+    // Collect all results
+    auto results = run_collect_handler(*index, xq.data(), nullptr);
+
+    // Build a map of id -> distance from collected results
+    std::unordered_map<int64_t, float> collected;
+    for (auto& [id, dist] : results) {
+        collected[id] = dist;
+    }
+
+    // Every reference result should appear in the collected set
+    for (int j = 0; j < k; j++) {
+        if (Iref[j] >= 0) {
+            EXPECT_TRUE(collected.count(Iref[j]) > 0)
+                    << "Top-" << k << " result id " << Iref[j]
+                    << " not found in collected results";
+        }
+    }
+}
+
+/*************************************************************
+ * Test: ntotal not a multiple of 32
+ *************************************************************/
+
+TEST(TestSingleQueryCollectHandler, NonAlignedNtotal) {
+    size_t db_size = 77; // not a multiple of 32
+    auto index = make_index(db_size);
+    auto xq = make_data(1, 7890);
+
+    auto results = run_collect_handler(*index, xq.data(), nullptr);
+
+    // Should collect exactly db_size results
+    EXPECT_EQ(results.size(), db_size)
+            << "Expected " << db_size << " results, got " << results.size();
+
+    // All IDs should be in [0, db_size)
+    for (auto& [id, dist] : results) {
+        EXPECT_GE(id, 0);
+        EXPECT_LT(id, static_cast<int64_t>(db_size));
+    }
+}
+
+/*************************************************************
+ * Test: IDSelector that excludes entire 32-vector blocks
+ * (exercises the block-skip optimization)
+ *************************************************************/
+
+TEST(TestSingleQueryCollectHandler, BlockSkipWithSelector) {
+    auto index = make_index();
+    auto xq = make_data(1, 7890);
+
+    // Exclude the first 32 IDs (one full block)
+    std::vector<idx_t> excluded;
+    for (idx_t i = 0; i < 32; i++) {
+        excluded.push_back(i);
+    }
+    std::unordered_set<int64_t> excluded_set(excluded.begin(), excluded.end());
+
+    IDSelectorBatch inner_sel(excluded.size(), excluded.data());
+    IDSelectorNot sel(&inner_sel);
+
+    auto results = run_collect_handler(*index, xq.data(), &sel);
+
+    // Should collect nb - 32 results
+    EXPECT_EQ(results.size(), nb - 32)
+            << "Expected " << nb - 32 << " results, got " << results.size();
+
+    // No excluded ID should appear
+    for (auto& [id, dist] : results) {
+        EXPECT_TRUE(excluded_set.count(id) == 0) << "Got excluded id " << id;
+    }
+}
+
+} // namespace


### PR DESCRIPTION
This PR introduces the following:
* a new type of a `ResultHandler` called `SingleQueryResultCollectHandler`
* adds a filtering capability to the core of the FastScan code
* `SIMDResultHandler::size_t in_range_num` and `SIMDResultHandlerToFloat::scan_cnt`, which can be effectively used for early stop checks. These are not currently used in the baseline `FAISS` code, but are used in the `Knowhere` fork 

@mdouze @mnorris11 @junjieqi please comment and suggest unit tests + locations that need to be written, given some possible unusual use cases on your end