### PR TITLE
Make READVECTOR byte limit configurable

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -80,6 +80,7 @@ namespace faiss {
 
 namespace {
 size_t deserialization_loop_limit_ = 0;
+size_t deserialization_vector_byte_limit_ = uint64_t{1} << 40; // 1 TB
 } // namespace
 
 size_t get_deserialization_loop_limit() {
@@ -88,6 +89,14 @@ size_t get_deserialization_loop_limit() {
 
 void set_deserialization_loop_limit(size_t value) {
     deserialization_loop_limit_ = value;
+}
+
+size_t get_deserialization_vector_byte_limit() {
+    return deserialization_vector_byte_limit_;
+}
+
+void set_deserialization_vector_byte_limit(size_t value) {
+    deserialization_vector_byte_limit_ = value;
 }
 
 #define FAISS_CHECK_DESERIALIZATION_LOOP_LIMIT(val, field_name) \

--- a/faiss/impl/io_macros.h
+++ b/faiss/impl/io_macros.h
@@ -17,6 +17,10 @@
  * always called f and thus is not passed in as a macro parameter.
  **************************************************************/
 
+namespace faiss {
+size_t get_deserialization_vector_byte_limit();
+} // namespace faiss
+
 #define READANDCHECK(ptr, n)                         \
     {                                                \
         size_t ret = (*f)(ptr, sizeof(*(ptr)), n);   \
@@ -37,14 +41,18 @@
         READ1(x);           \
     }
 
-// will fail if we write 256G of data at once...
-#define READVECTOR(vec)                                              \
-    {                                                                \
-        size_t size;                                                 \
-        READANDCHECK(&size, 1);                                      \
-        FAISS_THROW_IF_NOT(size >= 0 && size < (uint64_t{1} << 40)); \
-        (vec).resize(size);                                          \
-        READANDCHECK((vec).data(), size);                            \
+// Rejects vectors whose total allocation would exceed the configurable
+// byte limit (default 1 TB).
+#define READVECTOR(vec)                                                  \
+    {                                                                    \
+        size_t size;                                                     \
+        READANDCHECK(&size, 1);                                          \
+        FAISS_THROW_IF_NOT(                                              \
+                size >= 0 &&                                             \
+                size < (faiss::get_deserialization_vector_byte_limit() / \
+                        sizeof(*(vec).data())));                         \
+        (vec).resize(size);                                              \
+        READANDCHECK((vec).data(), size);                                \
     }
 
 #define WRITEANDCHECK(ptr, n)                         \
@@ -78,12 +86,15 @@
         WRITEANDCHECK((vec).data(), size * 4);     \
     }
 
-#define READXBVECTOR(vec)                                            \
-    {                                                                \
-        size_t size;                                                 \
-        READANDCHECK(&size, 1);                                      \
-        FAISS_THROW_IF_NOT(size >= 0 && size < (uint64_t{1} << 40)); \
-        size *= 4;                                                   \
-        (vec).resize(size);                                          \
-        READANDCHECK((vec).data(), size);                            \
+#define READXBVECTOR(vec)                                                \
+    {                                                                    \
+        size_t size;                                                     \
+        READANDCHECK(&size, 1);                                          \
+        FAISS_THROW_IF_NOT(                                              \
+                size >= 0 &&                                             \
+                size < (faiss::get_deserialization_vector_byte_limit() / \
+                        (4 * sizeof(*(vec).data()))));                   \
+        size *= 4;                                                       \
+        (vec).resize(size);                                              \
+        READANDCHECK((vec).data(), size);                                \
     }

--- a/faiss/index_io.h
+++ b/faiss/index_io.h
@@ -124,6 +124,15 @@ size_t get_deserialization_loop_limit();
 // and do not modify while deserialization is in progress on other threads.
 void set_deserialization_loop_limit(size_t value);
 
+// Returns the maximum number of bytes that a single READVECTOR call
+// may allocate.  Default: 1 TB (1 << 40).
+size_t get_deserialization_vector_byte_limit();
+
+// Sets the per-vector byte limit for deserialization.
+// NOT thread-safe: set before any concurrent deserialization calls
+// and do not modify while deserialization is in progress on other threads.
+void set_deserialization_vector_byte_limit(size_t value);
+
 } // namespace faiss
 
 #endif

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -14,6 +14,7 @@
 
 #include <faiss/Index.h>
 #include <faiss/IndexBinary.h>
+#include <faiss/VectorTransform.h>
 #include <faiss/impl/FaissException.h>
 #include <faiss/impl/io.h>
 #include <faiss/index_io.h>
@@ -190,6 +191,56 @@ TEST(ReadIndexDeserialize, PQCentroidsOverflow) {
     push_pq(buf, /*d=*/huge_d, /*M=*/1, /*nbits=*/24);
 
     expect_read_throws(buf);
+}
+
+// -----------------------------------------------------------------------
+// Test: READVECTOR rejects a vector whose total byte size exceeds the
+// configurable deserialization byte limit.  Uses a LinearTransform
+// ("LTra") whose A vector is read via READVECTOR.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, READVECTORByteLimit) {
+    // Build a "LTra" (LinearTransform) payload.
+    // Format: fourcc + have_bias + READVECTOR(A) + READVECTOR(b)
+    //         + d_in + d_out + is_trained
+    // A contains 1024 floats = 4096 bytes.
+    // READVECTOR check: size < limit / sizeof(float)
+    const size_t old_limit = get_deserialization_vector_byte_limit();
+
+    const int d_in = 32;
+    const int d_out = 32;
+    const size_t n_elements = d_in * d_out; // 1024
+
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "LTra");
+    push_val<bool>(buf, false); // have_bias
+    std::vector<float> A(n_elements, 0.0f);
+    push_vector<float>(buf, A);
+    // b vector: empty (no bias)
+    push_vector<float>(buf, {});
+    // Common VectorTransform fields
+    push_val<int>(buf, d_in);
+    push_val<int>(buf, d_out);
+    push_val<bool>(buf, true); // is_trained
+
+    // Exactly at the boundary: limit = n_elements * sizeof(float).
+    // Check is strict less-than, so this should be rejected.
+    set_deserialization_vector_byte_limit(n_elements * sizeof(float));
+    {
+        VectorIOReader reader;
+        reader.data = buf;
+        EXPECT_THROW(read_VectorTransform_up(&reader), FaissException);
+    }
+
+    // One element above the boundary: limit = (n_elements + 1) * sizeof(float).
+    // Now n_elements < limit / sizeof(float) = n_elements + 1, so it passes.
+    set_deserialization_vector_byte_limit((n_elements + 1) * sizeof(float));
+    {
+        VectorIOReader reader;
+        reader.data = buf;
+        EXPECT_NO_THROW(read_VectorTransform_up(&reader));
+    }
+
+    set_deserialization_vector_byte_limit(old_limit);
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
Summary:
The original intention of the `READVECTOR` and `READXBVECTOR` macros in
`io_macros.h` was to limit reads to 256GB (see comment above the previous
version of READVECTOR). However, the enforced limit was actualy based on
element count not bytes, allowing extremely large reads — requiring TBs of
memory — to pass the check and be attempted.

In this diff, represent the limit in bytes, and set the default value to
1TB. This value can be changed at runtime via the
set_deserialization_vector_byte_limit() API.

Reviewed By: mnorris11

Differential Revision: D96559593


