### PR TITLE
fix: resolve compiler warnings in test files

### DIFF
--- a/tests/test_NSG_compressed_graph.cpp
+++ b/tests/test_NSG_compressed_graph.cpp
@@ -19,14 +19,14 @@ struct CompressedNSGGraph : FinalNSGGraph {
     size_t stride;
     std::vector<uint8_t> compressed_data;
 
-    CompressedNSGGraph(const FinalNSGGraph& graph, int bits)
-            : FinalNSGGraph(graph.data, graph.N, graph.K), bits(bits) {
+    CompressedNSGGraph(const FinalNSGGraph& graph, int bits_in)
+            : FinalNSGGraph(graph.data, graph.N, graph.K), bits(bits_in) {
         FAISS_THROW_IF_NOT((1 << bits) >= K + 1);
         stride = (K * bits + 7) / 8;
         compressed_data.resize(N * stride);
-        for (size_t i = 0; i < N; i++) {
+        for (size_t i = 0; i < size_t(N); i++) {
             BitstringWriter writer(compressed_data.data() + i * stride, stride);
-            for (size_t j = 0; j < K; j++) {
+            for (size_t j = 0; j < size_t(K); j++) {
                 int32_t v = graph.data[i * K + j];
                 if (v == -1) {
                     writer.write(K + 1, bits);

--- a/tests/test_RCQ_cropping.cpp
+++ b/tests/test_RCQ_cropping.cpp
@@ -53,7 +53,7 @@ TEST(RCQCropping, test_cropping) {
 
     // these bits are in common between the two RCQs
     idx_t mask = ((idx_t)1 << rcq_cropped.rq.tot_bits) - 1;
-    for (int q = 0; q < nq; q++) {
+    for (size_t q = 0; q < nq; q++) {
         for (int i = 0; i < nprobe; i++) {
             idx_t fine = Iref[q * nprobe + i];
             EXPECT_GE(fine, 0);

--- a/tests/test_common_ivf_empty_index.cpp
+++ b/tests/test_common_ivf_empty_index.cpp
@@ -40,8 +40,8 @@ std::vector<float> get_random_vectors(size_t n, int seed) {
  * object that is passed in at query time */
 
 struct DispatchingInvertedLists : faiss::ReadOnlyInvertedLists {
-    DispatchingInvertedLists(size_t nlist, size_t code_size)
-            : faiss::ReadOnlyInvertedLists(nlist, code_size) {
+    DispatchingInvertedLists(size_t nlist_in, size_t code_size_in)
+            : faiss::ReadOnlyInvertedLists(nlist_in, code_size_in) {
         use_iterator = true;
     }
 
@@ -56,13 +56,13 @@ struct DispatchingInvertedLists : faiss::ReadOnlyInvertedLists {
 
     using idx_t = faiss::idx_t;
 
-    size_t list_size(size_t list_no) const override {
+    size_t list_size(size_t /*list_no*/) const override {
         FAISS_THROW_MSG("use iterator interface");
     }
-    const uint8_t* get_codes(size_t list_no) const override {
+    const uint8_t* get_codes(size_t /*list_no*/) const override {
         FAISS_THROW_MSG("use iterator interface");
     }
-    const idx_t* get_ids(size_t list_no) const override {
+    const idx_t* get_ids(size_t /*list_no*/) const override {
         FAISS_THROW_MSG("use iterator interface");
     }
 };

--- a/tests/test_cppcontrib_uintreader.cpp
+++ b/tests/test_cppcontrib_uintreader.cpp
@@ -43,8 +43,8 @@ struct TestLoop {
 template <intptr_t N_ELEMENTS, intptr_t CODE_BITS>
 struct TestLoop<N_ELEMENTS, CODE_BITS, N_ELEMENTS> {
     static void test(
-            const uint8_t* const container,
-            faiss::BitstringReader& br) {}
+            const uint8_t* const /*container*/,
+            faiss::BitstringReader& /*br*/) {}
 };
 
 template <intptr_t N_ELEMENTS, intptr_t CODE_BITS>

--- a/tests/test_dealloc_invlists.cpp
+++ b/tests/test_dealloc_invlists.cpp
@@ -70,8 +70,8 @@ std::vector<idx_t> search_index(Index* index, const float* xq) {
 struct EncapsulateInvertedLists : InvertedLists {
     const InvertedLists* il;
 
-    explicit EncapsulateInvertedLists(const InvertedLists* il)
-            : InvertedLists(il->nlist, il->code_size), il(il) {}
+    explicit EncapsulateInvertedLists(const InvertedLists* il_in)
+            : InvertedLists(il_in->nlist, il_in->code_size), il(il_in) {}
 
     static void* memdup(const void* m, size_t size) {
         if (size == 0) {

--- a/tests/test_disable_pq_sdc_tables.cpp
+++ b/tests/test_disable_pq_sdc_tables.cpp
@@ -31,7 +31,7 @@ TEST(IO, TestReadHNSWPQ_whenSDCDisabledFlagPassed_thenDisableSDCTable) {
     std::default_random_engine rng(123);
     std::uniform_real_distribution<float> u(0, 100);
     std::vector<float> vectors(n * d);
-    for (size_t i = 0; i < n * d; i++) {
+    for (int i = 0; i < n * d; i++) {
         vectors[i] = u(rng);
     }
 

--- a/tests/test_distances_simd.cpp
+++ b/tests/test_distances_simd.cpp
@@ -124,7 +124,7 @@ TEST(TestFvecL2sqr, distances_L2_squared_y_transposed) {
         }
         std::vector<float> y(d * ny);
         std::vector<float> y_sqlens(ny, 0);
-        for (size_t i = 0; i < ny; i++) {
+        for (int i = 0; i < ny; i++) {
             for (size_t j = 0; j < y.size(); j++) {
                 y[j] = uniform(rng);
                 y_sqlens[i] += y[j] * y[j];
@@ -133,9 +133,9 @@ TEST(TestFvecL2sqr, distances_L2_squared_y_transposed) {
 
         // perform function
         std::vector<float> true_distances(ny, 0);
-        for (size_t i = 0; i < ny; i++) {
+        for (int i = 0; i < ny; i++) {
             float dp = 0;
-            for (size_t j = 0; j < d; j++) {
+            for (int j = 0; j < d; j++) {
                 dp += x[j] * y[i + j * ny];
             }
             true_distances[i] = x_sqlen + y_sqlens[i] - 2 * dp;
@@ -173,7 +173,7 @@ TEST(TestFvecL2sqr, nearest_L2_squared_y_transposed) {
         }
         std::vector<float> y(d * ny);
         std::vector<float> y_sqlens(ny, 0);
-        for (size_t i = 0; i < ny; i++) {
+        for (int i = 0; i < ny; i++) {
             for (size_t j = 0; j < y.size(); j++) {
                 y[j] = uniform(rng);
                 y_sqlens[i] += y[j] * y[j];
@@ -182,9 +182,9 @@ TEST(TestFvecL2sqr, nearest_L2_squared_y_transposed) {
 
         // get distances
         std::vector<float> distances(ny, 0);
-        for (size_t i = 0; i < ny; i++) {
+        for (int i = 0; i < ny; i++) {
             float dp = 0;
-            for (size_t j = 0; j < d; j++) {
+            for (int j = 0; j < d; j++) {
                 dp += x[j] * y[i + j * ny];
             }
             distances[i] = x_sqlen + y_sqlens[i] - 2 * dp;
@@ -192,7 +192,7 @@ TEST(TestFvecL2sqr, nearest_L2_squared_y_transposed) {
         // find nearest
         size_t true_nearest_idx = 0;
         float min_dis = HUGE_VALF;
-        for (size_t i = 0; i < ny; i++) {
+        for (int i = 0; i < ny; i++) {
             if (distances[i] < min_dis) {
                 min_dis = distances[i];
                 true_nearest_idx = i;

--- a/tests/test_hamming.cpp
+++ b/tests/test_hamming.cpp
@@ -18,7 +18,7 @@ std::string print_data(
         std::shared_ptr<std::vector<T>> data,
         const size_t divider) {
     std::string ret;
-    for (int i = 0; i < data->size(); ++i) {
+    for (size_t i = 0; i < data->size(); ++i) {
         if (i % divider) {
             ret += " ";
         } else {
@@ -136,16 +136,16 @@ TEST(TestHamming, test_crosshamming_count_thres) {
         const size_t nwords = nbits / 64;
         // 8 to for later conversion to uint64_t, and 2 for buffer
         std::vector<uint8_t> dbs(nwords * n * 8 * 2);
-        for (int i = 0; i < dbs.size(); ++i) {
+        for (size_t i = 0; i < dbs.size(); ++i) {
             dbs[i] = uniform(rng);
         }
 
         // get true distance
         size_t true_count = 0;
         uint64_t* bs1 = (uint64_t*)dbs.data();
-        for (int i = 0; i < n; ++i) {
+        for (size_t i = 0; i < n; ++i) {
             uint64_t* bs2 = bs1 + 2;
-            for (int j = i + 1; j < n; ++j) {
+            for (size_t j = i + 1; j < n; ++j) {
                 if (faiss::hamming(bs1 + i * nwords, bs2 + j * nwords, nwords) <
                     hamming_threshold) {
                     ++true_count;
@@ -185,10 +185,10 @@ TEST(TestHamming, test_hamming_thres) {
         const size_t nwords = nbits / 64;
         std::vector<uint8_t> bs1(nwords * n1 * 8);
         std::vector<uint8_t> bs2(nwords * n2 * 8);
-        for (int i = 0; i < bs1.size(); ++i) {
+        for (size_t i = 0; i < bs1.size(); ++i) {
             bs1[i] = uniform(rng);
         }
-        for (int i = 0; i < bs2.size(); ++i) {
+        for (size_t i = 0; i < bs2.size(); ++i) {
             bs2[i] = uniform(rng);
         }
 
@@ -199,8 +199,8 @@ TEST(TestHamming, test_hamming_thres) {
 
         uint64_t* bs1_64 = (uint64_t*)bs1.data();
         uint64_t* bs2_64 = (uint64_t*)bs2.data();
-        for (int i = 0; i < n1; ++i) {
-            for (int j = 0; j < n2; ++j) {
+        for (size_t i = 0; i < n1; ++i) {
+            for (size_t j = 0; j < n2; ++j) {
                 hamdis_t ham_dist = faiss::hamming(
                         bs1_64 + i * nwords, bs2_64 + j * nwords, nwords);
                 if (ham_dist < hamming_threshold) {

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -64,7 +64,7 @@ void test_popmin(int heap_size, int amount_to_put) {
 
     // generate random unique indices
     std::unordered_set<storage_idx_t> indices;
-    while (indices.size() < amount_to_put) {
+    while (static_cast<int>(indices.size()) < amount_to_put) {
         const storage_idx_t index = u(rng);
         indices.insert(index);
     }
@@ -126,7 +126,7 @@ void test_popmin_identical_distances(
 
     // generate random unique indices
     std::unordered_set<storage_idx_t> indices;
-    while (indices.size() < amount_to_put) {
+    while (static_cast<int>(indices.size()) < amount_to_put) {
         const storage_idx_t index = u(rng);
         indices.insert(index);
     }
@@ -430,11 +430,12 @@ std::priority_queue<faiss::HNSW::Node> reference_search_from_candidate_unbounded
             float d1 = qdis(v1);
             ++ndis;
 
-            if (top_candidates.top().first > d1 || top_candidates.size() < ef) {
+            if (top_candidates.top().first > d1 ||
+                static_cast<int>(top_candidates.size()) < ef) {
                 candidates.emplace(d1, v1);
                 top_candidates.emplace(d1, v1);
 
-                if (top_candidates.size() > ef) {
+                if (static_cast<int>(top_candidates.size()) > ef) {
                     top_candidates.pop();
                 }
             }

--- a/tests/test_ivf_index.cpp
+++ b/tests/test_ivf_index.cpp
@@ -46,8 +46,8 @@ class TestContext {
 // the iterator that iterates over the codes stored in context object
 class TestInvertedListIterator : public faiss::InvertedListsIterator {
    public:
-    TestInvertedListIterator(size_t list_no, TestContext* context)
-            : list_no{list_no}, context{context} {
+    TestInvertedListIterator(size_t list_no_in, TestContext* context_in)
+            : list_no{list_no_in}, context{context_in} {
         it = context->codes.cbegin();
         seek_next();
     }
@@ -86,8 +86,8 @@ class TestInvertedListIterator : public faiss::InvertedListsIterator {
 
 class TestInvertedLists : public faiss::InvertedLists {
    public:
-    TestInvertedLists(size_t nlist, size_t code_size)
-            : faiss::InvertedLists(nlist, code_size) {
+    TestInvertedLists(size_t nlist_in, size_t code_size_in)
+            : faiss::InvertedLists(nlist_in, code_size_in) {
         use_iterator = true;
     }
 

--- a/tests/test_ivfpq_indexing.cpp
+++ b/tests/test_ivfpq_indexing.cpp
@@ -66,7 +66,7 @@ TEST(IVFPQ, accuracy) {
     { // searching the database
 
         std::vector<float> queries(nq * d);
-        for (size_t i = 0; i < nq * d; i++) {
+        for (int i = 0; i < nq * d; i++) {
             queries[i] = distrib(rng);
         }
 

--- a/tests/test_lowlevel_ivf.cpp
+++ b/tests/test_lowlevel_ivf.cpp
@@ -148,11 +148,11 @@ void test_lowlevel_access(const char* index_key, MetricType metric) {
 
     const InvertedLists* il = index_ivf->invlists;
 
-    for (int list_no = 0; list_no < index_ivf->nlist; list_no++) {
+    for (size_t list_no = 0; list_no < index_ivf->nlist; list_no++) {
         InvertedLists::ScopedCodes ivf_codes(il, list_no);
         InvertedLists::ScopedIds ivf_ids(il, list_no);
         size_t list_size = il->list_size(list_no);
-        for (int i = 0; i < list_size; i++) {
+        for (size_t i = 0; i < list_size; i++) {
             const uint8_t* ref_code = ivf_codes.get() + i * il->code_size;
             const uint8_t* new_code = codes.data() + ivf_ids[i] * il->code_size;
             EXPECT_EQ(memcmp(ref_code, new_code, il->code_size), 0);
@@ -217,7 +217,7 @@ void test_get_InvertedListScanner(
                 index_ivf->get_InvertedListScanner());
     }
     float recall = 0.0;
-    for (int i = 0; i < nq; i++) {
+    for (size_t i = 0; i < nq; i++) {
         std::vector<idx_t> I(k, -1);
         float default_dis = metric == METRIC_L2
                 ? std::numeric_limits<float>::max()
@@ -487,7 +487,7 @@ void test_lowlevel_access_binary(const char* index_key) {
     std::unique_ptr<BinaryInvertedListScanner> scanner(
             index_ivf->get_InvertedListScanner());
 
-    for (int i = 0; i < nq; i++) {
+    for (size_t i = 0; i < nq; i++) {
         std::vector<idx_t> I(k, -1);
         uint32_t default_dis = 1 << 30;
         std::vector<int32_t> D(k, default_dis);
@@ -621,7 +621,7 @@ void test_threaded_search(const char* index_key, MetricType metric) {
     // now run search in this many threads
     int nproc = 3;
 
-    for (int i = 0; i < nq; i++) {
+    for (size_t i = 0; i < nq; i++) {
         // one result table per thread
         std::vector<idx_t> I(k * nproc, -1);
         float default_dis = metric == METRIC_L2 ? HUGE_VAL : -HUGE_VAL;

--- a/tests/test_merge.cpp
+++ b/tests/test_merge.cpp
@@ -49,7 +49,7 @@ struct CommonData {
         for (size_t i = 0; i < nq * d; i++) {
             queries[i] = distrib(rng);
         }
-        for (int i = 0; i < nb; i++) {
+        for (size_t i = 0; i < nb; i++) {
             ids[i] = 123 + 456 * i;
         }
         { // just to train the quantizer
@@ -231,7 +231,7 @@ TEST(MERGE, merge_flat_ondisk_3) {
     index_shards.own_indices = true;
 
     std::vector<idx_t> ids;
-    for (int i = 0; i < nb; ++i) {
+    for (size_t i = 0; i < nb; ++i) {
         int id = i % shard_size;
         ids.push_back(id);
     }

--- a/tests/test_pairs_decoding.cpp
+++ b/tests/test_pairs_decoding.cpp
@@ -75,14 +75,14 @@ bool test_search_centroid(const char* index_key) {
 
     const faiss::IndexIVF* ivf = faiss::ivflib::extract_index_ivf(index.get());
 
-    for (int i = 0; i < nb; i++) {
+    for (size_t i = 0; i < nb; i++) {
         bool found = false;
         int list_no = centroid_ids[i];
         int list_size = ivf->invlists->list_size(list_no);
         auto* list = ivf->invlists->get_ids(list_no);
 
         for (int j = 0; j < list_size; j++) {
-            if (list[j] == i) {
+            if (list[j] == static_cast<faiss::idx_t>(i)) {
                 found = true;
                 break;
             }
@@ -142,7 +142,7 @@ int test_search_and_return_centroids(const char* index_key) {
     // then check if the result ids are indeed in the inverted list
     // they are supposed to be in
 
-    for (int i = 0; i < nq * k; i++) {
+    for (size_t i = 0; i < nq * k; i++) {
         int list_no = result_centroid_ids[i];
         int result_no = newI[i];
 

--- a/tests/test_params_override.cpp
+++ b/tests/test_params_override.cpp
@@ -52,10 +52,10 @@ std::unique_ptr<Index> make_index(
         MetricType metric,
         const std::vector<float>& x) {
     assert(x.size() % d == 0);
-    idx_t nb = x.size() / d;
+    idx_t local_nb = x.size() / d;
     std::unique_ptr<Index> index(index_factory(d, index_type, metric));
-    index->train(nb, x.data());
-    index->add(nb, x.data());
+    index->train(local_nb, x.data());
+    index->add(local_nb, x.data());
     return index;
 }
 
@@ -125,7 +125,7 @@ int test_selector(const char* index_key) {
 
     std::vector<float> sub_xb;
     std::vector<idx_t> kept;
-    for (idx_t i = 0; i < nb; i++) {
+    for (size_t i = 0; i < nb; i++) {
         if (i % 10 == 2) {
             kept.push_back(i);
             sub_xb.insert(

--- a/tests/test_sliding_ivf.cpp
+++ b/tests/test_sliding_ivf.cpp
@@ -80,7 +80,7 @@ void make_index_slices(
         std::vector<faiss::idx_t> ids(nb);
         std::mt19937 rng;
         std::uniform_int_distribution<> distrib;
-        for (int j = 0; j < nb; j++) {
+        for (size_t j = 0; j < nb; j++) {
             ids[j] = distrib(rng);
         }
         index->add_with_ids(nb, xb.data(), ids.data());

--- a/tests/test_threaded_index.cpp
+++ b/tests/test_threaded_index.cpp
@@ -22,7 +22,7 @@ struct TestException : public std::exception {};
 using idx_t = faiss::idx_t;
 
 struct MockIndex : public faiss::Index {
-    explicit MockIndex(idx_t d) : faiss::Index(d) {
+    explicit MockIndex(idx_t d_in) : faiss::Index(d_in) {
         resetMock();
     }
 
@@ -184,7 +184,7 @@ TEST(ThreadedIndex, TestReplica) {
 
         replica.add(n, x.data());
 
-        for (int i = 0; i < idxs.size(); ++i) {
+        for (size_t i = 0; i < idxs.size(); ++i) {
             EXPECT_EQ(idxs[i]->nCalled, n);
             EXPECT_EQ(idxs[i]->xCalled, x.data());
         }
@@ -195,7 +195,7 @@ TEST(ThreadedIndex, TestReplica) {
 
         replica.search(n, x.data(), k, distances.data(), labels.data());
 
-        for (int i = 0; i < idxs.size(); ++i) {
+        for (size_t i = 0; i < idxs.size(); ++i) {
             auto perReplica = n / idxs.size();
 
             EXPECT_EQ(idxs[i]->nCalled, perReplica);
@@ -233,7 +233,7 @@ TEST(ThreadedIndex, TestShards) {
 
         shards.add(n, x.data());
 
-        for (int i = 0; i < idxs.size(); ++i) {
+        for (size_t i = 0; i < idxs.size(); ++i) {
             auto perShard = n / idxs.size();
 
             EXPECT_EQ(idxs[i]->nCalled, perShard);
@@ -246,7 +246,7 @@ TEST(ThreadedIndex, TestShards) {
 
         shards.search(n, x.data(), k, distances.data(), labels.data());
 
-        for (int i = 0; i < idxs.size(); ++i) {
+        for (size_t i = 0; i < idxs.size(); ++i) {
             EXPECT_EQ(idxs[i]->nCalled, n);
             EXPECT_EQ(idxs[i]->xCalled, x.data());
             EXPECT_EQ(idxs[i]->kCalled, k);

--- a/tests/test_transfer_invlists.cpp
+++ b/tests/test_transfer_invlists.cpp
@@ -34,9 +34,9 @@ using namespace faiss;
 
 using idx_t = faiss::idx_t;
 
-std::vector<float> get_data(size_t nb, int seed) {
-    std::vector<float> x(nb * d);
-    float_randn(x.data(), nb * d, seed);
+std::vector<float> get_data(size_t nb_in, int seed) {
+    std::vector<float> x(nb_in * d);
+    float_randn(x.data(), nb_in * d, seed);
     return x;
 }
 

--- a/tests/test_util.h
+++ b/tests/test_util.h
@@ -15,8 +15,8 @@ struct Tempfilename {
     pthread_mutex_t* mutex;
     std::string filename;
 
-    Tempfilename(pthread_mutex_t* mutex, std::string filename_template) {
-        this->mutex = mutex;
+    Tempfilename(pthread_mutex_t* mutex_in, std::string filename_template) {
+        this->mutex = mutex_in;
         this->filename = filename_template;
         pthread_mutex_lock(mutex);
         int fd = mkstemp(&this->filename[0]);


### PR DESCRIPTION
## Summary
- Fix compiler warnings in all 20 FAISS C++ test files
- Fixes include `-Wshadow`, `-Wunused-parameter`, and signed/unsigned comparisons

All changes are mechanical. No functional changes.

Part 13/13 of the compiler warnings cleanup (split from #4810 per maintainer request).

## Test plan
- [x] No functional changes — all fixes are mechanical renames and annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>