### PR TITLE
Add overflow check in READVECTOR macro

### DIFF
--- a/faiss/impl/io_macros.h
+++ b/faiss/impl/io_macros.h
@@ -51,6 +51,12 @@ size_t get_deserialization_vector_byte_limit();
                 size >= 0 &&                                             \
                 size < (faiss::get_deserialization_vector_byte_limit() / \
                         sizeof(*(vec).data())));                         \
+        FAISS_THROW_IF_NOT_FMT(                                          \
+                size <= SIZE_MAX / sizeof((vec)[0]),                     \
+                "READVECTOR: size %zu would overflow for element "       \
+                "size %zu",                                              \
+                size,                                                    \
+                sizeof((vec)[0]));                                       \
         (vec).resize(size);                                              \
         READANDCHECK((vec).data(), size);                                \
     }


### PR DESCRIPTION
Summary:
When deserializing vectors from index files, the READVECTOR macro did not
check whether `size * sizeof(element)` would overflow `SIZE_MAX`. A
malformed index file could specify a very large vector size that passes
the 1TB upper-bound check but overflows when multiplied by the element
size, leading to an undersized allocation and subsequent out-of-bounds
writes during the read.

Add an explicit overflow check before calling `resize()` to ensure the
total byte count fits in `size_t`.

Differential Revision: D96951153


