### PR TITLE
Validate quantizer data sizes during index deserialization (#4947)

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -513,6 +513,13 @@ void read_ProductQuantizer(ProductQuantizer* pq, IOReader* f) {
     }
     pq->set_derived_values();
     READVECTOR(pq->centroids);
+    FAISS_THROW_IF_NOT_FMT(
+            pq->centroids.size() == pq->d * pq->ksub,
+            "ProductQuantizer centroids size %zu != d * ksub (%zu * %zu = %zu)",
+            pq->centroids.size(),
+            pq->d,
+            pq->ksub,
+            pq->d * pq->ksub);
 }
 
 static void read_ResidualQuantizer_old(ResidualQuantizer& rq, IOReader* f) {
@@ -646,6 +653,38 @@ void read_ScalarQuantizer(ScalarQuantizer* ivsc, IOReader* f) {
     READ1(ivsc->d);
     READ1(ivsc->code_size);
     READVECTOR(ivsc->trained);
+    // Validate trained vector size matches the quantizer type and dimension.
+    // An untrained ScalarQuantizer legitimately has trained.size() == 0,
+    // so only check when the vector is non-empty.
+    if (!ivsc->trained.empty()) {
+        size_t expected = 0;
+        switch (ivsc->qtype) {
+            case ScalarQuantizer::QT_4bit_uniform:
+            case ScalarQuantizer::QT_8bit_uniform:
+                expected = 2;
+                break;
+            case ScalarQuantizer::QT_4bit:
+            case ScalarQuantizer::QT_8bit:
+            case ScalarQuantizer::QT_6bit:
+                expected = 2 * ivsc->d;
+                break;
+            case ScalarQuantizer::QT_fp16:
+            case ScalarQuantizer::QT_bf16:
+            case ScalarQuantizer::QT_8bit_direct:
+            case ScalarQuantizer::QT_8bit_direct_signed:
+            case ScalarQuantizer::QT_count:
+                expected = 0;
+                break;
+        }
+        FAISS_THROW_IF_NOT_FMT(
+                ivsc->trained.size() == expected,
+                "ScalarQuantizer trained size %zu != expected %zu "
+                "for qtype %d, d %zu",
+                ivsc->trained.size(),
+                expected,
+                (int)ivsc->qtype,
+                ivsc->d);
+    }
     ivsc->set_derived_sizes();
 }
 

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -16,6 +16,7 @@
 #include <faiss/IndexBinary.h>
 #include <faiss/VectorTransform.h>
 #include <faiss/impl/FaissException.h>
+#include <faiss/impl/ScalarQuantizer.h>
 #include <faiss/impl/io.h>
 #include <faiss/index_io.h>
 #include <faiss/invlists/InvertedLists.h>
@@ -900,4 +901,40 @@ TEST(ReadIndexDeserialize, BlockInvertedListsValidCodesSize) {
     reader.data = buf;
     auto il = read_InvertedLists_up(&reader);
     EXPECT_NE(il, nullptr);
+}
+
+// -----------------------------------------------------------------------
+// Test: ProductQuantizer centroids size mismatch.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, PQCentroidsSizeMismatch) {
+    // "Imiq" (MultiIndexQuantizer): fourcc + index_header + PQ
+    // PQ: d=4, M=2, nbits=8 -> ksub=256, expected centroids = 4*256 = 1024
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "Imiq");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0);
+    std::vector<float> bad_centroids(100, 0.0f);
+    push_pq(buf, /*d=*/4, /*M=*/2, /*nbits=*/8, bad_centroids);
+
+    expect_read_throws_with(buf, "centroids size");
+}
+
+// -----------------------------------------------------------------------
+// Test: ScalarQuantizer trained vector size mismatch.
+// For QT_4bit (qtype=1), expected trained.size() = 2 * d.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, SQTrainedSizeMismatch) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IxSQ");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0);
+    // ScalarQuantizer fields:
+    push_val<int>(
+            buf, ScalarQuantizer::QT_4bit); // expects trained.size()=2*d=8
+    push_val<int>(buf, 0);                  // rangestat
+    push_val<float>(buf, 0.0f);             // rangestat_arg
+    push_val<size_t>(buf, 4);               // d
+    push_val<size_t>(buf, 1);               // code_size
+    // trained: 3 floats instead of expected 8
+    push_vector<float>(buf, {1.0f, 2.0f, 3.0f});
+
+    expect_read_throws_with(buf, "ScalarQuantizer trained size");
 }


### PR DESCRIPTION
Summary:

Add validation checks during index deserialization for quantizer data:

- ProductQuantizer: verify that the centroids vector size matches
  `d * ksub`. A mismatch indicates a corrupt or maliciously crafted
  index file and would cause out-of-bounds reads during search.

- ScalarQuantizer: verify that the trained vector size matches the
  expected size for the quantizer type and dimension. The expected size
  depends on the quantizer type (e.g., 2*d for per-dimension types,
  2 for uniform types, 0 for direct/fp16/bf16 types).

Differential Revision: D96965538
