### PR TITLE
Validate graph index data during deserialization (#4949)

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -10,6 +10,7 @@
 
 #include <faiss/impl/io_macros.h>
 
+#include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -906,6 +907,26 @@ static void read_NNDescent(NNDescent& nnd, IOReader* f) {
             nnd.ntotal >= 0, "invalid NNDescent ntotal %d", nnd.ntotal);
 
     READVECTOR(nnd.final_graph);
+    // Validate neighbor IDs in the graph
+    if (nnd.has_built && nnd.K > 0 && nnd.ntotal > 0) {
+        FAISS_THROW_IF_NOT_FMT(
+                nnd.final_graph.size() == (size_t)nnd.ntotal * (size_t)nnd.K,
+                "NNDescent final_graph size %zu != ntotal * K (%d * %d = %zu)",
+                nnd.final_graph.size(),
+                nnd.ntotal,
+                nnd.K,
+                (size_t)nnd.ntotal * (size_t)nnd.K);
+        for (size_t i = 0; i < nnd.final_graph.size(); i++) {
+            int id = nnd.final_graph[i];
+            FAISS_THROW_IF_NOT_FMT(
+                    id >= -1 && id < nnd.ntotal,
+                    "NNDescent final_graph[%zu] = %d out of range "
+                    "[-1, %d)",
+                    i,
+                    id,
+                    nnd.ntotal);
+        }
+    }
 }
 
 std::unique_ptr<ProductQuantizer> read_ProductQuantizer_up(const char* fname) {
@@ -1600,9 +1621,28 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
             }
         }
         read_HNSW(idxhnsw->hnsw, f);
+        // Cross-check HNSW graph size against index header ntotal
+        FAISS_THROW_IF_NOT_FMT(
+                idxhnsw->hnsw.levels.size() == (size_t)idxhnsw->ntotal,
+                "HNSW levels size %zu != index ntotal %" PRId64,
+                idxhnsw->hnsw.levels.size(),
+                idxhnsw->ntotal);
         idxhnsw->hnsw.is_panorama = (h == fourcc("IHfP"));
         idxhnsw->storage = read_index(f, io_flags);
         idxhnsw->own_fields = idxhnsw->storage != nullptr;
+        // Cross-check storage ntotal and d against index
+        if (idxhnsw->storage) {
+            FAISS_THROW_IF_NOT_FMT(
+                    idxhnsw->storage->ntotal == idxhnsw->ntotal,
+                    "HNSW storage ntotal %" PRId64 " != index ntotal %" PRId64,
+                    idxhnsw->storage->ntotal,
+                    idxhnsw->ntotal);
+            FAISS_THROW_IF_NOT_FMT(
+                    idxhnsw->storage->d == idxhnsw->d,
+                    "HNSW storage d %d != index d %d",
+                    idxhnsw->storage->d,
+                    idxhnsw->d);
+        }
         if (h == fourcc("IHNp") && !(io_flags & IO_FLAG_PQ_SKIP_SDC_TABLE)) {
             auto* storage_pq = dynamic_cast<IndexPQ*>(idxhnsw->storage);
             FAISS_THROW_IF_NOT_MSG(
@@ -1631,15 +1671,58 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         READ1(idxnsg->nndescent_L);
         READ1(idxnsg->nndescent_iter);
         read_NSG(idxnsg->nsg, f);
+        // Cross-check NSG graph ntotal against index header ntotal
+        if (idxnsg->nsg.is_built) {
+            FAISS_THROW_IF_NOT_FMT(
+                    idxnsg->nsg.ntotal == idxnsg->ntotal,
+                    "NSG ntotal %d != index ntotal %" PRId64,
+                    idxnsg->nsg.ntotal,
+                    idxnsg->ntotal);
+        }
         idxnsg->storage = read_index(f, io_flags);
         idxnsg->own_fields = true;
+        // Cross-check storage ntotal and d against index
+        if (idxnsg->storage) {
+            FAISS_THROW_IF_NOT_FMT(
+                    idxnsg->storage->ntotal == idxnsg->ntotal,
+                    "NSG storage ntotal %" PRId64 " != index ntotal %" PRId64,
+                    idxnsg->storage->ntotal,
+                    idxnsg->ntotal);
+            FAISS_THROW_IF_NOT_FMT(
+                    idxnsg->storage->d == idxnsg->d,
+                    "NSG storage d %d != index d %d",
+                    idxnsg->storage->d,
+                    idxnsg->d);
+        }
         idx = std::move(idxnsg);
     } else if (h == fourcc("INNf")) {
         auto idxnnd = std::make_unique<IndexNNDescentFlat>();
         read_index_header(*idxnnd, f);
         read_NNDescent(idxnnd->nndescent, f);
+        // Cross-check NNDescent ntotal against index header ntotal
+        if (idxnnd->nndescent.has_built) {
+            FAISS_THROW_IF_NOT_FMT(
+                    idxnnd->nndescent.ntotal == idxnnd->ntotal,
+                    "NNDescent ntotal %d != index ntotal %" PRId64,
+                    idxnnd->nndescent.ntotal,
+                    idxnnd->ntotal);
+        }
         idxnnd->storage = read_index(f, io_flags);
         idxnnd->own_fields = true;
+        // Cross-check storage ntotal and d against index
+        if (idxnnd->storage) {
+            FAISS_THROW_IF_NOT_FMT(
+                    idxnnd->storage->ntotal == idxnnd->ntotal,
+                    "NNDescent storage ntotal %" PRId64
+                    " != index ntotal %" PRId64,
+                    idxnnd->storage->ntotal,
+                    idxnnd->ntotal);
+            FAISS_THROW_IF_NOT_FMT(
+                    idxnnd->storage->d == idxnnd->d,
+                    "NNDescent storage d %d != index d %d",
+                    idxnnd->storage->d,
+                    idxnnd->d);
+        }
         idx = std::move(idxnnd);
     } else if (h == fourcc("IPfs")) {
         auto idxpqfs = std::make_unique<IndexPQFastScan>();

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -1100,3 +1100,186 @@ TEST(ReadIndexDeserialize, IndexProductLocalSearchQuantizerCodesSizeMismatch) {
 
     expect_read_throws_with(buf, "codes.size()");
 }
+
+// -----------------------------------------------------------------------
+// Graph index helpers
+// -----------------------------------------------------------------------
+
+/// Helper: append a minimal IndexFlatL2 ("IxF2") with the given d and ntotal.
+/// Uses the WRITEXBVECTOR format (size_t num_floats prefix, then raw data).
+static void push_minimal_flat(
+        std::vector<uint8_t>& buf,
+        int d,
+        int64_t ntotal = 0) {
+    push_fourcc(buf, "IxF2");
+    push_index_header(buf, d, ntotal);
+    size_t num_floats = (size_t)ntotal * (size_t)d;
+    push_val<size_t>(buf, num_floats);
+    buf.resize(buf.size() + num_floats * sizeof(float), 0);
+}
+
+/// Helper: append a minimal valid HNSW structure with the given number of
+/// nodes.  All nodes are at level 1 with zero neighbors, which passes
+/// validate_HNSW.
+static void push_minimal_hnsw(std::vector<uint8_t>& buf, int ntotal) {
+    // assign_probas (empty)
+    push_vector<double>(buf, {});
+    // cum_nneighbor_per_level: {0, 0} — 0 cumulative neighbors at each level
+    push_vector<int>(buf, {0, 0});
+    // levels: one entry per node, all at level 1 (1-indexed in HNSW)
+    std::vector<int> levels(ntotal, 1);
+    push_vector<int>(buf, levels);
+    // offsets: ntotal + 1 entries, all 0
+    std::vector<size_t> offsets(ntotal + 1, 0);
+    push_vector<size_t>(buf, offsets);
+    // neighbors (empty)
+    push_vector<int32_t>(buf, {});
+    // entry_point
+    push_val<int32_t>(buf, ntotal > 0 ? 0 : -1);
+    // max_level
+    push_val<int>(buf, 0);
+    // efConstruction
+    push_val<int>(buf, 40);
+    // efSearch
+    push_val<int>(buf, 16);
+    // upper_beam (deprecated, always 1)
+    push_val<int>(buf, 1);
+}
+
+/// Helper: append NNDescent fields.
+static void push_nndescent(
+        std::vector<uint8_t>& buf,
+        int ntotal,
+        int d,
+        int K,
+        bool has_built,
+        const std::vector<int>& final_graph) {
+    push_val<int>(buf, ntotal);
+    push_val<int>(buf, d);
+    push_val<int>(buf, K);
+    push_val<int>(buf, 10); // S
+    push_val<int>(buf, 10); // R
+    push_val<int>(buf, 10); // L
+    push_val<int>(buf, 1);  // iter
+    push_val<int>(buf, 10); // search_L
+    push_val<int>(buf, 42); // random_seed
+    push_val<bool>(buf, has_built);
+    push_vector<int>(buf, final_graph);
+}
+
+// -----------------------------------------------------------------------
+// Test: NNDescent final_graph size mismatch (should be ntotal * K).
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, NNDescentGraphSizeMismatch) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "INNf");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/2);
+    // NNDescent: ntotal=2, K=3, has_built=true
+    // Expected graph size = 2*3 = 6, but provide 10
+    push_nndescent(
+            buf,
+            /*ntotal=*/2,
+            /*d=*/4,
+            /*K=*/3,
+            /*has_built=*/true,
+            std::vector<int>(10, 0));
+
+    expect_read_throws_with(buf, "NNDescent final_graph size");
+}
+
+// -----------------------------------------------------------------------
+// Test: NNDescent final_graph contains out-of-range neighbor ID.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, NNDescentGraphInvalidId) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "INNf");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/2);
+    // NNDescent: ntotal=2, K=2, graph size = 4
+    // ID 99 is out of range [-1, 2)
+    push_nndescent(
+            buf,
+            /*ntotal=*/2,
+            /*d=*/4,
+            /*K=*/2,
+            /*has_built=*/true,
+            {0, 1, 99, 0});
+
+    expect_read_throws_with(buf, "out of range");
+}
+
+// -----------------------------------------------------------------------
+// Test: HNSW levels.size() != index ntotal.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, HNSWLevelsSizeMismatch) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IHNf");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/5);
+    // HNSW with 3 entries (mismatch with ntotal=5)
+    push_minimal_hnsw(buf, /*ntotal=*/3);
+
+    expect_read_throws_with(buf, "HNSW levels size");
+}
+
+// -----------------------------------------------------------------------
+// Test: HNSW storage ntotal != index ntotal.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, HNSWStorageNtotalMismatch) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IHNf");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/3);
+    // Valid HNSW with 3 entries (matches header)
+    push_minimal_hnsw(buf, /*ntotal=*/3);
+    // Storage with ntotal=99 (mismatch)
+    push_minimal_flat(buf, /*d=*/4, /*ntotal=*/99);
+
+    expect_read_throws_with(buf, "HNSW storage ntotal");
+}
+
+// -----------------------------------------------------------------------
+// Test: NSG ntotal != index ntotal.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, NSGNtotalMismatch) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "INSf");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/5);
+    push_val<int>(buf, 0);  // GK
+    push_val<char>(buf, 0); // build_type (char, not int)
+    push_val<int>(buf, 10); // nndescent_S
+    push_val<int>(buf, 10); // nndescent_R
+    push_val<int>(buf, 10); // nndescent_L
+    push_val<int>(buf, 1);  // nndescent_iter
+    // NSG: ntotal=3 (mismatch with index ntotal=5)
+    push_val<int>(buf, 3);     // ntotal
+    push_val<int>(buf, 2);     // R
+    push_val<int>(buf, 10);    // L
+    push_val<int>(buf, 10);    // C
+    push_val<int>(buf, 10);    // search_L
+    push_val<int>(buf, 0);     // enterpoint
+    push_val<bool>(buf, true); // is_built
+    // Graph: 3 nodes, R=2, all empty (EMPTY_ID terminates each)
+    for (int i = 0; i < 3; i++) {
+        push_val<int>(buf, -1); // EMPTY_ID
+    }
+
+    expect_read_throws_with(buf, "NSG ntotal");
+}
+
+// -----------------------------------------------------------------------
+// Test: NNDescent ntotal != index ntotal.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, NNDescentNtotalMismatch) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "INNf");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/5);
+    // NNDescent: ntotal=3, has_built=true (mismatch with index ntotal=5)
+    // Graph is internally valid: ntotal=3, K=2, 6 entries all in range
+    push_nndescent(
+            buf,
+            /*ntotal=*/3,
+            /*d=*/4,
+            /*K=*/2,
+            /*has_built=*/true,
+            {0, 1, 0, 2, 1, 2});
+
+    expect_read_throws_with(buf, "NNDescent ntotal");
+}


### PR DESCRIPTION
Summary:

Add validation checks for graph-based index types during deserialization:

- NNDescent: validate that `final_graph` size matches `ntotal * K` and
  that all neighbor IDs are in the valid range `[-1, ntotal)`.

- HNSW: cross-check that `hnsw.levels.size()` matches the index header
  `ntotal`, and that the storage sub-index `ntotal` and `d` match the
  parent index.

- NSG: cross-check that `nsg.ntotal` matches the index header `ntotal`
  (when built), and that the storage sub-index `ntotal` and `d` match.

- NNDescentFlat: cross-check that `nndescent.ntotal` matches the index
  header `ntotal` (when built), and that the storage sub-index `ntotal`
  and `d` match.

These checks catch corrupt or maliciously crafted index files that could
cause out-of-bounds memory access during graph traversal in search.

Reviewed By: mnorris11

Differential Revision: D96966646
