### PR TITLE
fix: resolve compiler warnings in graph-based index implementations

### DIFF
--- a/faiss/IndexBinaryHNSW.cpp
+++ b/faiss/IndexBinaryHNSW.cpp
@@ -172,14 +172,19 @@ IndexBinaryHNSW::IndexBinaryHNSW() {
     is_trained = true;
 }
 
-IndexBinaryHNSW::IndexBinaryHNSW(int d_, int M) : IndexBinary(d_), hnsw(M) {
-    storage = std::make_unique<IndexBinaryFlat>(d_).release();
-    own_fields = true;
+IndexBinaryHNSW::IndexBinaryHNSW(int d_, int M)
+        : IndexBinary(d_),
+          hnsw(M),
+          own_fields(true),
+          storage(std::make_unique<IndexBinaryFlat>(d_).release()) {
     is_trained = true;
 }
 
 IndexBinaryHNSW::IndexBinaryHNSW(IndexBinary* storage_, int M)
-        : IndexBinary(storage_->d), hnsw(M), storage(storage_) {
+        : IndexBinary(storage_->d),
+          hnsw(M),
+          own_fields(false),
+          storage(storage_) {
     is_trained = true;
 }
 


### PR DESCRIPTION
## Summary
- Fix compiler warnings in HNSW, NSG, NNDescent graph implementations and their Index wrappers
- Also covers ClusteringInitialization, Panorama, and IndexBinaryHNSW
- Fixes include `-Wshadow` (variable renames), `-Wunused-parameter`, and `-Wimplicit-fallthrough`

All changes are mechanical. No functional changes.

Part 3/13 of the compiler warnings cleanup (split from #4810 per maintainer request).

## Test plan
- [x] No functional changes — all fixes are mechanical renames and annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)