### PR TITLE
Enable quieting FAISS warning "inverted lists not stored" (#4964)

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -413,15 +413,19 @@ static void read_ArrayInvertedLists_sizes(
     }
 }
 
+bool index_read_warn_on_null_invlists = true;
+
 std::unique_ptr<InvertedLists> read_InvertedLists_up(
         IOReader* f,
         int io_flags) {
     uint32_t h;
     READ1(h);
     if (h == fourcc("il00")) {
-        fprintf(stderr,
-                "read_InvertedLists:"
-                " WARN! inverted lists not stored with IVF object\n");
+        if (index_read_warn_on_null_invlists) {
+            fprintf(stderr,
+                    "read_InvertedLists:"
+                    " WARN! inverted lists not stored with IVF object\n");
+        }
         return nullptr;
     } else if (h == fourcc("ilpn") && !(io_flags & IO_FLAG_SKIP_IVF_DATA)) {
         size_t nlist, code_size, n_levels;

--- a/faiss/index_io.h
+++ b/faiss/index_io.h
@@ -13,6 +13,8 @@
 #include <cstdio>
 #include <memory>
 
+#include <faiss/impl/platform_macros.h>
+
 /** I/O functions can read/write to a filename, a file handle or to an
  * object that abstracts the medium.
  *
@@ -67,6 +69,8 @@ const int IO_FLAG_MMAP = IO_FLAG_SKIP_IVF_DATA | 0x646f0000;
 // this is a temporary solution, it is expected to be merged with IO_FLAG_MMAP
 //   after OnDiskInvertedLists get properly updated.
 const int IO_FLAG_MMAP_IFC = 1 << 9;
+
+FAISS_API extern bool index_read_warn_on_null_invlists;
 
 Index* read_index(const char* fname, int io_flags = 0);
 Index* read_index(FILE* f, int io_flags = 0);


### PR DESCRIPTION
Summary:

This unthrottled log site is leading to log spew.

Reviewed By: luciang

Differential Revision: D97350834


