### PR TITLE
Fix avx512_result_handlers build on aarch64 (#4965)

### DIFF
--- a/benchs/avx512_result_handlers/bench_avx512_result_handler.cpp
+++ b/benchs/avx512_result_handlers/bench_avx512_result_handler.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#if defined(__x86_64__)
+
 #include "faiss_avx512_result_handler.h"
 
 #include <faiss/IndexIVF.h>
@@ -125,3 +127,5 @@ int main() {
 
     return 0;
 }
+
+#endif // defined(__x86_64__)

--- a/benchs/avx512_result_handlers/faiss_avx512_result_handler.h
+++ b/benchs/avx512_result_handlers/faiss_avx512_result_handler.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#if defined(__x86_64__)
+
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/ResultHandler.h>
 #include <immintrin.h>
@@ -145,3 +147,5 @@ struct ReservoirResultHandlerAVX512 : ResultHandler {
 };
 
 } // namespace faiss
+
+#endif // defined(__x86_64__)

--- a/benchs/avx512_result_handlers/partition.cpp
+++ b/benchs/avx512_result_handlers/partition.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#if defined(__x86_64__)
+
 #include "partition.h"
 
 #include <algorithm>
@@ -601,3 +603,5 @@ void argsort(size_t n, float* val, int32_t* idx) {
     argsort(left_size, val, idx);
     argsort(n - left_size, val + left_size, idx + left_size);
 }
+
+#endif // defined(__x86_64__)

--- a/benchs/avx512_result_handlers/partition.h
+++ b/benchs/avx512_result_handlers/partition.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#if defined(__x86_64__)
+
 #include <cstddef>
 #include <cstdint>
 
@@ -38,3 +40,5 @@ void argpartition(size_t n, float* val, int32_t* idx, size_t k);
  * @param idx   Array of indices (modified in place, reordered with values)
  */
 void argsort(size_t n, float* val, int32_t* idx);
+
+#endif // defined(__x86_64__)

--- a/benchs/avx512_result_handlers/test_bitonic.cpp
+++ b/benchs/avx512_result_handlers/test_bitonic.cpp
@@ -4,6 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+#if defined(__x86_64__)
+
 #include <immintrin.h>
 #include <algorithm>
 #include <cassert>
@@ -109,3 +112,5 @@ int main() {
 
     return 0;
 }
+
+#endif // defined(__x86_64__)

--- a/benchs/avx512_result_handlers/test_partition.cpp
+++ b/benchs/avx512_result_handlers/test_partition.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#if defined(__x86_64__)
+
 #include <gtest/gtest.h>
 
 #include "partition.h"
@@ -170,3 +172,5 @@ TEST(ArgpartitionTest, PartitionsCorrectly) {
         }
     }
 }
+
+#endif // defined(__x86_64__)


### PR DESCRIPTION
Summary:

The avx512_result_handlers targets fail to build on aarch64 because they
unconditionally pass `-mavx512f` and use x86-specific intrinsics. This diff:

1. Adds `select()` in the BUCK file so `-mavx512f` is only applied on x86_64.
2. Wraps all source files with `#if defined(__x86_64__)` guards as defense-in-depth.

Reviewed By: mnorris11

Differential Revision: D97347249
