### PR TITLE
Validate RaBitQ qb during deserialization (#4983)

### DIFF
--- a/faiss/IndexIVFRaBitQ.h
+++ b/faiss/IndexIVFRaBitQ.h
@@ -29,6 +29,8 @@ struct IndexIVFRaBitQ : IndexIVF {
 
     // the default number of bits to quantize a query with.
     // use '0' to disable quantization and use raw fp32 values.
+    // Note: qb=0 is NOT supported by FastScan variants, which require
+    // quantized queries for SIMD lookup table construction.
     uint8_t qb = 4;
 
     IndexIVFRaBitQ(

--- a/faiss/IndexRaBitQ.h
+++ b/faiss/IndexRaBitQ.h
@@ -26,6 +26,8 @@ struct IndexRaBitQ : IndexFlatCodes {
 
     // the default number of bits to quantize a query with.
     // use '0' to disable quantization and use raw fp32 values.
+    // Note: qb=0 is NOT supported by FastScan variants, which require
+    // quantized queries for SIMD lookup table construction.
     uint8_t qb = 4;
 
     // quantize the query with a zero-centered scalar quantizer.

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -1846,6 +1846,10 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         read_RaBitQuantizer(idxqfs->rabitq, f, true);
         READVECTOR(idxqfs->center);
         READ1(idxqfs->qb);
+        FAISS_THROW_IF_NOT_FMT(
+                idxqfs->qb > 0 && idxqfs->qb <= 8,
+                "invalid RaBitQ qb=%d (must be in [1, 8])",
+                idxqfs->qb);
 
         std::vector<uint8_t> legacy_flat_storage;
         if (is_legacy) {
@@ -1888,12 +1892,19 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
 
         idx = std::move(idxqfs);
     } else if (h == fourcc("Ixrq")) {
+        // Ixrq = original single-bit format
         auto idxq = std::make_unique<IndexRaBitQ>();
         read_index_header(*idxq, f);
         read_RaBitQuantizer(idxq->rabitq, f, false);
         READVECTOR(idxq->codes);
         READVECTOR(idxq->center);
         READ1(idxq->qb);
+        // qb=0: Not quantized - direct distance computation on given float32s.
+        // qb>0 && qb<=8: Scalar-quantized with qb bits of precision.
+        FAISS_THROW_IF_NOT_FMT(
+                idxq->qb <= 8,
+                "invalid RaBitQ qb=%d (must be in [0, 8])",
+                idxq->qb);
 
         // rabitq.nb_bits is already set to 1 by read_RaBitQuantizer
         idxq->code_size = idxq->rabitq.code_size;
@@ -1906,6 +1917,12 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         READVECTOR(idxq->codes);
         READVECTOR(idxq->center);
         READ1(idxq->qb);
+        // qb=0: Not quantized - direct distance computation on given float32s.
+        // qb>0 && qb<=8: Scalar-quantized with qb bits of precision.
+        FAISS_THROW_IF_NOT_FMT(
+                idxq->qb <= 8,
+                "invalid RaBitQ qb=%d (must be in [0, 8])",
+                idxq->qb);
 
         idxq->code_size = idxq->rabitq.code_size;
         idx = std::move(idxq);
@@ -1916,6 +1933,12 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         READ1(ivrq->code_size);
         READ1(ivrq->by_residual);
         READ1(ivrq->qb);
+        // qb=0: Not quantized - direct distance computation on given float32s.
+        // qb>0 && qb<=8: Scalar-quantized with qb bits of precision.
+        FAISS_THROW_IF_NOT_FMT(
+                ivrq->qb <= 8,
+                "invalid RaBitQ qb=%d (must be in [0, 8])",
+                ivrq->qb);
 
         // rabitq.nb_bits is already set to 1 by read_RaBitQuantizer
         // Update rabitq to match nb_bits
@@ -1932,6 +1955,12 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         READ1(ivrq->code_size);
         READ1(ivrq->by_residual);
         READ1(ivrq->qb);
+        // qb=0: Not quantized - direct distance computation on given float32s.
+        // qb>0 && qb<=8: Scalar-quantized with qb bits of precision.
+        FAISS_THROW_IF_NOT_FMT(
+                ivrq->qb <= 8,
+                "invalid RaBitQ qb=%d (must be in [0, 8])",
+                ivrq->qb);
 
         // Update rabitq to match nb_bits
         ivrq->rabitq.code_size =
@@ -2019,6 +2048,10 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         READ1(ivrqfs->M2);
         READ1(ivrqfs->implem);
         READ1(ivrqfs->qb);
+        FAISS_THROW_IF_NOT_FMT(
+                ivrqfs->qb > 0 && ivrqfs->qb <= 8,
+                "invalid RaBitQ qb=%d (must be in [1, 8])",
+                ivrqfs->qb);
         READ1(ivrqfs->centered);
 
         std::vector<uint8_t> legacy_flat_storage;

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -1459,3 +1459,214 @@ TEST(ReadIndexDeserialize, ITQTransformMeanTooSmall) {
 
     expect_vt_read_throws_with(buf, "ITQTransform mean size");
 }
+
+// -----------------------------------------------------------------------
+// RaBitQ qb deserialization validation tests
+// -----------------------------------------------------------------------
+
+/// Helper: push a minimal RaBitQuantizer (single-bit format, multi_bit=false).
+static void push_rabitq(std::vector<uint8_t>& buf, size_t d) {
+    push_val<size_t>(buf, d); // d
+    push_val<size_t>(buf, 1); // code_size
+    push_val<int>(buf, 1);    // metric_type (L2)
+}
+
+/// Helper: push a minimal RaBitQuantizer (multi-bit format, multi_bit=true).
+static void push_rabitq_multibit(std::vector<uint8_t>& buf, size_t d) {
+    push_val<size_t>(buf, d); // d
+    push_val<size_t>(buf, 1); // code_size
+    push_val<int>(buf, 1);    // metric_type (L2)
+    push_val<size_t>(buf, 1); // nb_bits
+}
+
+/// Helper: push an IVF header (index_header + nlist + nprobe + flat quantizer
+/// + empty direct_map).
+static void push_ivf_header(std::vector<uint8_t>& buf, int d) {
+    push_index_header(buf, d, /*ntotal=*/0);
+    push_val<size_t>(buf, 1); // nlist
+    push_val<size_t>(buf, 1); // nprobe
+    push_minimal_flat(buf, d);
+    push_empty_direct_map(buf);
+}
+
+// -- Ixrq (IndexRaBitQ, single-bit) --
+// qb=0 is valid for Ixrq: disables query quantization, uses raw fp32 values.
+// See IndexRaBitQ.h comment on qb and RaBitQDistanceComputerNotQ.
+
+TEST(ReadIndexDeserialize, RaBitQQbTooLarge_Ixrq) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "Ixrq");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0);
+    push_rabitq(buf, 4);
+    push_vector<uint8_t>(buf, {});         // codes
+    push_vector<float>(buf, {0, 0, 0, 0}); // center
+    push_val<uint8_t>(buf, 9);             // qb = 9 (> 8, invalid)
+
+    expect_read_throws_with(buf, "RaBitQ qb=");
+}
+
+TEST(ReadIndexDeserialize, RaBitQQbZeroAccepted_Ixrq) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "Ixrq");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0);
+    push_rabitq(buf, 4);
+    push_vector<uint8_t>(buf, {});         // codes
+    push_vector<float>(buf, {0, 0, 0, 0}); // center
+    push_val<uint8_t>(buf, 0);             // qb = 0 (valid for Ixrq)
+
+    VectorIOReader reader;
+    reader.data = buf;
+    EXPECT_NO_THROW(read_index_up(&reader));
+}
+
+// -- Ixrr (IndexRaBitQ, multi-bit) --
+// qb=0 is valid for Ixrr: disables query quantization, uses raw fp32 values.
+// See IndexRaBitQ.h comment on qb and RaBitQDistanceComputerNotQ.
+
+TEST(ReadIndexDeserialize, RaBitQQbTooLarge_Ixrr) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "Ixrr");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0);
+    push_rabitq_multibit(buf, 4);
+    push_vector<uint8_t>(buf, {});         // codes
+    push_vector<float>(buf, {0, 0, 0, 0}); // center
+    push_val<uint8_t>(buf, 9);             // qb = 9 (> 8, invalid)
+
+    expect_read_throws_with(buf, "RaBitQ qb=");
+}
+
+TEST(ReadIndexDeserialize, RaBitQQbZeroAccepted_Ixrr) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "Ixrr");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0);
+    push_rabitq_multibit(buf, 4);
+    push_vector<uint8_t>(buf, {});         // codes
+    push_vector<float>(buf, {0, 0, 0, 0}); // center
+    push_val<uint8_t>(buf, 0);             // qb = 0 (valid for Ixrr)
+
+    VectorIOReader reader;
+    reader.data = buf;
+    EXPECT_NO_THROW(read_index_up(&reader));
+}
+
+// -- Irfn (IndexRaBitQFastScan, new format) --
+// qb=0 is not supported: FastScan requires quantized queries for SIMD.
+
+TEST(ReadIndexDeserialize, RaBitQQbTooLarge_Irfn) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "Irfn");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0);
+    push_rabitq_multibit(buf, 4);
+    push_vector<float>(buf, {0, 0, 0, 0}); // center
+    push_val<uint8_t>(buf, 9);             // qb = 9 (> 8, invalid)
+
+    expect_read_throws_with(buf, "RaBitQ qb=");
+}
+
+TEST(ReadIndexDeserialize, RaBitQQbZeroRejected_Irfn) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "Irfn");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0);
+    push_rabitq_multibit(buf, 4);
+    push_vector<float>(buf, {0, 0, 0, 0}); // center
+    push_val<uint8_t>(buf, 0);             // qb = 0 (invalid for FastScan)
+
+    expect_read_throws_with(buf, "RaBitQ qb=");
+}
+
+// -- Iwrq (IndexIVFRaBitQ, single-bit) --
+// qb=0 is valid for Iwrq: disables query quantization, uses raw fp32 values.
+// See IndexIVFRaBitQ.h comment on qb and RaBitQDistanceComputerNotQ.
+
+TEST(ReadIndexDeserialize, RaBitQQbTooLarge_Iwrq) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "Iwrq");
+    push_ivf_header(buf, /*d=*/4);
+    push_rabitq(buf, 4);
+    push_val<size_t>(buf, 1);   // code_size
+    push_val<bool>(buf, false); // by_residual
+    push_val<uint8_t>(buf, 9);  // qb = 9 (> 8, invalid)
+
+    expect_read_throws_with(buf, "RaBitQ qb=");
+}
+
+TEST(ReadIndexDeserialize, RaBitQQbZeroAccepted_Iwrq) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "Iwrq");
+    push_ivf_header(buf, /*d=*/4);
+    push_rabitq(buf, 4);
+    push_val<size_t>(buf, 1);   // code_size
+    push_val<bool>(buf, false); // by_residual
+    push_val<uint8_t>(buf, 0);  // qb = 0 (valid for Iwrq)
+    push_null_invlists(buf);
+
+    VectorIOReader reader;
+    reader.data = buf;
+    EXPECT_NO_THROW(read_index_up(&reader));
+}
+
+// -- Iwrr (IndexIVFRaBitQ, multi-bit) --
+// qb=0 is valid for Iwrr: disables query quantization, uses raw fp32 values.
+// See IndexIVFRaBitQ.h comment on qb and RaBitQDistanceComputerNotQ.
+
+TEST(ReadIndexDeserialize, RaBitQQbTooLarge_Iwrr) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "Iwrr");
+    push_ivf_header(buf, /*d=*/4);
+    push_rabitq_multibit(buf, 4);
+    push_val<size_t>(buf, 1);   // code_size
+    push_val<bool>(buf, false); // by_residual
+    push_val<uint8_t>(buf, 9);  // qb = 9 (> 8, invalid)
+
+    expect_read_throws_with(buf, "RaBitQ qb=");
+}
+
+TEST(ReadIndexDeserialize, RaBitQQbZeroAccepted_Iwrr) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "Iwrr");
+    push_ivf_header(buf, /*d=*/4);
+    push_rabitq_multibit(buf, 4);
+    push_val<size_t>(buf, 1);   // code_size
+    push_val<bool>(buf, false); // by_residual
+    push_val<uint8_t>(buf, 0);  // qb = 0 (valid for Iwrr)
+    push_null_invlists(buf);
+
+    VectorIOReader reader;
+    reader.data = buf;
+    EXPECT_NO_THROW(read_index_up(&reader));
+}
+
+// -- Iwrn (IndexIVFRaBitQFastScan, new format) --
+// qb=0 is not supported: IVF FastScan requires quantized queries.
+
+TEST(ReadIndexDeserialize, RaBitQQbTooLarge_Iwrn) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "Iwrn");
+    push_ivf_header(buf, /*d=*/4);
+    push_rabitq_multibit(buf, 4);
+    push_val<bool>(buf, false); // by_residual
+    push_val<size_t>(buf, 1);   // code_size
+    push_val<int>(buf, 32);     // bbs
+    push_val<size_t>(buf, 0);   // qbs2
+    push_val<size_t>(buf, 1);   // M2
+    push_val<int>(buf, 0);      // implem
+    push_val<uint8_t>(buf, 9);  // qb = 9 (> 8, invalid)
+
+    expect_read_throws_with(buf, "RaBitQ qb=");
+}
+
+TEST(ReadIndexDeserialize, RaBitQQbZeroRejected_Iwrn) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "Iwrn");
+    push_ivf_header(buf, /*d=*/4);
+    push_rabitq_multibit(buf, 4);
+    push_val<bool>(buf, false); // by_residual
+    push_val<size_t>(buf, 1);   // code_size
+    push_val<int>(buf, 32);     // bbs
+    push_val<size_t>(buf, 0);   // qbs2
+    push_val<size_t>(buf, 1);   // M2
+    push_val<int>(buf, 0);      // implem
+    push_val<uint8_t>(buf, 0);  // qb = 0 (invalid for IVF FastScan)
+
+    expect_read_throws_with(buf, "RaBitQ qb=");
+}


### PR DESCRIPTION
Summary:

Validate that the `qb` (query quantization bits) field is valid for all
6 RaBitQ deserialization points (IndexRaBitQ, IndexRaBitQFastScan,
IndexIVFRaBitQ, IndexIVFRaBitQFastScan, and their multi-bit variants).

The `qb` parameter controls the scalar quantization precision of query
vectors in the RaBitQ algorithm.

- **'FastScan' formats: `qb = 0` is invalid for the quantized path.**
  The quantized distance computer (`RaBitQDistanceComputerQ`) computes
  `max_code = (1 << qb) - 1` and then divides by `delta = (v_max - v_min)
  / max_code`. With `qb = 0`, `max_code` is 0, producing a division by
  zero. The `Z_MAX_BY_QB` lookup table is also indexed by `qb - 1`, so
  `qb = 0` causes an out-of-bounds read from the 8-element array.

- **All other formats: `qb = 0` is valid and means "use unquantized float32 distance computation."**
  When `qb == 0`, the code returns a `RaBitQDistanceComputerNotQ` that
  operates on raw fp32 values without any scalar quantization of the query. Ixrq is the original/default 1-bit RaBitQ format and the only format that supports `qb==0`.

- **`qb > 8` overflows `uint8_t` quantized values.**
  The query vector is scalar-quantized into `rotated_qq`, a
  `std::vector<uint8_t>`, with values in `[0, (1 << qb) - 1]`. For `qb > 8`,
  `(1 << qb) - 1` exceeds 255 and the cast to `uint8_t` silently
  truncates, producing incorrect quantized values. The bit-rearrangement
  loop in `set_query` also extracts individual bits via `rotated_qq[idim]
  & (1 << iv)` for `iv` in `[0, qb)` — with `qb > 8` this shifts beyond
  the 8-bit width of `uint8_t`, yielding undefined behavior.

- **Existing runtime checks are `FAISS_ASSERT`, not `FAISS_THROW`.**
  Both `RaBitQDistanceComputerQ::set_query()` and
  `compute_query_factors()` have `FAISS_ASSERT(qb > 0)` / `FAISS_ASSERT(qb
  <= 8)` checks, but these compile to no-ops in release builds and call
  `abort()` in debug builds.  In either case, when reached inside an OMP
  parallel region (as happens during search), `abort()` terminates the
  entire process without cleanup.  Validating at deserialization time
  converts this into a catchable exception before the invalid value can
  reach any parallel code path.

Reviewed By: mnorris11

Differential Revision: D97815297


