### PR TITLE
large-malloc (805308336 bytes) in __sanitizer::RunMallocHooks()

### DIFF
--- a/faiss/invlists/BlockInvertedLists.cpp
+++ b/faiss/invlists/BlockInvertedLists.cpp
@@ -15,6 +15,7 @@
 
 #include <faiss/impl/io.h>
 #include <faiss/impl/io_macros.h>
+#include <faiss/index_io.h>
 
 namespace faiss {
 
@@ -167,6 +168,17 @@ InvertedLists* BlockInvertedListsIOHook::read(IOReader* f, int /* io_flags */)
         const {
     auto il = std::make_unique<BlockInvertedLists>();
     READ1(il->nlist);
+    {
+        auto limit = get_deserialization_loop_limit();
+        if (limit > 0) {
+            FAISS_THROW_IF_NOT_FMT(
+                    il->nlist <= limit,
+                    "BlockInvertedLists nlist=%zd exceeds "
+                    "deserialization_loop_limit of %zd",
+                    il->nlist,
+                    limit);
+        }
+    }
     READ1(il->code_size);
     READ1(il->n_per_block);
     READ1(il->block_size);


### PR DESCRIPTION
Differential Revision: D97448429


