### PR TITLE
Use omp_get_max_threads() for OpenMP thread count (#4991)

### DIFF
--- a/benchs/bench_cppcontrib_sa_decode.cpp
+++ b/benchs/bench_cppcontrib_sa_decode.cpp
@@ -12,7 +12,6 @@
 #include <iostream>
 #include <memory>
 #include <random>
-#include <thread>
 #include <tuple>
 #include <vector>
 
@@ -32,7 +31,7 @@ std::tuple<std::shared_ptr<faiss::Index>, std::vector<uint8_t>> trainDataset(
         const uint64_t d,
         const std::string& description) {
     //
-    omp_set_num_threads(std::thread::hardware_concurrency());
+    omp_set_num_threads(omp_get_max_threads());
 
     // train an index
     auto index = std::shared_ptr<faiss::Index>(


### PR DESCRIPTION
Summary:

This change replaces std::thread::hardware_concurrency() with
omp_get_max_threads() when choosing the thread count for this benchmark.

This code is OpenMP-based, and omp_get_max_threads() more directly reflects the
parallelism OpenMP will actually use. In particular, it respects the OpenMP
runtime configuration, including settings such as OMP_NUM_THREADS, instead of
querying the system for hardware concurrency.

Reviewed By: junjieqi

Differential Revision: D87909792
