### PR TITLE
Bump openblas from 0.3.30 to 0.3.32 in conda recipes

### DIFF
--- a/conda/faiss-gpu-cuvs/meta.yaml
+++ b/conda/faiss-gpu-cuvs/meta.yaml
@@ -60,14 +60,14 @@ outputs:
       host:
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
         - mkl >=2024.2.2  # [x86_64]
-        - openblas =0.3.30 # [not x86_64]
+        - openblas =0.3.32 # [not x86_64]
         - libcuvs =26.02
         - cuda-version {{ cuda_constraints }}
         - libsvs-runtime =0.2.0  # [x86_64 and linux]
       run:
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
         - mkl >=2024.2.2  # [x86_64]
-        - openblas =0.3.30 # [not x86_64]
+        - openblas =0.3.32 # [not x86_64]
         - cuda-cudart {{ cuda_constraints }}
         - libcublas {{ libcublas_constraints }}
         - libcuvs =26.02

--- a/conda/faiss-gpu/meta.yaml
+++ b/conda/faiss-gpu/meta.yaml
@@ -59,11 +59,11 @@ outputs:
         - cuda-toolkit {{ cudatoolkit }}
       host:
         - mkl >=2024.2.2  # [x86_64]
-        - openblas =0.3.30 # [not x86_64]
+        - openblas =0.3.32 # [not x86_64]
         - libsvs-runtime =0.2.0  # [x86_64 and linux]
       run:
         - mkl >=2024.2.2  # [x86_64]
-        - openblas =0.3.30 # [not x86_64]
+        - openblas =0.3.32 # [not x86_64]
         - cuda-cudart {{ cuda_constraints }}
         - libcublas {{ libcublas_constraints }}
         - libsvs-runtime =0.2.0  # [x86_64 and linux]

--- a/conda/faiss/meta.yaml
+++ b/conda/faiss/meta.yaml
@@ -69,7 +69,7 @@ outputs:
         - mkl >=2024.2.2  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
-        - openblas =0.3.30  # [not x86_64]
+        - openblas =0.3.32  # [not x86_64]
         - libopenblas=0.3.30=openmp_h60d53f8_1  # [osx]
       run:
         - python {{ python }}
@@ -83,7 +83,7 @@ outputs:
         - mkl >=2024.2.2  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
-        - openblas =0.3.30  # [not x86_64]
+        - openblas =0.3.32  # [not x86_64]
         - libopenblas=0.3.30=openmp_h60d53f8_1  # [osx]
     test:
       requires:


### PR DESCRIPTION
Summary:
🤖 This diff was automatically generated by myclaw_faiss_monitor

The arm64 nightly build (Linux arm64) started failing on Mar 26 because
conda-forge removed openblas 0.3.30 for linux-aarch64. The solver cannot
satisfy the exact pin `openblas =0.3.30` since only 0.3.32 is available.

Fix: bump `openblas =0.3.30` to `=0.3.32` in all three conda recipes
(faiss, faiss-gpu, faiss-gpu-cuvs) for the `# [not x86_64]` targets
(arm64 Linux). OSX libopenblas pins are unaffected (different package).

Reviewed By: mnorris11

Differential Revision: D98293081


