### PR TITLE
Add deserialization vector limit enforcement for ResidualCoarseQuantizer

### DIFF
--- a/faiss/IndexAdditiveQuantizer.cpp
+++ b/faiss/IndexAdditiveQuantizer.cpp
@@ -575,8 +575,17 @@ void ResidualCoarseQuantizer::search(
         return;
     }
 
-    std::vector<int32_t> codes(beam_size * rq.M * n);
-    std::vector<float> beam_distances(n * beam_size);
+    size_t codes_size = mul_no_overflow(
+            mul_no_overflow(
+                    static_cast<size_t>(beam_size), rq.M, "beam_size * M"),
+            static_cast<size_t>(n),
+            "beam_size * M * n");
+    size_t beam_dist_size = mul_no_overflow(
+            static_cast<size_t>(n),
+            static_cast<size_t>(beam_size),
+            "n * beam_size");
+    std::vector<int32_t> codes(codes_size);
+    std::vector<float> beam_distances(beam_dist_size);
 
     rq.refine_beam(
             n, 1, x, beam_size, codes.data(), nullptr, beam_distances.data());

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -617,6 +617,8 @@ static void read_ResidualQuantizer_old(ResidualQuantizer& rq, IOReader* f) {
 static void read_AdditiveQuantizer(AdditiveQuantizer& aq, IOReader* f) {
     READ1(aq.d);
     READ1(aq.M);
+    FAISS_THROW_IF_NOT_FMT(
+            aq.M > 0, "invalid AdditiveQuantizer M %zd, must be > 0", aq.M);
     READVECTOR(aq.nbits);
     READ1(aq.is_trained);
     READVECTOR(aq.codebooks);
@@ -652,6 +654,26 @@ static void read_ResidualQuantizer(
     read_AdditiveQuantizer(rq, f);
     READ1(rq.train_type);
     READ1(rq.max_beam_size);
+    FAISS_THROW_IF_NOT_FMT(
+            rq.max_beam_size > 0,
+            "invalid max_beam_size %d, must be > 0",
+            rq.max_beam_size);
+    {
+        // Validate that the key allocation driven by max_beam_size
+        // (beam_size * M * sizeof(int32_t)) fits within the byte limit.
+        size_t beam_alloc = mul_no_overflow(
+                static_cast<size_t>(rq.max_beam_size),
+                rq.M,
+                "max_beam_size * M");
+        beam_alloc = mul_no_overflow(
+                beam_alloc, sizeof(int32_t), "max_beam_size * M * elem");
+        FAISS_THROW_IF_NOT_FMT(
+                beam_alloc < get_deserialization_vector_byte_limit(),
+                "max_beam_size %d * M %zd would exceed "
+                "deserialization vector byte limit",
+                rq.max_beam_size,
+                rq.M);
+    }
     if ((rq.train_type & ResidualQuantizer::Skip_codebook_tables) ||
         (io_flags & IO_FLAG_SKIP_PRECOMPUTE_TABLE)) {
         // don't precompute the tables
@@ -1261,11 +1283,6 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         auto idxr = std::make_unique<ResidualCoarseQuantizer>();
         read_index_header(*idxr, f);
         read_ResidualQuantizer(idxr->rq, f, io_flags);
-        FAISS_THROW_IF_NOT_MSG(
-                static_cast<size_t>(idxr->ntotal) <
-                        get_deserialization_vector_byte_limit() / sizeof(float),
-                "ResidualCoarseQuantizer centroid_norms allocation would exceed "
-                "deserialization byte limit");
         READ1(idxr->beam_factor);
         if (io_flags & IO_FLAG_SKIP_PRECOMPUTE_TABLE) {
             // then we force the beam factor to -1
@@ -1277,6 +1294,31 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
                         get_deserialization_vector_byte_limit() / sizeof(float),
                 "ResidualCoarseQuantizer centroid norms allocation would "
                 "exceed deserialization byte limit");
+        // Validate beam_factor to prevent overflow in search() where
+        // beam_size = int(k * beam_factor) and allocations scale with it.
+        if (idxr->beam_factor > 0) {
+            FAISS_THROW_IF_NOT_FMT(
+                    idxr->beam_factor <= 1000.0f,
+                    "beam_factor %.6g is too large (max 1000)",
+                    idxr->beam_factor);
+        }
+        // Validate ntotal against byte limit: search() allocates
+        // O(ntotal * M) when beam_size is capped to ntotal.
+        {
+            size_t ntotal_alloc = mul_no_overflow(
+                    static_cast<size_t>(idxr->ntotal),
+                    idxr->rq.M,
+                    "ntotal * M");
+            ntotal_alloc = mul_no_overflow(
+                    ntotal_alloc, sizeof(int32_t), "ntotal * M * elem");
+            FAISS_THROW_IF_NOT_FMT(
+                    ntotal_alloc < get_deserialization_vector_byte_limit(),
+                    "ResidualCoarseQuantizer ntotal %" PRId64
+                    " * M %zd would exceed "
+                    "deserialization vector byte limit",
+                    idxr->ntotal,
+                    idxr->rq.M);
+        }
         idxr->set_beam_factor(idxr->beam_factor);
         idx = std::move(idxr);
     } else if (

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -1962,6 +1962,132 @@ TEST(ReadIndexDeserialize, BinaryHNSWCagraZeroEntrypoints) {
             faiss::FaissException);
 }
 
+// -----------------------------------------------------------------------
+// Test: ResidualCoarseQuantizer with huge ntotal triggers centroid_norms
+// byte limit check (pre-existing guard on ntotal vs byte_limit/sizeof(float)).
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, ResidualCoarseQuantizerHugeNtotal) {
+    // "ImRQ": fourcc + index_header + ResidualQuantizer + beam_factor
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "ImRQ");
+    // ntotal = 2^60: huge value that would cause OOM in search()
+    push_index_header(buf, /*d=*/4, /*ntotal=*/int64_t{1} << 60);
+    push_residual_quantizer(buf, /*d=*/4, /*M=*/2, /*nbits=*/{4, 4});
+    push_val<float>(buf, -1.0f); // beam_factor = -1 (skip tables)
+
+    expect_read_throws_with(buf, "centroid norms allocation");
+}
+
+// -----------------------------------------------------------------------
+// Test: ResidualCoarseQuantizer ntotal * M exceeds byte limit even when
+// ntotal alone passes the centroid_norms check.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, ResidualCoarseQuantizerNtotalTimesM) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "ImRQ");
+    // ntotal=200000 passes centroid_norms check (200000 < 1MB/4 = 262144)
+    // but ntotal*M*sizeof(int32_t) = 200000*2*4 = 1600000 > 1MB
+    push_index_header(buf, /*d=*/4, /*ntotal=*/200000);
+    push_residual_quantizer(buf, /*d=*/4, /*M=*/2, /*nbits=*/{4, 4});
+    push_val<float>(buf, -1.0f); // beam_factor = -1 (skip tables)
+
+    auto old_limit = get_deserialization_vector_byte_limit();
+    set_deserialization_vector_byte_limit(1 << 20); // 1 MB
+    expect_read_throws_with(buf, "deserialization vector byte limit");
+    set_deserialization_vector_byte_limit(old_limit);
+}
+
+// -----------------------------------------------------------------------
+// Test: ResidualCoarseQuantizer with huge beam_factor throws.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, ResidualCoarseQuantizerHugeBeamFactor) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "ImRQ");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/16);
+    push_residual_quantizer(buf, /*d=*/4, /*M=*/2, /*nbits=*/{4, 4});
+    push_val<float>(buf, 1e10f); // beam_factor = 1e10 (way too large)
+
+    expect_read_throws_with(buf, "beam_factor");
+}
+
+// -----------------------------------------------------------------------
+// Test: ResidualQuantizer with max_beam_size=0 throws.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, ResidualQuantizerMaxBeamSizeZero) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "ImRQ");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/16);
+    // Build AdditiveQuantizer manually + bad max_beam_size
+    push_additive_quantizer(buf, /*d=*/4, /*M=*/2, /*nbits=*/{4, 4});
+    push_val<int>(buf, 2048); // train_type = Skip_codebook_tables
+    push_val<int>(buf, 0);    // max_beam_size = 0 (invalid)
+
+    expect_read_throws_with(buf, "max_beam_size");
+}
+
+// -----------------------------------------------------------------------
+// Test: ResidualQuantizer with huge max_beam_size exceeds byte limit.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, ResidualQuantizerHugeMaxBeamSize) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "ImRQ");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/16);
+    push_additive_quantizer(buf, /*d=*/4, /*M=*/2, /*nbits=*/{4, 4});
+    push_val<int>(buf, 2048);    // train_type = Skip_codebook_tables
+    push_val<int>(buf, 1 << 30); // max_beam_size = 2^30 (huge)
+
+    // With a tight byte limit, this should fail
+    auto old_limit = get_deserialization_vector_byte_limit();
+    set_deserialization_vector_byte_limit(1 << 20); // 1 MB
+    expect_read_throws_with(buf, "deserialization vector byte limit");
+    set_deserialization_vector_byte_limit(old_limit);
+}
+
+// -----------------------------------------------------------------------
+// Test: Negative ntotal is rejected by read_index_header.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, ResidualCoarseQuantizerNegativeNtotal) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "ImRQ");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/-1);
+    push_residual_quantizer(buf, /*d=*/4, /*M=*/2, /*nbits=*/{4, 4});
+    push_val<float>(buf, -1.0f); // beam_factor
+
+    expect_read_throws_with(buf, "invalid ntotal");
+}
+
+// -----------------------------------------------------------------------
+// Test: AdditiveQuantizer with M=0 is rejected during deserialization.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, AdditiveQuantizerMZero) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "ImRQ");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/16);
+    // Build AdditiveQuantizer manually with M=0
+    push_additive_quantizer(buf, /*d=*/4, /*M=*/0, /*nbits=*/{});
+    push_val<int>(buf, 2048); // train_type = Skip_codebook_tables
+    push_val<int>(buf, 1);    // max_beam_size
+
+    expect_read_throws_with(buf, "invalid AdditiveQuantizer M");
+}
+
+// -----------------------------------------------------------------------
+// Test: ResidualCoarseQuantizer with ntotal=0 deserializes successfully
+// (empty index is valid).
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, ResidualCoarseQuantizerNtotalZero) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "ImRQ");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0);
+    push_residual_quantizer(buf, /*d=*/4, /*M=*/2, /*nbits=*/{4, 4});
+    push_val<float>(buf, -1.0f); // beam_factor = -1 (skip tables)
+
+    VectorIOReader reader;
+    reader.data = buf;
+    auto idx = read_index_up(&reader);
+    EXPECT_EQ(idx->ntotal, 0);
+}
+
 // ---- IndexBinaryIVF runtime safety checks ----
 
 TEST(ReadIndexDeserialize, BinaryIVFNullInvlistsSearch) {


### PR DESCRIPTION
Summary:
Collectively validate ntotal, beam_factor, and max_beam_size during
deserialization to ensure allocation limits are honored, even when
those allocations occur in search context (ResidualCoarseQuantizer::search()).

Specifically, search() allocates O(beam_size * M * n) int32_t elements where
beam_size is derived from min(k * beam_factor, ntotal). With an adversarial
ntotal of 2^60 or a beam_factor of 1e10, these allocations exceed max_size()
and throw an uncaught std::length_error, terminating the process.

This diff adds three layers of protection:

1. read_ResidualQuantizer(): Validates max_beam_size > 0 and that
   max_beam_size * M * sizeof(int32_t) fits within the configurable
   deserialization vector byte limit.

2. ResidualCoarseQuantizer ("ImRQ") deserialization path:
   Validates beam_factor <= 1000 to prevent int overflow in beam_size
   computation, and validates ntotal * M * sizeof(int32_t) against the
   byte limit since search() can allocate O(ntotal * M) when beam_size
   is capped to ntotal.
   Why 1000? The default beam_size is 4 (expand candidate serarch by 4x).
   A value of even 1000 makes no practical sense as in most cases it will
   be equivalent to an exhaustive search (beam_size = -1), but is sufficient
   to prevent overflow.

3. ResidualCoarseQuantizer::search():
   Replaces bare arithmetic with mul_no_overflow() for the codes and
   beam_distances allocations, so any overflow throws a catchable
   FaissException instead of silently wrapping and causing undefined
   behavior.

Differential Revision: D98169828


