### PR TITLE
Fix OSX arm64 nightly: bump libopenblas from 0.3.30 to 0.3.32 (#5006)

### DIFF
--- a/conda/faiss/meta.yaml
+++ b/conda/faiss/meta.yaml
@@ -56,7 +56,7 @@ outputs:
         - mkl-devel >=2024.2.2  # [x86_64 and win]
         - python_abi
         {% endif %}
-        - libopenblas=0.3.30=openmp_h60d53f8_1  # [osx]
+        - libopenblas =0.3.32  # [osx]
       host:
         - python {{ python }}
         - libcxx =20.1.1  # [osx and arm64]
@@ -70,7 +70,7 @@ outputs:
         - python_abi =3.12
         {% endif %}
         - openblas =0.3.32  # [not x86_64]
-        - libopenblas=0.3.30=openmp_h60d53f8_1  # [osx]
+        - libopenblas =0.3.32  # [osx]
       run:
         - python {{ python }}
         - libcxx =20.1.1  # [osx and arm64]
@@ -84,7 +84,7 @@ outputs:
         - python_abi =3.12
         {% endif %}
         - openblas =0.3.32  # [not x86_64]
-        - libopenblas=0.3.30=openmp_h60d53f8_1  # [osx]
+        - libopenblas =0.3.32  # [osx]
     test:
       requires:
         - conda-build =25.1.2
@@ -120,7 +120,7 @@ outputs:
         - mkl >=2024.2.2  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
-        - libopenblas=0.3.30=openmp_h60d53f8_1  # [osx]
+        - libopenblas =0.3.32  # [osx]
       host:
         - python {{ python }}
         - numpy >=2.0,<3.0
@@ -136,7 +136,7 @@ outputs:
         - mkl >=2024.2.2  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
-        - libopenblas=0.3.30=openmp_h60d53f8_1  # [osx]
+        - libopenblas =0.3.32  # [osx]
       run:
         - python {{ python }}
         - numpy >=2.0,<3.0
@@ -151,7 +151,7 @@ outputs:
         - mkl >=2024.2.2  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
-        - libopenblas=0.3.30=openmp_h60d53f8_1  # [osx]
+        - libopenblas =0.3.32  # [osx]
     test:
       requires:
         - numpy >=2.0,<3.0


### PR DESCRIPTION
Summary:

🤖 This diff was automatically generated by myclaw_faiss_monitor

The OSX arm64 nightly build has been failing since Mar 27 due to a
conda dependency conflict: the recipe pins libopenblas=0.3.30 (with
specific build hash) on osx, but also requires openblas=0.3.32 on
non-x86_64 platforms. Since libopenblas 0.3.30 constrains
openblas>=0.3.30,<0.3.31, conda cannot resolve the dependency.

Fix: bump all 6 libopenblas pins on osx from 0.3.30 to 0.3.32 to
match the openblas version, and drop the specific build hash pin.

Reviewed By: mnorris11

Differential Revision: D98718117
