### PR TITLE
Harden ScalarQuantizer deserialization validation (#5020)

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -812,7 +812,10 @@ static void read_ProductLocalSearchQuantizer(
     }
 }
 
-void read_ScalarQuantizer(ScalarQuantizer* ivsc, IOReader* f) {
+void read_ScalarQuantizer(
+        ScalarQuantizer* ivsc,
+        IOReader* f,
+        const Index& idx) {
     int qtype_int;
     READ1(qtype_int);
     FAISS_THROW_IF_NOT_FMT(
@@ -825,11 +828,18 @@ void read_ScalarQuantizer(ScalarQuantizer* ivsc, IOReader* f) {
     READ1(ivsc->rangestat_arg);
     READ1(ivsc->d);
     READ1(ivsc->code_size);
+    FAISS_THROW_IF_NOT_FMT(
+            static_cast<size_t>(idx.d) == ivsc->d,
+            "ScalarQuantizer d %zu != index header d %d",
+            ivsc->d,
+            idx.d);
     READVECTOR(ivsc->trained);
     // Validate trained vector size matches the quantizer type and dimension.
-    // An untrained ScalarQuantizer legitimately has trained.size() == 0,
-    // so only check when the vector is non-empty.
-    if (!ivsc->trained.empty()) {
+    // UNIFORM/NON_UNIFORM qtypes require training data; other qtypes
+    // (fp16, bf16, 8bit_direct*) need none.
+    // An untrained index (is_trained == false) legitimately has
+    // trained.size() == 0, so we allow that case.
+    {
         size_t expected = 0;
         switch (ivsc->qtype) {
             case ScalarQuantizer::QT_4bit_uniform:
@@ -849,14 +859,31 @@ void read_ScalarQuantizer(ScalarQuantizer* ivsc, IOReader* f) {
                 expected = 0;
                 break;
         }
-        FAISS_THROW_IF_NOT_FMT(
-                ivsc->trained.size() == expected,
-                "ScalarQuantizer trained size %zu != expected %zu "
-                "for qtype %d, d %zu",
-                ivsc->trained.size(),
-                expected,
-                (int)ivsc->qtype,
-                ivsc->d);
+        if (ivsc->trained.empty() && expected > 0) {
+            // Empty trained is only valid for untrained indices.
+            FAISS_THROW_IF_NOT_FMT(
+                    !idx.is_trained,
+                    "ScalarQuantizer trained size 0 != expected %zu "
+                    "for qtype %d, d %zu (index is marked as trained)",
+                    expected,
+                    (int)ivsc->qtype,
+                    ivsc->d);
+        } else {
+            FAISS_THROW_IF_NOT_FMT(
+                    ivsc->trained.size() == expected,
+                    "ScalarQuantizer trained size %zu != expected %zu "
+                    "for qtype %d, d %zu",
+                    ivsc->trained.size(),
+                    expected,
+                    (int)ivsc->qtype,
+                    ivsc->d);
+            if (expected > 0) {
+                FAISS_THROW_IF_NOT_MSG(
+                        idx.is_trained,
+                        "ScalarQuantizer has training data but "
+                        "index header is_trained is false");
+            }
+        }
     }
     ivsc->set_derived_sizes();
 }
@@ -1612,7 +1639,7 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
     } else if (h == fourcc("IxSQ")) {
         auto idxs = std::make_unique<IndexScalarQuantizer>();
         read_index_header(*idxs, f);
-        read_ScalarQuantizer(&idxs->sq, f);
+        read_ScalarQuantizer(&idxs->sq, f, *idxs);
         read_vector(idxs->codes, f);
         idxs->code_size = idxs->sq.code_size;
         idx = std::move(idxs);
@@ -1646,7 +1673,7 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         auto ivsc = std::make_unique<IndexIVFScalarQuantizer>();
         std::vector<std::vector<idx_t>> ids;
         read_ivf_header(ivsc.get(), f, &ids);
-        read_ScalarQuantizer(&ivsc->sq, f);
+        read_ScalarQuantizer(&ivsc->sq, f, *ivsc);
         READ1(ivsc->code_size);
         ArrayInvertedLists* ail = set_array_invlist(ivsc.get(), ids);
         for (size_t i = 0; i < ivsc->nlist; i++)
@@ -1655,7 +1682,7 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
     } else if (h == fourcc("IwSQ") || h == fourcc("IwSq")) {
         auto ivsc = std::make_unique<IndexIVFScalarQuantizer>();
         read_ivf_header(ivsc.get(), f);
-        read_ScalarQuantizer(&ivsc->sq, f);
+        read_ScalarQuantizer(&ivsc->sq, f, *ivsc);
         READ1(ivsc->code_size);
         if (h == fourcc("IwSQ")) {
             ivsc->by_residual = true;

--- a/faiss/impl/index_read_utils.h
+++ b/faiss/impl/index_read_utils.h
@@ -29,7 +29,7 @@ ArrayInvertedLists* set_array_invlist(
         IndexIVF* ivf,
         std::vector<std::vector<idx_t>>& ids);
 void read_ProductQuantizer(ProductQuantizer* pq, IOReader* f);
-void read_ScalarQuantizer(ScalarQuantizer* ivsc, IOReader* f);
+void read_ScalarQuantizer(ScalarQuantizer* ivsc, IOReader* f, const Index& idx);
 
 } // namespace faiss
 

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -2773,3 +2773,98 @@ TEST(ReadIndexDeserialize, IVFAQFastScanNegativeQbs) {
     auto buf = build_IVFAQFastScan_buf(/*qbs=*/-1);
     expect_read_throws_with(buf, "qbs must be non-negative");
 }
+
+// -----------------------------------------------------------------------
+// Test: ScalarQuantizer with empty trained vector for qtypes that require
+// training data must be rejected at deserialization time.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, SQEmptyTrainedNonUniform) {
+    // QT_8bit (NON_UNIFORM) expects trained.size() == 2*d == 8.
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IxSQ");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0);
+    push_val<int>(buf, ScalarQuantizer::QT_8bit);
+    push_val<int>(buf, 0);         // rangestat
+    push_val<float>(buf, 0.0f);    // rangestat_arg
+    push_val<size_t>(buf, 4);      // d
+    push_val<size_t>(buf, 1);      // code_size
+    push_vector<float>(buf, {});   // empty trained
+    push_vector<uint8_t>(buf, {}); // codes (ntotal=0)
+
+    expect_read_throws_with(buf, "ScalarQuantizer trained size");
+}
+
+TEST(ReadIndexDeserialize, SQEmptyTrainedUniform) {
+    // QT_8bit_uniform (UNIFORM) expects trained.size() == 2.
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IxSQ");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0);
+    push_val<int>(buf, ScalarQuantizer::QT_8bit_uniform);
+    push_val<int>(buf, 0);         // rangestat
+    push_val<float>(buf, 0.0f);    // rangestat_arg
+    push_val<size_t>(buf, 4);      // d
+    push_val<size_t>(buf, 1);      // code_size
+    push_vector<float>(buf, {});   // empty trained
+    push_vector<uint8_t>(buf, {}); // codes (ntotal=0)
+
+    expect_read_throws_with(buf, "ScalarQuantizer trained size");
+}
+
+// -----------------------------------------------------------------------
+// Test: ScalarQuantizer d must match the index header d.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, SQDimensionMismatch) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IxSQ");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0);
+    push_val<int>(buf, ScalarQuantizer::QT_8bit);
+    push_val<int>(buf, 0);      // rangestat
+    push_val<float>(buf, 0.0f); // rangestat_arg
+    push_val<size_t>(buf, 8);   // d = 8, mismatches header d = 4
+    push_val<size_t>(buf, 1);   // code_size
+    push_vector<float>(buf, std::vector<float>(16, 0.0f)); // trained
+    push_vector<uint8_t>(buf, {});                         // codes (ntotal=0)
+
+    expect_read_throws_with(buf, "ScalarQuantizer d");
+}
+
+// -----------------------------------------------------------------------
+// Test: ScalarQuantizer with training data but is_trained=false in header.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, SQIsTrainedMismatch) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IxSQ");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0, /*is_trained=*/false);
+    push_val<int>(buf, ScalarQuantizer::QT_8bit);
+    push_val<int>(buf, 0);      // rangestat
+    push_val<float>(buf, 0.0f); // rangestat_arg
+    push_val<size_t>(buf, 4);   // d
+    push_val<size_t>(buf, 1);   // code_size
+    // Provide correctly-sized trained data (2*d=8 floats)
+    push_vector<float>(buf, std::vector<float>(8, 0.0f));
+    push_vector<uint8_t>(buf, {}); // codes (ntotal=0)
+
+    expect_read_throws_with(buf, "is_trained");
+}
+
+// -----------------------------------------------------------------------
+// Test: Untrained ScalarQuantizer (is_trained=false, empty trained) must
+// deserialize successfully — this is a legitimate untrained index.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, SQUntrainedEmptyTrainedAccepted) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IxSQ");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0, /*is_trained=*/false);
+    push_val<int>(buf, ScalarQuantizer::QT_8bit);
+    push_val<int>(buf, 0);         // rangestat
+    push_val<float>(buf, 0.0f);    // rangestat_arg
+    push_val<size_t>(buf, 4);      // d
+    push_val<size_t>(buf, 1);      // code_size
+    push_vector<float>(buf, {});   // empty trained (untrained)
+    push_vector<uint8_t>(buf, {}); // codes (ntotal=0)
+
+    VectorIOReader reader;
+    reader.data = buf;
+    auto idx = read_index_up(&reader);
+    EXPECT_FALSE(idx->is_trained);
+}


### PR DESCRIPTION
Summary:

The prior deserialization validation for training data in
`read_ScalarQuantizer` skipped size checks when `trained` was empty,
allowing inconsistent index state to be materialized.

This diff hardens `read_ScalarQuantizer` in three ways:

1. **Trained size validation**:
   Replace the `if (!ivsc->trained.empty())` guard with two-branch
   validation. For qtypes that require training data
   (UNIFORM/NON_UNIFORM), an empty `trained` vector is only accepted
   when the index header has `is_trained == false` (a legitimate
   untrained index). When `is_trained == true`, the trained vector
   must match the expected size. Qtypes that need no training (fp16,
   bf16, 8bit_direct*) still require `trained.size() == 0`.

2. **Dimension cross-validation**:
   Validate that `ScalarQuantizer::d` matches `Index::d` from the index
   header. A mismatch indicates a corrupted file and could cause the
   trained size check to accept a wrong size.

3. **is_trained consistency**:
   When training data is present, validate that the index header
   `is_trained` flag is true. A false flag with valid training data
   indicates file corruption.

To support these cross-validations, `read_ScalarQuantizer` now takes
a `const Index&` parameter for access to the index header fields.

Untrained indices (created via `index_factory` but not yet trained)
are legitimately serialized with `is_trained=false` and an empty
`trained` vector. The existing `FAISS_THROW_IF_NOT(is_trained)` guards
in `IndexScalarQuantizer::search()` and related methods already prevent
querying such indices, so no additional query-time validation is needed.

Reviewed By: mnorris11

Differential Revision: D98924927
