### PR TITLE
Make distance_compute_blas_threshold dimension-aware (#5022)

### DIFF
--- a/c_api/utils/distances_c.h
+++ b/c_api/utils/distances_c.h
@@ -74,11 +74,11 @@ void faiss_fvec_norms_L2sqr(float* norms, const float* x, size_t d, size_t nx);
 /// L2-renormalize a set of vector. Nothing done if the vector is 0-normed
 void faiss_fvec_renorm_L2(size_t d, size_t nx, float* x);
 
-/// Setter of threshold value on nx above which we switch to BLAS to compute
+/// Setter of threshold value on nx * d above which we switch to BLAS to compute
 /// distances
 void faiss_set_distance_compute_blas_threshold(int value);
 
-/// Getter of threshold value on nx above which we switch to BLAS to compute
+/// Getter of threshold value on nx * d above which we switch to BLAS to compute
 /// distances
 int faiss_get_distance_compute_blas_threshold();
 

--- a/faiss/gpu/test/TestGpuIndexIVFFlat.cpp
+++ b/faiss/gpu/test/TestGpuIndexIVFFlat.cpp
@@ -28,6 +28,7 @@
 #include <faiss/gpu/StandardGpuResources.h>
 #include <faiss/gpu/test/TestUtils.h>
 #include <faiss/gpu/utils/DeviceUtils.h>
+#include <faiss/utils/distances.h>
 #include <gtest/gtest.h>
 #include <cmath>
 #include <sstream>
@@ -354,6 +355,11 @@ TEST(TestGpuIndexIVFFlat, Float32_Query_IP) {
 }
 
 TEST(TestGpuIndexIVFFlat, LargeBatch) {
+    // With low-dim vectors, CPU will use non-BLAS. Force the CPU to use
+    // the BLAS for consistent comparison.
+    int saved_threshold = faiss::distance_compute_blas_threshold;
+    faiss::distance_compute_blas_threshold = 1;
+
     Options opt;
     opt.dim = 3;
     opt.numQuery = 100000;
@@ -364,6 +370,8 @@ TEST(TestGpuIndexIVFFlat, LargeBatch) {
     opt.indicesOpt = faiss::gpu::INDICES_64_BIT;
     queryTest(opt, faiss::METRIC_L2, false);
 #endif
+
+    faiss::distance_compute_blas_threshold = saved_threshold;
 }
 
 // float16 coarse quantizer

--- a/faiss/gpu/test/TestGpuIndexIVFPQ.cpp
+++ b/faiss/gpu/test/TestGpuIndexIVFPQ.cpp
@@ -11,6 +11,7 @@
 #include <faiss/gpu/StandardGpuResources.h>
 #include <faiss/gpu/test/TestUtils.h>
 #include <faiss/gpu/utils/DeviceUtils.h>
+#include <faiss/utils/distances.h>
 #include <gtest/gtest.h>
 #include <cmath>
 #include <sstream>
@@ -190,6 +191,11 @@ TEST(TestGpuIndexIVFPQ, Query_IP) {
 
 // Large batch sizes (>= 65536) should also work
 TEST(TestGpuIndexIVFPQ, LargeBatch) {
+    // With low-dim vectors, CPU will use non-BLAS. Force the CPU to use
+    // the BLAS for consistent comparison.
+    int saved_threshold = faiss::distance_compute_blas_threshold;
+    faiss::distance_compute_blas_threshold = 1;
+
     for (bool usePrecomputed : {false, true}) {
         Options opt;
 
@@ -202,6 +208,8 @@ TEST(TestGpuIndexIVFPQ, LargeBatch) {
 
         queryTest(opt, faiss::MetricType::METRIC_L2);
     }
+
+    faiss::distance_compute_blas_threshold = saved_threshold;
 }
 
 void testMMCodeDistance(faiss::MetricType mt) {
@@ -697,6 +705,11 @@ TEST(TestGpuIndexIVFPQ, Query_IP_Cuvs) {
 
 // Large batch sizes (>= 65536) should also work
 TEST(TestGpuIndexIVFPQ, LargeBatch_Cuvs) {
+    // See LargeBatch comment: force CPU BLAS path to match GPU GEMM
+    // decomposition for consistent L2 distance computation.
+    int saved_threshold = faiss::distance_compute_blas_threshold;
+    faiss::distance_compute_blas_threshold = 1;
+
     Options opt;
 
     // override for large sizes
@@ -711,6 +724,8 @@ TEST(TestGpuIndexIVFPQ, LargeBatch_Cuvs) {
     opt.bitsPerCode = 8;
 
     queryTest(opt, faiss::MetricType::METRIC_L2);
+
+    faiss::distance_compute_blas_threshold = saved_threshold;
 }
 
 TEST(TestGpuIndexIVFPQ, CopyFrom_Cuvs) {

--- a/faiss/utils/distances.cpp
+++ b/faiss/utils/distances.cpp
@@ -551,7 +551,7 @@ struct Run_search_inner_product {
            size_t nx,
            size_t ny) {
         if (res.sel ||
-            nx < static_cast<size_t>(distance_compute_blas_threshold)) {
+            nx * d < static_cast<size_t>(distance_compute_blas_threshold)) {
             exhaustive_inner_product_seq(x, y, d, nx, ny, res);
         } else {
             exhaustive_inner_product_blas(x, y, d, nx, ny, res);
@@ -570,7 +570,7 @@ struct Run_search_L2sqr {
            size_t ny,
            const float* y_norm2) {
         if (res.sel ||
-            nx < static_cast<size_t>(distance_compute_blas_threshold)) {
+            nx * d < static_cast<size_t>(distance_compute_blas_threshold)) {
             exhaustive_L2sqr_seq(x, y, d, nx, ny, res);
         } else {
             exhaustive_L2sqr_blas(x, y, d, nx, ny, res, y_norm2);
@@ -584,7 +584,7 @@ struct Run_search_L2sqr {
  * KNN driver functions
  *******************************************************/
 
-int distance_compute_blas_threshold = 20;
+int distance_compute_blas_threshold = 128000;
 int distance_compute_blas_query_bs = 4096;
 int distance_compute_blas_database_bs = 1024;
 int distance_compute_min_k_reservoir = 100;

--- a/faiss/utils/distances.h
+++ b/faiss/utils/distances.h
@@ -369,7 +369,7 @@ void pairwise_indexed_inner_product(
  * KNN functions
  ***************************************************************************/
 
-// threshold on nx above which we switch to BLAS to compute distances
+// threshold on nx * d above which we switch to BLAS to compute distances
 FAISS_API extern int distance_compute_blas_threshold;
 
 // block sizes for BLAS distance computations

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -613,11 +613,11 @@ class TestDistancesPositive(unittest.TestCase):
         """
         roundoff errors occur only with the L2 decomposition used
         with BLAS, ie. in IndexFlatL2 and with
-        n > distance_compute_blas_threshold = 20
+        n * d > distance_compute_blas_threshold
         """
 
         d = 128
-        n = 100
+        n = 5000
 
         rs = np.random.RandomState(1234)
         x = rs.rand(n, d).astype('float32')

--- a/tests/test_index_accuracy.py
+++ b/tests/test_index_accuracy.py
@@ -660,32 +660,37 @@ class OPQRelativeAccuracy(unittest.TestCase):
 class TestRoundoff(unittest.TestCase):
     def test_roundoff(self):
         # params that force use of BLAS implementation
-        nb = 100
-        nq = 25
-        d = 4
-        xb = np.zeros((nb, d), dtype="float32")
+        saved_threshold = faiss.cvar.distance_compute_blas_threshold
+        faiss.cvar.distance_compute_blas_threshold = 1
+        try:
+            nb = 100
+            nq = 25
+            d = 4
+            xb = np.zeros((nb, d), dtype="float32")
 
-        xb[:, 0] = np.arange(nb) + 12345
-        xq = xb[:nq] + 0.3
+            xb[:, 0] = np.arange(nb) + 12345
+            xq = xb[:nq] + 0.3
 
-        index = faiss.IndexFlat(d)
-        index.add(xb)
+            index = faiss.IndexFlat(d)
+            index.add(xb)
 
-        D, I = index.search(xq, 1)
+            D, I = index.search(xq, 1)
 
-        # this does not work
-        assert not np.all(I.ravel() == np.arange(nq))
+            # this does not work
+            assert not np.all(I.ravel() == np.arange(nq))
 
-        index = faiss.IndexPreTransform(faiss.CenteringTransform(d),
-                                        faiss.IndexFlat(d))
+            index = faiss.IndexPreTransform(faiss.CenteringTransform(d),
+                                            faiss.IndexFlat(d))
 
-        index.train(xb)
-        index.add(xb)
+            index.train(xb)
+            index.add(xb)
 
-        D, I = index.search(xq, 1)
+            D, I = index.search(xq, 1)
 
-        # this works
-        assert np.all(I.ravel() == np.arange(nq))
+            # this works
+            assert np.all(I.ravel() == np.arange(nq))
+        finally:
+            faiss.cvar.distance_compute_blas_threshold = saved_threshold
 
 
 class TestSpectralHash(unittest.TestCase):


### PR DESCRIPTION
Summary:

I used the C++ benchmark in https://github.com/facebookresearch/faiss/pull/4971 but modified it a lot to measure on my machine.

```

  The BLAS threshold for flat distance computation was a fixed query count (nq < 20), regardless of vector dimension. This meant BLAS was
  used for as few as 20 queries even at d=128, where the sequential SIMD path is 10-25x faster.

  The optimal crossover between sequential and BLAS depends on the total work in the query matrix (nq × d), not just query count.
  Benchmarking across dimensions shows the crossover at roughly nq × d ≈ 128,000:

  ┌──────┬────────────────────┬──────────────────────────────┐
  │  d   │ Old threshold (nq) │ New effective threshold (nq) │
  ├──────┼────────────────────┼──────────────────────────────┤
  │ 128  │ 20                 │ 1000                         │
  ├──────┼────────────────────┼──────────────────────────────┤
  │ 256  │ 20                 │ 500                          │
  ├──────┼────────────────────┼──────────────────────────────┤
  │ 512  │ 20                 │ 250                          │
  ├──────┼────────────────────┼──────────────────────────────┤
  │ 1024 │ 20                 │ 125                          │
  ├──────┼────────────────────┼──────────────────────────────┤
  │ 2048 │ 20                 │ 63                           │
  └──────┴────────────────────┴──────────────────────────────┘

  This change replaces the comparison nq < threshold with nq * d < threshold and sets the default to 128,000.

  Speedup vs old default (nb=100,000, L2 (same as IP for me), compiled with optimizations):

      nq | d=128 | d=256 | d=512 | d=1024 | d=2048
     ----|-------|-------|-------|--------|-------
      20 | 22.8x |  9.3x |  4.5x |  2.6x  |  1.4x
      50 | 19.4x |  9.3x |  4.7x |  2.0x  |  1.2x
     100 | 13.3x |  5.6x |  2.1x |  1.0x  |  1.0x
     200 |  8.2x |  2.7x |  1.1x |  1.0x  |  1.0x
     500 |  3.2x |  1.0x |  1.0x |  1.0x  |  1.0x
    1000 |  1.0x |  1.0x |  1.0x |  1.0x  |  1.0x

  No regressions observed — the worst case is d=1024, nq=100 at 0.99x (within noise).
```

Differential Revision: D99032435
