### PR TITLE
Validate IndexIDMap id_map size during deserialization (#5024)

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -1835,6 +1835,12 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         idxmap->index = read_index(f, io_flags);
         idxmap->own_fields = true;
         READVECTOR(idxmap->id_map);
+        FAISS_THROW_IF_NOT_FMT(
+                idxmap->id_map.size() == idxmap->ntotal,
+                "IndexIDMap id_map size (%" PRId64
+                ") does not match ntotal (%" PRId64 ")",
+                int64_t(idxmap->id_map.size()),
+                idxmap->ntotal);
         if (is_map2) {
             static_cast<IndexIDMap2*>(idxmap.get())->construct_rev_map();
         }

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -807,6 +807,34 @@ TEST(ReadIndexDeserialize, BinaryIDMapIdMapSizeMismatch) {
 }
 
 // -----------------------------------------------------------------------
+// Test: IndexIDMap2 ("IxM2") with id_map size != ntotal.  Without the
+// check, construct_rev_map() reads past id_map bounds causing a crash.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, IndexIDMap2IdMapSizeMismatch) {
+    // Outer IxM2 header has ntotal=2, but the id_map vector has 5
+    // entries.  The check on id_map.size() == ntotal must reject this.
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IxM2");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/2);
+
+    // Nested IndexFlatL2 ("IxF2") with ntotal=2.
+    push_fourcc(buf, "IxF2");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/2);
+    // WRITEXBVECTOR: ntotal * d floats
+    size_t num_floats = 2 * 4;
+    push_val<size_t>(buf, num_floats);
+    for (size_t i = 0; i < num_floats; ++i) {
+        push_val<float>(buf, 0.0f);
+    }
+
+    // id_map with 5 entries (mismatches ntotal=2).
+    std::vector<int64_t> id_map = {10, 20, 30, 40, 50};
+    push_vector<int64_t>(buf, id_map);
+
+    expect_read_throws_with(buf, "id_map");
+}
+
+// -----------------------------------------------------------------------
 // InvertedLists helpers
 // -----------------------------------------------------------------------
 


### PR DESCRIPTION
Summary:

Fixes a null-deref crash in `IndexIDMap2::construct_rev_map()` when
deserializing a crafted index where `id_map.size() != ntotal`.

1. **Validation in index_read.cpp**:
   Added a `FAISS_THROW_IF_NOT_FMT` check after reading the `id_map`
   vector in the `IxMp`/`IxM2` deserialization path, verifying that
   `id_map.size() == ntotal` before `construct_rev_map()` is called.
   The binary index path (`IBMp`/`IBM2`) already had this check.

2. **Test in test_read_index_deserialize.cpp**:
   Added `IndexIDMap2IdMapSizeMismatch` test that constructs a serialized
   `IndexIDMap2` with `ntotal=2` but `id_map` containing 5 entries, and
   verifies deserialization throws with the expected error message.

Differential Revision: D99138339
