### PR TITLE
Debug manifold crash with NaN (#5025)

### DIFF
--- a/faiss/impl/hnsw/MinimaxHeap.cpp
+++ b/faiss/impl/hnsw/MinimaxHeap.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <cmath>
+
 #include <faiss/impl/hnsw/MinimaxHeap.h>
 
 #include <cassert>
@@ -14,6 +16,10 @@
 namespace faiss {
 
 void MinimaxHeap::push(storage_idx_t i, float v) {
+    // Treat NaN distances as infinitely far away so heap ordering is preserved.
+    if (std::isnan(v)) {
+        v = HC::neutral();
+    }
     if (k == n) {
         if (v >= dis[0]) {
             return;

--- a/tests/test_graph_based.py
+++ b/tests/test_graph_based.py
@@ -222,6 +222,32 @@ class TestHNSW(unittest.TestCase):
         self.assertEqual(index_hnsw.ntotal, 0)
 
 
+class TestHNSWNaN(unittest.TestCase):
+    """Adding a vector with NaN to an IVF+HNSW index used to crash because
+    NaN distances corrupt the MinimaxHeap ordering in HNSW search. The fix
+    converts NaN to +inf in MinimaxHeap::push so the heap stays well-ordered.
+    """
+
+    def test_add_nan_vector_to_ivf_hnsw(self):
+        d = 64
+        nt = 2000
+        nb = 1000
+        xt = np.random.default_rng(42).random((nt, d), dtype='float32')
+        xb = np.random.default_rng(43).random((nb, d), dtype='float32')
+
+        index = faiss.index_factory(d, "IVF256_HNSW32,SQ8")
+        index.train(xt)
+        index.add(xb)
+
+        # Create a vector with NaN in the first component
+        vec = np.zeros((1, d), dtype='float32')
+        vec[0, 0] = np.nan
+
+        # This should not crash
+        index.add(vec)
+        self.assertEqual(index.ntotal, nb + 1)
+
+
 class Issue3684(unittest.TestCase):
 
     def test_issue3684(self):


### PR DESCRIPTION
Summary:

In c++ when running in dev mode:
```
  Crash chain:
  1. index->add(1, vec) → IndexIVF::add_with_ids() (line 190)
  2. quantizer->assign() → Index::assign() → IndexHNSW::search() — searches the HNSW coarse quantizer with the NaN
  vector
  3. HNSW::search() computes d_nearest = qdis(entry_point) — this returns NaN because the input vector has NaN
  4. NaN is pushed into MinimaxHeap candidates. All comparisons with NaN return false, corrupting heap ordering
  5. search_from_candidates() pops a garbage node ID v0 from the corrupted heap
  6. neighbor_range(v0, ...) hits FAISS_CHECK_RANGE_DEBUG — v0 is out of bounds → crash
```

In python test or opt mode:
```
The test timed out — it hung instead of crashing. This is consistent with the analysis: in the Python bindings (which
  run with mode/opt, so no debug assertions), pop_min returns -1, neighbor_range(-1, ...) doesn't crash on the
  assertion (it's a debug-only check), and instead accesses offsets[-1] which is undefined behavior. The NaN corrupts
  the heap, the search loops forever because nvalid never decrements when pop_min returns -1.

  So in Python/opt mode: no stack trace, just a hang. The C++ debug build crashes with the assertion. Both are fixed by
  the same push() NaN→+inf change in HNSW.cpp.
```

Performance impact??
--
it is in the tightest loop in search_from_candidates.  Claude seems to think it is fine:
```
  In search_from_candidates (line 707), push() is called for every neighbor visited during greedy graph traversal — batched 4 at a time via
  add_to_heap. This is indeed the tightest inner loop in HNSW search.

  What std::isnan actually costs

  std::isnan(float) on x86_64 compiles to essentially v != v — a single ucomiss + conditional jump (jp). That's 1-2 instructions.

  Context: what else happens per push call

  Each push call is preceded by significantly more expensive work:
  1. Distance computation (distances_batch_4 at line 718): ~2×d FLOPs per vector (e.g., ~256 FLOPs for d=128)  NOTE: HNSW.cpp:718-726 (qdis.distances_batch_4(...))
  2. Existing comparisons in push: k == n, v >= dis[0], potential heap_pop/heap_push which are O(log efSearch) with memory accesses    NOTE: HNSW.cpp:1401  (k == n), 1402 (v >= dis[0]), 1408 (heap_pop), 1410 (heap_push)
  3. Visited table check (vt.set) with prefetching   NOTE:  HNSW.cpp:689 (vt.prefetch(v1)) and 714 (vt.set(v1))

  The isnan check is ~1 instruction compared to hundreds for the distance computation. Even against just the heap operations (several
  comparisons + pointer chasing), it's a rounding error.

  Branch prediction

  Since NaN distances essentially never occur in normal operation, this branch is always not-taken. The branch predictor will learn this
  within the first few iterations and predict it perfectly for the remainder of the search. A perfectly-predicted not-taken branch is ~0
  cycles on modern CPUs.
```

And mini benchmark:
```
  ┌────────┬────────────────────────┬────────────────────────┬───────────────────┐
  │        │ With NaN check (run 1) │ With NaN check (run 2) │ Without NaN check │
  ├────────┼────────────────────────┼────────────────────────┼───────────────────┤
  │ Mean   │ 401.146 ms             │ 400.515 ms             │ 401.191 ms        │
  ├────────┼────────────────────────┼────────────────────────┼───────────────────┤
  │ Median │ 396.746 ms             │ 398.172 ms             │ 398.520 ms        │
  ├────────┼────────────────────────┼────────────────────────┼───────────────────┤
  │ Min    │ 389.939 ms             │ 388.670 ms             │ 391.850 ms        │
  ├────────┼────────────────────────┼────────────────────────┼───────────────────┤
  │ Stddev │ 18.903 ms              │ 7.833 ms               │ 8.164 ms          │
  └────────┴────────────────────────┴────────────────────────┴───────────────────┘
```

I wanted to make sure it worked regardless of metric type:
```
  For inner product (and cosine, which is IP after normalization), HNSW wraps the distance computer in NegativeDistanceComputer, which
  negates the result. This means all metrics flow through the MinimaxHeap with the same convention: smaller = better.

  So the NaN → +inf replacement works correctly for all metrics:

  ┌────────┬──────────────────────────────┬──────┬───────┬─────────────────┐
  │ Metric │        qdis() returns        │ Best │ Worst │   +inf means    │
  ├────────┼──────────────────────────────┼──────┼───────┼─────────────────┤
  │ L2     │ ‖x-q‖²                       │ 0    │ +inf  │ worst (correct) │
  ├────────┼──────────────────────────────┼──────┼───────┼─────────────────┤
  │ IP     │ -<x,q> (negated)             │ -∞   │ +inf  │ worst (correct) │
  ├────────┼──────────────────────────────┼──────┼───────┼─────────────────┤
  │ Cosine │ -<x̂,q̂> (negated, normalized) │ -1   │ +inf  │ worst (correct) │
  └────────┴──────────────────────────────┴──────┴───────┴─────────────────┘

  In all cases, +inf sits at the top of the CMax heap and gets evicted first when the heap is full (v >= dis[0] returns early at line 1402).
   And pop_min() will never select it over any finite-distance candidate. The semantics are correct regardless of metric type.
```

Differential Revision: D99036639


