### PR TITLE
Add optional persistent locks to IndexHNSW for incremental adds (#5031)

### DIFF
--- a/benchs/bench_hnsw.py
+++ b/benchs/bench_hnsw.py
@@ -32,7 +32,7 @@ xt = ds.get_train()
 nq, d = xq.shape
 
 if todo == []:
-    todo = 'hnsw hnsw_sq ivf ivf_hnsw_quantizer kmeans kmeans_hnsw nsg'.split()
+    todo = "hnsw hnsw_sq ivf ivf_hnsw_quantizer kmeans kmeans_hnsw nsg".split()
 
 
 def evaluate(index):
@@ -45,11 +45,13 @@ def evaluate(index):
 
     missing_rate = (I == -1).sum() / float(k * nq)
     recall_at_1 = (I == gt[:, :1]).sum() / float(nq)
-    print("\t %7.3f ms per query, R@1 %.4f, missing rate %.4f" % (
-        (t1 - t0) * 1000.0 / nq, recall_at_1, missing_rate))
+    print(
+        "\t %7.3f ms per query, R@1 %.4f, missing rate %.4f"
+        % ((t1 - t0) * 1000.0 / nq, recall_at_1, missing_rate)
+    )
 
 
-if 'hnsw' in todo:
+if "hnsw" in todo:
 
     print("Testing HNSW Flat")
 
@@ -69,12 +71,12 @@ if 'hnsw' in todo:
     print("search")
     for efSearch in 16, 32, 64, 128, 256:
         for bounded_queue in [True, False]:
-            print("efSearch", efSearch, "bounded queue", bounded_queue, end=' ')
+            print("efSearch", efSearch, "bounded queue", bounded_queue, end=" ")
             index.hnsw.search_bounded_queue = bounded_queue
             index.hnsw.efSearch = efSearch
             evaluate(index)
 
-if 'hnsw_sq' in todo:
+if "hnsw_sq" in todo:
 
     print("Testing HNSW with a scalar quantizer")
     # also set M so that the vectors and links both use 128 bytes per
@@ -96,16 +98,16 @@ if 'hnsw_sq' in todo:
 
     print("search")
     for efSearch in 16, 32, 64, 128, 256:
-        print("efSearch", efSearch, end=' ')
+        print("efSearch", efSearch, end=" ")
         index.hnsw.efSearch = efSearch
         evaluate(index)
 
-if 'ivf' in todo:
+if "ivf" in todo:
 
     print("Testing IVF Flat (baseline)")
     quantizer = faiss.IndexFlatL2(d)
     index = faiss.IndexIVFFlat(quantizer, d, 16384)
-    index.cp.min_points_per_centroid = 5   # quiet warning
+    index.cp.min_points_per_centroid = 5  # quiet warning
 
     # to see progress
     index.verbose = True
@@ -118,16 +120,16 @@ if 'ivf' in todo:
 
     print("search")
     for nprobe in 1, 4, 16, 64, 256:
-        print("nprobe", nprobe, end=' ')
+        print("nprobe", nprobe, end=" ")
         index.nprobe = nprobe
         evaluate(index)
 
-if 'ivf_hnsw_quantizer' in todo:
+if "ivf_hnsw_quantizer" in todo:
 
     print("Testing IVF Flat with HNSW quantizer")
     quantizer = faiss.IndexHNSWFlat(d, 32)
     index = faiss.IndexIVFFlat(quantizer, d, 16384)
-    index.cp.min_points_per_centroid = 5   # quiet warning
+    index.cp.min_points_per_centroid = 5  # quiet warning
     index.quantizer_trains_alone = 2
 
     # to see progress
@@ -142,13 +144,13 @@ if 'ivf_hnsw_quantizer' in todo:
     print("search")
     quantizer.hnsw.efSearch = 64
     for nprobe in 1, 4, 16, 64, 256:
-        print("nprobe", nprobe, end=' ')
+        print("nprobe", nprobe, end=" ")
         index.nprobe = nprobe
         evaluate(index)
 
 # Bonus: 2 kmeans tests
 
-if 'kmeans' in todo:
+if "kmeans" in todo:
     print("Performing kmeans on sift1M database vectors (baseline)")
     clus = faiss.Clustering(d, 16384)
     clus.verbose = True
@@ -157,7 +159,7 @@ if 'kmeans' in todo:
     clus.train(xb, index)
 
 
-if 'kmeans_hnsw' in todo:
+if "kmeans_hnsw" in todo:
     print("Performing kmeans on sift1M using HNSW assignment")
     clus = faiss.Clustering(d, 16384)
     clus.verbose = True
@@ -168,7 +170,7 @@ if 'kmeans_hnsw' in todo:
     index.hnsw.efSearch = 128
     clus.train(xb, index)
 
-if 'nsg' in todo:
+if "nsg" in todo:
 
     print("Testing NSG Flat")
 
@@ -186,6 +188,47 @@ if 'nsg' in todo:
 
     print("search")
     for search_L in -1, 16, 32, 64, 128, 256:
-        print("search_L", search_L, end=' ')
+        print("search_L", search_L, end=" ")
         index.nsg.search_L = search_L
         evaluate(index)
+
+
+if "hnsw_locks" in todo:
+
+    ntotal, _ = xb.shape
+    batch_size = ntotal // 100
+    print(
+        f"Testing HNSW Flat: add with {batch_size=}, "
+        "with and without retaining locks"
+    )
+
+    # Unbatched
+    t0 = time.time()
+    index = faiss.IndexHNSWFlat(d, 32)
+    index.add(xb)
+    t1 = time.time()
+    print(
+        f"\t single bulk add(): {index.ntotal} added in {t1 - t0:6.3f}s"
+        f" = {index.ntotal / (t1 - t0):.0f}/s"
+    )
+
+    for retain_locks in [False, True]:
+        index = faiss.IndexHNSWFlat(d, 32)
+        index.retain_locks = retain_locks
+
+        t0 = time.time()
+        t1 = None
+        t2 = None
+        for i in range(0, len(xb), batch_size):
+            t1 = time.time()
+            index.add(xb[i: i + batch_size])
+            t2 = time.time()
+            if i > 2 and t2 - t0 > 2:
+                break
+
+        assert t1 and t2
+        dt = t2 - t0
+        print(
+            f"\t {retain_locks=:1}: {index.ntotal} added in {t2 - t0:6.3f}s"
+            f" = {index.ntotal / (t2 - t0):.0f}/s"
+        )

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -112,6 +112,7 @@ set(FAISS_SRC
   impl/IDSelector.cpp
   impl/FaissException.cpp
   impl/HNSW.cpp
+  impl/hnsw/LockVector.cpp
   impl/hnsw/MinimaxHeap.cpp
   impl/NSG.cpp
   impl/PolysemousTraining.cpp
@@ -237,6 +238,7 @@ set(FAISS_HEADERS
   impl/FaissAssert.h
   impl/FaissException.h
   impl/HNSW.h
+  impl/hnsw/LockVector.h
   impl/hnsw/MinimaxHeap.h
   impl/LocalSearchQuantizer.h
   impl/ProductAdditiveQuantizer.h

--- a/faiss/IndexBinaryHNSW.cpp
+++ b/faiss/IndexBinaryHNSW.cpp
@@ -61,10 +61,8 @@ void hnsw_add_vertices(
         printf("  max_level = %d\n", max_level);
     }
 
-    std::vector<omp_lock_t> locks(ntotal);
-    for (size_t i = 0; i < ntotal; i++) {
-        omp_init_lock(&locks[i]);
-    }
+    auto& locks = index_hnsw.locks;
+    locks.prepare(ntotal);
 
     // add vectors from highest to lowest level
     std::vector<int> hist;
@@ -158,9 +156,8 @@ void hnsw_add_vertices(
     if (verbose) {
         printf("Done in %.3f ms\n", getmillisecs() - t0);
     }
-
-    for (size_t i = 0; i < ntotal; i++) {
-        omp_destroy_lock(&locks[i]);
+    if (!index_hnsw.retain_locks) {
+        locks.clear();
     }
 }
 
@@ -274,6 +271,7 @@ void IndexBinaryHNSW::add(idx_t n, const uint8_t* x) {
 
 void IndexBinaryHNSW::reset() {
     hnsw.reset();
+    locks.clear();
     storage->reset();
     ntotal = 0;
 }

--- a/faiss/IndexBinaryHNSW.h
+++ b/faiss/IndexBinaryHNSW.h
@@ -11,6 +11,7 @@
 
 #include <faiss/IndexBinaryFlat.h>
 #include <faiss/impl/HNSW.h>
+#include <faiss/impl/hnsw/LockVector.h>
 #include <faiss/utils/utils.h>
 
 namespace faiss {
@@ -39,6 +40,11 @@ struct IndexBinaryHNSW : IndexBinary {
     // IndexBinaryHNSW to create a full base layer graph that is
     // used when GpuIndexBinaryCagra::copyFrom(IndexBinaryHNSW*) is called.
     bool keep_max_size_level0 = false;
+
+    // Per-node locks for HNSW graph construction.
+    LockVector locks;
+    // locks are freed after each call to add() unless this flag is set.
+    bool retain_locks = false;
 
     explicit IndexBinaryHNSW();
     explicit IndexBinaryHNSW(int d, int M = 32);

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -28,6 +28,7 @@
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/ResultHandler.h>
 #include <faiss/impl/VisitedTable.h>
+#include <faiss/impl/hnsw/MinimaxHeap.h>
 #include <faiss/utils/random.h>
 #include <faiss/utils/sorting.h>
 
@@ -81,10 +82,8 @@ void hnsw_add_vertices(
         printf("  max_level = %d\n", max_level);
     }
 
-    std::vector<omp_lock_t> locks(ntotal);
-    for (size_t i = 0; i < ntotal; i++) {
-        omp_init_lock(&locks[i]);
-    }
+    auto& locks = index_hnsw.locks;
+    locks.prepare(ntotal);
 
     // add vectors from highest to lowest level
     std::vector<int> hist;
@@ -200,9 +199,8 @@ void hnsw_add_vertices(
     if (verbose) {
         printf("Done in %.3f ms\n", getmillisecs() - t0);
     }
-
-    for (size_t i = 0; i < ntotal; i++) {
-        omp_destroy_lock(&locks[i]);
+    if (!index_hnsw.retain_locks) {
+        locks.clear();
     }
 }
 
@@ -366,6 +364,7 @@ void IndexHNSW::add(idx_t n, const float* x) {
 
 void IndexHNSW::reset() {
     hnsw.reset();
+    locks.clear();
     storage->reset();
     ntotal = 0;
 }
@@ -528,10 +527,7 @@ void IndexHNSW::init_level_0_from_entry_points(
         int n,
         const storage_idx_t* points,
         const storage_idx_t* nearests) {
-    std::vector<omp_lock_t> locks(ntotal);
-    for (idx_t i = 0; i < ntotal; i++) {
-        omp_init_lock(&locks[i]);
-    }
+    locks.prepare(ntotal);
 
 #pragma omp parallel
     {
@@ -549,7 +545,7 @@ void IndexHNSW::init_level_0_from_entry_points(
             dis->set_query(vec.data());
 
             hnsw.add_links_starting_from(
-                    *dis, pt_id, nearest, (*dis)(nearest), 0, locks.data(), vt);
+                    *dis, pt_id, nearest, (*dis)(nearest), 0, locks, vt);
 
             if (verbose && i % 10000 == 0) {
                 printf("  %d / %d\r", i, n);
@@ -561,8 +557,8 @@ void IndexHNSW::init_level_0_from_entry_points(
         printf("\n");
     }
 
-    for (idx_t i = 0; i < ntotal; i++) {
-        omp_destroy_lock(&locks[i]);
+    if (!retain_locks) {
+        locks.clear();
     }
 }
 

--- a/faiss/IndexHNSW.h
+++ b/faiss/IndexHNSW.h
@@ -18,6 +18,7 @@
 #include <faiss/IndexScalarQuantizer.h>
 #include <faiss/impl/HNSW.h>
 #include <faiss/impl/Panorama.h>
+#include <faiss/impl/hnsw/LockVector.h>
 #include <faiss/utils/utils.h>
 
 namespace faiss {
@@ -52,11 +53,17 @@ struct IndexHNSW : Index {
     // See impl/VisitedTable.h.
     std::optional<bool> use_visited_hashset;
 
+    // Per-node locks for HNSW graph construction.
+    LockVector locks;
+    // locks are freed after each call to add() unless this flag is set.
+    bool retain_locks = false;
+
     explicit IndexHNSW(int d = 0, int M = 32, MetricType metric = METRIC_L2);
     explicit IndexHNSW(Index* storage, int M = 32);
 
     ~IndexHNSW() override;
 
+    /// Adds vectors to the index. May not be called concurrently.
     void add(idx_t n, const float* x) override;
 
     /// Trains the storage if needed

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -9,6 +9,7 @@
 
 #include <cinttypes>
 #include <cstddef>
+#include <cstdlib>
 
 #include <faiss/IndexHNSW.h>
 
@@ -16,6 +17,7 @@
 #include <faiss/impl/IDSelector.h>
 #include <faiss/impl/ResultHandler.h>
 #include <faiss/impl/VisitedTable.h>
+#include <faiss/impl/hnsw/MinimaxHeap.h>
 
 namespace faiss {
 
@@ -497,7 +499,7 @@ void HNSW::add_links_starting_from(
         storage_idx_t nearest,
         float d_nearest,
         int level,
-        omp_lock_t* locks,
+        LockVector& locks,
         VisitedTable& vt,
         bool keep_max_size_level0) {
     std::priority_queue<NodeDistCloser> link_targets;
@@ -519,13 +521,13 @@ void HNSW::add_links_starting_from(
         link_targets.pop();
     }
 
-    omp_unset_lock(&locks[pt_id]);
+    locks.unlock(pt_id);
     for (storage_idx_t other_id : neighbors_to_add) {
-        omp_set_lock(&locks[other_id]);
+        locks.lock(other_id);
         add_link(*this, ptdis, other_id, pt_id, level, keep_max_size_level0);
-        omp_unset_lock(&locks[other_id]);
+        locks.unlock(other_id);
     }
-    omp_set_lock(&locks[pt_id]);
+    locks.lock(pt_id);
 }
 
 /**************************************************************
@@ -536,7 +538,7 @@ void HNSW::add_with_locks(
         DistanceComputer& ptdis,
         int pt_level,
         int pt_id,
-        std::vector<omp_lock_t>& locks,
+        LockVector& locks,
         VisitedTable& vt,
         bool keep_max_size_level0) {
     storage_idx_t nearest = entry_point;
@@ -556,7 +558,7 @@ void HNSW::add_with_locks(
         return;
     }
 
-    omp_set_lock(&locks[pt_id]);
+    locks.lock(pt_id);
 
     int level = max_level; // level at which we start adding neighbors
     float d_nearest = ptdis(nearest);
@@ -573,12 +575,12 @@ void HNSW::add_with_locks(
                 nearest,
                 d_nearest,
                 level,
-                locks.data(),
+                locks,
                 vt,
                 keep_max_size_level0);
     }
 
-    omp_unset_lock(&locks[pt_id]);
+    locks.unlock(pt_id);
 
     if (pt_level > max_level) {
         max_level = pt_level;

--- a/faiss/impl/HNSW.h
+++ b/faiss/impl/HNSW.h
@@ -16,9 +16,7 @@
 #include <faiss/Index.h>
 #include <faiss/impl/DistanceComputer.h>
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/impl/hnsw/MinimaxHeap.h>
 #include <faiss/impl/maybe_owned_vector.h>
-#include <faiss/impl/platform_macros.h>
 #include <faiss/utils/Heap.h>
 #include <faiss/utils/random.h>
 
@@ -27,6 +25,8 @@ namespace faiss {
 // Forward declarations to avoid circular dependency.
 struct IndexHNSW;
 struct IndexHNSWFlatPanorama;
+struct MinimaxHeap;
+class LockVector;
 
 /** Implementation of the Hierarchical Navigable Small World
  * datastructure.
@@ -170,7 +170,7 @@ struct HNSW {
             storage_idx_t nearest,
             float d_nearest,
             int level,
-            omp_lock_t* locks,
+            LockVector& locks,
             VisitedTable& vt,
             bool keep_max_size_level0 = false);
 
@@ -180,7 +180,7 @@ struct HNSW {
             DistanceComputer& ptdis,
             int pt_level,
             int pt_id,
-            std::vector<omp_lock_t>& locks,
+            LockVector& locks,
             VisitedTable& vt,
             bool keep_max_size_level0 = false);
 

--- a/faiss/impl/hnsw/LockVector.cpp
+++ b/faiss/impl/hnsw/LockVector.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <faiss/impl/hnsw/LockVector.h>
+
+#include <cstdlib>
+
+#include <utility>
+
+namespace faiss {
+
+LockVector::LockVector(LockVector&& other) noexcept
+        : data_(other.data_), size_(other.size_), capacity_(other.capacity_) {
+    other.data_ = nullptr;
+    other.size_ = 0;
+    other.capacity_ = 0;
+}
+
+void LockVector::prepare(size_t new_size) {
+    if (new_size <= size_) {
+        return;
+    }
+    if (new_size > capacity_) {
+        // Ensure geometric capacity growth.
+        size_t new_cap = std::max(new_size, capacity_ * 2);
+        // Just destroy old and init fresh; omp_lock_t is not copyable.
+        clear();
+        data_ = static_cast<omp_lock_t*>(malloc(new_cap * sizeof(omp_lock_t)));
+        FAISS_THROW_IF_NOT(data_ != nullptr);
+        capacity_ = new_cap;
+    }
+    for (size_t i = size_; i < new_size; i++) {
+        omp_init_lock(&data_[i]);
+    }
+    size_ = new_size;
+}
+
+void LockVector::clear() {
+    if (data_) {
+        for (size_t i = 0; i < size_; i++) {
+            omp_destroy_lock(&data_[i]);
+        }
+        free(data_);
+        data_ = nullptr;
+    }
+    size_ = 0;
+    capacity_ = 0;
+}
+
+} // namespace faiss

--- a/faiss/impl/hnsw/LockVector.h
+++ b/faiss/impl/hnsw/LockVector.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <omp.h>
+
+#include <faiss/impl/FaissAssert.h>
+
+namespace faiss {
+
+/// Contiguous, growable array of locks with geometric growth.
+class LockVector {
+   public:
+    LockVector() = default;
+    explicit LockVector(size_t n) {
+        prepare(n);
+    }
+    // Copy ctor for clone(), initialized as empty.
+    LockVector(const LockVector&) : LockVector() {}
+    LockVector(LockVector&& other) noexcept;
+
+    ~LockVector() {
+        clear();
+    }
+
+    LockVector& operator=(const LockVector&) = delete;
+    LockVector& operator=(LockVector&& other) = delete;
+
+    size_t size() const {
+        return size_;
+    }
+
+    // Ensure size is at least 'new_size'. No locks may be held.
+    void prepare(size_t new_size);
+    // Release all locks and free memory. No locks may be held.
+    void clear();
+
+    void lock(size_t i) {
+        FAISS_CHECK_RANGE_DEBUG(i, 0, size_);
+        omp_set_lock(&data_[i]);
+    }
+
+    void unlock(size_t i) {
+        FAISS_CHECK_RANGE_DEBUG(i, 0, size_);
+        omp_unset_lock(&data_[i]);
+    }
+
+    bool try_lock(size_t i) {
+        FAISS_CHECK_RANGE_DEBUG(i, 0, size_);
+        return omp_test_lock(&data_[i]);
+    }
+
+   private:
+    omp_lock_t* data_ = nullptr;
+    size_t size_ = 0;
+    size_t capacity_ = 0;
+};
+
+} // namespace faiss

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -558,6 +558,8 @@ void gpu_sync_all_devices()
 %include  <faiss/IndexIVFAdditiveQuantizer.h>
 %include  <faiss/impl/hnsw/MinimaxHeap.h>
 %include  <faiss/impl/HNSW.h>
+%ignore faiss::IndexHNSW::locks;
+%ignore faiss::IndexBinaryHNSW::locks;
 %include  <faiss/IndexHNSW.h>
 
 %include <faiss/impl/kmeans1d.h>

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -20,6 +20,7 @@
 #include <faiss/impl/HNSW.h>
 #include <faiss/impl/ResultHandler.h>
 #include <faiss/impl/VisitedTable.h>
+#include <faiss/impl/hnsw/MinimaxHeap.h>
 #include <faiss/utils/random.h>
 
 int reference_pop_min(faiss::MinimaxHeap& heap, float* vmin_out) {


### PR DESCRIPTION
Summary:

`IndexHNSW` allocates an initializes locks for `ntotal+n` nodes on every call to `add()`. This makes batched insertion very costly, and incremental insertion prohibitively so.

This diff introduces optional persistent locks for `IndexHNSW` to improve incremental `add()` performance. Previously, `omp_lock_t` arrays of size `ntotal+n` were created/destroyed on each `add()` call. Now locks can be retained via a new `retain_locks` flag (default: false), using a new `HNSW::Lock` RAII wrapper with geometric growth.

RFC: Instead of `retain_locks` being the only way to opt into this new behavior, this could be inferred on the first incremental add. That is, clear the locks after insertion iff `n0 == 0`. Workloads which call `add()` once would be unaffected, but workloads which call `add()` repeatedly would 1) forego the clearing of the lock vector after `add()` call #2, and reuse locks for all subsequent calls. The downside would be the lack of the ability to reclaim the locks after insertion without HNSW-specific behavior at the call site.

Reviewed By: mdouze

Differential Revision: D98232750


