### PR TITLE
Panorama Optimizations

### DIFF
--- a/benchs/bench_flat_l2_panorama.py
+++ b/benchs/bench_flat_l2_panorama.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import argparse
 import multiprocessing as mp
 import time
 
@@ -11,11 +12,18 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 try:
-    from faiss.contrib.datasets_fb import DatasetGIST1M
+    from faiss.contrib.datasets_fb import DatasetSIFT1M, DatasetGIST1M
 except ImportError:
-    from faiss.contrib.datasets import DatasetGIST1M
+    from faiss.contrib.datasets import DatasetSIFT1M, DatasetGIST1M
 
-ds = DatasetGIST1M()
+parser = argparse.ArgumentParser()
+parser.add_argument("--dataset", default="gist1m", choices=["sift1m", "gist1m"])
+args = parser.parse_args()
+
+if args.dataset == "sift1m":
+    ds = DatasetSIFT1M()
+else:
+    ds = DatasetGIST1M()
 
 nq = 10
 xq = ds.get_queries()[:nq]
@@ -61,7 +69,7 @@ def build_index(name):
 
 
 nlevels = 8
-batch_size = 512
+batch_size = 1024
 
 plt.figure(figsize=(8, 6), dpi=80)
 
@@ -93,7 +101,8 @@ ax.text(
 )
 plt.xticks(x, labels, rotation=0)
 plt.ylabel("QPS")
-plt.title("Flat Indexes on GIST1M")
+dataset_label = args.dataset.upper()
+plt.title(f"Flat Indexes on {dataset_label}")
 
 plt.tight_layout()
-plt.savefig("bench_flat_l2_panorama.png", bbox_inches="tight")
+plt.savefig(f"bench_flat_l2_panorama_{args.dataset}.png", bbox_inches="tight")

--- a/benchs/bench_flat_l2_panorama.py
+++ b/benchs/bench_flat_l2_panorama.py
@@ -69,7 +69,7 @@ def build_index(name):
 
 
 nlevels = 8
-batch_size = 1024
+batch_size = 512
 
 plt.figure(figsize=(8, 6), dpi=80)
 

--- a/benchs/bench_flat_l2_panorama.py
+++ b/benchs/bench_flat_l2_panorama.py
@@ -68,7 +68,7 @@ def build_index(name):
     return index
 
 
-nlevels = 8
+nlevels = 16 if args.dataset == "gist1m" else 8
 batch_size = 512
 
 plt.figure(figsize=(8, 6), dpi=80)

--- a/benchs/bench_ivf_flat_panorama.py
+++ b/benchs/bench_ivf_flat_panorama.py
@@ -37,7 +37,7 @@ nt, d = xt.shape
 
 k = 10
 gt = gt[:, :k]
-nlevels = 8
+nlevels = 16 if args.dataset == "gist1m" else 8
 
 
 def get_ivf_index(index):
@@ -98,7 +98,7 @@ plt.figure(figsize=(8, 6), dpi=80)
 eval_and_plot(f"IVF{nlist},Flat")
 
 # IVFFlatPanorama (with PCA transform to concentrate energy in early dimensions)
-eval_and_plot(f"PCA{d},IVF{nlist},FlatPanorama{nlevels}")
+eval_and_plot(f"PCA{d},IVF{nlist},FlatPanorama{nlevels}_{1024}")
 
 dataset_label = args.dataset.upper()
 plt.title(f"IVF Flat Indexes on {dataset_label}")

--- a/benchs/bench_ivf_flat_panorama.py
+++ b/benchs/bench_ivf_flat_panorama.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import argparse
 import multiprocessing as mp
 import time
 
@@ -11,11 +12,18 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 try:
-    from faiss.contrib.datasets_fb import DatasetGIST1M
+    from faiss.contrib.datasets_fb import DatasetSIFT1M, DatasetGIST1M
 except ImportError:
-    from faiss.contrib.datasets import DatasetGIST1M
+    from faiss.contrib.datasets import DatasetSIFT1M, DatasetGIST1M
 
-ds = DatasetGIST1M()
+parser = argparse.ArgumentParser()
+parser.add_argument("--dataset", default="gist1m", choices=["sift1m", "gist1m"])
+args = parser.parse_args()
+
+if args.dataset == "sift1m":
+    ds = DatasetSIFT1M()
+else:
+    ds = DatasetGIST1M()
 
 xq = ds.get_queries()
 xb = ds.get_database()
@@ -90,12 +98,12 @@ plt.figure(figsize=(8, 6), dpi=80)
 eval_and_plot(f"IVF{nlist},Flat")
 
 # IVFFlatPanorama (with PCA transform to concentrate energy in early dimensions)
-eval_and_plot(f"PCA{d},IVF{nlist},FlatPanorama{nlevels}")
+eval_and_plot(f"PCA{d},IVF{nlist},FlatPanorama{nlevels}_1024")
 
-plt.title("IVF Flat Indexes on GIST1M")
-plt.title("Indices on GIST1M")
+dataset_label = args.dataset.upper()
+plt.title(f"IVF Flat Indexes on {dataset_label}")
 plt.xlabel(f"Recall@{k}")
 plt.ylabel("QPS")
 plt.yscale("log")
 plt.legend(bbox_to_anchor=(1.02, 0.1), loc="upper left", borderaxespad=0)
-plt.savefig("bench_ivf_flat_panorama.png", bbox_inches="tight")
+plt.savefig(f"bench_ivf_flat_panorama_{args.dataset}.png", bbox_inches="tight")

--- a/benchs/bench_ivf_flat_panorama.py
+++ b/benchs/bench_ivf_flat_panorama.py
@@ -98,7 +98,7 @@ plt.figure(figsize=(8, 6), dpi=80)
 eval_and_plot(f"IVF{nlist},Flat")
 
 # IVFFlatPanorama (with PCA transform to concentrate energy in early dimensions)
-eval_and_plot(f"PCA{d},IVF{nlist},FlatPanorama{nlevels}_1024")
+eval_and_plot(f"PCA{d},IVF{nlist},FlatPanorama{nlevels}")
 
 dataset_label = args.dataset.upper()
 plt.title(f"IVF Flat Indexes on {dataset_label}")

--- a/benchs/results_after.txt
+++ b/benchs/results_after.txt
@@ -1,3 +1,3 @@
-=== AFTER OPTIMIZATIONS (batch_size=1024) ===
+=== AFTER OPTIMIZATIONS ===
 
 --- bench_ivf_flat_panorama.py GIST1M ---

--- a/benchs/results_after.txt
+++ b/benchs/results_after.txt
@@ -1,3 +1,0 @@
-=== AFTER OPTIMIZATIONS ===
-
---- bench_ivf_flat_panorama.py GIST1M ---

--- a/benchs/results_after.txt
+++ b/benchs/results_after.txt
@@ -1,0 +1,3 @@
+=== AFTER OPTIMIZATIONS (batch_size=1024) ===
+
+--- bench_ivf_flat_panorama.py GIST1M ---

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -364,7 +364,7 @@ endif()
 # Export FAISS_HEADERS variable to parent scope.
 set(FAISS_HEADERS ${FAISS_HEADERS} PARENT_SCOPE)
 
-# Detect BMI2 compiler support (for PEXT/PDEP).
+# Detect BMI2 compiler support.
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-mbmi2" COMPILER_SUPPORTS_BMI2)
 if(COMPILER_SUPPORTS_BMI2)

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -416,7 +416,7 @@ endif()
 if(NOT WIN32)
   # Architecture mode to support AVX512 extensions available since Intel(R) Sapphire Rapids.
   # Ref: https://networkbuilders.intel.com/solutionslibrary/intel-avx-512-fp16-instruction-set-for-intel-xeon-processor-based-products-technology-guide
-  target_compile_options(faiss_avx512_spr PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-mavx2 -mfma -mf16c -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mavx512vpopcntdq -mpopcnt -mavx512fp16 -mavx512bf16>)
+  target_compile_options(faiss_avx512_spr PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-mavx2 -mfma -mf16c -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mavx512vpopcntdq -mpopcnt -mavx512fp16 -mavx512bf16 ${FAISS_BMI2_FLAGS}>)
 else()
   target_compile_options(faiss_avx512_spr PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/arch:AVX512>)
   # we need bigobj for the swig wrapper

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -364,6 +364,15 @@ endif()
 # Export FAISS_HEADERS variable to parent scope.
 set(FAISS_HEADERS ${FAISS_HEADERS} PARENT_SCOPE)
 
+# Detect BMI2 compiler support (for PEXT/PDEP).
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-mbmi2" COMPILER_SUPPORTS_BMI2)
+if(COMPILER_SUPPORTS_BMI2)
+  set(FAISS_BMI2_FLAGS "-mbmi2")
+else()
+  set(FAISS_BMI2_FLAGS "")
+endif()
+
 add_library(faiss ${FAISS_SRC})
 
 add_library(faiss_avx2 ${FAISS_SRC})
@@ -371,7 +380,7 @@ if(NOT FAISS_OPT_LEVEL STREQUAL "avx2" AND NOT FAISS_OPT_LEVEL STREQUAL "avx512"
   set_target_properties(faiss_avx2 PROPERTIES EXCLUDE_FROM_ALL TRUE)
 endif()
 if(NOT WIN32)
-  target_compile_options(faiss_avx2 PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-mavx2 -mfma -mf16c -mpopcnt>)
+  target_compile_options(faiss_avx2 PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-mavx2 -mfma -mf16c -mpopcnt ${FAISS_BMI2_FLAGS}>)
 else()
   # MSVC enables FMA with /arch:AVX2; no separate flags for F16C, POPCNT
   # Ref. FMA (under /arch:AVX2): https://docs.microsoft.com/en-us/cpp/build/reference/arch-x64
@@ -391,7 +400,7 @@ endif()
 if(NOT WIN32)
   # All modern CPUs support F, CD, VL, DQ, BW extensions.
   # Ref: https://en.wikipedia.org/wiki/AVX512
-  target_compile_options(faiss_avx512 PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-mavx2 -mfma -mf16c -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mpopcnt>)
+  target_compile_options(faiss_avx512 PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-mavx2 -mfma -mf16c -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mpopcnt ${FAISS_BMI2_FLAGS}>)
 else()
   target_compile_options(faiss_avx512 PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/arch:AVX512>)
   # we need bigobj for the swig wrapper

--- a/faiss/IndexFlat.cpp
+++ b/faiss/IndexFlat.cpp
@@ -628,8 +628,10 @@ inline void flat_pano_search_core(
         SingleResultHandler res(handler);
 
         std::vector<float> query_cum_norms(index.n_levels + 1);
-        std::vector<float> exact_distances(index.batch_size);
         std::vector<uint32_t> active_indices(index.batch_size);
+        std::vector<uint8_t> active_byteset(index.batch_size);
+        std::vector<float> exact_distances(index.batch_size);
+        std::vector<float> dot_buffer(index.batch_size);
 
 #pragma omp for
         for (int64_t i = 0; i < n; i++) {
@@ -664,7 +666,9 @@ inline void flat_pano_search_core(
                                     nullptr,
                                     use_sel,
                                     active_indices,
+                                    active_byteset,
                                     exact_distances,
+                                    dot_buffer,
                                     threshold,
                                     local_stats);
                         });

--- a/faiss/IndexIVFFlatPanorama.cpp
+++ b/faiss/IndexIVFFlatPanorama.cpp
@@ -48,7 +48,8 @@ IndexIVFFlatPanorama::IndexIVFFlatPanorama(
     this->own_invlists = own_invlists_in;
 }
 
-IndexIVFFlatPanorama::IndexIVFFlatPanorama() : n_levels(0), batch_size(128) {}
+IndexIVFFlatPanorama::IndexIVFFlatPanorama()
+        : n_levels(0), batch_size(Panorama::kDefaultBatchSize) {}
 
 namespace {
 

--- a/faiss/IndexIVFFlatPanorama.cpp
+++ b/faiss/IndexIVFFlatPanorama.cpp
@@ -43,7 +43,8 @@ IndexIVFFlatPanorama::IndexIVFFlatPanorama(
     // We construct the inverted lists here so that we can use the
     // level-oriented storage. This does not cause a leak as we constructed
     // IndexIVF first, with own_invlists set to false.
-    this->invlists = new ArrayInvertedListsPanorama(nlist, code_size, n_levels, batch_size);
+    this->invlists = new ArrayInvertedListsPanorama(
+            nlist, code_size, n_levels, batch_size);
     this->own_invlists = own_invlists_in;
 }
 

--- a/faiss/IndexIVFFlatPanorama.cpp
+++ b/faiss/IndexIVFFlatPanorama.cpp
@@ -7,6 +7,7 @@
 
 // -*- c++ -*-
 
+#include <endian.h>
 #include <faiss/IndexIVFFlatPanorama.h>
 
 #include <cstdio>
@@ -20,7 +21,6 @@
 #include <faiss/impl/ResultHandler.h>
 
 #include <faiss/impl/FaissAssert.h>
-#include <faiss/utils/Heap.h>
 #include <faiss/utils/distances_dispatch.h>
 #include <faiss/utils/extra_distances.h>
 #include <faiss/utils/utils.h>
@@ -108,9 +108,7 @@ struct IVFFlatScannerPanorama : InvertedListScanner {
             size_t list_size,
             const uint8_t* codes,
             const idx_t* ids,
-            float* distances,
-            idx_t* labels,
-            size_t k) const override {
+            ResultHandler& handler) const override {
         size_t nup = 0;
 
         const size_t bs = storage->pano.batch_size;
@@ -123,7 +121,6 @@ struct IVFFlatScannerPanorama : InvertedListScanner {
 
         for (size_t batch_no = 0; batch_no < n_batches; batch_no++) {
             size_t batch_start = batch_no * bs;
-            float threshold = distances[0];
             size_t num_active = with_metric_type(metric, [&]<MetricType M>() {
                 return storage->pano.progressive_filter_batch<C, M>(
                         codes,
@@ -139,7 +136,7 @@ struct IVFFlatScannerPanorama : InvertedListScanner {
                         active_byteset_,
                         exact_distances_,
                         dot_buffer_,
-                        threshold,
+                        handler.threshold,
                         local_stats);
             });
 
@@ -148,10 +145,10 @@ struct IVFFlatScannerPanorama : InvertedListScanner {
                 size_t global_idx = batch_start + idx;
                 float dis = exact_distances_[idx];
 
-                if (C::cmp(distances[0], dis)) {
+                if (C::cmp(handler.threshold, dis)) {
                     int64_t id = store_pairs ? lo_build(list_no, global_idx)
                                              : ids[global_idx];
-                    heap_replace_top<C>(k, distances, labels, dis, id);
+                    handler.add_result(dis, id);
                     nup++;
                 }
             }

--- a/faiss/IndexIVFFlatPanorama.cpp
+++ b/faiss/IndexIVFFlatPanorama.cpp
@@ -20,6 +20,7 @@
 #include <faiss/impl/ResultHandler.h>
 
 #include <faiss/impl/FaissAssert.h>
+#include <faiss/utils/Heap.h>
 #include <faiss/utils/distances_dispatch.h>
 #include <faiss/utils/extra_distances.h>
 #include <faiss/utils/utils.h>
@@ -32,19 +33,21 @@ IndexIVFFlatPanorama::IndexIVFFlatPanorama(
         size_t nlist_in,
         int n_levels_in,
         MetricType metric,
-        bool own_invlists_in)
+        bool own_invlists_in,
+        size_t batch_size_in)
         : IndexIVFFlat(quantizer_in, d_in, nlist_in, metric, false),
-          n_levels(n_levels_in) {
+          n_levels(n_levels_in),
+          batch_size(batch_size_in) {
     FAISS_THROW_IF_NOT(metric == METRIC_L2 || metric == METRIC_INNER_PRODUCT);
 
     // We construct the inverted lists here so that we can use the
     // level-oriented storage. This does not cause a leak as we constructed
     // IndexIVF first, with own_invlists set to false.
-    this->invlists = new ArrayInvertedListsPanorama(nlist, code_size, n_levels);
+    this->invlists = new ArrayInvertedListsPanorama(nlist, code_size, n_levels, batch_size);
     this->own_invlists = own_invlists_in;
 }
 
-IndexIVFFlatPanorama::IndexIVFFlatPanorama() : n_levels(0) {}
+IndexIVFFlatPanorama::IndexIVFFlatPanorama() : n_levels(0), batch_size(128) {}
 
 namespace {
 
@@ -54,6 +57,11 @@ struct IVFFlatScannerPanorama : InvertedListScanner {
     const ArrayInvertedListsPanorama* storage;
     using C = typename VectorDistance::C;
     static constexpr MetricType metric = VectorDistance::metric;
+
+    mutable std::vector<uint32_t> active_indices_;
+    mutable std::vector<uint8_t> active_byteset_;
+    mutable std::vector<float> exact_distances_;
+    mutable std::vector<float> dot_buffer_;
 
     IVFFlatScannerPanorama(
             const VectorDistance& vd_in,
@@ -65,7 +73,11 @@ struct IVFFlatScannerPanorama : InvertedListScanner {
               storage(storage_in) {
         keep_max = vd.is_similarity;
         code_size = vd.d * sizeof(float);
-        cum_sums.resize(storage->n_levels + 1);
+        cum_sums.resize(storage->pano.n_levels + 1);
+        active_indices_.resize(storage->pano.batch_size);
+        active_byteset_.resize(storage->pano.batch_size);
+        exact_distances_.resize(storage->pano.batch_size);
+        dot_buffer_.resize(storage->pano.batch_size);
     }
 
     const float* xi = nullptr;
@@ -90,27 +102,27 @@ struct IVFFlatScannerPanorama : InvertedListScanner {
     }
 
     using InvertedListScanner::scan_codes;
+
     size_t scan_codes(
             size_t list_size,
             const uint8_t* codes,
             const idx_t* ids,
-            ResultHandler& handler) const override {
+            float* distances,
+            idx_t* labels,
+            size_t k) const override {
         size_t nup = 0;
 
-        const size_t n_batches =
-                (list_size + storage->kBatchSize - 1) / storage->kBatchSize;
+        const size_t bs = storage->pano.batch_size;
+        const size_t n_batches = (list_size + bs - 1) / bs;
 
         const float* cum_sums_data = storage->get_cum_sums(list_no);
-
-        std::vector<float> exact_distances(storage->kBatchSize);
-        std::vector<uint32_t> active_indices(storage->kBatchSize);
 
         PanoramaStats local_stats;
         local_stats.reset();
 
         for (size_t batch_no = 0; batch_no < n_batches; batch_no++) {
-            size_t batch_start = batch_no * storage->kBatchSize;
-
+            size_t batch_start = batch_no * bs;
+            float threshold = distances[0];
             size_t num_active = with_metric_type(metric, [&]<MetricType M>() {
                 return storage->pano.progressive_filter_batch<C, M>(
                         codes,
@@ -122,22 +134,23 @@ struct IVFFlatScannerPanorama : InvertedListScanner {
                         sel,
                         ids,
                         use_sel,
-                        active_indices,
-                        exact_distances,
-                        handler.threshold,
+                        active_indices_,
+                        active_byteset_,
+                        exact_distances_,
+                        dot_buffer_,
+                        threshold,
                         local_stats);
             });
 
-            // Add batch survivors to heap.
             for (size_t i = 0; i < num_active; i++) {
-                uint32_t idx = active_indices[i];
+                uint32_t idx = active_indices_[i];
                 size_t global_idx = batch_start + idx;
-                float dis = exact_distances[idx];
+                float dis = exact_distances_[idx];
 
-                if (C::cmp(handler.threshold, dis)) {
+                if (C::cmp(distances[0], dis)) {
                     int64_t id = store_pairs ? lo_build(list_no, global_idx)
                                              : ids[global_idx];
-                    handler.add_result(dis, id);
+                    heap_replace_top<C>(k, distances, labels, dis, id);
                     nup++;
                 }
             }

--- a/faiss/IndexIVFFlatPanorama.cpp
+++ b/faiss/IndexIVFFlatPanorama.cpp
@@ -7,7 +7,6 @@
 
 // -*- c++ -*-
 
-#include <endian.h>
 #include <faiss/IndexIVFFlatPanorama.h>
 
 #include <cstdio>

--- a/faiss/IndexIVFFlatPanorama.h
+++ b/faiss/IndexIVFFlatPanorama.h
@@ -37,6 +37,7 @@ namespace faiss {
 /// `ArrayInvertedListsPanorama`, which is a struct member of `IndexIVF`.
 struct IndexIVFFlatPanorama : IndexIVFFlat {
     size_t n_levels;
+    size_t batch_size;
 
     std::vector<MaybeOwnedVector<float>> cum_sums;
 
@@ -46,7 +47,8 @@ struct IndexIVFFlatPanorama : IndexIVFFlat {
             size_t nlist_,
             int n_levels,
             MetricType = METRIC_L2,
-            bool own_invlists = true);
+            bool own_invlists = true,
+            size_t batch_size = 128);
 
     InvertedListScanner* get_InvertedListScanner(
             bool store_pairs,

--- a/faiss/IndexIVFFlatPanorama.h
+++ b/faiss/IndexIVFFlatPanorama.h
@@ -48,7 +48,7 @@ struct IndexIVFFlatPanorama : IndexIVFFlat {
             int n_levels,
             MetricType = METRIC_L2,
             bool own_invlists = true,
-            size_t batch_size = 128);
+            size_t batch_size = Panorama::kDefaultBatchSize);
 
     InvertedListScanner* get_InvertedListScanner(
             bool store_pairs,

--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -76,7 +76,7 @@ static inline void compute_level_dot_products_flat(
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
-static inline size_t compact_active_pext(
+static inline size_t compact_active(
         uint32_t* active_indices,
         const uint8_t* FAISS_RESTRICT active_byteset,
         const size_t num_active) {
@@ -87,18 +87,16 @@ static inline size_t compact_active_pext(
     for (; i + 8 <= num_active; i += 8) {
         uint64_t bytes;
         memcpy(&bytes, &active_byteset[i], 8);
-        int mask = (int)_pext_u64(bytes, 0x0101010101010101ULL);
 
-        uint64_t expanded = _pdep_u64(mask, 0x0101010101010101ULL) * 0xFFULL;
+        uint64_t expanded = bytes * 0xFFULL;
         uint64_t packed = _pext_u64(0x0706050403020100ULL, expanded);
 
-        __m256i perm =
-                _mm256_cvtepu8_epi32(_mm_cvtsi64_si128((long long)packed));
+        __m256i perm = _mm256_cvtepu8_epi32(_mm_cvtsi64_si128((int64_t)packed));
         __m256i data = _mm256_loadu_si256((const __m256i*)&active_indices[i]);
         __m256i compacted = _mm256_permutevar8x32_epi32(data, perm);
         _mm256_storeu_si256((__m256i*)&active_indices[next_active], compacted);
 
-        next_active += __builtin_popcount(mask);
+        next_active += __builtin_popcountll(bytes);
     }
 #endif
 
@@ -348,7 +346,7 @@ struct Panorama {
                                 query_cum_norm,
                                 threshold);
 
-                        return compact_active_pext(
+                        return compact_active(
                                 active_indices.data(),
                                 active_byteset.data(),
                                 num_active);

--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -200,6 +200,8 @@ inline auto with_bool(bool value, Lambda&& fn) {
  * accelerating the refinement stage.
  */
 struct Panorama {
+    static constexpr size_t kDefaultBatchSize = 128;
+
     size_t d = 0;
     size_t code_size = 0;
     size_t n_levels = 0;

--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -256,6 +256,7 @@ struct Panorama {
     /// 4. After all levels, survivors are exact distances; update heap.
     /// This achieves early termination while maintaining SIMD-friendly
     /// sequential access patterns in the level-oriented storage layout.
+#ifndef SWIG
     template <typename C, MetricType M>
     size_t progressive_filter_batch(
             const uint8_t* codes_base,
@@ -357,6 +358,7 @@ struct Panorama {
 
         return num_active;
     };
+#endif // SWIG
 
     void reconstruct(idx_t key, float* recons, const uint8_t* codes_base) const;
 };

--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -28,6 +28,14 @@
 namespace faiss {
 
 #ifndef SWIG
+
+/// Compute dot products between query_level and active vectors.
+///
+/// @tparam AllActive  If true, vectors are at sequential positions 0..N-1
+///                    (first level, full batch). If false, positions come
+///                    from active_indices (subsequent levels after pruning).
+/// @tparam LevelWidth Compile-time level width in floats (0 = use runtime
+///                    level_width_dims). Enables full loop unrolling.
 FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN
 template <bool AllActive = false, size_t LevelWidth = 0>
 static inline void compute_level_dot_products_flat(
@@ -77,38 +85,13 @@ static inline void compute_level_dot_products_flat(
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
-static inline size_t compact_active(
-        uint32_t* active_indices,
-        const uint8_t* FAISS_RESTRICT active_byteset,
-        const size_t num_active) {
-    size_t next_active = 0;
-    size_t i = 0;
-
-#if defined(__BMI2__) && defined(__AVX2__)
-    for (; i + 8 <= num_active; i += 8) {
-        uint64_t bytes;
-        memcpy(&bytes, &active_byteset[i], 8);
-
-        uint64_t expanded = bytes * 0xFFULL;
-        uint64_t packed = _pext_u64(0x0706050403020100ULL, expanded);
-
-        __m256i perm = _mm256_cvtepu8_epi32(_mm_cvtsi64_si128((int64_t)packed));
-        __m256i data = _mm256_loadu_si256((const __m256i*)&active_indices[i]);
-        __m256i compacted = _mm256_permutevar8x32_epi32(data, perm);
-        _mm256_storeu_si256((__m256i*)&active_indices[next_active], compacted);
-
-        next_active += __builtin_popcountll(bytes);
-    }
-#endif
-
-    for (; i < num_active; i++) {
-        active_indices[next_active] = active_indices[i];
-        next_active += active_byteset[i] ? 1 : 0;
-    }
-
-    return next_active;
-}
-
+/// Update exact distances with the current level's dot products, then apply
+/// Panorama pruning: for each active vector, compute a lower bound on
+/// the final distance and mark it for removal if it cannot beat the current
+/// threshold. Writes 0/1 into active_byteset for subsequent compaction.
+///
+/// Uses `if constexpr` on C::is_max rather than C::cmp() to ensure the
+/// comparison autovectorizes (C::cmp generates scalar function calls).
 FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN
 template <bool AllActive, typename C, MetricType M>
 static inline void prune_level_kernel(
@@ -147,6 +130,47 @@ static inline void prune_level_kernel(
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
+/// Compact active_indices in-place, removing entries where active_byteset[i]
+/// is zero. Returns the new count of active elements. Uses a branchless BMI2 +
+/// AVX2 fast path (8 elements/iteration via _pext_u64 permutation) with a
+/// scalar fallback for the tail and non-x86 platforms.
+static inline size_t compact_active(
+        uint32_t* active_indices,
+        const uint8_t* FAISS_RESTRICT active_byteset,
+        const size_t num_active) {
+    size_t next_active = 0;
+    size_t i = 0;
+
+#if defined(__BMI2__) && defined(__AVX2__)
+    for (; i + 8 <= num_active; i += 8) {
+        uint64_t bytes;
+        memcpy(&bytes, &active_byteset[i], 8);
+
+        uint64_t expanded = bytes * 0xFFULL;
+        uint64_t packed = _pext_u64(0x0706050403020100ULL, expanded);
+
+        __m256i perm = _mm256_cvtepu8_epi32(_mm_cvtsi64_si128((int64_t)packed));
+        __m256i data = _mm256_loadu_si256((const __m256i*)&active_indices[i]);
+        __m256i compacted = _mm256_permutevar8x32_epi32(data, perm);
+        _mm256_storeu_si256((__m256i*)&active_indices[next_active], compacted);
+
+        next_active += __builtin_popcountll(bytes);
+    }
+#endif
+
+    for (; i < num_active; i++) {
+        active_indices[next_active] = active_indices[i];
+        next_active += active_byteset[i] ? 1 : 0;
+    }
+
+    return next_active;
+}
+
+
+/// Compile-time dispatch: converts a runtime `width` value into a template
+/// parameter by generating an if-else chain over [Lo, Hi] in steps of Step.
+/// Falls through to LevelWidth=0 (runtime path) if no specialization matches.
+/// Allows for specialization of common level widths.
 namespace detail {
 template <size_t Lo, size_t Hi, size_t Step, typename Lambda>
 inline auto dispatch_width(size_t width, Lambda&& fn) {

--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -180,42 +180,6 @@ inline auto with_bool(bool value, Lambda&& fn) {
 }
 #endif // SWIG
 
-template <bool AllActive, typename C, MetricType M>
-static inline size_t panorama_flat_level_body(
-        const float* query_level,
-        const float* level_storage,
-        uint32_t* active_indices,
-        const size_t num_active,
-        uint8_t* active_byteset,
-        const size_t actual_level_width,
-        float* exact_distances,
-        float* dot_buffer,
-        const float* level_cum_sums,
-        float query_cum_norm,
-        float threshold) {
-    with_level_width(actual_level_width, [&]<size_t LevelWidth>() {
-        compute_level_dot_products_flat<AllActive, LevelWidth>(
-                query_level,
-                level_storage,
-                active_indices,
-                num_active,
-                actual_level_width,
-                dot_buffer);
-    });
-
-    prune_level_kernel<AllActive, C, M>(
-            exact_distances,
-            dot_buffer,
-            level_cum_sums,
-            active_byteset,
-            active_indices,
-            (uint32_t)num_active,
-            query_cum_norm,
-            threshold);
-
-    return compact_active_pext(active_indices, active_byteset, num_active);
-}
-
 /**
  * Implements the core logic of Panorama-based refinement.
  * arXiv: https://arxiv.org/abs/2510.00566
@@ -359,18 +323,33 @@ struct Panorama {
 
             num_active = with_bool(
                     level == 0 && first_level_full, [&]<bool AllActive>() {
-                        return panorama_flat_level_body<AllActive, C, M>(
-                                query_level,
-                                level_storage,
-                                active_indices.data(),
-                                num_active,
-                                active_byteset.data(),
-                                actual_level_width,
+                        with_level_width(
+                                actual_level_width, [&]<size_t LevelWidth>() {
+                                    compute_level_dot_products_flat<
+                                            AllActive,
+                                            LevelWidth>(
+                                            query_level,
+                                            level_storage,
+                                            active_indices.data(),
+                                            num_active,
+                                            actual_level_width,
+                                            dot_buffer.data());
+                                });
+
+                        prune_level_kernel<AllActive, C, M>(
                                 exact_distances.data(),
                                 dot_buffer.data(),
                                 level_cum_sums,
+                                active_byteset.data(),
+                                active_indices.data(),
+                                (uint32_t)num_active,
                                 query_cum_norm,
                                 threshold);
+
+                        return compact_active_pext(
+                                active_indices.data(),
+                                active_byteset.data(),
+                                num_active);
                     });
 
             level_cum_sums += batch_size;

--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -78,7 +78,7 @@ FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
 static inline size_t compact_active_pext(
         uint32_t* active_indices,
-        const uint8_t* active_byteset,
+        const uint8_t* FAISS_RESTRICT active_byteset,
         const size_t num_active) {
     size_t next_active = 0;
     size_t i = 0;
@@ -308,96 +308,79 @@ struct Panorama {
             std::vector<float>& exact_distances,
             std::vector<float>& dot_buffer,
             float threshold,
-            PanoramaStats& local_stats) const;
+            PanoramaStats& local_stats) const {
+        size_t batch_start = batch_no * batch_size;
+        size_t curr_batch_size = std::min(list_size - batch_start, batch_size);
+
+        size_t cumsum_batch_offset = batch_no * batch_size * (n_levels + 1);
+        const float* batch_cum_sums = cum_sums + cumsum_batch_offset;
+        const float* level_cum_sums = batch_cum_sums + batch_size;
+        float q_norm = query_cum_sums[0] * query_cum_sums[0];
+
+        size_t batch_offset = batch_no * batch_size * code_size;
+        const uint8_t* storage_base = codes_base + batch_offset;
+
+        // Initialize active set with ID-filtered vectors.
+        size_t num_active = 0;
+        for (size_t i = 0; i < curr_batch_size; i++) {
+            size_t global_idx = batch_start + i;
+            idx_t id = (ids == nullptr) ? global_idx : ids[global_idx];
+            bool include = !use_sel || sel->is_member(id);
+
+            active_indices[num_active] = i;
+            float cum_sum = batch_cum_sums[i];
+
+            if constexpr (M == METRIC_INNER_PRODUCT) {
+                exact_distances[i] = 0.0f;
+            } else {
+                exact_distances[i] = cum_sum * cum_sum + q_norm;
+            }
+
+            num_active += include;
+        }
+
+        size_t total_active = num_active;
+        const bool first_level_full = (num_active == curr_batch_size);
+
+        local_stats.total_dims += total_active * n_levels;
+
+        for (size_t level = 0; (level < n_levels) && (num_active > 0);
+             level++) {
+            local_stats.total_dims_scanned += num_active;
+
+            float query_cum_norm = query_cum_sums[level + 1];
+
+            size_t level_offset = level * level_width * batch_size;
+            const float* level_storage =
+                    (const float*)(storage_base + level_offset);
+            const float* query_level = query + level * level_width_floats;
+            size_t actual_level_width = std::min(
+                    level_width_floats, d - level * level_width_floats);
+
+            num_active = with_bool(
+                    level == 0 && first_level_full, [&]<bool AllActive>() {
+                        return panorama_flat_level_body<AllActive, C, M>(
+                                query_level,
+                                level_storage,
+                                active_indices.data(),
+                                num_active,
+                                active_byteset.data(),
+                                actual_level_width,
+                                exact_distances.data(),
+                                dot_buffer.data(),
+                                level_cum_sums,
+                                query_cum_norm,
+                                threshold);
+                    });
+
+            level_cum_sums += batch_size;
+        }
+
+        return num_active;
+    };
 
     void reconstruct(idx_t key, float* recons, const uint8_t* codes_base) const;
 };
-
-template <typename C, MetricType M>
-size_t Panorama::progressive_filter_batch(
-        const uint8_t* codes_base,
-        const float* cum_sums,
-        const float* query,
-        const float* query_cum_sums,
-        size_t batch_no,
-        size_t list_size,
-        const IDSelector* sel,
-        const idx_t* ids,
-        bool use_sel,
-        std::vector<uint32_t>& active_indices,
-        std::vector<uint8_t>& active_byteset,
-        std::vector<float>& exact_distances,
-        std::vector<float>& dot_buffer,
-        float threshold,
-        PanoramaStats& local_stats) const {
-    size_t batch_start = batch_no * batch_size;
-    size_t curr_batch_size = std::min(list_size - batch_start, batch_size);
-
-    size_t cumsum_batch_offset = batch_no * batch_size * (n_levels + 1);
-    const float* batch_cum_sums = cum_sums + cumsum_batch_offset;
-    const float* level_cum_sums = batch_cum_sums + batch_size;
-    float q_norm = query_cum_sums[0] * query_cum_sums[0];
-
-    size_t batch_offset = batch_no * batch_size * code_size;
-    const uint8_t* storage_base = codes_base + batch_offset;
-
-    // Initialize active set with ID-filtered vectors.
-    size_t num_active = 0;
-    for (size_t i = 0; i < curr_batch_size; i++) {
-        size_t global_idx = batch_start + i;
-        idx_t id = (ids == nullptr) ? global_idx : ids[global_idx];
-        bool include = !use_sel || sel->is_member(id);
-
-        active_indices[num_active] = i;
-        float cum_sum = batch_cum_sums[i];
-
-        if constexpr (M == METRIC_INNER_PRODUCT) {
-            exact_distances[i] = 0.0f;
-        } else {
-            exact_distances[i] = cum_sum * cum_sum + q_norm;
-        }
-
-        num_active += include;
-    }
-
-    size_t total_active = num_active;
-    const bool first_level_full = (num_active == curr_batch_size);
-
-    local_stats.total_dims += total_active * n_levels;
-
-    for (size_t level = 0; (level < n_levels) && (num_active > 0); level++) {
-        local_stats.total_dims_scanned += num_active;
-
-        float query_cum_norm = query_cum_sums[level + 1];
-
-        size_t level_offset = level * level_width * batch_size;
-        const float* level_storage =
-                (const float*)(storage_base + level_offset);
-        const float* query_level = query + level * level_width_floats;
-        size_t actual_level_width =
-                std::min(level_width_floats, d - level * level_width_floats);
-
-        num_active = with_bool(
-                level == 0 && first_level_full, [&]<bool AllActive>() {
-                    return panorama_flat_level_body<AllActive, C, M>(
-                            query_level,
-                            level_storage,
-                            active_indices.data(),
-                            num_active,
-                            active_byteset.data(),
-                            actual_level_width,
-                            exact_distances.data(),
-                            dot_buffer.data(),
-                            level_cum_sums,
-                            query_cum_norm,
-                            threshold);
-                });
-
-        level_cum_sums += batch_size;
-    }
-
-    return num_active;
-}
 } // namespace faiss
 
 #endif

--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -65,8 +65,8 @@ static inline void compute_level_dot_products_flat(
         dot_products[i + 3] = dp3;
     }
     for (; i < num_active; i++) {
-        const float* yj = level_storage +
-                (Direct ? i : active_indices[i]) * width;
+        const float* yj =
+                level_storage + (Direct ? i : active_indices[i]) * width;
         float dp = 0;
         FAISS_PRAGMA_IMPRECISE_LOOP
         for (size_t j = 0; j < width; j++) {
@@ -90,17 +90,14 @@ static inline size_t compact_active_pext(
         memcpy(&bytes, &active_byteset[i], 8);
         int mask = (int)_pext_u64(bytes, 0x0101010101010101ULL);
 
-        uint64_t expanded =
-                _pdep_u64(mask, 0x0101010101010101ULL) * 0xFFULL;
+        uint64_t expanded = _pdep_u64(mask, 0x0101010101010101ULL) * 0xFFULL;
         uint64_t packed = _pext_u64(0x0706050403020100ULL, expanded);
 
-        __m256i perm = _mm256_cvtepu8_epi32(
-                _mm_cvtsi64_si128((long long)packed));
-        __m256i data =
-                _mm256_loadu_si256((const __m256i*)&active_indices[i]);
+        __m256i perm =
+                _mm256_cvtepu8_epi32(_mm_cvtsi64_si128((long long)packed));
+        __m256i data = _mm256_loadu_si256((const __m256i*)&active_indices[i]);
         __m256i compacted = _mm256_permutevar8x32_epi32(data, perm);
-        _mm256_storeu_si256(
-                (__m256i*)&active_indices[next_active], compacted);
+        _mm256_storeu_si256((__m256i*)&active_indices[next_active], compacted);
 
         next_active += __builtin_popcount(mask);
     }
@@ -197,14 +194,23 @@ static inline size_t panorama_flat_level_body(
         float threshold) {
     with_level_width(actual_level_width, [&]<size_t W>() {
         compute_level_dot_products_flat<Direct, W>(
-                query_level, level_storage, active_indices,
-                num_active, actual_level_width, dot_buffer);
+                query_level,
+                level_storage,
+                active_indices,
+                num_active,
+                actual_level_width,
+                dot_buffer);
     });
 
     prune_level_kernel<Direct, C, M>(
-            exact_distances, dot_buffer, level_cum_sums, active_byteset,
-            active_indices, (uint32_t)num_active,
-            query_cum_norm, threshold);
+            exact_distances,
+            dot_buffer,
+            level_cum_sums,
+            active_byteset,
+            active_indices,
+            (uint32_t)num_active,
+            query_cum_norm,
+            threshold);
 
     return compact_active_pext(active_indices, active_byteset, num_active);
 }
@@ -370,8 +376,8 @@ size_t Panorama::progressive_filter_batch(
         size_t actual_level_width =
                 std::min(level_width_floats, d - level * level_width_floats);
 
-        num_active = with_bool(
-                level == 0 && first_level_direct, [&]<bool Direct>() {
+        num_active =
+                with_bool(level == 0 && first_level_direct, [&]<bool Direct>() {
                     return panorama_flat_level_body<Direct, C, M>(
                             query_level,
                             level_storage,

--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -21,7 +21,7 @@
 #include <cstring>
 #include <vector>
 
-#ifdef __BMI2__
+#if defined(__BMI2__) && defined(__AVX2__)
 #include <immintrin.h>
 #endif
 
@@ -84,7 +84,7 @@ static inline size_t compact_active(
     size_t next_active = 0;
     size_t i = 0;
 
-#ifdef __BMI2__
+#if defined(__BMI2__) && defined(__AVX2__)
     for (; i + 8 <= num_active; i += 8) {
         uint64_t bytes;
         memcpy(&bytes, &active_byteset[i], 8);

--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -38,7 +38,7 @@ namespace faiss {
 ///                    level_width_dims). Enables full loop unrolling.
 FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN
 template <bool AllActive = false, size_t LevelWidth = 0>
-static inline void compute_level_dot_products_flat(
+static inline void compute_level_dot_kernel(
         const float* FAISS_RESTRICT query_level,
         const float* FAISS_RESTRICT level_storage,
         const uint32_t* active_indices,
@@ -94,7 +94,7 @@ FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 /// comparison autovectorizes (C::cmp generates scalar function calls).
 FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN
 template <bool AllActive, typename C, MetricType M>
-static inline void prune_level_kernel(
+static inline void prune_kernel(
         float* FAISS_RESTRICT exact_distances,
         const float* FAISS_RESTRICT dot_buffer,
         const float* FAISS_RESTRICT level_cum_sums,
@@ -134,7 +134,7 @@ FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 /// is zero. Returns the new count of active elements. Uses a branchless BMI2 +
 /// AVX2 fast path (8 elements/iteration via _pext_u64 permutation) with a
 /// scalar fallback for the tail and non-x86 platforms.
-static inline size_t compact_active(
+static inline size_t compact_active_kernel(
         uint32_t* active_indices,
         const uint8_t* FAISS_RESTRICT active_byteset,
         const size_t num_active) {
@@ -165,7 +165,6 @@ static inline size_t compact_active(
 
     return next_active;
 }
-
 
 /// Compile-time dispatch: converts a runtime `width` value into a template
 /// parameter by generating an if-else chain over [Lo, Hi] in steps of Step.
@@ -350,7 +349,7 @@ struct Panorama {
                     level == 0 && first_level_full, [&]<bool AllActive>() {
                         with_level_width(
                                 actual_level_width, [&]<size_t LevelWidth>() {
-                                    compute_level_dot_products_flat<
+                                    compute_level_dot_kernel<
                                             AllActive,
                                             LevelWidth>(
                                             query_level,
@@ -361,7 +360,7 @@ struct Panorama {
                                             dot_buffer.data());
                                 });
 
-                        prune_level_kernel<AllActive, C, M>(
+                        prune_kernel<AllActive, C, M>(
                                 exact_distances.data(),
                                 dot_buffer.data(),
                                 level_cum_sums,
@@ -371,7 +370,7 @@ struct Panorama {
                                 query_cum_norm,
                                 threshold);
 
-                        return compact_active(
+                        return compact_active_kernel(
                                 active_indices.data(),
                                 active_byteset.data(),
                                 num_active);

--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -21,33 +21,32 @@
 #include <cstring>
 #include <vector>
 
-#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || \
-        defined(_M_IX86)
+#ifdef __BMI2__
 #include <immintrin.h>
 #endif
 
 namespace faiss {
 
 FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN
-template <bool Direct = false, size_t FixedWidth = 0>
+template <bool AllActive = false, size_t LevelWidth = 0>
 static inline void compute_level_dot_products_flat(
         const float* FAISS_RESTRICT query_level,
         const float* FAISS_RESTRICT level_storage,
         const uint32_t* active_indices,
-        size_t num_active,
-        size_t level_width_dims,
+        const size_t num_active,
+        const size_t level_width_dims,
         float* FAISS_RESTRICT dot_products) {
-    const size_t width = FixedWidth > 0 ? FixedWidth : level_width_dims;
+    const size_t width = LevelWidth > 0 ? LevelWidth : level_width_dims;
     size_t i = 0;
     for (; i + 4 <= num_active; i += 4) {
         const float* y0 = level_storage +
-                (Direct ? (i + 0) : active_indices[i + 0]) * width;
+                (AllActive ? (i + 0) : active_indices[i + 0]) * width;
         const float* y1 = level_storage +
-                (Direct ? (i + 1) : active_indices[i + 1]) * width;
+                (AllActive ? (i + 1) : active_indices[i + 1]) * width;
         const float* y2 = level_storage +
-                (Direct ? (i + 2) : active_indices[i + 2]) * width;
+                (AllActive ? (i + 2) : active_indices[i + 2]) * width;
         const float* y3 = level_storage +
-                (Direct ? (i + 3) : active_indices[i + 3]) * width;
+                (AllActive ? (i + 3) : active_indices[i + 3]) * width;
 
         float dp0 = 0, dp1 = 0, dp2 = 0, dp3 = 0;
         FAISS_PRAGMA_IMPRECISE_LOOP
@@ -66,7 +65,7 @@ static inline void compute_level_dot_products_flat(
     }
     for (; i < num_active; i++) {
         const float* yj =
-                level_storage + (Direct ? i : active_indices[i]) * width;
+                level_storage + (AllActive ? i : active_indices[i]) * width;
         float dp = 0;
         FAISS_PRAGMA_IMPRECISE_LOOP
         for (size_t j = 0; j < width; j++) {
@@ -80,7 +79,7 @@ FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 static inline size_t compact_active_pext(
         uint32_t* active_indices,
         const uint8_t* active_byteset,
-        size_t num_active) {
+        const size_t num_active) {
     size_t next_active = 0;
     size_t i = 0;
 
@@ -112,19 +111,19 @@ static inline size_t compact_active_pext(
 }
 
 FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN
-template <bool Direct, typename C, MetricType M>
+template <bool AllActive, typename C, MetricType M>
 static inline void prune_level_kernel(
         float* FAISS_RESTRICT exact_distances,
         const float* FAISS_RESTRICT dot_buffer,
         const float* FAISS_RESTRICT level_cum_sums,
         uint8_t* FAISS_RESTRICT active_byteset,
         const uint32_t* FAISS_RESTRICT active_indices,
-        uint32_t num_active,
-        float query_cum_norm,
-        float threshold) {
+        const uint32_t num_active,
+        const float query_cum_norm,
+        const float threshold) {
     FAISS_PRAGMA_IMPRECISE_LOOP
     for (uint32_t i = 0; i < num_active; i++) {
-        uint32_t idx = Direct ? i : active_indices[i];
+        uint32_t idx = AllActive ? i : active_indices[i];
         if constexpr (M == METRIC_INNER_PRODUCT) {
             exact_distances[idx] += dot_buffer[i];
         } else {
@@ -179,21 +178,21 @@ inline auto with_bool(bool value, Lambda&& fn) {
     }
 }
 
-template <bool Direct, typename C, MetricType M>
+template <bool AllActive, typename C, MetricType M>
 static inline size_t panorama_flat_level_body(
         const float* query_level,
         const float* level_storage,
         uint32_t* active_indices,
-        size_t num_active,
+        const size_t num_active,
         uint8_t* active_byteset,
-        size_t actual_level_width,
+        const size_t actual_level_width,
         float* exact_distances,
         float* dot_buffer,
         const float* level_cum_sums,
         float query_cum_norm,
         float threshold) {
-    with_level_width(actual_level_width, [&]<size_t W>() {
-        compute_level_dot_products_flat<Direct, W>(
+    with_level_width(actual_level_width, [&]<size_t LevelWidth>() {
+        compute_level_dot_products_flat<AllActive, LevelWidth>(
                 query_level,
                 level_storage,
                 active_indices,
@@ -202,7 +201,7 @@ static inline size_t panorama_flat_level_body(
                 dot_buffer);
     });
 
-    prune_level_kernel<Direct, C, M>(
+    prune_level_kernel<AllActive, C, M>(
             exact_distances,
             dot_buffer,
             level_cum_sums,
@@ -360,7 +359,7 @@ size_t Panorama::progressive_filter_batch(
     }
 
     size_t total_active = num_active;
-    bool first_level_direct = (num_active == curr_batch_size);
+    const bool first_level_full = (num_active == curr_batch_size);
 
     local_stats.total_dims += total_active * n_levels;
 
@@ -377,8 +376,8 @@ size_t Panorama::progressive_filter_batch(
                 std::min(level_width_floats, d - level * level_width_floats);
 
         num_active =
-                with_bool(level == 0 && first_level_direct, [&]<bool Direct>() {
-                    return panorama_flat_level_body<Direct, C, M>(
+                with_bool(level == 0 && first_level_full, [&]<bool AllActive>() {
+                    return panorama_flat_level_body<AllActive, C, M>(
                             query_level,
                             level_storage,
                             active_indices.data(),

--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -375,8 +375,8 @@ size_t Panorama::progressive_filter_batch(
         size_t actual_level_width =
                 std::min(level_width_floats, d - level * level_width_floats);
 
-        num_active =
-                with_bool(level == 0 && first_level_full, [&]<bool AllActive>() {
+        num_active = with_bool(
+                level == 0 && first_level_full, [&]<bool AllActive>() {
                     return panorama_flat_level_body<AllActive, C, M>(
                             query_level,
                             level_storage,

--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -18,9 +18,196 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <vector>
 
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || \
+        defined(_M_IX86)
+#include <immintrin.h>
+#endif
+
 namespace faiss {
+
+FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN
+template <bool Direct = false, size_t FixedWidth = 0>
+static inline void compute_level_dot_products_flat(
+        const float* FAISS_RESTRICT query_level,
+        const float* FAISS_RESTRICT level_storage,
+        const uint32_t* active_indices,
+        size_t num_active,
+        size_t level_width_dims,
+        float* FAISS_RESTRICT dot_products) {
+    const size_t width = FixedWidth > 0 ? FixedWidth : level_width_dims;
+    size_t i = 0;
+    for (; i + 4 <= num_active; i += 4) {
+        const float* y0 = level_storage +
+                (Direct ? (i + 0) : active_indices[i + 0]) * width;
+        const float* y1 = level_storage +
+                (Direct ? (i + 1) : active_indices[i + 1]) * width;
+        const float* y2 = level_storage +
+                (Direct ? (i + 2) : active_indices[i + 2]) * width;
+        const float* y3 = level_storage +
+                (Direct ? (i + 3) : active_indices[i + 3]) * width;
+
+        float dp0 = 0, dp1 = 0, dp2 = 0, dp3 = 0;
+        FAISS_PRAGMA_IMPRECISE_LOOP
+        for (size_t j = 0; j < width; j++) {
+            float q = query_level[j];
+            dp0 += q * y0[j];
+            dp1 += q * y1[j];
+            dp2 += q * y2[j];
+            dp3 += q * y3[j];
+        }
+
+        dot_products[i + 0] = dp0;
+        dot_products[i + 1] = dp1;
+        dot_products[i + 2] = dp2;
+        dot_products[i + 3] = dp3;
+    }
+    for (; i < num_active; i++) {
+        const float* yj = level_storage +
+                (Direct ? i : active_indices[i]) * width;
+        float dp = 0;
+        FAISS_PRAGMA_IMPRECISE_LOOP
+        for (size_t j = 0; j < width; j++) {
+            dp += query_level[j] * yj[j];
+        }
+        dot_products[i] = dp;
+    }
+}
+FAISS_PRAGMA_IMPRECISE_FUNCTION_END
+
+static inline size_t compact_active_pext(
+        uint32_t* active_indices,
+        const uint8_t* active_byteset,
+        size_t num_active) {
+    size_t next_active = 0;
+    size_t i = 0;
+
+#ifdef __BMI2__
+    for (; i + 8 <= num_active; i += 8) {
+        uint64_t bytes;
+        memcpy(&bytes, &active_byteset[i], 8);
+        int mask = (int)_pext_u64(bytes, 0x0101010101010101ULL);
+
+        uint64_t expanded =
+                _pdep_u64(mask, 0x0101010101010101ULL) * 0xFFULL;
+        uint64_t packed = _pext_u64(0x0706050403020100ULL, expanded);
+
+        __m256i perm = _mm256_cvtepu8_epi32(
+                _mm_cvtsi64_si128((long long)packed));
+        __m256i data =
+                _mm256_loadu_si256((const __m256i*)&active_indices[i]);
+        __m256i compacted = _mm256_permutevar8x32_epi32(data, perm);
+        _mm256_storeu_si256(
+                (__m256i*)&active_indices[next_active], compacted);
+
+        next_active += __builtin_popcount(mask);
+    }
+#endif
+
+    for (; i < num_active; i++) {
+        active_indices[next_active] = active_indices[i];
+        next_active += active_byteset[i] ? 1 : 0;
+    }
+
+    return next_active;
+}
+
+FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN
+template <bool Direct, typename C, MetricType M>
+static inline void prune_level_kernel(
+        float* FAISS_RESTRICT exact_distances,
+        const float* FAISS_RESTRICT dot_buffer,
+        const float* FAISS_RESTRICT level_cum_sums,
+        uint8_t* FAISS_RESTRICT active_byteset,
+        const uint32_t* FAISS_RESTRICT active_indices,
+        uint32_t num_active,
+        float query_cum_norm,
+        float threshold) {
+    FAISS_PRAGMA_IMPRECISE_LOOP
+    for (uint32_t i = 0; i < num_active; i++) {
+        uint32_t idx = Direct ? i : active_indices[i];
+        if constexpr (M == METRIC_INNER_PRODUCT) {
+            exact_distances[idx] += dot_buffer[i];
+        } else {
+            exact_distances[idx] -= 2.0f * dot_buffer[i];
+        }
+
+        float cum_sum = level_cum_sums[idx];
+        float cauchy_schwarz_bound;
+        if constexpr (M == METRIC_INNER_PRODUCT) {
+            cauchy_schwarz_bound = -cum_sum * query_cum_norm;
+        } else {
+            cauchy_schwarz_bound = 2.0f * cum_sum * query_cum_norm;
+        }
+
+        float lower_bound = exact_distances[idx] - cauchy_schwarz_bound;
+        if constexpr (C::is_max) {
+            active_byteset[i] = (threshold > lower_bound) ? 1 : 0;
+        } else {
+            active_byteset[i] = (threshold < lower_bound) ? 1 : 0;
+        }
+    }
+}
+FAISS_PRAGMA_IMPRECISE_FUNCTION_END
+
+namespace detail {
+template <size_t Lo, size_t Hi, size_t Step, typename Lambda>
+inline auto dispatch_width(size_t width, Lambda&& fn) {
+    if constexpr (Lo > Hi) {
+        return fn.template operator()<0>();
+    } else {
+        if (width == Lo) {
+            return fn.template operator()<Lo>();
+        }
+        return dispatch_width<Lo + Step, Hi, Step>(
+                width, std::forward<Lambda>(fn));
+    }
+}
+} // namespace detail
+
+template <typename LambdaType>
+inline auto with_level_width(size_t width, LambdaType&& action) {
+    return detail::dispatch_width<16, 128, 16>(
+            width, std::forward<LambdaType>(action));
+}
+
+template <typename Lambda>
+inline auto with_bool(bool value, Lambda&& fn) {
+    if (value) {
+        return fn.template operator()<true>();
+    } else {
+        return fn.template operator()<false>();
+    }
+}
+
+template <bool Direct, typename C, MetricType M>
+static inline size_t panorama_flat_level_body(
+        const float* query_level,
+        const float* level_storage,
+        uint32_t* active_indices,
+        size_t num_active,
+        uint8_t* active_byteset,
+        size_t actual_level_width,
+        float* exact_distances,
+        float* dot_buffer,
+        const float* level_cum_sums,
+        float query_cum_norm,
+        float threshold) {
+    with_level_width(actual_level_width, [&]<size_t W>() {
+        compute_level_dot_products_flat<Direct, W>(
+                query_level, level_storage, active_indices,
+                num_active, actual_level_width, dot_buffer);
+    });
+
+    prune_level_kernel<Direct, C, M>(
+            exact_distances, dot_buffer, level_cum_sums, active_byteset,
+            active_indices, (uint32_t)num_active,
+            query_cum_norm, threshold);
+
+    return compact_active_pext(active_indices, active_byteset, num_active);
+}
 
 /**
  * Implements the core logic of Panorama-based refinement.
@@ -110,7 +297,9 @@ struct Panorama {
             const idx_t* ids,
             bool use_sel,
             std::vector<uint32_t>& active_indices,
+            std::vector<uint8_t>& active_byteset,
             std::vector<float>& exact_distances,
+            std::vector<float>& dot_buffer,
             float threshold,
             PanoramaStats& local_stats) const;
 
@@ -129,7 +318,9 @@ size_t Panorama::progressive_filter_batch(
         const idx_t* ids,
         bool use_sel,
         std::vector<uint32_t>& active_indices,
+        std::vector<uint8_t>& active_byteset,
         std::vector<float>& exact_distances,
+        std::vector<float>& dot_buffer,
         float threshold,
         PanoramaStats& local_stats) const {
     size_t batch_start = batch_no * batch_size;
@@ -162,12 +353,10 @@ size_t Panorama::progressive_filter_batch(
         num_active += include;
     }
 
-    if (num_active == 0) {
-        return 0;
-    }
-
     size_t total_active = num_active;
-    for (size_t level = 0; level < n_levels; level++) {
+    bool first_level_direct = (num_active == curr_batch_size);
+
+    for (size_t level = 0; (level < n_levels) && (num_active > 0); level++) {
         local_stats.total_dims_scanned += num_active;
         local_stats.total_dims += total_active;
 
@@ -176,40 +365,26 @@ size_t Panorama::progressive_filter_batch(
         size_t level_offset = level * level_width * batch_size;
         const float* level_storage =
                 (const float*)(storage_base + level_offset);
+        const float* query_level = query + level * level_width_floats;
+        size_t actual_level_width =
+                std::min(level_width_floats, d - level * level_width_floats);
 
-        size_t next_active = 0;
-        for (size_t i = 0; i < num_active; i++) {
-            uint32_t idx = active_indices[i];
-            size_t actual_level_width = std::min(
-                    level_width_floats, d - level * level_width_floats);
+        num_active = with_bool(
+                level == 0 && first_level_direct, [&]<bool Direct>() {
+                    return panorama_flat_level_body<Direct, C, M>(
+                            query_level,
+                            level_storage,
+                            active_indices.data(),
+                            num_active,
+                            active_byteset.data(),
+                            actual_level_width,
+                            exact_distances.data(),
+                            dot_buffer.data(),
+                            level_cum_sums,
+                            query_cum_norm,
+                            threshold);
+                });
 
-            const float* yj = level_storage + idx * actual_level_width;
-            const float* query_level = query + level * level_width_floats;
-
-            float dot_product =
-                    fvec_inner_product(query_level, yj, actual_level_width);
-
-            if constexpr (M == METRIC_INNER_PRODUCT) {
-                exact_distances[idx] += dot_product;
-            } else {
-                exact_distances[idx] -= 2.0f * dot_product;
-            }
-
-            float cum_sum = level_cum_sums[idx];
-            float cauchy_schwarz_bound;
-            if constexpr (M == METRIC_INNER_PRODUCT) {
-                cauchy_schwarz_bound = -cum_sum * query_cum_norm;
-            } else {
-                cauchy_schwarz_bound = 2.0f * cum_sum * query_cum_norm;
-            }
-
-            float lower_bound = exact_distances[idx] - cauchy_schwarz_bound;
-
-            active_indices[next_active] = idx;
-            next_active += C::cmp(threshold, lower_bound) ? 1 : 0;
-        }
-
-        num_active = next_active;
         level_cum_sums += batch_size;
     }
 

--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -185,6 +185,7 @@ inline auto dispatch_width(size_t width, Lambda&& fn) {
 }
 } // namespace detail
 
+/// Specialize for common float level widths (multiples of 8 up to 128).
 template <typename LambdaType>
 inline auto with_level_width(size_t width, LambdaType&& action) {
     return detail::dispatch_width<8, 128, 8>(

--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -356,9 +356,10 @@ size_t Panorama::progressive_filter_batch(
     size_t total_active = num_active;
     bool first_level_direct = (num_active == curr_batch_size);
 
+    local_stats.total_dims += total_active * n_levels;
+
     for (size_t level = 0; (level < n_levels) && (num_active > 0); level++) {
         local_stats.total_dims_scanned += num_active;
-        local_stats.total_dims += total_active;
 
         float query_cum_norm = query_cum_sums[level + 1];
 

--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -27,6 +27,7 @@
 
 namespace faiss {
 
+#ifndef SWIG
 FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN
 template <bool AllActive = false, size_t LevelWidth = 0>
 static inline void compute_level_dot_products_flat(
@@ -146,7 +147,6 @@ static inline void prune_level_kernel(
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
-#ifndef SWIG
 namespace detail {
 template <size_t Lo, size_t Hi, size_t Step, typename Lambda>
 inline auto dispatch_width(size_t width, Lambda&& fn) {

--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -166,7 +166,7 @@ inline auto dispatch_width(size_t width, Lambda&& fn) {
 
 template <typename LambdaType>
 inline auto with_level_width(size_t width, LambdaType&& action) {
-    return detail::dispatch_width<16, 128, 16>(
+    return detail::dispatch_width<8, 128, 8>(
             width, std::forward<LambdaType>(action));
 }
 

--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -148,6 +148,7 @@ static inline void prune_level_kernel(
 }
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 
+#ifndef SWIG
 namespace detail {
 template <size_t Lo, size_t Hi, size_t Step, typename Lambda>
 inline auto dispatch_width(size_t width, Lambda&& fn) {
@@ -177,6 +178,7 @@ inline auto with_bool(bool value, Lambda&& fn) {
         return fn.template operator()<false>();
     }
 }
+#endif // SWIG
 
 template <bool AllActive, typename C, MetricType M>
 static inline size_t panorama_flat_level_body(

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -511,7 +511,7 @@ std::unique_ptr<InvertedLists> read_InvertedLists_up(
         READ1(n_levels);
         FAISS_THROW_IF_NOT_FMT(
                 n_levels > 0, "invalid ilpn n_levels %zd", n_levels);
-        constexpr size_t bs = 128;
+        constexpr size_t bs = Panorama::kDefaultBatchSize;
         auto ailp = std::make_unique<ArrayInvertedListsPanorama>(
                 nlist, code_size, n_levels, bs);
         std::vector<size_t> sizes(nlist);
@@ -1789,7 +1789,7 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         read_ivf_header(ivfp.get(), f);
         ivfp->code_size = ivfp->d * sizeof(float);
         READ1(ivfp->n_levels);
-        ivfp->batch_size = 128;
+        ivfp->batch_size = Panorama::kDefaultBatchSize;
         read_InvertedLists(*ivfp, f, io_flags);
         idx = std::move(ivfp);
     } else if (h == fourcc("IwP2")) {

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -503,7 +503,6 @@ std::unique_ptr<InvertedLists> read_InvertedLists_up(
         }
         return nullptr;
     } else if (h == fourcc("ilpn") && !(io_flags & IO_FLAG_SKIP_IVF_DATA)) {
-        // Legacy format without batch_size (default to 128)
         size_t nlist, code_size, n_levels;
         READ1(nlist);
         FAISS_CHECK_DESERIALIZATION_LOOP_LIMIT(nlist, "ilpn nlist");

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -503,6 +503,7 @@ std::unique_ptr<InvertedLists> read_InvertedLists_up(
         }
         return nullptr;
     } else if (h == fourcc("ilpn") && !(io_flags & IO_FLAG_SKIP_IVF_DATA)) {
+        // Legacy format without batch_size (default to 128)
         size_t nlist, code_size, n_levels;
         READ1(nlist);
         FAISS_CHECK_DESERIALIZATION_LOOP_LIMIT(nlist, "ilpn nlist");
@@ -510,8 +511,9 @@ std::unique_ptr<InvertedLists> read_InvertedLists_up(
         READ1(n_levels);
         FAISS_THROW_IF_NOT_FMT(
                 n_levels > 0, "invalid ilpn n_levels %zd", n_levels);
+        constexpr size_t bs = 128;
         auto ailp = std::make_unique<ArrayInvertedListsPanorama>(
-                nlist, code_size, n_levels);
+                nlist, code_size, n_levels, bs);
         std::vector<size_t> sizes(nlist);
         read_ArrayInvertedLists_sizes(f, sizes);
         size_t byte_limit = get_deserialization_vector_byte_limit();
@@ -527,6 +529,63 @@ std::unique_ptr<InvertedLists> read_InvertedLists_up(
                     ((sizes[i] + ArrayInvertedListsPanorama::kBatchSize - 1) /
                      ArrayInvertedListsPanorama::kBatchSize) *
                     ArrayInvertedListsPanorama::kBatchSize;
+            size_t codes_bytes = mul_no_overflow(
+                    num_elems, code_size, "inverted list codes");
+            FAISS_THROW_IF_NOT_FMT(
+                    codes_bytes <= byte_limit,
+                    "inverted list %zu codes size %zu exceeds "
+                    "deserialization byte limit",
+                    i,
+                    codes_bytes);
+            ailp->codes[i].resize(codes_bytes);
+            size_t cum_sums_count = mul_no_overflow(
+                    num_elems,
+                    add_no_overflow(
+                            n_levels, 1, "inverted list cum_sums n_levels"),
+                    "inverted list cum_sums");
+            FAISS_THROW_IF_NOT_FMT(
+                    cum_sums_count <= byte_limit / sizeof(ailp->cum_sums[0][0]),
+                    "inverted list %zu cum_sums size %zu exceeds "
+                    "deserialization byte limit",
+                    i,
+                    cum_sums_count);
+            ailp->cum_sums[i].resize(cum_sums_count);
+        }
+        for (size_t i = 0; i < nlist; i++) {
+            size_t n = sizes[i];
+            if (n > 0) {
+                read_vector_with_known_size(
+                        ailp->codes[i], f, ailp->codes[i].size());
+                read_vector_with_known_size(ailp->ids[i], f, n);
+                read_vector_with_known_size(
+                        ailp->cum_sums[i], f, ailp->cum_sums[i].size());
+            }
+        }
+        return ailp;
+    } else if (h == fourcc("ilp2") && !(io_flags & IO_FLAG_SKIP_IVF_DATA)) {
+        size_t nlist, code_size, n_levels, bs;
+        READ1(nlist);
+        FAISS_CHECK_DESERIALIZATION_LOOP_LIMIT(nlist, "ilp2 nlist");
+        READ1(code_size);
+        READ1(n_levels);
+        READ1(bs);
+        FAISS_THROW_IF_NOT_FMT(
+                n_levels > 0, "invalid ilp2 n_levels %zd", n_levels);
+        FAISS_THROW_IF_NOT_FMT(bs > 0, "invalid ilp2 batch_size %zd", bs);
+        auto ailp = std::make_unique<ArrayInvertedListsPanorama>(
+                nlist, code_size, n_levels, bs);
+        std::vector<size_t> sizes(nlist);
+        read_ArrayInvertedLists_sizes(f, sizes);
+        size_t byte_limit = get_deserialization_vector_byte_limit();
+        for (size_t i = 0; i < nlist; i++) {
+            FAISS_THROW_IF_NOT_FMT(
+                    sizes[i] <= byte_limit / sizeof(idx_t),
+                    "inverted list %zu ids size %zu exceeds "
+                    "deserialization byte limit",
+                    i,
+                    sizes[i]);
+            ailp->ids[i].resize(sizes[i]);
+            size_t num_elems = ((sizes[i] + bs - 1) / bs) * bs;
             size_t codes_bytes = mul_no_overflow(
                     num_elems, code_size, "inverted list codes");
             FAISS_THROW_IF_NOT_FMT(
@@ -1730,6 +1789,15 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         read_ivf_header(ivfp.get(), f);
         ivfp->code_size = ivfp->d * sizeof(float);
         READ1(ivfp->n_levels);
+        ivfp->batch_size = 128;
+        read_InvertedLists(*ivfp, f, io_flags);
+        idx = std::move(ivfp);
+    } else if (h == fourcc("IwP2")) {
+        auto ivfp = std::make_unique<IndexIVFFlatPanorama>();
+        read_ivf_header(ivfp.get(), f);
+        ivfp->code_size = ivfp->d * sizeof(float);
+        READ1(ivfp->n_levels);
+        READ1(ivfp->batch_size);
         read_InvertedLists(*ivfp, f, io_flags);
         idx = std::move(ivfp);
     } else if (h == fourcc("IwFl")) {

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -524,10 +524,7 @@ std::unique_ptr<InvertedLists> read_InvertedLists_up(
                     i,
                     sizes[i]);
             ailp->ids[i].resize(sizes[i]);
-            size_t num_elems =
-                    ((sizes[i] + ArrayInvertedListsPanorama::kBatchSize - 1) /
-                     ArrayInvertedListsPanorama::kBatchSize) *
-                    ArrayInvertedListsPanorama::kBatchSize;
+            size_t num_elems = ((sizes[i] + bs - 1) / bs) * bs;
             size_t codes_bytes = mul_no_overflow(
                     num_elems, code_size, "inverted list codes");
             FAISS_THROW_IF_NOT_FMT(

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -269,12 +269,20 @@ void write_InvertedLists(const InvertedLists* ils, IOWriter* f) {
     } else if (
             const auto& ailp =
                     dynamic_cast<const ArrayInvertedListsPanorama*>(ils)) {
-        uint32_t h = fourcc("ilp2");
-        WRITE1(h);
-        WRITE1(ailp->nlist);
-        WRITE1(ailp->code_size);
-        WRITE1(ailp->n_levels);
-        WRITE1(ailp->pano.batch_size);
+        if (ailp->pano.batch_size == Panorama::kDefaultBatchSize) {
+            uint32_t h = fourcc("ilpn");
+            WRITE1(h);
+            WRITE1(ailp->nlist);
+            WRITE1(ailp->code_size);
+            WRITE1(ailp->n_levels);
+        } else {
+            uint32_t h = fourcc("ilp2");
+            WRITE1(h);
+            WRITE1(ailp->nlist);
+            WRITE1(ailp->code_size);
+            WRITE1(ailp->n_levels);
+            WRITE1(ailp->pano.batch_size);
+        }
         uint32_t list_type = fourcc("full");
         WRITE1(list_type);
         std::vector<size_t> sizes;
@@ -708,11 +716,18 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
     } else if (
             const IndexIVFFlatPanorama* ivfp =
                     dynamic_cast<const IndexIVFFlatPanorama*>(idx)) {
-        uint32_t h = fourcc("IwP2");
-        WRITE1(h);
-        write_ivf_header(ivfp, f);
-        WRITE1(ivfp->n_levels);
-        WRITE1(ivfp->batch_size);
+        if (ivfp->batch_size == Panorama::kDefaultBatchSize) {
+            uint32_t h = fourcc("IwPn");
+            WRITE1(h);
+            write_ivf_header(ivfp, f);
+            WRITE1(ivfp->n_levels);
+        } else {
+            uint32_t h = fourcc("IwP2");
+            WRITE1(h);
+            write_ivf_header(ivfp, f);
+            WRITE1(ivfp->n_levels);
+            WRITE1(ivfp->batch_size);
+        }
         write_InvertedLists(ivfp->invlists, f);
     } else if (
             const IndexIVFFlat* ivfl_2 =

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -269,11 +269,12 @@ void write_InvertedLists(const InvertedLists* ils, IOWriter* f) {
     } else if (
             const auto& ailp =
                     dynamic_cast<const ArrayInvertedListsPanorama*>(ils)) {
-        uint32_t h = fourcc("ilpn");
+        uint32_t h = fourcc("ilp2");
         WRITE1(h);
         WRITE1(ailp->nlist);
         WRITE1(ailp->code_size);
         WRITE1(ailp->n_levels);
+        WRITE1(ailp->pano.batch_size);
         uint32_t list_type = fourcc("full");
         WRITE1(list_type);
         std::vector<size_t> sizes;
@@ -707,10 +708,11 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
     } else if (
             const IndexIVFFlatPanorama* ivfp =
                     dynamic_cast<const IndexIVFFlatPanorama*>(idx)) {
-        uint32_t h = fourcc("IwPn");
+        uint32_t h = fourcc("IwP2");
         WRITE1(h);
         write_ivf_header(ivfp, f);
         WRITE1(ivfp->n_levels);
+        WRITE1(ivfp->batch_size);
         write_InvertedLists(ivfp->invlists, f);
     } else if (
             const IndexIVFFlat* ivfl_2 =

--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -110,6 +110,7 @@ inline int __builtin_clzll(uint64_t x) {
 // MSVC uses pragma pack instead of __attribute__((packed))
 // Use FAISS_PACK_STRUCTS_BEGIN/END to wrap packed structure definitions
 #define FAISS_PACKED
+#define FAISS_RESTRICT __restrict
 #define FAISS_PACK_STRUCTS_BEGIN __pragma(pack(push, 1))
 #define FAISS_PACK_STRUCTS_END __pragma(pack(pop))
 

--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -126,9 +126,11 @@ inline int __builtin_clzll(uint64_t x) {
 #ifdef SWIG
 #define ALIGNED(x)
 #define FAISS_PACKED
+#define FAISS_RESTRICT
 #else
 #define ALIGNED(x) __attribute__((aligned(x)))
 #define FAISS_PACKED __attribute__((packed))
+#define FAISS_RESTRICT __restrict
 #endif
 
 // On non-Windows, FAISS_PACKED handles packing, so these are no-ops

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -342,9 +342,11 @@ IndexIVF* parse_IndexIVF(
     if (match("FlatDedup")) {
         return new IndexIVFFlatDedup(get_q(), d, nlist, mt, own_il);
     }
-    if (match("FlatPanorama([0-9]+)?")) {
+    if (match("FlatPanorama([0-9]+)?(_([0-9]+))?")) {
         int nlevels = mres_to_int(sm[1], 8); // default to 8 levels
-        return new IndexIVFFlatPanorama(get_q(), d, nlist, nlevels, mt, own_il);
+        int bs = mres_to_int(sm[3], 128);
+        return new IndexIVFFlatPanorama(
+                get_q(), d, nlist, nlevels, mt, own_il, bs);
     }
     if (match(sq_pattern)) {
         return new IndexIVFScalarQuantizer(

--- a/faiss/invlists/InvertedLists.cpp
+++ b/faiss/invlists/InvertedLists.cpp
@@ -360,14 +360,15 @@ ArrayInvertedLists::~ArrayInvertedLists() {}
 ArrayInvertedListsPanorama::ArrayInvertedListsPanorama(
         size_t nlist_in,
         size_t code_size_in,
-        size_t n_levels_in)
+        size_t n_levels_in,
+        size_t batch_size)
         : ArrayInvertedLists(nlist_in, code_size_in),
           n_levels(n_levels_in),
           level_width(
                   (((code_size_in / sizeof(float)) + n_levels_in - 1) /
                    n_levels_in) *
                   sizeof(float)),
-          pano(code_size_in, n_levels_in, kBatchSize) {
+          pano(code_size_in, n_levels_in, batch_size) {
     FAISS_THROW_IF_NOT(n_levels_in > 0);
     FAISS_THROW_IF_NOT(code_size_in % sizeof(float) == 0);
     FAISS_THROW_IF_NOT_MSG(
@@ -395,9 +396,9 @@ size_t ArrayInvertedListsPanorama::add_entries(
     memcpy(&ids[list_no][o], ids_in, sizeof(ids_in[0]) * n_entry);
 
     size_t new_size = o + n_entry;
-    size_t num_batches = (new_size + kBatchSize - 1) / kBatchSize;
-    codes[list_no].resize(num_batches * kBatchSize * code_size);
-    cum_sums[list_no].resize(num_batches * kBatchSize * (n_levels + 1));
+    size_t num_batches = (new_size + pano.batch_size - 1) / pano.batch_size;
+    codes[list_no].resize(num_batches * pano.batch_size * code_size);
+    cum_sums[list_no].resize(num_batches * pano.batch_size * (n_levels + 1));
 
     // Cast to float* is safe here as we guarantee codes are always float
     // vectors for `IndexIVFFlatPanorama` (verified by the constructor).
@@ -431,9 +432,9 @@ void ArrayInvertedListsPanorama::update_entries(
 void ArrayInvertedListsPanorama::resize(size_t list_no, size_t new_size) {
     ids[list_no].resize(new_size);
 
-    size_t num_batches = (new_size + kBatchSize - 1) / kBatchSize;
-    codes[list_no].resize(num_batches * kBatchSize * code_size);
-    cum_sums[list_no].resize(num_batches * kBatchSize * (n_levels + 1));
+    size_t num_batches = (new_size + pano.batch_size - 1) / pano.batch_size;
+    codes[list_no].resize(num_batches * pano.batch_size * code_size);
+    cum_sums[list_no].resize(num_batches * pano.batch_size * (n_levels + 1));
 }
 
 const uint8_t* ArrayInvertedListsPanorama::get_single_code(

--- a/faiss/invlists/InvertedLists.h
+++ b/faiss/invlists/InvertedLists.h
@@ -298,7 +298,6 @@ struct ArrayInvertedLists : InvertedLists {
 /// Level-oriented storage as defined in the IVFFlat section of Panorama
 /// (https://www.arxiv.org/pdf/2510.00566).
 struct ArrayInvertedListsPanorama : ArrayInvertedLists {
-    static constexpr size_t kBatchSize = 128;
     std::vector<MaybeOwnedVector<float>> cum_sums;
     const size_t n_levels;
     const size_t level_width; // in code units
@@ -308,7 +307,7 @@ struct ArrayInvertedListsPanorama : ArrayInvertedLists {
             size_t nlist_in,
             size_t code_size_in,
             size_t n_levels_in,
-            size_t batch_size = 128);
+            size_t batch_size = Panorama::kDefaultBatchSize);
 
     const float* get_cum_sums(size_t list_no) const;
 

--- a/faiss/invlists/InvertedLists.h
+++ b/faiss/invlists/InvertedLists.h
@@ -307,7 +307,8 @@ struct ArrayInvertedListsPanorama : ArrayInvertedLists {
     ArrayInvertedListsPanorama(
             size_t nlist_in,
             size_t code_size_in,
-            size_t n_levels_in);
+            size_t n_levels_in,
+            size_t batch_size = 128);
 
     const float* get_cum_sums(size_t list_no) const;
 

--- a/tests/test_ivf_flat_panorama.py
+++ b/tests/test_ivf_flat_panorama.py
@@ -446,7 +446,7 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
     # Batch size and edge case tests
 
     def test_batch_boundaries(self):
-        """Test correctness at various batch size boundaries (kBatchSize=256)"""
+        """Test correctness at various batch size boundaries (kDefaultBatchSize=128)"""
         d, nlist, nlevels, nt, nq, k = 128, 64, 8, 10000, 200, 15
         np.random.seed(987)
         xt = np.random.rand(nt, d).astype("float32")


### PR DESCRIPTION
_Note: Should be merged before #4970 (IVFPQPanorama)._

## Changes
### Performance

This PR implements various optimizations to Panorama (L2Flat and IVFFlat).
1. Disaggregate distance computation from pruning decisions to avoid branches in distance computation hotpath.
2. Early batch processing termination when no points are remaining.
3. Manually unrolled distance kernel.
4. Template distance computation on level width for autovectorization.
5. `if constexpr (C::is_max)` instead of `C::cmp` for autovectorized pruning.
6. Byteset for vectorized compacting of active indices using `_pext_u64`.
7. Template distance computation and pruning on first level (no `active_indices` indirection) to let it autovectorize.
8. Hoist buffer allocations into `IndexFlat`/`IVFFlatScannerPanorama`.
9. Expose `batch_size` as a parameter for IVFFlatPanorama (for consistency with `IndexFlatPanorama` but also because 1024 `batch_size` can improve performance).

### Other

 - Define `kDefaultBatchSize` once in `Panorama.h` (previously defined in 5 separate locations).
 - Allow `bench_flat_l2_panorama.py` and `bench_ivf_flat_panorama.py` to accept `gist1M` or `sift1M` as dataset to bench on.

## Results

Together, these optimizations enable powerful additional speedups, especially on lower-dimensional datasets like SIFT (128d), by dramatically minimizing Panorama's overhead:

**GIST1M (IVF128, nlist=128, nlevels=16)**
| nprobe | Recall@10 | Old Speedup | New Speedup | _Additional_ Speedup |
|--------|-----------|-------------------------|-------------------------|--------------------|
|      1 | 0.1439    |                    3.92x |                    3.93x |               1.00x |
|      2 | 0.2605    |                    4.71x |                    5.19x |               1.10x |
|      4 | 0.4369    |                    5.53x |                    6.75x |               1.22x |
|      8 | 0.6470    |                    6.37x |                    8.21x |               1.29x |
|     16 | 0.8780    |                    7.30x |                    9.74x |               1.33x |
|     32 | 0.9764    |                    8.33x |                   11.29x |               1.36x |
|     64 | 0.9868    |                    9.38x |                   12.74x |               1.36x |


**SIFT1M (IVF128, nlist=128, nlevels=8)**
| nprobe | Recall@10 | Old Speedup | New Speedup | _Additional_ Speedup |
|--------|-----------|-------------------------|-------------------------|--------------------|
|      1 | 0.2678    |                    1.20x |                    1.81x |               1.52x |
|      2 | 0.4584    |                    1.38x |                    2.23x |               1.62x |
|      4 | 0.6855    |                    1.59x |                    2.70x |               1.70x |
|      8 | 0.8760    |                    1.83x |                    3.44x |               1.88x |
|     16 | 0.9679    |                    2.11x |                    4.72x |               2.24x |
|     32 | 0.9855    |                    2.44x |                    5.61x |               2.30x |
|     64 | 0.9861    |                    2.74x |                    6.39x |               2.33x |

### Raw Data

Collected by running the new benches on `main` and this branch. On main, you cannot specify `batch_size` so remove the `{1024}` from the factory string in the new benches to run them there. The results above are calculated from the following raw data as follows:
1. For each experiment (i.e., GIST (old) or SIFT (new), calculate the Panorama speedups for each `nprobe` ((original ms per query) / (pano ms per query))
2. For each pairing of (old) and (new) results, calculate the additional speedup by calculating (new speedup) / (old speedup).

#### Before (`main`)

GIST1M:
```
======IVF128,Flat
	nprobe   1, Recall@10: 0.145200, speed: 2.705442 ms/query, dims scanned: 100.00%
	nprobe   2, Recall@10: 0.260800, speed: 5.456891 ms/query, dims scanned: 100.00%
	nprobe   4, Recall@10: 0.441900, speed: 10.895120 ms/query, dims scanned: 100.00%
	nprobe   8, Recall@10: 0.648200, speed: 21.676788 ms/query, dims scanned: 100.00%
	nprobe  16, Recall@10: 0.878000, speed: 43.142261 ms/query, dims scanned: 100.00%
	nprobe  32, Recall@10: 0.975400, speed: 84.498397 ms/query, dims scanned: 100.00%
	nprobe  64, Recall@10: 0.986800, speed: 160.092644 ms/query, dims scanned: 100.00%
======PCA960,IVF128,FlatPanorama16
	nprobe   1, Recall@10: 0.143900, speed: 0.689507 ms/query, dims scanned: 12.96%
	nprobe   2, Recall@10: 0.260500, speed: 1.158416 ms/query, dims scanned: 11.18%
	nprobe   4, Recall@10: 0.436900, speed: 1.968814 ms/query, dims scanned: 9.90%
	nprobe   8, Recall@10: 0.647000, speed: 3.401469 ms/query, dims scanned: 8.91%
	nprobe  16, Recall@10: 0.878000, speed: 5.912757 ms/query, dims scanned: 8.10%
	nprobe  32, Recall@10: 0.976400, speed: 10.147847 ms/query, dims scanned: 7.44%
	nprobe  64, Recall@10: 0.986800, speed: 17.074573 ms/query, dims scanned: 6.93%
```

SIFT1M:

```
======IVF128,Flat
	nprobe   1, Recall@10: 0.267480, speed: 0.285990 ms/query, dims scanned: 100.00%
	nprobe   2, Recall@10: 0.457520, speed: 0.564067 ms/query, dims scanned: 100.00%
	nprobe   4, Recall@10: 0.685320, speed: 1.111833 ms/query, dims scanned: 100.00%
	nprobe   8, Recall@10: 0.877210, speed: 2.195088 ms/query, dims scanned: 100.00%
	nprobe  16, Recall@10: 0.967730, speed: 4.338444 ms/query, dims scanned: 100.00%
	nprobe  32, Recall@10: 0.985400, speed: 8.500538 ms/query, dims scanned: 100.00%
	nprobe  64, Recall@10: 0.986100, speed: 16.349893 ms/query, dims scanned: 100.00%
======PCA128,IVF128,FlatPanorama8
	nprobe   1, Recall@10: 0.267670, speed: 0.239243 ms/query, dims scanned: 27.97%
	nprobe   2, Recall@10: 0.458320, speed: 0.408590 ms/query, dims scanned: 24.42%
	nprobe   4, Recall@10: 0.685480, speed: 0.699694 ms/query, dims scanned: 21.50%
	nprobe   8, Recall@10: 0.875930, speed: 1.197310 ms/query, dims scanned: 19.06%
	nprobe  16, Recall@10: 0.967760, speed: 2.055968 ms/query, dims scanned: 16.98%
	nprobe  32, Recall@10: 0.985370, speed: 3.481555 ms/query, dims scanned: 15.26%
	nprobe  64, Recall@10: 0.985980, speed: 5.977346 ms/query, dims scanned: 14.02%
```

#### After (`optimize-pano`)

GIST1M:
```
======IVF128,Flat
	nprobe   1, Recall@10: 0.145200, speed: 2.625779 ms/query, dims scanned: 100.00%
	nprobe   2, Recall@10: 0.260800, speed: 5.285007 ms/query, dims scanned: 100.00%
	nprobe   4, Recall@10: 0.441900, speed: 10.555867 ms/query, dims scanned: 100.00%
	nprobe   8, Recall@10: 0.648200, speed: 21.012494 ms/query, dims scanned: 100.00%
	nprobe  16, Recall@10: 0.878000, speed: 41.794143 ms/query, dims scanned: 100.00%
	nprobe  32, Recall@10: 0.975400, speed: 81.865038 ms/query, dims scanned: 100.00%
	nprobe  64, Recall@10: 0.986800, speed: 155.067333 ms/query, dims scanned: 100.00%
======PCA960,IVF128,FlatPanorama16_1024
	nprobe   1, Recall@10: 0.143900, speed: 0.668800 ms/query, dims scanned: 20.33%
	nprobe   2, Recall@10: 0.260500, speed: 1.018440 ms/query, dims scanned: 14.81%
	nprobe   4, Recall@10: 0.436900, speed: 1.563622 ms/query, dims scanned: 11.72%
	nprobe   8, Recall@10: 0.647000, speed: 2.557981 ms/query, dims scanned: 9.82%
	nprobe  16, Recall@10: 0.878000, speed: 4.292616 ms/query, dims scanned: 8.56%
	nprobe  32, Recall@10: 0.976400, speed: 7.248832 ms/query, dims scanned: 7.68%
	nprobe  64, Recall@10: 0.986800, speed: 12.171319 ms/query, dims scanned: 7.06%
```

SIFT1M:

```
======IVF128,Flat
        nprobe   1, Recall@10: 0.267480, speed: 0.295904 ms/query, dims scanned: 100.00%
        nprobe   2, Recall@10: 0.457520, speed: 0.583204 ms/query, dims scanned: 100.00%
        nprobe   4, Recall@10: 0.685320, speed: 1.150055 ms/query, dims scanned: 100.00%
        nprobe   8, Recall@10: 0.877210, speed: 2.425575 ms/query, dims scanned: 100.00%
        nprobe  16, Recall@10: 0.967730, speed: 5.509365 ms/query, dims scanned: 100.00%
        nprobe  32, Recall@10: 0.985400, speed: 10.794491 ms/query, dims scanned: 100.00%
        nprobe  64, Recall@10: 0.986100, speed: 20.727924 ms/query, dims scanned: 100.00%
======PCA128,IVF128,FlatPanorama8_1024
        nprobe   1, Recall@10: 0.267750, speed: 0.163266 ms/query, dims scanned: 34.97%
        nprobe   2, Recall@10: 0.458370, speed: 0.261109 ms/query, dims scanned: 27.97%
        nprobe   4, Recall@10: 0.685540, speed: 0.425977 ms/query, dims scanned: 23.30%
        nprobe   8, Recall@10: 0.875990, speed: 0.704580 ms/query, dims scanned: 19.98%
        nprobe  16, Recall@10: 0.967860, speed: 1.167465 ms/query, dims scanned: 17.45%
        nprobe  32, Recall@10: 0.985470, speed: 1.925296 ms/query, dims scanned: 15.50%
        nprobe  64, Recall@10: 0.986080, speed: 3.245793 ms/query, dims scanned: 14.14%
```
