### PR TITLE
Fix: static SIMD dispatch falls to scalar for avx512_spr/avx512/arm_sve builds

### DIFF
--- a/faiss/impl/simd_dispatch.h
+++ b/faiss/impl/simd_dispatch.h
@@ -47,6 +47,37 @@ constexpr int AVAILABLE_SIMD_LEVELS_A2 = AVAILABLE_SIMD_LEVELS_NONE |
 
 constexpr int AVAILABLE_SIMD_LEVELS_ALL = -1;
 
+constexpr SIMDLevel get_simd_fallback(SIMDLevel level) {
+    switch (level) {
+        case SIMDLevel::AVX512_SPR:
+            return SIMDLevel::AVX512;
+        case SIMDLevel::AVX512:
+            return SIMDLevel::AVX2;
+        case SIMDLevel::ARM_SVE:
+            return SIMDLevel::ARM_NEON;
+        case SIMDLevel::AVX2:
+        case SIMDLevel::ARM_NEON:
+        case SIMDLevel::RISCV_RVV:
+            return SIMDLevel::NONE;
+        default:
+            return SIMDLevel::NONE;
+    }
+}
+
+template <int available_levels, SIMDLevel current_level, typename LambdaType>
+inline auto dispatch_with_fallback(LambdaType&& action) {
+    if constexpr (available_levels & (1 << int(current_level))) {
+        return action.template operator()<current_level>();
+    } else if constexpr (current_level != SIMDLevel::NONE) {
+        return dispatch_with_fallback<
+                available_levels,
+                get_simd_fallback(current_level)>(
+                std::forward<LambdaType>(action));
+    } else {
+        return action.template operator()<SIMDLevel::NONE>();
+    }
+}
+
 /** The complete dispatching function. It takes into account:
  * - the currently selected SIMD level
  * - the compiled in SIMD levels (given by COMPILE_SIMD_XXX)
@@ -114,14 +145,15 @@ inline auto with_selected_simd_levels(LambdaType&& action) {
     }
 #else // static dispatch
     // In static mode, SINGLE_SIMD_LEVEL is a constexpr resolved at compile
-    // time. If the compiled level is not in the available set, fall through
-    // to NONE (mirroring the DD fallthrough behavior). Only SINGLE_SIMD_LEVEL
-    // and NONE have compiled specializations.
-    if constexpr (available_levels & (1 << int(SINGLE_SIMD_LEVEL))) {
-        return action.template operator()<SINGLE_SIMD_LEVEL>();
-    } else {
-        return action.template operator()<SIMDLevel::NONE>();
-    }
+    // time. We mirror the DD fallthrough behavior at compile time via
+    // dispatch_with_fallback, which recursively walks get_simd_fallback:
+    //   x86:   AVX512_SPR -> AVX512 -> AVX2 -> NONE
+    //   ARM:   ARM_SVE -> ARM_NEON -> NONE
+    //   RISCV: RISCV_RVV -> NONE
+    // The first level in the chain that appears in available_levels is
+    // selected; if none match, NONE is used unconditionally.
+    return dispatch_with_fallback<available_levels, SINGLE_SIMD_LEVEL>(
+            std::forward<LambdaType>(action));
 #endif
 }
 


### PR DESCRIPTION
While running `benchs/bench_rabitq.py`, I observed that the execution path is using scalar instructions instead of AVX-512, despite FAISS being built with a static dispatch target of `avx512_spr`. Below is a summary and a fix.

**Summary**
 
Static (non-DD) builds with `avx512_spr`, and partially `avx512` and `arm_sve`, silently fall back to scalar (`SIMDLevel::NONE`) for all SIMD-dispatched functions. This is because the static dispatch path in `with_selected_simd_levels` lacks the fallthrough logic that the DD path implements via `switch`/`[[fallthrough]]`.
 
**Problem**
 
The static dispatch in `faiss/impl/simd_dispatch.h` performs a single check:
 
```cpp
if constexpr (available_levels & (1 << int(SINGLE_SIMD_LEVEL))) {
    return action.template operator()<SINGLE_SIMD_LEVEL>();
} else {
    return action.template operator()<SIMDLevel::NONE>();
}
```

This is a binary decision and none of the predefined masks (`A0`, `A1`, `A2`, `AVX2_NEON`, `MINIMAX_HEAP_SIMD_LEVELS`) include `AVX512_SPR`, so in a static `avx512_spr` build, it resolves to scalar.
 
For example, `RaBitQuantizer` dispatches via `with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A0>(...)`.
`AVAILABLE_SIMD_LEVELS_A0` is defined as:

```cpp   
constexpr int AVAILABLE_SIMD_LEVELS_A0 =
       AVAILABLE_SIMD_LEVELS_AVX2_NEON | (1 << int(SIMDLevel::AVX512));
```
       
This mask includes bits for `NONE (0)`, `AVX2 (1)`, `AVX512 (2`), and `ARM_NEON (4)` but it does NOT include `AVX512_SPR (3)`.

The DD path handles this correctly because its `switch` statement falls through from `AVX512_SPR` --> `AVX512` --> `AVX2` --> `NONE`, picking the best available implementation. The static path had no equivalent mechanism.
 
**Affected configurations**
 
| Static build | Mask | Dispatches to (current) | Should dispatch to |
|---|---|---|---|
| `avx512_spr` | A0, A1, MINIMAX | `NONE` | `AVX512` |
| `avx512_spr` | A2, AVX2_NEON | `NONE` | `AVX2` |
| `avx512` | A2, AVX2_NEON | `NONE` | `AVX2` |
| `arm_sve` | A0, AVX2_NEON | `NONE` | `ARM_NEON` |
 
DD builds are not affected.
 
**Fix**
 
Add a compile-time fallthrough chain in the static dispatch path that mirrors the DD runtime behavior:
 
- `AVX512_SPR` --> try `AVX512` --> try `AVX2` --> `NONE`
- `AVX512` --> try `AVX2` --> `NONE`
- `ARM_SVE` --> try `ARM_NEON` --> `NONE`
 
This would fix broken (level x mask) combinations across distances, RaBitQ, scalar/product quantizer, HNSW, IndexFlat, IVF, and fused distances.
