### PR TITLE
Expose fast_scan_code_size from non-IVF FastScan indices

### DIFF
--- a/faiss/IndexAdditiveQuantizerFastScan.cpp
+++ b/faiss/IndexAdditiveQuantizerFastScan.cpp
@@ -217,6 +217,10 @@ void IndexAdditiveQuantizerFastScan::sa_decode(
     aq->decode(bytes, x, n);
 }
 
+size_t IndexAdditiveQuantizerFastScan::fast_scan_code_size() const {
+    return M2 / 2;
+}
+
 /**************************************************************************************
  * IndexResidualQuantizerFastScan
  **************************************************************************************/

--- a/faiss/IndexAdditiveQuantizerFastScan.h
+++ b/faiss/IndexAdditiveQuantizerFastScan.h
@@ -86,6 +86,9 @@ struct IndexAdditiveQuantizerFastScan : IndexFastScan {
      * @param x       output vectors, size n * d
      */
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
+
+    /// Packed code size: M2 / 2 bytes (4-bit AQ sub-quantizer nibbles)
+    size_t fast_scan_code_size() const override;
 };
 
 /** Index based on a residual quantizer. Stored vectors are

--- a/faiss/IndexFastScan.h
+++ b/faiss/IndexFastScan.h
@@ -236,6 +236,18 @@ struct IndexFastScan : Index {
     void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override {
         compute_codes(bytes, n, x);
     }
+
+    /** Get the size of the code portion packed by pq4_pack_codes.
+     *
+     * Returns the number of bytes per vector that are interleaved into
+     * SIMD blocks by pq4_pack_codes, excluding any embedded metadata
+     * (e.g., RaBitQ factors). The meaning of these bytes depends on the
+     * quantizer: for PQ/AQ they are 4-bit sub-quantizer nibbles, for
+     * RaBitQ they are 1-bit-per-dimension sign bits packed into nibbles.
+     *
+     * Must be implemented by all derived classes.
+     */
+    virtual size_t fast_scan_code_size() const = 0;
 };
 
 struct FastScanStats {

--- a/faiss/IndexPQFastScan.cpp
+++ b/faiss/IndexPQFastScan.cpp
@@ -72,4 +72,8 @@ void IndexPQFastScan::sa_decode(idx_t n, const uint8_t* bytes, float* x) const {
     pq.decode(bytes, x, n);
 }
 
+size_t IndexPQFastScan::fast_scan_code_size() const {
+    return M2 / 2;
+}
+
 } // namespace faiss

--- a/faiss/IndexPQFastScan.h
+++ b/faiss/IndexPQFastScan.h
@@ -52,6 +52,9 @@ struct IndexPQFastScan : IndexFastScan {
             const FastScanDistancePostProcessing& context) const override;
 
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
+
+    /// Packed code size: M2 / 2 bytes (4-bit PQ sub-quantizer nibbles)
+    size_t fast_scan_code_size() const override;
 };
 
 } // namespace faiss

--- a/faiss/IndexRaBitQFastScan.cpp
+++ b/faiss/IndexRaBitQFastScan.cpp
@@ -467,6 +467,10 @@ void IndexRaBitQFastScan::compute_float_LUT(
     }
 }
 
+size_t IndexRaBitQFastScan::fast_scan_code_size() const {
+    return (d + 7) / 8;
+}
+
 void IndexRaBitQFastScan::sa_decode(idx_t n, const uint8_t* bytes, float* x)
         const {
     const float* centroid_in =

--- a/faiss/IndexRaBitQFastScan.h
+++ b/faiss/IndexRaBitQFastScan.h
@@ -78,6 +78,10 @@ struct IndexRaBitQFastScan : IndexFastScan {
 
     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
 
+    /// Packed code size: (d + 7) / 8 bytes (1-bit-per-dimension sign bits,
+    /// excluding factors)
+    size_t fast_scan_code_size() const override;
+
     /// Return CodePackerRaBitQ with enlarged block size
     CodePacker* get_CodePacker() const override;
 


### PR DESCRIPTION
Summary:
Mirror of D100047797 for the non-IVF IndexFastScan hierarchy.
Adds a pure virtual fast_scan_code_size() to IndexFastScan with
concrete implementations in IndexPQFastScan (M2/2),
IndexAdditiveQuantizerFastScan (M2/2), and IndexRaBitQFastScan ((d+7)/8).

Differential Revision: D100342866


