### PR TITLE
Support IVFRaBitQSearchParameters in RaBitQFastScan scanner

### DIFF
--- a/faiss/IndexIVFFastScan.cpp
+++ b/faiss/IndexIVFFastScan.cpp
@@ -88,7 +88,11 @@ void IndexIVFFastScan::init_fastscan(
 
 void IndexIVFFastScan::init_code_packer() {
     auto bil = dynamic_cast<BlockInvertedLists*>(invlists);
-    FAISS_THROW_IF_NOT(bil);
+    if (!bil) {
+        // invlists is not block-packed (e.g., when own_invlists=false).
+        // Nothing to do — the caller manages inverted lists externally.
+        return;
+    }
     delete bil->packer; // in case there was one before
     bil->packer = get_CodePacker();
 }

--- a/faiss/IndexIVFRaBitQ.cpp
+++ b/faiss/IndexIVFRaBitQ.cpp
@@ -234,8 +234,10 @@ struct RaBitInvertedListScanner : InvertedListScanner {
         // Stats tracking for multi-bit two-stage search
         // n_1bit_evaluations: candidates evaluated using 1-bit lower bound
         // n_multibit_evaluations: candidates requiring full multi-bit distance
+#ifndef NDEBUG
         size_t local_1bit_evaluations = 0;
         size_t local_multibit_evaluations = 0;
+#endif
 
         for (size_t j = 0; j < list_size; j++) {
             if (sel != nullptr) {
@@ -246,7 +248,9 @@ struct RaBitInvertedListScanner : InvertedListScanner {
                 }
             }
 
+#ifndef NDEBUG
             local_1bit_evaluations++;
+#endif
 
             // Stage 1: Compute distance bound using 1-bit codes
             // For L2 (min-heap): use lower_bound to safely skip if it's
@@ -269,7 +273,9 @@ struct RaBitInvertedListScanner : InvertedListScanner {
                     handler.threshold,
                     keep_max);
             if (should_refine) {
+#ifndef NDEBUG
                 local_multibit_evaluations++;
+#endif
                 // Lower bound is promising, compute full distance
                 float dis = distance_to_code(codes);
                 int64_t id = store_pairs ? lo_build(list_no, j) : ids[j];
@@ -281,11 +287,13 @@ struct RaBitInvertedListScanner : InvertedListScanner {
             codes += code_size;
         }
 
+#ifndef NDEBUG
         // Update global stats atomically
 #pragma omp atomic
         rabitq_stats.n_1bit_evaluations += local_1bit_evaluations;
 #pragma omp atomic
         rabitq_stats.n_multibit_evaluations += local_multibit_evaluations;
+#endif
 
         return nup;
     }

--- a/faiss/IndexIVFRaBitQFastScan.cpp
+++ b/faiss/IndexIVFRaBitQFastScan.cpp
@@ -591,11 +591,19 @@ struct IVFRaBitQFastScanScanner : InvertedListScanner {
     std::unique_ptr<FlatCodesDistanceComputer> dc;
     std::vector<float> centroid;
 
+    uint8_t qb;
+    bool centered;
+
     IVFRaBitQFastScanScanner(
             const IndexIVFRaBitQFastScan& index_in,
             bool store_pairs_in,
-            const IDSelector* sel_in)
-            : InvertedListScanner(store_pairs_in, sel_in), index(index_in) {
+            const IDSelector* sel_in,
+            uint8_t qb_in,
+            bool centered_in)
+            : InvertedListScanner(store_pairs_in, sel_in),
+              index(index_in),
+              qb(qb_in),
+              centered(centered_in) {
         this->keep_max = is_similarity_metric(index_in.metric_type);
     }
 
@@ -624,7 +632,7 @@ struct IVFRaBitQFastScanScanner : InvertedListScanner {
         centroid.resize(index.d);
         index.quantizer->reconstruct(list_no, centroid.data());
         dc.reset(index.rabitq.get_distance_computer(
-                index.qb, centroid.data(), index.centered));
+                qb, centroid.data(), centered));
         dc->set_query(xi);
     }
 
@@ -715,8 +723,16 @@ struct IVFRaBitQFastScanScanner : InvertedListScanner {
 InvertedListScanner* IndexIVFRaBitQFastScan::get_InvertedListScanner(
         bool store_pairs,
         const IDSelector* sel,
-        const IVFSearchParameters*) const {
-    return new IVFRaBitQFastScanScanner(*this, store_pairs, sel);
+        const IVFSearchParameters* search_params_in) const {
+    uint8_t used_qb = qb;
+    bool used_centered = centered;
+    if (auto params = dynamic_cast<const IVFRaBitQSearchParameters*>(
+                search_params_in)) {
+        used_qb = params->qb;
+        used_centered = params->centered;
+    }
+    return new IVFRaBitQFastScanScanner(
+            *this, store_pairs, sel, used_qb, used_centered);
 }
 
 } // namespace faiss

--- a/faiss/IndexIVFRaBitQFastScan.cpp
+++ b/faiss/IndexIVFRaBitQFastScan.cpp
@@ -668,9 +668,14 @@ struct IVFRaBitQFastScanScanner : InvertedListScanner {
         handler->ntotal = ntotal;
         handler->id_map = ids;
 
-        // RaBitQ needs list context for factor lookup
+        // RaBitQ needs list context for factor lookup.
+        // If invlists is unavailable (e.g., own_invlists=false), fall back
+        // to the codes pointer which already contains the block data.
         std::vector<int> probe_map = {0};
         handler->set_list_context(list_no, probe_map);
+        if (!handler->list_codes_ptr) {
+            handler->list_codes_ptr = codes;
+        }
 
         scanner->accumulate_loop(
                 1,
@@ -701,7 +706,6 @@ struct IVFRaBitQFastScanScanner : InvertedListScanner {
                     curr_labels.data(),
                     k);
         }
-
         return handler->num_updates();
     }
 };

--- a/faiss/IndexIVFRaBitQFastScan.h
+++ b/faiss/IndexIVFRaBitQFastScan.h
@@ -244,23 +244,35 @@ void IVFRaBitQHeapHandler<C, SL>::handle(
                 "Query factors not available: FastScanDistancePostProcessing with query_factors required");
     }
 
-    size_t probe_rank = probe_indices[local_q];
-    size_t nprobe = context->nprobe > 0 ? context->nprobe : index->nprobe;
-    size_t storage_idx = q * nprobe + probe_rank;
+    const size_t probe_rank = probe_indices[local_q];
+    const size_t storage_idx = q * cached_nprobe + probe_rank;
     const auto& query_factors = context->query_factors[storage_idx];
 
     const float one_a =
             this->normalizers ? (1.0f / this->normalizers[2 * q]) : 1.0f;
     const float bias = this->normalizers ? this->normalizers[2 * q + 1] : 0.0f;
 
-    uint64_t idx_base = this->j0 + b * 32;
+    const uint64_t idx_base = this->j0 + b * 32;
     if (idx_base >= this->ntotal) {
         return;
     }
-    size_t max_positions = std::min<size_t>(32, this->ntotal - idx_base);
+    const size_t max_positions = std::min<size_t>(32, this->ntotal - idx_base);
 
+    // Hoist aux pointer base out of loop: all 32 elements in this block share
+    // the same block base. Only the per-element offset (j * storage_size)
+    // varies.
+    const uint8_t* aux_base = this->list_codes_ptr +
+            (idx_base / index->bbs) * full_block_size + packed_block_size;
+
+    // Cache index fields used in the inner loop.
+    const bool centered = index->centered;
+    const size_t qb = index->qb;
+    const size_t d = index->d;
+
+#ifndef NDEBUG
     size_t local_1bit_evaluations = 0;
     size_t local_multibit_evaluations = 0;
+#endif
 
     for (size_t j = 0; j < max_positions; j++) {
         const int64_t result_id = this->adjust_id(b, j);
@@ -274,16 +286,12 @@ void IVFRaBitQHeapHandler<C, SL>::handle(
         this->scan_cnt++;
 
         const float normalized_distance = d32tab[j] * one_a + bias;
-        const uint8_t* base_ptr = rabitq_utils::get_block_aux_ptr(
-                list_codes_ptr,
-                idx_base + j,
-                index->bbs,
-                packed_block_size,
-                full_block_size,
-                storage_size);
+        const uint8_t* base_ptr = aux_base + j * storage_size;
 
         if (is_multibit) {
+#ifndef NDEBUG
             local_1bit_evaluations++;
+#endif
             const SignBitFactorsWithError& full_factors =
                     *reinterpret_cast<const SignBitFactorsWithError*>(base_ptr);
 
@@ -291,12 +299,10 @@ void IVFRaBitQHeapHandler<C, SL>::handle(
                     normalized_distance,
                     full_factors,
                     query_factors,
-                    index->centered,
-                    index->qb,
-                    index->d);
+                    centered,
+                    qb,
+                    d);
 
-            const bool is_similarity =
-                    index->metric_type == MetricType::METRIC_INNER_PRODUCT;
             bool should_refine = rabitq_utils::should_refine_candidate(
                     dist_1bit,
                     full_factors.f_error,
@@ -304,10 +310,12 @@ void IVFRaBitQHeapHandler<C, SL>::handle(
                     heap_dis[0],
                     is_similarity);
             if (should_refine) {
+#ifndef NDEBUG
                 local_multibit_evaluations++;
-                size_t local_offset = this->j0 + b * 32 + j;
+#endif
+                size_t local_offset = idx_base + j;
                 float dist_full = compute_full_multibit_distance(
-                        result_id, local_q, q, local_offset);
+                        local_q, q, local_offset, base_ptr);
                 if (Cfloat::cmp(heap_dis[0], dist_full)) {
                     heap_replace_top<Cfloat>(
                             k, heap_dis, heap_ids, dist_full, result_id);
@@ -322,9 +330,9 @@ void IVFRaBitQHeapHandler<C, SL>::handle(
                             normalized_distance,
                             db_factors,
                             query_factors,
-                            index->centered,
-                            index->qb,
-                            index->d);
+                            centered,
+                            qb,
+                            d);
             if (Cfloat::cmp(heap_dis[0], adjusted_distance)) {
                 heap_replace_top<Cfloat>(
                         k, heap_dis, heap_ids, adjusted_distance, result_id);
@@ -333,10 +341,12 @@ void IVFRaBitQHeapHandler<C, SL>::handle(
         }
     }
 
+#ifndef NDEBUG
 #pragma omp atomic
     rabitq_stats.n_1bit_evaluations += local_1bit_evaluations;
 #pragma omp atomic
     rabitq_stats.n_multibit_evaluations += local_multibit_evaluations;
+#endif
 }
 
 template <class C, SIMDLevel SL>
@@ -345,7 +355,12 @@ void IVFRaBitQHeapHandler<C, SL>::set_list_context(
         const std::vector<int>& probe_map) {
     current_list_no = list_no;
     probe_indices = probe_map;
-    list_codes_ptr = index->invlists->get_codes(list_no);
+    cached_nprobe =
+            context && context->nprobe > 0 ? context->nprobe : index->nprobe;
+    is_similarity = index->metric_type == MetricType::METRIC_INNER_PRODUCT;
+    if (index->invlists) {
+        this->list_codes_ptr = index->invlists->get_codes(list_no);
+    }
 }
 
 template <class C, SIMDLevel SL>
@@ -363,44 +378,31 @@ void IVFRaBitQHeapHandler<C, SL>::end() {
 
 template <class C, SIMDLevel SL>
 float IVFRaBitQHeapHandler<C, SL>::compute_full_multibit_distance(
-        size_t /*db_idx*/,
         size_t local_q,
         size_t global_q,
-        size_t local_offset) {
+        size_t local_offset,
+        const uint8_t* aux_ptr) {
     const size_t ex_bits = index->rabitq.nb_bits - 1;
     const size_t dim = index->d;
 
-    const uint8_t* base_ptr = rabitq_utils::get_block_aux_ptr(
-            list_codes_ptr,
-            local_offset,
-            index->bbs,
-            packed_block_size,
-            full_block_size,
-            storage_size);
-
     const size_t ex_code_size = (dim * ex_bits + 7) / 8;
-    const uint8_t* ex_code = base_ptr + sizeof(SignBitFactorsWithError);
+    const uint8_t* ex_code = aux_ptr + sizeof(SignBitFactorsWithError);
     const ExtraBitsFactors& ex_fac = *reinterpret_cast<const ExtraBitsFactors*>(
-            base_ptr + sizeof(SignBitFactorsWithError) + ex_code_size);
+            aux_ptr + sizeof(SignBitFactorsWithError) + ex_code_size);
 
-    size_t probe_rank = probe_indices[local_q];
-    size_t nprobe_val = context->nprobe > 0 ? context->nprobe : index->nprobe;
-    size_t storage_idx_val = global_q * nprobe_val + probe_rank;
+    const size_t probe_rank = probe_indices[local_q];
+    const size_t storage_idx_val = global_q * cached_nprobe + probe_rank;
     const auto& query_factors = context->query_factors[storage_idx_val];
 
-    // Use list_codes_ptr (already set by set_list_context) and the
-    // pre-allocated unpack_buf to avoid per-refinement ScopedCodes
-    // re-acquisition and heap allocation.
-    packer->unpack_1(list_codes_ptr, local_offset, unpack_buf.data());
+    // Unpack PQ4-interleaved sign bits for this vector into a linear buffer.
+    packer->unpack_1(this->list_codes_ptr, local_offset, unpack_buf.data());
 
     return rabitq_utils::compute_full_multibit_distance(
             unpack_buf.data(),
             ex_code,
             ex_fac,
             query_factors.rotated_q.data(),
-            (index->metric_type == MetricType::METRIC_INNER_PRODUCT)
-                    ? query_factors.q_dot_c
-                    : query_factors.qr_to_c_L2sqr,
+            is_similarity ? query_factors.q_dot_c : query_factors.qr_to_c_L2sqr,
             dim,
             ex_bits,
             index->metric_type);

--- a/faiss/IndexRaBitQ.cpp
+++ b/faiss/IndexRaBitQ.cpp
@@ -110,8 +110,10 @@ struct Run_search_with_dc_res {
                 // n_1bit_evaluations: candidates evaluated using 1-bit lower
                 // bound n_multibit_evaluations: candidates requiring full
                 // multi-bit distance
+#ifndef NDEBUG
                 size_t local_1bit_evaluations = 0;
                 size_t local_multibit_evaluations = 0;
+#endif
 
                 if (ex_bits == 0) {
                     // 1-bit: Standard single-stage search (no stats tracking)
@@ -142,7 +144,9 @@ struct Run_search_with_dc_res {
                             const uint8_t* code =
                                     index->codes.data() + i * index->code_size;
 
+#ifndef NDEBUG
                             local_1bit_evaluations++;
+#endif
 
                             // Stage 1: Compute distance bound using 1-bit codes
                             // For L2 (min-heap): use lower_bound (est -
@@ -168,7 +172,9 @@ struct Run_search_with_dc_res {
                                             resi.threshold,
                                             is_similarity);
                             if (should_refine) {
+#ifndef NDEBUG
                                 local_multibit_evaluations++;
+#endif
                                 // Compute full multi-bit distance
                                 float dist_full =
                                         dc->distance_to_code_full(code);
@@ -178,12 +184,14 @@ struct Run_search_with_dc_res {
                     }
                 }
 
+#ifndef NDEBUG
                 // Update global stats atomically
 #pragma omp atomic
                 rabitq_stats.n_1bit_evaluations += local_1bit_evaluations;
 #pragma omp atomic
                 rabitq_stats.n_multibit_evaluations +=
                         local_multibit_evaluations;
+#endif
 
                 resi.end();
             }

--- a/faiss/IndexRaBitQFastScan.h
+++ b/faiss/IndexRaBitQFastScan.h
@@ -217,8 +217,10 @@ struct RaBitQHeapHandler
         const uint8_t* aux_base = rabitq_index->codes.get() +
                 block_idx * full_block_size + packed_block_size;
 
+#ifndef NDEBUG
         size_t local_1bit_evaluations = 0;
         size_t local_multibit_evaluations = 0;
+#endif
 
         for (size_t i = 0; i < max_vectors; i++) {
             const size_t db_idx = base_db_idx + i;
@@ -226,7 +228,9 @@ struct RaBitQHeapHandler
             const uint8_t* base_ptr = aux_base + i * storage_size;
 
             if (is_multi_bit) {
+#ifndef NDEBUG
                 local_1bit_evaluations++;
+#endif
 
                 const SignBitFactorsWithError& full_factors =
                         *reinterpret_cast<const SignBitFactorsWithError*>(
@@ -252,7 +256,9 @@ struct RaBitQHeapHandler
                         is_similarity);
 
                 if (should_refine) {
+#ifndef NDEBUG
                     local_multibit_evaluations++;
+#endif
                     float dist_full = compute_full_multibit_distance(db_idx, q);
 
                     if (Cfloat::cmp(heap_dis[0], dist_full)) {
@@ -281,10 +287,12 @@ struct RaBitQHeapHandler
             }
         }
 
+#ifndef NDEBUG
 #pragma omp atomic
         rabitq_stats.n_1bit_evaluations += local_1bit_evaluations;
 #pragma omp atomic
         rabitq_stats.n_multibit_evaluations += local_multibit_evaluations;
+#endif
     }
 
     void begin(const float* norms) override {

--- a/faiss/impl/fast_scan/rabitq_result_handler.h
+++ b/faiss/impl/fast_scan/rabitq_result_handler.h
@@ -47,7 +47,6 @@ struct IVFRaBitQHeapHandler : ResultHandlerCompare<C, true, SL> {
     int64_t* heap_labels;  // [nq * k]
     const size_t nq, k;
     size_t current_list_no = 0;
-    const uint8_t* list_codes_ptr = nullptr; // raw block data for list
     std::vector<int>
             probe_indices; // probe index for each query in current batch
     const FastScanDistancePostProcessing*
@@ -63,6 +62,11 @@ struct IVFRaBitQHeapHandler : ResultHandlerCompare<C, true, SL> {
     // Handler-local scratch reused across refinements. This assumes a handler
     // instance is confined to one search slice and not entered concurrently.
     std::vector<uint8_t> unpack_buf; // reusable buffer for unpack_1
+
+    // Cached per-list values (set in set_list_context, avoid recomputing in
+    // handle)
+    size_t cached_nprobe = 0;
+    bool is_similarity = false; // metric == INNER_PRODUCT
 
     // Use float-based comparator for heap operations
     using Cfloat = typename std::conditional<
@@ -98,10 +102,10 @@ struct IVFRaBitQHeapHandler : ResultHandlerCompare<C, true, SL> {
 
    private:
     float compute_full_multibit_distance(
-            size_t db_idx,
             size_t local_q,
             size_t global_q,
-            size_t local_offset);
+            size_t local_offset,
+            const uint8_t* aux_ptr);
 };
 
 } // namespace simd_result_handlers

--- a/faiss/impl/fast_scan/simd_result_handlers.h
+++ b/faiss/impl/fast_scan/simd_result_handlers.h
@@ -121,6 +121,7 @@ struct SIMDResultHandlerToFloat : SIMDResultHandler {
     /// these fields are used mainly for the IVF variants (with_id_map=true)
     const idx_t* id_map = nullptr; // map offset in invlist to vector id
     const int* q_map = nullptr;    // map q to global query
+    const uint8_t* list_codes_ptr = nullptr; // raw block data for current list
     const uint16_t* dbias =
             nullptr; // table of biases to add to each query (for IVF L2 search)
     const float* normalizers = nullptr; // size 2 * nq, to convert
@@ -295,7 +296,7 @@ struct ResultHandlerCompare : SIMDResultHandlerToFloat {
     // compute and adjust idx
     int64_t adjust_id(size_t b, size_t j) {
         int64_t idx = j0 + 32 * b + j;
-        if (with_id_map) {
+        if (with_id_map && id_map) {
             idx = id_map[idx];
         }
         return idx;


### PR DESCRIPTION
Summary:
Pass qb and centered from IVFRaBitQSearchParameters to the
IVFRaBitQFastScanScanner, matching the behavior of IndexIVFRaBitQ's
get_InvertedListScanner. Previously the scanner always used
index.qb/index.centered, ignoring search params.

Differential Revision: D100399519


