### PR TITLE
Add byte-packed IVF RaBitQ fast-scan layout for 4+ bit indexes

### DIFF
--- a/faiss/IndexIVFRaBitQFastScan.cpp
+++ b/faiss/IndexIVFRaBitQFastScan.cpp
@@ -47,7 +47,8 @@ IndexIVFRaBitQFastScan::IndexIVFRaBitQFastScan(
         MetricType metric,
         int bbs_in,
         bool own_invlists_in,
-        uint8_t nb_bits)
+        uint8_t nb_bits,
+        bool byte_packed_excodes_in)
         : IndexIVFFastScan(
                   quantizer_in,
                   d_in,
@@ -55,7 +56,11 @@ IndexIVFRaBitQFastScan::IndexIVFRaBitQFastScan(
                   0,
                   metric,
                   own_invlists_in),
-          rabitq(d_in, metric, nb_bits) {
+          rabitq(d_in, metric, nb_bits),
+          byte_packed_excodes(byte_packed_excodes_in) {
+    if (byte_packed_excodes && nb_bits < 4) {
+        FAISS_THROW_MSG("byte_packed_excodes requires nb_bits >= 4");
+    }
     FAISS_THROW_IF_NOT_MSG(d_in > 0, "Dimension must be positive");
     FAISS_THROW_IF_NOT_MSG(
             metric == METRIC_L2 || metric == METRIC_INNER_PRODUCT,
@@ -104,6 +109,10 @@ IndexIVFRaBitQFastScan::IndexIVFRaBitQFastScan(
           rabitq(orig.rabitq) {}
 
 size_t IndexIVFRaBitQFastScan::compute_per_vector_storage_size() const {
+    if (byte_packed_excodes) {
+        return rabitq_utils::compute_per_vector_storage_size_bytepacked(
+                rabitq.nb_bits, d);
+    }
     return rabitq_utils::compute_per_vector_storage_size(rabitq.nb_bits, d);
 }
 
@@ -239,7 +248,9 @@ void IndexIVFRaBitQFastScan::encode_vectors(
                     }
 
                     // Quantize ex-bits
-                    const size_t ex_code_size = (d * ex_bits + 7) / 8;
+                    const size_t ex_code_bytes = byte_packed_excodes
+                            ? static_cast<size_t>(d)
+                            : (d * ex_bits + 7) / 8;
                     uint8_t* ex_code = fastscan_code + bit_pattern_size +
                             sizeof(SignBitFactorsWithError);
                     ExtraBitsFactors ex_factors_temp;
@@ -253,7 +264,19 @@ void IndexIVFRaBitQFastScan::encode_vectors(
                             rabitq.metric_type,
                             centroid.data());
 
-                    memcpy(ex_code + ex_code_size,
+                    if (byte_packed_excodes) {
+                        // quantize_ex_bits wrote bit-packed; repack to
+                        // byte-packed in-place via a temp buffer.
+                        std::vector<int> tmp(d);
+                        for (size_t j = 0; j < static_cast<size_t>(d); j++) {
+                            tmp[j] = rabitq_utils::extract_code_inline(
+                                    ex_code, j, ex_bits);
+                        }
+                        rabitq_multibit::pack_multibit_codes_bytepacked(
+                                tmp.data(), ex_code, d, rabitq.nb_bits);
+                    }
+
+                    memcpy(ex_code + ex_code_bytes,
                            &ex_factors_temp,
                            sizeof(ExtraBitsFactors));
                 }
@@ -632,6 +655,10 @@ struct IVFRaBitQFastScanScanner : InvertedListScanner {
         FAISS_THROW_IF_NOT_MSG(
                 dc,
                 "set_query and set_list must be called before distance_to_code");
+        FAISS_THROW_IF_NOT_MSG(
+                !index.byte_packed_excodes,
+                "distance_to_code not supported for byte-packed ex_code layout. "
+                "Use the FastScan batch search path instead.");
         return dc->distance_to_code(code);
     }
 

--- a/faiss/IndexIVFRaBitQFastScan.h
+++ b/faiss/IndexIVFRaBitQFastScan.h
@@ -56,6 +56,12 @@ struct IndexIVFRaBitQFastScan : IndexIVFFastScan {
     /// Use zero-centered scalar quantizer for queries
     bool centered = false;
 
+    /// When true, multibit ex_codes use byte-packed layout (1 byte/dim)
+    /// instead of bit-packed (ex_bits bits/dim). Enables FMA kernel for
+    /// faster search at the cost of higher storage. Only valid for nb_bits
+    /// >= 4.
+    bool byte_packed_excodes = false;
+
     // Constructors
 
     IndexIVFRaBitQFastScan();
@@ -67,7 +73,8 @@ struct IndexIVFRaBitQFastScan : IndexIVFFastScan {
             MetricType metric = METRIC_L2,
             int bbs = 32,
             bool own_invlists = true,
-            uint8_t nb_bits = 1);
+            uint8_t nb_bits = 1,
+            bool byte_packed_excodes = false);
 
     /// Build from an existing IndexIVFRaBitQ
     explicit IndexIVFRaBitQFastScan(const IndexIVFRaBitQ& orig, int bbs = 32);
@@ -378,29 +385,42 @@ float IVFRaBitQHeapHandler<C, SL>::compute_full_multibit_distance(
             full_block_size,
             storage_size);
 
-    const size_t ex_code_size = (dim * ex_bits + 7) / 8;
+    const size_t ex_code_bytes =
+            index->byte_packed_excodes ? dim : (dim * ex_bits + 7) / 8;
     const uint8_t* ex_code = base_ptr + sizeof(SignBitFactorsWithError);
     const ExtraBitsFactors& ex_fac = *reinterpret_cast<const ExtraBitsFactors*>(
-            base_ptr + sizeof(SignBitFactorsWithError) + ex_code_size);
+            base_ptr + sizeof(SignBitFactorsWithError) + ex_code_bytes);
 
     size_t probe_rank = probe_indices[local_q];
     size_t nprobe_val = context->nprobe > 0 ? context->nprobe : index->nprobe;
     size_t storage_idx_val = global_q * nprobe_val + probe_rank;
     const auto& query_factors = context->query_factors[storage_idx_val];
 
-    // Use list_codes_ptr (already set by set_list_context) and the
-    // pre-allocated unpack_buf to avoid per-refinement ScopedCodes
-    // re-acquisition and heap allocation.
     packer->unpack_1(list_codes_ptr, local_offset, unpack_buf.data());
 
-    return rabitq_utils::compute_full_multibit_distance(
+    const float qr_base =
+            (index->metric_type == MetricType::METRIC_INNER_PRODUCT)
+            ? query_factors.q_dot_c
+            : query_factors.qr_to_c_L2sqr;
+
+    if (index->byte_packed_excodes) {
+        return rabitq_utils::compute_full_multibit_distance_bytepacked<SL>(
+                unpack_buf.data(),
+                ex_code,
+                ex_fac,
+                query_factors.rotated_q.data(),
+                qr_base,
+                dim,
+                ex_bits,
+                index->metric_type);
+    }
+
+    return rabitq_utils::compute_full_multibit_distance<SL>(
             unpack_buf.data(),
             ex_code,
             ex_fac,
             query_factors.rotated_q.data(),
-            (index->metric_type == MetricType::METRIC_INNER_PRODUCT)
-                    ? query_factors.q_dot_c
-                    : query_factors.qr_to_c_L2sqr,
+            qr_base,
             dim,
             ex_bits,
             index->metric_type);

--- a/faiss/impl/RaBitQUtils.cpp
+++ b/faiss/impl/RaBitQUtils.cpp
@@ -307,6 +307,11 @@ size_t compute_per_vector_storage_size(size_t nb_bits, size_t d) {
     }
 }
 
+size_t compute_per_vector_storage_size_bytepacked(size_t nb_bits, size_t d) {
+    FAISS_THROW_IF_NOT(nb_bits >= 4);
+    return sizeof(SignBitFactorsWithError) + sizeof(ExtraBitsFactors) + d;
+}
+
 // Non-template wrapper with dynamic dispatch (one dispatch per call).
 // The hot path in RaBitQuantizer dispatches once at distance computer
 // construction, so per-vector dispatch only affects this utility path.

--- a/faiss/impl/RaBitQUtils.h
+++ b/faiss/impl/RaBitQUtils.h
@@ -388,6 +388,36 @@ inline T* get_block_aux_ptr(
  */
 size_t compute_per_vector_storage_size(size_t nb_bits, size_t d);
 
+/** Per-vector storage size for byte-packed ex_code layout.
+ * ex_code uses d bytes (one byte per dimension) instead of (d*ex_bits+7)/8.
+ */
+size_t compute_per_vector_storage_size_bytepacked(size_t nb_bits, size_t d);
+
+/** Full multibit distance using byte-packed ex_code layout. */
+template <SIMDLevel SL>
+inline float compute_full_multibit_distance_bytepacked(
+        const uint8_t* sign_bits,
+        const uint8_t* ex_code,
+        const ExtraBitsFactors& ex_fac,
+        const float* rotated_q,
+        float qr_base,
+        size_t d,
+        size_t ex_bits,
+        MetricType metric_type) {
+    const float cb = -(static_cast<float>(1 << ex_bits) - 0.5f);
+
+    float ex_ip = rabitq::multibit::compute_inner_product_bytepacked<SL>(
+            sign_bits, ex_code, rotated_q, d, ex_bits, cb);
+
+    float dist = qr_base + ex_fac.f_add_ex + ex_fac.f_rescale_ex * ex_ip;
+
+    if (metric_type == MetricType::METRIC_L2) {
+        dist = std::max(0.0f, dist);
+    }
+
+    return dist;
+}
+
 /** [LEGACY FORMAT SUPPORT] Migrate block data from old I/O format to new
  * format.
  *

--- a/faiss/impl/RaBitQuantizerMultiBit.cpp
+++ b/faiss/impl/RaBitQuantizerMultiBit.cpp
@@ -145,6 +145,18 @@ float compute_optimal_scaling_factor(
  * @param d Dimensionality
  * @param nb_bits Number of bits per dimension (2-9)
  */
+void pack_multibit_codes_bytepacked(
+        const int* tmp_code,
+        uint8_t* ex_code,
+        size_t d,
+        size_t /* nb_bits */) {
+    // Byte-packed layout: one byte per dimension, value in [0, 2^ex_bits-1].
+    // Enables cvtepu8→float FMA kernel instead of PEXT bit-plane extraction.
+    for (size_t i = 0; i < d; i++) {
+        ex_code[i] = static_cast<uint8_t>(tmp_code[i]);
+    }
+}
+
 void pack_multibit_codes(
         const int* tmp_code,
         uint8_t* ex_code,

--- a/faiss/impl/RaBitQuantizerMultiBit.h
+++ b/faiss/impl/RaBitQuantizerMultiBit.h
@@ -55,6 +55,13 @@ void pack_multibit_codes(
         size_t d,
         size_t nb_bits);
 
+/** Byte-packed variant: one byte per dimension. */
+void pack_multibit_codes_bytepacked(
+        const int* tmp_code,
+        uint8_t* ex_code,
+        size_t d,
+        size_t nb_bits);
+
 /**
  * Compute ex-bits factors for distance computation.
  *

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -2301,9 +2301,11 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         idx = std::move(svs);
     }
 #endif // FAISS_ENABLE_SVS
-    else if (h == fourcc("Iwrn") || h == fourcc("Iwrf")) {
-        // Iwrn = new format (aux data embedded in SIMD blocks)
+    else if (
+            h == fourcc("Iwrn") || h == fourcc("Iwrf") || h == fourcc("Iwrp")) {
+        // Iwrn = bit-packed ex_codes (aux data embedded in SIMD blocks)
         // Iwrf = legacy format (flat_storage separate, needs migration)
+        // Iwrp = byte-packed ex_codes (FMA-friendly layout)
         const bool is_legacy = (h == fourcc("Iwrf"));
 
         auto ivrqfs = std::make_unique<IndexIVFRaBitQFastScan>();
@@ -2321,6 +2323,9 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
                 "invalid RaBitQ qb=%d (must be in [1, 8])",
                 ivrqfs->qb);
         READ1(ivrqfs->centered);
+
+        // Set layout flag from fourcc — no extra field in stream.
+        ivrqfs->byte_packed_excodes = (h == fourcc("Iwrp"));
 
         std::vector<uint8_t> legacy_flat_storage;
         if (is_legacy) {

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -1070,7 +1070,9 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
     else if (
             const IndexIVFRaBitQFastScan* ivrqfs =
                     dynamic_cast<const IndexIVFRaBitQFastScan*>(idx)) {
-        uint32_t h = fourcc("Iwrn");
+        // Iwrp = byte-packed ex_codes, Iwrn = bit-packed (original)
+        uint32_t h =
+                ivrqfs->byte_packed_excodes ? fourcc("Iwrp") : fourcc("Iwrn");
         WRITE1(h);
         write_ivf_header(ivrqfs, f);
         write_RaBitQuantizer(&ivrqfs->rabitq, f);

--- a/faiss/utils/rabitq_simd.h
+++ b/faiss/utils/rabitq_simd.h
@@ -202,4 +202,54 @@ inline float compute_inner_product<SIMDLevel::NONE>(
     return ip_scalar(sign_bits, ex_code, rotated_q, 0, d, ex_bits, cb);
 }
 
+/*********************************************************
+ * Byte-packed ex_code kernels.
+ *
+ * Same semantics as above, but ex_code uses byte-packed layout:
+ * one byte per dimension (value in [0, 2^ex_bits - 1]).
+ * Enables cvtepu8→float FMA instead of PEXT bit-plane extraction.
+ * Only used for ex_bits >= 3 where the FMA path is faster.
+ *********************************************************/
+
+/// Scalar byte-packed inner product. Also serves as tail handler.
+inline float ip_scalar_bytepacked(
+        const uint8_t* __restrict sign_bits,
+        const uint8_t* __restrict ex_code,
+        const float* __restrict rotated_q,
+        size_t start,
+        size_t d,
+        size_t ex_bits,
+        float cb) {
+    float result = 0.0f;
+    const int sign_shift = static_cast<int>(ex_bits);
+    for (size_t i = start; i < d; i++) {
+        int sb = (sign_bits[i / 8] >> (i % 8)) & 1;
+        int ex_val = static_cast<int>(ex_code[i]);
+        result += rotated_q[i] *
+                (static_cast<float>((sb << sign_shift) + ex_val) + cb);
+    }
+    return result;
+}
+
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
+float compute_inner_product_bytepacked(
+        const uint8_t* __restrict sign_bits,
+        const uint8_t* __restrict ex_code,
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb);
+
+template <>
+inline float compute_inner_product_bytepacked<SIMDLevel::NONE>(
+        const uint8_t* __restrict sign_bits,
+        const uint8_t* __restrict ex_code,
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb) {
+    return ip_scalar_bytepacked(
+            sign_bits, ex_code, rotated_q, 0, d, ex_bits, cb);
+}
+
 } // namespace faiss::rabitq::multibit

--- a/faiss/utils/simd_impl/rabitq_avx2.cpp
+++ b/faiss/utils/simd_impl/rabitq_avx2.cpp
@@ -350,6 +350,60 @@ float compute_inner_product<SIMDLevel::AVX2>(
     return ip_scalar(sign_bits, ex_code, rotated_q, 0, d, ex_bits, cb);
 }
 
+// Byte-packed FMA kernel: ex_code[i] is one byte per dimension.
+// ~5 AVX instructions per 8 dims, no PEXT, no inner loop.
+namespace {
+inline float ip_bytepacked_avx2(
+        const uint8_t* __restrict sign_bits,
+        const uint8_t* __restrict ex_code,
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb) {
+    __m256 acc = _mm256_setzero_ps();
+    const __m256 v_cb = _mm256_set1_ps(cb);
+    const __m256 v_sign_weight =
+            _mm256_set1_ps(static_cast<float>(1u << ex_bits));
+    const __m256 v_one = _mm256_set1_ps(1.0f);
+    const __m256i bit_pos = _mm256_setr_epi32(1, 2, 4, 8, 16, 32, 64, 128);
+    const __m256i zero = _mm256_setzero_si256();
+
+    size_t i = 0;
+    for (; i + 8 <= d; i += 8) {
+        __m256i sb_cmp = _mm256_cmpgt_epi32(
+                _mm256_and_si256(_mm256_set1_epi32(sign_bits[i / 8]), bit_pos),
+                zero);
+        __m256 sb_f = _mm256_and_ps(_mm256_castsi256_ps(sb_cmp), v_one);
+
+        __m128i ex_bytes =
+                _mm_loadl_epi64(reinterpret_cast<const __m128i*>(ex_code + i));
+        __m256 ex_f = _mm256_cvtepi32_ps(_mm256_cvtepu8_epi32(ex_bytes));
+
+        __m256 recon = _mm256_fmadd_ps(sb_f, v_sign_weight, ex_f);
+        recon = _mm256_add_ps(recon, v_cb);
+
+        __m256 rq = _mm256_loadu_ps(rotated_q + i);
+        acc = _mm256_fmadd_ps(rq, recon, acc);
+    }
+
+    float result = hsum_avx2(acc);
+    result += ip_scalar_bytepacked(
+            sign_bits, ex_code, rotated_q, i, d, ex_bits, cb);
+    return result;
+}
+} // namespace
+
+template <>
+float compute_inner_product_bytepacked<SIMDLevel::AVX2>(
+        const uint8_t* __restrict sign_bits,
+        const uint8_t* __restrict ex_code,
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb) {
+    return ip_bytepacked_avx2(sign_bits, ex_code, rotated_q, d, ex_bits, cb);
+}
+
 } // namespace faiss::rabitq::multibit
 
 #endif // COMPILE_SIMD_AVX2

--- a/faiss/utils/simd_impl/rabitq_avx512.cpp
+++ b/faiss/utils/simd_impl/rabitq_avx512.cpp
@@ -472,6 +472,44 @@ float compute_inner_product<SIMDLevel::AVX512>(
     return ip_scalar(sign_bits, ex_code, rotated_q, 0, d, ex_bits, cb);
 }
 
+template <>
+float compute_inner_product_bytepacked<SIMDLevel::AVX512>(
+        const uint8_t* __restrict sign_bits,
+        const uint8_t* __restrict ex_code,
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb) {
+    // AVX512 byte-packed kernel: use 512-bit cvtepu8 + FMA.
+    __m512 acc = _mm512_setzero_ps();
+    const __m512 v_cb = _mm512_set1_ps(cb);
+    const __m512 v_sign_weight =
+            _mm512_set1_ps(static_cast<float>(1u << ex_bits));
+    const __m512 v_one = _mm512_set1_ps(1.0f);
+
+    size_t i = 0;
+    for (; i + 16 <= d; i += 16) {
+        uint16_t sb16;
+        memcpy(&sb16, sign_bits + i / 8, sizeof(uint16_t));
+        __m512 sb_f = _mm512_maskz_mov_ps(_cvtu32_mask16(sb16), v_one);
+
+        __m128i ex_bytes =
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(ex_code + i));
+        __m512 ex_f = _mm512_cvtepi32_ps(_mm512_cvtepu8_epi32(ex_bytes));
+
+        __m512 recon = _mm512_fmadd_ps(sb_f, v_sign_weight, ex_f);
+        recon = _mm512_add_ps(recon, v_cb);
+
+        __m512 rq = _mm512_loadu_ps(rotated_q + i);
+        acc = _mm512_fmadd_ps(rq, recon, acc);
+    }
+
+    float result = _mm512_reduce_add_ps(acc);
+    result += ip_scalar_bytepacked(
+            sign_bits, ex_code, rotated_q, i, d, ex_bits, cb);
+    return result;
+}
+
 } // namespace faiss::rabitq::multibit
 
 #endif // COMPILE_SIMD_AVX512

--- a/faiss/utils/simd_impl/rabitq_neon.cpp
+++ b/faiss/utils/simd_impl/rabitq_neon.cpp
@@ -50,6 +50,18 @@ float compute_inner_product<SIMDLevel::ARM_NEON>(
             sign_bits, ex_code, rotated_q, d, ex_bits, cb);
 }
 
+template <>
+float compute_inner_product_bytepacked<SIMDLevel::ARM_NEON>(
+        const uint8_t* __restrict sign_bits,
+        const uint8_t* __restrict ex_code,
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb) {
+    return compute_inner_product_bytepacked<SIMDLevel::NONE>(
+            sign_bits, ex_code, rotated_q, d, ex_bits, cb);
+}
+
 } // namespace faiss::rabitq::multibit
 
 #endif // COMPILE_SIMD_ARM_NEON


### PR DESCRIPTION
## Summary

  This PR adds an optional byte-packed multibit layout for `IndexIVFRaBitQFastScan` when `nb_bits >= 4`.

  The new layout stores `ex_code` as one byte per dimension and uses dedicated byte-packed multibit distance kernels in the FastScan refinement path. Lower-bit configurations keep the existing bit-packed layout, so `nbits=1/2/3` behavior is unchanged.

  ## Format / compatibility

  - existing fast-scan formats `Iwrn` and `Iwrf` continue to read through the old bit-packed path
  - new byte-packed indexes use a new `Iwrp` fourcc
  - `Iwrp` roundtrip serialization was verified

  ## Performance

  On Cohere 1M, single-threaded search, `nbits=4`:

  | nprobe | bit-packed | byte-packed | change |
  |-------:|-----------:|------------:|-------:|
  | 32 | 237 | 332 | +40% |
  | 64 | 169 | 234 | +38% |
  | 128 | 118 | 138 | +17% |

  Recall is unchanged:
  - `nprobe=32`: `0.8847`
  - `nprobe=64`: `0.9281`
  - `nprobe=128`: `0.9501`

  `nbits=2` is unchanged.

  ## Notes

  - the byte-packed path is only used for `nbits >= 4`
  - `distance_to_code()` is explicitly rejected for byte-packed IVF FastScan indexes, rather than silently using the wrong multibit decoder
