### PR TITLE
Remove extra semicolons after inline member function definitions (#5085)

### DIFF
--- a/faiss/IndexBinary.h
+++ b/faiss/IndexBinary.h
@@ -58,7 +58,7 @@ struct IndexBinary {
         } else {
             FAISS_THROW_MSG("IndexBinary::train: unsupported numeric type");
         }
-    };
+    }
 
     /** Add n vectors of dimension d to the index.
      *
@@ -72,7 +72,7 @@ struct IndexBinary {
         } else {
             FAISS_THROW_MSG("IndexBinary::add: unsupported numeric type");
         }
-    };
+    }
 
     /** Same as add, but stores xids instead of sequential ids.
      *
@@ -93,7 +93,7 @@ struct IndexBinary {
             FAISS_THROW_MSG(
                     "IndexBinary::add_with_ids: unsupported numeric type");
         }
-    };
+    }
 
     /** Query n vectors of dimension d to the index.
      *
@@ -129,7 +129,7 @@ struct IndexBinary {
         } else {
             FAISS_THROW_MSG("IndexBinary::search: unsupported numeric type");
         }
-    };
+    }
 
     /** Query n vectors of dimension d to the index.
      *


### PR DESCRIPTION
Summary:

Fix 4 `clang-diagnostic-extra-semi` lint warnings in `IndexBinary.h`. The extra semicolons after the closing braces of inline member function definitions (`train_ex`, `add_ex`, `add_with_ids_ex`, `search_ex`) are unnecessary and flagged by clang-tidy.

Differential Revision: D100575086


