### PR TITLE
Replace typedef with using declarations (#5086)

### DIFF
--- a/faiss/IndexBinary.h
+++ b/faiss/IndexBinary.h
@@ -58,7 +58,7 @@ struct IndexBinary {
         } else {
             FAISS_THROW_MSG("IndexBinary::train: unsupported numeric type");
         }
-    };
+    }
 
     /** Add n vectors of dimension d to the index.
      *
@@ -72,7 +72,7 @@ struct IndexBinary {
         } else {
             FAISS_THROW_MSG("IndexBinary::add: unsupported numeric type");
         }
-    };
+    }
 
     /** Same as add, but stores xids instead of sequential ids.
      *
@@ -93,7 +93,7 @@ struct IndexBinary {
             FAISS_THROW_MSG(
                     "IndexBinary::add_with_ids: unsupported numeric type");
         }
-    };
+    }
 
     /** Query n vectors of dimension d to the index.
      *
@@ -129,7 +129,7 @@ struct IndexBinary {
         } else {
             FAISS_THROW_MSG("IndexBinary::search: unsupported numeric type");
         }
-    };
+    }
 
     /** Query n vectors of dimension d to the index.
      *

--- a/faiss/IndexBinaryHNSW.h
+++ b/faiss/IndexBinaryHNSW.h
@@ -19,7 +19,7 @@ namespace faiss {
  * link structure built on top */
 
 struct IndexBinaryHNSW : IndexBinary {
-    typedef HNSW::storage_idx_t storage_idx_t;
+    using storage_idx_t = HNSW::storage_idx_t;
 
     // the link structure
     HNSW hnsw;

--- a/faiss/IndexHNSW.h
+++ b/faiss/IndexHNSW.h
@@ -28,7 +28,7 @@ struct IndexHNSW;
  * link structure built on top */
 
 struct IndexHNSW : Index {
-    typedef HNSW::storage_idx_t storage_idx_t;
+    using storage_idx_t = HNSW::storage_idx_t;
 
     // the link structure
     HNSW hnsw;

--- a/faiss/IndexRefine.cpp
+++ b/faiss/IndexRefine.cpp
@@ -125,12 +125,12 @@ void IndexRefine::search(
 
     // sort and store result
     if (metric_type == METRIC_L2) {
-        typedef CMax<float, idx_t> C;
+        using C = CMax<float, idx_t>;
         reorder_2_heaps<C>(
                 n, k, labels, distances, k_base, base_labels, base_distances);
 
     } else if (metric_type == METRIC_INNER_PRODUCT) {
-        typedef CMin<float, idx_t> C;
+        using C = CMin<float, idx_t>;
         reorder_2_heaps<C>(
                 n, k, labels, distances, k_base, base_labels, base_distances);
     } else {
@@ -298,12 +298,12 @@ void IndexRefineFlat::search(
 
     // sort and store result
     if (metric_type == METRIC_L2) {
-        typedef CMax<float, idx_t> C;
+        using C = CMax<float, idx_t>;
         reorder_2_heaps<C>(
                 n, k, labels, distances, k_base, base_labels, base_distances);
 
     } else if (metric_type == METRIC_INNER_PRODUCT) {
-        typedef CMin<float, idx_t> C;
+        using C = CMin<float, idx_t>;
         reorder_2_heaps<C>(
                 n, k, labels, distances, k_base, base_labels, base_distances);
     } else {


### PR DESCRIPTION
Summary:

Fix 6 `modernize-use-using` lint warnings by replacing C-style `typedef` declarations with modern C++ `using` declarations in `IndexBinaryHNSW.h`, `IndexHNSW.h`, and `IndexRefine.cpp`.

Differential Revision: D100575482


