### PR TITLE
Suppress unused static constexpr variable warnings (#5087)

### DIFF
--- a/faiss/IndexBinary.h
+++ b/faiss/IndexBinary.h
@@ -58,7 +58,7 @@ struct IndexBinary {
         } else {
             FAISS_THROW_MSG("IndexBinary::train: unsupported numeric type");
         }
-    };
+    }
 
     /** Add n vectors of dimension d to the index.
      *
@@ -72,7 +72,7 @@ struct IndexBinary {
         } else {
             FAISS_THROW_MSG("IndexBinary::add: unsupported numeric type");
         }
-    };
+    }
 
     /** Same as add, but stores xids instead of sequential ids.
      *
@@ -93,7 +93,7 @@ struct IndexBinary {
             FAISS_THROW_MSG(
                     "IndexBinary::add_with_ids: unsupported numeric type");
         }
-    };
+    }
 
     /** Query n vectors of dimension d to the index.
      *
@@ -129,7 +129,7 @@ struct IndexBinary {
         } else {
             FAISS_THROW_MSG("IndexBinary::search: unsupported numeric type");
         }
-    };
+    }
 
     /** Query n vectors of dimension d to the index.
      *

--- a/faiss/IndexBinaryHNSW.h
+++ b/faiss/IndexBinaryHNSW.h
@@ -19,7 +19,7 @@ namespace faiss {
  * link structure built on top */
 
 struct IndexBinaryHNSW : IndexBinary {
-    typedef HNSW::storage_idx_t storage_idx_t;
+    using storage_idx_t = HNSW::storage_idx_t;
 
     // the link structure
     HNSW hnsw;

--- a/faiss/IndexHNSW.h
+++ b/faiss/IndexHNSW.h
@@ -28,7 +28,7 @@ struct IndexHNSW;
  * link structure built on top */
 
 struct IndexHNSW : Index {
-    typedef HNSW::storage_idx_t storage_idx_t;
+    using storage_idx_t = HNSW::storage_idx_t;
 
     // the link structure
     HNSW hnsw;

--- a/faiss/IndexIVFPQFastScan.cpp
+++ b/faiss/IndexIVFPQFastScan.cpp
@@ -319,7 +319,8 @@ namespace {
 
 struct IVFPQFastScanScanner : InvertedListScanner {
     using InvertedListScanner::scan_codes;
-    static constexpr int impl = 10; // based on search_implem_10
+    [[maybe_unused]] static constexpr int impl =
+            10;                     // based on search_implem_10
     static constexpr size_t nq = 1; // 1 query at a time.
     const IndexIVFPQFastScan& index;
     AlignedTable<uint8_t> dis_tables;

--- a/faiss/IndexIVFRaBitQFastScan.cpp
+++ b/faiss/IndexIVFRaBitQFastScan.cpp
@@ -573,7 +573,7 @@ namespace {
 /// Provides IVF scanner interface using FastScan's SIMD batch processing.
 struct IVFRaBitQFastScanScanner : InvertedListScanner {
     using InvertedListScanner::scan_codes;
-    static constexpr int impl = 10;
+    [[maybe_unused]] static constexpr int impl = 10;
     static constexpr size_t nq = 1;
 
     const IndexIVFRaBitQFastScan& index;

--- a/faiss/IndexRefine.cpp
+++ b/faiss/IndexRefine.cpp
@@ -125,12 +125,12 @@ void IndexRefine::search(
 
     // sort and store result
     if (metric_type == METRIC_L2) {
-        typedef CMax<float, idx_t> C;
+        using C = CMax<float, idx_t>;
         reorder_2_heaps<C>(
                 n, k, labels, distances, k_base, base_labels, base_distances);
 
     } else if (metric_type == METRIC_INNER_PRODUCT) {
-        typedef CMin<float, idx_t> C;
+        using C = CMin<float, idx_t>;
         reorder_2_heaps<C>(
                 n, k, labels, distances, k_base, base_labels, base_distances);
     } else {
@@ -298,12 +298,12 @@ void IndexRefineFlat::search(
 
     // sort and store result
     if (metric_type == METRIC_L2) {
-        typedef CMax<float, idx_t> C;
+        using C = CMax<float, idx_t>;
         reorder_2_heaps<C>(
                 n, k, labels, distances, k_base, base_labels, base_distances);
 
     } else if (metric_type == METRIC_INNER_PRODUCT) {
-        typedef CMin<float, idx_t> C;
+        using C = CMin<float, idx_t>;
         reorder_2_heaps<C>(
                 n, k, labels, distances, k_base, base_labels, base_distances);
     } else {


### PR DESCRIPTION
Summary:

Fix 2 `clang-diagnostic-unused-const-variable` lint warnings by adding `[[maybe_unused]]` to `static constexpr int impl` in `IndexIVFPQFastScan.cpp` and `IndexIVFRaBitQFastScan.cpp`. The variable serves as documentation about the search implementation being used, so it is kept rather than removed.

Differential Revision: D100575853


