### PR TITLE
Add value-initialization to uninitialized member variables (#5089)

### DIFF
--- a/faiss/Index.cpp
+++ b/faiss/Index.cpp
@@ -168,7 +168,7 @@ struct GenericDistanceComputer : DistanceComputer {
     size_t d;
     const Index& storage;
     std::vector<float> buf;
-    const float* q;
+    const float* q = nullptr;
 
     explicit GenericDistanceComputer(const Index& storage_in)
             : storage(storage_in) {

--- a/faiss/Index2Layer.cpp
+++ b/faiss/Index2Layer.cpp
@@ -138,9 +138,10 @@ struct Distance2Level : DistanceComputer {
     size_t d;
     const Index2Layer& storage;
     std::vector<float> buf;
-    const float* q;
+    const float* q = nullptr;
 
-    const float *pq_l1_tab, *pq_l2_tab;
+    const float* pq_l1_tab = nullptr;
+    const float* pq_l2_tab = nullptr;
 
     explicit Distance2Level(const Index2Layer& storage_) : storage(storage_) {
         d = storage_.d;
@@ -162,7 +163,8 @@ struct Distance2Level : DistanceComputer {
 
 // well optimized for xNN+PQNN
 struct DistanceXPQ4 : Distance2Level {
-    int M, k;
+    int M = 0;
+    int k = 0;
 
     explicit DistanceXPQ4(const Index2Layer& storage_)
             : Distance2Level(storage_) {

--- a/faiss/IndexAdditiveQuantizer.cpp
+++ b/faiss/IndexAdditiveQuantizer.cpp
@@ -52,7 +52,7 @@ struct AQDistanceComputerDecompress : FlatCodesDistanceComputer {
               vd(vd_),
               d(iaq.d) {}
 
-    const float* q;
+    const float* q = nullptr;
     void set_query(const float* x) final {
         q = x;
     }
@@ -83,7 +83,7 @@ struct AQDistanceComputerLUT : FlatCodesDistanceComputer {
               aq(*iaq.aq),
               d(iaq.d) {}
 
-    float bias;
+    float bias = 0.0f;
     void set_query(const float* x) final {
         q = x;
         // this is quite sub-optimal for multiple queries

--- a/faiss/IndexAdditiveQuantizerFastScan.h
+++ b/faiss/IndexAdditiveQuantizerFastScan.h
@@ -28,7 +28,7 @@ namespace faiss {
  */
 
 struct IndexAdditiveQuantizerFastScan : IndexFastScan {
-    AdditiveQuantizer* aq;
+    AdditiveQuantizer* aq = nullptr;
     using Search_type_t = AdditiveQuantizer::Search_type_t;
 
     bool rescale_norm = true;

--- a/faiss/IndexBinaryHash.h
+++ b/faiss/IndexBinaryHash.h
@@ -66,10 +66,10 @@ struct IndexBinaryHash : IndexBinary {
 };
 
 struct IndexBinaryHashStats {
-    size_t nq;     // nb of queries run
-    size_t n0;     // nb of empty lists
-    size_t nlist;  // nb of non-empty inverted lists scanned
-    size_t ndis{}; // nb of distances computed
+    size_t nq = 0;    // nb of queries run
+    size_t n0 = 0;    // nb of empty lists
+    size_t nlist = 0; // nb of non-empty inverted lists scanned
+    size_t ndis = 0;  // nb of distances computed
 
     IndexBinaryHashStats() {
         reset();

--- a/faiss/IndexBinaryIVF.cpp
+++ b/faiss/IndexBinaryIVF.cpp
@@ -354,7 +354,7 @@ struct IVFBinaryScannerL2 : BinaryInvertedListScanner {
         hc.set(query_vector, code_size);
     }
 
-    idx_t list_no;
+    idx_t list_no = 0;
     void set_list(idx_t list_no_2, uint8_t /* coarse_dis */) override {
         this->list_no = list_no_2;
     }
@@ -611,10 +611,10 @@ template <class HammingComputer, int NQ, int K>
 struct BlockSearch {
     HammingComputer hcs[NQ];
     // heaps to update for each query
-    int32_t* distances[NQ];
-    idx_t* labels[NQ];
+    int32_t* distances[NQ] = {};
+    idx_t* labels[NQ] = {};
     // curent top of heap
-    int32_t heap_tops[NQ];
+    int32_t heap_tops[NQ] = {};
 
     BlockSearch(
             size_t code_size,
@@ -648,10 +648,10 @@ struct BlockSearchVariableK {
     int k;
     HammingComputer hcs[NQ];
     // heaps to update for each query
-    int32_t* distances[NQ];
-    idx_t* labels[NQ];
+    int32_t* distances[NQ] = {};
+    idx_t* labels[NQ] = {};
     // curent top of heap
-    int32_t heap_tops[NQ];
+    int32_t heap_tops[NQ] = {};
 
     BlockSearchVariableK(
             size_t code_size,

--- a/faiss/IndexFastScan.h
+++ b/faiss/IndexFastScan.h
@@ -44,8 +44,8 @@ struct IndexFastScan : Index {
 
     // vector quantizer
     size_t M;
-    size_t nbits;
-    size_t ksub;
+    size_t nbits = 0;
+    size_t ksub = 0;
     size_t code_size;
 
     // packed version of the codes

--- a/faiss/IndexHNSW.h
+++ b/faiss/IndexHNSW.h
@@ -261,7 +261,7 @@ struct IndexHNSWCagra : IndexHNSW {
 
     faiss::NumericType get_numeric_type() const;
     void set_numeric_type(faiss::NumericType numeric_type);
-    NumericType numeric_type_;
+    NumericType numeric_type_ = Float32;
 };
 
 } // namespace faiss

--- a/faiss/IndexIVFAdditiveQuantizer.cpp
+++ b/faiss/IndexIVFAdditiveQuantizer.cpp
@@ -181,14 +181,14 @@ struct AQInvertedListScanner : InvertedListScanner {
         tmp.resize(ia.d);
     }
 
-    const float* q0;
+    const float* q0 = nullptr;
 
     /// from now on we handle this query.
     void set_query(const float* query_vector) override {
         q0 = query_vector;
     }
 
-    const float* q;
+    const float* q = nullptr;
     /// following codes come from this inverted list
     void set_list(idx_t list_no_, float /*coarse_dis*/) override {
         this->list_no = list_no_;

--- a/faiss/IndexIVFFastScan.h
+++ b/faiss/IndexIVFFastScan.h
@@ -41,14 +41,14 @@ struct Quantizer;
 
 struct IndexIVFFastScan : IndexIVF {
     // size of the kernel
-    int bbs; // set at build time
+    int bbs = 0; // set at build time
 
-    size_t M;
-    size_t nbits;
-    size_t ksub;
+    size_t M = 0;
+    size_t nbits = 0;
+    size_t ksub = 0;
 
     // M rounded up to a multiple of 2
-    size_t M2;
+    size_t M2 = 0;
 
     // search-time implementation
     int implem = 0;

--- a/faiss/IndexIVFFlat.h
+++ b/faiss/IndexIVFFlat.h
@@ -76,7 +76,7 @@ struct IVFFlatScanner : InvertedListScanner {
         code_size = vd.d * sizeof(float);
     }
 
-    const float* xi;
+    const float* xi = nullptr;
     void set_query(const float* query) override {
         this->xi = query;
     }

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -554,7 +554,7 @@ struct QueryTables {
      *****************************************************/
 
     // field specific to query
-    const float* qi;
+    const float* qi = nullptr;
 
     // query-specific initialization
     void init_query(const float* qi_in) {
@@ -585,8 +585,8 @@ struct QueryTables {
      *****************************************************/
 
     // fields specific to list
-    idx_t key;
-    float coarse_dis;
+    idx_t key = 0;
+    float coarse_dis = 0.0f;
     std::vector<uint8_t> q_code;
 
     uint64_t init_list_cycles;
@@ -802,9 +802,9 @@ struct WrappedSearchResult {
 template <typename IDType, MetricType METRIC_TYPE, class PQCodeDist>
 struct IVFPQScannerT : QueryTables {
     using PQDecoder = typename PQCodeDist::PQDecoder;
-    const uint8_t* list_codes;
+    const uint8_t* list_codes = nullptr;
     const IDType* list_ids;
-    size_t list_size;
+    size_t list_size = 0;
 
     IVFPQScannerT(
             const IndexIVFPQ& ivfpq_in,
@@ -813,7 +813,7 @@ struct IVFPQScannerT : QueryTables {
         FAISS_THROW_IF_NOT(METRIC_TYPE == metric_type);
     }
 
-    float dis0;
+    float dis0 = 0.0f;
 
     void init_list(idx_t list_no, float coarse_dis_in, int mode) {
         this->key = list_no;

--- a/faiss/IndexPQ.cpp
+++ b/faiss/IndexPQ.cpp
@@ -640,7 +640,7 @@ struct SemiSortedArray {
     using HC = CMax<T, int>;
     std::vector<int> perm;
 
-    int k; // k elements are sorted
+    int k = 0; // k elements are sorted
 
     int initial_k, k_factor;
 
@@ -732,7 +732,8 @@ struct MinSumK {
      * terms involved in the sum.
      */
     using HC = CMin<T, int64_t>;
-    size_t heap_capacity, heap_size;
+    size_t heap_capacity = 0;
+    size_t heap_size = 0;
     T* bh_val;
     int64_t* bh_ids;
 

--- a/faiss/IndexPQ.h
+++ b/faiss/IndexPQ.h
@@ -121,7 +121,8 @@ struct IndexPQStats {
     size_t nq;    // nb of queries run
     size_t ncode; // nb of codes visited
 
-    size_t n_hamming_pass; // nb of passed Hamming distance tests (for polysemy)
+    size_t n_hamming_pass = 0; // nb of passed Hamming distance tests (for
+                               // polysemy)
 
     IndexPQStats() {
         reset();

--- a/faiss/IndexRowwiseMinMax.cpp
+++ b/faiss/IndexRowwiseMinMax.cpp
@@ -305,7 +305,7 @@ void train_impl(IndexRowwiseMinMaxBase* const index, idx_t n, const float* x) {
         const float scaler = maxv - minv;
 
         // save the coefficients
-        StorageMinMaxT storage;
+        StorageMinMaxT storage = {};
         storage.from_floats(scaler, minv);
 
         // and load them back, because the coefficients might


### PR DESCRIPTION
Summary:

Fix 59 `cppcoreguidelines-pro-type-member-init` lint warnings by adding `{}` value-initialization to uninitialized member fields across 17 files. This ensures all members are zero/null-initialized by default, preventing potential use of uninitialized values.

Affected files: Index.cpp, Index2Layer.cpp, IndexAdditiveQuantizer.cpp, IndexAdditiveQuantizerFastScan.h, IndexBinaryHash.h, IndexBinaryIVF.cpp, IndexFastScan.h, IndexHNSW.h, IndexIVF.h, IndexIVFAdditiveQuantizer.cpp, IndexIVFFastScan.h, IndexIVFFlat.h, IndexIVFPQ.cpp, IndexIVFPQ.h, IndexPQ.cpp, IndexPQ.h, IndexRowwiseMinMax.cpp.

Reviewed By: mnorris11

Differential Revision: D100577736


