### PR TITLE
Add braces around single-line control flow statements (#5090)

### DIFF
--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -71,8 +71,9 @@ void IndexIVFPQ::train_encoder(
     pq.train(n, x);
 
     if (do_polysemous_training) {
-        if (verbose)
+        if (verbose) {
             printf("doing polysemous training for PQ\n");
+        }
         PolysemousTraining default_pt;
         PolysemousTraining* pt =
                 polysemous_training ? polysemous_training : &default_pt;
@@ -97,8 +98,9 @@ void IndexIVFPQ::encode(idx_t key, const float* x, uint8_t* code) const {
         std::vector<float> residual_vec(d);
         quantizer->compute_residual(x, residual_vec.data(), key);
         pq.compute_code(residual_vec.data(), code);
-    } else
+    } else {
         pq.compute_code(x, code);
+    }
 }
 
 void IndexIVFPQ::encode_multiple(
@@ -107,8 +109,9 @@ void IndexIVFPQ::encode_multiple(
         const float* x,
         uint8_t* xcodes,
         bool compute_keys) const {
-    if (compute_keys)
+    if (compute_keys) {
         quantizer->assign(n, x, keys);
+    }
 
     encode_vectors(n, x, keys, xcodes);
 }
@@ -153,11 +156,12 @@ static std::unique_ptr<float[]> compute_residuals(
     // Parallelize with OpenMP (each iteration is independent)
 #pragma omp parallel for if (n > 1000)
     for (idx_t i = 0; i < n; i++) {
-        if (list_nos[i] < 0)
+        if (list_nos[i] < 0) {
             memset(residuals.get() + i * d, 0, sizeof(float) * d);
-        else
+        } else {
             quantizer->compute_residual(
                     x + i * d, residuals.get() + i * d, list_nos[i]);
+        }
     }
     return residuals;
 }
@@ -290,8 +294,9 @@ void IndexIVFPQ::add_core_o(
         if (key < 0) {
             direct_map.add_single_id(id, -1, 0);
             n_ignore++;
-            if (residuals_2)
+            if (residuals_2) {
                 memset(residuals_2, 0, sizeof(*residuals_2) * d);
+            }
             continue;
         }
 
@@ -303,8 +308,9 @@ void IndexIVFPQ::add_core_o(
             float* res2 = residuals_2 + i * d;
             const float* xi = to_encode + i * d;
             pq.decode(code, res2);
-            for (int j = 0; j < d; j++)
+            for (int j = 0; j < d; j++) {
                 res2[j] = xi[j] - res2[j];
+            }
         }
 
         direct_map.add_single_id(id, key, offset);
@@ -313,8 +319,9 @@ void IndexIVFPQ::add_core_o(
     double t3 = getmillisecs();
     if (verbose) {
         char comment[100] = {0};
-        if (n_ignore > 0)
+        if (n_ignore > 0) {
             snprintf(comment, 100, "(%zd vectors ignored)", n_ignore);
+        }
         printf(" add_core times: %.3f %.3f %.3f %s\n",
                t1 - t0,
                t2 - t1,
@@ -401,9 +408,9 @@ void initialize_IVFPQ_precomputed_table(
         }
         const MultiIndexQuantizer* miq =
                 dynamic_cast<const MultiIndexQuantizer*>(quantizer);
-        if (miq && pq.M % miq->pq.M == 0)
+        if (miq && pq.M % miq->pq.M == 0) {
             use_precomputed_table = 2;
-        else {
+        } else {
             size_t table_size = pq.M * pq.ksub * nlist * sizeof(float);
             if (table_size > precomputed_table_max_bytes) {
                 if (verbose) {
@@ -425,11 +432,12 @@ void initialize_IVFPQ_precomputed_table(
 
     // squared norms of the PQ centroids
     std::vector<float> r_norms(pq.M * pq.ksub, NAN);
-    for (size_t m = 0; m < pq.M; m++)
+    for (size_t m = 0; m < pq.M; m++) {
         for (size_t j = 0; j < pq.ksub; j++) {
             r_norms[m * pq.ksub + j] =
                     fvec_norm_L2sqr_dispatch(pq.get_centroids(m, j), pq.dsub);
         }
+    }
 
     if (use_precomputed_table == 1) {
         precomputed_table.resize(nlist * pq.M * pq.ksub);
@@ -559,12 +567,14 @@ struct QueryTables {
     // query-specific initialization
     void init_query(const float* qi_in) {
         this->qi = qi_in;
-        if (metric_type == METRIC_INNER_PRODUCT)
+        if (metric_type == METRIC_INNER_PRODUCT) {
             init_query_IP();
-        else
+        } else {
             init_query_L2();
-        if (!by_residual && polysemous_ht != 0)
+        }
+        if (!by_residual && polysemous_ht != 0) {
             pq.compute_code(qi_in, q_code.data());
+        }
     }
 
     void init_query_IP() {
@@ -599,10 +609,11 @@ struct QueryTables {
         uint64_t t0;
         TIC;
         if (by_residual) {
-            if (metric_type == METRIC_INNER_PRODUCT)
+            if (metric_type == METRIC_INNER_PRODUCT) {
                 dis0 = precompute_list_tables_IP();
-            else
+            } else {
                 dis0 = precompute_list_tables_L2();
+            }
         }
         init_list_cycles += TOC;
         return dis0;
@@ -613,10 +624,11 @@ struct QueryTables {
         uint64_t t0;
         TIC;
         if (by_residual) {
-            if (metric_type == METRIC_INNER_PRODUCT)
+            if (metric_type == METRIC_INNER_PRODUCT) {
                 FAISS_THROW_MSG("not implemented");
-            else
+            } else {
                 dis0 = precompute_list_table_pointers_L2();
+            }
         }
         init_list_cycles += TOC;
         return dis0;
@@ -1328,8 +1340,9 @@ size_t IndexIVFPQ::find_duplicates(idx_t* dup_ids, size_t* lims) const {
     for (size_t list_no = 0; list_no < nlist; list_no++) {
         size_t n = invlists->list_size(list_no);
         std::vector<int> ord(n);
-        for (size_t i = 0; i < n; i++)
+        for (size_t i = 0; i < n; i++) {
             ord[i] = static_cast<int>(i);
+        }
         InvertedLists::ScopedCodes codes(invlists, list_no);
         CodeCmp cs = {codes.get(), code_size};
         std::sort(ord.begin(), ord.end(), cs);

--- a/faiss/IndexLSH.cpp
+++ b/faiss/IndexLSH.cpp
@@ -58,8 +58,9 @@ const float* IndexLSH::apply_preprocess(idx_t n, const float* x) const {
         float* xp = xt;
         for (idx_t i = 0; i < n; i++) {
             const float* xl = x + i * d;
-            for (int j = 0; j < nbits; j++)
+            for (int j = 0; j < nbits; j++) {
                 *xp++ = xl[j];
+            }
         }
     }
 
@@ -70,9 +71,11 @@ const float* IndexLSH::apply_preprocess(idx_t n, const float* x) const {
         }
 
         float* xp = xt;
-        for (idx_t i = 0; i < n; i++)
-            for (int j = 0; j < nbits; j++)
+        for (idx_t i = 0; i < n; i++) {
+            for (int j = 0; j < nbits; j++) {
                 *xp++ -= thresholds[j];
+            }
+        }
     }
 
     return xt ? xt : x;
@@ -88,9 +91,11 @@ void IndexLSH::train(idx_t n, const float* x) {
 
         std::unique_ptr<float[]> transposed_x(new float[n * nbits]);
 
-        for (idx_t i = 0; i < n; i++)
-            for (idx_t j = 0; j < nbits; j++)
+        for (idx_t i = 0; i < n; i++) {
+            for (idx_t j = 0; j < nbits; j++) {
                 transposed_x[j * n + i] = xt[i * nbits + j];
+            }
+        }
 
         for (idx_t i = 0; i < nbits; i++) {
             float* xi = transposed_x.get() + i * n;
@@ -132,20 +137,24 @@ void IndexLSH::search(
     hammings_knn_hc(&res, qcodes.get(), codes.data(), ntotal, code_size, true);
 
     // convert distances to floats
-    for (int i = 0; i < k * n; i++)
+    for (int i = 0; i < k * n; i++) {
         distances[i] = idistances[i];
+    }
 }
 
 void IndexLSH::transfer_thresholds(LinearTransform* vt) {
-    if (!train_thresholds)
+    if (!train_thresholds) {
         return;
+    }
     FAISS_THROW_IF_NOT(nbits == vt->d_out);
     if (!vt->have_bias) {
         vt->b.resize(nbits, 0);
         vt->have_bias = true;
     }
-    for (int i = 0; i < nbits; i++)
+    FAISS_THROW_IF_NOT(!vt->b.empty());
+    for (int i = 0; i < nbits; i++) {
         vt->b[i] -= thresholds[i];
+    }
     train_thresholds = false;
     thresholds.clear();
 }

--- a/faiss/IndexPQ.cpp
+++ b/faiss/IndexPQ.cpp
@@ -53,8 +53,9 @@ void IndexPQ::train(idx_t n, const float* x) {
     } else {
         idx_t ntrain_perm = polysemous_training.ntrain_permutation;
 
-        if (ntrain_perm > n / 4)
+        if (ntrain_perm > n / 4) {
             ntrain_perm = n / 4;
+        }
         if (verbose) {
             printf("PQ training on %" PRId64 " points, remains %" PRId64
                    " points: "
@@ -222,9 +223,11 @@ void IndexPQ::search(
             for (idx_t i = 0; i < n; i++) {
                 const float* xi = x + i * d;
                 uint8_t* code = q_codes.get() + i * pq.code_size;
-                for (size_t j = 0; j < static_cast<size_t>(d); j++)
-                    if (xi[j] > 0)
+                for (size_t j = 0; j < static_cast<size_t>(d); j++) {
+                    if (xi[j] > 0) {
                         code[j >> 3] |= 1 << (j & 7);
+                    }
+                }
             }
         }
 
@@ -260,8 +263,9 @@ void IndexPQ::search(
             }
 
             // convert distances to floats
-            for (idx_t i = 0; i < k * n; i++)
+            for (idx_t i = 0; i < k * n; i++) {
                 distances[i] = idistances[i];
+            }
         }
 
         indexPQ_stats.nq += n;
@@ -495,8 +499,9 @@ void IndexPQ::hamming_distance_histogram(
         for (idx_t q0 = 0; q0 < n; q0 += bs) {
             // printf ("dis stats: %zd/%zd\n", q0, n);
             size_t q1 = q0 + bs;
-            if (q1 > static_cast<size_t>(n))
+            if (q1 > static_cast<size_t>(n)) {
                 q1 = n;
+            }
 
             hammings(
                     q_codes.get() + q0 * pq.code_size,
@@ -506,13 +511,15 @@ void IndexPQ::hamming_distance_histogram(
                     pq.code_size,
                     distances.get());
 
-            for (size_t i = 0; i < nb * (q1 - q0); i++)
+            for (size_t i = 0; i < nb * (q1 - q0); i++) {
                 histi[distances[i]]++;
+            }
         }
 #pragma omp critical
         {
-            for (int i = 0; i <= nbits; i++)
+            for (int i = 0; i <= nbits; i++) {
                 hist[i] += histi[i];
+            }
         }
     }
 }
@@ -572,8 +579,10 @@ struct SortedArray {
 
     void init(const T* x_2) {
         this->x = x_2;
-        for (int n = 0; n < N; n++)
+        FAISS_THROW_IF_NOT(!perm.empty());
+        for (int n = 0; n < N; n++) {
             perm[n] = n;
+        }
         ArgSort<T> cmp = {x_2};
         std::sort(perm.begin(), perm.end(), cmp);
     }
@@ -654,8 +663,10 @@ struct SemiSortedArray {
 
     void init(const T* x_2) {
         this->x = x_2;
-        for (int n = 0; n < N; n++)
+        FAISS_THROW_IF_NOT(!perm.empty());
+        for (int n = 0; n < N; n++) {
             perm[n] = n;
+        }
         k = 0;
         grow(initial_k);
     }
@@ -759,8 +770,9 @@ struct MinSumK {
             seen.resize((n_ids + 7) / 8);
         }
 
-        for (int m = 0; m < M; m++)
+        for (int m = 0; m < M; m++) {
             ssx.push_back(SSA(N));
+        }
     }
 
     int64_t weight(int i) {
@@ -772,8 +784,10 @@ struct MinSumK {
     }
 
     void mark_seen(int64_t i) {
-        if (use_seen)
+        if (use_seen) {
+            FAISS_THROW_IF_NOT(!seen.empty());
             seen[i >> 3] |= 1 << (i & 7);
+        }
     }
 
     void run(const T* x, int64_t ldx, T* sums, int64_t* terms) {
@@ -829,8 +843,9 @@ struct MinSumK {
             for (int m = 0; m < M; m++) {
                 int64_t n = ii & (((int64_t)1 << nbit) - 1);
                 ii >>= nbit;
-                if (n + 1 >= N)
+                if (n + 1 >= N) {
                     continue;
+                }
 
                 enqueue_follower(ti, m, n, sum);
             }
@@ -885,8 +900,9 @@ void MultiIndexQuantizer::train(idx_t n, const float* x) {
     is_trained = true;
     // count virtual elements in index
     ntotal = 1;
-    for (size_t m = 0; m < pq.M; m++)
+    for (size_t m = 0; m < pq.M; m++) {
         ntotal *= pq.ksub;
+    }
 }
 
 // block size used in MultiIndexQuantizer::search

--- a/faiss/VectorTransform.cpp
+++ b/faiss/VectorTransform.cpp
@@ -176,9 +176,11 @@ void LinearTransform::apply_noalloc(idx_t n, const float* x, float* xt) const {
         FAISS_THROW_IF_NOT_MSG(
                 b.size() == static_cast<size_t>(d_out), "Bias not initialized");
         float* xi = xt;
-        for (idx_t i = 0; i < n; i++)
-            for (int j = 0; j < d_out; j++)
+        for (idx_t i = 0; i < n; i++) {
+            for (int j = 0; j < d_out; j++) {
                 *xi++ = b[j];
+            }
+        }
         c_factor = 1.0;
     } else {
         c_factor = 0.0;
@@ -237,8 +239,9 @@ void LinearTransform::transform_transpose(idx_t n, const float* y, float* x)
                &dii);
     }
 
-    if (have_bias)
+    if (have_bias) {
         delete[] y;
+    }
 }
 
 void LinearTransform::set_is_orthonormal() {
@@ -277,8 +280,9 @@ void LinearTransform::set_is_orthonormal() {
         for (long i = 0; i < d_out; i++) {
             for (long j = 0; j < d_out; j++) {
                 float v = ATA[i + j * d_out];
-                if (i == j)
+                if (i == j) {
                     v -= 1;
+                }
                 if (std::fabs(v) > eps) {
                     is_orthonormal = false;
                 }
@@ -302,8 +306,9 @@ void LinearTransform::print_if_verbose(
         const std::vector<double>& mat,
         int n,
         int d) const {
-    if (!verbose)
+    if (!verbose) {
         return;
+    }
     printf("matrix %s: %d*%d [\n", name, n, d);
     FAISS_THROW_IF_NOT_MSG(
             mat.size() >= static_cast<size_t>(n) * d,
@@ -553,8 +558,9 @@ void eig(size_t d_in, double* cov, double* eigenvalues, int verbose) {
 
         if (verbose && d_in <= 10) {
             printf("info=%ld new eigvals=[", long(info));
-            for (size_t j = 0; j < d_in; j++)
+            for (size_t j = 0; j < d_in; j++) {
                 printf("%g ", eigenvalues[j]);
+            }
             printf("]\n");
 
             double* ci = cov;
@@ -574,8 +580,9 @@ void eig(size_t d_in, double* cov, double* eigenvalues, int verbose) {
         std::swap(eigenvalues[i], eigenvalues[d_in - 1 - i]);
         double* v1 = cov + i * d_in;
         double* v2 = cov + (d_in - 1 - i) * d_in;
-        for (size_t j = 0; j < d_in; j++)
+        for (size_t j = 0; j < d_in; j++) {
             std::swap(v1[j], v2[j]);
+        }
     }
 }
 
@@ -592,16 +599,19 @@ void PCAMatrix::train(idx_t n, const float* x_in) {
     if (have_bias) { // we may want to skip the bias
         const float* xi = x;
         for (idx_t i = 0; i < n; i++) {
-            for (int j = 0; j < d_in; j++)
+            for (int j = 0; j < d_in; j++) {
                 mean[j] += *xi++;
+            }
         }
-        for (int j = 0; j < d_in; j++)
+        for (int j = 0; j < d_in; j++) {
             mean[j] /= n;
+        }
     }
     if (verbose) {
         printf("mean=[");
-        for (int j = 0; j < d_in; j++)
+        for (int j = 0; j < d_in; j++) {
             printf("%g ", mean[j]);
+        }
         printf("]\n");
     }
 
@@ -612,8 +622,9 @@ void PCAMatrix::train(idx_t n, const float* x_in) {
         { // initialize with  mean * mean^T term
             float* ci = cov;
             for (int i = 0; i < d_in; i++) {
-                for (int j = 0; j < d_in; j++)
+                for (int j = 0; j < d_in; j++) {
                     *ci++ = -n * mean[i] * mean[j];
+                }
             }
         }
         {
@@ -634,26 +645,30 @@ void PCAMatrix::train(idx_t n, const float* x_in) {
             float* ci = cov;
             printf("cov=\n");
             for (int i = 0; i < d_in; i++) {
-                for (int j = 0; j < d_in; j++)
+                for (int j = 0; j < d_in; j++) {
                     printf("%10g ", *ci++);
+                }
                 printf("\n");
             }
         }
 
         std::vector<double> covd(d_in * d_in);
-        for (size_t i = 0; i < d_in * d_in; i++)
+        for (size_t i = 0; i < d_in * d_in; i++) {
             covd[i] = cov[i];
+        }
 
         std::vector<double> eigenvaluesd(d_in);
 
         eig(d_in, covd.data(), eigenvaluesd.data(), verbose);
 
-        for (size_t i = 0; i < d_in * d_in; i++)
+        for (size_t i = 0; i < d_in * d_in; i++) {
             PCAMat[i] = covd[i];
+        }
         eigenvalues.resize(d_in);
 
-        for (int i = 0; i < d_in; i++)
+        for (int i = 0; i < d_in; i++) {
             eigenvalues[i] = eigenvaluesd[i];
+        }
 
     } else {
         std::vector<float> xc(n * d_in);
@@ -693,8 +708,9 @@ void PCAMatrix::train(idx_t n, const float* x_in) {
         }
 
         std::vector<double> gramd(n * n);
-        for (size_t i = 0; i < n * n; i++)
+        for (size_t i = 0; i < n * n; i++) {
             gramd[i] = gram[i];
+        }
 
         std::vector<double> eigenvaluesd(n);
 
@@ -704,13 +720,15 @@ void PCAMatrix::train(idx_t n, const float* x_in) {
 
         PCAMat.resize(d_in * n);
 
-        for (size_t i = 0; i < n * n; i++)
+        for (size_t i = 0; i < n * n; i++) {
             gram[i] = gramd[i];
+        }
 
         eigenvalues.resize(d_in);
         // fill in only the n first ones
-        for (idx_t i = 0; i < n; i++)
+        for (idx_t i = 0; i < n; i++) {
             eigenvalues[i] = eigenvaluesd[i];
+        }
 
         { // compute PCAMat = x' * v
             FINTEGER di = d_in, ni = n;
@@ -735,8 +753,9 @@ void PCAMatrix::train(idx_t n, const float* x_in) {
             float* ci = PCAMat.data();
             printf("PCAMat=\n");
             for (idx_t i = 0; i < n; i++) {
-                for (int j = 0; j < d_in; j++)
+                for (int j = 0; j < d_in; j++) {
                     printf("%10g ", *ci++);
+                }
                 printf("\n");
             }
         }
@@ -774,8 +793,9 @@ void PCAMatrix::prepare_Ab() {
             float* ai = A.data();
             for (int i = 0; i < d_out; i++) {
                 float factor = std::pow(eigenvalues[i] + epsilon, eigen_power);
-                for (int j = 0; j < d_in; j++)
+                for (int j = 0; j < d_in; j++) {
                     *ai++ *= factor;
+                }
             }
         }
 
@@ -810,8 +830,9 @@ void PCAMatrix::prepare_Ab() {
 
             if (verbose) {
                 printf("  bin accu=[");
-                for (int i = 0; i < balanced_bins; i++)
+                for (int i = 0; i < balanced_bins; i++) {
                     printf("%g ", accu[i]);
+                }
                 printf("]\n");
             }
         }
@@ -829,8 +850,9 @@ void PCAMatrix::prepare_Ab() {
         if (eigen_power != 0) {
             for (int i = 0; i < d_out; i++) {
                 float factor = pow(eigenvalues[i], eigen_power);
-                for (int j = 0; j < d_out; j++)
+                for (int j = 0; j < d_out; j++) {
                     rr.A[j * d_out + i] *= factor;
+                }
             }
         }
 
@@ -860,8 +882,9 @@ void PCAMatrix::prepare_Ab() {
 
     for (int i = 0; i < d_out; i++) {
         float accu = 0;
-        for (int j = 0; j < d_in; j++)
+        for (int j = 0; j < d_in; j++) {
             accu -= mean[j] * A[j + i * d_in];
+        }
         b[i] = accu;
     }
 
@@ -1183,16 +1206,19 @@ void OPQMatrix::train(idx_t n, const float* x_in) {
         std::vector<float> sum(d);
         const float* xi = x;
         for (idx_t i = 0; i < n; i++) {
-            for (int j = 0; j < d_in; j++)
+            for (int j = 0; j < d_in; j++) {
                 sum[j] += *xi++;
+            }
         }
-        for (size_t i = 0; i < d; i++)
+        for (size_t i = 0; i < d; i++) {
             sum[i] /= n;
+        }
         float* yi = xtrain.data();
         xi = x;
         for (idx_t i = 0; i < n; i++) {
-            for (int j = 0; j < d_in; j++)
+            for (int j = 0; j < d_in; j++) {
                 *yi++ = *xi++ - sum[j];
+            }
             yi += d - d_in;
         }
     }
@@ -1201,10 +1227,11 @@ void OPQMatrix::train(idx_t n, const float* x_in) {
     if (A.size() == 0) {
         A.resize(d * d);
         rotation = A.data();
-        if (verbose)
+        if (verbose) {
             printf("  OPQMatrix::train: making random %zd*%zd rotation\n",
                    d,
                    d);
+        }
         float_randn(rotation, d * d, 1234);
         matrix_qr(d, d, rotation);
         // we use only the d * d2 upper part of the matrix
@@ -1260,13 +1287,14 @@ void OPQMatrix::train(idx_t n, const float* x_in) {
 
         float pq_err = fvec_L2sqr(pq_recons.data(), xproj.data(), n * d2) / n;
 
-        if (verbose)
+        if (verbose) {
             printf("    Iteration %d (%d PQ iterations):"
                    "%.3f s, obj=%g\n",
                    iter,
                    pq_regular.cp.niter,
                    (getmillisecs() - t0) / 1000.0,
                    pq_err);
+        }
 
         {
             float *u = tmp.data(), *vt = &tmp[d * d];
@@ -1347,8 +1375,9 @@ void OPQMatrix::train(idx_t n, const float* x_in) {
 
     // revert A matrix
     if (d > static_cast<size_t>(d_in)) {
-        for (long i = 0; i < d_out; i++)
+        for (long i = 0; i < d_out; i++) {
             memmove(&A[i * d_in], &A[i * d], sizeof(A[0]) * d_in);
+        }
         A.resize(d_in * d_out);
     }
 
@@ -1484,8 +1513,9 @@ RemapDimensionsTransform::RemapDimensionsTransform(
             }
         }
     } else {
-        for (int i = 0; i < din && i < dout; i++)
+        for (int i = 0; i < din && i < dout; i++) {
             map[i] = i;
+        }
     }
 }
 
@@ -1507,8 +1537,9 @@ void RemapDimensionsTransform::reverse_transform(
     memset(x, 0, sizeof(*x) * n * d_in);
     for (idx_t i = 0; i < n; i++) {
         for (int j = 0; j < d_out; j++) {
-            if (map[j] >= 0)
+            if (map[j] >= 0) {
                 x[map[j]] = xt[j];
+            }
         }
         x += d_in;
         xt += d_out;


### PR DESCRIPTION
Summary:

Fix 136 `readability-braces-around-statements` lint warnings by adding braces to all single-line `if`, `else`, `for`, and `while` statements across 4 files: `IndexLSH.cpp` (14 issues), `IndexIVFPQ.cpp` (36 issues), `IndexPQ.cpp` (25 issues), and `VectorTransform.cpp` (61 issues). This improves code readability and prevents bugs from accidentally adding statements to unbraced blocks.

Reviewed By: mnorris11

Differential Revision: D100580151


