### PR TITLE
Fix implicit integer precision loss from 64-bit to 32-bit (#5091)

### DIFF
--- a/faiss/AutoTune.cpp
+++ b/faiss/AutoTune.cpp
@@ -174,7 +174,7 @@ double OperatingPoints::t_for_perf(double perf) const {
     if (perf > a.back().perf) {
         return 1e50;
     }
-    int i0 = -1, i1 = a.size() - 1;
+    int i0 = -1, i1 = static_cast<int>(a.size()) - 1;
     while (i0 + 1 < i1) {
         int imed = (i0 + i1 + 1) / 2;
         if (a[imed].perf < perf) {
@@ -787,7 +787,7 @@ void ParameterSpace::explore(
     // make sure the slowest and fastest experiment are run
     perm[0] = 0;
     if (n_comb > 1) {
-        perm[1] = n_comb - 1;
+        perm[1] = static_cast<int>(n_comb - 1);
         rand_perm(&perm[2], n_comb - 2, 1234);
         for (size_t i = 2; i < perm.size(); i++) {
             perm[i]++;

--- a/faiss/AutoTune.cpp
+++ b/faiss/AutoTune.cpp
@@ -174,7 +174,7 @@ double OperatingPoints::t_for_perf(double perf) const {
     if (perf > a.back().perf) {
         return 1e50;
     }
-    int i0 = -1, i1 = a.size() - 1;
+    int i0 = -1, i1 = static_cast<int>(a.size()) - 1;
     while (i0 + 1 < i1) {
         int imed = (i0 + i1 + 1) / 2;
         if (a[imed].perf < perf) {
@@ -786,7 +786,7 @@ void ParameterSpace::explore(
     // make sure the slowest and fastest experiment are run
     perm[0] = 0;
     if (n_comb > 1) {
-        perm[1] = n_comb - 1;
+        perm[1] = static_cast<int>(n_comb - 1);
         rand_perm(&perm[2], n_comb - 2, 1234);
         for (size_t i = 2; i < perm.size(); i++) {
             perm[i]++;

--- a/faiss/Clustering.cpp
+++ b/faiss/Clustering.cpp
@@ -285,7 +285,7 @@ int split_clusters(
         }
     }
 
-    return nsplit;
+    return static_cast<int>(nsplit);
 }
 
 } // namespace
@@ -561,7 +561,7 @@ void Clustering::train_encoded(
                     obj,
                     (getmillisecs() - t0) / 1000.0,
                     t_search_tot / 1000,
-                    imbalance_factor(nx, k, assign.get()),
+                    imbalance_factor(nx, static_cast<int>(k), assign.get()),
                     nsplit};
             iteration_stats.push_back(stats);
 
@@ -672,7 +672,7 @@ float kmeans_clustering(
         size_t k,
         const float* x,
         float* centroids) {
-    Clustering clus(d, k);
+    Clustering clus(static_cast<int>(d), static_cast<int>(k));
     clus.verbose = d * n * k > (size_t(1) << 30);
     // display logs if > 1Gflop per iteration
     IndexFlatL2 index(d);
@@ -723,7 +723,7 @@ void ProgressiveDimClustering::train(
         ProgressiveDimIndexFactory& factory) {
     int d_prev = 0;
 
-    PCAMatrix pca(d, d);
+    PCAMatrix pca(static_cast<int>(d), static_cast<int>(d));
 
     std::vector<float> xbuf;
     if (apply_pca) {
@@ -748,7 +748,7 @@ void ProgressiveDimClustering::train(
         }
         std::unique_ptr<Index> clustering_index(factory(di));
 
-        Clustering clus(di, k, *this);
+        Clustering clus(di, static_cast<int>(k), *this);
         if (d_prev > 0) {
             // copy warm-start centroids (padded with 0s)
             clus.centroids.resize(k * di);

--- a/faiss/Clustering.cpp
+++ b/faiss/Clustering.cpp
@@ -92,7 +92,7 @@ idx_t subsample_training_set(
         const idx_t new_nx = clus.k * clus.max_points_per_centroid;
         perm.resize(new_nx);
         for (idx_t i = 0; i < new_nx; i++) {
-            perm[i] = rng.rand_int(nx);
+            perm[i] = rng.rand_int(static_cast<int>(nx));
         }
     } else {
         // use subsampling with a default std rng
@@ -262,7 +262,7 @@ int split_clusters(
         }
     }
 
-    return nsplit;
+    return static_cast<int>(nsplit);
 }
 
 } // namespace
@@ -538,7 +538,7 @@ void Clustering::train_encoded(
                     obj,
                     (getmillisecs() - t0) / 1000.0,
                     t_search_tot / 1000,
-                    imbalance_factor(nx, k, assign.get()),
+                    imbalance_factor(nx, static_cast<int>(k), assign.get()),
                     nsplit};
             iteration_stats.push_back(stats);
 
@@ -649,7 +649,7 @@ float kmeans_clustering(
         size_t k,
         const float* x,
         float* centroids) {
-    Clustering clus(d, k);
+    Clustering clus(static_cast<int>(d), static_cast<int>(k));
     clus.verbose = d * n * k > (size_t(1) << 30);
     // display logs if > 1Gflop per iteration
     IndexFlatL2 index(d);
@@ -700,7 +700,7 @@ void ProgressiveDimClustering::train(
         ProgressiveDimIndexFactory& factory) {
     int d_prev = 0;
 
-    PCAMatrix pca(d, d);
+    PCAMatrix pca(static_cast<int>(d), static_cast<int>(d));
 
     std::vector<float> xbuf;
     if (apply_pca) {
@@ -725,7 +725,7 @@ void ProgressiveDimClustering::train(
         }
         std::unique_ptr<Index> clustering_index(factory(di));
 
-        Clustering clus(di, k, *this);
+        Clustering clus(di, static_cast<int>(k), *this);
         if (d_prev > 0) {
             // copy warm-start centroids (padded with 0s)
             clus.centroids.resize(k * di);

--- a/faiss/IVFlib.cpp
+++ b/faiss/IVFlib.cpp
@@ -465,7 +465,7 @@ IndexIVFResidualQuantizer* ivf_residual_from_quantizer(
     std::vector<size_t> nbits(nlevel);
     std::copy(rq.nbits.begin(), rq.nbits.begin() + nlevel, nbits.begin());
     std::unique_ptr<ResidualCoarseQuantizer> rcq(
-            new ResidualCoarseQuantizer(rq.d, nbits));
+            new ResidualCoarseQuantizer(static_cast<int>(rq.d), nbits));
 
     // set the coarse quantizer from the 2 first quantizers
     rcq->rq.initialize_from(rq);
@@ -529,14 +529,14 @@ void ivf_residual_add_from_flat_codes(
             for (idx_t i = 0; i < static_cast<idx_t>(nb); i++) {
                 const uint8_t* code = &raw_codes[i * code_size];
                 BitstringReader rd(code, code_size);
-                idx_t list_no = rd.read(rcq->rq.tot_bits);
+                idx_t list_no = rd.read(static_cast<int>(rcq->rq.tot_bits));
 
                 if (list_no % nt ==
                     rank) { // each thread takes care of 1/nt of the invlists
                     // copy AQ indexes one by one
                     BitstringWriter wr(tmp_code.data(), tmp_code.size());
                     for (size_t j = 0; j < rq.M; j++) {
-                        int nbit = rq.nbits[j];
+                        int nbit = static_cast<int>(rq.nbits[j]);
                         wr.write(rd.read(nbit), nbit);
                     }
                     // we need to recompute the norm
@@ -544,7 +544,9 @@ void ivf_residual_add_from_flat_codes(
                     // ok
                     index->rq.decode(tmp_code.data(), tmp.data(), 1);
                     float norm = fvec_norm_L2sqr<SL>(tmp.data(), rq.d);
-                    wr.write(rq.encode_norm(norm), rq.norm_bits);
+                    wr.write(
+                            rq.encode_norm(norm),
+                            static_cast<int>(rq.norm_bits));
 
                     // add code to the inverted list
                     invlists.add_entry(list_no, i, tmp_code.data());

--- a/faiss/IVFlib.cpp
+++ b/faiss/IVFlib.cpp
@@ -465,7 +465,7 @@ IndexIVFResidualQuantizer* ivf_residual_from_quantizer(
     std::vector<size_t> nbits(nlevel);
     std::copy(rq.nbits.begin(), rq.nbits.begin() + nlevel, nbits.begin());
     std::unique_ptr<ResidualCoarseQuantizer> rcq(
-            new ResidualCoarseQuantizer(rq.d, nbits));
+            new ResidualCoarseQuantizer(static_cast<int>(rq.d), nbits));
 
     // set the coarse quantizer from the 2 first quantizers
     rcq->rq.initialize_from(rq);
@@ -528,14 +528,14 @@ void ivf_residual_add_from_flat_codes(
             for (idx_t i = 0; i < static_cast<idx_t>(nb); i++) {
                 const uint8_t* code = &raw_codes[i * code_size];
                 BitstringReader rd(code, code_size);
-                idx_t list_no = rd.read(rcq->rq.tot_bits);
+                idx_t list_no = rd.read(static_cast<int>(rcq->rq.tot_bits));
 
                 if (list_no % nt ==
                     rank) { // each thread takes care of 1/nt of the invlists
                     // copy AQ indexes one by one
                     BitstringWriter wr(tmp_code.data(), tmp_code.size());
                     for (size_t j = 0; j < rq.M; j++) {
-                        int nbit = rq.nbits[j];
+                        int nbit = static_cast<int>(rq.nbits[j]);
                         wr.write(rd.read(nbit), nbit);
                     }
                     // we need to recompute the norm
@@ -543,7 +543,9 @@ void ivf_residual_add_from_flat_codes(
                     // ok
                     index->rq.decode(tmp_code.data(), tmp.data(), 1);
                     float norm = fvec_norm_L2sqr<SL>(tmp.data(), rq.d);
-                    wr.write(rq.encode_norm(norm), rq.norm_bits);
+                    wr.write(
+                            rq.encode_norm(norm),
+                            static_cast<int>(rq.norm_bits));
 
                     // add code to the inverted list
                     invlists.add_entry(list_no, i, tmp_code.data());

--- a/faiss/Index.h
+++ b/faiss/Index.h
@@ -115,7 +115,7 @@ struct Index {
     float metric_arg; ///< argument of the metric type
 
     explicit Index(idx_t d_in = 0, MetricType metric = METRIC_L2)
-            : d(d_in),
+            : d(static_cast<int>(d_in)),
               ntotal(0),
               verbose(false),
               is_trained(true),

--- a/faiss/Index2Layer.cpp
+++ b/faiss/Index2Layer.cpp
@@ -168,7 +168,7 @@ struct DistanceXPQ4 : Distance2Level {
                 dynamic_cast<IndexFlat*>(storage.q1.quantizer);
 
         FAISS_ASSERT(quantizer);
-        M = storage.pq.M;
+        M = static_cast<int>(storage.pq.M);
         pq_l1_tab = quantizer->get_xb();
     }
 
@@ -207,8 +207,8 @@ struct Distance2xXPQ4 : Distance2Level {
 
         FAISS_ASSERT(mi);
         FAISS_ASSERT(storage.pq.M % 2 == 0);
-        M_2 = storage.pq.M / 2;
-        mi_nbits = mi->pq.nbits;
+        M_2 = static_cast<int>(storage.pq.M / 2);
+        mi_nbits = static_cast<int>(mi->pq.nbits);
         pq_l1_tab = mi->pq.centroids.data();
     }
 

--- a/faiss/IndexAdditiveQuantizer.cpp
+++ b/faiss/IndexAdditiveQuantizer.cpp
@@ -543,7 +543,7 @@ void ResidualCoarseQuantizer::search(
 
     int beam_size = int(k * actual_beam_factor);
     if (beam_size > ntotal) {
-        beam_size = ntotal;
+        beam_size = static_cast<int>(ntotal);
     }
     size_t memory_per_point = rq.memory_per_point(beam_size);
 

--- a/faiss/IndexAdditiveQuantizerFastScan.cpp
+++ b/faiss/IndexAdditiveQuantizerFastScan.cpp
@@ -56,7 +56,7 @@ void IndexAdditiveQuantizerFastScan::init(
     } else {
         M = aq_init->M;
     }
-    init_fastscan(aq_init->d, M, 4, metric, bbs_);
+    init_fastscan(static_cast<int>(aq_init->d), M, 4, metric, bbs_);
 
     max_train_points = 1024 * ksub * M;
 }

--- a/faiss/IndexBinary.cpp
+++ b/faiss/IndexBinary.cpp
@@ -17,7 +17,9 @@
 namespace faiss {
 
 IndexBinary::IndexBinary(idx_t d_, MetricType metric)
-        : d(d_), code_size(d_ / 8), metric_type(metric) {
+        : d(static_cast<int>(d_)),
+          code_size(static_cast<int>(d_ / 8)),
+          metric_type(metric) {
     FAISS_THROW_IF_NOT(d_ % 8 == 0);
 }
 

--- a/faiss/IndexBinaryHNSW.cpp
+++ b/faiss/IndexBinaryHNSW.cpp
@@ -72,7 +72,8 @@ void hnsw_add_vertices(
 
         // build histogram
         for (size_t i = 0; i < n; i++) {
-            HNSW::storage_idx_t pt_id = i + n0;
+            HNSW::storage_idx_t pt_id =
+                    static_cast<HNSW::storage_idx_t>(i + n0);
             int pt_level = hnsw.levels[pt_id] - 1;
             while (pt_level >= static_cast<int>(hist.size())) {
                 hist.push_back(0);
@@ -88,7 +89,8 @@ void hnsw_add_vertices(
 
         // bucket sort
         for (size_t i = 0; i < n; i++) {
-            HNSW::storage_idx_t pt_id = i + n0;
+            HNSW::storage_idx_t pt_id =
+                    static_cast<HNSW::storage_idx_t>(i + n0);
             int pt_level = hnsw.levels[pt_id] - 1;
             order[offsets[pt_level]++] = pt_id;
         }
@@ -97,7 +99,7 @@ void hnsw_add_vertices(
     { // perform add
         RandomGenerator rng2(789);
 
-        size_t i1 = n;
+        size_t i1 = static_cast<int>(n);
 
         for (int pt_level = static_cast<int>(hist.size()) - 1;
              pt_level >= int(!index_hnsw.init_level0);
@@ -384,7 +386,7 @@ void IndexBinaryHNSWCagra::search(
                 float distance = (*dis)(idx);
 
                 if (distance < nearest_d[i]) {
-                    nearest[i] = idx;
+                    nearest[i] = static_cast<storage_idx_t>(idx);
                     nearest_d[i] = distance;
                 }
             }

--- a/faiss/IndexBinaryHNSW.cpp
+++ b/faiss/IndexBinaryHNSW.cpp
@@ -74,7 +74,8 @@ void hnsw_add_vertices(
 
         // build histogram
         for (size_t i = 0; i < n; i++) {
-            HNSW::storage_idx_t pt_id = i + n0;
+            HNSW::storage_idx_t pt_id =
+                    static_cast<HNSW::storage_idx_t>(i + n0);
             int pt_level = hnsw.levels[pt_id] - 1;
             while (pt_level >= static_cast<int>(hist.size())) {
                 hist.push_back(0);
@@ -90,7 +91,8 @@ void hnsw_add_vertices(
 
         // bucket sort
         for (size_t i = 0; i < n; i++) {
-            HNSW::storage_idx_t pt_id = i + n0;
+            HNSW::storage_idx_t pt_id =
+                    static_cast<HNSW::storage_idx_t>(i + n0);
             int pt_level = hnsw.levels[pt_id] - 1;
             order[offsets[pt_level]++] = pt_id;
         }
@@ -99,7 +101,7 @@ void hnsw_add_vertices(
     { // perform add
         RandomGenerator rng2(789);
 
-        size_t i1 = n;
+        size_t i1 = static_cast<int>(n);
 
         for (int pt_level = static_cast<int>(hist.size()) - 1;
              pt_level >= int(!index_hnsw.init_level0);
@@ -392,7 +394,7 @@ void IndexBinaryHNSWCagra::search(
                 float distance = (*dis)(idx);
 
                 if (distance < nearest_d[i]) {
-                    nearest[i] = idx;
+                    nearest[i] = static_cast<storage_idx_t>(idx);
                     nearest_d[i] = distance;
                 }
             }

--- a/faiss/IndexBinaryIVF.cpp
+++ b/faiss/IndexBinaryIVF.cpp
@@ -151,7 +151,7 @@ void IndexBinaryIVF::search(
     indexIVF_stats.quantization_time += getmillisecs() - t0;
 
     t0 = getmillisecs();
-    invlists->prefetch_lists(idx.get(), n * nprobe_);
+    invlists->prefetch_lists(idx.get(), static_cast<int>(n * nprobe_));
 
     search_preassigned(
             n,
@@ -209,7 +209,7 @@ void IndexBinaryIVF::search_and_reconstruct(
 
     quantizer->search(n, x, nprobe_2, coarse_dis.get(), idx.get());
 
-    invlists->prefetch_lists(idx.get(), n * nprobe_2);
+    invlists->prefetch_lists(idx.get(), static_cast<int>(n * nprobe_2));
 
     // search_preassigned() with `store_pairs` enabled to obtain the list_no
     // and offset into `codes` for reconstruction
@@ -277,7 +277,7 @@ void IndexBinaryIVF::train(idx_t n, const uint8_t* x) {
             printf("Training quantizer on %" PRId64 " vectors in %dD\n", n, d);
         }
 
-        Clustering clus(d, nlist, cp);
+        Clustering clus(d, static_cast<int>(nlist), cp);
         quantizer->reset();
 
         IndexFlatL2 index_tmp(d);
@@ -706,9 +706,10 @@ void search_knn_hamming_per_invlist(
     int32_t* keys = new int32_t[n * nprobe];
     std::unique_ptr<int32_t[]> delete_keys(keys);
     for (size_t i = 0; i < n * static_cast<size_t>(nprobe); i++) {
-        keys[i] = keys_in[i];
+        keys[i] = static_cast<int32_t>(keys_in[i]);
     }
-    matrix_bucket_sort_inplace(n, nprobe, keys, ivf->nlist, lims.data(), 0);
+    matrix_bucket_sort_inplace(
+            n, nprobe, keys, static_cast<int32_t>(ivf->nlist), lims.data(), 0);
 
     using C = CMax<int32_t, idx_t>;
     heap_heapify<C>(n * k, distances, labels);
@@ -755,7 +756,12 @@ void search_knn_hamming_per_invlist(
         } else {
             for (; i + BS <= nq; i += BS) {
                 BlockSearchVariableK<HammingComputer, BS> bc(
-                        code_size, k, x, keys + l0 + i, distances, labels);
+                        code_size,
+                        static_cast<int>(k),
+                        x,
+                        keys + l0 + i,
+                        distances,
+                        labels);
                 for (idx_t j = 0; j < nb; j++) {
                     bc.add_bcode(bcodes + j * code_size, ids[j]);
                 }
@@ -765,7 +771,8 @@ void search_knn_hamming_per_invlist(
         // leftovers
         for (; i < nq; i++) {
             idx_t qno = keys[l0 + i];
-            HammingComputer hc(x + qno * code_size, code_size);
+            HammingComputer hc(
+                    x + qno * code_size, static_cast<int>(code_size));
             idx_t* __restrict idxi = labels + qno * k;
             int32_t* __restrict simi = distances + qno * k;
             int32_t simi0 = simi[0];
@@ -845,7 +852,7 @@ void IndexBinaryIVF::range_search(
     indexIVF_stats.quantization_time += getmillisecs() - t0;
 
     t0 = getmillisecs();
-    invlists->prefetch_lists(idx.get(), n * nprobe_2);
+    invlists->prefetch_lists(idx.get(), static_cast<int>(n * nprobe_2));
 
     range_search_preassigned(n, x, radius, idx.get(), coarse_dis.get(), res);
 

--- a/faiss/IndexBinaryIVF.cpp
+++ b/faiss/IndexBinaryIVF.cpp
@@ -151,7 +151,7 @@ void IndexBinaryIVF::search(
     indexIVF_stats.quantization_time += getmillisecs() - t0;
 
     t0 = getmillisecs();
-    invlists->prefetch_lists(idx.get(), n * nprobe_);
+    invlists->prefetch_lists(idx.get(), static_cast<int>(n * nprobe_));
 
     search_preassigned(
             n,
@@ -209,7 +209,7 @@ void IndexBinaryIVF::search_and_reconstruct(
 
     quantizer->search(n, x, nprobe_2, coarse_dis.get(), idx.get());
 
-    invlists->prefetch_lists(idx.get(), n * nprobe_2);
+    invlists->prefetch_lists(idx.get(), static_cast<int>(n * nprobe_2));
 
     // search_preassigned() with `store_pairs` enabled to obtain the list_no
     // and offset into `codes` for reconstruction
@@ -277,7 +277,7 @@ void IndexBinaryIVF::train(idx_t n, const uint8_t* x) {
             printf("Training quantizer on %" PRId64 " vectors in %dD\n", n, d);
         }
 
-        Clustering clus(d, nlist, cp);
+        Clustering clus(d, static_cast<int>(nlist), cp);
         quantizer->reset();
 
         IndexFlatL2 index_tmp(d);
@@ -705,9 +705,10 @@ void search_knn_hamming_per_invlist(
     int32_t* keys = new int32_t[n * nprobe];
     std::unique_ptr<int32_t[]> delete_keys(keys);
     for (size_t i = 0; i < n * static_cast<size_t>(nprobe); i++) {
-        keys[i] = keys_in[i];
+        keys[i] = static_cast<int32_t>(keys_in[i]);
     }
-    matrix_bucket_sort_inplace(n, nprobe, keys, ivf->nlist, lims.data(), 0);
+    matrix_bucket_sort_inplace(
+            n, nprobe, keys, static_cast<int32_t>(ivf->nlist), lims.data(), 0);
 
     using C = CMax<int32_t, idx_t>;
     heap_heapify<C>(n * k, distances, labels);
@@ -754,7 +755,12 @@ void search_knn_hamming_per_invlist(
         } else {
             for (; i + BS <= nq; i += BS) {
                 BlockSearchVariableK<HammingComputer, BS> bc(
-                        code_size, k, x, keys + l0 + i, distances, labels);
+                        code_size,
+                        static_cast<int>(k),
+                        x,
+                        keys + l0 + i,
+                        distances,
+                        labels);
                 for (idx_t j = 0; j < nb; j++) {
                     bc.add_bcode(bcodes + j * code_size, ids[j]);
                 }
@@ -764,7 +770,8 @@ void search_knn_hamming_per_invlist(
         // leftovers
         for (; i < nq; i++) {
             idx_t qno = keys[l0 + i];
-            HammingComputer hc(x + qno * code_size, code_size);
+            HammingComputer hc(
+                    x + qno * code_size, static_cast<int>(code_size));
             idx_t* __restrict idxi = labels + qno * k;
             int32_t* __restrict simi = distances + qno * k;
             int32_t simi0 = simi[0];
@@ -868,7 +875,7 @@ void IndexBinaryIVF::range_search(
     indexIVF_stats.quantization_time += getmillisecs() - t0;
 
     t0 = getmillisecs();
-    invlists->prefetch_lists(idx.get(), n * nprobe_2);
+    invlists->prefetch_lists(idx.get(), static_cast<int>(n * nprobe_2));
 
     range_search_preassigned(n, x, radius, idx.get(), coarse_dis.get(), res);
 

--- a/faiss/IndexFastScan.cpp
+++ b/faiss/IndexFastScan.cpp
@@ -187,14 +187,14 @@ void estimators_from_tables_generic(
         int nscale = context.pq2x4_scale ? 2 : 0;
 
         for (size_t m = 0; m < index.M - nscale; m++) {
-            uint64_t c = bsr.read(index.nbits);
+            uint64_t c = bsr.read(static_cast<int>(index.nbits));
             dis += dt[c];
             dt += index.ksub;
         }
 
         if (nscale) {
             for (size_t m = 0; m < nscale; m++) {
-                uint64_t c = bsr.read(index.nbits);
+                uint64_t c = bsr.read(static_cast<int>(index.nbits));
                 dis += dt[c] * context.pq2x4_scale;
                 dt += index.ksub;
             }
@@ -487,8 +487,8 @@ void IndexFastScan::search_implem_12(
         qbs_ = pq4_preferred_qbs(static_cast<int>(n));
     }
 
-    int LUT_nq =
-            pq4_pack_LUT_qbs(qbs_, M2, quantized_dis_tables.get(), LUT.get());
+    int LUT_nq = pq4_pack_LUT_qbs(
+            qbs_, static_cast<int>(M2), quantized_dis_tables.get(), LUT.get());
     FAISS_THROW_IF_NOT(LUT_nq == n);
 
     auto scanner = make_knn_scanner(
@@ -504,7 +504,7 @@ void IndexFastScan::search_implem_12(
                 qbs_,
 
                 ntotal2,
-                M2,
+                static_cast<int>(M2),
                 codes.get(),
                 LUT.get(),
                 context.pq2x4_scale,
@@ -570,7 +570,11 @@ void IndexFastScan::search_implem_14(
     }
 
     AlignedTable<uint8_t> LUT(n * dim12);
-    pq4_pack_LUT(n, M2, quantized_dis_tables.get(), LUT.get());
+    pq4_pack_LUT(
+            static_cast<int>(n),
+            static_cast<int>(M2),
+            quantized_dis_tables.get(),
+            LUT.get());
 
     auto scanner = make_knn_scanner(
             C::is_max, n, k, ntotal, distances, labels, nullptr, impl, context);
@@ -582,10 +586,10 @@ void IndexFastScan::search_implem_14(
     // accessible through the SIMDResultHandlerToFloat* interface.
     if (!(skip & (2 | 4))) {
         scanner->accumulate_loop(
-                n,
+                static_cast<int>(n),
                 ntotal2,
                 bbs,
-                M2,
+                static_cast<int>(M2),
                 codes.get(),
                 LUT.get(),
                 context.pq2x4_scale,

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -93,7 +93,7 @@ void hnsw_add_vertices(
 
         // build histogram
         for (size_t i = 0; i < n; i++) {
-            storage_idx_t pt_id = i + n0;
+            storage_idx_t pt_id = static_cast<storage_idx_t>(i + n0);
             int pt_level = hnsw.levels[pt_id] - 1;
             while (pt_level >= static_cast<int>(hist.size())) {
                 hist.push_back(0);
@@ -109,7 +109,7 @@ void hnsw_add_vertices(
 
         // bucket sort
         for (size_t i = 0; i < n; i++) {
-            storage_idx_t pt_id = i + n0;
+            storage_idx_t pt_id = static_cast<storage_idx_t>(i + n0);
             int pt_level = hnsw.levels[pt_id] - 1;
             order[offsets[pt_level]++] = pt_id;
         }
@@ -121,7 +121,7 @@ void hnsw_add_vertices(
     { // perform add
         RandomGenerator rng2(789);
 
-        size_t i1 = n;
+        size_t i1 = static_cast<int>(n);
 
         for (int pt_level = static_cast<int>(hist.size()) - 1;
              pt_level >= int(!index_hnsw.init_level0);
@@ -436,7 +436,7 @@ void IndexHNSW::search_level_0(
     FAISS_THROW_IF_NOT(k > 0);
     FAISS_THROW_IF_NOT(nprobe > 0);
 
-    storage_idx_t hnsw_ntotal = hnsw.levels.size();
+    size_t hnsw_ntotal = hnsw.levels.size();
 
     using RH = HeapBlockResultHandler<HNSW::C>;
     RH bres(n, distances, labels, k);
@@ -497,7 +497,7 @@ void IndexHNSW::init_level_0_from_knngraph(
         std::priority_queue<NodeDistFarther> initial_list;
 
         for (int j = 0; j < k; j++) {
-            int v1 = I[i * k + j];
+            int v1 = static_cast<int>(I[i * k + j]);
             if (v1 == i) {
                 continue;
             }
@@ -865,7 +865,7 @@ void IndexHNSW2Level::search(
                 index_ivfpq,
                 "IndexHNSW2Level mixed search requires IndexIVFPQ storage");
 
-        int nprobe = index_ivfpq->nprobe;
+        size_t nprobe = index_ivfpq->nprobe;
 
         std::unique_ptr<idx_t[]> coarse_assign(new idx_t[n * nprobe]);
         std::unique_ptr<float[]> coarse_dis(new float[n * nprobe]);
@@ -901,7 +901,7 @@ void IndexHNSW2Level::search(
 
                 // mark all inverted list elements as visited
 
-                for (int j = 0; j < nprobe; j++) {
+                for (size_t j = 0; j < nprobe; j++) {
                     idx_t key = coarse_assign[j + i * nprobe];
                     if (key < 0) {
                         break;
@@ -920,7 +920,8 @@ void IndexHNSW2Level::search(
                     if (idxi[j] < 0) {
                         break;
                     }
-                    candidates.push(idxi[j], simi[j]);
+                    candidates.push(
+                            static_cast<storage_idx_t>(idxi[j]), simi[j]);
                 }
 
                 // reorder from sorted to heap
@@ -930,14 +931,14 @@ void IndexHNSW2Level::search(
                 search_from_candidates_2(
                         hnsw,
                         *dis,
-                        k,
+                        static_cast<int>(k),
                         idxi,
                         simi,
                         candidates,
                         vt,
                         search_stats,
                         0,
-                        k);
+                        static_cast<int>(k));
                 n1 += search_stats.n1;
                 n2 += search_stats.n2;
                 ndis += search_stats.ndis;
@@ -1060,7 +1061,7 @@ void IndexHNSWCagra::search(
                 auto idx = distrib(gen);
                 auto distance = (*dis)(idx);
                 if (distance < nearest_d[i]) {
-                    nearest[i] = idx;
+                    nearest[i] = static_cast<storage_idx_t>(idx);
                     nearest_d[i] = distance;
                 }
             }

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -94,7 +94,7 @@ void hnsw_add_vertices(
 
         // build histogram
         for (size_t i = 0; i < n; i++) {
-            storage_idx_t pt_id = i + n0;
+            storage_idx_t pt_id = static_cast<storage_idx_t>(i + n0);
             int pt_level = hnsw.levels[pt_id] - 1;
             while (pt_level >= static_cast<int>(hist.size())) {
                 hist.push_back(0);
@@ -110,7 +110,7 @@ void hnsw_add_vertices(
 
         // bucket sort
         for (size_t i = 0; i < n; i++) {
-            storage_idx_t pt_id = i + n0;
+            storage_idx_t pt_id = static_cast<storage_idx_t>(i + n0);
             int pt_level = hnsw.levels[pt_id] - 1;
             order[offsets[pt_level]++] = pt_id;
         }
@@ -122,7 +122,7 @@ void hnsw_add_vertices(
     { // perform add
         RandomGenerator rng2(789);
 
-        size_t i1 = n;
+        size_t i1 = static_cast<int>(n);
 
         for (int pt_level = static_cast<int>(hist.size()) - 1;
              pt_level >= int(!index_hnsw.init_level0);
@@ -437,7 +437,7 @@ void IndexHNSW::search_level_0(
     FAISS_THROW_IF_NOT(k > 0);
     FAISS_THROW_IF_NOT(nprobe > 0);
 
-    storage_idx_t hnsw_ntotal = hnsw.levels.size();
+    size_t hnsw_ntotal = hnsw.levels.size();
 
     using RH = HeapBlockResultHandler<HNSW::C>;
     RH bres(n, distances, labels, k);
@@ -498,7 +498,7 @@ void IndexHNSW::init_level_0_from_knngraph(
         std::priority_queue<NodeDistFarther> initial_list;
 
         for (int j = 0; j < k; j++) {
-            int v1 = I[i * k + j];
+            int v1 = static_cast<int>(I[i * k + j]);
             if (v1 == i) {
                 continue;
             }
@@ -866,7 +866,7 @@ void IndexHNSW2Level::search(
         const IndexIVFPQ* index_ivfpq =
                 dynamic_cast<const IndexIVFPQ*>(storage);
 
-        int nprobe = index_ivfpq->nprobe;
+        size_t nprobe = index_ivfpq->nprobe;
 
         std::unique_ptr<idx_t[]> coarse_assign(new idx_t[n * nprobe]);
         std::unique_ptr<float[]> coarse_dis(new float[n * nprobe]);
@@ -902,7 +902,7 @@ void IndexHNSW2Level::search(
 
                 // mark all inverted list elements as visited
 
-                for (int j = 0; j < nprobe; j++) {
+                for (size_t j = 0; j < nprobe; j++) {
                     idx_t key = coarse_assign[j + i * nprobe];
                     if (key < 0) {
                         break;
@@ -921,7 +921,8 @@ void IndexHNSW2Level::search(
                     if (idxi[j] < 0) {
                         break;
                     }
-                    candidates.push(idxi[j], simi[j]);
+                    candidates.push(
+                            static_cast<storage_idx_t>(idxi[j]), simi[j]);
                 }
 
                 // reorder from sorted to heap
@@ -931,14 +932,14 @@ void IndexHNSW2Level::search(
                 search_from_candidates_2(
                         hnsw,
                         *dis,
-                        k,
+                        static_cast<int>(k),
                         idxi,
                         simi,
                         candidates,
                         vt,
                         search_stats,
                         0,
-                        k);
+                        static_cast<int>(k));
                 n1 += search_stats.n1;
                 n2 += search_stats.n2;
                 ndis += search_stats.ndis;
@@ -1061,7 +1062,7 @@ void IndexHNSWCagra::search(
                 auto idx = distrib(gen);
                 auto distance = (*dis)(idx);
                 if (distance < nearest_d[i]) {
-                    nearest[i] = idx;
+                    nearest[i] = static_cast<storage_idx_t>(idx);
                     nearest_d[i] = distance;
                 }
             }

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -79,7 +79,7 @@ void Level1Quantizer::train_q1(
             printf("Training level-1 quantizer on %zd vectors in %zdD\n", n, d);
         }
 
-        Clustering clus(d, nlist, cp);
+        Clustering clus(static_cast<int>(d), static_cast<int>(nlist), cp);
         quantizer->reset();
         if (clustering_index) {
             clus.train(n, x, *clustering_index);
@@ -101,7 +101,7 @@ void Level1Quantizer::train_q1(
                 metric_type == METRIC_L2 ||
                 (metric_type == METRIC_INNER_PRODUCT && cp.spherical));
 
-        Clustering clus(d, nlist, cp);
+        Clustering clus(static_cast<int>(d), static_cast<int>(nlist), cp);
         if (!clustering_index) {
             IndexFlatL2 assigner(d);
             clus.train(n, x, assigner);
@@ -343,7 +343,8 @@ void IndexIVF::search(
                 params ? params->quantizer_params : nullptr);
 
         double t1 = getmillisecs();
-        invlists->prefetch_lists(idx.get(), sub_n * cur_nprobe);
+        invlists->prefetch_lists(
+                idx.get(), static_cast<int>(sub_n * cur_nprobe));
 
         search_preassigned(
                 sub_n,
@@ -759,7 +760,7 @@ void IndexIVF::range_search(
     indexIVF_stats.quantization_time += getmillisecs() - t0;
 
     t0 = getmillisecs();
-    invlists->prefetch_lists(keys.get(), nx * cur_nprobe);
+    invlists->prefetch_lists(keys.get(), static_cast<int>(nx * cur_nprobe));
 
     range_search_preassigned(
             nx,
@@ -963,7 +964,7 @@ void IndexIVF::search1(
     indexIVF_stats.quantization_time += getmillisecs() - t0;
 
     t0 = getmillisecs();
-    invlists->prefetch_lists(keys.get(), nx * cur_nprobe);
+    invlists->prefetch_lists(keys.get(), static_cast<int>(nx * cur_nprobe));
 
     std::unique_ptr<InvertedListScanner> scanner(
             get_InvertedListScanner(false, nullptr, params));
@@ -1080,7 +1081,7 @@ void IndexIVF::search_and_reconstruct(
 
     quantizer->search(n, x, cur_nprobe, coarse_dis.get(), idx.get());
 
-    invlists->prefetch_lists(idx.get(), n * cur_nprobe);
+    invlists->prefetch_lists(idx.get(), static_cast<int>(n * cur_nprobe));
 
     // search_preassigned() with `store_pairs` enabled to obtain the list_no
     // and offset into `codes` for reconstruction
@@ -1102,8 +1103,8 @@ void IndexIVF::search_and_reconstruct(
             // Fill with NaNs
             memset(reconstructed, -1, sizeof(*reconstructed) * d);
         } else {
-            int list_no = lo_listno(key);
-            int offset = lo_offset(key);
+            size_t list_no = lo_listno(key);
+            size_t offset = lo_offset(key);
 
             // Update label to the actual id
             labels[ij] = invlists->get_single_id(list_no, offset);
@@ -1136,7 +1137,7 @@ void IndexIVF::search_and_return_codes(
 
     quantizer->search(n, x, cur_nprobe, coarse_dis.get(), idx.get());
 
-    invlists->prefetch_lists(idx.get(), n * cur_nprobe);
+    invlists->prefetch_lists(idx.get(), static_cast<int>(n * cur_nprobe));
 
     // search_preassigned() with `store_pairs` enabled to obtain the list_no
     // and offset into `codes` for reconstruction
@@ -1165,8 +1166,8 @@ void IndexIVF::search_and_return_codes(
             // Fill with 0xff
             memset(code1, -1, code_size_1);
         } else {
-            int list_no = lo_listno(key);
-            int offset = lo_offset(key);
+            size_t list_no = lo_listno(key);
+            size_t offset = lo_offset(key);
             const uint8_t* cc = invlists->get_single_code(list_no, offset);
 
             labels[ij] = invlists->get_single_id(list_no, offset);

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -78,7 +78,7 @@ void Level1Quantizer::train_q1(
             printf("Training level-1 quantizer on %zd vectors in %zdD\n", n, d);
         }
 
-        Clustering clus(d, nlist, cp);
+        Clustering clus(static_cast<int>(d), static_cast<int>(nlist), cp);
         quantizer->reset();
         if (clustering_index) {
             clus.train(n, x, *clustering_index);
@@ -100,7 +100,7 @@ void Level1Quantizer::train_q1(
                 metric_type == METRIC_L2 ||
                 (metric_type == METRIC_INNER_PRODUCT && cp.spherical));
 
-        Clustering clus(d, nlist, cp);
+        Clustering clus(static_cast<int>(d), static_cast<int>(nlist), cp);
         if (!clustering_index) {
             IndexFlatL2 assigner(d);
             clus.train(n, x, assigner);
@@ -339,7 +339,8 @@ void IndexIVF::search(
                 params ? params->quantizer_params : nullptr);
 
         double t1 = getmillisecs();
-        invlists->prefetch_lists(idx.get(), sub_n * cur_nprobe);
+        invlists->prefetch_lists(
+                idx.get(), static_cast<int>(sub_n * cur_nprobe));
 
         search_preassigned(
                 sub_n,
@@ -769,7 +770,7 @@ void IndexIVF::range_search(
     indexIVF_stats.quantization_time += getmillisecs() - t0;
 
     t0 = getmillisecs();
-    invlists->prefetch_lists(keys.get(), nx * cur_nprobe);
+    invlists->prefetch_lists(keys.get(), static_cast<int>(nx * cur_nprobe));
 
     range_search_preassigned(
             nx,
@@ -984,7 +985,7 @@ void IndexIVF::search1(
     indexIVF_stats.quantization_time += getmillisecs() - t0;
 
     t0 = getmillisecs();
-    invlists->prefetch_lists(keys.get(), nx * cur_nprobe);
+    invlists->prefetch_lists(keys.get(), static_cast<int>(nx * cur_nprobe));
 
     std::unique_ptr<InvertedListScanner> scanner(
             get_InvertedListScanner(false, nullptr, params));
@@ -1101,7 +1102,7 @@ void IndexIVF::search_and_reconstruct(
 
     quantizer->search(n, x, cur_nprobe, coarse_dis.get(), idx.get());
 
-    invlists->prefetch_lists(idx.get(), n * cur_nprobe);
+    invlists->prefetch_lists(idx.get(), static_cast<int>(n * cur_nprobe));
 
     // search_preassigned() with `store_pairs` enabled to obtain the list_no
     // and offset into `codes` for reconstruction
@@ -1123,8 +1124,8 @@ void IndexIVF::search_and_reconstruct(
             // Fill with NaNs
             memset(reconstructed, -1, sizeof(*reconstructed) * d);
         } else {
-            int list_no = lo_listno(key);
-            int offset = lo_offset(key);
+            size_t list_no = lo_listno(key);
+            size_t offset = lo_offset(key);
 
             // Update label to the actual id
             labels[ij] = invlists->get_single_id(list_no, offset);
@@ -1157,7 +1158,7 @@ void IndexIVF::search_and_return_codes(
 
     quantizer->search(n, x, cur_nprobe, coarse_dis.get(), idx.get());
 
-    invlists->prefetch_lists(idx.get(), n * cur_nprobe);
+    invlists->prefetch_lists(idx.get(), static_cast<int>(n * cur_nprobe));
 
     // search_preassigned() with `store_pairs` enabled to obtain the list_no
     // and offset into `codes` for reconstruction
@@ -1186,8 +1187,8 @@ void IndexIVF::search_and_return_codes(
             // Fill with 0xff
             memset(code1, -1, code_size_1);
         } else {
-            int list_no = lo_listno(key);
-            int offset = lo_offset(key);
+            size_t list_no = lo_listno(key);
+            size_t offset = lo_offset(key);
             const uint8_t* cc = invlists->get_single_code(list_no, offset);
 
             labels[ij] = invlists->get_single_id(list_no, offset);

--- a/faiss/IndexIVFFastScan.cpp
+++ b/faiss/IndexIVFFastScan.cpp
@@ -254,14 +254,14 @@ void estimators_from_tables_generic(
         const dis_t* __restrict dt = dis_table;
 
         for (size_t m = 0; m < index.M - nscale; m++) {
-            uint64_t c = bsr.read(index.nbits);
+            uint64_t c = bsr.read(static_cast<int>(index.nbits));
             dis += dt[c];
             dt += index.ksub;
         }
 
         if (nscale) {
             for (size_t m = 0; m < nscale; m++) {
-                uint64_t c = bsr.read(index.nbits);
+                uint64_t c = bsr.read(static_cast<int>(index.nbits));
                 dis += dt[c] * context.pq2x4_scale;
                 dt += index.ksub;
             }
@@ -462,7 +462,7 @@ int compute_search_nslice(
         size_t cur_nprobe) {
     int nslice;
     if (n <= static_cast<size_t>(omp_get_max_threads())) {
-        nslice = n;
+        nslice = static_cast<int>(n);
     } else if (index->lookup_table_is_3d()) {
         // make sure we don't make too big LUT tables
         size_t lut_size_per_query = index->M * index->ksub * cur_nprobe *
@@ -471,8 +471,8 @@ int compute_search_nslice(
         size_t max_lut_size = precomputed_table_max_bytes;
         // how many queries we can handle within mem budget
         size_t nq_ok = std::max(max_lut_size / lut_size_per_query, size_t(1));
-        nslice = roundup(
-                std::max(size_t(n / nq_ok), size_t(1)), omp_get_max_threads());
+        nslice = static_cast<int>(roundup(
+                std::max(size_t(n / nq_ok), size_t(1)), omp_get_max_threads()));
     } else {
         // LUTs unlikely to be a limiting factor
         nslice = omp_get_max_threads();
@@ -552,7 +552,7 @@ void IndexIVFFastScan::search_dispatch_implem(
         // sliced over threads (then it is more efficient to have each thread do
         // its own coarse quantization)
         cq.quantize(quantizer, n, x, quantizer_params);
-        invlists->prefetch_lists(cq.ids, n * cq.nprobe);
+        invlists->prefetch_lists(cq.ids, static_cast<int>(n * cq.nprobe));
     }
 
     if (impl == 1) {
@@ -717,7 +717,7 @@ void IndexIVFFastScan::range_search_dispatch_implem(
 
     if (!multiple_threads && !cq.done()) {
         cq.quantize(quantizer, n, x, quantizer_params);
-        invlists->prefetch_lists(cq.ids, n * cq.nprobe);
+        invlists->prefetch_lists(cq.ids, static_cast<int>(n * cq.nprobe));
     }
 
     size_t ndis = 0, nlist_visited = 0;
@@ -990,7 +990,7 @@ void IndexIVFFastScan::search_implem_10(
 
     for (idx_t i = 0; i < n; i++) {
         const uint8_t* LUT = nullptr;
-        qmap1[0] = i;
+        qmap1[0] = static_cast<int>(i);
 
         if (single_LUT) {
             LUT = dis_tables.get() + i * dim12;
@@ -1028,7 +1028,7 @@ void IndexIVFFastScan::search_implem_10(
                     1,
                     roundup(ls, bbs),
                     bbs,
-                    M2,
+                    static_cast<int>(M2),
                     codes.get(),
                     LUT,
                     context.pq2x4_scale,
@@ -1094,7 +1094,7 @@ void IndexIVFFastScan::search_implem_12(
 
     // prepare the result handlers
 
-    int actual_qbs2 = this->qbs2 ? this->qbs2 : 11;
+    int actual_qbs2 = static_cast<int>(this->qbs2 ? this->qbs2 : 11);
 
     std::vector<uint16_t> tmp_bias;
     if (biases.get()) {
@@ -1131,7 +1131,7 @@ void IndexIVFFastScan::search_implem_12(
         nlist_visited++;
 
         // re-organize LUTs and biases into the right order
-        int nc = i1 - i0;
+        int nc = static_cast<int>(i1 - i0);
 
         std::vector<int> q_map(nc), lut_entries(nc);
         AlignedTable<uint8_t> LUT(nc * dim12);
@@ -1141,7 +1141,7 @@ void IndexIVFFastScan::search_implem_12(
         for (size_t i = i0; i < i1; i++) {
             const QC& qc = qcs[i];
             q_map[i - i0] = qc.qno;
-            int ij = qc.qno * cur_nprobe + qc.rank;
+            int ij = static_cast<int>(qc.qno * cur_nprobe + qc.rank);
             lut_entries[i - i0] = single_LUT ? qc.qno : ij;
             if (biases.get()) {
                 tmp_bias[i - i0] = biases[ij];
@@ -1149,7 +1149,7 @@ void IndexIVFFastScan::search_implem_12(
         }
         pq4_pack_LUT_qbs_q_map(
                 qbs_for_list,
-                M2,
+                static_cast<int>(M2),
                 dis_tables.get(),
                 lut_entries.data(),
                 LUT.get());
@@ -1180,7 +1180,7 @@ void IndexIVFFastScan::search_implem_12(
         scanner.accumulate_loop_qbs(
                 qbs_for_list,
                 list_size,
-                M2,
+                static_cast<int>(M2),
                 codes.get(),
                 LUT.get(),
                 context.pq2x4_scale,
@@ -1328,7 +1328,7 @@ void IndexIVFFastScan::search_implem_14(
         SIMDResultHandlerToFloat* handler_ptr = scanner->handler();
         handler_ptr->begin(normalizers.get());
 
-        int actual_qbs2 = this->qbs2 ? this->qbs2 : 11;
+        int actual_qbs2 = static_cast<int>(this->qbs2 ? this->qbs2 : 11);
 
         std::vector<uint16_t> tmp_bias;
         if (biases.get()) {
@@ -1353,7 +1353,7 @@ void IndexIVFFastScan::search_implem_14(
             int list_no = qcs[i0].list_no;
 
             // re-organize LUTs and biases into the right order
-            int nc = i1 - i0;
+            int nc = static_cast<int>(i1 - i0);
 
             std::vector<int> q_map(nc), lut_entries(nc);
             AlignedTable<uint8_t> LUT(nc * dim12);
@@ -1364,7 +1364,7 @@ void IndexIVFFastScan::search_implem_14(
                 const QC& qc = qcs[i];
                 q_map[i - i0] = qc.qno;
                 q_set.insert(qc.qno);
-                int ij = qc.qno * cur_nprobe + qc.rank;
+                int ij = static_cast<int>(qc.qno * cur_nprobe + qc.rank);
                 lut_entries[i - i0] = single_LUT ? qc.qno : ij;
                 if (biases.get()) {
                     tmp_bias[i - i0] = biases[ij];
@@ -1372,7 +1372,7 @@ void IndexIVFFastScan::search_implem_14(
             }
             pq4_pack_LUT_qbs_q_map(
                     qbs_for_list,
-                    M2,
+                    static_cast<int>(M2),
                     dis_tables.get(),
                     lut_entries.data(),
                     LUT.get());
@@ -1403,7 +1403,7 @@ void IndexIVFFastScan::search_implem_14(
             scanner->accumulate_loop_qbs(
                     qbs_for_list,
                     list_size,
-                    M2,
+                    static_cast<int>(M2),
                     codes.get(),
                     LUT.get(),
                     context.pq2x4_scale,
@@ -1465,7 +1465,7 @@ void IndexIVFFastScan::reconstruct_from_offset(
     for (size_t m = 0; m < M; m++) {
         uint8_t c =
                 pq4_get_packed_element(list_codes.get(), bbs, M2, offset, m);
-        bsw.write(c, nbits);
+        bsw.write(c, static_cast<int>(nbits));
     }
 
     sa_decode(1, code.data(), recons);
@@ -1488,7 +1488,7 @@ void IndexIVFFastScan::reconstruct_orig_invlists() {
             for (size_t m = 0; m < M; m++) {
                 uint8_t c =
                         pq4_get_packed_element(codes.get(), bbs, M2, offset, m);
-                bsw.write(c, nbits);
+                bsw.write(c, static_cast<int>(nbits));
             }
 
             // get id

--- a/faiss/IndexIVFIndependentQuantizer.cpp
+++ b/faiss/IndexIVFIndependentQuantizer.cpp
@@ -91,7 +91,7 @@ void IndexIVFIndependentQuantizer::search(
         idx_t* labels,
         const SearchParameters* params) const {
     FAISS_THROW_IF_NOT_MSG(!params, "search parameters not supported");
-    int nprobe = index_ivf->nprobe;
+    size_t nprobe = index_ivf->nprobe;
     std::vector<float> D(n * nprobe);
     std::vector<idx_t> I(n * nprobe);
     quantizer->search(n, x, nprobe, D.data(), I.data());

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -692,7 +692,7 @@ struct QueryTables {
                     dynamic_cast<const MultiIndexQuantizer*>(ivfpq.quantizer);
             FAISS_THROW_IF_NOT(miq);
             const ProductQuantizer& cpq = miq->pq;
-            int Mf = pq.M / cpq.M;
+            size_t Mf = pq.M / cpq.M;
 
             const float* qtab = sim_table_2; // query-specific table
             float* ltab = sim_table;         // (output) list-specific table
@@ -700,7 +700,7 @@ struct QueryTables {
             long k = key;
             for (size_t cm = 0; cm < cpq.M; cm++) {
                 // compute PQ index
-                int ki = k & ((uint64_t(1) << cpq.nbits) - 1);
+                size_t ki = k & ((uint64_t(1) << cpq.nbits) - 1);
                 k >>= cpq.nbits;
 
                 // get corresponding table
@@ -746,18 +746,18 @@ struct QueryTables {
                     dynamic_cast<const MultiIndexQuantizer*>(ivfpq.quantizer);
             FAISS_THROW_IF_NOT(miq);
             const ProductQuantizer& cpq = miq->pq;
-            int Mf = pq.M / cpq.M;
+            size_t Mf = pq.M / cpq.M;
 
             long k = key;
-            int m0 = 0;
+            size_t m0 = 0;
             for (size_t cm = 0; cm < cpq.M; cm++) {
-                int ki = k & ((uint64_t(1) << cpq.nbits) - 1);
+                size_t ki = k & ((uint64_t(1) << cpq.nbits) - 1);
                 k >>= cpq.nbits;
 
                 const float* pc = ivfpq.precomputed_table.data() +
                         (ki * pq.M + cm * Mf) * pq.ksub;
 
-                for (int m = m0; m < m0 + Mf; m++) {
+                for (size_t m = m0; m < m0 + Mf; m++) {
                     sim_table_ptrs[m] = pc;
                     pc += pq.ksub;
                 }
@@ -1056,7 +1056,7 @@ struct IVFPQScannerT : QueryTables {
         int ht = ivfpq.polysemous_ht;
         size_t n_hamming_pass = 0;
 
-        int code_size = pq.code_size;
+        int code_size = static_cast<int>(pq.code_size);
 
         size_t saved_j[8];
         int counter = 0;

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -691,7 +691,7 @@ struct QueryTables {
                     dynamic_cast<const MultiIndexQuantizer*>(ivfpq.quantizer);
             FAISS_THROW_IF_NOT(miq);
             const ProductQuantizer& cpq = miq->pq;
-            int Mf = pq.M / cpq.M;
+            size_t Mf = pq.M / cpq.M;
 
             const float* qtab = sim_table_2; // query-specific table
             float* ltab = sim_table;         // (output) list-specific table
@@ -699,7 +699,7 @@ struct QueryTables {
             long k = key;
             for (size_t cm = 0; cm < cpq.M; cm++) {
                 // compute PQ index
-                int ki = k & ((uint64_t(1) << cpq.nbits) - 1);
+                size_t ki = k & ((uint64_t(1) << cpq.nbits) - 1);
                 k >>= cpq.nbits;
 
                 // get corresponding table
@@ -745,18 +745,18 @@ struct QueryTables {
                     dynamic_cast<const MultiIndexQuantizer*>(ivfpq.quantizer);
             FAISS_THROW_IF_NOT(miq);
             const ProductQuantizer& cpq = miq->pq;
-            int Mf = pq.M / cpq.M;
+            size_t Mf = pq.M / cpq.M;
 
             long k = key;
-            int m0 = 0;
+            size_t m0 = 0;
             for (size_t cm = 0; cm < cpq.M; cm++) {
-                int ki = k & ((uint64_t(1) << cpq.nbits) - 1);
+                size_t ki = k & ((uint64_t(1) << cpq.nbits) - 1);
                 k >>= cpq.nbits;
 
                 const float* pc = ivfpq.precomputed_table.data() +
                         (ki * pq.M + cm * Mf) * pq.ksub;
 
-                for (int m = m0; m < m0 + Mf; m++) {
+                for (size_t m = m0; m < m0 + Mf; m++) {
                     sim_table_ptrs[m] = pc;
                     pc += pq.ksub;
                 }
@@ -1055,7 +1055,7 @@ struct IVFPQScannerT : QueryTables {
         int ht = ivfpq.polysemous_ht;
         size_t n_hamming_pass = 0;
 
-        int code_size = pq.code_size;
+        int code_size = static_cast<int>(pq.code_size);
 
         size_t saved_j[8];
         int counter = 0;

--- a/faiss/IndexIVFPQR.cpp
+++ b/faiss/IndexIVFPQR.cpp
@@ -173,8 +173,8 @@ void IndexIVFPQR::search_preassigned(
                     continue;
                 }
 
-                int list_no = lo_listno(sl);
-                int ofs = lo_offset(sl);
+                int list_no = static_cast<int>(lo_listno(sl));
+                int ofs = static_cast<int>(lo_offset(sl));
 
                 FAISS_THROW_IF_NOT(
                         list_no >= 0 && static_cast<size_t>(list_no) < nlist);

--- a/faiss/IndexIVFSpectralHash.cpp
+++ b/faiss/IndexIVFSpectralHash.cpp
@@ -231,7 +231,7 @@ struct IVFScanner : InvertedListScanner {
               q(nbit),
               zero(nbit),
               qcode(index_in->code_size),
-              hc(qcode.data(), index_in->code_size) {
+              hc(qcode.data(), static_cast<int>(index_in->code_size)) {
         this->store_pairs = store_pairs_in;
         this->code_size = index->code_size;
         this->keep_max = is_similarity_metric(index->metric_type);

--- a/faiss/IndexLattice.cpp
+++ b/faiss/IndexLattice.cpp
@@ -19,7 +19,7 @@ IndexLattice::IndexLattice(idx_t d_in, int nsq_in, int scale_nbit_in, int r2)
         : IndexFlatCodes(0, d_in, METRIC_L2),
           nsq(nsq_in),
           dsq(d_in / nsq_in),
-          zn_sphere_codec(dsq, r2),
+          zn_sphere_codec(static_cast<int>(dsq), r2),
           scale_nbit(scale_nbit_in) {
     FAISS_THROW_IF_NOT(d_in % nsq_in == 0);
 

--- a/faiss/IndexNNDescent.cpp
+++ b/faiss/IndexNNDescent.cpp
@@ -142,7 +142,8 @@ void IndexNNDescent::search(
                     float* simi = distances + i * k;
                     dis->set_query(x + i * d);
 
-                    nndescent.search(*dis, k, idxi, simi, *vt);
+                    nndescent.search(
+                            *dis, static_cast<int>(k), idxi, simi, *vt);
                 } catch (...) {
                     omp_capture_exception(ex, [&] { interrupt = true; });
                 }
@@ -177,7 +178,7 @@ void IndexNNDescent::add(idx_t n, const float* x) {
     ntotal = storage->ntotal;
 
     std::unique_ptr<DistanceComputer> dis(storage_distance_computer(storage));
-    nndescent.build(*dis, ntotal, verbose);
+    nndescent.build(*dis, static_cast<int>(ntotal), verbose);
 }
 
 void IndexNNDescent::reset() {

--- a/faiss/IndexNNDescent.cpp
+++ b/faiss/IndexNNDescent.cpp
@@ -132,7 +132,7 @@ void IndexNNDescent::search(
                 float* simi = distances + i * k;
                 dis->set_query(x + i * d);
 
-                nndescent.search(*dis, k, idxi, simi, vt);
+                nndescent.search(*dis, static_cast<int>(k), idxi, simi, vt);
             }
         }
         InterruptCallback::check();
@@ -163,7 +163,7 @@ void IndexNNDescent::add(idx_t n, const float* x) {
     ntotal = storage->ntotal;
 
     std::unique_ptr<DistanceComputer> dis(storage_distance_computer(storage));
-    nndescent.build(*dis, ntotal, verbose);
+    nndescent.build(*dis, static_cast<int>(ntotal), verbose);
 }
 
 void IndexNNDescent::reset() {

--- a/faiss/IndexNSG.cpp
+++ b/faiss/IndexNSG.cpp
@@ -98,7 +98,7 @@ void IndexNSG::search(
                     float* simi = distances + i * k;
                     dis->set_query(x + i * d);
 
-                    nsg.search(*dis, k, idxi, simi, *vt);
+                    nsg.search(*dis, static_cast<int>(k), idxi, simi, *vt);
 
                     vt->advance();
                 } catch (...) {
@@ -131,7 +131,7 @@ void IndexNSG::build(idx_t n, const float* x, idx_t* knn_graph, int gk) {
     // check the knn graph
     check_knn_graph(knn_graph, n, gk);
 
-    const nsg::Graph<idx_t> knng(knn_graph, n, gk);
+    const nsg::Graph<idx_t> knng(knn_graph, static_cast<int>(n), gk);
     nsg.build(storage, n, knng, verbose);
     is_built = true;
 }
@@ -239,7 +239,7 @@ void IndexNSG::add(idx_t n, const float* x) {
         printf("  nsg building\n");
     }
 
-    const nsg::Graph<idx_t> knn_graph(knng.data(), n, GK);
+    const nsg::Graph<idx_t> knn_graph(knng.data(), static_cast<int>(n), GK);
     nsg.build(storage, n, knn_graph, verbose);
     is_built = true;
 }

--- a/faiss/IndexNSG.cpp
+++ b/faiss/IndexNSG.cpp
@@ -87,7 +87,7 @@ void IndexNSG::search(
                 float* simi = distances + i * k;
                 dis->set_query(x + i * d);
 
-                nsg.search(*dis, k, idxi, simi, vt);
+                nsg.search(*dis, static_cast<int>(k), idxi, simi, vt);
 
                 vt.advance();
             }
@@ -116,7 +116,7 @@ void IndexNSG::build(idx_t n, const float* x, idx_t* knn_graph, int gk) {
     // check the knn graph
     check_knn_graph(knn_graph, n, gk);
 
-    const nsg::Graph<idx_t> knng(knn_graph, n, gk);
+    const nsg::Graph<idx_t> knng(knn_graph, static_cast<int>(n), gk);
     nsg.build(storage, n, knng, verbose);
     is_built = true;
 }
@@ -224,7 +224,7 @@ void IndexNSG::add(idx_t n, const float* x) {
         printf("  nsg building\n");
     }
 
-    const nsg::Graph<idx_t> knn_graph(knng.data(), n, GK);
+    const nsg::Graph<idx_t> knn_graph(knng.data(), static_cast<int>(n), GK);
     nsg.build(storage, n, knn_graph, verbose);
     is_built = true;
 }

--- a/faiss/IndexNeuralNetCodec.cpp
+++ b/faiss/IndexNeuralNetCodec.cpp
@@ -34,13 +34,25 @@ void IndexNeuralNetCodec::sa_encode(idx_t n, const float* x, uint8_t* bytes)
         const {
     nn::Tensor2D x_tensor(n, d, x);
     nn::Int32Tensor2D codes_tensor = net->encode(x_tensor);
-    pack_bitstrings(n, M, nbits, codes_tensor.data(), bytes, code_size);
+    pack_bitstrings(
+            n,
+            M,
+            static_cast<int>(nbits),
+            codes_tensor.data(),
+            bytes,
+            code_size);
 }
 
 void IndexNeuralNetCodec::sa_decode(idx_t n, const uint8_t* bytes, float* x)
         const {
     nn::Int32Tensor2D codes_tensor(n, M);
-    unpack_bitstrings(n, M, nbits, bytes, code_size, codes_tensor.data());
+    unpack_bitstrings(
+            n,
+            M,
+            static_cast<int>(nbits),
+            bytes,
+            code_size,
+            codes_tensor.data());
     nn::Tensor2D x_tensor = net->decode(codes_tensor);
     memcpy(x, x_tensor.data(), d * n * sizeof(float));
 }

--- a/faiss/IndexPQ.cpp
+++ b/faiss/IndexPQ.cpp
@@ -32,7 +32,7 @@ IndexPQ::IndexPQ(int d_in, size_t M, size_t nbits, MetricType metric)
         : IndexFlatCodes(0, d_in, metric), pq(d_in, M, nbits) {
     is_trained = false;
     do_polysemous_training = false;
-    polysemous_ht = nbits * M + 1;
+    polysemous_ht = static_cast<int>(nbits * M) + 1;
     search_type = ST_PQ;
     encode_signs = false;
     code_size = pq.code_size;
@@ -42,7 +42,7 @@ IndexPQ::IndexPQ() {
     metric_type = METRIC_L2;
     is_trained = false;
     do_polysemous_training = false;
-    polysemous_ht = pq.nbits * pq.M + 1;
+    polysemous_ht = static_cast<int>(pq.nbits * pq.M) + 1;
     search_type = ST_PQ;
     encode_signs = false;
 }
@@ -299,7 +299,7 @@ size_t polysemous_inner_loop(
 
     size_t n_pass_i = 0;
 
-    HammingComputer hc(q_code, code_size);
+    HammingComputer hc(q_code, static_cast<int>(code_size));
 
     for (int64_t bi = 0; bi < static_cast<int64_t>(ntotal); bi++) {
         int hd = hc.hamming(b_code);
@@ -337,7 +337,7 @@ void IndexPQ::search_core_polysemous(
     FAISS_THROW_IF_NOT(pq.nbits == 8);
 
     if (param_polysemous_ht == 0) {
-        param_polysemous_ht = pq.nbits * pq.M + 1;
+        param_polysemous_ht = static_cast<int>(pq.nbits * pq.M) + 1;
     }
 
     // PQ distance tables
@@ -479,7 +479,7 @@ void IndexPQ::hamming_distance_histogram(
         nb = ntotal;
         b_codes = codes.data();
     }
-    int nbits = pq.M * pq.nbits;
+    int nbits = static_cast<int>(pq.M * pq.nbits);
     memset(hist, 0, sizeof(*hist) * (nbits + 1));
     size_t bs = 256;
 
@@ -939,7 +939,7 @@ void MultiIndexQuantizer::search(
         // simple version that just finds the min in each table
 
 #pragma omp parallel for
-        for (int i = 0; i < n; i++) {
+        for (idx_t i = 0; i < n; i++) {
             const float* dis_table = dis_tables.get() + i * pq.ksub * pq.M;
             float dis = 0;
             idx_t label = 0;
@@ -967,9 +967,12 @@ void MultiIndexQuantizer::search(
 #pragma omp parallel if (n > 1)
         {
             MinSumK<float, SemiSortedArray<float>, false> msk(
-                    k, pq.M, pq.nbits, pq.ksub);
+                    static_cast<int>(k),
+                    static_cast<int>(pq.M),
+                    static_cast<int>(pq.nbits),
+                    static_cast<int>(pq.ksub));
 #pragma omp for
-            for (int i = 0; i < n; i++) {
+            for (idx_t i = 0; i < n; i++) {
                 msk.run(dis_tables.get() + i * pq.ksub * pq.M,
                         pq.ksub,
                         distances + i * k,
@@ -1059,7 +1062,7 @@ void MultiIndexQuantizer2::search(
         return;
     }
 
-    int k2 = std::min(K, int64_t(pq.ksub));
+    int k2 = static_cast<int>(std::min(K, int64_t(pq.ksub)));
     FAISS_THROW_IF_NOT(k2);
 
     int64_t M = pq.M;
@@ -1105,7 +1108,10 @@ void MultiIndexQuantizer2::search(
 #pragma omp parallel if (n > 1)
         {
             MinSumK<float, PreSortedArray<float>, false> msk(
-                    K, pq.M, pq.nbits, k2);
+                    static_cast<int>(K),
+                    static_cast<int>(pq.M),
+                    static_cast<int>(pq.nbits),
+                    k2);
 #pragma omp for
             for (idx_t i = 0; i < n; i++) {
                 idx_t* li = labels + i * K;
@@ -1121,7 +1127,7 @@ void MultiIndexQuantizer2::search(
                     const idx_t* idmap = idmap0;
                     int64_t vin = li[k];
                     int64_t vout = 0;
-                    int bs = 0;
+                    size_t bs = 0;
                     for (int64_t m = 0; m < M; m++) {
                         int64_t s = vin & mask1;
                         vin >>= pq.nbits;

--- a/faiss/IndexPQ.cpp
+++ b/faiss/IndexPQ.cpp
@@ -32,7 +32,7 @@ IndexPQ::IndexPQ(int d_in, size_t M, size_t nbits, MetricType metric)
         : IndexFlatCodes(0, d_in, metric), pq(d_in, M, nbits) {
     is_trained = false;
     do_polysemous_training = false;
-    polysemous_ht = nbits * M + 1;
+    polysemous_ht = static_cast<int>(nbits * M) + 1;
     search_type = ST_PQ;
     encode_signs = false;
     code_size = pq.code_size;
@@ -42,7 +42,7 @@ IndexPQ::IndexPQ() {
     metric_type = METRIC_L2;
     is_trained = false;
     do_polysemous_training = false;
-    polysemous_ht = pq.nbits * pq.M + 1;
+    polysemous_ht = static_cast<int>(pq.nbits * pq.M) + 1;
     search_type = ST_PQ;
     encode_signs = false;
 }
@@ -299,7 +299,7 @@ size_t polysemous_inner_loop(
 
     size_t n_pass_i = 0;
 
-    HammingComputer hc(q_code, code_size);
+    HammingComputer hc(q_code, static_cast<int>(code_size));
 
     for (int64_t bi = 0; bi < static_cast<int64_t>(ntotal); bi++) {
         int hd = hc.hamming(b_code);
@@ -345,7 +345,7 @@ void IndexPQ::search_core_polysemous(
     FAISS_THROW_IF_NOT(pq.nbits == 8);
 
     if (param_polysemous_ht == 0) {
-        param_polysemous_ht = pq.nbits * pq.M + 1;
+        param_polysemous_ht = static_cast<int>(pq.nbits * pq.M) + 1;
     }
 
     // PQ distance tables
@@ -383,7 +383,7 @@ void IndexPQ::search_core_polysemous(
         if (!generalized_hamming) {
             Run_polysemous_inner_loop r;
             n_pass += dispatch_HammingComputer(
-                    pq.code_size,
+                    static_cast<int>(pq.code_size),
                     r,
                     this,
                     dis_table_qi,
@@ -487,7 +487,7 @@ void IndexPQ::hamming_distance_histogram(
         nb = ntotal;
         b_codes = codes.data();
     }
-    int nbits = pq.M * pq.nbits;
+    int nbits = static_cast<int>(pq.M * pq.nbits);
     memset(hist, 0, sizeof(*hist) * (nbits + 1));
     size_t bs = 256;
 
@@ -947,7 +947,7 @@ void MultiIndexQuantizer::search(
         // simple version that just finds the min in each table
 
 #pragma omp parallel for
-        for (int i = 0; i < n; i++) {
+        for (idx_t i = 0; i < n; i++) {
             const float* dis_table = dis_tables.get() + i * pq.ksub * pq.M;
             float dis = 0;
             idx_t label = 0;
@@ -975,9 +975,12 @@ void MultiIndexQuantizer::search(
 #pragma omp parallel if (n > 1)
         {
             MinSumK<float, SemiSortedArray<float>, false> msk(
-                    k, pq.M, pq.nbits, pq.ksub);
+                    static_cast<int>(k),
+                    static_cast<int>(pq.M),
+                    static_cast<int>(pq.nbits),
+                    static_cast<int>(pq.ksub));
 #pragma omp for
-            for (int i = 0; i < n; i++) {
+            for (idx_t i = 0; i < n; i++) {
                 msk.run(dis_tables.get() + i * pq.ksub * pq.M,
                         pq.ksub,
                         distances + i * k,
@@ -1067,7 +1070,7 @@ void MultiIndexQuantizer2::search(
         return;
     }
 
-    int k2 = std::min(K, int64_t(pq.ksub));
+    int k2 = static_cast<int>(std::min(K, int64_t(pq.ksub)));
     FAISS_THROW_IF_NOT(k2);
 
     int64_t M = pq.M;
@@ -1113,7 +1116,10 @@ void MultiIndexQuantizer2::search(
 #pragma omp parallel if (n > 1)
         {
             MinSumK<float, PreSortedArray<float>, false> msk(
-                    K, pq.M, pq.nbits, k2);
+                    static_cast<int>(K),
+                    static_cast<int>(pq.M),
+                    static_cast<int>(pq.nbits),
+                    k2);
 #pragma omp for
             for (idx_t i = 0; i < n; i++) {
                 idx_t* li = labels + i * K;
@@ -1129,7 +1135,7 @@ void MultiIndexQuantizer2::search(
                     const idx_t* idmap = idmap0;
                     int64_t vin = li[k];
                     int64_t vout = 0;
-                    int bs = 0;
+                    size_t bs = 0;
                     for (int64_t m = 0; m < M; m++) {
                         int64_t s = vin & mask1;
                         vin >>= pq.nbits;

--- a/faiss/IndexPreTransform.cpp
+++ b/faiss/IndexPreTransform.cpp
@@ -62,9 +62,9 @@ IndexPreTransform::~IndexPreTransform() {
 void IndexPreTransform::train(idx_t n, const float* x) {
     int last_untrained = 0;
     if (!index->is_trained) {
-        last_untrained = chain.size();
+        last_untrained = static_cast<int>(chain.size());
     } else {
-        for (int i = chain.size() - 1; i >= 0; i--) {
+        for (int i = static_cast<int>(chain.size()) - 1; i >= 0; i--) {
             if (!chain[i]->is_trained) {
                 last_untrained = i;
                 break;
@@ -140,7 +140,7 @@ void IndexPreTransform::reverse_chain(idx_t n, const float* xt, float* x)
     const float* next_x = xt;
     std::unique_ptr<const float[]> del;
 
-    for (int i = chain.size() - 1; i >= 0; i--) {
+    for (int i = static_cast<int>(chain.size()) - 1; i >= 0; i--) {
         float* prev_x = (i == 0) ? x : new float[n * chain[i]->d_in];
         std::unique_ptr<const float[]> del2((prev_x == x) ? nullptr : prev_x);
         chain[i]->reverse_transform(n, next_x, prev_x);

--- a/faiss/IndexPreTransform.cpp
+++ b/faiss/IndexPreTransform.cpp
@@ -62,9 +62,9 @@ IndexPreTransform::~IndexPreTransform() {
 void IndexPreTransform::train(idx_t n, const float* x) {
     int last_untrained = 0;
     if (!index->is_trained) {
-        last_untrained = chain.size();
+        last_untrained = static_cast<int>(chain.size());
     } else {
-        for (int i = chain.size() - 1; i >= 0; i--) {
+        for (int i = static_cast<int>(chain.size()) - 1; i >= 0; i--) {
             if (!chain[i]->is_trained) {
                 last_untrained = i;
                 break;
@@ -138,7 +138,7 @@ void IndexPreTransform::reverse_chain(idx_t n, const float* xt, float* x)
     const float* next_x = xt;
     std::unique_ptr<const float[]> del;
 
-    for (int i = chain.size() - 1; i >= 0; i--) {
+    for (int i = static_cast<int>(chain.size()) - 1; i >= 0; i--) {
         float* prev_x = (i == 0) ? x : new float[n * chain[i]->d_in];
         std::unique_ptr<const float[]> del2((prev_x == x) ? nullptr : prev_x);
         chain[i]->reverse_transform(n, next_x, prev_x);

--- a/faiss/IndexShards.cpp
+++ b/faiss/IndexShards.cpp
@@ -203,7 +203,7 @@ void IndexShardsTemplate<IndexT>::search(
         const SearchParameters* params) const {
     FAISS_THROW_IF_NOT(k > 0);
 
-    int64_t nshard = this->count();
+    int nshard = this->count();
 
     std::vector<distance_t> all_distances(nshard * k * n);
     std::vector<idx_t> all_labels(nshard * k * n);

--- a/faiss/IndexShardsIVF.cpp
+++ b/faiss/IndexShardsIVF.cpp
@@ -183,7 +183,7 @@ void IndexShardsIVF::search(
 
     quantizer->search(n, x, nprobe, Dq.data(), Iq.data());
 
-    int64_t nshard = this->count();
+    int nshard = this->count();
 
     std::vector<distance_t> all_distances(nshard * k * n);
     std::vector<idx_t> all_labels(nshard * k * n);

--- a/faiss/MetaIndexes.cpp
+++ b/faiss/MetaIndexes.cpp
@@ -217,7 +217,8 @@ void IndexRandom::search(
                 perm[j] = j;
             }
             for (int j = 0; j < k; j++) {
-                std::swap(perm[j], perm[rng.rand_int(ntotal)]);
+                std::swap(
+                        perm[j], perm[rng.rand_int(static_cast<int>(ntotal))]);
                 I[j] = perm[j];
             }
         }

--- a/faiss/VectorTransform.cpp
+++ b/faiss/VectorTransform.cpp
@@ -191,7 +191,7 @@ void LinearTransform::apply_noalloc(idx_t n, const float* x, float* xt) const {
             "Transformation matrix not initialized");
 
     float one = 1;
-    FINTEGER nbiti = d_out, ni = n, di = d_in;
+    FINTEGER nbiti = d_out, ni = static_cast<FINTEGER>(n), di = d_in;
     sgemm_("Transposed",
            "Not transposed",
            &nbiti,
@@ -223,7 +223,7 @@ void LinearTransform::transform_transpose(idx_t n, const float* y, float* x)
     }
 
     {
-        FINTEGER dii = d_in, doi = d_out, ni = n;
+        FINTEGER dii = d_in, doi = d_out, ni = static_cast<FINTEGER>(n);
         float one = 1.0, zero = 0.0;
         sgemm_("Not",
                "Not",
@@ -518,7 +518,7 @@ namespace {
 
 void eig(size_t d_in, double* cov, double* eigenvalues, int verbose) {
     { // compute eigenvalues and vectors
-        FINTEGER info = 0, lwork = -1, di = d_in;
+        FINTEGER info = 0, lwork = -1, di = static_cast<FINTEGER>(d_in);
         double workq;
 
         dsyev_("Vectors as well",
@@ -530,7 +530,7 @@ void eig(size_t d_in, double* cov, double* eigenvalues, int verbose) {
                &workq,
                &lwork,
                &info);
-        lwork = FINTEGER(workq);
+        lwork = static_cast<FINTEGER>(workq);
         std::vector<double> work(lwork);
 
         dsyev_("Vectors as well",
@@ -623,7 +623,7 @@ void PCAMatrix::train(idx_t n, const float* x_in) {
             }
         }
         {
-            FINTEGER di = d_in, ni = n;
+            FINTEGER di = d_in, ni = static_cast<FINTEGER>(n);
             float one = 1.0;
             ssyrk_("Up",
                    "Non transposed",
@@ -677,7 +677,7 @@ void PCAMatrix::train(idx_t n, const float* x_in) {
         // compute Gram matrix
         std::vector<float> gram(n * n);
         {
-            FINTEGER di = d_in, ni = n;
+            FINTEGER di = d_in, ni = static_cast<FINTEGER>(n);
             float one = 1.0, zero = 0.0;
             ssyrk_("Up",
                    "Transposed",
@@ -726,7 +726,7 @@ void PCAMatrix::train(idx_t n, const float* x_in) {
         }
 
         { // compute PCAMat = x' * v
-            FINTEGER di = d_in, ni = n;
+            FINTEGER di = d_in, ni = static_cast<FINTEGER>(n);
             float one = 1.0, zero = 0.0;
 
             sgemm_("Non",
@@ -903,7 +903,7 @@ void ITQMatrix::train(idx_t n, const float* xf) {
                init_rotation.data(),
                d * d * sizeof(rotation[0]));
     } else {
-        RandomRotationMatrix rrot(d, d);
+        RandomRotationMatrix rrot(static_cast<int>(d), static_cast<int>(d));
         rrot.init(seed);
         for (size_t i = 0; i < d * d; i++) {
             rotation[i] = rrot.A[i];
@@ -920,9 +920,11 @@ void ITQMatrix::train(idx_t n, const float* xf) {
     std::vector<double> u(d * d), vt(d * d), singvals(d);
 
     for (int i = 0; i < max_iter; i++) {
-        print_if_verbose("rotation", rotation, d, d);
+        print_if_verbose(
+                "rotation", rotation, static_cast<int>(d), static_cast<int>(d));
         { // rotated_data = np.dot(training_data, rotation)
-            FINTEGER di = d, ni = n;
+            FINTEGER di = static_cast<FINTEGER>(d),
+                     ni = static_cast<FINTEGER>(n);
             double one = 1, zero = 0;
             dgemm_("N",
                    "N",
@@ -938,14 +940,19 @@ void ITQMatrix::train(idx_t n, const float* xf) {
                    rotated_x.data(),
                    &di);
         }
-        print_if_verbose("rotated_x", rotated_x, n, d);
+        print_if_verbose(
+                "rotated_x",
+                rotated_x,
+                static_cast<int>(n),
+                static_cast<int>(d));
         // binarize
         for (size_t j = 0; j < n * d; j++) {
             rotated_x[j] = rotated_x[j] < 0 ? -1 : 1;
         }
         // covariance matrix
         { // rotated_data = np.dot(training_data, rotation)
-            FINTEGER di = d, ni = n;
+            FINTEGER di = static_cast<FINTEGER>(d),
+                     ni = static_cast<FINTEGER>(n);
             double one = 1, zero = 0;
             dgemm_("N",
                    "T",
@@ -961,10 +968,11 @@ void ITQMatrix::train(idx_t n, const float* xf) {
                    cov_mat.data(),
                    &di);
         }
-        print_if_verbose("cov_mat", cov_mat, d, d);
+        print_if_verbose(
+                "cov_mat", cov_mat, static_cast<int>(d), static_cast<int>(d));
         // SVD
         {
-            FINTEGER di = d;
+            FINTEGER di = static_cast<FINTEGER>(d);
             FINTEGER lwork = -1, info;
             double lwork1;
 
@@ -988,7 +996,7 @@ void ITQMatrix::train(idx_t n, const float* xf) {
                     info == 0,
                     "LAPACK dgesvd workspace query returned info=%d",
                     int(info));
-            lwork = size_t(lwork1);
+            lwork = static_cast<FINTEGER>(lwork1);
             std::vector<double> work(lwork);
             dgesvd_("A",
                     "A",
@@ -1006,11 +1014,11 @@ void ITQMatrix::train(idx_t n, const float* xf) {
                     &info);
             FAISS_THROW_IF_NOT_FMT(info == 0, "sgesvd returned info=%d", info);
         }
-        print_if_verbose("u", u, d, d);
-        print_if_verbose("vt", vt, d, d);
+        print_if_verbose("u", u, static_cast<int>(d), static_cast<int>(d));
+        print_if_verbose("vt", vt, static_cast<int>(d), static_cast<int>(d));
         // update rotation
         {
-            FINTEGER di = d;
+            FINTEGER di = static_cast<FINTEGER>(d);
             double one = 1, zero = 0;
             dgemm_("N",
                    "T",
@@ -1026,7 +1034,11 @@ void ITQMatrix::train(idx_t n, const float* xf) {
                    rotation.data(),
                    &di);
         }
-        print_if_verbose("final rot", rotation, d, d);
+        print_if_verbose(
+                "final rot",
+                rotation,
+                static_cast<int>(d),
+                static_cast<int>(d));
     }
     A.resize(d * d);
     for (size_t i = 0; i < d; i++) {
@@ -1249,7 +1261,9 @@ void OPQMatrix::train(idx_t n, const float* x_in) {
     double t0 = getmillisecs();
     for (int iter = 0; iter < niter; iter++) {
         { // torch.mm(xtrain, rotation:t())
-            FINTEGER di = d, d2i = d2, ni = n;
+            FINTEGER di = static_cast<FINTEGER>(d),
+                     d2i = static_cast<FINTEGER>(d2),
+                     ni = static_cast<FINTEGER>(n);
             float zero = 0, one = 1;
             sgemm_("Transposed",
                    "Not transposed",
@@ -1296,7 +1310,9 @@ void OPQMatrix::train(idx_t n, const float* x_in) {
         {
             float *u = tmp.data(), *vt = &tmp[d * d];
             float* sing_val = &tmp[2 * d * d];
-            FINTEGER di = d, d2i = d2, ni = n;
+            FINTEGER di = static_cast<FINTEGER>(d),
+                     d2i = static_cast<FINTEGER>(d2),
+                     ni = static_cast<FINTEGER>(n);
             float one = 1, zero = 0;
 
             if (verbose) {
@@ -1339,7 +1355,7 @@ void OPQMatrix::train(idx_t n, const float* x_in) {
                     info == 0,
                     "LAPACK sgesvd workspace query returned info=%d",
                     int(info));
-            lwork = int(worksz);
+            lwork = static_cast<FINTEGER>(worksz);
             std::vector<float> work(lwork);
             // u and vt swapped
             sgesvd_("All",

--- a/faiss/VectorTransform.cpp
+++ b/faiss/VectorTransform.cpp
@@ -191,7 +191,7 @@ void LinearTransform::apply_noalloc(idx_t n, const float* x, float* xt) const {
             "Transformation matrix not initialized");
 
     float one = 1;
-    FINTEGER nbiti = d_out, ni = n, di = d_in;
+    FINTEGER nbiti = d_out, ni = static_cast<FINTEGER>(n), di = d_in;
     sgemm_("Transposed",
            "Not transposed",
            &nbiti,
@@ -222,7 +222,7 @@ void LinearTransform::transform_transpose(idx_t n, const float* y, float* x)
     }
 
     {
-        FINTEGER dii = d_in, doi = d_out, ni = n;
+        FINTEGER dii = d_in, doi = d_out, ni = static_cast<FINTEGER>(n);
         float one = 1.0, zero = 0.0;
         sgemm_("Not",
                "Not",
@@ -521,7 +521,7 @@ namespace {
 
 void eig(size_t d_in, double* cov, double* eigenvalues, int verbose) {
     { // compute eigenvalues and vectors
-        FINTEGER info = 0, lwork = -1, di = d_in;
+        FINTEGER info = 0, lwork = -1, di = static_cast<FINTEGER>(d_in);
         double workq;
 
         dsyev_("Vectors as well",
@@ -533,7 +533,7 @@ void eig(size_t d_in, double* cov, double* eigenvalues, int verbose) {
                &workq,
                &lwork,
                &info);
-        lwork = FINTEGER(workq);
+        lwork = static_cast<FINTEGER>(workq);
         double* work = new double[lwork];
 
         dsyev_("Vectors as well",
@@ -628,7 +628,7 @@ void PCAMatrix::train(idx_t n, const float* x_in) {
             }
         }
         {
-            FINTEGER di = d_in, ni = n;
+            FINTEGER di = d_in, ni = static_cast<FINTEGER>(n);
             float one = 1.0;
             ssyrk_("Up",
                    "Non transposed",
@@ -682,7 +682,7 @@ void PCAMatrix::train(idx_t n, const float* x_in) {
         // compute Gram matrix
         std::vector<float> gram(n * n);
         {
-            FINTEGER di = d_in, ni = n;
+            FINTEGER di = d_in, ni = static_cast<FINTEGER>(n);
             float one = 1.0, zero = 0.0;
             ssyrk_("Up",
                    "Transposed",
@@ -731,7 +731,7 @@ void PCAMatrix::train(idx_t n, const float* x_in) {
         }
 
         { // compute PCAMat = x' * v
-            FINTEGER di = d_in, ni = n;
+            FINTEGER di = d_in, ni = static_cast<FINTEGER>(n);
             float one = 1.0;
 
             sgemm_("Non",
@@ -908,7 +908,7 @@ void ITQMatrix::train(idx_t n, const float* xf) {
                init_rotation.data(),
                d * d * sizeof(rotation[0]));
     } else {
-        RandomRotationMatrix rrot(d, d);
+        RandomRotationMatrix rrot(static_cast<int>(d), static_cast<int>(d));
         rrot.init(seed);
         for (size_t i = 0; i < d * d; i++) {
             rotation[i] = rrot.A[i];
@@ -925,9 +925,11 @@ void ITQMatrix::train(idx_t n, const float* xf) {
     std::vector<double> u(d * d), vt(d * d), singvals(d);
 
     for (int i = 0; i < max_iter; i++) {
-        print_if_verbose("rotation", rotation, d, d);
+        print_if_verbose(
+                "rotation", rotation, static_cast<int>(d), static_cast<int>(d));
         { // rotated_data = np.dot(training_data, rotation)
-            FINTEGER di = d, ni = n;
+            FINTEGER di = static_cast<FINTEGER>(d),
+                     ni = static_cast<FINTEGER>(n);
             double one = 1, zero = 0;
             dgemm_("N",
                    "N",
@@ -943,14 +945,19 @@ void ITQMatrix::train(idx_t n, const float* xf) {
                    rotated_x.data(),
                    &di);
         }
-        print_if_verbose("rotated_x", rotated_x, n, d);
+        print_if_verbose(
+                "rotated_x",
+                rotated_x,
+                static_cast<int>(n),
+                static_cast<int>(d));
         // binarize
         for (size_t j = 0; j < n * d; j++) {
             rotated_x[j] = rotated_x[j] < 0 ? -1 : 1;
         }
         // covariance matrix
         { // rotated_data = np.dot(training_data, rotation)
-            FINTEGER di = d, ni = n;
+            FINTEGER di = static_cast<FINTEGER>(d),
+                     ni = static_cast<FINTEGER>(n);
             double one = 1, zero = 0;
             dgemm_("N",
                    "T",
@@ -966,10 +973,11 @@ void ITQMatrix::train(idx_t n, const float* xf) {
                    cov_mat.data(),
                    &di);
         }
-        print_if_verbose("cov_mat", cov_mat, d, d);
+        print_if_verbose(
+                "cov_mat", cov_mat, static_cast<int>(d), static_cast<int>(d));
         // SVD
         {
-            FINTEGER di = d;
+            FINTEGER di = static_cast<FINTEGER>(d);
             FINTEGER lwork = -1, info;
             double lwork1;
 
@@ -991,7 +999,7 @@ void ITQMatrix::train(idx_t n, const float* xf) {
 
             FAISS_THROW_IF_NOT_MSG(
                     info == 0, "LAPACK dgesvd workspace query failed");
-            lwork = size_t(lwork1);
+            lwork = static_cast<FINTEGER>(lwork1);
             std::vector<double> work(lwork);
             dgesvd_("A",
                     "A",
@@ -1009,11 +1017,11 @@ void ITQMatrix::train(idx_t n, const float* xf) {
                     &info);
             FAISS_THROW_IF_NOT_FMT(info == 0, "sgesvd returned info=%d", info);
         }
-        print_if_verbose("u", u, d, d);
-        print_if_verbose("vt", vt, d, d);
+        print_if_verbose("u", u, static_cast<int>(d), static_cast<int>(d));
+        print_if_verbose("vt", vt, static_cast<int>(d), static_cast<int>(d));
         // update rotation
         {
-            FINTEGER di = d;
+            FINTEGER di = static_cast<FINTEGER>(d);
             double one = 1, zero = 0;
             dgemm_("N",
                    "T",
@@ -1029,7 +1037,11 @@ void ITQMatrix::train(idx_t n, const float* xf) {
                    rotation.data(),
                    &di);
         }
-        print_if_verbose("final rot", rotation, d, d);
+        print_if_verbose(
+                "final rot",
+                rotation,
+                static_cast<int>(d),
+                static_cast<int>(d));
     }
     A.resize(d * d);
     for (size_t i = 0; i < d; i++) {
@@ -1252,7 +1264,9 @@ void OPQMatrix::train(idx_t n, const float* x_in) {
     double t0 = getmillisecs();
     for (int iter = 0; iter < niter; iter++) {
         { // torch.mm(xtrain, rotation:t())
-            FINTEGER di = d, d2i = d2, ni = n;
+            FINTEGER di = static_cast<FINTEGER>(d),
+                     d2i = static_cast<FINTEGER>(d2),
+                     ni = static_cast<FINTEGER>(n);
             float zero = 0, one = 1;
             sgemm_("Transposed",
                    "Not transposed",
@@ -1299,7 +1313,9 @@ void OPQMatrix::train(idx_t n, const float* x_in) {
         {
             float *u = tmp.data(), *vt = &tmp[d * d];
             float* sing_val = &tmp[2 * d * d];
-            FINTEGER di = d, d2i = d2, ni = n;
+            FINTEGER di = static_cast<FINTEGER>(d),
+                     d2i = static_cast<FINTEGER>(d2),
+                     ni = static_cast<FINTEGER>(n);
             float one = 1, zero = 0;
 
             if (verbose) {
@@ -1338,7 +1354,7 @@ void OPQMatrix::train(idx_t n, const float* x_in) {
                     &lwork,
                     &info);
 
-            lwork = int(worksz);
+            lwork = static_cast<FINTEGER>(worksz);
             std::vector<float> work(lwork);
             // u and vt swapped
             sgesvd_("All",

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -183,7 +183,7 @@ AdditiveQuantizer::Search_type_t aq_parse_search_type(
         return metric == METRIC_L2 ? AdditiveQuantizer::ST_decompress
                                    : AdditiveQuantizer::ST_LUT_nonorm;
     }
-    int pos = stok.rfind('_');
+    size_t pos = stok.rfind('_');
     return aq_search_type[stok.substr(pos)];
 }
 


### PR DESCRIPTION
Summary:

Fix 172 `clang-diagnostic-shorten-64-to-32` lint warnings across 29 files by adding explicit `static_cast<int>()` or widening variable types where `size_t`/`idx_t` (64-bit) values were implicitly narrowed to `int`/`int32_t` (32-bit).

The fixes fall into two categories:
- **Explicit casts**: Where the receiving API requires `int` and the value is known to fit (e.g., vector dimensions, sub-quantizer counts, cluster counts, BLAS parameters)
- **Type widening**: Where the variable was unnecessarily narrow (e.g., `int nprobe` → `size_t nprobe`, `int list_no` → `size_t list_no`)

Reviewed By: limqiying

Differential Revision: D100588996
