### PR TITLE
Set code_size on IVFRaBitQFastScanScanner

### DIFF
--- a/faiss/IndexIVFRaBitQFastScan.cpp
+++ b/faiss/IndexIVFRaBitQFastScan.cpp
@@ -622,6 +622,7 @@ struct IVFRaBitQFastScanScanner : InvertedListScanner {
               qb(qb_in),
               centered(centered_in) {
         this->keep_max = is_similarity_metric(index_in.metric_type);
+        this->code_size = index_in.code_size;
     }
 
     void set_query(const float* query) override {


### PR DESCRIPTION
Summary:
As titled, add missing code_size. Unicorn needs code_size to be populated to pass some assertions used in code, e.g.: 

https://www.internalfb.com/code/fbsource/[b7f23f05067d]/fbcode/unicorn/features/encoders/IvfEncoder.cpp?lines=1516-1519

Reviewed By: alibeklfc

Differential Revision: D100840815


