### PR TITLE
  IVFRaBitQFastScan: add refine_error_scale to trade a small amount of recall for higher nbits=2 QPS

### DIFF
--- a/faiss/IndexIVFRaBitQ.h
+++ b/faiss/IndexIVFRaBitQ.h
@@ -21,6 +21,12 @@ namespace faiss {
 struct IVFRaBitQSearchParameters : IVFSearchParameters {
     uint8_t qb = 4;
     bool centered = false;
+
+    /// Scale factor for the multibit refinement error bound.
+    /// Default -1.0 = use index-level setting.
+    /// Values in [0, 1]: tighten the bound (fewer refinements, faster).
+    /// Value 1.0: exact bound (most accurate).
+    float refine_error_scale = -1.0f;
 };
 
 // * by_residual is true, just by design

--- a/faiss/IndexIVFRaBitQFastScan.cpp
+++ b/faiss/IndexIVFRaBitQFastScan.cpp
@@ -382,6 +382,16 @@ void IndexIVFRaBitQFastScan::search_preassigned(
     context.query_factors = query_factors_storage.data();
     context.nprobe = cur_nprobe;
 
+    // Resolve refine_error_scale: search params > index-level default
+    context.refine_error_scale = refine_error_scale;
+    if (params) {
+        auto* rq_params =
+                dynamic_cast<const IVFRaBitQSearchParameters*>(params);
+        if (rq_params && rq_params->refine_error_scale >= 0.0f) {
+            context.refine_error_scale = rq_params->refine_error_scale;
+        }
+    }
+
     const CoarseQuantized cq = {cur_nprobe, centroid_dis, assign};
     search_dispatch_implem(n, x, k, distances, labels, cq, context, params);
 }

--- a/faiss/IndexIVFRaBitQFastScan.h
+++ b/faiss/IndexIVFRaBitQFastScan.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <memory>
 #include <vector>
 
@@ -55,6 +56,14 @@ struct IndexIVFRaBitQFastScan : IndexIVFFastScan {
 
     /// Use zero-centered scalar quantizer for queries
     bool centered = false;
+
+    /// Scale factor for the refinement error bound. Default 0.4.
+    /// Values < 1.0 tighten the bound (fewer refinements, faster, may lose
+    /// recall). Value 1.0 = exact bound (most conservative).
+    /// Must be finite and >= 0. Recommended range: [0.3, 1.0].
+    /// Benchmarked across Cohere-768d, Bioasq-1024d, OpenAI-1536d:
+    /// 0.4 gives +23% to +47% QPS with < 0.3% recall loss.
+    float refine_error_scale = 0.4f;
 
     // Constructors
 
@@ -208,6 +217,13 @@ IVFRaBitQHeapHandler<C, SL>::IVFRaBitQHeapHandler(
           unpack_buf(idx->code_size) {
     current_list_no = 0;
     probe_indices.clear();
+    // Use context scale if set, otherwise fall back to index default.
+    refine_error_scale = (ctx && ctx->refine_error_scale >= 0.0f)
+            ? ctx->refine_error_scale
+            : idx->refine_error_scale;
+    FAISS_THROW_IF_NOT_MSG(
+            std::isfinite(refine_error_scale) && refine_error_scale >= 0.0f,
+            "refine_error_scale must be finite and >= 0");
     for (int64_t q = 0; q < static_cast<int64_t>(nq); q++) {
         heap_heapify<Cfloat>(k, heap_distances + q * k, heap_labels + q * k);
     }
@@ -299,7 +315,7 @@ void IVFRaBitQHeapHandler<C, SL>::handle(
                     index->metric_type == MetricType::METRIC_INNER_PRODUCT;
             bool should_refine = rabitq_utils::should_refine_candidate(
                     dist_1bit,
-                    full_factors.f_error,
+                    full_factors.f_error * refine_error_scale,
                     query_factors.g_error,
                     heap_dis[0],
                     is_similarity);

--- a/faiss/impl/fast_scan/FastScanDistancePostProcessing.h
+++ b/faiss/impl/fast_scan/FastScanDistancePostProcessing.h
@@ -35,6 +35,11 @@ struct FastScanDistancePostProcessing {
     /// Set to 0 to use index->nprobe as fallback.
     size_t nprobe = 0;
 
+    /// Effective refine_error_scale for this search. Resolved from
+    /// search params (if provided) or index-level default.
+    /// -1.0 means not set (use index default).
+    float refine_error_scale = -1.0f;
+
     /// Default constructor - no processing
     FastScanDistancePostProcessing() = default;
 

--- a/faiss/impl/fast_scan/rabitq_result_handler.h
+++ b/faiss/impl/fast_scan/rabitq_result_handler.h
@@ -55,6 +55,8 @@ struct IVFRaBitQHeapHandler : ResultHandlerCompare<C, true, SL> {
     const bool is_multibit; // Whether to use multi-bit two-stage search
     size_t nup = 0;         // Number of heap updates
 
+    float refine_error_scale = 1.0f;
+
     // Cached block-layout constants (invariant for handler lifetime)
     const size_t storage_size;
     const size_t packed_block_size;


### PR DESCRIPTION
## Summary

  This PR adds a new `refine_error_scale` knob to `IndexIVFRaBitQFastScan` and `IVFRaBitQSearchParameters`.

  In the current multibit IVF RaBitQ search path, candidates are first scored with the cheap 1-bit approximation, then a subset is sent to the more expensive multibit refinement step. The decision is made by `should_refine_candidate(...)`, which uses an error bound to decide whether a candidate is still close enough to the heap threshold to be worth refining.

  This change scales that error bound before the refinement decision:
  - `1.0`: current conservative behavior
  - `< 1.0`: tighten the bound, refine fewer candidates, higher QPS, possible small recall loss

  The goal is simple: keep the existing index format and kernels, but avoid spending multibit refinement work on candidates that are unlikely to matter.

  ## Why this helps

  For `nbits=2`, the extra-bit refinement path is expensive enough to be a major throughput limiter, but not all refinements contribute equally to recall.

  A fixed refinement cap turned out to be too blunt: it loses too much recall because it ignores candidate quality. Scaling the refinement error bound works better because it preserves the existing priority logic in `should_refine_candidate(...)` and only makes that gate more selective.

  In practice, this means:
  - fewer full multibit refinements
  - less time in the expensive refinement path
  - a smooth QPS / recall tradeoff instead of a cliff

  ## Behavior

  This PR:
  - adds an index-level default `refine_error_scale`
  - adds a per-search override in `IVFRaBitQSearchParameters`
  - applies the effective value in the FastScan refinement gate
  - validates that the effective scale is finite and non-negative

  Current default in this branch is `0.4`.

  ## Benchmarks

  All results below are for `nbits=2`, `nprobe=32`.

  ### Cohere-1M (768d, cosine)

  | scale | QPS | recall | QPS change | recall loss |
  |------:|----:|-------:|-----------:|------------:|
  | 1.00 | 347 | 0.8283 | baseline | - |
  | 0.80 | 383 | 0.8282 | +10% | -0.01% |
  | 0.60 | 419 | 0.8278 | +21% | -0.05% |
  | 0.40 | 441 | 0.8269 | +27% | -0.14% |
  | 0.20 | 488 | 0.8244 | +41% | -0.39% |
  | 0.00 | 519 | 0.8193 | +50% | -0.90% |

  ### BioASQ-1M (1024d, cosine)

  | scale | QPS | recall | QPS change | recall loss |
  |------:|----:|-------:|-----------:|------------:|
  | 1.00 | 223 | 0.7388 | baseline | - |
  | 0.80 | 257 | 0.7386 | +15% | -0.02% |
  | 0.60 | 291 | 0.7379 | +30% | -0.09% |
  | 0.40 | 328 | 0.7361 | +47% | -0.27% |
  | 0.20 | 366 | 0.7318 | +64% | -0.70% |
  | 0.00 | 399 | 0.7235 | +79% | -1.53% |

  ### OpenAI-500K (1536d, cosine)

  | scale | QPS | recall | QPS change | recall loss |
  |------:|----:|-------:|-----------:|------------:|
  | 1.00 | 210 | 0.8833 | baseline | - |
  | 0.80 | 229 | 0.8833 | +9% | 0.00% |
  | 0.60 | 246 | 0.8830 | +17% | -0.03% |
  | 0.40 | 258 | 0.8823 | +23% | -0.10% |
  | 0.20 | 275 | 0.8805 | +31% | -0.28% |
  | 0.00 | 285 | 0.8765 | +36% | -0.68% |

  ## Takeaway

  Across all three datasets, `scale=0.4` is a consistent sweet spot:
  - QPS improves by `+23%` to `+47%`
  - recall loss stays under `0.3%`

  `scale=0.6` is a more conservative option:
  - QPS improves by `+17%` to `+30%`
  - recall loss stays under `0.1%`
