### PR TITLE
Fix cuVS build (#5107)

### DIFF
--- a/faiss/gpu/impl/BinaryCuvsCagra.cu
+++ b/faiss/gpu/impl/BinaryCuvsCagra.cu
@@ -284,11 +284,12 @@ void BinaryCuvsCagra::search(
             distances_float_view,
             filter_ref);
 
-    thrust::copy(
-            raft::resource::get_thrust_policy(raft_handle),
+    faiss::gpu::sanitizeCuvsIndices(
+            resources_,
             indices_copy.data_handle(),
-            indices_copy.data_handle() + indices_copy.size(),
-            indices_view.data_handle());
+            indices_view.data_handle(),
+            indices_copy.size(),
+            n_);
     auto distances_view = raft::make_device_matrix_view(
             outDistances.data(),
             static_cast<int64_t>(numQueries),

--- a/faiss/gpu/impl/CuvsCagra.cu
+++ b/faiss/gpu/impl/CuvsCagra.cu
@@ -315,11 +315,12 @@ void CuvsCagra<data_t>::search(
             indices_copy.view(),
             distances_view,
             filter_ref);
-    thrust::copy(
-            raft::resource::get_thrust_policy(raft_handle),
+    faiss::gpu::sanitizeCuvsIndices(
+            resources_,
             indices_copy.data_handle(),
-            indices_copy.data_handle() + indices_copy.size(),
-            indices_view.data_handle());
+            indices_view.data_handle(),
+            indices_copy.size(),
+            n_);
 }
 
 template <typename data_t>

--- a/faiss/gpu/utils/CuvsUtils.cu
+++ b/faiss/gpu/utils/CuvsUtils.cu
@@ -33,6 +33,7 @@
 #include <thrust/gather.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/reduce.h>
+#include <thrust/transform.h>
 
 namespace faiss {
 namespace gpu {
@@ -113,6 +114,24 @@ idx_t inplaceGatherFilteredRows(
                 indices.data());
     }
     return n_rows_valid;
+}
+
+void sanitizeCuvsIndices(
+        GpuResources* res,
+        uint32_t* src,
+        idx_t* dst,
+        size_t count,
+        idx_t n) {
+    raft::device_resources& raft_handle = res->getRaftHandleCurrentDevice();
+    thrust::transform(
+            raft_handle.get_thrust_policy(),
+            src,
+            src + count,
+            dst,
+            [n] __device__(uint32_t idx) -> idx_t {
+                return idx < static_cast<uint32_t>(n) ? static_cast<idx_t>(idx)
+                                                      : idx_t{-1};
+            });
 }
 
 } // namespace gpu

--- a/faiss/gpu/utils/CuvsUtils.h
+++ b/faiss/gpu/utils/CuvsUtils.h
@@ -71,6 +71,17 @@ idx_t inplaceGatherFilteredRows(
         GpuResources* res,
         Tensor<float, 2, true>& vecs,
         Tensor<idx_t, 1, true>& indices);
+
+/// Copy uint32_t indices to idx_t, replacing any index >= n with -1.
+/// cuVS CAGRA returns sentinel values (e.g. INT32_MAX) for result slots
+/// where filtered search couldn't find a valid neighbor.
+void sanitizeCuvsIndices(
+        GpuResources* res,
+        uint32_t* src,
+        idx_t* dst,
+        size_t count,
+        idx_t n);
+
 } // namespace gpu
 } // namespace faiss
 #pragma GCC visibility pop


### PR DESCRIPTION
Summary:

  D96034911 adds filtered search to BinaryCuvsCagra.cu (calling cuvs::neighbors::cagra::search with a filter_ref), but does not update
  fbcode/faiss/gpu/CMakeLists.txt.

  In the cmake build, cuVS source files are compiled with -fvisibility=hidden to ensure that RAFT/cuVS function calls resolve locally within libfaiss.so rather than
  through the PLT to libcuvs.so. This is critical because RAFT resources (cublas handles, CUDA streams) must be created and used within the same dynamic library
  context.

  Look at fbcode/faiss/gpu/CMakeLists.txt:302-316:

  set_source_files_properties(
      GpuIndexCagra.cu              # ✓ float CAGRA
      GpuDistance.cu
      GpuIndexIVFFlat.cu
      GpuIndexIVFPQ.cu
      GpuIndexFlat.cu
      StandardGpuResources.cpp
      impl/CuvsCagra.cu             # ✓ float CAGRA impl
      impl/CuvsFlatIndex.cu
      impl/CuvsIVFFlat.cu
      impl/CuvsIVFPQ.cu
      utils/CuvsFilterConvert.cu
      utils/CuvsUtils.cu
      TARGET_DIRECTORY faiss
      PROPERTIES COMPILE_OPTIONS "-fvisibility=hidden")

  Missing:
  - GpuIndexBinaryCagra.cu
  - impl/BinaryCuvsCagra.cu

  Before D96034911, this didn't matter because GpuIndexBinaryCagra::search() threw on any params (FAISS_THROW_IF_NOT_MSG(!params, "params not implemented")). After
  D96034911, it processes params and calls cuvs::neighbors::cagra::search with a filter, making the code sensitive to cross-DSO symbol resolution. Without hidden
  visibility, cuVS template instantiations (particularly cagra::search<uint8_t, uint32_t> with the filter type) leak out of libfaiss.so and can conflict with/resolve
   to libcuvs.so symbols, causing RAFT context mismatches.

  The float CAGRA IDSelector tests (TestGpuIndexCagra) pass because GpuIndexCagra.cu and impl/CuvsCagra.cu are in the hidden visibility list. The binary CAGRA tests
  fail because they aren't.

  Buck doesn't have this issue because it links everything statically — there's no DSO boundary.

Differential Revision: D101072304


