### PR TITLE
Reject null quantizer during IVF index deserialization (#5112)

### DIFF
--- a/faiss/IndexFlatCodes.cpp
+++ b/faiss/IndexFlatCodes.cpp
@@ -7,6 +7,8 @@
 
 #include <faiss/IndexFlatCodes.h>
 
+#include <atomic>
+
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/CodePacker.h>
 #include <faiss/impl/DistanceComputer.h>
@@ -204,23 +206,39 @@ struct Run_search_with_decompress {
         using SingleResultHandler =
                 typename BlockResultHandler::SingleResultHandler;
         using DC = GenericFlatCodesDistanceComputer<VectorDistance>;
+        std::exception_ptr ex;
+        std::atomic<bool> interrupt{false};
 #pragma omp parallel // if (res.nq > 100)
         {
-            std::unique_ptr<DC> dc(new DC(&index, vd));
-            SingleResultHandler resi(res);
+            std::unique_ptr<DC> dc;
+            std::unique_ptr<SingleResultHandler> resi;
+            try {
+                dc = std::make_unique<DC>(&index, vd);
+                resi = std::make_unique<SingleResultHandler>(res);
+            } catch (...) {
+                omp_capture_exception(ex, [&] { interrupt = true; });
+            }
 #pragma omp for
             for (int64_t q = 0; q < static_cast<int64_t>(res.nq); q++) {
-                resi.begin(q);
-                dc->set_query(xq + vd.d * q);
-                for (size_t i = 0; i < ntotal; i++) {
-                    if (res.is_in_selection(i)) {
-                        float dis = (*dc)(i);
-                        resi.add_result(dis, i);
-                    }
+                if (interrupt.load(std::memory_order_relaxed)) {
+                    continue;
                 }
-                resi.end();
+                try {
+                    resi->begin(q);
+                    dc->set_query(xq + vd.d * q);
+                    for (size_t i = 0; i < ntotal; i++) {
+                        if (res.is_in_selection(i)) {
+                            float dis = (*dc)(i);
+                            resi->add_result(dis, i);
+                        }
+                    }
+                    resi->end();
+                } catch (...) {
+                    omp_capture_exception(ex, [&] { interrupt = true; });
+                }
             }
         }
+        omp_rethrow_if_exception(ex);
     }
 };
 

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -8,9 +8,9 @@
 #include <faiss/IndexIVF.h>
 
 #include <omp.h>
+#include <atomic>
 #include <cstdint>
 #include <memory>
-#include <mutex>
 
 #include <algorithm>
 #include <cinttypes>
@@ -360,32 +360,28 @@ void IndexIVF::search(
     if ((parallel_mode & ~PARALLEL_MODE_NO_HEAP_INIT) == 0) {
         int nt = std::min(omp_get_max_threads(), int(n));
         std::vector<IndexIVFStats> stats(nt);
-        std::mutex exception_mutex;
-        std::string exception_string;
+        std::exception_ptr ex;
 
 #pragma omp parallel for if (nt > 1)
         for (idx_t slice = 0; slice < nt; slice++) {
-            IndexIVFStats local_stats;
-            idx_t i0 = n * slice / nt;
-            idx_t i1 = n * (slice + 1) / nt;
-            if (i1 > i0) {
-                try {
+            try {
+                IndexIVFStats local_stats;
+                idx_t i0 = n * slice / nt;
+                idx_t i1 = n * (slice + 1) / nt;
+                if (i1 > i0) {
                     sub_search_func(
                             i1 - i0,
                             x + i0 * d,
                             distances + i0 * k,
                             labels + i0 * k,
                             &stats[slice]);
-                } catch (const std::exception& e) {
-                    std::lock_guard<std::mutex> lock(exception_mutex);
-                    exception_string = e.what();
                 }
+            } catch (...) {
+                omp_capture_exception(ex);
             }
         }
 
-        if (!exception_string.empty()) {
-            FAISS_THROW_MSG(exception_string.c_str());
-        }
+        omp_rethrow_if_exception(ex);
 
         // collect stats
         for (idx_t slice = 0; slice < nt; slice++) {
@@ -442,9 +438,8 @@ void IndexIVF::search_preassigned(
     using HeapForIP = CMin<float, idx_t>;
     using HeapForL2 = CMax<float, idx_t>;
 
-    bool interrupt = false;
-    std::mutex exception_mutex;
-    std::string exception_string;
+    std::exception_ptr ex;
+    std::atomic<bool> interrupt{false};
 
     int pmode = this->parallel_mode & ~PARALLEL_MODE_NO_HEAP_INIT;
     bool do_heap_init = !(this->parallel_mode & PARALLEL_MODE_NO_HEAP_INIT);
@@ -532,74 +527,65 @@ void IndexIVF::search_preassigned(
                     // not enough centroids for multiprobe
                     return (size_t)0;
                 }
-                try {
-                    FAISS_THROW_IF_NOT_FMT(
-                            key < (idx_t)nlist,
-                            "Invalid key=%" PRId64 " nlist=%zd\n",
-                            key,
-                            nlist);
+                FAISS_THROW_IF_NOT_FMT(
+                        key < (idx_t)nlist,
+                        "Invalid key=%" PRId64 " nlist=%zd\n",
+                        key,
+                        nlist);
 
-                    // don't waste time on empty lists
-                    if (invlists->is_empty(key, inverted_list_context)) {
-                        return (size_t)0;
+                // don't waste time on empty lists
+                if (invlists->is_empty(key, inverted_list_context)) {
+                    return (size_t)0;
+                }
+
+                scanner->set_list(key, coarse_dis_i);
+
+                nlistv++;
+                if (invlists->use_iterator) {
+                    size_t list_size = 0;
+
+                    std::unique_ptr<InvertedListsIterator> it(
+                            invlists->get_iterator(key, inverted_list_context));
+
+                    nheap += scanner->iterate_codes(
+                            it.get(), simi, idxi, k, list_size);
+
+                    return list_size;
+                } else {
+                    size_t list_size = invlists->list_size(key);
+                    if (list_size > static_cast<size_t>(list_size_max)) {
+                        list_size = static_cast<size_t>(list_size_max);
                     }
 
-                    scanner->set_list(key, coarse_dis_i);
+                    InvertedLists::ScopedCodes scodes(invlists, key);
+                    const uint8_t* codes = scodes.get();
 
-                    nlistv++;
-                    if (invlists->use_iterator) {
-                        size_t list_size = 0;
+                    std::unique_ptr<InvertedLists::ScopedIds> sids;
+                    const idx_t* ids = nullptr;
 
-                        std::unique_ptr<InvertedListsIterator> it(
-                                invlists->get_iterator(
-                                        key, inverted_list_context));
-
-                        nheap += scanner->iterate_codes(
-                                it.get(), simi, idxi, k, list_size);
-
-                        return list_size;
-                    } else {
-                        size_t list_size = invlists->list_size(key);
-                        if (list_size > static_cast<size_t>(list_size_max)) {
-                            list_size = static_cast<size_t>(list_size_max);
-                        }
-
-                        InvertedLists::ScopedCodes scodes(invlists, key);
-                        const uint8_t* codes = scodes.get();
-
-                        std::unique_ptr<InvertedLists::ScopedIds> sids;
-                        const idx_t* ids = nullptr;
-
-                        if (!store_pairs) {
-                            sids = std::make_unique<InvertedLists::ScopedIds>(
-                                    invlists, key);
-                            ids = sids->get();
-                        }
-
-                        if (selr) { // IDSelectorRange
-                            // restrict search to a section of the inverted list
-                            size_t jmin, jmax;
-                            selr->find_sorted_ids_bounds(
-                                    list_size, ids, &jmin, &jmax);
-                            list_size = jmax - jmin;
-                            if (list_size == 0) {
-                                return (size_t)0;
-                            }
-                            codes += jmin * code_size;
-                            ids += jmin;
-                        }
-
-                        nheap += scanner->scan_codes(
-                                list_size, codes, ids, simi, idxi, k);
-
-                        return list_size;
+                    if (!store_pairs) {
+                        sids = std::make_unique<InvertedLists::ScopedIds>(
+                                invlists, key);
+                        ids = sids->get();
                     }
-                } catch (const std::exception& e) {
-                    std::lock_guard<std::mutex> lock(exception_mutex);
-                    exception_string = demangle_cpp_symbol(typeid(e).name()) +
-                            "  " + e.what();
-                    interrupt = true;
-                    return size_t(0);
+
+                    if (selr) { // IDSelectorRange
+                        // restrict search to a section of the inverted list
+                        size_t jmin, jmax;
+                        selr->find_sorted_ids_bounds(
+                                list_size, ids, &jmin, &jmax);
+                        list_size = jmax - jmin;
+                        if (list_size == 0) {
+                            return (size_t)0;
+                        }
+                        codes += jmin * code_size;
+                        ids += jmin;
+                    }
+
+                    nheap += scanner->scan_codes(
+                            list_size, codes, ids, simi, idxi, k);
+
+                    return list_size;
                 }
             };
 
@@ -610,39 +596,39 @@ void IndexIVF::search_preassigned(
             if (pmode == 0 || pmode == 3) {
 #pragma omp for
                 for (idx_t i = 0; i < n; i++) {
-                    if (interrupt) {
+                    if (interrupt.load(std::memory_order_relaxed)) {
                         continue;
                     }
+                    try {
+                        // loop over queries
+                        scanner->set_query(x + i * d);
+                        float* simi = distances + i * k;
+                        idx_t* idxi = labels + i * k;
 
-                    // loop over queries
-                    scanner->set_query(x + i * d);
-                    float* simi = distances + i * k;
-                    idx_t* idxi = labels + i * k;
+                        init_result(simi, idxi);
 
-                    init_result(simi, idxi);
+                        idx_t nscan = 0;
 
-                    idx_t nscan = 0;
-
-                    // loop over probes
-                    for (idx_t ik = 0; ik < cur_nprobe; ik++) {
-                        nscan += scan_one_list(
-                                keys[i * cur_nprobe + ik],
-                                coarse_dis[i * cur_nprobe + ik],
-                                simi,
-                                idxi,
-                                cur_max_codes - nscan);
-                        if (nscan >= cur_max_codes) {
-                            break;
+                        // loop over probes
+                        for (idx_t ik = 0; ik < cur_nprobe; ik++) {
+                            nscan += scan_one_list(
+                                    keys[i * cur_nprobe + ik],
+                                    coarse_dis[i * cur_nprobe + ik],
+                                    simi,
+                                    idxi,
+                                    cur_max_codes - nscan);
+                            if (nscan >= cur_max_codes) {
+                                break;
+                            }
                         }
+
+                        ndis += nscan;
+                        reorder_result(simi, idxi);
+
+                        InterruptCallback::check();
+                    } catch (...) {
+                        omp_capture_exception(ex, [&] { interrupt = true; });
                     }
-
-                    ndis += nscan;
-                    reorder_result(simi, idxi);
-
-                    if (InterruptCallback::is_interrupted()) {
-                        interrupt = true;
-                    }
-
                 } // parallel for
             } else if (pmode == 1) {
                 std::vector<idx_t> local_idx(k);
@@ -654,14 +640,19 @@ void IndexIVF::search_preassigned(
 
 #pragma omp for schedule(dynamic)
                     for (idx_t ik = 0; ik < cur_nprobe; ik++) {
-                        ndis += scan_one_list(
-                                keys[i * cur_nprobe + ik],
-                                coarse_dis[i * cur_nprobe + ik],
-                                local_dis.data(),
-                                local_idx.data(),
-                                unlimited_list_size);
+                        try {
+                            ndis += scan_one_list(
+                                    keys[i * cur_nprobe + ik],
+                                    coarse_dis[i * cur_nprobe + ik],
+                                    local_dis.data(),
+                                    local_idx.data(),
+                                    unlimited_list_size);
 
-                        // can't do the test on max_codes
+                            // can't do the test on max_codes
+                        } catch (...) {
+                            omp_capture_exception(
+                                    ex, [&] { interrupt = true; });
+                        }
                     }
                     // merge thread-local results
 
@@ -691,23 +682,27 @@ void IndexIVF::search_preassigned(
 
 #pragma omp for schedule(dynamic)
                 for (int64_t ij = 0; ij < n * cur_nprobe; ij++) {
-                    size_t i = ij / cur_nprobe;
+                    try {
+                        size_t i = ij / cur_nprobe;
 
-                    scanner->set_query(x + i * d);
-                    init_result(local_dis.data(), local_idx.data());
-                    ndis += scan_one_list(
-                            keys[ij],
-                            coarse_dis[ij],
-                            local_dis.data(),
-                            local_idx.data(),
-                            unlimited_list_size);
-#pragma omp critical
-                    {
-                        add_local_results(
+                        scanner->set_query(x + i * d);
+                        init_result(local_dis.data(), local_idx.data());
+                        ndis += scan_one_list(
+                                keys[ij],
+                                coarse_dis[ij],
                                 local_dis.data(),
                                 local_idx.data(),
-                                distances + i * k,
-                                labels + i * k);
+                                unlimited_list_size);
+#pragma omp critical
+                        {
+                            add_local_results(
+                                    local_dis.data(),
+                                    local_idx.data(),
+                                    distances + i * k,
+                                    labels + i * k);
+                        }
+                    } catch (...) {
+                        omp_capture_exception(ex, [&] { interrupt = true; });
                     }
                 }
 #pragma omp single
@@ -717,24 +712,12 @@ void IndexIVF::search_preassigned(
             } else {
                 FAISS_THROW_FMT("parallel_mode %d not supported\n", pmode);
             }
-        } catch (const std::exception& e) {
-            std::lock_guard<std::mutex> lock(exception_mutex);
-            if (exception_string.empty()) {
-                exception_string =
-                        demangle_cpp_symbol(typeid(e).name()) + "  " + e.what();
-            }
-            interrupt = true;
+        } catch (...) {
+            omp_capture_exception(ex, [&] { interrupt = true; });
         }
     } // parallel section
 
-    if (interrupt) {
-        if (!exception_string.empty()) {
-            FAISS_THROW_FMT(
-                    "search interrupted with: %s", exception_string.c_str());
-        } else {
-            FAISS_THROW_MSG("computation interrupted");
-        }
-    }
+    omp_rethrow_if_exception(ex);
 
     if (ivf_stats == nullptr) {
         ivf_stats = &indexIVF_stats;
@@ -809,9 +792,7 @@ void IndexIVF::range_search_preassigned(
 
     size_t nlistv = 0, ndis = 0;
 
-    bool interrupt = false;
-    std::mutex exception_mutex;
-    std::string exception_string;
+    std::exception_ptr ex;
 
     std::vector<RangeSearchPartialResult*> all_pres(omp_get_max_threads());
 
@@ -840,63 +821,55 @@ void IndexIVF::range_search_preassigned(
             auto scan_list_func = [&](size_t i,
                                       size_t ik,
                                       RangeQueryResult& qres) {
-                try {
-                    idx_t key = keys[i * cur_nprobe + ik]; /* select the list */
-                    if (key < 0) {
-                        return;
-                    }
-
-                    FAISS_THROW_IF_NOT_FMT(
-                            key < (idx_t)nlist,
-                            "Invalid key=%" PRId64 " at ik=%zd nlist=%zd\n",
-                            key,
-                            ik,
-                            nlist);
-
-                    if (invlists->is_empty(key, inverted_list_context)) {
-                        return;
-                    }
-
-                    size_t list_size = 0;
-                    scanner->set_list(key, coarse_dis[i * cur_nprobe + ik]);
-                    if (invlists->use_iterator) {
-                        std::unique_ptr<InvertedListsIterator> it(
-                                invlists->get_iterator(
-                                        key, inverted_list_context));
-
-                        scanner->iterate_codes_range(
-                                it.get(), radius, qres, list_size);
-                    } else {
-                        InvertedLists::ScopedCodes scodes(invlists, key);
-                        InvertedLists::ScopedIds ids(invlists, key);
-                        list_size = invlists->list_size(key);
-
-                        scanner->scan_codes_range(
-                                list_size,
-                                scodes.get(),
-                                ids.get(),
-                                radius,
-                                qres);
-                    }
-                    nlistv++;
-                    ndis += list_size;
-                } catch (const std::exception& e) {
-                    std::lock_guard<std::mutex> lock(exception_mutex);
-                    exception_string = demangle_cpp_symbol(typeid(e).name()) +
-                            "  " + e.what();
-                    interrupt = true;
+                idx_t key = keys[i * cur_nprobe + ik]; /* select the list */
+                if (key < 0) {
+                    return;
                 }
+
+                FAISS_THROW_IF_NOT_FMT(
+                        key < (idx_t)nlist,
+                        "Invalid key=%" PRId64 " at ik=%zd nlist=%zd\n",
+                        key,
+                        ik,
+                        nlist);
+
+                if (invlists->is_empty(key, inverted_list_context)) {
+                    return;
+                }
+
+                size_t list_size = 0;
+                scanner->set_list(key, coarse_dis[i * cur_nprobe + ik]);
+                if (invlists->use_iterator) {
+                    std::unique_ptr<InvertedListsIterator> it(
+                            invlists->get_iterator(key, inverted_list_context));
+
+                    scanner->iterate_codes_range(
+                            it.get(), radius, qres, list_size);
+                } else {
+                    InvertedLists::ScopedCodes scodes(invlists, key);
+                    InvertedLists::ScopedIds ids(invlists, key);
+                    list_size = invlists->list_size(key);
+
+                    scanner->scan_codes_range(
+                            list_size, scodes.get(), ids.get(), radius, qres);
+                }
+                nlistv++;
+                ndis += list_size;
             };
 
             if (parallel_mode == 0) {
 #pragma omp for
                 for (idx_t i = 0; i < nx; i++) {
-                    scanner->set_query(x + i * d);
+                    try {
+                        scanner->set_query(x + i * d);
 
-                    RangeQueryResult& qres = pres.new_result(i);
+                        RangeQueryResult& qres = pres.new_result(i);
 
-                    for (idx_t ik = 0; ik < cur_nprobe; ik++) {
-                        scan_list_func(i, ik, qres);
+                        for (idx_t ik = 0; ik < cur_nprobe; ik++) {
+                            scan_list_func(i, ik, qres);
+                        }
+                    } catch (...) {
+                        omp_capture_exception(ex);
                     }
                 }
 
@@ -908,7 +881,11 @@ void IndexIVF::range_search_preassigned(
 
 #pragma omp for schedule(dynamic)
                     for (int64_t ik = 0; ik < cur_nprobe; ik++) {
-                        scan_list_func(i, ik, qres);
+                        try {
+                            scan_list_func(i, ik, qres);
+                        } catch (...) {
+                            omp_capture_exception(ex);
+                        }
                     }
                 }
             } else if (parallel_mode == 2) {
@@ -916,13 +893,17 @@ void IndexIVF::range_search_preassigned(
 
 #pragma omp for schedule(dynamic)
                 for (idx_t iik = 0; iik < nx * (idx_t)cur_nprobe; iik++) {
-                    idx_t i = iik / (idx_t)cur_nprobe;
-                    idx_t ik = iik % (idx_t)cur_nprobe;
-                    if (qres == nullptr || qres->qno != i) {
-                        qres = &pres.new_result(i);
-                        scanner->set_query(x + i * d);
+                    try {
+                        idx_t i = iik / (idx_t)cur_nprobe;
+                        idx_t ik = iik % (idx_t)cur_nprobe;
+                        if (qres == nullptr || qres->qno != i) {
+                            qres = &pres.new_result(i);
+                            scanner->set_query(x + i * d);
+                        }
+                        scan_list_func(i, ik, *qres);
+                    } catch (...) {
+                        omp_capture_exception(ex);
                     }
-                    scan_list_func(i, ik, *qres);
                 }
             } else {
                 FAISS_THROW_FMT(
@@ -936,22 +917,12 @@ void IndexIVF::range_search_preassigned(
                 RangeSearchPartialResult::merge(all_pres, false);
 #pragma omp barrier
             }
-        } catch (const std::exception& e) {
-            std::lock_guard<std::mutex> lock(exception_mutex);
-            exception_string =
-                    demangle_cpp_symbol(typeid(e).name()) + "  " + e.what();
-            interrupt = true;
+        } catch (...) {
+            omp_capture_exception(ex);
         }
     }
 
-    if (interrupt) {
-        if (!exception_string.empty()) {
-            FAISS_THROW_FMT(
-                    "search interrupted with: %s", exception_string.c_str());
-        } else {
-            FAISS_THROW_MSG("computation interrupted");
-        }
-    }
+    omp_rethrow_if_exception(ex);
 
     if (stats == nullptr) {
         stats = &indexIVF_stats;

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -58,6 +58,7 @@ void Level1Quantizer::train_q1(
         const float* x,
         bool verbose,
         MetricType metric_type) {
+    FAISS_THROW_IF_NOT_MSG(quantizer, "IVF quantizer must not be null");
     size_t d = quantizer->d;
     if (quantizer->is_trained &&
         (static_cast<size_t>(quantizer->ntotal) == nlist)) {
@@ -188,6 +189,7 @@ void IndexIVF::add(idx_t n, const float* x) {
 }
 
 void IndexIVF::add_with_ids(idx_t n, const float* x, const idx_t* xids) {
+    FAISS_THROW_IF_NOT_MSG(quantizer, "IVF quantizer must not be null");
     FAISS_THROW_IF_NOT_MSG(invlists, "IVF index has no inverted lists");
     std::unique_ptr<idx_t[]> coarse_idx(new idx_t[n]);
     quantizer->assign(n, x, coarse_idx.get());
@@ -309,6 +311,7 @@ void IndexIVF::search(
         idx_t* labels,
         const SearchParameters* params_in) const {
     FAISS_THROW_IF_NOT(k > 0);
+    FAISS_THROW_IF_NOT_MSG(quantizer, "IVF quantizer must not be null");
     FAISS_THROW_IF_NOT_MSG(invlists, "IVF index has no inverted lists");
     const IVFSearchParameters* params = nullptr;
     if (params_in) {
@@ -734,6 +737,7 @@ void IndexIVF::range_search(
         float radius,
         RangeSearchResult* result,
         const SearchParameters* params_in) const {
+    FAISS_THROW_IF_NOT_MSG(quantizer, "IVF quantizer must not be null");
     const IVFSearchParameters* params = nullptr;
     const SearchParameters* quantizer_params = nullptr;
     if (params_in) {

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -388,6 +388,7 @@ void initialize_IVFPQ_precomputed_table(
         AlignedTable<float>& precomputed_table,
         bool by_residual,
         bool verbose) {
+    FAISS_THROW_IF_NOT_MSG(quantizer, "IVF quantizer must not be null");
     size_t nlist = quantizer->ntotal;
     size_t d = quantizer->d;
     FAISS_THROW_IF_NOT(d == pq.d);

--- a/faiss/IndexNNDescent.cpp
+++ b/faiss/IndexNNDescent.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/IndexNNDescent.h>
 
+#include <atomic>
 #include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
@@ -119,22 +120,36 @@ void IndexNNDescent::search(
     for (idx_t i0 = 0; i0 < n; i0 += check_period) {
         idx_t i1 = std::min(i0 + check_period, n);
 
+        std::exception_ptr ex;
+        std::atomic<bool> interrupt{false};
 #pragma omp parallel
         {
-            VisitedTable vt(ntotal);
-
-            std::unique_ptr<DistanceComputer> dis(
-                    storage_distance_computer(storage));
+            std::unique_ptr<DistanceComputer> dis;
+            std::unique_ptr<VisitedTable> vt;
+            try {
+                vt = std::make_unique<VisitedTable>(ntotal);
+                dis.reset(storage_distance_computer(storage));
+            } catch (...) {
+                omp_capture_exception(ex, [&] { interrupt = true; });
+            }
 
 #pragma omp for
             for (idx_t i = i0; i < i1; i++) {
-                idx_t* idxi = labels + i * k;
-                float* simi = distances + i * k;
-                dis->set_query(x + i * d);
+                if (interrupt.load(std::memory_order_relaxed)) {
+                    continue;
+                }
+                try {
+                    idx_t* idxi = labels + i * k;
+                    float* simi = distances + i * k;
+                    dis->set_query(x + i * d);
 
-                nndescent.search(*dis, k, idxi, simi, vt);
+                    nndescent.search(*dis, k, idxi, simi, *vt);
+                } catch (...) {
+                    omp_capture_exception(ex, [&] { interrupt = true; });
+                }
             }
         }
+        omp_rethrow_if_exception(ex);
         InterruptCallback::check();
     }
 

--- a/faiss/IndexNSG.cpp
+++ b/faiss/IndexNSG.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/IndexNSG.h>
 
+#include <atomic>
 #include <cinttypes>
 #include <memory>
 
@@ -74,24 +75,39 @@ void IndexNSG::search(
     for (idx_t i0 = 0; i0 < n; i0 += check_period) {
         idx_t i1 = std::min(i0 + check_period, n);
 
+        std::exception_ptr ex;
+        std::atomic<bool> interrupt{false};
 #pragma omp parallel
         {
-            VisitedTable vt(ntotal, nsg.use_visited_hashset);
-
-            std::unique_ptr<DistanceComputer> dis(
-                    storage_distance_computer(storage));
+            std::unique_ptr<DistanceComputer> dis;
+            std::unique_ptr<VisitedTable> vt;
+            try {
+                vt = std::make_unique<VisitedTable>(
+                        ntotal, nsg.use_visited_hashset);
+                dis.reset(storage_distance_computer(storage));
+            } catch (...) {
+                omp_capture_exception(ex, [&] { interrupt = true; });
+            }
 
 #pragma omp for
             for (idx_t i = i0; i < i1; i++) {
-                idx_t* idxi = labels + i * k;
-                float* simi = distances + i * k;
-                dis->set_query(x + i * d);
+                if (interrupt.load(std::memory_order_relaxed)) {
+                    continue;
+                }
+                try {
+                    idx_t* idxi = labels + i * k;
+                    float* simi = distances + i * k;
+                    dis->set_query(x + i * d);
 
-                nsg.search(*dis, k, idxi, simi, vt);
+                    nsg.search(*dis, k, idxi, simi, *vt);
 
-                vt.advance();
+                    vt->advance();
+                } catch (...) {
+                    omp_capture_exception(ex, [&] { interrupt = true; });
+                }
             }
         }
+        omp_rethrow_if_exception(ex);
         InterruptCallback::check();
     }
 

--- a/faiss/impl/FaissException.h
+++ b/faiss/impl/FaissException.h
@@ -59,6 +59,54 @@ struct TransformedVectors {
 /// make typeids more readable
 std::string demangle_cpp_symbol(const char* name);
 
+/// Capture the current exception into `ex` if no prior exception has been
+/// recorded.  Call from a catch block inside an OpenMP parallel region.
+/// Uses `#pragma omp critical` to serialize access to `ex`.
+///
+/// The optional `cleanup` callable runs inside the critical section
+/// alongside the exception capture, so that side-effects visible to
+/// other threads (e.g. setting an interrupt flag) are serialized with
+/// the exception_ptr write.
+///
+/// Usage:
+///   std::exception_ptr ex;
+///   bool interrupt = false;
+///   #pragma omp parallel
+///   {
+///       try { ... } catch (...) {
+///           omp_capture_exception(ex, [&] { interrupt = true; });
+///       }
+///   }
+///   omp_rethrow_if_exception(ex);
+inline void omp_capture_exception(std::exception_ptr& ex) {
+#pragma omp critical(faiss_omp_exception)
+    {
+        if (!ex) {
+            ex = std::current_exception();
+        }
+    }
+}
+
+/// Overload with cleanup that runs inside the critical section.
+template <typename Cleanup>
+inline void omp_capture_exception(std::exception_ptr& ex, Cleanup&& cleanup) {
+#pragma omp critical(faiss_omp_exception)
+    {
+        cleanup();
+        if (!ex) {
+            ex = std::current_exception();
+        }
+    }
+}
+
+/// Rethrow the captured exception, if any.  Call on the main thread
+/// after the parallel region completes.
+inline void omp_rethrow_if_exception(std::exception_ptr& ex) {
+    if (ex) {
+        std::rethrow_exception(ex);
+    }
+}
+
 } // namespace faiss
 
 #endif

--- a/tests/test_omp_exception_safety.cpp
+++ b/tests/test_omp_exception_safety.cpp
@@ -14,6 +14,7 @@
 #include <gtest/gtest.h>
 
 #include <faiss/IndexFlat.h>
+#include <faiss/IndexFlatCodes.h>
 #include <faiss/IndexIVFFlat.h>
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissException.h>
@@ -299,4 +300,36 @@ TEST(OMPExceptionSafety, search_top_level_omp_slicing) {
             FaissException);
 
     f.restore(*throwing);
+}
+
+// Minimal IndexFlatCodes subclass whose sa_decode always throws, to
+// verify that exceptions thrown inside the OpenMP parallel region in
+// IndexFlatCodes::search are propagated to the caller.
+struct ThrowingIndex : IndexFlatCodes {
+    explicit ThrowingIndex(int d)
+            : IndexFlatCodes(sizeof(float) * d, d, METRIC_L2) {
+        ntotal = 1;
+        is_trained = true;
+        codes.resize(code_size, 0);
+    }
+
+    void sa_decode(idx_t /*n*/, const uint8_t* /*codes*/, float* /*x*/)
+            const override {
+        throw std::runtime_error("corrupt index");
+    }
+};
+
+// ---------------------------------------------------------------------------
+// IndexFlatCodes::search: exception in OMP worker propagates to caller
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, flatcodes_search) {
+    ThrowingIndex index(4);
+
+    std::vector<float> xq(4, 0.0f);
+    std::vector<float> distances(1);
+    std::vector<idx_t> labels(1);
+
+    EXPECT_THROW(
+            index.search(1, xq.data(), 1, distances.data(), labels.data()),
+            std::runtime_error);
 }

--- a/tests/test_omp_exception_safety.cpp
+++ b/tests/test_omp_exception_safety.cpp
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <atomic>
+#include <limits>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <faiss/IndexFlat.h>
+#include <faiss/IndexIVFFlat.h>
+#include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/FaissException.h>
+#include <faiss/invlists/InvertedLists.h>
+
+using namespace faiss;
+
+namespace {
+
+// InvertedLists wrapper that delegates to an underlying InvertedLists but
+// throws from get_codes() after a configurable number of successful calls.
+// This injects exceptions inside scan_one_list / scan_list_func, which
+// execute inside OMP worksharing constructs.
+struct ThrowingInvertedLists : InvertedLists {
+    const InvertedLists* delegate;
+    mutable std::atomic<int> calls_until_throw;
+
+    ThrowingInvertedLists(const InvertedLists* delegate_in, int throw_after)
+            : InvertedLists(delegate_in->nlist, delegate_in->code_size),
+              delegate(delegate_in),
+              calls_until_throw(throw_after) {}
+
+    size_t list_size(size_t list_no) const override {
+        return delegate->list_size(list_no);
+    }
+
+    const uint8_t* get_codes(size_t list_no) const override {
+        if (calls_until_throw.fetch_sub(1) <= 0) {
+            FAISS_THROW_MSG("injected get_codes failure");
+        }
+        return delegate->get_codes(list_no);
+    }
+
+    const idx_t* get_ids(size_t list_no) const override {
+        return delegate->get_ids(list_no);
+    }
+
+    size_t add_entries(size_t, size_t, const idx_t*, const uint8_t*) override {
+        FAISS_THROW_MSG("unexpected call");
+    }
+
+    void update_entries(size_t, size_t, size_t, const idx_t*, const uint8_t*)
+            override {
+        FAISS_THROW_MSG("unexpected call");
+    }
+
+    void resize(size_t, size_t) override {
+        FAISS_THROW_MSG("unexpected call");
+    }
+};
+
+// InterruptCallback that always signals an interrupt.
+struct AlwaysInterrupt : InterruptCallback {
+    bool want_interrupt() override {
+        return true;
+    }
+};
+
+// Build a trained IndexIVFFlat with data added, using enough vectors and
+// lists to exercise multi-threaded parallel modes.
+struct IVFFixture {
+    static constexpr int d = 8;
+    static constexpr int nb = 2000;
+    static constexpr int nlist = 16;
+    static constexpr int nq = 64;
+
+    IndexFlatL2 quantizer{d};
+    IndexIVFFlat index{&quantizer, d, nlist};
+    std::vector<float> xq;
+
+    IVFFixture() {
+        index.own_fields = false;
+        std::mt19937 rng(42);
+        std::uniform_real_distribution<float> dist;
+
+        std::vector<float> train(nlist * 40 * d);
+        for (auto& v : train) {
+            v = dist(rng);
+        }
+        index.train(train.size() / d, train.data());
+
+        std::vector<float> xb(nb * d);
+        for (auto& v : xb) {
+            v = dist(rng);
+        }
+        index.add(nb, xb.data());
+
+        xq.resize(nq * d);
+        for (auto& v : xq) {
+            v = dist(rng);
+        }
+    }
+
+    // Swap in a ThrowingInvertedLists that delegates to the real one.
+    // Returns the throwing wrapper. The real inverted lists is kept alive
+    // (disowned from the index) so the delegate pointer stays valid.
+    std::unique_ptr<ThrowingInvertedLists> install_throwing(int throw_after) {
+        auto* real = index.invlists;
+        auto throwing =
+                std::make_unique<ThrowingInvertedLists>(real, throw_after);
+        // Disown so replace_invlists doesn't delete the real lists.
+        index.own_invlists = false;
+        index.replace_invlists(throwing.get(), false);
+        return throwing;
+    }
+
+    // Restore the original inverted lists (the delegate from the wrapper).
+    void restore(const ThrowingInvertedLists& throwing) {
+        index.replace_invlists(
+                const_cast<InvertedLists*>(throwing.delegate), true);
+    }
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// search_preassigned: exception in scan_one_list, pmode 0
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, search_preassigned_pmode0) {
+    IVFFixture f;
+    f.index.parallel_mode = 0;
+    f.index.nprobe = 4;
+
+    auto throwing = f.install_throwing(2);
+
+    idx_t k = 4;
+    std::vector<float> dis(f.nq * k);
+    std::vector<idx_t> labels(f.nq * k);
+
+    EXPECT_THROW(
+            f.index.search(f.nq, f.xq.data(), k, dis.data(), labels.data()),
+            FaissException);
+
+    f.restore(*throwing);
+}
+
+// ---------------------------------------------------------------------------
+// search_preassigned: exception in scan_one_list, pmode 1
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, search_preassigned_pmode1) {
+    IVFFixture f;
+    f.index.parallel_mode = 1;
+    f.index.nprobe = 8;
+
+    auto throwing = f.install_throwing(2);
+
+    idx_t k = 4;
+    std::vector<float> dis(f.nq * k);
+    std::vector<idx_t> labels(f.nq * k);
+
+    EXPECT_THROW(
+            f.index.search(f.nq, f.xq.data(), k, dis.data(), labels.data()),
+            FaissException);
+
+    f.restore(*throwing);
+}
+
+// ---------------------------------------------------------------------------
+// search_preassigned: exception in scan_one_list, pmode 2
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, search_preassigned_pmode2) {
+    IVFFixture f;
+    f.index.parallel_mode = 2;
+    f.index.nprobe = 8;
+
+    auto throwing = f.install_throwing(2);
+
+    idx_t k = 4;
+    std::vector<float> dis(f.nq * k);
+    std::vector<idx_t> labels(f.nq * k);
+
+    EXPECT_THROW(
+            f.index.search(f.nq, f.xq.data(), k, dis.data(), labels.data()),
+            FaissException);
+
+    f.restore(*throwing);
+}
+
+// ---------------------------------------------------------------------------
+// search_preassigned: InterruptCallback::check() throws inside pmode 0 loop
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, search_interrupt_pmode0) {
+    IVFFixture f;
+    f.index.parallel_mode = 0;
+    f.index.nprobe = 4;
+
+    idx_t k = 4;
+    std::vector<float> dis(f.nq * k);
+    std::vector<idx_t> labels(f.nq * k);
+
+    InterruptCallback::instance.reset(new AlwaysInterrupt());
+
+    EXPECT_THROW(
+            f.index.search(f.nq, f.xq.data(), k, dis.data(), labels.data()),
+            FaissException);
+
+    InterruptCallback::clear_instance();
+}
+
+// ---------------------------------------------------------------------------
+// range_search_preassigned: exception in scan_list_func, pmode 0
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, range_search_pmode0) {
+    IVFFixture f;
+    f.index.parallel_mode = 0;
+    f.index.nprobe = 4;
+
+    auto throwing = f.install_throwing(2);
+    RangeSearchResult result(f.nq);
+
+    EXPECT_THROW(
+            f.index.range_search(
+                    f.nq,
+                    f.xq.data(),
+                    std::numeric_limits<float>::max(),
+                    &result),
+            FaissException);
+
+    f.restore(*throwing);
+}
+
+// ---------------------------------------------------------------------------
+// range_search_preassigned: exception in scan_list_func, pmode 1
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, range_search_pmode1) {
+    IVFFixture f;
+    f.index.parallel_mode = 1;
+    f.index.nprobe = 8;
+
+    auto throwing = f.install_throwing(2);
+    RangeSearchResult result(f.nq);
+
+    EXPECT_THROW(
+            f.index.range_search(
+                    f.nq,
+                    f.xq.data(),
+                    std::numeric_limits<float>::max(),
+                    &result),
+            FaissException);
+
+    f.restore(*throwing);
+}
+
+// ---------------------------------------------------------------------------
+// range_search_preassigned: exception in scan_list_func, pmode 2
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, range_search_pmode2) {
+    IVFFixture f;
+    f.index.parallel_mode = 2;
+    f.index.nprobe = 8;
+
+    auto throwing = f.install_throwing(2);
+    RangeSearchResult result(f.nq);
+
+    EXPECT_THROW(
+            f.index.range_search(
+                    f.nq,
+                    f.xq.data(),
+                    std::numeric_limits<float>::max(),
+                    &result),
+            FaissException);
+
+    f.restore(*throwing);
+}
+
+// ---------------------------------------------------------------------------
+// search (top-level OMP slicing): exception propagates from sub_search_func
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, search_top_level_omp_slicing) {
+    IVFFixture f;
+    f.index.parallel_mode = 0;
+    f.index.nprobe = 4;
+
+    // Allow a few successful calls so some slices start, then fail.
+    auto throwing = f.install_throwing(5);
+
+    idx_t k = 4;
+    std::vector<float> dis(f.nq * k);
+    std::vector<idx_t> labels(f.nq * k);
+
+    EXPECT_THROW(
+            f.index.search(f.nq, f.xq.data(), k, dis.data(), labels.data()),
+            FaissException);
+
+    f.restore(*throwing);
+}

--- a/tests/test_omp_exception_safety.cpp
+++ b/tests/test_omp_exception_safety.cpp
@@ -16,6 +16,8 @@
 #include <faiss/IndexFlat.h>
 #include <faiss/IndexFlatCodes.h>
 #include <faiss/IndexIVFFlat.h>
+#include <faiss/IndexNNDescent.h>
+#include <faiss/IndexNSG.h>
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissException.h>
 #include <faiss/invlists/InvertedLists.h>
@@ -332,4 +334,50 @@ TEST(OMPExceptionSafety, flatcodes_search) {
     EXPECT_THROW(
             index.search(1, xq.data(), 1, distances.data(), labels.data()),
             std::runtime_error);
+}
+
+// ---------------------------------------------------------------------------
+// IndexNNDescent::search: exception in OMP worker propagates to caller.
+// Constructing with has_built=false triggers a FaissException inside the
+// worksharing loop body.
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, nndescent_search) {
+    int d = 4;
+    auto storage = std::make_unique<IndexFlatL2>(d);
+    std::vector<float> xb(d, 1.0f);
+    storage->add(1, xb.data());
+
+    IndexNNDescent index(storage.get(), 4);
+    index.ntotal = 1;
+    // has_built defaults to false, so nndescent.search() will throw.
+
+    std::vector<float> xq(d, 0.0f);
+    std::vector<float> distances(1);
+    std::vector<idx_t> labels(1);
+
+    EXPECT_THROW(
+            index.search(1, xq.data(), 1, distances.data(), labels.data()),
+            FaissException);
+}
+
+// ---------------------------------------------------------------------------
+// IndexNSG::search: exception in OMP worker propagates to caller
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, nsg_search) {
+    int d = 4;
+    auto storage = std::make_unique<IndexFlatL2>(d);
+    std::vector<float> xb(d, 1.0f);
+    storage->add(1, xb.data());
+
+    IndexNSG index(storage.get(), 4);
+    index.ntotal = 1;
+    // nsg graph is not built, so nsg.search() will throw.
+
+    std::vector<float> xq(d, 0.0f);
+    std::vector<float> distances(1);
+    std::vector<idx_t> labels(1);
+
+    EXPECT_THROW(
+            index.search(1, xq.data(), 1, distances.data(), labels.data()),
+            FaissException);
 }

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -22,6 +22,7 @@
 #include <faiss/IndexIVFAdditiveQuantizerFastScan.h>
 #include <faiss/IndexIVFFlat.h>
 #include <faiss/IndexIVFIndependentQuantizer.h>
+#include <faiss/IndexIVFPQ.h>
 #include <faiss/IndexIVFPQR.h>
 #include <faiss/IndexRaBitQFastScan.h>
 #include <faiss/VectorTransform.h>
@@ -1645,6 +1646,62 @@ TEST(ReadIndexDeserialize, IVFQuantizerUntrained) {
     VectorIOReader reader;
     reader.data = buf;
     EXPECT_NO_THROW(read_index_up(&reader));
+}
+
+// -----------------------------------------------------------------------
+// Test: initialize_IVFPQ_precomputed_table rejects a null quantizer.
+// Protects against null-deref from corrupt serialized data where the
+// quantizer sub-index is absent (fourcc "null").
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, IVFPQNullQuantizerPrecomputeTableRejected) {
+    ProductQuantizer pq(4, 1, 8);
+    AlignedTable<float> precomputed_table;
+    int use_precomputed_table = 0;
+    EXPECT_THROW(
+            initialize_IVFPQ_precomputed_table(
+                    use_precomputed_table,
+                    /*quantizer=*/nullptr,
+                    pq,
+                    precomputed_table,
+                    /*by_residual=*/true,
+                    /*verbose=*/false),
+            faiss::FaissException);
+}
+
+TEST(ReadIndexDeserialize, IVFNullQuantizerSearchRejected) {
+    IndexIVFFlat ivf;
+    ivf.quantizer = nullptr;
+    ivf.is_trained = true;
+    std::vector<float> x(4);
+    std::vector<float> distances(1);
+    std::vector<idx_t> labels(1);
+    EXPECT_THROW(
+            ivf.search(1, x.data(), 1, distances.data(), labels.data()),
+            faiss::FaissException);
+}
+
+TEST(ReadIndexDeserialize, IVFNullQuantizerRangeSearchRejected) {
+    IndexIVFFlat ivf;
+    ivf.quantizer = nullptr;
+    ivf.is_trained = true;
+    std::vector<float> x(4);
+    RangeSearchResult result(1);
+    EXPECT_THROW(
+            ivf.range_search(1, x.data(), 1.0, &result), faiss::FaissException);
+}
+
+TEST(ReadIndexDeserialize, IVFNullQuantizerAddRejected) {
+    IndexIVFFlat ivf;
+    ivf.quantizer = nullptr;
+    std::vector<float> x(4);
+    EXPECT_THROW(ivf.add(1, x.data()), faiss::FaissException);
+}
+
+TEST(ReadIndexDeserialize, IVFNullQuantizerTrainRejected) {
+    IndexIVFFlat ivf;
+    ivf.quantizer = nullptr;
+    std::vector<float> x(4);
+    EXPECT_THROW(ivf.train(1, x.data()), faiss::FaissException);
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
Summary:

Add validation in read_ivf_header() to reject a null quantizer sub-index read from serialized data. The IVF deserialization reads the quantizer via read_index(), which returns nullptr when the stream contains the "null" fourcc. A null quantizer is fundamentally invalid for any IVF index type. Without this check, downstream code (e.g. initialize_IVFPQ_precomputed_table, IndexIVF::search) dereferences the null pointer.

This single validation protects all IVF index types that share read_ivf_header: IndexIVFFlat, IndexIVFPQ, IndexIVFScalarQuantizer, IndexIVFAdditiveQuantizer, and others.

Reviewed By: mnorris11

Differential Revision: D101236489
