### PR TITLE
Validate inverted list entry sizes against deserialization byte limit (#5117)

### DIFF
--- a/faiss/IndexFlatCodes.cpp
+++ b/faiss/IndexFlatCodes.cpp
@@ -7,6 +7,8 @@
 
 #include <faiss/IndexFlatCodes.h>
 
+#include <atomic>
+
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/CodePacker.h>
 #include <faiss/impl/DistanceComputer.h>
@@ -204,23 +206,39 @@ struct Run_search_with_decompress {
         using SingleResultHandler =
                 typename BlockResultHandler::SingleResultHandler;
         using DC = GenericFlatCodesDistanceComputer<VectorDistance>;
+        std::exception_ptr ex;
+        std::atomic<bool> interrupt{false};
 #pragma omp parallel // if (res.nq > 100)
         {
-            std::unique_ptr<DC> dc(new DC(&index, vd));
-            SingleResultHandler resi(res);
+            std::unique_ptr<DC> dc;
+            std::unique_ptr<SingleResultHandler> resi;
+            try {
+                dc = std::make_unique<DC>(&index, vd);
+                resi = std::make_unique<SingleResultHandler>(res);
+            } catch (...) {
+                omp_capture_exception(ex, [&] { interrupt = true; });
+            }
 #pragma omp for
             for (int64_t q = 0; q < static_cast<int64_t>(res.nq); q++) {
-                resi.begin(q);
-                dc->set_query(xq + vd.d * q);
-                for (size_t i = 0; i < ntotal; i++) {
-                    if (res.is_in_selection(i)) {
-                        float dis = (*dc)(i);
-                        resi.add_result(dis, i);
-                    }
+                if (interrupt.load(std::memory_order_relaxed)) {
+                    continue;
                 }
-                resi.end();
+                try {
+                    resi->begin(q);
+                    dc->set_query(xq + vd.d * q);
+                    for (size_t i = 0; i < ntotal; i++) {
+                        if (res.is_in_selection(i)) {
+                            float dis = (*dc)(i);
+                            resi->add_result(dis, i);
+                        }
+                    }
+                    resi->end();
+                } catch (...) {
+                    omp_capture_exception(ex, [&] { interrupt = true; });
+                }
             }
         }
+        omp_rethrow_if_exception(ex);
     }
 };
 

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -865,6 +865,9 @@ void IndexHNSW2Level::search(
 
         const IndexIVFPQ* index_ivfpq =
                 dynamic_cast<const IndexIVFPQ*>(storage);
+        FAISS_THROW_IF_NOT_MSG(
+                index_ivfpq,
+                "IndexHNSW2Level mixed search requires IndexIVFPQ storage");
 
         int nprobe = index_ivfpq->nprobe;
 

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -312,6 +312,7 @@ void IndexIVF::search(
         const SearchParameters* params_in) const {
     FAISS_THROW_IF_NOT(k > 0);
     FAISS_THROW_IF_NOT_MSG(quantizer, "IVF quantizer must not be null");
+    FAISS_THROW_IF_NOT_MSG(is_trained, "IVF index is not trained");
     FAISS_THROW_IF_NOT_MSG(invlists, "IVF index has no inverted lists");
     const IVFSearchParameters* params = nullptr;
     if (params_in) {
@@ -409,6 +410,7 @@ void IndexIVF::search_preassigned(
         const IVFSearchParameters* params,
         IndexIVFStats* ivf_stats) const {
     FAISS_THROW_IF_NOT(k > 0);
+    FAISS_THROW_IF_NOT_MSG(is_trained, "IVF index is not trained");
     FAISS_THROW_IF_NOT_MSG(invlists, "IVF index has no inverted lists");
 
     idx_t cur_nprobe = params ? params->nprobe : this->nprobe;
@@ -738,6 +740,7 @@ void IndexIVF::range_search(
         RangeSearchResult* result,
         const SearchParameters* params_in) const {
     FAISS_THROW_IF_NOT_MSG(quantizer, "IVF quantizer must not be null");
+    FAISS_THROW_IF_NOT_MSG(is_trained, "IVF index is not trained");
     const IVFSearchParameters* params = nullptr;
     const SearchParameters* quantizer_params = nullptr;
     if (params_in) {
@@ -782,6 +785,7 @@ void IndexIVF::range_search_preassigned(
         bool store_pairs,
         const IVFSearchParameters* params,
         IndexIVFStats* stats) const {
+    FAISS_THROW_IF_NOT_MSG(is_trained, "IVF index is not trained");
     idx_t cur_nprobe = params ? params->nprobe : this->nprobe;
     cur_nprobe = std::min((idx_t)nlist, cur_nprobe);
     FAISS_THROW_IF_NOT(cur_nprobe > 0);

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -8,9 +8,9 @@
 #include <faiss/IndexIVF.h>
 
 #include <omp.h>
+#include <atomic>
 #include <cstdint>
 #include <memory>
-#include <mutex>
 
 #include <algorithm>
 #include <cinttypes>
@@ -360,32 +360,28 @@ void IndexIVF::search(
     if ((parallel_mode & ~PARALLEL_MODE_NO_HEAP_INIT) == 0) {
         int nt = std::min(omp_get_max_threads(), int(n));
         std::vector<IndexIVFStats> stats(nt);
-        std::mutex exception_mutex;
-        std::string exception_string;
+        std::exception_ptr ex;
 
 #pragma omp parallel for if (nt > 1)
         for (idx_t slice = 0; slice < nt; slice++) {
-            IndexIVFStats local_stats;
-            idx_t i0 = n * slice / nt;
-            idx_t i1 = n * (slice + 1) / nt;
-            if (i1 > i0) {
-                try {
+            try {
+                IndexIVFStats local_stats;
+                idx_t i0 = n * slice / nt;
+                idx_t i1 = n * (slice + 1) / nt;
+                if (i1 > i0) {
                     sub_search_func(
                             i1 - i0,
                             x + i0 * d,
                             distances + i0 * k,
                             labels + i0 * k,
                             &stats[slice]);
-                } catch (const std::exception& e) {
-                    std::lock_guard<std::mutex> lock(exception_mutex);
-                    exception_string = e.what();
                 }
+            } catch (...) {
+                omp_capture_exception(ex);
             }
         }
 
-        if (!exception_string.empty()) {
-            FAISS_THROW_MSG(exception_string.c_str());
-        }
+        omp_rethrow_if_exception(ex);
 
         // collect stats
         for (idx_t slice = 0; slice < nt; slice++) {
@@ -442,9 +438,8 @@ void IndexIVF::search_preassigned(
     using HeapForIP = CMin<float, idx_t>;
     using HeapForL2 = CMax<float, idx_t>;
 
-    bool interrupt = false;
-    std::mutex exception_mutex;
-    std::string exception_string;
+    std::exception_ptr ex;
+    std::atomic<bool> interrupt{false};
 
     int pmode = this->parallel_mode & ~PARALLEL_MODE_NO_HEAP_INIT;
     bool do_heap_init = !(this->parallel_mode & PARALLEL_MODE_NO_HEAP_INIT);
@@ -532,74 +527,65 @@ void IndexIVF::search_preassigned(
                     // not enough centroids for multiprobe
                     return (size_t)0;
                 }
-                try {
-                    FAISS_THROW_IF_NOT_FMT(
-                            key < (idx_t)nlist,
-                            "Invalid key=%" PRId64 " nlist=%zd\n",
-                            key,
-                            nlist);
+                FAISS_THROW_IF_NOT_FMT(
+                        key < (idx_t)nlist,
+                        "Invalid key=%" PRId64 " nlist=%zd\n",
+                        key,
+                        nlist);
 
-                    // don't waste time on empty lists
-                    if (invlists->is_empty(key, inverted_list_context)) {
-                        return (size_t)0;
+                // don't waste time on empty lists
+                if (invlists->is_empty(key, inverted_list_context)) {
+                    return (size_t)0;
+                }
+
+                scanner->set_list(key, coarse_dis_i);
+
+                nlistv++;
+                if (invlists->use_iterator) {
+                    size_t list_size = 0;
+
+                    std::unique_ptr<InvertedListsIterator> it(
+                            invlists->get_iterator(key, inverted_list_context));
+
+                    nheap += scanner->iterate_codes(
+                            it.get(), simi, idxi, k, list_size);
+
+                    return list_size;
+                } else {
+                    size_t list_size = invlists->list_size(key);
+                    if (list_size > static_cast<size_t>(list_size_max)) {
+                        list_size = static_cast<size_t>(list_size_max);
                     }
 
-                    scanner->set_list(key, coarse_dis_i);
+                    InvertedLists::ScopedCodes scodes(invlists, key);
+                    const uint8_t* codes = scodes.get();
 
-                    nlistv++;
-                    if (invlists->use_iterator) {
-                        size_t list_size = 0;
+                    std::unique_ptr<InvertedLists::ScopedIds> sids;
+                    const idx_t* ids = nullptr;
 
-                        std::unique_ptr<InvertedListsIterator> it(
-                                invlists->get_iterator(
-                                        key, inverted_list_context));
-
-                        nheap += scanner->iterate_codes(
-                                it.get(), simi, idxi, k, list_size);
-
-                        return list_size;
-                    } else {
-                        size_t list_size = invlists->list_size(key);
-                        if (list_size > static_cast<size_t>(list_size_max)) {
-                            list_size = static_cast<size_t>(list_size_max);
-                        }
-
-                        InvertedLists::ScopedCodes scodes(invlists, key);
-                        const uint8_t* codes = scodes.get();
-
-                        std::unique_ptr<InvertedLists::ScopedIds> sids;
-                        const idx_t* ids = nullptr;
-
-                        if (!store_pairs) {
-                            sids = std::make_unique<InvertedLists::ScopedIds>(
-                                    invlists, key);
-                            ids = sids->get();
-                        }
-
-                        if (selr) { // IDSelectorRange
-                            // restrict search to a section of the inverted list
-                            size_t jmin, jmax;
-                            selr->find_sorted_ids_bounds(
-                                    list_size, ids, &jmin, &jmax);
-                            list_size = jmax - jmin;
-                            if (list_size == 0) {
-                                return (size_t)0;
-                            }
-                            codes += jmin * code_size;
-                            ids += jmin;
-                        }
-
-                        nheap += scanner->scan_codes(
-                                list_size, codes, ids, simi, idxi, k);
-
-                        return list_size;
+                    if (!store_pairs) {
+                        sids = std::make_unique<InvertedLists::ScopedIds>(
+                                invlists, key);
+                        ids = sids->get();
                     }
-                } catch (const std::exception& e) {
-                    std::lock_guard<std::mutex> lock(exception_mutex);
-                    exception_string = demangle_cpp_symbol(typeid(e).name()) +
-                            "  " + e.what();
-                    interrupt = true;
-                    return size_t(0);
+
+                    if (selr) { // IDSelectorRange
+                        // restrict search to a section of the inverted list
+                        size_t jmin, jmax;
+                        selr->find_sorted_ids_bounds(
+                                list_size, ids, &jmin, &jmax);
+                        list_size = jmax - jmin;
+                        if (list_size == 0) {
+                            return (size_t)0;
+                        }
+                        codes += jmin * code_size;
+                        ids += jmin;
+                    }
+
+                    nheap += scanner->scan_codes(
+                            list_size, codes, ids, simi, idxi, k);
+
+                    return list_size;
                 }
             };
 
@@ -610,39 +596,39 @@ void IndexIVF::search_preassigned(
             if (pmode == 0 || pmode == 3) {
 #pragma omp for
                 for (idx_t i = 0; i < n; i++) {
-                    if (interrupt) {
+                    if (interrupt.load(std::memory_order_relaxed)) {
                         continue;
                     }
+                    try {
+                        // loop over queries
+                        scanner->set_query(x + i * d);
+                        float* simi = distances + i * k;
+                        idx_t* idxi = labels + i * k;
 
-                    // loop over queries
-                    scanner->set_query(x + i * d);
-                    float* simi = distances + i * k;
-                    idx_t* idxi = labels + i * k;
+                        init_result(simi, idxi);
 
-                    init_result(simi, idxi);
+                        idx_t nscan = 0;
 
-                    idx_t nscan = 0;
-
-                    // loop over probes
-                    for (idx_t ik = 0; ik < cur_nprobe; ik++) {
-                        nscan += scan_one_list(
-                                keys[i * cur_nprobe + ik],
-                                coarse_dis[i * cur_nprobe + ik],
-                                simi,
-                                idxi,
-                                cur_max_codes - nscan);
-                        if (nscan >= cur_max_codes) {
-                            break;
+                        // loop over probes
+                        for (idx_t ik = 0; ik < cur_nprobe; ik++) {
+                            nscan += scan_one_list(
+                                    keys[i * cur_nprobe + ik],
+                                    coarse_dis[i * cur_nprobe + ik],
+                                    simi,
+                                    idxi,
+                                    cur_max_codes - nscan);
+                            if (nscan >= cur_max_codes) {
+                                break;
+                            }
                         }
+
+                        ndis += nscan;
+                        reorder_result(simi, idxi);
+
+                        InterruptCallback::check();
+                    } catch (...) {
+                        omp_capture_exception(ex, [&] { interrupt = true; });
                     }
-
-                    ndis += nscan;
-                    reorder_result(simi, idxi);
-
-                    if (InterruptCallback::is_interrupted()) {
-                        interrupt = true;
-                    }
-
                 } // parallel for
             } else if (pmode == 1) {
                 std::vector<idx_t> local_idx(k);
@@ -654,14 +640,19 @@ void IndexIVF::search_preassigned(
 
 #pragma omp for schedule(dynamic)
                     for (idx_t ik = 0; ik < cur_nprobe; ik++) {
-                        ndis += scan_one_list(
-                                keys[i * cur_nprobe + ik],
-                                coarse_dis[i * cur_nprobe + ik],
-                                local_dis.data(),
-                                local_idx.data(),
-                                unlimited_list_size);
+                        try {
+                            ndis += scan_one_list(
+                                    keys[i * cur_nprobe + ik],
+                                    coarse_dis[i * cur_nprobe + ik],
+                                    local_dis.data(),
+                                    local_idx.data(),
+                                    unlimited_list_size);
 
-                        // can't do the test on max_codes
+                            // can't do the test on max_codes
+                        } catch (...) {
+                            omp_capture_exception(
+                                    ex, [&] { interrupt = true; });
+                        }
                     }
                     // merge thread-local results
 
@@ -691,23 +682,27 @@ void IndexIVF::search_preassigned(
 
 #pragma omp for schedule(dynamic)
                 for (int64_t ij = 0; ij < n * cur_nprobe; ij++) {
-                    size_t i = ij / cur_nprobe;
+                    try {
+                        size_t i = ij / cur_nprobe;
 
-                    scanner->set_query(x + i * d);
-                    init_result(local_dis.data(), local_idx.data());
-                    ndis += scan_one_list(
-                            keys[ij],
-                            coarse_dis[ij],
-                            local_dis.data(),
-                            local_idx.data(),
-                            unlimited_list_size);
-#pragma omp critical
-                    {
-                        add_local_results(
+                        scanner->set_query(x + i * d);
+                        init_result(local_dis.data(), local_idx.data());
+                        ndis += scan_one_list(
+                                keys[ij],
+                                coarse_dis[ij],
                                 local_dis.data(),
                                 local_idx.data(),
-                                distances + i * k,
-                                labels + i * k);
+                                unlimited_list_size);
+#pragma omp critical
+                        {
+                            add_local_results(
+                                    local_dis.data(),
+                                    local_idx.data(),
+                                    distances + i * k,
+                                    labels + i * k);
+                        }
+                    } catch (...) {
+                        omp_capture_exception(ex, [&] { interrupt = true; });
                     }
                 }
 #pragma omp single
@@ -717,24 +712,12 @@ void IndexIVF::search_preassigned(
             } else {
                 FAISS_THROW_FMT("parallel_mode %d not supported\n", pmode);
             }
-        } catch (const std::exception& e) {
-            std::lock_guard<std::mutex> lock(exception_mutex);
-            if (exception_string.empty()) {
-                exception_string =
-                        demangle_cpp_symbol(typeid(e).name()) + "  " + e.what();
-            }
-            interrupt = true;
+        } catch (...) {
+            omp_capture_exception(ex, [&] { interrupt = true; });
         }
     } // parallel section
 
-    if (interrupt) {
-        if (!exception_string.empty()) {
-            FAISS_THROW_FMT(
-                    "search interrupted with: %s", exception_string.c_str());
-        } else {
-            FAISS_THROW_MSG("computation interrupted");
-        }
-    }
+    omp_rethrow_if_exception(ex);
 
     if (ivf_stats == nullptr) {
         ivf_stats = &indexIVF_stats;
@@ -809,9 +792,7 @@ void IndexIVF::range_search_preassigned(
 
     size_t nlistv = 0, ndis = 0;
 
-    bool interrupt = false;
-    std::mutex exception_mutex;
-    std::string exception_string;
+    std::exception_ptr ex;
 
     std::vector<RangeSearchPartialResult*> all_pres(omp_get_max_threads());
 
@@ -840,63 +821,55 @@ void IndexIVF::range_search_preassigned(
             auto scan_list_func = [&](size_t i,
                                       size_t ik,
                                       RangeQueryResult& qres) {
-                try {
-                    idx_t key = keys[i * cur_nprobe + ik]; /* select the list */
-                    if (key < 0) {
-                        return;
-                    }
-
-                    FAISS_THROW_IF_NOT_FMT(
-                            key < (idx_t)nlist,
-                            "Invalid key=%" PRId64 " at ik=%zd nlist=%zd\n",
-                            key,
-                            ik,
-                            nlist);
-
-                    if (invlists->is_empty(key, inverted_list_context)) {
-                        return;
-                    }
-
-                    size_t list_size = 0;
-                    scanner->set_list(key, coarse_dis[i * cur_nprobe + ik]);
-                    if (invlists->use_iterator) {
-                        std::unique_ptr<InvertedListsIterator> it(
-                                invlists->get_iterator(
-                                        key, inverted_list_context));
-
-                        scanner->iterate_codes_range(
-                                it.get(), radius, qres, list_size);
-                    } else {
-                        InvertedLists::ScopedCodes scodes(invlists, key);
-                        InvertedLists::ScopedIds ids(invlists, key);
-                        list_size = invlists->list_size(key);
-
-                        scanner->scan_codes_range(
-                                list_size,
-                                scodes.get(),
-                                ids.get(),
-                                radius,
-                                qres);
-                    }
-                    nlistv++;
-                    ndis += list_size;
-                } catch (const std::exception& e) {
-                    std::lock_guard<std::mutex> lock(exception_mutex);
-                    exception_string = demangle_cpp_symbol(typeid(e).name()) +
-                            "  " + e.what();
-                    interrupt = true;
+                idx_t key = keys[i * cur_nprobe + ik]; /* select the list */
+                if (key < 0) {
+                    return;
                 }
+
+                FAISS_THROW_IF_NOT_FMT(
+                        key < (idx_t)nlist,
+                        "Invalid key=%" PRId64 " at ik=%zd nlist=%zd\n",
+                        key,
+                        ik,
+                        nlist);
+
+                if (invlists->is_empty(key, inverted_list_context)) {
+                    return;
+                }
+
+                size_t list_size = 0;
+                scanner->set_list(key, coarse_dis[i * cur_nprobe + ik]);
+                if (invlists->use_iterator) {
+                    std::unique_ptr<InvertedListsIterator> it(
+                            invlists->get_iterator(key, inverted_list_context));
+
+                    scanner->iterate_codes_range(
+                            it.get(), radius, qres, list_size);
+                } else {
+                    InvertedLists::ScopedCodes scodes(invlists, key);
+                    InvertedLists::ScopedIds ids(invlists, key);
+                    list_size = invlists->list_size(key);
+
+                    scanner->scan_codes_range(
+                            list_size, scodes.get(), ids.get(), radius, qres);
+                }
+                nlistv++;
+                ndis += list_size;
             };
 
             if (parallel_mode == 0) {
 #pragma omp for
                 for (idx_t i = 0; i < nx; i++) {
-                    scanner->set_query(x + i * d);
+                    try {
+                        scanner->set_query(x + i * d);
 
-                    RangeQueryResult& qres = pres.new_result(i);
+                        RangeQueryResult& qres = pres.new_result(i);
 
-                    for (idx_t ik = 0; ik < cur_nprobe; ik++) {
-                        scan_list_func(i, ik, qres);
+                        for (idx_t ik = 0; ik < cur_nprobe; ik++) {
+                            scan_list_func(i, ik, qres);
+                        }
+                    } catch (...) {
+                        omp_capture_exception(ex);
                     }
                 }
 
@@ -908,7 +881,11 @@ void IndexIVF::range_search_preassigned(
 
 #pragma omp for schedule(dynamic)
                     for (int64_t ik = 0; ik < cur_nprobe; ik++) {
-                        scan_list_func(i, ik, qres);
+                        try {
+                            scan_list_func(i, ik, qres);
+                        } catch (...) {
+                            omp_capture_exception(ex);
+                        }
                     }
                 }
             } else if (parallel_mode == 2) {
@@ -916,13 +893,17 @@ void IndexIVF::range_search_preassigned(
 
 #pragma omp for schedule(dynamic)
                 for (idx_t iik = 0; iik < nx * (idx_t)cur_nprobe; iik++) {
-                    idx_t i = iik / (idx_t)cur_nprobe;
-                    idx_t ik = iik % (idx_t)cur_nprobe;
-                    if (qres == nullptr || qres->qno != i) {
-                        qres = &pres.new_result(i);
-                        scanner->set_query(x + i * d);
+                    try {
+                        idx_t i = iik / (idx_t)cur_nprobe;
+                        idx_t ik = iik % (idx_t)cur_nprobe;
+                        if (qres == nullptr || qres->qno != i) {
+                            qres = &pres.new_result(i);
+                            scanner->set_query(x + i * d);
+                        }
+                        scan_list_func(i, ik, *qres);
+                    } catch (...) {
+                        omp_capture_exception(ex);
                     }
-                    scan_list_func(i, ik, *qres);
                 }
             } else {
                 FAISS_THROW_FMT(
@@ -936,22 +917,12 @@ void IndexIVF::range_search_preassigned(
                 RangeSearchPartialResult::merge(all_pres, false);
 #pragma omp barrier
             }
-        } catch (const std::exception& e) {
-            std::lock_guard<std::mutex> lock(exception_mutex);
-            exception_string =
-                    demangle_cpp_symbol(typeid(e).name()) + "  " + e.what();
-            interrupt = true;
+        } catch (...) {
+            omp_capture_exception(ex);
         }
     }
 
-    if (interrupt) {
-        if (!exception_string.empty()) {
-            FAISS_THROW_FMT(
-                    "search interrupted with: %s", exception_string.c_str());
-        } else {
-            FAISS_THROW_MSG("computation interrupted");
-        }
-    }
+    omp_rethrow_if_exception(ex);
 
     if (stats == nullptr) {
         stats = &indexIVF_stats;

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -58,6 +58,7 @@ void Level1Quantizer::train_q1(
         const float* x,
         bool verbose,
         MetricType metric_type) {
+    FAISS_THROW_IF_NOT_MSG(quantizer, "IVF quantizer must not be null");
     size_t d = quantizer->d;
     if (quantizer->is_trained &&
         (static_cast<size_t>(quantizer->ntotal) == nlist)) {
@@ -188,6 +189,7 @@ void IndexIVF::add(idx_t n, const float* x) {
 }
 
 void IndexIVF::add_with_ids(idx_t n, const float* x, const idx_t* xids) {
+    FAISS_THROW_IF_NOT_MSG(quantizer, "IVF quantizer must not be null");
     FAISS_THROW_IF_NOT_MSG(invlists, "IVF index has no inverted lists");
     std::unique_ptr<idx_t[]> coarse_idx(new idx_t[n]);
     quantizer->assign(n, x, coarse_idx.get());
@@ -309,6 +311,7 @@ void IndexIVF::search(
         idx_t* labels,
         const SearchParameters* params_in) const {
     FAISS_THROW_IF_NOT(k > 0);
+    FAISS_THROW_IF_NOT_MSG(quantizer, "IVF quantizer must not be null");
     FAISS_THROW_IF_NOT_MSG(invlists, "IVF index has no inverted lists");
     const IVFSearchParameters* params = nullptr;
     if (params_in) {
@@ -734,6 +737,7 @@ void IndexIVF::range_search(
         float radius,
         RangeSearchResult* result,
         const SearchParameters* params_in) const {
+    FAISS_THROW_IF_NOT_MSG(quantizer, "IVF quantizer must not be null");
     const IVFSearchParameters* params = nullptr;
     const SearchParameters* quantizer_params = nullptr;
     if (params_in) {

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -388,6 +388,7 @@ void initialize_IVFPQ_precomputed_table(
         AlignedTable<float>& precomputed_table,
         bool by_residual,
         bool verbose) {
+    FAISS_THROW_IF_NOT_MSG(quantizer, "IVF quantizer must not be null");
     size_t nlist = quantizer->ntotal;
     size_t d = quantizer->d;
     FAISS_THROW_IF_NOT(d == pq.d);

--- a/faiss/IndexNNDescent.cpp
+++ b/faiss/IndexNNDescent.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/IndexNNDescent.h>
 
+#include <atomic>
 #include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
@@ -119,22 +120,36 @@ void IndexNNDescent::search(
     for (idx_t i0 = 0; i0 < n; i0 += check_period) {
         idx_t i1 = std::min(i0 + check_period, n);
 
+        std::exception_ptr ex;
+        std::atomic<bool> interrupt{false};
 #pragma omp parallel
         {
-            VisitedTable vt(ntotal);
-
-            std::unique_ptr<DistanceComputer> dis(
-                    storage_distance_computer(storage));
+            std::unique_ptr<DistanceComputer> dis;
+            std::unique_ptr<VisitedTable> vt;
+            try {
+                vt = std::make_unique<VisitedTable>(ntotal);
+                dis.reset(storage_distance_computer(storage));
+            } catch (...) {
+                omp_capture_exception(ex, [&] { interrupt = true; });
+            }
 
 #pragma omp for
             for (idx_t i = i0; i < i1; i++) {
-                idx_t* idxi = labels + i * k;
-                float* simi = distances + i * k;
-                dis->set_query(x + i * d);
+                if (interrupt.load(std::memory_order_relaxed)) {
+                    continue;
+                }
+                try {
+                    idx_t* idxi = labels + i * k;
+                    float* simi = distances + i * k;
+                    dis->set_query(x + i * d);
 
-                nndescent.search(*dis, k, idxi, simi, vt);
+                    nndescent.search(*dis, k, idxi, simi, *vt);
+                } catch (...) {
+                    omp_capture_exception(ex, [&] { interrupt = true; });
+                }
             }
         }
+        omp_rethrow_if_exception(ex);
         InterruptCallback::check();
     }
 

--- a/faiss/IndexNSG.cpp
+++ b/faiss/IndexNSG.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/IndexNSG.h>
 
+#include <atomic>
 #include <cinttypes>
 #include <memory>
 
@@ -74,24 +75,39 @@ void IndexNSG::search(
     for (idx_t i0 = 0; i0 < n; i0 += check_period) {
         idx_t i1 = std::min(i0 + check_period, n);
 
+        std::exception_ptr ex;
+        std::atomic<bool> interrupt{false};
 #pragma omp parallel
         {
-            VisitedTable vt(ntotal, nsg.use_visited_hashset);
-
-            std::unique_ptr<DistanceComputer> dis(
-                    storage_distance_computer(storage));
+            std::unique_ptr<DistanceComputer> dis;
+            std::unique_ptr<VisitedTable> vt;
+            try {
+                vt = std::make_unique<VisitedTable>(
+                        ntotal, nsg.use_visited_hashset);
+                dis.reset(storage_distance_computer(storage));
+            } catch (...) {
+                omp_capture_exception(ex, [&] { interrupt = true; });
+            }
 
 #pragma omp for
             for (idx_t i = i0; i < i1; i++) {
-                idx_t* idxi = labels + i * k;
-                float* simi = distances + i * k;
-                dis->set_query(x + i * d);
+                if (interrupt.load(std::memory_order_relaxed)) {
+                    continue;
+                }
+                try {
+                    idx_t* idxi = labels + i * k;
+                    float* simi = distances + i * k;
+                    dis->set_query(x + i * d);
 
-                nsg.search(*dis, k, idxi, simi, vt);
+                    nsg.search(*dis, k, idxi, simi, *vt);
 
-                vt.advance();
+                    vt->advance();
+                } catch (...) {
+                    omp_capture_exception(ex, [&] { interrupt = true; });
+                }
             }
         }
+        omp_rethrow_if_exception(ex);
         InterruptCallback::check();
     }
 

--- a/faiss/impl/FaissException.h
+++ b/faiss/impl/FaissException.h
@@ -59,6 +59,54 @@ struct TransformedVectors {
 /// make typeids more readable
 std::string demangle_cpp_symbol(const char* name);
 
+/// Capture the current exception into `ex` if no prior exception has been
+/// recorded.  Call from a catch block inside an OpenMP parallel region.
+/// Uses `#pragma omp critical` to serialize access to `ex`.
+///
+/// The optional `cleanup` callable runs inside the critical section
+/// alongside the exception capture, so that side-effects visible to
+/// other threads (e.g. setting an interrupt flag) are serialized with
+/// the exception_ptr write.
+///
+/// Usage:
+///   std::exception_ptr ex;
+///   bool interrupt = false;
+///   #pragma omp parallel
+///   {
+///       try { ... } catch (...) {
+///           omp_capture_exception(ex, [&] { interrupt = true; });
+///       }
+///   }
+///   omp_rethrow_if_exception(ex);
+inline void omp_capture_exception(std::exception_ptr& ex) {
+#pragma omp critical(faiss_omp_exception)
+    {
+        if (!ex) {
+            ex = std::current_exception();
+        }
+    }
+}
+
+/// Overload with cleanup that runs inside the critical section.
+template <typename Cleanup>
+inline void omp_capture_exception(std::exception_ptr& ex, Cleanup&& cleanup) {
+#pragma omp critical(faiss_omp_exception)
+    {
+        cleanup();
+        if (!ex) {
+            ex = std::current_exception();
+        }
+    }
+}
+
+/// Rethrow the captured exception, if any.  Call on the main thread
+/// after the parallel region completes.
+inline void omp_rethrow_if_exception(std::exception_ptr& ex) {
+    if (ex) {
+        std::rethrow_exception(ex);
+    }
+}
+
 } // namespace faiss
 
 #endif

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -421,6 +421,14 @@ std::unique_ptr<VectorTransform> read_VectorTransform_up(IOReader* f) {
                 (int)rdt->map.size(),
                 rdt->d_out);
     }
+    if (h == fourcc("VNrm")) {
+        FAISS_THROW_IF_NOT_FMT(
+                vt->d_in == vt->d_out,
+                "NormalizationTransform requires d_in == d_out, "
+                "got d_in=%d d_out=%d",
+                vt->d_in,
+                vt->d_out);
+    }
     if (h == fourcc("VCnt")) {
         auto* ct = dynamic_cast<CenteringTransform*>(vt.get());
         FAISS_THROW_IF_NOT_MSG(ct, "dynamic_cast to CenteringTransform failed");
@@ -429,6 +437,12 @@ std::unique_ptr<VectorTransform> read_VectorTransform_up(IOReader* f) {
                 "CenteringTransform mean size %d < d_in %d",
                 (int)ct->mean.size(),
                 ct->d_in);
+        FAISS_THROW_IF_NOT_FMT(
+                vt->d_in == vt->d_out,
+                "CenteringTransform requires d_in == d_out, "
+                "got d_in=%d d_out=%d",
+                vt->d_in,
+                vt->d_out);
     }
     if (h == fourcc("Viqt")) {
         auto* itqt = dynamic_cast<ITQTransform*>(vt.get());
@@ -1841,6 +1855,36 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
             ixpt->chain.push_back(read_VectorTransform(f));
         }
         ixpt->index = read_index(f, io_flags);
+        // Validate transform chain dimension consistency:
+        // chain[0].d_in must equal the outer index d, consecutive
+        // transforms must have matching d_out/d_in, and the last
+        // transform's d_out must equal the sub-index d.
+        if (nt > 0) {
+            FAISS_THROW_IF_NOT_FMT(
+                    ixpt->chain[0]->d_in == ixpt->d,
+                    "IndexPreTransform chain[0] d_in=%d != index d=%d",
+                    ixpt->chain[0]->d_in,
+                    ixpt->d);
+            for (int i = 1; i < nt; i++) {
+                FAISS_THROW_IF_NOT_FMT(
+                        ixpt->chain[i]->d_in == ixpt->chain[i - 1]->d_out,
+                        "IndexPreTransform chain[%d] d_in=%d != "
+                        "chain[%d] d_out=%d",
+                        i,
+                        ixpt->chain[i]->d_in,
+                        i - 1,
+                        ixpt->chain[i - 1]->d_out);
+            }
+            if (ixpt->index) {
+                FAISS_THROW_IF_NOT_FMT(
+                        ixpt->chain[nt - 1]->d_out == ixpt->index->d,
+                        "IndexPreTransform chain[%d] d_out=%d "
+                        "!= sub-index d=%d",
+                        nt - 1,
+                        ixpt->chain[nt - 1]->d_out,
+                        ixpt->index->d);
+            }
+        }
         idx = std::move(ixpt);
     } else if (h == fourcc("Imiq")) {
         auto imiq = std::make_unique<MultiIndexQuantizer>();

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -514,14 +514,40 @@ std::unique_ptr<InvertedLists> read_InvertedLists_up(
                 nlist, code_size, n_levels);
         std::vector<size_t> sizes(nlist);
         read_ArrayInvertedLists_sizes(f, sizes);
+        size_t byte_limit = get_deserialization_vector_byte_limit();
         for (size_t i = 0; i < nlist; i++) {
+            FAISS_THROW_IF_NOT_FMT(
+                    sizes[i] <= byte_limit / sizeof(idx_t),
+                    "inverted list %zu ids size %zu exceeds "
+                    "deserialization byte limit",
+                    i,
+                    sizes[i]);
             ailp->ids[i].resize(sizes[i]);
             size_t num_elems =
                     ((sizes[i] + ArrayInvertedListsPanorama::kBatchSize - 1) /
                      ArrayInvertedListsPanorama::kBatchSize) *
                     ArrayInvertedListsPanorama::kBatchSize;
-            ailp->codes[i].resize(num_elems * code_size);
-            ailp->cum_sums[i].resize(num_elems * (n_levels + 1));
+            size_t codes_bytes = mul_no_overflow(
+                    num_elems, code_size, "inverted list codes");
+            FAISS_THROW_IF_NOT_FMT(
+                    codes_bytes <= byte_limit,
+                    "inverted list %zu codes size %zu exceeds "
+                    "deserialization byte limit",
+                    i,
+                    codes_bytes);
+            ailp->codes[i].resize(codes_bytes);
+            size_t cum_sums_count = mul_no_overflow(
+                    num_elems,
+                    add_no_overflow(
+                            n_levels, 1, "inverted list cum_sums n_levels"),
+                    "inverted list cum_sums");
+            FAISS_THROW_IF_NOT_FMT(
+                    cum_sums_count <= byte_limit / sizeof(ailp->cum_sums[0][0]),
+                    "inverted list %zu cum_sums size %zu exceeds "
+                    "deserialization byte limit",
+                    i,
+                    cum_sums_count);
+            ailp->cum_sums[i].resize(cum_sums_count);
         }
         for (size_t i = 0; i < nlist; i++) {
             size_t n = sizes[i];
@@ -543,10 +569,24 @@ std::unique_ptr<InvertedLists> read_InvertedLists_up(
         ails->codes.resize(ails->nlist);
         std::vector<size_t> sizes(ails->nlist);
         read_ArrayInvertedLists_sizes(f, sizes);
+        size_t ilar_byte_limit = get_deserialization_vector_byte_limit();
         for (size_t i = 0; i < ails->nlist; i++) {
+            FAISS_THROW_IF_NOT_FMT(
+                    sizes[i] <= ilar_byte_limit / sizeof(idx_t),
+                    "inverted list %zu ids size %zu exceeds "
+                    "deserialization byte limit",
+                    i,
+                    sizes[i]);
             ails->ids[i].resize(sizes[i]);
-            ails->codes[i].resize(mul_no_overflow(
-                    sizes[i], ails->code_size, "inverted list codes"));
+            size_t codes_bytes = mul_no_overflow(
+                    sizes[i], ails->code_size, "inverted list codes");
+            FAISS_THROW_IF_NOT_FMT(
+                    codes_bytes <= ilar_byte_limit,
+                    "inverted list %zu codes size %zu exceeds "
+                    "deserialization byte limit",
+                    i,
+                    codes_bytes);
+            ails->codes[i].resize(codes_bytes);
         }
         for (size_t i = 0; i < ails->nlist; i++) {
             size_t n = ails->ids[i].size();

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -1982,6 +1982,15 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
                     idxhnsw->storage->d,
                     idxhnsw->d);
         }
+        if (h == fourcc("IHN2")) {
+            FAISS_THROW_IF_NOT_MSG(
+                    idxhnsw->storage,
+                    "IndexHNSW2Level requires non-null storage");
+            FAISS_THROW_IF_NOT_MSG(
+                    dynamic_cast<Index2Layer*>(idxhnsw->storage) ||
+                            dynamic_cast<IndexIVFPQ*>(idxhnsw->storage),
+                    "IndexHNSW2Level storage must be Index2Layer or IndexIVFPQ");
+        }
         if (h == fourcc("IHNp") && !(io_flags & IO_FLAG_PQ_SKIP_SDC_TABLE)) {
             auto* storage_pq = dynamic_cast<IndexPQ*>(idxhnsw->storage);
             FAISS_THROW_IF_NOT_MSG(

--- a/tests/test_omp_exception_safety.cpp
+++ b/tests/test_omp_exception_safety.cpp
@@ -14,6 +14,7 @@
 #include <gtest/gtest.h>
 
 #include <faiss/IndexFlat.h>
+#include <faiss/IndexFlatCodes.h>
 #include <faiss/IndexIVFFlat.h>
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissException.h>
@@ -299,4 +300,36 @@ TEST(OMPExceptionSafety, search_top_level_omp_slicing) {
             FaissException);
 
     f.restore(*throwing);
+}
+
+// Minimal IndexFlatCodes subclass whose sa_decode always throws, to
+// verify that exceptions thrown inside the OpenMP parallel region in
+// IndexFlatCodes::search are propagated to the caller.
+struct ThrowingIndex : IndexFlatCodes {
+    explicit ThrowingIndex(int d)
+            : IndexFlatCodes(sizeof(float) * d, d, METRIC_L2) {
+        ntotal = 1;
+        is_trained = true;
+        codes.resize(code_size, 0);
+    }
+
+    void sa_decode(idx_t /*n*/, const uint8_t* /*codes*/, float* /*x*/)
+            const override {
+        throw std::runtime_error("corrupt index");
+    }
+};
+
+// ---------------------------------------------------------------------------
+// IndexFlatCodes::search: exception in OMP worker propagates to caller
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, flatcodes_search) {
+    ThrowingIndex index(4);
+
+    std::vector<float> xq(4, 0.0f);
+    std::vector<float> distances(1);
+    std::vector<idx_t> labels(1);
+
+    EXPECT_THROW(
+            index.search(1, xq.data(), 1, distances.data(), labels.data()),
+            std::runtime_error);
 }

--- a/tests/test_omp_exception_safety.cpp
+++ b/tests/test_omp_exception_safety.cpp
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <atomic>
+#include <limits>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <faiss/IndexFlat.h>
+#include <faiss/IndexIVFFlat.h>
+#include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/FaissException.h>
+#include <faiss/invlists/InvertedLists.h>
+
+using namespace faiss;
+
+namespace {
+
+// InvertedLists wrapper that delegates to an underlying InvertedLists but
+// throws from get_codes() after a configurable number of successful calls.
+// This injects exceptions inside scan_one_list / scan_list_func, which
+// execute inside OMP worksharing constructs.
+struct ThrowingInvertedLists : InvertedLists {
+    const InvertedLists* delegate;
+    mutable std::atomic<int> calls_until_throw;
+
+    ThrowingInvertedLists(const InvertedLists* delegate_in, int throw_after)
+            : InvertedLists(delegate_in->nlist, delegate_in->code_size),
+              delegate(delegate_in),
+              calls_until_throw(throw_after) {}
+
+    size_t list_size(size_t list_no) const override {
+        return delegate->list_size(list_no);
+    }
+
+    const uint8_t* get_codes(size_t list_no) const override {
+        if (calls_until_throw.fetch_sub(1) <= 0) {
+            FAISS_THROW_MSG("injected get_codes failure");
+        }
+        return delegate->get_codes(list_no);
+    }
+
+    const idx_t* get_ids(size_t list_no) const override {
+        return delegate->get_ids(list_no);
+    }
+
+    size_t add_entries(size_t, size_t, const idx_t*, const uint8_t*) override {
+        FAISS_THROW_MSG("unexpected call");
+    }
+
+    void update_entries(size_t, size_t, size_t, const idx_t*, const uint8_t*)
+            override {
+        FAISS_THROW_MSG("unexpected call");
+    }
+
+    void resize(size_t, size_t) override {
+        FAISS_THROW_MSG("unexpected call");
+    }
+};
+
+// InterruptCallback that always signals an interrupt.
+struct AlwaysInterrupt : InterruptCallback {
+    bool want_interrupt() override {
+        return true;
+    }
+};
+
+// Build a trained IndexIVFFlat with data added, using enough vectors and
+// lists to exercise multi-threaded parallel modes.
+struct IVFFixture {
+    static constexpr int d = 8;
+    static constexpr int nb = 2000;
+    static constexpr int nlist = 16;
+    static constexpr int nq = 64;
+
+    IndexFlatL2 quantizer{d};
+    IndexIVFFlat index{&quantizer, d, nlist};
+    std::vector<float> xq;
+
+    IVFFixture() {
+        index.own_fields = false;
+        std::mt19937 rng(42);
+        std::uniform_real_distribution<float> dist;
+
+        std::vector<float> train(nlist * 40 * d);
+        for (auto& v : train) {
+            v = dist(rng);
+        }
+        index.train(train.size() / d, train.data());
+
+        std::vector<float> xb(nb * d);
+        for (auto& v : xb) {
+            v = dist(rng);
+        }
+        index.add(nb, xb.data());
+
+        xq.resize(nq * d);
+        for (auto& v : xq) {
+            v = dist(rng);
+        }
+    }
+
+    // Swap in a ThrowingInvertedLists that delegates to the real one.
+    // Returns the throwing wrapper. The real inverted lists is kept alive
+    // (disowned from the index) so the delegate pointer stays valid.
+    std::unique_ptr<ThrowingInvertedLists> install_throwing(int throw_after) {
+        auto* real = index.invlists;
+        auto throwing =
+                std::make_unique<ThrowingInvertedLists>(real, throw_after);
+        // Disown so replace_invlists doesn't delete the real lists.
+        index.own_invlists = false;
+        index.replace_invlists(throwing.get(), false);
+        return throwing;
+    }
+
+    // Restore the original inverted lists (the delegate from the wrapper).
+    void restore(const ThrowingInvertedLists& throwing) {
+        index.replace_invlists(
+                const_cast<InvertedLists*>(throwing.delegate), true);
+    }
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// search_preassigned: exception in scan_one_list, pmode 0
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, search_preassigned_pmode0) {
+    IVFFixture f;
+    f.index.parallel_mode = 0;
+    f.index.nprobe = 4;
+
+    auto throwing = f.install_throwing(2);
+
+    idx_t k = 4;
+    std::vector<float> dis(f.nq * k);
+    std::vector<idx_t> labels(f.nq * k);
+
+    EXPECT_THROW(
+            f.index.search(f.nq, f.xq.data(), k, dis.data(), labels.data()),
+            FaissException);
+
+    f.restore(*throwing);
+}
+
+// ---------------------------------------------------------------------------
+// search_preassigned: exception in scan_one_list, pmode 1
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, search_preassigned_pmode1) {
+    IVFFixture f;
+    f.index.parallel_mode = 1;
+    f.index.nprobe = 8;
+
+    auto throwing = f.install_throwing(2);
+
+    idx_t k = 4;
+    std::vector<float> dis(f.nq * k);
+    std::vector<idx_t> labels(f.nq * k);
+
+    EXPECT_THROW(
+            f.index.search(f.nq, f.xq.data(), k, dis.data(), labels.data()),
+            FaissException);
+
+    f.restore(*throwing);
+}
+
+// ---------------------------------------------------------------------------
+// search_preassigned: exception in scan_one_list, pmode 2
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, search_preassigned_pmode2) {
+    IVFFixture f;
+    f.index.parallel_mode = 2;
+    f.index.nprobe = 8;
+
+    auto throwing = f.install_throwing(2);
+
+    idx_t k = 4;
+    std::vector<float> dis(f.nq * k);
+    std::vector<idx_t> labels(f.nq * k);
+
+    EXPECT_THROW(
+            f.index.search(f.nq, f.xq.data(), k, dis.data(), labels.data()),
+            FaissException);
+
+    f.restore(*throwing);
+}
+
+// ---------------------------------------------------------------------------
+// search_preassigned: InterruptCallback::check() throws inside pmode 0 loop
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, search_interrupt_pmode0) {
+    IVFFixture f;
+    f.index.parallel_mode = 0;
+    f.index.nprobe = 4;
+
+    idx_t k = 4;
+    std::vector<float> dis(f.nq * k);
+    std::vector<idx_t> labels(f.nq * k);
+
+    InterruptCallback::instance.reset(new AlwaysInterrupt());
+
+    EXPECT_THROW(
+            f.index.search(f.nq, f.xq.data(), k, dis.data(), labels.data()),
+            FaissException);
+
+    InterruptCallback::clear_instance();
+}
+
+// ---------------------------------------------------------------------------
+// range_search_preassigned: exception in scan_list_func, pmode 0
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, range_search_pmode0) {
+    IVFFixture f;
+    f.index.parallel_mode = 0;
+    f.index.nprobe = 4;
+
+    auto throwing = f.install_throwing(2);
+    RangeSearchResult result(f.nq);
+
+    EXPECT_THROW(
+            f.index.range_search(
+                    f.nq,
+                    f.xq.data(),
+                    std::numeric_limits<float>::max(),
+                    &result),
+            FaissException);
+
+    f.restore(*throwing);
+}
+
+// ---------------------------------------------------------------------------
+// range_search_preassigned: exception in scan_list_func, pmode 1
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, range_search_pmode1) {
+    IVFFixture f;
+    f.index.parallel_mode = 1;
+    f.index.nprobe = 8;
+
+    auto throwing = f.install_throwing(2);
+    RangeSearchResult result(f.nq);
+
+    EXPECT_THROW(
+            f.index.range_search(
+                    f.nq,
+                    f.xq.data(),
+                    std::numeric_limits<float>::max(),
+                    &result),
+            FaissException);
+
+    f.restore(*throwing);
+}
+
+// ---------------------------------------------------------------------------
+// range_search_preassigned: exception in scan_list_func, pmode 2
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, range_search_pmode2) {
+    IVFFixture f;
+    f.index.parallel_mode = 2;
+    f.index.nprobe = 8;
+
+    auto throwing = f.install_throwing(2);
+    RangeSearchResult result(f.nq);
+
+    EXPECT_THROW(
+            f.index.range_search(
+                    f.nq,
+                    f.xq.data(),
+                    std::numeric_limits<float>::max(),
+                    &result),
+            FaissException);
+
+    f.restore(*throwing);
+}
+
+// ---------------------------------------------------------------------------
+// search (top-level OMP slicing): exception propagates from sub_search_func
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, search_top_level_omp_slicing) {
+    IVFFixture f;
+    f.index.parallel_mode = 0;
+    f.index.nprobe = 4;
+
+    // Allow a few successful calls so some slices start, then fail.
+    auto throwing = f.install_throwing(5);
+
+    idx_t k = 4;
+    std::vector<float> dis(f.nq * k);
+    std::vector<idx_t> labels(f.nq * k);
+
+    EXPECT_THROW(
+            f.index.search(f.nq, f.xq.data(), k, dis.data(), labels.data()),
+            FaissException);
+
+    f.restore(*throwing);
+}

--- a/tests/test_omp_exception_safety.cpp
+++ b/tests/test_omp_exception_safety.cpp
@@ -16,6 +16,8 @@
 #include <faiss/IndexFlat.h>
 #include <faiss/IndexFlatCodes.h>
 #include <faiss/IndexIVFFlat.h>
+#include <faiss/IndexNNDescent.h>
+#include <faiss/IndexNSG.h>
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissException.h>
 #include <faiss/invlists/InvertedLists.h>
@@ -332,4 +334,50 @@ TEST(OMPExceptionSafety, flatcodes_search) {
     EXPECT_THROW(
             index.search(1, xq.data(), 1, distances.data(), labels.data()),
             std::runtime_error);
+}
+
+// ---------------------------------------------------------------------------
+// IndexNNDescent::search: exception in OMP worker propagates to caller.
+// Constructing with has_built=false triggers a FaissException inside the
+// worksharing loop body.
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, nndescent_search) {
+    int d = 4;
+    auto storage = std::make_unique<IndexFlatL2>(d);
+    std::vector<float> xb(d, 1.0f);
+    storage->add(1, xb.data());
+
+    IndexNNDescent index(storage.get(), 4);
+    index.ntotal = 1;
+    // has_built defaults to false, so nndescent.search() will throw.
+
+    std::vector<float> xq(d, 0.0f);
+    std::vector<float> distances(1);
+    std::vector<idx_t> labels(1);
+
+    EXPECT_THROW(
+            index.search(1, xq.data(), 1, distances.data(), labels.data()),
+            FaissException);
+}
+
+// ---------------------------------------------------------------------------
+// IndexNSG::search: exception in OMP worker propagates to caller
+// ---------------------------------------------------------------------------
+TEST(OMPExceptionSafety, nsg_search) {
+    int d = 4;
+    auto storage = std::make_unique<IndexFlatL2>(d);
+    std::vector<float> xb(d, 1.0f);
+    storage->add(1, xb.data());
+
+    IndexNSG index(storage.get(), 4);
+    index.ntotal = 1;
+    // nsg graph is not built, so nsg.search() will throw.
+
+    std::vector<float> xq(d, 0.0f);
+    std::vector<float> distances(1);
+    std::vector<idx_t> labels(1);
+
+    EXPECT_THROW(
+            index.search(1, xq.data(), 1, distances.data(), labels.data()),
+            FaissException);
 }

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -22,6 +22,7 @@
 #include <faiss/IndexIVFAdditiveQuantizerFastScan.h>
 #include <faiss/IndexIVFFlat.h>
 #include <faiss/IndexIVFIndependentQuantizer.h>
+#include <faiss/IndexIVFPQ.h>
 #include <faiss/IndexIVFPQR.h>
 #include <faiss/IndexRaBitQFastScan.h>
 #include <faiss/VectorTransform.h>
@@ -1645,6 +1646,62 @@ TEST(ReadIndexDeserialize, IVFQuantizerUntrained) {
     VectorIOReader reader;
     reader.data = buf;
     EXPECT_NO_THROW(read_index_up(&reader));
+}
+
+// -----------------------------------------------------------------------
+// Test: initialize_IVFPQ_precomputed_table rejects a null quantizer.
+// Protects against null-deref from corrupt serialized data where the
+// quantizer sub-index is absent (fourcc "null").
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, IVFPQNullQuantizerPrecomputeTableRejected) {
+    ProductQuantizer pq(4, 1, 8);
+    AlignedTable<float> precomputed_table;
+    int use_precomputed_table = 0;
+    EXPECT_THROW(
+            initialize_IVFPQ_precomputed_table(
+                    use_precomputed_table,
+                    /*quantizer=*/nullptr,
+                    pq,
+                    precomputed_table,
+                    /*by_residual=*/true,
+                    /*verbose=*/false),
+            faiss::FaissException);
+}
+
+TEST(ReadIndexDeserialize, IVFNullQuantizerSearchRejected) {
+    IndexIVFFlat ivf;
+    ivf.quantizer = nullptr;
+    ivf.is_trained = true;
+    std::vector<float> x(4);
+    std::vector<float> distances(1);
+    std::vector<idx_t> labels(1);
+    EXPECT_THROW(
+            ivf.search(1, x.data(), 1, distances.data(), labels.data()),
+            faiss::FaissException);
+}
+
+TEST(ReadIndexDeserialize, IVFNullQuantizerRangeSearchRejected) {
+    IndexIVFFlat ivf;
+    ivf.quantizer = nullptr;
+    ivf.is_trained = true;
+    std::vector<float> x(4);
+    RangeSearchResult result(1);
+    EXPECT_THROW(
+            ivf.range_search(1, x.data(), 1.0, &result), faiss::FaissException);
+}
+
+TEST(ReadIndexDeserialize, IVFNullQuantizerAddRejected) {
+    IndexIVFFlat ivf;
+    ivf.quantizer = nullptr;
+    std::vector<float> x(4);
+    EXPECT_THROW(ivf.add(1, x.data()), faiss::FaissException);
+}
+
+TEST(ReadIndexDeserialize, IVFNullQuantizerTrainRejected) {
+    IndexIVFFlat ivf;
+    ivf.quantizer = nullptr;
+    std::vector<float> x(4);
+    EXPECT_THROW(ivf.train(1, x.data()), faiss::FaissException);
 }
 
 // -----------------------------------------------------------------------

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -2034,6 +2034,33 @@ static void push_ivf_header(std::vector<uint8_t>& buf, int d) {
     push_empty_direct_map(buf);
 }
 
+// -----------------------------------------------------------------------
+// Test: Inverted list with oversized entry exceeding deserialization byte
+// limit is rejected. Protects against corrupt data causing OOM via
+// unchecked vector::resize in read_InvertedLists_up.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, InvertedListOversizedEntry) {
+    const size_t old_limit = get_deserialization_vector_byte_limit();
+    set_deserialization_vector_byte_limit(1024); // 1 KB limit
+
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IwFl");
+    push_ivf_header(buf, /*d=*/4);
+    // "ilar" inverted lists with 1 list, code_size=16
+    push_fourcc(buf, "ilar");
+    push_val<size_t>(buf, 1);  // nlist = 1
+    push_val<size_t>(buf, 16); // code_size = 16
+    // "full" list type with 1 size entry
+    push_fourcc(buf, "full");
+    // sizes vector: 1 entry with absurdly large value
+    push_val<size_t>(buf, 1);               // vector length
+    push_val<size_t>(buf, (size_t)1 << 40); // sizes[0] = 1 TB
+
+    expect_read_throws_with(buf, "deserialization byte limit");
+
+    set_deserialization_vector_byte_limit(old_limit);
+}
+
 // -- Ixrq (IndexRaBitQ, single-bit) --
 // qb=0 is valid for Ixrq: disables query quantization, uses raw fp32 values.
 // See IndexRaBitQ.h comment on qb and RaBitQDistanceComputerNotQ.

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -1843,6 +1843,70 @@ TEST(ReadIndexDeserialize, IVFNullQuantizerTrainRejected) {
 // VectorTransform deserialization validation tests
 // -----------------------------------------------------------------------
 
+// Test: NormalizationTransform with d_in != d_out is rejected.
+// Protects against corrupt serialized data where dimension mismatch
+// causes memcpy to overflow the output buffer in apply_noalloc.
+TEST(ReadIndexDeserialize, NormalizationTransformDinDoutMismatch) {
+    // VNrm format: fourcc("VNrm") + norm(float) + d_in(int) + d_out(int) +
+    //              is_trained(bool)
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "VNrm");
+    push_val<float>(buf, 2.0f); // norm (L2)
+    push_val<int>(buf, 16);     // d_in
+    push_val<int>(buf, 8);      // d_out (mismatch!)
+    push_val<bool>(buf, true);  // is_trained
+
+    expect_vt_read_throws_with(buf, "d_in == d_out");
+}
+
+// Test: NormalizationTransform with d_in == d_out is accepted.
+TEST(ReadIndexDeserialize, NormalizationTransformDinDoutMatch) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "VNrm");
+    push_val<float>(buf, 2.0f); // norm (L2)
+    push_val<int>(buf, 16);     // d_in
+    push_val<int>(buf, 16);     // d_out (match)
+    push_val<bool>(buf, true);  // is_trained
+
+    VectorIOReader reader;
+    reader.data = buf;
+    EXPECT_NO_THROW(read_VectorTransform_up(&reader));
+}
+
+// Test: CenteringTransform with d_in != d_out is rejected.
+TEST(ReadIndexDeserialize, CenteringTransformDinDoutMismatch) {
+    // VCnt format: fourcc("VCnt") + mean(vector<float>) + d_in(int) +
+    //              d_out(int) + is_trained(bool)
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "VCnt");
+    push_vector<float>(buf, std::vector<float>(16, 0.0f)); // mean
+    push_val<int>(buf, 16);                                // d_in
+    push_val<int>(buf, 8);                                 // d_out (mismatch!)
+    push_val<bool>(buf, true);
+
+    expect_vt_read_throws_with(buf, "d_in == d_out");
+}
+
+// Test: IndexPreTransform with mismatched chain dimensions is rejected.
+TEST(ReadIndexDeserialize, PreTransformChainDimensionMismatch) {
+    // Build an IxPT with a NormalizationTransform (d_in=d_out=4) followed
+    // by a sub-index with d=8. The chain's d_out (4) != sub-index d (8).
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IxPT");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0);
+    push_val<int>(buf, 1); // nt = 1 transform
+    // NormalizationTransform with d_in=d_out=4
+    push_fourcc(buf, "VNrm");
+    push_val<float>(buf, 2.0f);
+    push_val<int>(buf, 4); // d_in
+    push_val<int>(buf, 4); // d_out
+    push_val<bool>(buf, true);
+    // Sub-index: IndexFlat with d=8 (mismatch with chain d_out=4)
+    push_minimal_flat(buf, /*d=*/8);
+
+    expect_read_throws_with(buf, "d_out=4");
+}
+
 TEST(ReadIndexDeserialize, HadamardRotationInvalidDout) {
     // HRot format: fourcc("HRot") + seed(int) + d_in(int) + d_out(int) +
     //              is_trained(bool)

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -1681,6 +1681,109 @@ TEST(ReadIndexDeserialize, IVFQuantizerUntrained) {
 }
 
 // -----------------------------------------------------------------------
+// Test: IndexIVFScalarQuantizer with empty trained vector and
+// is_trained=false deserializes successfully (legitimate untrained index),
+// but searching it throws because IndexIVF::search checks is_trained.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, IVFScalarQuantizerUntrainedSearchRejected) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IwSq");
+    // IVF header: index_header + nlist + nprobe + quantizer + direct_map
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0, /*is_trained=*/false);
+    push_val<size_t>(buf, 1); // nlist
+    push_val<size_t>(buf, 1); // nprobe
+    push_minimal_flat(buf, /*d=*/4);
+    push_empty_direct_map(buf);
+    // ScalarQuantizer fields:
+    push_val<int>(buf, 0);       // qtype = QT_8bit
+    push_val<int>(buf, 0);       // rangestat
+    push_val<float>(buf, 0.0f);  // rangestat_arg
+    push_val<size_t>(buf, 4);    // d
+    push_val<size_t>(buf, 4);    // code_size
+    push_vector<float>(buf, {}); // trained (empty — untrained)
+    // IwSq additional fields:
+    push_val<size_t>(buf, 4);   // code_size
+    push_val<bool>(buf, false); // by_residual
+    push_null_invlists(buf);
+
+    // Deserialization should succeed — untrained indexes are legitimate
+    VectorIOReader reader;
+    reader.data = buf;
+    auto idx = read_index_up(&reader);
+    ASSERT_NE(idx, nullptr);
+    EXPECT_FALSE(idx->is_trained);
+
+    // search should throw — is_trained check in IndexIVF::search
+    std::vector<float> xq(4, 0.0f);
+    std::vector<float> distances(1);
+    std::vector<idx_t> labels(1);
+    EXPECT_THROW(
+            idx->search(1, xq.data(), 1, distances.data(), labels.data()),
+            FaissException);
+
+    // range_search should throw — is_trained check in IndexIVF::range_search
+    RangeSearchResult rsr(1);
+    EXPECT_THROW(idx->range_search(1, xq.data(), 1.0f, &rsr), FaissException);
+
+    // search_preassigned should throw directly
+    auto* ivf = dynamic_cast<IndexIVF*>(idx.get());
+    ASSERT_NE(ivf, nullptr);
+    idx_t key = 0;
+    float coarse_dis = 0.0f;
+    EXPECT_THROW(
+            ivf->search_preassigned(
+                    1,
+                    xq.data(),
+                    1,
+                    &key,
+                    &coarse_dis,
+                    distances.data(),
+                    labels.data(),
+                    false,
+                    nullptr,
+                    nullptr),
+            FaissException);
+
+    // range_search_preassigned should throw directly
+    RangeSearchResult rsr2(1);
+    EXPECT_THROW(
+            ivf->range_search_preassigned(
+                    1,
+                    xq.data(),
+                    1.0f,
+                    &key,
+                    &coarse_dis,
+                    &rsr2,
+                    false,
+                    nullptr,
+                    nullptr),
+            FaissException);
+}
+
+// -----------------------------------------------------------------------
+// Test: IndexIVFScalarQuantizer with is_trained=true but empty trained
+// is rejected at deserialization time — corrupt data.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, IVFScalarQuantizerTrainedEmptyTrained) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IwSq");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0, /*is_trained=*/true);
+    push_val<size_t>(buf, 1); // nlist
+    push_val<size_t>(buf, 1); // nprobe
+    push_minimal_flat(buf, /*d=*/4);
+    push_empty_direct_map(buf);
+    // ScalarQuantizer fields:
+    push_val<int>(buf, 0);       // qtype = QT_8bit
+    push_val<int>(buf, 0);       // rangestat
+    push_val<float>(buf, 0.0f);  // rangestat_arg
+    push_val<size_t>(buf, 4);    // d
+    push_val<size_t>(buf, 4);    // code_size
+    push_vector<float>(buf, {}); // trained (empty — but is_trained=true!)
+
+    expect_read_throws_with(buf, "ScalarQuantizer trained size");
+}
+
+// -----------------------------------------------------------------------
 // Test: initialize_IVFPQ_precomputed_table rejects a null quantizer.
 // Protects against null-deref from corrupt serialized data where the
 // quantizer sub-index is absent (fourcc "null").

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -1468,6 +1468,38 @@ TEST(ReadIndexDeserialize, HNSWValidNeighborsSearchWorks) {
 }
 
 // -----------------------------------------------------------------------
+// Test: IndexHNSW2Level with wrong storage type is rejected.
+// Protects against corrupt serialized data where storage is not
+// Index2Layer or IndexIVFPQ, causing null-deref from failed dynamic_cast.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, HNSW2LevelWrongStorageType) {
+    // Build an IHN2 with IndexFlat storage (wrong type — must be
+    // Index2Layer or IndexIVFPQ).
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IHN2");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0);
+    push_minimal_hnsw(buf, /*ntotal=*/0);
+    // IndexFlat storage — wrong type for HNSW2Level
+    push_minimal_flat(buf, /*d=*/4, /*ntotal=*/0);
+
+    expect_read_throws_with(buf, "Index2Layer or IndexIVFPQ");
+}
+
+// -----------------------------------------------------------------------
+// Test: IndexHNSW2Level with null storage is rejected.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, HNSW2LevelNullStorage) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IHN2");
+    push_index_header(buf, /*d=*/4, /*ntotal=*/0);
+    push_minimal_hnsw(buf, /*ntotal=*/0);
+    // Null storage
+    push_fourcc(buf, "null");
+
+    expect_read_throws_with(buf, "non-null storage");
+}
+
+// -----------------------------------------------------------------------
 // Test: NSG ntotal != index ntotal.
 // -----------------------------------------------------------------------
 TEST(ReadIndexDeserialize, NSGNtotalMismatch) {


### PR DESCRIPTION
Summary:

Add deserialization byte limit checks before vector::resize calls in read_InvertedLists_up() for both ArrayInvertedListsPanorama ("ilpn") and ArrayInvertedLists ("ilar") paths. Previously, per-list sizes read from serialized data were used directly in .resize() calls without checking against get_deserialization_vector_byte_limit(). The READVECTOR macro enforces this limit, but explicit .resize() calls bypassed it.

Also add mul_no_overflow protection for the ilpn codes allocation (num_elems * code_size) which previously had no overflow check.

Reviewed By: mnorris11

Differential Revision: D101260923
