### PR TITLE
Work around GCC 12 miscompilation of AVX2 histogram (#5124)

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -276,6 +276,21 @@ jobs:
           fetch-tags: true
       - name: Build and Package (conda)
         uses: ./.github/actions/build_conda
+  linux-x86_64-GPU-conda:
+    name: Linux x86_64 GPU (conda, CUDA 12.6)
+    runs-on: 4-core-ubuntu-gpu-t4
+    env:
+      CUDA_ARCHS: "70-real;72-real;75-real;80;86-real"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Build and Package (conda)
+        uses: ./.github/actions/build_conda
+        with:
+          cuda: "12.6"
   linux-x86_64-svs:
     name: Linux x86_64 w/ SVS (cmake)
     needs: linux-x86_64-cmake

--- a/faiss/utils/partitioning.cpp
+++ b/faiss/utils/partitioning.cpp
@@ -386,6 +386,10 @@ void simd_histogram_16(
         uint16_t min,
         int shift,
         int* hist) {
+    // GCC 12 miscompiles the AVX2 SIMD histogram — fall back to scalar.
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ == 12
+    simd_histogram_16_scalar(data, n, min, shift, hist);
+#else
     with_simd_level_256bit([&]<SIMDLevel SL>() {
         if constexpr (SL == SIMDLevel::NONE) {
             simd_histogram_16_scalar(data, n, min, shift, hist);
@@ -393,6 +397,7 @@ void simd_histogram_16(
             faiss::simd_histogram_16<SL>(data, n, min, shift, hist);
         }
     });
+#endif
 }
 
 void PartitionStats::reset() {

--- a/tests/test_partitioning.cpp
+++ b/tests/test_partitioning.cpp
@@ -14,11 +14,8 @@ using namespace faiss;
 
 using AlignedTableUint16 = AlignedTable<uint16_t>;
 
-// TODO: This test fails when Faiss is compiled with
-// GCC 13.2 from conda-forge with AVX2 enabled. This may be
-// a GCC bug that needs to be investigated further.
-// As of 16-AUG-2023 the Faiss conda packages are built
-// with GCC 11.2, so the published binaries are not affected.
+// GCC 12 miscompiles the AVX2 SIMD histogram. The conda packages
+// now use GCC 12.4, so we fall back to scalar in partitioning.cpp.
 TEST(TestPartitioning, TestPartitioningBigRange) {
     auto n = 1024;
     AlignedTableUint16 tab(n);


### PR DESCRIPTION
Summary:

GCC 12.4 (used in the conda faiss-gpu build) miscompiles the SIMD
histogram_16 code path, causing test_16bin_bounded_bigrange to fail in
the CUDA 12.6 nightly.

Fall back to the scalar implementation when compiling with GCC 12.

🤖 This diff was automatically generated by myclaw_faiss_monitor

Reviewed By: junjieqi

Differential Revision: D101598734


