### PR TITLE
Fix race condition in HNSW::add_with_locks

### DIFF
--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -580,9 +580,12 @@ void HNSW::add_with_locks(
 
     omp_unset_lock(&locks[pt_id]);
 
-    if (pt_level > max_level) {
-        max_level = pt_level;
-        entry_point = pt_id;
+#pragma omp critical
+    {
+        if (pt_level > max_level) {
+            max_level = pt_level;
+            entry_point = pt_id;
+        }
     }
 }
 


### PR DESCRIPTION
Summary:
## Bug

`HNSW::add_with_locks()` updates two shared member variables — `max_level` and `entry_point` — after releasing the per-node lock, without any synchronization:

```cpp
omp_unset_lock(&locks[pt_id]);

if (pt_level > max_level) {   // read shared state
    max_level = pt_level;     // write shared state
    entry_point = pt_id;      // write shared state
}
```

This function is called from inside `#pragma omp for` in `hnsw_add_vertices()` (IndexHNSW.cpp), meaning multiple threads execute it concurrently. The unprotected check-then-act pattern is a classic TOCTOU race condition.

## Proof by interleaving

Suppose `max_level = 2` and two threads finish their link-building simultaneously:

- Thread A: `pt_level = 4`, `pt_id = 100`
- Thread B: `pt_level = 3`, `pt_id = 200`

| Step | Thread A                              | Thread B                              | max_level | entry_point |
|------|---------------------------------------|---------------------------------------|-----------|-------------|
| 0    | —                                     | —                                     | 2         | (level-2 node) |
| 1    | reads `4 > 2` -> true                 |                                       | 2         |             |
| 2    |                                       | reads `3 > 2` -> true                 | 2         |             |
| 3    | writes `max_level = 4`                |                                       | 4         |             |
| 4    | writes `entry_point = 100`            |                                       | 4         | 100         |
| 5    |                                       | writes `max_level = 3`                | 3         | 100         |
| 6    |                                       | writes `entry_point = 200`            | 3         | 200         |

**Result**: `max_level = 3`, `entry_point = 200` (a node at level 3). But node 100 exists at level 4 — the true maximum. The HNSW invariant that `entry_point` is a node at `max_level` is violated.

## Consequence

Search starts from `entry_point` and walks down from `max_level`. With a wrong entry point at a lower level, the upper levels of the graph are never traversed during search, leading to silently degraded recall. The index does not crash and still returns results — they are just worse.

## Fix

Wrap the check-and-update in `#pragma omp critical` to make it atomic:

```cpp
#pragma omp critical
{
    if (pt_level > max_level) {
        max_level = pt_level;
        entry_point = pt_id;
    }
}
```

This guarantees that only one thread executes the block at a time. In the interleaving above, Thread B would enter the critical section after Thread A completes, see `max_level = 4`, evaluate `3 > 4` as false, and correctly skip the write.

## Note on the read at line 561

`int level = max_level` reads `max_level` without synchronization. This is technically a data race under the C++ memory model, but it is benign: reading a stale value just means the greedy search starts one level too low, which the algorithm handles correctly (it still finds correct neighbors, just slightly less efficiently). Adding synchronization here would introduce overhead on every iteration of a hot loop for negligible benefit.

## Why existing tests did not catch this

1. **Tiny race window**: both threads must pass the `if` check in the few nanoseconds before either writes — extremely unlikely per run.
2. **Subtle consequence**: a wrong entry point degrades recall slightly but does not crash or return wrong types. Tests assert recall thresholds (e.g., recall > 0.9), not exact values.
3. **Rare trigger condition**: the race only fires when two nodes added concurrently both exceed the current `max_level`. Higher HNSW levels are exponentially less probable by design — most nodes are level 0, and the highest levels typically have only 1-2 nodes, making concurrent contention on `max_level` near-impossible in practice.

Differential Revision: D101444067


