### PR TITLE
Fix PCA training bug and memory safety issues in VectorTransform.cpp

### DIFF
--- a/faiss/VectorTransform.cpp
+++ b/faiss/VectorTransform.cpp
@@ -209,16 +209,17 @@ void LinearTransform::apply_noalloc(idx_t n, const float* x, float* xt) const {
 
 void LinearTransform::transform_transpose(idx_t n, const float* y, float* x)
         const {
+    std::vector<float> y_bias_corrected;
     if (have_bias) { // allocate buffer to store bias-corrected data
-        float* y_new = new float[n * d_out];
+        y_bias_corrected.resize(n * d_out);
         const float* yr = y;
-        float* yw = y_new;
+        float* yw = y_bias_corrected.data();
         for (idx_t i = 0; i < n; i++) {
             for (int j = 0; j < d_out; j++) {
                 *yw++ = *yr++ - b[j];
             }
         }
-        y = y_new;
+        y = y_bias_corrected.data();
     }
 
     {
@@ -237,10 +238,6 @@ void LinearTransform::transform_transpose(idx_t n, const float* y, float* x)
                &zero,
                x,
                &dii);
-    }
-
-    if (have_bias) {
-        delete[] y;
     }
 }
 
@@ -534,7 +531,7 @@ void eig(size_t d_in, double* cov, double* eigenvalues, int verbose) {
                &lwork,
                &info);
         lwork = FINTEGER(workq);
-        double* work = new double[lwork];
+        std::vector<double> work(lwork);
 
         dsyev_("Vectors as well",
                "Upper",
@@ -542,11 +539,9 @@ void eig(size_t d_in, double* cov, double* eigenvalues, int verbose) {
                cov,
                &di,
                eigenvalues,
-               work,
+               work.data(),
                &lwork,
                &info);
-
-        delete[] work;
 
         if (info != 0) {
             fprintf(stderr,
@@ -732,7 +727,7 @@ void PCAMatrix::train(idx_t n, const float* x_in) {
 
         { // compute PCAMat = x' * v
             FINTEGER di = d_in, ni = n;
-            float one = 1.0;
+            float one = 1.0, zero = 0.0;
 
             sgemm_("Non",
                    "Non Trans",
@@ -744,7 +739,7 @@ void PCAMatrix::train(idx_t n, const float* x_in) {
                    &di,
                    gram.data(),
                    &ni,
-                   &one,
+                   &zero,
                    PCAMat.data(),
                    &di);
         }
@@ -989,8 +984,10 @@ void ITQMatrix::train(idx_t n, const float* xf) {
                     &lwork,
                     &info);
 
-            FAISS_THROW_IF_NOT_MSG(
-                    info == 0, "LAPACK dgesvd workspace query failed");
+            FAISS_THROW_IF_NOT_FMT(
+                    info == 0,
+                    "LAPACK dgesvd workspace query returned info=%d",
+                    int(info));
             lwork = size_t(lwork1);
             std::vector<double> work(lwork);
             dgesvd_("A",
@@ -1338,6 +1335,10 @@ void OPQMatrix::train(idx_t n, const float* x_in) {
                     &lwork,
                     &info);
 
+            FAISS_THROW_IF_NOT_FMT(
+                    info == 0,
+                    "LAPACK sgesvd workspace query returned info=%d",
+                    int(info));
             lwork = int(worksz);
             std::vector<float> work(lwork);
             // u and vt swapped

--- a/tests/test_build_blocks.py
+++ b/tests/test_build_blocks.py
@@ -33,6 +33,30 @@ class TestPCA(unittest.TestCase):
             self.assertGreater(prev, o)
             prev = o
 
+    def test_pca_retraining_gram_path(self):
+        # Regression test for the sgemm_ beta=0 fix in PCAMatrix::train.
+        # When n < d_in, train() takes the Gram-matrix code path and
+        # writes PCAMat via sgemm_. Before the fix, beta=1.0 caused the
+        # second train() call to accumulate stale values from the first
+        # call, corrupting the PCA basis. Calling train() twice with the
+        # same data must produce the same projection.
+        d = 64
+        n = 20  # n < d_in exercises the Gram-matrix branch
+        np.random.seed(123)
+        x = np.random.random(size=(n, d)).astype('float32')
+
+        pca = faiss.PCAMatrix(d, 8)
+        pca.train(x)
+        y_first = pca.apply_py(x)
+
+        pca.train(x)
+        y_second = pca.apply_py(x)
+
+        # Eigenvectors are unique up to per-component sign; compare abs.
+        np.testing.assert_allclose(
+            np.abs(y_first), np.abs(y_second), atol=1e-4
+        )
+
     def test_pca_epsilon(self):
         d = 64
         n = 1000


### PR DESCRIPTION
Summary:
## Summary

This diff fixes several bugs and memory safety issues in VectorTransform.cpp:

### 1. Bug fix: Wrong beta parameter in PCAMatrix::train (sgemm_ call)
In the code path where n < d_in (Gram matrix approach), the sgemm_ call that computes
`PCAMat = xc * gram` incorrectly uses beta=1.0 instead of beta=0.0. This means the
computation is actually `PCAMat = xc * gram + PCAMat` instead of `PCAMat = xc * gram`.

On the first training call this works by accident because std::vector::resize
zero-initializes new elements. However, if PCAMatrix::train() is called a second time
(e.g., retraining with different data), PCAMat retains stale values from the previous
training, corrupting the PCA matrix and producing incorrect dimensionality reduction results.

### 2. Memory leak fix: eig() function
Replaced raw `new double[]` with `std::vector<double>` for the LAPACK workspace buffer.
The old code would leak memory if dsyev_ threw an exception.

### 3. Memory leak fix: LinearTransform::transform_transpose()
Replaced raw `new float[]` with `std::vector<float>` for the bias-corrected buffer.
The old code would leak memory if sgemm_ threw an exception between allocation and
the manual delete[].

### 4. Missing error check: OPQ SVD workspace query
Added FAISS_THROW_IF_NOT_FMT check after the sgesvd_ workspace query in OPQMatrix::train().
Previously, if the workspace query failed, the returned workspace size would be garbage,
leading to either a crash or silent data corruption in the subsequent SVD computation.

Differential Revision: D101975473


