### PR TITLE
Rely on cuVS for default values

### DIFF
--- a/faiss/gpu/GpuIndexIVFFlat.cu
+++ b/faiss/gpu/GpuIndexIVFFlat.cu
@@ -235,10 +235,10 @@ void GpuIndexIVFFlat::train(idx_t n, const float* x) {
         cuvs_index_params.n_lists = nlist;
         cuvs_index_params.metric = metricFaissToCuvs(metric_type, false);
         cuvs_index_params.add_data_on_build = false;
-        cuvs_index_params.kmeans_trainset_fraction =
-                static_cast<double>(cp.max_points_per_centroid * nlist) /
-                static_cast<double>(n);
-        cuvs_index_params.kmeans_n_iters = cp.niter;
+        // kmeans_trainset_fraction and kmeans_n_iters intentionally left
+        // at cuVS defaults (0.5 and 20). Faiss's cp.max_points_per_centroid
+        // (256) was designed for CPU k-means and produces severely
+        // underparameterized training at scale through cuVS.
 
         auto cuvsIndex_ =
                 std::static_pointer_cast<CuvsIVFFlat, IVFFlat>(index_);

--- a/faiss/gpu/GpuIndexIVFPQ.cu
+++ b/faiss/gpu/GpuIndexIVFPQ.cu
@@ -392,10 +392,10 @@ void GpuIndexIVFPQ::train(idx_t n, const float* x) {
         cuvs::neighbors::ivf_pq::index_params cuvs_index_params;
         cuvs_index_params.n_lists = nlist;
         cuvs_index_params.metric = metricFaissToCuvs(metric_type, false);
-        cuvs_index_params.kmeans_trainset_fraction =
-                static_cast<double>(cp.max_points_per_centroid * nlist) /
-                static_cast<double>(n);
-        cuvs_index_params.kmeans_n_iters = cp.niter;
+        // kmeans_trainset_fraction and kmeans_n_iters intentionally left
+        // at cuVS defaults (0.5 and 20). Faiss's cp.max_points_per_centroid
+        // (256) was designed for CPU k-means and produces severely
+        // underparameterized training at scale through cuVS.
         cuvs_index_params.pq_bits = bitsPerCode_;
         cuvs_index_params.pq_dim = subQuantizers_;
         cuvs_index_params.conservative_memory_allocation = false;


### PR DESCRIPTION
Summary:
Full logs: P2284358998

## TLDR: Fix vs No-fix: Is the improvement consistent? yes, seems like doing this fix is better than doing nothing.

  Net result: faster overall. 26/60 configs improve by >5%, only 4 regress by >5%.                    
                                                            
  ┌───────────────────────────────┬─────────────┬────────────┐                                        
  │       Worst regressions       │ ms increase │ % increase │
  ├───────────────────────────────┼─────────────┼────────────┤                                        
  │ M=100, bs=10000, np=16, k=100 │ +10.0 ms    │ +8.4%      │
  ├───────────────────────────────┼─────────────┼────────────┤
  │ M=50, bs=10000, np=16, k=100  │ +6.3 ms     │ +7.7%      │                                        
  ├───────────────────────────────┼─────────────┼────────────┤
  │ M=50, bs=10000, np=64, k=100  │ +10.2 ms    │ +6.2%      │                                        
  ├───────────────────────────────┼─────────────┼────────────┤                                        
  │ M=100, bs=1000, np=32, k=100  │ +11.8 ms    │ +5.2%      │
  └───────────────────────────────┴─────────────┴────────────┘                                        
                                                            
  ┌────────────────────────────────┬───────────┬──────────┐                                           
  │       Best improvements        │ ms saved  │ % faster │ 
  ├────────────────────────────────┼───────────┼──────────┤                                           
  │ M=50, bs=1000, np=16, k=100    │ -35.8 ms  │ -22.7%   │ 
  ├────────────────────────────────┼───────────┼──────────┤
  │ M=100, bs=10000, np=256, k=500 │ -359.8 ms │ -10.7%   │                                           
  ├────────────────────────────────┼───────────┼──────────┤                                           
  │ M=100, bs=1000, np=128, k=1000 │ -240.9 ms │ -10.4%   │                                           
  └────────────────────────────────┴───────────┴──────────┘                                           
                                                            
  No fix in Faiss D101399711 (migration only, no fix) vs baseline                                                     
                                                            
  More regressions: 14/60 configs regress >5%, 2 exceed 10%.                                          
                                                            
  ┌───────────────────────────────┬─────────────┬────────────┐                                        
  │       Worst regressions       │ ms increase │ % increase │
  ├───────────────────────────────┼─────────────┼────────────┤
  │ M=50, bs=10000, np=32, k=1000 │ +110.5 ms   │ +10.6%     │
  ├───────────────────────────────┼─────────────┼────────────┤
  │ M=50, bs=10000, np=16, k=1000 │ +68.3 ms    │ +10.1%     │                                        
  ├───────────────────────────────┼─────────────┼────────────┤                                        
  │ M=50, bs=10000, np=64, k=1000 │ +147.7 ms   │ +9.2%      │                                        
  └───────────────────────────────┴─────────────┴────────────┘

## what about variance?

 Variance summary (see mnorris11 notes, I don't agree with everything)           

  The search is mostly stable, with occasional single-run outliers.                                   
  
  ┌─────────────────────┬───────────────────────────────────┐                                         
  │       Metric        │               Value               │
  ├─────────────────────┼───────────────────────────────────┤                                         
  │ Median CV           │ 3.3%                              │
  ├─────────────────────┼───────────────────────────────────┤
  │ 90th percentile CV  │ 9.8%                              │                                         
  ├─────────────────────┼───────────────────────────────────┤                                         
  │ Most stable configs │ bs=1000, nprobe≥64: CV 0.3-1.7%   │                                         
  ├─────────────────────┼───────────────────────────────────┤                                         
  │ Noisiest configs    │ bs=10000, nprobe=16: CV up to 39% │
  └─────────────────────┴───────────────────────────────────┘                                         
                                                            
  What drives variance: absolute runtime. Sub-200ms configs (low nprobe, k=100) are noisy because GPU 
  scheduling jitter is proportionally large. Configs >1 second are rock-solid (CV < 2%).

  Outlier pattern: Every high-CV config is caused by a single extreme outlier (e.g., one run at 1124ms
   when 49 others are at 120-155ms), not general measurement noise. Using median instead of mean would
   remove these. The median values in the results file should be more reliable for these fast configs.

  Are the cross-trial differences real?                                                               
  
  - For stable configs (bs=1000, nprobe≥64, CV < 2%): the 8-11% improvements at high nprobe are       
  definitely real — intra-trial noise is well below 2%, so a 10% shift is ~5 standard errors.
  - For noisy configs (bs=10000, nprobe=16, CV 5-15%): the 5-8% regressions are borderline — they're  
  statistically detectable with 50 runs, but could partly reflect system-state differences between    
  trials (GPU thermals, background load) rather than code changes. ******[mnorris11 note: this explanation 
  sounds like BS, there was nothing else going on in the GPU...]******
  - To be fully confident about the small regressions at low nprobe, you'd want same-machine A/B      
  testing (build both versions, alternate runs within one script).  ******[mnorris11 note: this is nonsense, 
  this is what we did?]******

Differential Revision: D101500046


