### PR TITLE
Enforce minimum training set size for ScalarQuantizer, check nullptr (#5141)

### DIFF
--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -103,6 +103,8 @@ void ScalarQuantizer::train(size_t n, const float* x) {
     switch (qtype) {
         case QT_4bit_uniform:
         case QT_8bit_uniform:
+            FAISS_THROW_IF_NOT(n > 0);
+            FAISS_THROW_IF_NOT(x != nullptr);
             train_Uniform(
                     rangestat,
                     rangestat_arg,
@@ -114,6 +116,8 @@ void ScalarQuantizer::train(size_t n, const float* x) {
         case QT_4bit:
         case QT_8bit:
         case QT_6bit:
+            FAISS_THROW_IF_NOT(n > 0);
+            FAISS_THROW_IF_NOT(x != nullptr);
             train_NonUniform(
                     rangestat,
                     rangestat_arg,

--- a/tests/test_scalar_quantizer.cpp
+++ b/tests/test_scalar_quantizer.cpp
@@ -367,6 +367,30 @@ TEST(ScalarQuantizer, RSQuantilesSmallDataset) {
     ASSERT_NO_THROW(sq.train(n, x.data()));
 }
 
+TEST(ScalarQuantizer, MinimalTraining) {
+    std::vector<float> x = {1.0f, 2.0f, 3.0f, 4.0f};
+    using SQ = faiss::ScalarQuantizer;
+    for (auto qt : {
+                 SQ::QT_4bit,
+                 SQ::QT_4bit_uniform,
+                 SQ::QT_6bit,
+                 SQ::QT_8bit,
+                 SQ::QT_8bit_uniform,
+         }) {
+        SCOPED_TRACE(qt);
+        for (size_t d : {1, 2}) {
+            faiss::IndexScalarQuantizer index(d, qt);
+            index.sq.rangestat = SQ::RS_minmax;
+            // n=0 is insufficient.
+            EXPECT_THROW(index.train(0, x.data()), faiss::FaissException);
+            // nullptr throws, not crashes.
+            EXPECT_THROW(index.train(1, nullptr), faiss::FaissException);
+            // 1x1 values is allowed.
+            EXPECT_NO_THROW(index.train(1, x.data()));
+        }
+    }
+}
+
 TEST(TestSQ0bit, CoarseOnlySearch) {
     // Test QT_0bit: centroid-only distance
     int d = 64;


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/facebookresearch/faiss/pull/5141

Reviewed By: mnorris11

Differential Revision: D102078734


