### PR TITLE
Fix memory leak warning for unordered_multimap in IndexIVFFlatDedup Python binding (#1667)

### DIFF
--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -568,6 +568,9 @@ void gpu_sync_all_devices()
 %include  <faiss/impl/NNDescent.h>
 %include  <faiss/IndexNNDescent.h>
 
+// IndexIVFFlatDedup::instances is a std::unordered_multimap which SWIG has no
+// built-in destructor for; ignore the field to avoid memory leak warnings.
+%ignore faiss::IndexIVFFlatDedup::instances;
 %include  <faiss/IndexIVFFlat.h>
 %include  <faiss/IndexIVFFlatPanorama.h>
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -54,7 +54,7 @@ class TestFactory(unittest.TestCase):
 
     def test_factory_4(self):
         index = faiss.index_factory(12, "IVF10,FlatDedup")
-        assert index.instances is not None
+        assert isinstance(index, faiss.IndexIVFFlatDedup)
 
     def test_factory_5(self):
         index = faiss.index_factory(128, "OPQ16,Flat")


### PR DESCRIPTION
When running the Python test suite, SWIG emits a warning:

```
swig/python detected a memory leak of type 'std::unordered_multimap< faiss::Index::idx_t,faiss::Index::idx_t > *', no destructor found.
```

The root cause is that `faiss::IndexIVFFlatDedup::instances` is a `std::unordered_multimap<idx_t, idx_t>` member, and SWIG has no built-in destructor registration for that STL type. When SWIG wraps the field, it generates a raw pointer wrapper with no cleanup, causing the leak warning whenever an `IndexIVFFlatDedup` object is garbage-collected on the Python side.

The fix adds `%ignore faiss::IndexIVFFlatDedup::instances` in `faiss/python/swigfaiss.swig` before the `%include <faiss/IndexIVFFlat.h>` directive. This prevents SWIG from generating the untyped wrapper for the internal dedup map (which was never exposed in the Python type stubs anyway) and eliminates the memory leak warning.

Fixes #1667
