### PR TITLE
TurboQuant: full Algorithm 2 (QJL stage) with SIMD and optimizations

### DIFF
--- a/faiss/IndexIVFTurboQ.cpp
+++ b/faiss/IndexIVFTurboQ.cpp
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <faiss/IndexIVFTurboQ.h>
+
+#include <omp.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/ResultHandler.h>
+#include <faiss/impl/TurboQuantizer.h>
+#include <faiss/impl/expanded_scanners.h>
+
+namespace faiss {
+
+IndexIVFTurboQ::IndexIVFTurboQ(
+        Index* quantizer_in,
+        size_t d_in,
+        size_t nlist_in,
+        MetricType metric,
+        bool own_invlists_in,
+        uint8_t nb_bits_in,
+        QJLProjectionType qjl_type_in,
+        uint8_t nb_bits_lo_in,
+        size_t n_hi_dims_in)
+        : IndexIVF(quantizer_in, d_in, nlist_in, 0, metric, own_invlists_in),
+          turboq(d_in,
+                 metric,
+                 nb_bits_in,
+                 qjl_type_in,
+                 nb_bits_lo_in,
+                 n_hi_dims_in) {
+    code_size = turboq.code_size;
+    if (own_invlists_in) {
+        invlists->code_size = code_size;
+    }
+    is_trained = false;
+
+    // TurboQ operates on raw rotated vectors, not IVF residuals,
+    // because its Lloyd-Max codebook is calibrated for unit-sphere
+    // coordinates, not residual distributions.
+    by_residual = false;
+}
+
+IndexIVFTurboQ::IndexIVFTurboQ() {
+    by_residual = false;
+}
+
+void IndexIVFTurboQ::train_encoder(
+        idx_t n,
+        const float* x,
+        const idx_t* /*assign*/) {
+    turboq.train(n, x);
+}
+
+void IndexIVFTurboQ::encode_vectors(
+        idx_t n,
+        const float* x,
+        const idx_t* list_nos,
+        uint8_t* codes,
+        bool include_listnos) const {
+    size_t coarse_size = include_listnos ? coarse_code_size() : 0;
+    memset(codes, 0, (code_size + coarse_size) * n);
+
+#pragma omp parallel if (n > 1000)
+    {
+#pragma omp for
+        for (idx_t i = 0; i < n; i++) {
+            int64_t list_no = list_nos[i];
+            if (list_no >= 0) {
+                const float* xi = x + i * d;
+                uint8_t* code = codes + i * (code_size + coarse_size);
+
+                // by_residual=false: centroid is unused
+                turboq.compute_codes_core(xi, code + coarse_size, 1, nullptr);
+
+                if (coarse_size) {
+                    encode_listno(list_no, code);
+                }
+            }
+        }
+    }
+}
+
+void IndexIVFTurboQ::decode_vectors(
+        idx_t n,
+        const uint8_t* codes,
+        const idx_t* /*listnos*/,
+        float* x) const {
+#pragma omp parallel
+    {
+#pragma omp for
+        for (idx_t i = 0; i < n; i++) {
+            const uint8_t* code = codes + i * code_size;
+            float* xi = x + i * d;
+
+            turboq.decode_core(code, xi, 1, nullptr);
+        }
+    }
+}
+
+void IndexIVFTurboQ::add_core(
+        idx_t n,
+        const float* x,
+        const idx_t* xids,
+        const idx_t* precomputed_idx,
+        void* inverted_list_context) {
+    FAISS_THROW_IF_NOT(is_trained);
+
+    DirectMapAdd dm_add(direct_map, n, xids);
+
+#pragma omp parallel
+    {
+        std::vector<uint8_t> one_code(code_size);
+
+        int nt = omp_get_num_threads();
+        int rank = omp_get_thread_num();
+
+        // each thread takes care of a subset of lists
+        for (idx_t i = 0; i < n; i++) {
+            int64_t list_no = precomputed_idx[i];
+            if (list_no >= 0 && list_no % nt == rank) {
+                int64_t id = xids ? xids[i] : ntotal + i;
+
+                const float* xi = x + i * d;
+
+                turboq.compute_codes_core(xi, one_code.data(), 1, nullptr);
+
+                size_t ofs = invlists->add_entry(
+                        list_no, id, one_code.data(), inverted_list_context);
+
+                dm_add.add(i, list_no, ofs);
+
+            } else if (rank == 0 && list_no == -1) {
+                dm_add.add(i, -1, 0);
+            }
+        }
+    }
+
+    ntotal += n;
+}
+
+namespace {
+
+struct TurboQInvertedListScanner : InvertedListScanner {
+    using InvertedListScanner::scan_codes;
+    const IndexIVFTurboQ& ivf;
+
+    std::unique_ptr<FlatCodesDistanceComputer> dc;
+    TurboQDistanceComputer* turboq_dc = nullptr;
+
+    uint8_t qb = 0;
+    bool int_qjl = false;
+
+    explicit TurboQInvertedListScanner(
+            const IndexIVFTurboQ& ivf_in,
+            bool store_pairs_in = false,
+            const IDSelector* sel_in = nullptr,
+            uint8_t qb_in = 0,
+            bool int_qjl_in = false)
+            : InvertedListScanner(store_pairs_in, sel_in),
+              ivf{ivf_in},
+              qb{qb_in},
+              int_qjl{int_qjl_in} {
+        keep_max = is_similarity_metric(ivf.metric_type);
+        code_size = ivf.code_size;
+    }
+
+    void set_query(const float* query_vector_in) override {
+        dc.reset(ivf.turboq.get_distance_computer());
+        turboq_dc = dynamic_cast<TurboQDistanceComputer*>(dc.get());
+        FAISS_THROW_IF_NOT_MSG(
+                turboq_dc != nullptr, "TurboQ distance computer cast failed");
+
+        turboq_dc->qb = qb;
+        turboq_dc->int_qjl = int_qjl;
+
+        dc->set_query(query_vector_in);
+    }
+
+    void set_list(idx_t list_no_in, float /*coarse_dis*/) override {
+        this->list_no = list_no_in;
+    }
+
+    float distance_to_code(const uint8_t* code) const final {
+        return dc->distance_to_code(code);
+    }
+
+    size_t scan_codes(
+            size_t list_size,
+            const uint8_t* codes,
+            const idx_t* ids,
+            ResultHandler& handler) const override {
+        if (turboq_dc != nullptr) {
+            turboq_dc->threshold_ptr = &handler.threshold;
+            turboq_dc->prescreen_l2 = !keep_max;
+        }
+
+        size_t nup = run_scan_codes(*this, list_size, codes, ids, handler);
+
+        if (turboq_dc != nullptr) {
+            turboq_dc->threshold_ptr = nullptr;
+        }
+
+        return nup;
+    }
+};
+
+} // anonymous namespace
+
+InvertedListScanner* IndexIVFTurboQ::get_InvertedListScanner(
+        bool store_pairs,
+        const IDSelector* sel,
+        const IVFSearchParameters* search_params_in) const {
+    uint8_t used_qb = 0;
+    bool used_int_qjl = false;
+
+    if (auto params = dynamic_cast<const IVFTurboQSearchParameters*>(
+                search_params_in)) {
+        used_qb = params->qb;
+        used_int_qjl = params->int_qjl;
+    }
+
+    return new TurboQInvertedListScanner(
+            *this, store_pairs, sel, used_qb, used_int_qjl);
+}
+
+namespace {
+
+struct IVFTurboQDistanceComputer : DistanceComputer {
+    const IndexIVFTurboQ* parent = nullptr;
+    const float* q = nullptr;
+    std::unique_ptr<FlatCodesDistanceComputer> dc;
+
+    void set_query(const float* x) override {
+        q = x;
+        // Lazily initialize DC -- we need it for operator()
+        if (!dc) {
+            dc.reset(parent->turboq.get_distance_computer());
+        }
+        dc->set_query(x);
+    }
+
+    float operator()(idx_t i) override {
+        // Look up the code from the inverted lists via direct_map
+        idx_t lo = parent->direct_map.get(i);
+        uint64_t list_no = lo_listno(lo);
+        uint64_t offset = lo_offset(lo);
+
+        const uint8_t* code =
+                parent->invlists->get_single_code(list_no, offset);
+
+        float distance = dc->distance_to_code(code);
+
+        parent->invlists->release_codes(list_no, code);
+
+        return distance;
+    }
+
+    float symmetric_dis(idx_t /*i*/, idx_t /*j*/) override {
+        FAISS_THROW_MSG("Not implemented");
+    }
+};
+
+} // anonymous namespace
+
+void IndexIVFTurboQ::reconstruct_from_offset(
+        int64_t list_no,
+        int64_t offset,
+        float* recons) const {
+    const uint8_t* code = invlists->get_single_code(list_no, offset);
+
+    turboq.decode_core(code, recons, 1, nullptr);
+}
+
+void IndexIVFTurboQ::sa_decode(idx_t n, const uint8_t* codes, float* x) const {
+    size_t coarse_size = coarse_code_size();
+
+#pragma omp parallel
+    {
+#pragma omp for
+        for (idx_t i = 0; i < n; i++) {
+            const uint8_t* code = codes + i * (code_size + coarse_size);
+            float* xi = x + i * d;
+
+            turboq.decode_core(code + coarse_size, xi, 1, nullptr);
+        }
+    }
+}
+
+DistanceComputer* IndexIVFTurboQ::get_distance_computer() const {
+    IVFTurboQDistanceComputer* dc = new IVFTurboQDistanceComputer;
+    dc->parent = this;
+    return dc;
+}
+
+} // namespace faiss

--- a/faiss/IndexIVFTurboQ.h
+++ b/faiss/IndexIVFTurboQ.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// IndexIVFTurboQ: IVF index with TurboQuant fine quantizer.
+//
+// Key difference from RaBitQ: by_residual = false.
+// TurboQ operates on the raw rotated vector, not the IVF residual,
+// because its Lloyd-Max codebook is calibrated for unit-sphere coordinates,
+// not for residual distributions which vary per centroid.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <faiss/Index.h>
+#include <faiss/IndexIVF.h>
+#include <faiss/impl/TurboQuantizer.h>
+
+namespace faiss {
+
+struct IVFTurboQSearchParameters : IVFSearchParameters {
+    /// Query quantization bits for integer MSE pre-screening.
+    /// 0 = float path (default), 1-8 = integer popcount path.
+    uint8_t qb = 0;
+
+    /// Also use integer popcount for QJL stage (requires qb > 0).
+    bool int_qjl = false;
+};
+
+struct IndexIVFTurboQ : IndexIVF {
+    TurboQuantizer turboq;
+
+    IndexIVFTurboQ(
+            Index* quantizer,
+            size_t d,
+            size_t nlist,
+            MetricType metric = METRIC_L2,
+            bool own_invlists = true,
+            uint8_t nb_bits = 2,
+            QJLProjectionType qjl_type = QJLProjectionType::FWHT,
+            uint8_t nb_bits_lo = 0,
+            size_t n_hi_dims = 0);
+
+    IndexIVFTurboQ();
+
+    void train_encoder(idx_t n, const float* x, const idx_t* assign) override;
+
+    idx_t train_encoder_num_vectors() const override {
+        return 1;
+    }
+
+    void encode_vectors(
+            idx_t n,
+            const float* x,
+            const idx_t* list_nos,
+            uint8_t* codes,
+            bool include_listnos = false) const override;
+
+    void decode_vectors(
+            idx_t n,
+            const uint8_t* codes,
+            const idx_t* list_nos,
+            float* x) const override;
+
+    void add_core(
+            idx_t n,
+            const float* x,
+            const idx_t* xids,
+            const idx_t* precomputed_idx,
+            void* inverted_list_context = nullptr) override;
+
+    InvertedListScanner* get_InvertedListScanner(
+            bool store_pairs,
+            const IDSelector* sel,
+            const IVFSearchParameters* params) const override;
+
+    void reconstruct_from_offset(int64_t list_no, int64_t offset, float* recons)
+            const override;
+
+    void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
+
+    DistanceComputer* get_distance_computer() const override;
+};
+
+} // namespace faiss

--- a/faiss/factory_tools.cpp
+++ b/faiss/factory_tools.cpp
@@ -38,6 +38,11 @@ const std::map<faiss::ScalarQuantizer::QuantizerType, std::string> sq_types = {
         {faiss::ScalarQuantizer::QT_bf16, "SQbf16"},
         {faiss::ScalarQuantizer::QT_8bit_direct_signed, "SQ8_direct_signed"},
         {faiss::ScalarQuantizer::QT_8bit_direct, "SQ8_direct"},
+        {faiss::ScalarQuantizer::QT_1bit_tqmse, "SQtqmse1"},
+        {faiss::ScalarQuantizer::QT_2bit_tqmse, "SQtqmse2"},
+        {faiss::ScalarQuantizer::QT_3bit_tqmse, "SQtqmse3"},
+        {faiss::ScalarQuantizer::QT_4bit_tqmse, "SQtqmse4"},
+        {faiss::ScalarQuantizer::QT_8bit_tqmse, "SQtqmse8"},
 };
 
 int get_hnsw_M(const faiss::IndexHNSW* index) {

--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -38,15 +38,29 @@ ScalarQuantizer::ScalarQuantizer() {}
 
 void ScalarQuantizer::set_derived_sizes() {
     switch (qtype) {
+        case QT_1bit_tqmse:
+            code_size = (d + 7) / 8;
+            bits = 1;
+            break;
+        case QT_2bit_tqmse:
+            code_size = (d * 2 + 7) / 8;
+            bits = 2;
+            break;
+        case QT_3bit_tqmse:
+            code_size = (d * 3 + 7) / 8;
+            bits = 3;
+            break;
         case QT_8bit:
         case QT_8bit_uniform:
         case QT_8bit_direct:
         case QT_8bit_direct_signed:
+        case QT_8bit_tqmse:
             code_size = d;
             bits = 8;
             break;
         case QT_4bit:
         case QT_4bit_uniform:
+        case QT_4bit_tqmse:
             code_size = (d + 1) / 2;
             bits = 4;
             break;
@@ -114,6 +128,21 @@ void ScalarQuantizer::train(size_t n, const float* x) {
         case QT_bf16:
         case QT_8bit_direct_signed:
             // no training necessary
+            break;
+        case QT_1bit_tqmse:
+            scalar_quantizer::train_TurboQuantMSE(d, 1, trained);
+            break;
+        case QT_2bit_tqmse:
+            scalar_quantizer::train_TurboQuantMSE(d, 2, trained);
+            break;
+        case QT_3bit_tqmse:
+            scalar_quantizer::train_TurboQuantMSE(d, 3, trained);
+            break;
+        case QT_4bit_tqmse:
+            scalar_quantizer::train_TurboQuantMSE(d, 4, trained);
+            break;
+        case QT_8bit_tqmse:
+            scalar_quantizer::train_TurboQuantMSE(d, 8, trained);
             break;
         default:
             break;

--- a/faiss/impl/ScalarQuantizer.h
+++ b/faiss/impl/ScalarQuantizer.h
@@ -34,6 +34,11 @@ struct ScalarQuantizer : Quantizer {
         QT_8bit_direct_signed, ///< fast indexing of signed int8s ranging from
                                ///< [-128 to 127]
         QT_0bit, ///< 0 bits per component, centroid-only distance (for IVF)
+        QT_1bit_tqmse, ///< TurboQuant MSE-optimized, 1 bit per component
+        QT_2bit_tqmse, ///< TurboQuant MSE-optimized, 2 bits per component
+        QT_3bit_tqmse, ///< TurboQuant MSE-optimized, 3 bits per component
+        QT_4bit_tqmse, ///< TurboQuant MSE-optimized, 4 bits per component
+        QT_8bit_tqmse, ///< TurboQuant MSE-optimized, 8 bits per component
         QT_count
     };
 

--- a/faiss/impl/TurboQuantizer.cpp
+++ b/faiss/impl/TurboQuantizer.cpp
@@ -1,0 +1,861 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <faiss/impl/TurboQuantizer.h>
+
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/RaBitQUtils.h>
+#include <faiss/impl/scalar_quantizer/training.h>
+#include <faiss/impl/simd_dispatch.h>
+#include <faiss/utils/distances.h>
+#include <faiss/utils/rabitq_simd.h>
+#include <faiss/utils/random.h>
+#include <faiss/utils/turboq_simd.h>
+#include <faiss/utils/utils.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+namespace faiss {
+
+namespace {
+
+/// Return the smallest power of 2 >= n.
+size_t next_power_of_2(size_t n) {
+    if (n == 0) {
+        return 1;
+    }
+    size_t p = 1;
+    while (p < n) {
+        p <<= 1;
+    }
+    return p;
+}
+
+/// In-place unnormalized Walsh-Hadamard transform of length-d vector x.
+/// d must be a power of 2.
+void fwht_inplace(float* x, size_t d) {
+    for (size_t h = 1; h < d; h <<= 1) {
+        for (size_t i = 0; i < d; i += h << 1) {
+            for (size_t j = i; j < i + h; j++) {
+                float u = x[j];
+                float v = x[j + h];
+                x[j] = u + v;
+                x[j + h] = u - v;
+            }
+        }
+    }
+}
+
+/// Compute dimension-aware Lloyd-Max codebook using the exact Beta distribution
+/// of unit-sphere coordinates. Centroids and boundaries are returned in
+/// "N(0,1)-equivalent" space (scaled by sqrt(d)) so that the encoding logic
+/// can work uniformly: val = v_normalized * sqrt(d), then search boundaries.
+void compute_codebook_for_dim(
+        size_t d,
+        size_t mse_bits,
+        size_t& levels_out,
+        std::vector<float>& centroids_out,
+        std::vector<float>& boundaries_out) {
+    levels_out = size_t(1) << mse_bits;
+
+    // Use D102195204's numerical Beta-distribution codebook computation
+    std::vector<float> trained;
+    scalar_quantizer::train_TurboQuantMSE(d, mse_bits, trained);
+
+    size_t k = levels_out;
+    centroids_out.assign(trained.begin(), trained.begin() + k);
+    boundaries_out.assign(trained.begin() + k, trained.end());
+
+    // train_TurboQuantMSE returns centroids on [-1, 1] (coordinate space).
+    // Scale by sqrt(d) to convert to "N(0,1)-equivalent" space, matching
+    // the encoding convention: val = v_normalized * sqrt(d).
+    float sqrt_d = std::sqrt(static_cast<float>(d));
+    for (auto& c : centroids_out) {
+        c *= sqrt_d;
+    }
+    for (auto& b : boundaries_out) {
+        b *= sqrt_d;
+    }
+}
+
+} // anonymous namespace
+
+// =========================================================================
+// Constructor
+// =========================================================================
+
+TurboQuantizer::TurboQuantizer(
+        size_t d_in,
+        MetricType metric,
+        size_t nb_bits_in,
+        QJLProjectionType qjl_type_in,
+        size_t nb_bits_lo_in,
+        size_t n_hi_dims_in)
+        : Quantizer(d_in, 0),
+          metric_type{metric},
+          nb_bits{nb_bits_in},
+          qjl_type{qjl_type_in},
+          nb_bits_lo{nb_bits_lo_in},
+          n_hi_dims{n_hi_dims_in} {
+    if (d == 0) {
+        return;
+    }
+
+    // Validate nb_bits range (1-5 total = 0-4 MSE bits + 1 QJL bit)
+    FAISS_THROW_IF_NOT_MSG(
+            nb_bits >= 1 && nb_bits <= 5,
+            "TurboQuantizer: nb_bits must be in [1, 5]");
+
+    // Validate adaptive parameters
+    if (nb_bits_lo > 0) {
+        FAISS_THROW_IF_NOT_MSG(
+                nb_bits_lo < nb_bits,
+                "TurboQuantizer: nb_bits_lo must be < nb_bits");
+        FAISS_THROW_IF_NOT_MSG(
+                n_hi_dims > 0 && n_hi_dims < d,
+                "TurboQuantizer: n_hi_dims must be in (0, d)");
+    }
+
+    // Code layout: [MSE hi planes][MSE lo planes][QJL signs][TurboQFactors]
+    code_size = mse_code_size() + qjl_code_size() + sizeof(TurboQFactors);
+
+    // Initialize codebooks
+    init_codebook();
+
+    // Initialize projection matrix
+    switch (qjl_type) {
+        case QJLProjectionType::FWHT:
+            init_fwht();
+            break;
+        case QJLProjectionType::RANDOM_ROTATION:
+            init_random_rotation();
+            break;
+    }
+}
+
+// =========================================================================
+// Initialization methods
+// =========================================================================
+
+void TurboQuantizer::init_fwht() {
+    padded_d = next_power_of_2(d);
+    fwht_signs.resize(padded_d);
+
+    // Generate random +/-1 signs from seed
+    RandomGenerator rng(seed);
+    for (size_t i = 0; i < padded_d; i++) {
+        fwht_signs[i] = (rng.rand_int(2) == 0) ? 1.0f : -1.0f;
+    }
+}
+
+void TurboQuantizer::init_random_rotation() {
+    // Generate d x d Gaussian matrix, then QR orthogonalize
+    gaussian_matrix.resize(d * d);
+
+    // Fill with N(0,1) random values
+    float_randn(gaussian_matrix.data(), d * d, seed);
+
+    // QR decomposition to get orthogonal matrix
+    // matrix_qr expects column-major m x n matrix with m >= n
+    // We have a d x d matrix
+    matrix_qr(static_cast<int>(d), static_cast<int>(d), gaussian_matrix.data());
+}
+
+void TurboQuantizer::init_codebook() {
+    if (nb_bits <= 1) {
+        mse_levels = 0;
+        return;
+    }
+
+    size_t mse_bits = nb_bits - 1;
+    compute_codebook_for_dim(
+            d, mse_bits, mse_levels, mse_centroids, mse_boundaries);
+
+    if (is_adaptive()) {
+        size_t mse_bits_lo = nb_bits_lo > 1 ? nb_bits_lo - 1 : 0;
+        if (mse_bits_lo > 0) {
+            compute_codebook_for_dim(
+                    d,
+                    mse_bits_lo,
+                    mse_levels_lo,
+                    mse_centroids_lo,
+                    mse_boundaries_lo);
+        } else {
+            mse_levels_lo = 0;
+        }
+    }
+}
+
+void TurboQuantizer::apply_qjl_projection(const float* in, float* out) const {
+    if (use_fwht()) {
+        // FWHT mode: pad, sign-multiply, FWHT, truncate to d
+        std::vector<float> padded(padded_d, 0.0f);
+
+        // Copy input and multiply by random signs
+        for (size_t i = 0; i < d; i++) {
+            padded[i] = in[i] * fwht_signs[i];
+        }
+        // Zero-pad remaining (already done by initialization)
+        for (size_t i = d; i < padded_d; i++) {
+            padded[i] = 0.0f * fwht_signs[i]; // = 0
+        }
+
+        // Apply Walsh-Hadamard transform
+        fwht_inplace(padded.data(), padded_d);
+
+        // Truncate to d dimensions and normalize
+        float scale = 1.0f / std::sqrt(static_cast<float>(padded_d));
+        for (size_t i = 0; i < d; i++) {
+            out[i] = padded[i] * scale;
+        }
+    } else {
+        // Dense matrix multiply: out = gaussian_matrix * in
+        // gaussian_matrix is d x d, in is d x 1, out is d x 1
+        for (size_t i = 0; i < d; i++) {
+            float sum = 0.0f;
+            for (size_t j = 0; j < d; j++) {
+                sum += gaussian_matrix[i * d + j] * in[j];
+            }
+            out[i] = sum;
+        }
+    }
+}
+
+// =========================================================================
+// Training (no-op: codebooks are analytic)
+// =========================================================================
+
+void TurboQuantizer::train(size_t /*n*/, const float* /*x*/) {
+    // No-op: Lloyd-Max codebooks are analytic for N(0,1).
+}
+
+// =========================================================================
+// Encoding
+// =========================================================================
+
+void TurboQuantizer::compute_codes(const float* x, uint8_t* codes, size_t n)
+        const {
+    compute_codes_core(x, codes, n, nullptr);
+}
+
+void TurboQuantizer::compute_codes_core(
+        const float* x,
+        uint8_t* codes,
+        size_t n,
+        const float* centroid_in) const {
+    FAISS_ASSERT(codes != nullptr);
+    FAISS_ASSERT(x != nullptr);
+
+    if (n == 0) {
+        return;
+    }
+
+    const size_t mse_bits = (nb_bits > 1) ? (nb_bits - 1) : 0;
+    const float sqrt_d = std::sqrt(static_cast<float>(d));
+    const float inv_sqrt_d = 1.0f / sqrt_d;
+    const size_t mse_hi_size = mse_code_size_hi();
+    const size_t mse_total = mse_code_size();
+    const size_t qjl_size = qjl_code_size();
+    const size_t hi_dims = is_adaptive() ? n_hi_dims : d;
+
+    // Adaptive: lo bits
+    const size_t mse_bits_lo =
+            is_adaptive() ? ((nb_bits_lo > 1) ? (nb_bits_lo - 1) : 0) : 0;
+
+#pragma omp parallel for if (n > 1000)
+    for (int64_t i = 0; i < static_cast<int64_t>(n); i++) {
+        const float* x_row = x + i * d;
+        uint8_t* code = codes + i * code_size;
+
+        // Clear code memory
+        memset(code, 0, code_size);
+
+        // Step 1: Compute norm and normalize
+        float norm_sq = fvec_norm_L2sqr(x_row, d);
+        float norm = std::sqrt(norm_sq);
+        if (norm < 1e-30f) {
+            norm = 1e-30f;
+        }
+        float inv_norm = 1.0f / norm;
+
+        // v = x / ||x|| (unit vector)
+        std::vector<float> v(d);
+        for (size_t j = 0; j < d; j++) {
+            v[j] = x_row[j] * inv_norm;
+        }
+
+        // Step 2: MSE quantize in N(0,1) space
+        // val = v[j] * sqrt(d) maps unit sphere coords to approx N(0,1)
+        std::vector<float> dequant(d, 0.0f);
+
+        if (mse_bits > 0) {
+            // Pointers into MSE code region
+            uint8_t* mse_code = code;
+
+            // --- Hi dimensions ---
+            size_t hi_byte_plane = (hi_dims + 7) / 8;
+            for (size_t j = 0; j < hi_dims; j++) {
+                float val = v[j] * sqrt_d;
+
+                size_t idx = std::upper_bound(
+                                     mse_boundaries.begin(),
+                                     mse_boundaries.end(),
+                                     val) -
+                        mse_boundaries.begin();
+
+                // Store as BIT-PLANE layout
+                for (size_t b = 0; b < mse_bits; b++) {
+                    if (idx & (size_t(1) << b)) {
+                        mse_code[b * hi_byte_plane + j / 8] |= (1 << (j % 8));
+                    }
+                }
+
+                // Dequantize for residual computation
+                dequant[j] = mse_centroids[idx] * inv_sqrt_d;
+            }
+
+            // --- Lo dimensions (adaptive mode) ---
+            if (is_adaptive() && mse_bits_lo > 0) {
+                size_t lo_dims = d - n_hi_dims;
+                size_t lo_byte_plane = (lo_dims + 7) / 8;
+                uint8_t* mse_lo_code = mse_code + mse_hi_size;
+
+                for (size_t jj = 0; jj < lo_dims; jj++) {
+                    size_t j = n_hi_dims + jj;
+                    float val = v[j] * sqrt_d;
+
+                    size_t idx = std::upper_bound(
+                                         mse_boundaries_lo.begin(),
+                                         mse_boundaries_lo.end(),
+                                         val) -
+                            mse_boundaries_lo.begin();
+
+                    // Store as BIT-PLANE layout
+                    for (size_t b = 0; b < mse_bits_lo; b++) {
+                        if (idx & (size_t(1) << b)) {
+                            mse_lo_code[b * lo_byte_plane + jj / 8] |=
+                                    (1 << (jj % 8));
+                        }
+                    }
+
+                    // Dequantize
+                    dequant[j] = mse_centroids_lo[idx] * inv_sqrt_d;
+                }
+            }
+        }
+
+        // Step 3: Compute residual: r = v - dequant
+        std::vector<float> residual(d);
+        for (size_t j = 0; j < d; j++) {
+            residual[j] = v[j] - dequant[j];
+        }
+
+        // Step 4: QJL - project residual and take signs
+        std::vector<float> proj(d);
+        apply_qjl_projection(residual.data(), proj.data());
+
+        uint8_t* qjl_code = code + mse_total;
+        for (size_t j = 0; j < d; j++) {
+            if (proj[j] >= 0.0f) {
+                qjl_code[j / 8] |= (1 << (j % 8));
+            }
+        }
+
+        // Step 5: Store TurboQFactors
+        float gamma_sq = fvec_norm_L2sqr(residual.data(), d);
+        float gamma = std::sqrt(gamma_sq);
+
+        TurboQFactors* factors =
+                reinterpret_cast<TurboQFactors*>(code + mse_total + qjl_size);
+        factors->norm = norm;
+        factors->gamma = gamma;
+    }
+}
+
+// =========================================================================
+// Decoding
+// =========================================================================
+
+void TurboQuantizer::decode(const uint8_t* codes, float* x, size_t n) const {
+    decode_core(codes, x, n, nullptr);
+}
+
+void TurboQuantizer::decode_core(
+        const uint8_t* codes,
+        float* x,
+        size_t n,
+        const float* /*centroid_in*/) const {
+    FAISS_ASSERT(codes != nullptr);
+    FAISS_ASSERT(x != nullptr);
+
+    if (n == 0) {
+        return;
+    }
+
+    const size_t mse_bits = (nb_bits > 1) ? (nb_bits - 1) : 0;
+    const float inv_sqrt_d = 1.0f / std::sqrt(static_cast<float>(d));
+    const float sqrt_pi_over_2 = std::sqrt(static_cast<float>(M_PI) / 2.0f);
+    const float qjl_recon_coeff = sqrt_pi_over_2 / static_cast<float>(d);
+    const size_t mse_hi_size = mse_code_size_hi();
+    const size_t mse_total = mse_code_size();
+    const size_t qjl_size = qjl_code_size();
+    const size_t hi_dims = is_adaptive() ? n_hi_dims : d;
+
+    const size_t mse_bits_lo =
+            is_adaptive() ? ((nb_bits_lo > 1) ? (nb_bits_lo - 1) : 0) : 0;
+
+#pragma omp parallel for if (n > 1000)
+    for (int64_t i = 0; i < static_cast<int64_t>(n); i++) {
+        const uint8_t* code = codes + i * code_size;
+        float* x_out = x + i * d;
+
+        // Extract TurboQFactors
+        const TurboQFactors* factors = reinterpret_cast<const TurboQFactors*>(
+                code + mse_total + qjl_size);
+        float norm = factors->norm;
+        float gamma = factors->gamma;
+
+        // Step 1: Reconstruct MSE component
+        std::vector<float> x_mse(d, 0.0f);
+        if (mse_bits > 0) {
+            const uint8_t* mse_code = code;
+            size_t hi_byte_plane = (hi_dims + 7) / 8;
+
+            // Hi dimensions
+            for (size_t j = 0; j < hi_dims; j++) {
+                size_t idx = 0;
+                for (size_t b = 0; b < mse_bits; b++) {
+                    bool bit = (mse_code[b * hi_byte_plane + j / 8] &
+                                (1 << (j % 8))) != 0;
+                    if (bit) {
+                        idx |= (size_t(1) << b);
+                    }
+                }
+                x_mse[j] = mse_centroids[idx] * inv_sqrt_d;
+            }
+
+            // Lo dimensions (adaptive mode)
+            if (is_adaptive() && mse_bits_lo > 0) {
+                size_t lo_dims = d - n_hi_dims;
+                size_t lo_byte_plane = (lo_dims + 7) / 8;
+                const uint8_t* mse_lo_code = mse_code + mse_hi_size;
+
+                for (size_t jj = 0; jj < lo_dims; jj++) {
+                    size_t j = n_hi_dims + jj;
+                    size_t idx = 0;
+                    for (size_t b = 0; b < mse_bits_lo; b++) {
+                        bool bit = (mse_lo_code[b * lo_byte_plane + jj / 8] &
+                                    (1 << (jj % 8))) != 0;
+                        if (bit) {
+                            idx |= (size_t(1) << b);
+                        }
+                    }
+                    x_mse[j] = mse_centroids_lo[idx] * inv_sqrt_d;
+                }
+            }
+        }
+
+        // Step 2: Reconstruct QJL component
+        // x_qjl = sqrt(pi/2)/d * gamma * S^T * signs
+        std::vector<float> x_qjl(d, 0.0f);
+        const uint8_t* qjl_code = code + mse_total;
+
+        // Build sign vector (+1/-1 from bits)
+        std::vector<float> signs(d);
+        for (size_t j = 0; j < d; j++) {
+            bool bit = (qjl_code[j / 8] & (1 << (j % 8))) != 0;
+            signs[j] = bit ? 1.0f : -1.0f;
+        }
+
+        if (use_fwht()) {
+            // FWHT adjoint: embed signs in padded_d, FWHT, multiply by
+            // fwht_signs
+            std::vector<float> padded(padded_d, 0.0f);
+            float scale = 1.0f / std::sqrt(static_cast<float>(padded_d));
+            for (size_t j = 0; j < d; j++) {
+                padded[j] = signs[j] * scale;
+            }
+            fwht_inplace(padded.data(), padded_d);
+            for (size_t j = 0; j < d; j++) {
+                x_qjl[j] = qjl_recon_coeff * gamma * padded[j] * fwht_signs[j];
+            }
+        } else {
+            // Dense matrix transpose: S^T * signs
+            for (size_t j = 0; j < d; j++) {
+                float sum = 0.0f;
+                for (size_t k = 0; k < d; k++) {
+                    sum += gaussian_matrix[k * d + j] * signs[k];
+                }
+                x_qjl[j] = qjl_recon_coeff * gamma * sum;
+            }
+        }
+
+        // Step 3: Combine: x = norm * (x_mse + x_qjl)
+        for (size_t j = 0; j < d; j++) {
+            x_out[j] = norm * (x_mse[j] + x_qjl[j]);
+        }
+    }
+}
+
+// =========================================================================
+// Distance Computer
+// =========================================================================
+
+namespace {
+
+/// Template distance computer for TurboQ, parameterized on SIMD level.
+template <SIMDLevel SL>
+struct TurboQDistanceComputerImpl : TurboQDistanceComputer {
+    TurboQDistanceComputerImpl() {
+        codes = nullptr;
+        code_size = 0;
+    }
+
+    float symmetric_dis(idx_t /*i*/, idx_t /*j*/) override {
+        FAISS_THROW_MSG("TurboQ symmetric_dis not implemented");
+    }
+
+    void set_query(const float* x) override {
+        FAISS_ASSERT(x != nullptr);
+        FAISS_ASSERT(tq != nullptr);
+
+        const size_t dim = tq->d;
+        const size_t mse_bits = (tq->nb_bits > 1) ? (tq->nb_bits - 1) : 0;
+        const float id = 1.0f / std::sqrt(static_cast<float>(dim));
+        inv_sqrt_d = id;
+        qjl_coeff = std::sqrt(static_cast<float>(M_PI) / 2.0f) /
+                static_cast<float>(dim);
+
+        // Store query
+        q.resize(dim);
+        std::copy(x, x + dim, q.begin());
+        q_norm_sq = fvec_norm_L2sqr(x, dim);
+
+        // Project query: q_proj = S * q
+        q_proj.resize(dim);
+        tq->apply_qjl_projection(x, q_proj.data());
+
+        // Pre-compute total sums
+        total_q_sum = 0.0f;
+        for (size_t j = 0; j < dim; j++) {
+            total_q_sum += q[j];
+        }
+
+        total_qproj_sum = 0.0f;
+        for (size_t j = 0; j < dim; j++) {
+            total_qproj_sum += q_proj[j];
+        }
+
+        // Pre-compute scaled centroids for each quantization level
+        if (mse_bits > 0 && tq->mse_levels > 0) {
+            scaled_centroids.resize(tq->mse_levels);
+            for (size_t k = 0; k < tq->mse_levels; k++) {
+                scaled_centroids[k] = tq->mse_centroids[k] * inv_sqrt_d;
+            }
+
+            // For 1-bit MSE (nb_bits==2, uniform): compute delta_centroid
+            if (tq->nb_bits == 2 && !tq->is_adaptive()) {
+                delta_centroid = scaled_centroids[1] - scaled_centroids[0];
+            }
+
+            // Lo codebook scaled centroids (adaptive)
+            if (tq->is_adaptive() && tq->mse_levels_lo > 0) {
+                scaled_centroids_lo.resize(tq->mse_levels_lo);
+                for (size_t k = 0; k < tq->mse_levels_lo; k++) {
+                    scaled_centroids_lo[k] =
+                            tq->mse_centroids_lo[k] * inv_sqrt_d;
+                }
+            }
+        }
+
+        // Pre-screening: worst-case L1 bound on QJL error
+        {
+            float qproj_l1 = 0.0f;
+            for (size_t j = 0; j < dim; j++) {
+                qproj_l1 += std::abs(q_proj[j]);
+            }
+            qjl_error_coeff = qjl_coeff * qproj_l1;
+        }
+
+        // Integer popcount state (if qb > 0, nb_bits == 2, uniform)
+        if (qb > 0 && tq->nb_bits == 2 && !tq->is_adaptive()) {
+            // Quantize query to qb bits for integer popcount path
+            size_t byte_size = (dim + 7) / 8;
+
+            // Scale q by scaled_centroids for MSE accumulation
+            // For 1-bit MSE: the MSE dot product is
+            //   sum_j q[j] * centroid[idx_j] / sqrt(d)
+            // = scaled_centroids[0] * sum(q) + delta_centroid * sum(q[j] where
+            // bit=1)
+            //
+            // For integer path: quantize q into qb-bit values,
+            // rearrange into bit-planes for popcount
+            float q_min = *std::min_element(q.begin(), q.end());
+            float q_max = *std::max_element(q.begin(), q.end());
+            float q_range = q_max - q_min;
+            if (q_range < 1e-30f) {
+                q_range = 1e-30f;
+            }
+            float max_val = static_cast<float>((1 << qb) - 1);
+
+            rearranged_q.resize(byte_size * qb);
+            std::fill(rearranged_q.begin(), rearranged_q.end(), 0);
+
+            float scale = max_val / q_range;
+            // Quantize and rearrange into bit-planes
+            for (size_t j = 0; j < dim; j++) {
+                int qval = static_cast<int>(std::round((q[j] - q_min) * scale));
+                qval = std::max(0, std::min(static_cast<int>(max_val), qval));
+
+                for (int b = 0; b < qb; b++) {
+                    if (qval & (1 << b)) {
+                        rearranged_q[b * byte_size + j / 8] |= (1 << (j % 8));
+                    }
+                }
+            }
+
+            // Pre-compute base/scale for converting popcount to MSE dot
+            // mse_dot ≈ base + int_scale * and_dot + popcnt_scale * popcount
+            float delta_q = q_range / max_val;
+            mse_base = scaled_centroids[0] * total_q_sum;
+            mse_int_scale = delta_centroid * delta_q;
+            mse_popcnt_scale = delta_centroid * q_min;
+        }
+
+        // Integer QJL state (if qb > 0, int_qjl)
+        if (qb > 0 && int_qjl) {
+            size_t byte_size = (dim + 7) / 8;
+
+            float qp_min = *std::min_element(q_proj.begin(), q_proj.end());
+            float qp_max = *std::max_element(q_proj.begin(), q_proj.end());
+            float qp_range = qp_max - qp_min;
+            if (qp_range < 1e-30f) {
+                qp_range = 1e-30f;
+            }
+            float max_val = static_cast<float>((1 << qb) - 1);
+            float scale = max_val / qp_range;
+
+            rearranged_qproj.resize(byte_size * qb);
+            std::fill(rearranged_qproj.begin(), rearranged_qproj.end(), 0);
+
+            for (size_t j = 0; j < dim; j++) {
+                int qval = static_cast<int>(
+                        std::round((q_proj[j] - qp_min) * scale));
+                qval = std::max(0, std::min(static_cast<int>(max_val), qval));
+
+                for (int b = 0; b < qb; b++) {
+                    if (qval & (1 << b)) {
+                        rearranged_qproj[b * byte_size + j / 8] |=
+                                (1 << (j % 8));
+                    }
+                }
+            }
+
+            // Pre-compute coefficients for integer QJL dot product
+            // raw_and = sum over j: q_quantized[j] * sign_bit[j]
+            // real_dot approx= (raw_and / scale + qp_min * popcount(signs))
+            // but we fold this into: qjl_dot = qjl_base + qjl_and_scale *
+            // and_result + qjl_pop_scale * popcount
+            qjl_and_scale = 2.0f * qjl_coeff / scale;
+            qjl_pop_scale = 2.0f * qjl_coeff * qp_min;
+            qjl_base = -qjl_coeff * total_qproj_sum;
+        }
+    }
+
+    float distance_to_code(const uint8_t* code) override {
+        return turboq_distance_to_code(code);
+    }
+
+    float turboq_distance_to_code(const uint8_t* code) {
+        FAISS_ASSERT(tq != nullptr);
+        FAISS_ASSERT(code != nullptr);
+
+        const size_t dim = tq->d;
+        const size_t mse_bits = (tq->nb_bits > 1) ? (tq->nb_bits - 1) : 0;
+        const size_t mse_total = tq->mse_code_size();
+        const size_t qjl_size = tq->qjl_code_size();
+        const size_t hi_dims = tq->is_adaptive() ? tq->n_hi_dims : dim;
+
+        // Extract TurboQFactors
+        const TurboQFactors* factors = reinterpret_cast<const TurboQFactors*>(
+                code + mse_total + qjl_size);
+        float norm = factors->norm;
+        float gamma = factors->gamma;
+
+        n_total++;
+
+        // ============================================================
+        // Stage 1: MSE dot product
+        // ============================================================
+        float mse_dot = 0.0f;
+
+        if (mse_bits > 0) {
+            const uint8_t* mse_code = code;
+
+            if (tq->nb_bits == 2 && !tq->is_adaptive()) {
+                // 1-bit MSE (nb_bits == 2, uniform mode)
+                size_t byte_size = (dim + 7) / 8;
+
+                if (qb > 0) {
+                    // Integer popcount path
+                    uint64_t and_result = rabitq::bitwise_and_dot_product<SL>(
+                            rearranged_q.data(), mse_code, byte_size, qb);
+                    uint64_t pop = rabitq::popcount<SL>(mse_code, byte_size);
+                    mse_dot = mse_base +
+                            mse_int_scale * static_cast<float>(and_result) +
+                            mse_popcnt_scale * static_cast<float>(pop);
+                } else {
+                    // Float masked_sum path
+                    float masked =
+                            turboq::masked_sum<SL>(q.data(), mse_code, dim);
+                    mse_dot = scaled_centroids[0] * total_q_sum +
+                            delta_centroid * masked;
+                }
+            } else {
+                // Multi-bit or adaptive: scalar bit-plane decoding
+                size_t hi_byte_plane = (hi_dims + 7) / 8;
+
+                for (size_t j = 0; j < hi_dims; j++) {
+                    size_t idx = 0;
+                    for (size_t b = 0; b < mse_bits; b++) {
+                        bool bit = (mse_code[b * hi_byte_plane + j / 8] &
+                                    (1 << (j % 8))) != 0;
+                        if (bit) {
+                            idx |= (size_t(1) << b);
+                        }
+                    }
+                    mse_dot += scaled_centroids[idx] * q[j];
+                }
+
+                // Adaptive lo dimensions
+                if (tq->is_adaptive()) {
+                    const size_t mse_bits_lo_val =
+                            (tq->nb_bits_lo > 1) ? (tq->nb_bits_lo - 1) : 0;
+                    if (mse_bits_lo_val > 0) {
+                        size_t lo_dims = dim - tq->n_hi_dims;
+                        size_t lo_byte_plane = (lo_dims + 7) / 8;
+                        const uint8_t* mse_lo_code =
+                                mse_code + tq->mse_code_size_hi();
+
+                        for (size_t jj = 0; jj < lo_dims; jj++) {
+                            size_t j = tq->n_hi_dims + jj;
+                            size_t idx = 0;
+                            for (size_t b = 0; b < mse_bits_lo_val; b++) {
+                                bool bit =
+                                        (mse_lo_code
+                                                 [b * lo_byte_plane + jj / 8] &
+                                         (1 << (jj % 8))) != 0;
+                                if (bit) {
+                                    idx |= (size_t(1) << b);
+                                }
+                            }
+                            mse_dot += scaled_centroids_lo[idx] * q[j];
+                        }
+                    }
+                }
+            }
+        }
+
+        // Pre-screening: check if MSE-only distance +/- bound can beat
+        // threshold
+        if (threshold_ptr != nullptr) {
+            float bound = qjl_error_coeff * gamma * norm;
+            float mse_ip = norm * mse_dot;
+
+            if (tq->metric_type == MetricType::METRIC_INNER_PRODUCT) {
+                // IP max-heap: threshold is the worst kept result.
+                // Best possible IP = mse_ip + bound.
+                // If best possible <= threshold, can't beat it.
+                if (mse_ip + bound <= *threshold_ptr) {
+                    n_skipped++;
+                    return mse_ip;
+                }
+            } else {
+                // L2 (min-heap): want distance < threshold
+                // best possible = ||q||^2 + norm^2 - 2*(mse_ip + bound)
+                float best_possible =
+                        q_norm_sq + norm * norm - 2.0f * (mse_ip + bound);
+                if (best_possible >= *threshold_ptr) {
+                    n_skipped++;
+                    return q_norm_sq + norm * norm - 2.0f * mse_ip;
+                }
+            }
+        }
+
+        // ============================================================
+        // Stage 2: QJL dot product
+        // ============================================================
+        float qjl_dot = 0.0f;
+        const uint8_t* qjl_code = code + mse_total;
+
+        if (qb > 0 && int_qjl) {
+            // Integer popcount path for QJL
+            size_t byte_size = (dim + 7) / 8;
+            uint64_t and_result = rabitq::bitwise_and_dot_product<SL>(
+                    rearranged_qproj.data(), qjl_code, byte_size, qb);
+            uint64_t pop = rabitq::popcount<SL>(qjl_code, byte_size);
+            qjl_dot = gamma *
+                    (qjl_base + qjl_and_scale * static_cast<float>(and_result) +
+                     qjl_pop_scale * static_cast<float>(pop));
+        } else {
+            // Float masked_sum path
+            float masked = turboq::masked_sum<SL>(q_proj.data(), qjl_code, dim);
+            float raw_dot = 2.0f * masked - total_qproj_sum;
+            qjl_dot = qjl_coeff * gamma * raw_dot;
+        }
+
+        // ============================================================
+        // Combined distance
+        // ============================================================
+        float estimated_ip = norm * (mse_dot + qjl_dot);
+
+        if (tq->metric_type == MetricType::METRIC_INNER_PRODUCT) {
+            return estimated_ip;
+        } else {
+            return q_norm_sq + norm * norm - 2.0f * estimated_ip;
+        }
+    }
+};
+
+} // anonymous namespace
+
+// =========================================================================
+// TurboQDistanceComputer non-template methods
+// =========================================================================
+
+float TurboQDistanceComputer::symmetric_dis(idx_t /*i*/, idx_t /*j*/) {
+    FAISS_THROW_MSG("TurboQ symmetric_dis not implemented");
+}
+
+void TurboQDistanceComputer::set_query(const float* /*x*/) {
+    FAISS_THROW_MSG(
+            "TurboQDistanceComputer::set_query should not be called directly; "
+            "use the templatized implementation");
+}
+
+float TurboQDistanceComputer::distance_to_code(const uint8_t* /*code*/) {
+    FAISS_THROW_MSG(
+            "TurboQDistanceComputer::distance_to_code should not be called "
+            "directly; use the templatized implementation");
+}
+
+FlatCodesDistanceComputer* TurboQuantizer::get_distance_computer() const {
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A0>(
+            [&]<SIMDLevel SL>() -> FlatCodesDistanceComputer* {
+                auto dc = std::make_unique<TurboQDistanceComputerImpl<SL>>();
+                dc->tq = this;
+                dc->codes = nullptr;
+                dc->code_size = code_size;
+                return dc.release();
+            });
+}
+
+} // namespace faiss

--- a/faiss/impl/TurboQuantizer.h
+++ b/faiss/impl/TurboQuantizer.h
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// TurboQuant: Two-stage vector quantizer from ICLR 2026.
+//
+// Reference:
+//   Zandieh, Daliri, Hadian, Mirrokni. "TurboQuant: Online Vector
+//   Quantization with Near-optimal Distortion Rate." ICLR 2026.
+//
+// Algorithm overview (paper Algorithm 2, "TurboQuant_prod"):
+//
+//   Stage 1 (MSE, b-1 bits): Lloyd-Max scalar quantization of the rotated,
+//   normalized vector. Each coordinate is independently quantized using
+//   a codebook optimal for the Beta distribution of random points on the
+//   unit hypersphere (Lemma 1 of paper). In high dimensions this converges
+//   to N(0, 1/d). At b=2 (1-bit MSE), the boundary is at 0 (= sign bit),
+//   identical to RaBitQ's first bit.
+//
+//   Stage 2 (QJL, 1 bit): Quantized Johnson-Lindenstrauss transform of the
+//   Stage 1 residual. A random projection (FWHT or Gaussian) followed by
+//   sign-bit quantization. The QJL paper proves this yields an unbiased
+//   inner product estimator (Lemma 3.2 of Zandieh et al., 2024).
+//
+// The random rotation for variance equalization is handled externally by
+// IndexPreTransform (RR prefix), same as RaBitQ.
+//
+// Code layout per vector:
+//   [MSE hi bit planes][MSE lo bit planes][QJL sign bits][TurboQFactors]
+//
+// Factory strings:
+//   "TurboQ2"    = 2-bit (1-bit MSE + 1-bit QJL), FWHT projection (default)
+//   "TurboQ4"    = 4-bit (3-bit MSE + 1-bit QJL), FWHT projection
+//   "TurboQ2r"   = 2-bit, random rotation projection (QR-orthogonalized)
+//   "TurboQ2.5"  = adaptive: 3-bit hi on d/4 dims, 2-bit lo on rest
+//   "TurboQ3.5"  = adaptive: 4-bit hi on d/2 dims, 3-bit lo on rest
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <faiss/MetricType.h>
+#include <faiss/impl/DistanceComputer.h>
+#include <faiss/impl/Quantizer.h>
+#include <faiss/impl/platform_macros.h>
+
+namespace faiss {
+
+/// QJL projection matrix type for TurboQuant Stage 2.
+enum class QJLProjectionType {
+    FWHT = 0,            ///< SRHT: Hadamard x random signs, O(d log d)
+    RANDOM_ROTATION = 2, ///< Dense random orthogonal matrix (QR of Gaussian)
+};
+
+/// Per-vector correction factors for TurboQ distance computation.
+///
+/// Paper Algorithm 2, lines 7-8:
+///   norm  = ||x||  (for scaling back from unit sphere)
+///   gamma = ||r||  (residual norm, for QJL scaling: sqrt(pi/2)/d * gamma)
+FAISS_PACK_STRUCTS_BEGIN
+struct FAISS_PACKED TurboQFactors {
+    float norm = 0;  ///< ||x|| before normalization
+    float gamma = 0; ///< ||residual|| after MSE quantization
+};
+FAISS_PACK_STRUCTS_END
+
+struct TurboQuantizer : Quantizer {
+    MetricType metric_type = MetricType::METRIC_L2;
+
+    /// Total bits per dimension (1-5).
+    size_t nb_bits = 2;
+
+    /// QJL projection type: FWHT (default), Gaussian, or Random Rotation.
+    QJLProjectionType qjl_type = QJLProjectionType::FWHT;
+
+    /// Seed for random projection matrix generation.
+    uint64_t seed = 42;
+
+    /// Padded dimension for FWHT (next power of 2 >= d).
+    size_t padded_d = 0;
+
+    /// Random signs for FWHT mode (length padded_d).
+    std::vector<float> fwht_signs;
+
+    /// Dense matrix for Random Rotation mode (d x d floats).
+    std::vector<float> gaussian_matrix;
+
+    // --- Lloyd-Max codebook for the MSE stage ---
+    size_t mse_levels = 0;
+    std::vector<float> mse_centroids;
+    std::vector<float> mse_boundaries;
+
+    // --- Adaptive bit width (optional) ---
+    /// Low-precision bits for non-outlier dimensions. 0 = uniform mode.
+    size_t nb_bits_lo = 0;
+    /// Number of outlier (high-precision) dimensions.
+    size_t n_hi_dims = 0;
+    size_t mse_levels_lo = 0;
+    std::vector<float> mse_centroids_lo;
+    std::vector<float> mse_boundaries_lo;
+
+    TurboQuantizer(
+            size_t d = 0,
+            MetricType metric = MetricType::METRIC_L2,
+            size_t nb_bits = 2,
+            QJLProjectionType qjl_type = QJLProjectionType::FWHT,
+            size_t nb_bits_lo = 0,
+            size_t n_hi_dims = 0);
+
+    void train(size_t n, const float* x) override;
+    void compute_codes(const float* x, uint8_t* codes, size_t n) const override;
+    void compute_codes_core(
+            const float* x,
+            uint8_t* codes,
+            size_t n,
+            const float* centroid_in) const;
+    void decode(const uint8_t* codes, float* x, size_t n) const override;
+    void decode_core(
+            const uint8_t* codes,
+            float* x,
+            size_t n,
+            const float* centroid_in) const;
+
+    FlatCodesDistanceComputer* get_distance_computer() const;
+
+    void init_fwht();
+    void init_random_rotation();
+    void init_codebook();
+    void apply_qjl_projection(const float* in, float* out) const;
+
+    bool use_fwht() const {
+        return qjl_type == QJLProjectionType::FWHT;
+    }
+    bool use_dense_matrix() const {
+        return qjl_type != QJLProjectionType::FWHT;
+    }
+    bool is_adaptive() const {
+        return nb_bits_lo > 0;
+    }
+
+    size_t mse_code_size_hi() const {
+        size_t mse_bits = (nb_bits > 1) ? (nb_bits - 1) : 0;
+        size_t hi_dims = is_adaptive() ? n_hi_dims : d;
+        return mse_bits * ((hi_dims + 7) / 8);
+    }
+    size_t mse_code_size_lo() const {
+        if (!is_adaptive())
+            return 0;
+        size_t mse_bits_lo_val = (nb_bits_lo > 1) ? (nb_bits_lo - 1) : 0;
+        size_t lo_dims = d - n_hi_dims;
+        return mse_bits_lo_val * ((lo_dims + 7) / 8);
+    }
+    size_t mse_code_size() const {
+        return mse_code_size_hi() + mse_code_size_lo();
+    }
+    size_t qjl_code_size() const {
+        return (d + 7) / 8;
+    }
+};
+
+/// Distance computer for TurboQ with two-stage pre-screening.
+///
+/// When prescreen is active (threshold_ptr != nullptr), distance_to_code()
+/// computes the cheap MSE component first and checks whether the full
+/// MSE+QJL distance could possibly beat the current threshold. If not,
+/// it returns the MSE-only estimate, skipping the expensive QJL dot product.
+struct TurboQDistanceComputer : FlatCodesDistanceComputer {
+    const TurboQuantizer* tq = nullptr;
+
+    std::vector<float> q;
+    std::vector<float> q_proj;
+    float q_norm_sq = 0;
+    float inv_sqrt_d = 0;
+    float qjl_coeff = 0;
+
+    /// Pre-computed scaled centroids for SIMD accumulation.
+    std::vector<float> scaled_centroids;
+    std::vector<float> scaled_centroids_lo;
+
+    /// Per-query QJL error coefficient for pre-screening.
+    float qjl_error_coeff = 0;
+
+    /// Pointer to current heap threshold for pre-screening.
+    const float* threshold_ptr = nullptr;
+    bool prescreen_l2 = false;
+    mutable size_t n_total = 0;
+    mutable size_t n_skipped = 0;
+
+    /// Pre-computed sums for SIMD masked accumulation.
+    float total_qproj_sum = 0;
+    float total_q_sum = 0;
+    float delta_centroid = 0;
+
+    /// Integer popcount path for 1-bit MSE (qb > 0, nb_bits == 2, uniform).
+    uint8_t qb = 0;
+    std::vector<uint8_t> rearranged_q;
+    float mse_base = 0;
+    float mse_int_scale = 0;
+    float mse_popcnt_scale = 0;
+
+    /// Integer QJL path.
+    bool int_qjl = false;
+    std::vector<uint8_t> rearranged_qproj;
+    float qjl_and_scale = 0;
+    float qjl_pop_scale = 0;
+    float qjl_base = 0;
+
+    float symmetric_dis(idx_t, idx_t) override;
+    void set_query(const float* x) override;
+    float distance_to_code(const uint8_t* code) override;
+};
+
+} // namespace faiss

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -978,7 +978,7 @@ void read_ScalarQuantizer(
     READ1(qtype_int);
     FAISS_THROW_IF_NOT_FMT(
             qtype_int >= ScalarQuantizer::QT_8bit &&
-                    qtype_int <= ScalarQuantizer::QT_8bit_direct_signed,
+                    qtype_int < ScalarQuantizer::QT_count,
             "invalid ScalarQuantizer qtype %d",
             qtype_int);
     ivsc->qtype = static_cast<ScalarQuantizer::QuantizerType>(qtype_int);
@@ -1016,6 +1016,21 @@ void read_ScalarQuantizer(
             case ScalarQuantizer::QT_0bit:
             case ScalarQuantizer::QT_count:
                 expected = 0;
+                break;
+            case ScalarQuantizer::QT_1bit_tqmse:
+                expected = 2 + 1; // 2^bits centroids + (2^bits - 1) boundaries
+                break;
+            case ScalarQuantizer::QT_2bit_tqmse:
+                expected = 4 + 3;
+                break;
+            case ScalarQuantizer::QT_3bit_tqmse:
+                expected = 8 + 7;
+                break;
+            case ScalarQuantizer::QT_4bit_tqmse:
+                expected = 16 + 15;
+                break;
+            case ScalarQuantizer::QT_8bit_tqmse:
+                expected = 256 + 255;
                 break;
         }
         if (ivsc->trained.empty() && expected > 0) {

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -44,6 +44,7 @@
 #include <faiss/IndexIVFRaBitQ.h>
 #include <faiss/IndexIVFRaBitQFastScan.h>
 #include <faiss/IndexIVFSpectralHash.h>
+#include <faiss/IndexIVFTurboQ.h>
 #include <faiss/IndexLSH.h>
 #include <faiss/IndexLattice.h>
 #include <faiss/IndexNNDescent.h>
@@ -2594,6 +2595,45 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         }
 
         idx = std::move(ivrqfs);
+    } else if (h == fourcc("IwTq") || h == fourcc("IwT2")) {
+        auto ivtq = std::make_unique<IndexIVFTurboQ>();
+        read_ivf_header(ivtq.get(), f);
+        auto& tq = ivtq->turboq;
+        READ1(tq.d);
+        READ1(tq.code_size);
+        int metric_type_int;
+        READ1(metric_type_int);
+        tq.metric_type = metric_type_from_int(metric_type_int);
+        READ1(tq.nb_bits);
+        {
+            uint8_t qjl_type_u8;
+            READ1(qjl_type_u8);
+            tq.qjl_type = static_cast<QJLProjectionType>(qjl_type_u8);
+        }
+        READ1(tq.seed);
+        if (h == fourcc("IwT2")) {
+            READ1(tq.nb_bits_lo);
+            READ1(tq.n_hi_dims);
+        }
+        tq.init_codebook();
+        switch (tq.qjl_type) {
+            case QJLProjectionType::FWHT:
+                tq.init_fwht();
+                break;
+            case QJLProjectionType::RANDOM_ROTATION:
+                tq.init_random_rotation();
+                break;
+        }
+        tq.code_size =
+                tq.mse_code_size() + tq.qjl_code_size() + sizeof(TurboQFactors);
+        READ1(ivtq->code_size);
+        READ1(ivtq->by_residual);
+        {
+            uint8_t qb_ignored;
+            READ1(qb_ignored);
+        }
+        read_InvertedLists(*ivtq, f, io_flags);
+        idx = std::move(ivtq);
     } else {
         FAISS_THROW_FMT(
                 "Index type 0x%08x (\"%s\") not recognized",

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -39,6 +39,7 @@
 #include <faiss/IndexIVFRaBitQ.h>
 #include <faiss/IndexIVFRaBitQFastScan.h>
 #include <faiss/IndexIVFSpectralHash.h>
+#include <faiss/IndexIVFTurboQ.h>
 #include <faiss/IndexLSH.h>
 #include <faiss/IndexLattice.h>
 #include <faiss/IndexNNDescent.h>
@@ -1012,6 +1013,33 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
         WRITE1(ivrq->by_residual);
         WRITE1(ivrq->qb);
         write_InvertedLists(ivrq->invlists, f);
+    } else if (
+            const IndexIVFTurboQ* ivtq =
+                    dynamic_cast<const IndexIVFTurboQ*>(idx)) {
+        const auto& tq = ivtq->turboq;
+        uint32_t h = tq.is_adaptive() ? fourcc("IwT2") : fourcc("IwTq");
+        WRITE1(h);
+        write_ivf_header(ivtq, f);
+        WRITE1(tq.d);
+        WRITE1(tq.code_size);
+        WRITE1(tq.metric_type);
+        WRITE1(tq.nb_bits);
+        {
+            uint8_t qjl_type_u8 = static_cast<uint8_t>(tq.qjl_type);
+            WRITE1(qjl_type_u8);
+        }
+        WRITE1(tq.seed);
+        if (tq.is_adaptive()) {
+            WRITE1(tq.nb_bits_lo);
+            WRITE1(tq.n_hi_dims);
+        }
+        WRITE1(ivtq->code_size);
+        WRITE1(ivtq->by_residual);
+        {
+            uint8_t qb_compat = 0;
+            WRITE1(qb_compat);
+        }
+        write_InvertedLists(ivtq->invlists, f);
     }
 #ifdef FAISS_ENABLE_SVS
     else if (

--- a/faiss/impl/scalar_quantizer/quantizers.h
+++ b/faiss/impl/scalar_quantizer/quantizers.h
@@ -7,6 +7,9 @@
 
 #pragma once
 
+#include <algorithm>
+
+#include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/ScalarQuantizer.h>
 #include <faiss/impl/simdlib/simdlib_dispatch.h>
 #include <faiss/utils/bf16.h>
@@ -111,6 +114,90 @@ struct QuantizerTemplate<
         float xi = Codec::decode_component(code, i);
         return vmin[i] + xi * vdiff[i];
     }
+};
+
+/*******************************************************************
+ * TurboQuant MSE quantizer
+ *******************************************************************/
+template <int NBits, SIMDLevel SL>
+struct QuantizerTurboQuantMSE;
+
+template <int NBits>
+struct QuantizerTurboQuantMSE<NBits, SIMDLevel::NONE>
+        : ScalarQuantizer::SQuantizer {
+    static_assert(NBits >= 1 && NBits <= 8);
+
+    static constexpr size_t kCentroidsCount = size_t(1) << NBits;
+    static constexpr uint16_t kIndexMask =
+            static_cast<uint16_t>((1u << NBits) - 1);
+
+    const size_t d;
+    const float* centroids;
+    const float* boundaries;
+
+    QuantizerTurboQuantMSE(size_t d_in, const std::vector<float>& trained)
+            : d(d_in), centroids(nullptr), boundaries(nullptr) {
+        FAISS_THROW_IF_NOT(trained.size() == 2 * kCentroidsCount - 1);
+        centroids = trained.data();
+        boundaries = trained.data() + kCentroidsCount;
+    }
+
+    FAISS_ALWAYS_INLINE uint8_t select_index(float x) const {
+        return static_cast<uint8_t>(
+                std::upper_bound(
+                        boundaries, boundaries + (kCentroidsCount - 1), x) -
+                boundaries);
+    }
+
+    FAISS_ALWAYS_INLINE void encode_index(uint8_t idx, uint8_t* code, size_t i)
+            const {
+        const size_t bit_offset = i * NBits;
+        const size_t byte_offset = bit_offset >> 3;
+        const size_t bit_shift = bit_offset & 7;
+        const uint16_t packed = static_cast<uint16_t>(idx & kIndexMask)
+                << bit_shift;
+        code[byte_offset] |= packed & 0xff;
+        if (bit_shift + NBits > 8) {
+            code[byte_offset + 1] |= packed >> 8;
+        }
+    }
+
+    FAISS_ALWAYS_INLINE uint8_t
+    decode_index(const uint8_t* code, size_t i) const {
+        const size_t bit_offset = i * NBits;
+        const size_t byte_offset = bit_offset >> 3;
+        const size_t bit_shift = bit_offset & 7;
+
+        uint16_t packed = code[byte_offset];
+        if (bit_shift + NBits > 8) {
+            packed |= static_cast<uint16_t>(code[byte_offset + 1]) << 8;
+        }
+        return static_cast<uint8_t>((packed >> bit_shift) & kIndexMask);
+    }
+
+    void encode_vector(const float* x, uint8_t* code) const final {
+        for (size_t i = 0; i < d; i++) {
+            encode_index(select_index(x[i]), code, i);
+        }
+    }
+
+    void decode_vector(const uint8_t* code, float* x) const final {
+        for (size_t i = 0; i < d; i++) {
+            x[i] = centroids[decode_index(code, i)];
+        }
+    }
+
+    FAISS_ALWAYS_INLINE float reconstruct_component(
+            const uint8_t* code,
+            size_t i) const {
+        return centroids[decode_index(code, i)];
+    }
+};
+
+template <int NBits, SIMDLevel SL>
+struct QuantizerTurboQuantMSE : QuantizerTurboQuantMSE<NBits, SIMDLevel::NONE> {
+    using QuantizerTurboQuantMSE<NBits, SIMDLevel::NONE>::
+            QuantizerTurboQuantMSE;
 };
 
 /*******************************************************************

--- a/faiss/impl/scalar_quantizer/sq-avx2.cpp
+++ b/faiss/impl/scalar_quantizer/sq-avx2.cpp
@@ -9,6 +9,8 @@
 
 #include <faiss/impl/simdlib/simdlib_avx2.h>
 
+#include <cstring>
+
 #include <faiss/impl/scalar_quantizer/codecs.h>
 #include <faiss/impl/scalar_quantizer/distance_computers.h>
 #include <faiss/impl/scalar_quantizer/quantizers.h>
@@ -20,6 +22,61 @@ namespace faiss {
 namespace scalar_quantizer {
 
 using simd8float32 = faiss::simd8float32_tpl<SIMDLevel::AVX2>;
+
+namespace {
+
+FAISS_ALWAYS_INLINE uint16_t load_u16(const uint8_t* ptr) {
+    uint16_t value;
+    std::memcpy(&value, ptr, sizeof(value));
+    return value;
+}
+
+FAISS_ALWAYS_INLINE uint32_t load_u32(const uint8_t* ptr) {
+    uint32_t value;
+    std::memcpy(&value, ptr, sizeof(value));
+    return value;
+}
+
+FAISS_ALWAYS_INLINE uint32_t load_u24(const uint8_t* ptr) {
+    return static_cast<uint32_t>(ptr[0]) |
+            (static_cast<uint32_t>(ptr[1]) << 8) |
+            (static_cast<uint32_t>(ptr[2]) << 16);
+}
+
+FAISS_ALWAYS_INLINE __m256i unpack_8x1bit_to_u32(const uint8_t* code, int i) {
+    const uint32_t packed = code[static_cast<size_t>(i) >> 3];
+    const __m256i shifts = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
+    const __m256i indices =
+            _mm256_srlv_epi32(_mm256_set1_epi32(packed), shifts);
+    return _mm256_and_si256(indices, _mm256_set1_epi32(0x1));
+}
+
+FAISS_ALWAYS_INLINE __m256i unpack_8x2bit_to_u32(const uint8_t* code, int i) {
+    const uint32_t packed = load_u16(code + (static_cast<size_t>(i) >> 2));
+    const __m256i shifts = _mm256_setr_epi32(0, 2, 4, 6, 8, 10, 12, 14);
+    const __m256i indices =
+            _mm256_srlv_epi32(_mm256_set1_epi32(packed), shifts);
+    return _mm256_and_si256(indices, _mm256_set1_epi32(0x3));
+}
+
+FAISS_ALWAYS_INLINE __m256i unpack_8x3bit_to_u32(const uint8_t* code, int i) {
+    const uint32_t packed =
+            load_u24(code + ((static_cast<size_t>(i) >> 3) * 3));
+    const __m256i shifts = _mm256_setr_epi32(0, 3, 6, 9, 12, 15, 18, 21);
+    const __m256i indices =
+            _mm256_srlv_epi32(_mm256_set1_epi32(packed), shifts);
+    return _mm256_and_si256(indices, _mm256_set1_epi32(0x7));
+}
+
+FAISS_ALWAYS_INLINE __m256i unpack_8x4bit_to_u32(const uint8_t* code, int i) {
+    const uint32_t packed = load_u32(code + (static_cast<size_t>(i) >> 1));
+    const __m256i shifts = _mm256_setr_epi32(0, 4, 8, 12, 16, 20, 24, 28);
+    const __m256i indices =
+            _mm256_srlv_epi32(_mm256_set1_epi32(packed), shifts);
+    return _mm256_and_si256(indices, _mm256_set1_epi32(0xf));
+}
+
+} // namespace
 
 /**********************************************************
  * Codecs
@@ -165,6 +222,56 @@ struct QuantizerTemplate<
                 xi,
                 _mm256_loadu_ps(this->vdiff + i),
                 _mm256_loadu_ps(this->vmin + i)));
+    }
+};
+
+/**********************************************************
+ * TurboQuant MSE quantizer
+ **********************************************************/
+
+#define DEFINE_TQMSE_AVX2_SPECIALIZATION(NBITS, INDEX_EXPR)                 \
+    template <>                                                             \
+    struct QuantizerTurboQuantMSE<NBITS, SIMDLevel::AVX2>                   \
+            : QuantizerTurboQuantMSE<NBITS, SIMDLevel::NONE> {              \
+        using Base = QuantizerTurboQuantMSE<NBITS, SIMDLevel::NONE>;        \
+                                                                            \
+        QuantizerTurboQuantMSE(size_t d, const std::vector<float>& trained) \
+                : Base(d, trained) {                                        \
+            assert(d % 8 == 0);                                             \
+        }                                                                   \
+                                                                            \
+        FAISS_ALWAYS_INLINE simd8float32                                    \
+        reconstruct_8_components(const uint8_t* code, int i) const {        \
+            const __m256i indices = (INDEX_EXPR);                           \
+            return simd8float32(_mm256_i32gather_ps(                        \
+                    this->centroids, indices, sizeof(float)));              \
+        }                                                                   \
+    }
+
+DEFINE_TQMSE_AVX2_SPECIALIZATION(1, unpack_8x1bit_to_u32(code, i));
+DEFINE_TQMSE_AVX2_SPECIALIZATION(2, unpack_8x2bit_to_u32(code, i));
+DEFINE_TQMSE_AVX2_SPECIALIZATION(3, unpack_8x3bit_to_u32(code, i));
+DEFINE_TQMSE_AVX2_SPECIALIZATION(4, unpack_8x4bit_to_u32(code, i));
+
+#undef DEFINE_TQMSE_AVX2_SPECIALIZATION
+
+template <>
+struct QuantizerTurboQuantMSE<8, SIMDLevel::AVX2>
+        : QuantizerTurboQuantMSE<8, SIMDLevel::NONE> {
+    using Base = QuantizerTurboQuantMSE<8, SIMDLevel::NONE>;
+
+    QuantizerTurboQuantMSE(size_t d, const std::vector<float>& trained)
+            : Base(d, trained) {
+        assert(d % 8 == 0);
+    }
+
+    FAISS_ALWAYS_INLINE simd8float32
+    reconstruct_8_components(const uint8_t* code, int i) const {
+        const __m128i packed = _mm_loadl_epi64(
+                (const __m128i*)(code + static_cast<size_t>(i)));
+        const __m256i indices = _mm256_cvtepu8_epi32(packed);
+        return simd8float32(
+                _mm256_i32gather_ps(this->centroids, indices, sizeof(float)));
     }
 };
 

--- a/faiss/impl/scalar_quantizer/sq-avx512.cpp
+++ b/faiss/impl/scalar_quantizer/sq-avx512.cpp
@@ -9,6 +9,8 @@
 
 #include <faiss/impl/simdlib/simdlib_avx512.h>
 
+#include <cstring>
+
 #include <faiss/impl/scalar_quantizer/codecs.h>
 #include <faiss/impl/scalar_quantizer/distance_computers.h>
 #include <faiss/impl/scalar_quantizer/quantizers.h>
@@ -20,6 +22,81 @@ namespace faiss {
 namespace scalar_quantizer {
 
 using simd16float32 = faiss::simd16float32_tpl<SIMDLevel::AVX512>;
+
+namespace {
+
+FAISS_ALWAYS_INLINE uint16_t load_u16(const uint8_t* ptr) {
+    uint16_t value;
+    std::memcpy(&value, ptr, sizeof(value));
+    return value;
+}
+
+FAISS_ALWAYS_INLINE uint32_t load_u32(const uint8_t* ptr) {
+    uint32_t value;
+    std::memcpy(&value, ptr, sizeof(value));
+    return value;
+}
+
+FAISS_ALWAYS_INLINE uint64_t load_u64(const uint8_t* ptr) {
+    uint64_t value;
+    std::memcpy(&value, ptr, sizeof(value));
+    return value;
+}
+
+FAISS_ALWAYS_INLINE uint32_t load_u24(const uint8_t* ptr) {
+    return static_cast<uint32_t>(ptr[0]) |
+            (static_cast<uint32_t>(ptr[1]) << 8) |
+            (static_cast<uint32_t>(ptr[2]) << 16);
+}
+
+FAISS_ALWAYS_INLINE __m256i unpack_8x3bit_to_u32(uint32_t packed) {
+    const __m256i shifts = _mm256_setr_epi32(0, 3, 6, 9, 12, 15, 18, 21);
+    const __m256i indices =
+            _mm256_srlv_epi32(_mm256_set1_epi32(packed), shifts);
+    return _mm256_and_si256(indices, _mm256_set1_epi32(0x7));
+}
+
+FAISS_ALWAYS_INLINE __m512i unpack_16x1bit_to_u32(const uint8_t* code, int i) {
+    const uint32_t packed = load_u16(code + (static_cast<size_t>(i) >> 3));
+    const __m512i shifts = _mm512_setr_epi32(
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    const __m512i indices =
+            _mm512_srlv_epi32(_mm512_set1_epi32(packed), shifts);
+    return _mm512_and_si512(indices, _mm512_set1_epi32(0x1));
+}
+
+FAISS_ALWAYS_INLINE __m512i unpack_16x2bit_to_u32(const uint8_t* code, int i) {
+    const uint32_t packed = load_u32(code + (static_cast<size_t>(i) >> 2));
+    const __m512i shifts = _mm512_setr_epi32(
+            0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30);
+    const __m512i indices =
+            _mm512_srlv_epi32(_mm512_set1_epi32(packed), shifts);
+    return _mm512_and_si512(indices, _mm512_set1_epi32(0x3));
+}
+
+FAISS_ALWAYS_INLINE __m512i unpack_16x3bit_to_u32(const uint8_t* code, int i) {
+    const size_t byte_offset = (static_cast<size_t>(i) >> 4) * 6;
+    const __m256i low = unpack_8x3bit_to_u32(load_u24(code + byte_offset));
+    const __m256i high = unpack_8x3bit_to_u32(load_u24(code + byte_offset + 3));
+    __m512i indices = _mm512_castsi256_si512(low);
+    return _mm512_inserti32x8(indices, high, 1);
+}
+
+FAISS_ALWAYS_INLINE __m512i unpack_16x4bit_to_u32(const uint8_t* code, int i) {
+    const uint64_t packed = load_u64(code + (static_cast<size_t>(i) >> 1));
+    const __m256i shifts = _mm256_setr_epi32(0, 4, 8, 12, 16, 20, 24, 28);
+    const __m256i low = _mm256_and_si256(
+            _mm256_srlv_epi32(_mm256_set1_epi32((uint32_t)packed), shifts),
+            _mm256_set1_epi32(0xf));
+    const __m256i high = _mm256_and_si256(
+            _mm256_srlv_epi32(
+                    _mm256_set1_epi32((uint32_t)(packed >> 32)), shifts),
+            _mm256_set1_epi32(0xf));
+    __m512i indices = _mm512_castsi256_si512(low);
+    return _mm512_inserti32x8(indices, high, 1);
+}
+
+} // namespace
 
 /**********************************************************
  * Codecs
@@ -163,6 +240,56 @@ struct QuantizerTemplate<
                 xi,
                 _mm512_loadu_ps(this->vdiff + i),
                 _mm512_loadu_ps(this->vmin + i)));
+    }
+};
+
+/**********************************************************
+ * TurboQuant MSE quantizer
+ **********************************************************/
+
+#define DEFINE_TQMSE_AVX512_SPECIALIZATION(NBITS, INDEX_EXPR)               \
+    template <>                                                             \
+    struct QuantizerTurboQuantMSE<NBITS, SIMDLevel::AVX512>                 \
+            : QuantizerTurboQuantMSE<NBITS, SIMDLevel::NONE> {              \
+        using Base = QuantizerTurboQuantMSE<NBITS, SIMDLevel::NONE>;        \
+                                                                            \
+        QuantizerTurboQuantMSE(size_t d, const std::vector<float>& trained) \
+                : Base(d, trained) {                                        \
+            assert(d % 16 == 0);                                            \
+        }                                                                   \
+                                                                            \
+        FAISS_ALWAYS_INLINE simd16float32                                   \
+        reconstruct_16_components(const uint8_t* code, int i) const {       \
+            const __m512i indices = (INDEX_EXPR);                           \
+            return simd16float32(_mm512_i32gather_ps(                       \
+                    indices, this->centroids, sizeof(float)));              \
+        }                                                                   \
+    }
+
+DEFINE_TQMSE_AVX512_SPECIALIZATION(1, unpack_16x1bit_to_u32(code, i));
+DEFINE_TQMSE_AVX512_SPECIALIZATION(2, unpack_16x2bit_to_u32(code, i));
+DEFINE_TQMSE_AVX512_SPECIALIZATION(3, unpack_16x3bit_to_u32(code, i));
+DEFINE_TQMSE_AVX512_SPECIALIZATION(4, unpack_16x4bit_to_u32(code, i));
+
+#undef DEFINE_TQMSE_AVX512_SPECIALIZATION
+
+template <>
+struct QuantizerTurboQuantMSE<8, SIMDLevel::AVX512>
+        : QuantizerTurboQuantMSE<8, SIMDLevel::NONE> {
+    using Base = QuantizerTurboQuantMSE<8, SIMDLevel::NONE>;
+
+    QuantizerTurboQuantMSE(size_t d, const std::vector<float>& trained)
+            : Base(d, trained) {
+        assert(d % 16 == 0);
+    }
+
+    FAISS_ALWAYS_INLINE simd16float32
+    reconstruct_16_components(const uint8_t* code, int i) const {
+        const __m128i packed = _mm_loadu_si128(
+                (const __m128i*)(code + static_cast<size_t>(i)));
+        const __m512i indices = _mm512_cvtepu8_epi32(packed);
+        return simd16float32(
+                _mm512_i32gather_ps(indices, this->centroids, sizeof(float)));
     }
 };
 

--- a/faiss/impl/scalar_quantizer/sq-dispatch.h
+++ b/faiss/impl/scalar_quantizer/sq-dispatch.h
@@ -88,6 +88,16 @@ ScalarQuantizer::SQuantizer* sq_select_quantizer<THE_LEVEL_TO_DISPATCH>(
         case ScalarQuantizer::QT_0bit:
             FAISS_THROW_MSG(
                     "QT_0bit does not support standalone quantization, use IndexIVFScalarQuantizer");
+        case ScalarQuantizer::QT_1bit_tqmse:
+            return new QuantizerTurboQuantMSE<1, SL>(d, trained);
+        case ScalarQuantizer::QT_2bit_tqmse:
+            return new QuantizerTurboQuantMSE<2, SL>(d, trained);
+        case ScalarQuantizer::QT_3bit_tqmse:
+            return new QuantizerTurboQuantMSE<3, SL>(d, trained);
+        case ScalarQuantizer::QT_4bit_tqmse:
+            return new QuantizerTurboQuantMSE<4, SL>(d, trained);
+        case ScalarQuantizer::QT_8bit_tqmse:
+            return new QuantizerTurboQuantMSE<8, SL>(d, trained);
         default:
             FAISS_THROW_MSG("unknown qtype");
     }
@@ -181,6 +191,21 @@ SQDistanceComputer* select_distance_computer_body(
         case ScalarQuantizer::QT_0bit:
             FAISS_THROW_MSG(
                     "QT_0bit does not support standalone distance computation, use IndexIVFScalarQuantizer");
+        case ScalarQuantizer::QT_1bit_tqmse:
+            return new DCTemplate<QuantizerTurboQuantMSE<1, SL2>, Sim, SL2>(
+                    d, trained);
+        case ScalarQuantizer::QT_2bit_tqmse:
+            return new DCTemplate<QuantizerTurboQuantMSE<2, SL2>, Sim, SL2>(
+                    d, trained);
+        case ScalarQuantizer::QT_3bit_tqmse:
+            return new DCTemplate<QuantizerTurboQuantMSE<3, SL2>, Sim, SL2>(
+                    d, trained);
+        case ScalarQuantizer::QT_4bit_tqmse:
+            return new DCTemplate<QuantizerTurboQuantMSE<4, SL2>, Sim, SL2>(
+                    d, trained);
+        case ScalarQuantizer::QT_8bit_tqmse:
+            return new DCTemplate<QuantizerTurboQuantMSE<8, SL2>, Sim, SL2>(
+                    d, trained);
         default:
             FAISS_THROW_MSG("unknown qtype");
     }
@@ -318,6 +343,31 @@ InvertedListScanner* sq_select_InvertedListScanner<THE_LEVEL_TO_DISPATCH>(
             case ScalarQuantizer::QT_0bit:
                 return new IVFCoarseDistanceScanner(
                         Similarity::metric_type != METRIC_L2, store_pairs, sel);
+            case ScalarQuantizer::QT_1bit_tqmse:
+                return scan.template operator()<DCTemplate<
+                        QuantizerTurboQuantMSE<1, SL2>,
+                        Similarity,
+                        SL2>>();
+            case ScalarQuantizer::QT_2bit_tqmse:
+                return scan.template operator()<DCTemplate<
+                        QuantizerTurboQuantMSE<2, SL2>,
+                        Similarity,
+                        SL2>>();
+            case ScalarQuantizer::QT_3bit_tqmse:
+                return scan.template operator()<DCTemplate<
+                        QuantizerTurboQuantMSE<3, SL2>,
+                        Similarity,
+                        SL2>>();
+            case ScalarQuantizer::QT_4bit_tqmse:
+                return scan.template operator()<DCTemplate<
+                        QuantizerTurboQuantMSE<4, SL2>,
+                        Similarity,
+                        SL2>>();
+            case ScalarQuantizer::QT_8bit_tqmse:
+                return scan.template operator()<DCTemplate<
+                        QuantizerTurboQuantMSE<8, SL2>,
+                        Similarity,
+                        SL2>>();
             default:
                 FAISS_THROW_MSG("unknown qtype");
         }

--- a/faiss/impl/scalar_quantizer/sq-neon.cpp
+++ b/faiss/impl/scalar_quantizer/sq-neon.cpp
@@ -9,6 +9,8 @@
 
 #include <faiss/impl/simdlib/simdlib_neon.h>
 
+#include <cstring>
+
 #include <faiss/impl/scalar_quantizer/codecs.h>
 #include <faiss/impl/scalar_quantizer/distance_computers.h>
 #include <faiss/impl/scalar_quantizer/quantizers.h>
@@ -20,6 +22,79 @@ namespace faiss {
 namespace scalar_quantizer {
 
 using simd8float32 = faiss::simd8float32_tpl<SIMDLevel::ARM_NEON>;
+
+namespace {
+
+FAISS_ALWAYS_INLINE uint16_t load_u16(const uint8_t* ptr) {
+    uint16_t value;
+    std::memcpy(&value, ptr, sizeof(value));
+    return value;
+}
+
+FAISS_ALWAYS_INLINE uint32_t load_u32(const uint8_t* ptr) {
+    uint32_t value;
+    std::memcpy(&value, ptr, sizeof(value));
+    return value;
+}
+
+FAISS_ALWAYS_INLINE uint32_t load_u24(const uint8_t* ptr) {
+    return static_cast<uint32_t>(ptr[0]) |
+            (static_cast<uint32_t>(ptr[1]) << 8) |
+            (static_cast<uint32_t>(ptr[2]) << 16);
+}
+
+FAISS_ALWAYS_INLINE void unpack_8x1bit_to_u8(
+        const uint8_t* code,
+        int i,
+        uint8_t out[8]) {
+    const uint8_t packed = code[static_cast<size_t>(i) >> 3];
+    for (size_t j = 0; j < 8; ++j) {
+        out[j] = (packed >> j) & 0x1;
+    }
+}
+
+FAISS_ALWAYS_INLINE void unpack_8x2bit_to_u8(
+        const uint8_t* code,
+        int i,
+        uint8_t out[8]) {
+    const uint16_t packed = load_u16(code + (static_cast<size_t>(i) >> 2));
+    for (size_t j = 0; j < 8; ++j) {
+        out[j] = (packed >> (2 * j)) & 0x3;
+    }
+}
+
+FAISS_ALWAYS_INLINE void unpack_8x3bit_to_u8(
+        const uint8_t* code,
+        int i,
+        uint8_t out[8]) {
+    const uint32_t packed =
+            load_u24(code + ((static_cast<size_t>(i) >> 3) * 3));
+    for (size_t j = 0; j < 8; ++j) {
+        out[j] = (packed >> (3 * j)) & 0x7;
+    }
+}
+
+FAISS_ALWAYS_INLINE void unpack_8x4bit_to_u8(
+        const uint8_t* code,
+        int i,
+        uint8_t out[8]) {
+    const uint32_t packed = load_u32(code + (static_cast<size_t>(i) >> 1));
+    for (size_t j = 0; j < 8; ++j) {
+        out[j] = (packed >> (4 * j)) & 0xf;
+    }
+}
+
+FAISS_ALWAYS_INLINE simd8float32
+gather_8_components(const float* codebook, const uint8_t indices[8]) {
+    float result[8];
+    for (size_t j = 0; j < 8; ++j) {
+        result[j] = codebook[indices[j]];
+    }
+    return simd8float32(
+            float32x4x2_t{vld1q_f32(result), vld1q_f32(result + 4)});
+}
+
+} // namespace
 
 /**********************************************************
  * Codecs
@@ -137,6 +212,54 @@ struct QuantizerTemplate<
                                 vld1q_f32(this->vmin + i + 4),
                                 xi.data.val[1],
                                 vld1q_f32(this->vdiff + i + 4))});
+    }
+};
+
+/**********************************************************
+ * TurboQuant MSE quantizer
+ **********************************************************/
+
+#define DEFINE_TQMSE_NEON_SPECIALIZATION(NBITS, UNPACK_FN)                  \
+    template <>                                                             \
+    struct QuantizerTurboQuantMSE<NBITS, SIMDLevel::ARM_NEON>               \
+            : QuantizerTurboQuantMSE<NBITS, SIMDLevel::NONE> {              \
+        using Base = QuantizerTurboQuantMSE<NBITS, SIMDLevel::NONE>;        \
+                                                                            \
+        QuantizerTurboQuantMSE(size_t d, const std::vector<float>& trained) \
+                : Base(d, trained) {                                        \
+            assert(d % 8 == 0);                                             \
+        }                                                                   \
+                                                                            \
+        FAISS_ALWAYS_INLINE simd8float32                                    \
+        reconstruct_8_components(const uint8_t* code, int i) const {        \
+            uint8_t indices[8];                                             \
+            UNPACK_FN(code, i, indices);                                    \
+            return gather_8_components(this->centroids, indices);           \
+        }                                                                   \
+    }
+
+DEFINE_TQMSE_NEON_SPECIALIZATION(1, unpack_8x1bit_to_u8);
+DEFINE_TQMSE_NEON_SPECIALIZATION(2, unpack_8x2bit_to_u8);
+DEFINE_TQMSE_NEON_SPECIALIZATION(3, unpack_8x3bit_to_u8);
+DEFINE_TQMSE_NEON_SPECIALIZATION(4, unpack_8x4bit_to_u8);
+
+#undef DEFINE_TQMSE_NEON_SPECIALIZATION
+
+template <>
+struct QuantizerTurboQuantMSE<8, SIMDLevel::ARM_NEON>
+        : QuantizerTurboQuantMSE<8, SIMDLevel::NONE> {
+    using Base = QuantizerTurboQuantMSE<8, SIMDLevel::NONE>;
+
+    QuantizerTurboQuantMSE(size_t d, const std::vector<float>& trained)
+            : Base(d, trained) {
+        assert(d % 8 == 0);
+    }
+
+    FAISS_ALWAYS_INLINE simd8float32
+    reconstruct_8_components(const uint8_t* code, int i) const {
+        uint8_t indices[8];
+        std::memcpy(indices, code + static_cast<size_t>(i), sizeof(indices));
+        return gather_8_components(this->centroids, indices);
     }
 };
 

--- a/faiss/impl/scalar_quantizer/training.cpp
+++ b/faiss/impl/scalar_quantizer/training.cpp
@@ -22,6 +22,190 @@ static float sqr(float x) {
     return x * x;
 }
 
+constexpr size_t kTurboQuantMaxBits = 8;
+// TurboQuant builds a 1-D optimal scalar quantizer analytically. We approximate
+// the target density on a uniform grid over [-1, 1]; the grid is kept dense
+// enough both in absolute terms and per output centroid.
+constexpr size_t kTurboQuantGridMin = 1 << 15;
+constexpr size_t kTurboQuantGridPerCentroid = 512;
+constexpr int kTurboQuantMaxIter = 100;
+constexpr double kTurboQuantTol = 1e-8;
+
+void build_TurboQuantMSECodebook(
+        size_t d,
+        size_t nbits,
+        std::vector<float>& centroids,
+        std::vector<float>& boundaries) {
+    FAISS_THROW_IF_NOT_FMT(
+            nbits <= kTurboQuantMaxBits,
+            "invalid TurboQuant nbits %zu (must be in [0, %zu])",
+            nbits,
+            kTurboQuantMaxBits);
+
+    if (nbits == 0) {
+        centroids.clear();
+        boundaries.clear();
+        return;
+    }
+
+    const size_t k = size_t(1) << nbits;
+
+    if (d == 1) {
+        // In 1-D, a unit vector can only be -1 or +1, so the marginal
+        // distribution collapses to two atoms. The TurboQuant codebook is
+        // therefore a repeated pair of endpoint centroids.
+        centroids.resize(k);
+        for (size_t i = 0; i < k; i++) {
+            centroids[i] = i < k / 2 ? -1.0f : 1.0f;
+        }
+        boundaries.resize(k - 1);
+        for (size_t i = 0; i + 1 < k; i++) {
+            boundaries[i] = 0.5f * (centroids[i] + centroids[i + 1]);
+        }
+        return;
+    }
+
+    // For d > 1, TurboQuant uses the marginal distribution of one coordinate of
+    // a random unit vector in R^d. On [-1, 1], this density is proportional to
+    // (1 - x^2)^((d - 3) / 2), which is a symmetric beta-law after a change of
+    // variables. The code below discretizes that density.
+    const size_t ngrid =
+            std::max(kTurboQuantGridMin, k * kTurboQuantGridPerCentroid);
+    const double step = 2.0 / ngrid;
+    const double alpha = 0.5 * (double(d) - 3.0);
+
+    std::vector<double> xs(ngrid);
+    // prefix_w stores the cumulative mass of the discretized density and
+    // prefix_wx stores its cumulative first moment, so interval means can be
+    // recovered in O(1).
+    std::vector<double> prefix_w(ngrid + 1, 0.0);
+    std::vector<double> prefix_wx(ngrid + 1, 0.0);
+
+    for (size_t i = 0; i < ngrid; i++) {
+        const double x = -1.0 + (i + 0.5) * step;
+        const double one_minus_x2 = std::max(0.0, 1.0 - x * x);
+        double w;
+        if (alpha == 0.0) { // when d == 3
+            w = 1.0;
+        } else {
+            // (1-x^2)^((d-3)/2)
+            w = std::pow(one_minus_x2, alpha);
+        }
+        if (!std::isfinite(w) || w < 0.0) {
+            w = 0.0;
+        }
+        xs[i] = x;
+        prefix_w[i + 1] = prefix_w[i] + w;
+        prefix_wx[i + 1] = prefix_wx[i] + w * x;
+    }
+
+    auto range_mean = [&](size_t i0, size_t i1, double fallback) {
+        const double w = prefix_w[i1] - prefix_w[i0];
+        if (w <= 0.0) {
+            return fallback;
+        }
+        return (prefix_wx[i1] - prefix_wx[i0]) / w;
+    };
+
+    const double total_w = prefix_w.back();
+    std::vector<size_t> cuts(k + 1, 0);
+    cuts[k] = ngrid;
+
+    // Initialize with k equal-mass cells under the target density. This gives
+    // a stable starting point before the Lloyd refinements below.
+    for (size_t i = 1; i < k; i++) {
+        const double target = total_w * i / k;
+        cuts[i] = std::lower_bound(prefix_w.begin(), prefix_w.end(), target) -
+                prefix_w.begin();
+        cuts[i] = std::min(cuts[i], ngrid);
+    }
+
+    std::vector<double> centroids_d(k);
+    for (size_t i = 0; i < k; i++) {
+        const double left = -1.0 + 2.0 * i / k;
+        const double right = -1.0 + 2.0 * (i + 1) / k;
+        // First estimate of each centroid: the conditional mean of its initial
+        // equal-mass cell, with a uniform-cell midpoint as a fallback.
+        centroids_d[i] = range_mean(cuts[i], cuts[i + 1], 0.5 * (left + right));
+    }
+
+    std::vector<double> boundaries_d(k > 0 ? k - 1 : 0);
+
+    // Refine the 1-D codebook with a weighted Lloyd iteration over the
+    // discretized marginal density on [-1, 1]:
+    // 1. boundaries_d are the Voronoi separators implied by neighboring
+    //    centroids.
+    // 2. cuts map each boundary interval back to a contiguous range of the
+    //    integration grid xs[].
+    // 3. each centroid becomes the weighted mean of the samples currently in
+    //    its cell, clipped to stay within its neighboring boundaries.
+    //
+    // The loop stops once the largest centroid update is below kTurboQuantTol.
+    for (int iter = 0; iter < kTurboQuantMaxIter; iter++) {
+        // Midpoints between adjacent centroids define the current Voronoi
+        // partition of [-1, 1].
+        for (size_t i = 0; i + 1 < k; i++) {
+            boundaries_d[i] = 0.5 * (centroids_d[i] + centroids_d[i + 1]);
+        }
+
+        cuts[0] = 0;
+        cuts[k] = ngrid;
+        // Reassign the discretized density samples to the Voronoi cell induced
+        // by each boundary. Because xs is sorted, the reassignment reduces to
+        // finding the first grid point strictly greater than each boundary.
+        for (size_t i = 1; i < k; i++) {
+            cuts[i] = std::upper_bound(
+                              xs.begin(), xs.end(), boundaries_d[i - 1]) -
+                    xs.begin();
+        }
+
+        double max_delta = 0.0;
+        for (size_t i = 0; i < k; i++) {
+            const double left = i == 0 ? -1.0 : boundaries_d[i - 1];
+            const double right = i + 1 == k ? 1.0 : boundaries_d[i];
+            // Lloyd update: replace the centroid with the weighted average of
+            // the mass assigned to its cell. Empty cells fall back to the cell
+            // midpoint, and we clamp to [left, right] to preserve ordering.
+            double c = range_mean(cuts[i], cuts[i + 1], 0.5 * (left + right));
+            c = std::min(std::max(c, left), right);
+            max_delta = std::max(max_delta, std::abs(c - centroids_d[i]));
+            centroids_d[i] = c;
+        }
+
+        if (max_delta < kTurboQuantTol) {
+            break;
+        }
+    }
+
+    std::sort(centroids_d.begin(), centroids_d.end());
+
+    centroids.resize(k);
+    boundaries.resize(k - 1);
+    for (size_t i = 0; i < k; i++) {
+        centroids[i] = centroids_d[i];
+    }
+    for (size_t i = 0; i + 1 < k; i++) {
+        boundaries[i] = 0.5f * (centroids[i] + centroids[i + 1]);
+    }
+}
+
+void train_TurboQuantMSE(size_t d, size_t nbits, std::vector<float>& trained) {
+    FAISS_THROW_IF_NOT_FMT(
+            nbits > 0, "invalid TurboQuant SQ nbits %zu (must be > 0)", nbits);
+    std::vector<float> centroids;
+    std::vector<float> boundaries;
+    build_TurboQuantMSECodebook(d, nbits, centroids, boundaries);
+    const size_t k = centroids.size();
+
+    trained.resize(k + (k - 1));
+    for (size_t i = 0; i < k; i++) {
+        trained[i] = centroids[i];
+    }
+    for (size_t i = 0; i + 1 < k; i++) {
+        trained[k + i] = boundaries[i];
+    }
+}
+
 void train_Uniform(
         RangeStat rs,
         float rs_arg,

--- a/faiss/impl/scalar_quantizer/training.h
+++ b/faiss/impl/scalar_quantizer/training.h
@@ -37,6 +37,18 @@ void train_NonUniform(
         int k,
         const float* x,
         std::vector<float>& trained);
+
+/** Build the TurboQuant MSE codebook using the beta-distribution-optimal
+ *  quantizer from the TurboQuant paper. The codebook is analytical
+ *  (depends only on d and nbits, no training data needed).
+ *
+ *  @param d         vector dimensionality (used for beta-distribution shape)
+ *  @param nbits     bits per component (1-8)
+ *  @param trained   output: [centroids (k floats), boundaries (k-1 floats)]
+ *                   where k = 2^nbits
+ */
+void train_TurboQuantMSE(size_t d, size_t nbits, std::vector<float>& trained);
+
 } // namespace scalar_quantizer
 
 } // namespace faiss

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -155,9 +155,14 @@ std::map<std::string, ScalarQuantizer::QuantizerType> sq_types = {
         {"SQ8_direct_signed", ScalarQuantizer::QT_8bit_direct_signed},
         {"SQ8_direct", ScalarQuantizer::QT_8bit_direct},
         {"SQ0", ScalarQuantizer::QT_0bit},
+        {"SQtqmse1", ScalarQuantizer::QT_1bit_tqmse},
+        {"SQtqmse2", ScalarQuantizer::QT_2bit_tqmse},
+        {"SQtqmse3", ScalarQuantizer::QT_3bit_tqmse},
+        {"SQtqmse4", ScalarQuantizer::QT_4bit_tqmse},
+        {"SQtqmse8", ScalarQuantizer::QT_8bit_tqmse},
 };
 const std::string sq_pattern =
-        "(SQ0|SQ4|SQ8|SQ6|SQfp16|SQbf16|SQ8_direct_signed|SQ8_direct)";
+        "(SQ0|SQ4|SQ8|SQ6|SQfp16|SQbf16|SQ8_direct_signed|SQ8_direct|SQtqmse1|SQtqmse2|SQtqmse3|SQtqmse4|SQtqmse8)";
 
 std::map<std::string, AdditiveQuantizer::Search_type_t> aq_search_type = {
         {"_Nfloat", AdditiveQuantizer::ST_norm_float},

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -34,6 +34,7 @@
 #include <faiss/IndexIVFRaBitQ.h>
 #include <faiss/IndexIVFRaBitQFastScan.h>
 #include <faiss/IndexIVFSpectralHash.h>
+#include <faiss/IndexIVFTurboQ.h>
 #include <faiss/IndexLSH.h>
 #include <faiss/IndexLattice.h>
 #include <faiss/IndexNSG.h>
@@ -490,6 +491,54 @@ IndexIVF* parse_IndexIVF(
         return new IndexIVFRaBitQFastScan(
                 get_q(), d, nlist, mt, bbs, own_il, nb_bits);
     }
+    // IndexIVFTurboQ: adaptive bit widths
+    if (match("TurboQ2\\.5")) {
+        return new IndexIVFTurboQ(
+                get_q(),
+                d,
+                nlist,
+                mt,
+                own_il,
+                3,
+                QJLProjectionType::FWHT,
+                2,
+                d / 4);
+    }
+    if (match("TurboQ3\\.5")) {
+        return new IndexIVFTurboQ(
+                get_q(),
+                d,
+                nlist,
+                mt,
+                own_il,
+                4,
+                QJLProjectionType::FWHT,
+                3,
+                d / 2);
+    }
+    // IndexIVFTurboQ: suffixed variants (check before default)
+    if (match("TurboQ([1-9])r")) {
+        uint8_t nb_bits = std::stoi(sm[1].str());
+        return new IndexIVFTurboQ(
+                get_q(),
+                d,
+                nlist,
+                mt,
+                own_il,
+                nb_bits,
+                QJLProjectionType::RANDOM_ROTATION);
+    }
+    if (match("TurboQ([1-9])?")) {
+        uint8_t nb_bits = sm[1].length() > 0 ? std::stoi(sm[1].str()) : 2;
+        return new IndexIVFTurboQ(
+                get_q(),
+                d,
+                nlist,
+                mt,
+                own_il,
+                nb_bits,
+                QJLProjectionType::FWHT);
+    }
     return nullptr;
 }
 
@@ -858,6 +907,66 @@ Index* parse_other_indexes(
         uint8_t nb_bits = sm[1].length() > 0 ? std::stoi(sm[1].str()) : 1;
         int bbs = mres_to_int(sm[2], 32, 1);
         return new IndexRaBitQFastScan(d, metric, bbs, nb_bits);
+    }
+
+    // Standalone TurboQ (wraps in IVF1)
+    if (match("TurboQ2\\.5")) {
+        auto* quantizer = new IndexFlat(d, metric);
+        auto* idx = new IndexIVFTurboQ(
+                quantizer,
+                d,
+                1,
+                metric,
+                true,
+                3,
+                QJLProjectionType::FWHT,
+                2,
+                d / 4);
+        idx->own_fields = true;
+        return idx;
+    }
+    if (match("TurboQ3\\.5")) {
+        auto* quantizer = new IndexFlat(d, metric);
+        auto* idx = new IndexIVFTurboQ(
+                quantizer,
+                d,
+                1,
+                metric,
+                true,
+                4,
+                QJLProjectionType::FWHT,
+                3,
+                d / 2);
+        idx->own_fields = true;
+        return idx;
+    }
+    if (match("TurboQ([1-9])r")) {
+        uint8_t nb_bits = std::stoi(sm[1].str());
+        auto* quantizer = new IndexFlat(d, metric);
+        auto* idx = new IndexIVFTurboQ(
+                quantizer,
+                d,
+                1,
+                metric,
+                true,
+                nb_bits,
+                QJLProjectionType::RANDOM_ROTATION);
+        idx->own_fields = true;
+        return idx;
+    }
+    if (match("TurboQ([1-9])?")) {
+        uint8_t nb_bits = sm[1].length() > 0 ? std::stoi(sm[1].str()) : 2;
+        auto* quantizer = new IndexFlat(d, metric);
+        auto* idx = new IndexIVFTurboQ(
+                quantizer,
+                d,
+                1,
+                metric,
+                true,
+                nb_bits,
+                QJLProjectionType::FWHT);
+        idx->own_fields = true;
+        return idx;
     }
 
     return nullptr;

--- a/faiss/python/__init__.pyi
+++ b/faiss/python/__init__.pyi
@@ -1335,6 +1335,11 @@ class ScalarQuantizer(Quantizer):
     QT_6bit: int
     QT_bf16: int
     QT_8bit_direct_signed: int
+    QT_1bit_tqmse: int
+    QT_2bit_tqmse: int
+    QT_3bit_tqmse: int
+    QT_4bit_tqmse: int
+    QT_8bit_tqmse: int
 
     # RangeStat constants (as class attributes)
     RS_minmax: int

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -208,6 +208,8 @@ typedef uint64_t size_t;
 #include <faiss/IndexRaBitQFastScan.h>
 #include <faiss/IndexIVFRaBitQ.h>
 #include <faiss/IndexIVFRaBitQFastScan.h>
+#include <faiss/impl/TurboQuantizer.h>
+#include <faiss/IndexIVFTurboQ.h>
 
 #ifdef FAISS_ENABLE_SVS
 #include <faiss/svs/IndexSVSVamana.h>
@@ -674,6 +676,8 @@ void gpu_sync_all_devices()
 %include <faiss/IndexRaBitQFastScan.h>
 %include <faiss/IndexIVFRaBitQ.h>
 %include <faiss/IndexIVFRaBitQFastScan.h>
+%include <faiss/impl/TurboQuantizer.h>
+%include <faiss/IndexIVFTurboQ.h>
 
 %ignore faiss::BufferList::Buffer;
 %ignore faiss::RangeSearchPartialResult::QueryResult;
@@ -780,6 +784,7 @@ void gpu_sync_all_devices()
     DOWNCAST ( IndexRaBitQ )
     DOWNCAST ( IndexIVFRaBitQ )
     DOWNCAST ( IndexIVFRaBitQFastScan )
+    DOWNCAST ( IndexIVFTurboQ )
     DOWNCAST ( IndexIVFIndependentQuantizer)
     DOWNCAST ( IndexIVFPQR )
     DOWNCAST ( IndexIVFPQ )

--- a/faiss/utils/simd_impl/turboq_avx2.cpp
+++ b/faiss/utils/simd_impl/turboq_avx2.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifdef COMPILE_SIMD_AVX2
+
+#include <faiss/utils/turboq_simd.h>
+#include <immintrin.h>
+
+namespace faiss::turboq {
+
+template <>
+float masked_sum<SIMDLevel::AVX2>(
+        const float* arr,
+        const uint8_t* bits,
+        size_t d) {
+    const __m256i bit_masks = _mm256_set_epi32(128, 64, 32, 16, 8, 4, 2, 1);
+    __m256 acc = _mm256_setzero_ps();
+
+    size_t full_bytes = d / 8;
+    for (size_t byte_idx = 0; byte_idx < full_bytes; byte_idx++) {
+        __m256i byte_broadcast =
+                _mm256_set1_epi32(static_cast<int>(bits[byte_idx]));
+        __m256i masked = _mm256_and_si256(byte_broadcast, bit_masks);
+        __m256i cmp = _mm256_cmpeq_epi32(masked, bit_masks);
+        __m256 mask = _mm256_castsi256_ps(cmp);
+        __m256 vals = _mm256_loadu_ps(arr + byte_idx * 8);
+        acc = _mm256_add_ps(acc, _mm256_and_ps(mask, vals));
+    }
+
+    // Horizontal sum
+    __m128 hi = _mm256_extractf128_ps(acc, 1);
+    __m128 lo = _mm256_castps256_ps128(acc);
+    __m128 sum128 = _mm_add_ps(lo, hi);
+    __m128 shuf = _mm_movehdup_ps(sum128);
+    __m128 sums = _mm_add_ps(sum128, shuf);
+    shuf = _mm_movehl_ps(shuf, sums);
+    sums = _mm_add_ss(sums, shuf);
+    float result = _mm_cvtss_f32(sums);
+
+    // Tail
+    size_t tail_start = full_bytes * 8;
+    if (tail_start < d) {
+        uint8_t last_byte = bits[full_bytes];
+        for (size_t j = tail_start; j < d; j++) {
+            if (last_byte & (1 << (j - tail_start))) {
+                result += arr[j];
+            }
+        }
+    }
+
+    return result;
+}
+
+} // namespace faiss::turboq
+
+#endif

--- a/faiss/utils/simd_impl/turboq_avx512.cpp
+++ b/faiss/utils/simd_impl/turboq_avx512.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifdef COMPILE_SIMD_AVX512
+
+#include <faiss/utils/turboq_simd.h>
+#include <immintrin.h>
+
+#include <cstring>
+
+namespace faiss::turboq {
+
+template <>
+float masked_sum<SIMDLevel::AVX512>(
+        const float* arr,
+        const uint8_t* bits,
+        size_t d) {
+    __m512 acc = _mm512_setzero_ps();
+
+    size_t i = 0;
+    size_t full_16 = (d / 16) * 16;
+    for (; i < full_16; i += 16) {
+        uint16_t mask16;
+        memcpy(&mask16, bits + i / 8, sizeof(mask16));
+        __mmask16 k = _cvtu32_mask16(mask16);
+        __m512 vals = _mm512_loadu_ps(arr + i);
+        acc = _mm512_mask_add_ps(acc, k, acc, vals);
+    }
+
+    float result = _mm512_reduce_add_ps(acc);
+
+    // Tail: remaining elements
+    if (i < d) {
+        size_t remaining = d - i;
+        __mmask16 tail_mask = _cvtu32_mask16((1u << remaining) - 1);
+        __m512 tail_vals = _mm512_maskz_loadu_ps(tail_mask, arr + i);
+
+        // Load remaining bits
+        uint16_t bits_tail = 0;
+        size_t bytes_remaining = (remaining + 7) / 8;
+        memcpy(&bits_tail, bits + i / 8, bytes_remaining);
+        __mmask16 bits_k = _cvtu32_mask16(bits_tail);
+        __mmask16 combined = _kand_mask16(tail_mask, bits_k);
+
+        __m512 masked_tail = _mm512_maskz_mov_ps(combined, tail_vals);
+        result += _mm512_reduce_add_ps(masked_tail);
+    }
+
+    return result;
+}
+
+} // namespace faiss::turboq
+
+#endif

--- a/faiss/utils/simd_impl/turboq_neon.cpp
+++ b/faiss/utils/simd_impl/turboq_neon.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <faiss/utils/turboq_simd.h>
+
+#ifdef COMPILE_SIMD_ARM_NEON
+
+namespace faiss::turboq {
+
+template <>
+float masked_sum<SIMDLevel::ARM_NEON>(
+        const float* arr,
+        const uint8_t* bits,
+        size_t d) {
+    return masked_sum<SIMDLevel::NONE>(arr, bits, d);
+}
+
+} // namespace faiss::turboq
+
+#endif

--- a/faiss/utils/turboq_simd.h
+++ b/faiss/utils/turboq_simd.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+
+#include <faiss/utils/simd_levels.h>
+
+namespace faiss::turboq {
+
+/// Compute sum of arr[j] where bit j of the bitmask is set.
+/// Used for SIMD masked accumulation of QJL and 1-bit MSE dot products.
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
+float masked_sum(const float* arr, const uint8_t* bits, size_t d);
+
+template <>
+inline float masked_sum<SIMDLevel::NONE>(
+        const float* arr,
+        const uint8_t* bits,
+        size_t d) {
+    float result = 0;
+    for (size_t byte_idx = 0; byte_idx < (d + 7) / 8; byte_idx++) {
+        uint8_t b = bits[byte_idx];
+        size_t base = byte_idx * 8;
+        size_t end = std::min(base + 8, d);
+        for (size_t j = base; j < end; j++) {
+            if (b & (1 << (j - base))) {
+                result += arr[j];
+            }
+        }
+    }
+    return result;
+}
+
+} // namespace faiss::turboq

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -350,6 +350,23 @@ class TestQuantizerClone(unittest.TestCase):
         np.testing.assert_array_equal(codes, codes2)
 
 
+class TestTurboQuantMSESQFactory(unittest.TestCase):
+
+    def test_factory_tqmse(self):
+        cases = [
+            ("SQtqmse1", faiss.ScalarQuantizer.QT_1bit_tqmse),
+            ("SQtqmse2", faiss.ScalarQuantizer.QT_2bit_tqmse),
+            ("SQtqmse3", faiss.ScalarQuantizer.QT_3bit_tqmse),
+            ("SQtqmse4", faiss.ScalarQuantizer.QT_4bit_tqmse),
+            ("SQtqmse8", faiss.ScalarQuantizer.QT_8bit_tqmse),
+        ]
+        for factory_str, qtype in cases:
+            with self.subTest(factory_str=factory_str):
+                index = faiss.index_factory(32, factory_str)
+                self.assertEqual(index.__class__, faiss.IndexScalarQuantizer)
+                self.assertEqual(index.sq.qtype, qtype)
+
+
 class TestIVFSpectralHashOwnership(unittest.TestCase):
 
     def test_constructor(self):

--- a/tests/test_factory_tools.cpp
+++ b/tests/test_factory_tools.cpp
@@ -13,21 +13,13 @@ namespace faiss {
 
 TEST(TestFactoryTools, TestReverseIndexFactory) {
     for (const char* factory : {
-                 "Flat",
-                 "IMI2x5,PQ8x8",
-                 "IVF32_HNSW32,SQ8",
-                 "IVF8,Flat",
-                 "IVF8,SQ4",
-                 "IVF8,PQ4x8",
-                 "LSHrt",
-                 "PQ4x8",
-                 "HNSW32",
-                 "SQ8",
-                 "SQfp16",
-                 "NSG24,Flat",
-                 "NSG16,SQ8",
-                 "RaBitQ",
-                 "IVF8,RaBitQ",
+                 "Flat",      "IMI2x5,PQ8x8", "IVF32_HNSW32,SQ8",
+                 "IVF8,Flat", "IVF8,SQ4",     "IVF8,PQ4x8",
+                 "LSHrt",     "PQ4x8",        "HNSW32",
+                 "SQ8",       "SQtqmse1",     "SQtqmse2",
+                 "SQtqmse3",  "SQtqmse4",     "SQtqmse8",
+                 "SQfp16",    "NSG24,Flat",   "NSG16,SQ8",
+                 "RaBitQ",    "IVF8,RaBitQ",  "IVF8,SQtqmse8",
          }) {
         std::unique_ptr<Index> index{index_factory(64, factory)};
         ASSERT_TRUE(index);

--- a/tests/test_scalar_quantizer.cpp
+++ b/tests/test_scalar_quantizer.cpp
@@ -7,7 +7,9 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cmath>
+#include <cstring>
 #include <memory>
 #include <random>
 #include <vector>
@@ -16,7 +18,269 @@
 #include <faiss/IndexIVFFlat.h>
 #include <faiss/IndexScalarQuantizer.h>
 #include <faiss/impl/ScalarQuantizer.h>
+#include <faiss/impl/scalar_quantizer/distance_computers.h>
+#include <faiss/impl/scalar_quantizer/quantizers.h>
+#include <faiss/impl/scalar_quantizer/scanners.h>
+#include <faiss/impl/scalar_quantizer/similarities.h>
 #include <faiss/index_factory.h>
+#include <faiss/utils/distances.h>
+#include <faiss/utils/random.h>
+#include <faiss/utils/simd_levels.h>
+
+namespace {
+
+std::vector<float> make_normalized_vectors(size_t n, size_t d) {
+    std::vector<float> x(n * d);
+    faiss::float_randn(x.data(), x.size(), 1234);
+    faiss::fvec_renorm_L2(d, n, x.data());
+    return x;
+}
+
+float mean_squared_error(
+        const std::vector<float>& x,
+        const std::vector<float>& y) {
+    EXPECT_EQ(x.size(), y.size());
+    return faiss::fvec_L2sqr(x.data(), y.data(), x.size()) / x.size();
+}
+
+template <int NBits>
+using ScalarTurboQuantQuantizer = faiss::scalar_quantizer::
+        QuantizerTurboQuantMSE<NBits, faiss::SIMDLevel::NONE>;
+
+template <int NBits>
+using ScalarTurboQuantL2DistanceComputer = faiss::scalar_quantizer::DCTemplate<
+        ScalarTurboQuantQuantizer<NBits>,
+        faiss::scalar_quantizer::SimilarityL2<faiss::SIMDLevel::NONE>,
+        faiss::SIMDLevel::NONE>;
+
+template <int NBits>
+using ScalarTurboQuantL2Scanner = faiss::scalar_quantizer::IVFSQScannerL2<
+        ScalarTurboQuantL2DistanceComputer<NBits>>;
+
+faiss::ScalarQuantizer make_trained_tqmse_sq(
+        size_t d,
+        faiss::ScalarQuantizer::QuantizerType qtype) {
+    const size_t n = 128;
+    std::vector<float> x = make_normalized_vectors(n, d);
+    faiss::ScalarQuantizer sq(d, qtype);
+    sq.train(n, x.data());
+    return sq;
+}
+
+struct ScopedSIMDLevel {
+    faiss::SIMDLevel original_level;
+
+    explicit ScopedSIMDLevel(faiss::SIMDLevel level)
+            : original_level(faiss::SIMDConfig::get_level()) {
+        faiss::SIMDConfig::set_level(level);
+    }
+
+    ~ScopedSIMDLevel() {
+        faiss::SIMDConfig::set_level(original_level);
+    }
+};
+
+std::vector<faiss::SIMDLevel> available_tqmse_simd_levels() {
+    std::vector<faiss::SIMDLevel> levels;
+    for (faiss::SIMDLevel level :
+         {faiss::SIMDLevel::AVX512,
+          faiss::SIMDLevel::AVX2,
+          faiss::SIMDLevel::ARM_NEON}) {
+        if (faiss::SIMDConfig::is_simd_level_available(level)) {
+            levels.push_back(level);
+        }
+    }
+    return levels;
+}
+
+template <int NBits>
+void expect_tqmse_simd_dispatch_for_compatible_dim(
+        faiss::SIMDLevel level,
+        faiss::ScalarQuantizer::QuantizerType qtype) {
+    ScopedSIMDLevel scoped(level);
+    const size_t d = 32;
+    faiss::ScalarQuantizer sq = make_trained_tqmse_sq(d, qtype);
+
+    std::unique_ptr<faiss::ScalarQuantizer::SQuantizer> quantizer(
+            sq.select_quantizer());
+    ASSERT_NE(quantizer, nullptr);
+
+    std::unique_ptr<faiss::ScalarQuantizer::SQDistanceComputer> dc(
+            sq.get_distance_computer(faiss::METRIC_L2));
+    ASSERT_NE(dc, nullptr);
+
+    std::unique_ptr<faiss::InvertedListScanner> scanner(
+            sq.select_InvertedListScanner(
+                    faiss::METRIC_L2, nullptr, false, nullptr, false));
+    ASSERT_NE(scanner, nullptr);
+
+    auto* quantizer_raw = quantizer.get();
+    auto* dc_raw = dc.get();
+    auto* scanner_raw = scanner.get();
+
+    EXPECT_NE(typeid(*quantizer_raw), typeid(ScalarTurboQuantQuantizer<NBits>));
+    EXPECT_NE(
+            typeid(*dc_raw), typeid(ScalarTurboQuantL2DistanceComputer<NBits>));
+    EXPECT_NE(typeid(*scanner_raw), typeid(ScalarTurboQuantL2Scanner<NBits>));
+}
+
+template <int NBits>
+void expect_tqmse_simd_dispatch_fallback_for_incompatible_dim(
+        faiss::SIMDLevel level,
+        size_t d,
+        faiss::ScalarQuantizer::QuantizerType qtype) {
+    ScopedSIMDLevel scoped(level);
+    faiss::ScalarQuantizer sq = make_trained_tqmse_sq(d, qtype);
+
+    std::unique_ptr<faiss::ScalarQuantizer::SQuantizer> quantizer(
+            sq.select_quantizer());
+    ASSERT_NE(quantizer, nullptr);
+
+    std::unique_ptr<faiss::ScalarQuantizer::SQDistanceComputer> dc(
+            sq.get_distance_computer(faiss::METRIC_L2));
+    ASSERT_NE(dc, nullptr);
+
+    std::unique_ptr<faiss::InvertedListScanner> scanner(
+            sq.select_InvertedListScanner(
+                    faiss::METRIC_L2, nullptr, false, nullptr, false));
+    ASSERT_NE(scanner, nullptr);
+
+    auto* quantizer_raw = quantizer.get();
+    auto* dc_raw = dc.get();
+    auto* scanner_raw = scanner.get();
+
+    EXPECT_EQ(typeid(*quantizer_raw), typeid(ScalarTurboQuantQuantizer<NBits>));
+    EXPECT_EQ(
+            typeid(*dc_raw), typeid(ScalarTurboQuantL2DistanceComputer<NBits>));
+    EXPECT_EQ(typeid(*scanner_raw), typeid(ScalarTurboQuantL2Scanner<NBits>));
+}
+
+template <int NBits>
+void check_tqmse_distance_path_parity(
+        faiss::SIMDLevel level,
+        faiss::ScalarQuantizer::QuantizerType qtype) {
+    ScopedSIMDLevel scoped(level);
+    const size_t d = 32;
+    const size_t n = 128;
+    std::vector<float> xb = make_normalized_vectors(n, d);
+    std::vector<float> xq = make_normalized_vectors(1, d);
+
+    faiss::ScalarQuantizer sq(d, qtype);
+    sq.train(n, xb.data());
+
+    std::vector<uint8_t> codes(sq.code_size * n, 0);
+    sq.compute_codes(xb.data(), codes.data(), n);
+
+    std::unique_ptr<faiss::ScalarQuantizer::SQDistanceComputer> scalar_dc(
+            faiss::scalar_quantizer::sq_select_distance_computer<
+                    faiss::SIMDLevel::NONE>(
+                    faiss::METRIC_L2, qtype, d, sq.trained));
+    std::unique_ptr<faiss::ScalarQuantizer::SQDistanceComputer> simd_dc(
+            sq.get_distance_computer(faiss::METRIC_L2));
+    ASSERT_NE(scalar_dc, nullptr);
+    ASSERT_NE(simd_dc, nullptr);
+
+    scalar_dc->set_query(xq.data());
+    simd_dc->set_query(xq.data());
+
+    std::vector<uint8_t> zero_code(sq.code_size, 0);
+    std::vector<uint8_t> max_code(sq.code_size, 0xff);
+    const std::array<const uint8_t*, 6> query_codes = {
+            codes.data(),
+            codes.data() + sq.code_size,
+            codes.data() + 2 * sq.code_size,
+            codes.data() + 3 * sq.code_size,
+            zero_code.data(),
+            max_code.data()};
+
+    for (const uint8_t* code : query_codes) {
+        EXPECT_NEAR(
+                scalar_dc->query_to_code(code),
+                simd_dc->query_to_code(code),
+                1e-5);
+    }
+
+    std::vector<uint8_t> bundle(4 * sq.code_size, 0);
+    std::memcpy(bundle.data(), zero_code.data(), sq.code_size);
+    std::memcpy(bundle.data() + sq.code_size, max_code.data(), sq.code_size);
+    std::memcpy(bundle.data() + 2 * sq.code_size, codes.data(), sq.code_size);
+    std::memcpy(
+            bundle.data() + 3 * sq.code_size,
+            codes.data() + sq.code_size,
+            sq.code_size);
+
+    scalar_dc->codes = bundle.data();
+    scalar_dc->code_size = sq.code_size;
+    simd_dc->codes = bundle.data();
+    simd_dc->code_size = sq.code_size;
+
+    const std::array<std::pair<faiss::idx_t, faiss::idx_t>, 4> pairs = {{
+            {0, 1},
+            {0, 2},
+            {1, 3},
+            {2, 3},
+    }};
+    for (const auto& [lhs, rhs] : pairs) {
+        EXPECT_NEAR(
+                scalar_dc->symmetric_dis(lhs, rhs),
+                simd_dc->symmetric_dis(lhs, rhs),
+                1e-5);
+    }
+
+    std::unique_ptr<faiss::InvertedListScanner> scalar_scanner(
+            faiss::scalar_quantizer::sq_select_InvertedListScanner<
+                    faiss::SIMDLevel::NONE>(
+                    qtype,
+                    faiss::METRIC_L2,
+                    d,
+                    sq.code_size,
+                    sq.trained,
+                    nullptr,
+                    false,
+                    nullptr,
+                    false));
+    std::unique_ptr<faiss::InvertedListScanner> simd_scanner(
+            sq.select_InvertedListScanner(
+                    faiss::METRIC_L2, nullptr, false, nullptr, false));
+    ASSERT_NE(scalar_scanner, nullptr);
+    ASSERT_NE(simd_scanner, nullptr);
+
+    scalar_scanner->set_query(xq.data());
+    simd_scanner->set_query(xq.data());
+    scalar_scanner->set_list(0, 0.0f);
+    simd_scanner->set_list(0, 0.0f);
+
+    for (const uint8_t* code : query_codes) {
+        EXPECT_NEAR(
+                scalar_scanner->distance_to_code(code),
+                simd_scanner->distance_to_code(code),
+                1e-5);
+    }
+}
+
+void check_tqmse_roundtrip(
+        size_t d,
+        faiss::ScalarQuantizer::QuantizerType qtype) {
+    const size_t n = 128;
+    std::vector<float> x = make_normalized_vectors(n, d);
+    faiss::ScalarQuantizer sq(d, qtype);
+
+    sq.train(n, x.data());
+
+    std::vector<uint8_t> codes(sq.code_size * n, 0);
+    sq.compute_codes(x.data(), codes.data(), n);
+
+    std::vector<float> decoded(n * d);
+    sq.decode(codes.data(), decoded.data(), n);
+
+    for (float v : decoded) {
+        EXPECT_TRUE(std::isfinite(v));
+        EXPECT_LE(v, 1.0f);
+        EXPECT_GE(v, -1.0f);
+    }
+}
+
+} // namespace
 
 TEST(ScalarQuantizer, RSQuantilesClamping) {
     int d = 8;
@@ -212,5 +476,105 @@ TEST(TestSQ0bit, InnerProduct) {
 
     for (int q = 0; q < nq; q++) {
         EXPECT_GE(labels[q * k], 0);
+    }
+}
+
+TEST(ScalarQuantizer, TQMSEEncodeDecode) {
+    check_tqmse_roundtrip(32, faiss::ScalarQuantizer::QT_1bit_tqmse);
+    check_tqmse_roundtrip(32, faiss::ScalarQuantizer::QT_2bit_tqmse);
+    check_tqmse_roundtrip(32, faiss::ScalarQuantizer::QT_3bit_tqmse);
+    check_tqmse_roundtrip(32, faiss::ScalarQuantizer::QT_4bit_tqmse);
+    check_tqmse_roundtrip(32, faiss::ScalarQuantizer::QT_8bit_tqmse);
+}
+
+TEST(ScalarQuantizer, TQMSEAccuracyOrdering) {
+    const size_t d = 32;
+    const size_t n = 256;
+    std::vector<float> x = make_normalized_vectors(n, d);
+    const std::array<faiss::ScalarQuantizer::QuantizerType, 5> qtypes = {
+            faiss::ScalarQuantizer::QT_1bit_tqmse,
+            faiss::ScalarQuantizer::QT_2bit_tqmse,
+            faiss::ScalarQuantizer::QT_3bit_tqmse,
+            faiss::ScalarQuantizer::QT_4bit_tqmse,
+            faiss::ScalarQuantizer::QT_8bit_tqmse};
+
+    std::vector<float> mses;
+    mses.reserve(qtypes.size());
+
+    for (auto qtype : qtypes) {
+        faiss::ScalarQuantizer sq(d, qtype);
+        sq.train(n, x.data());
+
+        std::vector<uint8_t> codes(sq.code_size * n, 0);
+        sq.compute_codes(x.data(), codes.data(), n);
+
+        std::vector<float> decoded(n * d);
+        sq.decode(codes.data(), decoded.data(), n);
+        mses.push_back(mean_squared_error(x, decoded));
+    }
+
+    for (size_t i = 0; i + 1 < mses.size(); ++i) {
+        EXPECT_GE(mses[i], mses[i + 1]);
+    }
+}
+
+TEST(ScalarQuantizer, TQMSENonSimdDims) {
+    check_tqmse_roundtrip(7, faiss::ScalarQuantizer::QT_1bit_tqmse);
+    check_tqmse_roundtrip(9, faiss::ScalarQuantizer::QT_2bit_tqmse);
+    check_tqmse_roundtrip(11, faiss::ScalarQuantizer::QT_3bit_tqmse);
+    check_tqmse_roundtrip(13, faiss::ScalarQuantizer::QT_4bit_tqmse);
+    check_tqmse_roundtrip(33, faiss::ScalarQuantizer::QT_8bit_tqmse);
+}
+
+TEST(ScalarQuantizer, TQMSESimdDispatchSelection) {
+    const std::vector<faiss::SIMDLevel> levels = available_tqmse_simd_levels();
+    if (levels.empty()) {
+        GTEST_SKIP() << "No SIMD level available for TurboQuant dispatch tests";
+    }
+
+    for (faiss::SIMDLevel level : levels) {
+        SCOPED_TRACE(faiss::to_string(level));
+        expect_tqmse_simd_dispatch_for_compatible_dim<1>(
+                level, faiss::ScalarQuantizer::QT_1bit_tqmse);
+        expect_tqmse_simd_dispatch_for_compatible_dim<2>(
+                level, faiss::ScalarQuantizer::QT_2bit_tqmse);
+        expect_tqmse_simd_dispatch_for_compatible_dim<3>(
+                level, faiss::ScalarQuantizer::QT_3bit_tqmse);
+        expect_tqmse_simd_dispatch_for_compatible_dim<4>(
+                level, faiss::ScalarQuantizer::QT_4bit_tqmse);
+        expect_tqmse_simd_dispatch_for_compatible_dim<8>(
+                level, faiss::ScalarQuantizer::QT_8bit_tqmse);
+
+        expect_tqmse_simd_dispatch_fallback_for_incompatible_dim<1>(
+                level, 7, faiss::ScalarQuantizer::QT_1bit_tqmse);
+        expect_tqmse_simd_dispatch_fallback_for_incompatible_dim<2>(
+                level, 9, faiss::ScalarQuantizer::QT_2bit_tqmse);
+        expect_tqmse_simd_dispatch_fallback_for_incompatible_dim<3>(
+                level, 11, faiss::ScalarQuantizer::QT_3bit_tqmse);
+        expect_tqmse_simd_dispatch_fallback_for_incompatible_dim<4>(
+                level, 13, faiss::ScalarQuantizer::QT_4bit_tqmse);
+        expect_tqmse_simd_dispatch_fallback_for_incompatible_dim<8>(
+                level, 33, faiss::ScalarQuantizer::QT_8bit_tqmse);
+    }
+}
+
+TEST(ScalarQuantizer, TQMSESimdDistancePathParity) {
+    const std::vector<faiss::SIMDLevel> levels = available_tqmse_simd_levels();
+    if (levels.empty()) {
+        GTEST_SKIP() << "No SIMD level available for TurboQuant parity tests";
+    }
+
+    for (faiss::SIMDLevel level : levels) {
+        SCOPED_TRACE(faiss::to_string(level));
+        check_tqmse_distance_path_parity<1>(
+                level, faiss::ScalarQuantizer::QT_1bit_tqmse);
+        check_tqmse_distance_path_parity<2>(
+                level, faiss::ScalarQuantizer::QT_2bit_tqmse);
+        check_tqmse_distance_path_parity<3>(
+                level, faiss::ScalarQuantizer::QT_3bit_tqmse);
+        check_tqmse_distance_path_parity<4>(
+                level, faiss::ScalarQuantizer::QT_4bit_tqmse);
+        check_tqmse_distance_path_parity<8>(
+                level, faiss::ScalarQuantizer::QT_8bit_tqmse);
     }
 }

--- a/tests/test_scalar_quantizer_correctness.py
+++ b/tests/test_scalar_quantizer_correctness.py
@@ -44,6 +44,26 @@ class TestScalarQuantizerEncodeDecode(unittest.TestCase):
     def test_4bit_uniform(self):
         self.do_encode_decode(faiss.ScalarQuantizer.QT_4bit_uniform, 0.1)
 
+    def test_tqmse_1bit(self):
+        faiss.normalize_L2(self.xb)
+        self.do_encode_decode(faiss.ScalarQuantizer.QT_1bit_tqmse, 1.0)
+
+    def test_tqmse_2bit(self):
+        faiss.normalize_L2(self.xb)
+        self.do_encode_decode(faiss.ScalarQuantizer.QT_2bit_tqmse, 0.8)
+
+    def test_tqmse_3bit(self):
+        faiss.normalize_L2(self.xb)
+        self.do_encode_decode(faiss.ScalarQuantizer.QT_3bit_tqmse, 0.6)
+
+    def test_tqmse_4bit(self):
+        faiss.normalize_L2(self.xb)
+        self.do_encode_decode(faiss.ScalarQuantizer.QT_4bit_tqmse, 0.1)
+
+    def test_tqmse_8bit(self):
+        faiss.normalize_L2(self.xb)
+        self.do_encode_decode(faiss.ScalarQuantizer.QT_8bit_tqmse, 0.1)
+
 
 @for_all_simd_levels
 class TestScalarQuantizerSearch(unittest.TestCase):
@@ -53,6 +73,10 @@ class TestScalarQuantizerSearch(unittest.TestCase):
         self.ds = SyntheticDataset(d=self.d, nt=0, nb=10000, nq=100, seed=42)
         self.xb = self.ds.get_database()
         self.xq = self.ds.get_queries()
+        self.xb_unit = self.xb.copy()
+        self.xq_unit = self.xq.copy()
+        faiss.normalize_L2(self.xb_unit)
+        faiss.normalize_L2(self.xq_unit)
 
     def do_search(self, factory_str, min_recall):
         index_gt = faiss.IndexFlatL2(self.d)
@@ -73,6 +97,24 @@ class TestScalarQuantizerSearch(unittest.TestCase):
     def test_SQfp16(self):
         self.do_search('SQfp16', 0.99)
 
+    def test_tqmse_search(self):
+        index_gt = faiss.IndexFlatL2(self.d)
+        index_gt.add(self.xb_unit)
+        _, I_gt = index_gt.search(self.xq_unit, 10)
+
+        recalls = {}
+        for factory_str in ['L2norm,RR,SQtqmse4', 'L2norm,RR,SQtqmse8']:
+            index = faiss.index_factory(self.d, factory_str)
+            index.train(self.xb)
+            index.add(self.xb)
+            _, I = index.search(self.xq, 10)
+            recalls[factory_str] = (I_gt[:, 0] == I[:, 0]).mean()
+
+        self.assertGreater(recalls['L2norm,RR,SQtqmse4'], 0.2)
+        self.assertGreaterEqual(
+            recalls['L2norm,RR,SQtqmse8'],
+            recalls['L2norm,RR,SQtqmse4'])
+
 
 @for_all_simd_levels
 class TestScalarQuantizerDistances(unittest.TestCase):
@@ -84,6 +126,25 @@ class TestScalarQuantizerDistances(unittest.TestCase):
         xb = ds.get_database()
 
         index = faiss.index_factory(d, 'SQ8')
+        index.train(xb)
+        index.add(xb)
+
+        D, I = index.search(x, 10)
+
+        for i in range(10):
+            xr = index.reconstruct(int(I[0, i]))
+            dist = ((x[0] - xr) ** 2).sum()
+            self.assertAlmostEqual(D[0, i], dist, places=4)
+
+    def test_tqmse_distance_matches_reconstruct(self):
+        d = 32
+        ds = SyntheticDataset(d=d, nt=0, nb=100, nq=1, seed=42)
+        x = ds.get_queries()
+        xb = ds.get_database()
+        faiss.normalize_L2(x)
+        faiss.normalize_L2(xb)
+
+        index = faiss.index_factory(d, 'SQtqmse8')
         index.train(xb)
         index.add(xb)
 
@@ -143,6 +204,29 @@ class TestScalarQuantizerEdgeCases(unittest.TestCase):
                 D, I = index.search(xq, 10)
                 self.assertEqual(D.shape, (5, 10))
                 self.assertEqual(I.shape, (5, 10))
+
+    def test_tqmse_non_simd_dims(self):
+        factory_strings = [
+            'SQtqmse1',
+            'SQtqmse2',
+            'SQtqmse3',
+            'SQtqmse4',
+            'SQtqmse8',
+        ]
+        for d in [7, 9, 15, 17, 31, 33, 63, 65]:
+            for factory_str in factory_strings:
+                with self.subTest(d=d, factory_str=factory_str):
+                    ds = SyntheticDataset(d=d, nt=0, nb=100, nq=5, seed=42)
+                    xb = ds.get_database()
+                    xq = ds.get_queries()
+                    faiss.normalize_L2(xb)
+                    faiss.normalize_L2(xq)
+                    index = faiss.index_factory(d, factory_str)
+                    index.train(xb)
+                    index.add(xb)
+                    D, I = index.search(xq, 10)
+                    self.assertEqual(D.shape, (5, 10))
+                    self.assertEqual(I.shape, (5, 10))
 
 
 @for_all_simd_levels

--- a/tests/test_standalone_codec.py
+++ b/tests/test_standalone_codec.py
@@ -58,6 +58,21 @@ class TestEncodeDecode(unittest.TestCase):
     def test_SQ8(self):
         self.do_encode_twice('SQ8')
 
+    def test_SQtqmse1(self):
+        self.do_encode_twice('SQtqmse1')
+
+    def test_SQtqmse2(self):
+        self.do_encode_twice('SQtqmse2')
+
+    def test_SQtqmse3(self):
+        self.do_encode_twice('SQtqmse3')
+
+    def test_SQtqmse4(self):
+        self.do_encode_twice('SQtqmse4')
+
+    def test_SQtqmse8(self):
+        self.do_encode_twice('SQtqmse8')
+
     def test_IVFSQ8(self):
         self.do_encode_twice('IVF256,SQ8')
 
@@ -181,7 +196,6 @@ class TestAccuracy(unittest.TestCase):
 
     def test_SQ(self):
         self.compare_accuracy('SQ4', 'SQ8')
-
     def test_SQ2(self):
         self.compare_accuracy('SQ6', 'SQ8')
 
@@ -190,6 +204,33 @@ class TestAccuracy(unittest.TestCase):
 
     def test_SQ4(self):
         self.compare_accuracy('SQ8', 'SQbf16')
+
+    def test_SQtqmse(self):
+        self.compare_accuracy('SQtqmse4', 'SQtqmse8')
+
+    def test_SQtqmse_ordering(self):
+        d = 96
+        nb = 1000
+        nq = 0
+        nt = 2000
+
+        xt, x, _ = get_dataset_2(d, nt, nb, nq)
+
+        errs = []
+        for factory_string in (
+                'SQtqmse1',
+                'SQtqmse2',
+                'SQtqmse3',
+                'SQtqmse4',
+                'SQtqmse8'):
+            codec = faiss.index_factory(d, factory_string)
+            codec.train(xt)
+            codes = codec.sa_encode(x)
+            x2 = codec.sa_decode(codes)
+            errs.append(((x - x2) ** 2).sum())
+
+        for i in range(len(errs) - 1):
+            self.assertGreaterEqual(errs[i], errs[i + 1])
 
     def test_PQ(self):
         self.compare_accuracy('PQ6x8np', 'PQ8x8np')

--- a/tests/test_turboq.py
+++ b/tests/test_turboq.py
@@ -1,0 +1,495 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-ignore-all-errors
+
+"""Tests for TurboQuant (IndexIVFTurboQ).
+
+Mirrors test_rabitq.py structure: construction, factory strings,
+recall quality, serialization, IVF operations, and edge cases.
+Both L2 and IP metrics are tested throughout.
+"""
+
+import unittest
+
+import faiss
+import numpy as np
+from faiss.contrib import datasets
+
+
+def compute_expected_turboq_code_size(d, nb_bits):
+    """Compute expected code size for TurboQ.
+
+    Layout: [MSE bit planes] [QJL sign bits] [TurboQFactors(norm, gamma)]
+    """
+    return (d + 7) // 8 * nb_bits + 8
+
+
+def do_test_serde(description, metric=faiss.METRIC_L2):
+    ds = datasets.SyntheticDataset(64, 1000, 100, 20)
+    index = faiss.index_factory(ds.d, description, metric)
+    index.train(ds.get_train())
+    index.add(ds.get_database())
+    Dref, Iref = index.search(ds.get_queries(), 10)
+
+    b = faiss.serialize_index(index)
+    index2 = faiss.deserialize_index(b)
+    Dnew, Inew = index2.search(ds.get_queries(), 10)
+
+    np.testing.assert_equal(Dref, Dnew)
+    np.testing.assert_equal(Iref, Inew)
+
+    b2 = faiss.serialize_index(index2)
+    index3 = faiss.deserialize_index(b2)
+    Dnew3, Inew3 = index3.search(ds.get_queries(), 10)
+    np.testing.assert_equal(Dref, Dnew3)
+    np.testing.assert_equal(Iref, Inew3)
+
+
+class TestTurboQ(unittest.TestCase):
+    """Consolidated tests for TurboQuant."""
+
+    # ==================== Construction Tests ====================
+
+    def test_valid_nb_bits_range(self):
+        d = 128
+        for nb_bits in range(1, 6):
+            for metric in [faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT]:
+                with self.subTest(nb_bits=nb_bits, metric=metric):
+                    quantizer = faiss.IndexFlat(d, metric)
+                    index = faiss.IndexIVFTurboQ(
+                        quantizer, d, 1, metric, True, nb_bits
+                    )
+                    self.assertEqual(index.d, d)
+                    self.assertEqual(index.turboq.nb_bits, nb_bits)
+
+    def test_invalid_nb_bits(self):
+        d = 128
+        for nb_bits in [0, 6, 9]:
+            with self.subTest(nb_bits=nb_bits):
+                with self.assertRaises(RuntimeError):
+                    faiss.index_factory(
+                        d, f"RR{d},IVF1,TurboQ{nb_bits}", faiss.METRIC_L2
+                    )
+
+    def test_code_size_formula(self):
+        d = 128
+        for nb_bits in range(1, 6):
+            with self.subTest(nb_bits=nb_bits):
+                quantizer = faiss.IndexFlat(d, faiss.METRIC_L2)
+                index = faiss.IndexIVFTurboQ(
+                    quantizer, d, 1, faiss.METRIC_L2, True, nb_bits
+                )
+                expected = compute_expected_turboq_code_size(d, nb_bits)
+                self.assertEqual(index.code_size, expected)
+
+    # ==================== Factory String Tests ====================
+
+    def test_factory_default(self):
+        index = faiss.index_factory(128, "RR128,TurboQ")
+        ivf = faiss.extract_index_ivf(index)
+        self.assertEqual(
+            ivf.code_size, compute_expected_turboq_code_size(128, 2)
+        )
+
+    def test_factory_multibit(self):
+        for nb_bits in [1, 2, 3, 4, 5]:
+            with self.subTest(nb_bits=nb_bits):
+                index = faiss.index_factory(128, f"RR128,TurboQ{nb_bits}")
+                ivf = faiss.extract_index_ivf(index)
+                self.assertEqual(
+                    ivf.code_size,
+                    compute_expected_turboq_code_size(128, nb_bits),
+                )
+
+    def test_factory_random_rotation(self):
+        ds = datasets.SyntheticDataset(64, 150, 200, 10)
+        for nb_bits in [2, 4]:
+            with self.subTest(nb_bits=nb_bits):
+                index = faiss.index_factory(
+                    ds.d, f"RR{ds.d},TurboQ{nb_bits}r"
+                )
+                index.train(ds.get_train())
+                index.add(ds.get_database())
+                D, I = index.search(ds.get_queries(), 5)
+                self.assertTrue(np.all(I >= 0))
+
+    def test_factory_ivf(self):
+        for nlist in [1, 16]:
+            for nb_bits in [2, 4]:
+                with self.subTest(nlist=nlist, nb_bits=nb_bits):
+                    index = faiss.index_factory(
+                        128, f"RR128,IVF{nlist},TurboQ{nb_bits}"
+                    )
+                    ivf = faiss.extract_index_ivf(index)
+                    self.assertEqual(ivf.nlist, nlist)
+                    self.assertEqual(
+                        ivf.code_size,
+                        compute_expected_turboq_code_size(128, nb_bits),
+                    )
+
+    def test_factory_standalone(self):
+        index = faiss.index_factory(128, "RR128,TurboQ2")
+        ivf = faiss.extract_index_ivf(index)
+        self.assertEqual(ivf.nlist, 1)
+
+    def test_factory_end_to_end(self):
+        ds = datasets.SyntheticDataset(64, 150, 200, 10)
+        for nb_bits in [2, 4]:
+            for suffix in [f"TurboQ{nb_bits}", f"IVF16,TurboQ{nb_bits}"]:
+                factory_str = f"RR{ds.d},{suffix}"
+                with self.subTest(factory=factory_str):
+                    index = faiss.index_factory(
+                        ds.d, factory_str, faiss.METRIC_INNER_PRODUCT
+                    )
+                    index.train(ds.get_train())
+                    index.add(ds.get_database())
+                    D, I = index.search(ds.get_queries(), 5)
+                    self.assertEqual(D.shape, (ds.nq, 5))
+                    self.assertTrue(np.all(I >= 0))
+
+    # ==================== Basic Operations Tests ====================
+
+    def test_basic_operations(self):
+        ds = datasets.SyntheticDataset(128, 300, 500, 20)
+        k = 10
+
+        for metric in [faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT]:
+            for nb_bits in [2, 4]:
+                with self.subTest(metric=metric, nb_bits=nb_bits):
+                    index = faiss.index_factory(
+                        ds.d,
+                        f"RR{ds.d},IVF1,TurboQ{nb_bits}",
+                        metric,
+                    )
+                    index.train(ds.get_train())
+                    index.add(ds.get_database())
+                    D, I = index.search(ds.get_queries(), k)
+
+                    self.assertTrue(index.is_trained)
+                    self.assertEqual(index.ntotal, ds.nb)
+                    self.assertEqual(D.shape, (ds.nq, k))
+                    self.assertEqual(I.shape, (ds.nq, k))
+                    self.assertTrue(np.all(I >= 0))
+                    self.assertTrue(np.all(I < ds.nb))
+                    self.assertTrue(np.all(np.isfinite(D)))
+
+    # ==================== Recall Tests ====================
+
+    def test_recall_quality(self):
+        for metric in [faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT]:
+            metric_str = "L2" if metric == faiss.METRIC_L2 else "IP"
+            ds = datasets.SyntheticDataset(
+                128, 500, 2000, 50, metric=metric_str
+            )
+            I_gt = ds.get_groundtruth(10)
+
+            for nb_bits in [2, 4]:
+                with self.subTest(metric=metric_str, nb_bits=nb_bits):
+                    index = faiss.index_factory(
+                        ds.d,
+                        f"RR{ds.d},IVF1,TurboQ{nb_bits}",
+                        metric,
+                    )
+                    index.train(ds.get_train())
+                    index.add(ds.get_database())
+                    _, I = index.search(ds.get_queries(), 10)
+                    recall = (
+                        faiss.eval_intersection(I, I_gt) / (ds.nq * 10)
+                    )
+                    self.assertGreater(
+                        recall,
+                        0.10,
+                        f"TurboQ{nb_bits} {metric_str}: recall={recall:.3f}",
+                    )
+
+    def test_recall_monotonic_improvement(self):
+        for metric in [faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT]:
+            metric_str = "L2" if metric == faiss.METRIC_L2 else "IP"
+            ds = datasets.SyntheticDataset(
+                128, 500, 2000, 50, metric=metric_str
+            )
+            I_gt = ds.get_groundtruth(10)
+
+            with self.subTest(metric=metric_str):
+                recalls = {}
+                for nb_bits in [2, 3, 4]:
+                    index = faiss.index_factory(
+                        ds.d,
+                        f"RR{ds.d},IVF1,TurboQ{nb_bits}",
+                        metric,
+                    )
+                    index.train(ds.get_train())
+                    index.add(ds.get_database())
+                    _, I = index.search(ds.get_queries(), 10)
+                    recalls[nb_bits] = (
+                        faiss.eval_intersection(I, I_gt) / (ds.nq * 10)
+                    )
+
+                tolerance = 0.03
+                self.assertGreaterEqual(recalls[3], recalls[2] - tolerance)
+                self.assertGreaterEqual(recalls[4], recalls[3] - tolerance)
+
+    # ==================== QJL Projection Type Tests ====================
+
+    def test_both_qjl_projections_recall(self):
+        """Both FWHT and Random Rotation give reasonable recall."""
+        for metric in [faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT]:
+            metric_str = "L2" if metric == faiss.METRIC_L2 else "IP"
+            ds = datasets.SyntheticDataset(
+                128, 500, 2000, 50, metric=metric_str
+            )
+            I_gt = ds.get_groundtruth(10)
+
+            for suffix in ["TurboQ2", "TurboQ2r"]:
+                with self.subTest(metric=metric_str, qjl=suffix):
+                    index = faiss.index_factory(
+                        ds.d,
+                        f"RR{ds.d},IVF1,{suffix}",
+                        metric,
+                    )
+                    index.train(ds.get_train())
+                    index.add(ds.get_database())
+                    _, I = index.search(ds.get_queries(), 10)
+                    recall = (
+                        faiss.eval_intersection(I, I_gt)
+                        / (ds.nq * 10)
+                    )
+                    self.assertGreater(
+                        recall,
+                        0.10,
+                        f"{suffix} {metric_str}: recall={recall:.3f}",
+                    )
+
+    def test_rr_qjl_ivf(self):
+        """Random Rotation QJL works with multi-list IVF."""
+        ds = datasets.SyntheticDataset(128, 300, 500, 20)
+        for metric in [faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT]:
+            with self.subTest(metric=metric):
+                index = faiss.index_factory(
+                    ds.d,
+                    f"RR{ds.d},IVF16,TurboQ2r",
+                    metric,
+                )
+                index.train(ds.get_train())
+                index.add(ds.get_database())
+                params = faiss.IVFTurboQSearchParameters()
+                params.nprobe = 4
+                D, I = index.search(
+                    ds.get_queries(), 10, params=params
+                )
+                self.assertTrue(np.all(I >= 0))
+                self.assertTrue(np.all(np.isfinite(D)))
+
+    def test_rr_qjl_with_qb(self):
+        """Integer popcount path works with Random Rotation QJL."""
+        ds = datasets.SyntheticDataset(
+            128, 500, 2000, 50, metric="IP"
+        )
+        index = faiss.index_factory(
+            ds.d,
+            f"RR{ds.d},IVF1,TurboQ2r",
+            faiss.METRIC_INNER_PRODUCT,
+        )
+        index.train(ds.get_train())
+        index.add(ds.get_database())
+
+        sp0 = faiss.IVFTurboQSearchParameters()
+        sp0.nprobe = 1
+        sp0.qb = 0
+        D0, I0 = index.search(ds.get_queries(), 10, params=sp0)
+
+        for qb in [4, 8]:
+            sp = faiss.IVFTurboQSearchParameters()
+            sp.nprobe = 1
+            sp.qb = qb
+            D, I = index.search(ds.get_queries(), 10, params=sp)
+            recall = np.mean(
+                [
+                    len(np.intersect1d(I[i], I0[i])) / 10.0
+                    for i in range(len(I))
+                ]
+            )
+            self.assertGreater(
+                recall,
+                0.8,
+                f"TurboQ2r qb={qb}: recall {recall:.3f} "
+                f"too low vs float path",
+            )
+
+    # ==================== Query Quantization Tests ====================
+
+    def test_qb_integer_mse(self):
+        """qb parameter enables integer popcount MSE path."""
+        for metric in [faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT]:
+            metric_str = "L2" if metric == faiss.METRIC_L2 else "IP"
+            ds = datasets.SyntheticDataset(
+                128, 500, 2000, 50, metric=metric_str
+            )
+
+            with self.subTest(metric=metric_str):
+                index = faiss.index_factory(
+                    ds.d,
+                    f"RR{ds.d},IVF1,TurboQ2",
+                    metric,
+                )
+                index.train(ds.get_train())
+                index.add(ds.get_database())
+
+                sp0 = faiss.IVFTurboQSearchParameters()
+                sp0.nprobe = 1
+                sp0.qb = 0
+                D0, I0 = index.search(ds.get_queries(), 10, params=sp0)
+
+                for qb in [4, 8]:
+                    sp = faiss.IVFTurboQSearchParameters()
+                    sp.nprobe = 1
+                    sp.qb = qb
+                    D, I = index.search(ds.get_queries(), 10, params=sp)
+                    recall = np.mean(
+                        [
+                            len(np.intersect1d(I[i], I0[i])) / 10.0
+                            for i in range(len(I))
+                        ]
+                    )
+                    self.assertGreater(
+                        recall,
+                        0.8,
+                        f"qb={qb}: recall {recall:.3f} too low vs float path",
+                    )
+
+    # ==================== IVF Tests ====================
+
+    def test_ivf_basic_operations(self):
+        ds = datasets.SyntheticDataset(128, 300, 500, 20)
+
+        for metric in [faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT]:
+            for nb_bits in [2, 4]:
+                with self.subTest(metric=metric, nb_bits=nb_bits):
+                    index = faiss.index_factory(
+                        ds.d,
+                        f"RR{ds.d},IVF16,TurboQ{nb_bits}",
+                        metric,
+                    )
+                    index.train(ds.get_train())
+                    index.add(ds.get_database())
+
+                    params = faiss.IVFTurboQSearchParameters()
+                    params.nprobe = 4
+                    D, I = index.search(
+                        ds.get_queries(), 10, params=params
+                    )
+
+                    self.assertTrue(index.is_trained)
+                    self.assertEqual(index.ntotal, ds.nb)
+                    self.assertEqual(D.shape, (ds.nq, 10))
+                    self.assertTrue(np.all(I >= 0))
+                    self.assertTrue(np.all(np.isfinite(D)))
+
+    def test_ivf_nprobe_improves_recall(self):
+        for metric in [faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT]:
+            metric_str = "L2" if metric == faiss.METRIC_L2 else "IP"
+            ds = datasets.SyntheticDataset(
+                128, 500, 2000, 50, metric=metric_str
+            )
+            I_gt = ds.get_groundtruth(10)
+
+            for nb_bits in [2, 4]:
+                with self.subTest(metric=metric_str, nb_bits=nb_bits):
+                    index = faiss.index_factory(
+                        ds.d,
+                        f"RR{ds.d},IVF32,TurboQ{nb_bits}",
+                        metric,
+                    )
+                    index.train(ds.get_train())
+                    index.add(ds.get_database())
+
+                    recalls = {}
+                    for nprobe in [1, 2, 4, 8]:
+                        params = faiss.IVFTurboQSearchParameters()
+                        params.nprobe = nprobe
+                        _, I = index.search(
+                            ds.get_queries(), 10, params=params
+                        )
+                        recalls[nprobe] = (
+                            faiss.eval_intersection(I, I_gt) / (ds.nq * 10)
+                        )
+
+                    self.assertGreaterEqual(recalls[2], recalls[1])
+                    self.assertGreaterEqual(recalls[4], recalls[2])
+                    self.assertGreaterEqual(recalls[8], recalls[4])
+
+    # ==================== Serialization Tests ====================
+
+    def test_serde_turboq2_l2(self):
+        do_test_serde("RR64,IVF1,TurboQ2", faiss.METRIC_L2)
+
+    def test_serde_turboq2_ip(self):
+        do_test_serde("RR64,IVF1,TurboQ2", faiss.METRIC_INNER_PRODUCT)
+
+    def test_serde_turboq4(self):
+        do_test_serde("RR64,IVF1,TurboQ4")
+
+    def test_serde_ivf_turboq(self):
+        do_test_serde("RR64,IVF16,TurboQ2")
+
+    def test_serde_random_rotation(self):
+        do_test_serde("RR64,IVF1,TurboQ2r")
+
+    def test_serde_random_rotation_4bit(self):
+        do_test_serde("RR64,IVF1,TurboQ4r")
+
+    def test_serialization_all_configs(self):
+        ds = datasets.SyntheticDataset(64, 150, 200, 10)
+
+        for metric in [faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT]:
+            for nb_bits in [1, 2, 4]:
+                with self.subTest(metric=metric, nb_bits=nb_bits):
+                    index1 = faiss.index_factory(
+                        ds.d,
+                        f"RR{ds.d},IVF1,TurboQ{nb_bits}",
+                        metric,
+                    )
+                    index1.train(ds.get_train())
+                    index1.add(ds.get_database())
+                    D1, I1 = index1.search(ds.get_queries(), 5)
+
+                    index_bytes = faiss.serialize_index(index1)
+                    index2 = faiss.deserialize_index(index_bytes)
+
+                    self.assertEqual(index2.d, ds.d)
+                    self.assertEqual(index2.ntotal, ds.nb)
+                    self.assertTrue(index2.is_trained)
+
+                    D2, I2 = index2.search(ds.get_queries(), 5)
+                    np.testing.assert_array_equal(I1, I2)
+                    np.testing.assert_allclose(D1, D2, rtol=1e-5)
+
+    # ==================== Edge Cases ====================
+
+    def test_non_power_of_2_dims(self):
+        for d in [200, 300]:
+            with self.subTest(d=d):
+                ds = datasets.SyntheticDataset(d, 150, 500, 10)
+                index = faiss.index_factory(
+                    d,
+                    f"RR{d},IVF1,TurboQ2",
+                    faiss.METRIC_INNER_PRODUCT,
+                )
+                index.train(ds.get_train())
+                index.add(ds.get_database())
+                D, I = index.search(ds.get_queries(), 5)
+                self.assertTrue(np.all(I >= 0))
+                self.assertTrue(np.all(I < ds.nb))
+                self.assertTrue(np.all(np.isfinite(D)))
+
+    def test_by_residual_false(self):
+        d = 128
+        for nlist in [1, 16]:
+            quantizer = faiss.IndexFlat(d, faiss.METRIC_L2)
+            index = faiss.IndexIVFTurboQ(
+                quantizer, d, nlist, faiss.METRIC_L2
+            )
+            self.assertFalse(index.by_residual)


### PR DESCRIPTION
Summary:
Adds the complete TurboQuant implementation (paper Algorithm 2, "TurboQuant_prod") as a standalone TurboQuantizer class alongside the MSE-only ScalarQuantizer integration from D102195204.

Benchmark results
-
TLDR: TQ has a similar operating point to RaBitQ in terms of memory savings, but it never hit RaBitQ levels of recall.

We implemented and compared TurboQuant to our existing implementation of RaBitQ across 20+ datasets. Some were internal, 18 were open source (from https://vector-index-bench.github.io/datasets.html, a nice collection)
- RaBitQ had 4% to 53% higher recall than TurboQuant at equivalent bit widths (i.e. TurboQuant2 vs RaBitQ2), for every single parameter swept. 2 bit is one of the most interesting operating points. TurboQuant recall was notably coupled with dataset characteristics: recall correlates heavily with dataset effective dimensions.
- TurboQuant had ~1.7x faster scoring than non-FastScan RaBitQ at equivalent bit widths for practical qb values. But RaBitQFS is faster and has the same recall as non-FS RaBitQ for reasonable datasets.
- Fast Walsh Hadamard Transform rather than Gaussian in the QJL step improved TurboQuant recall 7-15%. Random rotation was also better than Gaussian, and even better than FWHT on 5/18 datasets. So we just dropped Gaussian here and kept RR and FWHT.
- TurboQuant may have some recall benefit on datasets with very high effective dimensions, e.g. after applying PCA. 
- TurboQuant adaptive bit lengths (2.5, 3.5) raised recall only marginally over 2 and 3 respectively, 2-4%. However there is no reason this can't also be applied to RaBitQ for additional operating points. We plan to investigate this sometime soon.

Note: the NEON simd is just a passthrough to get it to build.

Description
-

**Core algorithm:**
- TurboQuantizer: two-stage quantizer (Lloyd-Max MSE + QJL sign bits)
- IndexIVFTurboQ: IVF index with by_residual=false
- Bit-plane encoding layout for MSE codes
- Per-vector factors (norm, gamma) for distance computation
- FWHT and Random Rotation QJL projection options
- Custom distance computer with direct MSE+QJL scoring

**SIMD and pre-screening:**
- turboq::masked_sum SIMD kernel (AVX2/AVX512) for 1-bit MSE and QJL dot products
- Public TurboQDistanceComputer with pre-computed query state
- MSE-first pre-screening with worst-case L1 QJL error bound
- Adaptive bit width (TurboQ2.5, TurboQ3.5 factory strings)

**Integer popcount paths:**
- Integer popcount MSE path (qb parameter) reusing rabitq::bitwise_and_dot_product — 1.2-2.2x QPS with <1% recall loss
- Integer QJL path (int_qjl) — additional 1.3x QPS on top of qb

**Random Rotation QJL:**
- QJLProjectionType enum (FWHT, RANDOM_ROTATION)
- QR-orthogonalized Gaussian matrix for exact orthogonality
- TurboQ{n}r factory string

**Removed after benchmarking (not useful):**
- Gaussian QJL (TurboQ{n}g): strictly worse recall AND QPS than FWHT on all 26 datasets
- Statistical bound (stat_bound): catastrophic recall loss on real data (mean -0.20 R@10) due to CLT assumption failing on real embedding distributions
- Two-pass batch screening (two_pass_c): no benefit with practical IVF settings (candidate count > list size makes it a no-op)

Factory strings: TurboQ, TurboQ{1-5}, TurboQ{n}r, TurboQ2.5, TurboQ3.5
All work standalone or with IVF prefix (e.g., IVF100,TurboQ2).

Differential Revision: D102244696
