### PR TITLE
Add bit-exact RQ encode cross-level test (#5155)

### DIFF
--- a/tests/test_residual_quantizer.py
+++ b/tests/test_residual_quantizer.py
@@ -263,6 +263,34 @@ class TestResidualQuantizer(unittest.TestCase):
         for c0, c1 in zip(cb0, cb1):
             self.assertTrue(np.all(c0 == c1))
 
+    def test_compute_codes_matches_none(self):
+        """RQ encode is integer-valued, so codes must be bit-exact across
+        SIMD levels. Catches dispatch drift in
+        residual_quantizer_encode_steps.cpp:96,369 (with_simd_level_256bit).
+        Static-build CI lanes only have one SIMD level, so the comparison
+        is vacuous and skipped there.
+        """
+        if not faiss.SIMDConfig.is_simd_level_available(faiss.SIMDLevel_NONE):
+            self.skipTest("SIMDLevel.NONE not available in this build")
+
+        ds = datasets.SyntheticDataset(32, 1000, 200, 0)
+        rq = faiss.ResidualQuantizer(ds.d, 4, 6)
+        rq.train_type = faiss.ResidualQuantizer.Train_default
+        rq.max_beam_size = 5
+        rq.train(ds.get_train())
+
+        xb = ds.get_database()
+        codes = rq.compute_codes(xb)
+        # Switch to NONE, compute the reference, and restore so the rest of
+        # this test instance (and tearDown) sees the decorator's level.
+        prev_level = faiss.SIMDConfig.get_level()
+        faiss.SIMDConfig.set_level(faiss.SIMDLevel_NONE)
+        try:
+            codes_none = rq.compute_codes(xb)
+        finally:
+            faiss.SIMDConfig.set_level(prev_level)
+        np.testing.assert_array_equal(codes, codes_none)
+
     def test_clipping(self):
         """ verify that a clipped residual quantizer gives the same
         code prefix + suffix as the full RQ """


### PR DESCRIPTION
Summary:

The for_all_simd_levels decorator (D101822335) makes existing tests run
once per SIMD level, but only catches dispatch drift when the test's
correctness assertions compare against a level-independent reference.
RQ encode (residual_quantizer_encode_steps.cpp:96,369, dispatched via
with_simd_level_256bit) is integer-valued, but
test_residual_quantizer's existing assertions are tolerance-based --
silent dispatch drift between AVX2 and NONE could go undetected.

Adds test_compute_codes_matches_none in test_residual_quantizer.py: at
the decorator's level, run rq.compute_codes(xb), then switch to
SIMDLevel.NONE, run the reference, restore the level, assert
np.testing.assert_array_equal. Static-build lanes have only one level
available, so the test self.skipTest()'s there.

LSQ icm_encode_step already has a bit-exact Python reference comparison
(via icm_encode_step_ref) at every level, so cross-level NONE comparison
is transitively guaranteed -- no addition needed there.
test_extra_distances.py already has L1/Linf cases.

Differential Revision: D102821184


