### PR TITLE
Add SuperKMeans foundations: math primitives, PDX layout, SIMD kernels (#5163)

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -20,6 +20,7 @@ set(FAISS_SIMD_AVX2_SRC
   utils/simd_impl/partitioning_avx2.cpp
   utils/distances_fused/simdlib_based.cpp
   utils/simd_impl/rabitq_avx2.cpp
+  utils/simd_impl/super_kmeans_kernels_avx2.cpp
 )
 set(FAISS_SIMD_AVX512_SRC
   impl/fast_scan/impl-avx512.cpp
@@ -31,6 +32,7 @@ set(FAISS_SIMD_AVX512_SRC
   utils/distances_fused/avx512.cpp
   utils/hamming_distance/hamming_avx512.cpp
   utils/simd_impl/rabitq_avx512.cpp
+  utils/simd_impl/super_kmeans_kernels_avx512.cpp
 )
 set(FAISS_SIMD_NEON_SRC
   impl/fast_scan/impl-neon.cpp
@@ -115,9 +117,11 @@ set(FAISS_SRC
   VectorTransform.cpp
   clone_index.cpp
   index_factory.cpp
+  impl/AdSampling.cpp
   impl/AuxIndexStructures.cpp
   impl/VisitedTable.cpp
   impl/ClusteringInitialization.cpp
+  impl/ClusteringHelpers.cpp
   impl/CodePacker.cpp
   impl/CodePackerRaBitQ.cpp
   impl/IDSelector.cpp
@@ -150,6 +154,7 @@ set(FAISS_SRC
   impl/NNDescent.cpp
   impl/Panorama.cpp
   impl/PanoramaStats.cpp
+  impl/PdxLayout.cpp
   invlists/BlockInvertedLists.cpp
   invlists/DirectMap.cpp
   invlists/InvertedLists.cpp
@@ -238,10 +243,12 @@ set(FAISS_HEADERS
   index_factory.h
   factory_tools.h
   index_io.h
+  impl/AdSampling.h
   impl/AdditiveQuantizer.h
   impl/AuxIndexStructures.h
   impl/VisitedTable.h
   impl/ClusteringInitialization.h
+  impl/ClusteringHelpers.h
   impl/CodePacker.h
   impl/CodePackerRaBitQ.h
   impl/IDSelector.h
@@ -260,6 +267,7 @@ set(FAISS_HEADERS
   impl/NSG.h
   impl/Panorama.h
   impl/PanoramaStats.h
+  impl/PdxLayout.h
   impl/PolysemousTraining.h
   impl/ProductQuantizer-inl.h
   impl/ProductQuantizer.h
@@ -356,6 +364,8 @@ set(FAISS_HEADERS
   utils/simd_impl/distances_simdlib256.h
   utils/hamming_distance/hamming_impl.h
   utils/simd_impl/exhaustive_L2sqr_blas_cmax.h
+  utils/simd_impl/super_kmeans_dispatch.h
+  utils/simd_impl/super_kmeans_kernels.h
   utils/simd_impl/IVFFlatScanner-inl.h
   utils/simd_impl/distances_sse-inl.h
 )

--- a/faiss/Clustering.cpp
+++ b/faiss/Clustering.cpp
@@ -11,16 +11,14 @@
 #include <faiss/VectorTransform.h>
 #include <faiss/impl/AuxIndexStructures.h>
 
-#include <chrono>
 #include <cinttypes>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
 #include <limits>
 
-#include <omp.h>
-
 #include <faiss/IndexFlat.h>
+#include <faiss/impl/ClusteringHelpers.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/impl/kmeans1d.h>
 #include <faiss/utils/distances.h>
@@ -58,237 +56,6 @@ void Clustering::train(
             index,
             weights);
 }
-
-namespace {
-
-uint64_t get_actual_rng_seed(const int seed) {
-    return (seed >= 0)
-            ? seed
-            : static_cast<uint64_t>(std::chrono::high_resolution_clock::now()
-                                            .time_since_epoch()
-                                            .count());
-}
-
-idx_t subsample_training_set(
-        const Clustering& clus,
-        idx_t nx,
-        const uint8_t* x,
-        size_t line_size,
-        const float* weights,
-        uint8_t** x_out,
-        float** weights_out) {
-    if (clus.verbose) {
-        printf("Sampling a subset of %zd / %" PRId64 " for training\n",
-               clus.k * clus.max_points_per_centroid,
-               nx);
-    }
-
-    const uint64_t actual_seed = get_actual_rng_seed(clus.seed);
-
-    std::vector<idx_t> perm;
-    if (clus.use_faster_subsampling) {
-        // use subsampling with splitmix64 rng
-        SplitMix64RandomGenerator rng(actual_seed);
-
-        const idx_t new_nx = clus.k * clus.max_points_per_centroid;
-        perm.resize(new_nx);
-        for (idx_t i = 0; i < new_nx; i++) {
-            perm[i] = rng.rand_int64() % nx;
-        }
-    } else {
-        // use subsampling with a default std rng
-        FAISS_THROW_IF_NOT_FMT(
-                nx <= static_cast<idx_t>(std::numeric_limits<int>::max()),
-                "Dataset too large (%" PRId64
-                ") for standard subsampling; "
-                "set use_faster_subsampling=true",
-                nx);
-        std::vector<int> int_perm(nx);
-        rand_perm(int_perm.data(), nx, actual_seed);
-        perm.assign(int_perm.begin(), int_perm.end());
-    }
-
-    nx = clus.k * clus.max_points_per_centroid;
-    uint8_t* x_new = new uint8_t[nx * line_size];
-    *x_out = x_new;
-
-    // might be worth omp-ing as well
-    for (idx_t i = 0; i < nx; i++) {
-        memcpy(x_new + i * line_size, x + perm[i] * line_size, line_size);
-    }
-    if (weights) {
-        float* weights_new = new float[nx];
-        for (idx_t i = 0; i < nx; i++) {
-            weights_new[i] = weights[perm[i]];
-        }
-        *weights_out = weights_new;
-    } else {
-        *weights_out = nullptr;
-    }
-    return nx;
-}
-
-/** compute centroids as (weighted) sum of training points
- *
- * @param x            training vectors, size n * code_size (from codec)
- * @param codec        how to decode the vectors (if NULL then cast to float*)
- * @param weights      per-training vector weight, size n (or NULL)
- * @param assign       nearest centroid for each training vector, size n
- * @param k_frozen     do not update the k_frozen first centroids
- * @param centroids    centroid vectors (output only), size k * d
- * @param hassign      histogram of assignments per centroid (size k),
- *                     should be 0 on input
- *
- */
-
-void compute_centroids(
-        size_t d,
-        size_t k,
-        size_t n,
-        size_t k_frozen,
-        const uint8_t* x,
-        const Index* codec,
-        const int64_t* assign,
-        const float* weights,
-        float* hassign,
-        float* centroids) {
-    k -= k_frozen;
-    centroids += k_frozen * d;
-
-    memset(centroids, 0, sizeof(*centroids) * d * k);
-
-    size_t line_size = codec ? codec->sa_code_size() : d * sizeof(float);
-
-#pragma omp parallel
-    {
-        int nt = omp_get_num_threads();
-        int rank = omp_get_thread_num();
-
-        // this thread is taking care of centroids c0:c1
-        size_t c0 = (k * rank) / nt;
-        size_t c1 = (k * (rank + 1)) / nt;
-        std::vector<float> decode_buffer(d);
-
-        for (size_t i = 0; i < n; i++) {
-            int64_t ci = assign[i];
-            FAISS_THROW_IF_NOT_MSG(
-                    ci >= 0 && ci < k + k_frozen, "invalid cluster assignment");
-            ci -= k_frozen;
-            if (ci >= static_cast<int64_t>(c0) &&
-                ci < static_cast<int64_t>(c1)) {
-                float* c = centroids + ci * d;
-                const float* xi;
-                if (!codec) {
-                    xi = reinterpret_cast<const float*>(x + i * line_size);
-                } else {
-                    float* xif = decode_buffer.data();
-                    codec->sa_decode(1, x + i * line_size, xif);
-                    xi = xif;
-                }
-                if (weights) {
-                    float w = weights[i];
-                    hassign[ci] += w;
-                    for (size_t j = 0; j < d; j++) {
-                        c[j] += xi[j] * w;
-                    }
-                } else {
-                    hassign[ci] += 1.0;
-                    for (size_t j = 0; j < d; j++) {
-                        c[j] += xi[j];
-                    }
-                }
-            }
-        }
-    }
-
-#pragma omp parallel for
-    for (idx_t ci = 0; ci < static_cast<idx_t>(k); ci++) {
-        if (hassign[ci] == 0) {
-            continue;
-        }
-        float norm = 1 / hassign[ci];
-        float* c = centroids + ci * d;
-        for (size_t j = 0; j < d; j++) {
-            c[j] *= norm;
-        }
-    }
-}
-
-// a bit above machine epsilon for float16
-#define EPS (1 / 1024.)
-
-/** Handle empty clusters by splitting larger ones.
- *
- * It works by slightly changing the centroids to make 2 clusters from
- * a single one. Takes the same arguments as compute_centroids.
- *
- * @return           nb of splitting operations (larger is worse)
- */
-int split_clusters(
-        size_t d,
-        size_t k,
-        size_t n,
-        size_t k_frozen,
-        float* hassign,
-        float* centroids) {
-    k -= k_frozen;
-    centroids += k_frozen * d;
-
-    /* Take care of void clusters */
-    size_t nsplit = 0;
-    RandomGenerator rng(1234);
-    for (size_t ci = 0; ci < k; ci++) {
-        if (hassign[ci] == 0) { /* need to redefine a centroid */
-            size_t cj;
-            // Try probabilistic selection, with a deterministic fallback
-            // to the largest cluster if too many iterations pass.
-            size_t max_tries = 10 * k;
-            size_t n_tries = 0;
-            bool found = false;
-            for (cj = 0; n_tries < max_tries; cj = (cj + 1) % k) {
-                float p = (hassign[cj] - 1.0) / (float)(n - k);
-                float r = rng.rand_float();
-                if (r < p) {
-                    found = true;
-                    break;
-                }
-                n_tries++;
-            }
-            if (!found) {
-                // Deterministic fallback: split the largest cluster.
-                cj = 0;
-                for (size_t j = 1; j < k; j++) {
-                    if (hassign[j] > hassign[cj]) {
-                        cj = j;
-                    }
-                }
-            }
-            memcpy(centroids + ci * d,
-                   centroids + cj * d,
-                   sizeof(*centroids) * d);
-
-            /* small symmetric perturbation */
-            for (size_t j = 0; j < d; j++) {
-                if (j % 2 == 0) {
-                    centroids[ci * d + j] *= 1 + EPS;
-                    centroids[cj * d + j] *= 1 - EPS;
-                } else {
-                    centroids[ci * d + j] *= 1 - EPS;
-                    centroids[cj * d + j] *= 1 + EPS;
-                }
-            }
-
-            /* assume even split of the cluster */
-            hassign[ci] = hassign[cj] / 2;
-            hassign[cj] -= hassign[ci];
-            nsplit++;
-        }
-    }
-
-    return static_cast<int>(nsplit);
-}
-
-} // namespace
 
 void Clustering::train_encoded(
         idx_t nx,
@@ -337,7 +104,7 @@ void Clustering::train_encoded(
     if (static_cast<size_t>(nx) > k * max_points_per_centroid) {
         uint8_t* x_new;
         float* weights_new;
-        nx = subsample_training_set(
+        nx = detail::subsample_training_set(
                 *this, nx, x, line_size, weights, &x_new, &weights_new);
         del1.reset(x_new);
         x = x_new;
@@ -422,7 +189,7 @@ void Clustering::train_encoded(
     t0 = getmillisecs();
 
     // initialize seed
-    const uint64_t actual_seed = get_actual_rng_seed(seed);
+    const uint64_t actual_seed = detail::get_actual_rng_seed(seed);
 
     // temporary buffer to decode vectors during the optimization
     std::vector<float> decode_buffer(codec ? d * decode_block_size : 0);
@@ -541,7 +308,7 @@ void Clustering::train_encoded(
             std::vector<float> hassign(k);
 
             size_t k_frozen = frozen_centroids ? n_input_centroids : 0;
-            compute_centroids(
+            detail::compute_centroids(
                     d,
                     k,
                     nx,
@@ -553,7 +320,7 @@ void Clustering::train_encoded(
                     hassign.data(),
                     centroids.data());
 
-            int nsplit = split_clusters(
+            int nsplit = detail::split_clusters(
                     d, k, nx, k_frozen, hassign.data(), centroids.data());
 
             // collect statistics
@@ -647,7 +414,7 @@ void Clustering1D::train_exact(idx_t n, const float* x) {
     if (static_cast<size_t>(n) > k * max_points_per_centroid) {
         uint8_t* x_new;
         float* weights_new;
-        n = subsample_training_set(
+        n = detail::subsample_training_set(
                 *this,
                 n,
                 (uint8_t*)x,

--- a/faiss/impl/AdSampling.cpp
+++ b/faiss/impl/AdSampling.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <faiss/impl/AdSampling.h>
+
+#include <cmath>
+
+#include <faiss/impl/FaissAssert.h>
+
+namespace faiss {
+namespace detail {
+
+double normal_quantile(double p) {
+    // Three-branch rational polynomial; branch breakpoint p_low = 0.02425.
+    static constexpr double a[] = {
+            -3.969683028665376e+01,
+            2.209460984245205e+02,
+            -2.759285104469687e+02,
+            1.383577518672690e+02,
+            -3.066479806614716e+01,
+            2.506628277459239e+00,
+    };
+    static constexpr double b[] = {
+            -5.447609879822406e+01,
+            1.615858368580409e+02,
+            -1.556989798598866e+02,
+            6.680131188771972e+01,
+            -1.328068155288572e+01,
+    };
+    static constexpr double c[] = {
+            -7.784894002430293e-03,
+            -3.223964580411365e-01,
+            -2.400758277161838e+00,
+            -2.549732539343734e+00,
+            4.374664141464968e+00,
+            2.938163982698783e+00,
+    };
+    static constexpr double d[] = {
+            7.784695709041462e-03,
+            3.224671290700398e-01,
+            2.445134137142996e+00,
+            3.754408661907416e+00,
+    };
+    constexpr double p_low = 0.02425;
+    constexpr double p_high = 1.0 - p_low;
+    if (p < p_low) {
+        const double q = std::sqrt(-2.0 * std::log(p));
+        return (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q +
+                c[5]) /
+                ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0);
+    } else if (p <= p_high) {
+        const double q = p - 0.5;
+        const double r = q * q;
+        return (((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r +
+                a[5]) *
+                q /
+                (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r +
+                 1.0);
+    } else {
+        const double q = std::sqrt(-2.0 * std::log(1.0 - p));
+        return -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q +
+                 c[5]) /
+                ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0);
+    }
+}
+
+double chi2_quantile_wh(int p, double alpha) {
+    FAISS_THROW_IF_NOT(p > 0);
+    // Wilson-Hilferty cube-root approximation:
+    //   ((X/p)^(1/3) - (1 - 2/(9p))) / sqrt(2/(9p)) ~ N(0,1)
+    // inverted into a quantile formula.
+    //
+    // Domain constraint: for very small alpha (< ~0.001) and small p
+    // (< 4), t can go negative, producing a negative chi-squared quantile
+    // (physically impossible). In practice this cannot happen here:
+    // precompute_ad_thresholds calls with alpha = 1 - epsilon where
+    // epsilon = ad_epsilon_factor / d, and d_prime_min >= 16, so
+    // p >= 16 and alpha >= 1 - 1/16 = 0.9375 — well inside the accurate
+    // region of the approximation.
+    const double z = normal_quantile(alpha);
+    const double t = 1.0 - 2.0 / (9.0 * p) + z * std::sqrt(2.0 / (9.0 * p));
+    return p * t * t * t;
+}
+
+std::vector<float> precompute_ad_thresholds(int d, double epsilon) {
+    FAISS_THROW_IF_NOT_MSG(
+            epsilon > 0.0 && epsilon < 1.0,
+            "precompute_ad_thresholds: epsilon must be in (0, 1)");
+    FAISS_THROW_IF_NOT_MSG(
+            d > 0, "precompute_ad_thresholds: d must be positive");
+    std::vector<float> coeff(d + 1);
+    for (int p = 1; p <= d; p++) {
+        coeff[p] = static_cast<float>(chi2_quantile_wh(p, 1.0 - epsilon) / d);
+    }
+    return coeff;
+}
+
+} // namespace detail
+} // namespace faiss

--- a/faiss/impl/AdSampling.h
+++ b/faiss/impl/AdSampling.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <vector>
+
+namespace faiss {
+namespace detail {
+
+/** Inverse standard normal CDF. Three-branch rational polynomial,
+ * absolute error < 1.15e-9 over `p in (0, 1)`. Behavior at the boundaries
+ * (p <= 0 or p >= 1) is unspecified — returns NaN or +/-inf. */
+double normal_quantile(double p);
+
+/** Chi-squared quantile via cube-root approximation. Validated to within
+ * 2% of scipy for `p in [16, d]` and `alpha <= 1 - 1e-6`. Accuracy
+ * degrades for smaller `p` or for `alpha` near 1. */
+double chi2_quantile_wh(int p, double alpha);
+
+/** Build ADSampling threshold table of size `d + 1`:
+ *   coeff[p] = chi2_quantile_wh(p, 1 - epsilon) / d.
+ *
+ * Indexing: coeff[0] is reserved (left at 0.0f). coeff[1..15] are
+ * computed but NOT accuracy-bounded — callers requiring the 2% scipy
+ * tolerance must consume only coeff[16..d]. SuperKMeans enforces
+ * this via its `d_prime_min = 16` parameter. */
+std::vector<float> precompute_ad_thresholds(int d, double epsilon);
+
+} // namespace detail
+} // namespace faiss

--- a/faiss/impl/ClusteringHelpers.cpp
+++ b/faiss/impl/ClusteringHelpers.cpp
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <faiss/impl/ClusteringHelpers.h>
+
+#include <cassert>
+#include <chrono>
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+#include <omp.h>
+
+#include <faiss/Index.h>
+#include <faiss/impl/FaissAssert.h>
+#include <faiss/utils/random.h>
+
+namespace faiss {
+namespace detail {
+
+uint64_t get_actual_rng_seed(const int seed) {
+    return (seed >= 0)
+            ? seed
+            : static_cast<uint64_t>(std::chrono::high_resolution_clock::now()
+                                            .time_since_epoch()
+                                            .count());
+}
+
+idx_t subsample_training_set(
+        const Clustering& clus,
+        idx_t nx,
+        const uint8_t* x,
+        size_t line_size,
+        const float* weights,
+        uint8_t** x_out,
+        float** weights_out) {
+    FAISS_THROW_IF_NOT(clus.k > 0 && clus.max_points_per_centroid > 0);
+    if (clus.verbose) {
+        printf("Sampling a subset of %zd / %" PRId64 " for training\n",
+               clus.k * clus.max_points_per_centroid,
+               nx);
+    }
+
+    const uint64_t actual_seed = get_actual_rng_seed(clus.seed);
+
+    std::vector<idx_t> perm;
+    if (clus.use_faster_subsampling) {
+        SplitMix64RandomGenerator rng(actual_seed);
+
+        const idx_t new_nx = clus.k * clus.max_points_per_centroid;
+        perm.resize(new_nx);
+        assert(!perm.empty());
+        for (idx_t i = 0; i < new_nx; i++) {
+            perm[i] = rng.rand_int64() % nx;
+        }
+    } else {
+        FAISS_THROW_IF_NOT_FMT(
+                nx <= static_cast<idx_t>(std::numeric_limits<int>::max()),
+                "Dataset too large (%" PRId64
+                ") for standard subsampling; "
+                "set use_faster_subsampling=true",
+                nx);
+        std::vector<int> int_perm(nx);
+        rand_perm(int_perm.data(), nx, actual_seed);
+        perm.assign(int_perm.begin(), int_perm.end());
+    }
+
+    nx = clus.k * clus.max_points_per_centroid;
+    FAISS_THROW_IF_NOT_FMT(
+            perm.size() >= static_cast<size_t>(nx),
+            "subsample_training_set: perm size %zu < required nx %" PRId64,
+            perm.size(),
+            nx);
+    assert(!perm.empty()); // pattern for clang-tidy LocalUncheckedArrayBounds
+
+    uint8_t* x_new = new uint8_t[nx * line_size];
+    *x_out = x_new;
+
+    for (idx_t i = 0; i < nx; i++) {
+        memcpy(x_new + i * line_size, x + perm[i] * line_size, line_size);
+    }
+    if (weights) {
+        float* weights_new = new float[nx];
+        for (idx_t i = 0; i < nx; i++) {
+            weights_new[i] = weights[perm[i]];
+        }
+        *weights_out = weights_new;
+    } else {
+        *weights_out = nullptr;
+    }
+    return nx;
+}
+
+void compute_centroids(
+        size_t d,
+        size_t k,
+        size_t n,
+        size_t k_frozen,
+        const uint8_t* x,
+        const Index* codec,
+        const int64_t* assign,
+        const float* weights,
+        float* hassign,
+        float* centroids) {
+    k -= k_frozen;
+    centroids += k_frozen * d;
+
+    memset(centroids, 0, sizeof(*centroids) * d * k);
+
+    size_t line_size = codec ? codec->sa_code_size() : d * sizeof(float);
+
+    // NOTE: FAISS_THROW_IF_NOT inside this OMP region is formally UB per the
+    // OpenMP spec (exceptions cannot propagate out of a parallel region).
+    // In practice, most runtimes terminate the process, which is acceptable
+    // for a corrupted-assignment invariant violation. Inherited from
+    // Clustering.cpp; not worth refactoring without a broader FAISS effort.
+    //
+    // Thread safety of hassign[ci]: each thread owns the exclusive slice
+    // [c0, c1) and only writes hassign[ci] when ci falls in that slice
+    // (same guard as centroids[ci*d]). No two threads share an index.
+#pragma omp parallel
+    {
+        int nt = omp_get_num_threads();
+        int rank = omp_get_thread_num();
+
+        // this thread is taking care of centroids c0:c1
+        size_t c0 = (k * rank) / nt;
+        size_t c1 = (k * (rank + 1)) / nt;
+        std::vector<float> decode_buffer(d);
+
+        for (size_t i = 0; i < n; i++) {
+            int64_t ci = assign[i];
+            FAISS_THROW_IF_NOT_MSG(
+                    ci >= 0 && ci < k + k_frozen, "invalid cluster assignment");
+            ci -= k_frozen;
+            if (ci >= static_cast<int64_t>(c0) &&
+                ci < static_cast<int64_t>(c1)) {
+                float* c = centroids + ci * d;
+                const float* xi;
+                if (!codec) {
+                    xi = reinterpret_cast<const float*>(x + i * line_size);
+                } else {
+                    float* xif = decode_buffer.data();
+                    codec->sa_decode(1, x + i * line_size, xif);
+                    xi = xif;
+                }
+                if (weights) {
+                    float w = weights[i];
+                    hassign[ci] += w;
+                    for (size_t j = 0; j < d; j++) {
+                        c[j] += xi[j] * w;
+                    }
+                } else {
+                    hassign[ci] += 1.0;
+                    for (size_t j = 0; j < d; j++) {
+                        c[j] += xi[j];
+                    }
+                }
+            }
+        }
+    }
+
+#pragma omp parallel for
+    for (idx_t ci = 0; ci < static_cast<idx_t>(k); ci++) {
+        if (hassign[ci] == 0) {
+            continue;
+        }
+        float norm = 1 / hassign[ci];
+        float* c = centroids + ci * d;
+        for (size_t j = 0; j < d; j++) {
+            c[j] *= norm;
+        }
+    }
+}
+
+// a bit above machine epsilon for float16
+static constexpr float EPS = 1.f / 1024.f;
+
+int split_clusters(
+        size_t d,
+        size_t k,
+        size_t n,
+        size_t k_frozen,
+        float* hassign,
+        float* centroids) {
+    k -= k_frozen;
+    centroids += k_frozen * d;
+    FAISS_THROW_IF_NOT_MSG(
+            n > k,
+            "split_clusters: n must exceed k to find a non-empty donor centroid");
+
+    size_t nsplit = 0;
+    RandomGenerator rng(1234);
+    for (size_t ci = 0; ci < k; ci++) {
+        if (hassign[ci] == 0) {
+            // Probabilistic donor pick weighted by hassign; deterministic
+            // fallback to the largest cluster if too many iterations pass.
+            size_t cj;
+            size_t max_tries = 10 * k;
+            size_t n_tries = 0;
+            bool found = false;
+            for (cj = 0; n_tries < max_tries; cj = (cj + 1) % k) {
+                float p = (hassign[cj] - 1.0) / (float)(n - k);
+                float r = rng.rand_float();
+                if (r < p) {
+                    found = true;
+                    break;
+                }
+                n_tries++;
+            }
+            if (!found) {
+                // Deterministic fallback: split the largest cluster.
+                cj = 0;
+                for (size_t j = 1; j < k; j++) {
+                    if (hassign[j] > hassign[cj]) {
+                        cj = j;
+                    }
+                }
+            }
+            memcpy(centroids + ci * d,
+                   centroids + cj * d,
+                   sizeof(*centroids) * d);
+
+            /* small symmetric perturbation */
+            for (size_t j = 0; j < d; j++) {
+                if (j % 2 == 0) {
+                    centroids[ci * d + j] *= 1 + EPS;
+                    centroids[cj * d + j] *= 1 - EPS;
+                } else {
+                    centroids[ci * d + j] *= 1 - EPS;
+                    centroids[cj * d + j] *= 1 + EPS;
+                }
+            }
+
+            /* assume even split of the cluster */
+            hassign[ci] = hassign[cj] / 2;
+            hassign[cj] -= hassign[ci];
+            nsplit++;
+        }
+    }
+
+    return static_cast<int>(nsplit);
+}
+
+} // namespace detail
+} // namespace faiss

--- a/faiss/impl/ClusteringHelpers.h
+++ b/faiss/impl/ClusteringHelpers.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <faiss/Clustering.h>
+#include <faiss/Index.h>
+
+namespace faiss {
+namespace detail {
+
+/** Resolve the actual RNG seed for clustering helpers.
+ *
+ * If `seed >= 0`, returns `seed`. Otherwise returns a high-resolution
+ * timestamp so that callers get a non-deterministic seed.
+ *
+ * @param seed  user-provided seed; negative values request a time-based seed
+ * @return      the resolved seed
+ */
+uint64_t get_actual_rng_seed(const int seed);
+
+/** Subsample a training set down to `clus.k * clus.max_points_per_centroid`
+ * rows.
+ *
+ * Allocates `*x_out` (and `*weights_out` when `weights` is non-null) with
+ * `new[]`; ownership is transferred to the caller.
+ *
+ * @param clus        clustering parameters (reads `k`,
+ * `max_points_per_centroid`, `use_faster_subsampling`, `seed`, `verbose`)
+ * @param nx          number of input training rows
+ * @param x           input training data, row-major, `nx * line_size` bytes
+ * @param line_size   bytes per training row
+ * @param weights     optional per-row weights (length `nx`), or null
+ * @param x_out       output: newly allocated subsampled rows
+ * @param weights_out output: newly allocated subsampled weights, or null
+ * @return            number of rows in the subsampled set
+ */
+idx_t subsample_training_set(
+        const Clustering& clus,
+        idx_t nx,
+        const uint8_t* x,
+        size_t line_size,
+        const float* weights,
+        uint8_t** x_out,
+        float** weights_out);
+
+/** compute centroids as (weighted) sum of training points
+ *
+ * @param x            training vectors, size n * code_size (from codec)
+ * @param codec        how to decode the vectors (if NULL then cast to float*)
+ * @param weights      per-training vector weight, size n (or NULL)
+ * @param assign       nearest centroid for each training vector, size n
+ * @param k_frozen     do not update the k_frozen first centroids
+ * @param centroids    centroid vectors (output only), size k * d
+ * @param hassign      histogram of assignments per centroid (size k),
+ *                     should be 0 on input
+ *
+ */
+void compute_centroids(
+        size_t d,
+        size_t k,
+        size_t n,
+        size_t k_frozen,
+        const uint8_t* x,
+        const Index* codec,
+        const int64_t* assign,
+        const float* weights,
+        float* hassign,
+        float* centroids);
+
+/** Handle empty clusters by splitting larger ones.
+ *
+ * It works by slightly changing the centroids to make 2 clusters from
+ * a single one. Takes the same arguments as compute_centroids.
+ *
+ * @return           nb of splitting operations (larger is worse)
+ */
+int split_clusters(
+        size_t d,
+        size_t k,
+        size_t n,
+        size_t k_frozen,
+        float* hassign,
+        float* centroids);
+
+} // namespace detail
+} // namespace faiss

--- a/faiss/impl/PdxLayout.cpp
+++ b/faiss/impl/PdxLayout.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <faiss/impl/PdxLayout.h>
+
+#include <cstddef>
+#include <cstring>
+
+namespace faiss {
+namespace detail {
+
+void pdxify(
+        const float* Y,
+        int k,
+        int d_trail,
+        int pdx_block_size,
+        float* Y_pdx) {
+    const int n_full_blocks = d_trail / pdx_block_size;
+    const int tail = d_trail % pdx_block_size;
+    size_t offset = 0;
+    for (int b = 0; b < n_full_blocks; ++b) {
+        const size_t src_start = static_cast<size_t>(b) * pdx_block_size;
+        for (int j = 0; j < k; ++j) {
+            std::memcpy(
+                    Y_pdx + offset,
+                    Y + static_cast<size_t>(j) * d_trail + src_start,
+                    pdx_block_size * sizeof(float));
+            offset += pdx_block_size;
+        }
+    }
+    if (tail > 0) {
+        const size_t src_start =
+                static_cast<size_t>(n_full_blocks) * pdx_block_size;
+        for (int j = 0; j < k; ++j) {
+            std::memcpy(
+                    Y_pdx + offset,
+                    Y + static_cast<size_t>(j) * d_trail + src_start,
+                    tail * sizeof(float));
+            offset += tail;
+        }
+    }
+}
+
+void de_pdxify(
+        const float* Y_pdx,
+        int k,
+        int d_trail,
+        int pdx_block_size,
+        float* Y) {
+    const int n_full_blocks = d_trail / pdx_block_size;
+    const int tail = d_trail % pdx_block_size;
+    size_t offset = 0;
+    for (int b = 0; b < n_full_blocks; ++b) {
+        const size_t dst_start = static_cast<size_t>(b) * pdx_block_size;
+        for (int j = 0; j < k; ++j) {
+            std::memcpy(
+                    Y + static_cast<size_t>(j) * d_trail + dst_start,
+                    Y_pdx + offset,
+                    pdx_block_size * sizeof(float));
+            offset += pdx_block_size;
+        }
+    }
+    if (tail > 0) {
+        const size_t dst_start =
+                static_cast<size_t>(n_full_blocks) * pdx_block_size;
+        for (int j = 0; j < k; ++j) {
+            std::memcpy(
+                    Y + static_cast<size_t>(j) * d_trail + dst_start,
+                    Y_pdx + offset,
+                    tail * sizeof(float));
+            offset += tail;
+        }
+    }
+}
+
+void compute_partial_norms(const float* X, int n, int d, int p, float* norms) {
+#pragma omp parallel for
+    for (int i = 0; i < n; ++i) {
+        float s = 0.0f;
+        const float* row = X + static_cast<size_t>(i) * d;
+        for (int m = 0; m < p; ++m) {
+            s += row[m] * row[m];
+        }
+        norms[i] = s;
+    }
+}
+
+} // namespace detail
+} // namespace faiss

--- a/faiss/impl/PdxLayout.h
+++ b/faiss/impl/PdxLayout.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace faiss {
+namespace detail {
+
+/** Reorder a row-major (k, d_trail) matrix into PDX block-column-major
+ * layout. Inside each block of `pdx_block_size` dims the layout is
+ * column-major across centroids, so all k centroids' values for the same
+ * dim are contiguous — the access pattern that makes progressive pruning
+ * cache-friendly. Trailing block (size `d_trail % pdx_block_size`) uses
+ * the same convention. `Y_pdx` must already be sized to `k * d_trail`. */
+void pdxify(
+        const float* Y,
+        int k,
+        int d_trail,
+        int pdx_block_size,
+        float* Y_pdx);
+
+/** Inverse of pdxify (used in tests for the bit-identical round-trip
+ * check). */
+void de_pdxify(
+        const float* Y_pdx,
+        int k,
+        int d_trail,
+        int pdx_block_size,
+        float* Y);
+
+/** norms[i] = sum_{m<p} X[i, m]^2  for row-major X of shape (n, d).
+ * Parallel over rows. Used by SuperKMeans to keep partial-norm caches
+ * in sync with the current d_prime. */
+void compute_partial_norms(const float* X, int n, int d, int p, float* norms);
+
+} // namespace detail
+} // namespace faiss

--- a/faiss/utils/simd_impl/super_kmeans_dispatch.h
+++ b/faiss/utils/simd_impl/super_kmeans_dispatch.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// Private dispatch wrapper for SuperKMeans's block_l2. Routes to the
+// highest available SIMD specialization at runtime (DD mode) or the
+// compiled-in level (static mode). aarch64 currently falls through to the
+// scalar primary template; adding NEON/SVE means just adding a new
+// specialization file alongside the AVX ones.
+//
+// Known perf gap: aarch64 (NEON/SVE) specializations are not implemented in v1.
+// aarch64 falls through to the scalar primary template. Validating SVE requires
+// a Graviton-class host; deferred to a focused follow-up.
+
+#include <faiss/impl/simd_dispatch.h>
+#include <faiss/utils/simd_impl/super_kmeans_kernels.h>
+
+namespace faiss {
+namespace detail {
+
+inline float block_l2_dispatch(const float* x, const float* y, int n) {
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A0>(
+            [&]<SIMDLevel SL>() { return block_l2<SL>(x, y, n); });
+}
+
+} // namespace detail
+} // namespace faiss

--- a/faiss/utils/simd_impl/super_kmeans_kernels.h
+++ b/faiss/utils/simd_impl/super_kmeans_kernels.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+#include <faiss/utils/simd_levels.h>
+
+namespace faiss {
+namespace detail {
+
+// Squared L2 over `n` dimensions; n in [1, pdx_block_size].
+// Primary template is the scalar fallback; SIMDLevels without a dedicated
+// specialization (ARM_NEON, ARM_SVE, NONE, ...) use it directly.
+template <SIMDLevel Level>
+inline float block_l2(const float* x, const float* y, int n) {
+    float s = 0.0f;
+    for (int m = 0; m < n; ++m) {
+        const float d = x[m] - y[m];
+        s += d * d;
+    }
+    return s;
+}
+
+// Mirrors the impl-file guards; turns off-arch direct calls into a
+// compile-time error instead of a linker error.
+#if defined(__x86_64__)
+template <>
+float block_l2<SIMDLevel::AVX2>(const float* x, const float* y, int n);
+
+template <>
+float block_l2<SIMDLevel::AVX512>(const float* x, const float* y, int n);
+#endif // __x86_64__
+
+} // namespace detail
+} // namespace faiss

--- a/faiss/utils/simd_impl/super_kmeans_kernels_avx2.cpp
+++ b/faiss/utils/simd_impl/super_kmeans_kernels_avx2.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#if defined(__x86_64__)
+
+#include <faiss/utils/simd_impl/super_kmeans_kernels.h>
+
+#include <immintrin.h>
+
+namespace faiss {
+namespace detail {
+
+namespace {
+
+// Reduce 8 float lanes of an AVX2 register to a scalar sum.
+// Uses a shuffle+add tree instead of two _mm_hadd_ps. On Skylake-class
+// cores, hadd is 3-cycle latency / 2-uop, while movehdup/movehl/add_ss
+// are single-uop, single-cycle ops.
+inline float horizontal_sum_avx2(__m256 v) {
+    __m128 lo = _mm256_castps256_ps128(v);
+    __m128 hi = _mm256_extractf128_ps(v, 1);
+    __m128 sum128 = _mm_add_ps(lo, hi);     // 4 lanes
+    __m128 shuf = _mm_movehdup_ps(sum128);  // [s1, s1, s3, s3]
+    __m128 sums = _mm_add_ps(sum128, shuf); // [s0+s1, _, s2+s3, _]
+    shuf = _mm_movehl_ps(shuf, sums);       // [s2+s3, s3, _, _]
+    sums = _mm_add_ss(sums, shuf);          // (s0+s1) + (s2+s3)
+    return _mm_cvtss_f32(sums);
+}
+
+} // namespace
+
+template <>
+float block_l2<SIMDLevel::AVX2>(const float* x, const float* y, int n) {
+    __m256 acc = _mm256_setzero_ps();
+    int m = 0;
+    for (; m + 8 <= n; m += 8) {
+        __m256 xv = _mm256_loadu_ps(x + m);
+        __m256 yv = _mm256_loadu_ps(y + m);
+        __m256 diff = _mm256_sub_ps(xv, yv);
+        acc = _mm256_fmadd_ps(diff, diff, acc);
+    }
+    float result = horizontal_sum_avx2(acc);
+    for (; m < n; ++m) {
+        const float d = x[m] - y[m];
+        result += d * d;
+    }
+    return result;
+}
+
+} // namespace detail
+} // namespace faiss
+
+#endif // __x86_64__

--- a/faiss/utils/simd_impl/super_kmeans_kernels_avx512.cpp
+++ b/faiss/utils/simd_impl/super_kmeans_kernels_avx512.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#if defined(__x86_64__) && defined(__AVX512F__)
+
+#include <faiss/utils/simd_impl/super_kmeans_kernels.h>
+
+#include <immintrin.h>
+
+namespace faiss {
+namespace detail {
+
+template <>
+float block_l2<SIMDLevel::AVX512>(const float* x, const float* y, int n) {
+    __m512 acc = _mm512_setzero_ps();
+    int m = 0;
+    for (; m + 16 <= n; m += 16) {
+        __m512 xv = _mm512_loadu_ps(x + m);
+        __m512 yv = _mm512_loadu_ps(y + m);
+        __m512 diff = _mm512_sub_ps(xv, yv);
+        acc = _mm512_fmadd_ps(diff, diff, acc);
+    }
+    // _mm512_reduce_add_ps: on modern AVX-512 SKUs (Cascade Lake+, Sapphire
+    // Rapids) GCC/Clang lower this to a shuffle+add tree, ~5-cycle latency.
+    // On older AVX-512 SKUs (Skylake-X, Ice Lake) the cross-lane reduction
+    // can be ~20 cycles. Acceptable here because n ~ pdx_block_size = 64
+    // (4 iterations of 16-wide accumulation), so per-block work dominates
+    // the reduction cost. AVX2 uses a manual shuffle+add tree explicitly
+    // to avoid `_mm_hadd_ps` overhead, where the ratio is reversed.
+    float result = _mm512_reduce_add_ps(acc);
+    for (; m < n; ++m) {
+        const float d = x[m] - y[m];
+        result += d * d;
+    }
+    return result;
+}
+
+} // namespace detail
+} // namespace faiss
+
+#endif // __x86_64__ && __AVX512F__

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ set(FAISS_TEST_SRC
   test_distances_simd.cpp
   test_simd_levels.cpp
   test_fast_scan_distance_to_code.cpp
+  test_super_kmeans_foundations.cpp
 )
 
 # Tests that use POSIX APIs or have platform-specific issues on Windows

--- a/tests/test_super_kmeans_foundations.cpp
+++ b/tests/test_super_kmeans_foundations.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cmath>
+#include <random>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <faiss/impl/AdSampling.h>
+#include <faiss/impl/PdxLayout.h>
+#include <faiss/utils/simd_impl/super_kmeans_dispatch.h>
+#include <faiss/utils/simd_impl/super_kmeans_kernels.h>
+#include <faiss/utils/simd_levels.h>
+
+// =====================================================================
+// AdSampling tests
+// =====================================================================
+
+// Reference values from scipy.stats.norm.ppf, cited so a reader can
+// reproduce. Covers all three branches: lower tail (p < 0.02425), central
+// region, and upper tail.
+TEST(AdSampling, NormalQuantile_KnownValues) {
+    // scipy.stats.norm.ppf(0.001) == -3.0902323061678135
+    // scipy.stats.norm.ppf(0.025) == -1.959963984540054
+    // scipy.stats.norm.ppf(0.5)   ==  0.0
+    // scipy.stats.norm.ppf(0.975) ==  1.959963984540054
+    // scipy.stats.norm.ppf(0.999) ==  3.090232306167813
+    EXPECT_NEAR(
+            faiss::detail::normal_quantile(0.001), -3.0902323061678135, 1e-6);
+    EXPECT_NEAR(
+            faiss::detail::normal_quantile(0.025), -1.959963984540054, 1e-6);
+    EXPECT_NEAR(faiss::detail::normal_quantile(0.5), 0.0, 1e-9);
+    EXPECT_NEAR(faiss::detail::normal_quantile(0.975), 1.959963984540054, 1e-6);
+    EXPECT_NEAR(faiss::detail::normal_quantile(0.999), 3.090232306167813, 1e-6);
+}
+
+// Sweep across a representative (d, p) range; each scipy value cited inline.
+TEST(AdSampling, WilsonHilferty_SweepWithin2pct) {
+    // {d, p, scipy.stats.chi2.ppf(1 - 1/d, p)}
+    constexpr struct {
+        int d;
+        int p;
+        double scipy;
+    } refs[] = {
+            {128, 16, 32.8175588210},
+            {128, 64, 94.5448777626},
+            {128, 128, 169.8866700943},
+            {256, 16, 35.0547925053},
+            {512, 64, 101.5518691071},
+            {1024, 64, 104.8262690216},
+            {1024, 256, 331.8453440901},
+            {1024, 1024, 1169.9132946160},
+            {2048, 128, 187.4098077764},
+            {4096, 64, 111.0328823202},
+            {4096, 1024, 1189.2900132113},
+            {4096, 4096, 4419.0780429111},
+    };
+    for (const auto& r : refs) {
+        const double alpha = 1.0 - 1.0 / r.d;
+        const double wh = faiss::detail::chi2_quantile_wh(r.p, alpha);
+        const double rel_err = std::abs(wh - r.scipy) / r.scipy;
+        EXPECT_LT(rel_err, 0.02) << "d=" << r.d << " p=" << r.p
+                                 << " alpha=" << alpha << " scipy=" << r.scipy
+                                 << " wh=" << wh << " rel_err=" << rel_err;
+    }
+}
+
+// chi-squared quantile is monotone in degrees of freedom (distribution
+// property, not implementation choice). Validated range is p >= 16, so
+// loop from 17 to keep p-1 in range.
+TEST(AdSampling, ThresholdsMonotone) {
+    constexpr int d = 768;
+    const std::vector<float> coeff =
+            faiss::detail::precompute_ad_thresholds(d, 1.0 / d);
+
+    ASSERT_EQ(coeff.size(), static_cast<size_t>(d + 1));
+
+    for (int p = 17; p < d; p++) {
+        EXPECT_GT(coeff[p], coeff[p - 1])
+                << "monotonicity violated at p = " << p;
+    }
+}
+
+// =====================================================================
+// PdxLayout tests
+// =====================================================================
+
+// pdxify . de_pdxify == identity. d_trail=200, block=64 -> 3 full blocks +
+// 1 trailing block of 8 dims. Bit-equality: both transforms are pure memcpy.
+TEST(PdxLayout, RoundTrip) {
+    constexpr int k = 64;
+    constexpr int d_trail = 200;
+    constexpr int pdx_block_size = 64;
+
+    std::vector<float> Y(k * d_trail);
+    for (int j = 0; j < k; ++j) {
+        for (int dim = 0; dim < d_trail; ++dim) {
+            Y[j * d_trail + dim] =
+                    static_cast<float>(j) * 1000.0f + static_cast<float>(dim);
+        }
+    }
+
+    std::vector<float> Y_pdx(k * d_trail);
+    faiss::detail::pdxify(Y.data(), k, d_trail, pdx_block_size, Y_pdx.data());
+
+    std::vector<float> Y_back(k * d_trail);
+    faiss::detail::de_pdxify(
+            Y_pdx.data(), k, d_trail, pdx_block_size, Y_back.data());
+
+    ASSERT_EQ(Y, Y_back);
+}
+
+// Trailing dims are large/varied so a "summed too far" bug shows up
+// loudly (rows 1 and 2 expectations would jump to ~405 / 10000.5).
+TEST(PdxLayout, ComputePartialNormsMatchesReference) {
+    constexpr int n = 4;
+    constexpr int d = 8;
+    constexpr int p = 3;
+    // clang-format off
+    const std::vector<float> X = {
+        // row 0: ||row[0:3]||^2 = 1 + 4 + 9 = 14
+        1.0f, 2.0f, 3.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+        // row 1: ||row[0:3]||^2 = 0
+        0.0f, 0.0f, 0.0f, 9.0f, 9.0f, 9.0f, 9.0f, 9.0f,
+        // row 2: ||row[0:3]||^2 = 0.25 + 0 + 0.25 = 0.5
+        0.5f, 0.0f, 0.5f, 100.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+        // row 3: ||row[0:3]||^2 = 0.01 + 0.04 + 0.09 = 0.14
+        0.1f, 0.2f, 0.3f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+    };
+    // clang-format on
+    std::vector<float> norms(n, -1.0f); // sentinel
+    faiss::detail::compute_partial_norms(X.data(), n, d, p, norms.data());
+    EXPECT_NEAR(norms[0], 14.0f, 1e-6f);
+    EXPECT_NEAR(norms[1], 0.0f, 1e-6f);
+    EXPECT_NEAR(norms[2], 0.5f, 1e-6f);
+    EXPECT_NEAR(norms[3], 0.14f, 1e-6f);
+}
+
+// =====================================================================
+// SIMD kernel tests
+// =====================================================================
+
+TEST(BlockL2, ScalarMatchesReference) {
+    // y[m] = x[m] + 1 -> diff^2 = 1 for each m -> sum over n dims = n.
+    constexpr int N = 64;
+    std::vector<float> x(N), y(N);
+    for (int m = 0; m < N; ++m) {
+        x[m] = static_cast<float>(m);
+        y[m] = static_cast<float>(m + 1);
+    }
+
+    EXPECT_NEAR(
+            faiss::detail::block_l2<faiss::SIMDLevel::NONE>(
+                    x.data(), y.data(), N),
+            static_cast<float>(N),
+            1e-4f);
+
+    for (int n = 1; n < N; ++n) {
+        const float ref = static_cast<float>(n);
+        EXPECT_NEAR(
+                faiss::detail::block_l2<faiss::SIMDLevel::NONE>(
+                        x.data(), y.data(), n),
+                ref,
+                1e-4f)
+                << "n=" << n;
+    }
+}
+
+TEST(BlockL2, Avx512MatchesScalar) {
+#if defined(__x86_64__) && defined(__AVX512F__)
+    constexpr int N = 64;
+    std::mt19937 rng(43);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<float> x(N), y(N);
+    for (int m = 0; m < N; ++m) {
+        x[m] = dist(rng);
+        y[m] = dist(rng);
+    }
+
+    const float scalar = faiss::detail::block_l2<faiss::SIMDLevel::NONE>(
+            x.data(), y.data(), N);
+    const float avx512 = faiss::detail::block_l2<faiss::SIMDLevel::AVX512>(
+            x.data(), y.data(), N);
+    EXPECT_NEAR(avx512, scalar, 1e-4f);
+
+    for (int n = 1; n < N; ++n) {
+        const float s = faiss::detail::block_l2<faiss::SIMDLevel::NONE>(
+                x.data(), y.data(), n);
+        const float a = faiss::detail::block_l2<faiss::SIMDLevel::AVX512>(
+                x.data(), y.data(), n);
+        EXPECT_NEAR(a, s, 1e-4f) << "n=" << n;
+    }
+#else
+    GTEST_SKIP() << "AVX-512 test requires __AVX512F__";
+#endif
+}
+
+TEST(BlockL2, DispatchMatchesScalar) {
+    constexpr int N = 64;
+    std::mt19937 rng(44);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<float> x(N), y(N);
+    for (int m = 0; m < N; ++m) {
+        x[m] = dist(rng);
+        y[m] = dist(rng);
+    }
+
+    const float scalar = faiss::detail::block_l2<faiss::SIMDLevel::NONE>(
+            x.data(), y.data(), N);
+    const float dispatched =
+            faiss::detail::block_l2_dispatch(x.data(), y.data(), N);
+    EXPECT_NEAR(dispatched, scalar, 1e-4f);
+
+    for (int n = 1; n < N; ++n) {
+        const float s = faiss::detail::block_l2<faiss::SIMDLevel::NONE>(
+                x.data(), y.data(), n);
+        const float d = faiss::detail::block_l2_dispatch(x.data(), y.data(), n);
+        EXPECT_NEAR(d, s, 1e-4f) << "n=" << n;
+    }
+}


### PR DESCRIPTION
Summary:

Adds the foundational building blocks for SuperKMeans — a faster k-means alternative to `faiss::Clustering` for IVF training and other large-k workloads (diff [2/3] adds the algorithm itself; diff [3/3] wires the IVF integration and Python binding). This diff is pure infrastructure with zero impact on existing FAISS behavior.

## Why these components exist

SuperKMeans replaces the brute-force nearest-centroid assignment step of Lloyd's k-means with a two-phase scheme: a partial GEMM over the leading d/8 dimensions followed by progressive pruning over the remaining dimensions. This requires four new primitives that do not exist in the FAISS codebase today:

1. **A chi-squared statistical threshold for pruning** — to decide, after computing partial L2 distances over only the first d_prime dimensions, whether a centroid is statistically unlikely to be the nearest. The threshold comes from the chi-squared distribution's quantile function, which in turn requires the inverse standard normal CDF.

2. **A cache-friendly data layout for the trailing dimensions** — the pruning phase sweeps across surviving centroids in 64-dim blocks. Standard row-major layout causes cache misses because each centroid's block is far from the next. A block-column-major (PDX) layout interleaves all k centroids' values for the same block contiguously, making the per-block L2 sweep cache-friendly.

3. **SIMD-optimized block L2 distance kernels** — the inner loop of the pruning phase computes L2 distance over 64-dim PDX blocks. Vectorizing this with AVX2/AVX-512 intrinsics is where the wall-time reduction comes from (the pruning logic itself is scalar; only the distance kernel needs SIMD).

4. **Shared clustering helpers** — SuperKMeans reuses four functions from vanilla `Clustering` (subsample, split_clusters, compute_centroids, get_actual_rng_seed). These are currently in Clustering.cpp's anonymous namespace. Lifting them into `faiss::detail::` avoids code duplication.

## What is added

### faiss::detail::normal_quantile and chi2_quantile_wh (impl/AdSampling.{h,cpp})

Three pure-math functions under `faiss::detail::`:

- `normal_quantile(p)`: inverse standard normal CDF. Three-branch rational polynomial approximation (Acklam). Absolute error < 1.15e-9. No external dependencies (no scipy, no Boost).

- `chi2_quantile_wh(p, alpha)`: chi-squared quantile via the Wilson-Hilferty cube-root approximation. For degrees of freedom p >= 16 (the minimum d_prime SuperKMeans uses), the approximation is within 2% of scipy.stats.chi2.ppf. Domain constraint documented: for very small alpha and small p (< 4), the cube can go negative; in practice p >= 16 and alpha >= 0.9375 so this never happens.

- `precompute_ad_thresholds(d, epsilon)`: builds a per-prefix-length coefficient table of size d+1. Entry coeff[p] is the normalized chi-squared quantile at significance epsilon for p degrees of freedom. The SuperKMeans pruning loop reads coeff[d_prime] at the GEMM boundary and coeff[true_block_end] at each PDX block boundary. Input validated via FAISS_THROW_IF_NOT (not debug-only assert).

### faiss::detail::pdxify / de_pdxify (impl/PdxLayout.{h,cpp})

Row-major to block-column-major (PDX) transform and its inverse. Given k centroids in d_trail trailing dimensions with block_size = 64:

- Row-major: centroid j's dims are at `Y[j * d_trail ... j * d_trail + d_trail - 1]`
- PDX: block b contains all k centroids' dims `[b*64 ... (b+1)*64-1]` interleaved as `Y_pdx[offset + j * block_dim + dim_in_block]`

The trailing block handles `d_trail % 64` dims (non-power-of-2 safe). Both transforms are pure memcpy — no arithmetic, no rounding, bit-exact inverse.

Also provides `compute_partial_norms(X, n, d, p, norms)`: computes `||X[i, 0:p]||^2` for the L2-from-IP identity used in the GEMM phase.

### faiss::detail:: clustering helpers (impl/ClusteringHelpers.{h,cpp})

Four functions lifted from `Clustering.cpp`'s anonymous namespace into `faiss::detail::`:

- `subsample_training_set`: cap training data to k * max_points_per_centroid via random permutation
- `split_clusters`: replace empty centroids with perturbations of the largest cluster
- `compute_centroids`: partition-by-centroid OpenMP reduction (no cross-thread float accumulation, so bit-deterministic at fixed thread count)
- `get_actual_rng_seed`: resolve negative seed to high-resolution clock

Pure refactor. Existing call sites in Clustering.cpp updated to qualified names. Zero behavior change — verified by existing test_clustering (13 Python tests) passing unchanged.

### Per-arch block_l2 SIMD kernels (utils/simd_impl/super_kmeans_*.{h,cpp})

The inner loop of SuperKMeans's pruning phase: compute L2 distance over a PDX block of n floats (typically 64, but can be smaller for the trailing block).

- **Primary template** (super_kmeans_kernels.h): scalar fallback. Any architecture (x86, aarch64, anything) compiles and runs correctly via this path.

- **AVX2 specialization** (super_kmeans_kernels_avx2.cpp): 8-wide `_mm256` loop. Horizontal reduction uses a shuffle+add tree (`_mm_movehdup_ps` / `_mm_movehl_ps` / `_mm_add_ss`), not `_mm_hadd_ps` (which has 3-cycle latency on Skylake-class cores vs single-cycle for each shuffle/add).

- **AVX-512 specialization** (super_kmeans_kernels_avx512.cpp): 16-wide `_mm512` loop with `_mm512_fmadd_ps`. Horizontal reduction via `_mm512_reduce_add_ps` (a compiler pseudo-intrinsic that GCC/Clang expand to a shuffle+add tree — no separate manual reduction needed).

- **Runtime dispatch** (super_kmeans_dispatch.h): `block_l2_dispatch()` uses the existing FAISS `with_selected_simd_levels` template machinery to select AVX-512 > AVX2 > scalar at process startup.

Known perf gap: aarch64 (NEON/SVE) specializations are not implemented. aarch64 falls through to the scalar primary template. Validating SVE requires a Graviton-class host; deferred to a focused follow-up.

## Existing code changes

`Clustering.cpp`: the four helper functions are now called via `faiss::detail::subsample_training_set(...)` etc. instead of unqualified calls within the anonymous namespace. The function bodies are moved to ClusteringHelpers.cpp. No logic changes, no behavioral changes.

Next in stack: [2/3] adds the SuperKMeans class that consumes all of these primitives.

Differential Revision: D102713322


