### PR TITLE
Fix ccache for GPU, Metal, and Windows CI builds (#5174)

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -54,7 +54,7 @@ runs:
         conda config --set solver libmamba
         # Ensure starting packages are from conda-forge.
         conda list --show-channel-urls
-        conda install -y -q "conda<=25.07"
+        conda install -y -q "conda<=25.03"
         echo "$CONDA/bin" >> $GITHUB_PATH
 
         conda install -y -q python=3.12 cmake=3.30.4 make=4.2 swig=4.0 "numpy>=2.0,<3.0" scipy=1.16 pytest=7.4 gflags=2.2 setuptools
@@ -79,7 +79,7 @@ runs:
           conda install -y -q cuda-libraries-dev=12.6 cuda-nvcc=12.6 cuda-nvtx=12.6 cuda-cupti=12.6 cuda-cudart-dev=12.6 gxx_linux-64=12.4 -c "nvidia/label/cuda-12.6"
         # and CUDA from cuVS channel for cuVS builds
         elif [ "${{ inputs.cuvs }}" = "ON" ]; then
-          conda install -y -q libcuvs=26.02 'cuda-version=12.9' cuda-toolkit=12.9 sysroot_linux-64=2.34 -c rapidsai -c rapidsai-nightly -c conda-forge
+          conda install -y -q libcuvs=26.02 'cuda-version=12.9' cuda-libraries-dev cuda-nvcc sysroot_linux-64=2.34 -c rapidsai -c rapidsai-nightly -c conda-forge
         fi
 
         # install SVS runtime for SVS builds
@@ -92,7 +92,7 @@ runs:
           : # skip torch install via conda, we need to install via pip to get
             #  ROCm-enabled version until it's supported in conda by PyTorch
         elif [ "${{ inputs.gpu }}" = "ON" ]; then
-          conda install -y -q "pytorch>=2.7" "pytorch-gpu>=2.7" -c pytorch -c "nvidia/label/12.9"
+          CONDA_OVERRIDE_CUDA="12.6" conda install -y -q "pytorch>=2.7" "pytorch-gpu>=2.7" -c pytorch -c "nvidia/label/12.9"
         else
           # TestLowLevelIVF.IVFRQ hangs on pytorch>=2.7, so left it as <2.5 for now.
           conda install -y -q "pytorch<2.5" -c pytorch
@@ -168,8 +168,14 @@ runs:
       uses: hendrikmuhs/ccache-action@v1
       with:
         key: ${{ runner.os }}-${{ runner.arch }}-${{ inputs.opt_level }}-gpu${{ inputs.gpu }}-cuvs${{ inputs.cuvs }}-rocm${{ inputs.rocm }}-svs${{ inputs.svs }}
-        max-size: 2G
+        max-size: ${{ inputs.gpu == 'ON' && '4G' || '2G' }}
         update-package-index: true
+    - name: Configure ccache for CUDA/ROCm
+      if: inputs.gpu == 'ON'
+      shell: bash
+      run: |
+        ccache --set-config=sloppiness=pch_defines,time_macros,include_file_mtime,include_file_ctime
+        ccache --set-config=hash_dir=false
     - name: Setup macOS Metal environment
       if: inputs.metal == 'ON'
       shell: bash
@@ -177,6 +183,8 @@ runs:
     - name: Build all targets
       if: inputs.metal != 'ON'
       shell: bash
+      env:
+        CUDAARCHS: "75"
       run: |
         eval "$(conda shell.bash hook)"
         conda activate
@@ -209,6 +217,8 @@ runs:
               -DFAISS_ENABLE_PYTHON=OFF \
               -DBUILD_TESTING=ON \
               -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_PREFIX_PATH="$(brew --prefix libomp)" \
               .
         cmake --build build --target faiss_metal TestMetalIndexFlat -j$(sysctl -n hw.logicalcpu)

--- a/.github/actions/build_conda/action.yml
+++ b/.github/actions/build_conda/action.yml
@@ -43,8 +43,8 @@ runs:
       run: |
         # Ensure starting packages are from conda-forge.
         conda list --show-channel-urls
-        conda install -y -q "conda!=24.11.0,<=25.07"
-        conda install -y -q "conda-build=25.3.1" "liblief=0.14.1"
+        conda install -y -q "conda!=24.11.0,<=25.03"
+        conda install -y -q "conda-build>=25.5" "liblief=0.14.1"
     - name: Enable anaconda uploads
       if: inputs.label != ''
       shell: ${{ steps.choose_shell.outputs.shell }}

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -201,6 +201,11 @@ jobs:
         run: |
           conda install -y -q cmake swig "numpy>=2.0,<3.0" scipy pytest gflags setuptools
           conda install -y -q mkl=2024.2.2 mkl-devel=2024.2.2
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${{ runner.os }}-${{ runner.arch }}-dd-gpuOFF
+          max-size: 2G
       - name: Build
         shell: pwsh
         run: |
@@ -217,6 +222,8 @@ jobs:
             -DFAISS_ENABLE_C_API=OFF `
             -DBLA_VENDOR=Intel10_64_dyn `
             -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache `
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache `
             -DPython_ROOT_DIR="$pythonDir" `
             .
           # Add faiss.dll and dependency DLLs to PATH for GoogleTest discovery


### PR DESCRIPTION
Summary:

Fix ccache configuration to actually achieve cache hits across CI runs:

1. (P0) Configure ccache sloppiness for CUDA/ROCm builds — without `hash_dir=false` and relaxed sloppiness settings, nvcc/hipcc absolute paths cause 100% cache misses even when source is unchanged.
2. (P1) Add missing `-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache` to the Metal build step, which had its own cmake invocation that was missed in D102926935.
3. (P2) Increase cache size from 2G to 4G for GPU builds since CUDA object files are significantly larger.
4. (P3) Add ccache to the Windows build in build-pull-request.yml, which uses inline build steps instead of the build_cmake composite action.

Differential Revision: D103482603


