### PR TITLE
Filter wheel artifacts before publishing to PyPI

### DIFF
--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -48,10 +48,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Download all artifacts
+      - name: Download wheel artifacts
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e  # v4.1.7
         with:
           path: dist
+          pattern: wheels-*
           merge-multiple: true
 
       - name: Publish to PyPI
@@ -69,10 +70,11 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Download all artifacts
+      - name: Download wheel artifacts
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e  # v4.1.7
         with:
           path: dist
+          pattern: wheels-*
           merge-multiple: true
 
       - name: Publish to TestPyPI


### PR DESCRIPTION
Summary:
### THIS DIFF

Restrict the artifact download in the `publish` and `publish-testpypi` jobs of `build-pip.yml` to only the wheel artifacts (`pattern: wheels-*`). Without this filter, `actions/download-artifact` pulls every artifact from the workflow run and flattens them into `dist/`. The pypa/gh-action-pypi-publish action then runs twine, which globs all of `dist/*` and rejects any non-wheel/non-sdist entry.

The build-pull-request.yml workflow runs C++ tests via the build_cmake composite action with `GTEST_OUTPUT="xml:.../test-results/googletest/"`, then uploads test-results as artifacts. When the publish jobs downloaded all artifacts, the resulting `dist/googletest` directory caused twine to fail with `InvalidDistribution: Unknown distribution format: 'googletest'`.

### CONTEXT

Follow-up to D95258115 (landed as 3593ed4fa5c1), which introduced the pip wheel build pipeline via scikit-build-core and cibuildwheel. The publish jobs were never exercised end-to-end before merge because they only run on tag push or manual dispatch. First TestPyPI run surfaced the artifact-namespace collision with the test-results uploader.

Differential Revision: D103739933


