### PR TITLE
Enable verbose mode for TestPyPI publish step

### DIFF
--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -82,3 +82,4 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
+          verbose: true


### PR DESCRIPTION
Summary:
### THIS DIFF

Adds `verbose: true` to the `publish-testpypi` step of `build-pip.yml` so twine prints the full HTTP request/response body when uploading to TestPyPI. Without verbose mode, a 400 Bad Request from TestPyPI surfaces as the bare line `HTTPError: 400 Bad Request` with no further detail; twine's own warning even instructs the user to retry with `--verbose` for more details.

### CONTEXT

Follow-up to D103739933 (filter wheel artifacts) and D95258115 (pip wheel pipeline, landed). The first end-to-end TestPyPI upload attempt failed with an opaque 400 after wheel validation passed, attestations were generated, and the trusted publisher OIDC handshake succeeded (confirmed via PyPI security email naming environment `testpypi`). Without the response body, the cause cannot be diagnosed without round-tripping through GitHub Actions multiple times. Enabling verbose mode is the lightest-weight diagnostic: no behavior change on success, full error body on failure. We can flip it back off once the upload pipeline is known-good.

Differential Revision: D103893976


