### PR TITLE
Replace FAISS_ASSERT with FAISS_THROW_FMT for unsupported SVSStorageKind

### DIFF
--- a/faiss/svs/IndexSVSVamana.h
+++ b/faiss/svs/IndexSVSVamana.h
@@ -30,6 +30,7 @@
 #include <svs/runtime/dynamic_vamana_index.h>
 
 #include <iostream>
+#include <type_traits>
 
 namespace faiss {
 
@@ -76,7 +77,9 @@ inline svs_runtime::StorageKind to_svs_storage_kind(SVSStorageKind kind) {
         case SVS_LeanVec8x8:
             return svs_runtime::StorageKind::LeanVec8x8;
         default:
-            FAISS_ASSERT(false && "not supported SVS storage kind");
+            FAISS_THROW_FMT(
+                    "SVSStorageKind (%d) not supported",
+                    static_cast<std::underlying_type_t<SVSStorageKind>>(kind));
     }
 }
 


### PR DESCRIPTION
Summary:
The `default` branch of `to_svs_storage_kind()` previously used `FAISS_ASSERT(false && "not supported SVS storage kind")`, which calls `abort()` and tears down the process with no recoverable error. This makes invalid storage kinds — whether from a corrupted index file, a forward-compat mismatch, or a SWIG caller passing a bogus enum value — fatal in a way that cannot be caught by the Python or C++ exception machinery.

Replace with `FAISS_THROW_FMT(...)` so the unsupported-kind path raises a `FaissException` that callers can catch, and include the offending integer value in the message to make debugging easier.

Differential Revision: D103914271


