### PR TITLE
Add VPOPCNTDQ-based HammingComputer for Sapphire Rapids+

### DIFF
--- a/benchs/bench_hamming_computer.cpp
+++ b/benchs/bench_hamming_computer.cpp
@@ -13,6 +13,13 @@
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/hamming.h>
 #include <faiss/utils/hamming_distance/hamming_computer-generic.h>
+#ifdef COMPILE_SIMD_AVX512_SPR
+#include <faiss/utils/hamming_distance/hamming_computer-avx512_spr.h>
+#elif defined(COMPILE_SIMD_AVX512)
+#include <faiss/utils/hamming_distance/hamming_computer-avx512.h>
+#elif defined(COMPILE_SIMD_AVX2)
+#include <faiss/utils/hamming_distance/hamming_computer-avx2.h>
+#endif
 #include <faiss/utils/random.h>
 #include <faiss/utils/utils.h>
 
@@ -226,8 +233,7 @@ int main() {
                 double t0, t1, t2, t3;
                 t0 = getmillisecs();
 
-                // new implem from Zilliz
-                hamming_cpt_test<HammingComputerDefault_tpl<SIMDLevel::NONE>>(
+                hamming_cpt_test<HammingComputerDefault_tpl<SINGLE_SIMD_LEVEL>>(
                         cs, x.data(), x.data(), n, rst_default.data());
                 t1 = getmillisecs();
 
@@ -287,41 +293,37 @@ int main() {
             x1.data(), x2.data(), n1, n2, sumx, xorx);
     hamming_computer_test<faiss::HammingComputer8, 64>(
             x1.data(), x2.data(), n1, n2, sumx, xorx);
-    hamming_computer_test<
-            faiss::HammingComputer16_tpl<faiss::SIMDLevel::NONE>,
-            128>(x1.data(), x2.data(), n1, n2, sumx, xorx);
-    hamming_computer_test<
-            faiss::HammingComputer20_tpl<faiss::SIMDLevel::NONE>,
-            160>(x1.data(), x2.data(), n1, n2, sumx, xorx);
-    hamming_computer_test<
-            faiss::HammingComputer32_tpl<faiss::SIMDLevel::NONE>,
-            256>(x1.data(), x2.data(), n1, n2, sumx, xorx);
-    hamming_computer_test<
-            faiss::HammingComputer64_tpl<faiss::SIMDLevel::NONE>,
-            512>(x1.data(), x2.data(), n1, n2, sumx, xorx);
+    hamming_computer_test<faiss::HammingComputer16_tpl<SINGLE_SIMD_LEVEL>, 128>(
+            x1.data(), x2.data(), n1, n2, sumx, xorx);
+    hamming_computer_test<faiss::HammingComputer20_tpl<SINGLE_SIMD_LEVEL>, 160>(
+            x1.data(), x2.data(), n1, n2, sumx, xorx);
+    hamming_computer_test<faiss::HammingComputer32_tpl<SINGLE_SIMD_LEVEL>, 256>(
+            x1.data(), x2.data(), n1, n2, sumx, xorx);
+    hamming_computer_test<faiss::HammingComputer64_tpl<SINGLE_SIMD_LEVEL>, 512>(
+            x1.data(), x2.data(), n1, n2, sumx, xorx);
 
     // evaluate various GenHammingDistanceComputerXX
     hamming_computer_test<
-            faiss::GenHammingComputer8_tpl<faiss::SIMDLevel::NONE>,
+            faiss::GenHammingComputer8_tpl<SINGLE_SIMD_LEVEL>,
             64>(x1.data(), x2.data(), n1, n2, sumx, xorx);
     hamming_computer_test<
-            faiss::GenHammingComputer16_tpl<faiss::SIMDLevel::NONE>,
+            faiss::GenHammingComputer16_tpl<SINGLE_SIMD_LEVEL>,
             128>(x1.data(), x2.data(), n1, n2, sumx, xorx);
     hamming_computer_test<
-            faiss::GenHammingComputer32_tpl<faiss::SIMDLevel::NONE>,
+            faiss::GenHammingComputer32_tpl<SINGLE_SIMD_LEVEL>,
             256>(x1.data(), x2.data(), n1, n2, sumx, xorx);
 
     hamming_computer_test<
-            faiss::GenHammingComputerM8_tpl<faiss::SIMDLevel::NONE>,
+            faiss::GenHammingComputerM8_tpl<SINGLE_SIMD_LEVEL>,
             64>(x1.data(), x2.data(), n1, n2, sumx, xorx);
     hamming_computer_test<
-            faiss::GenHammingComputerM8_tpl<faiss::SIMDLevel::NONE>,
+            faiss::GenHammingComputerM8_tpl<SINGLE_SIMD_LEVEL>,
             128>(x1.data(), x2.data(), n1, n2, sumx, xorx);
     hamming_computer_test<
-            faiss::GenHammingComputerM8_tpl<faiss::SIMDLevel::NONE>,
+            faiss::GenHammingComputerM8_tpl<SINGLE_SIMD_LEVEL>,
             256>(x1.data(), x2.data(), n1, n2, sumx, xorx);
     hamming_computer_test<
-            faiss::GenHammingComputerM8_tpl<faiss::SIMDLevel::NONE>,
+            faiss::GenHammingComputerM8_tpl<SINGLE_SIMD_LEVEL>,
             512>(x1.data(), x2.data(), n1, n2, sumx, xorx);
 
     return 0;

--- a/benchs/bench_hamming_knn.py
+++ b/benchs/bench_hamming_knn.py
@@ -10,7 +10,7 @@ import faiss
 if __name__ == "__main__":
     faiss.omp_set_num_threads(1)
 
-    for d in 4, 8, 16, 13:
+    for d in 4, 8, 16, 32, 64, 128, 256, 512, 1024:
         nq = 10000
         nb = 30000
         print('Bits per vector = 8 *', d)

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -40,6 +40,7 @@ set(FAISS_SIMD_AVX512_SRC
 # flag. Not compiled into faiss_avx512 — that target stops at the
 # baseline AVX-512F/CD/VL/DQ/BW feature set.
 set(FAISS_SIMD_AVX512_SPR_SRC
+  utils/hamming_distance/hamming_avx512_spr.cpp
   utils/simd_impl/rabitq_avx512_spr.cpp
 )
 set(FAISS_SIMD_NEON_SRC
@@ -384,6 +385,7 @@ set(FAISS_HEADERS
   utils/hamming_distance/hamming_computer.h
   utils/hamming_distance/hamming_computer-avx2.h
   utils/hamming_distance/hamming_computer-avx512.h
+  utils/hamming_distance/hamming_computer-avx512_spr.h
   utils/hamming_distance/hamming_computer-generic.h
   utils/hamming_distance/hamming_computer-neon.h
   utils/hamming_distance/hamming_computer-rvv.h
@@ -476,7 +478,7 @@ else()
   add_compile_options(/bigobj)
 endif()
 target_sources(faiss_avx512_spr PRIVATE ${FAISS_SIMD_AVX2_SRC} ${FAISS_SIMD_AVX512_SRC} ${FAISS_SIMD_AVX512_SPR_SRC})
-target_compile_definitions(faiss_avx512_spr PRIVATE COMPILE_SIMD_AVX2 COMPILE_SIMD_AVX512 COMPILE_SIMD_AVX512_SPR )
+target_compile_definitions(faiss_avx512_spr PRIVATE COMPILE_SIMD_AVX2 COMPILE_SIMD_AVX512 COMPILE_SIMD_AVX512_SPR)
 
 add_library(faiss_sve ${FAISS_SRC})
 if(NOT FAISS_OPT_LEVEL STREQUAL "sve")

--- a/faiss/impl/simd_dispatch.h
+++ b/faiss/impl/simd_dispatch.h
@@ -176,4 +176,14 @@ inline auto with_simd_level_256bit(LambdaType&& action) {
             std::forward<LambdaType>(action));
 }
 
+/**
+ * Use for functions that have A0-level implementations plus an AVX512_SPR
+ * specialization (e.g. using VPOPCNTDQ).
+ */
+template <typename LambdaType>
+inline auto with_simd_level_a0_spr(LambdaType&& action) {
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A0_SPR>(
+            std::forward<LambdaType>(action));
+}
+
 } // namespace faiss

--- a/faiss/utils/hamming.cpp
+++ b/faiss/utils/hamming.cpp
@@ -146,7 +146,7 @@ void hammings(
         size_t nb,
         size_t ncodes,
         hamdis_t* __restrict dis) {
-    with_simd_level([&]<SIMDLevel SL>() {
+    with_simd_level_a0_spr([&]<SIMDLevel SL>() {
         hammings_fixSL<SL>(a, b, na, nb, ncodes, dis);
     });
 }
@@ -170,7 +170,7 @@ void hammings_knn_hc(
         int order,
         ApproxTopK_mode_t approx_topk_mode,
         const faiss::IDSelector* sel) {
-    with_simd_level([&]<SIMDLevel SL>() {
+    with_simd_level_a0_spr([&]<SIMDLevel SL>() {
         hammings_knn_hc_fixSL<SL>(
                 ha, a, b, nb, ncodes, order, approx_topk_mode, sel);
     });
@@ -186,7 +186,7 @@ void hammings_knn_mc(
         int32_t* __restrict distances,
         int64_t* __restrict labels,
         const faiss::IDSelector* sel) {
-    with_simd_level([&]<SIMDLevel SL>() {
+    with_simd_level_a0_spr([&]<SIMDLevel SL>() {
         hammings_knn_mc_fixSL<SL>(
                 a, b, na, nb, k, ncodes, distances, labels, sel);
     });
@@ -201,7 +201,7 @@ void hamming_range_search(
         size_t code_size,
         RangeSearchResult* result,
         const faiss::IDSelector* sel) {
-    with_simd_level([&]<SIMDLevel SL>() {
+    with_simd_level_a0_spr([&]<SIMDLevel SL>() {
         hamming_range_search_fixSL<SL>(
                 a, b, na, nb, radius, code_size, result, sel);
     });
@@ -215,7 +215,7 @@ void hamming_count_thres(
         hamdis_t ht,
         size_t ncodes,
         size_t* nptr) {
-    with_simd_level([&]<SIMDLevel SL>() {
+    with_simd_level_a0_spr([&]<SIMDLevel SL>() {
         hamming_count_thres_fixSL<SL>(bs1, bs2, n1, n2, ht, ncodes, nptr);
     });
 }
@@ -226,7 +226,7 @@ void crosshamming_count_thres(
         hamdis_t ht,
         size_t ncodes,
         size_t* nptr) {
-    with_simd_level([&]<SIMDLevel SL>() {
+    with_simd_level_a0_spr([&]<SIMDLevel SL>() {
         crosshamming_count_thres_fixSL<SL>(dbs, n, ht, ncodes, nptr);
     });
 }
@@ -240,7 +240,7 @@ size_t match_hamming_thres(
         size_t ncodes,
         int64_t* idx,
         hamdis_t* dis) {
-    return with_simd_level([&]<SIMDLevel SL>() -> size_t {
+    return with_simd_level_a0_spr([&]<SIMDLevel SL>() -> size_t {
         return match_hamming_thres_fixSL<SL>(
                 bs1, bs2, n1, n2, ht, ncodes, idx, dis);
     });
@@ -253,7 +253,7 @@ void generalized_hammings_knn_hc(
         size_t nb,
         size_t code_size,
         int ordered) {
-    with_simd_level([&]<SIMDLevel SL>() {
+    with_simd_level_a0_spr([&]<SIMDLevel SL>() {
         generalized_hammings_knn_hc_fixSL<SL>(ha, a, b, nb, code_size, ordered);
     });
 }

--- a/faiss/utils/hamming_distance/hamming_avx512_spr.cpp
+++ b/faiss/utils/hamming_distance/hamming_avx512_spr.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifdef COMPILE_SIMD_AVX512_SPR
+
+#define THE_SIMD_LEVEL SIMDLevel::AVX512_SPR
+// NOLINTNEXTLINE(facebook-hte-InlineHeader)
+#include <faiss/utils/hamming_distance/hamming_computer-avx512_spr.h>
+#include <faiss/utils/hamming_distance/hamming_impl.h>
+
+#endif // COMPILE_SIMD_AVX512_SPR

--- a/faiss/utils/hamming_distance/hamming_computer-avx512.h
+++ b/faiss/utils/hamming_distance/hamming_computer-avx512.h
@@ -10,10 +10,10 @@
 
 // AVX512 HammingComputer and GenHammingComputer specializations.
 // Types without custom AVX512 code inherit from the NONE specializations
-// in hamming_computer-generic.h. Custom specializations for
-// HammingComputer64 and HammingComputerDefault use _mm512_popcnt_epi64
-// when __AVX512VPOPCNTDQ__ is available. GenHammingComputer classes
-// leverage SSE/AVX2 intrinsics.
+// in hamming_computer-generic.h. HammingComputer64 and
+// HammingComputerDefault use scalar popcount here; the VPOPCNTDQ fast
+// path lives in hamming_computer-avx512_spr.h (AVX512_SPR level).
+// GenHammingComputer classes leverage SSE/AVX2 intrinsics.
 
 #include <cassert>
 #include <cstdint>
@@ -74,18 +74,10 @@ struct HammingComputer64_tpl<SIMDLevel::AVX512> {
 
     inline int hamming(const uint8_t* b8) const {
         const uint64_t* b = reinterpret_cast<const uint64_t*>(b8);
-#ifdef __AVX512VPOPCNTDQ__
-        __m512i vxor =
-                _mm512_xor_si512(_mm512_loadu_si512(a), _mm512_loadu_si512(b));
-        __m512i vpcnt = _mm512_popcnt_epi64(vxor);
-        // reduce performs better than adding the lower and higher parts
-        return _mm512_reduce_add_epi32(vpcnt);
-#else
         return popcount64(b[0] ^ a0) + popcount64(b[1] ^ a1) +
                 popcount64(b[2] ^ a2) + popcount64(b[3] ^ a3) +
                 popcount64(b[4] ^ a4) + popcount64(b[5] ^ a5) +
                 popcount64(b[6] ^ a6) + popcount64(b[7] ^ a7);
-#endif
     }
 
     inline static constexpr int get_code_size() {
@@ -112,27 +104,11 @@ struct HammingComputerDefault_tpl<SIMDLevel::AVX512> {
     }
 
     int hamming(const uint8_t* b8) const {
-        int accu = 0;
-
         const uint64_t* a64 = reinterpret_cast<const uint64_t*>(a8);
         const uint64_t* b64 = reinterpret_cast<const uint64_t*>(b8);
 
-        int i = 0;
-#ifdef __AVX512VPOPCNTDQ__
-        int quotient64 = quotient8 / 8;
-        for (; i < quotient64; ++i) {
-            __m512i vxor = _mm512_xor_si512(
-                    _mm512_loadu_si512(&a64[i * 8]),
-                    _mm512_loadu_si512(&b64[i * 8]));
-            __m512i vpcnt = _mm512_popcnt_epi64(vxor);
-            // reduce performs better than adding the lower and higher parts
-            accu += _mm512_reduce_add_epi32(vpcnt);
-        }
-        i *= 8;
-#endif
-        accu += hamming_popcount_tail(
-                a64, b64, i, quotient8, a8, b8, remainder8);
-        return accu;
+        return hamming_popcount_tail(
+                a64, b64, 0, quotient8, a8, b8, remainder8);
     }
 
     inline int get_code_size() const {

--- a/faiss/utils/hamming_distance/hamming_computer-avx512_spr.h
+++ b/faiss/utils/hamming_distance/hamming_computer-avx512_spr.h
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef HAMMING_COMPUTER_AVX512_SPR_H
+#define HAMMING_COMPUTER_AVX512_SPR_H
+
+// AVX512_SPR HammingComputer specializations using VPOPCNTDQ.
+// On Sapphire Rapids+, _mm512_popcnt_epi64 (and _mm256_popcnt_epi64 with VL)
+// are unconditionally available. This gives a faster path than the scalar
+// popcount fallback used in the base AVX512 specializations when compiled
+// without -mavx512vpopcntdq.
+
+#include <cassert>
+#include <cstdint>
+
+#include <faiss/impl/platform_macros.h>
+#include <faiss/utils/hamming_distance/hamming_computer-avx512.h>
+
+#include <immintrin.h>
+
+namespace faiss {
+
+/***************************************************************************
+ * AVX512_SPR inheriting specializations for types without custom SPR code.
+ ***************************************************************************/
+
+#define FAISS_INHERIT_HAMMING_SPR(Class)                                   \
+    template <>                                                            \
+    struct Class##                                                         \
+            _tpl<SIMDLevel::AVX512_SPR> : Class##_tpl<SIMDLevel::AVX512> { \
+        using Class##_tpl<SIMDLevel::AVX512>::Class##_tpl;                 \
+    }
+
+FAISS_INHERIT_HAMMING_SPR(HammingComputer16);
+FAISS_INHERIT_HAMMING_SPR(HammingComputer20);
+FAISS_INHERIT_HAMMING_SPR(GenHammingComputer8);
+FAISS_INHERIT_HAMMING_SPR(GenHammingComputer16);
+FAISS_INHERIT_HAMMING_SPR(GenHammingComputer32);
+FAISS_INHERIT_HAMMING_SPR(GenHammingComputerM8);
+
+#undef FAISS_INHERIT_HAMMING_SPR
+
+/***************************************************************************
+ * Custom AVX512_SPR specializations using VPOPCNTDQ.
+ ***************************************************************************/
+
+template <>
+struct HammingComputer32_tpl<SIMDLevel::AVX512_SPR> {
+    const uint8_t* a8;
+
+    HammingComputer32_tpl() {}
+
+    HammingComputer32_tpl(const uint8_t* a8_in, int code_size) {
+        set(a8_in, code_size);
+    }
+
+    void set(const uint8_t* a8_in, FAISS_MAYBE_UNUSED int code_size) {
+        assert(code_size == 32);
+        a8 = a8_in;
+    }
+
+    inline int hamming(const uint8_t* b8) const {
+        __m256i va = _mm256_loadu_si256((const __m256i*)a8);
+        __m256i vb = _mm256_loadu_si256((const __m256i*)b8);
+        __m256i vxor = _mm256_xor_si256(va, vb);
+        __m256i vpcnt = _mm256_popcnt_epi64(vxor);
+        __m128i lo = _mm256_castsi256_si128(vpcnt);
+        __m128i hi = _mm256_extracti128_si256(vpcnt, 1);
+        __m128i sum = _mm_add_epi64(lo, hi);
+        return static_cast<int>(
+                _mm_extract_epi64(sum, 0) + _mm_extract_epi64(sum, 1));
+    }
+
+    inline static constexpr int get_code_size() {
+        return 32;
+    }
+};
+
+template <>
+struct HammingComputer64_tpl<SIMDLevel::AVX512_SPR> {
+    const uint8_t* a8;
+
+    HammingComputer64_tpl() {}
+
+    HammingComputer64_tpl(const uint8_t* a8_in, int code_size) {
+        set(a8_in, code_size);
+    }
+
+    void set(const uint8_t* a8_in, FAISS_MAYBE_UNUSED int code_size) {
+        assert(code_size == 64);
+        a8 = a8_in;
+    }
+
+    inline int hamming(const uint8_t* b8) const {
+        __m512i vxor = _mm512_xor_si512(
+                _mm512_loadu_si512(a8), _mm512_loadu_si512(b8));
+        __m512i vpcnt = _mm512_popcnt_epi64(vxor);
+        return _mm512_reduce_add_epi32(vpcnt);
+    }
+
+    inline static constexpr int get_code_size() {
+        return 64;
+    }
+};
+
+template <>
+struct HammingComputerDefault_tpl<SIMDLevel::AVX512_SPR> {
+    const uint8_t* a8;
+    int quotient8;
+    int remainder8;
+
+    HammingComputerDefault_tpl() {}
+
+    HammingComputerDefault_tpl(const uint8_t* a8_in, int code_size) {
+        set(a8_in, code_size);
+    }
+
+    void set(const uint8_t* a8_2, int code_size) {
+        this->a8 = a8_2;
+        quotient8 = code_size / 8;
+        remainder8 = code_size % 8;
+    }
+
+    int hamming(const uint8_t* b8) const {
+        int accu = 0;
+
+        const uint64_t* a64 = reinterpret_cast<const uint64_t*>(a8);
+        const uint64_t* b64 = reinterpret_cast<const uint64_t*>(b8);
+
+        int i = 0;
+        int quotient64 = quotient8 / 8;
+        for (; i < quotient64; ++i) {
+            __m512i vxor = _mm512_xor_si512(
+                    _mm512_loadu_si512(&a64[i * 8]),
+                    _mm512_loadu_si512(&b64[i * 8]));
+            __m512i vpcnt = _mm512_popcnt_epi64(vxor);
+            accu += _mm512_reduce_add_epi32(vpcnt);
+        }
+        i *= 8;
+
+        // Handle 4-word (256-bit) remainder with VPOPCNTDQ VL
+        if (i + 4 <= quotient8) {
+            __m256i vxor = _mm256_xor_si256(
+                    _mm256_loadu_si256((const __m256i*)&a64[i]),
+                    _mm256_loadu_si256((const __m256i*)&b64[i]));
+            __m256i vpcnt = _mm256_popcnt_epi64(vxor);
+            __m128i lo = _mm256_castsi256_si128(vpcnt);
+            __m128i hi = _mm256_extracti128_si256(vpcnt, 1);
+            __m128i sum = _mm_add_epi64(lo, hi);
+            accu += static_cast<int>(
+                    _mm_extract_epi64(sum, 0) + _mm_extract_epi64(sum, 1));
+            i += 4;
+        }
+
+        accu += hamming_popcount_tail(
+                a64, b64, i, quotient8, a8, b8, remainder8);
+        return accu;
+    }
+
+    inline int get_code_size() const {
+        return quotient8 * 8 + remainder8;
+    }
+};
+
+} // namespace faiss
+
+#endif


### PR DESCRIPTION
This PR adds `SIMDLevel::AVX512_SPR` specializations for `HammingComputer32`, `HammingComputer64`, and `HammingComputerDefault` that unconditionally use `_mm512_popcnt_epi64` and `_mm256_popcnt_epi64` (VPOPCNTDQ + VL). End-to-end benchmarking with `benchs/bench_hamming_knn.py` shows up to a **1.91x** speedup over AVX512.

The existing AVX512 specializations had dead `#ifdef __AVX512VPOPCNTDQ__` blocks (the macro is never defined in the AVX512 TU). We remove them and leave only the scalar `popcount` path for the AVX512 level; the native vector popcount now lives exclusively in the AVX512_SPR specializations.

A new per-ISA TU (`hamming_avx512_spr.cpp`) compiled with `-mavx512vpopcntdq` provides the SPR specializations. The hamming dispatch is updated to route through `with_simd_level_a0_spr()`, which includes `AVX512_SPR` in its available-levels mask.

Also update `benchs/bench_hamming_computer.cpp` to use `SINGLE_SIMD_LEVEL` so it benchmarks the compiled-in SIMD specialization rather than hardcoded NONE.

Changes:
- hamming_computer-avx512.h: remove dead `VPOPCNTDQ` ifdefs
- New hamming_computer-avx512_spr.h with SPR specializations
- New hamming_avx512_spr.cpp TU (`COMPILE_SIMD_AVX512_SPR` guard)
- FAISS_SIMD_AVX512_SPR_SRC list in CMakeLists.txt
- Per-file `VPOPCNTDQ` flags for DD and MSVC builds
- `AVAILABLE_SIMD_LEVELS_A0_SPR mask + with_simd_level_a0_spr()` helper
- hamming.cpp dispatch updated to use the new helper
- bench_hamming_computer.cpp uses `SINGLE_SIMD_LEVEL`
- benchs/bench_hamming_knn.py uses dimensions 4, 8, 16, 32, 64, etc.

**Speedup of AVX512_SPR (VPOPCNTDQ) over AVX512 (scalar POPCNT), k=1:**

| Code size (bytes) | Bits | hc speedup | mc speedup |
|:-:|:-:|:-:|:-:|
| 4 | 32 | 1.00x | 1.05x |
| 8 | 64 | 0.93x | 1.01x |
| 16 | 128 | **1.25x** | **1.17x** |
| 32 | 256 | **1.26x** | **1.21x** |
| 64 | 512 | **1.37x** | **1.57x** |
| 128 | 1024 | **1.62x** | **1.91x** |
| 256 | 2048 | **1.60x** | **1.60x** |
| 512 | 4096 | **1.58x** | **1.74x** |
| 1024 | 8192 | **1.49x** | **1.73x** |

**Complete results:** https://gist.github.com/mulugetam/cf6d51ef730df969ce03fb35e3f43228 
