### PR TITLE
Add tolerance and assertion log to test_OIVFPQ (#5188)

### DIFF
--- a/tests/test_index_accuracy.py
+++ b/tests/test_index_accuracy.py
@@ -655,7 +655,10 @@ class OPQRelativeAccuracy(unittest.TestCase):
 
         # verify same on OIVFPQ
         for r in 1, 10, 100:
-            assert e_oivfpq[r] >= e_ivfpq[r]
+            assert e_oivfpq[r] >= e_ivfpq[r] - 0.005, (
+                f"recall@{r}: OPQ+IVFPQ ({e_oivfpq[r]:.4f}) "
+                f"< IVFPQ ({e_ivfpq[r]:.4f})"
+            )
 
 
 class TestRoundoff(unittest.TestCase):


### PR DESCRIPTION
Summary:

It breaks on unrelated tests, see https://github.com/facebookresearch/faiss/actions/runs/25464950049/job/74717916355?pr=5167

I tried it locally and differences usually favor OPQ by 0.007 at nq=100. So it could easily cross to favor non-OPQ. This adds threshold so now it has to win by additional 0.005.  Should be enough to catch OPQ regressions and still prevent flakiness.

Reviewed By: junjieqi

Differential Revision: D104144105


