### PR TITLE
Pin MKL to <2026 to avoid soname mismatch with pytorch

### DIFF
--- a/conda/faiss-gpu-cuvs/meta.yaml
+++ b/conda/faiss-gpu-cuvs/meta.yaml
@@ -49,8 +49,8 @@ outputs:
         - cmake >=3.30.4
         - make =4.2 # [not win]
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
-        - mkl >=2024.2.2  # [x86_64]
-        - mkl-devel >=2024.2.2  # [x86_64]
+        - mkl >=2024.2.2,<2026  # [x86_64]
+        - mkl-devel >=2024.2.2,<2026  # [x86_64]
         - cuda-toolkit {{ cudatoolkit }}
         - cuda-cudart {{ cudart_constraints }}
         - cuda-cudart-dev {{ cudart_constraints }}
@@ -60,14 +60,14 @@ outputs:
         - cuda-cudart-static_linux-64 {{ cudart_constraints }}  # [linux64]
       host:
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
-        - mkl >=2024.2.2  # [x86_64]
+        - mkl >=2024.2.2,<2026  # [x86_64]
         - openblas =0.3.32 # [not x86_64]
         - libcuvs =26.02
         - cuda-version {{ cuda_constraints }}
         - libsvs-runtime =0.3.0  # [x86_64 and linux]
       run:
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
-        - mkl >=2024.2.2  # [x86_64]
+        - mkl >=2024.2.2,<2026  # [x86_64]
         - openblas =0.3.32 # [not x86_64]
         - cuda-cudart {{ cuda_constraints }}
         - libcublas {{ libcublas_constraints }}
@@ -99,17 +99,17 @@ outputs:
         - cmake >=3.30.4
         - make =4.2 # [not win]
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
-        - mkl >=2024.2.2  # [x86_64]
+        - mkl >=2024.2.2,<2026  # [x86_64]
         - cuda-toolkit {{ cudatoolkit }}
       host:
-        - mkl >=2024.2.2  # [x86_64]
+        - mkl >=2024.2.2,<2026  # [x86_64]
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
         - python {{ python }}
         - numpy >=2.0,<2.3
         - setuptools
         - {{ pin_subpackage('libfaiss', exact=True) }}
       run:
-        - mkl >=2024.2.2  # [x86_64]
+        - mkl >=2024.2.2,<2026  # [x86_64]
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
         - python {{ python }}
         - numpy >=2.0,<2.3

--- a/conda/faiss-gpu/meta.yaml
+++ b/conda/faiss-gpu/meta.yaml
@@ -56,14 +56,14 @@ outputs:
         - cmake >=3.24.0
         - make =4.2 # [not win and not (osx and arm64)]
         - make =4.4 # [osx and arm64]
-        - mkl-devel >=2024.2.2  # [x86_64]
+        - mkl-devel >=2024.2.2,<2026  # [x86_64]
         - cuda-toolkit {{ cudatoolkit }}
       host:
-        - mkl >=2024.2.2  # [x86_64]
+        - mkl >=2024.2.2,<2026  # [x86_64]
         - openblas =0.3.32 # [not x86_64]
         - libsvs-runtime =0.3.0  # [x86_64 and linux]
       run:
-        - mkl >=2024.2.2  # [x86_64]
+        - mkl >=2024.2.2,<2026  # [x86_64]
         - openblas =0.3.32 # [not x86_64]
         - cuda-cudart {{ cuda_constraints }}
         - libcublas {{ libcublas_constraints }}
@@ -94,16 +94,16 @@ outputs:
         - make =4.4 # [osx and arm64]
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64 and not win]
         - cuda-toolkit {{ cudatoolkit }}
-        - mkl-devel >=2024.2.2  # [x86_64]
+        - mkl-devel >=2024.2.2,<2026  # [x86_64]
       host:
-        - mkl >=2024.2.2  # [x86_64]
+        - mkl >=2024.2.2,<2026  # [x86_64]
         - python {{ python }}
         - numpy >=2.0,<3.0
         - setuptools
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64 and not win]
         - {{ pin_subpackage('libfaiss', exact=True) }}
       run:
-        - mkl >=2024.2.2  # [x86_64]
+        - mkl >=2024.2.2,<2026  # [x86_64]
         - python {{ python }}
         - numpy >=2.0,<3.0
         - packaging

--- a/conda/faiss/meta.yaml
+++ b/conda/faiss/meta.yaml
@@ -45,15 +45,15 @@ outputs:
         - make =4.2 # [not win and not (osx and arm64)]
         - make =4.4 # [osx and arm64]
         {% if PY_VER == '3.10' or PY_VER == '3.11' %}
-        - mkl-devel >=2024.2.2  # [x86_64]
+        - mkl-devel >=2024.2.2,<2026  # [x86_64]
         - python_abi <3.12
         {% elif PY_VER == '3.12' %}
-        - mkl-devel >=2024.2.2  # [x86_64 and not win]
-        - mkl-devel >=2024.2.2  # [x86_64 and win]
+        - mkl-devel >=2024.2.2,<2026  # [x86_64 and not win]
+        - mkl-devel >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi =3.12
         {% else %}
-        - mkl-devel >=2024.2.2  # [x86_64 and not win]
-        - mkl-devel >=2024.2.2  # [x86_64 and win]
+        - mkl-devel >=2024.2.2,<2026  # [x86_64 and not win]
+        - mkl-devel >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi
         {% endif %}
         - libopenblas =0.3.32  # [osx]
@@ -62,11 +62,11 @@ outputs:
         - libcxx =20.1.1  # [osx and arm64]
         - libsvs-runtime =0.3.0  # [x86_64 and linux]
         {% if PY_VER == '3.10' or PY_VER == '3.11' %}
-        - mkl >=2024.2.2  # [x86_64]
+        - mkl >=2024.2.2,<2026  # [x86_64]
         - python_abi <3.12
         {% elif PY_VER == '3.12' %}
-        - mkl >=2024.2.2  # [x86_64 and not win]
-        - mkl >=2024.2.2  # [x86_64 and win]
+        - mkl >=2024.2.2,<2026  # [x86_64 and not win]
+        - mkl >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
         - openblas =0.3.32  # [not x86_64]
@@ -76,11 +76,11 @@ outputs:
         - libcxx =20.1.1  # [osx and arm64]
         - libsvs-runtime =0.3.0  # [x86_64 and linux]
         {% if PY_VER == '3.10' or PY_VER == '3.11' %}
-        - mkl >=2024.2.2  # [x86_64]
+        - mkl >=2024.2.2,<2026  # [x86_64]
         - python_abi <3.12
         {% elif PY_VER == '3.12' %}
-        - mkl >=2024.2.2  # [x86_64 and not win]
-        - mkl >=2024.2.2  # [x86_64 and win]
+        - mkl >=2024.2.2,<2026  # [x86_64 and not win]
+        - mkl >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
         - openblas =0.3.32  # [not x86_64]
@@ -113,11 +113,11 @@ outputs:
         - make =4.4 # [osx and arm64]
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64 and not win]
         {% if PY_VER == '3.10' or PY_VER == '3.11' %}
-        - mkl >=2024.2.2  # [x86_64]
+        - mkl >=2024.2.2,<2026  # [x86_64]
         - python_abi <3.12
         {% elif PY_VER == '3.12' %}
-        - mkl >=2024.2.2  # [x86_64 and not win]
-        - mkl >=2024.2.2  # [x86_64 and win]
+        - mkl >=2024.2.2,<2026  # [x86_64 and not win]
+        - mkl >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
         - libopenblas =0.3.32  # [osx]
@@ -129,11 +129,11 @@ outputs:
         - libcxx =20.1.1  # [osx and arm64]
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64 and not win]
         {% if PY_VER == '3.10' or PY_VER == '3.11' %}
-        - mkl >=2024.2.2  # [x86_64]
+        - mkl >=2024.2.2,<2026  # [x86_64]
         - python_abi <3.12
         {% elif PY_VER == '3.12' %}
-        - mkl >=2024.2.2  # [x86_64 and not win]
-        - mkl >=2024.2.2  # [x86_64 and win]
+        - mkl >=2024.2.2,<2026  # [x86_64 and not win]
+        - mkl >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
         - libopenblas =0.3.32  # [osx]
@@ -144,11 +144,11 @@ outputs:
         - {{ pin_subpackage('libfaiss', exact=True) }}
         - libcxx =20.1.1  # [osx and arm64]
         {% if PY_VER == '3.10' or PY_VER == '3.11' %}
-        - mkl >=2024.2.2  # [x86_64]
+        - mkl >=2024.2.2,<2026  # [x86_64]
         - python_abi <3.12
         {% elif PY_VER == '3.12' %}
-        - mkl >=2024.2.2  # [x86_64 and not win]
-        - mkl >=2024.2.2  # [x86_64 and win]
+        - mkl >=2024.2.2,<2026  # [x86_64 and not win]
+        - mkl >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
         - libopenblas =0.3.32  # [osx]
@@ -159,11 +159,11 @@ outputs:
         - pytorch-cpu >=2.7  # [not win]
         - pytorch >=2.7      # [win]
         {% if PY_VER == '3.10' or PY_VER == '3.11' %}
-        - mkl >=2024.2.2  # [x86_64]
+        - mkl >=2024.2.2,<2026  # [x86_64]
         - python_abi <3.12
         {% elif PY_VER == '3.12' %}
-        - mkl >=2024.2.2  # [x86_64 and not win]
-        - mkl >=2024.2.2  # [x86_64 and win]
+        - mkl >=2024.2.2,<2026  # [x86_64 and not win]
+        - mkl >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
       commands:


### PR DESCRIPTION
Summary:
conda-forge added MKL 2026.0.0 which uses a new soname (libmkl_intel_lp64.so.3
instead of .so.2). The build env now resolves mkl-devel >=2024.2.2 to 2026.0.0,
but the test env gets mkl 2025.3.1 because pytorch 2.10.0 is pinned to that
version. This soname mismatch causes ImportError at test time.

Adding <2026 upper bound forces both build and test envs to use MKL 2025.x,
keeping sonames consistent until pytorch supports MKL 2026.

🤖 This diff was automatically generated by myclaw_faiss_monitor

Differential Revision: D104219406


