### PR TITLE
perf: reserve() to avoid rehashing/reallocation

### DIFF
--- a/faiss/impl/NSG.cpp
+++ b/faiss/impl/NSG.cpp
@@ -256,6 +256,8 @@ void NSG::search_on_graph(
     retset.resize(pool_size + 1);
     std::vector<int> init_ids(pool_size);
 
+    vt.reserve(pool_size);
+
     int num_ids = 0;
     std::vector<index_t> neighbors(graph.K);
     size_t nneigh = graph.get_neighbors(ep, neighbors.data());

--- a/faiss/impl/VisitedTable.h
+++ b/faiss/impl/VisitedTable.h
@@ -45,6 +45,13 @@ struct VisitedTable {
         }
     }
 
+    /// pre-allocate bucket space to avoid rehashing during repeated set() calls
+    void reserve(size_t n) {
+        if (visno == 0) {
+            visited_set.reserve(n);
+        }
+    }
+
     /// get flag #no
     bool get(size_t no) const {
         if (visno == 0) {


### PR DESCRIPTION
Summary:
Optimized `faiss::VisitedTable::set` performance by avoiding expensive `std::unordered_set` rehashes:

1. **Added `VisitedTable::reserve(size_t n)` method** in `fbcode/faiss/impl/VisitedTable.h` — pre-allocates bucket space in the internal `visited_set` when in hashset mode (`visno == 0`), avoiding repeated rehashing during many `set()` calls.

2. **Added `vt.reserve(pool_size)` call** in `NSG::search_on_graph()` in `fbcode/faiss/impl/NSG.cpp` — before the loops that insert exactly `pool_size` elements into the visited set. This is a safe lower bound (more elements may be added in the subsequent while loop), ensuring no over-allocation.

The optimization helps especially on the first query when the `visited_set` has no pre-existing capacity, avoiding ~log2(pool_size) rehash operations during the initial population phase.

Differential Revision: D100526563


