### PR TITLE
Reduce BinaryCagra test parameters to prevent CI timeouts

### DIFF
--- a/faiss/gpu/test/TestGpuIndexBinaryCagra.cu
+++ b/faiss/gpu/test/TestGpuIndexBinaryCagra.cu
@@ -39,9 +39,9 @@
 
 struct Options {
     Options() {
-        numTrain = 2 * faiss::gpu::randVal(2000, 5000);
-        dim = faiss::gpu::randVal(1, 20) * 8;
-        numAdd = faiss::gpu::randVal(1000, 3000);
+        numTrain = 2 * faiss::gpu::randVal(1000, 2000);
+        dim = faiss::gpu::randVal(1, 10) * 8;
+        numAdd = faiss::gpu::randVal(500, 1500);
 
         graphDegree = faiss::gpu::randSelect({32, 64});
         intermediateGraphDegree = faiss::gpu::randSelect({64, 98});
@@ -75,7 +75,7 @@ struct Options {
 void queryTest(
         faiss::gpu::graph_build_algo build_algo,
         double expected_recall) {
-    for (int tries = 0; tries < 5; ++tries) {
+    for (int tries = 0; tries < 3; ++tries) {
         Options opt;
 
         auto trainVecs = faiss::gpu::randBinaryVecs(opt.numTrain, opt.dim);
@@ -190,7 +190,7 @@ TEST(TestGpuIndexBinaryCagra, Query_ITERATIVE_SEARCH) {
 void copyToTest(
         faiss::gpu::graph_build_algo build_algo,
         double expected_recall) {
-    for (int tries = 0; tries < 5; ++tries) {
+    for (int tries = 0; tries < 3; ++tries) {
         Options opt;
 
         auto trainVecs = faiss::gpu::randBinaryVecs(opt.numTrain, opt.dim);
@@ -324,7 +324,7 @@ TEST(TestGpuIndexBinaryCagra, CopyTo_ITERATIVE_SEARCH) {
 void copyFromTest(
         faiss::gpu::graph_build_algo build_algo,
         double expected_recall) {
-    for (int tries = 0; tries < 5; ++tries) {
+    for (int tries = 0; tries < 3; ++tries) {
         Options opt;
 
         auto trainVecs = faiss::gpu::randBinaryVecs(opt.numTrain, opt.dim);


### PR DESCRIPTION
Summary:
The TestGpuIndexBinaryCagra tests (especially CopyFrom_NN_DESCENT) occasionally time out in GitHub CI on T4 GPUs. The root cause (maybe) is the combination parameter ranges and 5 iterations per test function, each building NN_DESCENT graphs.

Changes:
- Reduce numTrain range from [4000, 10000] to [2000, 4000] (halved max dataset size)
- Reduce dim range from [8, 160] to [8, 80] (halved max dimension)
- Reduce numAdd range from [1000, 3000] to [500, 1500]
- Reduce iteration count from 5 to 3 in queryTest, copyToTest, and copyFromTest

On A100 over 100 runs of CopyFrom_NN_DESCENT:
- Before: avg 5292ms, max 8591ms, range 4057ms
- After:  avg 3510ms, max 4187ms, range 1155ms

Differential Revision: D104251912


