### PR TITLE
Update pattern for index factory string with SVSVamana (#5201)

### DIFF
--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -305,10 +305,25 @@ Index* parse_coarse_quantizer(
         return new IndexNSGFlat(d, R, mt);
     }
 #ifdef FAISS_ENABLE_SVS
-    if (match("IVF([0-9]+[kM]?)_SVSVamana([0-9]*)")) {
+    if (match("IVF([0-9]+[kM]?)_SVSVamana([0-9]*)(_.+)?")) {
         nlist = parse_nlist(sm[1].str());
         int degree = sm[2].length() > 0 ? std::stoi(sm[2]) : 32;
-        return new IndexSVSVamana(d, degree, mt);
+        SVSStorageKind storage = SVSStorageKind::SVS_FP32;
+        if (sm[3].matched) {
+            std::string s = sm[3].str().substr(1);
+            if (s == "SQI8") {
+                storage = SVSStorageKind::SVS_SQI8;
+            } else if (s == "FP16") {
+                storage = SVSStorageKind::SVS_FP16;
+            } else if (s == "FP32") {
+                storage = SVSStorageKind::SVS_FP32;
+            } else {
+                FAISS_THROW_FMT(
+                        "unsupported SVSVamana coarse quantizer storage: %s",
+                        s.c_str());
+            }
+        }
+        return new IndexSVSVamana(d, degree, mt, storage);
     }
 #endif
     if (match("IVF([0-9]+[kM]?)\\(Index([0-9])\\)")) {

--- a/tests/test_svs_py.py
+++ b/tests/test_svs_py.py
@@ -309,6 +309,35 @@ class TestSVSFactoryLVQLeanVec(unittest.TestCase):
 
 
 @unittest.skipIf(_SKIP_SVS, _SKIP_REASON)
+class TestSVSIVFCoarseQuantizerFactory(unittest.TestCase):
+    """Test that IVF with SVSVamana coarse quantizer supports storage kinds"""
+
+    def test_ivf_svsvamana_default(self):
+        index = faiss.index_factory(32, "IVF256_SVSVamana32,Flat")
+        self.assertEqual(index.d, 32)
+        self.assertEqual(index.nlist, 256)
+
+    def test_ivf_svsvamana_sqi8(self):
+        index = faiss.index_factory(32, "IVF256_SVSVamana32_SQI8,Flat")
+        self.assertEqual(index.d, 32)
+        self.assertEqual(index.nlist, 256)
+
+    def test_ivf_svsvamana_fp16(self):
+        index = faiss.index_factory(32, "IVF256_SVSVamana32_FP16,Flat")
+        self.assertEqual(index.d, 32)
+        self.assertEqual(index.nlist, 256)
+
+    def test_ivf_svsvamana_fp32_explicit(self):
+        index = faiss.index_factory(32, "IVF256_SVSVamana32_FP32,Flat")
+        self.assertEqual(index.d, 32)
+        self.assertEqual(index.nlist, 256)
+
+    def test_ivf_svsvamana_invalid_storage(self):
+        with self.assertRaises(RuntimeError):
+            faiss.index_factory(32, "IVF256_SVSVamana32_INVALID,Flat")
+
+
+@unittest.skipIf(_SKIP_SVS, _SKIP_REASON)
 class TestSVSAdapterFP16(TestSVSAdapter):
     """Repeat all tests for SVS Float16 variant"""
     def _create_instance(self):


### PR DESCRIPTION
Summary:

Currently SVSVamana failed with error:
Mitigation: Error in std::unique_ptr<Index> faiss::(anonymous namespace)::index_factory_sub(int, std::string, MetricType, bool) at fbcode/faiss/index_factory.cpp:1176: could not parse index string IVF524288_SVSVamana64_SQI8,SQ4

In this diff we will fix the issue
f1078497787

Reviewed By: mnorris11

Differential Revision: D104326684
