### PR TITLE
Upgrade GitHub Actions CI from CUDA 12.6 to CUDA 13.2 (#5207)

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -73,10 +73,10 @@ runs:
           :
         # regular CUDA for GPU builds
         elif [ "${{ inputs.gpu }}" = "ON" ] && [ "${{ inputs.cuvs }}" = "OFF" ]; then
-          conda install -y -q cuda-libraries-dev=12.6 cuda-nvcc=12.6 cuda-nvtx=12.6 cuda-cupti=12.6 cuda-cudart-dev=12.6 gxx_linux-64=12.4 -c "nvidia/label/cuda-12.6"
+          conda install -y -q cuda-libraries-dev=13.2 cuda-nvcc=13.2 cuda-nvtx=13.2 cuda-cupti=13.2 cuda-cudart-dev=13.2 gxx_linux-64=14.2 -c "nvidia/label/cuda-13.2"
         # and CUDA from cuVS channel for cuVS builds
         elif [ "${{ inputs.cuvs }}" = "ON" ]; then
-          conda install -y -q libcuvs=26.02 'cuda-version=12.9' sysroot_linux-64=2.34 -c rapidsai -c rapidsai-nightly -c conda-forge
+          conda install -y -q libcuvs=26.02 'cuda-version=13.2' sysroot_linux-64=2.34 -c rapidsai -c rapidsai-nightly -c conda-forge
           # Clean index cache to prevent sqlite3 "database is locked" errors
           # from conda-libmamba-solver's shards cache between consecutive installs.
           # See: https://github.com/conda/conda-libmamba-solver/issues/667
@@ -93,7 +93,10 @@ runs:
           : # skip torch install via conda, we need to install via pip to get
             #  ROCm-enabled version until it's supported in conda by PyTorch
         elif [ "${{ inputs.gpu }}" = "ON" ]; then
-          conda install -y -q "pytorch>=2.7" "pytorch-gpu>=2.7" -c pytorch -c "nvidia/label/12.9"
+          # PyTorch deprecated its official Anaconda channel (pytorch/pytorch#138506),
+          # so we install via pip for CUDA builds. --break-system-packages is needed
+          # because the CI runner's Python is PEP 668 externally-managed.
+          pip install "torch>=2.7" --break-system-packages --index-url https://download.pytorch.org/whl/cu132
         else
           # TestLowLevelIVF.IVFRQ hangs on pytorch>=2.7, so left it as <2.5 for now.
           conda install -y -q "pytorch<2.5" -c pytorch

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -277,10 +277,10 @@ jobs:
       - name: Build and Package (conda)
         uses: ./.github/actions/build_conda
   linux-x86_64-GPU-conda:
-    name: Linux x86_64 GPU (conda, CUDA 12.6)
+    name: Linux x86_64 GPU (conda, CUDA 13.2)
     runs-on: 4-core-ubuntu-gpu-t4
     env:
-      CUDA_ARCHS: "70-real;72-real;75-real;80;86-real"
+      CUDA_ARCHS: "75-real;80;86-real;90;100;120"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -290,7 +290,7 @@ jobs:
       - name: Build and Package (conda)
         uses: ./.github/actions/build_conda
         with:
-          cuda: "12.6"
+          cuda: "13.2"
   linux-x86_64-svs:
     name: Linux x86_64 w/ SVS (cmake)
     needs: linux-x86_64-cmake

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,11 +22,11 @@ jobs:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         with:
           label: main
-  linux-x86_64-GPU-packages-CUDA-12-4-0:
-    name: Linux x86_64 GPU packages (CUDA 12.6)
+  linux-x86_64-GPU-packages-CUDA-13-2-0:
+    name: Linux x86_64 GPU packages (CUDA 13.2)
     runs-on: 4-core-ubuntu-gpu-t4
     env:
-      CUDA_ARCHS: "70-real;72-real;75-real;80;86-real"
+      CUDA_ARCHS: "75-real;80;86-real;90;100;120"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,12 +39,12 @@ jobs:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         with:
           label: main
-          cuda: "12.6"
-  linux-x86_64-GPU-CUVS-packages-CUDA12-4-0:
-    name: Linux x86_64 GPU w/ cuVS packages (CUDA 12.6)
+          cuda: "13.2"
+  linux-x86_64-GPU-CUVS-packages-CUDA13-2-0:
+    name: Linux x86_64 GPU w/ cuVS packages (CUDA 13.2)
     runs-on: 4-core-ubuntu-gpu-t4
     env:
-      CUDA_ARCHS: "70-real;72-real;75-real;80;86-real"
+      CUDA_ARCHS: "75-real;80;86-real;90;100;120"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
         with:
           label: main
           cuvs: "ON"
-          cuda: "12.6"
+          cuda: "13.2"
   windows-x86_64-packages:
     name: Windows x86_64 packages
     runs-on: windows-2022

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,11 +20,11 @@ jobs:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         with:
           label: nightly
-  linux-x86_64-GPU-CUDA-12-6-nightly:
-    name: Linux x86_64 GPU nightlies (CUDA 12.6)
+  linux-x86_64-GPU-CUDA-13-2-nightly:
+    name: Linux x86_64 GPU nightlies (CUDA 13.2)
     runs-on: 4-core-ubuntu-gpu-t4
     env:
-      CUDA_ARCHS: "70-real;72-real;75-real;80;86-real"
+      CUDA_ARCHS: "75-real;80;86-real;90;100;120"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,26 +36,25 @@ jobs:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
         with:
           label: nightly
-          cuda: "12.6"
-  # TODO: re-enable when we have a newer machine in CI that can run CUDA 13.2
-  # linux-x86_64-GPU-CUVS-CUDA13-2-0-nightly:
-  #   name: Linux x86_64 GPU w/ cuVS nightlies (CUDA 13.2)
-  #   runs-on: 4-core-ubuntu-gpu-t4
-  #   env:
-  #     CUDA_ARCHS: "75-real;80;86-real;90;100"
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
-  #         fetch-tags: true
-  #     - uses: ./.github/actions/build_conda
-  #       env:
-  #         ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
-  #       with:
-  #         label: nightly
-  #         cuvs: "ON"
-  #         cuda: "13.2"
+          cuda: "13.2"
+  linux-x86_64-GPU-CUVS-CUDA13-2-0-nightly:
+    name: Linux x86_64 GPU w/ cuVS nightlies (CUDA 13.2)
+    runs-on: 4-core-ubuntu-gpu-t4
+    env:
+      CUDA_ARCHS: "75-real;80;86-real;90;100;120"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: ./.github/actions/build_conda
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        with:
+          label: nightly
+          cuvs: "ON"
+          cuda: "13.2"
   windows-x86_64-nightly:
     name: Windows x86_64 nightlies
     runs-on: windows-2022

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,8 +38,8 @@ $ conda install -c pytorch/label/nightly -c conda-forge faiss-cpu
 # GPU(+CPU) version
 $ conda install -c pytorch/label/nightly -c nvidia -c conda-forge faiss-gpu=1.14.1
 
-# GPU(+CPU) version with NVIDIA cuVS (package built with CUDA 12.6)
-conda install -c pytorch -c rapidsai -c rapidsai-nightly -c conda-forge -c nvidia pytorch/label/nightly::faiss-gpu-cuvs 'cuda-version=12.6'
+# GPU(+CPU) version with NVIDIA cuVS (package built with CUDA 13.2)
+conda install -c pytorch -c rapidsai -c rapidsai-nightly -c conda-forge -c nvidia pytorch/label/nightly::faiss-gpu-cuvs 'cuda-version=13.2'
 
 # GPU(+CPU) version using AMD ROCm not yet available
 ```
@@ -87,7 +87,7 @@ section of the wiki](https://github.com/facebookresearch/faiss/wiki/Troubleshoot
 
 The libcuvs dependency should be installed via conda:
 ```
-conda install -c rapidsai -c conda-forge -c nvidia libcuvs=26.02 'cuda-version=12.6'
+conda install -c rapidsai -c conda-forge -c nvidia libcuvs=26.02 'cuda-version=13.2'
 ```
 For more ways to install cuVS 26.02, refer to the [RAPIDS Installation Guide](https://docs.rapids.ai/install).
 


### PR DESCRIPTION
Summary:

Upgrades the GitHub Actions CI workflows to use CUDA 13.2 (from 12.6).

Changes:
- Updated CUDA toolkit version from 12.6 to 13.2 across all CI workflows (nightly, build-release, build-pull-request)
- Updated CUDA_ARCHS to include newer GPU architectures (sm_90/Hopper, sm_100/Blackwell) and drop older ones (sm_70/Volta)
- Upgraded gxx_linux-64 from 12.4 to 14.2 for CUDA builds in build_cmake action
- Uncommented the cuVS CUDA 13.2 nightly job

Reviewed By: junjieqi

Differential Revision: D104863424


