### PR TITLE
Fix cuVS CI: sqlite3 database locked error in conda-libmamba-solver shards cache (#5209)

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -58,7 +58,7 @@ runs:
 
         # install base packages for ARM64
         if [ "${{ runner.arch }}" = "ARM64" ]; then
-          conda install -y -q -c conda-forge openblas=0.3.29 gxx_linux-aarch64=14.2 sysroot_linux-aarch64=2.17
+          conda install -y -q -c conda-forge openblas=0.3.33 gxx_linux-aarch64=14.2 sysroot_linux-aarch64=2.17
         fi
 
         # install base packages for X86_64
@@ -77,6 +77,10 @@ runs:
         # and CUDA from cuVS channel for cuVS builds
         elif [ "${{ inputs.cuvs }}" = "ON" ]; then
           conda install -y -q libcuvs=26.02 'cuda-version=12.9' sysroot_linux-64=2.34 -c rapidsai -c rapidsai-nightly -c conda-forge
+          # Clean index cache to prevent sqlite3 "database is locked" errors
+          # from conda-libmamba-solver's shards cache between consecutive installs.
+          # See: https://github.com/conda/conda-libmamba-solver/issues/667
+          conda clean --index-cache 2>/dev/null || true
         fi
 
         # install SVS runtime for SVS builds

--- a/conda/faiss-gpu-cuvs/meta.yaml
+++ b/conda/faiss-gpu-cuvs/meta.yaml
@@ -61,14 +61,14 @@ outputs:
       host:
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
         - mkl >=2024.2.2,<2026  # [x86_64]
-        - openblas =0.3.32 # [not x86_64]
+        - openblas =0.3.33 # [not x86_64]
         - libcuvs =26.02
         - cuda-version {{ cuda_constraints }}
         - libsvs-runtime =0.3.0  # [x86_64 and linux]
       run:
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
         - mkl >=2024.2.2,<2026  # [x86_64]
-        - openblas =0.3.32 # [not x86_64]
+        - openblas =0.3.33 # [not x86_64]
         - cuda-cudart {{ cuda_constraints }}
         - libcublas {{ libcublas_constraints }}
         - libcuvs =26.02

--- a/conda/faiss-gpu/meta.yaml
+++ b/conda/faiss-gpu/meta.yaml
@@ -60,11 +60,11 @@ outputs:
         - cuda-toolkit {{ cudatoolkit }}
       host:
         - mkl >=2024.2.2,<2026  # [x86_64]
-        - openblas =0.3.32 # [not x86_64]
+        - openblas =0.3.33 # [not x86_64]
         - libsvs-runtime =0.3.0  # [x86_64 and linux]
       run:
         - mkl >=2024.2.2,<2026  # [x86_64]
-        - openblas =0.3.32 # [not x86_64]
+        - openblas =0.3.33 # [not x86_64]
         - cuda-cudart {{ cuda_constraints }}
         - libcublas {{ libcublas_constraints }}
         - libsvs-runtime =0.3.0  # [x86_64 and linux]

--- a/conda/faiss/meta.yaml
+++ b/conda/faiss/meta.yaml
@@ -56,7 +56,7 @@ outputs:
         - mkl-devel >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi
         {% endif %}
-        - libopenblas =0.3.32  # [osx]
+        - libopenblas =0.3.33  # [osx]
       host:
         - python {{ python }}
         - libcxx =20.1.1  # [osx and arm64]
@@ -69,8 +69,8 @@ outputs:
         - mkl >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
-        - openblas =0.3.32  # [not x86_64]
-        - libopenblas =0.3.32  # [osx]
+        - openblas =0.3.33  # [not x86_64]
+        - libopenblas =0.3.33  # [osx]
       run:
         - python {{ python }}
         - libcxx =20.1.1  # [osx and arm64]
@@ -83,8 +83,8 @@ outputs:
         - mkl >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
-        - openblas =0.3.32  # [not x86_64]
-        - libopenblas =0.3.32  # [osx]
+        - openblas =0.3.33  # [not x86_64]
+        - libopenblas =0.3.33  # [osx]
     test:
       requires:
         - conda-build =25.1.2
@@ -120,7 +120,7 @@ outputs:
         - mkl >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
-        - libopenblas =0.3.32  # [osx]
+        - libopenblas =0.3.33  # [osx]
       host:
         - python {{ python }}
         - numpy >=2.0,<3.0
@@ -136,7 +136,7 @@ outputs:
         - mkl >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
-        - libopenblas =0.3.32  # [osx]
+        - libopenblas =0.3.33  # [osx]
       run:
         - python {{ python }}
         - numpy >=2.0,<3.0
@@ -151,7 +151,7 @@ outputs:
         - mkl >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
-        - libopenblas =0.3.32  # [osx]
+        - libopenblas =0.3.33  # [osx]
     test:
       requires:
         - numpy >=2.0,<3.0

--- a/faiss/svs/IndexSVSVamanaLeanVec.cpp
+++ b/faiss/svs/IndexSVSVamanaLeanVec.cpp
@@ -56,7 +56,7 @@ IndexSVSVamanaLeanVec::~IndexSVSVamanaLeanVec() {
         FAISS_ASSERT(status.ok());
         training_data = nullptr;
     }
-    IndexSVSVamana::~IndexSVSVamana();
+    // Base class destructor handles impl cleanup
 }
 
 void IndexSVSVamanaLeanVec::add(idx_t n, const float* x) {


### PR DESCRIPTION
Summary:

Three fixes for GitHub Actions CI build/test failures:

1. sqlite3 "database is locked" error (cuVS cmake builds)

conda-libmamba-solver 26.4.0 uses a SQLite shards cache for package index
data. When consecutive conda install commands run in the same job step,
the SQLite lock from the first install is not fully released before the
second install begins, causing:
sqlite3.OperationalError: database is locked

Fix: Add conda clean --index-cache between the cuVS and PyTorch conda
installs to flush the shards cache and release the lock.

2. OpenBLAS version pin conflict (ARM64 conda builds)

conda-forge removed openblas 0.3.32, making it unresolvable. The conda
recipes pinned 0.3.32 for non-x86_64 (ARM64) and macOS builds, causing:
package libfaiss requires openblas 0.3.32.*, but none of the providers can be installed

Fix: Bump all openblas/libopenblas pins from 0.3.32 to 0.3.33 in the
conda recipes and from 0.3.29 to 0.3.33 in the cmake CI action.

3. Flaky SVS LeanVec test aborts (SVSLL tests)

IndexSVSVamanaLeanVec::~IndexSVSVamanaLeanVec() explicitly called
IndexSVSVamana::~IndexSVSVamana(), but C++ destructor chaining already
calls the base destructor automatically. This caused double-destruction of
base class members (notably std::vector<float> stored_vectors), resulting
in a double-free and non-deterministic SIGABRT. The IVF variant
(IndexSVSIVFLeanVec) correctly omits this call.

Fix: Remove the explicit base destructor call; let C++ handle it.

Differential Revision: D104902441


