### PR TITLE
Fix IDSelectorBitmap conversion to cuVS bitset (#5211)

### DIFF
--- a/faiss/gpu/test/TestGpuFilterConvert.cu
+++ b/faiss/gpu/test/TestGpuFilterConvert.cu
@@ -78,12 +78,12 @@ void run_complex() {
 
     auto or_selector = faiss::IDSelectorOr(&range_selector, &array_selector);
 
-    auto bitmap_faiss_cpu = std::vector<uint8_t>((spec.bitset_len + 8) / 8);
+    auto bitmap_faiss_cpu = std::vector<uint8_t>((spec.bitset_len + 7) / 8);
     for (indexing_t i = 0; i < bitmap_faiss_cpu.size(); i++) {
         bitmap_faiss_cpu[i] = (uint8_t)faiss::gpu::randVal(0, 255);
     }
-    auto bitmap_selector =
-            faiss::IDSelectorBitmap(spec.bitset_len, bitmap_faiss_cpu.data());
+    auto bitmap_selector = faiss::IDSelectorBitmap(
+            bitmap_faiss_cpu.size(), bitmap_faiss_cpu.data());
     auto not_bitmap_selector = faiss::IDSelectorNot(&bitmap_selector);
 
     auto xor_selector =
@@ -163,12 +163,12 @@ void run_bitmap() {
     const raft::device_resources& raft_handle =
             gpuRes->getRaftHandleCurrentDevice();
     // generate random bitmap selector
-    auto bitmap_faiss_cpu = std::vector<uint8_t>((spec.bitset_len + 8) / 8);
+    auto bitmap_faiss_cpu = std::vector<uint8_t>((spec.bitset_len + 7) / 8);
     for (indexing_t i = 0; i < bitmap_faiss_cpu.size(); i++) {
         bitmap_faiss_cpu[i] = (uint8_t)faiss::gpu::randVal(0, 255);
     }
-    auto bitmap_selector =
-            faiss::IDSelectorBitmap(spec.bitset_len, bitmap_faiss_cpu.data());
+    auto bitmap_selector = faiss::IDSelectorBitmap(
+            bitmap_faiss_cpu.size(), bitmap_faiss_cpu.data());
     auto bitset = cuvs::core::bitset<bitset_t, indexing_t>(
             raft_handle, spec.bitset_len, false);
     faiss::gpu::convert_to_bitset(gpuRes.get(), bitmap_selector, bitset.view());
@@ -230,6 +230,64 @@ void run_array() {
                     << i << " bitset_len: " << spec.bitset_len);
         }
     }
+}
+
+void run_bitmap_byte_convention() {
+    // Explicitly tests that n = byte count works correctly.
+    // This is the convention used by the Python wrapper:
+    //   faiss.IDSelectorBitmap(numpy_uint8_array)
+    //   -> IDSelectorBitmap(len(array), array.data())
+    using bitset_t = uint32_t;
+    using indexing_t = int64_t;
+
+    // Use a bit count that is NOT a multiple of 8 to stress edge cases
+    size_t bit_count = 100003;
+    size_t byte_count = (bit_count + 7) / 8; // 12501
+
+    faiss::gpu::StandardGpuResources res;
+    res.noTempMemory();
+    auto gpuRes = res.getResources();
+    const raft::device_resources& raft_handle =
+            gpuRes->getRaftHandleCurrentDevice();
+
+    // Generate random bitmap
+    auto bitmap_faiss_cpu = std::vector<uint8_t>(byte_count);
+    for (size_t i = 0; i < bitmap_faiss_cpu.size(); i++) {
+        bitmap_faiss_cpu[i] = (uint8_t)faiss::gpu::randVal(0, 255);
+    }
+
+    // Construct with n = byte_count (the only valid convention)
+    auto bitmap_selector =
+            faiss::IDSelectorBitmap(byte_count, bitmap_faiss_cpu.data());
+
+    // Create bitset with the actual number of bits
+    auto bitset = cuvs::core::bitset<bitset_t, indexing_t>(
+            raft_handle, bit_count, false);
+
+    faiss::gpu::convert_to_bitset(gpuRes.get(), bitmap_selector, bitset.view());
+
+    // Verify every bit matches
+    auto bitset_converted_cpu =
+            raft::make_host_vector<bitset_t, indexing_t>(bitset.n_elements());
+    raft::copy(raft_handle, bitset_converted_cpu.view(), bitset.to_mdspan());
+    raft::resource::sync_stream(raft_handle);
+    auto bitset_converted_cpu_view =
+            cuvs::core::bitset_view<bitset_t, indexing_t>(
+                    bitset_converted_cpu.data_handle(), bit_count);
+    for (indexing_t i = 0; i < static_cast<indexing_t>(bit_count); i++) {
+        if (bitset_converted_cpu_view.test(i) != bitmap_selector.is_member(i)) {
+            ASSERT_TRUE(
+                    testing::AssertionFailure()
+                    << "actual=" << bitset_converted_cpu_view.test(i)
+                    << " != expected=" << bitmap_selector.is_member(i) << " @"
+                    << i << " bit_count: " << bit_count
+                    << " byte_count (n): " << byte_count);
+        }
+    }
+}
+
+TEST(TestGpuFilterConvert, BitmapByteConvention) {
+    run_bitmap_byte_convention();
 }
 
 TEST(TestGpuFilterConvert, Complex) {

--- a/faiss/gpu/utils/CuvsFilterConvert.cu
+++ b/faiss/gpu/utils/CuvsFilterConvert.cu
@@ -145,25 +145,32 @@ void convert_to_bitset_bitmap(
         raft::resources const& res,
         const faiss::IDSelectorBitmap& selector,
         cuvs::core::bitset_view<uint32_t, int64_t> bitset) {
-    auto n = selector.n;
+    // IDSelectorBitmap.n is the byte count of the bitmap array (number of
+    // uint8_t elements). This matches the documented C++ API:
+    //   @param n size of the bitmap array
+    //   is_member(id) requires id / 8 < n
+    auto n = selector.n; // byte count of bitmap array
     auto bitset_original_nbits = bitset.get_original_nbits();
     if (bitset_original_nbits == 0) {
         bitset_original_nbits = sizeof(uint32_t) * 8;
     }
+    auto bitset_bytes = (bitset.size() + 7) / 8;
     RAFT_EXPECTS(
-            bitset.size() == n,
-            "IDSelectorBitmap is out of range for the given bitset: %ld != %zu",
-            bitset.size(),
-            n);
+            static_cast<int64_t>(n) >= bitset_bytes,
+            "IDSelectorBitmap is too small for the given bitset: "
+            "n=%zu bytes, bitset needs %ld bytes (%ld bits)",
+            n,
+            bitset_bytes,
+            bitset.size());
     auto stream = raft::resource::get_cuda_stream(res);
-    auto n_elements = (selector.n + 7) / 8;
+    auto n_elements = bitset_bytes;
     auto d_bitmap = raft::make_device_vector<uint8_t, int64_t>(res, n_elements);
     auto d_bitmap_ptr = d_bitmap.data_handle();
     raft::copy(
-            res,
-            d_bitmap.view(),
-            raft::make_host_vector_view<const uint8_t, int64_t>(
-                    selector.bitmap, n_elements));
+            d_bitmap_ptr,
+            reinterpret_cast<const uint8_t*>(selector.bitmap),
+            n_elements,
+            stream);
 
     const int threads_per_block = 256;
     const int blocks = (n_elements + threads_per_block - 1) / threads_per_block;


### PR DESCRIPTION
Summary:

`convert_to_bitset_bitmap` in `CuvsFilterConvert.cu` assumed that `IDSelectorBitmap.n` was the bit/vector count, but it can also be the byte count of the bitmap array (which is how the Python wrapper constructs it via `faiss.IDSelectorBitmap(numpy_array)`). This caused two bugs:

1. The `RAFT_EXPECTS(bitset.size() == n)` check failed when `n` was the byte count (e.g., 6.25M bytes vs 50M bits), throwing a `raft::logic_error` that propagated up and caused filtered search to silently fall back to unfiltered results.

2. `n_elements = (selector.n + 7) / 8` divided the byte count by 8 again, copying only 1/8 of the bitmap data when `n` was already the byte count.

The fix handles both conventions by computing the actual number of bytes to copy as `min(n, ceil(bitset_size / 8))`. This works regardless of whether `n` represents bytes or bits:
- Python wrapper (n = byte count): copies all n bytes
- C++ convention (n = bit count): copies ceil(bit_count / 8) bytes (the minimum needed)

Reviewed By: pankajsingh88

Differential Revision: D104935985


