### PR TITLE
Move RISC-V fast_scan forwarders to dedicated impl-riscv.cpp (#5216)

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -51,6 +51,7 @@ set(FAISS_SIMD_SVE_SRC
   utils/simd_impl/distances_arm_sve.cpp
 )
 set(FAISS_SIMD_RVV_SRC
+  impl/fast_scan/impl-riscv.cpp
   impl/pq_code_distance/rvv.cpp
   impl/scalar_quantizer/sq-rvv.cpp
   impl/binary_hamming/rvv.cpp

--- a/faiss/IndexRaBitQFastScan.h
+++ b/faiss/IndexRaBitQFastScan.h
@@ -134,6 +134,7 @@ template <
 struct RaBitQHeapHandler
         : simd_result_handlers::ResultHandlerCompare<C, with_id_map, SL> {
     using RHC = simd_result_handlers::ResultHandlerCompare<C, with_id_map, SL>;
+    using RHC::handle;
     using RHC::normalizers;
     static constexpr SIMDLevel SL256 = simd256_level_selector<SL>::value;
     using simd16uint16 = simd16uint16_tpl<SL256>;
@@ -187,7 +188,7 @@ struct RaBitQHeapHandler
         }
     }
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) override {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
         ALIGNED(32) uint16_t d32tab[32];
         d0.store(d32tab);
         d1.store(d32tab + 16);

--- a/faiss/impl/fast_scan/accumulate_loops.h
+++ b/faiss/impl/fast_scan/accumulate_loops.h
@@ -47,7 +47,12 @@ using namespace simd_result_handlers;
  * Search_1 path helpers (multi-BB kernel, bbs > 32)
  ***************************************************************/
 
-template <int NQ, int BB, class ResultHandler, class Scaler>
+template <
+        int NQ,
+        int BB,
+        SIMDLevel KernelSL = SINGLE_SIMD_LEVEL,
+        class ResultHandler,
+        class Scaler>
 void accumulate_fixed_blocks(
         size_t nb,
         int nsq,
@@ -58,13 +63,17 @@ void accumulate_fixed_blocks(
         size_t block_stride) {
     constexpr int bbs = 32 * BB;
     for_each_block<bbs>(nb, codes, block_stride, res, [&](size_t) {
-        FixedStorageHandler<NQ, 2 * BB> res2;
-        kernel_accumulate_block<NQ, BB>(nsq, codes, LUT, res2, scaler);
+        FixedStorageHandler<NQ, 2 * BB, KernelSL> res2;
+        kernel_accumulate_block<NQ, BB, KernelSL>(
+                nsq, codes, LUT, res2, scaler);
         res2.to_other_handler(res);
     });
 }
 
-template <class ResultHandler, class Scaler>
+template <
+        SIMDLevel KernelSL = SINGLE_SIMD_LEVEL,
+        class ResultHandler,
+        class Scaler>
 void pq4_accumulate_loop_fixed_scaler(
         int nq,
         size_t nb,
@@ -82,7 +91,7 @@ void pq4_accumulate_loop_fixed_scaler(
 
 #define FAISS_ACCLOOP_DISPATCH(NQ, BB)                           \
     case NQ * 1000 + BB:                                         \
-        accumulate_fixed_blocks<NQ, BB>(                         \
+        accumulate_fixed_blocks<NQ, BB, KernelSL>(               \
                 nb, nsq, codes, LUT, res, scaler, block_stride); \
         break
 
@@ -106,7 +115,11 @@ void pq4_accumulate_loop_fixed_scaler(
  * QBS path helpers (bbs == 32, 256-bit kernel only)
  ***************************************************************/
 
-template <int QBS, class ResultHandler, class Scaler>
+template <
+        int QBS,
+        SIMDLevel KernelSL = SINGLE_SIMD_LEVEL,
+        class ResultHandler,
+        class Scaler>
 void accumulate_q_4step_256(
         size_t ntotal2,
         int nsq,
@@ -122,29 +135,32 @@ void accumulate_q_4step_256(
     constexpr int SQ = Q1 + Q2 + Q3 + Q4;
 
     for_each_block<32>(ntotal2, codes, block_stride, res, [&](size_t) {
-        FixedStorageHandler<SQ, 2> res2;
+        FixedStorageHandler<SQ, 2, KernelSL> res2;
         const uint8_t* LUT = LUT0;
-        pq4_kernel_qbs_256<Q1>(nsq, codes, LUT, res2, scaler);
+        pq4_kernel_qbs_256<Q1, KernelSL>(nsq, codes, LUT, res2, scaler);
         LUT += Q1 * nsq * 16;
         if (Q2 > 0) {
             res2.set_block_origin(Q1, 0);
-            pq4_kernel_qbs_256<Q2>(nsq, codes, LUT, res2, scaler);
+            pq4_kernel_qbs_256<Q2, KernelSL>(nsq, codes, LUT, res2, scaler);
             LUT += Q2 * nsq * 16;
         }
         if (Q3 > 0) {
             res2.set_block_origin(Q1 + Q2, 0);
-            pq4_kernel_qbs_256<Q3>(nsq, codes, LUT, res2, scaler);
+            pq4_kernel_qbs_256<Q3, KernelSL>(nsq, codes, LUT, res2, scaler);
             LUT += Q3 * nsq * 16;
         }
         if (Q4 > 0) {
             res2.set_block_origin(Q1 + Q2 + Q3, 0);
-            pq4_kernel_qbs_256<Q4>(nsq, codes, LUT, res2, scaler);
+            pq4_kernel_qbs_256<Q4, KernelSL>(nsq, codes, LUT, res2, scaler);
         }
         res2.to_other_handler(res);
     });
 }
 
-template <class ResultHandler, class Scaler>
+template <
+        SIMDLevel KernelSL = SINGLE_SIMD_LEVEL,
+        class ResultHandler,
+        class Scaler>
 void pq4_accumulate_loop_qbs_fixed_scaler_256(
         int qbs,
         size_t ntotal2,
@@ -161,7 +177,7 @@ void pq4_accumulate_loop_qbs_fixed_scaler_256(
     switch (qbs) {
 #define FAISS_QBS256_DISPATCH(QBS)                                     \
     case QBS:                                                          \
-        accumulate_q_4step_256<QBS>(                                   \
+        accumulate_q_4step_256<QBS, KernelSL>(                         \
                 ntotal2, nsq, codes, LUT0, res, scaler, block_stride); \
         return;
         FAISS_QBS256_DISPATCH(0x3333); // 12
@@ -199,9 +215,9 @@ void pq4_accumulate_loop_qbs_fixed_scaler_256(
             int nq = qi & 15;
             qi >>= 4;
             res.set_block_origin(i0, j0);
-#define FAISS_NQ256_DISPATCH(NQ)                              \
-    case NQ:                                                  \
-        pq4_kernel_qbs_256<NQ>(nsq, codes, LUT, res, scaler); \
+#define FAISS_NQ256_DISPATCH(NQ)                                        \
+    case NQ:                                                            \
+        pq4_kernel_qbs_256<NQ, KernelSL>(nsq, codes, LUT, res, scaler); \
         break
             switch (nq) {
                 FAISS_NQ256_DISPATCH(1);

--- a/faiss/impl/fast_scan/accumulate_loops_512.h
+++ b/faiss/impl/fast_scan/accumulate_loops_512.h
@@ -15,10 +15,9 @@
  * (from kernels_simd512.h) instead of pq4_kernel_qbs_256.
  *
  * The 512-bit kernels produce simd16uint16_tpl<AVX2> results (via
- * combine4x2). The virtual SIMDResultHandler::handle() expects
- * simd16uint16_tpl<NONE> in DD mode. FixedStorage512 bridges this gap:
- * it stores AVX2-level results internally, then converts to the handler's
- * level via storeu/load in to_other_handler().
+ * combine4x2). FixedStorage512 stores these results without virtual
+ * dispatch, then forwards them to the outer handler via
+ * to_other_handler().
  *
  * Only included from the AVX512 per-ISA TU (impl-avx512.cpp) via
  * dispatching.h's conditional include.
@@ -46,8 +45,8 @@ using namespace simd_result_handlers;
  * 512-bit kernels produce simd16uint16_tpl<AVX2>. By avoiding
  * inheritance, handle() can accept AVX2-level types directly.
  *
- * The conversion to the outer handler's type happens in
- * to_other_handler() via a store-to-memory roundtrip.
+ * to_other_handler() passes AVX2-level values directly to the
+ * outer handler.
  ***************************************************************/
 
 template <int NQ, int BB>
@@ -72,17 +71,9 @@ struct FixedStorage512 {
 
     template <class OtherResultHandler>
     void to_other_handler(OtherResultHandler& other) const {
-        using handler_simd16 = simd16uint16_tpl<SINGLE_SIMD_LEVEL_256>;
         for (int q = 0; q < NQ; q++) {
             for (int b = 0; b < BB; b += 2) {
-                // Convert AVX2 → handler level (NONE in DD mode)
-                ALIGNED(32) uint16_t buf0[16], buf1[16];
-                dis[q][b].storeu(buf0);
-                dis[q][b + 1].storeu(buf1);
-                handler_simd16 h0, h1;
-                h0.loadu(buf0);
-                h1.loadu(buf1);
-                other.handle(q, b / 2, h0, h1);
+                other.handle(q, b / 2, dis[q][b], dis[q][b + 1]);
             }
         }
     }
@@ -176,17 +167,16 @@ void pq4_accumulate_loop_qbs_fixed_scaler_512(
 #undef FAISS_QBS512_DISPATCH
     }
 
-    // Fallback for unknown QBS values: use 256-bit path with NONE-level
-    // scalers for type compatibility. This is rare — pq4_preferred_qbs()
-    // covers all values above.
+    // Fallback for unknown QBS values: use 256-bit path.
+    // This is rare — pq4_preferred_qbs() covers all values above.
     if constexpr (Scaler::nscale == 0) {
-        DummyScaler<> scaler_none;
-        pq4_accumulate_loop_qbs_fixed_scaler_256(
-                qbs, ntotal2, nsq, codes, LUT0, res, scaler_none, block_stride);
+        DummyScaler<SIMDLevel::AVX2> scaler_avx2;
+        pq4_accumulate_loop_qbs_fixed_scaler_256<SIMDLevel::AVX2>(
+                qbs, ntotal2, nsq, codes, LUT0, res, scaler_avx2, block_stride);
     } else {
-        NormTableScaler<> scaler_none(scaler.scale_int);
-        pq4_accumulate_loop_qbs_fixed_scaler_256(
-                qbs, ntotal2, nsq, codes, LUT0, res, scaler_none, block_stride);
+        NormTableScaler<SIMDLevel::AVX2> scaler_avx2(scaler.scale_int);
+        pq4_accumulate_loop_qbs_fixed_scaler_256<SIMDLevel::AVX2>(
+                qbs, ntotal2, nsq, codes, LUT0, res, scaler_avx2, block_stride);
     }
 }
 

--- a/faiss/impl/fast_scan/decompose_qbs.h
+++ b/faiss/impl/fast_scan/decompose_qbs.h
@@ -21,8 +21,16 @@ using namespace simd_result_handlers;
 /*
  * Unified kernel: selects 256-bit vs 512-bit path based on
  * compile-time __AVX512F__ guard.
+ *
+ * KernelSL selects the SIMD type width used for the inner accumulation
+ * loop.  In DD mode the caller passes the dispatch level so the kernel
+ * uses real AVX2 types rather than the emulated-scalar fallback.
  */
-template <int NQ, class ResultHandler, class Scaler>
+template <
+        int NQ,
+        SIMDLevel KernelSL = SINGLE_SIMD_LEVEL,
+        class ResultHandler,
+        class Scaler>
 void kernel_accumulate_block(
         int nsq,
         const uint8_t* codes,
@@ -30,14 +38,24 @@ void kernel_accumulate_block(
         ResultHandler& res,
         const Scaler& scaler) {
 #ifdef __AVX512F__
-    pq4_kernel_qbs_512<NQ>(nsq, codes, LUT, res, scaler);
+    if constexpr (
+            KernelSL == SIMDLevel::AVX512 ||
+            KernelSL == SIMDLevel::AVX512_SPR) {
+        pq4_kernel_qbs_512<NQ>(nsq, codes, LUT, res, scaler);
+    } else {
+        pq4_kernel_qbs_256<NQ, KernelSL>(nsq, codes, LUT, res, scaler);
+    }
 #else
-    pq4_kernel_qbs_256<NQ>(nsq, codes, LUT, res, scaler);
+    pq4_kernel_qbs_256<NQ, KernelSL>(nsq, codes, LUT, res, scaler);
 #endif
 }
 
 // handle at most 4 blocks of queries
-template <int QBS, class ResultHandler, class Scaler>
+template <
+        int QBS,
+        SIMDLevel KernelSL = SINGLE_SIMD_LEVEL,
+        class ResultHandler,
+        class Scaler>
 void accumulate_q_4step(
         size_t ntotal2,
         int nsq,
@@ -53,29 +71,36 @@ void accumulate_q_4step(
     constexpr int SQ = Q1 + Q2 + Q3 + Q4;
 
     for_each_block<32>(ntotal2, codes, block_stride, res, [&](size_t) {
-        FixedStorageHandler<SQ, 2> res2;
+        FixedStorageHandler<SQ, 2, KernelSL> res2;
         const uint8_t* LUT = LUT0;
-        kernel_accumulate_block<Q1>(nsq, codes, LUT, res2, scaler);
+        kernel_accumulate_block<Q1, KernelSL>(nsq, codes, LUT, res2, scaler);
         LUT += Q1 * nsq * 16;
         if (Q2 > 0) {
             res2.set_block_origin(Q1, 0);
-            kernel_accumulate_block<Q2>(nsq, codes, LUT, res2, scaler);
+            kernel_accumulate_block<Q2, KernelSL>(
+                    nsq, codes, LUT, res2, scaler);
             LUT += Q2 * nsq * 16;
         }
         if (Q3 > 0) {
             res2.set_block_origin(Q1 + Q2, 0);
-            kernel_accumulate_block<Q3>(nsq, codes, LUT, res2, scaler);
+            kernel_accumulate_block<Q3, KernelSL>(
+                    nsq, codes, LUT, res2, scaler);
             LUT += Q3 * nsq * 16;
         }
         if (Q4 > 0) {
             res2.set_block_origin(Q1 + Q2 + Q3, 0);
-            kernel_accumulate_block<Q4>(nsq, codes, LUT, res2, scaler);
+            kernel_accumulate_block<Q4, KernelSL>(
+                    nsq, codes, LUT, res2, scaler);
         }
         res2.to_other_handler(res);
     });
 }
 
-template <int NQ, class ResultHandler, class Scaler>
+template <
+        int NQ,
+        SIMDLevel KernelSL = SINGLE_SIMD_LEVEL,
+        class ResultHandler,
+        class Scaler>
 void kernel_accumulate_block_loop(
         size_t ntotal2,
         int nsq,
@@ -85,13 +110,15 @@ void kernel_accumulate_block_loop(
         const Scaler& scaler,
         size_t block_stride) {
     for_each_block<32>(ntotal2, codes, block_stride, res, [&](size_t) {
-        kernel_accumulate_block<NQ, ResultHandler>(
-                nsq, codes, LUT, res, scaler);
+        kernel_accumulate_block<NQ, KernelSL>(nsq, codes, LUT, res, scaler);
     });
 }
 
 // non-template version of accumulate kernel -- dispatches dynamically
-template <class ResultHandler, class Scaler>
+template <
+        SIMDLevel KernelSL = SINGLE_SIMD_LEVEL,
+        class ResultHandler,
+        class Scaler>
 void accumulate(
         int nq,
         size_t ntotal2,
@@ -106,7 +133,7 @@ void accumulate(
 
 #define DISPATCH(NQ)                                                  \
     case NQ:                                                          \
-        kernel_accumulate_block_loop<NQ, ResultHandler>(              \
+        kernel_accumulate_block_loop<NQ, KernelSL>(                   \
                 ntotal2, nsq, codes, LUT, res, scaler, block_stride); \
         return
 
@@ -121,7 +148,10 @@ void accumulate(
 #undef DISPATCH
 }
 
-template <class ResultHandler, class Scaler>
+template <
+        SIMDLevel KernelSL = SINGLE_SIMD_LEVEL,
+        class ResultHandler,
+        class Scaler>
 void pq4_accumulate_loop_qbs_fixed_scaler(
         int qbs,
         size_t ntotal2,
@@ -139,7 +169,7 @@ void pq4_accumulate_loop_qbs_fixed_scaler(
     switch (qbs) {
 #define DISPATCH(QBS)                                                  \
     case QBS:                                                          \
-        accumulate_q_4step<QBS>(                                       \
+        accumulate_q_4step<QBS, KernelSL>(                             \
                 ntotal2, nsq, codes, LUT0, res, scaler, block_stride); \
         return;
         DISPATCH(0x3333); // 12
@@ -177,10 +207,9 @@ void pq4_accumulate_loop_qbs_fixed_scaler(
             int nq = qi & 15;
             qi >>= 4;
             res.set_block_origin(i0, j0);
-#define DISPATCH(NQ)                                \
-    case NQ:                                        \
-        kernel_accumulate_block<NQ, ResultHandler>( \
-                nsq, codes, LUT, res, scaler);      \
+#define DISPATCH(NQ)                                                         \
+    case NQ:                                                                 \
+        kernel_accumulate_block<NQ, KernelSL>(nsq, codes, LUT, res, scaler); \
         break
             switch (nq) {
                 DISPATCH(1);

--- a/faiss/impl/fast_scan/dispatching.h
+++ b/faiss/impl/fast_scan/dispatching.h
@@ -70,8 +70,8 @@ struct ScannerMixIn : FastScanCodeScanner {
             int pq2x4_scale,
             size_t block_stride) override {
         if (pq2x4_scale) {
-            NormTableScaler<> scaler(pq2x4_scale);
-            pq4_accumulate_loop_fixed_scaler(
+            NormTableScaler<THE_LEVEL_TO_DISPATCH> scaler(pq2x4_scale);
+            pq4_accumulate_loop_fixed_scaler<THE_LEVEL_TO_DISPATCH>(
                     nq,
                     nb,
                     bbs,
@@ -82,8 +82,8 @@ struct ScannerMixIn : FastScanCodeScanner {
                     scaler,
                     block_stride);
         } else {
-            DummyScaler<> dummy;
-            pq4_accumulate_loop_fixed_scaler(
+            DummyScaler<THE_LEVEL_TO_DISPATCH> dummy;
+            pq4_accumulate_loop_fixed_scaler<THE_LEVEL_TO_DISPATCH>(
                     nq,
                     nb,
                     bbs,
@@ -138,8 +138,8 @@ struct ScannerMixIn : FastScanCodeScanner {
             }
         } else {
             if (pq2x4_scale) {
-                NormTableScaler<> scaler(pq2x4_scale);
-                pq4_accumulate_loop_qbs_fixed_scaler_256(
+                NormTableScaler<THE_LEVEL_TO_DISPATCH> scaler(pq2x4_scale);
+                pq4_accumulate_loop_qbs_fixed_scaler_256<THE_LEVEL_TO_DISPATCH>(
                         qbs,
                         nb,
                         nsq,
@@ -149,8 +149,8 @@ struct ScannerMixIn : FastScanCodeScanner {
                         scaler,
                         block_stride);
             } else {
-                DummyScaler<> dummy;
-                pq4_accumulate_loop_qbs_fixed_scaler_256(
+                DummyScaler<THE_LEVEL_TO_DISPATCH> dummy;
+                pq4_accumulate_loop_qbs_fixed_scaler_256<THE_LEVEL_TO_DISPATCH>(
                         qbs,
                         nb,
                         nsq,
@@ -188,15 +188,15 @@ std::unique_ptr<FastScanCodeScanner> make_fast_scan_scanner_impl<
     // Helper lambda: given comparator C and with_id_map W, select handler
     auto make = [&]<class C, bool W>() -> std::unique_ptr<FastScanCodeScanner> {
         if (k == 1) {
-            using H = SingleResultHandler<C, W>;
+            using H = SingleResultHandler<C, W, THE_LEVEL_TO_DISPATCH>;
             return std::make_unique<ScannerMixIn<H>>(
                     nq, ntotal, distances, ids, sel);
         } else if (impl % 2 == 0) {
-            using H = HeapHandler<C, W>;
+            using H = HeapHandler<C, W, THE_LEVEL_TO_DISPATCH>;
             return std::make_unique<ScannerMixIn<H>>(
                     nq, ntotal, k, distances, ids, sel);
         } else {
-            using H = ReservoirHandler<C, W>;
+            using H = ReservoirHandler<C, W, THE_LEVEL_TO_DISPATCH>;
             return std::make_unique<ScannerMixIn<H>>(
                     nq, ntotal, size_t(k), size_t(2 * k), distances, ids, sel);
         }
@@ -231,11 +231,13 @@ std::unique_ptr<FastScanCodeScanner> make_range_scanner_impl<
         const IDSelector* sel) {
     if (is_max) {
         using C = CMax<uint16_t, int64_t>;
-        return std::make_unique<ScannerMixIn<RangeHandler<C, true>>>(
+        return std::make_unique<
+                ScannerMixIn<RangeHandler<C, true, THE_LEVEL_TO_DISPATCH>>>(
                 rres, radius, ntotal, sel);
     } else {
         using C = CMin<uint16_t, int64_t>;
-        return std::make_unique<ScannerMixIn<RangeHandler<C, true>>>(
+        return std::make_unique<
+                ScannerMixIn<RangeHandler<C, true, THE_LEVEL_TO_DISPATCH>>>(
                 rres, radius, ntotal, sel);
     }
 }
@@ -252,11 +254,13 @@ std::unique_ptr<FastScanCodeScanner> make_partial_range_scanner_impl<
         const IDSelector* sel) {
     if (is_max) {
         using C = CMax<uint16_t, int64_t>;
-        return std::make_unique<ScannerMixIn<PartialRangeHandler<C, true>>>(
+        return std::make_unique<ScannerMixIn<
+                PartialRangeHandler<C, true, THE_LEVEL_TO_DISPATCH>>>(
                 pres, radius, ntotal, q0, q1, sel);
     } else {
         using C = CMin<uint16_t, int64_t>;
-        return std::make_unique<ScannerMixIn<PartialRangeHandler<C, true>>>(
+        return std::make_unique<ScannerMixIn<
+                PartialRangeHandler<C, true, THE_LEVEL_TO_DISPATCH>>>(
                 pres, radius, ntotal, q0, q1, sel);
     }
 }

--- a/faiss/impl/fast_scan/fast_scan.cpp
+++ b/faiss/impl/fast_scan/fast_scan.cpp
@@ -385,20 +385,6 @@ int pq4_preferred_qbs(int n) {
     }
 }
 
-void accumulate_to_mem(
-        int nq,
-        size_t ntotal2,
-        int nsq,
-        const uint8_t* codes,
-        const uint8_t* LUT,
-        uint16_t* accu) {
-    using namespace simd_result_handlers;
-    FAISS_THROW_IF_NOT(ntotal2 % 32 == 0);
-    StoreResultHandler<> handler(accu, ntotal2);
-    DummyScaler<> scaler;
-    accumulate(nq, ntotal2, nsq, codes, LUT, handler, scaler, 32 * nsq / 2);
-}
-
 } // namespace faiss
 
 /***************************************************************
@@ -413,6 +399,56 @@ void accumulate_to_mem(
 #include <faiss/impl/fast_scan/dispatching.h>        // IWYU pragma: keep
 #include <faiss/impl/fast_scan/rabitq_dispatching.h> // IWYU pragma: keep
 #undef THE_LEVEL_TO_DISPATCH
+
+namespace faiss {
+
+using namespace simd_result_handlers;
+
+/***************************************************************
+ * accumulate_to_mem: NONE specialization + runtime dispatch.
+ ***************************************************************/
+
+template <>
+void accumulate_to_mem_impl<SIMDLevel::NONE>(
+        int nq,
+        size_t ntotal2,
+        int nsq,
+        const uint8_t* codes,
+        const uint8_t* LUT,
+        uint16_t* accu) {
+    StoreResultHandler<SIMDLevel::NONE> handler(accu, ntotal2);
+    DummyScaler<SIMDLevel::NONE> scaler;
+    accumulate<SIMDLevel::NONE>(
+            nq, ntotal2, nsq, codes, LUT, handler, scaler, 32 * nsq / 2);
+}
+
+#ifdef COMPILE_SIMD_RISCV_RVV
+template <>
+void accumulate_to_mem_impl<SIMDLevel::RISCV_RVV>(
+        int nq,
+        size_t ntotal2,
+        int nsq,
+        const uint8_t* codes,
+        const uint8_t* LUT,
+        uint16_t* accu) {
+    accumulate_to_mem_impl<SIMDLevel::NONE>(nq, ntotal2, nsq, codes, LUT, accu);
+}
+#endif
+
+void accumulate_to_mem(
+        int nq,
+        size_t ntotal2,
+        int nsq,
+        const uint8_t* codes,
+        const uint8_t* LUT,
+        uint16_t* accu) {
+    FAISS_THROW_IF_NOT(ntotal2 % 32 == 0);
+    with_simd_level([&]<SIMDLevel SL>() {
+        accumulate_to_mem_impl<SL>(nq, ntotal2, nsq, codes, LUT, accu);
+    });
+}
+
+} // namespace faiss
 
 namespace faiss {
 

--- a/faiss/impl/fast_scan/fast_scan.cpp
+++ b/faiss/impl/fast_scan/fast_scan.cpp
@@ -422,19 +422,6 @@ void accumulate_to_mem_impl<SIMDLevel::NONE>(
             nq, ntotal2, nsq, codes, LUT, handler, scaler, 32 * nsq / 2);
 }
 
-#ifdef COMPILE_SIMD_RISCV_RVV
-template <>
-void accumulate_to_mem_impl<SIMDLevel::RISCV_RVV>(
-        int nq,
-        size_t ntotal2,
-        int nsq,
-        const uint8_t* codes,
-        const uint8_t* LUT,
-        uint16_t* accu) {
-    accumulate_to_mem_impl<SIMDLevel::NONE>(nq, ntotal2, nsq, codes, LUT, accu);
-}
-#endif
-
 void accumulate_to_mem(
         int nq,
         size_t ntotal2,
@@ -451,82 +438,6 @@ void accumulate_to_mem(
 } // namespace faiss
 
 namespace faiss {
-
-#ifdef COMPILE_SIMD_RISCV_RVV
-template <>
-std::unique_ptr<FastScanCodeScanner> make_fast_scan_scanner_impl<
-        SIMDLevel::RISCV_RVV>(
-        bool is_max,
-        int impl,
-        size_t nq,
-        size_t ntotal,
-        int64_t k,
-        float* distances,
-        int64_t* ids,
-        const IDSelector* sel,
-        bool with_id_map) {
-    return make_fast_scan_scanner_impl<SIMDLevel::NONE>(
-            is_max, impl, nq, ntotal, k, distances, ids, sel, with_id_map);
-}
-
-template <>
-std::unique_ptr<FastScanCodeScanner> make_range_scanner_impl<
-        SIMDLevel::RISCV_RVV>(
-        bool is_max,
-        RangeSearchResult& rres,
-        float radius,
-        size_t ntotal,
-        const IDSelector* sel) {
-    return make_range_scanner_impl<SIMDLevel::NONE>(
-            is_max, rres, radius, ntotal, sel);
-}
-
-template <>
-std::unique_ptr<FastScanCodeScanner> make_partial_range_scanner_impl<
-        SIMDLevel::RISCV_RVV>(
-        bool is_max,
-        RangeSearchPartialResult& pres,
-        float radius,
-        size_t ntotal,
-        size_t q0,
-        size_t q1,
-        const IDSelector* sel) {
-    return make_partial_range_scanner_impl<SIMDLevel::NONE>(
-            is_max, pres, radius, ntotal, q0, q1, sel);
-}
-
-template <>
-std::unique_ptr<FastScanCodeScanner> rabitq_make_knn_scanner_impl<
-        SIMDLevel::RISCV_RVV>(
-        const IndexRaBitQFastScan* index,
-        bool is_max,
-        size_t nq,
-        int64_t k,
-        float* distances,
-        int64_t* ids,
-        const IDSelector* sel,
-        const FastScanDistancePostProcessing& context,
-        bool is_multi_bit) {
-    return rabitq_make_knn_scanner_impl<SIMDLevel::NONE>(
-            index, is_max, nq, k, distances, ids, sel, context, is_multi_bit);
-}
-
-template <>
-std::unique_ptr<FastScanCodeScanner> rabitq_ivf_make_knn_scanner_impl<
-        SIMDLevel::RISCV_RVV>(
-        bool is_max,
-        const IndexIVFRaBitQFastScan* index,
-        size_t nq,
-        size_t k,
-        float* distances,
-        int64_t* ids,
-        const IDSelector* sel,
-        const FastScanDistancePostProcessing* context,
-        bool multi_bit) {
-    return rabitq_ivf_make_knn_scanner_impl<SIMDLevel::NONE>(
-            is_max, index, nq, k, distances, ids, sel, context, multi_bit);
-}
-#endif // COMPILE_SIMD_RISCV_RVV
 
 std::unique_ptr<FastScanCodeScanner> make_fast_scan_knn_scanner(
         bool is_max,

--- a/faiss/impl/fast_scan/fast_scan.h
+++ b/faiss/impl/fast_scan/fast_scan.h
@@ -168,6 +168,16 @@ void accumulate_to_mem(
         const uint8_t* LUT,
         uint16_t* accu);
 
+/// Per-SIMD specialization of accumulate_to_mem (defined in per-SIMD TUs)
+template <SIMDLevel SL>
+void accumulate_to_mem_impl(
+        int nq,
+        size_t ntotal2,
+        int nsq,
+        const uint8_t* codes,
+        const uint8_t* LUT,
+        uint16_t* accu);
+
 /***************************************************************
  * FastScanCodeScanner: virtual base that bundles handler + kernel
  * behind the SIMD dispatch boundary. Per-SIMD TUs instantiate this

--- a/faiss/impl/fast_scan/impl-avx2.cpp
+++ b/faiss/impl/fast_scan/impl-avx2.cpp
@@ -11,4 +11,26 @@
 #include <faiss/impl/fast_scan/dispatching.h>        // IWYU pragma: keep
 #include <faiss/impl/fast_scan/rabitq_dispatching.h> // IWYU pragma: keep
 
+#include <faiss/impl/fast_scan/decompose_qbs.h>
+
+namespace faiss {
+
+using namespace simd_result_handlers;
+
+template <>
+void accumulate_to_mem_impl<SIMDLevel::AVX2>(
+        int nq,
+        size_t ntotal2,
+        int nsq,
+        const uint8_t* codes,
+        const uint8_t* LUT,
+        uint16_t* accu) {
+    StoreResultHandler<SIMDLevel::AVX2> handler(accu, ntotal2);
+    DummyScaler<SIMDLevel::AVX2> scaler;
+    accumulate<SIMDLevel::AVX2>(
+            nq, ntotal2, nsq, codes, LUT, handler, scaler, 32 * nsq / 2);
+}
+
+} // namespace faiss
+
 #endif // COMPILE_SIMD_AVX2

--- a/faiss/impl/fast_scan/impl-avx512.cpp
+++ b/faiss/impl/fast_scan/impl-avx512.cpp
@@ -11,4 +11,30 @@
 #include <faiss/impl/fast_scan/dispatching.h>        // IWYU pragma: keep
 #include <faiss/impl/fast_scan/rabitq_dispatching.h> // IWYU pragma: keep
 
+#include <faiss/impl/fast_scan/decompose_qbs.h>
+
+namespace faiss {
+
+using namespace simd_result_handlers;
+
+template <>
+void accumulate_to_mem_impl<SIMDLevel::AVX512>(
+        int nq,
+        size_t ntotal2,
+        int nsq,
+        const uint8_t* codes,
+        const uint8_t* LUT,
+        uint16_t* accu) {
+    // Use AVX2-level handler (256-bit StoreResultHandler) since the 512-bit
+    // kernels reduce to AVX2-level simd16uint16 via FixedStorage512.
+    StoreResultHandler<SIMDLevel::AVX2> handler(accu, ntotal2);
+    DummyScaler<SIMDLevel::AVX512> scaler;
+    // kernel_accumulate_block in decompose_qbs.h selects pq4_kernel_qbs_512
+    // via #ifdef __AVX512F__ (which is set for this TU).
+    accumulate<SIMDLevel::AVX512>(
+            nq, ntotal2, nsq, codes, LUT, handler, scaler, 32 * nsq / 2);
+}
+
+} // namespace faiss
+
 #endif // COMPILE_SIMD_AVX512

--- a/faiss/impl/fast_scan/impl-neon.cpp
+++ b/faiss/impl/fast_scan/impl-neon.cpp
@@ -11,6 +11,28 @@
 #include <faiss/impl/fast_scan/dispatching.h>        // IWYU pragma: keep
 #include <faiss/impl/fast_scan/rabitq_dispatching.h> // IWYU pragma: keep
 
+#include <faiss/impl/fast_scan/decompose_qbs.h>
+
+namespace faiss {
+
+using namespace simd_result_handlers;
+
+template <>
+void accumulate_to_mem_impl<SIMDLevel::ARM_NEON>(
+        int nq,
+        size_t ntotal2,
+        int nsq,
+        const uint8_t* codes,
+        const uint8_t* LUT,
+        uint16_t* accu) {
+    StoreResultHandler<SIMDLevel::ARM_NEON> handler(accu, ntotal2);
+    DummyScaler<SIMDLevel::ARM_NEON> scaler;
+    accumulate<SIMDLevel::ARM_NEON>(
+            nq, ntotal2, nsq, codes, LUT, handler, scaler, 32 * nsq / 2);
+}
+
+} // namespace faiss
+
 // ARM_SVE: forward to ARM_NEON implementation until a dedicated SVE
 // specialization is written (same pattern as scalar_quantizer/sq-neon.cpp).
 #ifdef COMPILE_SIMD_ARM_SVE

--- a/faiss/impl/fast_scan/impl-riscv.cpp
+++ b/faiss/impl/fast_scan/impl-riscv.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RISC-V RVV: forward all fast_scan specializations to NONE until
+// dedicated RVV implementations are written.
+
+#ifdef COMPILE_SIMD_RISCV_RVV
+
+#include <faiss/impl/fast_scan/fast_scan.h>
+
+namespace faiss {
+
+template <>
+void accumulate_to_mem_impl<SIMDLevel::RISCV_RVV>(
+        int nq,
+        size_t ntotal2,
+        int nsq,
+        const uint8_t* codes,
+        const uint8_t* LUT,
+        uint16_t* accu) {
+    accumulate_to_mem_impl<SIMDLevel::NONE>(nq, ntotal2, nsq, codes, LUT, accu);
+}
+
+template <>
+std::unique_ptr<FastScanCodeScanner> make_fast_scan_scanner_impl<
+        SIMDLevel::RISCV_RVV>(
+        bool is_max,
+        int impl,
+        size_t nq,
+        size_t ntotal,
+        int64_t k,
+        float* distances,
+        int64_t* ids,
+        const IDSelector* sel,
+        bool with_id_map) {
+    return make_fast_scan_scanner_impl<SIMDLevel::NONE>(
+            is_max, impl, nq, ntotal, k, distances, ids, sel, with_id_map);
+}
+
+template <>
+std::unique_ptr<FastScanCodeScanner> make_range_scanner_impl<
+        SIMDLevel::RISCV_RVV>(
+        bool is_max,
+        RangeSearchResult& rres,
+        float radius,
+        size_t ntotal,
+        const IDSelector* sel) {
+    return make_range_scanner_impl<SIMDLevel::NONE>(
+            is_max, rres, radius, ntotal, sel);
+}
+
+template <>
+std::unique_ptr<FastScanCodeScanner> make_partial_range_scanner_impl<
+        SIMDLevel::RISCV_RVV>(
+        bool is_max,
+        RangeSearchPartialResult& pres,
+        float radius,
+        size_t ntotal,
+        size_t q0,
+        size_t q1,
+        const IDSelector* sel) {
+    return make_partial_range_scanner_impl<SIMDLevel::NONE>(
+            is_max, pres, radius, ntotal, q0, q1, sel);
+}
+
+template <>
+std::unique_ptr<FastScanCodeScanner> rabitq_make_knn_scanner_impl<
+        SIMDLevel::RISCV_RVV>(
+        const IndexRaBitQFastScan* index,
+        bool is_max,
+        size_t nq,
+        int64_t k,
+        float* distances,
+        int64_t* ids,
+        const IDSelector* sel,
+        const FastScanDistancePostProcessing& context,
+        bool is_multi_bit) {
+    return rabitq_make_knn_scanner_impl<SIMDLevel::NONE>(
+            index, is_max, nq, k, distances, ids, sel, context, is_multi_bit);
+}
+
+template <>
+std::unique_ptr<FastScanCodeScanner> rabitq_ivf_make_knn_scanner_impl<
+        SIMDLevel::RISCV_RVV>(
+        bool is_max,
+        const IndexIVFRaBitQFastScan* index,
+        size_t nq,
+        size_t k,
+        float* distances,
+        int64_t* ids,
+        const IDSelector* sel,
+        const FastScanDistancePostProcessing* context,
+        bool multi_bit) {
+    return rabitq_ivf_make_knn_scanner_impl<SIMDLevel::NONE>(
+            is_max, index, nq, k, distances, ids, sel, context, multi_bit);
+}
+
+} // namespace faiss
+
+#endif // COMPILE_SIMD_RISCV_RVV

--- a/faiss/impl/fast_scan/kernels_simd256.h
+++ b/faiss/impl/fast_scan/kernels_simd256.h
@@ -11,21 +11,31 @@
 
 namespace faiss {
 
-// Explicit SIMD-level aliases for this file (no global bare aliases).
-using simd16uint16 = simd16uint16_tpl<SINGLE_SIMD_LEVEL_256>;
-using simd32uint8 = simd32uint8_tpl<SINGLE_SIMD_LEVEL_256>;
-
 /*
  * Multi-BB variant: accumulates NQ queries x BB*32 database elements.
  * Used by the search_1 path (bbs > 32).
+ *
+ * KernelSL selects the SIMD type width used for the inner accumulation
+ * loop.  In DD mode the caller passes THE_LEVEL_TO_DISPATCH so the
+ * kernel uses real AVX2/AVX512 types rather than the emulated-scalar
+ * fallback that SINGLE_SIMD_LEVEL_256 would give.
  */
-template <int NQ, int BB, class ResultHandler, class Scaler>
+template <
+        int NQ,
+        int BB,
+        SIMDLevel KernelSL = SINGLE_SIMD_LEVEL,
+        class ResultHandler,
+        class Scaler>
 void kernel_accumulate_block(
         int nsq,
         const uint8_t* codes,
         const uint8_t* LUT,
         ResultHandler& res,
         const Scaler& scaler) {
+    constexpr SIMDLevel SL256 = simd256_level_selector<KernelSL>::value;
+    using simd16uint16 = simd16uint16_tpl<SL256>;
+    using simd32uint8 = simd32uint8_tpl<SL256>;
+
     // distance accumulators
     simd16uint16 accu[NQ][BB][4];
 
@@ -112,13 +122,21 @@ void kernel_accumulate_block(
  * Single-BB QBS variant: accumulates NQ queries x 32 db elements (BB=1).
  * Used by the decompose_qbs layer for non-AVX512 paths.
  */
-template <int NQ, class ResultHandler, class Scaler>
+template <
+        int NQ,
+        SIMDLevel KernelSL = SINGLE_SIMD_LEVEL,
+        class ResultHandler,
+        class Scaler>
 void pq4_kernel_qbs_256(
         int nsq,
         const uint8_t* codes,
         const uint8_t* LUT,
         ResultHandler& res,
         const Scaler& scaler) {
+    constexpr SIMDLevel SL256 = simd256_level_selector<KernelSL>::value;
+    using simd16uint16 = simd16uint16_tpl<SL256>;
+    using simd32uint8 = simd32uint8_tpl<SL256>;
+
     // dummy alloc to keep the windows compiler happy
     constexpr int NQA = NQ > 0 ? NQ : 1;
     // distance accumulators

--- a/faiss/impl/fast_scan/rabitq_dispatching.h
+++ b/faiss/impl/fast_scan/rabitq_dispatching.h
@@ -43,11 +43,17 @@ std::unique_ptr<FastScanCodeScanner> rabitq_make_knn_scanner_impl<
         const FastScanDistancePostProcessing& context,
         bool is_multi_bit) {
     if (is_max) {
-        using H = RaBitQHeapHandler<CMax<uint16_t, int>, false>;
+        using H = RaBitQHeapHandler<
+                CMax<uint16_t, int>,
+                false,
+                THE_LEVEL_TO_DISPATCH>;
         return std::make_unique<ScannerMixIn<H>>(
                 index, nq, k, distances, ids, sel, &context, is_multi_bit);
     } else {
-        using H = RaBitQHeapHandler<CMin<uint16_t, int>, false>;
+        using H = RaBitQHeapHandler<
+                CMin<uint16_t, int>,
+                false,
+                THE_LEVEL_TO_DISPATCH>;
         return std::make_unique<ScannerMixIn<H>>(
                 index, nq, k, distances, ids, sel, &context, is_multi_bit);
     }
@@ -68,12 +74,14 @@ std::unique_ptr<FastScanCodeScanner> rabitq_ivf_make_knn_scanner_impl<
         bool multi_bit) {
     if (is_max) {
         using C = CMax<uint16_t, int64_t>;
-        using H = simd_result_handlers::IVFRaBitQHeapHandler<C>;
+        using H = simd_result_handlers::
+                IVFRaBitQHeapHandler<C, THE_LEVEL_TO_DISPATCH>;
         return std::make_unique<ScannerMixIn<H>>(
                 index, nq, k, distances, ids, sel, context, multi_bit);
     } else {
         using C = CMin<uint16_t, int64_t>;
-        using H = simd_result_handlers::IVFRaBitQHeapHandler<C>;
+        using H = simd_result_handlers::
+                IVFRaBitQHeapHandler<C, THE_LEVEL_TO_DISPATCH>;
         return std::make_unique<ScannerMixIn<H>>(
                 index, nq, k, distances, ids, sel, context, multi_bit);
     }

--- a/faiss/impl/fast_scan/rabitq_result_handler.h
+++ b/faiss/impl/fast_scan/rabitq_result_handler.h
@@ -38,6 +38,7 @@ using rabitq_utils::SignBitFactorsWithError;
 template <class C, SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
 struct IVFRaBitQHeapHandler : ResultHandlerCompare<C, true, SL> {
     using RHC = ResultHandlerCompare<C, true, SL>;
+    using RHC::handle;
     using typename RHC::simd16uint16;
 
     const IndexIVFRaBitQFastScan* index;
@@ -82,7 +83,7 @@ struct IVFRaBitQHeapHandler : ResultHandlerCompare<C, true, SL> {
             const FastScanDistancePostProcessing* ctx = nullptr,
             bool multibit = false);
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) override;
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1);
 
     void set_list_context(size_t list_no, const std::vector<int>& probe_map)
             override;

--- a/faiss/impl/fast_scan/simd_result_handlers.h
+++ b/faiss/impl/fast_scan/simd_result_handlers.h
@@ -83,7 +83,8 @@ inline void for_each_block(
 
 } // namespace
 
-// Explicit SIMD-level alias for the virtual interface below.
+// SIMD-level alias for the virtual interface fallback (always NONE so the
+// base-class signature is stable across translation units in DD mode).
 using simd16uint16 = simd16uint16_tpl<SINGLE_SIMD_LEVEL_256>;
 
 struct SIMDResultHandler {
@@ -100,12 +101,19 @@ struct SIMDResultHandler {
 
     /**  called when 32 distances are computed and provided in two
      *   simd16uint16. (q, b) indicate which entry it is
-     * in the block. */
+     * in the block.
+     *
+     * Non-pure: concrete handlers define their own handle() with the
+     * SIMD types matching their SL template parameter.  When SL != NONE
+     * the handler's handle() hides this base version (different param
+     * types); when SL == NONE it overrides it.  The kernel code always
+     * calls handle() through a concrete-type reference, so virtual
+     * dispatch is not on the hot path. */
     virtual void handle(
-            size_t q,
-            size_t b,
-            simd16uint16 d0,
-            simd16uint16 d1) = 0;
+            size_t /* q */,
+            size_t /* b */,
+            simd16uint16 /* d0 */,
+            simd16uint16 /* d1 */) {}
 
     /// set the sub-matrix that is being computed
     virtual void set_block_origin(size_t i0, size_t j0) = 0;
@@ -179,18 +187,17 @@ namespace simd_result_handlers {
  * (to avoid the computation to be optimized away) */
 template <SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
 struct DummyResultHandler : SIMDResultHandler {
+    using SIMDResultHandler::handle;
     static constexpr SIMDLevel SL256 = simd256_level_selector<SL>::value;
     using simd16uint16 = simd16uint16_tpl<SL256>;
 
     size_t cs = 0;
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
         cs += q * 123 + b * 789 + d0.get_scalar_0() + d1.get_scalar_0();
     }
 
     void set_block_origin(size_t, size_t) final {}
-
-    ~DummyResultHandler() {}
 };
 
 /** memorize results in a nq-by-nb matrix.
@@ -199,6 +206,7 @@ struct DummyResultHandler : SIMDResultHandler {
  */
 template <SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
 struct StoreResultHandler : SIMDResultHandler {
+    using SIMDResultHandler::handle;
     static constexpr SIMDLevel SL256 = simd256_level_selector<SL>::value;
     using simd16uint16 = simd16uint16_tpl<SL256>;
 
@@ -209,7 +217,7 @@ struct StoreResultHandler : SIMDResultHandler {
 
     StoreResultHandler(uint16_t* data, size_t ld) : data(data), ld(ld) {}
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
         size_t ofs = (q + i0) * ld + j0 + b * 32;
         d0.storeu(data + ofs);
         d1.storeu(data + ofs + 16);
@@ -224,13 +232,14 @@ struct StoreResultHandler : SIMDResultHandler {
 /** stores results in fixed-size matrix. */
 template <int NQ, int BB, SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
 struct FixedStorageHandler : SIMDResultHandler {
+    using SIMDResultHandler::handle;
     static constexpr SIMDLevel SL256 = simd256_level_selector<SL>::value;
     using simd16uint16 = simd16uint16_tpl<SL256>;
 
     simd16uint16 dis[NQ][BB];
     int i0 = 0;
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
         dis[q + i0][2 * b] = d0;
         dis[q + i0][2 * b + 1] = d1;
     }
@@ -248,13 +257,12 @@ struct FixedStorageHandler : SIMDResultHandler {
             }
         }
     }
-
-    virtual ~FixedStorageHandler() {}
 };
 
 /** Result handler that compares distances to check if they need to be kept */
 template <class C, bool with_id_map, SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
 struct ResultHandlerCompare : SIMDResultHandlerToFloat {
+    using SIMDResultHandler::handle;
     using TI = typename C::TI;
     static constexpr SIMDLevel SL256 = simd256_level_selector<SL>::value;
     using simd16uint16 = simd16uint16_tpl<SL256>;
@@ -332,8 +340,6 @@ struct ResultHandlerCompare : SIMDResultHandlerToFloat {
         }
         return lt_mask;
     }
-
-    virtual ~ResultHandlerCompare() {}
 };
 
 /** Special version for k=1 */
@@ -345,6 +351,7 @@ struct SingleResultHandler : ResultHandlerCompare<C, with_id_map, SL> {
     using T = typename C::T;
     using TI = typename C::TI;
     using RHC = ResultHandlerCompare<C, with_id_map, SL>;
+    using RHC::handle;
     using RHC::normalizers;
     using typename RHC::simd16uint16;
 
@@ -365,7 +372,7 @@ struct SingleResultHandler : ResultHandlerCompare<C, with_id_map, SL> {
         }
     }
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
         if (this->disable) {
             return;
         }
@@ -438,6 +445,7 @@ struct HeapHandler : ResultHandlerCompare<C, with_id_map, SL> {
     using T = typename C::T;
     using TI = typename C::TI;
     using RHC = ResultHandlerCompare<C, with_id_map, SL>;
+    using RHC::handle;
     using RHC::normalizers;
     using typename RHC::simd16uint16;
 
@@ -480,7 +488,7 @@ struct HeapHandler : ResultHandlerCompare<C, with_id_map, SL> {
         return C::neutral();
     }
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
         if (this->disable) {
             return;
         }
@@ -580,6 +588,7 @@ struct ReservoirHandler : ResultHandlerCompare<C, with_id_map, SL> {
     using T = typename C::T;
     using TI = typename C::TI;
     using RHC = ResultHandlerCompare<C, with_id_map, SL>;
+    using RHC::handle;
     using RHC::normalizers;
     using typename RHC::simd16uint16;
 
@@ -617,7 +626,7 @@ struct ReservoirHandler : ResultHandlerCompare<C, with_id_map, SL> {
         }
     }
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
         if (this->disable) {
             return;
         }
@@ -714,6 +723,7 @@ struct RangeHandler : ResultHandlerCompare<C, with_id_map, SL> {
     using T = typename C::T;
     using TI = typename C::TI;
     using RHC = ResultHandlerCompare<C, with_id_map, SL>;
+    using RHC::handle;
     using RHC::normalizers;
     using RHC::nq;
     using typename RHC::simd16uint16;
@@ -751,7 +761,7 @@ struct RangeHandler : ResultHandlerCompare<C, with_id_map, SL> {
         }
     }
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
         if (this->disable) {
             return;
         }
@@ -902,6 +912,7 @@ struct SingleQueryResultCollectHandler
     using T = typename C::T;
     using TI = typename C::TI;
     using RHC = ResultHandlerCompare<C, with_id_map, SL>;
+    using RHC::handle;
     using RHC::normalizers;
     using simd16uint16 = typename RHC::simd16uint16;
 
@@ -921,7 +932,7 @@ struct SingleQueryResultCollectHandler
         normalizers = norms;
     }
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
         if (this->disable) {
             return;
         }

--- a/tests/test_fast_scan.py
+++ b/tests/test_fast_scan.py
@@ -26,7 +26,7 @@ faiss.omp_set_num_threads(4)
 class TestSearch(unittest.TestCase):
 
     def test_PQ4_accuracy(self):
-        ds  = datasets.SyntheticDataset(32, 2000, 5000, 1000)
+        ds = datasets.SyntheticDataset(32, 2000, 5000, 1000)
 
         index_gt = faiss.IndexFlatL2(32)
         index_gt.add(ds.get_database())
@@ -45,14 +45,17 @@ class TestSearch(unittest.TestCase):
         """Fast-scan PQ search dispatches via the 256/512-bit QBS path.
 
         The integer QBS kernel is deterministic across SIMD levels *only if*
-        the upstream float PQ distance table is bit-identical. On some
-        toolchains (cmake aarch64 NEON/SVE) the float distance-table
-        computation reduces in a different order at NEON/SVE vs scalar,
-        producing a non-bit-identical LUT and thus different integer
-        distances. We diagnose which case applies, then assert accordingly:
-          - LUT identical -> assert (D, I) matches exactly (tie-tolerantly).
-          - LUT diverges  -> fall back to a recall@1 check (the integer
-            kernel can't be bit-exact if its input isn't).
+        the upstream float PQ distance table is bit-identical AND the
+        handler's end() method (int-to-float conversion) compiles to
+        identical FP code.  Two cases break this:
+
+          1. aarch64 NEON/SVE: float distance-table computation reduces
+             in a different order, producing non-bit-identical LUT.
+          2. DD mode: per-SIMD TUs compile with different flags (-mfma
+             vs no -mfma), so handler end() may contract mul+add into
+             fma, producing 1-ULP float distance differences.
+
+        In both cases, fall back to a recall@1 check.
         """
         ds = datasets.SyntheticDataset(32, 2000, 5000, 200)
         index = faiss.index_factory(32, 'PQ16x4fs')
@@ -75,62 +78,80 @@ class TestSearch(unittest.TestCase):
             D_none, I_none = index.search(xq, 10)
 
         lut_diffs = int((tab != tab_none).sum())
-        if lut_diffs == 0:
-            # Float LUT is bit-identical -> integer kernel must be too
-            # (modulo tied-index ordering).
+        dd_mode = "DD" in faiss.get_compile_options()
+        if lut_diffs == 0 and not dd_mode:
             compare_binary_result_lists(D, I, D_none, I_none)
         else:
-            # Float LUT diverges across SIMD levels (float reductions are
-            # not order-stable across vector widths). Integer distances
-            # cannot be expected to match; check result-list overlap.
             recall_at_1 = (I[:, 0] == I_none[:, 0]).mean()
             self.assertGreater(
                 recall_at_1, 0.95,
-                f"LUT diverges ({lut_diffs} entries differ); "
+                f"LUT diverges ({lut_diffs} entries differ, DD={dd_mode}); "
                 f"recall@1 vs NONE = {recall_at_1:.3f}")
 
 
-    # This is an experiment to see if we can catch performance
-    # regressions. It runs 2 codes, one should be faster than the
-    # other by a factor ~10 in opt mode. We check for a factor 5.
-    # hopefully the jitter in executtion time will not produce
-    # too many spurious test failures. Unoptimized timings are
-    # not exploitable, hence the flag test on that as well.
-    # DD mode uses virtual dispatch which, combined with ASAN overhead,
-    # makes the 4x speed threshold unreliable on dev machines.
-    @unittest.skipUnless(
-        ('AVX2' in faiss.get_compile_options() or
-        'AVX512' in faiss.get_compile_options() or
-        'NEON' in faiss.get_compile_options()) and
-        "OPTIMIZE" in faiss.get_compile_options() and
-        "DD" not in faiss.get_compile_options(),
-        "only test in static optimized mode with avx2/avx512/neon")
-    def test_PQ4_speed(self):
-        ds  = datasets.SyntheticDataset(32, 2000, 5000, 1000)
-        xt = ds.get_train()
-        xb = ds.get_database()
-        xq = ds.get_queries()
+class TestFastScanDDSpeed(unittest.TestCase):
+    """Verify DD-mode FastScan kernels use real SIMD."""
 
-        index = faiss.index_factory(32, 'PQ16x4')
-        index.train(xt)
+    def _build_index(self):
+        d, n, nq, k = 128, 100_000, 1000, 10
+        np.random.seed(123)
+        xb = np.random.randn(n, d).astype("float32")
+        xq = np.random.randn(nq, d).astype("float32")
+        index = faiss.index_factory(d, "PQ16x4fs")
+        index.train(xb)
         index.add(xb)
+        index.search(xq, k)
+        return index, xq, k
 
+    def _bench(self, index, xq, k, level, iters=50):
+        faiss.SIMDConfig.set_level(level)
         t0 = time.time()
-        D1, I1 = index.search(xq, 10)
-        t1 = time.time()
-        pq_t = t1 - t0
-        print('PQ16x4 search time:', pq_t)
+        for _ in range(iters):
+            index.search(xq, k)
+        return time.time() - t0
 
-        index2 = faiss.index_factory(32, 'PQ16x4fs')
-        index2.train(xt)
-        index2.add(xb)
+    def _check_speedup(self, none_time, simd_time, label):
+        speedup = none_time / simd_time
+        print(
+            f"FastScan DD: NONE={none_time:.3f}s, "
+            f"{label}={simd_time:.3f}s, {speedup:.1f}x"
+        )
+        # 2x is conservative: scalar-to-AVX2 theoretical max is ~32x,
+        # observed 5-27x in isolation. 2x leaves margin for CI noise.
+        self.assertGreater(
+            speedup, 2.0,
+            f"{label} should be >2x faster than NONE, "
+            f"got {speedup:.1f}x",
+        )
 
-        t0 = time.time()
-        D2, I2 = index2.search(xq, 10)
-        t1 = time.time()
-        pqfs_t = t1 - t0
-        print('PQ16x4fs search time:', pqfs_t)
-        self.assertLess(pqfs_t * 4, pq_t)
+    @unittest.skipUnless(
+        "DD" in faiss.get_compile_options()
+        and "OPTIMIZE" in faiss.get_compile_options()
+        and faiss.SIMDConfig.is_simd_level_available(faiss.SIMDLevel_AVX2),
+        "DD-only, needs opt mode and AVX2",
+    )
+    def test_dd_fastscan_avx2_faster_than_none(self):
+        index, xq, k = self._build_index()
+        none_t = self._bench(index, xq, k, faiss.SIMDLevel_NONE)
+        avx2_t = self._bench(index, xq, k, faiss.SIMDLevel_AVX2)
+        faiss.SIMDConfig.set_level(
+            faiss.SIMDConfig.get_dispatched_level())
+        self._check_speedup(none_t, avx2_t, "AVX2")
+
+    @unittest.skipUnless(
+        "DD" in faiss.get_compile_options()
+        and "OPTIMIZE" in faiss.get_compile_options()
+        and faiss.SIMDConfig.is_simd_level_available(faiss.SIMDLevel_AVX512),
+        "DD-only, needs opt mode and AVX512",
+    )
+    def test_dd_fastscan_avx512_faster_than_none(self):
+        index, xq, k = self._build_index()
+        none_t = self._bench(index, xq, k, faiss.SIMDLevel_NONE)
+        avx512_t = self._bench(
+            index, xq, k, faiss.SIMDLevel_AVX512)
+        faiss.SIMDConfig.set_level(
+            faiss.SIMDConfig.get_dispatched_level())
+        self._check_speedup(none_t, avx512_t, "AVX512")
 
 
 @for_all_simd_levels
@@ -235,7 +256,7 @@ def reference_accu(codes, LUT):
             a = np.uint16(0)
             for sp in range(0, nsp, 2):
                 c = codes[j, sp // 2]
-                a += LUT[i, sp    , c & 15].astype('uint16')
+                a += LUT[i, sp, c & 15].astype('uint16')
                 a += LUT[i, sp + 1, c >> 4].astype('uint16')
             accu[i, j] = a
     return accu
@@ -300,12 +321,12 @@ class ThisIsNotATestLoop5:    # (unittest.TestCase):
 ##########################################################
 
 def verify_with_draws(testcase, Dref, Iref, Dnew, Inew):
-    """ verify a list of results where there are draws in the distances (because
-    they are integer). """
+    """Verify a list of results where there are draws in the distances
+    (because they are integer)."""
     np.testing.assert_array_almost_equal(Dref, Dnew, decimal=5)
     # here we have to be careful because of draws
     for i in range(len(Iref)):
-        if np.all(Iref[i] == Inew[i]): # easy case
+        if np.all(Iref[i] == Inew[i]):
             continue
         # we can deduce nothing about the latest line
         skip_dis = Dref[i, -1]
@@ -476,7 +497,7 @@ class TestAdd(unittest.TestCase):
 
         ds = datasets.SyntheticDataset(d, 2000, 5000, 200)
 
-        index = faiss.index_factory(d, f'PQ{d//2}x4np')
+        index = faiss.index_factory(d, f'PQ{d // 2}x4np')
         index.train(ds.get_train())
 
         xb = ds.get_database()
@@ -506,7 +527,7 @@ class TestAdd(unittest.TestCase):
         d = 32
         ds = datasets.SyntheticDataset(d, 2000, 5000, 200)
 
-        index = faiss.index_factory(d, f'PQ{d//2}x4np')
+        index = faiss.index_factory(d, f'PQ{d // 2}x4np')
         index.train(ds.get_train())
         index.add(ds.get_database())
         Dref, Iref = index.search(ds.get_queries(), 10)
@@ -764,7 +785,7 @@ class TestBlockDecode(unittest.TestCase):
         index.train(ds.get_train())
         index.add(ds.get_database())
 
-        np.testing.assert_array_equal(
-            index.pq.decode(index.pq.compute_codes(ds.get_database()))[0, ::100],
-            index.reconstruct(0)[::100]
-        )
+        decoded = index.pq.decode(
+            index.pq.compute_codes(ds.get_database())
+        )[0, ::100]
+        np.testing.assert_array_equal(decoded, index.reconstruct(0)[::100])


### PR DESCRIPTION
Summary:

Move all RISC-V RVV template specialization forwarders from fast_scan.cpp to a new impl-riscv.cpp file, following the same pattern as impl-avx2.cpp, impl-avx512.cpp, and impl-neon.cpp.

Previously, RISC-V forwarders were inline in fast_scan.cpp behind #ifdef COMPILE_SIMD_RISCV_RVV guards, which contradicts the DD design principle of using per-SIMD translation units instead of ifdefs.

Moved forwarders: accumulate_to_mem_impl, make_fast_scan_scanner_impl, make_range_scanner_impl, make_partial_range_scanner_impl, rabitq_make_knn_scanner_impl, rabitq_ivf_make_knn_scanner_impl. All forward to their NONE counterparts.

Also adds impl-riscv.cpp to FAISS_SIMD_RVV_SRC in CMakeLists.txt.

Differential Revision: D105404584


