### PR TITLE
Fix flaky test_hnsw smoke test by increasing efSearch

### DIFF
--- a/tests/test_wheel_smoke.py
+++ b/tests/test_wheel_smoke.py
@@ -101,6 +101,7 @@ class TestIndexFactory(unittest.TestCase):
         np.random.seed(42)
         xb = np.random.random((n, d)).astype("float32")
         index = faiss.IndexHNSWFlat(d, 16)
+        index.hnsw.efSearch = 64
         index.add(xb)
         assert index.ntotal == n
         D, I = index.search(xb[:5], 10)


### PR DESCRIPTION
Summary:
test_wheel_smoke::TestIndexFactory::test_hnsw assumes HNSW returns the query vector itself as the nearest neighbor, but the default efSearch (16) is too low to guarantee self-retrieval on 2000 random vectors in d=64. This caused intermittent failures on macOS CI.

Set efSearch=64 so the search explores enough of the graph to find exact matches reliably.

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: faiss

Differential Revision: D105621052


