### PR TITLE
Templatize SIMDResultHandler on SL, mark handle() final

### DIFF
--- a/faiss/IndexIVFRaBitQFastScan.h
+++ b/faiss/IndexIVFRaBitQFastScan.h
@@ -225,9 +225,6 @@ IVFRaBitQHeapHandler<C, SL>::IVFRaBitQHeapHandler(
     }
 }
 
-// Explicit alias — must match SIMDResultHandler::handle() signature.
-using simd16uint16 = simd16uint16_tpl<SINGLE_SIMD_LEVEL_256>;
-
 template <class C, SIMDLevel SL>
 void IVFRaBitQHeapHandler<C, SL>::handle(
         size_t q,

--- a/faiss/IndexRaBitQFastScan.h
+++ b/faiss/IndexRaBitQFastScan.h
@@ -134,7 +134,6 @@ template <
 struct RaBitQHeapHandler
         : simd_result_handlers::ResultHandlerCompare<C, with_id_map, SL> {
     using RHC = simd_result_handlers::ResultHandlerCompare<C, with_id_map, SL>;
-    using RHC::handle;
     using RHC::normalizers;
     static constexpr SIMDLevel SL256 = simd256_level_selector<SL>::value;
     using simd16uint16 = simd16uint16_tpl<SL256>;
@@ -188,7 +187,7 @@ struct RaBitQHeapHandler
         }
     }
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
         ALIGNED(32) uint16_t d32tab[32];
         d0.store(d32tab);
         d1.store(d32tab + 16);

--- a/faiss/impl/fast_scan/fast_scan.cpp
+++ b/faiss/impl/fast_scan/fast_scan.cpp
@@ -353,9 +353,6 @@ int pq4_pack_LUT_qbs_q_map(
     return i0;
 }
 
-// declared in simd_result_handlers.h
-bool simd_result_handlers_accept_virtual = true;
-
 int pq4_qbs_to_nq(int qbs) {
     int i0 = 0;
     int qi = qbs;

--- a/faiss/impl/fast_scan/rabitq_result_handler.h
+++ b/faiss/impl/fast_scan/rabitq_result_handler.h
@@ -38,7 +38,6 @@ using rabitq_utils::SignBitFactorsWithError;
 template <class C, SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
 struct IVFRaBitQHeapHandler : ResultHandlerCompare<C, true, SL> {
     using RHC = ResultHandlerCompare<C, true, SL>;
-    using RHC::handle;
     using typename RHC::simd16uint16;
 
     const IndexIVFRaBitQFastScan* index;
@@ -83,7 +82,7 @@ struct IVFRaBitQHeapHandler : ResultHandlerCompare<C, true, SL> {
             const FastScanDistancePostProcessing* ctx = nullptr,
             bool multibit = false);
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1);
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final;
 
     void set_list_context(size_t list_no, const std::vector<int>& probe_map)
             override;

--- a/faiss/impl/fast_scan/simd_result_handlers.h
+++ b/faiss/impl/fast_scan/simd_result_handlers.h
@@ -83,11 +83,10 @@ inline void for_each_block(
 
 } // namespace
 
-// SIMD-level alias for the virtual interface fallback (always NONE so the
-// base-class signature is stable across translation units in DD mode).
-using simd16uint16 = simd16uint16_tpl<SINGLE_SIMD_LEVEL_256>;
-
-struct SIMDResultHandler {
+/* Result handler that will return float results eventually.
+ * Non-template base so it can serve as a polymorphic interface
+ * (e.g. FastScanCodeScanner::handler() returns SIMDResultHandlerToFloat*). */
+struct SIMDResultHandlerToFloat {
     // used to dispatch templates
     bool is_CMax = false;
     uint8_t sizeof_ids = 0;
@@ -99,32 +98,8 @@ struct SIMDResultHandler {
     //   should be hit due to having zero search progress.
     size_t in_range_num = 0;
 
-    /**  called when 32 distances are computed and provided in two
-     *   simd16uint16. (q, b) indicate which entry it is
-     * in the block.
-     *
-     * Non-pure: concrete handlers define their own handle() with the
-     * SIMD types matching their SL template parameter.  When SL != NONE
-     * the handler's handle() hides this base version (different param
-     * types); when SL == NONE it overrides it.  The kernel code always
-     * calls handle() through a concrete-type reference, so virtual
-     * dispatch is not on the hot path. */
-    virtual void handle(
-            size_t /* q */,
-            size_t /* b */,
-            simd16uint16 /* d0 */,
-            simd16uint16 /* d1 */) {}
-
-    /// set the sub-matrix that is being computed
-    virtual void set_block_origin(size_t i0, size_t j0) = 0;
-
-    virtual ~SIMDResultHandler() {}
-};
-
-/* Result handler that will return float results eventually */
-struct SIMDResultHandlerToFloat : SIMDResultHandler {
-    size_t nq;     // number of queries
-    size_t ntotal; // ignore excess elements after ntotal
+    size_t nq = 0;     // number of queries
+    size_t ntotal = 0; // ignore excess elements after ntotal
 
     /// these fields are used mainly for the IVF variants (with_id_map=true)
     const idx_t* id_map = nullptr; // map offset in invlist to vector id
@@ -136,6 +111,7 @@ struct SIMDResultHandlerToFloat : SIMDResultHandler {
 
     size_t scan_cnt = 0; // scanned vector number (except filtered)
 
+    SIMDResultHandlerToFloat() = default;
     SIMDResultHandlerToFloat(size_t nq, size_t ntotal)
             : nq(nq), ntotal(ntotal) {}
 
@@ -173,27 +149,41 @@ struct SIMDResultHandlerToFloat : SIMDResultHandler {
      */
     virtual void set_list_context(
             size_t /* list_no */,
-            const std::vector<int>& /* probe_map */) {
-        // Default implementation does nothing
-        // Derived handlers can override if they need this context
-    }
+            const std::vector<int>& /* probe_map */) {}
+
+    virtual void set_block_origin(size_t i0, size_t j0) = 0;
+
+    virtual ~SIMDResultHandlerToFloat() = default;
 };
 
-FAISS_API extern bool simd_result_handlers_accept_virtual;
+/** SL-specific base: adds virtual handle() whose simd16uint16 type
+ *  matches the SL template parameter. Concrete handlers override
+ *  with `final` so the compiler can devirtualize and inline. */
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
+struct SIMDResultHandler : SIMDResultHandlerToFloat {
+    using SIMDResultHandlerToFloat::SIMDResultHandlerToFloat;
+
+    static constexpr SIMDLevel SL256 = simd256_level_selector<SL>::value;
+    using simd16uint16 = simd16uint16_tpl<SL256>;
+
+    virtual void handle(
+            size_t /* q */,
+            size_t /* b */,
+            simd16uint16 /* d0 */,
+            simd16uint16 /* d1 */) {}
+};
 
 namespace simd_result_handlers {
 
 /** Dummy structure that just computes a checksum on results
  * (to avoid the computation to be optimized away) */
 template <SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
-struct DummyResultHandler : SIMDResultHandler {
-    using SIMDResultHandler::handle;
-    static constexpr SIMDLevel SL256 = simd256_level_selector<SL>::value;
-    using simd16uint16 = simd16uint16_tpl<SL256>;
+struct DummyResultHandler : SIMDResultHandler<SL> {
+    using typename SIMDResultHandler<SL>::simd16uint16;
 
     size_t cs = 0;
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
         cs += q * 123 + b * 789 + d0.get_scalar_0() + d1.get_scalar_0();
     }
 
@@ -205,10 +195,8 @@ struct DummyResultHandler : SIMDResultHandler {
  * j0 is the current upper-left block of the matrix
  */
 template <SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
-struct StoreResultHandler : SIMDResultHandler {
-    using SIMDResultHandler::handle;
-    static constexpr SIMDLevel SL256 = simd256_level_selector<SL>::value;
-    using simd16uint16 = simd16uint16_tpl<SL256>;
+struct StoreResultHandler : SIMDResultHandler<SL> {
+    using typename SIMDResultHandler<SL>::simd16uint16;
 
     uint16_t* data;
     size_t ld; // total number of columns
@@ -217,7 +205,7 @@ struct StoreResultHandler : SIMDResultHandler {
 
     StoreResultHandler(uint16_t* data, size_t ld) : data(data), ld(ld) {}
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
         size_t ofs = (q + i0) * ld + j0 + b * 32;
         d0.storeu(data + ofs);
         d1.storeu(data + ofs + 16);
@@ -231,15 +219,13 @@ struct StoreResultHandler : SIMDResultHandler {
 
 /** stores results in fixed-size matrix. */
 template <int NQ, int BB, SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
-struct FixedStorageHandler : SIMDResultHandler {
-    using SIMDResultHandler::handle;
-    static constexpr SIMDLevel SL256 = simd256_level_selector<SL>::value;
-    using simd16uint16 = simd16uint16_tpl<SL256>;
+struct FixedStorageHandler : SIMDResultHandler<SL> {
+    using typename SIMDResultHandler<SL>::simd16uint16;
 
     simd16uint16 dis[NQ][BB];
     int i0 = 0;
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
         dis[q + i0][2 * b] = d0;
         dis[q + i0][2 * b + 1] = d1;
     }
@@ -261,11 +247,9 @@ struct FixedStorageHandler : SIMDResultHandler {
 
 /** Result handler that compares distances to check if they need to be kept */
 template <class C, bool with_id_map, SIMDLevel SL = SINGLE_SIMD_LEVEL_256>
-struct ResultHandlerCompare : SIMDResultHandlerToFloat {
-    using SIMDResultHandler::handle;
+struct ResultHandlerCompare : SIMDResultHandler<SL> {
     using TI = typename C::TI;
-    static constexpr SIMDLevel SL256 = simd256_level_selector<SL>::value;
-    using simd16uint16 = simd16uint16_tpl<SL256>;
+    using typename SIMDResultHandler<SL>::simd16uint16;
 
     bool disable = false;
 
@@ -275,7 +259,7 @@ struct ResultHandlerCompare : SIMDResultHandlerToFloat {
     const IDSelector* sel;
 
     ResultHandlerCompare(size_t nq, size_t ntotal, const IDSelector* sel_in)
-            : SIMDResultHandlerToFloat(nq, ntotal), sel{sel_in} {
+            : SIMDResultHandler<SL>(nq, ntotal), sel{sel_in} {
         this->is_CMax = C::is_max;
         this->sizeof_ids = sizeof(typename C::TI);
         this->with_fields = with_id_map;
@@ -290,22 +274,22 @@ struct ResultHandlerCompare : SIMDResultHandlerToFloat {
     void adjust_with_origin(size_t& q, simd16uint16& d0, simd16uint16& d1) {
         q += i0;
 
-        if (dbias) {
-            simd16uint16 dbias16(dbias[q]);
+        if (this->dbias) {
+            simd16uint16 dbias16(this->dbias[q]);
             d0 += dbias16;
             d1 += dbias16;
         }
 
         if (with_id_map) { // FIXME test on q_map instead
-            q = q_map[q];
+            q = this->q_map[q];
         }
     }
 
     // compute and adjust idx
     int64_t adjust_id(size_t b, size_t j) {
         int64_t idx = j0 + 32 * b + j;
-        if (id_map) {
-            idx = id_map[idx];
+        if (this->id_map) {
+            idx = this->id_map[idx];
         }
         return idx;
     }
@@ -331,11 +315,11 @@ struct ResultHandlerCompare : SIMDResultHandlerToFloat {
             return 0;
         }
         uint64_t idx = j0 + b * 32;
-        if (idx + 32 > ntotal) {
-            if (idx >= ntotal) {
+        if (idx + 32 > this->ntotal) {
+            if (idx >= this->ntotal) {
                 return 0;
             }
-            int nbit = (ntotal - idx);
+            int nbit = static_cast<int>(this->ntotal - idx);
             lt_mask &= (uint32_t(1) << nbit) - 1;
         }
         return lt_mask;
@@ -351,7 +335,6 @@ struct SingleResultHandler : ResultHandlerCompare<C, with_id_map, SL> {
     using T = typename C::T;
     using TI = typename C::TI;
     using RHC = ResultHandlerCompare<C, with_id_map, SL>;
-    using RHC::handle;
     using RHC::normalizers;
     using typename RHC::simd16uint16;
 
@@ -372,7 +355,7 @@ struct SingleResultHandler : ResultHandlerCompare<C, with_id_map, SL> {
         }
     }
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
         if (this->disable) {
             return;
         }
@@ -422,7 +405,7 @@ struct SingleResultHandler : ResultHandlerCompare<C, with_id_map, SL> {
         }
     }
 
-    void end() {
+    void end() override {
         for (size_t q = 0; q < this->nq; q++) {
             if (!normalizers) {
                 dis[q] = idis[q];
@@ -445,7 +428,6 @@ struct HeapHandler : ResultHandlerCompare<C, with_id_map, SL> {
     using T = typename C::T;
     using TI = typename C::TI;
     using RHC = ResultHandlerCompare<C, with_id_map, SL>;
-    using RHC::handle;
     using RHC::normalizers;
     using typename RHC::simd16uint16;
 
@@ -488,7 +470,7 @@ struct HeapHandler : ResultHandlerCompare<C, with_id_map, SL> {
         return C::neutral();
     }
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
         if (this->disable) {
             return;
         }
@@ -523,7 +505,11 @@ struct HeapHandler : ResultHandlerCompare<C, with_id_map, SL> {
                     T dis_for_j = d32tab[j];
                     if (C::cmp(heap_dis[0], dis_for_j)) {
                         heap_replace_top<C>(
-                                k, heap_dis, heap_ids, dis_for_j, real_idx);
+                                k,
+                                heap_dis,
+                                heap_ids,
+                                dis_for_j,
+                                static_cast<TI>(real_idx));
                         nup++;
 
                         this->in_range_num++;
@@ -539,7 +525,12 @@ struct HeapHandler : ResultHandlerCompare<C, with_id_map, SL> {
                 T dis_for_j = d32tab[j];
                 if (C::cmp(heap_dis[0], dis_for_j)) {
                     int64_t idx = this->adjust_id(b, j);
-                    heap_replace_top<C>(k, heap_dis, heap_ids, dis_for_j, idx);
+                    heap_replace_top<C>(
+                            k,
+                            heap_dis,
+                            heap_ids,
+                            dis_for_j,
+                            static_cast<TI>(idx));
                     nup++;
 
                     this->in_range_num++;
@@ -588,7 +579,6 @@ struct ReservoirHandler : ResultHandlerCompare<C, with_id_map, SL> {
     using T = typename C::T;
     using TI = typename C::TI;
     using RHC = ResultHandlerCompare<C, with_id_map, SL>;
-    using RHC::handle;
     using RHC::normalizers;
     using typename RHC::simd16uint16;
 
@@ -626,7 +616,7 @@ struct ReservoirHandler : ResultHandlerCompare<C, with_id_map, SL> {
         }
     }
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
         if (this->disable) {
             return;
         }
@@ -651,7 +641,7 @@ struct ReservoirHandler : ResultHandlerCompare<C, with_id_map, SL> {
                 if (this->sel->is_member(real_idx)) {
                     this->scan_cnt++;
                     T dis_for_j = d32tab[j];
-                    res.add(dis_for_j, real_idx);
+                    res.add(dis_for_j, static_cast<TI>(real_idx));
 
                     this->in_range_num++;
                 }
@@ -663,7 +653,7 @@ struct ReservoirHandler : ResultHandlerCompare<C, with_id_map, SL> {
                 lt_mask -= 1 << j;
                 T dis_for_j = d32tab[j];
                 this->scan_cnt++;
-                res.add(dis_for_j, this->adjust_id(b, j));
+                res.add(dis_for_j, static_cast<TI>(this->adjust_id(b, j)));
 
                 this->in_range_num++;
             }
@@ -723,7 +713,6 @@ struct RangeHandler : ResultHandlerCompare<C, with_id_map, SL> {
     using T = typename C::T;
     using TI = typename C::TI;
     using RHC = ResultHandlerCompare<C, with_id_map, SL>;
-    using RHC::handle;
     using RHC::normalizers;
     using RHC::nq;
     using typename RHC::simd16uint16;
@@ -753,7 +742,7 @@ struct RangeHandler : ResultHandlerCompare<C, with_id_map, SL> {
         n_per_query.resize(nq + 1);
     }
 
-    virtual void begin(const float* norms) override {
+    void begin(const float* norms) override {
         normalizers = norms;
         for (int q = 0; q < nq; ++q) {
             thresholds[q] =
@@ -761,7 +750,7 @@ struct RangeHandler : ResultHandlerCompare<C, with_id_map, SL> {
         }
     }
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
         if (this->disable) {
             return;
         }
@@ -912,9 +901,8 @@ struct SingleQueryResultCollectHandler
     using T = typename C::T;
     using TI = typename C::TI;
     using RHC = ResultHandlerCompare<C, with_id_map, SL>;
-    using RHC::handle;
     using RHC::normalizers;
-    using simd16uint16 = typename RHC::simd16uint16;
+    using typename RHC::simd16uint16;
 
     // Store as float (not T=uint16_t) since end() applies normalizer scaling
     std::vector<std::pair<TI, float>>& collect;
@@ -932,7 +920,7 @@ struct SingleQueryResultCollectHandler
         normalizers = norms;
     }
 
-    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) {
+    void handle(size_t q, size_t b, simd16uint16 d0, simd16uint16 d1) final {
         if (this->disable) {
             return;
         }
@@ -985,77 +973,6 @@ struct SingleQueryResultCollectHandler
 };
 
 #endif
-
-/********************************************************************************
- * Dynamic dispatching function. Calls a lambda with the concrete
- * SIMDResultHandler type, determined at runtime via dynamic_cast.
- *
- * Usage:
- *   with_SIMDResultHandler(res, [&](auto& handler) {
- *       // handler has the concrete type (HeapHandler, ReservoirHandler, etc.)
- *       kernel(handler, ...);
- *   });
- */
-
-template <class Lambda>
-void with_SIMDResultHandler(SIMDResultHandler& res, Lambda&& lambda) {
-    auto fixedCW = [&]<class C, bool W>() {
-        if (auto resh = dynamic_cast<SingleResultHandler<C, W>*>(&res)) {
-            lambda(*resh);
-        } else if (auto resh = dynamic_cast<HeapHandler<C, W>*>(&res)) {
-            lambda(*resh);
-        } else if (auto resh = dynamic_cast<ReservoirHandler<C, W>*>(&res)) {
-            lambda(*resh);
-        } else if (
-                auto resh =
-                        dynamic_cast<SingleQueryResultCollectHandler<C, W>*>(
-                                &res)) {
-            lambda(*resh);
-        } else { // generic handler -- will not be inlined
-            FAISS_THROW_IF_NOT_FMT(
-                    simd_result_handlers_accept_virtual,
-                    "Running virtual handler for %s",
-                    typeid(res).name());
-            lambda(res);
-        }
-    };
-
-    auto fixedC = [&]<class C>() {
-        if (res.with_fields) {
-            fixedCW.template operator()<C, true>();
-        } else {
-            fixedCW.template operator()<C, false>();
-        }
-    };
-
-    if (res.sizeof_ids == 0) {
-        if (auto resh = dynamic_cast<StoreResultHandler<>*>(&res)) {
-            lambda(*resh);
-        } else if (auto resh = dynamic_cast<DummyResultHandler<>*>(&res)) {
-            lambda(*resh);
-        } else { // generic path
-            FAISS_THROW_IF_NOT_FMT(
-                    simd_result_handlers_accept_virtual,
-                    "Running virtual handler for %s",
-                    typeid(res).name());
-            lambda(res);
-        }
-    } else if (res.sizeof_ids == sizeof(int)) {
-        if (res.is_CMax) {
-            fixedC.template operator()<CMax<uint16_t, int>>();
-        } else {
-            fixedC.template operator()<CMin<uint16_t, int>>();
-        }
-    } else if (res.sizeof_ids == sizeof(int64_t)) {
-        if (res.is_CMax) {
-            fixedC.template operator()<CMax<uint16_t, int64_t>>();
-        } else {
-            fixedC.template operator()<CMin<uint16_t, int64_t>>();
-        }
-    } else {
-        FAISS_THROW_FMT("Unknown id size %d", res.sizeof_ids);
-    }
-}
 
 } // namespace simd_result_handlers
 


### PR DESCRIPTION
Summary:
Follow-up to D104552827 per Matthijs's review feedback. The non-template `SIMDResultHandler` base class had a virtual `handle()` using `simd16uint16_tpl<NONE>` in DD mode, while derived handlers used SL-specific types. This meant derived `handle()` methods HIDED rather than OVERRODE the base, preventing use of `override`/`final`.

This restructures the hierarchy: metadata fields from the old `SIMDResultHandler` are merged into `SIMDResultHandlerToFloat` (stays non-template for the polymorphic `FastScanCodeScanner::handler()` interface), and a new template `SIMDResultHandler<SL>` is inserted between them with a virtual `handle()` whose `simd16uint16` type matches the SL parameter. Concrete handlers now genuinely override this virtual and are marked `final`, signaling devirtualization/inlining intent.

Also removes dead code: `with_SIMDResultHandler()` (zero callers), `simd_result_handlers_accept_virtual` (only used by that function), and the file-scope `simd16uint16` alias (only used by the old base class).

Differential Revision: D105611944


