### PR TITLE
Disable attestations for prod PyPI publish (#5230)

### DIFF
--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -59,6 +59,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # release/v1
         with:
           verbose: true
+          attestations: false
 
   publish-testpypi:
     name: Publish to TestPyPI


### PR DESCRIPTION
Summary:

Disables Sigstore attestations (`attestations: false`) in the prod PyPI publish step. The `pypa/gh-action-pypi-publish` action generates attestation certificates that carry the top-level workflow (`build.yml`) as the Build Config URI, but PyPI verifies attestations against the trusted publisher which is configured as `build-pip.yml` (the reusable workflow where the publish job is defined). This mismatch causes a `400 Invalid attestations` rejection when `build.yml` calls `build-pip.yml` via `workflow_call`.

TestPyPI is unaffected because `workflow_dispatch` triggers `build-pip.yml` directly, so the certificate and publisher both say `build-pip.yml`.

This is a known limitation of `pypa/gh-action-pypi-publish` with reusable workflows. Attestations can be re-enabled once PyPI supports matching against `workflow_ref` in addition to `job_workflow_ref` for attestation verification, or once the publish job is moved out of the reusable workflow.

Reviewed By: mnorris11

Differential Revision: D106110673
