### PR TITLE
Use per-SIMD TU scan for standalone PQ (AVX2 gather inlining)

### DIFF
--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -13,12 +13,15 @@
 #include <cstdio>
 #include <cstring>
 #include <memory>
+#include <type_traits>
 
 #include <algorithm>
 
 #include <faiss/IndexFlat.h>
 #include <faiss/VectorTransform.h>
 #include <faiss/impl/FaissAssert.h>
+// NOLINTNEXTLINE(facebook-hte-InlineHeader)
+#include <faiss/impl/pq_code_distance/pq_code_distance-inl.h>
 #include <faiss/impl/simd_dispatch.h>
 #include <faiss/utils/distances.h>
 
@@ -719,8 +722,28 @@ void pq_knn_search_with_tables(
 
         switch (nbits) {
             case 8:
-                pq_estimators_from_tables<uint8_t, C>(
-                        pq, codes, ncodes, dis_table, k, heap_dis, heap_ids);
+                if (ksub == 256) {
+                    constexpr bool max_heap =
+                            std::is_same_v<C, CMax<float, int64_t>>;
+                    pq_code_distance::pq_scan_8bit(
+                            M,
+                            dis_table,
+                            codes,
+                            ncodes,
+                            k,
+                            heap_dis,
+                            heap_ids,
+                            max_heap);
+                } else {
+                    pq_estimators_from_tables<uint8_t, C>(
+                            pq,
+                            codes,
+                            ncodes,
+                            dis_table,
+                            k,
+                            heap_dis,
+                            heap_ids);
+                }
                 break;
 
             case 16:

--- a/faiss/impl/pq_code_distance/avx2.cpp
+++ b/faiss/impl/pq_code_distance/avx2.cpp
@@ -13,6 +13,8 @@
 #include <faiss/impl/pq_code_distance/pq_code_distance-avx2.h>
 // NOLINTNEXTLINE(facebook-hte-InlineHeader)
 #include <faiss/utils/hamming_distance/hamming_computer-avx2.h>
+// NOLINTNEXTLINE(facebook-hte-InlineHeader,facebook-unused-include-check)
+#include <faiss/impl/pq_code_distance/pq_scan_impl.h>
 // NOLINTNEXTLINE(facebook-hte-InlineHeader)
 #include <faiss/impl/pq_code_distance/PQDistanceComputer_impl.h>
 // NOLINTNEXTLINE(facebook-hte-InlineHeader)

--- a/faiss/impl/pq_code_distance/avx512.cpp
+++ b/faiss/impl/pq_code_distance/avx512.cpp
@@ -14,6 +14,8 @@
 // NOLINTNEXTLINE(facebook-hte-InlineHeader)
 #include <faiss/utils/hamming_distance/hamming_computer-avx512.h>
 // NOLINTNEXTLINE(facebook-hte-InlineHeader)
+#include <faiss/impl/pq_code_distance/pq_scan_impl.h>
+// NOLINTNEXTLINE(facebook-hte-InlineHeader)
 #include <faiss/impl/pq_code_distance/PQDistanceComputer_impl.h>
 // NOLINTNEXTLINE(facebook-hte-InlineHeader)
 #include <faiss/impl/pq_code_distance/IVFPQScanner_impl.h>

--- a/faiss/impl/pq_code_distance/neon.cpp
+++ b/faiss/impl/pq_code_distance/neon.cpp
@@ -14,6 +14,8 @@
 // NOLINTNEXTLINE(facebook-hte-InlineHeader)
 #include <faiss/utils/hamming_distance/hamming_computer-neon.h>
 // NOLINTNEXTLINE(facebook-hte-InlineHeader)
+#include <faiss/impl/pq_code_distance/pq_scan_impl.h>
+// NOLINTNEXTLINE(facebook-hte-InlineHeader)
 #include <faiss/impl/pq_code_distance/PQDistanceComputer_impl.h>
 // NOLINTNEXTLINE(facebook-hte-InlineHeader)
 #include <faiss/impl/pq_code_distance/IVFPQScanner_impl.h>

--- a/faiss/impl/pq_code_distance/pq_code_distance-generic.cpp
+++ b/faiss/impl/pq_code_distance/pq_code_distance-generic.cpp
@@ -17,8 +17,28 @@
 
 #include <faiss/impl/pq_code_distance/pq_code_distance-generic.h>
 
+#define THE_SIMD_LEVEL SIMDLevel::NONE
+// NOLINTNEXTLINE(facebook-hte-InlineHeader)
+#include <faiss/impl/pq_code_distance/pq_scan_impl.h>
+#undef THE_SIMD_LEVEL
+
 namespace faiss {
 namespace pq_code_distance {
+
+void pq_scan_8bit(
+        size_t M,
+        const float* dis_table,
+        const uint8_t* codes,
+        size_t ncodes,
+        size_t k,
+        float* heap_dis,
+        int64_t* heap_ids,
+        bool max_heap) {
+    with_simd_level([&]<SIMDLevel SL>() {
+        pq_scan_8bit_impl<SL>(
+                M, dis_table, codes, ncodes, k, heap_dis, heap_ids, max_heap);
+    });
+}
 
 float pq_code_distance_8bit_single(
         size_t M,

--- a/faiss/impl/pq_code_distance/pq_code_distance-inl.h
+++ b/faiss/impl/pq_code_distance/pq_code_distance-inl.h
@@ -245,11 +245,47 @@ FAISS_API void pq_code_distance_8bit_four(
         float& result2,
         float& result3);
 
+/*********************************************************************
+ * Standalone PQ scan — SIMD-dispatched full-index scan.
+ *
+ * Scans all ncodes PQ codes against a precomputed distance table,
+ * maintaining a k-nearest-neighbor heap. Uses the SIMD PQ distance
+ * kernels (AVX2 gathers, etc.) for the inner loop, with the SIMD
+ * gathers inlined into the scan loop in each per-SIMD TU.
+ *
+ * Definitions are in pq_scan_impl.h (per-SIMD TUs) and
+ * pq_code_distance-generic.cpp (dispatch wrapper).
+ *********************************************************************/
+
+template <SIMDLevel SL>
+void pq_scan_8bit_impl(
+        size_t M,
+        const float* dis_table,
+        const uint8_t* codes,
+        size_t ncodes,
+        size_t k,
+        float* heap_dis,
+        int64_t* heap_ids,
+        bool max_heap);
+
+/// Scan all ncodes 8-bit PQ codes, dispatching to the best SIMD level.
+/// max_heap=true for L2 (CMax), false for IP (CMin).
+FAISS_API void pq_scan_8bit(
+        size_t M,
+        const float* dis_table,
+        const uint8_t* codes,
+        size_t ncodes,
+        size_t k,
+        float* heap_dis,
+        int64_t* heap_ids,
+        bool max_heap);
+
 } // namespace pq_code_distance
 
 // Re-export public API into namespace faiss for convenience
 using pq_code_distance::pq_code_distance_8bit_four;
 using pq_code_distance::pq_code_distance_8bit_single;
+using pq_code_distance::pq_scan_8bit;
 using pq_code_distance::PQCodeDistance;
 using pq_code_distance::PQCodeDistanceScalar;
 

--- a/faiss/impl/pq_code_distance/pq_code_distance-sve.cpp
+++ b/faiss/impl/pq_code_distance/pq_code_distance-sve.cpp
@@ -347,4 +347,9 @@ void pq_code_distance_8bit_four_impl<SIMDLevel::ARM_SVE>(
 } // namespace pq_code_distance
 } // namespace faiss
 
+#define THE_SIMD_LEVEL SIMDLevel::ARM_SVE
+// NOLINTNEXTLINE(facebook-hte-InlineHeader)
+#include <faiss/impl/pq_code_distance/pq_scan_impl.h>
+#undef THE_SIMD_LEVEL
+
 #endif // COMPILE_SIMD_ARM_SVE

--- a/faiss/impl/pq_code_distance/pq_scan_impl.h
+++ b/faiss/impl/pq_code_distance/pq_scan_impl.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifndef THE_SIMD_LEVEL
+#error "THE_SIMD_LEVEL must be defined before including pq_scan_impl.h"
+#endif
+
+#include <faiss/impl/pq_code_distance/pq_code_distance-inl.h>
+#include <faiss/utils/Heap.h>
+
+namespace faiss {
+namespace pq_code_distance {
+
+namespace {
+
+template <class C>
+void pq_scan_8bit_at_level(
+        size_t M,
+        const float* dis_table,
+        const uint8_t* codes,
+        size_t ncodes,
+        size_t k,
+        float* heap_dis,
+        int64_t* heap_ids) {
+    const size_t code_size = M;
+
+    size_t j = 0;
+    for (; j + 3 < ncodes; j += 4) {
+        float d0, d1, d2, d3;
+        pq_code_distance_8bit_four_impl<THE_SIMD_LEVEL>( // NOLINT(facebook-modularize-issue-check)
+                M,
+                dis_table,
+                codes + j * code_size,
+                codes + (j + 1) * code_size,
+                codes + (j + 2) * code_size,
+                codes + (j + 3) * code_size,
+                d0,
+                d1,
+                d2,
+                d3);
+
+        if (C::cmp(heap_dis[0], d0)) {
+            heap_replace_top<C>(k, heap_dis, heap_ids, d0, j);
+        }
+        if (C::cmp(heap_dis[0], d1)) {
+            heap_replace_top<C>(k, heap_dis, heap_ids, d1, j + 1);
+        }
+        if (C::cmp(heap_dis[0], d2)) {
+            heap_replace_top<C>(k, heap_dis, heap_ids, d2, j + 2);
+        }
+        if (C::cmp(heap_dis[0], d3)) {
+            heap_replace_top<C>(k, heap_dis, heap_ids, d3, j + 3);
+        }
+    }
+
+    for (; j < ncodes; j++) {
+        float dis = pq_code_distance_8bit_single_impl<THE_SIMD_LEVEL>( // NOLINT(facebook-modularize-issue-check)
+                M, dis_table, codes + j * code_size);
+        if (C::cmp(heap_dis[0], dis)) {
+            heap_replace_top<C>(k, heap_dis, heap_ids, dis, j);
+        }
+    }
+}
+
+} // anonymous namespace
+
+template <SIMDLevel SL>
+void pq_scan_8bit_impl(
+        size_t M,
+        const float* dis_table,
+        const uint8_t* codes,
+        size_t ncodes,
+        size_t k,
+        float* heap_dis,
+        int64_t* heap_ids,
+        bool max_heap);
+
+// NOLINTNEXTLINE(facebook-hte-MisplacedTemplateSpecialization,facebook-modularize-issue-check)
+template <>
+void pq_scan_8bit_impl<THE_SIMD_LEVEL>(
+        size_t M,
+        const float* dis_table,
+        const uint8_t* codes,
+        size_t ncodes,
+        size_t k,
+        float* heap_dis,
+        int64_t* heap_ids,
+        bool max_heap) {
+    if (max_heap) {
+        pq_scan_8bit_at_level<CMax<float, int64_t>>(
+                M, dis_table, codes, ncodes, k, heap_dis, heap_ids);
+    } else {
+        pq_scan_8bit_at_level<CMin<float, int64_t>>(
+                M, dis_table, codes, ncodes, k, heap_dis, heap_ids);
+    }
+}
+
+} // namespace pq_code_distance
+} // namespace faiss

--- a/faiss/impl/pq_code_distance/rvv.cpp
+++ b/faiss/impl/pq_code_distance/rvv.cpp
@@ -57,6 +57,8 @@ void pq_code_distance_8bit_four_impl<SIMDLevel::RISCV_RVV>(
 #define THE_SIMD_LEVEL SIMDLevel::RISCV_RVV
 
 // NOLINTNEXTLINE(facebook-hte-InlineHeader)
+#include <faiss/impl/pq_code_distance/pq_scan_impl.h>
+// NOLINTNEXTLINE(facebook-hte-InlineHeader)
 #include <faiss/utils/hamming_distance/hamming_computer-rvv.h>
 // NOLINTNEXTLINE(facebook-hte-InlineHeader)
 #include <faiss/impl/pq_code_distance/PQDistanceComputer_impl.h>


### PR DESCRIPTION
Summary:
TLDR: we captured a statistically significant regression in PQ even though the code wasn't touched since 2022. AI thinks it was due to including more things in the translation unit due to DD. I am unsure of that explanation, but this diff SIMDifies this part of PQ and make it faster on Intel. On AMD AVX2, it was slower across all 10 datasets tested, but with AVX-512 (DD mode) AMD is competitive except for PQ16. Since we're moving to DD mode anyway, we ship without an AMD-specific workaround.

What this diff does
--

The standalone PQ scan in `pq_estimators_from_tables` uses a scalar gather loop (`dis += dt[*codes++]`) to accumulate distances from precomputed tables. This diff moves it into per-SIMD translation units so that AVX2/AVX-512 gather intrinsics inline into the scan loop, following the same pattern already used by the IVF+PQ scanner.

- New `pq_scan_impl.h` defines the scan loop calling `pq_code_distance_8bit_four_impl<THE_SIMD_LEVEL>()` directly
- Included from `avx2.cpp`, `avx512.cpp`, `neon.cpp`, `rvv.cpp`, `pq_code_distance-sve.cpp` — SIMD gathers inline into the scan loop in each TU
- Non-templated `pq_scan_8bit()` dispatch wrapper in `pq_code_distance-generic.cpp`
- `pq_knn_search_with_tables` dispatches to `pq_scan_8bit()` for 8-bit codes with ksub=256
- One cross-TU call per query (not per code), so dispatch overhead is negligible
- IVF+PQ and FastScan (`PQ32x4fs`) are unchanged

Initial benchmark results (Intel only)
--

Benchmarked with vench on sift-1M (dim=128, L2) and vibe-yi-128 (dim=128, IP):

**sift-1M standalone PQ (Median QPS, higher is better):**

| Algorithm | nq | Baseline | This diff | Speedup |
|---|---|---|---|---|
| `PQ8` | 100 | 3,236 | 3,672 | +13% |
| `PQ8` | 10,000 | 5,149 | 6,476 | +26% |
| `PQ16` | 100 | 2,461 | 2,875 | +17% |
| `PQ16` | 10,000 | 3,072 | 3,729 | +21% |
| `PQ32` | 1 | 47 | 64 | +36% |
| `PQ32` | 100 | 1,006 | 1,499 | +49% |
| `PQ32` | 10,000 | 1,338 | 1,918 | +43% |
| `PQ32x4fs` | 10,000 | 2,363 | 2,364 | ~0% (control) |

**vibe-yi-128 standalone PQ (Median QPS):**

| Algorithm | nq | Baseline | This diff | Speedup |
|---|---|---|---|---|
| `PQ8` | 10,000 | 24,037 | 31,544 | +31% |
| `PQ32` | 1 | 220 | 341 | +55% |
| `PQ32` | 100 | 5,173 | 7,424 | +44% |
| `PQ32` | 10,000 | 5,826 | 9,360 | +61% |
| `PQ32x4fs` | 10,000 | 9,556 | 9,704 | ~0% (control) |

AVX2 gather results across Intel and AMD
--

The initial benchmarks above ran on Intel only. AVX2 `vpgatherdd` (`_mm256_i32gather_ps`) performance differs fundamentally between Intel and AMD: Intel has a hardware gather unit, AMD Zen 4 micro-codes gathers into individual scalar loads.

ServiceLab A/B across 10 datasets (d=128 to d=2048), `force_same_processor_type=True`. Side A = old scalar code (parent commit), Side B = this diff (AVX2 gathers). Median QPS:

**Intel (Cooper Lake, Xeon Platinum 8321HC) — gains for PQ32/PQ64:**

| PQ | nq | scalar | gather | Δ% |
|---|---:|---:|---:|---|
| PQ8 | 1 | 116 | 98 | -16% |
| PQ8 | 100 | 3,442 | 3,168 | -8% |
| PQ8 | 10,000 | 3,732 | 3,698 | -1% |
| PQ16 | 1 | 68 | 82 | +21% |
| PQ16 | 100 | 1,871 | 1,485 | -21% |
| PQ16 | 10,000 | 2,239 | 2,122 | -5% |
| PQ32 | 1 | 43 | 50 | +16% |
| PQ32 | 100 | 896 | 1,044 | +17% |
| PQ32 | 10,000 | 987 | 1,218 | **+23%** |
| PQ64 | 1 | 25 | 32 | +28% |
| PQ64 | 100 | 388 | 508 | +31% |
| PQ64 | 10,000 | 403 | 533 | **+32%** |

**AMD (Bergamo, EPYC 9D64 88-Core) — regression across the board:**

| PQ | nq | scalar | gather | Δ% |
|---|---:|---:|---:|---|
| PQ8 | 1 | 237 | 180 | -24% |
| PQ8 | 100 | 4,370 | 2,176 | -50% |
| PQ8 | 10,000 | 7,389 | 4,078 | **-45%** |
| PQ16 | 1 | 142 | 76 | -46% |
| PQ16 | 100 | 2,350 | 1,524 | -35% |
| PQ16 | 10,000 | 3,745 | 2,085 | **-44%** |
| PQ32 | 1 | 63 | 41 | -35% |
| PQ32 | 100 | 1,111 | 765 | -31% |
| PQ32 | 10,000 | 1,262 | 874 | **-31%** |
| PQ64 | 1 | 33 | 24 | -27% |
| PQ64 | 100 | 430 | 402 | -7% |
| PQ64 | 10,000 | 543 | 452 | **-17%** |

AVX-512 gather results (DD mode)
--

AVX-512 gathers on AMD Zen 4 are much better than AVX2 gathers. Tested with Dynamic Dispatch enabled (`benchmark_vench_cpu_dd` workload). Side A = parent commit (old scalar code), Side B = this diff (AVX-512 gathers via `with_simd_level`). See D106248768 for the test commit.

**Intel (Cooper Lake) — large gains for PQ16/32/64:**

| Dataset | PQ | scalar | gather | Δ% |
|---|---|---:|---:|---|
| contriever-1M | PQ8 | 2,878 | 3,172 | +10% ns |
| contriever-1M | PQ16 | 1,783 | 2,282 | **+28%** |
| contriever-1M | PQ32 | 710 | 1,082 | **+52%** |
| contriever-1M | PQ64 | 349 | 510 | **+46%** |
| vibe-celeba-resnet-2048 | PQ8 | 13,152 | 13,595 | +3% ns |
| vibe-celeba-resnet-2048 | PQ16 | 8,070 | 9,522 | **+18%** |
| vibe-celeba-resnet-2048 | PQ32 | 3,410 | 5,233 | **+54%** |
| vibe-celeba-resnet-2048 | PQ64 | 1,695 | 2,418 | **+43%** |
| vibe-llama-128 | PQ8 | 9,802 | 8,051 | -18% |
| vibe-llama-128 | PQ16 | 5,183 | 8,446 | **+63%** |
| vibe-llama-128 | PQ32 | 2,567 | 4,156 | **+62%** |
| vibe-llama-128 | PQ64 | 1,276 | 1,963 | **+54%** |

**AMD (Bergamo) — competitive except PQ16:**

| Dataset | PQ | scalar | gather | Δ% |
|---|---|---:|---:|---|
| sift-1M | PQ8 | 3,958 | 5,271 | **+33%** |
| sift-1M | PQ16 | 2,452 | 1,900 | **-23%** |
| sift-1M | PQ32 | 1,018 | 994 | -2% ns |
| sift-1M | PQ64 | 458 | 447 | -2% ns |
| gist-1M | PQ8 | 4,043 | 5,222 | **+29%** |
| gist-1M | PQ16 | 2,421 | 1,896 | **-22%** |
| gist-1M | PQ32 | 1,001 | 990 | -1% ns |
| gist-1M | PQ64 | 430 | 421 | -2% ns |
| vibe-imagenet-clip-512 | PQ8 | 3,160 | 3,852 | **+22%** |
| vibe-imagenet-clip-512 | PQ16 | 1,908 | 1,490 | **-22%** |
| vibe-imagenet-clip-512 | PQ32 | 803 | 784 | -2% ns |
| vibe-imagenet-clip-512 | PQ64 | 353 | 346 | -2% ns |

With AVX-512, AMD goes from -17% to -45% regression (AVX2) to: PQ8 gains +22-33%, PQ32/64 neutral, only PQ16 still regresses -22%. This is acceptable since we're moving to DD mode.

Investigation details
--

**Why the original regression happened:** The standalone PQ scan code hasn't changed since 2022, but its performance regressed vs the pre-DD baseline (D98255490). The most likely cause is compilation-context interference: `ProductQuantizer.cpp` now includes `simd_dispatch.h` and instantiates `with_simd_level` lambdas for `compute_distance_table` / `compute_inner_prod_table`, pulling in more template machinery. The compiler's optimization budget is finite — additional template instantiations in the same TU can change register allocation, loop unrolling, and instruction scheduling decisions for unrelated functions like the scalar PQ scan loop, even though that loop's source code is identical.

**Why PQ16 still regresses on AMD with AVX-512:** The AVX-512 inner loop processes 16 subquantizers per iteration. For PQ16 (M=16), this means one loop iteration with 4 `_mm512_i32gather_ps` instructions (one per code in the 4-code batch). Each gathers 16 floats from scattered locations in a 16 KB distance table. Even with AVX-512, Zen 4 decomposes each gather into 16 individual loads, creating 64 scattered loads per iteration that congest the load-store unit. Scalar code lets the out-of-order engine overlap independent loads more freely.

**Why PQ8 gains on AMD:** The AVX-512 code's main loop doesn't execute for M=8 (`M/16 = 0`) — it falls through to the scalar leftover path. The +33% gain is purely from the per-SIMD TU compilation context isolation (same scalar algorithm, better codegen in a clean TU).

**Why PQ32/PQ64 are neutral on AMD:** The gather overhead is amortized over more loop iterations, and the distance table exceeds L1 cache (32 KB on Zen 4), so cache misses dominate regardless of scalar vs SIMD.

**Other strategies evaluated (D106200308):** We also benchmarked manual scalar loads packed into SIMD (`_mm256_setr_ps`) and an M-threshold hybrid (scalar for M<=16, gathers for M>16). Both performed worse than unconditional `with_simd_level` dispatch.

See ServiceLab experiments in D106200308 (AVX2 strategy comparison), D106248768 (AVX-512 DD test), and P2347932292, P2347835369.

Differential Revision: D105966976


