### PR TITLE
avoid runtime checks in VisitedTable (#5234)

### DIFF
--- a/benchs/bench_visited_table.cpp
+++ b/benchs/bench_visited_table.cpp
@@ -29,7 +29,8 @@ void bench_visited_table(benchmark::State& state) {
         total_queries += nq;
 #pragma omp parallel
         {
-            VisitedTable vt(ntotal, use_hashset);
+            std::unique_ptr<VisitedTable> vt =
+                    VisitedTable::create(ntotal, use_hashset);
 
 #pragma omp for schedule(static)
             for (size_t q0 = 0; q0 < nq; q0 += batch_size) {
@@ -40,18 +41,18 @@ void bench_visited_table(benchmark::State& state) {
                     size_t added = 0;
                     for (int i = 0; i < ndis; ++i) {
                         auto id = randId(rng1);
-                        added += vt.set(id);
+                        added += vt->set(id);
                     }
                     size_t other_visited = 0;
                     for (int i = 0; i < ndis; ++i) {
                         auto id = randId(rng2);
-                        other_visited += vt.get(randId(rng1));
-                        auto r = vt.get(id);
+                        other_visited += vt->get(randId(rng1));
+                        auto r = vt->get(id);
                         FAISS_ASSERT(r);
-                        other_visited += vt.get(randId(rng1));
+                        other_visited += vt->get(randId(rng1));
                     }
                     benchmark::DoNotOptimize(other_visited + added);
-                    vt.advance();
+                    vt->advance();
                 }
             }
         }

--- a/faiss/IndexBinaryHNSW.cpp
+++ b/faiss/IndexBinaryHNSW.cpp
@@ -128,7 +128,7 @@ void hnsw_add_vertices(
 
 #pragma omp parallel
             {
-                VisitedTable vt(ntotal);
+                std::unique_ptr<VisitedTable> vt = VisitedTable::create(ntotal);
 
                 std::unique_ptr<DistanceComputer> dis(
                         index_hnsw.get_distance_computer());
@@ -146,7 +146,7 @@ void hnsw_add_vertices(
                             pt_level,
                             pt_id,
                             locks,
-                            vt,
+                            *vt,
                             index_hnsw.keep_max_size_level0 && (pt_level == 0));
 
                     if (do_display && i - i0 > prev_display + 10000) {
@@ -236,7 +236,7 @@ void IndexBinaryHNSW::search(
 
 #pragma omp parallel
     {
-        VisitedTable vt(ntotal);
+        std::unique_ptr<VisitedTable> vt = VisitedTable::create(ntotal);
         std::unique_ptr<DistanceComputer> dis(get_distance_computer());
         RH::SingleResultHandler res(bres);
 
@@ -248,7 +248,7 @@ void IndexBinaryHNSW::search(
             // as the index parameter. This state does not get used in the
             // search function, as it is merely there to enable Panorama
             // execution for IndexHNSWFlatPanorama.
-            HNSWStats stats = hnsw.search(*dis, nullptr, res, vt, params_in);
+            HNSWStats stats = hnsw.search(*dis, nullptr, res, *vt, params_in);
             n1 += stats.n1;
             n2 += stats.n2;
             ndis += stats.ndis;
@@ -376,7 +376,7 @@ void IndexBinaryHNSWCagra::search(
 
 #pragma omp parallel
         {
-            VisitedTable vt(ntotal);
+            std::unique_ptr<VisitedTable> vt = VisitedTable::create(ntotal);
             std::unique_ptr<DistanceComputer> dis(get_distance_computer());
             HNSWStats search_stats;
             RH::SingleResultHandler res(bres);
@@ -394,7 +394,7 @@ void IndexBinaryHNSWCagra::search(
                         &nearest_d[i],
                         1, // search_type
                         search_stats,
-                        vt,
+                        *vt,
                         params);
 
                 res.end();

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -145,7 +145,8 @@ void hnsw_add_vertices(
 
 #pragma omp parallel if (i1 > i0 + 100)
             {
-                VisitedTable vt(ntotal, hnsw.use_visited_hashset);
+                std::unique_ptr<VisitedTable> vt =
+                        VisitedTable::create(ntotal, hnsw.use_visited_hashset);
 
                 std::unique_ptr<DistanceComputer> dis(
                         storage_distance_computer(index_hnsw.storage));
@@ -171,7 +172,7 @@ void hnsw_add_vertices(
                             pt_level,
                             pt_id,
                             locks,
-                            vt,
+                            *vt,
                             index_hnsw.keep_max_size_level0 && (pt_level == 0));
 
                     if (do_display && i - i0 > prev_display + 10000) {
@@ -276,7 +277,7 @@ void hnsw_search(
                     res;
             std::unique_ptr<DistanceComputer> dis;
             try {
-                vt = std::make_unique<VisitedTable>(
+                vt = VisitedTable::create(
                         index->ntotal, hnsw.use_visited_hashset);
                 res = std::make_unique<
                         typename BlockResultHandler::SingleResultHandler>(bres);
@@ -472,8 +473,7 @@ void IndexHNSW::search_level_0(
         std::unique_ptr<RH::SingleResultHandler> res;
         try {
             qdis.reset(storage_distance_computer(storage));
-            vt = std::make_unique<VisitedTable>(
-                    hnsw_ntotal, hnsw.use_visited_hashset);
+            vt = VisitedTable::create(hnsw_ntotal, hnsw.use_visited_hashset);
             res = std::make_unique<RH::SingleResultHandler>(bres);
         } catch (...) {
             omp_capture_exception(ex, [&] { interrupt = true; });
@@ -569,7 +569,8 @@ void IndexHNSW::init_level_0_from_entry_points(
 
 #pragma omp parallel
     {
-        VisitedTable vt(ntotal, hnsw.use_visited_hashset);
+        std::unique_ptr<VisitedTable> vt =
+                VisitedTable::create(ntotal, hnsw.use_visited_hashset);
 
         std::unique_ptr<DistanceComputer> dis(
                 storage_distance_computer(storage));
@@ -583,7 +584,7 @@ void IndexHNSW::init_level_0_from_entry_points(
             dis->set_query(vec.data());
 
             hnsw.add_links_starting_from(
-                    *dis, pt_id, nearest, (*dis)(nearest), 0, locks, vt);
+                    *dis, pt_id, nearest, (*dis)(nearest), 0, locks, *vt);
 
             if (verbose && i % 10000 == 0) {
                 printf("  %d / %d\r", i, n);
@@ -824,7 +825,7 @@ int search_from_candidates_2(
         idx_t* I,
         float* D,
         MinimaxHeap& candidates,
-        VisitedTable& vt,
+        VisitedTableVector& vt,
         HNSWStats& stats,
         int level,
         int nres_in = 0) {
@@ -934,8 +935,7 @@ void IndexHNSW2Level::search(
             constexpr int candidates_size = 1;
             std::unique_ptr<MinimaxHeap> candidates;
             try {
-                vt = std::make_unique<VisitedTable>(
-                        ntotal, /*use_hashset=*/false);
+                vt = VisitedTable::create(ntotal, /*use_hashset=*/false);
                 dis.reset(storage_distance_computer(storage));
                 candidates = std::make_unique<MinimaxHeap>(candidates_size);
             } catch (...) {
@@ -987,7 +987,7 @@ void IndexHNSW2Level::search(
                             idxi,
                             simi,
                             *candidates,
-                            *vt,
+                            static_cast<VisitedTableVector&>(*vt),
                             search_stats,
                             0,
                             k);
@@ -1180,10 +1180,11 @@ void IndexHNSWCagra::range_search(
 
         RangeQueryResult& qres = pres.new_result(i);
         RangeResultHandler<HNSW::C> res(&qres, threshold);
-        VisitedTable vt(ntotal, hnsw.use_visited_hashset);
+        std::unique_ptr<VisitedTable> vt =
+                VisitedTable::create(ntotal, hnsw.use_visited_hashset);
         HNSWStats stats;
         hnsw.search_level_0(
-                *dis, res, 1, &nearest, &nearest_d, 1, stats, vt, params);
+                *dis, res, 1, &nearest, &nearest_d, 1, stats, *vt, params);
         n1 += stats.n1;
         n2 += stats.n2;
         ndis += stats.ndis;

--- a/faiss/IndexNNDescent.cpp
+++ b/faiss/IndexNNDescent.cpp
@@ -126,7 +126,7 @@ void IndexNNDescent::search(
             std::unique_ptr<DistanceComputer> dis;
             std::unique_ptr<VisitedTable> vt;
             try {
-                vt = std::make_unique<VisitedTable>(ntotal);
+                vt = VisitedTable::create(ntotal);
                 dis.reset(storage_distance_computer(storage));
             } catch (...) {
                 omp_capture_exception(ex, [&] { interrupt = true; });

--- a/faiss/IndexNSG.cpp
+++ b/faiss/IndexNSG.cpp
@@ -81,8 +81,7 @@ void IndexNSG::search(
             std::unique_ptr<DistanceComputer> dis;
             std::unique_ptr<VisitedTable> vt;
             try {
-                vt = std::make_unique<VisitedTable>(
-                        ntotal, nsg.use_visited_hashset);
+                vt = VisitedTable::create(ntotal, nsg.use_visited_hashset);
                 dis.reset(storage_distance_computer(storage));
             } catch (...) {
                 omp_capture_exception(ex, [&] { interrupt = true; });

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -362,31 +362,34 @@ void add_link(
     }
 }
 
-} // namespace
-
-/// search neighbors on a single level, starting from an entry point
-void search_neighbors_to_add(
+/** Templated body of `search_neighbors_to_add` — instantiated once per final
+ * VisitedTable subclass so that `vt.set/advance` are inlined and the cost of
+ * virtual dispatch is paid only once at the top of the call.
+ */
+template <typename VTType>
+static void search_neighbors_to_add_fixVT(
         HNSW& hnsw,
         DistanceComputer& qdis,
-        std::priority_queue<NodeDistCloser>& results,
+        std::priority_queue<HNSW::NodeDistCloser>& results,
         int entry_point,
         float d_entry_point,
         int level,
-        VisitedTable& vt,
+        VTType& vt,
         bool reference_version) {
+    using C = HNSW::C;
     // top is nearest candidate
-    std::priority_queue<NodeDistFarther> candidates;
+    std::priority_queue<HNSW::NodeDistFarther> candidates;
 
-    NodeDistFarther ev(d_entry_point, entry_point);
+    HNSW::NodeDistFarther ev(d_entry_point, entry_point);
     candidates.push(ev);
     results.emplace(d_entry_point, entry_point);
     vt.set(entry_point);
 
     while (!candidates.empty()) {
         // get nearest
-        const NodeDistFarther& currEv = candidates.top();
+        const HNSW::NodeDistFarther& currEv = candidates.top();
 
-        if (currEv.d > results.top().d) {
+        if (C::cmp(currEv.d, results.top().d)) {
             break;
         }
         int currNode = currEv.id;
@@ -407,7 +410,7 @@ void search_neighbors_to_add(
         if (reference_version) {
             // a reference version
             for (size_t i = begin; i < end; i++) {
-                storage_idx_t nodeId = hnsw.neighbors[i];
+                HNSW::storage_idx_t nodeId = hnsw.neighbors[i];
                 if (nodeId < 0) {
                     break;
                 }
@@ -416,10 +419,10 @@ void search_neighbors_to_add(
                 }
 
                 float dis = qdis(nodeId);
-                NodeDistFarther evE1(dis, nodeId);
+                HNSW::NodeDistFarther evE1(dis, nodeId);
 
                 if (results.size() < static_cast<size_t>(hnsw.efConstruction) ||
-                    results.top().d > dis) {
+                    C::cmp(results.top().d, dis)) {
                     results.emplace(dis, nodeId);
                     candidates.emplace(dis, nodeId);
                     if (results.size() >
@@ -432,10 +435,10 @@ void search_neighbors_to_add(
             // a faster version
 
             // the following version processes 4 neighbors at a time
-            auto update_with_candidate = [&](const storage_idx_t idx,
+            auto update_with_candidate = [&](const HNSW::storage_idx_t idx,
                                              const float dis) {
                 if (results.size() < static_cast<size_t>(hnsw.efConstruction) ||
-                    results.top().d > dis) {
+                    C::cmp(results.top().d, dis)) {
                     results.emplace(dis, idx);
                     candidates.emplace(dis, idx);
                     if (results.size() >
@@ -446,10 +449,10 @@ void search_neighbors_to_add(
             };
 
             int n_buffered = 0;
-            storage_idx_t buffered_ids[4];
+            HNSW::storage_idx_t buffered_ids[4];
 
             for (size_t j = begin; j < end; j++) {
-                storage_idx_t nodeId = hnsw.neighbors[j];
+                HNSW::storage_idx_t nodeId = hnsw.neighbors[j];
                 if (nodeId < 0) {
                     break;
                 }
@@ -491,6 +494,40 @@ void search_neighbors_to_add(
     vt.advance();
 }
 
+} // namespace
+
+/// search neighbors on a single level, starting from an entry point.
+/// Routes to the appropriate templated instantiation based on the concrete
+/// type of `vt`.
+void hnsw_detail::search_neighbors_to_add(
+        HNSW& hnsw,
+        DistanceComputer& qdis,
+        std::priority_queue<NodeDistCloser>& results,
+        int entry_point,
+        float d_entry_point,
+        int level,
+        VisitedTable& vt,
+        bool reference_version) {
+    auto call = [&]<typename VTType>(VTType& vt_concrete) {
+        search_neighbors_to_add_fixVT(
+                hnsw,
+                qdis,
+                results,
+                entry_point,
+                d_entry_point,
+                level,
+                vt_concrete,
+                reference_version);
+    };
+
+    if (VisitedTableVector* vtv = dynamic_cast<VisitedTableVector*>(&vt)) {
+        call(*vtv);
+        return;
+    }
+    VisitedTableSet& vts = dynamic_cast<VisitedTableSet&>(vt);
+    call(vts);
+}
+
 /// Finds neighbors and builds links with them, starting from an entry
 /// point. The own neighbor list is assumed to be locked.
 void HNSW::add_links_starting_from(
@@ -504,7 +541,7 @@ void HNSW::add_links_starting_from(
         bool keep_max_size_level0) {
     std::priority_queue<NodeDistCloser> link_targets;
 
-    search_neighbors_to_add(
+    hnsw_detail::search_neighbors_to_add(
             *this, ptdis, link_targets, nearest, d_nearest, level, vt);
 
     // but we can afford only this many neighbors
@@ -565,7 +602,8 @@ void HNSW::add_with_locks(
 
     //  greedy search on upper levels
     for (; level > pt_level; level--) {
-        greedy_update_nearest(*this, ptdis, level, nearest, d_nearest);
+        hnsw_detail::greedy_update_nearest(
+                *this, ptdis, level, nearest, d_nearest);
     }
 
     for (; level >= 0; level--) {
@@ -619,13 +657,17 @@ static inline void extract_search_params(
     }
 }
 
-/** Do a BFS on the candidates list */
-int search_from_candidates(
+/** Templated body of `search_from_candidates` — instantiated once per final
+ * VisitedTable subclass so that `vt.set/get/prefetch` are inlined and the cost
+ * of virtual dispatch is paid only once at the top of the call.
+ */
+template <typename VTType>
+static int search_from_candidates_fixVT(
         const HNSW& hnsw,
         DistanceComputer& qdis,
         ResultHandler& res,
         MinimaxHeap& candidates,
-        VisitedTable& vt,
+        VTType& vt,
         HNSWStats& stats,
         int level,
         int nres_in,
@@ -644,7 +686,7 @@ int search_from_candidates(
         float d = candidates.dis[i];
         FAISS_ASSERT(v1 >= 0);
         if (!sel || sel->is_member(v1)) {
-            if (d < threshold) {
+            if (C::cmp(threshold, d)) {
                 if (res.add_result(d, v1)) {
                     threshold = res.threshold;
                 }
@@ -693,7 +735,7 @@ int search_from_candidates(
 
         auto add_to_heap = [&](const size_t idx, const float dis) {
             if (!sel || sel->is_member(idx)) {
-                if (dis < threshold) {
+                if (C::cmp(threshold, dis)) {
                     if (res.add_result(dis, idx)) {
                         threshold = res.threshold;
                         nres += 1;
@@ -756,7 +798,39 @@ int search_from_candidates(
     return nres;
 }
 
-int search_from_candidates_panorama(
+/** Do a BFS on the candidates list. Routes to the appropriate templated
+ *  instantiation based on the concrete type of `vt`. */
+int hnsw_detail::search_from_candidates(
+        const HNSW& hnsw,
+        DistanceComputer& qdis,
+        ResultHandler& res,
+        MinimaxHeap& candidates,
+        VisitedTable& vt,
+        HNSWStats& stats,
+        int level,
+        int nres_in,
+        const SearchParameters* params) {
+    auto call = [&]<typename VTType>(VTType& vt_concrete) -> int {
+        return search_from_candidates_fixVT(
+                hnsw,
+                qdis,
+                res,
+                candidates,
+                vt_concrete,
+                stats,
+                level,
+                nres_in,
+                params);
+    };
+
+    if (VisitedTableVector* vtv = dynamic_cast<VisitedTableVector*>(&vt)) {
+        return call(*vtv);
+    }
+    VisitedTableSet& vts = dynamic_cast<VisitedTableSet&>(vt);
+    return call(vts);
+}
+
+int hnsw_detail::search_from_candidates_panorama(
         const HNSW& hnsw,
         const IndexHNSW* index,
         DistanceComputer& qdis,
@@ -781,7 +855,7 @@ int search_from_candidates_panorama(
         float d = candidates.dis[i];
         FAISS_ASSERT(v1 >= 0);
         if (!sel || sel->is_member(v1)) {
-            if (d < threshold) {
+            if (C::cmp(threshold, d)) {
                 if (res.add_result(d, v1)) {
                     threshold = res.threshold;
                 }
@@ -917,28 +991,28 @@ int search_from_candidates_panorama(
                 // the maintenance of the candidate heap), but micro-benchmarks
                 // have shown that it is not worth it to write horrible code to
                 // squeeze out those cycles.
-                if (lower_bound_0 <= threshold) {
+                if (!C::cmp(lower_bound_0, threshold)) {
                     exact_distances[next_batch_size] = new_exact_0;
                     index_array[next_batch_size] = idx_0;
                     next_batch_size += 1;
                 } else {
                     candidates.push(idx_0, new_exact_0);
                 }
-                if (lower_bound_1 <= threshold) {
+                if (!C::cmp(lower_bound_1, threshold)) {
                     exact_distances[next_batch_size] = new_exact_1;
                     index_array[next_batch_size] = idx_1;
                     next_batch_size += 1;
                 } else {
                     candidates.push(idx_1, new_exact_1);
                 }
-                if (lower_bound_2 <= threshold) {
+                if (!C::cmp(lower_bound_2, threshold)) {
                     exact_distances[next_batch_size] = new_exact_2;
                     index_array[next_batch_size] = idx_2;
                     next_batch_size += 1;
                 } else {
                     candidates.push(idx_2, new_exact_2);
                 }
-                if (lower_bound_3 <= threshold) {
+                if (!C::cmp(lower_bound_3, threshold)) {
                     exact_distances[next_batch_size] = new_exact_3;
                     index_array[next_batch_size] = idx_3;
                     next_batch_size += 1;
@@ -961,7 +1035,7 @@ int search_from_candidates_panorama(
                 float cs_bound = 2.0f * cum_sum * query_cum_norm;
                 float lower_bound = new_exact - cs_bound;
 
-                if (lower_bound <= threshold) {
+                if (!C::cmp(lower_bound, threshold)) {
                     exact_distances[next_batch_size] = new_exact;
                     index_array[next_batch_size] = idx;
                     next_batch_size += 1;
@@ -1017,7 +1091,7 @@ void reservePriorityQueue(
     q = std::move(access);
 }
 
-std::priority_queue<HNSW::Node> search_from_candidate_unbounded(
+std::priority_queue<HNSW::Node> hnsw_detail::search_from_candidate_unbounded(
         const HNSW& hnsw,
         const Node& node,
         DistanceComputer& qdis,
@@ -1041,7 +1115,7 @@ std::priority_queue<HNSW::Node> search_from_candidate_unbounded(
         storage_idx_t v0;
         std::tie(d0, v0) = candidates.top();
 
-        if (d0 > top_candidates.top().first) {
+        if (C::cmp(d0, top_candidates.top().first)) {
             break;
         }
 
@@ -1067,7 +1141,7 @@ std::priority_queue<HNSW::Node> search_from_candidate_unbounded(
         size_t saved_j[4];
 
         auto add_to_heap = [&](const size_t idx, const float dis) {
-            if (top_candidates.top().first > dis ||
+            if (C::cmp(top_candidates.top().first, dis) ||
                 top_candidates.size() < ef) {
                 candidates.emplace(dis, idx);
                 top_candidates.emplace(dis, idx);
@@ -1126,7 +1200,7 @@ std::priority_queue<HNSW::Node> search_from_candidate_unbounded(
 }
 
 /// greedily update a nearest vector at a given level
-HNSWStats greedy_update_nearest(
+HNSWStats hnsw_detail::greedy_update_nearest(
         const HNSW& hnsw,
         DistanceComputer& qdis,
         int level,
@@ -1146,7 +1220,7 @@ HNSWStats greedy_update_nearest(
         // the following version processes 4 neighbors at a time
         auto update_with_candidate = [&](const storage_idx_t idx,
                                          const float dis) {
-            if (dis < d_nearest) {
+            if (C::cmp(d_nearest, dis)) {
                 nearest = idx;
                 d_nearest = dis;
             }
@@ -1243,8 +1317,8 @@ HNSWStats HNSW::search(
     float d_nearest = qdis(nearest);
 
     for (int level = max_level; level >= 1; level--) {
-        HNSWStats local_stats =
-                greedy_update_nearest(*this, qdis, level, nearest, d_nearest);
+        HNSWStats local_stats = hnsw_detail::greedy_update_nearest(
+                *this, qdis, level, nearest, d_nearest);
         stats.combine(local_stats);
     }
 
@@ -1256,10 +1330,10 @@ HNSWStats HNSW::search(
         candidates.push(nearest, d_nearest);
 
         if (!is_panorama) {
-            search_from_candidates(
+            hnsw_detail::search_from_candidates(
                     *this, qdis, res, candidates, vt, stats, 0, 0, params);
         } else {
-            search_from_candidates_panorama(
+            hnsw_detail::search_from_candidates_panorama(
                     *this,
                     index,
                     qdis,
@@ -1273,7 +1347,7 @@ HNSWStats HNSW::search(
         }
     } else {
         std::priority_queue<Node> top_candidates =
-                search_from_candidate_unbounded(
+                hnsw_detail::search_from_candidate_unbounded(
                         *this, Node(d_nearest, nearest), qdis, ef, &vt, stats);
 
         while (top_candidates.size() > static_cast<size_t>(k)) {
@@ -1335,7 +1409,7 @@ void HNSW::search_level_0(
 
             candidates.push(cj, nearest_d[j]);
 
-            nres = search_from_candidates(
+            nres = hnsw_detail::search_from_candidates(
                     hnsw,
                     qdis,
                     res,
@@ -1361,7 +1435,7 @@ void HNSW::search_level_0(
             candidates.push(cj, nearest_d[j]);
         }
 
-        search_from_candidates(
+        hnsw_detail::search_from_candidates(
                 hnsw, qdis, res, candidates, vt, search_stats, 0, 0, params);
     }
 }

--- a/faiss/impl/HNSW.h
+++ b/faiss/impl/HNSW.h
@@ -250,6 +250,11 @@ struct HNSWStats {
 // global var that collects them all
 FAISS_API extern HNSWStats hnsw_stats;
 
+/// Internal HNSW algorithm helpers. These are not part of the public API; they
+/// are exposed here only so that unit tests (and a few cross-TU callers such as
+/// the Panorama search variant) can reach them.
+namespace hnsw_detail {
+
 int search_from_candidates(
         const HNSW& hnsw,
         DistanceComputer& qdis,
@@ -301,5 +306,7 @@ void search_neighbors_to_add(
         int level,
         VisitedTable& vt,
         bool reference_version = false);
+
+} // namespace hnsw_detail
 
 } // namespace faiss

--- a/faiss/impl/NSG.cpp
+++ b/faiss/impl/NSG.cpp
@@ -234,10 +234,11 @@ void NSG::init_graph(Index* storage, const nsg::Graph<idx_t>& knn_graph) {
     std::unique_ptr<DistanceComputer> dis(storage_distance_computer(storage));
 
     dis->set_query(center.get());
-    VisitedTable vt(ntotal, use_visited_hashset);
+    std::unique_ptr<VisitedTable> vt =
+            VisitedTable::create(ntotal, use_visited_hashset);
 
     // Do not collect the visited nodes
-    search_on_graph<false>(knn_graph, *dis, vt, ep, L, retset, tmpset);
+    search_on_graph<false>(knn_graph, *dis, *vt, ep, L, retset, tmpset);
 
     // set enterpoint
     enterpoint = retset[0].id;
@@ -344,7 +345,8 @@ void NSG::link(
         std::vector<Node> pool;
         std::vector<Neighbor> tmp;
 
-        VisitedTable vt(ntotal, use_visited_hashset);
+        std::unique_ptr<VisitedTable> vt =
+                VisitedTable::create(ntotal, use_visited_hashset);
         std::unique_ptr<DistanceComputer> dis(
                 storage_distance_computer(storage));
 
@@ -355,13 +357,13 @@ void NSG::link(
 
             // Collect the visited nodes into pool
             search_on_graph<true>(
-                    knn_graph, *dis, vt, enterpoint, L, tmp, pool);
+                    knn_graph, *dis, *vt, enterpoint, L, tmp, pool);
 
-            sync_prune(i, pool, *dis, vt, knn_graph, graph);
+            sync_prune(i, pool, *dis, *vt, knn_graph, graph);
 
             pool.clear();
             tmp.clear();
-            vt.advance();
+            vt->advance();
         }
     } // omp parallel
 
@@ -531,19 +533,21 @@ void NSG::add_reverse_links(
 
 int NSG::tree_grow(Index* storage, std::vector<int>& degrees) {
     int root = enterpoint;
-    VisitedTable vt(ntotal, use_visited_hashset);
-    VisitedTable vt2(ntotal, use_visited_hashset);
+    std::unique_ptr<VisitedTable> vt =
+            VisitedTable::create(ntotal, use_visited_hashset);
+    std::unique_ptr<VisitedTable> vt2 =
+            VisitedTable::create(ntotal, use_visited_hashset);
 
     int num_attached = 0;
     int cnt = 0;
     while (true) {
-        cnt = dfs(vt, root, cnt);
+        cnt = dfs(*vt, root, cnt);
         if (cnt >= ntotal) {
             break;
         }
 
-        root = attach_unlinked(storage, vt, vt2, degrees);
-        vt2.advance();
+        root = attach_unlinked(storage, *vt, *vt2, degrees);
+        vt2->advance();
         num_attached += 1;
     }
 

--- a/faiss/impl/VisitedTable.cpp
+++ b/faiss/impl/VisitedTable.cpp
@@ -18,19 +18,19 @@ namespace faiss {
 // A size of ~1M seems to be the threshold where the hash set wins.
 size_t visited_table_hashset_threshold = 500000;
 
-VisitedTable::VisitedTable(size_t size, std::optional<bool> use_hashset)
-        : visno(use_hashset.value_or(size >= visited_table_hashset_threshold)
-                        ? 0
-                        : 1) {
-    if (visno != 0) {
-        visited.resize(size, 0);
+std::unique_ptr<VisitedTable> VisitedTable::create(
+        size_t size,
+        std::optional<bool> use_hashset) {
+    bool use_set =
+            use_hashset.value_or(size >= visited_table_hashset_threshold);
+    if (use_set) {
+        return std::make_unique<VisitedTableSet>();
     }
+    return std::make_unique<VisitedTableVector>(size);
 }
 
-void VisitedTable::advance() {
-    if (visno == 0) {
-        visited_set.clear();
-    } else if (visno < 254) {
+void VisitedTableVector::advance() {
+    if (visno < 254) {
         // 254 rather than 255 because sometimes we use visno and visno+1
         ++visno;
     } else {

--- a/faiss/impl/VisitedTable.h
+++ b/faiss/impl/VisitedTable.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 
+#include <memory>
 #include <optional>
 #include <unordered_set>
 #include <vector>
@@ -21,54 +22,88 @@ namespace faiss {
 
 FAISS_API extern size_t visited_table_hashset_threshold;
 
-/// A fast, reusable Visited Set for graph search algorithms.
+/// Abstract base class for a fast, reusable Visited Set for graph search
+/// algorithms.
 struct VisitedTable {
-    std::vector<uint8_t> visited;
-    std::unordered_set<size_t> visited_set;
-    uint8_t visno; // 0 if using visited_set, 1..250 if using vector.
-
-    // If use_hashset is nullopt, the use of a hashset will be determined by
-    // size >= visited_table_hashset_threshold.
-    explicit VisitedTable(
-            size_t size,
-            std::optional<bool> use_hashset = std::nullopt);
+    virtual ~VisitedTable() = default;
 
     /// set flag #no to true, return whether this changed it.
-    bool set(size_t no) {
-        if (visno == 0) {
-            return visited_set.insert(no).second;
-        } else if (visited[no] == visno) {
-            return false;
-        } else {
-            visited[no] = visno;
-            return true;
-        }
-    }
-
-    /// pre-allocate bucket space to avoid rehashing during repeated set() calls
-    void reserve(size_t n) {
-        if (visno == 0) {
-            visited_set.reserve(n);
-        }
-    }
+    virtual bool set(size_t no) = 0;
 
     /// get flag #no
-    bool get(size_t no) const {
-        if (visno == 0) {
-            return visited_set.count(no) != 0;
-        } else {
-            return visited[no] == visno;
-        }
-    }
+    virtual bool get(size_t no) const = 0;
 
-    void prefetch(size_t no) const {
-        if (visno != 0) {
-            prefetch_L2(&visited[no]);
-        }
-    }
+    /// prefetch flag #no
+    virtual void prefetch(size_t no) const = 0;
+
+    /// pre-allocate bucket space to avoid rehashing during repeated set() calls
+    virtual void reserve(size_t /*n*/) {}
 
     /// reset all flags to false
-    void advance();
+    virtual void advance() = 0;
+
+    /// Factory method to create appropriate implementation.
+    /// If use_hashset is nullopt, the use of a hashset will be determined by
+    /// size >= visited_table_hashset_threshold.
+    static std::unique_ptr<VisitedTable> create(
+            size_t size,
+            std::optional<bool> use_hashset = std::nullopt);
+};
+
+/// Set-based implementation using unordered_set.
+/// O(1) to construct and O(visits) to advance.
+struct VisitedTableSet FAISS_FINAL : VisitedTable {
+    std::unordered_set<size_t> visited_set;
+
+    VisitedTableSet() = default;
+
+    bool set(size_t no) final {
+        return visited_set.insert(no).second;
+    }
+
+    bool get(size_t no) const final {
+        return visited_set.count(no) != 0;
+    }
+
+    void prefetch(size_t /*no*/) const final {
+        // No-op for set-based implementation
+    }
+
+    void reserve(size_t n) final {
+        visited_set.reserve(n);
+    }
+
+    void advance() final {
+        visited_set.clear();
+    }
+};
+
+/// Vector-based implementation using a versioned byte array.
+/// Faster for get()/set(), but O(size) to initialize.
+/// advance() is O(1) except every 250 calls, which are O(size).
+struct VisitedTableVector FAISS_FINAL : VisitedTable {
+    std::vector<uint8_t> visited;
+    uint8_t visno{1}; // Version number, 1..254
+
+    explicit VisitedTableVector(size_t size) : visited(size, 0) {}
+
+    bool set(size_t no) final {
+        if (visited[no] == visno) {
+            return false;
+        }
+        visited[no] = visno;
+        return true;
+    }
+
+    bool get(size_t no) const final {
+        return visited[no] == visno;
+    }
+
+    void prefetch(size_t no) const final {
+        prefetch_L2(&visited[no]);
+    }
+
+    void advance() final;
 };
 
 } // namespace faiss

--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -110,12 +110,6 @@ inline int __builtin_clzll(uint64_t x) {
 #define FAISS_PACK_STRUCTS_BEGIN __pragma(pack(push, 1))
 #define FAISS_PACK_STRUCTS_END __pragma(pack(pop))
 
-#ifdef SWIG
-#define FAISS_MAYBE_UNUSED
-#else
-#define FAISS_MAYBE_UNUSED [[maybe_unused]]
-#endif
-
 #else
 /*******************************************************
  * Linux and OSX
@@ -130,12 +124,10 @@ inline int __builtin_clzll(uint64_t x) {
 #define ALIGNED(x)
 #define FAISS_PACKED
 #define FAISS_RESTRICT
-#define FAISS_MAYBE_UNUSED
 #else
 #define ALIGNED(x) __attribute__((aligned(x)))
 #define FAISS_PACKED __attribute__((packed))
 #define FAISS_RESTRICT __restrict
-#define FAISS_MAYBE_UNUSED [[maybe_unused]]
 #endif
 
 // On non-Windows, FAISS_PACKED handles packing, so these are no-ops
@@ -220,3 +212,15 @@ inline int __builtin_clzll(uint64_t x) {
 #define Swap4Bytes(val)                                           \
     ((((val) >> 24) & 0x000000FF) | (((val) >> 8) & 0x0000FF00) | \
      (((val) << 8) & 0x00FF0000) | (((val) << 24) & 0xFF000000))
+
+/*******************************************************
+ * A few things that SWIG has trouble parsing
+ *******************************************************/
+
+#ifdef SWIG
+#define FAISS_MAYBE_UNUSED
+#define FAISS_FINAL
+#else
+#define FAISS_MAYBE_UNUSED [[maybe_unused]]
+#define FAISS_FINAL final
+#endif

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -694,6 +694,8 @@ void gpu_sync_all_devices()
 %ignore faiss::InterruptCallback::lock;
 
 %include <faiss/impl/AuxIndexStructures.h>
+
+%ignore faiss::VisitedTable::create; // causes errors on OSS compile (?)
 %include <faiss/impl/VisitedTable.h>
 %include <faiss/impl/IDSelector.h>
 

--- a/tests/test_NSG_compressed_graph.cpp
+++ b/tests/test_NSG_compressed_graph.cpp
@@ -116,13 +116,13 @@ TEST(NSGBugs, SyncPruneSingleNode) {
 
     // Search returns the only node
     nsg_obj.search_L = 1;
-    faiss::VisitedTable vt(1);
+    std::unique_ptr<faiss::VisitedTable> vt = faiss::VisitedTable::create(1);
     auto dis = std::unique_ptr<faiss::DistanceComputer>(
             faiss::nsg::storage_distance_computer(&storage));
     dis->set_query(vec);
 
     faiss::idx_t label = -1;
     float distance = -1;
-    nsg_obj.search(*dis, 1, &label, &distance, vt);
+    nsg_obj.search(*dis, 1, &label, &distance, *vt);
     EXPECT_EQ(label, 0);
 }

--- a/tests/test_graph_based.py
+++ b/tests/test_graph_based.py
@@ -330,7 +330,7 @@ class TestNSG(unittest.TestCase):
         np.testing.assert_array_equal(Insg3, Insg)
 
     def subtest_connectivity(self, index, nb):
-        vt = faiss.VisitedTable(nb)
+        vt = faiss.VisitedTableVector(nb)
         count = index.nsg.dfs(vt, index.nsg.enterpoint, 0)
         self.assertEqual(count, nb)
 

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -538,18 +538,20 @@ TEST_F(HNSWTest, TEST_search_from_candidate_unbounded) {
     auto nearest = index->hnsw.entry_point;
     float d_nearest = (*dis)(nearest);
     auto node = faiss::HNSW::Node(d_nearest, nearest);
-    faiss::VisitedTable vt(index->ntotal);
+    std::unique_ptr<faiss::VisitedTable> vt =
+            faiss::VisitedTable::create(index->ntotal);
     faiss::HNSWStats stats;
 
     // actual version
-    auto top_candidates = faiss::search_from_candidate_unbounded(
-            index->hnsw, node, *dis, k, &vt, stats);
+    auto top_candidates = faiss::hnsw_detail::search_from_candidate_unbounded(
+            index->hnsw, node, *dis, k, vt.get(), stats);
 
     auto reference_nearest = index->hnsw.entry_point;
     float reference_d_nearest = (*dis)(nearest);
     auto reference_node =
             faiss::HNSW::Node(reference_d_nearest, reference_nearest);
-    faiss::VisitedTable reference_vt(index->ntotal);
+    std::unique_ptr<faiss::VisitedTable> reference_vt =
+            faiss::VisitedTable::create(index->ntotal);
     faiss::HNSWStats reference_stats;
 
     // reference version
@@ -558,7 +560,7 @@ TEST_F(HNSWTest, TEST_search_from_candidate_unbounded) {
             reference_node,
             *dis,
             k,
-            &reference_vt,
+            reference_vt.get(),
             reference_stats);
     EXPECT_EQ(stats.ndis, reference_stats.ndis);
     EXPECT_EQ(stats.nhops, reference_stats.nhops);
@@ -576,7 +578,7 @@ TEST_F(HNSWTest, TEST_greedy_update_nearest) {
     float reference_d_nearest = (*dis)(reference_nearest);
 
     // actual version
-    auto stats = faiss::greedy_update_nearest(
+    auto stats = faiss::hnsw_detail::greedy_update_nearest(
             index->hnsw, *dis, 0, nearest, d_nearest);
 
     // reference version
@@ -599,15 +601,17 @@ TEST_F(HNSWTest, TEST_search_from_candidates) {
     std::vector<float> reference_D(k * nq);
     using RH = faiss::HeapBlockResultHandler<faiss::HNSW::C>;
 
-    faiss::VisitedTable vt(index->ntotal);
-    faiss::VisitedTable reference_vt(index->ntotal);
+    std::unique_ptr<faiss::VisitedTable> vt =
+            faiss::VisitedTable::create(index->ntotal);
+    std::unique_ptr<faiss::VisitedTable> reference_vt =
+            faiss::VisitedTable::create(index->ntotal);
     int num_candidates = 10;
     faiss::MinimaxHeap candidates(num_candidates);
     faiss::MinimaxHeap reference_candidates(num_candidates);
 
     for (int i = 0; i < num_candidates; i++) {
-        vt.set(i);
-        reference_vt.set(i);
+        vt->set(i);
+        reference_vt->set(i);
         candidates.push(i, (*dis)(i));
         reference_candidates.push(i, (*dis)(i));
     }
@@ -618,8 +622,8 @@ TEST_F(HNSWTest, TEST_search_from_candidates) {
             bres);
 
     res.begin(0);
-    faiss::search_from_candidates(
-            index->hnsw, *dis, res, candidates, vt, stats, 0, 0, nullptr);
+    faiss::hnsw_detail::search_from_candidates(
+            index->hnsw, *dis, res, candidates, *vt, stats, 0, 0, nullptr);
     res.end();
 
     faiss::HNSWStats reference_stats;
@@ -632,7 +636,7 @@ TEST_F(HNSWTest, TEST_search_from_candidates) {
             *dis,
             reference_res,
             reference_candidates,
-            reference_vt,
+            *reference_vt,
             reference_stats,
             0,
             0,
@@ -653,30 +657,32 @@ TEST_F(HNSWTest, TEST_search_from_candidates) {
 TEST_F(HNSWTest, TEST_search_neighbors_to_add) {
     omp_set_num_threads(1);
 
-    faiss::VisitedTable vt(index->ntotal);
-    faiss::VisitedTable reference_vt(index->ntotal);
+    std::unique_ptr<faiss::VisitedTable> vt =
+            faiss::VisitedTable::create(index->ntotal);
+    std::unique_ptr<faiss::VisitedTable> reference_vt =
+            faiss::VisitedTable::create(index->ntotal);
 
     std::priority_queue<faiss::HNSW::NodeDistCloser> link_targets;
     std::priority_queue<faiss::HNSW::NodeDistCloser> reference_link_targets;
 
-    faiss::search_neighbors_to_add(
+    faiss::hnsw_detail::search_neighbors_to_add(
             index->hnsw,
             *dis,
             link_targets,
             index->hnsw.entry_point,
             (*dis)(index->hnsw.entry_point),
             index->hnsw.max_level,
-            vt,
+            *vt,
             false);
 
-    faiss::search_neighbors_to_add(
+    faiss::hnsw_detail::search_neighbors_to_add(
             index->hnsw,
             *dis,
             reference_link_targets,
             index->hnsw.entry_point,
             (*dis)(index->hnsw.entry_point),
             index->hnsw.max_level,
-            reference_vt,
+            *reference_vt,
             true);
 
     EXPECT_EQ(link_targets.size(), reference_link_targets.size());
@@ -714,8 +720,10 @@ TEST_F(HNSWTest, TEST_search_level_0) {
             bres2);
 
     faiss::HNSWStats stats1, stats2;
-    faiss::VisitedTable vt1(index->ntotal);
-    faiss::VisitedTable vt2(index->ntotal);
+    std::unique_ptr<faiss::VisitedTable> vt1 =
+            faiss::VisitedTable::create(index->ntotal);
+    std::unique_ptr<faiss::VisitedTable> vt2 =
+            faiss::VisitedTable::create(index->ntotal);
     auto nprobe = 5;
     const faiss::HNSW::storage_idx_t values[] = {1, 2, 3, 4, 5};
     const faiss::HNSW::storage_idx_t* nearest_i = values;
@@ -725,13 +733,13 @@ TEST_F(HNSWTest, TEST_search_level_0) {
     // search_type == 1
     res1.begin(0);
     index->hnsw.search_level_0(
-            *dis, res1, nprobe, nearest_i, nearest_d, 1, stats1, vt1, nullptr);
+            *dis, res1, nprobe, nearest_i, nearest_d, 1, stats1, *vt1, nullptr);
     res1.end();
 
     // search_type == 2
     res2.begin(0);
     index->hnsw.search_level_0(
-            *dis, res2, nprobe, nearest_i, nearest_d, 2, stats2, vt2, nullptr);
+            *dis, res2, nprobe, nearest_i, nearest_d, 2, stats2, *vt2, nullptr);
     res2.end();
 
     // search_type 1 calls search_from_candidates in a loop nprobe times.


### PR DESCRIPTION
Summary:

There are two VisitedTable implementations. Avoid runtime checks between the two by making them separate classes and templatizing the visited tables on them.

Differential Revision: D105961848


