### PR TITLE
Guard Panorama autovec pragmas against nvcc frontend

### DIFF
--- a/faiss/impl/Panorama.h
+++ b/faiss/impl/Panorama.h
@@ -36,7 +36,12 @@ namespace faiss {
 ///                    from active_indices (subsequent levels after pruning).
 /// @tparam LevelWidth Compile-time level width in floats (0 = use runtime
 ///                    level_width_dims). Enables full loop unrolling.
+// Skip pragmas under nvcc: its EDG frontend warns on `#pragma GCC optimize`
+// (#1675-D) for every `.cu` that transitively includes this header. These
+// templates are CPU-only, so the hint is irrelevant during nvcc parse.
+#if !defined(__NVCC__)
 FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN
+#endif
 template <bool AllActive = false, size_t LevelWidth = 0>
 static inline void compute_level_dot_kernel(
         const float* FAISS_RESTRICT query_level,
@@ -83,7 +88,9 @@ static inline void compute_level_dot_kernel(
         dot_products[i] = dp;
     }
 }
+#if !defined(__NVCC__)
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
+#endif
 
 /// Update exact distances with the current level's dot products, then apply
 /// Panorama pruning: for each active vector, compute a lower bound on
@@ -92,7 +99,9 @@ FAISS_PRAGMA_IMPRECISE_FUNCTION_END
 ///
 /// Uses `if constexpr` on C::is_max rather than C::cmp() to ensure the
 /// comparison autovectorizes (C::cmp generates scalar function calls).
+#if !defined(__NVCC__)
 FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN
+#endif
 template <bool AllActive, typename C, MetricType M>
 static inline void prune_kernel(
         float* FAISS_RESTRICT exact_distances,
@@ -128,7 +137,9 @@ static inline void prune_kernel(
         }
     }
 }
+#if !defined(__NVCC__)
 FAISS_PRAGMA_IMPRECISE_FUNCTION_END
+#endif
 
 /// Compact active_indices in-place, removing entries where active_byteset[i]
 /// is zero. Returns the new count of active elements. Uses a branchless BMI2 +


### PR DESCRIPTION
Summary:
## THIS DIFF

Wrap the four `FAISS_PRAGMA_IMPRECISE_FUNCTION_BEGIN` / `_END` callsites in `faiss/impl/Panorama.h` with `#if !defined(__NVCC__)` so the GCC `#pragma GCC optimize(...)` they expand to is skipped when nvcc's frontend parses translation units that transitively include this header.

## CONTEXT

When nvcc (EDG-based frontend) parses `.cu` files that transitively include `faiss/impl/Panorama.h`, it emits warning #1675-D for each `#pragma GCC optimize(...)` it does not recognize. We saw ~16 of these per `.cu` file in the faiss-gpu pip wheel build, all originating from `Panorama.h:39` (`compute_level_dot_kernel`) and `Panorama.h:95` (`prune_kernel`). The pragmas guide GCC's host-side autovectorization for those templates and are not relevant to nvcc's device-code generation, since the templates are CPU-only and never instantiated on the GPU side.

Skipping the pragmas under `__NVCC__` is safe:
1. nvcc defines `__NVCC__` during both its device pass and its host pass. The pragmas are skipped for both. The wrapped templates are only instantiated by CPU translation units (compiled by gcc directly, without nvcc), so the optimization hint is still applied where it matters.
2. Localizing the guard to `Panorama.h` instead of `platform_macros.h` keeps the shared macro definition untouched for everyone else. `Panorama.h` is the only header observed to trigger this warning in the current GPU build path; other `FAISS_PRAGMA_IMPRECISE_*` users (`kernels_simd512.h`, `distances_autovec-inl.h`, `distances_arm_sve.cpp`) are not transitively included by any `.cu` file.

No functional change for CPU builds. Eliminates the warning noise in the GPU build and improves log readability for the faiss-gpu wheel CI on D97507525.

## PLAN

Land this diff first. D97507525 (`[faiss] Add faiss-gpu pip wheel packaging`) is stacked on top and will pick up the fix automatically.

Differential Revision: D106398648


