### PR TITLE
Fix #5226 build: avoid HNSW::C shadow in shrink_neighbor_list template

### DIFF
--- a/benchs/bench_visited_table.cpp
+++ b/benchs/bench_visited_table.cpp
@@ -29,7 +29,8 @@ void bench_visited_table(benchmark::State& state) {
         total_queries += nq;
 #pragma omp parallel
         {
-            VisitedTable vt(ntotal, use_hashset);
+            std::unique_ptr<VisitedTable> vt =
+                    VisitedTable::create(ntotal, use_hashset);
 
 #pragma omp for schedule(static)
             for (size_t q0 = 0; q0 < nq; q0 += batch_size) {
@@ -40,18 +41,18 @@ void bench_visited_table(benchmark::State& state) {
                     size_t added = 0;
                     for (int i = 0; i < ndis; ++i) {
                         auto id = randId(rng1);
-                        added += vt.set(id);
+                        added += vt->set(id);
                     }
                     size_t other_visited = 0;
                     for (int i = 0; i < ndis; ++i) {
                         auto id = randId(rng2);
-                        other_visited += vt.get(randId(rng1));
-                        auto r = vt.get(id);
+                        other_visited += vt->get(randId(rng1));
+                        auto r = vt->get(id);
                         FAISS_ASSERT(r);
-                        other_visited += vt.get(randId(rng1));
+                        other_visited += vt->get(randId(rng1));
                     }
                     benchmark::DoNotOptimize(other_visited + added);
-                    vt.advance();
+                    vt->advance();
                 }
             }
         }

--- a/faiss/IndexBinaryHNSW.cpp
+++ b/faiss/IndexBinaryHNSW.cpp
@@ -129,7 +129,7 @@ void hnsw_add_vertices(
 
 #pragma omp parallel
             {
-                VisitedTable vt(ntotal);
+                std::unique_ptr<VisitedTable> vt = VisitedTable::create(ntotal);
 
                 std::unique_ptr<DistanceComputer> dis(
                         index_hnsw.get_distance_computer());
@@ -147,7 +147,7 @@ void hnsw_add_vertices(
                             pt_level,
                             pt_id,
                             locks,
-                            vt,
+                            *vt,
                             index_hnsw.keep_max_size_level0 && (pt_level == 0));
 
                     if (do_display && i - i0 > prev_display + 10000) {
@@ -237,7 +237,7 @@ void IndexBinaryHNSW::search(
 
 #pragma omp parallel
     {
-        VisitedTable vt(ntotal);
+        std::unique_ptr<VisitedTable> vt = VisitedTable::create(ntotal);
         std::unique_ptr<DistanceComputer> dis(get_distance_computer());
         RH::SingleResultHandler res(bres);
 
@@ -249,7 +249,7 @@ void IndexBinaryHNSW::search(
             // as the index parameter. This state does not get used in the
             // search function, as it is merely there to enable Panorama
             // execution for IndexHNSWFlatPanorama.
-            HNSWStats stats = hnsw.search(*dis, nullptr, res, vt, params_in);
+            HNSWStats stats = hnsw.search(*dis, nullptr, res, *vt, params_in);
             n1 += stats.n1;
             n2 += stats.n2;
             ndis += stats.ndis;
@@ -377,7 +377,7 @@ void IndexBinaryHNSWCagra::search(
 
 #pragma omp parallel
         {
-            VisitedTable vt(ntotal);
+            std::unique_ptr<VisitedTable> vt = VisitedTable::create(ntotal);
             std::unique_ptr<DistanceComputer> dis(get_distance_computer());
             HNSWStats search_stats;
             RH::SingleResultHandler res(bres);
@@ -395,7 +395,7 @@ void IndexBinaryHNSWCagra::search(
                         &nearest_d[i],
                         1, // search_type
                         search_stats,
-                        vt,
+                        *vt,
                         params);
 
                 res.end();

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -145,7 +145,8 @@ void hnsw_add_vertices(
 
 #pragma omp parallel if (i1 > i0 + 100)
             {
-                VisitedTable vt(ntotal, hnsw.use_visited_hashset);
+                std::unique_ptr<VisitedTable> vt =
+                        VisitedTable::create(ntotal, hnsw.use_visited_hashset);
 
                 std::unique_ptr<DistanceComputer> dis(
                         storage_distance_computer(index_hnsw.storage));
@@ -171,7 +172,7 @@ void hnsw_add_vertices(
                             pt_level,
                             pt_id,
                             locks,
-                            vt,
+                            *vt,
                             index_hnsw.keep_max_size_level0 && (pt_level == 0));
 
                     if (do_display && i - i0 > prev_display + 10000) {
@@ -276,7 +277,7 @@ void hnsw_search(
                     res;
             std::unique_ptr<DistanceComputer> dis;
             try {
-                vt = std::make_unique<VisitedTable>(
+                vt = VisitedTable::create(
                         index->ntotal, hnsw.use_visited_hashset);
                 res = std::make_unique<
                         typename BlockResultHandler::SingleResultHandler>(bres);
@@ -472,8 +473,7 @@ void IndexHNSW::search_level_0(
         std::unique_ptr<RH::SingleResultHandler> res;
         try {
             qdis.reset(storage_distance_computer(storage));
-            vt = std::make_unique<VisitedTable>(
-                    hnsw_ntotal, hnsw.use_visited_hashset);
+            vt = VisitedTable::create(hnsw_ntotal, hnsw.use_visited_hashset);
             res = std::make_unique<RH::SingleResultHandler>(bres);
         } catch (...) {
             omp_capture_exception(ex, [&] { interrupt = true; });
@@ -569,7 +569,8 @@ void IndexHNSW::init_level_0_from_entry_points(
 
 #pragma omp parallel
     {
-        VisitedTable vt(ntotal, hnsw.use_visited_hashset);
+        std::unique_ptr<VisitedTable> vt =
+                VisitedTable::create(ntotal, hnsw.use_visited_hashset);
 
         std::unique_ptr<DistanceComputer> dis(
                 storage_distance_computer(storage));
@@ -583,7 +584,7 @@ void IndexHNSW::init_level_0_from_entry_points(
             dis->set_query(vec.data());
 
             hnsw.add_links_starting_from(
-                    *dis, pt_id, nearest, (*dis)(nearest), 0, locks, vt);
+                    *dis, pt_id, nearest, (*dis)(nearest), 0, locks, *vt);
 
             if (verbose && i % 10000 == 0) {
                 printf("  %d / %d\r", i, n);
@@ -824,7 +825,7 @@ int search_from_candidates_2(
         idx_t* I,
         float* D,
         MinimaxHeap& candidates,
-        VisitedTable& vt,
+        VisitedTableVector& vt,
         HNSWStats& stats,
         int level,
         int nres_in = 0) {
@@ -934,8 +935,7 @@ void IndexHNSW2Level::search(
             constexpr int candidates_size = 1;
             std::unique_ptr<MinimaxHeap> candidates;
             try {
-                vt = std::make_unique<VisitedTable>(
-                        ntotal, /*use_hashset=*/false);
+                vt = VisitedTable::create(ntotal, /*use_hashset=*/false);
                 dis.reset(storage_distance_computer(storage));
                 candidates = std::make_unique<MinimaxHeap>(candidates_size);
             } catch (...) {
@@ -987,7 +987,7 @@ void IndexHNSW2Level::search(
                             idxi,
                             simi,
                             *candidates,
-                            *vt,
+                            static_cast<VisitedTableVector&>(*vt),
                             search_stats,
                             0,
                             k);
@@ -1180,10 +1180,11 @@ void IndexHNSWCagra::range_search(
 
         RangeQueryResult& qres = pres.new_result(i);
         RangeResultHandler<HNSW::C> res(&qres, threshold);
-        VisitedTable vt(ntotal, hnsw.use_visited_hashset);
+        std::unique_ptr<VisitedTable> vt =
+                VisitedTable::create(ntotal, hnsw.use_visited_hashset);
         HNSWStats stats;
         hnsw.search_level_0(
-                *dis, res, 1, &nearest, &nearest_d, 1, stats, vt, params);
+                *dis, res, 1, &nearest, &nearest_d, 1, stats, *vt, params);
         n1 += stats.n1;
         n2 += stats.n2;
         ndis += stats.ndis;

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -47,12 +47,17 @@ HNSWStats hnsw_stats;
 
 namespace {
 
+// Returns the storage's native distance computer. For similarity metrics
+// (e.g. METRIC_INNER_PRODUCT), distance values are real similarity scores
+// (larger = better); HNSW handles the ordering via `hnsw.is_similarity`.
+//
+// NOTE: callers that drive the legacy max-heap-only code paths (notably
+// `search_from_candidates_2` in the IndexHNSW2Level mixed search) cannot
+// consume similarity scores directly; they assume smaller-is-better.
+// Those paths only fire for the (default) L2 IndexHNSW2Level + Index2Layer
+// configuration today, so passing the native DC is safe in practice.
 DistanceComputer* storage_distance_computer(const Index* storage) {
-    if (is_similarity_metric(storage->metric_type)) {
-        return new NegativeDistanceComputer(storage->get_distance_computer());
-    } else {
-        return storage->get_distance_computer();
-    }
+    return storage->get_distance_computer();
 }
 
 void hnsw_add_vertices(
@@ -214,13 +219,16 @@ void hnsw_add_vertices(
  **************************************************************/
 
 IndexHNSW::IndexHNSW(int d_in, int M, MetricType metric)
-        : Index(d_in, metric), hnsw(M) {}
+        : Index(d_in, metric), hnsw(M) {
+    hnsw.is_similarity = is_similarity_metric(metric);
+}
 
 IndexHNSW::IndexHNSW(Index* storage_in, int M)
         : Index(storage_in->d, storage_in->metric_type),
           hnsw(M),
           storage(storage_in) {
     metric_arg = storage->metric_arg;
+    hnsw.is_similarity = is_similarity_metric(metric_type);
 }
 
 IndexHNSW::~IndexHNSW() {
@@ -326,16 +334,14 @@ void IndexHNSW::search(
         const SearchParameters* params) const {
     FAISS_THROW_IF_NOT(k > 0);
 
-    using RH = HeapBlockResultHandler<HNSW::C>;
-    RH bres(n, distances, labels, k);
-
-    hnsw_search(this, n, x, bres, params);
-
     if (is_similarity_metric(this->metric_type)) {
-        // we need to revert the negated distances
-        for (idx_t i = 0; i < k * n; i++) {
-            distances[i] = -distances[i];
-        }
+        using RH = HeapBlockResultHandler<HNSW::C_similarity>;
+        RH bres(n, distances, labels, k);
+        hnsw_search(this, n, x, bres, params);
+    } else {
+        using RH = HeapBlockResultHandler<HNSW::C_distance>;
+        RH bres(n, distances, labels, k);
+        hnsw_search(this, n, x, bres, params);
     }
 }
 
@@ -345,16 +351,14 @@ void IndexHNSW::range_search(
         float radius,
         RangeSearchResult* result,
         const SearchParameters* params) const {
-    using RH = RangeSearchBlockResultHandler<HNSW::C>;
-    RH bres(result, is_similarity_metric(metric_type) ? -radius : radius);
-
-    hnsw_search(this, n, x, bres, params);
-
-    if (is_similarity_metric(this->metric_type)) {
-        // we need to revert the negated distances
-        for (size_t i = 0; i < result->lims[result->nq]; i++) {
-            result->distances[i] = -result->distances[i];
-        }
+    if (is_similarity_metric(metric_type)) {
+        using RH = RangeSearchBlockResultHandler<HNSW::C_similarity>;
+        RH bres(result, radius);
+        hnsw_search(this, n, x, bres, params);
+    } else {
+        using RH = RangeSearchBlockResultHandler<HNSW::C_distance>;
+        RH bres(result, radius);
+        hnsw_search(this, n, x, bres, params);
     }
 }
 
@@ -362,8 +366,13 @@ void IndexHNSW::search1(
         const float* x,
         ResultHandler& handler,
         SearchParameters* params) const {
-    SingleQueryBlockResultHandler<HNSW::C, false> bres(handler);
-    hnsw_search(this, 1, x, bres, params);
+    if (is_similarity_metric(metric_type)) {
+        SingleQueryBlockResultHandler<HNSW::C_similarity, false> bres(handler);
+        hnsw_search(this, 1, x, bres, params);
+    } else {
+        SingleQueryBlockResultHandler<HNSW::C_distance, false> bres(handler);
+        hnsw_search(this, 1, x, bres, params);
+    }
 }
 
 void IndexHNSW::add(idx_t n, const float* x) {
@@ -460,62 +469,64 @@ void IndexHNSW::search_level_0(
 
     size_t hnsw_ntotal = hnsw.levels.size();
 
-    using RH = HeapBlockResultHandler<HNSW::C>;
-    RH bres(n, distances, labels, k);
+    auto run = [&]<class C>() {
+        using RH = HeapBlockResultHandler<C>;
+        RH bres(n, distances, labels, k);
 
-    std::exception_ptr ex;
-    std::atomic<bool> interrupt{false};
+        std::exception_ptr ex;
+        std::atomic<bool> interrupt{false};
 #pragma omp parallel
-    {
-        std::unique_ptr<DistanceComputer> qdis;
-        HNSWStats search_stats;
-        std::unique_ptr<VisitedTable> vt;
-        std::unique_ptr<RH::SingleResultHandler> res;
-        try {
-            qdis.reset(storage_distance_computer(storage));
-            vt = VisitedTable::create(hnsw_ntotal, hnsw.use_visited_hashset);
-            res = std::make_unique<RH::SingleResultHandler>(bres);
-        } catch (...) {
-            omp_capture_exception(ex, [&] { interrupt = true; });
-        }
-
-#pragma omp for
-        for (idx_t i = 0; i < n; i++) {
-            if (interrupt.load(std::memory_order_relaxed)) {
-                continue;
-            }
+        {
+            std::unique_ptr<DistanceComputer> qdis;
+            HNSWStats search_stats;
+            std::unique_ptr<VisitedTable> vt;
+            std::unique_ptr<typename RH::SingleResultHandler> res;
             try {
-                res->begin(i);
-                qdis->set_query(x + i * d);
-
-                hnsw.search_level_0(
-                        *qdis.get(),
-                        *res,
-                        nprobe,
-                        nearest + i * nprobe,
-                        nearest_d + i * nprobe,
-                        search_type,
-                        search_stats,
-                        *vt,
-                        params);
-                res->end();
-                vt->advance();
+                qdis.reset(storage_distance_computer(storage));
+                vt = VisitedTable::create(
+                        hnsw_ntotal, hnsw.use_visited_hashset);
+                res = std::make_unique<typename RH::SingleResultHandler>(bres);
             } catch (...) {
                 omp_capture_exception(ex, [&] { interrupt = true; });
             }
-        }
+
+#pragma omp for
+            for (idx_t i = 0; i < n; i++) {
+                if (interrupt.load(std::memory_order_relaxed)) {
+                    continue;
+                }
+                try {
+                    res->begin(i);
+                    qdis->set_query(x + i * d);
+
+                    hnsw.search_level_0(
+                            *qdis.get(),
+                            *res,
+                            nprobe,
+                            nearest + i * nprobe,
+                            nearest_d + i * nprobe,
+                            search_type,
+                            search_stats,
+                            *vt,
+                            params);
+                    res->end();
+                    vt->advance();
+                } catch (...) {
+                    omp_capture_exception(ex, [&] { interrupt = true; });
+                }
+            }
 #pragma omp critical
-        {
-            hnsw_stats.combine(search_stats);
+            {
+                hnsw_stats.combine(search_stats);
+            }
         }
-    }
-    omp_rethrow_if_exception(ex);
+        omp_rethrow_if_exception(ex);
+    };
+
     if (is_similarity_metric(this->metric_type)) {
-// we need to revert the negated distances
-#pragma omp parallel for
-        for (int64_t i = 0; i < k * n; i++) {
-            distances[i] = -distances[i];
-        }
+        run.template operator()<HNSW::C_similarity>();
+    } else {
+        run.template operator()<HNSW::C_distance>();
     }
 }
 
@@ -1101,28 +1112,40 @@ void IndexHNSWCagra::search(
         std::vector<storage_idx_t> nearest(n);
         std::vector<float> nearest_d(n);
 
+        auto pick_entrypoints = [&]<class C>() {
 #pragma omp parallel for
-        for (idx_t i = 0; i < n; i++) {
-            std::unique_ptr<DistanceComputer> dis(
-                    storage_distance_computer(this->storage));
-            dis->set_query(x + i * d);
-            nearest[i] = -1;
-            nearest_d[i] = std::numeric_limits<float>::max();
+            for (idx_t i = 0; i < n; i++) {
+                std::unique_ptr<DistanceComputer> dis(
+                        storage_distance_computer(this->storage));
+                dis->set_query(x + i * d);
+                nearest[i] = -1;
+                // C::neutral() is the "worst possible" value: +inf for
+                // CMax (distance) and -inf for CMin (similarity). The
+                // first real candidate will always be strictly better.
+                nearest_d[i] = C::neutral();
 
-            std::random_device rd;
-            std::mt19937 gen(rd());
-            std::uniform_int_distribution<idx_t> distrib(0, this->ntotal - 1);
+                std::random_device rd;
+                std::mt19937 gen(rd());
+                std::uniform_int_distribution<idx_t> distrib(
+                        0, this->ntotal - 1);
 
-            for (idx_t j = 0; j < num_base_level_search_entrypoints; j++) {
-                auto idx = distrib(gen);
-                auto distance = (*dis)(idx);
-                if (distance < nearest_d[i]) {
-                    nearest[i] = static_cast<storage_idx_t>(idx);
-                    nearest_d[i] = distance;
+                for (idx_t j = 0; j < num_base_level_search_entrypoints; j++) {
+                    auto idx = distrib(gen);
+                    auto distance = (*dis)(idx);
+                    if (C::cmp(nearest_d[i], distance)) {
+                        nearest[i] = static_cast<storage_idx_t>(idx);
+                        nearest_d[i] = distance;
+                    }
                 }
+                FAISS_THROW_IF_NOT_MSG(
+                        nearest[i] >= 0, "Could not find a valid entrypoint.");
             }
-            FAISS_THROW_IF_NOT_MSG(
-                    nearest[i] >= 0, "Could not find a valid entrypoint.");
+        };
+
+        if (is_similarity_metric(metric_type)) {
+            pick_entrypoints.template operator()<HNSW::C_similarity>();
+        } else {
+            pick_entrypoints.template operator()<HNSW::C_distance>();
         }
 
         search_level_0(
@@ -1150,57 +1173,63 @@ void IndexHNSWCagra::range_search(
         return;
     }
 
-    const HNSW& hnsw = this->hnsw;
-    size_t n1 = 0, n2 = 0, ndis = 0, nhops = 0;
-    float threshold = is_similarity_metric(metric_type) ? -radius : radius;
-    RangeSearchPartialResult pres(result);
+    auto run = [&]<class C>() {
+        const HNSW& hnsw = this->hnsw;
+        size_t n1 = 0, n2 = 0, ndis = 0, nhops = 0;
+        RangeSearchPartialResult pres(result);
 
-    for (idx_t i = 0; i < n; i++) {
-        std::unique_ptr<DistanceComputer> dis(
-                storage_distance_computer(storage));
-        dis->set_query(x + i * d);
+        for (idx_t i = 0; i < n; i++) {
+            std::unique_ptr<DistanceComputer> dis(
+                    storage_distance_computer(storage));
+            dis->set_query(x + i * d);
 
-        storage_idx_t nearest = -1;
-        float nearest_d = std::numeric_limits<float>::max();
+            storage_idx_t nearest = -1;
+            // C::neutral() is the "worst possible" value under C: +inf for
+            // CMax (distance) and -inf for CMin (similarity). The first
+            // real candidate will always be strictly better.
+            float nearest_d = C::neutral();
 
-        std::random_device rd;
-        std::mt19937 gen(rd());
-        std::uniform_int_distribution<idx_t> distrib(0, ntotal - 1);
+            std::random_device rd;
+            std::mt19937 gen(rd());
+            std::uniform_int_distribution<idx_t> distrib(0, ntotal - 1);
 
-        for (idx_t j = 0; j < num_base_level_search_entrypoints; j++) {
-            auto idx = distrib(gen);
-            auto distance = (*dis)(idx);
-            if (distance < nearest_d) {
-                nearest = idx;
-                nearest_d = distance;
+            for (idx_t j = 0; j < num_base_level_search_entrypoints; j++) {
+                auto idx = distrib(gen);
+                auto distance = (*dis)(idx);
+                // C::cmp(nearest_d, distance) is true iff distance is
+                // strictly better than the current nearest_d.
+                if (C::cmp(nearest_d, distance)) {
+                    nearest = idx;
+                    nearest_d = distance;
+                }
             }
+            FAISS_THROW_IF_NOT_MSG(
+                    nearest >= 0, "Could not find a valid entrypoint.");
+
+            RangeQueryResult& qres = pres.new_result(i);
+            RangeResultHandler<C> res(&qres, radius);
+            std::unique_ptr<VisitedTable> vt =
+                    VisitedTable::create(ntotal, hnsw.use_visited_hashset);
+            HNSWStats stats;
+            hnsw.search_level_0(
+                    *dis, res, 1, &nearest, &nearest_d, 1, stats, *vt, params);
+            n1 += stats.n1;
+            n2 += stats.n2;
+            ndis += stats.ndis;
+            nhops += stats.nhops;
         }
-        FAISS_THROW_IF_NOT_MSG(
-                nearest >= 0, "Could not find a valid entrypoint.");
 
-        RangeQueryResult& qres = pres.new_result(i);
-        RangeResultHandler<HNSW::C> res(&qres, threshold);
-        std::unique_ptr<VisitedTable> vt =
-                VisitedTable::create(ntotal, hnsw.use_visited_hashset);
-        HNSWStats stats;
-        hnsw.search_level_0(
-                *dis, res, 1, &nearest, &nearest_d, 1, stats, *vt, params);
-        n1 += stats.n1;
-        n2 += stats.n2;
-        ndis += stats.ndis;
-        nhops += stats.nhops;
-    }
+        pres.set_lims();
+        result->do_allocation();
+        pres.copy_result();
 
-    pres.set_lims();
-    result->do_allocation();
-    pres.copy_result();
-
-    hnsw_stats.combine({n1, n2, ndis, nhops});
+        hnsw_stats.combine({n1, n2, ndis, nhops});
+    };
 
     if (is_similarity_metric(metric_type)) {
-        for (size_t i = 0; i < result->lims[result->nq]; i++) {
-            result->distances[i] = -result->distances[i];
-        }
+        run.template operator()<HNSW::C_similarity>();
+    } else {
+        run.template operator()<HNSW::C_distance>();
     }
 }
 

--- a/faiss/IndexNNDescent.cpp
+++ b/faiss/IndexNNDescent.cpp
@@ -126,7 +126,7 @@ void IndexNNDescent::search(
             std::unique_ptr<DistanceComputer> dis;
             std::unique_ptr<VisitedTable> vt;
             try {
-                vt = std::make_unique<VisitedTable>(ntotal);
+                vt = VisitedTable::create(ntotal);
                 dis.reset(storage_distance_computer(storage));
             } catch (...) {
                 omp_capture_exception(ex, [&] { interrupt = true; });

--- a/faiss/IndexNSG.cpp
+++ b/faiss/IndexNSG.cpp
@@ -81,8 +81,7 @@ void IndexNSG::search(
             std::unique_ptr<DistanceComputer> dis;
             std::unique_ptr<VisitedTable> vt;
             try {
-                vt = std::make_unique<VisitedTable>(
-                        ntotal, nsg.use_visited_hashset);
+                vt = VisitedTable::create(ntotal, nsg.use_visited_hashset);
                 dis.reset(storage_distance_computer(storage));
             } catch (...) {
                 omp_capture_exception(ex, [&] { interrupt = true; });

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -234,32 +234,34 @@ int HNSW::prepare_level_tab(size_t n, bool preset_levels) {
  * neighbor only if there is no previous neighbor that is closer to
  * that vertex than the query.
  */
-template <class C>
+// Template parameter must not be named `C`: HNSW has a member `using C =
+// C_distance` that would shadow it during parameter-list lookup here.
+template <class Comp>
 void HNSW::shrink_neighbor_list(
         DistanceComputer& qdis,
-        std::priority_queue<NodeDistFartherT<C>>& input,
-        std::vector<NodeDistFartherT<C>>& output,
+        std::priority_queue<NodeDistFartherT<Comp>>& input,
+        std::vector<NodeDistFartherT<Comp>>& output,
         size_t max_size,
         bool keep_max_size_level0) {
     // This prevents number of neighbors at
     // level 0 from being shrunk to less than 2 * M.
     // This is essential in making sure
     // `faiss::gpu::GpuIndexCagra::copyFrom(IndexHNSWCagra*)` is functional
-    std::vector<NodeDistFartherT<C>> outsiders;
+    std::vector<NodeDistFartherT<Comp>> outsiders;
 
     while (input.size() > 0) {
-        NodeDistFartherT<C> v1 = input.top();
+        NodeDistFartherT<Comp> v1 = input.top();
         input.pop();
         float dist_v1_q = v1.d;
 
         bool good = true;
-        for (NodeDistFartherT<C> v2 : output) {
+        for (NodeDistFartherT<Comp> v2 : output) {
             float dist_v1_v2 = qdis.symmetric_dis(v2.id, v1.id);
 
             // "v1 is bad" if some previously-kept neighbor v2 is closer
             // (more similar, under CMin) to v1 than the query is. Encoded
-            // generically as: v1v2 is "better than" v1q under C.
-            if (C::cmp(dist_v1_q, dist_v1_v2)) {
+            // generically as: v1v2 is "better than" v1q under Comp.
+            if (Comp::cmp(dist_v1_q, dist_v1_v2)) {
                 good = false;
                 break;
             }

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -362,31 +362,34 @@ void add_link(
     }
 }
 
-} // namespace
-
-/// search neighbors on a single level, starting from an entry point
-void search_neighbors_to_add(
+/** Templated body of `search_neighbors_to_add` — instantiated once per final
+ * VisitedTable subclass so that `vt.set/advance` are inlined and the cost of
+ * virtual dispatch is paid only once at the top of the call.
+ */
+template <typename VTType>
+static void search_neighbors_to_add_fixVT(
         HNSW& hnsw,
         DistanceComputer& qdis,
-        std::priority_queue<NodeDistCloser>& results,
+        std::priority_queue<HNSW::NodeDistCloser>& results,
         int entry_point,
         float d_entry_point,
         int level,
-        VisitedTable& vt,
+        VTType& vt,
         bool reference_version) {
+    using C = HNSW::C;
     // top is nearest candidate
-    std::priority_queue<NodeDistFarther> candidates;
+    std::priority_queue<HNSW::NodeDistFarther> candidates;
 
-    NodeDistFarther ev(d_entry_point, entry_point);
+    HNSW::NodeDistFarther ev(d_entry_point, entry_point);
     candidates.push(ev);
     results.emplace(d_entry_point, entry_point);
     vt.set(entry_point);
 
     while (!candidates.empty()) {
         // get nearest
-        const NodeDistFarther& currEv = candidates.top();
+        const HNSW::NodeDistFarther& currEv = candidates.top();
 
-        if (currEv.d > results.top().d) {
+        if (C::cmp(currEv.d, results.top().d)) {
             break;
         }
         int currNode = currEv.id;
@@ -407,7 +410,7 @@ void search_neighbors_to_add(
         if (reference_version) {
             // a reference version
             for (size_t i = begin; i < end; i++) {
-                storage_idx_t nodeId = hnsw.neighbors[i];
+                HNSW::storage_idx_t nodeId = hnsw.neighbors[i];
                 if (nodeId < 0) {
                     break;
                 }
@@ -416,10 +419,10 @@ void search_neighbors_to_add(
                 }
 
                 float dis = qdis(nodeId);
-                NodeDistFarther evE1(dis, nodeId);
+                HNSW::NodeDistFarther evE1(dis, nodeId);
 
                 if (results.size() < static_cast<size_t>(hnsw.efConstruction) ||
-                    results.top().d > dis) {
+                    C::cmp(results.top().d, dis)) {
                     results.emplace(dis, nodeId);
                     candidates.emplace(dis, nodeId);
                     if (results.size() >
@@ -432,10 +435,10 @@ void search_neighbors_to_add(
             // a faster version
 
             // the following version processes 4 neighbors at a time
-            auto update_with_candidate = [&](const storage_idx_t idx,
+            auto update_with_candidate = [&](const HNSW::storage_idx_t idx,
                                              const float dis) {
                 if (results.size() < static_cast<size_t>(hnsw.efConstruction) ||
-                    results.top().d > dis) {
+                    C::cmp(results.top().d, dis)) {
                     results.emplace(dis, idx);
                     candidates.emplace(dis, idx);
                     if (results.size() >
@@ -446,10 +449,10 @@ void search_neighbors_to_add(
             };
 
             int n_buffered = 0;
-            storage_idx_t buffered_ids[4];
+            HNSW::storage_idx_t buffered_ids[4];
 
             for (size_t j = begin; j < end; j++) {
-                storage_idx_t nodeId = hnsw.neighbors[j];
+                HNSW::storage_idx_t nodeId = hnsw.neighbors[j];
                 if (nodeId < 0) {
                     break;
                 }
@@ -491,6 +494,40 @@ void search_neighbors_to_add(
     vt.advance();
 }
 
+} // namespace
+
+/// search neighbors on a single level, starting from an entry point.
+/// Routes to the appropriate templated instantiation based on the concrete
+/// type of `vt`.
+void hnsw_detail::search_neighbors_to_add(
+        HNSW& hnsw,
+        DistanceComputer& qdis,
+        std::priority_queue<NodeDistCloser>& results,
+        int entry_point,
+        float d_entry_point,
+        int level,
+        VisitedTable& vt,
+        bool reference_version) {
+    auto call = [&]<typename VTType>(VTType& vt_concrete) {
+        search_neighbors_to_add_fixVT(
+                hnsw,
+                qdis,
+                results,
+                entry_point,
+                d_entry_point,
+                level,
+                vt_concrete,
+                reference_version);
+    };
+
+    if (VisitedTableVector* vtv = dynamic_cast<VisitedTableVector*>(&vt)) {
+        call(*vtv);
+        return;
+    }
+    VisitedTableSet& vts = dynamic_cast<VisitedTableSet&>(vt);
+    call(vts);
+}
+
 /// Finds neighbors and builds links with them, starting from an entry
 /// point. The own neighbor list is assumed to be locked.
 void HNSW::add_links_starting_from(
@@ -504,7 +541,7 @@ void HNSW::add_links_starting_from(
         bool keep_max_size_level0) {
     std::priority_queue<NodeDistCloser> link_targets;
 
-    search_neighbors_to_add(
+    hnsw_detail::search_neighbors_to_add(
             *this, ptdis, link_targets, nearest, d_nearest, level, vt);
 
     // but we can afford only this many neighbors
@@ -565,7 +602,8 @@ void HNSW::add_with_locks(
 
     //  greedy search on upper levels
     for (; level > pt_level; level--) {
-        greedy_update_nearest(*this, ptdis, level, nearest, d_nearest);
+        hnsw_detail::greedy_update_nearest(
+                *this, ptdis, level, nearest, d_nearest);
     }
 
     for (; level >= 0; level--) {
@@ -619,13 +657,17 @@ static inline void extract_search_params(
     }
 }
 
-/** Do a BFS on the candidates list */
-int search_from_candidates(
+/** Templated body of `search_from_candidates` — instantiated once per final
+ * VisitedTable subclass so that `vt.set/get/prefetch` are inlined and the cost
+ * of virtual dispatch is paid only once at the top of the call.
+ */
+template <typename VTType>
+static int search_from_candidates_fixVT(
         const HNSW& hnsw,
         DistanceComputer& qdis,
         ResultHandler& res,
         MinimaxHeap& candidates,
-        VisitedTable& vt,
+        VTType& vt,
         HNSWStats& stats,
         int level,
         int nres_in,
@@ -644,7 +686,7 @@ int search_from_candidates(
         float d = candidates.dis[i];
         FAISS_ASSERT(v1 >= 0);
         if (!sel || sel->is_member(v1)) {
-            if (d < threshold) {
+            if (C::cmp(threshold, d)) {
                 if (res.add_result(d, v1)) {
                     threshold = res.threshold;
                 }
@@ -693,7 +735,7 @@ int search_from_candidates(
 
         auto add_to_heap = [&](const size_t idx, const float dis) {
             if (!sel || sel->is_member(idx)) {
-                if (dis < threshold) {
+                if (C::cmp(threshold, dis)) {
                     if (res.add_result(dis, idx)) {
                         threshold = res.threshold;
                         nres += 1;
@@ -756,7 +798,39 @@ int search_from_candidates(
     return nres;
 }
 
-int search_from_candidates_panorama(
+/** Do a BFS on the candidates list. Routes to the appropriate templated
+ *  instantiation based on the concrete type of `vt`. */
+int hnsw_detail::search_from_candidates(
+        const HNSW& hnsw,
+        DistanceComputer& qdis,
+        ResultHandler& res,
+        MinimaxHeap& candidates,
+        VisitedTable& vt,
+        HNSWStats& stats,
+        int level,
+        int nres_in,
+        const SearchParameters* params) {
+    auto call = [&]<typename VTType>(VTType& vt_concrete) -> int {
+        return search_from_candidates_fixVT(
+                hnsw,
+                qdis,
+                res,
+                candidates,
+                vt_concrete,
+                stats,
+                level,
+                nres_in,
+                params);
+    };
+
+    if (VisitedTableVector* vtv = dynamic_cast<VisitedTableVector*>(&vt)) {
+        return call(*vtv);
+    }
+    VisitedTableSet& vts = dynamic_cast<VisitedTableSet&>(vt);
+    return call(vts);
+}
+
+int hnsw_detail::search_from_candidates_panorama(
         const HNSW& hnsw,
         const IndexHNSW* index,
         DistanceComputer& qdis,
@@ -781,7 +855,7 @@ int search_from_candidates_panorama(
         float d = candidates.dis[i];
         FAISS_ASSERT(v1 >= 0);
         if (!sel || sel->is_member(v1)) {
-            if (d < threshold) {
+            if (C::cmp(threshold, d)) {
                 if (res.add_result(d, v1)) {
                     threshold = res.threshold;
                 }
@@ -917,28 +991,28 @@ int search_from_candidates_panorama(
                 // the maintenance of the candidate heap), but micro-benchmarks
                 // have shown that it is not worth it to write horrible code to
                 // squeeze out those cycles.
-                if (lower_bound_0 <= threshold) {
+                if (!C::cmp(lower_bound_0, threshold)) {
                     exact_distances[next_batch_size] = new_exact_0;
                     index_array[next_batch_size] = idx_0;
                     next_batch_size += 1;
                 } else {
                     candidates.push(idx_0, new_exact_0);
                 }
-                if (lower_bound_1 <= threshold) {
+                if (!C::cmp(lower_bound_1, threshold)) {
                     exact_distances[next_batch_size] = new_exact_1;
                     index_array[next_batch_size] = idx_1;
                     next_batch_size += 1;
                 } else {
                     candidates.push(idx_1, new_exact_1);
                 }
-                if (lower_bound_2 <= threshold) {
+                if (!C::cmp(lower_bound_2, threshold)) {
                     exact_distances[next_batch_size] = new_exact_2;
                     index_array[next_batch_size] = idx_2;
                     next_batch_size += 1;
                 } else {
                     candidates.push(idx_2, new_exact_2);
                 }
-                if (lower_bound_3 <= threshold) {
+                if (!C::cmp(lower_bound_3, threshold)) {
                     exact_distances[next_batch_size] = new_exact_3;
                     index_array[next_batch_size] = idx_3;
                     next_batch_size += 1;
@@ -961,7 +1035,7 @@ int search_from_candidates_panorama(
                 float cs_bound = 2.0f * cum_sum * query_cum_norm;
                 float lower_bound = new_exact - cs_bound;
 
-                if (lower_bound <= threshold) {
+                if (!C::cmp(lower_bound, threshold)) {
                     exact_distances[next_batch_size] = new_exact;
                     index_array[next_batch_size] = idx;
                     next_batch_size += 1;
@@ -1017,7 +1091,7 @@ void reservePriorityQueue(
     q = std::move(access);
 }
 
-std::priority_queue<HNSW::Node> search_from_candidate_unbounded(
+std::priority_queue<HNSW::Node> hnsw_detail::search_from_candidate_unbounded(
         const HNSW& hnsw,
         const Node& node,
         DistanceComputer& qdis,
@@ -1041,7 +1115,7 @@ std::priority_queue<HNSW::Node> search_from_candidate_unbounded(
         storage_idx_t v0;
         std::tie(d0, v0) = candidates.top();
 
-        if (d0 > top_candidates.top().first) {
+        if (C::cmp(d0, top_candidates.top().first)) {
             break;
         }
 
@@ -1067,7 +1141,7 @@ std::priority_queue<HNSW::Node> search_from_candidate_unbounded(
         size_t saved_j[4];
 
         auto add_to_heap = [&](const size_t idx, const float dis) {
-            if (top_candidates.top().first > dis ||
+            if (C::cmp(top_candidates.top().first, dis) ||
                 top_candidates.size() < ef) {
                 candidates.emplace(dis, idx);
                 top_candidates.emplace(dis, idx);
@@ -1126,7 +1200,7 @@ std::priority_queue<HNSW::Node> search_from_candidate_unbounded(
 }
 
 /// greedily update a nearest vector at a given level
-HNSWStats greedy_update_nearest(
+HNSWStats hnsw_detail::greedy_update_nearest(
         const HNSW& hnsw,
         DistanceComputer& qdis,
         int level,
@@ -1146,7 +1220,7 @@ HNSWStats greedy_update_nearest(
         // the following version processes 4 neighbors at a time
         auto update_with_candidate = [&](const storage_idx_t idx,
                                          const float dis) {
-            if (dis < d_nearest) {
+            if (C::cmp(d_nearest, dis)) {
                 nearest = idx;
                 d_nearest = dis;
             }
@@ -1243,8 +1317,8 @@ HNSWStats HNSW::search(
     float d_nearest = qdis(nearest);
 
     for (int level = max_level; level >= 1; level--) {
-        HNSWStats local_stats =
-                greedy_update_nearest(*this, qdis, level, nearest, d_nearest);
+        HNSWStats local_stats = hnsw_detail::greedy_update_nearest(
+                *this, qdis, level, nearest, d_nearest);
         stats.combine(local_stats);
     }
 
@@ -1256,10 +1330,10 @@ HNSWStats HNSW::search(
         candidates.push(nearest, d_nearest);
 
         if (!is_panorama) {
-            search_from_candidates(
+            hnsw_detail::search_from_candidates(
                     *this, qdis, res, candidates, vt, stats, 0, 0, params);
         } else {
-            search_from_candidates_panorama(
+            hnsw_detail::search_from_candidates_panorama(
                     *this,
                     index,
                     qdis,
@@ -1273,7 +1347,7 @@ HNSWStats HNSW::search(
         }
     } else {
         std::priority_queue<Node> top_candidates =
-                search_from_candidate_unbounded(
+                hnsw_detail::search_from_candidate_unbounded(
                         *this, Node(d_nearest, nearest), qdis, ef, &vt, stats);
 
         while (top_candidates.size() > static_cast<size_t>(k)) {
@@ -1335,7 +1409,7 @@ void HNSW::search_level_0(
 
             candidates.push(cj, nearest_d[j]);
 
-            nres = search_from_candidates(
+            nres = hnsw_detail::search_from_candidates(
                     hnsw,
                     qdis,
                     res,
@@ -1361,7 +1435,7 @@ void HNSW::search_level_0(
             candidates.push(cj, nearest_d[j]);
         }
 
-        search_from_candidates(
+        hnsw_detail::search_from_candidates(
                 hnsw, qdis, res, candidates, vt, search_stats, 0, 0, params);
     }
 }

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -10,6 +10,7 @@
 #include <cinttypes>
 #include <cstddef>
 #include <cstdlib>
+#include <type_traits>
 
 #include <faiss/IndexHNSW.h>
 
@@ -233,28 +234,32 @@ int HNSW::prepare_level_tab(size_t n, bool preset_levels) {
  * neighbor only if there is no previous neighbor that is closer to
  * that vertex than the query.
  */
+template <class C>
 void HNSW::shrink_neighbor_list(
         DistanceComputer& qdis,
-        std::priority_queue<NodeDistFarther>& input,
-        std::vector<NodeDistFarther>& output,
+        std::priority_queue<NodeDistFartherT<C>>& input,
+        std::vector<NodeDistFartherT<C>>& output,
         size_t max_size,
         bool keep_max_size_level0) {
     // This prevents number of neighbors at
     // level 0 from being shrunk to less than 2 * M.
     // This is essential in making sure
     // `faiss::gpu::GpuIndexCagra::copyFrom(IndexHNSWCagra*)` is functional
-    std::vector<NodeDistFarther> outsiders;
+    std::vector<NodeDistFartherT<C>> outsiders;
 
     while (input.size() > 0) {
-        NodeDistFarther v1 = input.top();
+        NodeDistFartherT<C> v1 = input.top();
         input.pop();
         float dist_v1_q = v1.d;
 
         bool good = true;
-        for (NodeDistFarther v2 : output) {
+        for (NodeDistFartherT<C> v2 : output) {
             float dist_v1_v2 = qdis.symmetric_dis(v2.id, v1.id);
 
-            if (dist_v1_v2 < dist_v1_q) {
+            // "v1 is bad" if some previously-kept neighbor v2 is closer
+            // (more similar, under CMin) to v1 than the query is. Encoded
+            // generically as: v1v2 is "better than" v1q under C.
+            if (C::cmp(dist_v1_q, dist_v1_v2)) {
                 good = false;
                 break;
             }
@@ -277,44 +282,88 @@ void HNSW::shrink_neighbor_list(
     }
 }
 
+// Explicit instantiations for the two supported comparators.
+template void HNSW::shrink_neighbor_list<HNSW::C_distance>(
+        DistanceComputer&,
+        std::priority_queue<HNSW::NodeDistFartherT<HNSW::C_distance>>&,
+        std::vector<HNSW::NodeDistFartherT<HNSW::C_distance>>&,
+        size_t,
+        bool);
+template void HNSW::shrink_neighbor_list<HNSW::C_similarity>(
+        DistanceComputer&,
+        std::priority_queue<HNSW::NodeDistFartherT<HNSW::C_similarity>>&,
+        std::vector<HNSW::NodeDistFartherT<HNSW::C_similarity>>&,
+        size_t,
+        bool);
+
 namespace {
 
 using storage_idx_t = HNSW::storage_idx_t;
-using NodeDistCloser = HNSW::NodeDistCloser;
-using NodeDistFarther = HNSW::NodeDistFarther;
+
+// Map a (high-level) HNSW comparator C — which uses int64_t IDs — to the
+// (low-level) MinimaxHeap comparator HC, which uses int32_t IDs.
+template <class C>
+using HC_for = std::
+        conditional_t<C::is_max, CMax<float, int32_t>, CMin<float, int32_t>>;
+
+// Priority queue types used by the unbounded search variant. For CMax
+// (distance) "top_candidates" is a max-heap of the kept-so-far results
+// (top is the farthest) and "candidates" is a min-heap of the next nodes
+// to explore (top is the closest). For CMin (similarity) the orderings are
+// swapped: top_candidates is a min-heap (top is the least similar) and
+// candidates is a max-heap (top is the most similar).
+template <class C>
+using TopCandidatesQueue = std::conditional_t<
+        C::is_max,
+        std::priority_queue<HNSW::Node>,
+        std::priority_queue<
+                HNSW::Node,
+                std::vector<HNSW::Node>,
+                std::greater<HNSW::Node>>>;
+
+template <class C>
+using CandidatesQueue = std::conditional_t<
+        C::is_max,
+        std::priority_queue<
+                HNSW::Node,
+                std::vector<HNSW::Node>,
+                std::greater<HNSW::Node>>,
+        std::priority_queue<HNSW::Node>>;
 
 /**************************************************************
  * Addition subroutines
  **************************************************************/
 
 /// remove neighbors from the list to make it smaller than max_size
-void shrink_neighbor_list(
+template <class C>
+void shrink_neighbor_list_inner(
         DistanceComputer& qdis,
-        std::priority_queue<NodeDistCloser>& resultSet1,
+        std::priority_queue<HNSW::NodeDistCloserT<C>>& resultSet1,
         size_t max_size,
         bool keep_max_size_level0 = false) {
     if (resultSet1.size() < static_cast<size_t>(max_size)) {
         return;
     }
-    std::priority_queue<NodeDistFarther> resultSet;
-    std::vector<NodeDistFarther> returnlist;
+    std::priority_queue<HNSW::NodeDistFartherT<C>> resultSet;
+    std::vector<HNSW::NodeDistFartherT<C>> returnlist;
 
     while (resultSet1.size() > 0) {
         resultSet.emplace(resultSet1.top().d, resultSet1.top().id);
         resultSet1.pop();
     }
 
-    HNSW::shrink_neighbor_list(
+    HNSW::shrink_neighbor_list<C>(
             qdis, resultSet, returnlist, max_size, keep_max_size_level0);
 
-    for (NodeDistFarther curen2 : returnlist) {
+    for (HNSW::NodeDistFartherT<C> curen2 : returnlist) {
         resultSet1.emplace(curen2.d, curen2.id);
     }
 }
 
 /// add a link between two elements, possibly shrinking the list
 /// of links to make room for it.
-void add_link(
+template <class C>
+void add_link_tpl(
         HNSW& hnsw,
         DistanceComputer& qdis,
         storage_idx_t src,
@@ -339,16 +388,17 @@ void add_link(
     // otherwise we let them fight out which to keep
 
     // copy to resultSet...
-    std::priority_queue<NodeDistCloser> resultSet;
+    std::priority_queue<HNSW::NodeDistCloserT<C>> resultSet;
     resultSet.emplace(qdis.symmetric_dis(src, dest), dest);
-    for (size_t i = begin; i < end; i++) { // HERE WAS THE BUG
+    for (size_t i = begin; i < end; i++) {
         storage_idx_t neigh = hnsw.neighbors[i];
         resultSet.emplace(qdis.symmetric_dis(src, neigh), neigh);
     }
 
     size_t max_size = end - begin;
     max_size -= max_size * std::clamp(hnsw.prune_headroom, 0.0f, 0.5f);
-    shrink_neighbor_list(qdis, resultSet, max_size, keep_max_size_level0);
+    shrink_neighbor_list_inner<C>(
+            qdis, resultSet, max_size, keep_max_size_level0);
 
     // ...and back
     size_t i = begin;
@@ -363,31 +413,30 @@ void add_link(
 }
 
 /** Templated body of `search_neighbors_to_add` — instantiated once per final
- * VisitedTable subclass so that `vt.set/advance` are inlined and the cost of
- * virtual dispatch is paid only once at the top of the call.
+ * VisitedTable subclass × comparator so that `vt.set/advance` are inlined
+ * and the cost of virtual dispatch is paid only once at the top of the call.
  */
-template <typename VTType>
+template <typename VTType, class C>
 static void search_neighbors_to_add_fixVT(
         HNSW& hnsw,
         DistanceComputer& qdis,
-        std::priority_queue<HNSW::NodeDistCloser>& results,
+        std::priority_queue<HNSW::NodeDistCloserT<C>>& results,
         int entry_point,
         float d_entry_point,
         int level,
         VTType& vt,
         bool reference_version) {
-    using C = HNSW::C;
     // top is nearest candidate
-    std::priority_queue<HNSW::NodeDistFarther> candidates;
+    std::priority_queue<HNSW::NodeDistFartherT<C>> candidates;
 
-    HNSW::NodeDistFarther ev(d_entry_point, entry_point);
+    HNSW::NodeDistFartherT<C> ev(d_entry_point, entry_point);
     candidates.push(ev);
     results.emplace(d_entry_point, entry_point);
     vt.set(entry_point);
 
     while (!candidates.empty()) {
         // get nearest
-        const HNSW::NodeDistFarther& currEv = candidates.top();
+        const HNSW::NodeDistFartherT<C>& currEv = candidates.top();
 
         if (C::cmp(currEv.d, results.top().d)) {
             break;
@@ -419,7 +468,7 @@ static void search_neighbors_to_add_fixVT(
                 }
 
                 float dis = qdis(nodeId);
-                HNSW::NodeDistFarther evE1(dis, nodeId);
+                HNSW::NodeDistFartherT<C> evE1(dis, nodeId);
 
                 if (results.size() < static_cast<size_t>(hnsw.efConstruction) ||
                     C::cmp(results.top().d, dis)) {
@@ -494,22 +543,20 @@ static void search_neighbors_to_add_fixVT(
     vt.advance();
 }
 
-} // namespace
-
-/// search neighbors on a single level, starting from an entry point.
-/// Routes to the appropriate templated instantiation based on the concrete
-/// type of `vt`.
-void hnsw_detail::search_neighbors_to_add(
+/// Dispatches the VisitedTable concrete type for a given C, then calls
+/// the templated `search_neighbors_to_add_fixVT<VTType, C>`.
+template <class C>
+void search_neighbors_to_add_dispatch(
         HNSW& hnsw,
         DistanceComputer& qdis,
-        std::priority_queue<NodeDistCloser>& results,
+        std::priority_queue<HNSW::NodeDistCloserT<C>>& results,
         int entry_point,
         float d_entry_point,
         int level,
         VisitedTable& vt,
         bool reference_version) {
     auto call = [&]<typename VTType>(VTType& vt_concrete) {
-        search_neighbors_to_add_fixVT(
+        search_neighbors_to_add_fixVT<VTType, C>(
                 hnsw,
                 qdis,
                 results,
@@ -519,7 +566,6 @@ void hnsw_detail::search_neighbors_to_add(
                 vt_concrete,
                 reference_version);
     };
-
     if (VisitedTableVector* vtv = dynamic_cast<VisitedTableVector*>(&vt)) {
         call(*vtv);
         return;
@@ -527,6 +573,50 @@ void hnsw_detail::search_neighbors_to_add(
     VisitedTableSet& vts = dynamic_cast<VisitedTableSet&>(vt);
     call(vts);
 }
+
+/// Templated implementation of `HNSW::add_links_starting_from`.
+template <class C>
+void add_links_starting_from_impl(
+        HNSW& hnsw,
+        DistanceComputer& ptdis,
+        storage_idx_t pt_id,
+        storage_idx_t nearest,
+        float d_nearest,
+        int level,
+        LockVector& locks,
+        VisitedTable& vt,
+        bool keep_max_size_level0) {
+    std::priority_queue<HNSW::NodeDistCloserT<C>> link_targets;
+
+    search_neighbors_to_add_dispatch<C>(
+            hnsw, ptdis, link_targets, nearest, d_nearest, level, vt, false);
+
+    // but we can afford only this many neighbors
+    int M = hnsw.nb_neighbors(level);
+
+    shrink_neighbor_list_inner<C>(ptdis, link_targets, M, keep_max_size_level0);
+
+    std::vector<storage_idx_t> neighbors_to_add;
+    neighbors_to_add.reserve(link_targets.size());
+    while (!link_targets.empty()) {
+        storage_idx_t other_id = link_targets.top().id;
+        add_link_tpl<C>(
+                hnsw, ptdis, pt_id, other_id, level, keep_max_size_level0);
+        neighbors_to_add.push_back(other_id);
+        link_targets.pop();
+    }
+
+    locks.unlock(pt_id);
+    for (storage_idx_t other_id : neighbors_to_add) {
+        locks.lock(other_id);
+        add_link_tpl<C>(
+                hnsw, ptdis, other_id, pt_id, level, keep_max_size_level0);
+        locks.unlock(other_id);
+    }
+    locks.lock(pt_id);
+}
+
+} // namespace
 
 /// Finds neighbors and builds links with them, starting from an entry
 /// point. The own neighbor list is assumed to be locked.
@@ -539,55 +629,177 @@ void HNSW::add_links_starting_from(
         LockVector& locks,
         VisitedTable& vt,
         bool keep_max_size_level0) {
-    std::priority_queue<NodeDistCloser> link_targets;
-
-    hnsw_detail::search_neighbors_to_add(
-            *this, ptdis, link_targets, nearest, d_nearest, level, vt);
-
-    // but we can afford only this many neighbors
-    int M = nb_neighbors(level);
-
-    ::faiss::shrink_neighbor_list(ptdis, link_targets, M, keep_max_size_level0);
-
-    std::vector<storage_idx_t> neighbors_to_add;
-    neighbors_to_add.reserve(link_targets.size());
-    while (!link_targets.empty()) {
-        storage_idx_t other_id = link_targets.top().id;
-        add_link(*this, ptdis, pt_id, other_id, level, keep_max_size_level0);
-        neighbors_to_add.push_back(other_id);
-        link_targets.pop();
+    if (is_similarity) {
+        add_links_starting_from_impl<C_similarity>(
+                *this,
+                ptdis,
+                pt_id,
+                nearest,
+                d_nearest,
+                level,
+                locks,
+                vt,
+                keep_max_size_level0);
+    } else {
+        add_links_starting_from_impl<C_distance>(
+                *this,
+                ptdis,
+                pt_id,
+                nearest,
+                d_nearest,
+                level,
+                locks,
+                vt,
+                keep_max_size_level0);
     }
+}
 
-    locks.unlock(pt_id);
-    for (storage_idx_t other_id : neighbors_to_add) {
-        locks.lock(other_id);
-        add_link(*this, ptdis, other_id, pt_id, level, keep_max_size_level0);
-        locks.unlock(other_id);
-    }
-    locks.lock(pt_id);
+/// search neighbors on a single level, starting from an entry point.
+/// Public dispatcher: always operates in distance (CMax) mode because its
+/// `priority_queue<HNSW::NodeDistCloser>` signature is the back-compat
+/// distance flavor. Internal callers that need similarity mode reach the
+/// templated implementation directly via `search_neighbors_to_add_dispatch`.
+void hnsw_detail::search_neighbors_to_add(
+        HNSW& hnsw,
+        DistanceComputer& qdis,
+        std::priority_queue<HNSW::NodeDistCloser>& results,
+        int entry_point,
+        float d_entry_point,
+        int level,
+        VisitedTable& vt,
+        bool reference_version) {
+    search_neighbors_to_add_dispatch<HNSW::C_distance>(
+            hnsw,
+            qdis,
+            results,
+            entry_point,
+            d_entry_point,
+            level,
+            vt,
+            reference_version);
 }
 
 /**************************************************************
  * Building, parallel
  **************************************************************/
 
-void HNSW::add_with_locks(
+namespace {
+
+/// Greedy update of the nearest entry point at a given level.
+template <class C>
+HNSWStats greedy_update_nearest_impl(
+        const HNSW& hnsw,
+        DistanceComputer& qdis,
+        int level,
+        storage_idx_t& nearest,
+        float& d_nearest) {
+    HNSWStats stats;
+
+    for (;;) {
+        storage_idx_t prev_nearest = nearest;
+
+        size_t begin, end;
+        hnsw.neighbor_range(nearest, level, &begin, &end);
+
+        size_t ndis = 0;
+
+        // a faster version: reference version in unit test test_hnsw.cpp
+        // the following version processes 4 neighbors at a time
+        auto update_with_candidate = [&](const storage_idx_t idx,
+                                         const float dis) {
+            if (C::cmp(d_nearest, dis)) {
+                nearest = idx;
+                d_nearest = dis;
+            }
+        };
+
+        int n_buffered = 0;
+        storage_idx_t buffered_ids[4];
+
+        for (size_t j = begin; j < end; j++) {
+            storage_idx_t v = hnsw.neighbors[j];
+            if (v < 0) {
+                break;
+            }
+            ndis += 1;
+
+            buffered_ids[n_buffered] = v;
+            n_buffered += 1;
+
+            if (n_buffered == 4) {
+                float dis[4];
+                qdis.distances_batch_4(
+                        buffered_ids[0],
+                        buffered_ids[1],
+                        buffered_ids[2],
+                        buffered_ids[3],
+                        dis[0],
+                        dis[1],
+                        dis[2],
+                        dis[3]);
+
+                for (size_t id4 = 0; id4 < 4; id4++) {
+                    update_with_candidate(buffered_ids[id4], dis[id4]);
+                }
+
+                n_buffered = 0;
+            }
+        }
+
+        // process leftovers
+        for (int icnt = 0; icnt < n_buffered; icnt++) {
+            float dis = qdis(buffered_ids[icnt]);
+            update_with_candidate(buffered_ids[icnt], dis);
+        }
+
+        // update stats
+        stats.ndis += ndis;
+        stats.nhops += 1;
+
+        if (nearest == prev_nearest) {
+            return stats;
+        }
+    }
+}
+
+} // namespace
+
+/// greedily update a nearest vector at a given level
+HNSWStats hnsw_detail::greedy_update_nearest(
+        const HNSW& hnsw,
+        DistanceComputer& qdis,
+        int level,
+        storage_idx_t& nearest,
+        float& d_nearest) {
+    if (hnsw.is_similarity) {
+        return greedy_update_nearest_impl<HNSW::C_similarity>(
+                hnsw, qdis, level, nearest, d_nearest);
+    }
+    return greedy_update_nearest_impl<HNSW::C_distance>(
+            hnsw, qdis, level, nearest, d_nearest);
+}
+
+namespace {
+
+template <class C>
+void add_with_locks_impl(
+        HNSW& hnsw,
         DistanceComputer& ptdis,
         int pt_level,
         int pt_id,
         LockVector& locks,
         VisitedTable& vt,
         bool keep_max_size_level0) {
-    storage_idx_t nearest = entry_point;
+    storage_idx_t nearest = hnsw.entry_point;
     if (nearest == -1) { // avoid locking after the first point.
 #pragma omp critical
-        if (entry_point == -1) { // double-check under lock.
-            max_level = pt_level;
-            entry_point = pt_id;
+        if (hnsw.entry_point == -1) { // double-check under lock.
+            hnsw.max_level = pt_level;
+            hnsw.entry_point = pt_id;
             // leave nearest = -1 to trigger early exit after critical block.
         } else {
             // else: Another thread set the entry point.
-            nearest = entry_point;
+            nearest = hnsw.entry_point;
         }
     }
 
@@ -597,17 +809,17 @@ void HNSW::add_with_locks(
 
     locks.lock(pt_id);
 
-    int level = max_level; // level at which we start adding neighbors
+    int level = hnsw.max_level; // level at which we start adding neighbors
     float d_nearest = ptdis(nearest);
 
     //  greedy search on upper levels
     for (; level > pt_level; level--) {
-        hnsw_detail::greedy_update_nearest(
-                *this, ptdis, level, nearest, d_nearest);
+        greedy_update_nearest_impl<C>(hnsw, ptdis, level, nearest, d_nearest);
     }
 
     for (; level >= 0; level--) {
-        add_links_starting_from(
+        add_links_starting_from_impl<C>(
+                hnsw,
                 ptdis,
                 pt_id,
                 nearest,
@@ -622,10 +834,28 @@ void HNSW::add_with_locks(
 
 #pragma omp critical
     {
-        if (pt_level > max_level) {
-            max_level = pt_level;
-            entry_point = pt_id;
+        if (pt_level > hnsw.max_level) {
+            hnsw.max_level = pt_level;
+            hnsw.entry_point = pt_id;
         }
+    }
+}
+
+} // namespace
+
+void HNSW::add_with_locks(
+        DistanceComputer& ptdis,
+        int pt_level,
+        int pt_id,
+        LockVector& locks,
+        VisitedTable& vt,
+        bool keep_max_size_level0) {
+    if (is_similarity) {
+        add_with_locks_impl<C_similarity>(
+                *this, ptdis, pt_level, pt_id, locks, vt, keep_max_size_level0);
+    } else {
+        add_with_locks_impl<C_distance>(
+                *this, ptdis, pt_level, pt_id, locks, vt, keep_max_size_level0);
     }
 }
 
@@ -633,11 +863,10 @@ void HNSW::add_with_locks(
  * Searching
  **************************************************************/
 
-using Node = HNSW::Node;
-using C = HNSW::C;
+namespace {
 
 /** Helper to extract search parameters from HNSW and SearchParameters */
-static inline void extract_search_params(
+inline void extract_search_params(
         const HNSW& hnsw,
         const SearchParameters* params,
         bool& do_dis_check,
@@ -657,16 +886,15 @@ static inline void extract_search_params(
     }
 }
 
-/** Templated body of `search_from_candidates` — instantiated once per final
- * VisitedTable subclass so that `vt.set/get/prefetch` are inlined and the cost
- * of virtual dispatch is paid only once at the top of the call.
+/** Templated body of `search_from_candidates` — instantiated once per
+ * VisitedTable subclass × comparator.
  */
-template <typename VTType>
-static int search_from_candidates_fixVT(
+template <typename VTType, class C>
+int search_from_candidates_fixVT(
         const HNSW& hnsw,
         DistanceComputer& qdis,
         ResultHandler& res,
-        MinimaxHeap& candidates,
+        MinimaxHeapT<HC_for<C>>& candidates,
         VTType& vt,
         HNSWStats& stats,
         int level,
@@ -680,7 +908,7 @@ static int search_from_candidates_fixVT(
     const IDSelector* sel;
     extract_search_params(hnsw, params, do_dis_check, efSearch, sel);
 
-    C::T threshold = res.threshold;
+    typename C::T threshold = res.threshold;
     for (int i = 0; i < candidates.size(); i++) {
         idx_t v1 = candidates.ids[i];
         float d = candidates.dis[i];
@@ -798,20 +1026,21 @@ static int search_from_candidates_fixVT(
     return nres;
 }
 
-/** Do a BFS on the candidates list. Routes to the appropriate templated
- *  instantiation based on the concrete type of `vt`. */
-int hnsw_detail::search_from_candidates(
+/// Dispatches the VisitedTable concrete type for a given C, then calls
+/// the templated `search_from_candidates_fixVT<VTType, C>`.
+template <class C>
+int search_from_candidates_dispatch(
         const HNSW& hnsw,
         DistanceComputer& qdis,
         ResultHandler& res,
-        MinimaxHeap& candidates,
+        MinimaxHeapT<HC_for<C>>& candidates,
         VisitedTable& vt,
         HNSWStats& stats,
         int level,
         int nres_in,
         const SearchParameters* params) {
     auto call = [&]<typename VTType>(VTType& vt_concrete) -> int {
-        return search_from_candidates_fixVT(
+        return search_from_candidates_fixVT<VTType, C>(
                 hnsw,
                 qdis,
                 res,
@@ -822,12 +1051,30 @@ int hnsw_detail::search_from_candidates(
                 nres_in,
                 params);
     };
-
     if (VisitedTableVector* vtv = dynamic_cast<VisitedTableVector*>(&vt)) {
         return call(*vtv);
     }
     VisitedTableSet& vts = dynamic_cast<VisitedTableSet&>(vt);
     return call(vts);
+}
+
+} // namespace
+
+/** Do a BFS on the candidates list. Public dispatcher: only handles the
+ *  distance (CMax) flavor because its `MinimaxHeap` parameter is the
+ *  CMax instantiation. */
+int hnsw_detail::search_from_candidates(
+        const HNSW& hnsw,
+        DistanceComputer& qdis,
+        ResultHandler& res,
+        MinimaxHeap& candidates,
+        VisitedTable& vt,
+        HNSWStats& stats,
+        int level,
+        int nres_in,
+        const SearchParameters* params) {
+    return search_from_candidates_dispatch<HNSW::C_distance>(
+            hnsw, qdis, res, candidates, vt, stats, level, nres_in, params);
 }
 
 int hnsw_detail::search_from_candidates_panorama(
@@ -841,6 +1088,14 @@ int hnsw_detail::search_from_candidates_panorama(
         int level,
         int nres_in,
         const SearchParameters* params) {
+    // Panorama's progressive-bound math is L2-specific: refuse to run in
+    // similarity mode.
+    FAISS_THROW_IF_NOT_MSG(
+            !hnsw.is_similarity,
+            "search_from_candidates_panorama does not support is_similarity=true");
+
+    using C = HNSW::C_distance;
+
     int nres = nres_in;
     int ndis = 0;
 
@@ -1079,6 +1334,8 @@ int hnsw_detail::search_from_candidates_panorama(
     return nres;
 }
 
+namespace {
+
 template <typename T, typename Container, typename Compare>
 void reservePriorityQueue(
         std::priority_queue<T, Container, Compare>& q,
@@ -1091,18 +1348,22 @@ void reservePriorityQueue(
     q = std::move(access);
 }
 
-std::priority_queue<HNSW::Node> hnsw_detail::search_from_candidate_unbounded(
+/// Templated body of `search_from_candidate_unbounded`. The choice of
+/// max-heap vs min-heap for both `top_candidates` and `candidates` is
+/// derived from C via `TopCandidatesQueue` / `CandidatesQueue`.
+template <class C>
+TopCandidatesQueue<C> search_from_candidate_unbounded_impl(
         const HNSW& hnsw,
-        const Node& node,
+        const HNSW::Node& node,
         DistanceComputer& qdis,
         int ef,
         VisitedTable* vt,
         HNSWStats& stats) {
     int ndis = 0;
-    std::priority_queue<Node> top_candidates;
+    TopCandidatesQueue<C> top_candidates;
     reservePriorityQueue(top_candidates, ef);
 
-    std::priority_queue<Node, std::vector<Node>, std::greater<Node>> candidates;
+    CandidatesQueue<C> candidates;
     reservePriorityQueue(candidates, ef);
 
     top_candidates.push(node);
@@ -1142,11 +1403,11 @@ std::priority_queue<HNSW::Node> hnsw_detail::search_from_candidate_unbounded(
 
         auto add_to_heap = [&](const size_t idx, const float dis) {
             if (C::cmp(top_candidates.top().first, dis) ||
-                top_candidates.size() < ef) {
+                top_candidates.size() < static_cast<size_t>(ef)) {
                 candidates.emplace(dis, idx);
                 top_candidates.emplace(dis, idx);
 
-                if (top_candidates.size() > ef) {
+                if (top_candidates.size() > static_cast<size_t>(ef)) {
                     top_candidates.pop();
                 }
             }
@@ -1199,111 +1460,51 @@ std::priority_queue<HNSW::Node> hnsw_detail::search_from_candidate_unbounded(
     return top_candidates;
 }
 
-/// greedily update a nearest vector at a given level
-HNSWStats hnsw_detail::greedy_update_nearest(
+} // namespace
+
+/// Public dispatcher: only the distance (CMax) flavor is exposed because
+/// its return type — `std::priority_queue<HNSW::Node>` — is the CMax
+/// max-heap. Internal callers that need similarity mode use
+/// `search_from_candidate_unbounded_impl<C_similarity>` directly.
+std::priority_queue<HNSW::Node> hnsw_detail::search_from_candidate_unbounded(
         const HNSW& hnsw,
+        const HNSW::Node& node,
         DistanceComputer& qdis,
-        int level,
-        storage_idx_t& nearest,
-        float& d_nearest) {
-    HNSWStats stats;
-
-    for (;;) {
-        storage_idx_t prev_nearest = nearest;
-
-        size_t begin, end;
-        hnsw.neighbor_range(nearest, level, &begin, &end);
-
-        size_t ndis = 0;
-
-        // a faster version: reference version in unit test test_hnsw.cpp
-        // the following version processes 4 neighbors at a time
-        auto update_with_candidate = [&](const storage_idx_t idx,
-                                         const float dis) {
-            if (C::cmp(d_nearest, dis)) {
-                nearest = idx;
-                d_nearest = dis;
-            }
-        };
-
-        int n_buffered = 0;
-        storage_idx_t buffered_ids[4];
-
-        for (size_t j = begin; j < end; j++) {
-            storage_idx_t v = hnsw.neighbors[j];
-            if (v < 0) {
-                break;
-            }
-            ndis += 1;
-
-            buffered_ids[n_buffered] = v;
-            n_buffered += 1;
-
-            if (n_buffered == 4) {
-                float dis[4];
-                qdis.distances_batch_4(
-                        buffered_ids[0],
-                        buffered_ids[1],
-                        buffered_ids[2],
-                        buffered_ids[3],
-                        dis[0],
-                        dis[1],
-                        dis[2],
-                        dis[3]);
-
-                for (size_t id4 = 0; id4 < 4; id4++) {
-                    update_with_candidate(buffered_ids[id4], dis[id4]);
-                }
-
-                n_buffered = 0;
-            }
-        }
-
-        // process leftovers
-        for (int icnt = 0; icnt < n_buffered; icnt++) {
-            float dis = qdis(buffered_ids[icnt]);
-            update_with_candidate(buffered_ids[icnt], dis);
-        }
-
-        // update stats
-        stats.ndis += ndis;
-        stats.nhops += 1;
-
-        if (nearest == prev_nearest) {
-            return stats;
-        }
-    }
+        int ef,
+        VisitedTable* vt,
+        HNSWStats& stats) {
+    return search_from_candidate_unbounded_impl<HNSW::C_distance>(
+            hnsw, node, qdis, ef, vt, stats);
 }
 
 namespace {
-using Node = HNSW::Node;
-using C = HNSW::C;
 
 // just used as a lower bound for the minmaxheap, but it is set for heap search
+template <class C>
 int extract_k_from_ResultHandler(ResultHandler& res) {
     using RH = HeapBlockResultHandler<C>;
-    if (auto hres = dynamic_cast<RH::SingleResultHandler*>(&res)) {
+    if (auto hres = dynamic_cast<typename RH::SingleResultHandler*>(&res)) {
         return hres->k;
     }
     return 1;
 }
 
-} // namespace
-
-HNSWStats HNSW::search(
+template <class C>
+HNSWStats search_impl(
+        const HNSW& hnsw,
         DistanceComputer& qdis,
         const IndexHNSW* index,
         ResultHandler& res,
         VisitedTable& vt,
-        const SearchParameters* params) const {
+        const SearchParameters* params) {
     HNSWStats stats;
-    if (entry_point == -1) {
+    if (hnsw.entry_point == -1) {
         return stats;
     }
-    int k = extract_k_from_ResultHandler(res);
+    int k = extract_k_from_ResultHandler<C>(res);
 
-    bool bounded_queue = this->search_bounded_queue;
-    int cur_efSearch = this->efSearch;
+    bool bounded_queue = hnsw.search_bounded_queue;
+    int cur_efSearch = hnsw.efSearch;
     if (params) {
         if (const SearchParametersHNSW* hnsw_params =
                     dynamic_cast<const SearchParametersHNSW*>(params)) {
@@ -1313,42 +1514,49 @@ HNSWStats HNSW::search(
     }
 
     //  greedy search on upper levels
-    storage_idx_t nearest = entry_point;
+    storage_idx_t nearest = hnsw.entry_point;
     float d_nearest = qdis(nearest);
 
-    for (int level = max_level; level >= 1; level--) {
-        HNSWStats local_stats = hnsw_detail::greedy_update_nearest(
-                *this, qdis, level, nearest, d_nearest);
+    for (int level = hnsw.max_level; level >= 1; level--) {
+        HNSWStats local_stats = greedy_update_nearest_impl<C>(
+                hnsw, qdis, level, nearest, d_nearest);
         stats.combine(local_stats);
     }
 
     int ef = std::max(cur_efSearch, k);
     if (bounded_queue) { // this is the most common branch, for now we only
                          // support Panorama search in this branch
-        MinimaxHeap candidates(ef);
+        MinimaxHeapT<HC_for<C>> candidates(ef);
 
         candidates.push(nearest, d_nearest);
 
-        if (!is_panorama) {
-            hnsw_detail::search_from_candidates(
-                    *this, qdis, res, candidates, vt, stats, 0, 0, params);
+        if (!hnsw.is_panorama) {
+            search_from_candidates_dispatch<C>(
+                    hnsw, qdis, res, candidates, vt, stats, 0, 0, params);
         } else {
-            hnsw_detail::search_from_candidates_panorama(
-                    *this,
-                    index,
-                    qdis,
-                    res,
-                    candidates,
-                    vt,
-                    stats,
-                    0,
-                    0,
-                    params);
+            // Panorama is L2-specific and is only valid for C_distance.
+            // The public dispatch ensures we never reach this code path
+            // with C != C_distance, but assert in debug builds.
+            if constexpr (std::is_same_v<C, HNSW::C_distance>) {
+                hnsw_detail::search_from_candidates_panorama(
+                        hnsw,
+                        index,
+                        qdis,
+                        res,
+                        candidates,
+                        vt,
+                        stats,
+                        0,
+                        0,
+                        params);
+            } else {
+                FAISS_THROW_MSG(
+                        "Panorama search is not supported with is_similarity=true");
+            }
         }
     } else {
-        std::priority_queue<Node> top_candidates =
-                hnsw_detail::search_from_candidate_unbounded(
-                        *this, Node(d_nearest, nearest), qdis, ef, &vt, stats);
+        auto top_candidates = search_from_candidate_unbounded_impl<C>(
+                hnsw, HNSW::Node(d_nearest, nearest), qdis, ef, &vt, stats);
 
         while (top_candidates.size() > static_cast<size_t>(k)) {
             top_candidates.pop();
@@ -1368,7 +1576,9 @@ HNSWStats HNSW::search(
     return stats;
 }
 
-void HNSW::search_level_0(
+template <class C>
+void search_level_0_impl(
+        const HNSW& hnsw,
         DistanceComputer& qdis,
         ResultHandler& res,
         idx_t nprobe,
@@ -1377,9 +1587,7 @@ void HNSW::search_level_0(
         int search_type,
         HNSWStats& search_stats,
         VisitedTable& vt,
-        const SearchParameters* params) const {
-    const HNSW& hnsw = *this;
-
+        const SearchParameters* params) {
     auto cur_efSearch = hnsw.efSearch;
     if (params) {
         if (const SearchParametersHNSW* hnsw_params =
@@ -1388,7 +1596,7 @@ void HNSW::search_level_0(
         }
     }
 
-    int k = extract_k_from_ResultHandler(res);
+    int k = extract_k_from_ResultHandler<C>(res);
 
     if (search_type == 1) {
         int nres = 0;
@@ -1405,11 +1613,11 @@ void HNSW::search_level_0(
             }
 
             int candidates_size = std::max(cur_efSearch, k);
-            MinimaxHeap candidates(candidates_size);
+            MinimaxHeapT<HC_for<C>> candidates(candidates_size);
 
             candidates.push(cj, nearest_d[j]);
 
-            nres = hnsw_detail::search_from_candidates(
+            nres = search_from_candidates_dispatch<C>(
                     hnsw,
                     qdis,
                     res,
@@ -1425,7 +1633,7 @@ void HNSW::search_level_0(
         int candidates_size = std::max(cur_efSearch, int(k));
         candidates_size = std::max(candidates_size, int(nprobe));
 
-        MinimaxHeap candidates(candidates_size);
+        MinimaxHeapT<HC_for<C>> candidates(candidates_size);
         for (idx_t j = 0; j < nprobe; j++) {
             storage_idx_t cj = nearest_i[j];
 
@@ -1435,8 +1643,59 @@ void HNSW::search_level_0(
             candidates.push(cj, nearest_d[j]);
         }
 
-        hnsw_detail::search_from_candidates(
+        search_from_candidates_dispatch<C>(
                 hnsw, qdis, res, candidates, vt, search_stats, 0, 0, params);
+    }
+}
+
+} // namespace
+
+HNSWStats HNSW::search(
+        DistanceComputer& qdis,
+        const IndexHNSW* index,
+        ResultHandler& res,
+        VisitedTable& vt,
+        const SearchParameters* params) const {
+    if (is_similarity) {
+        return search_impl<C_similarity>(*this, qdis, index, res, vt, params);
+    }
+    return search_impl<C_distance>(*this, qdis, index, res, vt, params);
+}
+
+void HNSW::search_level_0(
+        DistanceComputer& qdis,
+        ResultHandler& res,
+        idx_t nprobe,
+        const storage_idx_t* nearest_i,
+        const float* nearest_d,
+        int search_type,
+        HNSWStats& search_stats,
+        VisitedTable& vt,
+        const SearchParameters* params) const {
+    if (is_similarity) {
+        search_level_0_impl<C_similarity>(
+                *this,
+                qdis,
+                res,
+                nprobe,
+                nearest_i,
+                nearest_d,
+                search_type,
+                search_stats,
+                vt,
+                params);
+    } else {
+        search_level_0_impl<C_distance>(
+                *this,
+                qdis,
+                res,
+                nprobe,
+                nearest_i,
+                nearest_d,
+                search_type,
+                search_stats,
+                vt,
+                params);
     }
 }
 

--- a/faiss/impl/HNSW.h
+++ b/faiss/impl/HNSW.h
@@ -250,6 +250,11 @@ struct HNSWStats {
 // global var that collects them all
 FAISS_API extern HNSWStats hnsw_stats;
 
+/// Internal HNSW algorithm helpers. These are not part of the public API; they
+/// are exposed here only so that unit tests (and a few cross-TU callers such as
+/// the Panorama search variant) can reach them.
+namespace hnsw_detail {
+
 int search_from_candidates(
         const HNSW& hnsw,
         DistanceComputer& qdis,
@@ -301,5 +306,7 @@ void search_neighbors_to_add(
         int level,
         VisitedTable& vt,
         bool reference_version = false);
+
+} // namespace hnsw_detail
 
 } // namespace faiss

--- a/faiss/impl/HNSW.h
+++ b/faiss/impl/HNSW.h
@@ -25,7 +25,9 @@ namespace faiss {
 // Forward declarations to avoid circular dependency.
 struct IndexHNSW;
 struct IndexHNSWFlatPanorama;
-struct MinimaxHeap;
+template <class HC_>
+struct MinimaxHeapT;
+using MinimaxHeap = MinimaxHeapT<CMax<float, int32_t>>;
 class LockVector;
 
 /** Implementation of the Hierarchical Navigable Small World
@@ -60,29 +62,51 @@ struct HNSW {
     /// internal storage of vectors (32 bits: this is expensive)
     using storage_idx_t = int32_t;
 
-    // for now we do only these distances
-    using C = CMax<float, int64_t>;
+    // The two comparator flavors HNSW supports. CMax (smaller-is-better)
+    // is the default; CMin (larger-is-better) is used when `is_similarity`
+    // is set on the owning index.
+    using C_distance = CMax<float, int64_t>;
+    using C_similarity = CMin<float, int64_t>;
+
+    // Back-compat alias: keeps `HNSW::C` resolving to the distance
+    // (CMax) comparator everywhere the type is referenced directly.
+    using C = C_distance;
 
     typedef std::pair<float, storage_idx_t> Node;
 
     /// to sort pairs of (id, distance) from nearest to farthest or the reverse
-    struct NodeDistCloser {
+    template <class CT>
+    struct NodeDistCloserT {
         float d;
         int id;
-        NodeDistCloser(float d_in, int id_in) : d(d_in), id(id_in) {}
-        bool operator<(const NodeDistCloser& obj1) const {
-            return d < obj1.d;
+        NodeDistCloserT(float d_in, int id_in) : d(d_in), id(id_in) {}
+        bool operator<(const NodeDistCloserT& obj1) const {
+            // priority_queue keeps the "worst" element at the top so that
+            // when the queue is full we can pop it. For CMax (distance) the
+            // worst element is the largest d; for CMin (similarity) it is
+            // the smallest d. Equivalent to: obj1.d "better than" d.
+            return CT::cmp(obj1.d, d);
         }
     };
 
-    struct NodeDistFarther {
+    template <class CT>
+    struct NodeDistFartherT {
         float d;
         int id;
-        NodeDistFarther(float d_in, int id_in) : d(d_in), id(id_in) {}
-        bool operator<(const NodeDistFarther& obj1) const {
-            return d > obj1.d;
+        NodeDistFartherT(float d_in, int id_in) : d(d_in), id(id_in) {}
+        bool operator<(const NodeDistFartherT& obj1) const {
+            // priority_queue here keeps the "best" element at the top so we
+            // can process the nearest candidate first. For CMax (distance)
+            // the best is the smallest d; for CMin (similarity) the best is
+            // the largest d. Equivalent to: d "better than" obj1.d.
+            return CT::cmp(d, obj1.d);
         }
     };
+
+    // Back-compat aliases: default to the distance (CMax) comparator so
+    // existing call sites that mention `HNSW::NodeDist*` keep working.
+    using NodeDistCloser = NodeDistCloserT<C_distance>;
+    using NodeDistFarther = NodeDistFartherT<C_distance>;
 
     /// assignment probability to each layer (sum=1)
     std::vector<double> assign_probas;
@@ -130,6 +154,12 @@ struct HNSW {
 
     /// use Panorama progressive pruning in search
     bool is_panorama = false;
+
+    /// distance comparison semantics: when true, distances are treated as
+    /// similarity scores (larger is better). Default false matches the
+    /// historical L2/Hamming behavior (smaller is better).
+    /// Not serialized: must be re-set by the owning Index after loading.
+    bool is_similarity = false;
 
     // See impl/VisitedTable.h.
     std::optional<bool> use_visited_hashset;
@@ -216,10 +246,11 @@ struct HNSW {
 
     int prepare_level_tab(size_t n, bool preset_levels = false);
 
+    template <class C = C_distance>
     static void shrink_neighbor_list(
             DistanceComputer& qdis,
-            std::priority_queue<NodeDistFarther>& input,
-            std::vector<NodeDistFarther>& output,
+            std::priority_queue<NodeDistFartherT<C>>& input,
+            std::vector<NodeDistFartherT<C>>& output,
             size_t max_size,
             bool keep_max_size_level0 = false);
 

--- a/faiss/impl/NSG.cpp
+++ b/faiss/impl/NSG.cpp
@@ -234,10 +234,11 @@ void NSG::init_graph(Index* storage, const nsg::Graph<idx_t>& knn_graph) {
     std::unique_ptr<DistanceComputer> dis(storage_distance_computer(storage));
 
     dis->set_query(center.get());
-    VisitedTable vt(ntotal, use_visited_hashset);
+    std::unique_ptr<VisitedTable> vt =
+            VisitedTable::create(ntotal, use_visited_hashset);
 
     // Do not collect the visited nodes
-    search_on_graph<false>(knn_graph, *dis, vt, ep, L, retset, tmpset);
+    search_on_graph<false>(knn_graph, *dis, *vt, ep, L, retset, tmpset);
 
     // set enterpoint
     enterpoint = retset[0].id;
@@ -344,7 +345,8 @@ void NSG::link(
         std::vector<Node> pool;
         std::vector<Neighbor> tmp;
 
-        VisitedTable vt(ntotal, use_visited_hashset);
+        std::unique_ptr<VisitedTable> vt =
+                VisitedTable::create(ntotal, use_visited_hashset);
         std::unique_ptr<DistanceComputer> dis(
                 storage_distance_computer(storage));
 
@@ -355,13 +357,13 @@ void NSG::link(
 
             // Collect the visited nodes into pool
             search_on_graph<true>(
-                    knn_graph, *dis, vt, enterpoint, L, tmp, pool);
+                    knn_graph, *dis, *vt, enterpoint, L, tmp, pool);
 
-            sync_prune(i, pool, *dis, vt, knn_graph, graph);
+            sync_prune(i, pool, *dis, *vt, knn_graph, graph);
 
             pool.clear();
             tmp.clear();
-            vt.advance();
+            vt->advance();
         }
     } // omp parallel
 
@@ -531,19 +533,21 @@ void NSG::add_reverse_links(
 
 int NSG::tree_grow(Index* storage, std::vector<int>& degrees) {
     int root = enterpoint;
-    VisitedTable vt(ntotal, use_visited_hashset);
-    VisitedTable vt2(ntotal, use_visited_hashset);
+    std::unique_ptr<VisitedTable> vt =
+            VisitedTable::create(ntotal, use_visited_hashset);
+    std::unique_ptr<VisitedTable> vt2 =
+            VisitedTable::create(ntotal, use_visited_hashset);
 
     int num_attached = 0;
     int cnt = 0;
     while (true) {
-        cnt = dfs(vt, root, cnt);
+        cnt = dfs(*vt, root, cnt);
         if (cnt >= ntotal) {
             break;
         }
 
-        root = attach_unlinked(storage, vt, vt2, degrees);
-        vt2.advance();
+        root = attach_unlinked(storage, *vt, *vt2, degrees);
+        vt2->advance();
         num_attached += 1;
     }
 

--- a/faiss/impl/VisitedTable.cpp
+++ b/faiss/impl/VisitedTable.cpp
@@ -18,19 +18,19 @@ namespace faiss {
 // A size of ~1M seems to be the threshold where the hash set wins.
 size_t visited_table_hashset_threshold = 500000;
 
-VisitedTable::VisitedTable(size_t size, std::optional<bool> use_hashset)
-        : visno(use_hashset.value_or(size >= visited_table_hashset_threshold)
-                        ? 0
-                        : 1) {
-    if (visno != 0) {
-        visited.resize(size, 0);
+std::unique_ptr<VisitedTable> VisitedTable::create(
+        size_t size,
+        std::optional<bool> use_hashset) {
+    bool use_set =
+            use_hashset.value_or(size >= visited_table_hashset_threshold);
+    if (use_set) {
+        return std::make_unique<VisitedTableSet>();
     }
+    return std::make_unique<VisitedTableVector>(size);
 }
 
-void VisitedTable::advance() {
-    if (visno == 0) {
-        visited_set.clear();
-    } else if (visno < 254) {
+void VisitedTableVector::advance() {
+    if (visno < 254) {
         // 254 rather than 255 because sometimes we use visno and visno+1
         ++visno;
     } else {

--- a/faiss/impl/VisitedTable.h
+++ b/faiss/impl/VisitedTable.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 
+#include <memory>
 #include <optional>
 #include <unordered_set>
 #include <vector>
@@ -21,54 +22,88 @@ namespace faiss {
 
 FAISS_API extern size_t visited_table_hashset_threshold;
 
-/// A fast, reusable Visited Set for graph search algorithms.
+/// Abstract base class for a fast, reusable Visited Set for graph search
+/// algorithms.
 struct VisitedTable {
-    std::vector<uint8_t> visited;
-    std::unordered_set<size_t> visited_set;
-    uint8_t visno; // 0 if using visited_set, 1..250 if using vector.
-
-    // If use_hashset is nullopt, the use of a hashset will be determined by
-    // size >= visited_table_hashset_threshold.
-    explicit VisitedTable(
-            size_t size,
-            std::optional<bool> use_hashset = std::nullopt);
+    virtual ~VisitedTable() = default;
 
     /// set flag #no to true, return whether this changed it.
-    bool set(size_t no) {
-        if (visno == 0) {
-            return visited_set.insert(no).second;
-        } else if (visited[no] == visno) {
-            return false;
-        } else {
-            visited[no] = visno;
-            return true;
-        }
-    }
-
-    /// pre-allocate bucket space to avoid rehashing during repeated set() calls
-    void reserve(size_t n) {
-        if (visno == 0) {
-            visited_set.reserve(n);
-        }
-    }
+    virtual bool set(size_t no) = 0;
 
     /// get flag #no
-    bool get(size_t no) const {
-        if (visno == 0) {
-            return visited_set.count(no) != 0;
-        } else {
-            return visited[no] == visno;
-        }
-    }
+    virtual bool get(size_t no) const = 0;
 
-    void prefetch(size_t no) const {
-        if (visno != 0) {
-            prefetch_L2(&visited[no]);
-        }
-    }
+    /// prefetch flag #no
+    virtual void prefetch(size_t no) const = 0;
+
+    /// pre-allocate bucket space to avoid rehashing during repeated set() calls
+    virtual void reserve(size_t /*n*/) {}
 
     /// reset all flags to false
-    void advance();
+    virtual void advance() = 0;
+
+    /// Factory method to create appropriate implementation.
+    /// If use_hashset is nullopt, the use of a hashset will be determined by
+    /// size >= visited_table_hashset_threshold.
+    static std::unique_ptr<VisitedTable> create(
+            size_t size,
+            std::optional<bool> use_hashset = std::nullopt);
+};
+
+/// Set-based implementation using unordered_set.
+/// O(1) to construct and O(visits) to advance.
+struct VisitedTableSet final : VisitedTable {
+    std::unordered_set<size_t> visited_set;
+
+    VisitedTableSet() = default;
+
+    bool set(size_t no) final {
+        return visited_set.insert(no).second;
+    }
+
+    bool get(size_t no) const final {
+        return visited_set.count(no) != 0;
+    }
+
+    void prefetch(size_t /*no*/) const final {
+        // No-op for set-based implementation
+    }
+
+    void reserve(size_t n) final {
+        visited_set.reserve(n);
+    }
+
+    void advance() final {
+        visited_set.clear();
+    }
+};
+
+/// Vector-based implementation using a versioned byte array.
+/// Faster for get()/set(), but O(size) to initialize.
+/// advance() is O(1) except every 250 calls, which are O(size).
+struct VisitedTableVector final : VisitedTable {
+    std::vector<uint8_t> visited;
+    uint8_t visno{1}; // Version number, 1..254
+
+    explicit VisitedTableVector(size_t size) : visited(size, 0) {}
+
+    bool set(size_t no) final {
+        if (visited[no] == visno) {
+            return false;
+        }
+        visited[no] = visno;
+        return true;
+    }
+
+    bool get(size_t no) const final {
+        return visited[no] == visno;
+    }
+
+    void prefetch(size_t no) const final {
+        prefetch_L2(&visited[no]);
+    }
+
+    void advance() final;
 };
 
 } // namespace faiss

--- a/faiss/impl/VisitedTable.h
+++ b/faiss/impl/VisitedTable.h
@@ -52,7 +52,7 @@ struct VisitedTable {
 
 /// Set-based implementation using unordered_set.
 /// O(1) to construct and O(visits) to advance.
-struct VisitedTableSet final : VisitedTable {
+struct VisitedTableSet FAISS_FINAL : VisitedTable {
     std::unordered_set<size_t> visited_set;
 
     VisitedTableSet() = default;
@@ -81,7 +81,7 @@ struct VisitedTableSet final : VisitedTable {
 /// Vector-based implementation using a versioned byte array.
 /// Faster for get()/set(), but O(size) to initialize.
 /// advance() is O(1) except every 250 calls, which are O(size).
-struct VisitedTableVector final : VisitedTable {
+struct VisitedTableVector FAISS_FINAL : VisitedTable {
     std::vector<uint8_t> visited;
     uint8_t visno{1}; // Version number, 1..254
 

--- a/faiss/impl/hnsw/MinimaxHeap.cpp
+++ b/faiss/impl/hnsw/MinimaxHeap.cpp
@@ -5,39 +5,32 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <cmath>
-
 #include <faiss/impl/hnsw/MinimaxHeap.h>
-
-#include <cassert>
 
 #include <faiss/impl/simd_dispatch.h>
 
 namespace faiss {
 
-void MinimaxHeap::push(storage_idx_t i, float v) {
-    // Treat NaN distances as infinitely far away so heap ordering is preserved.
-    if (std::isnan(v)) {
-        v = HC::neutral();
-    }
-    if (k == n) {
-        if (v >= dis[0]) {
-            return;
-        }
-        if (ids[0] != -1) {
-            --nvalid;
-        }
-        faiss::heap_pop<HC>(k--, dis.data(), ids.data());
-    }
-    faiss::heap_push<HC>(++k, dis.data(), ids.data(), v, i);
-    ++nvalid;
+// Runtime-dispatched pop_min (NONE + AVX2 + AVX512 only).
+constexpr int MINIMAX_HEAP_SIMD_LEVELS = (1 << int(SIMDLevel::NONE)) |
+        (1 << int(SIMDLevel::AVX2)) | (1 << int(SIMDLevel::AVX512));
+
+template <class HC_>
+int MinimaxHeapT<HC_>::pop_min(float* vmin_out) {
+    return with_selected_simd_levels<MINIMAX_HEAP_SIMD_LEVELS>(
+            [&]<SIMDLevel SL>() {
+                return pop_min_tpl<HC_, SL>(this, vmin_out);
+            });
 }
 
-// Scalar (NONE) specialization of pop_min_tpl
-template <>
-int MinimaxHeap::pop_min_tpl<SIMDLevel::NONE>(float* vmin_out) {
+// Primary-template scalar implementation. Used directly when SL==NONE
+template <class HC>
+int pop_min_simd_none(MinimaxHeapT<HC>* heap, float* vmin_out) {
+    int k = heap->k;
+    int* ids = heap->ids.data();
+    float* dis = heap->dis.data();
     assert(k > 0);
-    // returns min. This is an O(n) operation
+    // Returns the "best" entry. This is an O(n) operation.
     int i = k - 1;
     while (i >= 0) {
         if (ids[i] != -1) {
@@ -52,7 +45,8 @@ int MinimaxHeap::pop_min_tpl<SIMDLevel::NONE>(float* vmin_out) {
     float vmin = dis[i];
     i--;
     while (i >= 0) {
-        if (ids[i] != -1 && dis[i] < vmin) {
+        // HC::cmp(vmin, dis[i]) → "dis[i] is better than vmin".
+        if (ids[i] != -1 && HC::cmp(vmin, dis[i])) {
             vmin = dis[i];
             imin = i;
         }
@@ -63,29 +57,27 @@ int MinimaxHeap::pop_min_tpl<SIMDLevel::NONE>(float* vmin_out) {
     }
     int ret = ids[imin];
     ids[imin] = -1;
-    --nvalid;
-
+    --heap->nvalid;
     return ret;
 }
 
-// Runtime-dispatched pop_min (NONE + AVX2 + AVX512 only)
-constexpr int MINIMAX_HEAP_SIMD_LEVELS = (1 << int(SIMDLevel::NONE)) |
-        (1 << int(SIMDLevel::AVX2)) | (1 << int(SIMDLevel::AVX512));
-
-int MinimaxHeap::pop_min(float* vmin_out) {
-    return with_selected_simd_levels<MINIMAX_HEAP_SIMD_LEVELS>(
-            [&]<SIMDLevel SL>() { return pop_min_tpl<SL>(vmin_out); });
+// declare for min and max heap at simd level NONE
+template <>
+int pop_min_tpl<CMin<float, int32_t>, SIMDLevel::NONE>(
+        MinimaxHeapT<CMin<float, int32_t>>* heap,
+        float* vmin_out) {
+    return pop_min_simd_none(heap, vmin_out);
 }
 
-int MinimaxHeap::count_below(float thresh) {
-    int n_below = 0;
-    for (int i = 0; i < k; i++) {
-        if (dis[i] < thresh) {
-            n_below++;
-        }
-    }
-
-    return n_below;
+template <>
+int pop_min_tpl<CMax<float, int32_t>, SIMDLevel::NONE>(
+        MinimaxHeapT<CMax<float, int32_t>>* heap,
+        float* vmin_out) {
+    return pop_min_simd_none(heap, vmin_out);
 }
+
+// Explicit instantiations of pop_min for the two HC variants
+template int MinimaxHeapT<CMax<float, int32_t>>::pop_min(float*);
+template int MinimaxHeapT<CMin<float, int32_t>>::pop_min(float*);
 
 } // namespace faiss

--- a/faiss/impl/hnsw/MinimaxHeap.h
+++ b/faiss/impl/hnsw/MinimaxHeap.h
@@ -7,21 +7,30 @@
 
 #pragma once
 
+#include <cassert>
+#include <cmath>
 #include <cstdint>
 #include <vector>
 
 #include <faiss/utils/Heap.h>
+#include <faiss/utils/ordered_key_value.h>
 #include <faiss/utils/simd_levels.h>
 
 namespace faiss {
 
 /** Heap structure that allows fast access and updates.
  *
- * Supports both max-heap operations (via the underlying CMax heap)
- * and efficient min extraction via linear scan (with optional SIMD
- * acceleration).
+ * Templated on the comparator HC_ so that the same data structure can
+ * service both distance-style searches (HC_ = CMax<float, int32_t>, smaller
+ * is better) and similarity-style searches (HC_ = CMin<float, int32_t>,
+ * larger is better). For the distance variant the underlying heap is a
+ * max-heap and "pop_min" returns the closest element; for similarity the
+ * underlying heap is a min-heap and "pop_min" returns the most similar
+ * element.
  */
-struct MinimaxHeap {
+template <class HC_ = CMax<float, int32_t>>
+struct MinimaxHeapT {
+    using HC = HC_;
     using storage_idx_t = int32_t;
 
     int n;
@@ -30,12 +39,34 @@ struct MinimaxHeap {
 
     std::vector<storage_idx_t> ids;
     std::vector<float> dis;
-    using HC = faiss::CMax<float, storage_idx_t>;
 
-    explicit MinimaxHeap(int n_in)
+    explicit MinimaxHeapT(int n_in)
             : n(n_in), k(0), nvalid(0), ids(n_in), dis(n_in) {}
 
-    void push(storage_idx_t i, float v);
+    void push(storage_idx_t i, float v) {
+        // Treat NaN distances as the "worst" value so heap ordering is
+        // preserved (insertion is then guaranteed to fall through the
+        // not-better-than-top early-reject branch when the heap is full).
+        if (std::isnan(v)) {
+            v = HC::neutral();
+        }
+        if (k == n) {
+            // top of the heap is the "worst" entry under HC. If the new
+            // value is not strictly better than the worst, drop it.
+            // HC::cmp(top, v) means "v is better than top" for both CMax
+            // (cmp = a > b → top > v → v < top) and CMin (cmp = a < b →
+            // top < v → v > top).
+            if (!HC::cmp(dis[0], v)) {
+                return;
+            }
+            if (ids[0] != -1) {
+                --nvalid;
+            }
+            faiss::heap_pop<HC>(k--, dis.data(), ids.data());
+        }
+        faiss::heap_push<HC>(++k, dis.data(), ids.data(), v, i);
+        ++nvalid;
+    }
 
     float max() const {
         return dis[0];
@@ -49,16 +80,34 @@ struct MinimaxHeap {
         nvalid = k = 0;
     }
 
-    /// SIMD-templated pop_min implementation.
-    /// Specializations exist for NONE, AVX2, and AVX512.
-    template <SIMDLevel SL>
-    int pop_min_tpl(float* vmin_out = nullptr);
-
-    /// Runtime-dispatched pop_min (calls pop_min_tpl with best available
-    /// SIMD level).
+    /// Runtime-dispatched best-element extraction (NONE + AVX2 + AVX512).
     int pop_min(float* vmin_out = nullptr);
 
-    int count_below(float thresh);
+    int count_below(float thresh) {
+        int n_below = 0;
+        for (int i = 0; i < k; i++) {
+            // Count entries that are strictly "better than" thresh.
+            // HC::cmp(thresh, dis[i]) → for CMax: thresh > dis[i]
+            // (i.e., dis[i] < thresh, the historical L2 semantics);
+            // for CMin: thresh < dis[i] (similarity above threshold).
+            if (HC::cmp(thresh, dis[i])) {
+                n_below++;
+            }
+        }
+        return n_below;
+    }
 };
+
+// Default `MinimaxHeap` keeps the historical max-heap semantics (smaller
+// distance is better). The CMin instantiation is used when the owning
+// HNSW has `is_similarity = true`. The alias itself is declared once,
+// alongside the forward declaration in HNSW.h, to avoid duplicate
+// `using` declarations that SWIG treats as redundant.
+
+// Forward declarations of the SIMD specializations. The actual bodies live
+// in the SIMD-specific translation units (avx2.cpp, avx512.cpp) and are
+// resolved at link time.
+template <class HC_, SIMDLevel SL>
+int pop_min_tpl(MinimaxHeapT<HC_>* heap, float* vmin_out);
 
 } // namespace faiss

--- a/faiss/impl/hnsw/avx2.cpp
+++ b/faiss/impl/hnsw/avx2.cpp
@@ -16,87 +16,133 @@
 
 namespace faiss {
 
-template <>
-int MinimaxHeap::pop_min_tpl<SIMDLevel::AVX2>(float* vmin_out) {
-    assert(k > 0);
+namespace {
+
+/// Templated AVX2 implementation of "pop best" for both CMax (returns
+/// the smallest distance) and CMin (returns the largest similarity).
+/// The only differences between the two flavors are: (1) the initial
+/// "worst possible" value, (2) the running-best update comparison
+/// (`_CMP_LT_OS` vs `_CMP_GT_OS`), and (3) the tiebreaker direction.
+template <class HC>
+int pop_best_avx2(MinimaxHeapT<HC>& heap, float* vmin_out) {
+    using storage_idx_t = typename MinimaxHeapT<HC>::storage_idx_t;
     static_assert(
             std::is_same<storage_idx_t, int32_t>::value,
             "This code expects storage_idx_t to be int32_t");
+    assert(heap.k > 0);
 
-    int32_t min_idx = -1;
-    float min_dis = std::numeric_limits<float>::infinity();
+    // For CMax (distance) the "best" candidate is the smallest value, so
+    // we initialize the running best to +inf. For CMin (similarity) the
+    // best is the largest value, so we initialize to -inf.
+    constexpr float worst_v = HC::is_max
+            ? std::numeric_limits<float>::infinity()
+            : -std::numeric_limits<float>::infinity();
+
+    int32_t best_idx = -1;
+    float best_dis = worst_v;
 
     size_t iii = 0;
 
-    __m256i min_indices = _mm256_setr_epi32(-1, -1, -1, -1, -1, -1, -1, -1);
-    __m256 min_distances =
-            _mm256_set1_ps(std::numeric_limits<float>::infinity());
+    __m256i best_indices = _mm256_setr_epi32(-1, -1, -1, -1, -1, -1, -1, -1);
+    __m256 best_distances = _mm256_set1_ps(worst_v);
     __m256i current_indices = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
     __m256i offset = _mm256_set1_epi32(8);
 
-    // The baseline version is available in the NONE specialization.
-
-    // The following loop tracks the rightmost index with the min distance.
-    // -1 index values are ignored.
-    const size_t k8 = (k / 8) * 8;
+    // Track the rightmost index whose distance equals the running best.
+    // -1 index values are filtered out via m1mask.
+    const size_t k8 = (heap.k / 8) * 8;
     for (; iii < k8; iii += 8) {
         __m256i indices =
-                _mm256_loadu_si256((const __m256i*)(ids.data() + iii));
-        __m256 distances = _mm256_loadu_ps(dis.data() + iii);
+                _mm256_loadu_si256((const __m256i*)(heap.ids.data() + iii));
+        __m256 distances = _mm256_loadu_ps(heap.dis.data() + iii);
 
-        // This mask filters out -1 values among indices.
+        // Mask out -1 indices (invalid entries).
         __m256i m1mask = _mm256_cmpgt_epi32(_mm256_setzero_si256(), indices);
 
-        __m256i dmask = _mm256_castps_si256(
-                _mm256_cmp_ps(min_distances, distances, _CMP_LT_OS));
+        // dmask is "true where best is already (strictly) better than the
+        // candidate" — entries the candidate should NOT update. For CMax,
+        // best < candidate means we keep best (we want the smallest);
+        // for CMin we keep best when best > candidate (we want the largest).
+        __m256i dmask;
+        if constexpr (HC::is_max) {
+            dmask = _mm256_castps_si256(
+                    _mm256_cmp_ps(best_distances, distances, _CMP_LT_OS));
+        } else {
+            dmask = _mm256_castps_si256(
+                    _mm256_cmp_ps(best_distances, distances, _CMP_GT_OS));
+        }
         __m256 finalmask = _mm256_castsi256_ps(_mm256_or_si256(m1mask, dmask));
 
-        const __m256i min_indices_new = _mm256_castps_si256(_mm256_blendv_ps(
+        const __m256i best_indices_new = _mm256_castps_si256(_mm256_blendv_ps(
                 _mm256_castsi256_ps(current_indices),
-                _mm256_castsi256_ps(min_indices),
+                _mm256_castsi256_ps(best_indices),
                 finalmask));
 
-        const __m256 min_distances_new =
-                _mm256_blendv_ps(distances, min_distances, finalmask);
+        const __m256 best_distances_new =
+                _mm256_blendv_ps(distances, best_distances, finalmask);
 
-        min_indices = min_indices_new;
-        min_distances = min_distances_new;
+        best_indices = best_indices_new;
+        best_distances = best_distances_new;
 
         current_indices = _mm256_add_epi32(current_indices, offset);
     }
 
-    // Vectorizing is doable, but is not practical
+    // Vectorizing the horizontal reduction is doable but not practical.
     int32_t vidx8[8];
     float vdis8[8];
-    _mm256_storeu_ps(vdis8, min_distances);
-    _mm256_storeu_si256((__m256i*)vidx8, min_indices);
+    _mm256_storeu_ps(vdis8, best_distances);
+    _mm256_storeu_si256((__m256i*)vidx8, best_indices);
 
     for (size_t j = 0; j < 8; j++) {
-        if (min_dis > vdis8[j] || (min_dis == vdis8[j] && min_idx < vidx8[j])) {
-            min_idx = vidx8[j];
-            min_dis = vdis8[j];
+        const bool strictly_better =
+                HC::is_max ? (best_dis > vdis8[j]) : (best_dis < vdis8[j]);
+        if (strictly_better || (best_dis == vdis8[j] && best_idx < vidx8[j])) {
+            best_idx = vidx8[j];
+            best_dis = vdis8[j];
         }
     }
 
-    // process last values. Vectorizing is doable, but is not practical
-    for (; iii < static_cast<size_t>(k); iii++) {
-        if (ids[iii] != -1 && dis[iii] <= min_dis) {
-            min_dis = dis[iii];
-            min_idx = iii;
+    // Tail (under 8 entries). Vectorizing is doable but not practical.
+    for (; iii < static_cast<size_t>(heap.k); iii++) {
+        if (heap.ids[iii] == -1) {
+            continue;
+        }
+        const bool weakly_better = HC::is_max ? (best_dis >= heap.dis[iii])
+                                              : (best_dis <= heap.dis[iii]);
+        if (weakly_better) {
+            best_dis = heap.dis[iii];
+            best_idx = iii;
         }
     }
 
-    if (min_idx == -1) {
+    if (best_idx == -1) {
         return -1;
     }
 
     if (vmin_out) {
-        *vmin_out = min_dis;
+        *vmin_out = best_dis;
     }
-    int ret = ids[min_idx];
-    ids[min_idx] = -1;
-    --nvalid;
+    int ret = heap.ids[best_idx];
+    heap.ids[best_idx] = -1;
+    --heap.nvalid;
     return ret;
+}
+
+} // namespace
+
+// Explicit specializations for AVX2
+template <>
+int pop_min_tpl<CMax<float, int32_t>, SIMDLevel::AVX2>(
+        MinimaxHeapT<CMax<float, int32_t>>* heap,
+        float* vmin_out) {
+    return pop_best_avx2<CMax<float, int32_t>>(*heap, vmin_out);
+}
+
+template <>
+int pop_min_tpl<CMin<float, int32_t>, SIMDLevel::AVX2>(
+        MinimaxHeapT<CMin<float, int32_t>>* heap,
+        float* vmin_out) {
+    return pop_best_avx2<CMin<float, int32_t>>(*heap, vmin_out);
 }
 
 } // namespace faiss

--- a/faiss/impl/hnsw/avx512.cpp
+++ b/faiss/impl/hnsw/avx512.cpp
@@ -16,94 +16,125 @@
 
 namespace faiss {
 
-template <>
-int MinimaxHeap::pop_min_tpl<SIMDLevel::AVX512>(float* vmin_out) {
-    assert(k > 0);
+namespace {
+
+/// Templated AVX512 implementation of "pop best" for both CMax (returns
+/// the smallest distance) and CMin (returns the largest similarity).
+template <class HC>
+int pop_best_avx512(MinimaxHeapT<HC>& heap, float* vmin_out) {
+    using storage_idx_t = typename MinimaxHeapT<HC>::storage_idx_t;
     static_assert(
             std::is_same<storage_idx_t, int32_t>::value,
             "This code expects storage_idx_t to be int32_t");
+    assert(heap.k > 0);
 
-    int32_t min_idx = -1;
-    float min_dis = std::numeric_limits<float>::infinity();
+    constexpr float worst_v = HC::is_max
+            ? std::numeric_limits<float>::infinity()
+            : -std::numeric_limits<float>::infinity();
 
-    __m512i min_indices = _mm512_set1_epi32(-1);
-    __m512 min_distances =
-            _mm512_set1_ps(std::numeric_limits<float>::infinity());
+    int32_t best_idx = -1;
+    float best_dis = worst_v;
+
+    __m512i best_indices = _mm512_set1_epi32(-1);
+    __m512 best_distances = _mm512_set1_ps(worst_v);
     __m512i current_indices = _mm512_setr_epi32(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
     __m512i offset = _mm512_set1_epi32(16);
 
-    // The following loop tracks the rightmost index with the min distance.
-    // -1 index values are ignored.
-    const size_t k16 = (k / 16) * 16;
+    auto best_vs_cand_mask = [](__m512 best_d, __m512 cand_d) -> __mmask16 {
+        // Returns the mask of lanes where the current best is already
+        // (strictly) better than the candidate.
+        if constexpr (HC::is_max) {
+            return _mm512_cmp_ps_mask(best_d, cand_d, _CMP_LT_OS);
+        } else {
+            return _mm512_cmp_ps_mask(best_d, cand_d, _CMP_GT_OS);
+        }
+    };
+
+    const size_t k16 = (heap.k / 16) * 16;
     for (size_t iii = 0; iii < k16; iii += 16) {
         __m512i indices =
-                _mm512_loadu_si512((const __m512i*)(ids.data() + iii));
-        __m512 distances = _mm512_loadu_ps(dis.data() + iii);
+                _mm512_loadu_si512((const __m512i*)(heap.ids.data() + iii));
+        __m512 distances = _mm512_loadu_ps(heap.dis.data() + iii);
 
-        // This mask filters out -1 values among indices.
         __mmask16 m1mask =
                 _mm512_cmpgt_epi32_mask(_mm512_setzero_si512(), indices);
-
-        __mmask16 dmask =
-                _mm512_cmp_ps_mask(min_distances, distances, _CMP_LT_OS);
+        __mmask16 dmask = best_vs_cand_mask(best_distances, distances);
         __mmask16 finalmask = m1mask | dmask;
 
-        const __m512i min_indices_new = _mm512_mask_blend_epi32(
-                finalmask, current_indices, min_indices);
-        const __m512 min_distances_new =
-                _mm512_mask_blend_ps(finalmask, distances, min_distances);
+        const __m512i best_indices_new = _mm512_mask_blend_epi32(
+                finalmask, current_indices, best_indices);
+        const __m512 best_distances_new =
+                _mm512_mask_blend_ps(finalmask, distances, best_distances);
 
-        min_indices = min_indices_new;
-        min_distances = min_distances_new;
+        best_indices = best_indices_new;
+        best_distances = best_distances_new;
 
         current_indices = _mm512_add_epi32(current_indices, offset);
     }
 
-    // leftovers
-    if (k16 != static_cast<size_t>(k)) {
-        const __mmask16 kmask = (1 << (k - k16)) - 1;
+    // Leftovers.
+    if (k16 != static_cast<size_t>(heap.k)) {
+        const __mmask16 kmask = (1 << (heap.k - k16)) - 1;
 
         __m512i indices = _mm512_mask_loadu_epi32(
-                _mm512_set1_epi32(-1), kmask, ids.data() + k16);
-        __m512 distances = _mm512_maskz_loadu_ps(kmask, dis.data() + k16);
+                _mm512_set1_epi32(-1), kmask, heap.ids.data() + k16);
+        __m512 distances = _mm512_maskz_loadu_ps(kmask, heap.dis.data() + k16);
 
-        // This mask filters out -1 values among indices.
         __mmask16 m1mask =
                 _mm512_cmpgt_epi32_mask(_mm512_setzero_si512(), indices);
-
-        __mmask16 dmask =
-                _mm512_cmp_ps_mask(min_distances, distances, _CMP_LT_OS);
+        __mmask16 dmask = best_vs_cand_mask(best_distances, distances);
         __mmask16 finalmask = m1mask | dmask;
 
-        const __m512i min_indices_new = _mm512_mask_blend_epi32(
-                finalmask, current_indices, min_indices);
-        const __m512 min_distances_new =
-                _mm512_mask_blend_ps(finalmask, distances, min_distances);
+        const __m512i best_indices_new = _mm512_mask_blend_epi32(
+                finalmask, current_indices, best_indices);
+        const __m512 best_distances_new =
+                _mm512_mask_blend_ps(finalmask, distances, best_distances);
 
-        min_indices = min_indices_new;
-        min_distances = min_distances_new;
+        best_indices = best_indices_new;
+        best_distances = best_distances_new;
     }
 
-    // grab min distance
-    min_dis = _mm512_reduce_min_ps(min_distances);
-    // blend
-    __mmask16 mindmask =
-            _mm512_cmpeq_ps_mask(min_distances, _mm512_set1_ps(min_dis));
-    // pick the max one
-    min_idx = _mm512_mask_reduce_max_epi32(mindmask, min_indices);
+    // Horizontal best: min for CMax (distance), max for CMin (similarity).
+    if constexpr (HC::is_max) {
+        best_dis = _mm512_reduce_min_ps(best_distances);
+    } else {
+        best_dis = _mm512_reduce_max_ps(best_distances);
+    }
+    // Tiebreak by picking the rightmost (largest) index among lanes
+    // matching the best distance, matching the original behavior.
+    __mmask16 best_lane_mask =
+            _mm512_cmpeq_ps_mask(best_distances, _mm512_set1_ps(best_dis));
+    best_idx = _mm512_mask_reduce_max_epi32(best_lane_mask, best_indices);
 
-    if (min_idx == -1) {
+    if (best_idx == -1) {
         return -1;
     }
 
     if (vmin_out) {
-        *vmin_out = min_dis;
+        *vmin_out = best_dis;
     }
-    int ret = ids[min_idx];
-    ids[min_idx] = -1;
-    --nvalid;
+    int ret = heap.ids[best_idx];
+    heap.ids[best_idx] = -1;
+    --heap.nvalid;
     return ret;
+}
+
+} // namespace
+
+// Explicit specializations for AVX512
+template <>
+int pop_min_tpl<CMax<float, int32_t>, SIMDLevel::AVX512>(
+        MinimaxHeapT<CMax<float, int32_t>>* heap,
+        float* vmin_out) {
+    return pop_best_avx512<CMax<float, int32_t>>(*heap, vmin_out);
+}
+
+template <>
+int pop_min_tpl<CMin<float, int32_t>, SIMDLevel::AVX512>(
+        MinimaxHeapT<CMin<float, int32_t>>* heap,
+        float* vmin_out) {
+    return pop_best_avx512<CMin<float, int32_t>>(*heap, vmin_out);
 }
 
 } // namespace faiss

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -2237,6 +2237,12 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
                 idxhnsw->hnsw.levels.size(),
                 idxhnsw->ntotal);
         idxhnsw->hnsw.is_panorama = (h == fourcc("IHfP"));
+        // `HNSW::is_similarity` is intentionally not serialized, so we
+        // re-derive it here from the persisted metric type. Without this,
+        // a saved IP/similarity index would come back configured as a
+        // distance index and silently produce wrong rankings on search.
+        idxhnsw->hnsw.is_similarity =
+                is_similarity_metric(idxhnsw->metric_type);
         idxhnsw->storage = read_index(f, io_flags);
         idxhnsw->own_fields = idxhnsw->storage != nullptr;
         // Cross-check storage ntotal and d against index

--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -112,8 +112,10 @@ inline int __builtin_clzll(uint64_t x) {
 
 #ifdef SWIG
 #define FAISS_MAYBE_UNUSED
+#define FAISS_FINAL
 #else
 #define FAISS_MAYBE_UNUSED [[maybe_unused]]
+#define FAISS_FINAL final
 #endif
 
 #else
@@ -131,11 +133,13 @@ inline int __builtin_clzll(uint64_t x) {
 #define FAISS_PACKED
 #define FAISS_RESTRICT
 #define FAISS_MAYBE_UNUSED
+#define FAISS_FINAL
 #else
 #define ALIGNED(x) __attribute__((aligned(x)))
 #define FAISS_PACKED __attribute__((packed))
 #define FAISS_RESTRICT __restrict
 #define FAISS_MAYBE_UNUSED [[maybe_unused]]
+#define FAISS_FINAL final
 #endif
 
 // On non-Windows, FAISS_PACKED handles packing, so these are no-ops

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -694,6 +694,8 @@ void gpu_sync_all_devices()
 %ignore faiss::InterruptCallback::lock;
 
 %include <faiss/impl/AuxIndexStructures.h>
+
+%ignore faiss::VisitedTable::create; // causes errors on OSS compile (?)
 %include <faiss/impl/VisitedTable.h>
 %include <faiss/impl/IDSelector.h>
 

--- a/tests/test_NSG_compressed_graph.cpp
+++ b/tests/test_NSG_compressed_graph.cpp
@@ -116,13 +116,13 @@ TEST(NSGBugs, SyncPruneSingleNode) {
 
     // Search returns the only node
     nsg_obj.search_L = 1;
-    faiss::VisitedTable vt(1);
+    std::unique_ptr<faiss::VisitedTable> vt = faiss::VisitedTable::create(1);
     auto dis = std::unique_ptr<faiss::DistanceComputer>(
             faiss::nsg::storage_distance_computer(&storage));
     dis->set_query(vec);
 
     faiss::idx_t label = -1;
     float distance = -1;
-    nsg_obj.search(*dis, 1, &label, &distance, vt);
+    nsg_obj.search(*dis, 1, &label, &distance, *vt);
     EXPECT_EQ(label, 0);
 }

--- a/tests/test_graph_based.py
+++ b/tests/test_graph_based.py
@@ -330,7 +330,7 @@ class TestNSG(unittest.TestCase):
         np.testing.assert_array_equal(Insg3, Insg)
 
     def subtest_connectivity(self, index, nb):
-        vt = faiss.VisitedTable(nb)
+        vt = faiss.VisitedTableVector(nb)
         count = index.nsg.dfs(vt, index.nsg.enterpoint, 0)
         self.assertEqual(count, nb)
 

--- a/tests/test_graph_based.py
+++ b/tests/test_graph_based.py
@@ -223,6 +223,121 @@ class TestHNSW(unittest.TestCase):
         self.assertEqual(index_hnsw.ntotal, 0)
 
 
+class TestHNSWSimilarity(unittest.TestCase):
+    """Coverage for HNSW variants built with a similarity metric
+    (METRIC_INNER_PRODUCT). These tests exercise the
+    HNSW::is_similarity dispatch in IndexHNSW{Flat,PQ,SQ,Cagra}: build,
+    search, and (for IndexHNSWFlat) save/load round trips that have to
+    re-derive `hnsw.is_similarity` from the persisted metric type.
+    """
+
+    def setUp(self):
+        d = 32
+        nt = 1500
+        nb = 1500
+        nq = 200
+        (self.xt, self.xb, self.xq) = get_dataset_2(d, nt, nb, nq)
+        # Reference IP search results.
+        ref = faiss.IndexFlatIP(d)
+        ref.add(self.xb)
+        self.Dref_ip, self.Iref_ip = ref.search(self.xq, 1)
+
+    def test_hnsw_flat_IP_is_similarity_set(self):
+        d = self.xb.shape[1]
+        index = faiss.IndexHNSWFlat(d, 16, faiss.METRIC_INNER_PRODUCT)
+        self.assertTrue(index.hnsw.is_similarity)
+
+        index_l2 = faiss.IndexHNSWFlat(d, 16, faiss.METRIC_L2)
+        self.assertFalse(index_l2.hnsw.is_similarity)
+
+    def _check_quantized_IP(self, index, min_agreement):
+        """Build (train if needed), search, then save / load and assert
+        that the round trip preserves ordering and `hnsw.is_similarity`.
+        The agreement floors are calibrated against the observed values
+        on the test dataset with a small (~5%) headroom for RNG noise;
+        they catch ordering regressions (which collapse agreement to
+        ~0) and quantizer-quality regressions (which would shift
+        agreement by tens of points)."""
+        self.assertTrue(index.hnsw.is_similarity)
+        if not index.is_trained:
+            index.train(self.xt)
+        index.add(self.xb)
+
+        Dhnsw, Ihnsw = index.search(self.xq, 1)
+        agreement = (self.Iref_ip[:, 0] == Ihnsw[:, 0]).sum()
+        self.assertGreaterEqual(
+            agreement,
+            min_agreement,
+            f"{type(index).__name__} agreement={agreement} < {min_agreement}",
+        )
+
+        index2 = faiss.deserialize_index(faiss.serialize_index(index))
+        # `hnsw.is_similarity` is not serialized; index_read must
+        # re-derive it from the persisted metric_type.
+        self.assertTrue(index2.hnsw.is_similarity)
+        self.assertEqual(index2.metric_type, faiss.METRIC_INNER_PRODUCT)
+        D2, I2 = index2.search(self.xq, 1)
+        np.testing.assert_array_equal(I2, Ihnsw)
+        np.testing.assert_array_equal(D2, Dhnsw)
+
+    # Agreement floors below are calibrated against measured values
+    # (Flat: 199, PQ: 26-30, SQ: 195, Cagra: 200 over nq=200) with a
+    # small headroom for RNG noise.
+
+    def test_hnsw_flat_IP(self):
+        d = self.xb.shape[1]
+        self._check_quantized_IP(
+            faiss.IndexHNSWFlat(d, 16, faiss.METRIC_INNER_PRODUCT),
+            min_agreement=195,
+        )
+
+    def test_hnsw_pq_IP(self):
+        d = self.xb.shape[1]
+        self._check_quantized_IP(
+            faiss.IndexHNSWPQ(d, 8, 16, 8, faiss.METRIC_INNER_PRODUCT),
+            min_agreement=20,
+        )
+
+    def test_hnsw_sq_IP(self):
+        d = self.xb.shape[1]
+        self._check_quantized_IP(
+            faiss.IndexHNSWSQ(
+                d,
+                faiss.ScalarQuantizer.QT_8bit,
+                16,
+                faiss.METRIC_INNER_PRODUCT,
+            ),
+            min_agreement=190,
+        )
+
+    def test_hnsw_cagra_IP(self):
+        d = self.xb.shape[1]
+        self._check_quantized_IP(
+            faiss.IndexHNSWCagra(d, 16, faiss.METRIC_INNER_PRODUCT),
+            min_agreement=195,
+        )
+
+    def test_hnsw_cagra_IP_base_level_only(self):
+        """IndexHNSWCagra.base_level_only takes a separate code path
+        (random entry-point selection + search_level_0) that also
+        needs to dispatch on is_similarity."""
+        d = self.xb.shape[1]
+        index = faiss.IndexHNSWCagra(d, 16, faiss.METRIC_INNER_PRODUCT)
+        index.add(self.xb)
+        index.base_level_only = True
+        index.num_base_level_search_entrypoints = 64
+
+        _, Ihnsw = index.search(self.xq, 1)
+        agreement = (self.Iref_ip[:, 0] == Ihnsw[:, 0]).sum()
+        # Measured value on this dataset is 200/200; leave headroom for
+        # the RNG-driven entry-point selection (this path is unseeded).
+        self.assertGreaterEqual(
+            agreement,
+            190,
+            f"Cagra base_only agreement={agreement}",
+        )
+
+
 class TestHNSWNaN(unittest.TestCase):
     """Adding a vector with NaN to an IVF+HNSW index used to crash because
     NaN distances corrupt the MinimaxHeap ordering in HNSW search. The fix

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -538,18 +538,20 @@ TEST_F(HNSWTest, TEST_search_from_candidate_unbounded) {
     auto nearest = index->hnsw.entry_point;
     float d_nearest = (*dis)(nearest);
     auto node = faiss::HNSW::Node(d_nearest, nearest);
-    faiss::VisitedTable vt(index->ntotal);
+    std::unique_ptr<faiss::VisitedTable> vt =
+            faiss::VisitedTable::create(index->ntotal);
     faiss::HNSWStats stats;
 
     // actual version
-    auto top_candidates = faiss::search_from_candidate_unbounded(
-            index->hnsw, node, *dis, k, &vt, stats);
+    auto top_candidates = faiss::hnsw_detail::search_from_candidate_unbounded(
+            index->hnsw, node, *dis, k, vt.get(), stats);
 
     auto reference_nearest = index->hnsw.entry_point;
     float reference_d_nearest = (*dis)(nearest);
     auto reference_node =
             faiss::HNSW::Node(reference_d_nearest, reference_nearest);
-    faiss::VisitedTable reference_vt(index->ntotal);
+    std::unique_ptr<faiss::VisitedTable> reference_vt =
+            faiss::VisitedTable::create(index->ntotal);
     faiss::HNSWStats reference_stats;
 
     // reference version
@@ -558,7 +560,7 @@ TEST_F(HNSWTest, TEST_search_from_candidate_unbounded) {
             reference_node,
             *dis,
             k,
-            &reference_vt,
+            reference_vt.get(),
             reference_stats);
     EXPECT_EQ(stats.ndis, reference_stats.ndis);
     EXPECT_EQ(stats.nhops, reference_stats.nhops);
@@ -576,7 +578,7 @@ TEST_F(HNSWTest, TEST_greedy_update_nearest) {
     float reference_d_nearest = (*dis)(reference_nearest);
 
     // actual version
-    auto stats = faiss::greedy_update_nearest(
+    auto stats = faiss::hnsw_detail::greedy_update_nearest(
             index->hnsw, *dis, 0, nearest, d_nearest);
 
     // reference version
@@ -599,15 +601,17 @@ TEST_F(HNSWTest, TEST_search_from_candidates) {
     std::vector<float> reference_D(k * nq);
     using RH = faiss::HeapBlockResultHandler<faiss::HNSW::C>;
 
-    faiss::VisitedTable vt(index->ntotal);
-    faiss::VisitedTable reference_vt(index->ntotal);
+    std::unique_ptr<faiss::VisitedTable> vt =
+            faiss::VisitedTable::create(index->ntotal);
+    std::unique_ptr<faiss::VisitedTable> reference_vt =
+            faiss::VisitedTable::create(index->ntotal);
     int num_candidates = 10;
     faiss::MinimaxHeap candidates(num_candidates);
     faiss::MinimaxHeap reference_candidates(num_candidates);
 
     for (int i = 0; i < num_candidates; i++) {
-        vt.set(i);
-        reference_vt.set(i);
+        vt->set(i);
+        reference_vt->set(i);
         candidates.push(i, (*dis)(i));
         reference_candidates.push(i, (*dis)(i));
     }
@@ -618,8 +622,8 @@ TEST_F(HNSWTest, TEST_search_from_candidates) {
             bres);
 
     res.begin(0);
-    faiss::search_from_candidates(
-            index->hnsw, *dis, res, candidates, vt, stats, 0, 0, nullptr);
+    faiss::hnsw_detail::search_from_candidates(
+            index->hnsw, *dis, res, candidates, *vt, stats, 0, 0, nullptr);
     res.end();
 
     faiss::HNSWStats reference_stats;
@@ -632,7 +636,7 @@ TEST_F(HNSWTest, TEST_search_from_candidates) {
             *dis,
             reference_res,
             reference_candidates,
-            reference_vt,
+            *reference_vt,
             reference_stats,
             0,
             0,
@@ -653,30 +657,32 @@ TEST_F(HNSWTest, TEST_search_from_candidates) {
 TEST_F(HNSWTest, TEST_search_neighbors_to_add) {
     omp_set_num_threads(1);
 
-    faiss::VisitedTable vt(index->ntotal);
-    faiss::VisitedTable reference_vt(index->ntotal);
+    std::unique_ptr<faiss::VisitedTable> vt =
+            faiss::VisitedTable::create(index->ntotal);
+    std::unique_ptr<faiss::VisitedTable> reference_vt =
+            faiss::VisitedTable::create(index->ntotal);
 
     std::priority_queue<faiss::HNSW::NodeDistCloser> link_targets;
     std::priority_queue<faiss::HNSW::NodeDistCloser> reference_link_targets;
 
-    faiss::search_neighbors_to_add(
+    faiss::hnsw_detail::search_neighbors_to_add(
             index->hnsw,
             *dis,
             link_targets,
             index->hnsw.entry_point,
             (*dis)(index->hnsw.entry_point),
             index->hnsw.max_level,
-            vt,
+            *vt,
             false);
 
-    faiss::search_neighbors_to_add(
+    faiss::hnsw_detail::search_neighbors_to_add(
             index->hnsw,
             *dis,
             reference_link_targets,
             index->hnsw.entry_point,
             (*dis)(index->hnsw.entry_point),
             index->hnsw.max_level,
-            reference_vt,
+            *reference_vt,
             true);
 
     EXPECT_EQ(link_targets.size(), reference_link_targets.size());
@@ -714,8 +720,10 @@ TEST_F(HNSWTest, TEST_search_level_0) {
             bres2);
 
     faiss::HNSWStats stats1, stats2;
-    faiss::VisitedTable vt1(index->ntotal);
-    faiss::VisitedTable vt2(index->ntotal);
+    std::unique_ptr<faiss::VisitedTable> vt1 =
+            faiss::VisitedTable::create(index->ntotal);
+    std::unique_ptr<faiss::VisitedTable> vt2 =
+            faiss::VisitedTable::create(index->ntotal);
     auto nprobe = 5;
     const faiss::HNSW::storage_idx_t values[] = {1, 2, 3, 4, 5};
     const faiss::HNSW::storage_idx_t* nearest_i = values;
@@ -725,13 +733,13 @@ TEST_F(HNSWTest, TEST_search_level_0) {
     // search_type == 1
     res1.begin(0);
     index->hnsw.search_level_0(
-            *dis, res1, nprobe, nearest_i, nearest_d, 1, stats1, vt1, nullptr);
+            *dis, res1, nprobe, nearest_i, nearest_d, 1, stats1, *vt1, nullptr);
     res1.end();
 
     // search_type == 2
     res2.begin(0);
     index->hnsw.search_level_0(
-            *dis, res2, nprobe, nearest_i, nearest_d, 2, stats2, vt2, nullptr);
+            *dis, res2, nprobe, nearest_i, nearest_d, 2, stats2, *vt2, nullptr);
     res2.end();
 
     // search_type 1 calls search_from_candidates in a loop nprobe times.


### PR DESCRIPTION
## Summary

PR #5226 currently fails to build on every CI target (gcc, MSVC, clang) because the out-of-class definition of `HNSW::shrink_neighbor_list<C>` shadows its own template parameter against the class-scope `using C = C_distance;`. During parameter-list lookup outside the class body, `NodeDistFartherT<C>` resolves to `NodeDistFartherT<C_distance>`, doesn't match the templated declaration in `HNSW.h`, and the explicit instantiations at the bottom of `HNSW.cpp` have nothing to bind to.

Example error (Linux x86_64 cmake, gcc 11) on #5226:

```
faiss/impl/HNSW.cpp:238:6: error: no declaration matches
  'void faiss::HNSW::shrink_neighbor_list(...NodeDistFartherT<CMax<float, long int>>...)'
faiss/impl/HNSW.h:250:17: note: candidate is:
  'template<class C> static void faiss::HNSW::shrink_neighbor_list(...NodeDistFartherT<C>...)'
faiss/impl/HNSW.cpp:291:13: error: explicit instantiation of '...' but no definition available
```

This PR contains all of #5226 (rebased on current main) plus a one-line fix: rename the function template parameter from `C` to `Comp` in the out-of-class definition only. The in-class declaration and call sites already pass the comparator type explicitly, so nothing else has to change. A short comment is added so the next reader doesn't reintroduce the shadow.

If #5226 is rebased / reopened in a different form, this PR can be closed and the equivalent rename applied there.

## Test plan

- [x] `g++ -std=c++17 -fsyntax-only -c faiss/impl/HNSW.cpp` clean locally (reproduced the original failure first, then confirmed it goes away with the patch)
- [x] `IndexHNSW.cpp` also compiles cleanly with the patched code
- [ ] Full CI on this PR (Linux x86_64 cmake/conda, AVX2/AVX512, arm64, macOS, Windows, GPU) should turn green
