### PR TITLE
faiss: Replace remaining get_single_code calls with ScopedCodes

### DIFF
--- a/faiss/IndexBinaryIVF.cpp
+++ b/faiss/IndexBinaryIVF.cpp
@@ -257,7 +257,9 @@ void IndexBinaryIVF::reconstruct_from_offset(
         idx_t list_no,
         idx_t offset,
         uint8_t* recons) const {
-    memcpy(recons, invlists->get_single_code(list_no, offset), code_size);
+    memcpy(recons,
+           InvertedLists::ScopedCodes(invlists, list_no, offset).get(),
+           code_size);
 }
 
 void IndexBinaryIVF::reset() {

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -1223,7 +1223,7 @@ void IndexIVF::search_and_return_codes(
         } else {
             size_t list_no = lo_listno(key);
             size_t offset = lo_offset(key);
-            const uint8_t* cc = invlists->get_single_code(list_no, offset);
+            InvertedLists::ScopedCodes cc(invlists, list_no, offset);
 
             labels[ij] = invlists->get_single_id(list_no, offset);
 
@@ -1231,7 +1231,7 @@ void IndexIVF::search_and_return_codes(
                 encode_listno(list_no, code1);
                 code1 += code_size_1 - code_size;
             }
-            memcpy(code1, cc, code_size);
+            memcpy(code1, cc.get(), code_size);
         }
     }
 }

--- a/faiss/IndexIVFAdditiveQuantizer.cpp
+++ b/faiss/IndexIVFAdditiveQuantizer.cpp
@@ -145,8 +145,8 @@ void IndexIVFAdditiveQuantizer::reconstruct_from_offset(
         int64_t list_no,
         int64_t offset,
         float* recons) const {
-    const uint8_t* code = invlists->get_single_code(list_no, offset);
-    aq->decode(code, recons, 1);
+    InvertedLists::ScopedCodes sc(invlists, list_no, offset);
+    aq->decode(sc.get(), recons, 1);
     if (by_residual) {
         std::vector<float> centroid(d);
         quantizer->reconstruct(list_no, centroid.data());

--- a/faiss/IndexIVFFlat.cpp
+++ b/faiss/IndexIVFFlat.cpp
@@ -164,7 +164,9 @@ void IndexIVFFlat::reconstruct_from_offset(
         int64_t list_no,
         int64_t offset,
         float* recons) const {
-    memcpy(recons, invlists->get_single_code(list_no, offset), code_size);
+    memcpy(recons,
+           InvertedLists::ScopedCodes(invlists, list_no, offset).get(),
+           code_size);
 }
 
 /*****************************************

--- a/faiss/IndexIVFFlatPanorama.cpp
+++ b/faiss/IndexIVFFlatPanorama.cpp
@@ -194,9 +194,9 @@ void IndexIVFFlatPanorama::reconstruct_from_offset(
         int64_t list_no,
         int64_t offset,
         float* recons) const {
-    const uint8_t* code = invlists->get_single_code(list_no, offset);
-    memcpy(recons, code, code_size);
-    invlists->release_codes(list_no, code);
+    memcpy(recons,
+           InvertedLists::ScopedCodes(invlists, list_no, offset).get(),
+           code_size);
 }
 
 } // namespace faiss

--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -341,9 +341,8 @@ void IndexIVFPQ::reconstruct_from_offset(
         int64_t list_no,
         int64_t offset,
         float* recons) const {
-    const uint8_t* code = invlists->get_single_code(list_no, offset);
-
-    pq.decode(code, recons);
+    InvertedLists::ScopedCodes sc(invlists, list_no, offset);
+    pq.decode(sc.get(), recons);
     if (by_residual) {
         std::vector<float> centroid(d);
         quantizer->reconstruct(list_no, centroid.data());

--- a/faiss/IndexIVFPQR.cpp
+++ b/faiss/IndexIVFPQR.cpp
@@ -187,9 +187,8 @@ void IndexIVFPQR::search_preassigned(
                 quantizer->compute_residual(xq, residual_1.get(), list_no);
 
                 // 2nd level residual
-                const uint8_t* l2code = invlists->get_single_code(list_no, ofs);
-
-                pq.decode(l2code, residual_2);
+                InvertedLists::ScopedCodes l2sc(invlists, list_no, ofs);
+                pq.decode(l2sc.get(), residual_2);
                 for (int l = 0; l < d; l++) {
                     residual_2[l] = residual_1[l] - residual_2[l];
                 }

--- a/faiss/IndexIVFRaBitQ.cpp
+++ b/faiss/IndexIVFRaBitQ.cpp
@@ -309,12 +309,12 @@ void IndexIVFRaBitQ::reconstruct_from_offset(
         int64_t list_no,
         int64_t offset,
         float* recons) const {
-    const uint8_t* code = invlists->get_single_code(list_no, offset);
+    InvertedLists::ScopedCodes sc(invlists, list_no, offset);
 
     std::vector<float> centroid(d);
     quantizer->reconstruct(list_no, centroid.data());
 
-    rabitq.decode_core(code, recons, 1, centroid.data());
+    rabitq.decode_core(sc.get(), recons, 1, centroid.data());
 }
 
 void IndexIVFRaBitQ::sa_decode(idx_t n, const uint8_t* codes, float* x) const {
@@ -357,26 +357,17 @@ float IVFRaBitDistanceComputer::operator()(idx_t i) {
     uint64_t list_no = lo_listno(lo);
     uint64_t offset = lo_offset(lo);
 
-    const uint8_t* code = parent->invlists->get_single_code(list_no, offset);
+    InvertedLists::ScopedCodes sc(parent->invlists, list_no, offset);
 
     // ok, we know the appropriate cluster that we need
     std::vector<float> centroid(parent->d);
     parent->quantizer->reconstruct(list_no, centroid.data());
 
-    // compute the distance
-    float distance = 0;
-
     std::unique_ptr<FlatCodesDistanceComputer> dc(
             parent->rabitq.get_distance_computer(
                     parent->qb, centroid.data(), /*centered=*/false));
     dc->set_query(q);
-    distance = dc->distance_to_code(code);
-
-    // deallocate
-    parent->invlists->release_codes(list_no, code);
-
-    // done
-    return distance;
+    return dc->distance_to_code(sc.get());
 }
 
 float IVFRaBitDistanceComputer::symmetric_dis(idx_t /*i*/, idx_t /*j*/) {

--- a/faiss/IndexScalarQuantizer.cpp
+++ b/faiss/IndexScalarQuantizer.cpp
@@ -344,18 +344,18 @@ void IndexIVFScalarQuantizer::reconstruct_from_offset(
         quantizer->reconstruct(list_no, recons);
         return;
     }
-    const uint8_t* code = invlists->get_single_code(list_no, offset);
+    InvertedLists::ScopedCodes sc(invlists, list_no, offset);
 
     if (by_residual) {
         std::vector<float> centroid(d);
         quantizer->reconstruct(list_no, centroid.data());
 
-        sq.decode(code, recons, 1);
+        sq.decode(sc.get(), recons, 1);
         for (int i = 0; i < d; ++i) {
             recons[i] += centroid[i];
         }
     } else {
-        sq.decode(code, recons, 1);
+        sq.decode(sc.get(), recons, 1);
     }
 }
 

--- a/faiss/invlists/DirectMap.cpp
+++ b/faiss/invlists/DirectMap.cpp
@@ -254,7 +254,10 @@ void DirectMap::update_codes(
                 int64_t id2 = invlists->get_single_id(il, l - 1);
                 array[id2] = lo_build(il, ofs);
                 invlists->update_entry(
-                        il, ofs, id2, invlists->get_single_code(il, l - 1));
+                        il,
+                        ofs,
+                        id2,
+                        InvertedLists::ScopedCodes(invlists, il, l - 1).get());
             }
             invlists->resize(il, l - 1);
         }


### PR DESCRIPTION
Summary:
D106493174 converted several `get_single_code` call sites to
`InvertedLists::ScopedCodes`. This diff converts the 11 remaining
sites across 10 files that were missed.

Per the `InvertedLists` API contract, callers of `get_single_code`
must call `release_codes` on the returned pointer. For
`ArrayInvertedLists` (the default), `release_codes` is a no-op so
omitting it is benign. However, `ArrayInvertedListsPanorama` and
`HStackInvertedLists` both heap-allocate in `get_single_code`
(via `new uint8_t[code_size]`), so omitting `release_codes`
leaks memory for users of these backends.

Sites converted:
- `IndexIVFFlat::reconstruct_from_offset`
- `IndexIVFPQ::reconstruct_from_offset`
- `IndexIVFAdditiveQuantizer::reconstruct_from_offset`
- `IndexIVFRaBitQ::reconstruct_from_offset`
- `IVFRaBitDistanceComputer::operator()` (had manual release_codes)
- `IndexIVFScalarQuantizer::reconstruct_from_offset`
- `IndexBinaryIVF::reconstruct_from_offset`
- `IndexIVFPQR::search_preassigned` (refinement loop, inside OMP parallel for)
- `IndexIVF::reconstruct_n` (reorder_quantizer_codes path)
- `IndexIVFFlatPanorama::reconstruct_from_offset` (had manual release_codes)
- `DirectMap::update_id`

All changes are mechanical. No functional change for ArrayInvertedLists users.

Reviewed By: mdouze

Differential Revision: D106638578


