### PR TITLE
Remove unused include of platform_macros.h in partitioning.cpp

### DIFF
--- a/faiss/utils/partitioning.cpp
+++ b/faiss/utils/partitioning.cpp
@@ -18,8 +18,6 @@
 #include <faiss/utils/AlignedTable.h>
 #include <faiss/utils/ordered_key_value.h>
 
-#include <faiss/impl/platform_macros.h>
-
 namespace faiss {
 
 /******************************************************************


### PR DESCRIPTION
Summary:
Remove the unused `#include <faiss/impl/platform_macros.h>` from `fbcode/faiss/utils/partitioning.cpp`. None of the macros defined in that header (`FAISS_API`, `FAISS_PRAGMA_IMPRECISE_*`, `FAISS_ALWAYS_INLINE`, `FAISS_PACKED`, `FAISS_RESTRICT`, `FAISS_MAYBE_UNUSED`, `ALIGNED`, `FAISS_DEPRECATED`, `FAISS_BIG_ENDIAN`, `Swap2Bytes`, etc.) are referenced in this translation unit, so the include is dead.

Removing it reduces preprocessor work, trims the dependency graph, and addresses the `facebook-unused-include-check` finding. No behavioral change.

[Session trajectory link](https://www.internalfb.com/intern/devai/devmate/inspector/?id=23e5eec8-7249-44e6-a173-d1dc6f01eb2c)

Differential Revision: D106760253


