### PR TITLE
docs(ivfpq): clarify recall depends on clustered data structure

### DIFF
--- a/tutorial/python/3-IVFPQ.py
+++ b/tutorial/python/3-IVFPQ.py
@@ -3,6 +3,27 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Note on recall for IVFPQ
+# ------------------------
+# IVFPQ is a lossy index: the inverted-file step prunes the search to a few
+# Voronoi cells, and the product quantizer replaces each residual with its
+# nearest codebook entry. Both steps assume the database has exploitable
+# cluster structure, so that (a) most true neighbours of a query fall in
+# the few cells visited, and (b) residuals concentrate around a small set
+# of prototypes. Real-world embedding datasets (image features such as
+# SIFT1M, sentence embeddings, learned representations) carry that
+# structure and give the recall numbers reported in the Faiss benchmarks.
+#
+# Uniform random vectors do not. With no clusters to exploit, nprobe=10
+# out of nlist=100 cells visits roughly 10% of the database and per-cell
+# quantization noise is large, so top-k recall is typically an order of
+# magnitude below what is seen on clustered data. The synthetic data
+# below uses a single coordinate ramp (xb[:, 0] += arange / 1000.) to
+# inject light structure for a runnable demo; if you swap it for purely
+# uniform vectors, expect recall to drop sharply. This is a property of
+# the data, not a bug in the index. See Jegou, Douze, Schmid, "Product
+# Quantization for Nearest Neighbor Search," IEEE TPAMI 2011.
+
 import numpy as np
 
 d = 64                           # dimension


### PR DESCRIPTION
## Summary

Add a comment block to `tutorial/python/3-IVFPQ.py` that explains the most common confusion users hit when they first run IVFPQ on synthetic data: recall on uniform random vectors is far below the numbers reported on real embedding datasets such as SIFT1M, because IVFPQ depends on the data carrying cluster structure that the inverted-file step and the residual product quantizer can exploit.

## The doc gap

The IVFPQ tutorial currently builds an index over `np.random.random((nb, d))` plus a single coordinate ramp. A new user who copies the tutorial, swaps in their own uniform synthetic data, and measures recall will often see something an order of magnitude below the wiki numbers and conclude either that the index is broken or that their parameters are wrong. The actual cause is upstream of any parameter: uniform data has no exploitable structure. Nothing in the in-source tutorial, the class doxygen for `IndexIVFPQ`, or the README spells this out.

The issue tracker has a long tail of "low IVFPQ recall" reports, including:

- #4465 "the recall rate of the ivfflat index's 1% filtering query is very low"
- #4182 "Hard to achieve high recall rate(recall@R) for huge workload"
- #2971 "Why is the recall rate of IP lower than L2 for IVFPQ"
- #3019 IndexIVFPQ query process question
- #3344 "Low recall with SPACEV1B dataset"

Many of these resolve to the same underlying principle.

## The clarification

The added comment block:

1. States that IVFPQ is lossy in two ways (inverted-file pruning and PQ residual coding) and that both steps assume cluster structure.
2. Names the canonical real datasets (SIFT1M, sentence embeddings, learned representations) where the published recall numbers come from.
3. Warns explicitly that uniform random vectors will give recall an order of magnitude lower, and that this is a property of the data not a bug in the index.
4. Cites Jegou, Douze, Schmid 2011 (the IVFPQ paper) so a reader who wants the math has the entry point.

The tutorial code itself is unchanged. The light coordinate ramp on `xb[:, 0]` already in the example injects enough structure for a runnable demo; the comment makes that explicit.

## Why the tutorial and not the FAQ

The official FAQ lives on the GitHub wiki and is not in this repo, so a tutorial-side note is the only path that ships with the source and reaches every user who reads `tutorial/python/3-IVFPQ.py`. The IVFPQ tutorial is the highest-traffic in-source surface for this class of confusion.

## Test plan

- [x] Python syntax check passes (`python3 -m ast` parse).
- [x] No code path is changed; runtime behaviour of the tutorial is unaffected.
- [x] Comment block uses only ASCII, no em-dashes.
- [ ] Maintainer review of phrasing and citation form.