### PR TITLE
Install missing InvertedListScannerStats.h header

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -268,6 +268,7 @@ set(FAISS_HEADERS
   impl/AdSampling.h
   impl/AdditiveQuantizer.h
   impl/AuxIndexStructures.h
+  impl/InvertedListScannerStats.h
   impl/VisitedTable.h
   impl/ClusteringInitialization.h
   impl/ClusteringHelpers.h


### PR DESCRIPTION
Fixes #5267

`faiss/impl/InvertedListScannerStats.h` is included by installed public headers (`impl/AuxIndexStructures.h` and `impl/ResultHandler.h`) but is itself missing from the `FAISS_HEADERS` install list, so building against an installed faiss fails to find it (for example COLMAP, as reported in the issue).

This adds `impl/InvertedListScannerStats.h` to `FAISS_HEADERS`. There is no code change; the header is already part of the public include graph.
