### PR TITLE
[SVS] Implement memory-mapped I/O for Flat and static Vamana SVS indices

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -85,7 +85,7 @@ runs:
 
         # install SVS runtime for SVS builds
         if [ "${{ inputs.svs }}" = "ON" ]; then
-          conda install -y -q libsvs-runtime -c conda-forge
+          conda install -y -q libsvs-runtime=0.4.0 -c conda-forge
         fi
 
         # install test packages

--- a/conda/faiss-gpu-cuvs/meta.yaml
+++ b/conda/faiss-gpu-cuvs/meta.yaml
@@ -64,7 +64,7 @@ outputs:
         - openblas =0.3.33 # [not x86_64]
         - libcuvs =26.06
         - cuda-version {{ cuda_constraints }}
-        - libsvs-runtime =0.3.0  # [x86_64 and linux]
+        - libsvs-runtime =0.4.0  # [x86_64 and linux]
       run:
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
         - mkl >=2024.2.2,<2026  # [x86_64]
@@ -74,7 +74,7 @@ outputs:
         - libcuvs =26.06
         - cuda-version {{ cuda_constraints }}
         - libnvjitlink
-        - libsvs-runtime =0.3.0  # [x86_64 and linux]
+        - libsvs-runtime =0.4.0  # [x86_64 and linux]
     test:
       requires:
         - conda-build

--- a/conda/faiss-gpu/meta.yaml
+++ b/conda/faiss-gpu/meta.yaml
@@ -61,13 +61,13 @@ outputs:
       host:
         - mkl >=2024.2.2,<2026  # [x86_64]
         - openblas =0.3.33 # [not x86_64]
-        - libsvs-runtime =0.3.0  # [x86_64 and linux]
+        - libsvs-runtime =0.4.0  # [x86_64 and linux]
       run:
         - mkl >=2024.2.2,<2026  # [x86_64]
         - openblas =0.3.33 # [not x86_64]
         - cuda-cudart {{ cuda_constraints }}
         - libcublas {{ libcublas_constraints }}
-        - libsvs-runtime =0.3.0  # [x86_64 and linux]
+        - libsvs-runtime =0.4.0  # [x86_64 and linux]
     test:
       requires:
         - conda-build

--- a/conda/faiss/meta.yaml
+++ b/conda/faiss/meta.yaml
@@ -60,7 +60,7 @@ outputs:
       host:
         - python {{ python }}
         - libcxx =20.1.1  # [osx and arm64]
-        - libsvs-runtime =0.3.0  # [x86_64 and linux]
+        - libsvs-runtime =0.4.0  # [x86_64 and linux]
         {% if PY_VER == '3.10' or PY_VER == '3.11' %}
         - mkl >=2024.2.2,<2026  # [x86_64]
         - python_abi <3.12
@@ -74,7 +74,7 @@ outputs:
       run:
         - python {{ python }}
         - libcxx =20.1.1  # [osx and arm64]
-        - libsvs-runtime =0.3.0  # [x86_64 and linux]
+        - libsvs-runtime =0.4.0  # [x86_64 and linux]
         {% if PY_VER == '3.10' or PY_VER == '3.11' %}
         - mkl >=2024.2.2,<2026  # [x86_64]
         - python_abi <3.12

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -2645,10 +2645,22 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         bool initialized;
         READ1_BOOL(initialized);
         if (initialized) {
-            faiss::svs_io::ReaderStreambuf rbuf(
-                    f, get_deserialization_vector_byte_limit());
-            std::istream is(&rbuf);
-            svs->deserialize_impl(is);
+            if ((io_flags & IO_FLAG_MMAP_IFC) == IO_FLAG_MMAP_IFC &&
+                svs->is_static) {
+                // Use memory-mapped I/O for static indices
+                auto* mf = dynamic_cast<MappedFileIOReader*>(f);
+                FAISS_THROW_IF_NOT_MSG(
+                        mf,
+                        "IO_FLAG_MMAP_IFC flag set but IOReader is not "
+                        "MappedFileIOReader");
+                svs->map_to(mf);
+            } else {
+                // Use standard deserialization
+                faiss::svs_io::ReaderStreambuf rbuf(
+                        f, get_deserialization_vector_byte_limit());
+                std::istream is(&rbuf);
+                svs->deserialize_impl(is);
+            }
         }
         if (h == fourcc("ISVL")) {
             bool trained;
@@ -2677,10 +2689,21 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         bool initialized;
         READ1_BOOL(initialized);
         if (initialized) {
-            faiss::svs_io::ReaderStreambuf rbuf(
-                    f, get_deserialization_vector_byte_limit());
-            std::istream is(&rbuf);
-            svs->deserialize_impl(is);
+            if ((io_flags & IO_FLAG_MMAP_IFC) == IO_FLAG_MMAP_IFC) {
+                // Use memory-mapped I/O for static indices
+                auto* mf = dynamic_cast<MappedFileIOReader*>(f);
+                FAISS_THROW_IF_NOT_MSG(
+                        mf,
+                        "IO_FLAG_MMAP_IFC flag set but IOReader is not "
+                        "MappedFileIOReader");
+                svs->map_to(mf);
+            } else {
+                // Use standard deserialization
+                faiss::svs_io::ReaderStreambuf rbuf(
+                        f, get_deserialization_vector_byte_limit());
+                std::istream is(&rbuf);
+                svs->deserialize_impl(is);
+            }
         }
         idx = std::move(svs);
     } else if (

--- a/faiss/svs/IndexSVSFlat.cpp
+++ b/faiss/svs/IndexSVSFlat.cpp
@@ -61,7 +61,7 @@ void IndexSVSFlat::reset() {
             FAISS_THROW_MSG(status.message());
         }
     }
-    mmap_owner.reset();  // Release the memory mapping
+    mmap_owner.reset(); // Release the memory mapping
     ntotal = 0;
 }
 
@@ -137,11 +137,7 @@ void IndexSVSFlat::map_to(MappedFileIOReader* mf) {
 
     size_t read_bytes = 0;
     auto status = svs_runtime::FlatIndex::map_to_memory(
-            &impl,
-            data,
-            actual_size,
-            svs_metric,
-            &read_bytes);
+            &impl, data, actual_size, svs_metric, &read_bytes);
 
     if (!status.ok()) {
         FAISS_THROW_MSG(status.message());

--- a/faiss/svs/IndexSVSFlat.cpp
+++ b/faiss/svs/IndexSVSFlat.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <faiss/Index.h>
+#include <faiss/impl/mapped_io.h>
 #include <faiss/svs/IndexSVSFaissUtils.h>
 #include <faiss/svs/IndexSVSFlat.h>
 
@@ -60,6 +61,7 @@ void IndexSVSFlat::reset() {
             FAISS_THROW_MSG(status.message());
         }
     }
+    mmap_owner.reset();  // Release the memory mapping
     ntotal = 0;
 }
 
@@ -112,6 +114,54 @@ void IndexSVSFlat::deserialize_impl(std::istream& in) {
         FAISS_THROW_MSG(status.message());
     }
     FAISS_THROW_IF_NOT_MSG(impl, "Failed to load SVS Flat index.");
+}
+
+void IndexSVSFlat::map_to(MappedFileIOReader* mf) {
+    FAISS_THROW_IF_MSG(impl, "Cannot map_to: SVS index already loaded.");
+    FAISS_THROW_IF_NOT(mf);
+
+    // Get current position and remaining size
+    size_t pos = mf->pos;
+    size_t size_to_end = mf->mmap_owner->size() - pos;
+
+    // Get memory-mapped pointer
+    void* data = nullptr;
+    size_t actual_size = mf->mmap(&data, 1, size_to_end);
+    FAISS_THROW_IF_NOT_FMT(
+            actual_size == size_to_end,
+            "mmap() returned unexpected size: %zu (expected %zu)",
+            actual_size,
+            size_to_end);
+
+    auto svs_metric = to_svs_metric(metric_type);
+
+    size_t read_bytes = 0;
+    auto status = svs_runtime::FlatIndex::map_to_memory(
+            &impl,
+            data,
+            actual_size,
+            svs_metric,
+            &read_bytes);
+
+    if (!status.ok()) {
+        FAISS_THROW_MSG(status.message());
+    }
+
+    FAISS_THROW_IF_NOT_FMT(
+            read_bytes > 0 && read_bytes <= size_to_end,
+            "VamanaIndex::map_to_memory returned invalid read_bytes: %zu",
+            read_bytes);
+
+    // Store the mmap_owner to keep the memory mapping alive for the lifetime
+    // of this index. This ensures the memory buffer remains mapped while SVS
+    // is using the pointers we obtained from it.
+    mmap_owner = mf->mmap_owner;
+
+    // Adjust the position to account for the actual bytes read by SVS.
+    // The mmap() call advanced the position by size_to_end, but SVS may have
+    // consumed less data. We need to set it to the correct position for
+    // subsequent read operations.
+    mf->pos = pos + read_bytes;
 }
 
 } // namespace faiss

--- a/faiss/svs/IndexSVSFlat.h
+++ b/faiss/svs/IndexSVSFlat.h
@@ -29,8 +29,13 @@
 #include <svs/runtime/flat_index.h>
 
 #include <iostream>
+#include <memory>
 
 namespace faiss {
+
+// Forward declarations
+struct MappedFileIOReader;
+struct MmappedFileMappingOwner;
 
 struct IndexSVSFlat : Index {
     // sequential labels
@@ -56,9 +61,17 @@ struct IndexSVSFlat : Index {
     /* The actual SVS implementation */
     svs_runtime::FlatIndex* impl{nullptr};
 
+    // Holds a reference to the memory-mapped file owner to keep the memory
+    // mapping alive for the lifetime of this index. Only used when index is
+    // loaded via map_to() with memory-mapped I/O.
+    std::shared_ptr<MmappedFileMappingOwner> mmap_owner{nullptr};
+
     /* Serialization */
     void serialize_impl(std::ostream& out) const;
     void deserialize_impl(std::istream& in);
+
+    /* Memory-mapped deserialization */
+    void map_to(MappedFileIOReader* mf);
 
    protected:
     /* Initializes the implementation*/

--- a/faiss/svs/IndexSVSVamana.cpp
+++ b/faiss/svs/IndexSVSVamana.cpp
@@ -188,7 +188,7 @@ void IndexSVSVamana::reset() {
     }
     stored_vectors.clear();
     stored_vectors_valid = true;
-    mmap_owner.reset();  // Release the memory mapping
+    mmap_owner.reset(); // Release the memory mapping
     is_trained = false;
     ntotal = 0;
 }

--- a/faiss/svs/IndexSVSVamana.cpp
+++ b/faiss/svs/IndexSVSVamana.cpp
@@ -25,6 +25,7 @@
 #include <faiss/svs/IndexSVSVamana.h>
 
 #include <faiss/Index.h>
+#include <faiss/impl/mapped_io.h>
 
 #include <svs/runtime/api_defs.h>
 #include <svs/runtime/dynamic_vamana_index.h>
@@ -187,6 +188,7 @@ void IndexSVSVamana::reset() {
     }
     stored_vectors.clear();
     stored_vectors_valid = true;
+    mmap_owner.reset();  // Release the memory mapping
     is_trained = false;
     ntotal = 0;
 }
@@ -361,6 +363,61 @@ svs_runtime::DynamicVamanaIndex* IndexSVSVamana::dynamic_impl() const {
             is_static, "Operation not supported on a static Vamana index.");
     FAISS_THROW_IF_NOT(impl);
     return static_cast<svs_runtime::DynamicVamanaIndex*>(impl);
+}
+
+void IndexSVSVamana::map_to(MappedFileIOReader* mf) {
+    FAISS_THROW_IF_MSG(
+            !is_static,
+            "map_to() is only supported for static Vamana indices.");
+    FAISS_THROW_IF_MSG(impl, "Cannot map_to: SVS index already loaded.");
+    FAISS_THROW_IF_NOT(mf);
+
+    // Get current position and remaining size
+    size_t pos = mf->pos;
+    size_t size_to_end = mf->mmap_owner->size() - pos;
+
+    // Get memory-mapped pointer
+    void* data = nullptr;
+    size_t actual_size = mf->mmap(&data, 1, size_to_end);
+    FAISS_THROW_IF_NOT_FMT(
+            actual_size == size_to_end,
+            "mmap() returned unexpected size: %zu (expected %zu)",
+            actual_size,
+            size_to_end);
+
+    auto svs_metric = to_svs_metric(metric_type);
+    auto svs_storage_kind = to_svs_storage_kind(storage_kind);
+
+    size_t read_bytes = 0;
+    auto status = svs_runtime::VamanaIndex::map_to_memory(
+            &impl,
+            data,
+            actual_size,
+            svs_metric,
+            svs_storage_kind,
+            &read_bytes);
+
+    if (!status.ok()) {
+        FAISS_THROW_MSG(status.message());
+    }
+
+    FAISS_THROW_IF_NOT_FMT(
+            read_bytes > 0 && read_bytes <= size_to_end,
+            "VamanaIndex::map_to_memory returned invalid read_bytes: %zu",
+            read_bytes);
+
+    // Store the mmap_owner to keep the memory mapping alive for the lifetime
+    // of this index. This ensures the memory buffer remains mapped while SVS
+    // is using the pointers we obtained from it.
+    mmap_owner = mf->mmap_owner;
+
+    // Adjust the position to account for the actual bytes read by SVS.
+    // The mmap() call advanced the position by size_to_end, but SVS may have
+    // consumed less data. We need to set it to the correct position for
+    // subsequent read operations.
+    mf->pos = pos + read_bytes;
+
+    is_trained = true;
 }
 
 } // namespace faiss

--- a/faiss/svs/IndexSVSVamana.h
+++ b/faiss/svs/IndexSVSVamana.h
@@ -30,10 +30,15 @@
 #include <svs/runtime/dynamic_vamana_index.h>
 
 #include <iostream>
+#include <memory>
 #include <type_traits>
 #include <vector>
 
 namespace faiss {
+
+// Forward declarations
+struct MappedFileIOReader;
+struct MmappedFileMappingOwner;
 
 struct SearchParametersSVSVamana : public SearchParameters {
     size_t search_window_size = 0;
@@ -141,9 +146,17 @@ struct IndexSVSVamana : Index {
     void serialize_impl(std::ostream& out) const;
     virtual void deserialize_impl(std::istream& in);
 
+    /* Memory-mapped deserialization for static indices */
+    virtual void map_to(MappedFileIOReader* mf);
+
     /* The actual SVS implementation (VamanaIndex is the base for both
        static and dynamic variants) */
     svs_runtime::VamanaIndex* impl{nullptr};
+
+    // Holds a reference to the memory-mapped file owner to keep the memory
+    // mapping alive for the lifetime of this index. Only used when index is
+    // loaded via map_to() with memory-mapped I/O.
+    std::shared_ptr<MmappedFileMappingOwner> mmap_owner{nullptr};
 
     // The SVS runtime API does not expose vector retrieval, so we keep a copy
     // of added vectors to support reconstruct(). When used as a coarse

--- a/tests/test_svs.cpp
+++ b/tests/test_svs.cpp
@@ -855,7 +855,8 @@ template <typename T>
 void write_and_read_static_vamana_index(
         T& index,
         const std::vector<float>& xb,
-        size_t n) {
+        size_t n,
+        int read_io_flags = 0) {
     ASSERT_TRUE(index.is_static);
 
     // For LeanVec the training step seeds training_data; for plain Vamana
@@ -883,7 +884,7 @@ void write_and_read_static_vamana_index(
     // Deserialize
     T* loaded = nullptr;
     ASSERT_NO_THROW({
-        loaded = dynamic_cast<T*>(faiss::read_index(filename.c_str()));
+        loaded = dynamic_cast<T*>(faiss::read_index(filename.c_str(), read_io_flags));
     });
 
     // Basic checks
@@ -994,4 +995,39 @@ TEST_F(SVS, StaticVamanaReconstruct) {
     for (size_t i = 0; i < d; ++i) {
         EXPECT_EQ(recons[i], test_data[i]);
     }
+}
+
+TEST_F(SVS, WriteAndMapStaticVamana) {
+    faiss::IndexSVSVamana index{
+            d, 64ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_FP32, true};
+    write_and_read_static_vamana_index(index, test_data, n, faiss::IO_FLAG_MMAP_IFC);
+}
+
+TEST_F(SVS, WriteAndMapStaticVamanaFP16) {
+    faiss::IndexSVSVamana index{
+            d, 64ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_FP16, true};
+    write_and_read_static_vamana_index(index, test_data, n, faiss::IO_FLAG_MMAP_IFC);
+}
+
+TEST_F(SVS, WriteAndMapStaticVamanaSQI8) {
+    faiss::IndexSVSVamana index{
+            d, 64ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_SQI8, true};
+    write_and_read_static_vamana_index(index, test_data, n, faiss::IO_FLAG_MMAP_IFC);
+}
+
+TEST_F(SVSLL, WriteAndMapStaticVamanaLVQ4x4) {
+    faiss::IndexSVSVamanaLVQ index{
+            d, 64ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_LVQ4x4, true};
+    write_and_read_static_vamana_index(index, test_data, n, faiss::IO_FLAG_MMAP_IFC);
+}
+
+TEST_F(SVSLL, WriteAndMapStaticVamanaLeanVec4x4) {
+    faiss::IndexSVSVamanaLeanVec index{
+            d,
+            64ul,
+            faiss::METRIC_L2,
+            0,
+            faiss::SVSStorageKind::SVS_LeanVec4x4,
+            true};
+    write_and_read_static_vamana_index(index, test_data, n, faiss::IO_FLAG_MMAP_IFC);
 }

--- a/tests/test_svs.cpp
+++ b/tests/test_svs.cpp
@@ -884,7 +884,8 @@ void write_and_read_static_vamana_index(
     // Deserialize
     T* loaded = nullptr;
     ASSERT_NO_THROW({
-        loaded = dynamic_cast<T*>(faiss::read_index(filename.c_str(), read_io_flags));
+        loaded = dynamic_cast<T*>(
+                faiss::read_index(filename.c_str(), read_io_flags));
     });
 
     // Basic checks
@@ -1000,25 +1001,29 @@ TEST_F(SVS, StaticVamanaReconstruct) {
 TEST_F(SVS, WriteAndMapStaticVamana) {
     faiss::IndexSVSVamana index{
             d, 64ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_FP32, true};
-    write_and_read_static_vamana_index(index, test_data, n, faiss::IO_FLAG_MMAP_IFC);
+    write_and_read_static_vamana_index(
+            index, test_data, n, faiss::IO_FLAG_MMAP_IFC);
 }
 
 TEST_F(SVS, WriteAndMapStaticVamanaFP16) {
     faiss::IndexSVSVamana index{
             d, 64ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_FP16, true};
-    write_and_read_static_vamana_index(index, test_data, n, faiss::IO_FLAG_MMAP_IFC);
+    write_and_read_static_vamana_index(
+            index, test_data, n, faiss::IO_FLAG_MMAP_IFC);
 }
 
 TEST_F(SVS, WriteAndMapStaticVamanaSQI8) {
     faiss::IndexSVSVamana index{
             d, 64ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_SQI8, true};
-    write_and_read_static_vamana_index(index, test_data, n, faiss::IO_FLAG_MMAP_IFC);
+    write_and_read_static_vamana_index(
+            index, test_data, n, faiss::IO_FLAG_MMAP_IFC);
 }
 
 TEST_F(SVSLL, WriteAndMapStaticVamanaLVQ4x4) {
     faiss::IndexSVSVamanaLVQ index{
             d, 64ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_LVQ4x4, true};
-    write_and_read_static_vamana_index(index, test_data, n, faiss::IO_FLAG_MMAP_IFC);
+    write_and_read_static_vamana_index(
+            index, test_data, n, faiss::IO_FLAG_MMAP_IFC);
 }
 
 TEST_F(SVSLL, WriteAndMapStaticVamanaLeanVec4x4) {
@@ -1029,5 +1034,6 @@ TEST_F(SVSLL, WriteAndMapStaticVamanaLeanVec4x4) {
             0,
             faiss::SVSStorageKind::SVS_LeanVec4x4,
             true};
-    write_and_read_static_vamana_index(index, test_data, n, faiss::IO_FLAG_MMAP_IFC);
+    write_and_read_static_vamana_index(
+            index, test_data, n, faiss::IO_FLAG_MMAP_IFC);
 }

--- a/tests/test_svs.cpp
+++ b/tests/test_svs.cpp
@@ -1012,9 +1012,9 @@ TEST_F(SVS, WriteAndMapStaticVamanaFP16) {
             index, test_data, n, faiss::IO_FLAG_MMAP_IFC);
 }
 
-TEST_F(SVS, WriteAndMapStaticVamanaSQI8) {
+TEST_F(SVS, WriteAndMapStaticVamanaSQ8) {
     faiss::IndexSVSVamana index{
-            d, 64ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_SQI8, true};
+            d, 64ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_SQ8, true};
     write_and_read_static_vamana_index(
             index, test_data, n, faiss::IO_FLAG_MMAP_IFC);
 }

--- a/tests/test_svs_py.py
+++ b/tests/test_svs_py.py
@@ -21,6 +21,8 @@
 import numpy as np
 import unittest
 import faiss
+import os
+import tempfile
 
 _SKIP_SVS = "SVS" not in faiss.get_compile_options().split()
 _SKIP_REASON = "SVS support not compiled in"
@@ -1391,6 +1393,34 @@ class TestSVSStaticVamana(unittest.TestCase):
         D_after, _ = loaded.search(self.xq, 4)
         np.testing.assert_allclose(D_before, D_after, rtol=1e-4)
 
+    def test_static_memmapping(self):
+        """Serialize/deserialize preserves is_static and search results"""
+        index = self._create_static()
+        index.add(self.xb)
+
+        D_before, I_before = index.search(self.xq, 4)
+
+        fd, fname = tempfile.mkstemp()
+        os.close(fd)
+
+        loaded = None
+        try:
+            faiss.write_index(index, fname)
+            loaded = faiss.read_index(fname, faiss.IO_FLAG_MMAP_IFC)
+            self.assertIsInstance(loaded, faiss.IndexSVSVamana)
+            self.assertTrue(loaded.is_static)
+            self.assertEqual(loaded.ntotal, self.nb)
+
+            D_after, _ = loaded.search(self.xq, 4)
+            np.testing.assert_allclose(D_before, D_after, rtol=1e-4)
+        finally:
+            del loaded
+            if os.path.exists(fname):
+                try:
+                    os.unlink(fname)
+                except Exception:
+                    pass
+
     def test_static_fp16(self):
         """Static Vamana with FP16 storage"""
         index = self._create_static(faiss.SVS_FP16)
@@ -1478,6 +1508,31 @@ class TestSVSStaticVamanaLVQ(unittest.TestCase):
         D_after, _ = loaded.search(self.xq, 4)
         np.testing.assert_allclose(D_before, D_after, rtol=1e-4)
 
+    def test_static_lvq_memmapping(self):
+        index = self._create_static_lvq()
+        index.add(self.xb)
+
+        D_before, _ = index.search(self.xq, 4)
+
+        fd, fname = tempfile.mkstemp()
+        os.close(fd)
+
+        loaded = None
+        try:
+            faiss.write_index(index, fname)
+            loaded = faiss.read_index(fname, faiss.IO_FLAG_MMAP_IFC)
+            self.assertIsInstance(loaded, faiss.IndexSVSVamana)
+            self.assertTrue(loaded.is_static)
+
+            D_after, _ = loaded.search(self.xq, 4)
+            np.testing.assert_allclose(D_before, D_after, rtol=1e-4)
+        finally:
+            del loaded
+            if os.path.exists(fname):
+                try:
+                    os.unlink(fname)
+                except Exception:
+                    pass
 
 @unittest.skipIf(_SKIP_SVS_LL, _SKIP_SVS_LL_REASON)
 class TestSVSStaticVamanaLeanVec(unittest.TestCase):
@@ -1539,6 +1594,32 @@ class TestSVSStaticVamanaLeanVec(unittest.TestCase):
         D_after, _ = loaded.search(self.xq, 4)
         np.testing.assert_allclose(D_before, D_after, rtol=1e-4)
 
+    def test_static_leanvec_memmapping(self):
+        index = self._create_static_leanvec()
+        index.train(self.xb)
+        index.add(self.xb)
+
+        D_before, _ = index.search(self.xq, 4)
+
+        fd, fname = tempfile.mkstemp()
+        os.close(fd)
+
+        loaded = None
+        try:
+            faiss.write_index(index, fname)
+            loaded = faiss.read_index(fname, faiss.IO_FLAG_MMAP_IFC)
+            self.assertIsInstance(loaded, faiss.IndexSVSVamana)
+            self.assertTrue(loaded.is_static)
+
+            D_after, _ = loaded.search(self.xq, 4)
+            np.testing.assert_allclose(D_before, D_after, rtol=1e-4)
+        finally:
+            del loaded
+            if os.path.exists(fname):
+                try:
+                    os.unlink(fname)
+                except Exception:
+                    pass
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request adds support for memory-mapped I/O (mmap) loading of static SVS (Scalable Vector Search) indices in Faiss, enabling faster and more memory-efficient index loading. The main changes include implementing mmap-based deserialization for static Vamana and Flat indices, updating the index loading logic to use mmap when requested, and adding comprehensive tests for the new functionality.

**Memory-mapped index loading support:**

* Added `map_to` methods to `IndexSVSVamana` and `IndexSVSFlat` for loading static indices directly from memory-mapped files, including logic to manage memory mapping ownership and adjust file positions after mapping.

**Index and file structure updates:**

* Extended `IndexSVSVamana` and `IndexSVSFlat` classes to hold a reference to the mmap owner, ensuring the mapped memory remains valid for the lifetime of the index. Also added forward declarations and includes for mmap-related types.
* Modified `reset` methods to release memory mappings when the index is reset, preventing resource leaks.

**Testing and interface improvements:**

* Enhanced test utilities and added new tests to verify correct mmap loading for various static Vamana index types, including FP32, FP16, SQI8, LVQ4x4, and LeanVec4x4 in `tests/test_svs.cpp`

These changes collectively provide robust and efficient support for memory-mapped loading of static SVS indices, improving both performance and usability for large-scale vector search applications.