### PR TITLE
Fix Windows ARM64 (MSVC) build broken by NEON SIMD templatization

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -591,7 +591,11 @@ endif()
 # NEON is mandatory on ARM64 — ensure COMPILE_SIMD_ARM_NEON is always defined
 # and NEON source files are always compiled into the main faiss target.
 # (On x86, AVX2/AVX512 are optional and only compiled per opt_level above.)
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64|arm64|ARM64)")
+# MSVC on Windows ARM64 is excluded: simdlib_neon.h takes the address of NEON
+# intrinsics as non-type template parameters, but MSVC implements many of them
+# as macros/compiler builtins, so &vmulq_u16 et al. are not usable. MSVC ARM64
+# falls back to simdlib_emulated.h, matching the pre-D95392150 behavior.
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64|arm64|ARM64)" AND NOT MSVC)
   target_compile_definitions(faiss PRIVATE COMPILE_SIMD_ARM_NEON)
   target_sources(faiss PRIVATE ${FAISS_SIMD_NEON_SRC})
 endif()


### PR DESCRIPTION
Summary:
D95392150 (templatize simdlib types on SIMDLevel) added an unconditional CMake block that compiles `${FAISS_SIMD_NEON_SRC}` and defines `COMPILE_SIMD_ARM_NEON` for any ARM64 build target. Those TUs include `simdlib_neon.h`, which uses GCC/Clang-style patterns that MSVC's `<arm_neon.h>` cannot compile — most notably taking the address of NEON intrinsics as non-type template parameters (e.g. `.call<&vmulq_u16>()`, `.call<&detail::simdlib::vdupq_n_u16>()`). MSVC implements many of those intrinsics as macros/compiler builtins, so their addresses are not usable. AArch64-only intrinsics like `vmovn_high_u16` and `vsraq_n_*` further widen the gap.

Before D95392150, `simdlib.h` dispatched via `#elif defined(__aarch64__)`. MSVC on Windows ARM64 defines `_M_ARM64` (not `__aarch64__`), so the ARM64/MSVC build silently fell through to `simdlib_emulated.h` and worked. This diff restores that behavior for the new CMake gate.

Fixes the OSS Windows ARM64 build break reported on facebookresearch/faiss issue 4993.

Differential Revision: D107447785


