### PR TITLE
Validate zero-copy vector sizes when reading indexes

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -158,8 +158,11 @@ template <typename VectorT>
 size_t checked_deserialization_vector_size(
         size_t size,
         size_t size_multiplier) {
+    FAISS_THROW_IF_NOT_MSG(
+            size_multiplier > 0,
+            "deserialization vector size multiplier must be positive");
     FAISS_THROW_IF_NOT_FMT(
-            size_multiplier == 0 || size <= SIZE_MAX / size_multiplier,
+            size <= SIZE_MAX / size_multiplier,
             "deserialization vector size %zu would overflow with multiplier %zu",
             size,
             size_multiplier);

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -155,6 +155,29 @@ void set_deserialization_lattice_r2_limit(size_t value) {
 // * if `size_multiplier` is defined, then a size will be multiplied by it.
 // * returns true is the case was handled; otherwise, false
 template <typename VectorT>
+size_t checked_deserialization_vector_size(
+        size_t size,
+        size_t size_multiplier) {
+    FAISS_THROW_IF_NOT_FMT(
+            size_multiplier == 0 || size <= SIZE_MAX / size_multiplier,
+            "deserialization vector size %zu would overflow with multiplier %zu",
+            size,
+            size_multiplier);
+
+    size *= size_multiplier;
+    FAISS_THROW_IF_NOT_FMT(
+            size < get_deserialization_vector_byte_limit() /
+                            sizeof(typename VectorT::value_type),
+            "deserialization vector size %zu exceeds byte limit %zu for "
+            "element size %zu",
+            size,
+            get_deserialization_vector_byte_limit(),
+            sizeof(typename VectorT::value_type));
+
+    return size;
+}
+
+template <typename VectorT>
 bool read_vector_base(
         VectorT& target,
         IOReader* f,
@@ -173,8 +196,8 @@ bool read_vector_base(
                 READANDCHECK(&size, 1);
             }
 
-            // perform the size multiplication
-            size *= size_multiplier.value_or(1);
+            size = checked_deserialization_vector_size<VectorT>(
+                    size, size_multiplier.value_or(1));
 
             // ok, mmap and check
             char* address = nullptr;
@@ -209,8 +232,8 @@ bool read_vector_base(
                 READANDCHECK(&size, 1);
             }
 
-            // perform the size multiplication
-            size *= size_multiplier.value_or(1);
+            size = checked_deserialization_vector_size<VectorT>(
+                    size, size_multiplier.value_or(1));
 
             // create a view
             char* address = nullptr;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(FAISS_TEST_SRC
   test_callback.cpp
   test_utils.cpp
   test_hamming.cpp
+  test_read_index_deserialize.cpp
   test_zerocopy.cpp
   test_scalar_quantizer.cpp
   test_factory_tools.cpp

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -35,6 +35,7 @@
 #include <faiss/impl/FaissException.h>
 #include <faiss/impl/ScalarQuantizer.h>
 #include <faiss/impl/io.h>
+#include <faiss/impl/zerocopy_io.h>
 #include <faiss/index_io.h>
 #include <faiss/invlists/InvertedLists.h>
 #include <faiss/utils/hamming.h>
@@ -273,6 +274,39 @@ TEST(ReadIndexDeserialize, READVECTORByteLimit) {
         VectorIOReader reader;
         reader.data = buf;
         EXPECT_NO_THROW(read_VectorTransform_up(&reader));
+    }
+
+    set_deserialization_vector_byte_limit(old_limit);
+}
+
+// -----------------------------------------------------------------------
+// Test: Zero-copy IndexFlat reads apply the same byte limit as READXBVECTOR.
+// The fast path returns a view over serialized data instead of resizing a
+// vector, so it must validate before mapping the payload.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, ZeroCopyReadXBVectorByteLimit) {
+    const size_t old_limit = get_deserialization_vector_byte_limit();
+
+    const int d = 1;
+    const int64_t ntotal = 8;
+    const size_t xb_elements = ntotal * d;
+
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IxF2");
+    push_index_header(buf, d, ntotal);
+    push_val<size_t>(buf, xb_elements);
+    buf.insert(buf.end(), xb_elements * sizeof(float), 0);
+
+    set_deserialization_vector_byte_limit(xb_elements * sizeof(float));
+    {
+        ZeroCopyIOReader reader(buf.data(), buf.size());
+        EXPECT_THROW(read_index_up(&reader), FaissException);
+    }
+
+    set_deserialization_vector_byte_limit((xb_elements + 1) * sizeof(float));
+    {
+        ZeroCopyIOReader reader(buf.data(), buf.size());
+        EXPECT_NO_THROW(read_index_up(&reader));
     }
 
     set_deserialization_vector_byte_limit(old_limit);

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -7,8 +7,10 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdio>
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <numeric>
 #include <random>
 #include <vector>
@@ -35,6 +37,7 @@
 #include <faiss/impl/FaissException.h>
 #include <faiss/impl/ScalarQuantizer.h>
 #include <faiss/impl/io.h>
+#include <faiss/impl/mapped_io.h>
 #include <faiss/impl/zerocopy_io.h>
 #include <faiss/index_io.h>
 #include <faiss/invlists/InvertedLists.h>
@@ -80,6 +83,19 @@ static void push_index_header(
     push_val<int64_t>(buf, dummy);
     push_val<bool>(buf, is_trained);
     push_val<int>(buf, metric_type);
+}
+
+/// Helper: build a minimal IndexFlatL2 payload whose xb data is read through
+/// READXBVECTOR.
+static std::vector<uint8_t> make_flat_l2_xb_payload(int d, int64_t ntotal) {
+    const size_t xb_elements = size_t(ntotal) * size_t(d);
+
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IxF2");
+    push_index_header(buf, d, ntotal);
+    push_val<size_t>(buf, xb_elements);
+    buf.insert(buf.end(), xb_elements * sizeof(float), 0);
+    return buf;
 }
 
 /// Helper: append write_ProductQuantizer fields (d, M, nbits, centroids vec).
@@ -289,13 +305,8 @@ TEST(ReadIndexDeserialize, ZeroCopyReadXBVectorByteLimit) {
 
     const int d = 1;
     const int64_t ntotal = 8;
-    const size_t xb_elements = ntotal * d;
-
-    std::vector<uint8_t> buf;
-    push_fourcc(buf, "IxF2");
-    push_index_header(buf, d, ntotal);
-    push_val<size_t>(buf, xb_elements);
-    buf.insert(buf.end(), xb_elements * sizeof(float), 0);
+    const size_t xb_elements = size_t(ntotal) * size_t(d);
+    const std::vector<uint8_t> buf = make_flat_l2_xb_payload(d, ntotal);
 
     set_deserialization_vector_byte_limit(xb_elements * sizeof(float));
     {
@@ -308,6 +319,42 @@ TEST(ReadIndexDeserialize, ZeroCopyReadXBVectorByteLimit) {
         ZeroCopyIOReader reader(buf.data(), buf.size());
         EXPECT_NO_THROW(read_index_up(&reader));
     }
+
+    set_deserialization_vector_byte_limit(old_limit);
+}
+
+// -----------------------------------------------------------------------
+// Test: MappedFileIOReader uses the same read_vector_base() fast path as
+// ZeroCopyIOReader. It must also validate the READXBVECTOR byte limit before
+// returning a view into the mapped file.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, MappedFileReadXBVectorByteLimit) {
+    const size_t old_limit = get_deserialization_vector_byte_limit();
+
+    const int d = 1;
+    const int64_t ntotal = 8;
+    const size_t xb_elements = size_t(ntotal) * size_t(d);
+    const std::vector<uint8_t> buf = make_flat_l2_xb_payload(d, ntotal);
+
+    auto read_with_mmap = [&buf]() {
+        std::unique_ptr<FILE, decltype(&std::fclose)> file(
+                std::tmpfile(), &std::fclose);
+        ASSERT_NE(file.get(), nullptr);
+        ASSERT_EQ(
+                std::fwrite(buf.data(), 1, buf.size(), file.get()),
+                buf.size());
+        ASSERT_EQ(std::fflush(file.get()), 0);
+
+        auto owner = std::make_shared<MmappedFileMappingOwner>(file.get());
+        MappedFileIOReader reader(owner);
+        read_index_up(&reader);
+    };
+
+    set_deserialization_vector_byte_limit(xb_elements * sizeof(float));
+    EXPECT_THROW(read_with_mmap(), FaissException);
+
+    set_deserialization_vector_byte_limit((xb_elements + 1) * sizeof(float));
+    EXPECT_NO_THROW(read_with_mmap());
 
     set_deserialization_vector_byte_limit(old_limit);
 }


### PR DESCRIPTION
## Summary

`read_vector_base()` handles mmap and zero-copy vector reads during index deserialization, but it did not apply the vector byte-limit and overflow checks used by the normal `READVECTOR`/`READXBVECTOR` paths before mapping serialized data.

This updates the mmap/zero-copy fast path to validate the multiplied element count before creating a view, so it matches the existing deserialization guardrails for owned vectors.

## Test plan

- Added `ReadIndexDeserialize.ZeroCopyReadXBVectorByteLimit`, which builds a small serialized `IndexFlatL2` payload and verifies `ZeroCopyIOReader` rejects an `READXBVECTOR` payload at the strict byte-limit boundary.
- Ran `git diff --check` locally.

I could not run the C++ test binary in this checkout because `cmake` is not installed in the local environment.
