### PR TITLE
Stabilize RaBitQ tests on AVX512_SPR by switching to cross-level equivalence

### DIFF
--- a/tests/test_rabitq.py
+++ b/tests/test_rabitq.py
@@ -423,13 +423,11 @@ class TestIVFRaBitQ(unittest.TestCase):
         self.do_comparison_vs_pq_test(faiss.METRIC_INNER_PRODUCT)
 
     def test_comparison_vs_ref_L2(self):
+        # SIMD path must return identical results to NONE on the same index.
         ds = datasets.SyntheticDataset(TEST_DIM, TEST_N, TEST_N, 100)
 
         k = 10
         nlist = 200
-        ref_rbq = ReferenceIVFRabitQ(ds.d, nlist, Bq=4)
-        ref_rbq.train(ds.get_train(), np.identity(ds.d))
-        ref_rbq.add(ds.get_database())
 
         index_flat = faiss.IndexFlat(ds.d, faiss.METRIC_L2)
         index_rbq = faiss.IndexIVFRaBitQ(
@@ -440,25 +438,19 @@ class TestIVFRaBitQ(unittest.TestCase):
         index_rbq.add(ds.get_database())
 
         for nprobe in 1, 4, 16:
-            ref_rbq.nprobe = nprobe
-            _, Iref = ref_rbq.search(ds.get_queries(), k)
-            r_ref_k = faiss.eval_intersection(
-                Iref[:, :k], ds.get_groundtruth()[:, :k]
-            ) / (ds.nq * k)
-            print(f"{nprobe=} k-recall@10={r_ref_k}")
-
             params = faiss.IVFRaBitQSearchParameters()
             params.qb = index_rbq.qb
             params.nprobe = nprobe
-            _, Inew, _ = faiss.search_with_parameters(
+            _, I_simd, _ = faiss.search_with_parameters(
                 index_rbq, ds.get_queries(), k, params, output_stats=True
             )
-            r_new_k = faiss.eval_intersection(
-                Inew[:, :k], ds.get_groundtruth()[:, :k]
-            ) / (ds.nq * k)
-            print(f"{nprobe=} k-recall@10={r_new_k}")
 
-            np.testing.assert_almost_equal(r_ref_k, r_new_k, 3)
+            with NoneSIMDLevel():
+                _, I_none, _ = faiss.search_with_parameters(
+                    index_rbq, ds.get_queries(), k, params, output_stats=True
+                )
+
+            np.testing.assert_array_equal(I_simd, I_none)
 
     def test_comparison_vs_ref_L2_rrot(self):
         ds = datasets.SyntheticDataset(128, 4096, 4096, 100)

--- a/tests/test_rabitq_fastscan.py
+++ b/tests/test_rabitq_fastscan.py
@@ -9,7 +9,7 @@ import numpy as np
 import faiss
 from faiss.contrib import datasets
 
-from common_faiss_tests import for_all_simd_levels
+from common_faiss_tests import for_all_simd_levels, NoneSIMDLevel
 
 
 def compute_expected_code_size(d, nb_bits):
@@ -804,43 +804,43 @@ class TestMultiBitRaBitQFastScan(unittest.TestCase):
                         np.testing.assert_(abs(eval_rbq - eval_fs) < 0.05)
 
     def test_ivf_vs_ivfrabitq_equivalence(self):
-        """Test that multi-bit IVF FastScan matches IndexIVFRaBitQ."""
+        """SIMD path must return identical results to NONE on the same index."""
         d, nlist, nprobe, k = 128, 16, 4, 10
         ds = datasets.SyntheticDataset(d, 1000, 1000, 50)
+
+        if not faiss.SIMDConfig.is_simd_level_available(
+                faiss.SIMDLevel_NONE):
+            self.skipTest("SIMDLevel.NONE not available")
 
         for metric in [faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT]:
             for nb_bits in [2, 4, 8]:
                 with self.subTest(metric=metric, nb_bits=nb_bits):
                     quantizer1 = faiss.IndexFlat(d, metric)
-                    index_ref = faiss.IndexIVFRaBitQ(
+                    index_rbq = faiss.IndexIVFRaBitQ(
                         quantizer1, d, nlist, metric, True, nb_bits
                     )
-                    index_ref.nprobe = nprobe
-                    index_ref.train(ds.get_train())
-                    index_ref.add(ds.get_database())
-                    _, I_ref = index_ref.search(ds.get_queries(), k)
+                    index_rbq.nprobe = nprobe
+                    index_rbq.train(ds.get_train())
+                    index_rbq.add(ds.get_database())
+                    _, I_rbq_simd = index_rbq.search(ds.get_queries(), k)
 
                     quantizer2 = faiss.IndexFlat(d, metric)
-                    index_test = faiss.IndexIVFRaBitQFastScan(
+                    index_fs = faiss.IndexIVFRaBitQFastScan(
                         quantizer2, d, nlist, metric, 32, True, nb_bits
                     )
-                    index_test.nprobe = nprobe
-                    index_test.train(ds.get_train())
-                    index_test.add(ds.get_database())
-                    _, I_test = index_test.search(ds.get_queries(), k)
+                    index_fs.nprobe = nprobe
+                    index_fs.train(ds.get_train())
+                    index_fs.add(ds.get_database())
+                    _, I_fs_simd = index_fs.search(ds.get_queries(), k)
 
-                    index_flat = faiss.IndexFlat(d, metric)
-                    index_flat.add(ds.get_database())
-                    _, I_gt = index_flat.search(ds.get_queries(), k)
+                    with NoneSIMDLevel():
+                        _, I_rbq_none = index_rbq.search(
+                            ds.get_queries(), k)
+                        _, I_fs_none = index_fs.search(
+                            ds.get_queries(), k)
 
-                    recall_ref = faiss.eval_intersection(
-                        I_ref[:, :k], I_gt[:, :k]
-                    ) / (ds.nq * k)
-                    recall_test = faiss.eval_intersection(
-                        I_test[:, :k], I_gt[:, :k]
-                    ) / (ds.nq * k)
-
-                    self.assertLess(abs(recall_ref - recall_test), 0.05)
+                    np.testing.assert_array_equal(I_rbq_simd, I_rbq_none)
+                    np.testing.assert_array_equal(I_fs_simd, I_fs_none)
 
     # ==================== Serialization Tests ====================
 


### PR DESCRIPTION
Summary:
Two RaBitQ tests flaked on AVX512_SPR (T273736519) because they compared independently-trained indexes under tight tolerances. OpenMP k-means float reductions are nondeterministic across thread counts, and SPR hosts differ from AVX512 hosts.

Switch both tests to cross-SIMD-level equivalence: train one index, search at the parameterized SIMD level and at NONE, assert identical hit sets. This is a stronger assertion and eliminates hardware-dependent flakiness.

Differential Revision: D107426687


