### PR TITLE
Enable Metal by default on Apple machines (#5280)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,29 @@ if(FAISS_ENABLE_METAL)
   list(APPEND FAISS_LANGUAGES OBJCXX)
 endif()
 
+# FAISS_ENABLE_METAL may not yet be in the cache on the first cmake run
+# (the option() call is after project()). If the user didn't pass
+# -DFAISS_ENABLE_METAL=... on the command line we pre-seed the cache
+# now so that OBJCXX is added to the project languages.
+# Only default to ON on Apple Silicon (arm64); Intel Macs are not
+# supported by the Metal backend.
+# Prefer CMAKE_SYSTEM_* (target platform, set by toolchain files for
+# cross-compiles) and fall back to CMAKE_HOST_* (build machine).
+if(NOT DEFINED FAISS_ENABLE_METAL)
+  if(DEFINED CMAKE_SYSTEM_NAME)
+    set(_faiss_metal_sys "${CMAKE_SYSTEM_NAME}")
+    set(_faiss_metal_proc "${CMAKE_SYSTEM_PROCESSOR}")
+  else()
+    set(_faiss_metal_sys "${CMAKE_HOST_SYSTEM_NAME}")
+    set(_faiss_metal_proc "${CMAKE_HOST_SYSTEM_PROCESSOR}")
+  endif()
+  if(_faiss_metal_sys STREQUAL "Darwin" AND _faiss_metal_proc STREQUAL "arm64")
+    set(FAISS_ENABLE_METAL ON CACHE BOOL
+      "Enable Metal GPU backend for Apple Silicon.")
+    list(APPEND FAISS_LANGUAGES OBJCXX)
+  endif()
+endif()
+
 if(FAISS_ENABLE_CUVS)
   include(cmake/thirdparty/fetch_rapids.cmake)
   include(rapids-cmake)
@@ -72,7 +95,13 @@ option(FAISS_ENABLE_PYTHON "Build Python extension." ON)
 option(FAISS_ENABLE_C_API "Build C API." OFF)
 option(FAISS_ENABLE_EXTRAS "Build extras like benchmarks and demos" ON)
 option(FAISS_USE_LTO "Enable Link-Time optimization" OFF)
-option(FAISS_ENABLE_METAL "Enable Metal GPU backend for Apple Silicon." OFF)
+if(APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+  set(_FAISS_METAL_DEFAULT ON)
+else()
+  set(_FAISS_METAL_DEFAULT OFF)
+endif()
+option(FAISS_ENABLE_METAL "Enable Metal GPU backend for Apple Silicon."
+  ${_FAISS_METAL_DEFAULT})
 option(FAISS_ENABLE_SVS "Enable SVS (Intel(R) Scalable Vector Search) integration." OFF)
 set(FAISS_SVS_RUNTIME_VERSION "v0" CACHE STRING "Version of the SVS runtime API to use")
 set_property(CACHE FAISS_SVS_RUNTIME_VERSION PROPERTY STRINGS "v0")

--- a/conda/faiss/build-lib-arm64.sh
+++ b/conda/faiss/build-lib-arm64.sh
@@ -18,7 +18,11 @@ cmake -B _build \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DCMAKE_BUILD_TYPE=Release .
 
-make -C _build -j$(nproc) faiss faiss_sve faiss_c faiss_c_sve
+if [ "$(uname -s)" = "Darwin" ]; then
+  make -C _build -j"$(nproc)" faiss faiss_sve faiss_c faiss_c_sve faiss_metal metal_shaders
+else
+  make -C _build -j"$(nproc)" faiss faiss_sve faiss_c faiss_c_sve
+fi
 
 cmake --install _build --prefix $PREFIX
 cmake --install _build --prefix _libfaiss_stage/

--- a/conda/faiss/build-pkg-arm64.sh
+++ b/conda/faiss/build-pkg-arm64.sh
@@ -8,9 +8,16 @@ set -e
 
 
 # Build swigfaiss.so
+# Metal bindings are enabled on macOS where faiss_metal was built.
+METAL_FLAG=""
+if [ "$(uname -s)" = "Darwin" ]; then
+  METAL_FLAG="-DFAISS_ENABLE_METAL=ON"
+fi
+
 cmake -B _build_python_${PY_VER} \
       -Dfaiss_ROOT=_libfaiss_stage/ \
       -DFAISS_ENABLE_GPU=OFF \
+      $METAL_FLAG \
       -DCMAKE_BUILD_TYPE=Release \
       -DPython_EXECUTABLE=$PYTHON \
       faiss/python

--- a/conda/faiss/meta.yaml
+++ b/conda/faiss/meta.yaml
@@ -91,6 +91,8 @@ outputs:
       commands:
         - test -f $PREFIX/lib/libfaiss$SHLIB_EXT       # [not win]
         - test -f $PREFIX/lib/libfaiss_avx2$SHLIB_EXT  # [x86_64 and not win]
+        - test -f $PREFIX/lib/libfaiss_metal.a         # [osx and arm64]
+        - test -f $PREFIX/lib/MetalDistance.metallib   # [osx and arm64]
         - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
         - conda inspect objects -p $PREFIX $PKG_NAME   # [osx]
 

--- a/faiss/gpu_metal/CMakeLists.txt
+++ b/faiss/gpu_metal/CMakeLists.txt
@@ -36,9 +36,10 @@ target_link_libraries(faiss_metal
 
 target_include_directories(faiss_metal
   PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/impl
-    ${CMAKE_CURRENT_SOURCE_DIR}/utils
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/impl>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/utils>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   PRIVATE
     ${PROJECT_SOURCE_DIR}
 )
@@ -74,5 +75,39 @@ add_custom_target(metal_shaders DEPENDS ${METAL_LIB})
 add_dependencies(faiss_metal metal_shaders)
 
 target_compile_definitions(faiss_metal PRIVATE
-  FAISS_METALLIB_PATH="${METAL_LIB}"
+  FAISS_METALLIB_BUILD_PATH="${METAL_LIB}"
+)
+
+# Install the static library, headers, and pre-compiled metallib so that
+# consumers of an installed faiss package can use the Metal backend.
+install(TARGETS faiss_metal
+  EXPORT faiss-targets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+set(FAISS_METAL_HEADERS
+  GpuIndexFlat.h
+  MetalCloner.h
+  MetalDistance.h
+  MetalFlatKernels.h
+  MetalIndex.h
+  MetalIndexFlat.h
+  MetalIndexIVFFlat.h
+  MetalKernels.h
+  MetalPythonBridge.h
+  MetalResources.h
+  StandardMetalResources.h
+)
+foreach(header ${FAISS_METAL_HEADERS})
+  install(FILES ${header}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/faiss/gpu_metal
+  )
+endforeach()
+
+install(FILES impl/MetalIVFFlat.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/faiss/gpu_metal/impl
+)
+
+install(FILES ${METAL_LIB}
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )

--- a/faiss/gpu_metal/MetalKernels.mm
+++ b/faiss/gpu_metal/MetalKernels.mm
@@ -10,11 +10,13 @@
  */
 
 #import "MetalKernels.h"
+#include <dlfcn.h>
+#include <faiss/impl/FaissAssert.h>
 #include <algorithm>
 #include <mutex>
 
-#ifndef FAISS_METALLIB_PATH
-#error "FAISS_METALLIB_PATH must be defined by CMake"
+#ifndef FAISS_METALLIB_BUILD_PATH
+#error "FAISS_METALLIB_BUILD_PATH must be defined by CMake"
 #endif
 
 namespace faiss {
@@ -43,9 +45,48 @@ int MetalKernels::selectTopKVariantIndex(int k) {
     return kNumTopKVariants - 1;
 }
 
+// Locate MetalDistance.metallib at runtime.
+// Search order:
+//   1. FAISS_METALLIB_PATH env var (explicit override)
+//   2. Compiled-in build-tree path (development builds)
+//   3. Next to the library/binary containing this code (dladdr;
+//      works for pip/conda where metallib is in the Python package)
+static NSString* findMetalLibPath() {
+    NSFileManager* fm = [NSFileManager defaultManager];
+
+    const char* envPath = getenv("FAISS_METALLIB_PATH");
+    if (envPath) {
+        NSString* ep = @(envPath);
+        if ([fm fileExistsAtPath:ep])
+            return ep;
+    }
+
+    NSString* buildPath = @(FAISS_METALLIB_BUILD_PATH);
+    if ([fm fileExistsAtPath:buildPath])
+        return buildPath;
+
+    Dl_info info;
+    if (dladdr(reinterpret_cast<void*>(&faiss::gpu_metal::getMetalKernels),
+               &info) &&
+        info.dli_fname) {
+        NSString* libDir =
+                [@(info.dli_fname) stringByDeletingLastPathComponent];
+        NSString* installed = [libDir
+                stringByAppendingPathComponent:@"MetalDistance.metallib"];
+        if ([fm fileExistsAtPath:installed])
+            return installed;
+    }
+
+    return nil;
+}
+
 MetalKernels::MetalKernels(id<MTLDevice> device)
         : device_(device), library_(nil) {
-    NSString* path = @(FAISS_METALLIB_PATH);
+    NSString* path = findMetalLibPath();
+    FAISS_THROW_IF_NOT_MSG(
+            path,
+            "MetalDistance.metallib not found. Set FAISS_METALLIB_PATH or "
+            "reinstall faiss.");
     NSURL* url = [NSURL fileURLWithPath:path];
     NSError* err = nil;
     library_ = [device_ newLibraryWithURL:url error:&err];

--- a/faiss/python/CMakeLists.txt
+++ b/faiss/python/CMakeLists.txt
@@ -470,6 +470,27 @@ if(FAISS_ENABLE_GPU)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/_gpu_build.py" DESTINATION faiss)
 endif()
 
+if(FAISS_ENABLE_METAL)
+  find_file(FAISS_METALLIB_FILE MetalDistance.metallib
+    HINTS "${faiss_ROOT}/lib" "${CMAKE_INSTALL_PREFIX}/lib"
+          "${CMAKE_BINARY_DIR}/faiss/gpu_metal"
+    NO_DEFAULT_PATH
+  )
+  if(FAISS_METALLIB_FILE)
+    install(FILES "${FAISS_METALLIB_FILE}" DESTINATION faiss)
+  elseif(TARGET faiss_metal)
+    # In-tree build: the metallib is compiled by the metal_shaders custom
+    # target and does not exist at configure time. Install from the known
+    # build output path — it will be present at install time.
+    install(FILES "${CMAKE_BINARY_DIR}/faiss/gpu_metal/MetalDistance.metallib"
+      DESTINATION faiss)
+  else()
+    message(WARNING
+      "FAISS_ENABLE_METAL is ON but MetalDistance.metallib was not found. "
+      "The Python package will not include GPU Metal support at runtime.")
+  endif()
+endif()
+
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/py.typed")
   install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/py.typed" DESTINATION faiss)
 endif()


### PR DESCRIPTION
Summary:

Enable the Metal GPU backend by default on Apple Silicon (arm64) macOS. Intel Macs are not affected — Metal remains OFF on x86_64.

Changes:
- CMake pre-seeds `FAISS_ENABLE_METAL=ON` before `project()` on arm64 Darwin so OBJCXX is added to the project languages. The `option()` default also gates on arm64.
- `MetalKernels.mm`: replaced hard-coded `FAISS_METALLIB_PATH` with a runtime search (env var → build-tree path → `dladdr` co-located metallib). Throws a clear error if the metallib is not found instead of silently leaving `library_` nil.
- Conda: `build-lib-arm64.sh` / `build-pkg-arm64.sh` build and link `faiss_metal` + `metal_shaders` on macOS. The x86_64 macOS scripts (`build-lib-osx.sh`, `build-pkg-osx.sh`) are unchanged.
- `python/CMakeLists.txt`: installs `MetalDistance.metallib` into the Python package so the `dladdr` fallback finds it at runtime.
- `gpu_metal/CMakeLists.txt`: installs the static library, headers, and metallib for downstream consumers.

Differential Revision: D107334403


