### PR TITLE
Fix AVX512_SPR dispatch on AMD: require AVX512_FP16 CPUID (#5281)

### DIFF
--- a/faiss/utils/simd_levels.cpp
+++ b/faiss/utils/simd_levels.cpp
@@ -129,6 +129,9 @@ SIMDLevel SIMDConfig::auto_detect_simd_level() {
         asm volatile("cpuid"
                      : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx)
                      : "a"(eax), "c"(ecx));
+        // Save EDX before xgetbv clobbers it — needed for
+        // AVX512_FP16 check (bit 23) in the SPR detection below.
+        unsigned int cpuid7_edx = edx;
 
         unsigned int xcr0;
         asm volatile("xgetbv" : "=a"(xcr0), "=d"(edx) : "c"(0));
@@ -155,8 +158,15 @@ SIMDLevel SIMDConfig::auto_detect_simd_level() {
                         (1 << static_cast<int>(SIMDLevel::AVX512));
 
 #if defined(COMPILE_SIMD_AVX512_SPR)
-                // Check for Sapphire Rapids features (AVX512_BF16)
+                // Check for Sapphire Rapids features.
+                // The SPR code path is compiled with -mavx512fp16, so we
+                // must verify both AVX512_BF16 and AVX512_FP16 before
+                // dispatching to it. AMD Zen 4 (bergamo) has BF16 but
+                // not FP16 — using SPR code there causes SIGILL.
                 // CPUID EAX=7, ECX=1: EAX bit 5 = AVX512_BF16
+                // CPUID EAX=7, ECX=0: EDX bit 23 = AVX512_FP16
+                // (Linux: X86_FEATURE_AVX512_FP16 = 18*32+23)
+                bool has_avx512_fp16 = (cpuid7_edx & (1 << 23)) != 0;
                 unsigned int eax1, ebx1, ecx1, edx1;
                 eax1 = 7;
                 ecx1 = 1;
@@ -164,7 +174,7 @@ SIMDLevel SIMDConfig::auto_detect_simd_level() {
                              : "=a"(eax1), "=b"(ebx1), "=c"(ecx1), "=d"(edx1)
                              : "a"(eax1), "c"(ecx1));
                 bool has_avx512_bf16 = (eax1 & (1 << 5)) != 0;
-                if (has_avx512_bf16) {
+                if (has_avx512_bf16 && has_avx512_fp16) {
                     detected_level = SIMDLevel::AVX512_SPR;
                     supported_simd_levels |=
                             (1 << static_cast<int>(SIMDLevel::AVX512_SPR));

--- a/tests/test_simd_dispatch.py
+++ b/tests/test_simd_dispatch.py
@@ -19,12 +19,32 @@ import sys
 import unittest
 
 
+def get_cpu_flags():
+    """Return the set of CPU feature flags from /proc/cpuinfo, or None.
+
+    On Linux x86_64 this includes tokens like 'avx512f', 'avx512_bf16' and
+    'avx512_fp16' - the OS-reported ground truth for SIMD feature detection.
+    """
+    try:
+        with open("/proc/cpuinfo") as f:
+            cpuinfo = f.read()
+    except OSError:
+        return None
+
+    for line in cpuinfo.splitlines():
+        # 'flags' on x86, 'Features' on aarch64.
+        if line.startswith("flags") or line.startswith("Features"):
+            return set(line.split(":", 1)[1].split())
+    return set()
+
+
 def get_available_simd_levels():
     """
     Returns SIMD levels that are available on the current platform.
     NONE is always available. Others depend on architecture.
     """
     import platform
+
     arch = platform.machine().lower()
 
     # SIMDLevel enum names
@@ -52,7 +72,7 @@ class TestSIMDDispatch(unittest.TestCase):
             self.skipTest("faiss not available")
 
         # Method should exist on SIMDConfig
-        self.assertTrue(hasattr(faiss.SIMDConfig, 'get_dispatched_level'))
+        self.assertTrue(hasattr(faiss.SIMDConfig, "get_dispatched_level"))
 
         # Should return a value (SIMDLevel enum)
         result = faiss.SIMDConfig.get_dispatched_level()
@@ -80,6 +100,7 @@ class TestSIMDDispatch(unittest.TestCase):
         # Only run in DD mode
         try:
             import faiss
+
             if "DD" not in faiss.get_compile_options():
                 self.skipTest("Not a DD build - SIMD level is fixed at compile time")
         except ImportError:
@@ -97,7 +118,7 @@ class TestSIMDDispatch(unittest.TestCase):
                 env["FAISS_SIMD_LEVEL"] = level_name
                 env["PYTHONPATH"] = python_path
 
-                script = f'''
+                script = f"""
 import faiss
 level = faiss.SIMDConfig.get_level()
 dispatched = faiss.SIMDConfig.get_dispatched_level()
@@ -114,18 +135,129 @@ if level_name != "{level_name}":
     exit(1)
 
 print(f"OK: SIMD level {level_name} dispatched correctly")
-'''
+"""
                 result = subprocess.run(
                     [sys.executable, "-c", script],
                     env=env,
                     capture_output=True,
-                    text=True
+                    text=True,
                 )
 
                 self.assertEqual(
-                    result.returncode, 0,
-                    f"Failed for {level_name}: {result.stdout} {result.stderr}"
+                    result.returncode,
+                    0,
+                    f"Failed for {level_name}: {result.stdout} {result.stderr}",
                 )
+
+    def test_detected_level_does_not_crash_fp16(self):
+        """The auto-detected SIMD level must always be safe to execute on the
+        running CPU. AVX512_SPR is compiled with -mavx512fp16, so it must
+        only be detected on CPUs that actually have AVX512_FP16. AMD Zen 4
+        (bergamo) has AVX512_BF16 but NOT AVX512_FP16; before the fix,
+        detection classified it as SPR and SQfp16 distance computations
+        dispatched to SPR code, which crashed.
+        """
+        try:
+            import faiss
+
+            if "DD" not in faiss.get_compile_options():
+                self.skipTest("Not a DD build - SIMD level is fixed at compile time")
+        except ImportError:
+            self.skipTest("faiss not available")
+
+        env = os.environ.copy()
+        env["PYTHONPATH"] = os.pathsep.join(sys.path)
+
+        script = """
+import faiss
+import numpy as np
+
+d = 32
+rs = np.random.RandomState(123)
+xb = rs.rand(2000, d).astype("float32")
+xq = rs.rand(20, d).astype("float32")
+
+
+def exercise_sqfp16():
+    index = faiss.index_factory(d, "SQfp16")
+    index.train(xb)
+    index.add(xb)
+    # SQfp16 distance computations are the code path that SIGILL'd when
+    # SPR was mis-detected on a CPU without AVX512_FP16.
+    index.search(xq, 10)
+
+
+# Auto-detected level: this is exactly what the detection fix controls.
+exercise_sqfp16()
+print("OK auto", faiss.SIMDConfig.get_level_name())
+
+# Every level that detection reports as available must also be safe to run.
+for lvl in range(int(faiss.SIMDLevel_COUNT)):
+    if faiss.SIMDConfig.is_simd_level_available(lvl):
+        faiss.SIMDConfig.set_level(lvl)
+        exercise_sqfp16()
+        print("OK", faiss.SIMDConfig.get_level_name())
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        # A negative return code means the child was killed by a signal;
+        # -signal.SIGILL is the regression we are guarding against.
+        self.assertEqual(
+            result.returncode,
+            0,
+            "SQfp16 crashed at a detected SIMD level (likely SIGILL from "
+            f"SPR mis-detection, D107684495). returncode={result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}",
+        )
+
+    def test_spr_detection_matches_cpu_features(self):
+        """SPR detection must agree with the CPU's real feature flags. The SPR
+        code path is compiled with -mavx512fp16, so AVX512_SPR must be
+        reported available if and only if the CPU actually has the full
+        AVX512 core feature set AND AVX512_BF16 AND AVX512_FP16.
+        """
+        import platform
+
+        try:
+            import faiss
+
+            if "DD" not in faiss.get_compile_options():
+                self.skipTest("Not a DD build - SIMD level is fixed at compile time")
+        except ImportError:
+            self.skipTest("faiss not available")
+
+        if platform.machine().lower() not in ("x86_64", "amd64"):
+            self.skipTest("x86_64-only test")
+
+        flags = get_cpu_flags()
+        if flags is None:
+            self.skipTest("/proc/cpuinfo not available")
+
+        # The exact feature set faiss requires before selecting AVX512_SPR.
+        avx512_core = {"avx512f", "avx512cd", "avx512vl", "avx512dq", "avx512bw"}
+        spr_capable = (
+            avx512_core <= flags and "avx512_bf16" in flags and "avx512_fp16" in flags
+        )
+
+        spr_detected = faiss.SIMDConfig.is_simd_level_available(
+            faiss.SIMDLevel_AVX512_SPR
+        )
+
+        self.assertEqual(
+            spr_detected,
+            spr_capable,
+            "AVX512_SPR detection disagrees with /proc/cpuinfo: "
+            f"detected={spr_detected}, cpu_spr_capable={spr_capable} "
+            f"(avx512_core={avx512_core <= flags}, "
+            f"bf16={'avx512_bf16' in flags}, fp16={'avx512_fp16' in flags}). "
+            "detected=True with fp16=False is the D107684495 regression "
+            "(AMD Zen 4 mis-detected as SPR).",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:

The SPR code path (`sq-avx512-spr.cpp`) is compiled with `-mavx512fp16`, which enables native AVX512-FP16 instructions. The runtime CPUID detection only checked for `AVX512_BF16` before classifying a CPU as SPR-class, but AMD Zen 4 (bergamo) has `AVX512_BF16` without `AVX512_FP16`. This caused SIGILL crashes when `SQfp16` distance computations dispatched to SPR code on bergamo machines.

Fix: require both `AVX512_BF16` (CPUID leaf 7, sub-leaf 1, EAX bit 5) and `AVX512_FP16` (CPUID leaf 7, sub-leaf 0, EDX bit 23) before selecting `SIMDLevel::AVX512_SPR`. AMD bergamo now correctly falls back to the regular `AVX512` path, which uses F16C convert-then-compute-in-FP32.

Test changes:
- get_cpu_flags() helper (parses /proc/cpuinfo). 
- test_detected_level_does_not_crash_fp16 — subprocess SIGILL guard exercising the real SQfp16 path.
- test_spr_detection_matches_cpu_features — deterministic detection-vs-cpuinfo biconditional (the strong
  regression guard).

Reviewed By: junjieqi

Differential Revision: D107684495


