### PR TITLE
Add multi-GPU CAGRA → HNSW build with trainAllNeighbors and multi-GPU optimize (#5282)

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -74,16 +74,19 @@ runs:
         # CUDA install for GPU builds
         elif [ "${{ inputs.gpu }}" = "ON" ]; then
           if [ "${{ inputs.cuvs }}" = "ON" ]; then
-            # Use CUDA 12.9 for cuVS cmake builds: pytorch-gpu on
-            # conda-forge only has CUDA 12 builds, 12.8+ supports GCC 14,
-            # and libcuvs needs libnvjitlink >=12.9.86. Skip the
-            # cuda-libraries-dev metapackage to avoid pinning libnvjitlink.
+            # Use CUDA 13.3 for cuVS cmake builds: the conda libcuvs 26.06 build
+            # links libnvJitLink 13.3 (needs the __nvJitLinkCreate_13_3 symbol).
+            # The nvjitlink runtime lib is a separate package that cuda-nvcc /
+            # cuda-cudart-dev / cuda-version do NOT pull to 13.3, so pin
+            # libnvjitlink explicitly — otherwise an older libnvJitLink.so.13 is
+            # left in the env and libcuvs fails to load at import. PyTorch via pip
+            # supports cu132, avoiding the conda-forge pytorch-gpu CUDA-12 limit.
             conda install -y -q \
-              cuda-nvcc=12.9 cuda-nvtx=12.9 cuda-cupti=12.9 cuda-cudart-dev=12.9 \
+              cuda-nvcc=13.3 cuda-nvtx=13.3 cuda-cupti=13.3 cuda-cudart-dev=13.3 \
+              'libnvjitlink>=13.3,<14' \
               libcublas-dev libcusolver-dev libcusparse-dev \
               gxx_linux-64=14.2 \
-              libcuvs=26.06 'cuda-version>=12,<13' sysroot_linux-64=2.34 \
-              'pytorch-gpu>=2.7' \
+              libcuvs=26.06 'cuda-version>=13.3,<14' sysroot_linux-64=2.34 \
               -c rapidsai -c rapidsai-nightly -c conda-forge -c nvidia
             conda clean --index-cache 2>/dev/null || true
           else
@@ -101,13 +104,22 @@ runs:
           : # skip torch install via conda, we need to install via pip to get
             #  ROCm-enabled version until it's supported in conda by PyTorch
         elif [ "${{ inputs.gpu }}" = "ON" ]; then
-          if [ "${{ inputs.cuvs }}" != "ON" ]; then
-            # PyTorch deprecated its official Anaconda channel (pytorch/pytorch#138506),
-            # so we install via pip for CUDA builds. --break-system-packages is needed
-            # because the CI runner's Python is PEP 668 externally-managed.
-            pip install "torch>=2.7" --break-system-packages --index-url https://download.pytorch.org/whl/cu132
+          # PyTorch deprecated its official Anaconda channel (pytorch/pytorch#138506),
+          # so we install via pip for CUDA builds. --break-system-packages is needed
+          # because the CI runner's Python is PEP 668 externally-managed.
+          # Use cu132 wheels for both cuVS and non-cuVS paths now that cuVS builds
+          # use CUDA 13.2 toolkit.
+          pip install "torch>=2.7" --break-system-packages --index-url https://download.pytorch.org/whl/cu132
+          # cuVS builds previously got pytorch-gpu from conda, now unified to pip.
+          # torch's cu132 wheels bundle a CUDA 13.2 nvidia-nvjitlink; when torch is
+          # imported it dlopens that libnvJitLink.so.13 RTLD_GLOBAL and shadows the
+          # conda 13.3 lib that cuVS 26.06 needs, so faiss then fails to load with
+          # "undefined symbol __nvJitLinkCreate_13_3". No torch cu133 build exists,
+          # so upgrade the pip nvjitlink to 13.3 (symbol-complete, CUDA-13 forward
+          # compatible). cuVS-only: the non-cuVS GPU path is CUDA 12.
+          if [ "${{ inputs.cuvs }}" = "ON" ]; then
+            pip install --break-system-packages --upgrade "nvidia-nvjitlink>=13.3,<14"
           fi
-          # cuVS builds get pytorch-gpu from conda (installed above).
         else
           # TestLowLevelIVF.IVFRQ hangs on pytorch>=2.7, so left it as <2.5 for now.
           conda install -y -q "pytorch<2.5" -c pytorch

--- a/faiss/gpu/GpuIndexCagra.cu
+++ b/faiss/gpu/GpuIndexCagra.cu
@@ -23,12 +23,77 @@
 
 #include <faiss/IndexHNSW.h>
 #include <faiss/gpu/GpuIndexCagra.h>
+#include <faiss/gpu/GpuIndexFlat.h>
 #include <faiss/gpu/StandardGpuResources.h>
+#include <chrono>
 #include <cstddef>
 #include <cstdio>
 #include <faiss/gpu/impl/CuvsCagra.cuh>
+#include <numeric>
 #include <optional>
+#include <random>
 #include <type_traits>
+
+#include <cuvs/neighbors/all_neighbors.hpp>
+#include <cuvs/neighbors/cagra.hpp>
+#include <faiss/gpu/utils/CuvsUtils.h>
+#include <faiss/gpu/utils/DeviceUtils.h>
+#include <raft/core/device_resources_snmg.hpp>
+#include <raft/core/resource/multi_gpu.hpp>
+#include <thrust/copy.h>
+#include <thrust/device_ptr.h>
+
+namespace {
+
+template <int MAX_DEGREE>
+__global__ void kern_detour_count(
+        const uint32_t* __restrict__ knn_graph,
+        const uint32_t graph_size,
+        const uint32_t graph_degree,
+        const uint32_t output_degree,
+        const uint32_t batch_size,
+        const uint32_t offset,
+        uint8_t* __restrict__ detour_count) {
+    __shared__ uint32_t smem[MAX_DEGREE];
+
+    const uint64_t iA = blockIdx.x + (uint64_t)offset;
+    if (iA >= graph_size)
+        return;
+
+    for (uint32_t k = threadIdx.x; k < graph_degree; k += blockDim.x) {
+        smem[k] = 0;
+        if (knn_graph[k + (uint64_t)graph_degree * iA] == (uint32_t)iA)
+            smem[k] = graph_degree;
+    }
+    __syncthreads();
+
+    for (uint32_t kAD = 0; kAD < graph_degree - 1; kAD++) {
+        const uint64_t iD = knn_graph[kAD + (uint64_t)graph_degree * iA];
+        if (iD >= graph_size)
+            continue;
+        for (uint32_t kDB = threadIdx.x; kDB < graph_degree;
+             kDB += blockDim.x) {
+            const uint64_t iB_cand =
+                    knn_graph[kDB + (uint64_t)graph_degree * iD];
+            for (uint32_t kAB = kAD + 1; kAB < graph_degree; kAB++) {
+                const uint64_t iB =
+                        knn_graph[kAB + (uint64_t)graph_degree * iA];
+                if (iB == iB_cand) {
+                    atomicAdd(smem + kAB, 1);
+                    break;
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    for (uint32_t k = threadIdx.x; k < graph_degree; k += blockDim.x) {
+        detour_count[k + (uint64_t)graph_degree * iA] =
+                static_cast<uint8_t>(min(smem[k], 255u));
+    }
+}
+
+} // anonymous namespace
 
 namespace faiss {
 namespace gpu {
@@ -305,6 +370,753 @@ void GpuIndexCagra::searchImpl_(
             search_params);
 }
 
+void GpuIndexCagra::trainMultiGpu(
+        idx_t n,
+        const float* x,
+        std::vector<GpuResourcesProvider*>& providers,
+        std::vector<int>& devices,
+        idx_t stitch_per_shard,
+        int stitch_k,
+        int stitch_mode) {
+    FAISS_THROW_IF_NOT_MSG(!is_trained, "index is already trained");
+    FAISS_THROW_IF_NOT_MSG(!devices.empty(), "must provide at least one GPU");
+    FAISS_THROW_IF_NOT_MSG(stitch_k >= 1, "stitch_k must be >= 1");
+
+    numeric_type_ = NumericType::Float32;
+    int num_shards = static_cast<int>(devices.size());
+    idx_t shard_size = (n + num_shards - 1) / num_shards;
+
+    int total_cross = (num_shards > 1) ? stitch_k * (num_shards - 1) : 0;
+
+    auto t_phase = std::chrono::high_resolution_clock::now();
+    auto t_start = t_phase;
+
+    // Use cuVS native multi-GPU CAGRA build via SNMG
+    raft::device_resources_snmg clique(devices);
+
+    cuvs::neighbors::mg_index_params<cuvs::neighbors::cagra::index_params>
+            mg_params;
+    mg_params.mode = cuvs::neighbors::SHARDED;
+    mg_params.intermediate_graph_degree =
+            cagraConfig_.intermediate_graph_degree;
+    mg_params.graph_degree = cagraConfig_.graph_degree;
+    mg_params.guarantee_connectivity = cagraConfig_.guarantee_connectivity;
+    mg_params.metric = metricFaissToCuvs(this->metric_type, false);
+
+    if (cagraConfig_.build_algo == graph_build_algo::IVF_PQ) {
+        cuvs::neighbors::cagra::graph_build_params::ivf_pq_params
+                graph_build_params;
+        if (cagraConfig_.ivf_pq_params) {
+            graph_build_params.build_params.n_lists =
+                    cagraConfig_.ivf_pq_params->n_lists;
+            graph_build_params.build_params.kmeans_n_iters =
+                    cagraConfig_.ivf_pq_params->kmeans_n_iters;
+            graph_build_params.build_params.kmeans_trainset_fraction =
+                    cagraConfig_.ivf_pq_params->kmeans_trainset_fraction;
+            graph_build_params.build_params.pq_bits =
+                    cagraConfig_.ivf_pq_params->pq_bits;
+            graph_build_params.build_params.pq_dim =
+                    cagraConfig_.ivf_pq_params->pq_dim;
+            graph_build_params.build_params.codebook_kind =
+                    static_cast<cuvs::neighbors::ivf_pq::codebook_gen>(
+                            cagraConfig_.ivf_pq_params->codebook_kind);
+            graph_build_params.build_params.force_random_rotation =
+                    cagraConfig_.ivf_pq_params->force_random_rotation;
+            graph_build_params.build_params.conservative_memory_allocation =
+                    cagraConfig_.ivf_pq_params->conservative_memory_allocation;
+        }
+        if (cagraConfig_.ivf_pq_search_params) {
+            graph_build_params.search_params.n_probes =
+                    cagraConfig_.ivf_pq_search_params->n_probes;
+            graph_build_params.search_params.lut_dtype =
+                    cagraConfig_.ivf_pq_search_params->lut_dtype;
+            graph_build_params.search_params.preferred_shmem_carveout =
+                    cagraConfig_.ivf_pq_search_params->preferred_shmem_carveout;
+        }
+        graph_build_params.build_params.metric =
+                metricFaissToCuvs(this->metric_type, false);
+        graph_build_params.refinement_rate = cagraConfig_.refine_rate;
+        mg_params.graph_build_params = graph_build_params;
+        if (mg_params.graph_degree == mg_params.intermediate_graph_degree) {
+            mg_params.intermediate_graph_degree = 1.5 * mg_params.graph_degree;
+        }
+    } else {
+        cuvs::neighbors::cagra::graph_build_params::nn_descent_params
+                graph_build_params(mg_params.intermediate_graph_degree);
+        graph_build_params.max_iterations = cagraConfig_.nn_descent_niter;
+        graph_build_params.metric = metricFaissToCuvs(this->metric_type, false);
+        mg_params.graph_build_params = graph_build_params;
+    }
+
+    auto dataset = raft::make_host_matrix_view<const float, int64_t>(
+            x, n, static_cast<int64_t>(this->d));
+
+    auto mg_idx = cuvs::neighbors::cagra::build(clique, mg_params, dataset);
+
+    auto t_now = std::chrono::high_resolution_clock::now();
+    fprintf(stderr,
+            "  [trainMultiGpu] SNMG CAGRA build: %.2f seconds\n",
+            std::chrono::duration<double>(t_now - t_phase).count());
+    t_phase = t_now;
+
+    // Extract per-shard graphs into expanded layout: [CAGRA neighbors |
+    // cross-shard slots]
+    idx_t graph_degree = static_cast<idx_t>(cagraConfig_.graph_degree);
+    idx_t expanded_degree = graph_degree + total_cross;
+    merged_knngraph_.assign(n * expanded_degree, -1);
+
+    for (int s = 0; s < num_shards; s++) {
+        idx_t offset = static_cast<idx_t>(s) * shard_size;
+        idx_t actual_size = std::min(shard_size, n - offset);
+
+        auto& shard_idx = mg_idx.ann_interfaces_[s].index_.value();
+        auto device_graph = shard_idx.graph();
+
+        const auto& dev_res =
+                raft::resource::set_current_device_to_rank(clique, s);
+        FAISS_THROW_IF_NOT_FMT(
+                device_graph.extent(1) == graph_degree,
+                "Shard %d has graph_degree %ld, expected %ld",
+                s,
+                (long)device_graph.extent(1),
+                (long)graph_degree);
+
+        std::vector<uint32_t> host_graph(actual_size * graph_degree);
+        raft::resource::sync_stream(dev_res);
+        thrust::copy(
+                thrust::device_ptr<const uint32_t>(device_graph.data_handle()),
+                thrust::device_ptr<const uint32_t>(
+                        device_graph.data_handle() +
+                        actual_size * graph_degree),
+                host_graph.data());
+
+#pragma omp parallel for
+        for (idx_t i = 0; i < actual_size; i++) {
+            for (idx_t j = 0; j < graph_degree; j++) {
+                merged_knngraph_[(offset + i) * expanded_degree + j] =
+                        static_cast<idx_t>(host_graph[i * graph_degree + j]) +
+                        offset;
+            }
+        }
+    }
+
+    merged_knngraph_degree_ = expanded_degree;
+
+    t_now = std::chrono::high_resolution_clock::now();
+    fprintf(stderr,
+            "  [trainMultiGpu] Graph extract + merge: %.2f seconds\n",
+            std::chrono::duration<double>(t_now - t_phase).count());
+    t_phase = t_now;
+
+    // Cross-shard stitching: appends cross-shard edges after CAGRA neighbors.
+    // Mode 0: CPU HNSW search (approximate). Mode 1: GPU brute-force (exact).
+    if (num_shards > 1) {
+        if (stitch_mode == 1 && stitch_per_shard == 0) {
+            stitch_per_shard = 100000;
+            fprintf(stderr,
+                    "  [trainMultiGpu] GPU brute-force mode: defaulting "
+                    "stitch_per_shard to %ld (all-vectors is O(N^2))\n",
+                    (long)stitch_per_shard);
+        }
+
+        fprintf(stderr,
+                "  [trainMultiGpu] Stitching: mode=%s, stitch_per_shard=%ld, "
+                "stitch_k=%d, total_cross=%d, expanded_degree=%ld\n",
+                stitch_mode == 1 ? "GPU-brute-force" : "CPU-HNSW",
+                (long)stitch_per_shard,
+                stitch_k,
+                total_cross,
+                (long)expanded_degree);
+
+        if (stitch_mode == 1) {
+            // GPU brute-force stitching: exact cross-shard neighbors
+            for (int j = 0; j < num_shards; j++) {
+                idx_t j_offset = static_cast<idx_t>(j) * shard_size;
+                idx_t j_size = std::min(shard_size, n - j_offset);
+                if (j_size == 0)
+                    continue;
+
+                GpuIndexFlatConfig flat_config;
+                flat_config.device = devices[j];
+                GpuIndexFlatL2 flat_idx(providers[j], this->d, flat_config);
+                flat_idx.add(j_size, x + j_offset * this->d);
+
+                for (int i = 0; i < num_shards; i++) {
+                    if (i == j)
+                        continue;
+                    idx_t i_offset = static_cast<idx_t>(i) * shard_size;
+                    idx_t i_size = std::min(shard_size, n - i_offset);
+                    if (i_size == 0)
+                        continue;
+
+                    int target_pos = (j < i) ? j : j - 1;
+                    idx_t slot_base = graph_degree +
+                            static_cast<idx_t>(target_pos) * stitch_k;
+
+                    idx_t num_queries = i_size;
+                    const float* query_data = x + i_offset * this->d;
+                    std::vector<idx_t> sampled_indices;
+                    std::vector<float> sampled_vectors;
+
+                    if (stitch_per_shard > 0 && stitch_per_shard < i_size) {
+                        num_queries = stitch_per_shard;
+                        sampled_indices.resize(i_size);
+                        std::iota(
+                                sampled_indices.begin(),
+                                sampled_indices.end(),
+                                idx_t(0));
+                        std::mt19937 rng(42 + i * num_shards + j);
+                        for (idx_t s = 0; s < stitch_per_shard; s++) {
+                            std::uniform_int_distribution<idx_t> dist(
+                                    s, i_size - 1);
+                            std::swap(
+                                    sampled_indices[s],
+                                    sampled_indices[dist(rng)]);
+                        }
+                        sampled_indices.resize(stitch_per_shard);
+
+                        sampled_vectors.resize(stitch_per_shard * this->d);
+#pragma omp parallel for
+                        for (idx_t s = 0; s < stitch_per_shard; s++) {
+                            memcpy(sampled_vectors.data() + s * this->d,
+                                   x +
+                                           (i_offset + sampled_indices[s]) *
+                                                   this->d,
+                                   this->d * sizeof(float));
+                        }
+                        query_data = sampled_vectors.data();
+                    }
+
+                    std::vector<float> distances(num_queries * stitch_k);
+                    std::vector<idx_t> labels(num_queries * stitch_k);
+                    flat_idx.search(
+                            num_queries,
+                            query_data,
+                            stitch_k,
+                            distances.data(),
+                            labels.data());
+
+#pragma omp parallel for
+                    for (idx_t s = 0; s < num_queries; s++) {
+                        idx_t orig_idx = (!sampled_indices.empty())
+                                ? sampled_indices[s]
+                                : s;
+                        idx_t global_id = i_offset + orig_idx;
+                        for (int k = 0; k < stitch_k; k++) {
+                            idx_t local_nb = labels[s * stitch_k + k];
+                            merged_knngraph_
+                                    [global_id * expanded_degree + slot_base +
+                                     k] = (local_nb >= 0)
+                                    ? (local_nb + j_offset)
+                                    : local_nb;
+                        }
+                    }
+                }
+                fprintf(stderr,
+                        "    Shard %d/%d GPU-stitched\n",
+                        j + 1,
+                        num_shards);
+            }
+        } else {
+            // CPU HNSW stitching (Approach C)
+            auto M_temp = graph_degree / 2;
+            for (int j = 0; j < num_shards; j++) {
+                idx_t j_offset = static_cast<idx_t>(j) * shard_size;
+                idx_t j_size = std::min(shard_size, n - j_offset);
+                if (j_size == 0)
+                    continue;
+
+                IndexHNSWCagra temp_idx;
+                temp_idx.d = this->d;
+                temp_idx.metric_type = this->metric_type;
+                temp_idx.base_level_only = true;
+                temp_idx.num_base_level_search_entrypoints = 32;
+                if (this->metric_type == METRIC_L2) {
+                    temp_idx.storage = new IndexFlatL2(this->d);
+                } else {
+                    temp_idx.storage = new IndexFlatIP(this->d);
+                }
+                temp_idx.own_fields = true;
+                temp_idx.keep_max_size_level0 = true;
+                temp_idx.hnsw.reset();
+                temp_idx.hnsw.assign_probas.clear();
+                temp_idx.hnsw.cum_nneighbor_per_level.clear();
+                temp_idx.hnsw.set_default_probas(M_temp, 1.0 / log(M_temp));
+                temp_idx.init_level0 = false;
+                temp_idx.hnsw.prepare_level_tab(j_size, false);
+                temp_idx.storage->add(j_size, x + j_offset * this->d);
+                temp_idx.ntotal = j_size;
+
+#pragma omp parallel for
+                for (idx_t i = 0; i < j_size; i++) {
+                    size_t begin, end;
+                    temp_idx.hnsw.neighbor_range(i, 0, &begin, &end);
+                    for (size_t k = begin; k < end; k++) {
+                        idx_t global_nb = merged_knngraph_
+                                [(j_offset + i) * expanded_degree +
+                                 (k - begin)];
+                        temp_idx.hnsw.neighbors[k] = global_nb - j_offset;
+                    }
+                }
+
+                temp_idx.hnsw.efSearch = 64;
+
+                for (int i = 0; i < num_shards; i++) {
+                    if (i == j)
+                        continue;
+                    idx_t i_offset = static_cast<idx_t>(i) * shard_size;
+                    idx_t i_size = std::min(shard_size, n - i_offset);
+                    if (i_size == 0)
+                        continue;
+
+                    int target_pos = (j < i) ? j : j - 1;
+                    idx_t slot_base = graph_degree +
+                            static_cast<idx_t>(target_pos) * stitch_k;
+
+                    idx_t num_queries = i_size;
+                    const float* query_data = x + i_offset * this->d;
+                    std::vector<idx_t> sampled_indices;
+                    std::vector<float> sampled_vectors;
+
+                    if (stitch_per_shard > 0 && stitch_per_shard < i_size) {
+                        num_queries = stitch_per_shard;
+                        sampled_indices.resize(i_size);
+                        std::iota(
+                                sampled_indices.begin(),
+                                sampled_indices.end(),
+                                idx_t(0));
+                        std::mt19937 rng(42 + i * num_shards + j);
+                        for (idx_t s = 0; s < stitch_per_shard; s++) {
+                            std::uniform_int_distribution<idx_t> dist(
+                                    s, i_size - 1);
+                            std::swap(
+                                    sampled_indices[s],
+                                    sampled_indices[dist(rng)]);
+                        }
+                        sampled_indices.resize(stitch_per_shard);
+
+                        sampled_vectors.resize(stitch_per_shard * this->d);
+#pragma omp parallel for
+                        for (idx_t s = 0; s < stitch_per_shard; s++) {
+                            memcpy(sampled_vectors.data() + s * this->d,
+                                   x +
+                                           (i_offset + sampled_indices[s]) *
+                                                   this->d,
+                                   this->d * sizeof(float));
+                        }
+                        query_data = sampled_vectors.data();
+                    }
+
+                    std::vector<float> distances(num_queries * stitch_k);
+                    std::vector<idx_t> labels(num_queries * stitch_k);
+                    temp_idx.search(
+                            num_queries,
+                            query_data,
+                            stitch_k,
+                            distances.data(),
+                            labels.data());
+
+#pragma omp parallel for
+                    for (idx_t s = 0; s < num_queries; s++) {
+                        idx_t orig_idx = (!sampled_indices.empty())
+                                ? sampled_indices[s]
+                                : s;
+                        idx_t global_id = i_offset + orig_idx;
+                        for (int k = 0; k < stitch_k; k++) {
+                            idx_t local_nb = labels[s * stitch_k + k];
+                            merged_knngraph_
+                                    [global_id * expanded_degree + slot_base +
+                                     k] = (local_nb >= 0)
+                                    ? (local_nb + j_offset)
+                                    : local_nb;
+                        }
+                    }
+                }
+                fprintf(stderr,
+                        "    Shard %d/%d stitched\n",
+                        j + 1,
+                        num_shards);
+            }
+        } // end else (CPU HNSW)
+    }
+
+    t_now = std::chrono::high_resolution_clock::now();
+    fprintf(stderr,
+            "  [trainMultiGpu] Stitching: %.2f seconds\n",
+            std::chrono::duration<double>(t_now - t_phase).count());
+    fprintf(stderr,
+            "  [trainMultiGpu] Total: %.2f seconds\n",
+            std::chrono::duration<double>(t_now - t_start).count());
+
+    multi_gpu_dataset_ = x;
+    this->is_trained = true;
+    this->ntotal = n;
+}
+
+void GpuIndexCagra::trainAllNeighbors(
+        idx_t n,
+        const float* x,
+        std::vector<int>& devices,
+        int n_clusters_override,
+        int overlap_factor_override,
+        bool multi_gpu_optimize,
+        int build_algo,
+        float refinement_rate,
+        int ivfpq_search_batch) {
+    FAISS_THROW_IF_NOT_MSG(!is_trained, "index is already trained");
+    FAISS_THROW_IF_NOT_MSG(!devices.empty(), "must provide at least one GPU");
+
+    numeric_type_ = NumericType::Float32;
+    idx_t graph_degree = static_cast<idx_t>(cagraConfig_.graph_degree);
+    idx_t intermediate_degree =
+            static_cast<idx_t>(cagraConfig_.intermediate_graph_degree);
+
+    auto t_start = std::chrono::high_resolution_clock::now();
+    auto t_phase = t_start;
+
+    // Phase 1+2: Build kNN graph (multi-GPU) then D2H + cast.
+    // clique and d_indices are scoped so SNMG resources are fully destroyed
+    // before Phase 3, avoiding CUDA context interference with single-GPU
+    // optimize.
+    auto h_knn =
+            raft::make_host_matrix<uint32_t, int64_t>(n, intermediate_degree);
+    {
+        raft::device_resources_snmg clique(devices);
+
+        cuvs::neighbors::all_neighbors::all_neighbors_params an_params;
+        int num_gpus = static_cast<int>(devices.size());
+        an_params.n_clusters = n_clusters_override > 0
+                ? static_cast<size_t>(n_clusters_override)
+                : std::max(num_gpus * 2, 4);
+        an_params.overlap_factor = overlap_factor_override > 0
+                ? static_cast<size_t>(overlap_factor_override)
+                : 2;
+        an_params.metric = metricFaissToCuvs(this->metric_type, false);
+
+        const char* algo_name = "nn_descent";
+        if (build_algo == 1) {
+            // Brute-force: exact kNN via tiled GEMM, O(N²D) per cluster
+            cuvs::neighbors::all_neighbors::graph_build_params::
+                    brute_force_params bf_params;
+            an_params.graph_build_params = bf_params;
+            algo_name = "brute_force";
+        } else if (build_algo == 2) {
+            // IVF-PQ: approximate kNN with refinement
+            auto dataset_ext = raft::make_extents<int64_t>(
+                    n, static_cast<int64_t>(this->d));
+            cuvs::neighbors::all_neighbors::graph_build_params::ivf_pq_params
+                    ivfpq_params(dataset_ext);
+            ivfpq_params.refinement_rate = refinement_rate;
+            // Bound the IVF-PQ search workspace to avoid GPU OOM at scale. The
+            // cuVS default max_internal_batch_size is 128*1024, whose search
+            // buffers can exceed H100 memory for dense 100M clusters. Capping
+            // it batches the search into smaller query chunks (results
+            // unchanged).
+            if (ivfpq_search_batch > 0) {
+                ivfpq_params.search_params.max_internal_batch_size =
+                        static_cast<uint32_t>(ivfpq_search_batch);
+            }
+            an_params.graph_build_params = ivfpq_params;
+            algo_name = "ivf_pq";
+        } else {
+            // Default: NN-descent
+            cuvs::neighbors::all_neighbors::graph_build_params::
+                    nn_descent_params nn_params;
+            nn_params.graph_degree = intermediate_degree;
+            nn_params.max_iterations = cagraConfig_.nn_descent_niter;
+            an_params.graph_build_params = nn_params;
+        }
+
+        auto dataset = raft::make_host_matrix_view<const float, int64_t>(
+                x, n, static_cast<int64_t>(this->d));
+
+        auto d_indices = raft::make_device_matrix<int64_t, int64_t>(
+                clique, n, static_cast<int64_t>(intermediate_degree));
+
+        fprintf(stderr,
+                "  [trainAllNeighbors] Building kNN graph: n=%ld, "
+                "intermediate_degree=%ld, n_clusters=%zu, overlap=%zu, "
+                "algo=%s, refinement_rate=%.2f\n",
+                (long)n,
+                (long)intermediate_degree,
+                an_params.n_clusters,
+                an_params.overlap_factor,
+                algo_name,
+                build_algo == 2 ? refinement_rate : 0.0f);
+
+        cuvs::neighbors::all_neighbors::build(
+                clique, an_params, dataset, d_indices.view());
+
+        auto t_now = std::chrono::high_resolution_clock::now();
+        fprintf(stderr,
+                "  [trainAllNeighbors] all_neighbors build: %.2f seconds\n",
+                std::chrono::duration<double>(t_now - t_phase).count());
+        t_phase = t_now;
+
+        // D2H + cast int64 -> uint32
+        std::vector<int64_t> h_indices_i64(n * intermediate_degree);
+        raft::copy(
+                h_indices_i64.data(),
+                d_indices.data_handle(),
+                n * intermediate_degree,
+                raft::resource::get_cuda_stream(clique));
+        raft::resource::sync_stream(clique);
+
+#pragma omp parallel for
+        for (idx_t i = 0; i < n * intermediate_degree; i++) {
+            h_knn.data_handle()[i] = static_cast<uint32_t>(h_indices_i64[i]);
+        }
+    } // clique + d_indices destroyed here, freeing all GPU resources
+
+    auto t_now = std::chrono::high_resolution_clock::now();
+    fprintf(stderr,
+            "  [trainAllNeighbors] D2H + cast: %.2f seconds\n",
+            std::chrono::duration<double>(t_now - t_phase).count());
+    t_phase = t_now;
+
+    // Phase 3: Optimize kNN graph into CAGRA graph
+    auto h_cagra = raft::make_host_matrix<uint32_t, int64_t>(n, graph_degree);
+    memset(h_cagra.data_handle(), 0xff, n * graph_degree * sizeof(uint32_t));
+
+    if (multi_gpu_optimize && devices.size() > 1) {
+        // S2: Multi-GPU detour counting + CPU pruning/reverse/merge
+        int num_gpus = static_cast<int>(devices.size());
+        fprintf(stderr,
+                "  [trainAllNeighbors] Multi-GPU optimize: %d GPUs, "
+                "n=%ld, %ld->%ld\n",
+                num_gpus,
+                (long)n,
+                (long)intermediate_degree,
+                (long)graph_degree);
+
+        // Phase 3a: Multi-GPU detour counting
+        FAISS_THROW_IF_NOT_MSG(
+                intermediate_degree <= 1024,
+                "intermediate_graph_degree must be <= 1024 for "
+                "multi-GPU optimize");
+
+        auto h_detour = raft::make_host_matrix<uint8_t, int64_t>(
+                n, intermediate_degree);
+        memset(h_detour.data_handle(),
+               0xff,
+               n * intermediate_degree * sizeof(uint8_t));
+
+        idx_t chunk = (n + num_gpus - 1) / num_gpus;
+
+#pragma omp parallel for num_threads(num_gpus)
+        for (int g = 0; g < num_gpus; g++) {
+            idx_t my_start = g * chunk;
+            idx_t my_end = std::min(my_start + chunk, n);
+            idx_t my_n = my_end - my_start;
+            if (my_n <= 0)
+                continue;
+
+            CUDA_VERIFY(cudaSetDevice(devices[g]));
+            cudaStream_t stream;
+            CUDA_VERIFY(cudaStreamCreate(&stream));
+
+            uint32_t* d_knn_graph;
+            CUDA_VERIFY(cudaMalloc(
+                    &d_knn_graph,
+                    (size_t)n * intermediate_degree * sizeof(uint32_t)));
+            CUDA_VERIFY(cudaMemcpyAsync(
+                    d_knn_graph,
+                    h_knn.data_handle(),
+                    (size_t)n * intermediate_degree * sizeof(uint32_t),
+                    cudaMemcpyHostToDevice,
+                    stream));
+
+            uint8_t* d_detour;
+            CUDA_VERIFY(cudaMalloc(
+                    &d_detour,
+                    (size_t)n * intermediate_degree * sizeof(uint8_t)));
+            CUDA_VERIFY(cudaMemsetAsync(
+                    d_detour,
+                    0xff,
+                    (size_t)n * intermediate_degree * sizeof(uint8_t),
+                    stream));
+
+            // Launch detour counting for this GPU's node range
+            constexpr uint32_t BATCH = 262144;
+            dim3 threads(32, 1, 1);
+            uint32_t total_batches =
+                    (static_cast<uint32_t>(my_n) + BATCH - 1) / BATCH;
+
+            for (uint32_t ib = 0; ib < total_batches; ib++) {
+                uint32_t batch_start =
+                        static_cast<uint32_t>(my_start) + ib * BATCH;
+                uint32_t batch_n = std::min(
+                        BATCH, static_cast<uint32_t>(my_end) - batch_start);
+                dim3 blocks(batch_n, 1, 1);
+                kern_detour_count<1024><<<blocks, threads, 0, stream>>>(
+                        d_knn_graph,
+                        static_cast<uint32_t>(n),
+                        static_cast<uint32_t>(intermediate_degree),
+                        static_cast<uint32_t>(graph_degree),
+                        BATCH,
+                        batch_start,
+                        d_detour);
+            }
+
+            CUDA_VERIFY(cudaGetLastError());
+            CUDA_VERIFY(cudaMemcpyAsync(
+                    h_detour.data_handle() + my_start * intermediate_degree,
+                    d_detour + my_start * intermediate_degree,
+                    (size_t)my_n * intermediate_degree * sizeof(uint8_t),
+                    cudaMemcpyDeviceToHost,
+                    stream));
+
+            CUDA_VERIFY(cudaStreamSynchronize(stream));
+            CUDA_VERIFY(cudaFree(d_knn_graph));
+            CUDA_VERIFY(cudaFree(d_detour));
+            CUDA_VERIFY(cudaStreamDestroy(stream));
+        }
+
+        auto t_opt1 = std::chrono::high_resolution_clock::now();
+        fprintf(stderr,
+                "  [trainAllNeighbors] multi-GPU detour counting: "
+                "%.2f seconds\n",
+                std::chrono::duration<double>(t_opt1 - t_phase).count());
+
+        // Phase 3b: CPU pruning (select top-graph_degree by lowest detour
+        // count)
+        auto* output_ptr = h_cagra.data_handle();
+#pragma omp parallel for
+        for (idx_t i = 0; i < n; i++) {
+            idx_t pk = 0;
+            uint32_t num_detour = 0;
+            for (uint32_t l = 0;
+                 l < (uint32_t)intermediate_degree && pk < graph_degree;
+                 l++) {
+                uint32_t next_num_detour = std::numeric_limits<uint32_t>::max();
+                for (idx_t k = 0; k < intermediate_degree; k++) {
+                    uint32_t dc =
+                            h_detour.data_handle()[i * intermediate_degree + k];
+                    if (dc > num_detour)
+                        next_num_detour = std::min(dc, next_num_detour);
+                    if (dc != num_detour)
+                        continue;
+
+                    uint32_t candidate =
+                            h_knn.data_handle()[i * intermediate_degree + k];
+                    bool dup = false;
+                    for (idx_t dk = 0; dk < pk; dk++) {
+                        if (candidate == output_ptr[i * graph_degree + dk]) {
+                            dup = true;
+                            break;
+                        }
+                    }
+                    if (!dup && candidate < (uint32_t)n) {
+                        output_ptr[i * graph_degree + pk] = candidate;
+                        pk++;
+                    }
+                    if (pk >= graph_degree)
+                        break;
+                }
+                if (pk >= graph_degree)
+                    break;
+                if (next_num_detour == std::numeric_limits<uint32_t>::max())
+                    break;
+                num_detour = next_num_detour;
+            }
+        }
+
+        auto t_opt2 = std::chrono::high_resolution_clock::now();
+        fprintf(stderr,
+                "  [trainAllNeighbors] CPU pruning: %.2f seconds\n",
+                std::chrono::duration<double>(t_opt2 - t_opt1).count());
+
+        // Phase 3c: Build reverse graph and merge into output
+        // (matches graph_core.cuh Phase 4+5 logic)
+        std::vector<uint32_t> rev_graph(n * graph_degree, UINT32_MAX);
+        std::vector<uint32_t> rev_count(n, 0);
+
+        // Build reverse adjacency: for each edge A→B, record B←A
+        for (idx_t i = 0; i < n; i++) {
+            for (idx_t k = 0; k < graph_degree; k++) {
+                uint32_t dest = output_ptr[i * graph_degree + k];
+                if (dest >= (uint32_t)n)
+                    continue;
+                uint32_t slot = rev_count[dest];
+                if (slot < (uint32_t)graph_degree) {
+                    rev_graph[dest * graph_degree + slot] =
+                            static_cast<uint32_t>(i);
+                    rev_count[dest]++;
+                }
+            }
+        }
+
+        // Merge reverse edges into output graph (replace tail edges)
+#pragma omp parallel for
+        for (idx_t i = 0; i < n; i++) {
+            uint32_t num_protected = std::max<uint32_t>(graph_degree / 2, 1);
+            uint32_t kr =
+                    std::min(rev_count[i], static_cast<uint32_t>(graph_degree));
+            while (kr > 0) {
+                kr--;
+                uint32_t rev_node = rev_graph[i * graph_degree + kr];
+                if (rev_node >= (uint32_t)n)
+                    continue;
+
+                // Check if already in neighbor list
+                bool found = false;
+                for (idx_t j = 0; j < graph_degree; j++) {
+                    if (output_ptr[i * graph_degree + j] == rev_node) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (found)
+                    continue;
+
+                // Shift tail edges and insert at protected boundary
+                for (idx_t j = graph_degree - 1; j > (idx_t)num_protected;
+                     j--) {
+                    output_ptr[i * graph_degree + j] =
+                            output_ptr[i * graph_degree + j - 1];
+                }
+                output_ptr[i * graph_degree + num_protected] = rev_node;
+            }
+        }
+
+        auto t_opt3 = std::chrono::high_resolution_clock::now();
+        fprintf(stderr,
+                "  [trainAllNeighbors] reverse graph: %.2f seconds\n",
+                std::chrono::duration<double>(t_opt3 - t_opt2).count());
+    } else {
+        // Single-GPU optimize (original path)
+        cudaSetDevice(devices[0]);
+        cudaDeviceSynchronize();
+        raft::device_resources single_gpu_res;
+        cuvs::neighbors::cagra::helpers::optimize(
+                single_gpu_res, h_knn.view(), h_cagra.view());
+    }
+
+    t_now = std::chrono::high_resolution_clock::now();
+    fprintf(stderr,
+            "  [trainAllNeighbors] optimize: %.2f seconds\n",
+            std::chrono::duration<double>(t_now - t_phase).count());
+    t_phase = t_now;
+
+    // Phase 4: Store as merged_knngraph_ for copyTo()
+    merged_knngraph_.resize(n * graph_degree);
+    merged_knngraph_degree_ = graph_degree;
+
+#pragma omp parallel for
+    for (idx_t i = 0; i < n * graph_degree; i++) {
+        merged_knngraph_[i] = static_cast<idx_t>(h_cagra.data_handle()[i]);
+    }
+
+    multi_gpu_dataset_ = x;
+    this->is_trained = true;
+    this->ntotal = n;
+
+    t_now = std::chrono::high_resolution_clock::now();
+    fprintf(stderr,
+            "  [trainAllNeighbors] Total: %.2f seconds\n",
+            std::chrono::duration<double>(t_now - t_start).count());
+}
+
 void GpuIndexCagra::copyFrom_ex(
         const faiss::IndexHNSWCagra* index,
         NumericType numeric_type) {
@@ -407,6 +1219,10 @@ void GpuIndexCagra::copyFrom(const faiss::IndexHNSWCagra* index) {
 }
 
 void GpuIndexCagra::copyTo(faiss::IndexHNSWCagra* index) const {
+    if (!merged_knngraph_.empty()) {
+        copyToMultiGpu_(index);
+        return;
+    }
     FAISS_ASSERT(
             !std::holds_alternative<std::monostate>(index_) &&
             this->is_trained && index);
@@ -595,8 +1411,69 @@ void GpuIndexCagra::copyTo(faiss::IndexHNSWCagra* index) const {
     index->init_level0 = true;
 }
 
+void GpuIndexCagra::copyToMultiGpu_(faiss::IndexHNSWCagra* index) const {
+    FAISS_ASSERT(this->is_trained && index && !merged_knngraph_.empty());
+    FAISS_THROW_IF_NOT_MSG(
+            numeric_type_ == NumericType::Float32,
+            "Multi-GPU copyTo only supports Float32");
+
+    GpuIndex::copyTo(index);
+    index->ntotal = 0;
+    index->set_numeric_type(numeric_type_);
+
+    auto graph_degree = merged_knngraph_degree_;
+    auto M = graph_degree / 2;
+
+    if (index->storage && index->own_fields) {
+        delete index->storage;
+        index->storage = nullptr;
+    }
+    if (this->metric_type == METRIC_L2) {
+        index->storage = new IndexFlatL2(index->d);
+    } else if (this->metric_type == METRIC_INNER_PRODUCT) {
+        index->storage = new IndexFlatIP(index->d);
+    } else {
+        FAISS_THROW_MSG(
+                "Multi-GPU copyTo only supports METRIC_L2 and METRIC_INNER_PRODUCT");
+    }
+    index->own_fields = true;
+    index->keep_max_size_level0 = true;
+    index->hnsw.reset();
+    index->hnsw.assign_probas.clear();
+    index->hnsw.cum_nneighbor_per_level.clear();
+    index->hnsw.set_default_probas(M, 1.0 / log(M));
+
+    auto n_train = this->ntotal;
+
+    index->init_level0 = false;
+    if (!index->base_level_only) {
+        index->add(n_train, multi_gpu_dataset_);
+    } else {
+        index->hnsw.prepare_level_tab(n_train, false);
+        index->storage->add(n_train, multi_gpu_dataset_);
+        index->ntotal = n_train;
+    }
+
+#pragma omp parallel for
+    for (idx_t i = 0; i < n_train; i++) {
+        size_t begin, end;
+        index->hnsw.neighbor_range(i, 0, &begin, &end);
+        for (size_t j = begin; j < end; j++) {
+            index->hnsw.neighbors[j] =
+                    merged_knngraph_[i * graph_degree + (j - begin)];
+        }
+    }
+
+    index->init_level0 = true;
+}
+
 void GpuIndexCagra::reset() {
     DeviceScope scope(config_.device);
+
+    bool had_multi_gpu = !merged_knngraph_.empty();
+    merged_knngraph_.clear();
+    merged_knngraph_degree_ = 0;
+    multi_gpu_dataset_ = nullptr;
 
     if (!std::holds_alternative<std::monostate>(index_)) {
         std::visit(
@@ -612,16 +1489,22 @@ void GpuIndexCagra::reset() {
                 index_);
         this->ntotal = 0;
         this->is_trained = false;
+    } else if (had_multi_gpu) {
+        this->ntotal = 0;
+        this->is_trained = false;
     } else {
         FAISS_ASSERT(this->ntotal == 0);
     }
 }
 
 std::vector<idx_t> GpuIndexCagra::get_knngraph() const {
-    FAISS_ASSERT(
-            !std::holds_alternative<std::monostate>(index_) &&
-            this->is_trained);
+    FAISS_ASSERT(this->is_trained);
 
+    if (!merged_knngraph_.empty()) {
+        return merged_knngraph_;
+    }
+
+    FAISS_ASSERT(!std::holds_alternative<std::monostate>(index_));
     return std::visit(
             [](auto&& index_ptr) -> std::vector<idx_t> {
                 using IndexPtrT = std::decay_t<decltype(index_ptr)>;

--- a/faiss/gpu/GpuIndexCagra.h
+++ b/faiss/gpu/GpuIndexCagra.h
@@ -284,6 +284,46 @@ struct GpuIndexCagra : public GpuIndex {
     /// in the index instance
     void copyTo(faiss::IndexHNSWCagra* index) const;
 
+    /// Train CAGRA using multiple GPUs by sharding the dataset.
+    /// Uses cuVS native SNMG (single-node multi-GPU) CAGRA build.
+    /// Each device builds one shard in parallel via OpenMP.
+    /// Float32 only. After training, call copyTo() to produce a CPU
+    /// IndexHNSWCagra with full HNSW upper levels.
+    /// The training data pointer must remain valid until copyTo() completes.
+    /// stitch_mode: 0=CPU HNSW (Approach C), 1=GPU brute-force (Approach B)
+    void trainMultiGpu(
+            idx_t n,
+            const float* x,
+            std::vector<GpuResourcesProvider*>& providers,
+            std::vector<int>& devices,
+            idx_t stitch_per_shard = 0,
+            int stitch_k = 2,
+            int stitch_mode = 0);
+
+    /// Build a unified CAGRA graph using cuVS all_neighbors
+    /// (multi-GPU kNN graph construction with overlapping clusters) followed
+    /// by cagra::optimize (graph pruning). Produces a single unified graph
+    /// without stitching. The training data pointer must remain valid until
+    /// copyTo() completes.
+    /// build_algo: 0=NN-descent (default), 1=brute-force, 2=IVF-PQ
+    /// refinement_rate: IVF-PQ refinement multiplier (only used when
+    /// build_algo==2). Higher values trade build time for recall; the cuVS
+    /// default is 2.0.
+    /// ivfpq_search_batch: cap the IVF-PQ search `max_internal_batch_size` used
+    /// during the all_neighbors kNN build (build_algo==2). 0 = cuVS default
+    /// (128*1024), which can OOM at 100M; a smaller value (e.g. 8192) bounds
+    /// the GPU search workspace with no effect on results (recall-neutral).
+    void trainAllNeighbors(
+            idx_t n,
+            const float* x,
+            std::vector<int>& devices,
+            int n_clusters = 0,
+            int overlap_factor = 0,
+            bool multi_gpu_optimize = false,
+            int build_algo = 0,
+            float refinement_rate = 2.0f,
+            int ivfpq_search_batch = 0);
+
     void reset() override;
 
     std::vector<idx_t> get_knngraph() const;
@@ -317,6 +357,8 @@ struct GpuIndexCagra : public GpuIndex {
             idx_t* labels,
             const SearchParameters* search_params) const override;
 
+    void copyToMultiGpu_(faiss::IndexHNSWCagra* index) const;
+
     /// Our configuration options
     const GpuIndexCagraConfig cagraConfig_;
 
@@ -329,6 +371,11 @@ struct GpuIndexCagra : public GpuIndex {
             std::shared_ptr<CuvsCagra<half>>,
             std::shared_ptr<CuvsCagra<int8_t>>>
             index_;
+
+    /// Multi-GPU state: populated by trainMultiGpu(), used by copyTo()
+    std::vector<idx_t> merged_knngraph_;
+    idx_t merged_knngraph_degree_ = 0;
+    const float* multi_gpu_dataset_ = nullptr;
 };
 
 } // namespace gpu

--- a/faiss/gpu/test/bench_approaches.py
+++ b/faiss/gpu/test/bench_approaches.py
@@ -1,0 +1,862 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Benchmark 4 approaches for multi-GPU CAGRA -> HNSW:
+  A. IndexShards (independent HNSW per shard, no stitching)
+  B. Unified + GPU brute-force sampled stitching (exact cross-shard NNs)
+  C. Unified + CPU HNSW stitching (approximate cross-shard NNs)
+  D. all_neighbors + optimize (multi-GPU overlapping clusters, no stitching)
+
+Usage:
+  buck run @//mode/opt fbcode//faiss/gpu/test:bench_approaches -- \\
+      --data /path/to/vectors.npy --approaches D --multi-gpu-optimize
+"""
+
+import argparse
+import os
+import sys
+import tempfile
+import time
+import faiss
+import numpy as np
+
+_local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+_SENTINEL = "/tmp/bench_done"
+if "CUDA_VISIBLE_DEVICES" in os.environ:
+    del os.environ["CUDA_VISIBLE_DEVICES"]
+
+if _local_rank == 0 and os.path.exists(_SENTINEL):
+    os.remove(_SENTINEL)
+elif _local_rank != 0:
+    while not os.path.exists(_SENTINEL):
+        time.sleep(5)
+    sys.exit(0)
+
+sys.stdout = sys.stderr
+
+
+_t0 = time.time()
+
+
+def compute_recall(I_test, I_gt, k):
+    nq = I_test.shape[0]
+    return np.mean([len(set(I_test[i]) & set(I_gt[i])) / k for i in range(nq)])
+
+
+def load_from_hive(
+    n, table, namespace, ds, ts, oncall="faiss", batch_size=4096
+):
+    """Stream `n` real `prefilter_embedding` vectors from a Hive table into a
+    preallocated (n, d) float32 array using the in-process Koski reader.
+
+    This is the no-duplicate path: it reads genuine rows from the warehouse on
+    the MAST host (no Manifold .npy, no tiling).
+    `batch_iterator()` yields a list
+    of rows; each row is a tuple of columns; row[0] is the embedding (list of d
+    floats). dim is inferred from the first row.
+    """
+    import koski.dataframes as kd
+
+    print(
+        f"Loading {n:,} vectors from Hive {namespace}/{table} "
+        f"(ds={ds}, ts={ts}) via Koski...",
+        flush=True,
+    )
+    t0 = time.time()
+    ctx = kd.create_ctx(
+        oncall=oncall,
+        use_case=kd.UseCase.TEST,
+        description="multi-GPU CAGRA benchmark data load",
+    )
+    df = kd.data_warehouse(namespace=namespace, table=table, session_ctx=ctx)
+    df = df.filter(f"ds = '{ds}' AND ts = '{ts}'").map(["prefilter_embedding"])
+    df = df.limit(n).rebatch(batch_size=batch_size)
+
+    xb = None
+    i = 0
+    for batch in df.batch_iterator():
+        rows = [row[0] for row in batch]
+        arr = np.asarray(rows, dtype=np.float32)
+        if xb is None:
+            xb = np.empty((n, arr.shape[1]), dtype=np.float32)
+        m = min(arr.shape[0], n - i)
+        xb[i:i+m] = arr[:m]
+        i += m
+        if i % (batch_size * 50) == 0:
+            elapsed = time.time() - t0
+            print(f"  {i:,}/{n:,} ({elapsed:.0f}s)", flush=True)
+        if i >= n:
+            break
+    if xb is None or i == 0:
+        print("ERROR: Hive returned no rows", file=sys.stderr)
+        sys.exit(1)
+    print(f"  Loaded {i:,} vectors from Hive in {time.time() - t0:.1f}s")
+    return xb[:i]
+
+
+def approach_a_indexshards(xb, d, num_gpus, graph_degree=32, save_dir=None):
+    """Build N independent CAGRA->HNSW, wrap in IndexShards."""
+    n = xb.shape[0]
+    shard_size = (n + num_gpus - 1) // num_gpus
+    timings = {}
+
+    t0 = time.time()
+    shards = []
+    for g in range(num_gpus):
+        start = g * shard_size
+        end = min(start + shard_size, n)
+        shard_data = xb[start:end]
+        if len(shard_data) == 0:
+            continue
+
+        res = faiss.StandardGpuResources()
+        config = faiss.GpuIndexCagraConfig()
+        config.graph_degree = graph_degree
+        config.intermediate_graph_degree = graph_degree * 2
+        config.build_algo = faiss.graph_build_algo_NN_DESCENT
+        idx = faiss.GpuIndexCagra(res, d, faiss.METRIC_L2, config)
+        idx.train(shard_data)
+
+        cpu_idx = faiss.IndexHNSWCagra()
+        idx.copyTo(cpu_idx)
+        shards.append(cpu_idx)
+    timings["build"] = time.time() - t0
+
+    t0 = time.time()
+    index = faiss.IndexShards(d, True, True)
+    for s in shards:
+        index.add_shard(s)
+    timings["assemble"] = time.time() - t0
+
+    out_dir = save_dir or tempfile.mkdtemp()
+    t0 = time.time()
+    total_bytes = 0
+    for i, s in enumerate(shards):
+        path = os.path.join(out_dir, f"A_shard_{i}_{n // 1_000_000}M.faiss")
+        faiss.write_index(s, path)
+        total_bytes += os.path.getsize(path)
+    timings["serialize"] = time.time() - t0
+    timings["file_size_gb"] = total_bytes / 1e9
+
+    return index, shards, timings
+
+
+def approach_b_unified_gpu_stitch(
+    xb,
+    d,
+    num_gpus,
+    graph_degree=32,
+    stitch_per_shard=100000,
+    stitch_k=16,
+    save_dir=None,
+):
+    """Unified SNMG build + GPU brute-force sampled stitching (exact NNs)."""
+    n = xb.shape[0]
+    timings = {}
+
+    resources = faiss.GpuResourcesVector()
+    devices = faiss.Int32Vector()
+    res_list = []
+    for i in range(num_gpus):
+        res = faiss.StandardGpuResources()
+        res_list.append(res)
+        resources.push_back(res)
+        devices.push_back(i)
+
+    config = faiss.GpuIndexCagraConfig()
+    config.graph_degree = graph_degree
+    config.intermediate_graph_degree = graph_degree * 2
+    config.build_algo = faiss.graph_build_algo_NN_DESCENT
+    index = faiss.GpuIndexCagra(res_list[0], d, faiss.METRIC_L2, config)
+
+    t0 = time.time()
+    index.trainMultiGpu(
+        n,
+        faiss.swig_ptr(xb),
+        resources,
+        devices,
+        stitch_per_shard,
+        stitch_k,
+        1,
+    )
+    timings["build"] = time.time() - t0
+
+    t0 = time.time()
+    cpu_index = faiss.IndexHNSWCagra()
+    index.copyTo(cpu_index)
+    timings["copyTo"] = time.time() - t0
+
+    out_dir = save_dir or tempfile.mkdtemp()
+    path = os.path.join(out_dir, f"B_unified_{n // 1_000_000}M.faiss")
+    t0 = time.time()
+    faiss.write_index(cpu_index, path)
+    timings["file_size_gb"] = os.path.getsize(path) / 1e9
+    timings["serialize"] = time.time() - t0
+
+    return cpu_index, timings
+
+
+def approach_c_unified_cpu_stitch(
+    xb,
+    d,
+    num_gpus,
+    graph_degree=32,
+    stitch_per_shard=0,
+    stitch_k=16,
+    save_dir=None,
+):
+    """Unified SNMG build + CPU HNSW stitching (approximate NNs)."""
+    n = xb.shape[0]
+    timings = {}
+
+    resources = faiss.GpuResourcesVector()
+    devices = faiss.Int32Vector()
+    res_list = []
+    for i in range(num_gpus):
+        res = faiss.StandardGpuResources()
+        res_list.append(res)
+        resources.push_back(res)
+        devices.push_back(i)
+
+    config = faiss.GpuIndexCagraConfig()
+    config.graph_degree = graph_degree
+    config.intermediate_graph_degree = graph_degree * 2
+    config.build_algo = faiss.graph_build_algo_NN_DESCENT
+    index = faiss.GpuIndexCagra(res_list[0], d, faiss.METRIC_L2, config)
+
+    t0 = time.time()
+    index.trainMultiGpu(
+        n,
+        faiss.swig_ptr(xb),
+        resources,
+        devices,
+        stitch_per_shard,
+        stitch_k,
+        0,
+    )
+    timings["build"] = time.time() - t0
+
+    t0 = time.time()
+    cpu_index = faiss.IndexHNSWCagra()
+    index.copyTo(cpu_index)
+    timings["copyTo"] = time.time() - t0
+
+    out_dir = save_dir or tempfile.mkdtemp()
+    path = os.path.join(out_dir, f"C_unified_{n // 1_000_000}M.faiss")
+    t0 = time.time()
+    faiss.write_index(cpu_index, path)
+    timings["file_size_gb"] = os.path.getsize(path) / 1e9
+    timings["serialize"] = time.time() - t0
+
+    return cpu_index, timings
+
+
+def approach_d_all_neighbors(
+    xb,
+    d,
+    num_gpus,
+    graph_degree=32,
+    save_dir=None,
+    n_clusters=0,
+    overlap_factor=0,
+    multi_gpu_optimize=False,
+    build_algo=0,
+    base_level_only=False,
+    intermediate_graph_degree=48,
+    refinement_rate=2.0,
+    ivfpq_search_batch=0,
+):
+    """all_neighbors + cagra::optimize → unified CAGRA graph. No stitching."""
+    n = xb.shape[0]
+    timings = {}
+
+    devices = faiss.Int32Vector()
+    res_list = []
+    for i in range(num_gpus):
+        res = faiss.StandardGpuResources()
+        res_list.append(res)
+        devices.push_back(i)
+
+    config = faiss.GpuIndexCagraConfig()
+    config.graph_degree = graph_degree
+    config.intermediate_graph_degree = intermediate_graph_degree
+    config.build_algo = faiss.graph_build_algo_NN_DESCENT
+    index = faiss.GpuIndexCagra(res_list[0], d, faiss.METRIC_L2, config)
+
+    t0 = time.time()
+    index.trainAllNeighbors(
+        n,
+        faiss.swig_ptr(xb),
+        devices,
+        n_clusters,
+        overlap_factor,
+        multi_gpu_optimize,
+        build_algo,
+        refinement_rate,
+        ivfpq_search_batch,
+    )
+    timings["build"] = time.time() - t0
+
+    t0 = time.time()
+    cpu_index = faiss.IndexHNSWCagra()
+    cpu_index.base_level_only = base_level_only
+    index.copyTo(cpu_index)
+    timings["copyTo"] = time.time() - t0
+
+    out_dir = save_dir or tempfile.mkdtemp()
+    path = os.path.join(out_dir, f"D_allneighbors_{n // 1_000_000}M.faiss")
+    t0 = time.time()
+    faiss.write_index(cpu_index, path)
+    timings["file_size_gb"] = os.path.getsize(path) / 1e9
+    timings["serialize"] = time.time() - t0
+
+    return cpu_index, timings
+
+
+def _set_ef(index, ef):
+    if isinstance(index, faiss.IndexShards):
+        for i in range(index.count()):
+            shard = faiss.downcast_index(index.at(i))
+            if hasattr(shard, "hnsw"):
+                shard.hnsw.efSearch = ef
+    elif hasattr(index, "hnsw"):
+        index.hnsw.efSearch = ef
+
+
+def eval_recall(index, xq, Igt, k=10, ef_values=None):
+    if ef_values is None:
+        ef_values = [64, 128, 256]
+    results = {}
+
+    for ef in ef_values:
+        _set_ef(index, ef)
+        D, I = index.search(xq, k)
+        results[ef] = compute_recall(I, Igt, k)
+
+    return results
+
+
+def eval_kcycles(index, xq, k=10, ef_values=None, warmup=3, repeat=5):
+    """Measure kcycles/query using vench CycleCounter."""
+    if ef_values is None:
+        ef_values = [64, 128, 256]
+
+    try:
+        from vector_search.vench.perf_cycles import CycleCounter
+    except ImportError:
+        print("  [kcycles] vench not available, skipping")
+        return {}
+
+    cc = CycleCounter()
+    if not cc.available:
+        print("  [kcycles] perf_event_open not available, skipping")
+        return {}
+
+    nq = xq.shape[0]
+    results = {}
+    prev_threads = faiss.omp_get_max_threads()
+    faiss.omp_set_num_threads(1)
+
+    measure_index = index
+    if isinstance(index, faiss.IndexShards) and index.count() > 0:
+        measure_index = faiss.IndexShards(index.d, False, True)
+        for i in range(index.count()):
+            measure_index.add_shard(index.at(i))
+
+    for ef in ef_values:
+        _set_ef(index, ef)
+        _set_ef(measure_index, ef)
+        for _ in range(warmup):
+            measure_index.search(xq, k)
+
+        best_kcycles = float("inf")
+        for _ in range(repeat):
+            c0 = cc.read()
+            measure_index.search(xq, k)
+            c1 = cc.read()
+            kc = (c1 - c0) / 1000.0 / nq
+            best_kcycles = min(best_kcycles, kc)
+        results[ef] = best_kcycles
+
+    faiss.omp_set_num_threads(prev_threads)
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark multi-GPU CAGRA->HNSW approaches"
+    )
+    parser.add_argument(
+        "--data",
+        type=str,
+        default="",
+        help="Path to .npy file with vectors (n, d) float32 "
+        "(not needed when --hive-table is set)",
+    )
+    parser.add_argument(
+        "--n", type=int, default=0,
+        help="Use first N vectors (0=all)"
+    )
+    parser.add_argument(
+        "--nq", type=int, default=1000,
+        help="Number of queries"
+    )
+    parser.add_argument("--num-gpus", type=int, default=0)
+    parser.add_argument("--graph-degree", type=int, default=32)
+    parser.add_argument("--stitch-k", type=int, default=16)
+    parser.add_argument("--stitch-per-shard", type=int, default=100000)
+    parser.add_argument(
+        "--n-clusters",
+        type=int,
+        default=0,
+        help="all_neighbors n_clusters (0=auto)"
+    )
+    parser.add_argument(
+        "--overlap-factor",
+        type=int,
+        default=0,
+        help="all_neighbors overlap_factor (0=default 2)",
+    )
+    parser.add_argument(
+        "--multi-gpu-optimize",
+        action="store_true",
+        help="Partition detour counting across GPUs",
+    )
+    parser.add_argument(
+        "--build-algo",
+        type=int,
+        default=0,
+        help="0=nn_descent, 1=brute_force, 2=ivf_pq",
+    )
+    parser.add_argument(
+        "--base-level-only",
+        action="store_true",
+        help="Skip HNSW upper-level construction in copyTo",
+    )
+    parser.add_argument(
+        "--intermediate-graph-degree",
+        type=int,
+        default=48,
+        help="kNN graph degree before pruning (use 32 for 100M+)",
+    )
+    parser.add_argument(
+        "--refinement-rate",
+        type=float,
+        default=2.0,
+        help="IVF-PQ refinement multiplier (build-algo=2 only); "
+        "higher trades build time for recall (cuVS default 2.0)",
+    )
+    parser.add_argument(
+        "--ivfpq-search-batch",
+        type=int,
+        default=0,
+        help="Cap IVF-PQ search max_internal_batch_size in the all_neighbors "
+        "build (build-algo=2). 0=cuVS default (131072); smaller (e.g. 8192) "
+        "bounds GPU search workspace to avoid OOM at 100M (recall-neutral)",
+    )
+    parser.add_argument(
+        "--approaches",
+        type=str,
+        default="A,B,C,D",
+        help=("A (IndexShards), B (GPU stitch), "
+                "C (CPU stitch), D (all_neighbors)"),
+    )
+    parser.add_argument(
+        "--index-dir",
+        type=str,
+        default="/tmp/cagra_bench/indices",
+        help="Directory to persist serialized indices for later experiments",
+    )
+    parser.add_argument(
+        "--kcycles-only",
+        action="store_true",
+        help="Load persisted indices and measure kcycles only",
+    )
+    parser.add_argument(
+        "--manifold-data",
+        type=str,
+        default="",
+        help="If data file doesn't exist, download from this Manifold path",
+    )
+    parser.add_argument(
+        "--hive-table",
+        type=str,
+        default="",
+        help="If set, stream real vectors from this Hive table via Koski "
+        "(no Manifold/tiling). Requires --n for the row count.",
+    )
+    parser.add_argument("--hive-namespace", type=str, default="feed_fblearner")
+    parser.add_argument("--hive-ds", type=str, default="2026-06-07")
+    parser.add_argument("--hive-ts", type=str, default="2026-06-07+19:00:99")
+    parser.add_argument("--hive-oncall", type=str, default="faiss")
+    args = parser.parse_args()
+
+    if "CUVS" not in faiss.get_compile_options():
+        print("ERROR: faiss not compiled with cuVS support", file=sys.stderr)
+        sys.exit(1)
+
+    if args.num_gpus > 0:
+        num_gpus = args.num_gpus
+    else:
+        num_gpus = min(faiss.get_num_gpus(), 8)
+    if num_gpus < 2:
+        print(
+            f"ERROR: need >= 2 GPUs, found {faiss.get_num_gpus()}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if args.hive_table:
+        # Preferred path: stream real (non-duplicated) vectors from Hive.
+        if args.n <= 0:
+            print("ERROR: --hive-table requires --n", file=sys.stderr)
+            sys.exit(1)
+        xb = load_from_hive(
+            args.n,
+            args.hive_table,
+            args.hive_namespace,
+            args.hive_ds,
+            args.hive_ts,
+            oncall=args.hive_oncall,
+        )
+        n, d = xb.shape
+        print(f"  Loaded: {n:,} vectors, dim={d}")
+    else:
+        if not args.data:
+            print(
+                "ERROR: provide --data (.npy) or --hive-table",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if not os.path.exists(args.data) and args.manifold_data:
+            os.makedirs(os.path.dirname(args.data), exist_ok=True)
+            try:
+                from manifold.clients.python import ManifoldClient
+            except ImportError:
+                print(
+                    "ERROR: manifold client not available and "
+                    f"data file {args.data} not found",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            print(f"Downloading from Manifold: {args.manifold_data}")
+            parts = args.manifold_data.split("/", 1)
+            with ManifoldClient.get_client(bucket=parts[0]) as mc:
+                mc.sync_get(path=parts[1], output=args.data)
+            print(f"  Downloaded to {args.data}")
+        elif not os.path.exists(args.data):
+            print(f"ERROR: data file {args.data} not found", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"Loading data from {args.data}...")
+        xb = np.load(args.data).astype(np.float32)
+        if args.n > 0 and args.n > xb.shape[0]:
+            reps = (args.n + xb.shape[0] - 1) // xb.shape[0]
+            print(
+                f"  WARNING: tiling {reps}x to reach {args.n:,} vectors "
+                "(duplicates inflate recall; prefer --hive-table)..."
+            )
+            xb = np.tile(xb, (reps, 1))[: args.n]
+        elif args.n > 0:
+            xb = xb[: args.n]
+        n, d = xb.shape
+        print(f"  Loaded: {n:,} vectors, dim={d}")
+
+    xq = xb[: args.nq].copy()
+    k = 10
+
+    print(
+        f"Computing ground truth (brute-force on {n:,} vectors)...",
+        flush=True,
+    )
+    t0 = time.time()
+    gt = faiss.IndexFlatL2(d)
+    gt.add(xb)
+    Dgt, Igt = gt.search(xq, k)
+    del gt
+    print(f"  Done in {time.time() - t0:.1f}s")
+
+    print(
+        f"\nConfig: n={n:,}, d={d}, GPUs={num_gpus}, "
+        f"graph_degree={args.graph_degree}"
+    )
+    print(
+        f"        stitch_k={args.stitch_k}, "
+        f"stitch_per_shard={args.stitch_per_shard}"
+    )
+    print(
+        f"        [D] n_clusters={args.n_clusters or 'auto'}, "
+        f"overlap_factor={args.overlap_factor or 'auto'}, "
+        f"intermediate_graph_degree={args.intermediate_graph_degree}, "
+        f"build_algo={args.build_algo}, refinement_rate={args.refinement_rate}"
+    )
+    print()
+
+    approaches_to_run = [a.strip().upper() for a in args.approaches.split(",")]
+    results_table = []
+    save_dir = args.index_dir
+    os.makedirs(save_dir, exist_ok=True)
+
+    if args.kcycles_only:
+        print(f"Loading persisted indices from {save_dir} (kcycles-only mode)")
+        n_tag = f"{n // 1_000_000}M"
+        for approach in approaches_to_run:
+            if approach == "A":
+                pre = "A_shard_"
+                suf = f"_{n_tag}.faiss"
+                shard_files = sorted(
+                    f
+                    for f in os.listdir(save_dir)
+                    if f.startswith(pre) and f.endswith(suf)
+                )
+                if not shard_files:
+                    print(f"  No A files for {n_tag}")
+                    continue
+                shards = [
+                    faiss.read_index(os.path.join(save_dir, f))
+                    for f in shard_files
+                ]
+                idx = faiss.IndexShards(d, True, True)
+                for s in shards:
+                    idx.add_shard(s)
+                label = f"A: IndexShards ({len(shard_files)})"
+            else:
+                prefixes = {
+                    "B": "B_unified",
+                    "C": "C_unified",
+                    "D": "D_allneighbors",
+                }
+                prefix = prefixes.get(approach)
+                if not prefix:
+                    prefix = f"{approach}_unified"
+                path = os.path.join(save_dir, f"{prefix}_{n_tag}.faiss")
+                if not os.path.exists(path):
+                    print(f"  No {prefix} for {n_tag}")
+                    continue
+                idx = faiss.read_index(path)
+                label = f"{approach}: unified"
+
+            recall = eval_recall(idx, xq, Igt, k)
+            kcycles = eval_kcycles(idx, xq, k)
+            for ef in sorted(recall.keys()):
+                kc = kcycles.get(ef, 0)
+                print(
+                    f"  {label:25s} ef={ef:>3d}  recall={recall[ef]:.4f}  "
+                    f"kcyc/q={kc:.0f}"
+                )
+            del idx
+        return
+
+    print(f"Indices will be saved to: {save_dir}")
+
+    if "A" in approaches_to_run:
+        print("=" * 60)
+        print("APPROACH A: IndexShards (independent HNSW per shard)")
+        print("=" * 60)
+        index_a, shards_a, timings_a = approach_a_indexshards(
+            xb,
+            d,
+            num_gpus,
+            args.graph_degree,
+            save_dir=save_dir,
+        )
+        recall_a = eval_recall(index_a, xq, Igt, k)
+        kcycles_a = eval_kcycles(index_a, xq, k)
+        total_build_a = timings_a["build"] + timings_a.get("assemble", 0)
+        print(f"  Build:     {timings_a['build']:.1f}s")
+        print(
+            f"  Serialize: {timings_a['serialize']:.1f}s "
+            f"({timings_a['file_size_gb']:.2f} GB, {num_gpus} files)"
+        )
+        for ef in sorted(recall_a.keys()):
+            kc = kcycles_a.get(ef, 0)
+            print(
+                f"  efSearch={ef}: recall@{k}={recall_a[ef]:.4f}  "
+                f"kcycles/q={kc:.0f}"
+            )
+        results_table.append(
+            (
+                "A: IndexShards",
+                total_build_a,
+                timings_a["serialize"],
+                timings_a["file_size_gb"],
+                recall_a,
+                kcycles_a,
+            )
+        )
+        del index_a, shards_a
+        print()
+
+    if "B" in approaches_to_run:
+        print("=" * 60)
+        print(
+            f"APPROACH B: Unified + GPU brute-force stitch "
+            f"(sps={args.stitch_per_shard}, k={args.stitch_k})"
+        )
+        print("=" * 60)
+        index_b, timings_b = approach_b_unified_gpu_stitch(
+            xb,
+            d,
+            num_gpus,
+            args.graph_degree,
+            args.stitch_per_shard,
+            args.stitch_k,
+            save_dir=save_dir,
+        )
+        recall_b = eval_recall(index_b, xq, Igt, k)
+        kcycles_b = eval_kcycles(index_b, xq, k)
+        total_build_b = timings_b["build"] + timings_b["copyTo"]
+        print(f"  Build (SNMG+GPU-stitch): {timings_b['build']:.1f}s")
+        print(f"  copyTo:                  {timings_b['copyTo']:.1f}s")
+        print(
+            f"  Serialize:               {timings_b['serialize']:.1f}s "
+            f"({timings_b['file_size_gb']:.2f} GB)"
+        )
+        for ef in sorted(recall_b.keys()):
+            kc = kcycles_b.get(ef, 0)
+            print(
+                f"  efSearch={ef}: recall@{k}={recall_b[ef]:.4f}  "
+                f"kcycles/q={kc:.0f}"
+            )
+        results_table.append(
+            (
+                "B: GPU-brute",
+                total_build_b,
+                timings_b["serialize"],
+                timings_b["file_size_gb"],
+                recall_b,
+                kcycles_b,
+            )
+        )
+        del index_b
+        print()
+
+    if "C" in approaches_to_run:
+        print("=" * 60)
+        print(f"APPROACH C: Unified + CPU stitch (sps=0, k={args.stitch_k})")
+        print("=" * 60)
+        index_c, timings_c = approach_c_unified_cpu_stitch(
+            xb,
+            d,
+            num_gpus,
+            args.graph_degree,
+            0,
+            args.stitch_k,
+            save_dir=save_dir,
+        )
+        recall_c = eval_recall(index_c, xq, Igt, k)
+        kcycles_c = eval_kcycles(index_c, xq, k)
+        total_build_c = timings_c["build"] + timings_c["copyTo"]
+        print(f"  Build (SNMG+CPU-stitch): {timings_c['build']:.1f}s")
+        print(f"  copyTo:                  {timings_c['copyTo']:.1f}s")
+        print(
+            f"  Serialize:               {timings_c['serialize']:.1f}s "
+            f"({timings_c['file_size_gb']:.2f} GB)"
+        )
+        for ef in sorted(recall_c.keys()):
+            kc = kcycles_c.get(ef, 0)
+            print(
+                f"  efSearch={ef}: recall@{k}={recall_c[ef]:.4f}  "
+                f"kcycles/q={kc:.0f}"
+            )
+        results_table.append(
+            (
+                "C: CPU-stitch",
+                total_build_c,
+                timings_c["serialize"],
+                timings_c["file_size_gb"],
+                recall_c,
+                kcycles_c,
+            )
+        )
+        del index_c
+        print()
+
+    if "D" in approaches_to_run:
+        print("=" * 60)
+        print("APPROACH D: all_neighbors + cagra::optimize (no stitching)")
+        print("=" * 60)
+        index_d, timings_d = approach_d_all_neighbors(
+            xb,
+            d,
+            num_gpus,
+            args.graph_degree,
+            save_dir=save_dir,
+            n_clusters=args.n_clusters,
+            overlap_factor=args.overlap_factor,
+            multi_gpu_optimize=args.multi_gpu_optimize,
+            build_algo=args.build_algo,
+            base_level_only=args.base_level_only,
+            intermediate_graph_degree=args.intermediate_graph_degree,
+            refinement_rate=args.refinement_rate,
+            ivfpq_search_batch=args.ivfpq_search_batch,
+        )
+        recall_d = eval_recall(index_d, xq, Igt, k)
+        kcycles_d = eval_kcycles(index_d, xq, k)
+        total_build_d = timings_d["build"] + timings_d["copyTo"]
+        print(f"  Build (allneighbors+optimize): {timings_d['build']:.1f}s")
+        print(f"  copyTo:                        {timings_d['copyTo']:.1f}s")
+        ser = timings_d["serialize"]
+        gb = timings_d["file_size_gb"]
+        print(f"  Serialize:                     {ser:.1f}s " f"({gb:.2f} GB)")
+        # Index-build wall-clock, isolated from data load (Koski/Manifold) and
+        # ground-truth: this is the headline build->serialize number.
+        index_total_d = (
+            timings_d["build"] + timings_d["copyTo"] + timings_d["serialize"]
+        )
+        print(
+            f"  >>> INDEX build->serialize total "
+            f"(excl. data load + ground truth): "
+            f"{index_total_d:.1f}s ({index_total_d / 60:.1f} min)"
+        )
+        for ef in sorted(recall_d.keys()):
+            kc = kcycles_d.get(ef, 0)
+            print(
+                f"  efSearch={ef}: recall@{k}="
+                f"{recall_d[ef]:.4f}  kcyc/q={kc:.0f}"
+            )
+        results_table.append(
+            (
+                "D: all_neighbors",
+                total_build_d,
+                timings_d["serialize"],
+                timings_d["file_size_gb"],
+                recall_d,
+                kcycles_d,
+            )
+        )
+        del index_d
+        print()
+
+    print("=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    header = (
+        f"{'Approach':<20s} {'Build':>7s} {'Ser':>5s} {'GB':>5s}"
+        f" {'ef':>4s} {'recall':>7s} {'kcyc/q':>7s}"
+    )
+    print(header)
+    print("-" * len(header))
+    for name, build, ser, size, recalls, kcycles in results_table:
+        for ef in [64, 128, 256]:
+            r = recalls.get(ef, 0)
+            kc = kcycles.get(ef, 0)
+            bld = f"{build:.0f}" if ef == 64 else ""
+            sr = f"{ser:.0f}" if ef == 64 else ""
+            sz = f"{size:.1f}" if ef == 64 else ""
+            nm = name if ef == 64 else ""
+            print(
+                f"{nm:<20s} {bld:>7s} {sr:>5s} {sz:>5s}"
+                f" {ef:>4d} {r:>7.4f} {kc:>7.0f}"
+            )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        open(_SENTINEL, "w").close()

--- a/faiss/gpu/test/test_cagra.py
+++ b/faiss/gpu/test/test_cagra.py
@@ -243,3 +243,100 @@ class TestIDMapCagra(unittest.TestCase):
 
     def test_IDMapCagra_IP_Int8(self):
         self.do_IDMapCagra(faiss.METRIC_INNER_PRODUCT, faiss.Int8)
+
+
+@unittest.skipIf(
+    "CUVS" not in faiss.get_compile_options(),
+    "only if cuVS is compiled in")
+@unittest.skipIf(
+    faiss.get_num_gpus() < 2,
+    "need at least 2 GPUs for multi-GPU test")
+class TestMultiGpuCagra(unittest.TestCase):
+
+    def test_multi_gpu_build_and_search(self):
+        ds = datasets.SyntheticDataset(128, 0, 100_000, 1000)
+        xb = ds.get_database()
+        xq = ds.get_queries()
+        k = 10
+
+        gt_index = faiss.IndexFlatL2(ds.d)
+        gt_index.add(xb)
+        Dref, Iref = gt_index.search(xq, k)
+
+        num_gpus = min(faiss.get_num_gpus(), 4)
+        resources = faiss.GpuResourcesVector()
+        devices = faiss.Int32Vector()
+        res_list = []
+        for i in range(num_gpus):
+            res = faiss.StandardGpuResources()
+            res_list.append(res)
+            resources.push_back(res)
+            devices.push_back(i)
+
+        config = faiss.GpuIndexCagraConfig()
+        config.graph_degree = 32
+        index = faiss.GpuIndexCagra(res_list[0], ds.d, faiss.METRIC_L2, config)
+        index.trainMultiGpu(ds.nb, faiss.swig_ptr(xb), resources, devices, 0, 2)
+
+        cpu_index = faiss.IndexHNSWCagra()
+        index.copyTo(cpu_index)
+        self.assertEqual(cpu_index.ntotal, ds.nb)
+
+        cpu_index.hnsw.efSearch = 128
+        Dnew, Inew = cpu_index.search(xq, k)
+
+        recall = np.mean([
+            len(set(Inew[i]) & set(Iref[i])) / k for i in range(ds.nq)
+        ])
+        self.assertGreater(recall, 0.80,
+                           f"Multi-GPU recall@{k} too low: {recall:.4f}")
+
+        # Serialization roundtrip
+        data = faiss.serialize_index(cpu_index)
+        loaded = faiss.deserialize_index(data)
+        loaded.hnsw.efSearch = 128
+        Dnew2, Inew2 = loaded.search(xq, k)
+        np.testing.assert_array_equal(Inew, Inew2)
+
+    def test_all_neighbors_build(self):
+        ds = datasets.SyntheticDataset(32, 0, 50_000, 100)
+        xb = ds.get_database()
+        xq = ds.get_queries()
+        k = 10
+
+        gt_index = faiss.IndexFlatL2(ds.d)
+        gt_index.add(xb)
+        Dref, Iref = gt_index.search(xq, k)
+
+        num_gpus = min(faiss.get_num_gpus(), 4)
+        devices = faiss.Int32Vector()
+        for i in range(num_gpus):
+            devices.push_back(i)
+
+        res = faiss.StandardGpuResources()
+        config = faiss.GpuIndexCagraConfig()
+        config.graph_degree = 32
+        config.intermediate_graph_degree = 48
+        index = faiss.GpuIndexCagra(
+            res, ds.d, faiss.METRIC_L2, config)
+        index.trainAllNeighbors(
+            ds.nb, faiss.swig_ptr(xb), devices,
+            0, 0, True, 0)
+
+        cpu_index = faiss.IndexHNSWCagra()
+        cpu_index.base_level_only = True
+        index.copyTo(cpu_index)
+        self.assertEqual(cpu_index.ntotal, ds.nb)
+
+        cpu_index.hnsw.efSearch = 128
+        Dnew, Inew = cpu_index.search(xq, k)
+
+        recall = np.mean(
+            [
+                len(set(Inew[i]) & set(Iref[i])) / k
+                for i in range(ds.nq)
+            ]
+        )
+        self.assertGreater(
+            recall, 0.70,
+            f"all_neighbors recall@{k} too low: {recall:.4f}")

--- a/faiss/gpu/test/test_gpu_index.py
+++ b/faiss/gpu/test/test_gpu_index.py
@@ -211,7 +211,7 @@ class TestIVFPluggableCoarseQuantizer(unittest.TestCase):
 
         self.assertGreaterEqual(knn_intersection_measure(i_c, i_g), 0.9)
 
-        self.assertTrue(np.allclose(d_g, d_c, rtol=2e-4, atol=2e-4))
+        self.assertTrue(np.allclose(d_g, d_c, rtol=5e-4, atol=5e-4))
 
     def test_ivfpq_cpu_coarse(self):
         res = faiss.StandardGpuResources()

--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -17,10 +17,11 @@ import inspect
 def _preload_gpu_libs():
     """Pre-load CUDA / RAPIDS shared libs from pip wheels with RTLD_GLOBAL.
 
-    These libs ship in nvidia-*-cu12 / libcuvs-cu12 wheels, off ld.so's search
+    These libs ship in nvidia-*-cuNN / libcuvs-cuNN wheels, off ld.so's search
     path, so we dlopen them before the SWIG extension loads libfaiss.so. Gated
     on the `faiss._gpu_build` marker (CMake writes it only for GPU builds); the
-    `_cuvs_build` marker adds the cuVS stack. Missing wheels raise a fix-it.
+    `_cuvs_build` marker selects the CUDA 13 cuVS variant (else CUDA 12) and adds
+    the cuVS stack. Missing wheels raise a fix-it.
     """
     try:
         from . import _gpu_build  # noqa: F401
@@ -30,50 +31,81 @@ def _preload_gpu_libs():
     import ctypes
     import os
 
-    def _nvidia_lib_dir(import_name, pip_spec):
-        """Return the lib/ dir of an nvidia-*-cu12 wheel, or raise a fix-it."""
-        try:
-            mod = __import__("nvidia." + import_name, fromlist=[import_name])
-        except ImportError as e:
-            pip_name = pip_spec.split(">")[0].split("<")[0].split("=")[0]
-            raise RuntimeError(
-                f"faiss-gpu installed but {pip_name} is missing — "
-                f"pip install '{pip_spec}'"
-            ) from e
-        # __path__[0] not __file__: PEP 420 namespace pkgs have __file__ = None.
-        return os.path.join(mod.__path__[0], "lib")
-
     def _load(path):
         """dlopen one .so with global visibility, or raise a fix-it."""
         try:
             ctypes.CDLL(path, mode=ctypes.RTLD_GLOBAL)
         except OSError as e:
             raise RuntimeError(
-                f"faiss-gpu: failed to load {os.path.basename(path)} from {path} — "
-                f"corrupt or incomplete nvidia-*-cu12 wheel? Try: pip install "
-                f"--force-reinstall 'nvidia-cuda-runtime-cu12>=12.6,<13' "
-                f"'nvidia-cublas-cu12>=12.6,<13' 'nvidia-curand-cu12>=10.3.7,<11'"
+                f"faiss-gpu: failed to load {os.path.basename(path)} from {path} "
+                f"— corrupt or incomplete nvidia CUDA wheel?"
             ) from e
 
-    # Base CUDA libs the faiss extension links directly, in dependency order
-    # (libcudart first — it provides symbols the others resolve against). Loaded
-    # RTLD_GLOBAL so the SWIG extension's later dlopen of libfaiss.so resolves them.
-    _cudart = _nvidia_lib_dir("cuda_runtime", "nvidia-cuda-runtime-cu12>=12.6,<13")
-    _cublas = _nvidia_lib_dir("cublas", "nvidia-cublas-cu12>=12.6,<13")
-    _curand = _nvidia_lib_dir("curand", "nvidia-curand-cu12>=10.3.7,<11")
-    _load(os.path.join(_cudart, "libcudart.so.12"))
-    _load(os.path.join(_cublas, "libcublas.so.12"))
-    _load(os.path.join(_cublas, "libcublasLt.so.12"))
-    _load(os.path.join(_curand, "libcurand.so.10"))
-
-    # faiss-gpu-cuvs wheels (the _cuvs_build marker) also need the cuVS stack.
-    # Delegate to RAPIDS' load_library() (loads each .so RTLD_GLOBAL + its CUDA deps);
-    # order rmm -> raft -> cuvs makes every symbol global before the SWIG extension loads.
+    # faiss-gpu-cuvs wheels carry the `_cuvs_build` marker and are built against
+    # CUDA 13 (+ the cuVS stack); the plain faiss-gpu wheel is CUDA 12. The two
+    # use different pip wheel layouts (handled separately below). Load order
+    # matters: libcudart first (others resolve symbols against it), and load
+    # RTLD_GLOBAL so the SWIG extension's later dlopen of libfaiss.so sees them.
     try:
         from . import _cuvs_build  # noqa: F401
+
+        is_cuvs = True
     except ImportError:
+        is_cuvs = False
+
+    if is_cuvs:
+        # CUDA 13 nvidia wheels (nvidia-cuda-runtime / -cublas / -curand /
+        # -nvjitlink — all unsuffixed) ship every lib in one PEP 420 namespace
+        # dir, nvidia/cu13/lib/, with no importable per-component module. This
+        # differs from CUDA 12's per-component nvidia/<name>/lib/ layout.
+        try:
+            import nvidia.cu13 as _cu13
+
+            _libdir = os.path.join(list(_cu13.__path__)[0], "lib")
+        except ImportError as e:
+            raise RuntimeError(
+                "faiss-gpu-cuvs installed but the CUDA 13 runtime wheels are "
+                "missing — pip install 'nvidia-cuda-runtime>=13.2,<14' "
+                "'nvidia-cublas>=13.2,<14' 'nvidia-curand>=10.3.7,<11' "
+                "'nvidia-nvjitlink>=13.2,<14'"
+            ) from e
+        # nvjitlink before cublas: cublas 13 links it.
+        for _soname in (
+            "libcudart.so.13",
+            "libnvJitLink.so.13",
+            "libcublas.so.13",
+            "libcublasLt.so.13",
+            "libcurand.so.10",
+        ):
+            _load(os.path.join(_libdir, _soname))
+    else:
+        # CUDA 12 per-component layout: each nvidia-*-cu12 wheel exposes an
+        # importable module whose lib/ dir holds the .so.
+        def _nvidia_lib_dir(import_name, pip_spec):
+            """Return the lib/ dir of an nvidia-*-cu12 wheel, or raise a fix-it."""
+            try:
+                mod = __import__("nvidia." + import_name, fromlist=[import_name])
+            except ImportError as e:
+                pip_name = pip_spec.split(">")[0].split("<")[0].split("=")[0]
+                raise RuntimeError(
+                    f"faiss-gpu installed but {pip_name} is missing — "
+                    f"pip install '{pip_spec}'"
+                ) from e
+            # __path__[0] not __file__: PEP 420 namespace pkgs have __file__ = None.
+            return os.path.join(mod.__path__[0], "lib")
+
+        _cudart = _nvidia_lib_dir("cuda_runtime", "nvidia-cuda-runtime-cu12>=12.6,<13")
+        _cublas = _nvidia_lib_dir("cublas", "nvidia-cublas-cu12>=12.6,<13")
+        _curand = _nvidia_lib_dir("curand", "nvidia-curand-cu12>=10.3.7,<11")
+        _load(os.path.join(_cudart, "libcudart.so.12"))
+        _load(os.path.join(_cublas, "libcublas.so.12"))
+        _load(os.path.join(_cublas, "libcublasLt.so.12"))
+        _load(os.path.join(_curand, "libcurand.so.10"))
         return  # faiss-gpu (non-cuVS) build: base CUDA preload is sufficient.
 
+    # faiss-gpu-cuvs wheels also need the cuVS stack. Delegate to RAPIDS'
+    # load_library() (loads each .so RTLD_GLOBAL + its CUDA deps); order
+    # rmm -> raft -> cuvs makes every symbol global before the SWIG extension loads.
     try:
         import libcuvs
         import libraft
@@ -81,7 +113,7 @@ def _preload_gpu_libs():
     except ImportError as e:
         raise RuntimeError(
             "faiss-gpu-cuvs installed but the cuVS runtime wheels are missing — "
-            "pip install 'libcuvs-cu12>=26.06,<27' "
+            "pip install 'libcuvs-cu13>=26.06,<27' "
             "--extra-index-url https://pypi.nvidia.com"
         ) from e
 

--- a/pyproject-gpu-cuvs.toml
+++ b/pyproject-gpu-cuvs.toml
@@ -35,16 +35,16 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries :: Python Modules",
-  "Environment :: GPU :: NVIDIA CUDA :: 12",
+  "Environment :: GPU :: NVIDIA CUDA :: 13",
 ]
 dependencies = [
   "numpy>=1.25",
   "packaging",
-  "nvidia-cuda-runtime-cu12>=12.6,<13",
-  "nvidia-cublas-cu12>=12.6,<13",
-  "nvidia-curand-cu12>=10.3.7,<11",
-  "nvidia-nvjitlink-cu12>=12.6,<13",
-  "libcuvs-cu12>=26.06,<27",
+  "nvidia-cuda-runtime>=13.2,<14",
+  "nvidia-cublas>=13.2,<14",
+  "nvidia-curand>=10.3.7,<11",
+  "nvidia-nvjitlink>=13.2,<14",
+  "libcuvs-cu13>=26.06,<27",
 ]
 
 [project.urls]
@@ -75,9 +75,11 @@ FAISS_ENABLE_C_API = "OFF"
 FAISS_ENABLE_EXTRAS = "OFF"
 FAISS_ENABLE_SVS = "OFF"
 FAISS_USE_LTO = "ON"
-# V100 → Hopper SASS + Hopper PTX trailer for forward compat (e.g. Blackwell JIT).
-# Drop 72 (Jetson Xavier) for a datacenter-targeted wheel; include 89 (L4/L40/RTX 40xx).
-CMAKE_CUDA_ARCHITECTURES = "70-real;75-real;80-real;86-real;89-real;90"
+# Turing → Hopper SASS + Hopper PTX trailer for forward compat (e.g. Blackwell JIT).
+# CUDA 13 dropped offline compilation for Maxwell/Pascal/Volta, so 70 (V100) is gone
+# and 75 (Turing) is the floor. Drop 72 (Jetson Xavier) for a datacenter-targeted
+# wheel; include 89 (L4/L40/RTX 40xx).
+CMAKE_CUDA_ARCHITECTURES = "75-real;80-real;86-real;89-real;90"
 CMAKE_CUDA_FLAGS_RELEASE = "-O3 -Xfatbin=-compress-all --threads 4 -Xcompiler=-fdata-sections,-ffunction-sections"
 CMAKE_C_FLAGS = "-fdata-sections -ffunction-sections"
 CMAKE_CXX_FLAGS = "-fdata-sections -ffunction-sections"
@@ -90,7 +92,7 @@ BUILD_SHARED_LIBS = "ON"
 # mirroring the conda build — no explicit *_DIR, agnostic to lib/ vs lib64/.
 
 # Stable ABI (abi3): one cp311 wheel covers all 3.11+.
-# Floor is 3.11 because the runtime dep libcuvs-cu12>=26.06 (RAPIDS) requires
+# Floor is 3.11 because the runtime dep libcuvs-cu13>=26.06 (RAPIDS) requires
 # Python >=3.11 — RAPIDS dropped 3.10 in the 26.04 release.
 # GPU is Linux-only; free-threaded Python (cp3*t) cannot use abi3.
 [[tool.scikit-build.overrides]]
@@ -107,18 +109,18 @@ build = "cp311-manylinux_x86_64"
 test-requires = [
   "numpy>=1.25,<3.0",
   "pytest",
-  "nvidia-cuda-runtime-cu12>=12.6,<13",
-  "nvidia-cublas-cu12>=12.6,<13",
-  "nvidia-curand-cu12>=10.3.7,<11",
-  "nvidia-nvjitlink-cu12>=12.6,<13",
-  "libcuvs-cu12>=26.06,<27",
+  "nvidia-cuda-runtime>=13.2,<14",
+  "nvidia-cublas>=13.2,<14",
+  "nvidia-curand>=10.3.7,<11",
+  "nvidia-nvjitlink>=13.2,<14",
+  "libcuvs-cu13>=26.06,<27",
 ]
 test-command = "python -m pytest {project}/tests/test_wheel_smoke_gpu.py -v"
 
 [tool.cibuildwheel.linux]
-# manylinux_2_28 ships gcc-toolset-14; CUDA 12.6 only supports GCC <=13, so install
-# gcc-toolset-13 explicitly and force the build to use it via CC/CXX/CUDAHOSTCXX below.
-# epel-release is needed for swig. Install the FULL cuda-toolkit-12-6 (not just nvcc +
+# manylinux_2_28 ships gcc-toolset-14; CUDA 13.2 supports GCC 14, so install
+# gcc-toolset-14 explicitly and force the build to use it via CC/CXX/CUDAHOSTCXX below.
+# epel-release is needed for swig. Install the FULL cuda-toolkit-13-2 (not just nvcc +
 # narrow dev libs as faiss-gpu does) because cuVS pulls in RAFT which transitively
 # needs cuSOLVER, cuSPARSE, nvrtc, etc. headers — easier to install all than to track
 # the exact list. Wheel size is unaffected since auditwheel excludes all CUDA libs.
@@ -127,11 +129,11 @@ test-command = "python -m pytest {project}/tests/test_wheel_smoke_gpu.py -v"
 # `pip install --target /opt/cuvs` — ABI-clean, so no libstdc++/libgcc_s/libgomp strip
 # or RMM symlink shim. cp311 interpreter is explicit (manylinux puts no `pip` on PATH).
 manylinux-x86_64-image = "manylinux_2_28"
-before-all = "dnf install -y gcc-toolset-13 epel-release && dnf install -y openblas-devel openblas-openmp swig && dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && dnf install -y --setopt=obsoletes=0 cuda-toolkit-12-6 && /opt/python/cp311-cp311/bin/python -m pip install --target /opt/cuvs --no-deps --only-binary ':all:' --extra-index-url https://pypi.nvidia.com 'libcuvs-cu12==26.06.*' 'libraft-cu12==26.06.*' 'librmm-cu12==26.06.*' 'rapids-logger'"
-# auditwheel excludes (not vendored; supplied at runtime by nvidia-*-cu12 / libcuvs-cu12
+before-all = "dnf install -y gcc-toolset-14 epel-release && dnf install -y openblas-devel openblas-openmp swig && dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && dnf install -y --setopt=obsoletes=0 cuda-toolkit-13-2 && /opt/python/cp311-cp311/bin/python -m pip install --target /opt/cuvs --no-deps --only-binary ':all:' --extra-index-url https://pypi.nvidia.com 'libcuvs-cu13==26.06.*' 'libraft-cu13==26.06.*' 'librmm-cu13==26.06.*' 'rapids-logger'"
+# auditwheel excludes (not vendored; supplied at runtime by nvidia-* / libcuvs-cu13
 # wheels): host driver libcuda, CUDA runtime/math libs (cusparse/cusolver are explicit —
 # under the cuda-toolkit RPM, not /opt/cuvs), and every RAPIDS .so found under /opt/cuvs.
-repair-wheel-command = "bash -c 'EXCLUDES=\"--exclude libcuda.so.1 --exclude libcudart.so.12 --exclude libcublas.so.12 --exclude libcublasLt.so.12 --exclude libcurand.so.10 --exclude libnvJitLink.so.12 --exclude libcusparse.so.12 --exclude libcusolver.so.11\"; for f in $(find /opt/cuvs -name \"lib*.so*\" -printf \"%f\\n\" | sort -u); do EXCLUDES=\"$EXCLUDES --exclude $f\"; done; auditwheel repair -w {dest_dir} {wheel} $EXCLUDES'"
+repair-wheel-command = "bash -c 'EXCLUDES=\"--exclude libcuda.so.1 --exclude libcudart.so.13 --exclude libcublas.so.13 --exclude libcublasLt.so.13 --exclude libcurand.so.10 --exclude libnvJitLink.so.13 --exclude libcusparse.so.12 --exclude libcusolver.so.11\"; for f in $(find /opt/cuvs -name \"lib*.so*\" -printf \"%f\\n\" | sort -u); do EXCLUDES=\"$EXCLUDES --exclude $f\"; done; auditwheel repair -w {dest_dir} {wheel} $EXCLUDES'"
 # Canary: ensure the host GPU is actually visible to the container before tests
 # run. Without this, smoke tests would silently skip on broken --gpus passthrough.
 before-test = "nvidia-smi || (echo 'GPU not visible to container; check container-engine create-args' && exit 1)"
@@ -144,15 +146,15 @@ select = "*-manylinux*"
 inherit.repair-wheel-command = "append"
 repair-wheel-command = "pipx run abi3audit --strict --report {wheel}"
 
-# Build-tool paths. CUDA from /usr/local/cuda-12.6 (NVIDIA RPM convention);
-# GCC pinned to toolset-13 because CUDA 12.6 does not support GCC 14.
+# Build-tool paths. CUDA from /usr/local/cuda-13.2 (NVIDIA RPM convention);
+# GCC pinned to toolset-14 for CUDA 13.2 support.
 # CUDAHOSTCXX must match CXX or nvcc host TUs get an ABI-mismatched libstdc++.
 # CMAKE_PREFIX_PATH points at the RAPIDS wheel roots so find_package(cuvs) resolves.
 # Set as env (not cmake.define) so CMake merges it with scikit-build-core's own path.
 [tool.cibuildwheel.linux.environment]
-CUDA_HOME = "/usr/local/cuda-12.6"
-CUDACXX = "/usr/local/cuda-12.6/bin/nvcc"
-CC = "/opt/rh/gcc-toolset-13/root/usr/bin/gcc"
-CXX = "/opt/rh/gcc-toolset-13/root/usr/bin/g++"
-CUDAHOSTCXX = "/opt/rh/gcc-toolset-13/root/usr/bin/g++"
+CUDA_HOME = "/usr/local/cuda-13.2"
+CUDACXX = "/usr/local/cuda-13.2/bin/nvcc"
+CC = "/opt/rh/gcc-toolset-14/root/usr/bin/gcc"
+CXX = "/opt/rh/gcc-toolset-14/root/usr/bin/g++"
+CUDAHOSTCXX = "/opt/rh/gcc-toolset-14/root/usr/bin/g++"
 CMAKE_PREFIX_PATH = "/opt/cuvs/libcuvs:/opt/cuvs/libraft:/opt/cuvs/librmm:/opt/cuvs/rapids_logger"


### PR DESCRIPTION
Summary:

Adds `GpuIndexCagra::trainAllNeighbors()`: builds a single unified HNSW index for a large dataset sharded across multiple GPUs using cuVS `all_neighbors` (overlapping-cluster kNN graph, no stitching) plus a multi-GPU graph-optimize pass, then `copyTo(IndexHNSWCagra)`.

End-to-end pipeline (Approach D):
1. Data load: stream real `prefilter_embedding` vectors from Hive (`feed_fblearner/test_unicorn_model_streaming_full_dump_fbr_umia_i2i_clic_ts`) in-process via Koski into a preallocated host `(N, 129)` float32 array. No Manifold file, no tiling, no duplicate vectors. A Manifold `.npy` + `--n` tiling path is retained as a fallback.
2. kNN graph: `cuvs::neighbors::all_neighbors::build` with IVF-PQ per-cluster construction across 8 GPUs; overlapping clusters provide cross-cluster connectivity so no post-hoc stitching is needed.
3. Optimize/prune: multi-GPU 2-hop detour counting (custom `kern_detour_count` kernel) + CPU pruning + reverse-graph construction; prunes `intermediate_graph_degree` down to `graph_degree`.
4. Convert: `copyTo(IndexHNSWCagra)` with `base_level_only=True` — use the CAGRA graph directly as HNSW level-0, skipping upper-level construction.
5. Serialize the HNSW index to disk.

API: `trainAllNeighbors(n, x, devices, n_clusters, overlap_factor, multi_gpu_optimize, build_algo, refinement_rate, ivfpq_search_batch)` on `GpuIndexCagra`, followed by `copyTo(IndexHNSWCagra)`.

Approaches evaluated (D recommended):
- A: independent HNSW per GPU shard via `IndexShards` -- fast build, but serving-time query cost multiplies by the number of graphs.
- B: SNMG CAGRA + GPU brute-force stitching -- poor recall (0.82).
- C: SNMG CAGRA + CPU HNSW stitching -- good recall, slow at scale.
- D: `all_neighbors` + multi-GPU optimize -- best recall/speed/query-cost trade-off.

Key optimizations and knobs:
- Multi-GPU detour counting: ~120x speedup on the optimize phase.
- IVF-PQ per-cluster build: ~2.3x faster than NN-descent for `all_neighbors`.
- `base_level_only` copyTo: ~59x faster CAGRA->HNSW conversion.
- New `refinement_rate` knob (IVF-PQ refinement multiplier; previously hardcoded).
- New `ivfpq_search_batch` knob: caps the IVF-PQ search `max_internal_batch_size` (cuVS default 131072) to bound the GPU search workspace; recall-neutral.

100M memory tuning: at 100M real vectors the cuVS IVF-PQ build OOMs on H100 (96 GB) with the default search batch (a 12.76 GB workspace) and at `intermediate_graph_degree=48`. Capping `ivfpq_search_batch` (e.g. 8192) and/or lowering `igd` to 32/24 makes it fit while keeping recall@10 >= 0.95. (The earlier "0.902 @ 100M" number was on 50M tiled 2x, which has duplicate vectors and is not representative.)

Build/runtime note: the MAST H100 fleet runs the CUDA 13.0 driver, so the fbpkg must be built for it: `buck2 build mode/opt -c fbcode.nvcc_arch=h100 --modifier ovr_config//third-party/cuda/constraints:13.0 //faiss/gpu/test:bench_approaches`. Otherwise cuVS kernels fail at runtime with `cudaErrorInvalidKernelImage`.

Files: `faiss/gpu/GpuIndexCagra.{cu,h}` (API + knobs), `faiss/gpu/test/bench_approaches.py` (benchmark + Koski Hive loader + isolated index-build timing), `faiss/gpu/test/BUCK` (Koski dep), `users/mnorris/launch_mast.sh` (single MAST launcher), `users/mnorris/STITCH_OPTIMIZATION.md` (design notes, results, debugging log).

Reviewed By: junjieqi

Differential Revision: D106837134


