### PR TITLE
Reserve VisitedTableSet capacity to avoid rehashes during HNSW search (#5290)

### DIFF
--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -908,6 +908,8 @@ int search_from_candidates_fixVT(
     const IDSelector* sel;
     extract_search_params(hnsw, params, do_dis_check, efSearch, sel);
 
+    vt.reserve(efSearch);
+
     typename C::T threshold = res.threshold;
     for (int i = 0; i < candidates.size(); i++) {
         idx_t v1 = candidates.ids[i];


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/facebookresearch/faiss/pull/5290

Reviewed By: yuxuanchen1997

Differential Revision: D107761385


