### PR TITLE
Run CI on push to main to refresh ccache cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 jobs:
@@ -17,5 +19,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
   build-pip:
     uses: ./.github/workflows/build-pip.yml
+    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/v')
   build-pip-gpu:
     uses: ./.github/workflows/build-pip-gpu.yml
+    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Summary:
TLDR: this runs the build on every merge of a PR. Yes it doubles the cost (assuming 1 CI run per PR then 1 more when merged) but it may increase cache hit rate to speed up builds, which is super low right now. Right now the cache is from May 5 when I first integrated it because there's no refresh on main branch. This is supposed to fix that.
--

AI description:

The `Build` workflow only triggered on `pull_request` and tag pushes,
never on pushes to `main`. GitHub Actions caches are scoped per branch:
PR runs read main's cache and write to their own throwaway PR scope.
Main's cache is therefore only refreshed when the workflow runs on
`main` itself, which never happened.

Result: PRs were restoring a month-old ccache (`2026-05-05`) on every
run, with hit rates around ~28%. Cache size sat at ~13 MB out of 2 GB.

This adds `push: branches: [main]` so the cmake build (and only the
cmake build) runs on each merge, populating main's ccache. The pip
wheel jobs are gated to non-push or tag-push events to preserve their
current behavior — they only run on PRs, manual dispatch, or tag
releases, never on plain main pushes. PyPI publish jobs are already
guarded by `startsWith(github.ref, 'refs/tags/v')`, so there is no
risk of accidental publishes.

Differential Revision: D107964344


