### PR TITLE
Speed up Top1 and Reservoir add_results with AVX2/AVX512

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -11,6 +11,7 @@
 set(FAISS_SIMD_AVX2_SRC
   impl/fast_scan/impl-avx2.cpp
   impl/hnsw/avx2.cpp
+  impl/result_handler/avx2.cpp
   impl/pq_code_distance/avx2.cpp
   impl/scalar_quantizer/sq-avx2.cpp
   impl/approx_topk/avx2.cpp
@@ -25,6 +26,7 @@ set(FAISS_SIMD_AVX2_SRC
 set(FAISS_SIMD_AVX512_SRC
   impl/fast_scan/impl-avx512.cpp
   impl/hnsw/avx512.cpp
+  impl/result_handler/avx512.cpp
   impl/pq_code_distance/avx512.cpp
   impl/scalar_quantizer/sq-avx512.cpp
   impl/binary_hamming/avx512.cpp
@@ -150,6 +152,7 @@ set(FAISS_SRC
   impl/HNSW.cpp
   impl/hnsw/LockVector.cpp
   impl/hnsw/MinimaxHeap.cpp
+  impl/result_handler/ResultHandler.cpp
   impl/NSG.cpp
   impl/PolysemousTraining.cpp
   impl/ProductQuantizer.cpp

--- a/faiss/impl/ResultHandler.h
+++ b/faiss/impl/ResultHandler.h
@@ -18,6 +18,7 @@
 #include <faiss/impl/InvertedListScannerStats.h>
 #include <faiss/utils/Heap.h>
 #include <faiss/utils/partitioning.h>
+#include <faiss/utils/simd_levels.h>
 #include <algorithm>
 #include <iostream>
 
@@ -234,23 +235,9 @@ struct Top1BlockResultHandler : TopkBlockResultHandler<C, use_sel> {
     }
 
     /// add results for query i0..i1 and j0..j1
-    void add_results(size_t j0, size_t j1, const T* dis_tab_2) final {
-        for (size_t i = i0; i < i1; i++) {
-            const T* dis_tab_i = dis_tab_2 + (j1 - j0) * (i - i0) - j0;
-
-            auto& min_distance = this->dis_tab[i];
-            auto& min_index = this->ids_tab[i];
-
-            for (size_t j = j0; j < j1; j++) {
-                const T distance = dis_tab_i[j];
-
-                if (C::cmp(min_distance, distance)) {
-                    min_distance = distance;
-                    min_index = j;
-                }
-            }
-        }
-    }
+    /// Implemented in result_handler.cpp; dispatches via
+    /// with_selected_simd_levels to top1_add_results_tpl<C, use_sel, SL>.
+    void add_results(size_t j0, size_t j1, const T* dis_tab_2) final;
 
     void add_result(const size_t i, const T dis, const TI idx) {
         auto& min_distance = this->dis_tab[i];
@@ -553,20 +540,9 @@ struct ReservoirBlockResultHandler : TopkBlockResultHandler<C, use_sel> {
     }
 
     /// add results for query i0..i1 and j0..j1
-    void add_results(size_t j0, size_t j1, const T* dis_in) {
-#pragma omp parallel for
-        for (int64_t i = static_cast<int64_t>(i0); i < static_cast<int64_t>(i1);
-             i++) {
-            ReservoirTopN<C>& reservoir =
-                    reservoirs[i - static_cast<int64_t>(i0)];
-            const T* dis_tab_i =
-                    dis_in + (j1 - j0) * (i - static_cast<int64_t>(i0)) - j0;
-            for (size_t j = j0; j < j1; j++) {
-                T dis = dis_tab_i[j];
-                reservoir.add_result(dis, j);
-            }
-        }
-    }
+    /// Implemented in result_handler.cpp; dispatches via
+    /// with_selected_simd_levels to reservoir_add_results_tpl<C, use_sel, SL>.
+    void add_results(size_t j0, size_t j1, const T* dis_in);
 
     /// series of results for queries i0..i1 is done
     void end_multiple() final {
@@ -798,5 +774,23 @@ typename Consumer::T dispatch_range_ResultHandler(
     }
 #undef DISPATCH_C_SEL
 }
+
+// ------------------------------------------------------------------
+// SIMD-dispatch entry points for Top1 and Reservoir add_results.
+// ------------------------------------------------------------------
+
+template <class C, bool use_sel, SIMDLevel SL>
+void top1_add_results_tpl(
+        Top1BlockResultHandler<C, use_sel>* self,
+        size_t j0,
+        size_t j1,
+        const typename C::T* dis_tab);
+
+template <class C, bool use_sel, SIMDLevel SL>
+void reservoir_add_results_tpl(
+        ReservoirBlockResultHandler<C, use_sel>* self,
+        size_t j0,
+        size_t j1,
+        const typename C::T* dis_in);
 
 } // namespace faiss

--- a/faiss/impl/result_handler/ResultHandler.cpp
+++ b/faiss/impl/result_handler/ResultHandler.cpp
@@ -32,6 +32,8 @@ constexpr int RESERVOIR_SIMD_LEVELS =
 // Scalar (NONE) helper implementations
 // ----------------------------------------------------------------
 
+namespace {
+
 template <class C, bool use_sel>
 void top1_add_results_none(
         Top1BlockResultHandler<C, use_sel>* self,
@@ -98,85 +100,43 @@ void reservoir_add_results_none(
     }
 }
 
+} // namespace
+
 // ----------------------------------------------------------------
 // SIMDLevel::NONE explicit specialisations
 // ----------------------------------------------------------------
 
-template <>
-void top1_add_results_tpl<CMax<float, int64_t>, false, SIMDLevel::NONE>(
-        Top1BlockResultHandler<CMax<float, int64_t>, false>* self,
-        size_t j0,
-        size_t j1,
-        const float* dis_tab) {
-    top1_add_results_none<CMax<float, int64_t>, false>(self, j0, j1, dis_tab);
-}
+// Instantiate top1_add_results_tpl<C, use_sel, SIMDLevel::NONE> and
+// reservoir_add_results_tpl<C, use_sel, SIMDLevel::NONE> for all
+// (C, use_sel) combinations that the rest of FAISS uses.
+#define INSTANTIATE_NONE(C, use_sel)                                  \
+    template <>                                                       \
+    void top1_add_results_tpl<C, use_sel, SIMDLevel::NONE>(           \
+            Top1BlockResultHandler<C, use_sel> * self,                \
+            size_t j0,                                                \
+            size_t j1,                                                \
+            const float* dis_tab) {                                   \
+        top1_add_results_none<C, use_sel>(self, j0, j1, dis_tab);     \
+    }                                                                 \
+    template <>                                                       \
+    void reservoir_add_results_tpl<C, use_sel, SIMDLevel::NONE>(      \
+            ReservoirBlockResultHandler<C, use_sel> * self,           \
+            size_t j0,                                                \
+            size_t j1,                                                \
+            const float* dis_in) {                                    \
+        reservoir_add_results_none<C, use_sel>(self, j0, j1, dis_in); \
+    }
 
-template <>
-void top1_add_results_tpl<CMax<float, int64_t>, true, SIMDLevel::NONE>(
-        Top1BlockResultHandler<CMax<float, int64_t>, true>* self,
-        size_t j0,
-        size_t j1,
-        const float* dis_tab) {
-    top1_add_results_none<CMax<float, int64_t>, true>(self, j0, j1, dis_tab);
-}
+// Type aliases so the comma in CMax<float, int64_t> doesn't split macro args.
+using CMaxFI = CMax<float, int64_t>;
+using CMinFI = CMin<float, int64_t>;
 
-template <>
-void top1_add_results_tpl<CMin<float, int64_t>, false, SIMDLevel::NONE>(
-        Top1BlockResultHandler<CMin<float, int64_t>, false>* self,
-        size_t j0,
-        size_t j1,
-        const float* dis_tab) {
-    top1_add_results_none<CMin<float, int64_t>, false>(self, j0, j1, dis_tab);
-}
+INSTANTIATE_NONE(CMaxFI, false)
+INSTANTIATE_NONE(CMaxFI, true)
+INSTANTIATE_NONE(CMinFI, false)
+INSTANTIATE_NONE(CMinFI, true)
 
-template <>
-void top1_add_results_tpl<CMin<float, int64_t>, true, SIMDLevel::NONE>(
-        Top1BlockResultHandler<CMin<float, int64_t>, true>* self,
-        size_t j0,
-        size_t j1,
-        const float* dis_tab) {
-    top1_add_results_none<CMin<float, int64_t>, true>(self, j0, j1, dis_tab);
-}
-
-template <>
-void reservoir_add_results_tpl<CMax<float, int64_t>, false, SIMDLevel::NONE>(
-        ReservoirBlockResultHandler<CMax<float, int64_t>, false>* self,
-        size_t j0,
-        size_t j1,
-        const float* dis_in) {
-    reservoir_add_results_none<CMax<float, int64_t>, false>(
-            self, j0, j1, dis_in);
-}
-
-template <>
-void reservoir_add_results_tpl<CMax<float, int64_t>, true, SIMDLevel::NONE>(
-        ReservoirBlockResultHandler<CMax<float, int64_t>, true>* self,
-        size_t j0,
-        size_t j1,
-        const float* dis_in) {
-    reservoir_add_results_none<CMax<float, int64_t>, true>(
-            self, j0, j1, dis_in);
-}
-
-template <>
-void reservoir_add_results_tpl<CMin<float, int64_t>, false, SIMDLevel::NONE>(
-        ReservoirBlockResultHandler<CMin<float, int64_t>, false>* self,
-        size_t j0,
-        size_t j1,
-        const float* dis_in) {
-    reservoir_add_results_none<CMin<float, int64_t>, false>(
-            self, j0, j1, dis_in);
-}
-
-template <>
-void reservoir_add_results_tpl<CMin<float, int64_t>, true, SIMDLevel::NONE>(
-        ReservoirBlockResultHandler<CMin<float, int64_t>, true>* self,
-        size_t j0,
-        size_t j1,
-        const float* dis_in) {
-    reservoir_add_results_none<CMin<float, int64_t>, true>(
-            self, j0, j1, dis_in);
-}
+#undef INSTANTIATE_NONE
 
 // ----------------------------------------------------------------
 // add_results method definitions — dispatch to the right SL kernel

--- a/faiss/impl/result_handler/ResultHandler.cpp
+++ b/faiss/impl/result_handler/ResultHandler.cpp
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Generic (NONE) implementations of Top1 and Reservoir add_results, plus the
+// runtime-dispatch method bodies.  SIMD specialisations live in
+// result_handler_avx2.cpp and result_handler_avx512.cpp.
+
+#include <faiss/impl/ResultHandler.h>
+#include <faiss/impl/simd_dispatch.h>
+
+namespace faiss {
+
+// ----------------------------------------------------------------
+// SIMD-level masks
+// ----------------------------------------------------------------
+
+// Top-1: scalar fallback + AVX2 (8-wide) + AVX512 (16-wide).
+constexpr int TOP1_SIMD_LEVELS = (1 << int(SIMDLevel::NONE)) |
+        (1 << int(SIMDLevel::AVX2)) | (1 << int(SIMDLevel::AVX512));
+
+// Reservoir: scalar fallback + AVX512 compress path.
+// VPCOMPRESSPS/VPCOMPRESSD require AVX512F so there is no AVX2 path.
+// On non-AVX512 hosts the dispatch falls back to NONE automatically.
+constexpr int RESERVOIR_SIMD_LEVELS =
+        (1 << int(SIMDLevel::NONE)) | (1 << int(SIMDLevel::AVX512));
+
+// ----------------------------------------------------------------
+// Scalar (NONE) helper implementations
+// ----------------------------------------------------------------
+
+template <class C, bool use_sel>
+void top1_add_results_none(
+        Top1BlockResultHandler<C, use_sel>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_tab_in) {
+    using T = typename C::T;
+    using TI = typename C::TI;
+
+    for (size_t qi = self->i0; qi < self->i1; qi++) {
+        const T* dis_tab_i = dis_tab_in + (j1 - j0) * (qi - self->i0) - j0;
+
+        // Hoist best_dis / best_idx into locals so the compiler keeps them in
+        // registers across the inner loop (no aliasing with dis_tab reads).
+        T best_dis = self->dis_tab[qi];
+        TI best_idx = self->ids_tab[qi];
+
+        for (size_t j = j0; j < j1; j++) {
+            if (C::cmp(best_dis, dis_tab_i[j])) {
+                best_dis = dis_tab_i[j];
+                best_idx = (TI)j;
+            }
+        }
+
+        self->dis_tab[qi] = best_dis;
+        self->ids_tab[qi] = best_idx;
+    }
+}
+
+template <class C, bool use_sel>
+void reservoir_add_results_none(
+        ReservoirBlockResultHandler<C, use_sel>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_in) {
+    using T = typename C::T;
+    using TI = typename C::TI;
+
+#pragma omp parallel for
+    for (int64_t qi = (int64_t)self->i0; qi < (int64_t)self->i1; qi++) {
+        ReservoirTopN<C>& res = self->reservoirs[qi - (int64_t)self->i0];
+        const T* dis_tab_i = dis_in + (j1 - j0) * (qi - (int64_t)self->i0) - j0;
+
+        // Hoist res.i and res.threshold into locals so the compiler keeps
+        // them in registers.
+        size_t ri = res.i;
+        T thresh = res.threshold;
+
+        for (size_t j = j0; j < j1; j++) {
+            T dis = dis_tab_i[j];
+            if (C::cmp(thresh, dis)) {
+                res.vals[ri] = dis;
+                res.ids[ri] = (TI)j;
+                ri++;
+                if (ri >= res.capacity) {
+                    res.i = ri;
+                    res.shrink_fuzzy();
+                    ri = res.i;
+                    thresh = res.threshold;
+                }
+            }
+        }
+        res.i = ri;
+    }
+}
+
+// ----------------------------------------------------------------
+// SIMDLevel::NONE explicit specialisations
+// ----------------------------------------------------------------
+
+template <>
+void top1_add_results_tpl<CMax<float, int64_t>, false, SIMDLevel::NONE>(
+        Top1BlockResultHandler<CMax<float, int64_t>, false>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_tab) {
+    top1_add_results_none<CMax<float, int64_t>, false>(self, j0, j1, dis_tab);
+}
+
+template <>
+void top1_add_results_tpl<CMax<float, int64_t>, true, SIMDLevel::NONE>(
+        Top1BlockResultHandler<CMax<float, int64_t>, true>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_tab) {
+    top1_add_results_none<CMax<float, int64_t>, true>(self, j0, j1, dis_tab);
+}
+
+template <>
+void top1_add_results_tpl<CMin<float, int64_t>, false, SIMDLevel::NONE>(
+        Top1BlockResultHandler<CMin<float, int64_t>, false>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_tab) {
+    top1_add_results_none<CMin<float, int64_t>, false>(self, j0, j1, dis_tab);
+}
+
+template <>
+void top1_add_results_tpl<CMin<float, int64_t>, true, SIMDLevel::NONE>(
+        Top1BlockResultHandler<CMin<float, int64_t>, true>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_tab) {
+    top1_add_results_none<CMin<float, int64_t>, true>(self, j0, j1, dis_tab);
+}
+
+template <>
+void reservoir_add_results_tpl<CMax<float, int64_t>, false, SIMDLevel::NONE>(
+        ReservoirBlockResultHandler<CMax<float, int64_t>, false>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_in) {
+    reservoir_add_results_none<CMax<float, int64_t>, false>(
+            self, j0, j1, dis_in);
+}
+
+template <>
+void reservoir_add_results_tpl<CMax<float, int64_t>, true, SIMDLevel::NONE>(
+        ReservoirBlockResultHandler<CMax<float, int64_t>, true>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_in) {
+    reservoir_add_results_none<CMax<float, int64_t>, true>(
+            self, j0, j1, dis_in);
+}
+
+template <>
+void reservoir_add_results_tpl<CMin<float, int64_t>, false, SIMDLevel::NONE>(
+        ReservoirBlockResultHandler<CMin<float, int64_t>, false>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_in) {
+    reservoir_add_results_none<CMin<float, int64_t>, false>(
+            self, j0, j1, dis_in);
+}
+
+template <>
+void reservoir_add_results_tpl<CMin<float, int64_t>, true, SIMDLevel::NONE>(
+        ReservoirBlockResultHandler<CMin<float, int64_t>, true>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_in) {
+    reservoir_add_results_none<CMin<float, int64_t>, true>(
+            self, j0, j1, dis_in);
+}
+
+// ----------------------------------------------------------------
+// add_results method definitions — dispatch to the right SL kernel
+// ----------------------------------------------------------------
+
+template <class C, bool use_sel>
+void Top1BlockResultHandler<C, use_sel>::add_results(
+        size_t j0,
+        size_t j1,
+        const T* dis_tab_2) {
+    with_selected_simd_levels<TOP1_SIMD_LEVELS>([&]<SIMDLevel SL>() {
+        top1_add_results_tpl<C, use_sel, SL>(this, j0, j1, dis_tab_2);
+    });
+}
+
+template <class C, bool use_sel>
+void ReservoirBlockResultHandler<C, use_sel>::add_results(
+        size_t j0,
+        size_t j1,
+        const T* dis_in) {
+    with_selected_simd_levels<RESERVOIR_SIMD_LEVELS>([&]<SIMDLevel SL>() {
+        reservoir_add_results_tpl<C, use_sel, SL>(this, j0, j1, dis_in);
+    });
+}
+
+// ----------------------------------------------------------------
+// Explicit class-template instantiations (force linkage)
+// ----------------------------------------------------------------
+
+template void Top1BlockResultHandler<CMax<float, int64_t>, false>::add_results(
+        size_t,
+        size_t,
+        const float*);
+template void Top1BlockResultHandler<CMax<float, int64_t>, true>::add_results(
+        size_t,
+        size_t,
+        const float*);
+template void Top1BlockResultHandler<CMin<float, int64_t>, false>::add_results(
+        size_t,
+        size_t,
+        const float*);
+template void Top1BlockResultHandler<CMin<float, int64_t>, true>::add_results(
+        size_t,
+        size_t,
+        const float*);
+
+template void ReservoirBlockResultHandler<CMax<float, int64_t>, false>::
+        add_results(size_t, size_t, const float*);
+template void ReservoirBlockResultHandler<CMax<float, int64_t>, true>::
+        add_results(size_t, size_t, const float*);
+template void ReservoirBlockResultHandler<CMin<float, int64_t>, false>::
+        add_results(size_t, size_t, const float*);
+template void ReservoirBlockResultHandler<CMin<float, int64_t>, true>::
+        add_results(size_t, size_t, const float*);
+
+} // namespace faiss

--- a/faiss/impl/result_handler/avx2.cpp
+++ b/faiss/impl/result_handler/avx2.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// AVX2 specialisation of Top1 add_results (8-wide branchless argmin/argmax).
+// Reservoir stays on the NONE path — VPCOMPRESSPS requires AVX512F.
+
+#ifdef COMPILE_SIMD_AVX2
+
+#include <faiss/impl/ResultHandler.h>
+
+#include <immintrin.h>
+#include <type_traits>
+
+namespace faiss {
+
+namespace {
+
+/// Templated AVX2 implementation of Top1 add_results for both CMax (keeps the
+/// smallest distance) and CMin (keeps the largest similarity).
+template <class C, bool use_sel>
+void top1_add_results_avx2(
+        Top1BlockResultHandler<C, use_sel>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_tab_in) {
+    static_assert(
+            std::is_same<typename C::T, float>::value,
+            "This code expects float distances");
+    using TI = typename C::TI;
+    const __m256i vstep = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
+
+    for (size_t qi = self->i0; qi < self->i1; qi++) {
+        const float* dis_tab_i = dis_tab_in + (j1 - j0) * (qi - self->i0) - j0;
+
+        // Hoist best_dis / best_idx into locals so the compiler keeps them in
+        // registers across the inner loop (no aliasing with dis_tab reads).
+        float best_dis = self->dis_tab[qi];
+        TI best_idx = self->ids_tab[qi];
+        size_t j = j0;
+
+        __m256 vbest = _mm256_set1_ps(best_dis);
+        __m256i vbest_idx = _mm256_set1_epi32((int32_t)best_idx);
+
+        for (; j + 8 <= j1; j += 8) {
+            __m256 vdis = _mm256_loadu_ps(dis_tab_i + j);
+            __m256i vidx =
+                    _mm256_add_epi32(_mm256_set1_epi32((int32_t)j), vstep);
+
+            // CMax (L2 nearest neighbour): keep lane if dis < best.
+            // CMin (inner product):        keep lane if dis > best.
+            __m256 mask;
+            if constexpr (C::is_max) {
+                mask = _mm256_cmp_ps(vdis, vbest, _CMP_LT_OS);
+            } else {
+                mask = _mm256_cmp_ps(vdis, vbest, _CMP_GT_OS);
+            }
+            vbest = _mm256_blendv_ps(vbest, vdis, mask);
+            vbest_idx = _mm256_blendv_epi8(
+                    vbest_idx, vidx, _mm256_castps_si256(mask));
+        }
+
+        // Horizontal reduction across 8 lanes.
+        alignas(32) float best_arr[8];
+        alignas(32) int32_t idx_arr[8];
+        _mm256_store_ps(best_arr, vbest);
+        _mm256_store_si256((__m256i*)idx_arr, vbest_idx);
+        for (int k = 0; k < 8; k++) {
+            if (C::cmp(best_dis, best_arr[k])) {
+                best_dis = best_arr[k];
+                best_idx = (TI)idx_arr[k];
+            }
+        }
+
+        // Scalar tail.
+        for (; j < j1; j++) {
+            if (C::cmp(best_dis, dis_tab_i[j])) {
+                best_dis = dis_tab_i[j];
+                best_idx = (TI)j;
+            }
+        }
+
+        self->dis_tab[qi] = best_dis;
+        self->ids_tab[qi] = best_idx;
+    }
+}
+
+} // namespace
+
+// Explicit specialisations for AVX2
+
+template <>
+void top1_add_results_tpl<CMax<float, int64_t>, false, SIMDLevel::AVX2>(
+        Top1BlockResultHandler<CMax<float, int64_t>, false>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_tab) {
+    top1_add_results_avx2<CMax<float, int64_t>, false>(self, j0, j1, dis_tab);
+}
+
+template <>
+void top1_add_results_tpl<CMax<float, int64_t>, true, SIMDLevel::AVX2>(
+        Top1BlockResultHandler<CMax<float, int64_t>, true>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_tab) {
+    top1_add_results_avx2<CMax<float, int64_t>, true>(self, j0, j1, dis_tab);
+}
+
+template <>
+void top1_add_results_tpl<CMin<float, int64_t>, false, SIMDLevel::AVX2>(
+        Top1BlockResultHandler<CMin<float, int64_t>, false>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_tab) {
+    top1_add_results_avx2<CMin<float, int64_t>, false>(self, j0, j1, dis_tab);
+}
+
+template <>
+void top1_add_results_tpl<CMin<float, int64_t>, true, SIMDLevel::AVX2>(
+        Top1BlockResultHandler<CMin<float, int64_t>, true>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_tab) {
+    top1_add_results_avx2<CMin<float, int64_t>, true>(self, j0, j1, dis_tab);
+}
+
+} // namespace faiss
+
+#endif // COMPILE_SIMD_AVX2

--- a/faiss/impl/result_handler/avx512.cpp
+++ b/faiss/impl/result_handler/avx512.cpp
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// AVX-512 specialisations of Top1 and Reservoir add_results.
+//
+// Top-1:    16-wide branchless argmin/argmax via mask_blend.
+// Reservoir: VPCOMPRESSPS / VPCOMPRESSD bulk-insert of passing elements,
+//            eliminating the per-element threshold branch entirely.
+
+#ifdef COMPILE_SIMD_AVX512
+
+#include <faiss/impl/ResultHandler.h>
+#include <faiss/utils/popcount.h>
+
+#include <immintrin.h>
+#include <type_traits>
+
+namespace faiss {
+
+namespace {
+
+/// Templated AVX-512 implementation of Top1 add_results for both CMax (keeps
+/// the smallest distance) and CMin (keeps the largest similarity).
+template <class C, bool use_sel>
+void top1_add_results_avx512(
+        Top1BlockResultHandler<C, use_sel>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_tab_in) {
+    static_assert(
+            std::is_same<typename C::T, float>::value,
+            "This code expects float distances");
+    using TI = typename C::TI;
+    const __m512i vstep = _mm512_set_epi32(
+            15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+
+    for (size_t qi = self->i0; qi < self->i1; qi++) {
+        const float* dis_tab_i = dis_tab_in + (j1 - j0) * (qi - self->i0) - j0;
+
+        // Hoist best_dis / best_idx into locals so the compiler keeps them in
+        // registers across the inner loop (no aliasing with dis_tab reads).
+        float best_dis = self->dis_tab[qi];
+        TI best_idx = self->ids_tab[qi];
+        size_t j = j0;
+
+        __m512 vbest = _mm512_set1_ps(best_dis);
+        __m512i vbest_idx = _mm512_set1_epi32((int32_t)best_idx);
+
+        for (; j + 16 <= j1; j += 16) {
+            __m512 vdis = _mm512_loadu_ps(dis_tab_i + j);
+            __m512i vidx =
+                    _mm512_add_epi32(_mm512_set1_epi32((int32_t)j), vstep);
+
+            // CMax (L2 nearest neighbour): keep lane if dis < best.
+            // CMin (inner product):        keep lane if dis > best.
+            __mmask16 mask;
+            if constexpr (C::is_max) {
+                mask = _mm512_cmp_ps_mask(vdis, vbest, _CMP_LT_OS);
+            } else {
+                mask = _mm512_cmp_ps_mask(vdis, vbest, _CMP_GT_OS);
+            }
+            vbest = _mm512_mask_blend_ps(mask, vbest, vdis);
+            vbest_idx = _mm512_mask_blend_epi32(mask, vbest_idx, vidx);
+        }
+
+        // Horizontal reduction across 16 lanes.
+        alignas(64) float best_arr[16];
+        alignas(64) int32_t idx_arr[16];
+        _mm512_store_ps(best_arr, vbest);
+        _mm512_store_si512((__m512i*)idx_arr, vbest_idx);
+        for (int k = 0; k < 16; k++) {
+            if (C::cmp(best_dis, best_arr[k])) {
+                best_dis = best_arr[k];
+                best_idx = (TI)idx_arr[k];
+            }
+        }
+
+        // Scalar tail.
+        for (; j < j1; j++) {
+            if (C::cmp(best_dis, dis_tab_i[j])) {
+                best_dis = dis_tab_i[j];
+                best_idx = (TI)j;
+            }
+        }
+
+        self->dis_tab[qi] = best_dis;
+        self->ids_tab[qi] = best_idx;
+    }
+}
+
+/// Templated AVX-512 implementation of Reservoir add_results for both CMax
+/// and CMin.  Uses VPCOMPRESSPS / VPCOMPRESSD to bulk-insert all elements that
+/// beat the current threshold in a single pass, avoiding the per-element branch
+/// that dominates the scalar path.
+///
+/// Falls back to the scalar NONE path for small reservoirs (capacity < 64)
+/// where the compress-path setup cost outweighs its throughput benefit.
+template <class C, bool use_sel>
+void reservoir_add_results_avx512(
+        ReservoirBlockResultHandler<C, use_sel>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_in) {
+    static_assert(
+            std::is_same<typename C::T, float>::value,
+            "This code expects float distances");
+    static_assert(
+            std::is_same<typename C::TI, int64_t>::value,
+            "This code expects int64_t indices");
+
+    // AVX-512 compress amortizes its setup cost only for large reservoirs.
+    // Benchmarks show a ~9% regression at k=10 (capacity≈20) and a ~25%
+    // gain at k=100 (capacity≈200).  32 = 2 × lane-width is the crossover.
+    // All reservoirs in a handler share the same capacity, so check once.
+    constexpr size_t AVX512_RESERVOIR_MIN_CAPACITY = 32;
+    if (self->i0 < self->i1 &&
+        self->reservoirs[0].capacity < AVX512_RESERVOIR_MIN_CAPACITY) {
+        reservoir_add_results_tpl<C, use_sel, SIMDLevel::NONE>(
+                self, j0, j1, dis_in);
+        return;
+    }
+
+    const __m512i vstep = _mm512_set_epi32(
+            15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+
+#pragma omp parallel for
+    for (int64_t qi = (int64_t)self->i0; qi < (int64_t)self->i1; qi++) {
+        ReservoirTopN<C>& res = self->reservoirs[qi - (int64_t)self->i0];
+        const float* dis_tab_i =
+                dis_in + (j1 - j0) * (qi - (int64_t)self->i0) - j0;
+        size_t j = j0;
+
+        for (; j + 16 <= j1; j += 16) {
+            // Near-capacity: fewer than 16 free slots remain.  Fall back to
+            // the scalar add_result which handles overflow correctly.
+            if (res.i + 16 > res.capacity) {
+                for (size_t jj = j; jj < j + 16; jj++)
+                    res.add_result(dis_tab_i[jj], jj);
+                continue;
+            }
+
+            __m512 vthresh = _mm512_set1_ps(res.threshold);
+            __m512 vdis = _mm512_loadu_ps(dis_tab_i + j);
+
+            // CMax (L2): keep elements with dis < threshold.
+            // CMin (IP): keep elements with dis > threshold.
+            __mmask16 mask;
+            if constexpr (C::is_max) {
+                mask = _mm512_cmp_ps_mask(vdis, vthresh, _CMP_LT_OS);
+            } else {
+                mask = _mm512_cmp_ps_mask(vdis, vthresh, _CMP_GT_OS);
+            }
+            if (mask == 0)
+                continue;
+
+            int count = popcount32(mask);
+
+            // Compress passing distances into a contiguous run (VPCOMPRESSPS).
+            __m512 passing_dis = _mm512_maskz_compress_ps(mask, vdis);
+
+            // Compress the sequential indices j..j+15 (VPCOMPRESSD).
+            __m512i vidx32 =
+                    _mm512_add_epi32(_mm512_set1_epi32((int32_t)j), vstep);
+            __m512i passing_idx32 = _mm512_maskz_compress_epi32(mask, vidx32);
+
+            // Unconditional 16-element stores are safe: the res.i + 16 <=
+            // res.capacity check above guarantees slots res.i .. res.i+15
+            // are all unused.  The (count .. 15) tail positions get garbage
+            // that res.i never reaches.
+            _mm512_storeu_ps(res.vals + res.i, passing_dis);
+
+            // Widen int32 indices to int64 (TI = int64_t) in two 8-element
+            // halves and store them.
+            _mm512_storeu_si512(
+                    (void*)(res.ids + res.i),
+                    _mm512_cvtepi32_epi64(
+                            _mm512_castsi512_si256(passing_idx32)));
+            _mm512_storeu_si512(
+                    (void*)(res.ids + res.i + 8),
+                    _mm512_cvtepi32_epi64(
+                            _mm512_extracti64x4_epi64(passing_idx32, 1)));
+
+            res.i += count;
+            if (res.i >= res.capacity) {
+                res.shrink_fuzzy();
+            }
+        }
+
+        // Scalar tail.
+        for (; j < j1; j++)
+            res.add_result(dis_tab_i[j], j);
+    }
+}
+
+} // namespace
+
+// Explicit specialisations for AVX-512
+
+template <>
+void top1_add_results_tpl<CMax<float, int64_t>, false, SIMDLevel::AVX512>(
+        Top1BlockResultHandler<CMax<float, int64_t>, false>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_tab) {
+    top1_add_results_avx512<CMax<float, int64_t>, false>(self, j0, j1, dis_tab);
+}
+
+template <>
+void top1_add_results_tpl<CMax<float, int64_t>, true, SIMDLevel::AVX512>(
+        Top1BlockResultHandler<CMax<float, int64_t>, true>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_tab) {
+    top1_add_results_avx512<CMax<float, int64_t>, true>(self, j0, j1, dis_tab);
+}
+
+template <>
+void top1_add_results_tpl<CMin<float, int64_t>, false, SIMDLevel::AVX512>(
+        Top1BlockResultHandler<CMin<float, int64_t>, false>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_tab) {
+    top1_add_results_avx512<CMin<float, int64_t>, false>(self, j0, j1, dis_tab);
+}
+
+template <>
+void top1_add_results_tpl<CMin<float, int64_t>, true, SIMDLevel::AVX512>(
+        Top1BlockResultHandler<CMin<float, int64_t>, true>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_tab) {
+    top1_add_results_avx512<CMin<float, int64_t>, true>(self, j0, j1, dis_tab);
+}
+
+template <>
+void reservoir_add_results_tpl<CMax<float, int64_t>, false, SIMDLevel::AVX512>(
+        ReservoirBlockResultHandler<CMax<float, int64_t>, false>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_in) {
+    reservoir_add_results_avx512<CMax<float, int64_t>, false>(
+            self, j0, j1, dis_in);
+}
+
+template <>
+void reservoir_add_results_tpl<CMax<float, int64_t>, true, SIMDLevel::AVX512>(
+        ReservoirBlockResultHandler<CMax<float, int64_t>, true>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_in) {
+    reservoir_add_results_avx512<CMax<float, int64_t>, true>(
+            self, j0, j1, dis_in);
+}
+
+template <>
+void reservoir_add_results_tpl<CMin<float, int64_t>, false, SIMDLevel::AVX512>(
+        ReservoirBlockResultHandler<CMin<float, int64_t>, false>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_in) {
+    reservoir_add_results_avx512<CMin<float, int64_t>, false>(
+            self, j0, j1, dis_in);
+}
+
+template <>
+void reservoir_add_results_tpl<CMin<float, int64_t>, true, SIMDLevel::AVX512>(
+        ReservoirBlockResultHandler<CMin<float, int64_t>, true>* self,
+        size_t j0,
+        size_t j1,
+        const float* dis_in) {
+    reservoir_add_results_avx512<CMin<float, int64_t>, true>(
+            self, j0, j1, dis_in);
+}
+
+} // namespace faiss
+
+#endif // COMPILE_SIMD_AVX512


### PR DESCRIPTION
This PR replaces the scalar `add_results` loops in `Top1BlockResultHandler` and `ReservoirBlockResultHandler` with runtime-dispatched SIMD kernels.

### Top1 (k=1)

- **AVX2:** 8-wide branchless argmin/argmax via `_mm256_blendv_ps` / `_mm256_blendv_epi8`, with horizontal reduction and scalar tail.
- **AVX512:** 16-wide via `_mm512_mask_blend_ps` / `_mm512_mask_blend_epi32`.

### Reservoir (k>1)

- **NONE:** Scalar path with `res.i` and `res.threshold` hoisted into local variables, eliminating per-iteration struct field reloads caused by `float*` / `int64_t*` aliasing.
- **AVX512:** `VPCOMPRESSPS` + `VPCOMPRESSD` bulk-insert all elements beating the threshold in a single pass. Indices are widened from int32 to int64 via `_mm512_cvtepi32_epi64`. Falls back to the scalar path when reservoir capacity < 32 (2× lane width), where compress setup cost outweighs throughput benefit.

### Performance

Benchmarking using `benchs/bench_index_flat.py` (on Xeon) gives the below gains.

```
+-----+------+------+------+-------+
|  d  | k=10 | k=32 | k=64 | k=100 |
+-----+------+------+------+-------+
|  16 | +10% | +15% | +28% |  +31% |
|  32 |  +7% | +12% | +25% |  +28% |
|  64 |  +7% | +11% | +21% |  +25% |
| 128 |  +7% | +10% | +18% |  +19% |
+-----+------+------+------+-------+
```
k=1 is neutral — distance compute dominates at all tested dimensions.

Raw results (old and new): https://gist.github.com/mulugetam/82ef99c25f532f7439070c802b746865