### PR TITLE
Move partitioning shifts tables to .rodata to fix non-AVX2 import SIGILL (#5298)

### DIFF
--- a/faiss/utils/simd_impl/partitioning_simdlib256.h
+++ b/faiss/utils/simd_impl/partitioning_simdlib256.h
@@ -592,39 +592,12 @@ simd16uint16 accu8to16(simd32uint8 a8) {
     return hadd(a8_0, a8_1);
 }
 
-static const simd32uint8 shifts = simd32uint8::create<
-        1,
-        16,
-        0,
-        0,
-        4,
-        64,
-        0,
-        0,
-        0,
-        0,
-        1,
-        16,
-        0,
-        0,
-        4,
-        64,
-        1,
-        16,
-        0,
-        0,
-        4,
-        64,
-        0,
-        0,
-        0,
-        0,
-        1,
-        16,
-        0,
-        0,
-        4,
-        64>();
+// Lookup table held as a plain byte array in .rodata. Storing it as a
+// `simd32uint8` global would emit an AVX2 initializer into `.init_array` that
+// runs at dlopen, before runtime SIMD dispatch, and SIGILLs on non-AVX2 CPUs
+alignas(32) static const uint8_t shifts[32] = {
+        1, 16, 0, 0, 4, 64, 0, 0, 0, 0, 1, 16, 0, 0, 4, 64,
+        1, 16, 0, 0, 4, 64, 0, 0, 0, 0, 1, 16, 0, 0, 4, 64};
 
 // 2-bit accumulator: we can add only up to 3 elements
 // on output we return 2*4-bit results
@@ -644,7 +617,8 @@ void compute_accu2(
         v = pp(v);
         // 0x800 -> force second half of table
         simd16uint16 idx = v | (v << 8) | simd16uint16(0x800);
-        a2 += simd16uint16(shifts.lookup_2_lanes(simd32uint8(idx)));
+        a2 += simd16uint16(
+                simd32uint8(shifts).lookup_2_lanes(simd32uint8(idx)));
     }
     a4lo += a2 & mask2;
     a4hi += (a2 >> 2) & mask2;
@@ -694,39 +668,11 @@ simd16uint16 histogram_8(const uint16_t* data, Preproc pp, size_t n_in) {
  * 16 bins
  ************************************************************/
 
-static const simd32uint8 shifts2 = simd32uint8::create<
-        1,
-        2,
-        4,
-        8,
-        16,
-        32,
-        64,
-        128,
-        1,
-        2,
-        4,
-        8,
-        16,
-        32,
-        64,
-        128,
-        1,
-        2,
-        4,
-        8,
-        16,
-        32,
-        64,
-        128,
-        1,
-        2,
-        4,
-        8,
-        16,
-        32,
-        64,
-        128>();
+// See the note on `shifts` above: kept as a .rodata byte array so its
+// initializer does not emit AVX2 into `.init_array`
+alignas(32) static const uint8_t shifts2[32] = {
+        1, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128,
+        1, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128};
 
 simd32uint8 shiftr_16(simd32uint8 x, int n) {
     return simd32uint8(simd16uint16(x) >> n);
@@ -754,7 +700,7 @@ void compute_accu2_16(
         v = pp(v);
 
         simd16uint16 idx = v | (v << 8);
-        simd32uint8 a1 = shifts2.lookup_2_lanes(simd32uint8(idx));
+        simd32uint8 a1 = simd32uint8(shifts2).lookup_2_lanes(simd32uint8(idx));
         // contains 0s for out-of-bounds elements
 
         simd16uint16 lt8 = (v >> 3) == simd16uint16(0);


### PR DESCRIPTION
Summary:

The `faiss-cpu` 1.14.2 manylinux x86_64 wheel (the first build from the in-repo `FAISS_OPT_LEVEL=dd` pipeline) SIGILLs during `import faiss` on x86-64 CPUs that support AVX but not AVX2 (Sandy Bridge / Ivy Bridge). The crash is inside `dlopen` of `libfaiss.so` (reproducible with a bare `ctypes.CDLL(".../libfaiss.so")`), so it precedes all runtime SIMD dispatch — neither the CPUID dispatch nor `FAISS_SIMD_LEVEL=NONE` can prevent it. Reported as facebookresearch/faiss#5296.

Root cause: two namespace-scope globals in `faiss/utils/simd_impl/partitioning_simdlib256.h`, `shifts` and `shifts2`, are defined as `static const simd32uint8 = simd32uint8::create<...>()`. When this header is compiled into `partitioning_avx2.cpp` — which DD mode compiles with `-mavx2 -mfma` — `create<>()` resolves to `_mm256_setr_epi8(...)`, an AVX2 intrinsic. Because these objects wrap `__m256i` and are not constant-initialized, the compiler emits their constructors into `.init_array`, which runs at `dlopen`, before the CPUID dispatch in `simd_levels.cpp` can select a safe path. On a non-AVX2 CPU the load-time AVX instruction faults with SIGILL. These two are the only namespace-scope SIMD objects in the tree that escape the dispatch mechanism; every other SIMD constant is function-local and runs only after dispatch.

Fix: store both lookup tables as plain `alignas(32) static const uint8_t[32]` arrays. A byte array is constant-initialized into `.rodata` with no `.init_array` entry, and the SIMD register is built at the use site (`simd32uint8(shifts)` / `simd32uint8(shifts2)`) — i.e. only after dispatch has confirmed the level is available. The load is loop-invariant, so the compiler hoists it out of the histogram loop; no runtime cost. Byte order is identical to the previous `create<...>()` form on both AVX2 (`_mm256_setr_epi8`) and NEON (whose `create<>` already routes through a `const uint8_t*` load), so the lookup tables are bit-identical — no functional change. NEON is unaffected at runtime since it is baseline-mandatory on aarch64.

Reviewed By: mnorris11

Differential Revision: D108211237


