### PR TITLE
Add manual Faiss nightly workflow dispatch

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,10 @@
 name: Nightly
 on:
+  # The Faiss OSS autofix sidecar pushes generated fixes to short-lived
+  # validation branches and then dispatches this workflow on that branch. The
+  # scheduled trigger alone only tests the default branch, so it cannot validate
+  # a candidate fix before the sidecar asks a human to review it.
+  workflow_dispatch:
   schedule:
     - cron:  '10 6 * * *'
 env:


### PR DESCRIPTION
Summary:
Add `workflow_dispatch` to the Faiss public nightly workflow so the OSS autofix sidecar can validate generated fixes on short-lived validation branches before asking a human to review them. The scheduled trigger only runs on GitHub's default branch at the cron time, so it does not validate an unlanded Phabricator diff or a candidate branch.

`workflow_dispatch` does not run the nightly by itself; it adds a manual/API entry point. After the sidecar pushes a candidate branch such as `myclaw/<run_id>-<attempt>`, it calls the GitHub Actions workflow dispatch endpoint for `nightly.yml` with `ref` set to that branch. GitHub then checks out and runs the workflow at the commit currently pointed to by that ref.

The dispatch request does not need a separate commit number when using a branch ref: the branch name resolves to its HEAD commit at dispatch time. If we ever want to pin an exact revision instead of a movable branch, the sidecar can dispatch with a more specific Git ref accepted by GitHub, but the current deterministic branch-per-attempt design makes the branch HEAD the validation candidate.

Reviewed By: mnorris11

Differential Revision: D108214872


