### PR TITLE
Migrate remaining faiss OpenMP-off consumers to //faiss:faiss + use_omp_mock (2/4)

### DIFF
--- a/perf_tests/bench_no_multithreading_rcq_search.cpp
+++ b/perf_tests/bench_no_multithreading_rcq_search.cpp
@@ -8,8 +8,8 @@
 #include <gflags/gflags.h>
 
 #include <benchmark/benchmark.h>
-#include <faiss/IndexAdditiveQuantizer.h> // @manual=//faiss:faiss_no_multithreading
-#include <faiss/utils/random.h> // @manual=//faiss:faiss_no_multithreading
+#include <faiss/IndexAdditiveQuantizer.h> // @manual=//faiss:faiss
+#include <faiss/utils/random.h>           // @manual=//faiss:faiss
 
 using namespace faiss;
 DEFINE_uint32(iterations, 20, "iterations");


### PR DESCRIPTION
Differential Revision: D108237243


