### PR TITLE
make intentional cudaGetLastError() error-clears explicit ((void)) for clang21 -- fixes S674096

### DIFF
--- a/faiss/gpu/StandardGpuResources.cpp
+++ b/faiss/gpu/StandardGpuResources.cpp
@@ -561,7 +561,7 @@ void* StandardGpuResourcesImpl::allocMemory(const AllocRequest& req) {
             // FIXME: as of CUDA 11, a memory allocation error appears to be
             // presented via cudaGetLastError as well, and needs to be
             // cleared. Just call the function to clear it
-            cudaGetLastError();
+            (void)cudaGetLastError();
 
             std::stringstream ss;
             ss << "StandardGpuResources: alloc fail " << adjReq.toString()
@@ -595,7 +595,7 @@ void* StandardGpuResourcesImpl::allocMemory(const AllocRequest& req) {
             // FIXME: as of CUDA 11, a memory allocation error appears to be
             // presented via cudaGetLastError as well, and needs to be cleared.
             // Just call the function to clear it
-            cudaGetLastError();
+            (void)cudaGetLastError();
 
             std::stringstream ss;
             ss << "StandardGpuResources: alloc fail " << adjReq.toString()


### PR DESCRIPTION
Summary:
StandardGpuResources.cpp calls cudaGetLastError() twice solely to CLEAR a sticky
allocation error on the alloc-failure path (per the existing FIXME comments: "needs
to be cleared. Just call the function to clear it"), immediately before FAISS_THROW.
In the AMD/ROCm build these hipify to hipGetLastError(); clang-21 promotes the
ignored [[nodiscard]] return to -Werror,-Wunused-value, which broke the
light_cli_amd fbpkg build (SEV S674096 -- root-caused to the llvm-fb 21 enablement
of minimal_viable_ai/fire, D107891160, since reverted via D108161569).

Make the discard explicit with (void). These are deliberate error-clears on a
failure path right before a throw, so inspecting the return (e.g. C10_CUDA_CHECK)
would be wrong -- it would throw on the very error being cleared. No behavior change.
Unblocks re-landing the fire llvm-fb 21 migration.

Differential Revision: D108245375


