### PR TITLE
Add IVFSQTurboQSearchParameters to __init__.pyi stub

### DIFF
--- a/.github/workflows/build-pip-gpu.yml
+++ b/.github/workflows/build-pip-gpu.yml
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-name: Build GPU pip wheel
+name: Build GPU pip wheels
 
 on:
   workflow_call:
@@ -88,6 +88,84 @@ jobs:
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e  # v4.1.7
         with:
           name: wheels-gpu
+          path: dist
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          verbose: true
+
+  build-faiss-gpu-cuvs:
+    name: Build & test faiss-gpu-cuvs
+    runs-on: 4-core-ubuntu-gpu-t4
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Activate cuVS pyproject.toml
+        # cibuildwheel + scikit-build-core both require literal pyproject.toml.
+        # Workspace is fresh per job (actions/checkout creates new tree).
+        run: cp pyproject-gpu-cuvs.toml pyproject.toml
+
+      - name: Set up Python
+        # Same broken-3.14.4-runner workaround as the faiss-gpu job above.
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Build wheel (cibuildwheel)
+        uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a  # v3.4.0
+        env:
+          CIBW_BUILD_VERBOSITY: 1
+
+      - name: Upload wheel
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: wheels-gpu-cuvs
+          path: wheelhouse/*.whl
+
+  publish-gpu-cuvs:
+    name: Publish faiss-gpu-cuvs to PyPI
+    needs: [build-faiss-gpu-cuvs]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/faiss-gpu-cuvs
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download wheel
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e  # v4.1.7
+        with:
+          name: wheels-gpu-cuvs
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # release/v1
+        with:
+          verbose: true
+          attestations: false
+
+  publish-testpypi-gpu-cuvs:
+    name: Publish faiss-gpu-cuvs to TestPyPI
+    needs: [build-faiss-gpu-cuvs]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/faiss-gpu-cuvs
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download wheel
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e  # v4.1.7
+        with:
+          name: wheels-gpu-cuvs
           path: dist
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # release/v1

--- a/faiss/python/CMakeLists.txt
+++ b/faiss/python/CMakeLists.txt
@@ -491,6 +491,16 @@ if(FAISS_ENABLE_METAL)
   endif()
 endif()
 
+# cuVS build marker: only present in faiss-gpu-cuvs wheels. Used by __init__.py
+# to additionally preload libcuvs / libraft / librmm / librapids_logger from the
+# libcuvs-cu12 pip package, on top of the base CUDA preload gated by _gpu_build.
+if(FAISS_ENABLE_CUVS)
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/_cuvs_build.py"
+    "# Auto-generated when FAISS_ENABLE_CUVS=ON.\n"
+    "IS_CUVS_BUILD = True\n")
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/_cuvs_build.py" DESTINATION faiss)
+endif()
+
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/py.typed")
   install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/py.typed" DESTINATION faiss)
 endif()

--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -15,23 +15,12 @@ import inspect
 
 
 def _preload_gpu_libs():
-    """Pre-load CUDA shared libraries from nvidia-*-cu12 pip packages.
+    """Pre-load CUDA / RAPIDS shared libs from pip wheels with RTLD_GLOBAL.
 
-    The libcudart.so / libcublas.so / libcurand.so files live in
-    site-packages/nvidia/{cuda_runtime,cublas,curand}/lib/ — not on the
-    default ld.so search path. Pre-load them with RTLD_GLOBAL before the
-    SWIG extension dlopen()s libfaiss.so (which has CUDA undefined symbols).
-
-    Gating: keyed on the `faiss._gpu_build` module, which CMake writes only
-    when FAISS_ENABLE_GPU=ON. We can't gate on `nvidia.cuda_runtime`
-    importability — PyTorch and cupy CUDA wheels pull that in transitively,
-    so a faiss-cpu user with PyTorch+CUDA would otherwise hit this path and
-    see a misleading error if any nvidia-* package were missing.
-
-    Behavior:
-    - faiss-cpu install (no `_gpu_build` marker): silent no-op.
-    - faiss-gpu install with missing nvidia-cuda-runtime / cublas / curand:
-      raises RuntimeError with fix-it message.
+    These libs ship in nvidia-*-cu12 / libcuvs-cu12 wheels, off ld.so's search
+    path, so we dlopen them before the SWIG extension loads libfaiss.so. Gated
+    on the `faiss._gpu_build` marker (CMake writes it only for GPU builds); the
+    `_cuvs_build` marker adds the cuVS stack. Missing wheels raise a fix-it.
     """
     try:
         from . import _gpu_build  # noqa: F401
@@ -41,51 +30,63 @@ def _preload_gpu_libs():
     import ctypes
     import os
 
-    try:
-        import nvidia.cuda_runtime
-    except ImportError as e:
-        raise RuntimeError(
-            "faiss-gpu installed but nvidia-cuda-runtime-cu12 is missing — "
-            "pip install 'nvidia-cuda-runtime-cu12>=12.6,<13'"
-        ) from e
-
-    try:
-        import nvidia.cublas
-    except ImportError as e:
-        raise RuntimeError(
-            "faiss-gpu installed but nvidia-cublas-cu12 is missing — "
-            "pip install 'nvidia-cublas-cu12>=12.6,<13'"
-        ) from e
-
-    try:
-        import nvidia.curand
-    except ImportError as e:
-        raise RuntimeError(
-            "faiss-gpu installed but nvidia-curand-cu12 is missing — "
-            "pip install 'nvidia-curand-cu12>=10.3.7,<11'"
-        ) from e
-
-    # Order matters: libcudart provides symbols that libcublas* / libcurand depend on.
-    _LIBS = [
-        (nvidia.cuda_runtime, "libcudart.so.12"),
-        (nvidia.cublas,       "libcublas.so.12"),
-        (nvidia.cublas,       "libcublasLt.so.12"),
-        (nvidia.curand,       "libcurand.so.10"),
-    ]
-    for pkg, soname in _LIBS:
-        # Use __path__[0] not __file__ — the nvidia-*-cu12 wheels are PEP 420
-        # implicit namespace packages, so pkg.__file__ is None.
-        so_path = os.path.join(pkg.__path__[0], "lib", soname)
+    def _nvidia_lib_dir(import_name, pip_spec):
+        """Return the lib/ dir of an nvidia-*-cu12 wheel, or raise a fix-it."""
         try:
-            ctypes.CDLL(so_path, mode=ctypes.RTLD_GLOBAL)
+            mod = __import__("nvidia." + import_name, fromlist=[import_name])
+        except ImportError as e:
+            pip_name = pip_spec.split(">")[0].split("<")[0].split("=")[0]
+            raise RuntimeError(
+                f"faiss-gpu installed but {pip_name} is missing — "
+                f"pip install '{pip_spec}'"
+            ) from e
+        # __path__[0] not __file__: PEP 420 namespace pkgs have __file__ = None.
+        return os.path.join(mod.__path__[0], "lib")
+
+    def _load(path):
+        """dlopen one .so with global visibility, or raise a fix-it."""
+        try:
+            ctypes.CDLL(path, mode=ctypes.RTLD_GLOBAL)
         except OSError as e:
             raise RuntimeError(
-                f"faiss-gpu: failed to load {soname} from {so_path} — "
-                f"corrupt nvidia-*-cu12 wheel? Try: pip install --force-reinstall "
-                f"'nvidia-cuda-runtime-cu12>=12.6,<13' "
-                f"'nvidia-cublas-cu12>=12.6,<13' "
-                f"'nvidia-curand-cu12>=10.3.7,<11'"
+                f"faiss-gpu: failed to load {os.path.basename(path)} from {path} — "
+                f"corrupt or incomplete nvidia-*-cu12 wheel? Try: pip install "
+                f"--force-reinstall 'nvidia-cuda-runtime-cu12>=12.6,<13' "
+                f"'nvidia-cublas-cu12>=12.6,<13' 'nvidia-curand-cu12>=10.3.7,<11'"
             ) from e
+
+    # Base CUDA libs the faiss extension links directly, in dependency order
+    # (libcudart first — it provides symbols the others resolve against). Loaded
+    # RTLD_GLOBAL so the SWIG extension's later dlopen of libfaiss.so resolves them.
+    _cudart = _nvidia_lib_dir("cuda_runtime", "nvidia-cuda-runtime-cu12>=12.6,<13")
+    _cublas = _nvidia_lib_dir("cublas", "nvidia-cublas-cu12>=12.6,<13")
+    _curand = _nvidia_lib_dir("curand", "nvidia-curand-cu12>=10.3.7,<11")
+    _load(os.path.join(_cudart, "libcudart.so.12"))
+    _load(os.path.join(_cublas, "libcublas.so.12"))
+    _load(os.path.join(_cublas, "libcublasLt.so.12"))
+    _load(os.path.join(_curand, "libcurand.so.10"))
+
+    # faiss-gpu-cuvs wheels (the _cuvs_build marker) also need the cuVS stack.
+    # Delegate to RAPIDS' load_library() (loads each .so RTLD_GLOBAL + its CUDA deps);
+    # order rmm -> raft -> cuvs makes every symbol global before the SWIG extension loads.
+    try:
+        from . import _cuvs_build  # noqa: F401
+    except ImportError:
+        return  # faiss-gpu (non-cuVS) build: base CUDA preload is sufficient.
+
+    try:
+        import libcuvs
+        import libraft
+        import librmm
+    except ImportError as e:
+        raise RuntimeError(
+            "faiss-gpu-cuvs installed but the cuVS runtime wheels are missing — "
+            "pip install 'libcuvs-cu12>=26.06,<27' "
+            "--extra-index-url https://pypi.nvidia.com"
+        ) from e
+
+    for _mod in (librmm, libraft, libcuvs):
+        _mod.load_library()
 
 
 _preload_gpu_libs()
@@ -98,16 +99,37 @@ from .loader import *
 from faiss import class_wrappers
 from faiss.gpu_wrappers import *
 from faiss.array_conversions import *
-from faiss.extra_wrappers import kmin, kmax, pairwise_distances, rand, randint, \
-    lrand, randn, rand_smooth_vectors, eval_intersection, normalize_L2, \
-    ResultHeap, knn, Kmeans, SuperKmeans, checksum, matrix_bucket_sort_inplace, \
-    bucket_sort, merge_knn_results, MapInt64ToInt64, knn_hamming, \
-    pack_bitstrings, unpack_bitstrings
+from faiss.extra_wrappers import (
+    kmin,
+    kmax,
+    pairwise_distances,
+    rand,
+    randint,
+    lrand,
+    randn,
+    rand_smooth_vectors,
+    eval_intersection,
+    normalize_L2,
+    ResultHeap,
+    knn,
+    Kmeans,
+    SuperKmeans,
+    checksum,
+    matrix_bucket_sort_inplace,
+    bucket_sort,
+    merge_knn_results,
+    MapInt64ToInt64,
+    knn_hamming,
+    pack_bitstrings,
+    unpack_bitstrings,
+)
 
 
-__version__ = "%d.%d.%d" % (FAISS_VERSION_MAJOR,
-                            FAISS_VERSION_MINOR,
-                            FAISS_VERSION_PATCH)
+__version__ = "%d.%d.%d" % (
+    FAISS_VERSION_MAJOR,
+    FAISS_VERSION_MINOR,
+    FAISS_VERSION_PATCH,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +145,9 @@ class_wrappers.handle_NSG(IndexNSG)
 class_wrappers.handle_MapLong2Long(MapLong2Long)
 class_wrappers.handle_IDSelectorSubset(IDSelectorBatch, class_owns=True)
 class_wrappers.handle_IDSelectorSubset(IDSelectorArray, class_owns=False)
-class_wrappers.handle_IDSelectorSubset(IDSelectorBitmap, class_owns=False, force_int64=False)
+class_wrappers.handle_IDSelectorSubset(
+    IDSelectorBitmap, class_owns=False, force_int64=False
+)
 class_wrappers.handle_CodeSet(CodeSet)
 
 class_wrappers.handle_Tensor2D(Tensor2D)
@@ -132,7 +156,9 @@ class_wrappers.handle_Embedding(Embedding)
 class_wrappers.handle_Linear(Linear)
 class_wrappers.handle_QINCo(QINCo)
 class_wrappers.handle_QINCoStep(QINCoStep)
-shard_ivf_index_centroids = class_wrappers.handle_shard_ivf_index_centroids(shard_ivf_index_centroids)
+shard_ivf_index_centroids = class_wrappers.handle_shard_ivf_index_centroids(
+    shard_ivf_index_centroids
+)
 
 
 this_module = sys.modules[__name__]
@@ -155,8 +181,9 @@ for symbol in dir(this_module):
         if issubclass(the_class, Quantizer):
             class_wrappers.handle_Quantizer(the_class)
 
-        if issubclass(the_class, IndexRowwiseMinMax) or \
-                issubclass(the_class, IndexRowwiseMinMaxFP16):
+        if issubclass(the_class, IndexRowwiseMinMax) or issubclass(
+            the_class, IndexRowwiseMinMaxFP16
+        ):
             class_wrappers.handle_IndexRowwiseMinMax(the_class)
 
         if issubclass(the_class, SearchParameters):
@@ -197,8 +224,9 @@ def add_ref_in_constructor(the_class, parameter_no):
     else:
         the_class.__init__ = replacement_init
 
+
 def add_to_referenced_objects(self, ref):
-    if not hasattr(self, 'referenced_objects'):
+    if not hasattr(self, "referenced_objects"):
         self.referenced_objects = [ref]
     else:
         self.referenced_objects.append(ref)
@@ -211,6 +239,7 @@ def add_ref_in_method(the_class, method_name, parameter_no):
         ref = args[parameter_no]
         add_to_referenced_objects(self, ref)
         return original_method(self, *args)
+
     setattr(the_class, method_name, replacement_method)
 
 
@@ -220,7 +249,7 @@ def add_ref_in_method_explicit_own(the_class, method_name):
 
     def replacement_method(self, ref, own=False):
         if not own:
-            if not hasattr(self, 'referenced_objects'):
+            if not hasattr(self, "referenced_objects"):
                 self.referenced_objects = [ref]
             else:
                 self.referenced_objects.append(ref)
@@ -228,6 +257,7 @@ def add_ref_in_method_explicit_own(the_class, method_name):
             # transfer ownership to C++ class
             ref.this.disown()
         return original_method(self, ref, own)
+
     setattr(the_class, method_name, replacement_method)
 
 
@@ -240,6 +270,7 @@ def add_ref_in_function(function_name, parameter_no):
         ref = args[parameter_no]
         result.referenced_objects = [ref]
         return result
+
     setattr(this_module, function_name, replacement_function)
 
 
@@ -254,7 +285,7 @@ add_ref_in_constructor(IndexIVFFlat, 0)
 add_ref_in_constructor(IndexIVFFlatDedup, 0)
 add_ref_in_constructor(IndexIVFFlatPanorama, 0)
 add_ref_in_constructor(IndexPreTransform, {2: [0, 1], 1: [0]})
-add_ref_in_method(IndexPreTransform, 'prepend_transform', 0)
+add_ref_in_method(IndexPreTransform, "prepend_transform", 0)
 add_ref_in_constructor(IndexIVFPQ, 0)
 add_ref_in_constructor(IndexIVFPQR, 0)
 add_ref_in_constructor(IndexIVFPQFastScan, 0)
@@ -273,8 +304,8 @@ add_ref_in_constructor(IndexRowwiseMinMaxFP16, 0)
 add_ref_in_constructor(IndexIDMap, 0)
 add_ref_in_constructor(IndexIDMap2, 0)
 add_ref_in_constructor(IndexHNSW, 0)
-add_ref_in_method(IndexShards, 'add_shard', 0)
-add_ref_in_method(IndexBinaryShards, 'add_shard', 0)
+add_ref_in_method(IndexShards, "add_shard", 0)
+add_ref_in_method(IndexBinaryShards, "add_shard", 0)
 add_ref_in_constructor(IndexRefineFlat, {2: [0], 1: [0]})
 add_ref_in_constructor(IndexRefinePanorama, {2: [0, 1]})
 add_ref_in_constructor(IndexRefine, {2: [0, 1]})
@@ -284,8 +315,8 @@ add_ref_in_constructor(IndexBinaryFromFloat, 0)
 add_ref_in_constructor(IndexBinaryIDMap, 0)
 add_ref_in_constructor(IndexBinaryIDMap2, 0)
 
-add_ref_in_method(IndexReplicas, 'addIndex', 0)
-add_ref_in_method(IndexBinaryReplicas, 'addIndex', 0)
+add_ref_in_method(IndexReplicas, "addIndex", 0)
+add_ref_in_method(IndexBinaryReplicas, "addIndex", 0)
 
 add_ref_in_constructor(BufferedIOWriter, 0)
 add_ref_in_constructor(BufferedIOReader, 0)
@@ -320,7 +351,7 @@ search_with_parameters_c = search_with_parameters
 
 
 def search_with_parameters(index, x, k, params=None, output_stats=False):
-    x = np.ascontiguousarray(x, dtype='float32')
+    x = np.ascontiguousarray(x, dtype="float32")
     n, d = x.shape
     assert d == index.d
     if not params:
@@ -329,24 +360,29 @@ def search_with_parameters(index, x, k, params=None, output_stats=False):
         index_ivf = extract_index_ivf(index)
         params.nprobe = index_ivf.nprobe
         params.max_codes = index_ivf.max_codes
-    nb_dis = np.empty(1, 'uint64')
-    ms_per_stage = np.empty(3, 'float64')
+    nb_dis = np.empty(1, "uint64")
+    ms_per_stage = np.empty(3, "float64")
     distances = np.empty((n, k), dtype=np.float32)
     labels = np.empty((n, k), dtype=np.int64)
     search_with_parameters_c(
-        index, n, swig_ptr(x),
-        k, swig_ptr(distances),
+        index,
+        n,
+        swig_ptr(x),
+        k,
+        swig_ptr(distances),
         swig_ptr(labels),
-        params, swig_ptr(nb_dis), swig_ptr(ms_per_stage)
+        params,
+        swig_ptr(nb_dis),
+        swig_ptr(ms_per_stage),
     )
     if not output_stats:
         return distances, labels
     else:
         stats = {
-            'ndis': nb_dis[0],
-            'pre_transform_ms': ms_per_stage[0],
-            'coarse_quantizer_ms': ms_per_stage[1],
-            'invlist_scan_ms': ms_per_stage[2],
+            "ndis": nb_dis[0],
+            "pre_transform_ms": ms_per_stage[0],
+            "coarse_quantizer_ms": ms_per_stage[1],
+            "invlist_scan_ms": ms_per_stage[2],
         }
         return distances, labels, stats
 
@@ -355,7 +391,7 @@ range_search_with_parameters_c = range_search_with_parameters
 
 
 def range_search_with_parameters(index, x, radius, params=None, output_stats=False):
-    x = np.ascontiguousarray(x, dtype='float32')
+    x = np.ascontiguousarray(x, dtype="float32")
     n, d = x.shape
     assert d == index.d
     if not params:
@@ -364,13 +400,18 @@ def range_search_with_parameters(index, x, radius, params=None, output_stats=Fal
         index_ivf = extract_index_ivf(index)
         params.nprobe = index_ivf.nprobe
         params.max_codes = index_ivf.max_codes
-    nb_dis = np.empty(1, 'uint64')
-    ms_per_stage = np.empty(3, 'float64')
+    nb_dis = np.empty(1, "uint64")
+    ms_per_stage = np.empty(3, "float64")
     res = RangeSearchResult(n)
     range_search_with_parameters_c(
-        index, n, swig_ptr(x),
-        radius, res,
-        params, swig_ptr(nb_dis), swig_ptr(ms_per_stage)
+        index,
+        n,
+        swig_ptr(x),
+        radius,
+        res,
+        params,
+        swig_ptr(nb_dis),
+        swig_ptr(ms_per_stage),
     )
     lims = rev_swig_ptr(res.lims, n + 1).copy()
     nd = int(lims[-1])
@@ -380,10 +421,10 @@ def range_search_with_parameters(index, x, radius, params=None, output_stats=Fal
         return lims, Dout, Iout
     else:
         stats = {
-            'ndis': nb_dis[0],
-            'pre_transform_ms': ms_per_stage[0],
-            'coarse_quantizer_ms': ms_per_stage[1],
-            'invlist_scan_ms': ms_per_stage[2],
+            "ndis": nb_dis[0],
+            "pre_transform_ms": ms_per_stage[0],
+            "coarse_quantizer_ms": ms_per_stage[1],
+            "invlist_scan_ms": ms_per_stage[2],
         }
         return lims, Dout, Iout, stats
 
@@ -402,7 +443,7 @@ IVFSearchParameters = SearchParametersIVF
 
 
 def serialize_index(index, io_flags=0):
-    """ convert an index to a numpy uint8 array  """
+    """convert an index to a numpy uint8 array"""
     writer = VectorIOWriter()
     write_index(index, writer, io_flags)
     return vector_to_array(writer.data)
@@ -415,7 +456,7 @@ def deserialize_index(data, io_flags=0):
 
 
 def serialize_index_binary(index):
-    """ convert an index to a numpy uint8 array  """
+    """convert an index to a numpy uint8 array"""
     writer = VectorIOWriter()
     write_index_binary(index, writer)
     return vector_to_array(writer.data)

--- a/faiss/python/__init__.pyi
+++ b/faiss/python/__init__.pyi
@@ -2290,6 +2290,12 @@ class IVFSearchParameters(SearchParameters):
     sel: IDSelector | None
     def __init__(self) -> None: ...
 
+class IVFSQTurboQSearchParameters(IVFSearchParameters):
+    qb: int
+    int_qjl: bool
+
+    def __init__(self) -> None: ...
+
 # IVF Statistics tracking
 class IndexIVFStats:
     nq: int  # number of queries run

--- a/pyproject-gpu-cuvs.toml
+++ b/pyproject-gpu-cuvs.toml
@@ -1,0 +1,158 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+[build-system]
+# cuVS requires rapids-cmake which needs cmake >= 3.30.4.
+requires = ["scikit-build-core>=0.10", "swig>=4.2,<5", "numpy>=2.0", "cmake>=3.30.4", "ninja"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "faiss-gpu-cuvs"
+dynamic = ["version"]
+description = "A library for efficient similarity search and clustering of dense vectors (GPU + cuVS/CAGRA support)."
+readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE", "THIRD_PARTY_NOTICES"]
+requires-python = ">=3.11"
+authors = [
+  {name = "Meta AI Research"},
+]
+keywords = ["search", "nearest-neighbors", "clustering", "vectors", "similarity", "gpu", "cuda", "cuvs", "cagra"]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "Operating System :: POSIX :: Linux",
+  "Programming Language :: C++",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Environment :: GPU :: NVIDIA CUDA :: 12",
+]
+dependencies = [
+  "numpy>=1.25",
+  "packaging",
+  "nvidia-cuda-runtime-cu12>=12.6,<13",
+  "nvidia-cublas-cu12>=12.6,<13",
+  "nvidia-curand-cu12>=10.3.7,<11",
+  "nvidia-nvjitlink-cu12>=12.6,<13",
+  "libcuvs-cu12>=26.06,<27",
+]
+
+[project.urls]
+Homepage = "https://github.com/facebookresearch/faiss"
+Documentation = "https://github.com/facebookresearch/faiss/wiki"
+Repository = "https://github.com/facebookresearch/faiss"
+Issues = "https://github.com/facebookresearch/faiss/issues"
+
+[tool.scikit-build]
+cmake.build-type = "Release"
+
+# Pull version from CMakeLists.txt's project(VERSION ...) — single source of truth.
+metadata.version.provider = "scikit_build_core.metadata.regex"
+metadata.version.input = "CMakeLists.txt"
+metadata.version.regex = '^\s+VERSION\s+(?P<value>[0-9]+\.[0-9]+\.[0-9]+)'
+
+# Exclude C++ headers, cmake configs, static libs, and binaries from the wheel.
+# Only the Python package (faiss/) and bundled shared libs remain.
+wheel.exclude = ["include/**", "share/**", "lib/**", "lib64/**", "bin/**"]
+
+[tool.scikit-build.cmake.define]
+FAISS_OPT_LEVEL = "dd"
+FAISS_ENABLE_GPU = "ON"
+FAISS_ENABLE_CUVS = "ON"
+FAISS_ENABLE_PYTHON = "ON"
+FAISS_ENABLE_MKL = "OFF"
+FAISS_ENABLE_C_API = "OFF"
+FAISS_ENABLE_EXTRAS = "OFF"
+FAISS_ENABLE_SVS = "OFF"
+FAISS_USE_LTO = "ON"
+# V100 → Hopper SASS + Hopper PTX trailer for forward compat (e.g. Blackwell JIT).
+# Drop 72 (Jetson Xavier) for a datacenter-targeted wheel; include 89 (L4/L40/RTX 40xx).
+CMAKE_CUDA_ARCHITECTURES = "70-real;75-real;80-real;86-real;89-real;90"
+CMAKE_CUDA_FLAGS_RELEASE = "-O3 -Xfatbin=-compress-all --threads 4 -Xcompiler=-fdata-sections,-ffunction-sections"
+CMAKE_C_FLAGS = "-fdata-sections -ffunction-sections"
+CMAKE_CXX_FLAGS = "-fdata-sections -ffunction-sections"
+CMAKE_SHARED_LINKER_FLAGS = "-Wl,--gc-sections -Wl,--strip-all"
+CMAKE_MODULE_LINKER_FLAGS = "-Wl,--gc-sections -Wl,--strip-all"
+BUILD_TESTING = "OFF"
+BUILD_SHARED_LIBS = "ON"
+# cuVS + transitive deps (raft, rmm, rapids_logger, header-only cutlass/cuco/nvtx3)
+# are found via CMAKE_PREFIX_PATH (environment block below) at the RAPIDS wheel roots,
+# mirroring the conda build — no explicit *_DIR, agnostic to lib/ vs lib64/.
+
+# Stable ABI (abi3): one cp311 wheel covers all 3.11+.
+# Floor is 3.11 because the runtime dep libcuvs-cu12>=26.06 (RAPIDS) requires
+# Python >=3.11 — RAPIDS dropped 3.10 in the 26.04 release.
+# GPU is Linux-only; free-threaded Python (cp3*t) cannot use abi3.
+[[tool.scikit-build.overrides]]
+if.platform-system = "linux"
+if.abi-flags = "^$"  # Free-threaded Python does not support stable ABI.
+wheel.py-api = "cp311"
+
+[tool.cibuildwheel]
+# Pass through the host GPU so the smoke test can actually exercise CUDA + cuVS.
+# Without this, faiss.get_num_gpus() returns 0 inside the container and all
+# GPU tests silently skip — masking real packaging / driver / SASS-arch problems.
+container-engine = { name = "docker", create-args = ["--gpus", "all"] }
+build = "cp311-manylinux_x86_64"
+test-requires = [
+  "numpy>=1.25,<3.0",
+  "pytest",
+  "nvidia-cuda-runtime-cu12>=12.6,<13",
+  "nvidia-cublas-cu12>=12.6,<13",
+  "nvidia-curand-cu12>=10.3.7,<11",
+  "nvidia-nvjitlink-cu12>=12.6,<13",
+  "libcuvs-cu12>=26.06,<27",
+]
+test-command = "python -m pytest {project}/tests/test_wheel_smoke_gpu.py -v"
+
+[tool.cibuildwheel.linux]
+# manylinux_2_28 ships gcc-toolset-14; CUDA 12.6 only supports GCC <=13, so install
+# gcc-toolset-13 explicitly and force the build to use it via CC/CXX/CUDAHOSTCXX below.
+# epel-release is needed for swig. Install the FULL cuda-toolkit-12-6 (not just nvcc +
+# narrow dev libs as faiss-gpu does) because cuVS pulls in RAFT which transitively
+# needs cuSOLVER, cuSPARSE, nvrtc, etc. headers — easier to install all than to track
+# the exact list. Wheel size is unaffected since auditwheel excludes all CUDA libs.
+#
+# cuVS dev files (headers + cmake) come from RAPIDS' manylinux PyPI wheels via
+# `pip install --target /opt/cuvs` — ABI-clean, so no libstdc++/libgcc_s/libgomp strip
+# or RMM symlink shim. cp311 interpreter is explicit (manylinux puts no `pip` on PATH).
+manylinux-x86_64-image = "manylinux_2_28"
+before-all = "dnf install -y gcc-toolset-13 epel-release && dnf install -y openblas-devel openblas-openmp swig && dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && dnf install -y --setopt=obsoletes=0 cuda-toolkit-12-6 && /opt/python/cp311-cp311/bin/python -m pip install --target /opt/cuvs --no-deps --only-binary ':all:' --extra-index-url https://pypi.nvidia.com 'libcuvs-cu12==26.06.*' 'libraft-cu12==26.06.*' 'librmm-cu12==26.06.*' 'rapids-logger'"
+# auditwheel excludes (not vendored; supplied at runtime by nvidia-*-cu12 / libcuvs-cu12
+# wheels): host driver libcuda, CUDA runtime/math libs (cusparse/cusolver are explicit —
+# under the cuda-toolkit RPM, not /opt/cuvs), and every RAPIDS .so found under /opt/cuvs.
+repair-wheel-command = "bash -c 'EXCLUDES=\"--exclude libcuda.so.1 --exclude libcudart.so.12 --exclude libcublas.so.12 --exclude libcublasLt.so.12 --exclude libcurand.so.10 --exclude libnvJitLink.so.12 --exclude libcusparse.so.12 --exclude libcusolver.so.11\"; for f in $(find /opt/cuvs -name \"lib*.so*\" -printf \"%f\\n\" | sort -u); do EXCLUDES=\"$EXCLUDES --exclude $f\"; done; auditwheel repair -w {dest_dir} {wheel} $EXCLUDES'"
+# Canary: ensure the host GPU is actually visible to the container before tests
+# run. Without this, smoke tests would silently skip on broken --gpus passthrough.
+before-test = "nvidia-smi || (echo 'GPU not visible to container; check container-engine create-args' && exit 1)"
+
+# Run abi3audit on Linux to guarantee Stable ABI compliance.
+# We use 'append' so that the auditwheel repair-wheel-command from
+# [tool.cibuildwheel.linux] (with the CUDA + cuVS --exclude flags) still runs first.
+[[tool.cibuildwheel.overrides]]
+select = "*-manylinux*"
+inherit.repair-wheel-command = "append"
+repair-wheel-command = "pipx run abi3audit --strict --report {wheel}"
+
+# Build-tool paths. CUDA from /usr/local/cuda-12.6 (NVIDIA RPM convention);
+# GCC pinned to toolset-13 because CUDA 12.6 does not support GCC 14.
+# CUDAHOSTCXX must match CXX or nvcc host TUs get an ABI-mismatched libstdc++.
+# CMAKE_PREFIX_PATH points at the RAPIDS wheel roots so find_package(cuvs) resolves.
+# Set as env (not cmake.define) so CMake merges it with scikit-build-core's own path.
+[tool.cibuildwheel.linux.environment]
+CUDA_HOME = "/usr/local/cuda-12.6"
+CUDACXX = "/usr/local/cuda-12.6/bin/nvcc"
+CC = "/opt/rh/gcc-toolset-13/root/usr/bin/gcc"
+CXX = "/opt/rh/gcc-toolset-13/root/usr/bin/g++"
+CUDAHOSTCXX = "/opt/rh/gcc-toolset-13/root/usr/bin/g++"
+CMAKE_PREFIX_PATH = "/opt/cuvs/libcuvs:/opt/cuvs/libraft:/opt/cuvs/librmm:/opt/cuvs/rapids_logger"

--- a/tests/test_swig_wrapper.py
+++ b/tests/test_swig_wrapper.py
@@ -146,6 +146,14 @@ class TestSWIGWrap(unittest.TestCase):
         with self.assertRaises(AttributeError):
             index.centered2 = False
 
+    def test_ivfsq_turboq_search_parameters(self):
+        params = faiss.IVFSQTurboQSearchParameters()
+        self.assertEqual(params.qb, 0)
+        self.assertFalse(params.int_qjl)
+        params.qb = 4
+        params.int_qjl = True
+        self.assertEqual(params.qb, 4)
+        self.assertTrue(params.int_qjl)
 
 
 class TestRevSwigPtr(unittest.TestCase):

--- a/tests/test_wheel_smoke_gpu.py
+++ b/tests/test_wheel_smoke_gpu.py
@@ -33,6 +33,13 @@ _skip_unless_gpu_build = unittest.skipUnless(
     _GPU_BUILD, "Skipping faiss-gpu smoke tests: built without GPU support"
 )
 
+# cuVS-specific build marker: faiss.GpuIndexCagra exists only when FAISS was
+# built with FAISS_ENABLE_CUVS=ON (i.e., this is a faiss-gpu-cuvs wheel).
+_CUVS_BUILD = _GPU_BUILD and hasattr(faiss, "GpuIndexCagra")
+_skip_unless_cuvs_build = unittest.skipUnless(
+    _CUVS_BUILD, "Skipping cuVS smoke tests: built without cuVS support"
+)
+
 
 def skip_if_no_gpu(test_func):
     """Skip test if no GPU is available."""
@@ -195,3 +202,46 @@ class TestGPUSerialization(unittest.TestCase):
         D2, I2 = gpu_index2.search(xb[:3], 5)
         np.testing.assert_array_equal(I1, I2)
         np.testing.assert_allclose(D1, D2, atol=1e-5)
+
+
+@_skip_unless_cuvs_build
+class TestCuvsKnnGpu(unittest.TestCase):
+    """Catch: libcuvs / libraft / librmm preload; cuVS bfKnn dispatch."""
+
+    @skip_if_no_gpu
+    def test_knn_gpu_use_cuvs(self):
+        # knn_gpu with use_cuvs=True routes through cuVS's brute-force kernel,
+        # exercising libcuvs / libraft / librmm at runtime. Without the wheel's
+        # cuVS preload working, this fails at the first cuVS symbol lookup.
+        d, n, nq = 64, 1000, 5
+        np.random.seed(42)
+        xb = np.random.random((n, d)).astype("float32")
+        xq = xb[:nq]
+
+        res = faiss.StandardGpuResources()
+        D, I = faiss.knn_gpu(res, xq, xb, 10, use_cuvs=True)
+        self.assertEqual(I.shape, (nq, 10))
+        np.testing.assert_array_equal(I[:, 0], np.arange(nq))
+        np.testing.assert_allclose(D[:, 0], 0, atol=1e-5)
+
+
+@_skip_unless_cuvs_build
+class TestCuvsCagra(unittest.TestCase):
+    """Catch: GpuIndexCagra construction + cuVS CAGRA graph build."""
+
+    @skip_if_no_gpu
+    def test_gpu_index_cagra(self):
+        d, n, nq = 32, 2000, 5
+        np.random.seed(42)
+        xb = np.random.random((n, d)).astype("float32")
+
+        res = faiss.StandardGpuResources()
+        index = faiss.GpuIndexCagra(res, d, faiss.METRIC_L2)
+        index.train(xb)
+        # CAGRA is a graph-based index; ntotal reflects the training set.
+        self.assertEqual(index.ntotal, n)
+
+        D, I = index.search(xb[:nq], 10)
+        self.assertEqual(I.shape, (nq, 10))
+        # CAGRA is approximate, so allow itself-as-first-NN as the contract.
+        np.testing.assert_array_equal(I[:, 0], np.arange(nq))


### PR DESCRIPTION
Summary:
Add IVFSQTurboQSearchParameters to the authoritative __init__.pyi type stub.

TurboQuant was added to ScalarQuantizer in D102408184, which introduced
IVFSQTurboQSearchParameters in IndexScalarQuantizer.h. The struct controls
two new per-search parameters:
- qb: query quantization bits for MSE pre-screening (0 = float path,
  1-8 = integer popcount path)
- int_qjl: use integer popcount for the QJL sign-bit stage (requires qb > 0)

IndexScalarQuantizer.h is `%include`d in swigfaiss.swig so SWIG wraps the
struct at runtime. However, __init__.pyi (the authoritative Pyre type source
since D107274305) was not updated when the struct was added. Any Pyre-checked
code that uses IVFSQTurboQSearchParameters receives [missing-attribute] errors.

Pattern matches the approach used in D107508282, which added
SearchParametersHNSW and SearchParametersPQ for the same gap.

Reviewed By: limqiying, mnorris11

Differential Revision: D108001955


