### PR TITLE
Fix out-of-bounds memory access in bvec_checksum

### DIFF
--- a/faiss/utils/utils.cpp
+++ b/faiss/utils/utils.cpp
@@ -462,7 +462,7 @@ uint64_t ivec_checksum(size_t n, const int32_t* assigned) {
 uint64_t bvec_checksum(size_t n, const uint8_t* a) {
     uint64_t cs = ivec_checksum(n / 4, (const int32_t*)a);
     for (size_t i = n / 4 * 4; i < n; i++) {
-        cs = cs * 65713 + a[n] * 1686049;
+        cs = cs * 65713 + a[i] * 1686049;
     }
     return cs;
 }


### PR DESCRIPTION
The leftover byte processing loop in `bvec_checksum` incorrectly hardcoded the array index as `n` instead of the loop variable `i`. Replaced `a[n]` with `a[i]` to correctly iterate through the tail bytes.