### PR TITLE
Remove unused fields in various DistanceComputers (#5318)

### DIFF
--- a/faiss/IndexAdditiveQuantizer.cpp
+++ b/faiss/IndexAdditiveQuantizer.cpp
@@ -58,8 +58,8 @@ struct AQDistanceComputerDecompress : FlatCodesDistanceComputer {
     }
 
     float symmetric_dis(idx_t i, idx_t j) final {
-        aq.decode(codes + i * d, tmp.data(), 1);
-        aq.decode(codes + j * d, tmp.data() + d, 1);
+        aq.decode(codes + i * code_size, tmp.data(), 1);
+        aq.decode(codes + j * code_size, tmp.data() + d, 1);
         return vd(tmp.data(), tmp.data() + d);
     }
 
@@ -79,7 +79,8 @@ struct AQDistanceComputerLUT : FlatCodesDistanceComputer {
 
     explicit AQDistanceComputerLUT(const IndexAdditiveQuantizer& iaq)
             : FlatCodesDistanceComputer(iaq.codes.data(), iaq.code_size),
-              LUT(iaq.aq->total_codebook_size + iaq.d * 2),
+              LUT(iaq.aq->total_codebook_size // Storage for LUT.
+                  + size_t(iaq.d) * 2), // tmp storage for symmetric distance.
               aq(*iaq.aq),
               d(iaq.d) {}
 
@@ -96,9 +97,9 @@ struct AQDistanceComputerLUT : FlatCodesDistanceComputer {
     }
 
     float symmetric_dis(idx_t i, idx_t j) final {
-        float* tmp = LUT.data();
-        aq.decode(codes + i * d, tmp, 1);
-        aq.decode(codes + j * d, tmp + d, 1);
+        float* tmp = LUT.data() + aq.total_codebook_size;
+        aq.decode(codes + i * code_size, tmp, 1);
+        aq.decode(codes + j * code_size, tmp + d, 1);
         return fvec_L2sqr(tmp, tmp + d, d);
     }
 

--- a/faiss/IndexFlat.cpp
+++ b/faiss/IndexFlat.cpp
@@ -105,13 +105,8 @@ namespace {
 template <SIMDLevel SL>
 struct FlatL2Dis : FlatCodesDistanceComputer {
     size_t d;
-    idx_t nb;
-    const float* b;
-    size_t ndis;
-    size_t npartial_dot_products;
 
     float distance_to_code(const uint8_t* code) final {
-        ndis++;
         return fvec_L2sqr<SL>(q, (float*)code, d);
     }
 
@@ -119,25 +114,21 @@ struct FlatL2Dis : FlatCodesDistanceComputer {
             const idx_t i,
             const uint32_t offset,
             const uint32_t num_components) final override {
-        npartial_dot_products++;
+        const float* b = (const float*)this->codes;
         return fvec_inner_product<SL>(
                 q + offset, b + i * d + offset, num_components);
     }
 
     float symmetric_dis(idx_t i, idx_t j) override {
+        const float* b = (const float*)this->codes;
         return fvec_L2sqr<SL>(b + j * d, b + i * d, d);
     }
 
-    explicit FlatL2Dis(const IndexFlat& storage, const float* q_ = nullptr)
+    explicit FlatL2Dis(const IndexFlat& storage)
             : FlatCodesDistanceComputer(
                       storage.codes.data(),
-                      storage.code_size,
-                      q_),
-              d(storage.d),
-              nb(storage.ntotal),
-              b(storage.get_xb()),
-              ndis(0),
-              npartial_dot_products(0) {}
+                      storage.code_size),
+              d(storage.d) {}
 
     void set_query(const float* x) override {
         q = x;
@@ -153,8 +144,6 @@ struct FlatL2Dis : FlatCodesDistanceComputer {
             float& dis1,
             float& dis2,
             float& dis3) final override {
-        ndis += 4;
-
         // compute first, assign next
         const float* __restrict y0 =
                 reinterpret_cast<const float*>(codes + idx0 * code_size);
@@ -187,8 +176,6 @@ struct FlatL2Dis : FlatCodesDistanceComputer {
             float& dp3,
             const uint32_t offset,
             const uint32_t num_components) final override {
-        npartial_dot_products += 4;
-
         // compute first, assign next
         const float* __restrict y0 =
                 reinterpret_cast<const float*>(codes + idx0 * code_size);
@@ -224,29 +211,21 @@ struct FlatL2Dis : FlatCodesDistanceComputer {
 template <SIMDLevel SL>
 struct FlatIPDis : FlatCodesDistanceComputer {
     size_t d;
-    idx_t nb;
-    const float* q;
-    const float* b;
-    size_t ndis;
 
     float symmetric_dis(idx_t i, idx_t j) final override {
+        const float* b = (const float*)this->codes;
         return fvec_inner_product<SL>(b + j * d, b + i * d, d);
     }
 
     float distance_to_code(const uint8_t* code) final override {
-        ndis++;
         return fvec_inner_product<SL>(q, (const float*)code, d);
     }
 
-    explicit FlatIPDis(const IndexFlat& storage, const float* q_in = nullptr)
+    explicit FlatIPDis(const IndexFlat& storage)
             : FlatCodesDistanceComputer(
                       storage.codes.data(),
                       storage.code_size),
-              d(storage.d),
-              nb(storage.ntotal),
-              q(q_in),
-              b(storage.get_xb()),
-              ndis(0) {}
+              d(storage.d) {}
 
     void set_query(const float* x) override {
         q = x;
@@ -262,8 +241,6 @@ struct FlatIPDis : FlatCodesDistanceComputer {
             float& dis1,
             float& dis2,
             float& dis3) final override {
-        ndis += 4;
-
         // compute first, assign next
         const float* __restrict y0 =
                 reinterpret_cast<const float*>(codes + idx0 * code_size);
@@ -296,8 +273,7 @@ FlatCodesDistanceComputer* IndexFlat::get_FlatCodesDistanceComputer() const {
     } else if (metric_type == METRIC_INNER_PRODUCT) {
         with_simd_level([&]<SIMDLevel SL>() { dc = new FlatIPDis<SL>(*this); });
     } else {
-        dc = get_extra_distance_computer(
-                d, metric_type, metric_arg, ntotal, get_xb());
+        dc = get_extra_distance_computer(d, metric_type, metric_arg, get_xb());
     }
     return dc;
 }
@@ -327,16 +303,11 @@ namespace {
 template <SIMDLevel SL>
 struct FlatL2WithNormsDis : FlatCodesDistanceComputer {
     size_t d;
-    idx_t nb;
-    const float* q;
-    const float* b;
-    size_t ndis;
 
     const float* l2norms;
     float query_l2norm;
 
     float distance_to_code(const uint8_t* code) final override {
-        ndis++;
         return fvec_L2sqr<SL>(q, (float*)code, d);
     }
 
@@ -361,17 +332,11 @@ struct FlatL2WithNormsDis : FlatCodesDistanceComputer {
         return l2norms[i] + l2norms[j] - 2 * dp0;
     }
 
-    explicit FlatL2WithNormsDis(
-            const IndexFlatL2& storage,
-            const float* q_in = nullptr)
+    explicit FlatL2WithNormsDis(const IndexFlatL2& storage)
             : FlatCodesDistanceComputer(
                       storage.codes.data(),
                       storage.code_size),
               d(storage.d),
-              nb(storage.ntotal),
-              q(q_in),
-              b(storage.get_xb()),
-              ndis(0),
               l2norms(storage.cached_l2norms.data()),
               query_l2norm(0) {}
 
@@ -390,8 +355,6 @@ struct FlatL2WithNormsDis : FlatCodesDistanceComputer {
             float& dis1,
             float& dis2,
             float& dis3) final override {
-        ndis += 4;
-
         // compute first, assign next
         const float* __restrict y0 =
                 reinterpret_cast<const float*>(codes + idx0 * code_size);

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -2261,27 +2261,23 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
     } else if (
             h == fourcc("IHNf") || h == fourcc("IHNp") || h == fourcc("IHNs") ||
             h == fourcc("IHN2") || h == fourcc("IHNc") || h == fourcc("IHc2") ||
-            h == fourcc("IHfP")) {
+            h == fourcc("IHfP") || h == fourcc("IH00")) {
         std::unique_ptr<IndexHNSW> idxhnsw;
-        if (h == fourcc("IHNf")) {
+        if (h == fourcc("IH00")) {
+            idxhnsw = std::make_unique<IndexHNSW>();
+        } else if (h == fourcc("IHNf")) {
             idxhnsw = std::make_unique<IndexHNSWFlat>();
-        }
-        if (h == fourcc("IHfP")) {
+        } else if (h == fourcc("IHfP")) {
             idxhnsw = std::make_unique<IndexHNSWFlatPanorama>();
-        }
-        if (h == fourcc("IHNp")) {
+        } else if (h == fourcc("IHNp")) {
             idxhnsw = std::make_unique<IndexHNSWPQ>();
-        }
-        if (h == fourcc("IHNs")) {
+        } else if (h == fourcc("IHNs")) {
             idxhnsw = std::make_unique<IndexHNSWSQ>();
-        }
-        if (h == fourcc("IHN2")) {
+        } else if (h == fourcc("IHN2")) {
             idxhnsw = std::make_unique<IndexHNSW2Level>();
-        }
-        if (h == fourcc("IHNc")) {
+        } else if (h == fourcc("IHNc")) {
             idxhnsw = std::make_unique<IndexHNSWCagra>();
-        }
-        if (h == fourcc("IHc2")) {
+        } else if (h == fourcc("IHc2")) {
             idxhnsw = std::make_unique<IndexHNSWCagra>();
         }
         read_index_header(*idxhnsw, f);
@@ -2297,8 +2293,7 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
             const_cast<Panorama&>(idx_panorama->pano) =
                     Panorama(idx_panorama->d * sizeof(float), nlevels, 1);
             READVECTOR(idx_panorama->cum_sums);
-        }
-        if (h == fourcc("IHNc") || h == fourcc("IHc2")) {
+        } else if (h == fourcc("IHNc") || h == fourcc("IHc2")) {
             READ1_BOOL(idxhnsw->keep_max_size_level0);
             auto idx_hnsw_cagra = dynamic_cast<IndexHNSWCagra*>(idxhnsw.get());
             FAISS_THROW_IF_NOT_MSG(

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -871,8 +871,12 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
                 : dynamic_cast<const IndexHNSWSQ*>(idx)     ? fourcc("IHNs")
                 : dynamic_cast<const IndexHNSW2Level*>(idx) ? fourcc("IHN2")
                 : dynamic_cast<const IndexHNSWCagra*>(idx)  ? fourcc("IHc2")
+                : typeid(*idx) == typeid(IndexHNSW)         ? fourcc("IH00")
                                                             : 0;
-        FAISS_THROW_IF_NOT(h != 0);
+        FAISS_THROW_IF_NOT_FMT(
+                h != 0,
+                "don't know how to serialize this IndexHNSW subtype: %s",
+                typeid(*idx).name());
         WRITE1(h);
         write_index_header(idxhnsw, f);
         if (h == fourcc("IHfP")) {

--- a/faiss/utils/extra_distances.cpp
+++ b/faiss/utils/extra_distances.cpp
@@ -29,11 +29,9 @@ namespace {
 template <class VD>
 struct ExtraDistanceComputer : FlatCodesDistanceComputer {
     VD vd;
-    idx_t nb;
-    const float* q;
-    const float* b;
 
     float symmetric_dis(idx_t i, idx_t j) final {
+        const float* b = (const float*)codes;
         return vd(b + j * vd.d, b + i * vd.d);
     }
 
@@ -41,16 +39,9 @@ struct ExtraDistanceComputer : FlatCodesDistanceComputer {
         return vd(q, (float*)code);
     }
 
-    ExtraDistanceComputer(
-            const VD& vd_in,
-            const float* xb,
-            size_t nb_in,
-            const float* q_in = nullptr)
+    ExtraDistanceComputer(const VD& vd_in, const float* xb)
             : FlatCodesDistanceComputer((uint8_t*)xb, vd_in.d * sizeof(float)),
-              vd(vd_in),
-              nb(nb_in),
-              q(q_in),
-              b(xb) {}
+              vd(vd_in) {}
 
     void set_query(const float* x) override {
         q = x;
@@ -149,11 +140,10 @@ FlatCodesDistanceComputer* get_extra_distance_computer(
         size_t d,
         MetricType mt,
         float metric_arg,
-        size_t nb,
         const float* xb) {
     return with_VectorDistance(
             d, mt, metric_arg, [&](auto vd) -> FlatCodesDistanceComputer* {
-                return new ExtraDistanceComputer<decltype(vd)>(vd, xb, nb);
+                return new ExtraDistanceComputer<decltype(vd)>(vd, xb);
             });
 }
 

--- a/faiss/utils/extra_distances.h
+++ b/faiss/utils/extra_distances.h
@@ -49,12 +49,11 @@ void knn_extra_metrics(
         const IDSelector* sel = nullptr);
 
 /** get a DistanceComputer that refers to this type of distance and
- *  indexes a flat array of size nb */
+ *  indexes a flat array */
 FlatCodesDistanceComputer* get_extra_distance_computer(
         size_t d,
         MetricType mt,
         float metric_arg,
-        size_t nb,
         const float* xb);
 
 /// Dispatch to a lambda with MetricType as a compile-time constant.

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3,23 +3,24 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import numpy as np
-import unittest
-import faiss
-import tempfile
-import os
 import io
-import sys
+import os
 import pickle
 import platform
+import sys
+import tempfile
+import unittest
 from multiprocessing.pool import ThreadPool
+
+import faiss
+import numpy as np
 from common_faiss_tests import get_dataset_2
 
 
 d = 32
-nt = 2000
-nb = 1000
-nq = 200
+nt = 10000
+nb = 10000
+nq = 1000
 
 
 class TestIOVariants(unittest.TestCase):
@@ -727,3 +728,62 @@ class TestIORoundTrip(unittest.TestCase):
         index2 = faiss.read_index(reader)
 
         self.assertIsNone(index2)
+
+
+class Test_IO_HNSW(unittest.TestCase):
+    def __init__(self, methodName="runTest"):
+        unittest.TestCase.__init__(self, methodName)
+        self.xt, self.xb, self.xq = get_dataset_2(d, nt, nb, nq)
+
+    def _test_roundtrip(self, index):
+        for _trips in range(3):
+            read_index = faiss.deserialize_index(faiss.serialize_index(index))
+            self.assertEqual(index.hnsw.efSearch, read_index.hnsw.efSearch)
+            self.assertEqual(
+                index.hnsw.efConstruction, read_index.hnsw.efConstruction)
+            D, I = index.search(self.xq, 10)
+            D_read, I_read = read_index.search(self.xq, 10)
+            np.testing.assert_array_equal(D, D_read)
+            np.testing.assert_array_equal(I, I_read)
+            index = read_index  # test re-serialization
+
+    def _test_io_hnsw(self, index):
+        index.train(self.xt)
+        index.add(self.xb)
+        self._test_roundtrip(index)
+
+    def test_hnsw_flat(self):
+        index = faiss.IndexHNSWFlat(d, 16)
+        self._test_io_hnsw(index)
+
+    def test_hnsw_pq(self):
+        index = faiss.IndexHNSWPQ(d, 16, 16, 4)
+        self._test_io_hnsw(index)
+
+    def test_hnsw_prq(self):
+        """Exercise HNSW with aritrary storage"""
+        storage = faiss.IndexProductResidualQuantizer(
+            d, 8, 2, 4, faiss.METRIC_L2, faiss.AdditiveQuantizer.ST_norm_qint8
+        )
+        index = faiss.IndexHNSW(storage, 32)
+        del storage
+        self._test_io_hnsw(index)
+
+    def test_hnsw_noadd(self):
+        """Exercise HNSW with a swapped-out storage"""
+        index = faiss.IndexHNSWFlat(d, 16)
+        index.train(self.xt)
+        index.add(self.xb)
+        # Note: RaBitQ lacks symmetric_distance, so it can be used for
+        # `search()`, but not `add()`.
+        I_flat = index.storage.assign(self.xq, 10)
+        I_hnsw_flat = index.assign(self.xq, 10)
+        index.storage = faiss.IndexRaBitQ(d)
+        index.storage.train(self.xb)
+        index.storage.add(self.xb)
+        I_hnsw_rabitq = index.assign(self.xq, 10)
+        recall_hnsw_flat = faiss.eval_intersection(I_hnsw_flat, I_flat)
+        recall_hnsw_rabitq = faiss.eval_intersection(I_hnsw_rabitq, I_flat)
+        self.assertGreater(recall_hnsw_flat, 0.999)
+        self.assertGreater(recall_hnsw_rabitq, 0.999)
+        self._test_roundtrip(index)

--- a/tests/test_residual_quantizer.py
+++ b/tests/test_residual_quantizer.py
@@ -1276,6 +1276,33 @@ class TestIndexProductResidualQuantizer(unittest.TestCase):
         code_size = (ns * Msub * nbits + 7) // 8 + 1
         self.assertEqual(index.prq.code_size, code_size)
 
+    def test_symmetric_dis(self):
+        """AQDistanceComputerLUT::symmetric_dis must decode into its reserved
+        scratch region, not into LUT.data(). Decoding into LUT.data() silently
+        clobbers the lookup table computed by set_query(), so an interleaved
+        symmetric_dis() corrupts subsequent asymmetric distances -- which is
+        exactly what HNSW construction does. No crash, so only a value check
+        catches it."""
+        ds = datasets.SyntheticDataset(64, 1000, 10000, 1)
+        for search_type in (
+            faiss.AdditiveQuantizer.ST_LUT_nonorm,
+            faiss.AdditiveQuantizer.ST_decompress,
+        ):
+            index = faiss.IndexProductResidualQuantizer(
+                ds.d, 8, 2, 4, faiss.METRIC_INNER_PRODUCT, search_type
+            )
+            index.train(ds.get_train())
+            index.add(ds.get_database())
+            dc = index.get_distance_computer()
+            dc.set_query(faiss.swig_ptr(ds.get_queries()[0]))
+            before = [dc(j) for j in range(20)]
+            # An interleaved symmetric_dis() must leave the LUT
+            # untouched, and must stay in bounds.
+
+            dc.symmetric_dis(ds.nb - 1, ds.nb - 2)
+            after = [dc(j) for j in range(20)]
+            self.assertEqual(before, after)
+
 
 class TestIndexIVFProductResidualQuantizer(unittest.TestCase):
 


### PR DESCRIPTION
Summary:

* `size_t nb`, and `size_t ndis` are all write-only, just wasting space in the structure. In the case of `ndis`, the needless writes could lead to actual performance costs due to cache contention.
* `const float* q` is now defined in the `FlatCodesDistanceComputer` base class, but many child classes still have a redundant field.
* `const float *b` is just a type alias of the base class's `codes`, which can be done at the usage site.
* Constructor argument `const float* q_in` seems to never be used.

Most `DistanceComputer` implementations have internal linkage, so no consumers can be broken by the removal of an apparently-unused fields. Even DC's without internal linkage are effectively implementation details, so there is no reasonable expectation of these fields being preserved.

Reviewed By: limqiying

Differential Revision: D108796936


