### PR TITLE
Fix IndexAdditiveQuantizer::symmetric_dis() (#5319)

### DIFF
--- a/faiss/IndexAdditiveQuantizer.cpp
+++ b/faiss/IndexAdditiveQuantizer.cpp
@@ -58,8 +58,8 @@ struct AQDistanceComputerDecompress : FlatCodesDistanceComputer {
     }
 
     float symmetric_dis(idx_t i, idx_t j) final {
-        aq.decode(codes + i * d, tmp.data(), 1);
-        aq.decode(codes + j * d, tmp.data() + d, 1);
+        aq.decode(codes + i * code_size, tmp.data(), 1);
+        aq.decode(codes + j * code_size, tmp.data() + d, 1);
         return vd(tmp.data(), tmp.data() + d);
     }
 
@@ -79,7 +79,8 @@ struct AQDistanceComputerLUT : FlatCodesDistanceComputer {
 
     explicit AQDistanceComputerLUT(const IndexAdditiveQuantizer& iaq)
             : FlatCodesDistanceComputer(iaq.codes.data(), iaq.code_size),
-              LUT(iaq.aq->total_codebook_size + iaq.d * 2),
+              LUT(iaq.aq->total_codebook_size // Storage for LUT.
+                  + size_t(iaq.d) * 2), // tmp storage for symmetric distance.
               aq(*iaq.aq),
               d(iaq.d) {}
 
@@ -96,9 +97,9 @@ struct AQDistanceComputerLUT : FlatCodesDistanceComputer {
     }
 
     float symmetric_dis(idx_t i, idx_t j) final {
-        float* tmp = LUT.data();
-        aq.decode(codes + i * d, tmp, 1);
-        aq.decode(codes + j * d, tmp + d, 1);
+        float* tmp = LUT.data() + aq.total_codebook_size;
+        aq.decode(codes + i * code_size, tmp, 1);
+        aq.decode(codes + j * code_size, tmp + d, 1);
         return fvec_L2sqr(tmp, tmp + d, d);
     }
 

--- a/tests/test_residual_quantizer.py
+++ b/tests/test_residual_quantizer.py
@@ -1276,6 +1276,33 @@ class TestIndexProductResidualQuantizer(unittest.TestCase):
         code_size = (ns * Msub * nbits + 7) // 8 + 1
         self.assertEqual(index.prq.code_size, code_size)
 
+    def test_symmetric_dis(self):
+        """AQDistanceComputerLUT::symmetric_dis must decode into its reserved
+        scratch region, not into LUT.data(). Decoding into LUT.data() silently
+        clobbers the lookup table computed by set_query(), so an interleaved
+        symmetric_dis() corrupts subsequent asymmetric distances -- which is
+        exactly what HNSW construction does. No crash, so only a value check
+        catches it."""
+        ds = datasets.SyntheticDataset(64, 1000, 10000, 1)
+        for search_type in (
+            faiss.AdditiveQuantizer.ST_LUT_nonorm,
+            faiss.AdditiveQuantizer.ST_decompress,
+        ):
+            index = faiss.IndexProductResidualQuantizer(
+                ds.d, 8, 2, 4, faiss.METRIC_INNER_PRODUCT, search_type
+            )
+            index.train(ds.get_train())
+            index.add(ds.get_database())
+            dc = index.get_distance_computer()
+            dc.set_query(faiss.swig_ptr(ds.get_queries()[0]))
+            before = [dc(j) for j in range(20)]
+            # An interleaved symmetric_dis() must leave the LUT
+            # untouched, and must stay in bounds.
+
+            dc.symmetric_dis(ds.nb - 1, ds.nb - 2)
+            after = [dc(j) for j in range(20)]
+            self.assertEqual(before, after)
+
 
 class TestIndexIVFProductResidualQuantizer(unittest.TestCase):
 


### PR DESCRIPTION
Summary:

Both `symmetric_dis` overrides in `IndexAdditiveQuantizer.cpp` mishandled the flat code buffer:

- Stride: they indexed `codes` by the vector dimension `d` instead of `code_size`, reading past the allocation whenever `d != code_size` (e.g. a `IndexProductResidualQuantizer` used as HNSW storage). This is a heap-buffer-overflow that ASan catches during HNSW graph construction.

- LUT aliasing: `AQDistanceComputerLUT::symmetric_dis` decoded its operand vectors into `LUT.data()`, clobbering the lookup table that `set_query()` had computed, so subsequent asymmetric `distance_to_code()` calls under the same query returned wrong distances (silent graph-quality degradation, no crash). The constructor already reserves `d * 2` scratch floats past the LUT (`total_codebook_size + d * 2`); decode into that region instead.

Reviewed By: limqiying

Differential Revision: D108917547


