### PR TITLE
fix: reverse_index_factory missing 11 SQ types including all TurboQuant variants

### DIFF
--- a/contrib/factory_tools.py
+++ b/contrib/factory_tools.py
@@ -82,6 +82,30 @@ def reverse_index_factory(index):
     """
     attempts to get the factory string the index was built with
     """
+    sq_names = {
+        faiss.ScalarQuantizer.QT_8bit: "SQ8",
+        faiss.ScalarQuantizer.QT_4bit: "SQ4",
+        # QT_8bit_uniform/QT_4bit_uniform have no index_factory string; these
+        # synthetic names are not round-trippable through index_factory.
+        faiss.ScalarQuantizer.QT_8bit_uniform: "SQ8u",
+        faiss.ScalarQuantizer.QT_4bit_uniform: "SQ4u",
+        faiss.ScalarQuantizer.QT_6bit: "SQ6",
+        faiss.ScalarQuantizer.QT_fp16: "SQfp16",
+        faiss.ScalarQuantizer.QT_bf16: "SQbf16",
+        faiss.ScalarQuantizer.QT_8bit_direct: "SQ8_direct",
+        faiss.ScalarQuantizer.QT_8bit_direct_signed: "SQ8_direct_signed",
+        # QT_0bit ("SQ0") is parsed by index_factory; for the IVF path.
+        faiss.ScalarQuantizer.QT_0bit: "SQ0",
+        faiss.ScalarQuantizer.QT_1bit_tqmse: "SQtqmse1",
+        faiss.ScalarQuantizer.QT_2bit_tqmse: "SQtqmse2",
+        faiss.ScalarQuantizer.QT_3bit_tqmse: "SQtqmse3",
+        faiss.ScalarQuantizer.QT_4bit_tqmse: "SQtqmse4",
+        faiss.ScalarQuantizer.QT_8bit_tqmse: "SQtqmse8",
+        faiss.ScalarQuantizer.QT_2bit_tq: "SQtq2",
+        faiss.ScalarQuantizer.QT_3bit_tq: "SQtq3",
+        faiss.ScalarQuantizer.QT_4bit_tq: "SQtq4",
+        faiss.ScalarQuantizer.QT_5bit_tq: "SQtq5",
+    }
     index = faiss.downcast_index(index)
     if isinstance(index, faiss.IndexFlat):
         return "Flat"
@@ -100,7 +124,7 @@ def reverse_index_factory(index):
         if isinstance(index, faiss.IndexIVFFlat):
             return prefix + ",Flat"
         if isinstance(index, faiss.IndexIVFScalarQuantizer):
-            return prefix + ",SQ8"
+            return prefix + "," + sq_names[index.sq.qtype]
         if isinstance(index, faiss.IndexIVFPQ):
             return prefix + f",PQ{index.pq.M}x{index.pq.nbits}"
         if isinstance(index, faiss.IndexIVFPQFastScan):
@@ -137,14 +161,7 @@ def reverse_index_factory(index):
         return "LSH" + ("r" if index.rotate_data else "") + ("t" if index.train_thresholds else "")
 
     elif isinstance(index, faiss.IndexScalarQuantizer):
-        sqtypes = {
-            faiss.ScalarQuantizer.QT_8bit: "8",
-            faiss.ScalarQuantizer.QT_4bit: "4",
-            faiss.ScalarQuantizer.QT_6bit: "6",
-            faiss.ScalarQuantizer.QT_fp16: "fp16",
-            faiss.ScalarQuantizer.QT_bf16: "bf16",
-        }
-        return f"SQ{sqtypes[index.sq.qtype]}"
+        return sq_names[index.sq.qtype]
 
     # IndexIDMap2 is a subclass of IndexIDMap, so it must be checked first.
     elif isinstance(index, faiss.IndexIDMap2):

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -844,8 +844,63 @@ class TestFactoryTools(unittest.TestCase):
         self.assertEqual(
             factory_tools.reverse_index_factory(index), "IDMap,Flat"
         )
-        # IndexIDMap2 subclasses IndexIDMap, so it must be matched first.
+        # IndexIDMap2 subclasses IndexIDMap, so it must be checked first.
         index2 = faiss.IndexIDMap2(faiss.IndexFlatL2(32))
         self.assertEqual(
             factory_tools.reverse_index_factory(index2), "IDMap2,Flat"
         )
+
+    def test_ivf_scalar_quantizer_types(self):
+        d = 32
+        sq_types = {
+            faiss.ScalarQuantizer.QT_8bit: "IVF32,SQ8",
+            faiss.ScalarQuantizer.QT_4bit: "IVF32,SQ4",
+            faiss.ScalarQuantizer.QT_8bit_uniform: "IVF32,SQ8u",
+            faiss.ScalarQuantizer.QT_4bit_uniform: "IVF32,SQ4u",
+            faiss.ScalarQuantizer.QT_6bit: "IVF32,SQ6",
+            faiss.ScalarQuantizer.QT_fp16: "IVF32,SQfp16",
+            faiss.ScalarQuantizer.QT_bf16: "IVF32,SQbf16",
+            faiss.ScalarQuantizer.QT_8bit_direct: "IVF32,SQ8_direct",
+            faiss.ScalarQuantizer.QT_8bit_direct_signed: "IVF32,SQ8_direct_signed",
+            faiss.ScalarQuantizer.QT_0bit: "IVF32,SQ0",
+            faiss.ScalarQuantizer.QT_1bit_tqmse: "IVF32,SQtqmse1",
+            faiss.ScalarQuantizer.QT_2bit_tqmse: "IVF32,SQtqmse2",
+            faiss.ScalarQuantizer.QT_3bit_tqmse: "IVF32,SQtqmse3",
+            faiss.ScalarQuantizer.QT_4bit_tqmse: "IVF32,SQtqmse4",
+            faiss.ScalarQuantizer.QT_8bit_tqmse: "IVF32,SQtqmse8",
+            faiss.ScalarQuantizer.QT_2bit_tq: "IVF32,SQtq2",
+            faiss.ScalarQuantizer.QT_3bit_tq: "IVF32,SQtq3",
+            faiss.ScalarQuantizer.QT_4bit_tq: "IVF32,SQtq4",
+            faiss.ScalarQuantizer.QT_5bit_tq: "IVF32,SQtq5",
+        }
+        for qtype, expected in sq_types.items():
+            index = faiss.IndexIVFScalarQuantizer(
+                faiss.IndexFlatL2(d), d, 32, qtype
+            )
+            self.assertEqual(factory_tools.reverse_index_factory(index), expected)
+
+    def test_scalar_quantizer_types(self):
+        d = 32
+        sq_types = {
+            faiss.ScalarQuantizer.QT_8bit: "SQ8",
+            faiss.ScalarQuantizer.QT_4bit: "SQ4",
+            faiss.ScalarQuantizer.QT_8bit_uniform: "SQ8u",
+            faiss.ScalarQuantizer.QT_4bit_uniform: "SQ4u",
+            faiss.ScalarQuantizer.QT_6bit: "SQ6",
+            faiss.ScalarQuantizer.QT_fp16: "SQfp16",
+            faiss.ScalarQuantizer.QT_bf16: "SQbf16",
+            faiss.ScalarQuantizer.QT_8bit_direct: "SQ8_direct",
+            faiss.ScalarQuantizer.QT_8bit_direct_signed: "SQ8_direct_signed",
+            faiss.ScalarQuantizer.QT_1bit_tqmse: "SQtqmse1",
+            faiss.ScalarQuantizer.QT_2bit_tqmse: "SQtqmse2",
+            faiss.ScalarQuantizer.QT_3bit_tqmse: "SQtqmse3",
+            faiss.ScalarQuantizer.QT_4bit_tqmse: "SQtqmse4",
+            faiss.ScalarQuantizer.QT_8bit_tqmse: "SQtqmse8",
+            faiss.ScalarQuantizer.QT_2bit_tq: "SQtq2",
+            faiss.ScalarQuantizer.QT_3bit_tq: "SQtq3",
+            faiss.ScalarQuantizer.QT_4bit_tq: "SQtq4",
+            faiss.ScalarQuantizer.QT_5bit_tq: "SQtq5",
+        }
+        for qtype, expected in sq_types.items():
+            index = faiss.IndexScalarQuantizer(d, qtype)
+            self.assertEqual(factory_tools.reverse_index_factory(index), expected)


### PR DESCRIPTION
Summary:
`reverse_index_factory` in `contrib/factory_tools.py` had two bugs:

1. `IndexIVFScalarQuantizer` branch hardcoded `prefix + ",SQ8"` for every quantizer type. Any IVF+SQfp16, IVF+SQ4, IVF+SQbf16, IVF+SQ8_direct, IVF+SQ8_direct_signed, or IVF+TurboQuant index returned the wrong factory string. When used to reconstruct the index via `index_factory`, the string produced a wrong type. All non-SQ8 IVF scalar-quantizer indexes were mislogged by the telemetry wrapper.

2. `IndexScalarQuantizer` branch's `sqtypes` dict held 5 entries (QT_8bit, QT_4bit, QT_6bit, QT_fp16, QT_bf16) and used `sqtypes[index.sq.qtype]` directly. Any standalone SQ index with QT_8bit_direct, QT_8bit_direct_signed, or any of the 9 TurboQuant types (QT_1bit_tqmse through QT_5bit_tq, added in b985e9c43271, 2026-06-04) raises KeyError with no error message.

We fix both by hoisting a single `sq_names` dict to the top of `reverse_index_factory`, covering all 19 `ScalarQuantizer::QuantizerType` values. Both the IVF and standalone branches look up from this shared dict.

Addressing review feedback (mnorris): the dict now also includes the three remaining enum values that were initially missed — `QT_0bit` ("SQ0", parsed by `index_factory` and intended for the IVF path), and `QT_8bit_uniform`/`QT_4bit_uniform` ("SQ8u"/"SQ4u", synthetic names since `index_factory` does not parse the uniform variants). The dict is ordered to mirror the C++ enum so it can be checked for completeness against it.

`test_ivf_scalar_quantizer_types` verifies all 19 types in the IVF context; `test_scalar_quantizer_types` verifies the 18 standalone types (`QT_0bit` is IVF-only).

Reviewed By: mnorris11

Differential Revision: D108272403


