### PR TITLE
Add QT_0bit and QT_2bit_tq..QT_5bit_tq to ScalarQuantizer pyi stub

### DIFF
--- a/faiss/python/__init__.pyi
+++ b/faiss/python/__init__.pyi
@@ -1346,11 +1346,16 @@ class ScalarQuantizer(Quantizer):
     QT_6bit: int
     QT_bf16: int
     QT_8bit_direct_signed: int
+    QT_0bit: int
     QT_1bit_tqmse: int
     QT_2bit_tqmse: int
     QT_3bit_tqmse: int
     QT_4bit_tqmse: int
     QT_8bit_tqmse: int
+    QT_2bit_tq: int
+    QT_3bit_tq: int
+    QT_4bit_tq: int
+    QT_5bit_tq: int
 
     # RangeStat constants (as class attributes)
     RS_minmax: int

--- a/tests/test_swig_wrapper.py
+++ b/tests/test_swig_wrapper.py
@@ -155,6 +155,21 @@ class TestSWIGWrap(unittest.TestCase):
         self.assertEqual(params.qb, 4)
         self.assertTrue(params.int_qjl)
 
+    def test_scalar_quantizer_tq_enum_values(self):
+        # QT_2bit_tq..QT_5bit_tq were added in the TurboQuant commit and must
+        # be accessible as ScalarQuantizer class attributes (pyi stub regression
+        # test: they were absent until this fix).
+        sq = faiss.ScalarQuantizer
+        self.assertEqual(sq.QT_2bit_tq, 15)
+        self.assertEqual(sq.QT_3bit_tq, 16)
+        self.assertEqual(sq.QT_4bit_tq, 17)
+        self.assertEqual(sq.QT_5bit_tq, 18)
+
+    def test_scalar_quantizer_0bit_enum_value(self):
+        # QT_0bit (centroid-only SQ, for IVF) was likewise absent from the
+        # pyi stub until this fix.
+        self.assertEqual(faiss.ScalarQuantizer.QT_0bit, 9)
+
 
 class TestRevSwigPtr(unittest.TestCase):
 


### PR DESCRIPTION
Summary:
QT_2bit_tq, QT_3bit_tq, QT_4bit_tq, and QT_5bit_tq were added in D102408184 (TurboQuant full algorithm, June 4) but were not added to the authoritative `__init__.pyi` stub wired in D107274305 (June 3). `QT_0bit` (the centroid-only scalar quantizer used by IVF) is likewise missing from the stub. Pyre users referencing these types (e.g. `faiss.ScalarQuantizer.QT_2bit_tq` or `faiss.ScalarQuantizer.QT_0bit`) get [missing-attribute] errors even though the values are accessible at runtime (`QT_0bit` = 9, `QT_2bit_tq`..`QT_5bit_tq` = 15-18).

We add all five enum values to the `ScalarQuantizer` stub, ordered to mirror the C++ enum in `impl/ScalarQuantizer.h`. Two tests in `test_swig_wrapper` assert the ordinal values: `test_scalar_quantizer_tq_enum_values` (15-18) and `test_scalar_quantizer_0bit_enum_value` (9).

This is the same pattern as D108001955 (IVFSQTurboQSearchParameters stub), which fixed the search-params side of the same June 4 commit. The `QT_0bit` entry also unblocks D108272403, which references `faiss.ScalarQuantizer.QT_0bit` in `reverse_index_factory`.

Reviewed By: limqiying

Differential Revision: D108738051


