### PR TITLE
Add ClusteringInitMethod enum constants to __init__.pyi stub (#5324)

### DIFF
--- a/faiss/python/__init__.pyi
+++ b/faiss/python/__init__.pyi
@@ -34,6 +34,11 @@ METRIC_Jaccard: int
 METRIC_NaNEuclidean: int
 METRIC_GOWER: int
 
+ClusteringInitMethod = int
+ClusteringInitMethod_RANDOM: int
+ClusteringInitMethod_KMEANS_PLUS_PLUS: int
+ClusteringInitMethod_AFK_MC2: int
+
 # I/O flag constants for reading/writing indexes
 IO_FLAG_SKIP_STORAGE: int  # skip the storage for graph-based indexes
 IO_FLAG_READ_ONLY: int  # read-only mode
@@ -2446,7 +2451,7 @@ class ClusteringParameters:
     decode_block_size: int
     check_input_data_for_NaNs: bool
     use_faster_subsampling: bool
-    init_method: int  # ClusteringInitMethod enum (RANDOM=0, KMEANS_PLUS_PLUS=1, AFK_MC2=2)
+    init_method: ClusteringInitMethod
     afkmc2_chain_length: int  # chain length for AFK-MC² initialization
     early_stop_threshold: float  # early stop threshold [0, 1]
 


### PR DESCRIPTION
Summary:

Add the three ClusteringInitMethod enum constants
(ClusteringInitMethod_RANDOM, ClusteringInitMethod_KMEANS_PLUS_PLUS,
ClusteringInitMethod_AFK_MC2) and the ClusteringInitMethod type alias to
the authoritative __init__.pyi Pyre stub.

These constants were introduced in commit bc5fe3d75e85 (Dec 2025) when
k-means++ and AFK-MC² centroid initialization were added to Clustering.h.
They are accessible at runtime via the SWIG-generated module but were never
added to __init__.pyi. When D107274305 (Jun 2026) wired __init__.pyi as
the authoritative Pyre source, all code using these constants acquired
[missing-attribute] errors. test_clustering_initialization.py already
references them 14 times.

Fix: add ClusteringInitMethod = int type alias and three int constants
near the MetricType block at the top of the stub (matching the established
pattern for SWIG-wrapped scoped enums). Update ClusteringParameters.init_method
from 'int  # comment' to 'ClusteringInitMethod' to match how MetricType
is used throughout the file.

Test: buck test fbcode//faiss/tests:test_swig_wrapper — 25 pass, 0 fail
(24 pre-existing + 1 new: test_clustering_init_method_enum_values).
Test session: https://www.internalfb.com/intern/testinfra/testrun/32369622335973550

Reviewed By: limqiying

Differential Revision: D109007472


