### PR TITLE
Faiss OSS autofix: force cuVS nightly to break (E2E validation) (#5328)

### DIFF
--- a/.github/actions/build_conda/action.yml
+++ b/.github/actions/build_conda/action.yml
@@ -45,7 +45,6 @@ runs:
         # Ensure starting packages are from conda-forge.
         conda list --show-channel-urls
         conda install -y -q "conda!=24.11.0,<25.7"
-        conda config --set solver libmamba
         conda install -y -q "conda-build=25.3.1" "liblief=0.14.1"
     - name: Enable anaconda uploads
       if: inputs.label != ''


### PR DESCRIPTION
Summary:

Deliberately break the cuVS conda nightly build to validate the Faiss OSS autofix sidecar end-to-end: watcher detects nightly failure -> opens session in `manifold://faiss_oss_autofix/tree/sessions/` -> MyClaw generates patch -> pusher applies the patch to a `myclaw/<run>-<attempt>` GitHub branch and dispatches `nightly.yml` on it.

Two changes:

1. **`build_conda/action.yml`**: Revert the `conda config --set solver libmamba` line introduced by D107388234. Without libmamba, the classic conda solver runs against the cuVS resolve (rapidsai + nvidia + conda-forge), which is expected to time out within the GitHub Actions 6h budget.

2. **`build-pull-request.yml`**: Temporarily add the `linux-x86_64-GPU-CUVS-CUDA13-2-0-nightly` job (mirror of the nightly job, with `ANACONDA_API_TOKEN` and `label: nightly` stripped) so PR CI exercises the broken cuVS build and we can confirm the breakage before landing. **This addition must be removed before landing** — leaving it in would run the broken cuVS build on every PR.

Notes:
- D109045137 (token-fallback safety fix) is landed, so the autofix pusher's GitHub identity is safe under Chronos (only honors `FAISS_GITHUB_TOKEN`, not the generic `GITHUB_TOKEN`).
- The watcher and pusher chronos jobs are enabled (https://www.internalfb.com/chronos/job/gp/9007208073320589, https://www.internalfb.com/chronos/job/gp/135107997926649017), so the autofix should pick up the broken nightly without further setup.

Reviewed By: mnorris11

Differential Revision: D109092204


