### PR TITLE
Fix AVX-512 PQ-encode falling back to scalar in fvec_L2sqr_ny_nearest_y_transposed (#5330)

### DIFF
--- a/faiss/utils/simd_impl/distances_avx512.cpp
+++ b/faiss/utils/simd_impl/distances_avx512.cpp
@@ -954,21 +954,6 @@ size_t fvec_L2sqr_ny_nearest<SIMDLevel::AVX512>(
             &fvec_L2sqr_ny_nearest_D8<SIMDLevel::AVX512>);
 }
 
-template <>
-size_t fvec_L2sqr_ny_nearest_y_transposed<SIMDLevel::AVX512>(
-        float* distances_tmp_buffer,
-        const float* x,
-        const float* y,
-        const float* y_sqlen,
-        size_t d,
-        size_t d_offset,
-        size_t ny) {
-    return fvec_L2sqr_ny_nearest_y_transposed<SIMDLevel::NONE>(
-            distances_tmp_buffer, x, y, y_sqlen, d, d_offset, ny);
-}
-
-// TODO: Following functions are not used in the current codebase. Check AVX2 ,
-// respective implementation has been used
 template <size_t DIM>
 size_t fvec_L2sqr_ny_nearest_y_transposed_D(
         float* /* distances_tmp_buffer */,
@@ -1080,6 +1065,33 @@ size_t fvec_L2sqr_ny_nearest_y_transposed_D(
     }
 
     return current_min_index;
+}
+
+template <>
+size_t fvec_L2sqr_ny_nearest_y_transposed<SIMDLevel::AVX512>(
+        float* distances_tmp_buffer,
+        const float* x,
+        const float* y,
+        const float* y_sqlen,
+        size_t d,
+        size_t d_offset,
+        size_t ny) {
+    // optimized for a few special cases
+#define DISPATCH(dval)                                     \
+    case dval:                                             \
+        return fvec_L2sqr_ny_nearest_y_transposed_D<dval>( \
+                distances_tmp_buffer, x, y, y_sqlen, d_offset, ny);
+
+    switch (d) {
+        DISPATCH(1)
+        DISPATCH(2)
+        DISPATCH(4)
+        DISPATCH(8)
+        default:
+            return fvec_L2sqr_ny_nearest_y_transposed<SIMDLevel::NONE>(
+                    distances_tmp_buffer, x, y, y_sqlen, d, d_offset, ny);
+    }
+#undef DISPATCH
 }
 
 template <>

--- a/tests/bench_transposed_encode.py
+++ b/tests/bench_transposed_encode.py
@@ -1,0 +1,120 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import sys
+import time
+import unittest
+
+import faiss
+import numpy as np
+
+
+def _time_compute_codes(
+    pq: faiss.ProductQuantizer, xb: np.ndarray, n_repeat: int
+) -> tuple[float, int]:
+    # warmup (also primes any lazy state)
+    codes = pq.compute_codes(xb)
+    checksum = int(codes.astype(np.int64).sum())
+    t0 = time.perf_counter()
+    for _ in range(n_repeat):
+        pq.compute_codes(xb)
+    dt = time.perf_counter() - t0
+    return dt / n_repeat, checksum
+
+
+def run_case(
+    d: int,
+    m: int,
+    nbits: int,
+    nb: int,
+    ntrain: int,
+    n_repeat: int,
+) -> None:
+    dsub = d // m
+    rng = np.random.RandomState(1234)
+    xt = rng.rand(ntrain, d).astype("float32")
+    xb = rng.rand(nb, d).astype("float32")
+
+    pq = faiss.ProductQuantizer(d, m, nbits)
+    pq.train(xt)
+    # populate transposed_centroids -> compute_1_code uses the
+    # fvec_L2sqr_ny_nearest_y_transposed kernel.
+    pq.sync_transposed_centroids()
+
+    threads = faiss.omp_get_max_threads()
+    print(
+        f"\n=== d={d} M={m} dsub={dsub} nbits={nbits} "
+        f"nb={nb:,} repeats={n_repeat} (threads={threads}) ==="
+    )
+    print(f"{'level':<10} {'ms/encode-call':>15} {'vs AVX512':>12}  checksum")
+
+    levels = [
+        faiss.SIMDLevel_NONE,
+        faiss.SIMDLevel_AVX2,
+        faiss.SIMDLevel_AVX512,
+    ]
+    names = {
+        faiss.SIMDLevel_NONE: "NONE",
+        faiss.SIMDLevel_AVX2: "AVX2",
+        faiss.SIMDLevel_AVX512: "AVX512",
+    }
+
+    results: dict[str, float] = {}
+    checks: dict[str, int] = {}
+    for lvl in levels:
+        if not faiss.SIMDConfig.is_simd_level_available(lvl):
+            print(f"{names[lvl]:<10} {'(not available)':>15}")
+            continue
+        faiss.SIMDConfig.set_level(lvl)
+        per_call, checksum = _time_compute_codes(pq, xb, n_repeat)
+        results[names[lvl]] = per_call
+        checks[names[lvl]] = checksum
+
+    avx512 = results.get("AVX512")
+    for name in ("NONE", "AVX2", "AVX512"):
+        if name not in results:
+            continue
+        ms = results[name] * 1e3
+        ratio = (results[name] / avx512) if avx512 else float("nan")
+        print(f"{name:<10} {ms:>15.3f} {ratio:>11.2f}x  {checks[name]}")
+
+    # correctness: all levels must produce identical codes
+    distinct = set(checks.values())
+    status = "YES" if len(distinct) == 1 else f"NO {checks}"
+    print(f"codes identical across levels: {status}")
+    if "NONE" in results and avx512:
+        speedup = results["NONE"] / avx512
+        print(f"==> AVX512 fix speedup vs pre-fix NONE: {speedup:.2f}x")
+
+
+def main() -> None:
+    print(
+        "faiss build SIMD level (auto-detected):",
+        faiss.SIMDConfig.get_level(),
+    )
+    print(
+        "AVX512 available:",
+        faiss.SIMDConfig.is_simd_level_available(faiss.SIMDLevel_AVX512),
+    )
+    # Single-threaded for a clean per-core kernel signal.
+    faiss.omp_set_num_threads(1)
+
+    # dsub in {1,2,4,8} -> the fast _D specialization is taken.
+    run_case(d=128, m=32, nbits=8, nb=1_000_000, ntrain=100_000, n_repeat=5)
+    run_case(d=64, m=16, nbits=8, nb=1_000_000, ntrain=100_000, n_repeat=5)
+    # dsub=16 -> _D fast path NOT taken (control: no AVX512 vs NONE gap).
+    run_case(d=128, m=8, nbits=8, nb=1_000_000, ntrain=100_000, n_repeat=5)
+    sys.stdout.flush()
+
+
+class BenchTransposedEncode(unittest.TestCase):
+    def test_bench(self) -> None:
+        main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:

TLDR: function got missed. This fix makes it mimic the AVX2 path which is correct already. Claude did leave a TODO though. We should audit those.
--

AI stuff:

PQ encoding ran ~6x slower under AVX-512 than AVX2 in production.

Root cause: the AVX-512 specialization `fvec_L2sqr_ny_nearest_y_transposed<SIMDLevel::AVX512>` in `faiss/utils/simd_impl/distances_avx512.cpp` skipped its per-dimension dispatch and called the scalar `<SIMDLevel::NONE>` implementation directly. The vectorized AVX-512 kernel `fvec_L2sqr_ny_nearest_y_transposed_D<DIM>` was implemented in the same file but left as dead code behind a stale `// TODO: Following functions are not used in the current codebase` comment. The AVX2 sibling in `distances_avx2.cpp` dispatches correctly: `switch (d) { case 1/2/4/8 -> fvec_L2sqr_ny_nearest_y_transposed_D<dval>; default -> NONE }`.

This kernel is on the PQ encode path: `ProductQuantizer::compute_1_code` calls it per database vector, per subquantizer, when `transposed_centroids` is populated. AVX-512 only exists in the Dynamic Dispatch (DD) build, so the runtime correctly selected `SIMDLevel::AVX512` and then executed scalar code — AVX-512 hosts encoded with a scalar inner loop while AVX2 hosts used the vectorized kernel.

Fix: wire `fvec_L2sqr_ny_nearest_y_transposed<SIMDLevel::AVX512>` to the existing `_D<dval>` kernel via the same `switch` as AVX2, move the kernel definition above the wrapper to mirror `distances_avx2.cpp`, and delete the stale TODO. The neighboring `fvec_L2sqr_ny_transposed<SIMDLevel::AVX512>` was already wired correctly and is unchanged.

Found via the AVX2-vs-AVX512 Strobelight comparison: under `tryEncode`, the transposed-distance family went from ~2,686 samples (AVX2, using the fast `_D` leaf) to ~14,951 samples (AVX512, running scalar) — about 5.6x; meanwhile `fvec_L2sqr_batch_4` (the HNSW distance kernel) was actually faster on AVX-512, confirming the regression was isolated to this one kernel.

  Results

  dsub=4 — the fast _D path applies (where the fix matters):

  ┌─────────────┬─────────────────────────┬──────────┬────────────────┬─────────────┐
  │   config    │ NONE (= pre-fix AVX512) │   AVX2   │ AVX512 (fixed) │ fix speedup │
  ├─────────────┼─────────────────────────┼──────────┼────────────────┼─────────────┤
  │ d=128, M=32 │ 31,790 ms               │ 2,025 ms │ 2,248 ms       │ 14.1×       │
  ├─────────────┼─────────────────────────┼──────────┼────────────────┼─────────────┤
  │ d=64, M=16  │ 15,902 ms               │ 1,033 ms │ 1,139 ms       │ 14.0×       │
  └─────────────┴─────────────────────────┴──────────┴────────────────┴─────────────┘

  dsub=16 — control, _D path not taken (all levels fall to NONE default):

  ┌────────────┬──────────┬──────────┬──────────┬─────────────────────┐
  │   config   │   NONE   │   AVX2   │  AVX512  │       speedup       │
  ├────────────┼──────────┼──────────┼──────────┼─────────────────────┤
  │ d=128, M=8 │ 4,195 ms │ 4,147 ms │ 4,121 ms │ 1.02× (no change) ✓ │
  └────────────┴──────────┴──────────┴──────────┴─────────────────────┘

Reviewed By: ddrcoder, junjieqi

Differential Revision: D109100196


