### PR TITLE
Rename SQI8 to SQ8 to be consistent with the rest of Faiss

### DIFF
--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -315,8 +315,8 @@ Index* parse_coarse_quantizer(
         SVSStorageKind storage = SVSStorageKind::SVS_FP32;
         if (sm[3].matched) {
             std::string s = sm[3].str().substr(1);
-            if (s == "SQI8") {
-                storage = SVSStorageKind::SVS_SQI8;
+            if (s == "SQ8") {
+                storage = SVSStorageKind::SVS_SQ8;
             } else if (s == "FP16") {
                 storage = SVSStorageKind::SVS_FP16;
             } else if (s == "FP32") {
@@ -681,16 +681,16 @@ Index* parse_svs_datatype(
         }
         FAISS_ASSERT(false && "Unsupported SVS index type for Float16");
     }
-    if (re_match(datatype_string, "SQI8", sm)) {
+    if (re_match(datatype_string, "SQ8", sm)) {
         if (index_type == "Vamana") {
             return new IndexSVSVamana(
-                    d, std::stoul(arg_string), mt, SVSStorageKind::SVS_SQI8);
+                    d, std::stoul(arg_string), mt, SVSStorageKind::SVS_SQ8);
         }
         if (index_type == "IVF") {
             return new IndexSVSIVF(
-                    d, std::stoul(arg_string), mt, SVSStorageKind::SVS_SQI8);
+                    d, std::stoul(arg_string), mt, SVSStorageKind::SVS_SQ8);
         }
-        FAISS_ASSERT(false && "Unsupported SVS index type for SQI8");
+        FAISS_ASSERT(false && "Unsupported SVS index type for SQ8");
     }
     if (re_match(datatype_string, "(LVQ[0-9]+x[0-9]+)", sm)) {
         if (index_type == "Vamana") {

--- a/faiss/svs/IndexSVSVamana.h
+++ b/faiss/svs/IndexSVSVamana.h
@@ -44,7 +44,7 @@ struct SearchParametersSVSVamana : public SearchParameters {
 enum SVSStorageKind {
     SVS_FP32,
     SVS_FP16,
-    SVS_SQI8,
+    SVS_SQ8,
     SVS_LVQ4x0,
     SVS_LVQ4x4,
     SVS_LVQ4x8,
@@ -61,7 +61,7 @@ inline svs_runtime::StorageKind to_svs_storage_kind(SVSStorageKind kind) {
             return svs_runtime::StorageKind::FP32;
         case SVS_FP16:
             return svs_runtime::StorageKind::FP16;
-        case SVS_SQI8:
+        case SVS_SQ8:
             return svs_runtime::StorageKind::SQI8;
         case SVS_LVQ4x0:
             return svs_runtime::StorageKind::LVQ4x0;

--- a/tests/test_svs.cpp
+++ b/tests/test_svs.cpp
@@ -184,9 +184,9 @@ TEST_F(SVS, WriteAndReadIndexSVSFP16) {
     write_and_read_index(index, test_data, n);
 }
 
-TEST_F(SVS, WriteAndReadIndexSVSSQI8) {
+TEST_F(SVS, WriteAndReadIndexSVSSQ8) {
     faiss::IndexSVSVamana index{
-            d, 64ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_SQI8};
+            d, 64ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_SQ8};
     write_and_read_index(index, test_data, n);
 }
 
@@ -259,9 +259,9 @@ TEST_F(SVS, VamanaFP16TrainSaveLoadAndAdd) {
     train_save_load_and_add_index(index, test_data, n);
 }
 
-TEST_F(SVS, VamanaSQI8TrainSaveLoadAndAdd) {
+TEST_F(SVS, VamanaSQ8TrainSaveLoadAndAdd) {
     faiss::IndexSVSVamana index{
-            d, 64ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_SQI8};
+            d, 64ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_SQ8};
     train_save_load_and_add_index(index, test_data, n);
 }
 
@@ -559,9 +559,9 @@ TEST_F(SVS, WriteAndReadIndexSVSIVFFP16) {
     write_and_read_ivf_index(index, test_data, n);
 }
 
-TEST_F(SVS, WriteAndReadIndexSVSIVFSQI8) {
+TEST_F(SVS, WriteAndReadIndexSVSIVFSQ8) {
     faiss::IndexSVSIVF index{
-            d, 4ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_SQI8};
+            d, 4ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_SQ8};
     write_and_read_ivf_index(index, test_data, n);
 }
 
@@ -618,9 +618,9 @@ TEST_F(SVS, IVFFP16TrainAndAdd) {
     train_and_add_ivf_index(index, test_data, n);
 }
 
-TEST_F(SVS, IVFSQI8TrainAndAdd) {
+TEST_F(SVS, IVFSQ8TrainAndAdd) {
     faiss::IndexSVSIVF index{
-            d, 4ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_SQI8};
+            d, 4ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_SQ8};
     train_and_add_ivf_index(index, test_data, n);
 }
 
@@ -923,9 +923,9 @@ TEST_F(SVS, WriteAndReadStaticVamanaFP16) {
     write_and_read_static_vamana_index(index, test_data, n);
 }
 
-TEST_F(SVS, WriteAndReadStaticVamanaSQI8) {
+TEST_F(SVS, WriteAndReadStaticVamanaSQ8) {
     faiss::IndexSVSVamana index{
-            d, 64ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_SQI8, true};
+            d, 64ul, faiss::METRIC_L2, faiss::SVSStorageKind::SVS_SQ8, true};
     write_and_read_static_vamana_index(index, test_data, n);
 }
 

--- a/tests/test_svs_py.py
+++ b/tests/test_svs_py.py
@@ -283,11 +283,11 @@ class TestSVSFactory(unittest.TestCase):
         self.assertEqual(index.graph_max_degree, 16)
         self.assertEqual(index.storage_kind, faiss.SVS_FP16)
 
-    def test_svs_factory_sqi8(self):
-        index = faiss.index_factory(64, "SVSVamana24,SQI8")
+    def test_svs_factory_sq8(self):
+        index = faiss.index_factory(64, "SVSVamana24,SQ8")
         self.assertEqual(index.d, 64)
         self.assertEqual(index.graph_max_degree, 24)
-        self.assertEqual(index.storage_kind, faiss.SVS_SQI8)
+        self.assertEqual(index.storage_kind, faiss.SVS_SQ8)
 
 
 @unittest.skipIf(_SKIP_SVS_LL, _SKIP_SVS_LL_REASON)
@@ -317,8 +317,8 @@ class TestSVSIVFCoarseQuantizerFactory(unittest.TestCase):
         self.assertEqual(index.d, 32)
         self.assertEqual(index.nlist, 256)
 
-    def test_ivf_svsvamana_sqi8(self):
-        index = faiss.index_factory(32, "IVF256_SVSVamana32_SQI8,Flat")
+    def test_ivf_svsvamana_sq8(self):
+        index = faiss.index_factory(32, "IVF256_SVSVamana32_SQ8,Flat")
         self.assertEqual(index.d, 32)
         self.assertEqual(index.nlist, 256)
 
@@ -347,11 +347,11 @@ class TestSVSAdapterFP16(TestSVSAdapter):
 
 
 @unittest.skipIf(_SKIP_SVS, _SKIP_REASON)
-class TestSVSAdapterSQI8(TestSVSAdapter):
+class TestSVSAdapterSQ8(TestSVSAdapter):
     """Repeat all tests for SVS SQ int8 variant"""
     def _create_instance(self):
         idx = self.target_class(self.d, 64)
-        idx.storage_kind = faiss.SVS_SQI8
+        idx.storage_kind = faiss.SVS_SQ8
         return idx
 
 
@@ -559,11 +559,11 @@ class TestSVSVamanaParametersFP16(TestSVSVamanaParameters):
 
 
 @unittest.skipIf(_SKIP_SVS, _SKIP_REASON)
-class TestSVSVamanaParametersSQI8(TestSVSVamanaParameters):
+class TestSVSVamanaParametersSQ8(TestSVSVamanaParameters):
     """Repeat Vamana parameter tests for SVS SQ int8 variant"""
     def _create_instance(self):
         idx = self.target_class(self.d, 64)
-        idx.storage_kind = faiss.SVS_SQI8
+        idx.storage_kind = faiss.SVS_SQ8
         return idx
 
 
@@ -769,11 +769,11 @@ class TestSVSIVFAdapterFP16(TestSVSIVFAdapter):
 
 
 @unittest.skipIf(_SKIP_SVS, _SKIP_REASON)
-class TestSVSIVFAdapterSQI8(TestSVSIVFAdapter):
-    """Repeat IVF tests for SQI8 variant"""
+class TestSVSIVFAdapterSQ8(TestSVSIVFAdapter):
+    """Repeat IVF tests for SQ8 variant"""
     def _create_instance(self):
         idx = self.target_class(self.d, self.nlist, faiss.METRIC_L2,
-                                faiss.SVS_SQI8)
+                                faiss.SVS_SQ8)
         idx.num_threads = 4
         return idx
 
@@ -856,11 +856,11 @@ class TestSVSIVFFactory(unittest.TestCase):
         self.assertIsInstance(index, faiss.IndexSVSIVF)
         self.assertEqual(index.storage_kind, faiss.SVS_FP16)
 
-    def test_svs_factory_ivf_sqi8(self):
-        index = faiss.index_factory(64, "SVSIVF8,SQI8")
+    def test_svs_factory_ivf_sq8(self):
+        index = faiss.index_factory(64, "SVSIVF8,SQ8")
         self.assertEqual(index.d, 64)
         self.assertIsInstance(index, faiss.IndexSVSIVF)
-        self.assertEqual(index.storage_kind, faiss.SVS_SQI8)
+        self.assertEqual(index.storage_kind, faiss.SVS_SQ8)
 
 
 @unittest.skipIf(_SKIP_SVS_LL, _SKIP_SVS_LL_REASON)
@@ -1401,9 +1401,9 @@ class TestSVSStaticVamana(unittest.TestCase):
         D, _ = index.search(self.xq, 4)
         self.assertEqual(D.shape, (self.nq, 4))
 
-    def test_static_sqi8(self):
-        """Static Vamana with SQI8 storage"""
-        index = self._create_static(faiss.SVS_SQI8)
+    def test_static_sq8(self):
+        """Static Vamana with SQ8 storage"""
+        index = self._create_static(faiss.SVS_SQ8)
         index.add(self.xb)
         self.assertTrue(index.is_trained)
         self.assertTrue(index.is_static)


### PR DESCRIPTION
Summary: We will use SQ8 more frequently in Vamana in particular, so this will reduce friction

Differential Revision: D109480499


