### PR TITLE
ProductQuantizer::search_sdc: hoist per-subquantizer row pointers out of database-vector loop (#5338)

### DIFF
--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -862,32 +862,44 @@ void ProductQuantizer::search_sdc(
     size_t k = res->k;
     int64_t nq_signed = nq;
 
-#pragma omp parallel for
-    for (int64_t i = 0; i < nq_signed; i++) {
-        /* Compute distances and keep smallest values */
-        idx_t* heap_ids = res->ids + i * k;
-        float* heap_dis = res->val + i * k;
-        const uint8_t* qcode = qcodes + i * code_size;
+#pragma omp parallel
+    {
+        // One allocation per OMP thread instead of one per query.
+        std::vector<const float*> q_row(M);
+#pragma omp for
+        for (int64_t i = 0; i < nq_signed; i++) {
+            idx_t* heap_ids = res->ids + i * k;
+            float* heap_dis = res->val + i * k;
+            const uint8_t* qcode = qcodes + i * code_size;
 
-        if (init_finalize_heap)
-            maxheap_heapify(k, heap_dis, heap_ids);
+            if (init_finalize_heap)
+                maxheap_heapify(k, heap_dis, heap_ids);
 
-        const uint8_t* bcode = bcodes;
-        for (size_t j = 0; j < nb; j++) {
-            float dis = 0;
-            const float* tab = sdc_table.data();
+            // Precompute per-subquantizer row pointers: q_row[m] points to
+            // sdc_table[m*ksub^2 + qcode[m]*ksub], eliminating M
+            // multiplications and M pointer advances per database vector in the
+            // j-loop.
+            const float* sdc = sdc_table.data();
             for (size_t m = 0; m < M; m++) {
-                dis += tab[bcode[m] + qcode[m] * ksub];
-                tab += ksub * ksub;
+                q_row[m] = sdc + m * (size_t)(ksub * ksub) +
+                        (size_t)qcode[m] * ksub;
             }
-            if (dis < heap_dis[0]) {
-                maxheap_replace_top(k, heap_dis, heap_ids, dis, j);
-            }
-            bcode += code_size;
-        }
 
-        if (init_finalize_heap)
-            maxheap_reorder(k, heap_dis, heap_ids);
+            const uint8_t* bcode = bcodes;
+            for (size_t j = 0; j < nb; j++) {
+                float dis = 0;
+                for (size_t m = 0; m < M; m++) {
+                    dis += q_row[m][bcode[m]];
+                }
+                if (dis < heap_dis[0]) {
+                    maxheap_replace_top(k, heap_dis, heap_ids, dis, j);
+                }
+                bcode += code_size;
+            }
+
+            if (init_finalize_heap)
+                maxheap_reorder(k, heap_dis, heap_ids);
+        }
     }
 }
 


### PR DESCRIPTION
Summary:

### THIS DIFF

We precompute M row pointers into the SDC (symmetric distance computation) table before the per-database-vector j-loop in `ProductQuantizer::search_sdc`. The original inner loop computed `sdc_table.data() + m * ksub^2 + qcode[m] * ksub` on every j iteration, introducing M multiplications and M pointer advances per database vector. The new code computes `q_row[m]` once per query, reducing the j-loop body to M direct indexed loads: `dis += q_row[m][bcode[m]]`.

The `q_row` buffer is declared inside a `#pragma omp parallel` block and reused across the inner `#pragma omp for`, so it is allocated once per OMP thread rather than once per query.

### CONTEXT

`search_sdc` is the symmetric distance computation path for `ProductQuantizer`-based search (used by `IndexPQ::search` with `search_type == ST_SDC`). It scans all `nb` database codes per query, accumulating M sub-table lookups per vector. With `nbits == 8` (enforced by assertion), `ksub = 256` and the SDC table has M × 256 × 256 entries. The per-j pointer arithmetic — resetting `tab` to `sdc_table.data()` and advancing by `ksub * ksub = 65536` M times — ran on every one of the `nb` database vectors, despite `qcode[m]` being constant across the entire j-loop.

### BENCHMARK

Dataset: SyntheticDataset, d=128, M=8, nb=200K, nq=500, k=10, OMP_NUM_THREADS=1, 10 runs median.

| | Before | After | Speedup |
|---|---|---|---|
| search_sdc | 42.0 ms | 27.8 ms | 33.8% |

Note: D107233641 (prior draft from 2026-06-02) contained this same optimization but was stale (based on a June 1 parent) and additionally included a benchmark script that should not land. This diff supersedes it cleanly on the current HEAD, addresses the Devmate review comment by hoisting the buffer allocation outside the OMP for, and omits the benchmark file.

Reviewed By: limqiying

Differential Revision: D109426404


