### PR TITLE
De-flake panorama / graph_based / hamming_utils tests

### DIFF
--- a/tests/test_flat_panorama.py
+++ b/tests/test_flat_panorama.py
@@ -57,13 +57,14 @@ class TestIndexFlatPanorama(unittest.TestCase):
         D_panorama,
         I_panorama,
         rtol=1e-5,
-        atol=1e-7,
+        atol=1e-4,
         otol=1e-3,
     ):
         # Allow small tolerance in overlap rate to account for
         # floating-point errors in distance computations that can affect
         # ordering when distances are nearly equal.
-        # Faiss: (a - b) * (a - b) vs. Panorama: a * a + b * b - 2(a * b)
+        # Faiss: (a - b) * (a - b) vs. Panorama: a * a + b * b - 2(a * b);
+        # these differ at the float32 ULP level, so atol absorbs the gap.
         overlap_rate = np.mean(I_regular == I_panorama)
 
         self.assertGreater(
@@ -363,6 +364,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
         """Test correctness at various batch size boundaries"""
         d, nq, k = 128, 10, 15
         # random train not needed for Flat indexes
+        # seed the (otherwise unseeded) query draw so runs are reproducible
+        np.random.seed(1234)
         xq = np.random.rand(nq, d).astype("float32")
 
         for metric in self.METRICS:

--- a/tests/test_graph_based.py
+++ b/tests/test_graph_based.py
@@ -288,7 +288,9 @@ class TestHNSWSimilarity(unittest.TestCase):
         d = self.xb.shape[1]
         self._check_quantized_IP(
             faiss.IndexHNSWFlat(d, 16, faiss.METRIC_INNER_PRODUCT),
-            min_agreement=195,
+            # observed ~199/200; headroom for OpenMP-parallel-build
+            # nondeterminism
+            min_agreement=180,
         )
 
     def test_hnsw_pq_IP(self):
@@ -626,7 +628,9 @@ class TestNSG(unittest.TestCase):
 
         # test accuracy
         recalls = (Iref == I).sum()
-        self.assertGreaterEqual(recalls, 190)  # 193
+        # observed ~193/500; PQ4 is coarse -- headroom for OpenMP
+        # FP-reduction / tie-break nondeterminism in NSG build + PQ assign
+        self.assertGreaterEqual(recalls, 180)
 
         # test I/O
         self.subtest_io_and_clone(index, D, I)
@@ -651,7 +655,8 @@ class TestNSG(unittest.TestCase):
 
         # test accuracy
         recalls = (Iref == I).sum()
-        self.assertGreaterEqual(recalls, 405)  # 411
+        # nominal ~411/500; loosened for OpenMP graph-build nondeterminism
+        self.assertGreaterEqual(recalls, 395)
 
         # test I/O
         self.subtest_io_and_clone(index, D, I)


### PR DESCRIPTION
Summary:
These three faiss CPU test modules were filed as flaky by the test-health tracker. Root causes and fixes (test-only):

- `test_flat_panorama.py::test_batch_boundaries`: the query matrix `xq` was drawn from an unseeded global NumPy RNG (the existing `np.random.seed(987)` only governs the database `xb`), so near-tied neighbors occasionally reordered between `IndexFlat` and `IndexFlatPanorama` and breached the tight comparison. Seed the query draw, and loosen the distance `atol` in `assert_search_results_equal` from `1e-7` to `1e-4` (the two distance formulas `(a-b)^2` vs `a*a+b*b-2ab` differ at the float32 ULP level).
- `test_graph_based.py`: `test_hnsw_flat_IP`, `test_nsg_pq`, and `test_nsg_sq` asserted recall/agreement floors only a few counts above the observed values, so OpenMP-parallel graph-build nondeterminism intermittently breached them. Loosened each floor with documented ~5-10% headroom; these still collapse by tens-to-hundreds of points on a real regression.
- `test_hamming_utils.py` (`BUCK` only): `for_all_simd_levels` mutates the process-global `faiss.SIMDConfig` level in `setUp`/`tearDown`; concurrent SIMD-level variant cases within one binary could stomp it. Gave `test_hamming_utils` a dedicated `python_unittest` target carrying `tpx_labels.serialize_test_cases` so its cases run one at a time. No source change to the test itself.

Differential Revision: D109488320


