### PR TITLE
fix IDMap add_sa_codes returning -1 labels with ivf subindex Issue #5333

### DIFF
--- a/faiss/IndexIDMap.cpp
+++ b/faiss/IndexIDMap.cpp
@@ -138,7 +138,8 @@ void IndexIDMapTemplate<IndexT>::add_sa_codes(
         idx_t n,
         const uint8_t* codes,
         const idx_t* xids) {
-    index->add_sa_codes(n, codes, xids);
+    // don't pass the ids to the sub-index, they are kept in id_map
+    index->add_sa_codes(n, codes, nullptr);
     for (idx_t i = 0; i < n; i++) {
         id_map.push_back(xids[i]);
     }
@@ -327,6 +328,18 @@ void IndexIDMap2Template<IndexT>::add_with_ids(
             static_cast<const void*>(x),
             component_t_to_numeric<typename IndexT::component_t>(),
             xids);
+}
+
+template <typename IndexT>
+void IndexIDMap2Template<IndexT>::add_sa_codes(
+        idx_t n,
+        const uint8_t* codes,
+        const idx_t* xids) {
+    idx_t prev_ntotal = this->ntotal;
+    IndexIDMapTemplate<IndexT>::add_sa_codes(n, codes, xids);
+    for (idx_t i = prev_ntotal; i < this->ntotal; i++) {
+        rev_map[this->id_map[i]] = i;
+    }
 }
 
 template <typename IndexT>

--- a/faiss/IndexIDMap.h
+++ b/faiss/IndexIDMap.h
@@ -110,6 +110,8 @@ struct IndexIDMap2Template : IndexIDMapTemplate<IndexT> {
             NumericType numeric_type,
             const idx_t* xids) override;
 
+    void add_sa_codes(idx_t n, const uint8_t* x, const idx_t* xids) override;
+
     size_t remove_ids(const IDSelector& sel) override;
 
     void reconstruct(idx_t key, component_t* recons) const override;

--- a/tests/test_standalone_codec.py
+++ b/tests/test_standalone_codec.py
@@ -434,7 +434,36 @@ class TestIDMap(unittest.TestCase):
 
         np.testing.assert_array_equal(Iref, Inew)
         np.testing.assert_array_equal(Dref, Dnew)
-        
+
+    def test_idmap_ivf(self):
+        # IVF stores ids in its inverted lists, so add_sa_codes must not
+        # forward them to the sub-index (issue #5333)
+        ds = SyntheticDataset(32, 2000, 200, 100)
+        ids = (1000 + np.arange(ds.nb)).astype('int64')
+
+        index = faiss.index_factory(ds.d, "IDMap2,IVF20,Flat")
+        index.train(ds.get_train())
+        faiss.downcast_index(index.index).nprobe = 4
+        index.add_with_ids(ds.get_database(), ids)
+        Dref, Iref = index.search(ds.get_queries(), 10)
+
+        index.reset()
+
+        index.train(ds.get_train())
+        faiss.downcast_index(index.index).nprobe = 4
+        codes = index.index.sa_encode(ds.get_database())
+        index.add_sa_codes(codes, ids)
+        Dnew, Inew = index.search(ds.get_queries(), 10)
+
+        np.testing.assert_array_equal(Iref, Inew)
+        np.testing.assert_array_equal(Dref, Dnew)
+
+        # reconstruct should work too (rev_map is updated)
+        faiss.extract_index_ivf(index).make_direct_map()
+        for key in ids[:5]:
+            recons = index.reconstruct(int(key))
+            np.testing.assert_array_almost_equal(
+                recons, ds.get_database()[int(key) - 1000])
 
 
 class TestRefine(unittest.TestCase):


### PR DESCRIPTION
IndexIDMap.add_sa_codes was passing the user ids straight through to the sub-index instead of keeping them in id_map. For sub-indexes that don't store ids themselves (Flat/PQ) this happened to work, but an IVF sub-index keeps the ids in its inverted lists, so after add_sa_codes a search returned the raw external ids. Those don't index into id_map, so the IDMap layer mapped them all to -1 (see #5333).

The fix is to pass nullptr for the ids when forwarding to the sub-index, the same way add_with_ids already does, so the sub-index uses sequential numbering and the external ids stay in id_map.

While here I also added the add_sa_codes override on IndexIDMap2 that was missing. Without it rev_map was never updated for codes added this way, so reconstruct on an id added via add_sa_codes would fail.

Test

Added test_idmap_ivf in tests/test_standalone_codec.py. It builds an IDMap2,IVF20,Flat, adds the same data both ways (add_with_ids and add_sa_codes) and checks the search results match, plus a reconstruct check to cover the rev_map fix.

Fixes #5333