### PR TITLE
De-flake test_refine_panorama.test_incremental_add (seed + tolerance)

### DIFF
--- a/tests/test_refine_panorama.py
+++ b/tests/test_refine_panorama.py
@@ -36,9 +36,7 @@ class TestIndexRefinePanorama(unittest.TestCase):
         ds = SyntheticDataset(d, nt, nb, nq, seed=seed)
         return ds.get_train(), ds.get_database(), ds.get_queries()
 
-    def create_flat(
-        self, d, base_factory, xt=None, xb=None, metric=faiss.METRIC_L2
-    ):
+    def create_flat(self, d, base_factory, xt=None, xb=None, metric=faiss.METRIC_L2):
         """Create and initialize IndexRefineFlat."""
         base_index = faiss.index_factory(d, base_factory, metric)
         index = faiss.IndexRefineFlat(base_index)
@@ -61,8 +59,7 @@ class TestIndexRefinePanorama(unittest.TestCase):
         base_index = faiss.index_factory(d, base_factory, metric)
         refine_index = faiss.index_factory(
             d,
-            f"Flat{metric == faiss.METRIC_L2 and 'L2' or 'IP'}"
-            f"Panorama{nlevels}_1",
+            f"Flat{metric == faiss.METRIC_L2 and 'L2' or 'IP'}" f"Panorama{nlevels}_1",
             metric,
         )
         index = faiss.IndexRefinePanorama(base_index, refine_index)
@@ -115,14 +112,13 @@ class TestIndexRefinePanorama(unittest.TestCase):
             with self.subTest(metric=metric):
                 # Build two identical refine indexes
                 base_cfg = "Flat"
-                index_flat = self.create_flat(
-                    d, base_cfg, xt=xt, xb=xb, metric=metric)
+                index_flat = self.create_flat(d, base_cfg, xt=xt, xb=xb, metric=metric)
                 index_pan = self.create_panorama(
-                    d, base_cfg, n_levels, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, n_levels, xt=xt, xb=xb, metric=metric
+                )
 
                 for k_factor in [1, 8, 64, 256, 1024, 50000]:
-                    params = faiss.IndexRefineSearchParameters(
-                        k_factor=float(k_factor))
+                    params = faiss.IndexRefineSearchParameters(k_factor=float(k_factor))
 
                     D_flat, I_flat = index_flat.search(xq, k, params=params)
                     D_pano, I_pano = index_pan.search(xq, k, params=params)
@@ -139,8 +135,7 @@ class TestIndexRefinePanorama(unittest.TestCase):
         base_cfg = "Flat"
 
         for metric in self.METRICS:
-            index_base = self.create_flat(
-                d, base_cfg, xt=xt, xb=xb, metric=metric)
+            index_base = self.create_flat(d, base_cfg, xt=xt, xb=xb, metric=metric)
             D_base, I_base = index_base.search(xq, k)
 
             params = faiss.IndexRefineSearchParameters(k_factor=1000)
@@ -153,14 +148,14 @@ class TestIndexRefinePanorama(unittest.TestCase):
                 with self.subTest(metric=metric, nlevels=nlevels):
                     faiss.cvar.indexPanorama_stats.reset()
                     index = self.create_panorama(
-                        d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                        d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                    )
                     D, I = index.search(xq, k, params=params)
                     self.assert_search_results_equal(D_base, I_base, D, I)
 
                     stats = faiss.cvar.indexPanorama_stats
                     ratio_dims_scanned = stats.ratio_dims_scanned
-                    self.assertLess(ratio_dims_scanned,
-                                    prev_ratio_dims_scanned)
+                    self.assertLess(ratio_dims_scanned, prev_ratio_dims_scanned)
                     prev_ratio_dims_scanned = ratio_dims_scanned
 
             faiss.omp_set_num_threads(nt_threads)
@@ -177,9 +172,11 @@ class TestIndexRefinePanorama(unittest.TestCase):
 
                     base_cfg = "Flat"
                     index_regular = self.create_flat(
-                        d, base_cfg, xt=xt, xb=xb, metric=metric)
+                        d, base_cfg, xt=xt, xb=xb, metric=metric
+                    )
                     index_panorama = self.create_panorama(
-                        d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                        d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                    )
 
                     D_regular, I_regular = index_regular.search(xq, k)
                     D_panorama, I_panorama = index_panorama.search(xq, k)
@@ -198,15 +195,18 @@ class TestIndexRefinePanorama(unittest.TestCase):
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(
-                    d, base_cfg, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, xt=xt, xb=xb, metric=metric
+                )
                 index_panorama = self.create_panorama(
-                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                )
 
                 D_regular, I_regular = index_regular.search(xq, k)
                 D_panorama, I_panorama = index_panorama.search(xq, k)
 
                 self.assert_search_results_equal(
-                    D_regular, I_regular, D_panorama, I_panorama)
+                    D_regular, I_regular, D_panorama, I_panorama
+                )
 
     def test_multiple_levels_small_dimension(self):
         """Test edge case: more levels than dimension naturally supports"""
@@ -218,15 +218,18 @@ class TestIndexRefinePanorama(unittest.TestCase):
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(
-                    d, base_cfg, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, xt=xt, xb=xb, metric=metric
+                )
                 index_panorama = self.create_panorama(
-                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                )
 
                 D_regular, I_regular = index_regular.search(xq, k)
                 D_panorama, I_panorama = index_panorama.search(xq, k)
 
                 self.assert_search_results_equal(
-                    D_regular, I_regular, D_panorama, I_panorama)
+                    D_regular, I_regular, D_panorama, I_panorama
+                )
 
     def test_id_selector_range(self):
         """Test ID filtering with range selector"""
@@ -238,19 +241,20 @@ class TestIndexRefinePanorama(unittest.TestCase):
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(
-                    d, base_cfg, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, xt=xt, xb=xb, metric=metric
+                )
                 index_panorama = self.create_panorama(
-                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                )
 
                 base_params = faiss.SearchParameters()
                 base_params.sel = faiss.IDSelectorRange(10000, 50000)
                 params = faiss.IndexRefineSearchParameters(
-                    k_factor=1, base_index_params=base_params)
+                    k_factor=1, base_index_params=base_params
+                )
 
-                D_regular, I_regular = index_regular.search(
-                    xq, k, params=params)
-                D_panorama, I_panorama = index_panorama.search(
-                    xq, k, params=params)
+                D_regular, I_regular = index_regular.search(xq, k, params=params)
+                D_panorama, I_panorama = index_panorama.search(xq, k, params=params)
 
                 self.assertTrue(np.all(I_panorama >= 10000))
                 self.assertTrue(np.all(I_panorama < 50000))
@@ -268,21 +272,21 @@ class TestIndexRefinePanorama(unittest.TestCase):
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(
-                    d, base_cfg, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, xt=xt, xb=xb, metric=metric
+                )
                 index_panorama = self.create_panorama(
-                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                )
 
-                allowed_ids = np.array(
-                    [i * 100 for i in range(500)], dtype=np.int64)
+                allowed_ids = np.array([i * 100 for i in range(500)], dtype=np.int64)
                 base_params = faiss.SearchParameters()
                 base_params.sel = faiss.IDSelectorBatch(allowed_ids)
                 params = faiss.IndexRefineSearchParameters(
-                    k_factor=1, base_index_params=base_params)
+                    k_factor=1, base_index_params=base_params
+                )
 
-                D_regular, I_regular = index_regular.search(
-                    xq, k, params=params)
-                D_panorama, I_panorama = index_panorama.search(
-                    xq, k, params=params)
+                D_regular, I_regular = index_regular.search(xq, k, params=params)
+                D_panorama, I_panorama = index_panorama.search(xq, k, params=params)
 
                 allowed_set = set(allowed_ids)
                 for id_val in I_panorama.flatten():
@@ -301,19 +305,20 @@ class TestIndexRefinePanorama(unittest.TestCase):
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(
-                    d, base_cfg, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, xt=xt, xb=xb, metric=metric
+                )
                 index_panorama = self.create_panorama(
-                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                )
 
                 base_params = faiss.SearchParameters()
                 base_params.sel = faiss.IDSelectorRange(20, 60)
                 params = faiss.IndexRefineSearchParameters(
-                    k_factor=1, base_index_params=base_params)
+                    k_factor=1, base_index_params=base_params
+                )
 
-                D_regular, I_regular = index_regular.search(
-                    xq, k, params=params)
-                D_panorama, I_panorama = index_panorama.search(
-                    xq, k, params=params)
+                D_regular, I_regular = index_regular.search(xq, k, params=params)
+                D_panorama, I_panorama = index_panorama.search(xq, k, params=params)
 
                 self.assertTrue(np.all(I_panorama >= 20))
                 self.assertTrue(np.all(I_panorama < 60))
@@ -325,15 +330,15 @@ class TestIndexRefinePanorama(unittest.TestCase):
         """Test handling of empty search results (shapes only)"""
         d, nb, nt, nq, nlevels, k = 32, 100, 200, 10, 4, 10
         xt, xb, _ = self.generate_data(d, nt, nb, nq, seed=111)
-        xq = np.random.rand(nq, d).astype("float32") + \
-            10.0  # Queries far from database
+        xq = np.random.rand(nq, d).astype("float32") + 10.0  # Queries far from database
 
         base_cfg = "Flat"
 
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index = self.create_panorama(
-                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                )
                 D, I = index.search(xq, k)
 
                 self.assertEqual(D.shape, (nq, k))
@@ -341,6 +346,10 @@ class TestIndexRefinePanorama(unittest.TestCase):
 
     def test_incremental_add(self):
         """Test adding vectors incrementally in multiple batches"""
+        # Seed the (otherwise unseeded) incremental batch + query draws so
+        # near-tied neighbors don't reorder run-to-run (matches the sibling
+        # test_add_search_add_search).
+        np.random.seed(1234)
         d, nlevels, k = 128, 8, 15
 
         base_cfg = "Flat"
@@ -349,7 +358,8 @@ class TestIndexRefinePanorama(unittest.TestCase):
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(d, base_cfg, metric=metric)
                 index_panorama = self.create_panorama(
-                    d, base_cfg, nlevels, metric=metric)
+                    d, base_cfg, nlevels, metric=metric
+                )
 
                 # Keep total nb under 100k
                 batch_sizes = [5000, 10000, 15000, 20000]
@@ -364,8 +374,12 @@ class TestIndexRefinePanorama(unittest.TestCase):
                 D_regular, I_regular = index_regular.search(xq, k)
                 D_panorama, I_panorama = index_panorama.search(xq, k)
 
+                # Panorama distance reformulation (a*a+b*b-2ab vs (a-b)^2)
+                # differs at float32 ULP; atol absorbs it while the strong
+                # ID-overlap floor still trips on a real regression.
                 self.assert_search_results_equal(
-                    D_regular, I_regular, D_panorama, I_panorama)
+                    D_regular, I_regular, D_panorama, I_panorama, atol=1e-4
+                )
 
     def test_add_search_add_search(self):
         """Test interleaved add and search operations"""
@@ -378,7 +392,8 @@ class TestIndexRefinePanorama(unittest.TestCase):
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(d, base_cfg, metric=metric)
                 index_panorama = self.create_panorama(
-                    d, base_cfg, nlevels, metric=metric)
+                    d, base_cfg, nlevels, metric=metric
+                )
 
                 # First add and search
                 xb1 = np.random.rand(200, d).astype("float32")
@@ -389,8 +404,7 @@ class TestIndexRefinePanorama(unittest.TestCase):
 
                 D_reg_1, I_reg_1 = index_regular.search(xq1, k)
                 D_pan_1, I_pan_1 = index_panorama.search(xq1, k)
-                self.assert_search_results_equal(
-                    D_reg_1, I_reg_1, D_pan_1, I_pan_1)
+                self.assert_search_results_equal(D_reg_1, I_reg_1, D_pan_1, I_pan_1)
 
                 # Second add and search
                 xb2 = np.random.rand(300, d).astype("float32")
@@ -400,8 +414,7 @@ class TestIndexRefinePanorama(unittest.TestCase):
                 xq2 = np.random.rand(10, d).astype("float32")
                 D_reg_2, I_reg_2 = index_regular.search(xq2, k)
                 D_pan_2, I_pan_2 = index_panorama.search(xq2, k)
-                self.assert_search_results_equal(
-                    D_reg_2, I_reg_2, D_pan_2, I_pan_2)
+                self.assert_search_results_equal(D_reg_2, I_reg_2, D_pan_2, I_pan_2)
 
     def test_serialization(self):
         """Test write/read Panorama indexes preserves search results"""
@@ -413,11 +426,11 @@ class TestIndexRefinePanorama(unittest.TestCase):
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index = self.create_panorama(
-                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                )
 
                 D_before, I_before = index.search(xq, k)
-                index_after = faiss.deserialize_index(
-                    faiss.serialize_index(index))
+                index_after = faiss.deserialize_index(faiss.serialize_index(index))
                 D_after, I_after = index_after.search(xq, k)
 
                 np.testing.assert_array_equal(I_before, I_after)
@@ -447,37 +460,29 @@ class TestIndexRefinePanorama(unittest.TestCase):
 
                 # Force k_base = nb
                 k_factor = nb // k  # 500000 // 10 = 50000
-                params = faiss.IndexRefineSearchParameters(
-                    k_factor=float(k_factor))
+                params = faiss.IndexRefineSearchParameters(k_factor=float(k_factor))
 
                 ratios = []
                 nlevels_list = [1, 2, 4, 8, 16, 32]
                 for nlevels in nlevels_list:
                     with self.subTest(nlevels=nlevels):
-                        metric_str = (
-                            "L2" if metric == faiss.METRIC_L2 else "IP"
-                        )
+                        metric_str = "L2" if metric == faiss.METRIC_L2 else "IP"
                         factory_str = f"Flat{metric_str}Panorama{nlevels}_1"
-                        refine_index = faiss.index_factory(
-                            d, factory_str, metric
-                        )
+                        refine_index = faiss.index_factory(d, factory_str, metric)
                         refine_index.add(xb)
-                        index = faiss.IndexRefinePanorama(
-                            index_base, refine_index)
+                        index = faiss.IndexRefinePanorama(index_base, refine_index)
 
                         faiss.cvar.indexPanorama_stats.reset()
                         D, I = index.search(xq, k, params=params)
                         self.assert_search_results_equal(
-                            D_base, I_base, D, I, atol=1e-4)
+                            D_base, I_base, D, I, atol=1e-4
+                        )
 
-                        ratios.append(
-                            faiss.cvar.indexPanorama_stats.ratio_dims_scanned)
+                        ratios.append(faiss.cvar.indexPanorama_stats.ratio_dims_scanned)
 
                 expected_ratios = [1 / nlevels for nlevels in nlevels_list]
 
                 # Extra low tolerance for point-wise Panorama refinement
-                np.testing.assert_allclose(
-                    ratios, expected_ratios, atol=1e-5
-                )
+                np.testing.assert_allclose(ratios, expected_ratios, atol=1e-5)
 
                 faiss.omp_set_num_threads(nt)


### PR DESCRIPTION
Summary:
Failing test: https://www.internalfb.com/intern/test/844425256556599 (`test_refine_panorama.TestIndexRefinePanorama_ARM_NEON` - `test_incremental_add`, ~97.5% flaky on the `faiss` oncall: https://www.internalfb.com/omh/view/faiss/tests).

`test_incremental_add` is the only test in the file that draws its incremental batches and queries from a bare unseeded `np.random.rand`, so near-tied neighbors reorder run-to-run. Two compounding causes: (1) unseeded data; (2) `IndexRefineFlat` computes L2 as `(a-b)^2` while `IndexRefinePanorama` uses `a*a+b*b-2ab`, which diverge at the float32 ULP level and trip the default `atol=1e-7`.

Fix: seed the draw with `np.random.seed(1234)` (mirrors the sibling `test_add_search_add_search`) and pass `atol=1e-4` to `assert_search_results_equal`. The strong `otol=1e-3` ID-overlap floor is unchanged, so a real refinement regression still trips the test.

Differential Revision: D109643860


