### PR TITLE
Align faiss .flake8 with black and the 80-char standard

### DIFF
--- a/benchs/bench_all_ivf/bench_all_ivf.py
+++ b/benchs/bench_all_ivf/bench_all_ivf.py
@@ -20,7 +20,6 @@ except ModuleNotFoundError:
 sanitize = datasets.sanitize
 
 
-
 def unwind_index_ivf(index):
     if isinstance(index, faiss.IndexPreTransform):
         assert index.chain.size() == 1
@@ -63,9 +62,8 @@ def apply_AQ_options(index, args):
         index.rq.use_beam_LUT = args.RQ_use_beam_LUT
 
 
-
 def eval_setting(index, xq, gt, k, inter, min_time):
-    """ evaluate searching in terms of precision vs. speed """
+    """evaluate searching in terms of precision vs. speed"""
     nq = xq.shape[0]
     ivf_stats = faiss.cvar.indexIVF_stats
     ivf_stats.reset()
@@ -77,28 +75,28 @@ def eval_setting(index, xq, gt, k, inter, min_time):
         t1 = time.time()
         if t1 - t0 > min_time:
             break
-    ms_per_query = ((t1 - t0) * 1000.0 / nq / nrun)
-    res = {
-        "ms_per_query": ms_per_query,
-        "nrun": nrun
-    }
+    ms_per_query = (t1 - t0) * 1000.0 / nq / nrun
+    res = {"ms_per_query": ms_per_query, "nrun": nrun}
     res["n"] = ms_per_query
     if inter:
         rank = k
-        inter_measure = faiss.eval_intersection(gt[:, :rank], I[:, :rank]) / (nq * rank)
-        print("%.4f" % inter_measure, end=' ')
+        inter_measure = faiss.eval_intersection(gt[:, :rank], I[:, :rank]) / (
+            nq * rank
+        )
+        print("%.4f" % inter_measure, end=" ")
         res["inter_measure"] = inter_measure
     else:
         res["recalls"] = {}
         for rank in 1, 10, 100:
             recall = (I[:, :rank] == gt[:, :1]).sum() / float(nq)
-            print("%.4f" % recall, end=' ')
+            print("%.4f" % recall, end=" ")
             res["recalls"][rank] = recall
-    print("   %9.5f  " % ms_per_query, end=' ')
-    print("%12d   " % (ivf_stats.ndis / nrun), end=' ')
+    print("   %9.5f  " % ms_per_query, end=" ")
+    print("%12d   " % (ivf_stats.ndis / nrun), end=" ")
     print(nrun)
     res["ndis"] = ivf_stats.ndis / nrun
     return res
+
 
 ######################################################
 # Training
@@ -109,8 +107,9 @@ def run_train(args, ds, res):
     print("build index, key=", args.indexkey)
 
     index = faiss.index_factory(
-        ds.d, args.indexkey, faiss.METRIC_L2 if ds.metric == "L2" else
-        faiss.METRIC_INNER_PRODUCT
+        ds.d,
+        args.indexkey,
+        faiss.METRIC_L2 if ds.metric == "L2" else faiss.METRIC_INNER_PRODUCT,
     )
 
     index_ivf, vec_transform = unwind_index_ivf(index)
@@ -118,7 +117,7 @@ def run_train(args, ds, res):
     if args.by_residual != -1:
         by_residual = args.by_residual == 1
         print("setting by_residual = ", by_residual)
-        index_ivf.by_residual   # check if field exists
+        index_ivf.by_residual  # check if field exists
         index_ivf.by_residual = by_residual
 
     if index_ivf:
@@ -127,16 +126,21 @@ def run_train(args, ds, res):
         # because otherwise the assignment is inaccurate
         quantizer = faiss.downcast_index(index_ivf.quantizer)
         if isinstance(quantizer, faiss.IndexRefine):
-            print("   update quantizer k_factor=", quantizer.k_factor, end=" -> ")
+            print(
+                "   update quantizer k_factor=", quantizer.k_factor, end=" -> "
+            )
             quantizer.k_factor = 32 if index_ivf.nlist < 1e6 else 64
             print(quantizer.k_factor)
             base_index = faiss.downcast_index(quantizer.base_index)
             if isinstance(base_index, faiss.IndexIVF):
-                print("   update quantizer nprobe=", base_index.nprobe, end=" -> ")
+                print(
+                    "   update quantizer nprobe=", base_index.nprobe, end=" -> "
+                )
                 base_index.nprobe = (
-                    16 if base_index.nlist < 1e5 else
-                    32 if base_index.nlist < 4e6 else
-                    64)
+                    16
+                    if base_index.nlist < 1e5
+                    else 32 if base_index.nlist < 4e6 else 64
+                )
                 print(base_index.nprobe)
         elif isinstance(quantizer, faiss.IndexHNSW):
             hnsw = quantizer.hnsw
@@ -159,7 +163,7 @@ def run_train(args, ds, res):
 
     maxtrain = args.maxtrain
     if maxtrain == 0:
-        if 'IMI' in args.indexkey:
+        if "IMI" in args.indexkey:
             maxtrain = int(256 * 2 ** (np.log2(index_ivf.nlist) / 2))
         elif index_ivf:
             maxtrain = 50 * index_ivf.nlist
@@ -178,28 +182,31 @@ def run_train(args, ds, res):
     print("train, size", xt2.shape)
     assert np.all(np.isfinite(xt2))
 
-    if (isinstance(vec_transform, faiss.OPQMatrix) and
-        isinstance(index_ivf, faiss.IndexIVFPQFastScan)):
+    if isinstance(vec_transform, faiss.OPQMatrix) and isinstance(
+        index_ivf, faiss.IndexIVFPQFastScan
+    ):
         print("  Forcing OPQ training PQ to PQ4")
         ref_pq = index_ivf.pq
-        training_pq = faiss.ProductQuantizer(
-            ref_pq.d, ref_pq.M, ref_pq.nbits
-        )
+        training_pq = faiss.ProductQuantizer(ref_pq.d, ref_pq.M, ref_pq.nbits)
         vec_transform.pq
         vec_transform.pq = training_pq
 
-
-    if args.get_centroids_from == '':
+    if args.get_centroids_from == "":
 
         if args.clustering_niter >= 0:
-            print(("setting nb of clustering iterations to %d" %
-                   args.clustering_niter))
+            print(
+                (
+                    "setting nb of clustering iterations to %d"
+                    % args.clustering_niter
+                )
+            )
             index_ivf.cp.niter = args.clustering_niter
 
         if args.train_on_gpu:
             print("add a training index on GPU")
             train_index = faiss.index_cpu_to_all_gpus(
-                    faiss.IndexFlatL2(index_ivf.d))
+                faiss.IndexFlatL2(index_ivf.d)
+            )
             index_ivf.clustering_index = train_index
 
     else:
@@ -229,6 +236,7 @@ def run_train(args, ds, res):
     print("  train in %.3f s" % res.train_time)
     return index
 
+
 ######################################################
 # Populating index
 ######################################################
@@ -242,14 +250,15 @@ def run_add(args, ds, index, res):
         assert args.split == [1, 0], "split not supported with full batch add"
         index.add(sanitize(ds.get_database()))
     else:
-        totn = ds.nb // args.split[0] # approximate
+        totn = ds.nb // args.split[0]  # approximate
         i0 = 0
         print(f"Adding in block sizes {args.add_bs} with split {args.split}")
         for xblock in ds.database_iterator(bs=args.add_bs, split=args.split):
             i1 = i0 + len(xblock)
-            print("  adding %d:%d / %d [%.3f s, RSS %d kiB] " % (
-                i0, i1, totn, time.time() - t0,
-                faiss.get_mem_usage_kb()))
+            print(
+                "  adding %d:%d / %d [%.3f s, RSS %d kiB] "
+                % (i0, i1, totn, time.time() - t0, faiss.get_mem_usage_kb())
+            )
             index.add(xblock)
             i0 = i1
 
@@ -260,6 +269,7 @@ def run_add(args, ds, index, res):
 ######################################################
 # Search
 ######################################################
+
 
 def run_search(args, ds, index, res):
 
@@ -283,7 +293,7 @@ def run_search(args, ds, index, res):
     print("current RSS:", faiss.get_mem_usage_kb() * 1024)
 
     precomputed_table_size = 0
-    if hasattr(index_ivf, 'precomputed_table'):
+    if hasattr(index_ivf, "precomputed_table"):
         precomputed_table_size = index_ivf.precomputed_table.size() * 4
 
     print("precomputed tables size:", precomputed_table_size)
@@ -294,7 +304,7 @@ def run_search(args, ds, index, res):
     nq, d = xq.shape
     gt = ds.get_groundtruth(k=args.k)
 
-    if not args.accept_short_gt: # Deep1B has only a single NN per query
+    if not args.accept_short_gt:  # Deep1B has only a single NN per query
         assert gt.shape[1] == args.k
 
     if args.searchthreads != -1:
@@ -309,26 +319,25 @@ def run_search(args, ds, index, res):
     parametersets = args.searchparams
 
     if args.inter:
-        header = (
-            '%-40s     inter@%3d time(ms/q)   nb distances #runs' %
-            ("parameters", args.k)
+        header = "%-40s     inter@%3d time(ms/q)   nb distances #runs" % (
+            "parameters",
+            args.k,
         )
     else:
 
         header = (
-            '%-40s     R@1   R@10  R@100  time(ms/q)   nb distances #runs' %
-            "parameters"
+            "%-40s     R@1   R@10  R@100  time(ms/q)   nb distances #runs"
+            % "parameters"
         )
 
-
     res.search_results = {}
-    if parametersets == ['autotune']:
+    if parametersets == ["autotune"]:
 
         ps.n_experiments = args.n_autotune
         ps.min_test_duration = args.min_test_duration
 
         for kv in args.autotune_max:
-            k, vmax = kv.split(':')
+            k, vmax = kv.split(":")
             vmax = float(vmax)
             print("limiting %s to %g" % (k, vmax))
             pr = ps.add_range(k)
@@ -337,8 +346,8 @@ def run_search(args, ds, index, res):
             faiss.copy_array_to_vector(values, pr.values)
 
         for kv in args.autotune_range:
-            k, vals = kv.split(':')
-            vals = np.fromstring(vals, sep=',')
+            k, vals = kv.split(":")
+            vals = np.fromstring(vals, sep=",")
             print("setting %s to %s" % (k, vals))
             pr = ps.add_range(k)
             faiss.copy_array_to_vector(vals, pr.values)
@@ -353,10 +362,13 @@ def run_search(args, ds, index, res):
 
         # by default, the criterion will request only 1 NN
         crit.nnn = args.k
-        crit.set_groundtruth(None, gt.astype('int64'))
+        crit.set_groundtruth(None, gt.astype("int64"))
 
         # then we let Faiss find the optimal parameters by itself
-        print("exploring operating points, %d threads" % faiss.omp_get_max_threads());
+        print(
+            "exploring operating points, %d threads"
+            % faiss.omp_get_max_threads()
+        )
         ps.display()
 
         t0 = time.time()
@@ -375,22 +387,25 @@ def run_search(args, ds, index, res):
 
             ps.set_index_parameters(index, opt.key)
 
-            print(opt.key.ljust(maxw), end=' ')
+            print(opt.key.ljust(maxw), end=" ")
             sys.stdout.flush()
 
-            res_i = eval_setting(index, xq, gt, args.k, args.inter, args.min_test_duration)
+            res_i = eval_setting(
+                index, xq, gt, args.k, args.inter, args.min_test_duration
+            )
             res.search_results[opt.key] = res_i
 
     else:
         print(header)
         for param in parametersets:
-            print("%-40s " % param, end=' ')
+            print("%-40s " % param, end=" ")
             sys.stdout.flush()
             ps.set_index_parameters(index, param)
 
-            res_i = eval_setting(index, xq, gt, args.k, args.inter, args.min_test_duration)
+            res_i = eval_setting(
+                index, xq, gt, args.k, args.inter, args.min_test_duration
+            )
             res.search_results[param] = res_i
-
 
 
 ######################################################
@@ -405,76 +420,173 @@ def main():
     def aa(*args, **kwargs):
         group.add_argument(*args, **kwargs)
 
-    group = parser.add_argument_group('general options')
-    aa('--nthreads', default=-1, type=int,
-        help='nb of threads to use at train and add time')
-    aa('--json', default=False, action="store_true",
-        help="output stats in JSON format at the end")
-    aa('--todo', default=["check_files"],
-       choices=["train", "add", "search", "check_files"],
-       nargs="+", help='what to do (check_files means decide depending on which index files exist)')
+    group = parser.add_argument_group("general options")
+    aa(
+        "--nthreads",
+        default=-1,
+        type=int,
+        help="nb of threads to use at train and add time",
+    )
+    aa(
+        "--json",
+        default=False,
+        action="store_true",
+        help="output stats in JSON format at the end",
+    )
+    aa(
+        "--todo",
+        default=["check_files"],
+        choices=["train", "add", "search", "check_files"],
+        nargs="+",
+        help="what to do (check_files means decide depending on which index files exist)",
+    )
 
-    group = parser.add_argument_group('dataset options')
-    aa('--db', default='deep1M', help='dataset')
-    aa('--compute_gt', default=False, action='store_true',
-        help='compute and store the groundtruth')
-    aa('--force_IP', default=False, action="store_true",
-        help='force IP search instead of L2')
-    aa('--accept_short_gt', default=False, action='store_true',
-        help='work around a problem with Deep1B GT')
+    group = parser.add_argument_group("dataset options")
+    aa("--db", default="deep1M", help="dataset")
+    aa(
+        "--compute_gt",
+        default=False,
+        action="store_true",
+        help="compute and store the groundtruth",
+    )
+    aa(
+        "--force_IP",
+        default=False,
+        action="store_true",
+        help="force IP search instead of L2",
+    )
+    aa(
+        "--accept_short_gt",
+        default=False,
+        action="store_true",
+        help="work around a problem with Deep1B GT",
+    )
 
-    group = parser.add_argument_group('index construction')
-    aa('--indexkey', default='HNSW32', help='index_factory type')
-    aa('--trained_indexfile', default='',
-       help='file to read or write a trained index from')
-    aa('--maxtrain', default=256 * 256, type=int,
-        help='maximum number of training points (0 to set automatically)')
-    aa('--indexfile', default='', help='file to read or write index from')
-    aa('--split', default=[1, 0], type=int, nargs=2, help="database split")
-    aa('--add_bs', default=-1, type=int,
-        help='add elements index by batches of this size')
+    group = parser.add_argument_group("index construction")
+    aa("--indexkey", default="HNSW32", help="index_factory type")
+    aa(
+        "--trained_indexfile",
+        default="",
+        help="file to read or write a trained index from",
+    )
+    aa(
+        "--maxtrain",
+        default=256 * 256,
+        type=int,
+        help="maximum number of training points (0 to set automatically)",
+    )
+    aa("--indexfile", default="", help="file to read or write index from")
+    aa("--split", default=[1, 0], type=int, nargs=2, help="database split")
+    aa(
+        "--add_bs",
+        default=-1,
+        type=int,
+        help="add elements index by batches of this size",
+    )
 
-    group = parser.add_argument_group('IVF options')
-    aa('--by_residual', default=-1, type=int,
-        help="set if index should use residuals (default=unchanged)")
-    aa('--no_precomputed_tables', action='store_true', default=False,
-        help='disable precomputed tables (uses less memory)')
-    aa('--get_centroids_from', default='',
-        help='get the centroids from this index (to speed up training)')
-    aa('--clustering_niter', default=-1, type=int,
-        help='number of clustering iterations (-1 = leave default)')
-    aa('--train_on_gpu', default=False, action='store_true',
-        help='do training on GPU')
+    group = parser.add_argument_group("IVF options")
+    aa(
+        "--by_residual",
+        default=-1,
+        type=int,
+        help="set if index should use residuals (default=unchanged)",
+    )
+    aa(
+        "--no_precomputed_tables",
+        action="store_true",
+        default=False,
+        help="disable precomputed tables (uses less memory)",
+    )
+    aa(
+        "--get_centroids_from",
+        default="",
+        help="get the centroids from this index (to speed up training)",
+    )
+    aa(
+        "--clustering_niter",
+        default=-1,
+        type=int,
+        help="number of clustering iterations (-1 = leave default)",
+    )
+    aa(
+        "--train_on_gpu",
+        default=False,
+        action="store_true",
+        help="do training on GPU",
+    )
 
-    group = parser.add_argument_group('index-specific options')
-    aa('--M0', default=-1, type=int, help='size of base level for HNSW')
-    aa('--RQ_train_default', default=False, action="store_true",
-        help='disable progressive dim training for RQ')
-    aa('--RQ_beam_size', default=-1, type=int,
-        help='set beam size at add time')
-    aa('--LSQ_encode_ils_iters', default=-1, type=int,
-        help='ILS iterations for LSQ')
-    aa('--RQ_use_beam_LUT', default=-1, type=int,
-        help='use beam LUT at add time')
+    group = parser.add_argument_group("index-specific options")
+    aa("--M0", default=-1, type=int, help="size of base level for HNSW")
+    aa(
+        "--RQ_train_default",
+        default=False,
+        action="store_true",
+        help="disable progressive dim training for RQ",
+    )
+    aa("--RQ_beam_size", default=-1, type=int, help="set beam size at add time")
+    aa(
+        "--LSQ_encode_ils_iters",
+        default=-1,
+        type=int,
+        help="ILS iterations for LSQ",
+    )
+    aa(
+        "--RQ_use_beam_LUT",
+        default=-1,
+        type=int,
+        help="use beam LUT at add time",
+    )
 
-    group = parser.add_argument_group('searching')
-    aa('--k', default=100, type=int, help='nb of nearest neighbors')
-    aa('--inter', default=False, action='store_true',
-        help='use intersection measure instead of 1-recall as metric')
-    aa('--searchthreads', default=-1, type=int,
-        help='nb of threads to use at search time')
-    aa('--searchparams', nargs='+', default=['autotune'],
-        help="search parameters to use (can be autotune or a list of params)")
-    aa('--n_autotune', default=500, type=int,
-        help="max nb of autotune experiments")
-    aa('--autotune_max', default=[], nargs='*',
-        help='set max value for autotune variables format "var:val" (exclusive)')
-    aa('--autotune_range', default=[], nargs='*',
-        help='set complete autotune range, format "var:val1,val2,..."')
-    aa('--min_test_duration', default=3.0, type=float,
-        help='run test at least for so long to avoid jitter')
-    aa('--indexes_to_merge', default=[], nargs="*",
-        help="load these indexes to search and merge them before searching")
+    group = parser.add_argument_group("searching")
+    aa("--k", default=100, type=int, help="nb of nearest neighbors")
+    aa(
+        "--inter",
+        default=False,
+        action="store_true",
+        help="use intersection measure instead of 1-recall as metric",
+    )
+    aa(
+        "--searchthreads",
+        default=-1,
+        type=int,
+        help="nb of threads to use at search time",
+    )
+    aa(
+        "--searchparams",
+        nargs="+",
+        default=["autotune"],
+        help="search parameters to use (can be autotune or a list of params)",
+    )
+    aa(
+        "--n_autotune",
+        default=500,
+        type=int,
+        help="max nb of autotune experiments",
+    )
+    aa(
+        "--autotune_max",
+        default=[],
+        nargs="*",
+        help='set max value for autotune variables format "var:val" (exclusive)',
+    )
+    aa(
+        "--autotune_range",
+        default=[],
+        nargs="*",
+        help='set complete autotune range, format "var:val1,val2,..."',
+    )
+    aa(
+        "--min_test_duration",
+        default=3.0,
+        type=float,
+        help="run test at least for so long to avoid jitter",
+    )
+    aa(
+        "--indexes_to_merge",
+        default=[],
+        nargs="*",
+        help="load these indexes to search and merge them before searching",
+    )
 
     args = parser.parse_args()
 
@@ -489,22 +601,23 @@ def main():
 
     print("args:", args)
 
-    os.system('echo -n "nb processors "; '
-            'cat /proc/cpuinfo | grep ^processor | wc -l; '
-            'cat /proc/cpuinfo | grep ^"model name" | tail -1')
+    os.system(
+        'echo -n "nb processors "; '
+        "cat /proc/cpuinfo | grep ^processor | wc -l; "
+        'cat /proc/cpuinfo | grep ^"model name" | tail -1'
+    )
 
     # object to collect results
     res = argparse.Namespace()
     res.args = args.__dict__
 
     res.cpu_model = [
-        l for l in open("/proc/cpuinfo", "r")
-        if "model name" in l][0]
+        l for l in open("/proc/cpuinfo", "r") if "model name" in l
+    ][0]
 
     print("Load dataset")
 
-    ds = datasets.load_dataset(
-        dataset=args.db, compute_gt=args.compute_gt)
+    ds = datasets.load_dataset(dataset=args.db, compute_gt=args.compute_gt)
 
     if args.force_IP:
         ds.metric = "IP"

--- a/benchs/bench_all_ivf/bench_kmeans.py
+++ b/benchs/bench_all_ivf/bench_kmeans.py
@@ -21,28 +21,30 @@ def aa(*args, **kwargs):
     group.add_argument(*args, **kwargs)
 
 
-group = parser.add_argument_group('dataset options')
+group = parser.add_argument_group("dataset options")
 
-aa('--db', default='deep1M', help='dataset')
-aa('--nt', default=65536, type=int)
-aa('--nb', default=100000, type=int)
-aa('--nt_sample', default=0, type=int)
+aa("--db", default="deep1M", help="dataset")
+aa("--nt", default=65536, type=int)
+aa("--nb", default=100000, type=int)
+aa("--nt_sample", default=0, type=int)
 
-group = parser.add_argument_group('kmeans options')
-aa('--k', default=256, type=int)
-aa('--seed', default=12345, type=int)
-aa('--pcadim', default=-1, type=int, help='PCA to this dimension')
-aa('--niter', default=25, type=int)
-aa('--eval_freq', default=100, type=int)
+group = parser.add_argument_group("kmeans options")
+aa("--k", default=256, type=int)
+aa("--seed", default=12345, type=int)
+aa("--pcadim", default=-1, type=int, help="PCA to this dimension")
+aa("--niter", default=25, type=int)
+aa("--eval_freq", default=100, type=int)
 
 
 args = parser.parse_args()
 
 print("args:", args)
 
-os.system('echo -n "nb processors "; '
-          'cat /proc/cpuinfo | grep ^processor | wc -l; '
-          'cat /proc/cpuinfo | grep ^"model name" | tail -1')
+os.system(
+    'echo -n "nb processors "; '
+    "cat /proc/cpuinfo | grep ^processor | wc -l; "
+    'cat /proc/cpuinfo | grep ^"model name" | tail -1'
+)
 
 ngpu = faiss.get_num_gpus()
 print("nb GPUs:", ngpu)
@@ -55,15 +57,15 @@ xt, xb, xq, gt = datasets.load_data(dataset=args.db)
 
 
 if args.nt_sample == 0:
-    xt_pca = xt[args.nt:args.nt + 10000]
-    xt = xt[:args.nt]
+    xt_pca = xt[args.nt : args.nt + 10000]
+    xt = xt[: args.nt]
 else:
-    xt_pca = xt[args.nt_sample:args.nt_sample + 10000]
+    xt_pca = xt[args.nt_sample : args.nt_sample + 10000]
     rs = np.random.RandomState(args.seed)
     idx = rs.choice(args.nt_sample, size=args.nt, replace=False)
     xt = xt[idx]
 
-xb = xb[:args.nb]
+xb = xb[: args.nb]
 
 d = xb.shape[1]
 

--- a/benchs/bench_all_ivf/cmp_with_scann.py
+++ b/benchs/bench_all_ivf/cmp_with_scann.py
@@ -47,31 +47,38 @@ def main():
     def aa(*args, **kwargs):
         group.add_argument(*args, **kwargs)
 
-    group = parser.add_argument_group('dataset options')
+    group = parser.add_argument_group("dataset options")
 
-    aa('--db', default='deep1M', help='dataset')
-    aa('--measure', default="1-recall",
-        help="perf measure to use: 1-recall or inter")
-    aa('--download', default=False, action="store_true")
-    aa('--lib', default='faiss', help='library to use (faiss or scann)')
-    aa('--thenscann', default=False, action="store_true")
-    aa('--base_dir',
-       default='/checkpoint/matthijs/faiss_improvements/cmp_ivf_scan_2')
+    aa("--db", default="deep1M", help="dataset")
+    aa(
+        "--measure",
+        default="1-recall",
+        help="perf measure to use: 1-recall or inter",
+    )
+    aa("--download", default=False, action="store_true")
+    aa("--lib", default="faiss", help="library to use (faiss or scann)")
+    aa("--thenscann", default=False, action="store_true")
+    aa(
+        "--base_dir",
+        default="/checkpoint/matthijs/faiss_improvements/cmp_ivf_scan_2",
+    )
 
-    group = parser.add_argument_group('searching')
-    aa('--k', default=10, type=int, help='nb of nearest neighbors')
-    aa('--pre_reorder_k', default="0,10,100,1000", help='values for reorder_k')
-    aa('--nprobe', default="1,2,5,10,20,50,100,200", help='values for nprobe')
-    aa('--nrun', default=5, type=int, help='nb of runs to perform')
+    group = parser.add_argument_group("searching")
+    aa("--k", default=10, type=int, help="nb of nearest neighbors")
+    aa("--pre_reorder_k", default="0,10,100,1000", help="values for reorder_k")
+    aa("--nprobe", default="1,2,5,10,20,50,100,200", help="values for nprobe")
+    aa("--nrun", default=5, type=int, help="nb of runs to perform")
     args = parser.parse_args()
 
     print("args:", args)
-    pre_reorder_k_tab = [int(x) for x in args.pre_reorder_k.split(',')]
-    nprobe_tab = [int(x) for x in args.nprobe.split(',')]
+    pre_reorder_k_tab = [int(x) for x in args.pre_reorder_k.split(",")]
+    nprobe_tab = [int(x) for x in args.nprobe.split(",")]
 
-    os.system('echo -n "nb processors "; '
-            'cat /proc/cpuinfo | grep ^processor | wc -l; '
-            'cat /proc/cpuinfo | grep ^"model name" | tail -1')
+    os.system(
+        'echo -n "nb processors "; '
+        "cat /proc/cpuinfo | grep ^processor | wc -l; "
+        'cat /proc/cpuinfo | grep ^"model name" | tail -1'
+    )
 
     cache_dir = args.base_dir + "/" + args.db + "/"
     k = args.k
@@ -80,6 +87,7 @@ def main():
     if not os.path.exists(cache_dir + "xb.npy"):
         # prepare cache
         from datasets import load_dataset
+
         ds = load_dataset(args.db, download=args.download)
         print(ds)
         # store for SCANN
@@ -95,7 +103,7 @@ def main():
             np.save(fname, v)
 
         open(cache_dir + "metric", "w").write(ds.metric)
-        
+
     dataset = {}
     for kn in "xb xq gt".split():
         fname = cache_dir + "/" + kn + ".npy"
@@ -103,55 +111,69 @@ def main():
         dataset[kn] = np.load(fname)
     xb = dataset["xb"]
     xq = dataset["xq"]
-    gt = dataset["gt"] 
+    gt = dataset["gt"]
     distance_measure = open(cache_dir + "metric").read()
-    
+
     if args.lib == "faiss":
         import faiss
 
         name1_to_metric = {
             "IP": faiss.METRIC_INNER_PRODUCT,
-            "L2": faiss.METRIC_L2
+            "L2": faiss.METRIC_L2,
         }
 
         index_fname = cache_dir + "index.faiss"
         if not os.path.exists(index_fname):
             index = faiss_make_index(
-                xb, name1_to_metric[distance_measure], index_fname)
+                xb, name1_to_metric[distance_measure], index_fname
+            )
         else:
             index = faiss.read_index(index_fname)
 
         faiss_eval_search(
-                index, xq, xb, nprobe_tab, pre_reorder_k_tab, k, gt,
-                nrun, args.measure
+            index,
+            xq,
+            xb,
+            nprobe_tab,
+            pre_reorder_k_tab,
+            k,
+            gt,
+            nrun,
+            args.measure,
         )
 
     if args.lib == "scann":
         from scann.scann_ops.py import scann_ops_pybind
 
-        name1_to_name2 = {
-            "IP": "dot_product",
-            "L2": "squared_l2"
-        }
+        name1_to_name2 = {"IP": "dot_product", "L2": "squared_l2"}
 
         scann_dir = cache_dir + "/scann1.1.1_serialized"
         if os.path.exists(scann_dir + "/scann_config.pb"):
             searcher = scann_ops_pybind.load_searcher(scann_dir)
         else:
             searcher = scann_make_index(
-                xb, name1_to_name2[distance_measure], scann_dir, 0)
+                xb, name1_to_name2[distance_measure], scann_dir, 0
+            )
 
         scann_dir = cache_dir + "/scann1.1.1_serialized_reorder"
         if os.path.exists(scann_dir + "/scann_config.pb"):
             searcher_reo = scann_ops_pybind.load_searcher(scann_dir)
         else:
             searcher_reo = scann_make_index(
-                xb, name1_to_name2[distance_measure], scann_dir, 100)
+                xb, name1_to_name2[distance_measure], scann_dir, 100
+            )
 
         scann_eval_search(
-            searcher, searcher_reo,
-            xq, xb, nprobe_tab, pre_reorder_k_tab, k, gt,
-            nrun, args.measure
+            searcher,
+            searcher_reo,
+            xq,
+            xb,
+            nprobe_tab,
+            pre_reorder_k_tab,
+            k,
+            gt,
+            nrun,
+            args.measure,
         )
 
     if args.lib != "scann" and args.thenscann:
@@ -159,9 +181,10 @@ def main():
         # options
         cmdline = " ".join(sys.argv) + " --lib scann"
         cmdline = (
-            ". ~/anaconda3/etc/profile.d/conda.sh ; " +
-            "conda activate scann_1.1.1; "
-            "python -u " + cmdline)
+            ". ~/anaconda3/etc/profile.d/conda.sh ; "
+            + "conda activate scann_1.1.1; "
+            "python -u " + cmdline
+        )
 
         print("running", cmdline)
 
@@ -183,10 +206,10 @@ def scann_make_index(xb, distance_measure, scann_dir, reorder_k):
     else:
         thr = 0
     k = 10
-    sb = scann.scann_ops_pybind.builder(
-        xb, k, distance_measure)
+    sb = scann.scann_ops_pybind.builder(xb, k, distance_measure)
     sb = sb.tree(
-        num_leaves=2000, num_leaves_to_search=100, training_sample_size=250000)
+        num_leaves=2000, num_leaves_to_search=100, training_sample_size=250000
+    )
     sb = sb.score_ah(2, anisotropic_quantization_threshold=thr)
 
     if reorder_k > 0:
@@ -205,9 +228,17 @@ def scann_make_index(xb, distance_measure, scann_dir, reorder_k):
 
 
 def scann_eval_search(
-        searcher, searcher_reo,
-        xq, xb, nprobe_tab, pre_reorder_k_tab, k, gt,
-        nrun, measure):
+    searcher,
+    searcher_reo,
+    xq,
+    xb,
+    nprobe_tab,
+    pre_reorder_k_tab,
+    k,
+    gt,
+    nrun,
+    measure,
+):
 
     # warmup
     for _run in range(5):
@@ -228,8 +259,10 @@ def scann_eval_search(
                 else:
                     t0 = time.time()
                     I, D = searcher_reo.search_batched(
-                        xq, leaves_to_search=nprobe, final_num_neighbors=k,
-                        pre_reorder_num_neighbors=pre_reorder_k
+                        xq,
+                        leaves_to_search=nprobe,
+                        final_num_neighbors=k,
+                        pre_reorder_num_neighbors=pre_reorder_k,
                     )
                     t1 = time.time()
 
@@ -267,13 +300,16 @@ def faiss_make_index(xb, metric_type, fname):
 
 
 def faiss_eval_search(
-            index, xq, xb, nprobe_tab, pre_reorder_k_tab,
-            k, gt, nrun, measure
-    ):
+    index, xq, xb, nprobe_tab, pre_reorder_k_tab, k, gt, nrun, measure
+):
     import faiss
 
-    print("use precomputed table=", index.use_precomputed_table,
-          "by residual=", index.by_residual)
+    print(
+        "use precomputed table=",
+        index.use_precomputed_table,
+        "by residual=",
+        index.by_residual,
+    )
 
     print("adding a refine index")
     index_refine = faiss.IndexRefineFlat(index, faiss.swig_ptr(xb))

--- a/benchs/bench_all_ivf/datasets_oss.py
+++ b/benchs/bench_all_ivf/datasets_oss.py
@@ -15,11 +15,11 @@ from faiss.contrib import datasets as faiss_datasets
 
 print("path:", faiss_datasets.__file__)
 
-faiss_datasets.dataset_basedir = '/checkpoint/matthijs/simsearch/'
+faiss_datasets.dataset_basedir = "/checkpoint/matthijs/simsearch/"
 
 
 def sanitize(x):
-    return np.ascontiguousarray(x, dtype='float32')
+    return np.ascontiguousarray(x, dtype="float32")
 
 
 #################################################################
@@ -53,44 +53,46 @@ class DatasetCentroids(faiss_datasets.Dataset):
 
     def get_groundtruth(self, k=100):
         return faiss.knn(
-            self.xq, self.xb, k,
-            faiss.METRIC_L2 if self.metric == 'L2' else faiss.METRIC_INNER_PRODUCT
+            self.xq,
+            self.xb,
+            k,
+            (
+                faiss.METRIC_L2
+                if self.metric == "L2"
+                else faiss.METRIC_INNER_PRODUCT
+            ),
         )[1]
 
 
-
-
-
-
-def load_dataset(dataset='deep1M', compute_gt=False, download=False):
+def load_dataset(dataset="deep1M", compute_gt=False, download=False):
 
     print("load data", dataset)
 
-    if dataset == 'sift1M':
+    if dataset == "sift1M":
         return faiss_datasets.DatasetSIFT1M()
 
-    elif dataset.startswith('bigann'):
+    elif dataset.startswith("bigann"):
 
         dbsize = 1000 if dataset == "bigann1B" else int(dataset[6:-1])
 
         return faiss_datasets.DatasetBigANN(nb_M=dbsize)
 
     elif dataset.startswith("deep_centroids_"):
-        ncent = int(dataset[len("deep_centroids_"):])
+        ncent = int(dataset[len("deep_centroids_") :])
         centdir = "/checkpoint/matthijs/bench_all_ivf/precomputed_clusters"
         return DatasetCentroids(
             faiss_datasets.DatasetDeep1B(nb=1000000),
-            f"{centdir}/clustering.dbdeep1M.IVF{ncent}.faissindex"
+            f"{centdir}/clustering.dbdeep1M.IVF{ncent}.faissindex",
         )
 
     elif dataset.startswith("deep"):
 
         szsuf = dataset[4:]
-        if szsuf[-1] == 'M':
-            dbsize = 10 ** 6 * int(szsuf[:-1])
-        elif szsuf == '1B':
-            dbsize = 10 ** 9
-        elif szsuf[-1] == 'k':
+        if szsuf[-1] == "M":
+            dbsize = 10**6 * int(szsuf[:-1])
+        elif szsuf == "1B":
+            dbsize = 10**9
+        elif szsuf[-1] == "k":
             dbsize = 1000 * int(szsuf[:-1])
         else:
             assert False, "did not recognize suffix " + szsuf
@@ -117,7 +119,7 @@ def evaluate_DI(D, I, gt):
     rank = 1
     while rank <= k:
         recall = (I[:, :rank] == gt[:, :1]).sum() / float(nq)
-        print("R@%d: %.4f" % (rank, recall), end=' ')
+        print("R@%d: %.4f" % (rank, recall), end=" ")
         rank *= 10
 
 
@@ -126,12 +128,11 @@ def evaluate(xq, gt, index, k=100, endl=True):
     D, I = index.search(xq, k)
     t1 = time.time()
     nq = xq.shape[0]
-    print("\t %8.4f ms per query, " % (
-        (t1 - t0) * 1000.0 / nq), end=' ')
+    print("\t %8.4f ms per query, " % ((t1 - t0) * 1000.0 / nq), end=" ")
     rank = 1
     while rank <= k:
         recall = (I[:, :rank] == gt[:, :1]).sum() / float(nq)
-        print("R@%d: %.4f" % (rank, recall), end=' ')
+        print("R@%d: %.4f" % (rank, recall), end=" ")
         rank *= 10
     if endl:
         print()

--- a/benchs/bench_all_ivf/make_groundtruth.py
+++ b/benchs/bench_all_ivf/make_groundtruth.py
@@ -7,7 +7,7 @@ import logging
 
 # https://stackoverflow.com/questions/7016056/python-logging-not-outputting-anything
 logging.basicConfig()
-logger = logging.getLogger('faiss.contrib.exhaustive_search')
+logger = logging.getLogger("faiss.contrib.exhaustive_search")
 logger.setLevel(logging.INFO)
 
 from faiss.contrib import datasets
@@ -18,10 +18,6 @@ ds = datasets.DatasetDeep1B(nb=int(1e9))
 
 print("computing GT matches for", ds)
 
-D, I = knn_ground_truth(
-    ds.get_queries(),
-    ds.database_iterator(bs=65536),
-    k=100
-)
+D, I = knn_ground_truth(ds.get_queries(), ds.database_iterator(bs=65536), k=100)
 
 vecs_io.ivecs_write("/tmp/tt.ivecs", I)

--- a/benchs/bench_all_ivf/parse_bench_all_ivf.py
+++ b/benchs/bench_all_ivf/parse_bench_all_ivf.py
@@ -12,10 +12,10 @@ from faiss.contrib.factory_tools import get_code_size as unitsize
 
 def dbsize_from_name(dbname):
     sufs = {
-        '1B': 10**9,
-        '100M': 10**8,
-        '10M': 10**7,
-        '1M': 10**6,
+        "1B": 10**9,
+        "100M": 10**8,
+        "10M": 10**7,
+        "1M": 10**6,
     }
     for s in sufs:
         if dbname.endswith(s):
@@ -25,7 +25,7 @@ def dbsize_from_name(dbname):
 
 
 def keep_latest_stdout(fnames):
-    fnames = [fname for fname in fnames if fname.endswith('.stdout')]
+    fnames = [fname for fname in fnames if fname.endswith(".stdout")]
     fnames.sort()
     n = len(fnames)
     fnames2 = []
@@ -42,7 +42,7 @@ def parse_result_file(fname):
     res = []
     keys = []
     stats = {}
-    stats['run_version'] = fname[-8]
+    stats["run_version"] = fname[-8]
     indexkey = None
     for l in open(fname):
         if l.startswith("srun:"):
@@ -57,42 +57,42 @@ def parse_result_file(fname):
                 stats["nq"] = int(fi[9])
                 stats["nb"] = int(fi[11])
                 stats["nt"] = int(fi[13])
-            if l.startswith('index size on disk:'):
-                stats['index_size'] = int(l.split()[-1])
-            if l.startswith('current RSS:'):
-                stats['RSS'] = int(l.split()[-1])
-            if l.startswith('precomputed tables size:'):
-                stats['tables_size'] = int(l.split()[-1])
-            if l.startswith('Setting nb of threads to'):
-                stats['n_threads'] = int(l.split()[-1])
-            if l.startswith('  add in'):
-                stats['add_time'] = float(l.split()[-2])
+            if l.startswith("index size on disk:"):
+                stats["index_size"] = int(l.split()[-1])
+            if l.startswith("current RSS:"):
+                stats["RSS"] = int(l.split()[-1])
+            if l.startswith("precomputed tables size:"):
+                stats["tables_size"] = int(l.split()[-1])
+            if l.startswith("Setting nb of threads to"):
+                stats["n_threads"] = int(l.split()[-1])
+            if l.startswith("  add in"):
+                stats["add_time"] = float(l.split()[-2])
             if l.startswith("vector code_size"):
-                stats['code_size'] = float(l.split()[-1])
-            if l.startswith('args:'):
-                args = eval(l[l.find(' '):])
+                stats["code_size"] = float(l.split()[-1])
+            if l.startswith("args:"):
+                args = eval(l[l.find(" ") :])
                 indexkey = args.indexkey
             elif "time(ms/q)" in l:
                 # result header
-                if 'R@1   R@10  R@100' in l:
+                if "R@1   R@10  R@100" in l:
                     stats["measure"] = "recall"
                     stats["ranks"] = [1, 10, 100]
-                elif 'I@1   I@10  I@100' in l:
+                elif "I@1   I@10  I@100" in l:
                     stats["measure"] = "inter"
                     stats["ranks"] = [1, 10, 100]
-                elif 'inter@' in l:
+                elif "inter@" in l:
                     stats["measure"] = "inter"
                     fi = l.split()
                     if fi[1] == "inter@":
                         rank = int(fi[2])
                     else:
-                        rank = int(fi[1][len("inter@"):])
+                        rank = int(fi[1][len("inter@") :])
                     stats["ranks"] = [rank]
 
                 else:
                     assert False
                 st = 1
-            elif 'index size on disk:' in l:
+            elif "index size on disk:" in l:
                 stats["index_size"] = int(l.split()[-1])
         elif st == 1:
             st = 2
@@ -105,12 +105,13 @@ def parse_result_file(fname):
             res.append([float(x) for x in fi[1:]])
     return indexkey, np.array(res), keys, stats
 
+
 # the directory used in run_on_cluster.bash
 basedir = "/checkpoint/matthijs/bench_all_ivf/"
-logdir = basedir + 'logs/'
+logdir = basedir + "logs/"
 
 
-def collect_results_for(db='deep1M', prefix="autotune."):
+def collect_results_for(db="deep1M", prefix="autotune."):
     # run parsing
     allres = {}
     allstats = {}
@@ -124,10 +125,10 @@ def collect_results_for(db='deep1M', prefix="autotune."):
 
     for fname in fnames:
         if not (
-                'db' + db in fname and
-                fname.startswith(prefix) and
-                fname.endswith('.stdout')
-            ):
+            "db" + db in fname
+            and fname.startswith(prefix)
+            and fname.endswith(".stdout")
+        ):
             continue
         print("parse", fname, end="   ", flush=True)
         try:
@@ -144,7 +145,7 @@ def collect_results_for(db='deep1M', prefix="autotune."):
             missing.append(fname)
         else:
             if indexkey in allres:
-                if allstats[indexkey]['run_version'] > stats['run_version']:
+                if allstats[indexkey]["run_version"] > stats["run_version"]:
                     # don't use this run
                     continue
 
@@ -160,12 +161,7 @@ def extract_pareto_optimal(allres, keys, recall_idx=0, times_idx=3):
         v = allres[k]
         perf = v[:, recall_idx]
         times = v[:, times_idx]
-        bigtab.append(
-            np.vstack((
-                np.ones(times.size) * i,
-                perf, times
-            ))
-        )
+        bigtab.append(np.vstack((np.ones(times.size) * i, perf, times)))
     if bigtab == []:
         return [], np.zeros((3, 0))
 
@@ -175,10 +171,9 @@ def extract_pareto_optimal(allres, keys, recall_idx=0, times_idx=3):
     perm = np.argsort(bigtab[1, :])
     bigtab_sorted = bigtab[:, perm]
     best_times = np.minimum.accumulate(bigtab_sorted[2, ::-1])[::-1]
-    selection, = np.where(bigtab_sorted[2, :] == best_times)
+    (selection,) = np.where(bigtab_sorted[2, :] == best_times)
     selected_keys = [
-        keys[i] for i in
-        np.unique(bigtab_sorted[0, selection].astype(int))
+        keys[i] for i in np.unique(bigtab_sorted[0, selection].astype(int))
     ]
     ops = bigtab_sorted[:, selection]
 
@@ -186,8 +181,13 @@ def extract_pareto_optimal(allres, keys, recall_idx=0, times_idx=3):
 
 
 def plot_subset(
-    allres, allstats, selected_methods, recall_idx, times_idx=3,
-    report=["overhead", "build time"]):
+    allres,
+    allstats,
+    selected_methods,
+    recall_idx,
+    times_idx=3,
+    report=["overhead", "build time"],
+):
 
     # important methods
     for k in selected_methods:
@@ -197,20 +197,20 @@ def plot_subset(
         d = stats["d"]
         dbsize = stats["nb"]
         if "index_size" in stats and "tables_size" in stats:
-            tot_size = stats['index_size'] + stats['tables_size']
+            tot_size = stats["index_size"] + stats["tables_size"]
         else:
             tot_size = -1
-        id_size = 8 # 64 bit
+        id_size = 8  # 64 bit
 
-        addt = ''
-        if 'add_time' in stats:
-            add_time = stats['add_time']
+        addt = ""
+        if "add_time" in stats:
+            add_time = stats["add_time"]
             if add_time > 7200:
                 add_min = add_time / 60
-                addt = ', %dh%02d' % (add_min / 60, add_min % 60)
+                addt = ", %dh%02d" % (add_min / 60, add_min % 60)
             else:
                 add_sec = int(add_time)
-                addt = ', %dm%02d' % (add_sec / 60, add_sec % 60)
+                addt = ", %dm%02d" % (add_sec / 60, add_sec % 60)
 
         code_size = unitsize(d, k)
 
@@ -222,33 +222,37 @@ def plot_subset(
         tight_size = (code_size + id_size) * dbsize
 
         if tot_size < 0 or "overhead" not in report:
-            pass # don't know what the index size is
+            pass  # don't know what the index size is
         elif tot_size > 10 * tight_size:
             label += " overhead x%.1f" % (tot_size / tight_size)
         else:
-            label += " overhead+%.1f%%" % (
-                tot_size / tight_size * 100 - 100)
+            label += " overhead+%.1f%%" % (tot_size / tight_size * 100 - 100)
 
         if "build time" in report:
             label += " " + addt
 
-        linestyle = (':' if 'Refine' in k or 'RFlat' in k else
-                     '-.' if 'SQ' in k else
-                     '-' if '4fs' in k else
-                     '-')
+        linestyle = (
+            ":"
+            if "Refine" in k or "RFlat" in k
+            else "-." if "SQ" in k else "-" if "4fs" in k else "-"
+        )
         print(k, linestyle)
-        pyplot.semilogy(v[:, recall_idx], 1000 / v[:, times_idx], label=label,
-                        linestyle=linestyle,
-                        marker='o' if '4fs' in k else '+')
+        pyplot.semilogy(
+            v[:, recall_idx],
+            1000 / v[:, times_idx],
+            label=label,
+            linestyle=linestyle,
+            marker="o" if "4fs" in k else "+",
+        )
 
     recall_rank = stats["ranks"][recall_idx]
     if stats["measure"] == "recall":
-        pyplot.xlabel('1-recall at %d' % recall_rank)
+        pyplot.xlabel("1-recall at %d" % recall_rank)
     elif stats["measure"] == "inter":
-        pyplot.xlabel('inter @ %d' % recall_rank)
+        pyplot.xlabel("inter @ %d" % recall_rank)
     else:
         assert False
-    pyplot.ylabel('QPS (%d threads)' % stats["n_threads"])
+    pyplot.ylabel("QPS (%d threads)" % stats["n_threads"])
 
 
 def plot_tradeoffs(db, allres, allstats, code_size, recall_rank):
@@ -275,64 +279,74 @@ def plot_tradeoffs(db, allres, allstats, code_size, recall_rank):
 
     for k in sorted(allres):
         v = allres[k]
-        if v.ndim != 2: continue
+        if v.ndim != 2:
+            continue
         us = unitsize(d, k)
-        if not code_size[0] <= us <= code_size[1]: continue
+        if not code_size[0] <= us <= code_size[1]:
+            continue
         names_maxperf.append((v[-1, recall_idx], k))
 
     # sort from lowest to highest topline accuracy
     names_maxperf.sort()
     names = [name for mp, name in names_maxperf]
 
-    selected_methods, optimal_points =  \
-        extract_pareto_optimal(allres, names, recall_idx, times_idx)
+    selected_methods, optimal_points = extract_pareto_optimal(
+        allres, names, recall_idx, times_idx
+    )
 
     not_selected = list(set(names) - set(selected_methods))
 
     print("methods without an optimal OP: ", not_selected)
 
-    pyplot.title('database ' + db + ' ' + code_size_name)
+    pyplot.title("database " + db + " " + code_size_name)
 
     # grayed out lines
 
     for k in not_selected:
         v = allres[k]
-        if v.ndim != 2: continue
+        if v.ndim != 2:
+            continue
         us = unitsize(d, k)
-        if not code_size[0] <= us <= code_size[1]: continue
+        if not code_size[0] <= us <= code_size[1]:
+            continue
 
-        linestyle = (':' if 'PQ' in k else
-                     '-.' if 'SQ4' in k else
-                     '--' if 'SQ8' in k else '-')
+        linestyle = (
+            ":"
+            if "PQ" in k
+            else "-." if "SQ4" in k else "--" if "SQ8" in k else "-"
+        )
 
-        pyplot.semilogy(v[:, recall_idx], 1000 / v[:, times_idx], label=None,
-                        linestyle=linestyle,
-                        marker='o' if 'HNSW' in k else '+',
-                        color='#cccccc', linewidth=0.2)
+        pyplot.semilogy(
+            v[:, recall_idx],
+            1000 / v[:, times_idx],
+            label=None,
+            linestyle=linestyle,
+            marker="o" if "HNSW" in k else "+",
+            color="#cccccc",
+            linewidth=0.2,
+        )
 
     plot_subset(allres, allstats, selected_methods, recall_idx, times_idx)
 
-
     if len(not_selected) == 0:
-        om = ''
+        om = ""
     else:
-        om = '\nomitted:'
+        om = "\nomitted:"
         nc = len(om)
         for m in not_selected:
             if nc > 80:
-                om += '\n'
+                om += "\n"
                 nc = 0
-            om += ' ' + m
+            om += " " + m
             nc += len(m) + 1
 
     # pyplot.semilogy(optimal_points[1, :], optimal_points[2, :], marker="s")
     # print(optimal_points[0, :])
-    pyplot.xlabel('1-recall at %d %s' % (recall_rank, om) )
-    pyplot.ylabel('QPS (%d threads)' % n_threads)
+    pyplot.xlabel("1-recall at %d %s" % (recall_rank, om))
+    pyplot.ylabel("QPS (%d threads)" % n_threads)
     pyplot.legend()
     pyplot.grid()
     return selected_methods, not_selected
-
 
 
 if __name__ == "__main__xx":
@@ -342,16 +356,17 @@ if __name__ == "__main__xx":
         pyplot.gcf().set_size_inches(15, 10)
         i = 1
         for ncent in 65536, 262144, 1048576, 4194304:
-            db = f'deep_centroids_{ncent}.k{k}.'
-            allres, allstats = collect_results_for(
-                db=db, prefix="cent_index.")
+            db = f"deep_centroids_{ncent}.k{k}."
+            allres, allstats = collect_results_for(db=db, prefix="cent_index.")
 
             pyplot.subplot(2, 2, i)
             plot_subset(
-                allres, allstats, list(allres.keys()),
+                allres,
+                allstats,
+                list(allres.keys()),
                 recall_idx=0,
                 times_idx=1,
-                report=["code_size"]
+                report=["code_size"],
             )
             i += 1
             pyplot.title(f"{ncent} centroids")
@@ -359,7 +374,7 @@ if __name__ == "__main__xx":
             pyplot.xlim([0.95, 1])
             pyplot.grid()
 
-        pyplot.savefig('figs/deep1B_centroids_k%d.png' % k)
+        pyplot.savefig("figs/deep1B_centroids_k%d.png" % k)
 
 
 if __name__ == "__main__xx":
@@ -367,18 +382,18 @@ if __name__ == "__main__xx":
 
     pyplot.gcf().set_size_inches(15, 10)
 
-    i=1
+    i = 1
     for ncent in 65536, 262144, 1048576, 4194304:
 
         xyd = defaultdict(list)
 
         for k in 1, 4, 8, 16, 32, 64, 128, 256:
 
-            db = f'deep_centroids_{ncent}.k{k}.'
+            db = f"deep_centroids_{ncent}.k{k}."
             allres, allstats = collect_results_for(db=db, prefix="cent_index.")
 
             for indexkey, res in allres.items():
-                idx, = np.where(res[:, 0] >= 0.99)
+                (idx,) = np.where(res[:, 0] >= 0.99)
                 if idx.size > 0:
                     xyd[indexkey].append((k, 1000 / res[idx[0], 1]))
 
@@ -386,43 +401,44 @@ if __name__ == "__main__xx":
         i += 1
         for indexkey, xy in xyd.items():
             xy = np.array(xy)
-            pyplot.loglog(xy[:, 0], xy[:, 1], 'o-', label=indexkey)
+            pyplot.loglog(xy[:, 0], xy[:, 1], "o-", label=indexkey)
 
         pyplot.title(f"{ncent} centroids")
         pyplot.xlabel("k")
-        xt = 2**np.arange(9)
+        xt = 2 ** np.arange(9)
         pyplot.xticks(xt, ["%d" % x for x in xt])
         pyplot.ylabel("QPS (32 threads)")
         pyplot.legend()
         pyplot.grid()
 
-    pyplot.savefig('../plots/deep1B_centroids_min99.png')
-
-
-
+    pyplot.savefig("../plots/deep1B_centroids_min99.png")
 
 
 if __name__ == "__main__xx":
     # main indexing plots
 
     i = 0
-    for db in 'bigann10M', 'deep10M', 'bigann100M', 'deep100M', 'deep1B', 'bigann1B':
-        allres, allstats = collect_results_for(
-            db=db, prefix="autotune.")
+    for db in (
+        "bigann10M",
+        "deep10M",
+        "bigann100M",
+        "deep100M",
+        "deep1B",
+        "bigann1B",
+    ):
+        allres, allstats = collect_results_for(db=db, prefix="autotune.")
 
         for cs in 8, 16, 32, 64:
             pyplot.figure(i)
             i += 1
             pyplot.gcf().set_size_inches(15, 10)
 
-            cs_range = (
-                (0, 8) if cs == 8 else (cs // 2 + 1, cs)
-            )
+            cs_range = (0, 8) if cs == 8 else (cs // 2 + 1, cs)
 
             plot_tradeoffs(
-                db, allres, allstats, code_size=cs_range, recall_rank=1)
-            pyplot.savefig('../plots/tradeoffs_%s_cs%d_r1.png' % (
-                   db, cs))
+                db, allres, allstats, code_size=cs_range, recall_rank=1
+            )
+            pyplot.savefig("../plots/tradeoffs_%s_cs%d_r1.png" % (db, cs))
 
 
 if __name__ == "__main__":
@@ -434,7 +450,7 @@ if __name__ == "__main__":
         i += 1
         allres, allstats = collect_results_for(db=db, prefix="autotune.")
         plot_tradeoffs(db, allres, allstats, code_size=0, recall_rank=1)
-        pyplot.savefig('../plots/1M_tradeoffs_' + db + ".png")
+        pyplot.savefig("../plots/1M_tradeoffs_" + db + ".png")
 
     for db in "sift1M", "deep1M":
         allres, allstats = collect_results_for(db=db, prefix="autotune.")
@@ -442,18 +458,19 @@ if __name__ == "__main__":
         pyplot.gcf().set_size_inches(15, 10)
         i += 1
         plot_tradeoffs(db, allres, allstats, code_size=(0, 64), recall_rank=1)
-        pyplot.savefig('../plots/1M_tradeoffs_' + db + "_small.png")
+        pyplot.savefig("../plots/1M_tradeoffs_" + db + "_small.png")
 
         pyplot.figure(i)
         pyplot.gcf().set_size_inches(15, 10)
         i += 1
-        plot_tradeoffs(db, allres, allstats, code_size=(65, 10000), recall_rank=1)
-        pyplot.savefig('../plots/1M_tradeoffs_' + db + "_large.png")
-
+        plot_tradeoffs(
+            db, allres, allstats, code_size=(65, 10000), recall_rank=1
+        )
+        pyplot.savefig("../plots/1M_tradeoffs_" + db + "_large.png")
 
 
 if __name__ == "__main__xx":
-    db = 'sift1M'
+    db = "sift1M"
     allres, allstats = collect_results_for(db=db, prefix="autotune.")
     pyplot.gcf().set_size_inches(15, 10)
 
@@ -463,7 +480,7 @@ if __name__ == "__main__xx":
         "IVF1024,PQ64x4fs",
         "IVF1024,PQ64x4fsr",
         "IVF1024,SQ4",
-        "IVF1024,SQ8"
+        "IVF1024,SQ8",
     ]
 
     plot_subset(allres, allstats, keys, recall_idx=0, report=["code_size"])
@@ -474,7 +491,7 @@ if __name__ == "__main__xx":
     pyplot.ylabel("QPS (32 threads)")
     pyplot.grid()
 
-    pyplot.savefig('../plots/ivf1024_variants.png')
+    pyplot.savefig("../plots/ivf1024_variants.png")
 
     pyplot.figure(2)
     pyplot.gcf().set_size_inches(15, 10)
@@ -496,4 +513,4 @@ if __name__ == "__main__xx":
     pyplot.ylabel("QPS (32 threads)")
     pyplot.grid()
 
-    pyplot.savefig('../plots/ivf1024_rerank.png')
+    pyplot.savefig("../plots/ivf1024_rerank.png")

--- a/benchs/bench_big_batch_ivf.py
+++ b/benchs/bench_big_batch_ivf.py
@@ -20,17 +20,17 @@ def aa(*args, **kwargs):
     group.add_argument(*args, **kwargs)
 
 
-group = parser.add_argument_group('dataset options')
-aa('--dim', type=int, default=64)
-aa('--size', default="S")
+group = parser.add_argument_group("dataset options")
+aa("--dim", type=int, default=64)
+aa("--size", default="S")
 
-group = parser.add_argument_group('index options')
-aa('--nlist', type=int, default=100)
-aa('--factory_string', default="", help="overrides nlist")
-aa('--k', type=int, default=10)
-aa('--nprobe', type=int, default=5)
-aa('--nt', type=int, default=-1, help="nb search threads")
-aa('--method', default="pairwise_distances", help="")
+group = parser.add_argument_group("index options")
+aa("--nlist", type=int, default=100)
+aa("--factory_string", default="", help="overrides nlist")
+aa("--k", type=int, default=10)
+aa("--nprobe", type=int, default=5)
+aa("--nt", type=int, default=-1, help="nb search threads")
+aa("--method", default="pairwise_distances", help="")
 
 args = parser.parse_args()
 print("args:", args)
@@ -98,8 +98,7 @@ t_ref = toc()
 
 tic("block search")
 Dnew, Inew = big_batch_search(
-    index, ds.get_queries(),
-    k, method=args.method, verbose=10
+    index, ds.get_queries(), k, method=args.method, verbose=10
 )
 t_tot = toc()
 

--- a/benchs/bench_flat_l2_panorama.py
+++ b/benchs/bench_flat_l2_panorama.py
@@ -17,9 +17,7 @@ except ImportError:
     from faiss.contrib.datasets import DatasetSIFT1M, DatasetGIST1M
 
 parser = argparse.ArgumentParser()
-parser.add_argument(
-    "--dataset", default="gist1m", choices=["sift1m", "gist1m"]
-)
+parser.add_argument("--dataset", default="gist1m", choices=["sift1m", "gist1m"])
 args = parser.parse_args()
 
 if args.dataset == "sift1m":
@@ -91,15 +89,15 @@ for name in names:
     qps_values.append(qps)
 
 x = np.arange(len(names))
-plt.bar(x, qps_values, color=['#1f77b4', '#ff7f0e'])
+plt.bar(x, qps_values, color=["#1f77b4", "#ff7f0e"])
 speedup = qps_values[1] / qps_values[0]
 ax = plt.gca()
 ax.text(
-	x[1],
-	qps_values[1] * 1.01,
-	f"{speedup:.2f}x",
-	ha="center",
-	va="bottom",
+    x[1],
+    qps_values[1] * 1.01,
+    f"{speedup:.2f}x",
+    ha="center",
+    va="bottom",
 )
 plt.xticks(x, labels, rotation=0)
 plt.ylabel("QPS")

--- a/benchs/bench_for_interrupt.py
+++ b/benchs/bench_for_interrupt.py
@@ -18,15 +18,16 @@ parser = argparse.ArgumentParser()
 def aa(*args, **kwargs):
     group.add_argument(*args, **kwargs)
 
-group = parser.add_argument_group('dataset options')
-aa('--dim', type=int, default=64)
-aa('--nb', type=int, default=int(1e6))
-aa('--subset_len', type=int, default=int(1e5))
-aa('--key', default='IVF1000,Flat')
-aa('--nprobe', type=int, default=640)
-aa('--no_intcallback', default=False, action='store_true')
-aa('--twostage', default=False, action='store_true')
-aa('--nt', type=int, default=-1)
+
+group = parser.add_argument_group("dataset options")
+aa("--dim", type=int, default=64)
+aa("--nb", type=int, default=int(1e6))
+aa("--subset_len", type=int, default=int(1e5))
+aa("--key", default="IVF1000,Flat")
+aa("--nprobe", type=int, default=640)
+aa("--no_intcallback", default=False, action="store_true")
+aa("--twostage", default=False, action="store_true")
+aa("--nt", type=int, default=-1)
 
 
 args = parser.parse_args()
@@ -41,9 +42,9 @@ subset_len = args.subset_len
 
 
 np.random.seed(1234)  # make reproducible
-xb = np.random.random((nb, d)).astype('float32')
-xq = np.random.random((nq, d)).astype('float32')
-xt = np.random.random((nt, d)).astype('float32')
+xb = np.random.random((nb, d)).astype("float32")
+xq = np.random.random((nq, d)).astype("float32")
+xt = np.random.random((nt, d)).astype("float32")
 k = 100
 
 if args.no_intcallback:
@@ -54,41 +55,41 @@ if args.nt != -1:
 
 nprobe = args.nprobe
 key = args.key
-#key = 'IVF1000,Flat'
+# key = 'IVF1000,Flat'
 # key = 'IVF1000,PQ64'
 # key = 'IVF100_HNSW32,PQ64'
 
 # faiss.omp_set_num_threads(1)
 
-pf = 'dim%d_' % d
+pf = "dim%d_" % d
 if d == 64:
-    pf = ''
+    pf = ""
 
-basename = '/tmp/base%s%s.index' % (pf, key)
+basename = "/tmp/base%s%s.index" % (pf, key)
 
 if os.path.exists(basename):
-    print('load', basename)
+    print("load", basename)
     index_1 = faiss.read_index(basename)
 else:
-    print('train + write', basename)
+    print("train + write", basename)
     index_1 = faiss.index_factory(d, key)
     index_1.train(xt)
     faiss.write_index(index_1, basename)
 
-print('add')
+print("add")
 index_1.add(xb)
 
-print('set nprobe=', nprobe)
-faiss.ParameterSpace().set_index_parameter(index_1, 'nprobe', nprobe)
+print("set nprobe=", nprobe)
+faiss.ParameterSpace().set_index_parameter(index_1, "nprobe", nprobe)
 
 
 class ResultHeap:
-    """ Combine query results from a sliced dataset """
+    """Combine query results from a sliced dataset"""
 
     def __init__(self, nq, k):
-        " nq: number of query vectors, k: number of results per query "
-        self.I = np.zeros((nq, k), dtype='int64')
-        self.D = np.zeros((nq, k), dtype='float32')
+        "nq: number of query vectors, k: number of results per query"
+        self.I = np.zeros((nq, k), dtype="int64")
+        self.D = np.zeros((nq, k), dtype="float32")
         self.nq, self.k = nq, k
         heaps = faiss.float_maxheap_array_t()
         heaps.k = k
@@ -103,30 +104,37 @@ class ResultHeap:
         assert I.shape == (self.nq, self.k)
         I += i0
         self.heaps.addn_with_ids(
-            self.k, faiss.swig_ptr(D),
-            faiss.swig_ptr(I), self.k)
+            self.k, faiss.swig_ptr(D), faiss.swig_ptr(I), self.k
+        )
 
     def finalize(self):
         self.heaps.reorder()
 
+
 stats = faiss.cvar.indexIVF_stats
 stats.reset()
 
-print('index size', index_1.ntotal,
-      'imbalance', index_1.invlists.imbalance_factor())
+print(
+    "index size",
+    index_1.ntotal,
+    "imbalance",
+    index_1.invlists.imbalance_factor(),
+)
 start = time.time()
 Dref, Iref = index_1.search(xq, k)
-print('time of searching: %.3f s = %.3f + %.3f ms' % (
-    time.time() - start, stats.quantization_time, stats.search_time))
+print(
+    "time of searching: %.3f s = %.3f + %.3f ms"
+    % (time.time() - start, stats.quantization_time, stats.search_time)
+)
 
 indexes = {}
 if args.twostage:
 
     for i in range(0, nb, subset_len):
         index = faiss.read_index(basename)
-        faiss.ParameterSpace().set_index_parameter(index, 'nprobe', nprobe)
-        print("add %d:%d" %(i, i+subset_len))
-        index.add(xb[i:i + subset_len])
+        faiss.ParameterSpace().set_index_parameter(index, "nprobe", nprobe)
+        print("add %d:%d" % (i, i + subset_len))
+        index.add(xb[i : i + subset_len])
         indexes[i] = index
 
 rh = ResultHeap(nq, k)
@@ -134,9 +142,9 @@ sum_time = tq = ts = 0
 for i in range(0, nb, subset_len):
     if not args.twostage:
         index = faiss.read_index(basename)
-        faiss.ParameterSpace().set_index_parameter(index, 'nprobe', nprobe)
-        print("add %d:%d" %(i, i+subset_len))
-        index.add(xb[i:i + subset_len])
+        faiss.ParameterSpace().set_index_parameter(index, "nprobe", nprobe)
+        print("add %d:%d" % (i, i + subset_len))
+        index.add(xb[i : i + subset_len])
     else:
         index = indexes[i]
 
@@ -148,9 +156,10 @@ for i in range(0, nb, subset_len):
     ts += stats.search_time
     rh.add_batch_result(Di, Ii, i)
 
-print('time of searching separately: %.3f s = %.3f + %.3f ms' %
-      (sum_time, tq, ts))
+print(
+    "time of searching separately: %.3f s = %.3f + %.3f ms" % (sum_time, tq, ts)
+)
 
 rh.finalize()
 
-print('diffs: %d / %d'  % ((Iref != rh.I).sum(), Iref.size))
+print("diffs: %d / %d" % ((Iref != rh.I).sum(), Iref.size))

--- a/benchs/bench_fw/benchmark.py
+++ b/benchs/bench_fw/benchmark.py
@@ -239,7 +239,8 @@ class TrainOperator(IndexOperator):
 
         if codec_desc.factory is not None:
             assert (
-                codec_desc.factory == "Flat" or codec_desc.training_vectors is not None
+                codec_desc.factory == "Flat"
+                or codec_desc.training_vectors is not None
             )
             index = IndexFromFactory(
                 num_threads=self.num_threads,
@@ -257,7 +258,10 @@ class TrainOperator(IndexOperator):
             assert codec_desc.is_trained()
 
     def train_one(
-        self, codec_desc: CodecDescriptor, results: Dict[str, Any], dry_run=False
+        self,
+        codec_desc: CodecDescriptor,
+        results: Dict[str, Any],
+        dry_run=False,
     ):
         faiss.omp_set_num_threads(codec_desc.num_threads)
         self.build_index_wrapper(codec_desc)
@@ -390,7 +394,9 @@ class SearchOperator(IndexOperator):
 
         knn_desc.index.get_index()
 
-    def range_search_reference(self, index, parameters, range_metric, query_dataset):
+    def range_search_reference(
+        self, index, parameters, range_metric, query_dataset
+    ):
         logger.info("range_search_reference: begin")
         if isinstance(range_metric, list):
             assert len(range_metric) > 0
@@ -428,7 +434,9 @@ class SearchOperator(IndexOperator):
             coefficients_training_data,
         )
 
-    def estimate_range(self, index, parameters, range_scoring_radius, query_dataset):
+    def estimate_range(
+        self, index, parameters, range_scoring_radius, query_dataset
+    ):
         D, I, R, P, _ = index.knn_search(
             False,
             parameters,
@@ -477,7 +485,9 @@ class SearchOperator(IndexOperator):
             return None, None, None, None, None, requires
         if range_search_metric_function is not None:
             range_search_metric = range_search_metric_function(R)
-            range_search_pr = range_search_pr_curve(D, range_search_metric, gt_rsm)
+            range_search_pr = range_search_pr_curve(
+                D, range_search_metric, gt_rsm
+            )
             range_score_sum = np.sum(range_search_metric).item()
             P |= {
                 "range_score_sum": range_score_sum,
@@ -716,8 +726,8 @@ class SearchOperator(IndexOperator):
                 assert requires is None
 
         if (
-            knn_desc.range_ref_index_desc is None or
-            not knn_desc.index.supports_range_search()
+            knn_desc.range_ref_index_desc is None
+            or not knn_desc.index.supports_range_search()
         ):
             return results, None
 
@@ -778,15 +788,17 @@ class SearchOperator(IndexOperator):
         return results, None
 
     def search(
-            self,
-            results: Dict[str, Any],
-            dry_run: bool = False,):
+        self,
+        results: Dict[str, Any],
+        dry_run: bool = False,
+    ):
         for knn_desc in self.knn_descs:
             results, requires = self.search_one(
                 knn_desc=knn_desc,
                 results=results,
                 dry_run=dry_run,
-                range=self.range)
+                range=self.range,
+            )
             if dry_run:
                 if requires is None:
                     continue
@@ -901,24 +913,29 @@ class ExecutionOperator:
 
     def create_range_ref_knn(self, knn_desc):
         if (
-            knn_desc.range_ref_index_desc is None or
-            not knn_desc.index.supports_range_search()
+            knn_desc.range_ref_index_desc is None
+            or not knn_desc.index.supports_range_search()
         ):
             return
 
         if knn_desc.range_ref_index_desc is not None:
-            ref_index_desc = (
-                self.search_op.get_desc(knn_desc.range_ref_index_desc)
+            ref_index_desc = self.search_op.get_desc(
+                knn_desc.range_ref_index_desc
             )
             if ref_index_desc is None:
-                raise ValueError(f"Unknown range index {knn_desc.range_ref_index_desc}")
+                raise ValueError(
+                    f"Unknown range index {knn_desc.range_ref_index_desc}"
+                )
             if ref_index_desc.range_metrics is None:
                 raise ValueError(
                     f"Range index {knn_desc.get_name()} has no radius_score"
                 )
             results["metrics"] = {}
             self.build_index_wrapper(ref_index_desc)
-            for metric_key, range_metric in ref_index_desc.range_metrics.items():
+            for (
+                metric_key,
+                range_metric,
+            ) in ref_index_desc.range_metrics.items():
                 (
                     knn_desc.gt_radius,
                     range_search_metric_function,
@@ -962,8 +979,8 @@ class ExecutionOperator:
     def execute(self, results: Dict[str, Any], dry_run: bool = False):
         faiss.omp_set_num_threads(self.num_threads)
         if self.train_op is not None:
-            results, requires = (
-                self.train_op.train(results=results, dry_run=dry_run)
+            results, requires = self.train_op.train(
+                results=results, dry_run=dry_run
             )
             if dry_run and requires:
                 return results, requires
@@ -975,8 +992,8 @@ class ExecutionOperator:
             if not dry_run and self.compute_gt:
                 self.prepare_gt_or_range_knn(results)
 
-            results, requires = (
-                self.search_op.search(results=results, dry_run=dry_run)
+            results, requires = self.search_op.search(
+                results=results, dry_run=dry_run
             )
             if dry_run and requires:
                 return results, requires
@@ -1025,7 +1042,13 @@ class Benchmark:
         raise ValueError("Failed to determine dimension of dataset")
 
     def create_descriptors(
-        self, ci_desc: IndexDescriptorClassic, train, build, knn, reconstruct, range
+        self,
+        ci_desc: IndexDescriptorClassic,
+        train,
+        build,
+        knn,
+        reconstruct,
+        range,
     ):
         codec_desc = None
         index_desc = None
@@ -1126,7 +1149,9 @@ class Benchmark:
             database_vectors=self.database_vectors,
             query_vectors=self.query_vectors,
             # index_descs=[self.get_flat_desc("Flat"), index_desc],
-            index_descs=[index_desc],  # Should automatically find flat descriptors
+            index_descs=[
+                index_desc
+            ],  # Should automatically find flat descriptors
             range_ref_index_desc=self.range_ref_index_desc,
             k=self.k,
             distance_metric=self.distance_metric,

--- a/benchs/bench_fw/descriptors.py
+++ b/benchs/bench_fw/descriptors.py
@@ -142,9 +142,9 @@ class DatasetDescriptor:
         assert self.tablename is not None
         filename += self.tablename
         if self.partitions is not None:
-            filename += "_" + "_".join(
-                self.partitions
-            ).replace("=", "_").replace("/", "_")
+            filename += "_" + "_".join(self.partitions).replace(
+                "=", "_"
+            ).replace("/", "_")
         if self.num_vectors is not None:
             filename += f"_{self.num_vectors}"
         if self.filename_suffix is not None:
@@ -278,8 +278,12 @@ class CodecDescriptor(IndexBaseDescriptor):
         name += f"d_{self.d}.{self.metric.upper()}."
         if self.factory != "Flat":
             assert self.training_vectors is not None
-            name += self.training_vectors.get_filename(CodecDescriptor.FILENAME_PREFIX)
-        name += IndexBaseDescriptor.param_dict_list_to_name(self.construction_params)
+            name += self.training_vectors.get_filename(
+                CodecDescriptor.FILENAME_PREFIX
+            )
+        name += IndexBaseDescriptor.param_dict_list_to_name(
+            self.construction_params
+        )
         return name
 
     def name_from_path(self):
@@ -287,16 +291,23 @@ class CodecDescriptor(IndexBaseDescriptor):
         filename = os.path.basename(self.path)
         ext = filename.split(".")[-1]
         if filename.endswith(ext):
-            name = filename[:-len(ext)]
-        else: # should never hit this rather raise value error
+            name = filename[: -len(ext)]
+        else:  # should never hit this rather raise value error
             name = filename
         return name
 
     def alias(self, benchmark_io: BenchmarkIO):
         if hasattr(benchmark_io, "bucket"):
-            return CodecDescriptor(desc_name=self.get_name(), bucket=benchmark_io.bucket, path=self.get_path(benchmark_io), d=self.d, metric=self.metric)
-        return CodecDescriptor(desc_name=self.get_name(), d=self.d, metric=self.metric)
-
+            return CodecDescriptor(
+                desc_name=self.get_name(),
+                bucket=benchmark_io.bucket,
+                path=self.get_path(benchmark_io),
+                d=self.d,
+                metric=self.metric,
+            )
+        return CodecDescriptor(
+            desc_name=self.get_name(), d=self.d, metric=self.metric
+        )
 
 
 @dataclass
@@ -316,21 +327,39 @@ class IndexDescriptor(IndexBaseDescriptor):
 
     def get_name(self) -> str:
         if self.desc_name is None:
-            self.desc_name = self.codec_desc.get_name() + self.database_desc.get_filename(prefix=IndexDescriptor.FILENAME_PREFIX)
+            self.desc_name = (
+                self.codec_desc.get_name()
+                + self.database_desc.get_filename(
+                    prefix=IndexDescriptor.FILENAME_PREFIX
+                )
+            )
 
         return self.desc_name
 
     def flat_name(self):
         if self.flat_desc_name is not None:
             return self.flat_desc_name
-        self.flat_desc_name = self.codec_desc.flat_name() + self.database_desc.get_filename(prefix=IndexDescriptor.FILENAME_PREFIX)
+        self.flat_desc_name = (
+            self.codec_desc.flat_name()
+            + self.database_desc.get_filename(
+                prefix=IndexDescriptor.FILENAME_PREFIX
+            )
+        )
         return self.flat_desc_name
 
     # alias is used to refer when index is uploaded to blobstore and referred again
     def alias(self, benchmark_io: BenchmarkIO):
         if hasattr(benchmark_io, "bucket"):
-            return IndexDescriptor(desc_name=self.get_name(), bucket=benchmark_io.bucket, path=self.get_path(benchmark_io), d=self.d, metric=self.metric)
-        return IndexDescriptor(desc_name=self.get_name(), d=self.d, metric=self.metric)
+            return IndexDescriptor(
+                desc_name=self.get_name(),
+                bucket=benchmark_io.bucket,
+                path=self.get_path(benchmark_io),
+                d=self.d,
+                metric=self.metric,
+            )
+        return IndexDescriptor(
+            desc_name=self.get_name(), d=self.d, metric=self.metric
+        )
 
 
 @dataclass

--- a/benchs/bench_fw/index.py
+++ b/benchs/bench_fw/index.py
@@ -73,9 +73,8 @@ class IndexBase:
     def set_index_param(index, name, val, assert_same=False):
         index = faiss.downcast_index(index)
         val = int(val)
-        if (
-            isinstance(index, faiss.IndexPreTransform)
-            or isinstance(index, faiss.IndexIDMap)
+        if isinstance(index, faiss.IndexPreTransform) or isinstance(
+            index, faiss.IndexIDMap
         ):
             Index.set_index_param(index.index, name, val)
             return
@@ -278,8 +277,8 @@ class IndexBase:
     ):
         logger.info("knn_search: begin")
         if (
-            search_parameters is not None and
-            search_parameters.get("snap", 0) == 1
+            search_parameters is not None
+            and search_parameters.get("snap", 0) == 1
         ):
             query_vectors = self.snap(query_vectors)
         filename = (
@@ -329,9 +328,9 @@ class IndexBase:
                 xq = self.io.get_dataset(query_vectors)
                 (D, I), t, _ = timer("knn_search", lambda: index.search(xq, k))
             if (
-                self.is_flat() or
-                not hasattr(self, "database_vectors") or
-                (self.database_vectors is None)
+                self.is_flat()
+                or not hasattr(self, "database_vectors")
+                or (self.database_vectors is None)
             ):  # TODO
                 R = D
             else:
@@ -350,9 +349,7 @@ class IndexBase:
                     "nlist": int(stats.nlist // repeat),
                     "ndis": int(stats.ndis // repeat),
                     "nheap_updates": int(stats.nheap_updates // repeat),
-                    "quantization_time": int(
-                        stats.quantization_time // repeat
-                    ),
+                    "quantization_time": int(stats.quantization_time // repeat),
                     "search_time": int(stats.search_time // repeat),
                 }
             self.io.write_file(filename, ["D", "I", "R", "P"], [D, I, R, P])
@@ -482,14 +479,12 @@ class IndexBase:
     ):
         logger.info("range_search: begin")
         if (
-            search_parameters is not None and
-            search_parameters.get("snap", 0) == 1
+            search_parameters is not None
+            and search_parameters.get("snap", 0) == 1
         ):
             query_vectors = self.snap(query_vectors)
         filename = (
-            self.get_range_search_name(
-                search_parameters, query_vectors, radius
-            )
+            self.get_range_search_name(search_parameters, query_vectors, radius)
             + "zip"
         )
         if self.io.file_exist(filename):
@@ -527,9 +522,7 @@ class IndexBase:
                 R = D
             else:
                 xb = self.io.get_dataset(self.database_vectors)
-                R = refine_distances_range(
-                    lims, D, I, xq, xb, self.metric_type
-                )
+                R = refine_distances_range(lims, D, I, xq, xb, self.metric_type)
             P = {
                 "time": t,
                 "radius": radius,
@@ -543,9 +536,7 @@ class IndexBase:
                     "nlist": int(stats.nlist // repeat),
                     "ndis": int(stats.ndis // repeat),
                     "nheap_updates": int(stats.nheap_updates // repeat),
-                    "quantization_time": int(
-                        stats.quantization_time // repeat
-                    ),
+                    "quantization_time": int(stats.quantization_time // repeat),
                     "search_time": int(stats.search_time // repeat),
                 }
             self.io.write_file(
@@ -681,7 +672,8 @@ class Index(IndexBase):
             _, t, _ = timer(
                 "add_with_ids",
                 lambda: index.add_with_ids(
-                    xb, np.arange(len(xb), dtype='int32')),
+                    xb, np.arange(len(xb), dtype="int32")
+                ),
                 once=True,
             )
         else:
@@ -934,7 +926,9 @@ class IndexFromFactory(Index):
                 assert self.training_vectors is not None
                 codec_name += self.training_vectors.get_filename("xt")
             if self.construction_params is not None:
-                codec_name += IndexBaseDescriptor.param_dict_list_to_name(self.construction_params)
+                codec_name += IndexBaseDescriptor.param_dict_list_to_name(
+                    self.construction_params
+                )
         self.codec_name = codec_name
         return self.codec_name
 
@@ -969,7 +963,11 @@ class IndexFromFactory(Index):
             assert codec_size is not None
             meta = {
                 "training_time": training_time,
-                "training_size": self.training_vectors.num_vectors if self.training_vectors else 0,
+                "training_size": (
+                    self.training_vectors.num_vectors
+                    if self.training_vectors
+                    else 0
+                ),
                 "codec_size": codec_size,
                 "sa_code_size": self.get_sa_code_size(codec),
                 "code_size": self.get_code_size(codec),

--- a/benchs/bench_fw/optimize.py
+++ b/benchs/bench_fw/optimize.py
@@ -70,9 +70,9 @@ class Optimizer:
             evaluation="knn",
             accuracy_metric="knn_intersection",
             min_accuracy=min_accuracy,
-            name_filter=None
-            if include_flat
-            else (lambda n: not n.startswith("Flat")),
+            name_filter=(
+                None if include_flat else (lambda n: not n.startswith("Flat"))
+            ),
             pareto_mode=ParetoMode.GLOBAL,
             pareto_metric=pareto_metric,
         )
@@ -103,7 +103,9 @@ class Optimizer:
                 dry_run=False,
             )
 
-            descs = [IndexDescriptorClassic(factory="Flat"),] + [
+            descs = [
+                IndexDescriptorClassic(factory="Flat"),
+            ] + [
                 IndexDescriptorClassic(
                     factory="HNSW32",
                     construction_params=[{"efConstruction": 2**i}],
@@ -229,7 +231,8 @@ class Optimizer:
                 (None, "SQbf16"),
                 (None, "SQ8"),
                 (None, "SQ8_direct_signed"),
-            ] + [
+            ]
+            + [
                 (f"OPQ{M}_{M * dim}", f"PQ{M}x{b}")
                 for M in [8, 12, 16, 32, 48, 64, 96, 128, 192, 256]
                 if d % M == 0
@@ -237,7 +240,8 @@ class Optimizer:
                 if M * dim <= d
                 for b in range(4, 14, 2)
                 if M * b < d * 8  # smaller than SQ8
-            ] + [
+            ]
+            + [
                 (None, f"PQ{M}x{b}")
                 for M in [8, 12, 16, 32, 48, 64, 96, 128, 192, 256]
                 if d % M == 0
@@ -257,9 +261,11 @@ class Optimizer:
         _, filtered = self.benchmark_and_filter_candidates(
             index_descs=[
                 IndexDescriptorClassic(
-                    factory=f"IVF{nlist},{pq}"
-                    if opq is None
-                    else f"{opq},IVF{nlist},{pq}",
+                    factory=(
+                        f"IVF{nlist},{pq}"
+                        if opq is None
+                        else f"{opq},IVF{nlist},{pq}"
+                    ),
                     search_params={
                         "nprobe": nprobe,
                     },

--- a/benchs/bench_fw/utils.py
+++ b/benchs/bench_fw/utils.py
@@ -91,14 +91,18 @@ def refine_distances_range(
     with ThreadPool(32) as pool:
         R = pool.map(
             lambda i: (
-                np.sum(np.square(xq[i] - xb[I[lims[i] : lims[i + 1]]]), axis=1)
-                if metric == faiss.METRIC_L2
-                else np.tensordot(
-                    xq[i], xb[I[lims[i] : lims[i + 1]]], axes=(0, 1)
+                (
+                    np.sum(
+                        np.square(xq[i] - xb[I[lims[i] : lims[i + 1]]]), axis=1
+                    )
+                    if metric == faiss.METRIC_L2
+                    else np.tensordot(
+                        xq[i], xb[I[lims[i] : lims[i + 1]]], axes=(0, 1)
+                    )
                 )
-            )
-            if lims[i + 1] > lims[i]
-            else [],
+                if lims[i + 1] > lims[i]
+                else []
+            ),
             range(len(lims) - 1),
         )
     return np.hstack(R)

--- a/benchs/bench_fw_codecs.py
+++ b/benchs/bench_fw_codecs.py
@@ -9,97 +9,130 @@ import os
 
 from faiss.benchs.bench_fw.benchmark import Benchmark
 from faiss.benchs.bench_fw.benchmark_io import BenchmarkIO
-from faiss.benchs.bench_fw.descriptors import DatasetDescriptor, IndexDescriptorClassic
+from faiss.benchs.bench_fw.descriptors import (
+    DatasetDescriptor,
+    IndexDescriptorClassic,
+)
 
 logging.basicConfig(level=logging.INFO)
 
 
 def factory_factory(d):
-    return [
-        ("SQ4", None, 256 * (2 ** 10), None),
-        ("SQ8", None, 256 * (2 ** 10), None),
-        ("SQfp16", None, 256 * (2 ** 10), None),
-        ("ITQ64,LSH", None, 256 * (2 ** 10), None),
-        ("Pad128,ITQ128,LSH", None, 256 * (2 ** 10), None),
-        ("Pad256,ITQ256,LSH", None, 256 * (2 ** 10), None),
-    ] + [
-        (f"OPQ32_128,Residual2x14,PQ32x{b}", None, 256 * (2 ** 14), None)
-        for b in range(8, 16, 2)
-    ] + [
-        (f"PCAR{2 ** d_out},SQ{b}", None, 256 * (2 ** 10), None)
-        for d_out in range(6, 11) 
-        if 2 ** d_out <= d
-        for b in [4, 8]
-    ] + [
-        (f"OPQ{M}_{M * dim},PQ{M}x{b}", None, 256 * (2 ** b), None)
-        for M in [8, 12, 16, 32, 64, 128]
-        for dim in [2, 4, 6, 8, 12, 16]
-        if M * dim <= d
-        for b in range(8, 16, 2)
-    ] + [
-        (f"RQ{cs // b}x{b}", [{"max_beam_size": 32}], 256 * (2 ** b), {"max_beam_size": bs, "use_beam_LUT": bl}) 
-        for cs in [64, 128, 256, 512]
-        for b in [6, 8, 10, 12]
-        for bs in [1, 2, 4, 8, 16, 32]
-        for bl in [0, 1]
-        if cs // b > 1
-        if cs // b < 65
-        if cs < d * 8 * 2
-    ] + [
-        (f"LSQ{cs // b}x{b}", [{"encode_ils_iters": 16}], 256 * (2 ** b), {"encode_ils_iters": eii, "lsq_gpu": lg}) 
-        for cs in [64, 128, 256, 512]
-        for b in [6, 8, 10, 12]
-        for eii in [2, 4, 8, 16]
-        for lg in [0, 1]
-        if cs // b > 1
-        if cs // b < 65
-        if cs < d * 8 * 2
-    ] + [
-        (f"PRQ{sub}x{cs // sub // b}x{b}", [{"max_beam_size": 32}], 256 * (2 ** b), {"max_beam_size": bs, "use_beam_LUT": bl})
-        for sub in [2, 3, 4, 8, 16, 32]
-        for cs in [64, 96, 128, 192, 256, 384, 512, 768, 1024, 2048]
-        for b in [6, 8, 10, 12]
-        for bs in [1, 2, 4, 8, 16, 32]
-        for bl in [0, 1]
-        if cs // sub // b > 1
-        if cs // sub // b < 65
-        if cs < d * 8 * 2
-        if d % sub == 0
-    ] + [
-        (f"PLSQ{sub}x{cs // sub // b}x{b}", [{"encode_ils_iters": 16}], 256 * (2 ** b), {"encode_ils_iters": eii, "lsq_gpu": lg}) 
-        for sub in [2, 3, 4, 8, 16, 32]
-        for cs in [64, 128, 256, 512, 1024, 2048]
-        for b in [6, 8, 10, 12]
-        for eii in [2, 4, 8, 16]
-        for lg in [0, 1]
-        if cs // sub // b > 1
-        if cs // sub // b < 65
-        if cs < d * 8 * 2
-        if d % sub == 0
-    ]
+    return (
+        [
+            ("SQ4", None, 256 * (2**10), None),
+            ("SQ8", None, 256 * (2**10), None),
+            ("SQfp16", None, 256 * (2**10), None),
+            ("ITQ64,LSH", None, 256 * (2**10), None),
+            ("Pad128,ITQ128,LSH", None, 256 * (2**10), None),
+            ("Pad256,ITQ256,LSH", None, 256 * (2**10), None),
+        ]
+        + [
+            (f"OPQ32_128,Residual2x14,PQ32x{b}", None, 256 * (2**14), None)
+            for b in range(8, 16, 2)
+        ]
+        + [
+            (f"PCAR{2 ** d_out},SQ{b}", None, 256 * (2**10), None)
+            for d_out in range(6, 11)
+            if 2**d_out <= d
+            for b in [4, 8]
+        ]
+        + [
+            (f"OPQ{M}_{M * dim},PQ{M}x{b}", None, 256 * (2**b), None)
+            for M in [8, 12, 16, 32, 64, 128]
+            for dim in [2, 4, 6, 8, 12, 16]
+            if M * dim <= d
+            for b in range(8, 16, 2)
+        ]
+        + [
+            (
+                f"RQ{cs // b}x{b}",
+                [{"max_beam_size": 32}],
+                256 * (2**b),
+                {"max_beam_size": bs, "use_beam_LUT": bl},
+            )
+            for cs in [64, 128, 256, 512]
+            for b in [6, 8, 10, 12]
+            for bs in [1, 2, 4, 8, 16, 32]
+            for bl in [0, 1]
+            if cs // b > 1
+            if cs // b < 65
+            if cs < d * 8 * 2
+        ]
+        + [
+            (
+                f"LSQ{cs // b}x{b}",
+                [{"encode_ils_iters": 16}],
+                256 * (2**b),
+                {"encode_ils_iters": eii, "lsq_gpu": lg},
+            )
+            for cs in [64, 128, 256, 512]
+            for b in [6, 8, 10, 12]
+            for eii in [2, 4, 8, 16]
+            for lg in [0, 1]
+            if cs // b > 1
+            if cs // b < 65
+            if cs < d * 8 * 2
+        ]
+        + [
+            (
+                f"PRQ{sub}x{cs // sub // b}x{b}",
+                [{"max_beam_size": 32}],
+                256 * (2**b),
+                {"max_beam_size": bs, "use_beam_LUT": bl},
+            )
+            for sub in [2, 3, 4, 8, 16, 32]
+            for cs in [64, 96, 128, 192, 256, 384, 512, 768, 1024, 2048]
+            for b in [6, 8, 10, 12]
+            for bs in [1, 2, 4, 8, 16, 32]
+            for bl in [0, 1]
+            if cs // sub // b > 1
+            if cs // sub // b < 65
+            if cs < d * 8 * 2
+            if d % sub == 0
+        ]
+        + [
+            (
+                f"PLSQ{sub}x{cs // sub // b}x{b}",
+                [{"encode_ils_iters": 16}],
+                256 * (2**b),
+                {"encode_ils_iters": eii, "lsq_gpu": lg},
+            )
+            for sub in [2, 3, 4, 8, 16, 32]
+            for cs in [64, 128, 256, 512, 1024, 2048]
+            for b in [6, 8, 10, 12]
+            for eii in [2, 4, 8, 16]
+            for lg in [0, 1]
+            if cs // sub // b > 1
+            if cs // sub // b < 65
+            if cs < d * 8 * 2
+            if d % sub == 0
+        ]
+    )
 
 
 def run_local(rp):
     bio, d, tablename, distance_metric = rp
     if tablename == "contriever":
-        training_vectors=DatasetDescriptor(
-            tablename="training_set.npy"
-        )
-        database_vectors=DatasetDescriptor(
+        training_vectors = DatasetDescriptor(tablename="training_set.npy")
+        database_vectors = DatasetDescriptor(
             tablename="database1M.npy",
         )
-        query_vectors=DatasetDescriptor(
+        query_vectors = DatasetDescriptor(
             tablename="queries.npy",
         )
     else:
-        training_vectors=DatasetDescriptor(
-            namespace="std_t", tablename=tablename,
+        training_vectors = DatasetDescriptor(
+            namespace="std_t",
+            tablename=tablename,
         )
-        database_vectors=DatasetDescriptor(
-            namespace="std_d", tablename=tablename,
+        database_vectors = DatasetDescriptor(
+            namespace="std_d",
+            tablename=tablename,
         )
-        query_vectors=DatasetDescriptor(
-            namespace="std_q", tablename=tablename,
+        query_vectors = DatasetDescriptor(
+            namespace="std_q",
+            tablename=tablename,
         )
 
     benchmark = Benchmark(
@@ -114,22 +147,33 @@ def run_local(rp):
                 training_size=training_size,
                 search_params=search_params,
             )
-            for factory, construction_params, training_size, search_params in factory_factory(d)
+            for factory, construction_params, training_size, search_params in factory_factory(
+                d
+            )
         ],
         k=1,
         distance_metric=distance_metric,
     )
     benchmark.set_io(bio)
-    benchmark.benchmark(result_file="result.json", train=True, reconstruct=False, knn=False, range=False)
+    benchmark.benchmark(
+        result_file="result.json",
+        train=True,
+        reconstruct=False,
+        knn=False,
+        range=False,
+    )
 
 
 def run(bio, d, tablename, distance_metric):
-    bio.launch_jobs(run_local, [(bio, d, tablename, distance_metric)], local=True)
+    bio.launch_jobs(
+        run_local, [(bio, d, tablename, distance_metric)], local=True
+    )
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('experiment')
-    parser.add_argument('path')
+    parser.add_argument("experiment")
+    parser.add_argument("path")
     args = parser.parse_args()
     assert os.path.exists(args.path)
     path = os.path.join(args.path, args.experiment)

--- a/benchs/bench_fw_ivf.py
+++ b/benchs/bench_fw_ivf.py
@@ -26,9 +26,7 @@ def sift1M(bio):
         database_vectors=DatasetDescriptor(
             namespace="std_d", tablename="sift1M"
         ),
-        query_vectors=DatasetDescriptor(
-            namespace="std_q", tablename="sift1M"
-        ),
+        query_vectors=DatasetDescriptor(namespace="std_q", tablename="sift1M"),
         index_descs=[
             IndexDescriptorClassic(
                 factory=f"IVF{2 ** nlist},Flat",
@@ -39,7 +37,14 @@ def sift1M(bio):
         distance_metric="L2",
     )
     benchmark.io = bio
-    benchmark.benchmark(result_file="result.json", local=True, train=True, reconstruct=False, knn=True, range=False)
+    benchmark.benchmark(
+        result_file="result.json",
+        local=True,
+        train=True,
+        reconstruct=False,
+        knn=True,
+        range=False,
+    )
 
 
 def bigann(bio):
@@ -58,41 +63,52 @@ def bigann(bio):
             index_descs=[
                 IndexDescriptorClassic(
                     factory=f"IVF{2 ** nlist},Flat",
-                ) for nlist in range(11, 19)
-            ] + [
+                )
+                for nlist in range(11, 19)
+            ]
+            + [
                 IndexDescriptorClassic(
                     factory=f"IVF{2 ** nlist}_HNSW32,Flat",
-                    construction_params=[None, {"efConstruction": 200, "efSearch": 40}],
-                ) for nlist in range(11, 19)
+                    construction_params=[
+                        None,
+                        {"efConstruction": 200, "efSearch": 40},
+                    ],
+                )
+                for nlist in range(11, 19)
             ],
             k=1,
             distance_metric="L2",
         )
         benchmark.set_io(bio)
-        benchmark.benchmark(f"result{scale}.json", local=False, train=True, reconstruct=False, knn=True, range=False)
+        benchmark.benchmark(
+            f"result{scale}.json",
+            local=False,
+            train=True,
+            reconstruct=False,
+            knn=True,
+            range=False,
+        )
 
 
 def ssnpp(bio):
     benchmark = Benchmark(
         num_threads=32,
-        training_vectors=DatasetDescriptor(
-            tablename="ssnpp_training_5M.npy"
-        ),
-        database_vectors=DatasetDescriptor(
-            tablename="ssnpp_database_5M.npy"
-        ),
-        query_vectors=DatasetDescriptor(
-            tablename="ssnpp_queries_10K.npy"
-        ),
+        training_vectors=DatasetDescriptor(tablename="ssnpp_training_5M.npy"),
+        database_vectors=DatasetDescriptor(tablename="ssnpp_database_5M.npy"),
+        query_vectors=DatasetDescriptor(tablename="ssnpp_queries_10K.npy"),
         index_descs=[
             IndexDescriptorClassic(
                 factory=f"IVF{2 ** nlist},PQ256x4fs,Refine(SQfp16)",
-            ) for nlist in range(9, 16)
-        ] + [
+            )
+            for nlist in range(9, 16)
+        ]
+        + [
             IndexDescriptorClassic(
                 factory=f"IVF{2 ** nlist},Flat",
-            ) for nlist in range(9, 16)
-        ] + [
+            )
+            for nlist in range(9, 16)
+        ]
+        + [
             IndexDescriptorClassic(
                 factory=f"PQ256x4fs,Refine(SQfp16)",
             ),
@@ -104,12 +120,20 @@ def ssnpp(bio):
         distance_metric="L2",
     )
     benchmark.set_io(bio)
-    benchmark.benchmark("result.json", local=False, train=True, reconstruct=False, knn=True, range=False)
+    benchmark.benchmark(
+        "result.json",
+        local=False,
+        train=True,
+        reconstruct=False,
+        knn=True,
+        range=False,
+    )
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('experiment')
-    parser.add_argument('path')
+    parser.add_argument("experiment")
+    parser.add_argument("path")
     args = parser.parse_args()
     assert os.path.exists(args.path)
     path = os.path.join(args.path, args.experiment)

--- a/benchs/bench_fw_range.py
+++ b/benchs/bench_fw_range.py
@@ -9,7 +9,10 @@ import os
 
 from faiss.benchs.bench_fw.benchmark import Benchmark
 from faiss.benchs.bench_fw.benchmark_io import BenchmarkIO
-from faiss.benchs.bench_fw.descriptors import DatasetDescriptor, IndexDescriptorClassic
+from faiss.benchs.bench_fw.descriptors import (
+    DatasetDescriptor,
+    IndexDescriptorClassic,
+)
 
 logging.basicConfig(level=logging.INFO)
 
@@ -34,25 +37,25 @@ def ssnpp(bio):
                         [0.15, 0.923],
                         [0.2, 0.887],
                         [0.25, 0.801],
-                        [0.3, 0.729], 
-                        [0.35, 0.651], 
-                        [0.4, 0.55], 
-                        [0.45, 0.459], 
-                        [0.5, 0.372], 
-                        [0.55, 0.283], 
-                        [0.6, 0.189], 
-                        [0.65, 0.143], 
-                        [0.7, 0.106], 
-                        [0.75, 0.116], 
-                        [0.8, 0.088], 
+                        [0.3, 0.729],
+                        [0.35, 0.651],
+                        [0.4, 0.55],
+                        [0.45, 0.459],
+                        [0.5, 0.372],
+                        [0.55, 0.283],
+                        [0.6, 0.189],
+                        [0.65, 0.143],
+                        [0.7, 0.106],
+                        [0.75, 0.116],
+                        [0.8, 0.088],
                         [0.85, 0.064],
-                        [0.9, 0.05], 
-                        [0.95, 0.04], 
-                        [1.0, 0.028], 
-                        [1.05, 0.02], 
+                        [0.9, 0.05],
+                        [0.95, 0.04],
+                        [1.0, 0.028],
+                        [1.05, 0.02],
                         [1.1, 0.013],
-                        [1.15, 0.007], 
-                        [1.2, 0.004], 
+                        [1.15, 0.007],
+                        [1.2, 0.004],
                         [1.3, 0],
                     ]
                 },
@@ -66,13 +69,20 @@ def ssnpp(bio):
         range_ref_index_desc="Flat",
     )
     benchmark.set_io(bio)
-    benchmark.benchmark("result.json", local=False, train=True, reconstruct=False, knn=False, range=True)
+    benchmark.benchmark(
+        "result.json",
+        local=False,
+        train=True,
+        reconstruct=False,
+        knn=False,
+        range=True,
+    )
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('experiment')
-    parser.add_argument('path')
+    parser.add_argument("experiment")
+    parser.add_argument("path")
     args = parser.parse_args()
     assert os.path.exists(args.path)
     path = os.path.join(args.path, args.experiment)

--- a/benchs/bench_fwht.py
+++ b/benchs/bench_fwht.py
@@ -18,17 +18,17 @@ n = 10000
 nq = 200
 n_trials = 15
 
-print(f'n={n} vectors, nq={nq} queries, {n_trials} speed trials')
+print(f"n={n} vectors, nq={nq} queries, {n_trials} speed trials")
 
 # --- Speed benchmark ---
-print('\n=== Speed ===')
+print("\n=== Speed ===")
 print(f'{"dim":>6s}  {"HR (ms)":>10s}  {"RRM (ms)":>10s}  {"speedup":>8s}')
-print('-' * 42)
+print("-" * 42)
 
 dims = [64, 128, 256, 384, 512, 768, 1024, 1536, 2048, 3072, 4096, 6144, 8192]
 for d in dims:
     np.random.seed(42)
-    x = np.random.randn(n, d).astype('float32')
+    x = np.random.randn(n, d).astype("float32")
 
     hr = faiss.HadamardRotation(d, 42)
     hr.apply(x[:100])  # warmup
@@ -52,17 +52,17 @@ for d in dims:
     rr_ms = sorted(times_rr)[1]
 
     speedup = rr_ms / hr_ms
-    print(f'{d:6d}  {hr_ms:10.2f}  {rr_ms:10.2f}  {speedup:7.1f}x')
+    print(f"{d:6d}  {hr_ms:10.2f}  {rr_ms:10.2f}  {speedup:7.1f}x")
 
 # --- Recall benchmark with IVF (where rotation actually matters) ---
-print(f'\n=== Recall@1 with IVF (L2, n={n}, nq={nq}, k=1) ===')
+print(f"\n=== Recall@1 with IVF (L2, n={n}, nq={nq}, k=1) ===")
 print(f'{"dim":>6s}  {"HR R@1":>8s}  {"RRM R@1":>8s}  {"none R@1":>8s}')
-print('-' * 40)
+print("-" * 40)
 
 for d in [64, 128, 256, 768, 1024, 2048, 4096]:
     np.random.seed(42)
-    xb = np.random.randn(n, d).astype('float32')
-    xq = np.random.randn(nq, d).astype('float32')
+    xb = np.random.randn(n, d).astype("float32")
+    xq = np.random.randn(nq, d).astype("float32")
 
     # Ground truth (brute force, no transform)
     gt_index = faiss.IndexFlatL2(d)
@@ -72,9 +72,9 @@ for d in [64, 128, 256, 768, 1024, 2048, 4096]:
     nlist = 64
     recalls = {}
     for label, factory_str in [
-        ('HR', f'HR,IVF{nlist},Flat'),
-        ('RRM', f'RR,IVF{nlist},Flat'),
-        ('none', f'IVF{nlist},Flat'),
+        ("HR", f"HR,IVF{nlist},Flat"),
+        ("RRM", f"RR,IVF{nlist},Flat"),
+        ("none", f"IVF{nlist},Flat"),
     ]:
         index = faiss.index_factory(d, factory_str)
         index.train(xb)

--- a/benchs/bench_gpu_1bn.py
+++ b/benchs/bench_gpu_1bn.py
@@ -21,7 +21,8 @@ from datasets import ivecs_read
 
 
 def usage():
-    print("""
+    print(
+        """
 
 Usage: bench_gpu_1bn.py dataset indextype [options]
 
@@ -60,7 +61,9 @@ indextype: any index type supported by index_factory that runs on GPU.
                    %d will be replaced with the nprobe
 -oD xx%d.npy       output the search result distances to this file
 
-""", file=sys.stderr)
+""",
+        file=sys.stderr,
+    )
     sys.exit(1)
 
 
@@ -90,33 +93,33 @@ args = sys.argv[1:]
 
 while args:
     a = args.pop(0)
-    if a == '-h':
+    if a == "-h":
         usage()
-    elif a == '-ngpu':
+    elif a == "-ngpu":
         ngpu = int(args.pop(0))
-    elif a == '-R':
+    elif a == "-R":
         replicas = int(args.pop(0))
-    elif a == '-noptables':
+    elif a == "-noptables":
         use_precomputed_tables = False
-    elif a == '-abs':
+    elif a == "-abs":
         add_batch_size = int(args.pop(0))
-    elif a == '-qbs':
+    elif a == "-qbs":
         query_batch_size = int(args.pop(0))
-    elif a == '-nnn':
+    elif a == "-nnn":
         nnn = int(args.pop(0))
-    elif a == '-tempmem':
+    elif a == "-tempmem":
         tempmem = int(args.pop(0))
-    elif a == '-nocache':
+    elif a == "-nocache":
         use_cache = False
-    elif a == '-knngraph':
+    elif a == "-knngraph":
         knngraph = True
-    elif a == '-altadd':
+    elif a == "-altadd":
         altadd = True
-    elif a == '-float16':
+    elif a == "-float16":
         use_float16 = True
-    elif a == '-nprobe':
-        nprobes = [int(x) for x in args.pop(0).split(',')]
-    elif a == '-max_add':
+    elif a == "-nprobe":
+        nprobes = [int(x) for x in args.pop(0).split(",")]
+    elif a == "-max_add":
         max_add = int(args.pop(0))
     elif not dbname:
         dbname = a
@@ -126,7 +129,7 @@ while args:
         print("argument %s unknown" % a, file=sys.stderr)
         sys.exit(1)
 
-cacheroot = '/tmp/bench_gpu_1bn'
+cacheroot = "/tmp/bench_gpu_1bn"
 
 if not os.path.isdir(cacheroot):
     print("%s does not exist, creating it" % cacheroot)
@@ -141,14 +144,14 @@ if not os.path.isdir(cacheroot):
 
 
 def mmap_fvecs(fname):
-    x = np.memmap(fname, dtype='int32', mode='r')
+    x = np.memmap(fname, dtype="int32", mode="r")
     d = x[0]
-    return x.view('float32').reshape(-1, d + 1)[:, 1:]
+    return x.view("float32").reshape(-1, d + 1)[:, 1:]
 
 
 def mmap_bvecs(fname):
-    x = np.memmap(fname, dtype='uint8', mode='r')
-    d = x[:4].view('int32')[0]
+    x = np.memmap(fname, dtype="uint8", mode="r")
+    d = x[:4].view("int32")[0]
     return x.reshape(-1, d + 4)[:, 4:]
 
 
@@ -158,7 +161,7 @@ def rate_limited_imap(f, l):
     pool = ThreadPool(1)
     res = None
     for i in l:
-        res_next = pool.apply_async(f, (i, ))
+        res_next = pool.apply_async(f, (i,))
         if res:
             yield res.get()
         res = res_next
@@ -176,16 +179,15 @@ class IdentPreproc:
 
 
 def sanitize(x):
-    """ convert array to a c-contiguous float array """
-    return np.ascontiguousarray(x.astype('float32'))
+    """convert array to a c-contiguous float array"""
+    return np.ascontiguousarray(x.astype("float32"))
 
 
 def dataset_iterator(x, preproc, bs):
-    """ iterate over the lines of x in blocks of size bs"""
+    """iterate over the lines of x in blocks of size bs"""
 
     nb = x.shape[0]
-    block_ranges = [(i0, min(nb, i0 + bs))
-                    for i0 in range(0, nb, bs)]
+    block_ranges = [(i0, min(nb, i0 + bs)) for i0 in range(0, nb, bs)]
 
     def prepare_block(i01):
         i0, i1 = i01
@@ -196,14 +198,17 @@ def dataset_iterator(x, preproc, bs):
 
 
 def eval_intersection_measure(gt_I, I):
-    """ measure intersection measure (used for knngraph)"""
+    """measure intersection measure (used for knngraph)"""
     inter = 0
     rank = I.shape[1]
     assert gt_I.shape[1] >= rank
     for q in range(nq_gt):
         inter += faiss.ranklist_intersection_size(
-            rank, faiss.swig_ptr(gt_I[q, :]),
-            rank, faiss.swig_ptr(I[q, :].astype('int64')))
+            rank,
+            faiss.swig_ptr(gt_I[q, :]),
+            rank,
+            faiss.swig_ptr(I[q, :].astype("int64")),
+        )
     return inter / float(rank * nq_gt)
 
 
@@ -213,28 +218,28 @@ def eval_intersection_measure(gt_I, I):
 
 print("Preparing dataset", dbname)
 
-if dbname.startswith('SIFT'):
+if dbname.startswith("SIFT"):
     # SIFT1M to SIFT1000M
     dbsize = int(dbname[4:-1])
-    xb = mmap_bvecs('bigann/bigann_base.bvecs')
-    xq = mmap_bvecs('bigann/bigann_query.bvecs')
-    xt = mmap_bvecs('bigann/bigann_learn.bvecs')
+    xb = mmap_bvecs("bigann/bigann_base.bvecs")
+    xq = mmap_bvecs("bigann/bigann_query.bvecs")
+    xt = mmap_bvecs("bigann/bigann_learn.bvecs")
 
     # trim xb to correct size
-    xb = xb[:dbsize * 1000 * 1000]
+    xb = xb[: dbsize * 1000 * 1000]
 
-    gt_I = ivecs_read('bigann/gnd/idx_%dM.ivecs' % dbsize)
+    gt_I = ivecs_read("bigann/gnd/idx_%dM.ivecs" % dbsize)
 
-elif dbname == 'Deep1B':
-    xb = mmap_fvecs('deep1b/base.fvecs')
-    xq = mmap_fvecs('deep1b/deep1B_queries.fvecs')
-    xt = mmap_fvecs('deep1b/learn.fvecs')
+elif dbname == "Deep1B":
+    xb = mmap_fvecs("deep1b/base.fvecs")
+    xq = mmap_fvecs("deep1b/deep1B_queries.fvecs")
+    xt = mmap_fvecs("deep1b/learn.fvecs")
     # deep1B's train is outrageously big
-    xt = xt[:10 * 1000 * 1000]
-    gt_I = ivecs_read('deep1b/deep1B_groundtruth.ivecs')
+    xt = xt[: 10 * 1000 * 1000]
+    gt_I = ivecs_read("deep1b/deep1B_groundtruth.ivecs")
 
 else:
-    print('unknown dataset', dbname, file=sys.stderr)
+    print("unknown dataset", dbname, file=sys.stderr)
     sys.exit(1)
 
 
@@ -250,9 +255,10 @@ if knngraph:
     gt_I = None
 
 
-print("sizes: B %s Q %s T %s gt %s" % (
-    xb.shape, xq.shape, xt.shape,
-    gt_I.shape if gt_I is not None else None))
+print(
+    "sizes: B %s Q %s T %s gt %s"
+    % (xb.shape, xq.shape, xt.shape, gt_I.shape if gt_I is not None else None)
+)
 
 
 #################################################################
@@ -263,13 +269,13 @@ print("sizes: B %s Q %s T %s gt %s" % (
 #################################################################
 
 
-pat = re.compile('(OPQ[0-9]+(_[0-9]+)?,|PCAR[0-9]+,)?' +
-                 '(IVF[0-9]+),' +
-                 '(PQ[0-9]+|Flat)')
+pat = re.compile(
+    "(OPQ[0-9]+(_[0-9]+)?,|PCAR[0-9]+,)?" + "(IVF[0-9]+)," + "(PQ[0-9]+|Flat)"
+)
 
 matchobject = pat.match(index_key)
 
-assert matchobject, 'could not parse ' + index_key
+assert matchobject, "could not parse " + index_key
 
 mog = matchobject.groups()
 
@@ -279,26 +285,41 @@ pqflat_str = mog[3]
 
 ncent = int(ivf_str[3:])
 
-prefix = ''
+prefix = ""
 
 if knngraph:
-    gt_cachefile = '%s/BK_gt_%s.npy' % (cacheroot, dbname)
-    prefix = 'BK_'
+    gt_cachefile = "%s/BK_gt_%s.npy" % (cacheroot, dbname)
+    prefix = "BK_"
     # files must be kept distinct because the training set is not the
     # same for the knngraph
 
 if preproc_str:
-    preproc_cachefile = '%s/%spreproc_%s_%s.vectrans' % (
-        cacheroot, prefix, dbname, preproc_str[:-1])
+    preproc_cachefile = "%s/%spreproc_%s_%s.vectrans" % (
+        cacheroot,
+        prefix,
+        dbname,
+        preproc_str[:-1],
+    )
 else:
     preproc_cachefile = None
-    preproc_str = ''
+    preproc_str = ""
 
-cent_cachefile = '%s/%scent_%s_%s%s.npy' % (
-    cacheroot, prefix, dbname, preproc_str, ivf_str)
+cent_cachefile = "%s/%scent_%s_%s%s.npy" % (
+    cacheroot,
+    prefix,
+    dbname,
+    preproc_str,
+    ivf_str,
+)
 
-index_cachefile = '%s/%s%s_%s%s,%s.index' % (
-    cacheroot, prefix, dbname, preproc_str, ivf_str, pqflat_str)
+index_cachefile = "%s/%s%s_%s%s,%s.index" % (
+    cacheroot,
+    prefix,
+    dbname,
+    preproc_str,
+    ivf_str,
+    pqflat_str,
+)
 
 
 if not use_cache:
@@ -328,7 +349,7 @@ for _ in range(ngpu):
 
 
 def make_vres_vdev(i0=0, i1=-1):
-    " return vectors of device ids and resources useful for gpu_multiple"
+    "return vectors of device ids and resources useful for gpu_multiple"
     vres = faiss.GpuResourcesVector()
     vdev = faiss.IntVector()
     if i1 == -1:
@@ -348,33 +369,31 @@ def compute_GT():
     print("compute GT")
     t0 = time.time()
 
-    gt_I = np.zeros((nq_gt, gt_sl), dtype='int64')
-    gt_D = np.zeros((nq_gt, gt_sl), dtype='float32')
+    gt_I = np.zeros((nq_gt, gt_sl), dtype="int64")
+    gt_D = np.zeros((nq_gt, gt_sl), dtype="float32")
     heaps = faiss.float_maxheap_array_t()
     heaps.k = gt_sl
     heaps.nh = nq_gt
     heaps.val = faiss.swig_ptr(gt_D)
     heaps.ids = faiss.swig_ptr(gt_I)
     heaps.heapify()
-    bs = 10 ** 5
+    bs = 10**5
 
     n, d = xb.shape
     xqs = sanitize(xq[:nq_gt])
 
     db_gt = faiss.IndexFlatL2(d)
     vres, vdev = make_vres_vdev()
-    db_gt_gpu = faiss.index_cpu_to_gpu_multiple(
-        vres, vdev, db_gt)
+    db_gt_gpu = faiss.index_cpu_to_gpu_multiple(vres, vdev, db_gt)
 
     # compute ground-truth by blocks of bs, and add to heaps
     for i0, xsl in dataset_iterator(xb, IdentPreproc(d), bs):
         db_gt_gpu.add(xsl)
         D, I = db_gt_gpu.search(xqs, gt_sl)
         I += i0
-        heaps.addn_with_ids(
-            gt_sl, faiss.swig_ptr(D), faiss.swig_ptr(I), gt_sl)
+        heaps.addn_with_ids(gt_sl, faiss.swig_ptr(D), faiss.swig_ptr(I), gt_sl)
         db_gt_gpu.reset()
-        print("\r   %d/%d, %.3f s" % (i0, n, time.time() - t0), end=' ')
+        print("\r   %d/%d, %.3f s" % (i0, n, time.time() - t0), end=" ")
     print()
     heaps.reorder()
 
@@ -402,12 +421,12 @@ def train_preprocessor():
     print("train preproc", preproc_str)
     d = xt.shape[1]
     t0 = time.time()
-    if preproc_str.startswith('OPQ'):
-        fi = preproc_str[3:-1].split('_')
+    if preproc_str.startswith("OPQ"):
+        fi = preproc_str[3:-1].split("_")
         m = int(fi[0])
         dout = int(fi[1]) if len(fi) == 2 else d
         preproc = faiss.OPQMatrix(d, m, dout)
-    elif preproc_str.startswith('PCAR'):
+    elif preproc_str.startswith("PCAR"):
         dout = int(preproc_str[4:-1])
         preproc = faiss.PCAMatrix(d, dout, 0, True)
     else:
@@ -445,15 +464,13 @@ def train_coarse_quantizer(x, k, preproc):
     # clus.niter = 2
     clus.max_points_per_centroid = 10000000
 
-    print("apply preproc on shape", x.shape, 'k=', k)
+    print("apply preproc on shape", x.shape, "k=", k)
     t0 = time.time()
     x = preproc.apply_py(sanitize(x))
-    print("   preproc %.3f s output shape %s" % (
-        time.time() - t0, x.shape))
+    print("   preproc %.3f s output shape %s" % (time.time() - t0, x.shape))
 
     vres, vdev = make_vres_vdev()
-    index = faiss.index_cpu_to_gpu_multiple(
-        vres, vdev, faiss.IndexFlatL2(d))
+    index = faiss.index_cpu_to_gpu_multiple(vres, vdev, faiss.IndexFlatL2(d))
 
     clus.train(x, index)
     centroids = faiss.vector_float_to_array(clus.centroids)
@@ -491,10 +508,11 @@ def prepare_trained_index(preproc):
 
     coarse_quantizer = prepare_coarse_quantizer(preproc)
     d = preproc.d_out
-    if pqflat_str == 'Flat':
+    if pqflat_str == "Flat":
         print("making an IVFFlat index")
-        idx_model = faiss.IndexIVFFlat(coarse_quantizer, d, ncent,
-                                       faiss.METRIC_L2)
+        idx_model = faiss.IndexIVFFlat(
+            coarse_quantizer, d, ncent, faiss.METRIC_L2
+        )
     else:
         m = int(pqflat_str[2:])
         assert m < 56 or use_float16, "PQ%d will work only with -float16" % m
@@ -516,7 +534,7 @@ def prepare_trained_index(preproc):
 
 def compute_populated_index(preproc):
     """Add elements to a sharded index. Return the index and if available
-    a sharded gpu_index that contains the same data. """
+    a sharded gpu_index that contains the same data."""
 
     indexall = prepare_trained_index(preproc)
 
@@ -530,8 +548,7 @@ def compute_populated_index(preproc):
     co.shard = True
     assert co.shard_type in (0, 1, 2)
     vres, vdev = make_vres_vdev()
-    gpu_index = faiss.index_cpu_to_gpu_multiple(
-        vres, vdev, indexall, co)
+    gpu_index = faiss.index_cpu_to_gpu_multiple(vres, vdev, indexall, co)
 
     print("add...")
     t0 = time.time()
@@ -550,15 +567,14 @@ def compute_populated_index(preproc):
                 index_src_gpu.reserveMemory(max_add)
             gpu_index.sync_with_shard_indexes()
 
-        print('\r%d/%d (%.3f s)  ' % (
-            i0, nb, time.time() - t0), end=' ')
+        print("\r%d/%d (%.3f s)  " % (i0, nb, time.time() - t0), end=" ")
         sys.stdout.flush()
     print("Add time: %.3f s" % (time.time() - t0))
 
     print("Aggregate indexes to CPU")
     t0 = time.time()
 
-    if hasattr(gpu_index, 'at'):
+    if hasattr(gpu_index, "at"):
         # it is a sharded index
         for i in range(ngpu):
             index_src = faiss.index_gpu_to_cpu(gpu_index.at(i))
@@ -591,7 +607,8 @@ def compute_populated_index_2(preproc):
 
     vres, vdev = make_vres_vdev()
     coarse_quantizer_gpu = faiss.index_cpu_to_gpu_multiple(
-        vres, vdev, indexall.quantizer)
+        vres, vdev, indexall.quantizer
+    )
 
     def quantize(args):
         (i0, xs) = args
@@ -607,16 +624,17 @@ def compute_populated_index_2(preproc):
     for i0, xs, assign in stage2:
         i1 = i0 + xs.shape[0]
         if indexall.__class__ == faiss.IndexIVFPQ:
-            indexall.add_core_o(i1 - i0, faiss.swig_ptr(xs),
-                                None, None, faiss.swig_ptr(assign))
+            indexall.add_core_o(
+                i1 - i0, faiss.swig_ptr(xs), None, None, faiss.swig_ptr(assign)
+            )
         elif indexall.__class__ == faiss.IndexIVFFlat:
-            indexall.add_core(i1 - i0, faiss.swig_ptr(xs), None,
-                              faiss.swig_ptr(assign))
+            indexall.add_core(
+                i1 - i0, faiss.swig_ptr(xs), None, faiss.swig_ptr(assign)
+            )
         else:
             assert False
 
-        print('\r%d/%d (%.3f s)  ' % (
-            i0, nb, time.time() - t0), end=' ')
+        print("\r%d/%d (%.3f s)  " % (i0, nb, time.time() - t0), end=" ")
         sys.stdout.flush()
     print("Add time: %.3f s" % (time.time() - t0))
 
@@ -644,7 +662,7 @@ def get_populated_index(preproc):
     co.usePrecomputed = use_precomputed_tables
     co.indicesOptions = 0
     co.verbose = True
-    co.shard = True    # the replicas will be made "manually"
+    co.shard = True  # the replicas will be made "manually"
     t0 = time.time()
     print("CPU index contains %d vectors, move to GPU" % indexall.ntotal)
     if replicas == 1:
@@ -652,8 +670,7 @@ def get_populated_index(preproc):
         if not gpu_index:
             print("copying loaded index to GPUs")
             vres, vdev = make_vres_vdev()
-            index = faiss.index_cpu_to_gpu_multiple(
-                vres, vdev, indexall, co)
+            index = faiss.index_cpu_to_gpu_multiple(vres, vdev, indexall, co)
         else:
             index = gpu_index
 
@@ -671,15 +688,13 @@ def get_populated_index(preproc):
 
             print("   dispatch to GPUs %d:%d" % (gpu0, gpu1))
 
-            index1 = faiss.index_cpu_to_gpu_multiple(
-                vres, vdev, indexall, co)
+            index1 = faiss.index_cpu_to_gpu_multiple(vres, vdev, indexall, co)
             index1.this.disown()
             index.addIndex(index1)
         index.own_fields = True
     del indexall
     print("move to GPU done in %.3f s" % (time.time() - t0))
     return index
-
 
 
 #################################################################
@@ -697,20 +712,23 @@ def eval_dataset(index, preproc):
     sl = query_batch_size
     nq = xq.shape[0]
     for nprobe in nprobes:
-        ps.set_index_parameter(index, 'nprobe', nprobe)
+        ps.set_index_parameter(index, "nprobe", nprobe)
         t0 = time.time()
 
         if sl == 0:
             D, I = index.search(preproc.apply_py(sanitize(xq)), nnn)
         else:
-            I = np.empty((nq, nnn), dtype='int32')
-            D = np.empty((nq, nnn), dtype='float32')
+            I = np.empty((nq, nnn), dtype="int32")
+            D = np.empty((nq, nnn), dtype="float32")
 
-            inter_res = ''
+            inter_res = ""
 
             for i0, xs in dataset_iterator(xq, preproc, sl):
-                print('\r%d/%d (%.3f s%s)   ' % (
-                    i0, nq, time.time() - t0, inter_res), end=' ')
+                print(
+                    "\r%d/%d (%.3f s%s)   "
+                    % (i0, nq, time.time() - t0, inter_res),
+                    end=" ",
+                )
                 sys.stdout.flush()
 
                 i1 = i0 + xs.shape[0]
@@ -720,24 +738,25 @@ def eval_dataset(index, preproc):
                 D[i0:i1] = Di
 
                 if knngraph and not inter_res and i1 >= nq_gt:
-                    ires = eval_intersection_measure(
-                        gt_I[:, :nnn], I[:nq_gt])
-                    inter_res = ', %.4f' % ires
+                    ires = eval_intersection_measure(gt_I[:, :nnn], I[:nq_gt])
+                    inter_res = ", %.4f" % ires
 
         t1 = time.time()
         if knngraph:
             ires = eval_intersection_measure(gt_I[:, :nnn], I[:nq_gt])
-            print("  probe=%-3d: %.3f s rank-%d intersection results: %.4f" % (
-                nprobe, t1 - t0, nnn, ires))
+            print(
+                "  probe=%-3d: %.3f s rank-%d intersection results: %.4f"
+                % (nprobe, t1 - t0, nnn, ires)
+            )
         else:
-            print("  probe=%-3d: %.3f s" % (nprobe, t1 - t0), end=' ')
+            print("  probe=%-3d: %.3f s" % (nprobe, t1 - t0), end=" ")
             gtc = gt_I[:, :1]
             nq = xq.shape[0]
             for rank in (1, 10, 100):
                 if rank > nnn:
                     continue
                 nok = (I[:, :rank] == gtc).sum()
-                print("1-R@%d: %.4f" % (rank, nok / float(nq)), end=' ')
+                print("1-R@%d: %.4f" % (rank, nok / float(nq)), end=" ")
             print()
         if I_fname:
             I_fname_i = I_fname % nprobe

--- a/benchs/bench_gpu_sift1m.py
+++ b/benchs/bench_gpu_sift1m.py
@@ -84,4 +84,7 @@ for lnprobe in range(10):
     index.nprobe = nprobe
     t, r = evaluate(index, xq, gt, 100)
 
-    print("nprobe=%4d %.3f ms recalls= %.4f %.4f %.4f" % (nprobe, t, r[1], r[10], r[100]))
+    print(
+        "nprobe=%4d %.3f ms recalls= %.4f %.4f %.4f"
+        % (nprobe, t, r[1], r[10], r[100])
+    )

--- a/benchs/bench_hamming_knn.py
+++ b/benchs/bench_hamming_knn.py
@@ -13,9 +13,9 @@ if __name__ == "__main__":
     for d in 4, 8, 16, 32, 64, 128, 256, 512, 1024:
         nq = 10000
         nb = 30000
-        print('Bits per vector = 8 *', d)
-        xq = faiss.randint((nq, d // 4), seed=1234, vmax=256**4).view('uint8')
-        xb = faiss.randint((nb, d // 4), seed=1234, vmax=256**4).view('uint8')
+        print("Bits per vector = 8 *", d)
+        xq = faiss.randint((nq, d // 4), seed=1234, vmax=256**4).view("uint8")
+        xb = faiss.randint((nb, d // 4), seed=1234, vmax=256**4).view("uint8")
         for variant in "hc", "mc":
             print(f"{variant=:}", end="\t")
             for k in 1, 4, 16, 64, 256:
@@ -25,5 +25,9 @@ if __name__ == "__main__":
                     D, I = faiss.knn_hamming(xq, xb, k, variant=variant)
                     t1 = time.time()
                     times.append(t1 - t0)
-                print(f'| {k=:} t={np.mean(times):.3f} s ± {np.std(times):.3f} ', flush=True, end="")
+                print(
+                    f"| {k=:} t={np.mean(times):.3f} s ± {np.std(times):.3f} ",
+                    flush=True,
+                    end="",
+                )
             print()

--- a/benchs/bench_hnsw.py
+++ b/benchs/bench_hnsw.py
@@ -221,7 +221,7 @@ if "hnsw_locks" in todo:
         t2 = None
         for i in range(0, len(xb), batch_size):
             t1 = time.time()
-            index.add(xb[i: i + batch_size])
+            index.add(xb[i : i + batch_size])
             t2 = time.time()
             if i > 2 and t2 - t0 > 2:
                 break

--- a/benchs/bench_hnsw_flat_panorama.py
+++ b/benchs/bench_hnsw_flat_panorama.py
@@ -104,7 +104,9 @@ def benchmark_dataset(ds, dataset_name, k=10, nlevels=8, M=32):
     plot_data = []
 
     # HNSW Flat (baseline)
-    eval_and_plot(f"HNSW{M},Flat", ds, k=k, nlevels=nlevels, plot_data=plot_data)
+    eval_and_plot(
+        f"HNSW{M},Flat", ds, k=k, nlevels=nlevels, plot_data=plot_data
+    )
 
     # HNSW Flat Panorama (with PCA to concentrate energy)
     eval_and_plot(
@@ -153,6 +155,6 @@ if __name__ == "__main__":
         print(f"{'='*60}")
         benchmark_dataset(ds, name, k=k, nlevels=nlevels, M=M)
 
-    print("\n" + "="*60)
+    print("\n" + "=" * 60)
     print("All benchmarks completed!")
-    print("="*60)
+    print("=" * 60)

--- a/benchs/bench_hnsw_prune_headroom.py
+++ b/benchs/bench_hnsw_prune_headroom.py
@@ -108,7 +108,8 @@ def run_benchmark(
     for headroom in headroom_values:
         for rep in range(reps):
             index, build_time = build_hnsw_index(
-                d, m, xb, ef_construction, headroom)
+                d, m, xb, ef_construction, headroom
+            )
             results["build_times"][headroom] = build_time
 
             faiss.cvar.hnsw_stats.reset()

--- a/benchs/bench_hybrid_cpu_gpu.py
+++ b/benchs/bench_hybrid_cpu_gpu.py
@@ -34,12 +34,13 @@ def search_preassigned(xq, k, index, quantizer, batch_size=0):
     nprobe = index.nprobe
     if batch_size == 0:
         batch_size = n + 1
-    D = np.empty((n, k), dtype='float32')
-    I = np.empty((n, k), dtype='int64')
+    D = np.empty((n, k), dtype="float32")
+    I = np.empty((n, k), dtype="int64")
     for i0 in range(0, n, batch_size):
-        Dq, Iq = quantizer.search(xq[i0:i0 + batch_size], nprobe)
-        D[i0:i0 + batch_size], I[i0:i0 + batch_size] = \
-            index.search_preassigned(xq[i0:i0 + batch_size], k, Iq, Dq)
+        Dq, Iq = quantizer.search(xq[i0 : i0 + batch_size], nprobe)
+        D[i0 : i0 + batch_size], I[i0 : i0 + batch_size] = (
+            index.search_preassigned(xq[i0 : i0 + batch_size], k, Iq, Dq)
+        )
     return D, I
 
 
@@ -61,16 +62,17 @@ def tiled_search_preassigned(xq, k, index, quantizer, batch_size=32768):
         i1 = min(i0 + batch_size, n)
         return quantizer.search(xq[i0:i1], nprobe)
 
-    D = np.empty((n, k), dtype='float32')
-    I = np.empty((n, k), dtype='int64')
+    D = np.empty((n, k), dtype="float32")
+    I = np.empty((n, k), dtype="int64")
     qq = coarse_quant(0)
 
     for i0 in range(0, n, batch_size):
         i1 = min(i0 + batch_size, n)
-        qq_next = qq_pool.apply_async(coarse_quant, (i0 + batch_size, ))
+        qq_next = qq_pool.apply_async(coarse_quant, (i0 + batch_size,))
         Dq, Iq = qq
         index.search_preassigned(
-            xq[i0:i1], k, Iq=Iq, Dq=Dq, I=I[i0:i1], D=D[i0:i1])
+            xq[i0:i1], k, Iq=Iq, Dq=Dq, I=I[i0:i1], D=D[i0:i1]
+        )
         qq = qq_next.get()
 
     qq_pool.close()
@@ -80,6 +82,7 @@ def tiled_search_preassigned(xq, k, index, quantizer, batch_size=32768):
 #################################################################
 # IVF index objects with a separate coarse quantizer
 #################################################################
+
 
 class SeparateCoarseQuantizationIndex:
     """
@@ -120,10 +123,12 @@ class SeparateCoarseQuantizationIndex:
             return self.index_ivf.search_preassigned(xq, k, Iq, Dq)
         if self.seq_tiling:
             return search_preassigned(
-                xq, k, self.index_ivf, self.quantizer, self.bs)
+                xq, k, self.index_ivf, self.quantizer, self.bs
+            )
         else:
             return tiled_search_preassigned(
-                xq, k, self.index_ivf, self.quantizer, self.bs)
+                xq, k, self.index_ivf, self.quantizer, self.bs
+            )
 
 
 class ShardedGPUIndex:
@@ -131,6 +136,7 @@ class ShardedGPUIndex:
     Multiple GPU indexes, each on its GPU, with a common coarse quantizer.
     The Python version of IndexShardsIVF
     """
+
     def __init__(self, quantizer, index, bs=-1, seq_tiling=False):
         self.quantizer = quantizer
         self.cpu_index = index
@@ -159,8 +165,8 @@ class ShardedGPUIndex:
         sub_index_0 = faiss.downcast_index(index.at(0))
         nprobe = sub_index_0.nprobe
 
-        Dall = np.empty((ngpu, nq, k), dtype='float32')
-        Iall = np.empty((ngpu, nq, k), dtype='int64')
+        Dall = np.empty((ngpu, nq, k), dtype="float32")
+        Iall = np.empty((ngpu, nq, k), dtype="int64")
         bs = self.bs
         if bs <= 0:
 
@@ -169,7 +175,9 @@ class ShardedGPUIndex:
             def do_search(rank):
                 gpu_index = faiss.downcast_index(index.at(rank))
                 Dall[rank], Iall[rank] = gpu_index.search_preassigned(
-                    xq, k, Iq, Dq)
+                    xq, k, Iq, Dq
+                )
+
             list(self.pool.map(do_search, range(ngpu)))
         else:
             qq_pool = self.q_pool
@@ -178,30 +186,32 @@ class ShardedGPUIndex:
             def coarse_quant(i0):
                 if i0 >= nq:
                     return None
-                return self.quantizer.search(xq[i0:i0 + bs], nprobe)
+                return self.quantizer.search(xq[i0 : i0 + bs], nprobe)
 
             def do_search(rank, i0, qq):
                 gpu_index = faiss.downcast_index(index.at(rank))
                 Dq, Iq = qq
-                Dall[rank, i0:i0 + bs], Iall[rank, i0:i0 + bs] = \
-                    gpu_index.search_preassigned(xq[i0:i0 + bs], k, Iq, Dq)
+                Dall[rank, i0 : i0 + bs], Iall[rank, i0 : i0 + bs] = (
+                    gpu_index.search_preassigned(xq[i0 : i0 + bs], k, Iq, Dq)
+                )
 
             qq = coarse_quant(0)
 
             for i0 in range(0, nq, bs):
-                qq_next = qq_pool.apply_async(coarse_quant, (i0 + bs, ))
-                list(self.pool.map(
-                    lambda rank: do_search(rank, i0, qq),
-                    range(ngpu)
-                ))
+                qq_next = qq_pool.apply_async(coarse_quant, (i0 + bs,))
+                list(
+                    self.pool.map(
+                        lambda rank: do_search(rank, i0, qq), range(ngpu)
+                    )
+                )
                 qq = qq_next.get()
 
         return faiss.merge_knn_results(Dall, Iall)
 
 
 def extract_index_ivf(index):
-    """ extract the IVF sub-index from the index, supporting GpuIndexes
-    as well """
+    """extract the IVF sub-index from the index, supporting GpuIndexes
+    as well"""
     try:
         return faiss.extract_index_ivf(index)
     except RuntimeError:
@@ -221,7 +231,8 @@ def set_index_parameter(index, name, val):
             set_index_parameter(index.index_ivf, name, val)
         elif name.startswith("quantizer_"):
             set_index_parameter(
-                index.quantizer, name[name.find("_") + 1:], val)
+                index.quantizer, name[name.find("_") + 1 :], val
+            )
         else:
             raise RuntimeError()
         return
@@ -231,7 +242,8 @@ def set_index_parameter(index, name, val):
             set_index_parameter(index.cpu_index, name, val)
         elif name.startswith("quantizer_"):
             set_index_parameter(
-                index.quantizer, name[name.find("_") + 1:], val)
+                index.quantizer, name[name.find("_") + 1 :], val
+            )
         else:
             raise RuntimeError()
         return
@@ -244,20 +256,23 @@ def set_index_parameter(index, name, val):
     elif isinstance(index, faiss.IndexShardsIVF):
         if name != "nprobe" and name.startswith("quantizer_"):
             set_index_parameter(
-                index.quantizer, name[name.find("_") + 1:], val)
+                index.quantizer, name[name.find("_") + 1 :], val
+            )
         else:
             for i in range(index.count()):
                 sub_index = index.at(i)
                 set_index_parameter(sub_index, name, val)
-    elif (isinstance(index, faiss.IndexShards) or
-          isinstance(index, faiss.IndexReplicas)):
+    elif isinstance(index, faiss.IndexShards) or isinstance(
+        index, faiss.IndexReplicas
+    ):
         for i in range(index.count()):
             sub_index = index.at(i)
             set_index_parameter(sub_index, name, val)
     elif name.startswith("quantizer_"):
         index_ivf = extract_index_ivf(index)
         set_index_parameter(
-            index_ivf.quantizer, name[name.find("_") + 1:], val)
+            index_ivf.quantizer, name[name.find("_") + 1 :], val
+        )
     elif name == "efSearch":
         index.hnsw.efSearch
         index.hnsw.efSearch = int(val)
@@ -280,47 +295,85 @@ def main():
     def aa(*args, **kwargs):
         group.add_argument(*args, **kwargs)
 
-    group = parser.add_argument_group('dataset options')
-    aa('--nq', type=int, default=int(10e5),
-       help="nb queries (queries will be duplicated if below that number)")
-    aa('--db', default='bigann10M', help='dataset')
+    group = parser.add_argument_group("dataset options")
+    aa(
+        "--nq",
+        type=int,
+        default=int(10e5),
+        help="nb queries (queries will be duplicated if below that number)",
+    )
+    aa("--db", default="bigann10M", help="dataset")
 
-    group = parser.add_argument_group('index options')
-    aa('--indexname', default="", help="override index name")
-    aa('--mmap', default=False, action='store_true', help='mmap index')
-    aa('--shard_type', default=1, type=int, help="set type of sharding")
-    aa('--useFloat16', default=False, action='store_true',
-       help='GPU cloner options')
-    aa('--useFloat16CoarseQuantizer', default=False, action='store_true',
-       help='GPU cloner options')
-    aa('--usePrecomputed', default=False, action='store_true',
-       help='GPU cloner options')
-    group = parser.add_argument_group('search options')
-    aa('--k', type=int, default=100)
-    aa('--search_type', default="cpu",
+    group = parser.add_argument_group("index options")
+    aa("--indexname", default="", help="override index name")
+    aa("--mmap", default=False, action="store_true", help="mmap index")
+    aa("--shard_type", default=1, type=int, help="set type of sharding")
+    aa(
+        "--useFloat16",
+        default=False,
+        action="store_true",
+        help="GPU cloner options",
+    )
+    aa(
+        "--useFloat16CoarseQuantizer",
+        default=False,
+        action="store_true",
+        help="GPU cloner options",
+    )
+    aa(
+        "--usePrecomputed",
+        default=False,
+        action="store_true",
+        help="GPU cloner options",
+    )
+    group = parser.add_argument_group("search options")
+    aa("--k", type=int, default=100)
+    aa(
+        "--search_type",
+        default="cpu",
         choices=[
-            "cpu", "gpu", "gpu_flat_quantizer",
-            "cpu_flat_gpu_quantizer", "gpu_tiled", "gpu_ivf_quantizer",
-            "multi_gpu", "multi_gpu_flat_quantizer",
-            "multi_gpu_sharded", "multi_gpu_flat_quantizer_sharded",
-            "multi_gpu_sharded1", "multi_gpu_sharded1_flat",
+            "cpu",
+            "gpu",
+            "gpu_flat_quantizer",
+            "cpu_flat_gpu_quantizer",
+            "gpu_tiled",
+            "gpu_ivf_quantizer",
+            "multi_gpu",
+            "multi_gpu_flat_quantizer",
+            "multi_gpu_sharded",
+            "multi_gpu_flat_quantizer_sharded",
+            "multi_gpu_sharded1",
+            "multi_gpu_sharded1_flat",
             "multi_gpu_sharded1_ivf",
-            "multi_gpu_Csharded1", "multi_gpu_Csharded1_flat",
+            "multi_gpu_Csharded1",
+            "multi_gpu_Csharded1_flat",
             "multi_gpu_Csharded1_ivf",
         ],
-        help="how to search"
+        help="how to search",
     )
-    aa('--ivf_quant_nlist', type=int, default=1024,
-       help="nb of inverted lists for IVF quantizer")
-    aa('--batch_size', type=int, default=-1,
-       help="batch size for tiled CPU / GPU computation (-1= no tiling)")
-    aa('--n_autotune', type=int, default=300,
-        help="max nb of auto-tuning steps")
-    aa('--nt', type=int, default=-1, help="force number of CPU threads to this")
+    aa(
+        "--ivf_quant_nlist",
+        type=int,
+        default=1024,
+        help="nb of inverted lists for IVF quantizer",
+    )
+    aa(
+        "--batch_size",
+        type=int,
+        default=-1,
+        help="batch size for tiled CPU / GPU computation (-1= no tiling)",
+    )
+    aa(
+        "--n_autotune",
+        type=int,
+        default=300,
+        help="max nb of auto-tuning steps",
+    )
+    aa("--nt", type=int, default=-1, help="force number of CPU threads to this")
 
-    group = parser.add_argument_group('output options')
-    aa('--quiet', default=False, action="store_true")
-    aa('--stats', default="", help="pickle to store output stats")
+    group = parser.add_argument_group("output options")
+    aa("--quiet", default=False, action="store_true")
+    aa("--stats", default="", help="pickle to store output stats")
 
     args = parser.parse_args()
     print("args:", args)
@@ -342,7 +395,7 @@ def main():
         xqx = []
         n = 0
         while n < args.nq:
-            xqx.append(xq[:args.nq - n])
+            xqx.append(xq[: args.nq - n])
             n += len(xqx[-1])
         print(f"increased nb queries from {len(xq)} to {n}")
         xq = np.vstack(xqx)
@@ -365,10 +418,12 @@ def main():
     print("prepare index")
     op = OperatingPointsWithRanges()
     op.add_range(
-        "nprobe", [
-            2 ** i for i in range(20)
-            if 2 ** i < index_ivf.nlist * 0.1 and 2 ** i <= 4096
-        ]
+        "nprobe",
+        [
+            2**i
+            for i in range(20)
+            if 2**i < index_ivf.nlist * 0.1 and 2**i <= 4096
+        ],
     )
 
     # prepare options for GPU clone
@@ -380,18 +435,12 @@ def main():
     co.shard_type = args.shard_type
 
     if args.search_type == "cpu":
-        op.add_range(
-            "quantizer_efSearch",
-            [2 ** i for i in range(10)]
-        )
+        op.add_range("quantizer_efSearch", [2**i for i in range(10)])
     elif args.search_type == "gpu":
         print("move index to 1 GPU")
         res = faiss.StandardGpuResources()
         index = faiss.index_cpu_to_gpu(res, 0, index, co)
-        op.add_range(
-            "quantizer_efSearch",
-            [2 ** i for i in range(10)]
-        )
+        op.add_range("quantizer_efSearch", [2**i for i in range(10)])
         op.restrict_range("nprobe", 2049)
     elif args.search_type == "gpu_tiled":
         print("move index to 1 GPU")
@@ -399,31 +448,28 @@ def main():
         quantizer_hnsw = replace_ivf_quantizer(index_ivf, new_quantizer)
         res = faiss.StandardGpuResources()
         index = faiss.index_cpu_to_gpu(res, 0, index, co)
-        op.add_range(
-            "quantizer_efSearch",
-            [2 ** i for i in range(10)]
-        )
+        op.add_range("quantizer_efSearch", [2**i for i in range(10)])
         op.restrict_range("nprobe", 2049)
         index = SeparateCoarseQuantizationIndex(
-            quantizer_hnsw, index, bs=args.batch_size)
+            quantizer_hnsw, index, bs=args.batch_size
+        )
     elif args.search_type == "gpu_ivf_quantizer":
         index_ivf = faiss.extract_index_ivf(index)
         centroids = index_ivf.quantizer.reconstruct_n()
         replace_ivf_quantizer(index_ivf, faiss.IndexFlatL2(index_ivf.d))
         res = faiss.StandardGpuResources()
         new_quantizer = faiss.index_factory(
-            index_ivf.d, f"IVF{args.ivf_quant_nlist},Flat")
+            index_ivf.d, f"IVF{args.ivf_quant_nlist},Flat"
+        )
         new_quantizer.train(centroids)
         new_quantizer.add(centroids)
         index = SeparateCoarseQuantizationIndex(
             faiss.index_cpu_to_gpu(res, 0, new_quantizer, co),
             faiss.index_cpu_to_gpu(res, 0, index, co),
-            bs=args.batch_size, seq_tiling=True
+            bs=args.batch_size,
+            seq_tiling=True,
         )
-        op.add_range(
-            "quantizer_nprobe",
-            [2 ** i for i in range(9)]
-        )
+        op.add_range("quantizer_nprobe", [2**i for i in range(9)])
         op.restrict_range("nprobe", 1025)
     elif args.search_type == "gpu_flat_quantizer":
         index_ivf = faiss.extract_index_ivf(index)
@@ -438,27 +484,29 @@ def main():
         res = faiss.StandardGpuResources()
         quantizer = faiss.index_cpu_to_gpu(res, 0, quantizer, co)
         index = SeparateCoarseQuantizationIndex(
-            quantizer, index, bs=args.batch_size)
+            quantizer, index, bs=args.batch_size
+        )
         op.restrict_range("nprobe", 2049)
     elif args.search_type in ("multi_gpu", "multi_gpu_sharded"):
         print(f"move index to {faiss.get_num_gpus()} GPU")
         co.shard = "sharded" in args.search_type
         index = faiss.index_cpu_to_all_gpus(index, co=co)
-        op.add_range(
-            "quantizer_efSearch",
-            [2 ** i for i in range(10)]
-        )
+        op.add_range("quantizer_efSearch", [2**i for i in range(10)])
         op.restrict_range("nprobe", 2049)
     elif args.search_type in (
-            "multi_gpu_flat_quantizer", "multi_gpu_flat_quantizer_sharded"):
+        "multi_gpu_flat_quantizer",
+        "multi_gpu_flat_quantizer_sharded",
+    ):
         index_ivf = faiss.extract_index_ivf(index)
         new_quantizer = faiss.IndexFlatL2(ds.d)
         replace_ivf_quantizer(index_ivf, new_quantizer)
         index = faiss.index_cpu_to_all_gpus(index, co=co)
         op.restrict_range("nprobe", 2049)
     elif args.search_type in (
-            "multi_gpu_sharded1", "multi_gpu_sharded1_flat",
-            "multi_gpu_sharded1_ivf"):
+        "multi_gpu_sharded1",
+        "multi_gpu_sharded1_flat",
+        "multi_gpu_sharded1_ivf",
+    ):
         print(f"move index to {faiss.get_num_gpus()} GPU")
         new_quantizer = faiss.IndexFlatL2(index_ivf.d)
         hnsw_quantizer = replace_ivf_quantizer(index_ivf, new_quantizer)
@@ -469,47 +517,43 @@ def main():
         index = faiss.index_cpu_to_gpu_multiple_py(res, index, co, gpus)
         op.restrict_range("nprobe", 2049)
         if args.search_type == "multi_gpu_sharded1":
-            op.add_range(
-                "quantizer_efSearch",
-                [2 ** i for i in range(10)]
-            )
+            op.add_range("quantizer_efSearch", [2**i for i in range(10)])
             index = ShardedGPUIndex(hnsw_quantizer, index, bs=args.batch_size)
         elif args.search_type == "multi_gpu_sharded1_ivf":
             centroids = hnsw_quantizer.storage.reconstruct_n()
             quantizer = faiss.index_factory(
-                centroids.shape[1], f"IVF{args.ivf_quant_nlist},Flat")
+                centroids.shape[1], f"IVF{args.ivf_quant_nlist},Flat"
+            )
             quantizer.train(centroids)
             quantizer.add(centroids)
             co.shard = False
             quantizer = faiss.index_cpu_to_gpu_multiple_py(
-                res, quantizer, co, gpus)
+                res, quantizer, co, gpus
+            )
             index = ShardedGPUIndex(quantizer, index, bs=args.batch_size)
 
-            op.add_range(
-                "quantizer_nprobe",
-                [2 ** i for i in range(9)]
-            )
+            op.add_range("quantizer_nprobe", [2**i for i in range(9)])
             op.restrict_range("nprobe", 1025)
         elif args.search_type == "multi_gpu_sharded1_flat":
             quantizer = hnsw_quantizer.storage
             quantizer = faiss.index_cpu_to_gpu_multiple_py(
-                res, quantizer, co, gpus)
+                res, quantizer, co, gpus
+            )
             index = ShardedGPUIndex(quantizer, index, bs=args.batch_size)
         else:
             raise RuntimeError()
     elif args.search_type in (
-            "multi_gpu_Csharded1", "multi_gpu_Csharded1_flat",
-            "multi_gpu_Csharded1_ivf"):
+        "multi_gpu_Csharded1",
+        "multi_gpu_Csharded1_flat",
+        "multi_gpu_Csharded1_ivf",
+    ):
         print(f"move index to {faiss.get_num_gpus()} GPU")
         co.shard = True
         co.common_ivf_quantizer
         co.common_ivf_quantizer = True
         op.restrict_range("nprobe", 2049)
         if args.search_type == "multi_gpu_Csharded1":
-            op.add_range(
-                "quantizer_efSearch",
-                [2 ** i for i in range(10)]
-            )
+            op.add_range("quantizer_efSearch", [2**i for i in range(10)])
             index = faiss.index_cpu_to_all_gpus(index, co)
         elif args.search_type == "multi_gpu_Csharded1_flat":
             new_quantizer = faiss.IndexFlatL2(index_ivf.d)
@@ -517,12 +561,10 @@ def main():
             index = faiss.index_cpu_to_all_gpus(index, co)
         elif args.search_type == "multi_gpu_Csharded1_ivf":
             quantizer = faiss.index_factory(
-                index_ivf.d, f"IVF{args.ivf_quant_nlist},Flat")
-            quantizer_hnsw = replace_ivf_quantizer(index_ivf, quantizer)
-            op.add_range(
-                "quantizer_nprobe",
-                [2 ** i for i in range(9)]
+                index_ivf.d, f"IVF{args.ivf_quant_nlist},Flat"
             )
+            quantizer_hnsw = replace_ivf_quantizer(index_ivf, quantizer)
+            op.add_range("quantizer_nprobe", [2**i for i in range(9)])
             index = faiss.index_cpu_to_all_gpus(index, co)
         else:
             raise RuntimeError()
@@ -543,7 +585,7 @@ def main():
         "processor": [l for l in open("/proc/cpuinfo") if "model name" in l][0],
         "GPU": list(os.popen("nvidia-smi", "r")),
         "mem": open("/proc/meminfo", "r").readlines(),
-        "pid": os.getpid()
+        "pid": os.getpid(),
     }
     op.args = args
     if args.stats:
@@ -556,7 +598,9 @@ def main():
 
         (max_perf, min_time) = op.predict_bounds(key)
         if not op.is_pareto_optimal(max_perf, min_time):
-            print(f"SKIP, {max_perf=:.3f} {min_time=:.3f}", )
+            print(
+                f"SKIP, {max_perf=:.3f} {min_time=:.3f}",
+            )
             continue
 
         for name, val in parameters.items():
@@ -577,19 +621,21 @@ def main():
 
         recalls = {}
         for rank in 1, 10, 100:
-            recall = (gt[:, :1] == I[:ds.nq, :rank]).sum() / ds.nq
+            recall = (gt[:, :1] == I[: ds.nq, :rank]).sum() / ds.nq
             recalls[rank] = recall
 
         print(f"time={t1 - t0:.3f} s recalls={recalls}")
         perf = recalls[1]
         op.add_operating_point(key, perf, t1 - t0)
-        op.all_experiments.append({
-            "cno": cno,
-            "key": key,
-            "parameters": parameters,
-            "time": t1 - t0,
-            "recalls": recalls
-        })
+        op.all_experiments.append(
+            {
+                "cno": cno,
+                "key": key,
+                "parameters": parameters,
+                "time": t1 - t0,
+                "recalls": recalls,
+            }
+        )
 
         if args.stats:
             pickle.dump(op, open(args.stats, "wb"))

--- a/benchs/bench_index_flat.py
+++ b/benchs/bench_index_flat.py
@@ -22,7 +22,7 @@ def format_tab(x):
 faiss.cvar.distance_compute_min_k_reservoir = 5
 
 # for have_threads in True, False:
-for have_threads in False, :
+for have_threads in (False,):
 
     if have_threads:
         # good config for Intel(R) Xeon(R) CPU E5-2698 v4 @ 2.20GHz
@@ -70,17 +70,21 @@ for have_threads in False, :
                     t0 = time.time()
                     index.search(ds.get_queries(), k)
                     t1 = time.time()
-                    if run >= nrun // 5: # the rest is considered warmup
+                    if run >= nrun // 5:  # the rest is considered warmup
                         times.append((t1 - t0))
                 times = np.array(times)
 
                 if unit == "ms":
                     times *= 1000
-                    print("search k=%3d t=%.3f ms (± %.4f)" % (
-                        k, np.mean(times), np.std(times)))
+                    print(
+                        "search k=%3d t=%.3f ms (± %.4f)"
+                        % (k, np.mean(times), np.std(times))
+                    )
                 else:
-                    print("search k=%3d t=%.3f s (± %.4f)" % (
-                        k, np.mean(times), np.std(times)))
+                    print(
+                        "search k=%3d t=%.3f s (± %.4f)"
+                        % (k, np.mean(times), np.std(times))
+                    )
                 restab1.append(np.mean(times))
 
         print("restab=\n", format_tab(restab))

--- a/benchs/bench_ivf_fastscan.py
+++ b/benchs/bench_ivf_fastscan.py
@@ -11,11 +11,9 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 try:
-    from faiss.contrib.datasets_fb import \
-        DatasetSIFT1M
+    from faiss.contrib.datasets_fb import DatasetSIFT1M
 except ImportError:
-    from faiss.contrib.datasets import \
-        DatasetSIFT1M
+    from faiss.contrib.datasets import DatasetSIFT1M
 
 
 # ds = DatasetDeep1B(10**6)
@@ -46,8 +44,8 @@ def eval_recall(index, name):
     corrects = (gt == I).sum()
     recall = corrects / nq
     print(
-        f'\tnprobe {index.nprobe:3d}, Recall@{k}: '
-        f'{recall:.6f}, speed: {speed:.6f} ms/query'
+        f"\tnprobe {index.nprobe:3d}, Recall@{k}: "
+        f"{recall:.6f}, speed: {speed:.6f} ms/query"
     )
 
     return recall, qps
@@ -66,7 +64,7 @@ def eval_and_plot(name, rescale_norm=True, plot=True):
         faiss.write_index(index, index_path)
 
     # search params
-    if hasattr(index, 'rescale_norm'):
+    if hasattr(index, "rescale_norm"):
         index.rescale_norm = rescale_norm
         name += f"(rescale_norm={rescale_norm})"
     faiss.omp_set_num_threads(1)
@@ -108,5 +106,5 @@ eval_and_plot(f"IVF{nlist},RQ{M-2}x4fs_Nrq2x4")
 plt.title("Indices on SIFT1M")
 plt.xlabel("Recall@1")
 plt.ylabel("QPS")
-plt.legend(bbox_to_anchor=(1.02, 0.1), loc='upper left', borderaxespad=0)
-plt.savefig("bench_ivf_fastscan.png", bbox_inches='tight')
+plt.legend(bbox_to_anchor=(1.02, 0.1), loc="upper left", borderaxespad=0)
+plt.savefig("bench_ivf_fastscan.png", bbox_inches="tight")

--- a/benchs/bench_ivf_fastscan_single_query.py
+++ b/benchs/bench_ivf_fastscan_single_query.py
@@ -30,7 +30,7 @@ nb, d = xb.shape
 nq, d = xq.shape
 nt, d = xt.shape
 
-print('the dimension is {}, {}'.format(nb, d))
+print("the dimension is {}, {}".format(nb, d))
 
 k = 64
 
@@ -43,7 +43,7 @@ def eval_recall(index, name, single_query=False):
     if single_query:
         t0 = time.time()
         for row in range(nq):
-            Ds, Is = index.search(xq[row:row + 1], k=k)
+            Ds, Is = index.search(xq[row : row + 1], k=k)
             D[row, :] = Ds
             I[row, :] = Is
         t = time.time() - t0
@@ -53,16 +53,21 @@ def eval_recall(index, name, single_query=False):
     corrects = (gt[:, :1] == I[:, :k]).sum()
     recall = corrects / nq
     print(
-        f'\tnprobe {index.nprobe:3d}, 1Recall@{k}: '
-        f'{recall:.6f}, speed: {speed:.6f} ms/query'
+        f"\tnprobe {index.nprobe:3d}, 1Recall@{k}: "
+        f"{recall:.6f}, speed: {speed:.6f} ms/query"
     )
 
     return recall, qps
 
 
 def eval_and_plot(
-        name, rescale_norm=True, plot=True, single_query=False,
-        implem=None, num_threads=1):
+    name,
+    rescale_norm=True,
+    plot=True,
+    single_query=False,
+    implem=None,
+    num_threads=1,
+):
     index = faiss.index_factory(d, name)
     index_path = f"indices/{name}.faissindex"
 
@@ -75,10 +80,10 @@ def eval_and_plot(
         faiss.write_index(index, index_path)
 
     # search params
-    if hasattr(index, 'rescale_norm'):
+    if hasattr(index, "rescale_norm"):
         index.rescale_norm = rescale_norm
         name += f"(rescale_norm={rescale_norm})"
-    if implem is not None and hasattr(index, 'implem'):
+    if implem is not None and hasattr(index, "implem"):
         index.implem = implem
         name += f"(implem={implem})"
     if single_query:
@@ -109,12 +114,18 @@ M, nlist = 64, 4096
 plt.figure(figsize=(8, 6), dpi=80)
 
 eval_and_plot(f"IVF{nlist},PQ{M}x4fs", num_threads=8)
-eval_and_plot(f"IVF{nlist},PQ{M}x4fs", single_query=True, implem=0, num_threads=8)
-eval_and_plot(f"IVF{nlist},PQ{M}x4fs", single_query=True, implem=14, num_threads=8)
-eval_and_plot(f"IVF{nlist},PQ{M}x4fs", single_query=True, implem=15, num_threads=8)
+eval_and_plot(
+    f"IVF{nlist},PQ{M}x4fs", single_query=True, implem=0, num_threads=8
+)
+eval_and_plot(
+    f"IVF{nlist},PQ{M}x4fs", single_query=True, implem=14, num_threads=8
+)
+eval_and_plot(
+    f"IVF{nlist},PQ{M}x4fs", single_query=True, implem=15, num_threads=8
+)
 
 plt.title("Indices on Bigann50M")
 plt.xlabel("1Recall@{}".format(k))
 plt.ylabel("QPS")
-plt.legend(bbox_to_anchor=(1.02, 0.1), loc='upper left', borderaxespad=0)
-plt.savefig("bench_ivf_fastscan.png", bbox_inches='tight')
+plt.legend(bbox_to_anchor=(1.02, 0.1), loc="upper left", borderaxespad=0)
+plt.savefig("bench_ivf_fastscan.png", bbox_inches="tight")

--- a/benchs/bench_ivf_flat_panorama.py
+++ b/benchs/bench_ivf_flat_panorama.py
@@ -17,9 +17,7 @@ except ImportError:
     from faiss.contrib.datasets import DatasetSIFT1M, DatasetGIST1M
 
 parser = argparse.ArgumentParser()
-parser.add_argument(
-    "--dataset", default="gist1m", choices=["sift1m", "gist1m"]
-)
+parser.add_argument("--dataset", default="gist1m", choices=["sift1m", "gist1m"])
 args = parser.parse_args()
 
 if args.dataset == "sift1m":

--- a/benchs/bench_ivfflat_cuvs.py
+++ b/benchs/bench_ivfflat_cuvs.py
@@ -26,11 +26,9 @@ import argparse
 import rmm
 
 try:
-    from faiss.contrib.datasets_fb import \
-        DatasetSIFT1M
+    from faiss.contrib.datasets_fb import DatasetSIFT1M
 except ImportError:
-    from faiss.contrib.datasets import \
-        DatasetSIFT1M
+    from faiss.contrib.datasets import DatasetSIFT1M
 
 
 # ds = DatasetDeep1B(10**6)
@@ -58,25 +56,33 @@ def aa(*args, **kwargs):
     group.add_argument(*args, **kwargs)
 
 
-group = parser.add_argument_group('benchmarking options')
+group = parser.add_argument_group("benchmarking options")
 
-aa('--bm_train', default=True,
-   help='whether to benchmark train operation on GPU index')
-aa('--bm_add', default=True,
-   help='whether to benchmark add operation on GPU index')
-aa('--bm_search', default=True,
-   help='whether to benchmark search operation on GPU index')
+aa(
+    "--bm_train",
+    default=True,
+    help="whether to benchmark train operation on GPU index",
+)
+aa(
+    "--bm_add",
+    default=True,
+    help="whether to benchmark add operation on GPU index",
+)
+aa(
+    "--bm_search",
+    default=True,
+    help="whether to benchmark search operation on GPU index",
+)
 
 
-group = parser.add_argument_group('IVF options')
-aa('--nlist', default=1024, type=int,
-    help="number of IVF centroids")
+group = parser.add_argument_group("IVF options")
+aa("--nlist", default=1024, type=int, help="number of IVF centroids")
 
 
-group = parser.add_argument_group('searching')
+group = parser.add_argument_group("searching")
 
-aa('--k', default=10, type=int, help='nb of nearest neighbors')
-aa('--nprobe', default=10, help='nb of IVF lists to probe')
+aa("--k", default=10, type=int, help="nb of nearest neighbors")
+aa("--nprobe", default=10, help="nb of IVF lists to probe")
 
 args = parser.parse_args()
 
@@ -97,10 +103,10 @@ def bench_train_milliseconds(trainVecs, ncols, nlist, use_cuvs):
     index = faiss.GpuIndexIVFFlat(res, ncols, nlist, faiss.METRIC_L2, config)
     t0 = time.time()
     index.train(trainVecs)
-    return 1000*(time.time() - t0)
+    return 1000 * (time.time() - t0)
 
 
-#warmup
+# warmup
 xw = rs.rand(nt, d)
 bench_train_milliseconds(xw, d, args.nlist, True)
 
@@ -111,20 +117,26 @@ if args.bm_train:
     print("=" * 40)
 
     cuvs_gpu_train_time = bench_train_milliseconds(xt, d, args.nlist, True)
-    classical_gpu_train_time = bench_train_milliseconds(xt, d, args.nlist, False)
-    print("Method: IVFFlat, Operation: TRAIN, dim: %d, nlist %d, numTrain: %d, classical GPU train time: %.3f milliseconds, cuVS enabled GPU train time: %.3f milliseconds" % (
-        d, args.nlist, nt, classical_gpu_train_time, cuvs_gpu_train_time))
+    classical_gpu_train_time = bench_train_milliseconds(
+        xt, d, args.nlist, False
+    )
+    print(
+        "Method: IVFFlat, Operation: TRAIN, dim: %d, nlist %d, numTrain: %d, classical GPU train time: %.3f milliseconds, cuVS enabled GPU train time: %.3f milliseconds"
+        % (d, args.nlist, nt, classical_gpu_train_time, cuvs_gpu_train_time)
+    )
 
 
 def bench_add_milliseconds(addVecs, q, use_cuvs):
     # construct a GPU index using the same trained coarse quantizer
     config = faiss.GpuIndexIVFFlatConfig()
     config.use_cuvs = use_cuvs
-    index_gpu = faiss.GpuIndexIVFFlat(res, q, d, args.nlist, faiss.METRIC_L2, config)
-    assert(index_gpu.is_trained)
+    index_gpu = faiss.GpuIndexIVFFlat(
+        res, q, d, args.nlist, faiss.METRIC_L2, config
+    )
+    assert index_gpu.is_trained
     t0 = time.time()
     index_gpu.add(addVecs)
-    return 1000*(time.time() - t0)
+    return 1000 * (time.time() - t0)
 
 
 if args.bm_add:
@@ -136,8 +148,10 @@ if args.bm_add:
     idx_cpu.train(xt)
     cuvs_gpu_add_time = bench_add_milliseconds(xb, quantizer, True)
     classical_gpu_add_time = bench_add_milliseconds(xb, quantizer, False)
-    print("Method: IVFFlat, Operation: ADD, dim: %d, nlist %d, numAdd: %d, classical GPU add time: %.3f milliseconds, cuVS enabled GPU add time: %.3f milliseconds" % (
-        d, args.nlist, nb, classical_gpu_add_time, cuvs_gpu_add_time))
+    print(
+        "Method: IVFFlat, Operation: ADD, dim: %d, nlist %d, numAdd: %d, classical GPU add time: %.3f milliseconds, cuVS enabled GPU add time: %.3f milliseconds"
+        % (d, args.nlist, nb, classical_gpu_add_time, cuvs_gpu_add_time)
+    )
 
 
 def bench_search_milliseconds(index, queryVecs, nprobe, k, use_cuvs):
@@ -147,21 +161,33 @@ def bench_search_milliseconds(index, queryVecs, nprobe, k, use_cuvs):
     index_gpu.nprobe = nprobe
     t0 = time.time()
     index_gpu.search(queryVecs, k)
-    return 1000*(time.time() - t0)
+    return 1000 * (time.time() - t0)
 
 
 if args.bm_search:
     print("=" * 40)
     print("GPU Search Benchmarks")
     print("=" * 40)
-    idx_cpu = faiss.IndexIVFFlat(
-            faiss.IndexFlatL2(d), d, args.nlist)
+    idx_cpu = faiss.IndexIVFFlat(faiss.IndexFlatL2(d), d, args.nlist)
     idx_cpu.train(xt)
     idx_cpu.add(xb)
 
     cuvs_gpu_search_time = bench_search_milliseconds(
-        idx_cpu, xq, args.nprobe, args.k, True)
+        idx_cpu, xq, args.nprobe, args.k, True
+    )
     classical_gpu_search_time = bench_search_milliseconds(
-        idx_cpu, xq, args.nprobe, args.k, False)
-    print("Method: IVFFlat, Operation: SEARCH, dim: %d, nlist: %d, numVecs: %d, numQuery: %d, nprobe: %d, k: %d, classical GPU search time: %.3f milliseconds, cuVS enabled GPU search time: %.3f milliseconds" % (
-        d, args.nlist, nb, nq, args.nprobe, args.k, classical_gpu_search_time, cuvs_gpu_search_time))
+        idx_cpu, xq, args.nprobe, args.k, False
+    )
+    print(
+        "Method: IVFFlat, Operation: SEARCH, dim: %d, nlist: %d, numVecs: %d, numQuery: %d, nprobe: %d, k: %d, classical GPU search time: %.3f milliseconds, cuVS enabled GPU search time: %.3f milliseconds"
+        % (
+            d,
+            args.nlist,
+            nb,
+            nq,
+            args.nprobe,
+            args.k,
+            classical_gpu_search_time,
+            cuvs_gpu_search_time,
+        )
+    )

--- a/benchs/bench_ivfpq_cuvs.py
+++ b/benchs/bench_ivfpq_cuvs.py
@@ -26,11 +26,9 @@ import argparse
 import rmm
 
 try:
-    from faiss.contrib.datasets_fb import \
-        DatasetSIFT1M
+    from faiss.contrib.datasets_fb import DatasetSIFT1M
 except ImportError:
-    from faiss.contrib.datasets import \
-        DatasetSIFT1M
+    from faiss.contrib.datasets import DatasetSIFT1M
 
 
 # ds = DatasetDeep1B(10**6)
@@ -60,32 +58,45 @@ def aa(*args, **kwargs):
     group.add_argument(*args, **kwargs)
 
 
-group = parser.add_argument_group('benchmarking options')
+group = parser.add_argument_group("benchmarking options")
 
-aa('--bm_train', default=True,
-   help='whether to benchmark train operation on GPU index')
-aa('--bm_add', default=True,
-   help='whether to benchmark add operation on GPU index')
-aa('--bm_search', default=True,
-   help='whether to benchmark search operation on GPU index')
+aa(
+    "--bm_train",
+    default=True,
+    help="whether to benchmark train operation on GPU index",
+)
+aa(
+    "--bm_add",
+    default=True,
+    help="whether to benchmark add operation on GPU index",
+)
+aa(
+    "--bm_search",
+    default=True,
+    help="whether to benchmark search operation on GPU index",
+)
 
 
-group = parser.add_argument_group('IVF options')
-aa('--nlist', default=1024, type=np.int64,
-    help="number of IVF centroids")
-aa('--bits_per_code', default=8, type=np.int64, help='bits per code. Note that < 8 is only supported when cuVS is enabled')
+group = parser.add_argument_group("IVF options")
+aa("--nlist", default=1024, type=np.int64, help="number of IVF centroids")
+aa(
+    "--bits_per_code",
+    default=8,
+    type=np.int64,
+    help="bits per code. Note that < 8 is only supported when cuVS is enabled",
+)
 
 
-group = parser.add_argument_group('searching')
+group = parser.add_argument_group("searching")
 
-aa('--k', default=10, type=int, help='nb of nearest neighbors')
-aa('--nprobe', default=10, help='nb of IVF lists to probe')
+aa("--k", default=10, type=int, help="nb of nearest neighbors")
+aa("--nprobe", default=10, help="nb of IVF lists to probe")
 
 args = parser.parse_args()
 
 print("args:", args)
 
-gt = gt[:, :args.k]
+gt = gt[:, : args.k]
 nlist = args.nlist
 bits_per_code = args.bits_per_code
 
@@ -114,10 +125,10 @@ def bench_train_milliseconds(trainVecs, use_cuvs):
     index = faiss.GpuIndexIVFPQ(res, d, 1024, 32, 8, faiss.METRIC_L2, config)
     t0 = time.time()
     index.train(trainVecs)
-    return 1000*(time.time() - t0)
+    return 1000 * (time.time() - t0)
 
 
-#warmup
+# warmup
 xw = rs.rand(nt, d)
 bench_train_milliseconds(xw, True)
 
@@ -129,8 +140,10 @@ if args.bm_train:
 
     cuvs_gpu_train_time = bench_train_milliseconds(xt, True)
     classical_gpu_train_time = bench_train_milliseconds(xt, False)
-    print("TRAIN, dim: %d, nlist %d, numTrain: %d, classical GPU train time: %.3f milliseconds, cuVS enabled GPU train time: %.3f milliseconds" % (
-        d, nlist, nt, classical_gpu_train_time, cuvs_gpu_train_time))
+    print(
+        "TRAIN, dim: %d, nlist %d, numTrain: %d, classical GPU train time: %.3f milliseconds, cuVS enabled GPU train time: %.3f milliseconds"
+        % (d, nlist, nt, classical_gpu_train_time, cuvs_gpu_train_time)
+    )
 
 
 def bench_add_milliseconds(addVecs, index_cpu, use_cuvs):
@@ -138,10 +151,10 @@ def bench_add_milliseconds(addVecs, index_cpu, use_cuvs):
     config = faiss.GpuClonerOptions()
     config.use_cuvs = use_cuvs
     index_gpu = faiss.index_cpu_to_gpu(res, 0, index_cpu, config)
-    assert(index_gpu.is_trained)
+    assert index_gpu.is_trained
     t0 = time.time()
     index_gpu.add(addVecs)
-    return 1000*(time.time() - t0)
+    return 1000 * (time.time() - t0)
 
 
 if args.bm_add:
@@ -153,8 +166,10 @@ if args.bm_add:
     index_cpu.train(xt)
     cuvs_gpu_add_time = bench_add_milliseconds(xb, index_cpu, True)
     classical_gpu_add_time = bench_add_milliseconds(xb, index_cpu, False)
-    print("ADD, dim: %d, nlist %d, numAdd: %d, classical GPU add time: %.3f milliseconds, cuVS enabled GPU add time: %.3f milliseconds" % (
-        d, nlist, nb, classical_gpu_add_time, cuvs_gpu_add_time))
+    print(
+        "ADD, dim: %d, nlist %d, numAdd: %d, classical GPU add time: %.3f milliseconds, cuVS enabled GPU add time: %.3f milliseconds"
+        % (d, nlist, nb, classical_gpu_add_time, cuvs_gpu_add_time)
+    )
 
 
 def bench_search_milliseconds(index, queryVecs, nprobe, k, use_cuvs):
@@ -164,10 +179,10 @@ def bench_search_milliseconds(index, queryVecs, nprobe, k, use_cuvs):
     index_gpu.nprobe = nprobe
     t0 = time.time()
     _, I = index_gpu.search(queryVecs, k)
-    return I, 1000*(time.time() - t0)
+    return I, 1000 * (time.time() - t0)
 
 
-# Search benchmarks: both indexes have identical IVF centroids and lists. 
+# Search benchmarks: both indexes have identical IVF centroids and lists.
 if args.bm_search:
     print("=" * 40)
     print("GPU Search Benchmarks")
@@ -177,10 +192,16 @@ if args.bm_search:
     index_cpu.add(xb)
 
     cuvs_indices, cuvs_gpu_search_time = bench_search_milliseconds(
-        index_cpu, xq, args.nprobe, args.k, True)
-    classical_gpu_indices, classical_gpu_search_time = bench_search_milliseconds(
-        index_cpu, xq, args.nprobe, args.k, False)
+        index_cpu, xq, args.nprobe, args.k, True
+    )
+    classical_gpu_indices, classical_gpu_search_time = (
+        bench_search_milliseconds(index_cpu, xq, args.nprobe, args.k, False)
+    )
     cuvs_recall, cuvs_qps = eval_recall(cuvs_indices, cuvs_gpu_search_time)
-    classical_recall, classical_qps = eval_recall(classical_gpu_indices, classical_gpu_search_time)
-    print("SEARCH, dim: %d, nlist: %d, numVecs: %d, numQuery: %d, nprobe: %d, k: %d, classical GPU qps: %.3f, cuVS enabled GPU qps: %.3f"  % (
-        d, nlist, nb, nq, args.nprobe, args.k, classical_qps, cuvs_qps))
+    classical_recall, classical_qps = eval_recall(
+        classical_gpu_indices, classical_gpu_search_time
+    )
+    print(
+        "SEARCH, dim: %d, nlist: %d, numVecs: %d, numQuery: %d, nprobe: %d, k: %d, classical GPU qps: %.3f, cuVS enabled GPU qps: %.3f"
+        % (d, nlist, nb, nq, args.nprobe, args.k, classical_qps, cuvs_qps)
+    )

--- a/benchs/bench_partition.py
+++ b/benchs/bench_partition.py
@@ -8,15 +8,16 @@ import faiss
 import numpy as np
 
 
-def do_partition(n, qin, maxval=65536, seed=123, id_type='int64'):
+def do_partition(n, qin, maxval=65536, seed=123, id_type="int64"):
     print(
         f"n={n} qin={qin} maxval={maxval} id_type={id_type}  ",
-        end="\t", flush=True
+        end="\t",
+        flush=True,
     )
 
     # print("seed=", seed)
     rs = np.random.RandomState(seed)
-    vals = rs.randint(maxval, size=n).astype('uint16')
+    vals = rs.randint(maxval, size=n).astype("uint16")
     ids = (rs.permutation(n) + 12345).astype(id_type)
 
     sp = faiss.swig_ptr
@@ -37,13 +38,13 @@ def do_partition(n, qin, maxval=65536, seed=123, id_type='int64'):
         if isinstance(qin, int):
             q = qin
             faiss.CMax_uint16_partition_fuzzy(
-                tab_a.get(), sp(ids), n, q, q, None)
+                tab_a.get(), sp(ids), n, q, q, None
+            )
         else:
             q_min, q_max = qin
-            q = np.array([-1], dtype='uint64')
+            q = np.array([-1], dtype="uint64")
             faiss.CMax_uint16_partition_fuzzy(
-                tab_a.get(), sp(ids), n,
-                q_min, q_max, sp(q)
+                tab_a.get(), sp(ids), n, q_min, q_max, sp(q)
             )
             q = q[0]
 
@@ -56,12 +57,12 @@ def do_partition(n, qin, maxval=65536, seed=123, id_type='int64'):
 
     times = np.array(times[100:]) * 1000000
 
-
     print(
         f"times {times.mean():.3f} µs (± {times.std():.4f} µs) nerr={nerr} "
         f"bisect {stats.bissect_cycles / 1e6:.3f} Mcy "
         f"compress {stats.compress_cycles / 1e6:.3f} Mcy"
     )
+
 
 do_partition(200, (100, 100))
 do_partition(200, (100, 150))
@@ -71,9 +72,9 @@ do_partition(20000, (10000, 10000))
 do_partition(20000, (10000, 15000))
 
 
-do_partition(200, (100, 100), id_type='int32')
-do_partition(200, (100, 150), id_type='int32')
-do_partition(2000, (1000, 1000), id_type='int32')
-do_partition(2000, (1000, 1500), id_type='int32')
-do_partition(20000, (10000, 10000), id_type='int32')
-do_partition(20000, (10000, 15000), id_type='int32')
+do_partition(200, (100, 100), id_type="int32")
+do_partition(200, (100, 150), id_type="int32")
+do_partition(2000, (1000, 1000), id_type="int32")
+do_partition(2000, (1000, 1500), id_type="int32")
+do_partition(20000, (10000, 10000), id_type="int32")
+do_partition(20000, (10000, 15000), id_type="int32")

--- a/benchs/bench_polysemous_1bn.py
+++ b/benchs/bench_polysemous_1bn.py
@@ -18,14 +18,14 @@ from datasets import ivecs_read
 
 
 def mmap_fvecs(fname):
-    x = np.memmap(fname, dtype='int32', mode='r')
+    x = np.memmap(fname, dtype="int32", mode="r")
     d = x[0]
-    return x.view('float32').reshape(-1, d + 1)[:, 1:]
+    return x.view("float32").reshape(-1, d + 1)[:, 1:]
 
 
 def mmap_bvecs(fname):
-    x = np.memmap(fname, dtype='uint8', mode='r')
-    d = x[:4].view('int32')[0]
+    x = np.memmap(fname, dtype="uint8", mode="r")
+    d = x[:4].view("int32")[0]
     return x.reshape(-1, d + 4)[:, 4:]
 
 
@@ -34,12 +34,12 @@ def mmap_bvecs(fname):
 #################################################################
 
 
-dbname        = sys.argv[1]
-index_key     = sys.argv[2]
+dbname = sys.argv[1]
+index_key = sys.argv[2]
 parametersets = sys.argv[3:]
 
 
-tmpdir = '/tmp/bench_polysemous'
+tmpdir = "/tmp/bench_polysemous"
 
 if not os.path.isdir(tmpdir):
     print("%s does not exist, creating it" % tmpdir)
@@ -53,33 +53,32 @@ if not os.path.isdir(tmpdir):
 
 print("Preparing dataset", dbname)
 
-if dbname.startswith('SIFT'):
+if dbname.startswith("SIFT"):
     # SIFT1M to SIFT1000M
     dbsize = int(dbname[4:-1])
-    xb = mmap_bvecs('bigann/bigann_base.bvecs')
-    xq = mmap_bvecs('bigann/bigann_query.bvecs')
-    xt = mmap_bvecs('bigann/bigann_learn.bvecs')
+    xb = mmap_bvecs("bigann/bigann_base.bvecs")
+    xq = mmap_bvecs("bigann/bigann_query.bvecs")
+    xt = mmap_bvecs("bigann/bigann_learn.bvecs")
 
     # trim xb to correct size
-    xb = xb[:dbsize * 1000 * 1000]
+    xb = xb[: dbsize * 1000 * 1000]
 
-    gt = ivecs_read('bigann/gnd/idx_%dM.ivecs' % dbsize)
+    gt = ivecs_read("bigann/gnd/idx_%dM.ivecs" % dbsize)
 
-elif dbname == 'Deep1B':
-    xb = mmap_fvecs('deep1b/base.fvecs')
-    xq = mmap_fvecs('deep1b/deep1B_queries.fvecs')
-    xt = mmap_fvecs('deep1b/learn.fvecs')
+elif dbname == "Deep1B":
+    xb = mmap_fvecs("deep1b/base.fvecs")
+    xq = mmap_fvecs("deep1b/deep1B_queries.fvecs")
+    xt = mmap_fvecs("deep1b/learn.fvecs")
     # deep1B's train is outrageously big
-    xt = xt[:10 * 1000 * 1000]
-    gt = ivecs_read('deep1b/deep1B_groundtruth.ivecs')
+    xt = xt[: 10 * 1000 * 1000]
+    gt = ivecs_read("deep1b/deep1B_groundtruth.ivecs")
 
 else:
-    print('unknown dataset', dbname, file=sys.stderr)
+    print("unknown dataset", dbname, file=sys.stderr)
     sys.exit(1)
 
 
-print("sizes: B %s Q %s T %s gt %s" % (
-    xb.shape, xq.shape, xt.shape, gt.shape))
+print("sizes: B %s Q %s T %s gt %s" % (xb.shape, xq.shape, xt.shape, gt.shape))
 
 nq, d = xq.shape
 nb, d = xb.shape
@@ -97,19 +96,18 @@ def choose_train_size(index_key):
     n_train = 256 * 1000
 
     if "IVF" in index_key:
-        matches = re.findall('IVF([0-9]+)', index_key)
+        matches = re.findall("IVF([0-9]+)", index_key)
         ncentroids = int(matches[0])
         n_train = max(n_train, 100 * ncentroids)
     elif "IMI" in index_key:
-        matches = re.findall('IMI2x([0-9]+)', index_key)
+        matches = re.findall("IMI2x([0-9]+)", index_key)
         nbit = int(matches[0])
         n_train = max(n_train, 256 * (1 << nbit))
     return n_train
 
 
 def get_trained_index():
-    filename = "%s/%s_%s_trained.index" % (
-        tmpdir, dbname, index_key)
+    filename = "%s/%s_%s_trained.index" % (tmpdir, dbname, index_key)
 
     if not os.path.exists(filename):
         index = faiss.index_factory(d, index_key)
@@ -119,7 +117,7 @@ def get_trained_index():
         xtsub = xt[:n_train]
         print("Keeping %d train vectors" % xtsub.shape[0])
         # make sure the data is actually in RAM and in float
-        xtsub = xtsub.astype('float32').copy()
+        xtsub = xtsub.astype("float32").copy()
         index.verbose = True
 
         t0 = time.time()
@@ -138,12 +136,13 @@ def get_trained_index():
 # Adding vectors to dataset
 #################################################################
 
+
 def rate_limited_imap(f, l):
-    'a thread pre-processes the next element'
+    "a thread pre-processes the next element"
     pool = ThreadPool(1)
     res = None
     for i in l:
-        res_next = pool.apply_async(f, (i, ))
+        res_next = pool.apply_async(f, (i,))
         if res:
             yield res.get()
         res = res_next
@@ -151,20 +150,18 @@ def rate_limited_imap(f, l):
 
 
 def matrix_slice_iterator(x, bs):
-    " iterate over the lines of x in blocks of size bs"
+    "iterate over the lines of x in blocks of size bs"
     nb = x.shape[0]
-    block_ranges = [(i0, min(nb, i0 + bs))
-                    for i0 in range(0, nb, bs)]
+    block_ranges = [(i0, min(nb, i0 + bs)) for i0 in range(0, nb, bs)]
 
     return rate_limited_imap(
-        lambda i01: x[i01[0]:i01[1]].astype('float32').copy(),
-        block_ranges)
+        lambda i01: x[i01[0] : i01[1]].astype("float32").copy(), block_ranges
+    )
 
 
 def get_populated_index():
 
-    filename = "%s/%s_%s_populated.index" % (
-        tmpdir, dbname, index_key)
+    filename = "%s/%s_%s_populated.index" % (tmpdir, dbname, index_key)
 
     if not os.path.exists(filename):
         index = get_trained_index()
@@ -172,7 +169,7 @@ def get_populated_index():
         t0 = time.time()
         for xs in matrix_slice_iterator(xb, 100000):
             i1 = i0 + xs.shape[0]
-            print('\radd %d:%d, %.3f s' % (i0, i1, time.time() - t0), end=' ')
+            print("\radd %d:%d, %.3f s" % (i0, i1, time.time() - t0), end=" ")
             sys.stdout.flush()
             index.add(xs)
             i0 = i1
@@ -196,23 +193,23 @@ ps = faiss.ParameterSpace()
 ps.initialize(index)
 
 # make sure queries are in RAM
-xq = xq.astype('float32').copy()
+xq = xq.astype("float32").copy()
 
 # a static C++ object that collects statistics about searches
 ivfpq_stats = faiss.cvar.indexIVFPQ_stats
 ivf_stats = faiss.cvar.indexIVF_stats
 
 
-if parametersets == ['autotune'] or parametersets == ['autotuneMT']:
+if parametersets == ["autotune"] or parametersets == ["autotuneMT"]:
 
-    if parametersets == ['autotune']:
+    if parametersets == ["autotune"]:
         faiss.omp_set_num_threads(1)
 
     # setup the Criterion object: optimize for 1-R@1
     crit = faiss.OneRecallAtRCriterion(nq, 1)
     # by default, the criterion will request only 1 NN
     crit.nnn = 100
-    crit.set_groundtruth(None, gt.astype('int64'))
+    crit.set_groundtruth(None, gt.astype("int64"))
 
     # then we let Faiss find the optimal parameters by itself
     print("exploring operating points")
@@ -233,10 +230,14 @@ else:
     # we do queries in a single thread
     faiss.omp_set_num_threads(1)
 
-    print(' ' * len(parametersets[0]), '\t', 'R@1    R@10   R@100     time    %pass')
+    print(
+        " " * len(parametersets[0]),
+        "\t",
+        "R@1    R@10   R@100     time    %pass",
+    )
 
     for param in parametersets:
-        print(param, '\t', end=' ')
+        print(param, "\t", end=" ")
         sys.stdout.flush()
         ps.set_index_parameters(index, param)
         t0 = time.time()
@@ -246,6 +247,6 @@ else:
         t1 = time.time()
         for rank in 1, 10, 100:
             n_ok = (I[:, :rank] == gt[:, :1]).sum()
-            print("%.4f" % (n_ok / float(nq)), end=' ')
-        print("%8.3f  " % ((t1 - t0) * 1000.0 / nq), end=' ')
+            print("%.4f" % (n_ok / float(nq)), end=" ")
+        print("%8.3f  " % ((t1 - t0) * 1000.0 / nq), end=" ")
         print("%5.2f" % (ivfpq_stats.n_hamming_pass * 100.0 / ivf_stats.ndis))

--- a/benchs/bench_polysemous_sift1m.py
+++ b/benchs/bench_polysemous_sift1m.py
@@ -31,13 +31,13 @@ nt = 1
 faiss.omp_set_num_threads(1)
 
 
-print("PQ baseline", end=' ')
+print("PQ baseline", end=" ")
 index.search_type = faiss.IndexPQ.ST_PQ
 t, r = evaluate(index, xq, gt, 1)
 print("\t %7.3f ms per query, R@1 %.4f" % (t, r[1]))
 
 for ht in 64, 62, 58, 54, 50, 46, 42, 38, 34, 30:
-    print("Polysemous", ht, end=' ')
+    print("Polysemous", ht, end=" ")
     index.search_type = faiss.IndexPQ.ST_polysemous
     index.polysemous_ht = ht
     t, r = evaluate(index, xq, gt, 1)

--- a/benchs/bench_pq_tables.py
+++ b/benchs/bench_pq_tables.py
@@ -21,7 +21,6 @@ def run_bench(d, dsub, nbit=8, metric=None):
     pq = faiss.ProductQuantizer(d, M, nbit)
     pq.train(faiss.randn((max(1000, pq.ksub * 50), d), 123))
 
-
     sp = faiss.swig_ptr
 
     times = []
@@ -43,15 +42,18 @@ def run_bench(d, dsub, nbit=8, metric=None):
             else:
                 assert False
             t1 = time.time()
-            if run >= nrun // 5: # the rest is considered warmup
+            if run >= nrun // 5:  # the rest is considered warmup
                 times.append((t1 - t0))
         times = np.array(times) * 1000
 
-        print(f"nx={nx}: {np.mean(times):.3f} ms (± {np.std(times):.4f})",
-               end="\t")
+        print(
+            f"nx={nx}: {np.mean(times):.3f} ms (± {np.std(times):.4f})",
+            end="\t",
+        )
         res.append(times.mean())
     print()
     return res
+
 
 # for have_threads in True, False:
 for have_threads in False, True:

--- a/benchs/bench_pq_transposed_centroid_table.py
+++ b/benchs/bench_pq_transposed_centroid_table.py
@@ -45,11 +45,13 @@ def test_bigann10m(index_file, index_parameters):
 
     index_ivf, vec_transform = unwind_index_ivf(index)
 
-    print('params                                                                      regular    transp_centroids   regular   R@1    R@10   R@100')
+    print(
+        "params                                                                      regular    transp_centroids   regular   R@1    R@10   R@100"
+    )
     for index_parameter in index_parameters:
         ps.set_index_parameters(index, index_parameter)
 
-        print(index_parameter.ljust(70), end=' ')
+        print(index_parameter.ljust(70), end=" ")
 
         k = 100
 
@@ -76,28 +78,96 @@ def test_bigann10m(index_file, index_parameters):
         D, I = index.search(xq, k)
         t4_1 = time.time()
 
-        print("   %9.5f  " % (t2_1 - t2_0), end=' ')
-        print("   %9.5f  " % (t3_1 - t3_0), end=' ')
-        print("   %9.5f  " % (t4_1 - t4_0), end=' ')
+        print("   %9.5f  " % (t2_1 - t2_0), end=" ")
+        print("   %9.5f  " % (t3_1 - t3_0), end=" ")
+        print("   %9.5f  " % (t4_1 - t4_0), end=" ")
 
         for rank in 1, 10, 100:
             n_ok = (I[:, :rank] == gt[:, :1]).sum()
-            print("%.4f" % (n_ok / float(nq)), end=' ')
+            print("%.4f" % (n_ok / float(nq)), end=" ")
         print()
 
 
 if __name__ == "__main__":
-    faiss.contrib.datasets.dataset_basedir = '/home/aguzhva/ANN_SIFT1B/'
+    faiss.contrib.datasets.dataset_basedir = "/home/aguzhva/ANN_SIFT1B/"
 
     # represents OPQ32_128,IVF65536_HNSW32,PQ32 index
     index_file_1 = "/home/aguzhva/ANN_SIFT1B/run_tests/bench_ivf/indexes/hnsw32/.faissindex"
 
     nprobe_values = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
     quantizer_efsearch_values = [4, 8, 16, 32, 64, 128, 256, 512]
-    ht_values = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62, 64, 66, 68, 70, 72, 74, 76, 78, 80, 82, 84, 86, 88, 90, 92, 94, 96, 98, 100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124, 126, 128, 256]
+    ht_values = [
+        2,
+        4,
+        6,
+        8,
+        10,
+        12,
+        14,
+        16,
+        18,
+        20,
+        22,
+        24,
+        26,
+        28,
+        30,
+        32,
+        34,
+        36,
+        38,
+        40,
+        42,
+        44,
+        46,
+        48,
+        50,
+        52,
+        54,
+        56,
+        58,
+        60,
+        62,
+        64,
+        66,
+        68,
+        70,
+        72,
+        74,
+        76,
+        78,
+        80,
+        82,
+        84,
+        86,
+        88,
+        90,
+        92,
+        94,
+        96,
+        98,
+        100,
+        102,
+        104,
+        106,
+        108,
+        110,
+        112,
+        114,
+        116,
+        118,
+        120,
+        122,
+        124,
+        126,
+        128,
+        256,
+    ]
 
     # represents OPQ32_128,IVF65536(IVF256,PQHDx4fs,RFlat),PQ32 index
-    index_file_2 = "/home/aguzhva/ANN_SIFT1B/run_tests/bench_ivf/indexes/pq4/.faissindex"
+    index_file_2 = (
+        "/home/aguzhva/ANN_SIFT1B/run_tests/bench_ivf/indexes/pq4/.faissindex"
+    )
 
     quantizer_k_factor_rf_values = [1, 2, 4, 8, 16, 32, 64]
     quantizer_nprobe_values = [1, 2, 4, 8, 16, 32, 64, 128]
@@ -110,9 +180,8 @@ if __name__ == "__main__":
         ht = random.choice(ht_values)
         index_parameters_1.append(
             "nprobe={},quantizer_efSearch={},ht={}".format(
-                nprobe,
-                quantizer_efsearch,
-                ht)
+                nprobe, quantizer_efsearch, ht
+            )
         )
 
     test_bigann10m(index_file_1, index_parameters_1)
@@ -126,10 +195,8 @@ if __name__ == "__main__":
         ht = random.choice(ht_values)
         index_parameters_2.append(
             "nprobe={},quantizer_k_factor_rf={},quantizer_nprobe={},ht={}".format(
-                nprobe,
-                quantizer_k_factor_rf,
-                quantizer_nprobe,
-                ht)
+                nprobe, quantizer_k_factor_rf, quantizer_nprobe, ht
+            )
         )
 
     test_bigann10m(index_file_2, index_parameters_2)

--- a/benchs/bench_quantizer.py
+++ b/benchs/bench_quantizer.py
@@ -9,11 +9,17 @@ import time
 import numpy as np
 
 try:
-    from faiss.contrib.datasets_fb import \
-        DatasetSIFT1M, DatasetDeep1B, DatasetBigANN
+    from faiss.contrib.datasets_fb import (
+        DatasetSIFT1M,
+        DatasetDeep1B,
+        DatasetBigANN,
+    )
 except ImportError:
-    from faiss.contrib.datasets import \
-        DatasetSIFT1M, DatasetDeep1B, DatasetBigANN
+    from faiss.contrib.datasets import (
+        DatasetSIFT1M,
+        DatasetDeep1B,
+        DatasetBigANN,
+    )
 
 
 def eval_codec(q, xq, xb, gt):
@@ -29,7 +35,8 @@ def eval_codec(q, xq, xb, gt):
     recall = (I[:, 0] == gt[:, 0]).sum() / nq
     print(
         f"\tencode time: {t1 - t0:.3f} reconstruction error: {recons_err:.3f} "
-        f"1-recall@1: {recall:.4f} recons_err_compat {err_compat:.3f}")
+        f"1-recall@1: {recall:.4f} recons_err_compat {err_compat:.3f}"
+    )
 
 
 def eval_quantizer(q, xq, xb, gt, xt, variants=None):
@@ -39,7 +46,7 @@ def eval_quantizer(q, xq, xb, gt, xt, variants=None):
     q.train(xt)
     t1 = time.time()
     train_t = t1 - t0
-    print(f'\ttraining time: {train_t:.3f} s')
+    print(f"\ttraining time: {train_t:.3f} s")
     for name, val in variants:
         if name is not None:
             print(f"{name}={val}")
@@ -92,19 +99,19 @@ nt, d = xt.shape
 
 # fastest to slowest
 
-if 'lsq-gpu' in todo:
+if "lsq-gpu" in todo:
     lsq = faiss.LocalSearchQuantizer(d, M, nbits)
     ngpus = faiss.get_num_gpus()
     lsq.icm_encoder_factory = faiss.GpuIcmEncoderFactory(ngpus)
     lsq.verbose = True
-    eval_quantizer(lsq, xb, xt, 'lsq-gpu')
+    eval_quantizer(lsq, xb, xt, "lsq-gpu")
 
-if 'pq' in todo:
+if "pq" in todo:
     pq = faiss.ProductQuantizer(d, M, nbits)
     print("===== PQ")
     eval_quantizer(pq, xq, xb, gt, xt)
 
-if 'opq' in todo:
+if "opq" in todo:
     d2 = ((d + M - 1) // M) * M
     print("OPQ d2=", d2)
     opq = faiss.OPQMatrix(d, M, d2)
@@ -116,33 +123,41 @@ if 'opq' in todo:
     print("===== PQ")
     eval_quantizer(pq, xq2, xb2, gt, xt2)
 
-if 'prq' in todo:
+if "prq" in todo:
     print(f"===== PRQ{nsplits}x{Msub}x{nbits}")
     prq = faiss.ProductResidualQuantizer(d, nsplits, Msub, nbits)
     variants = [("max_beam_size", i) for i in (1, 2, 4, 8, 16, 32)]
     eval_quantizer(prq, xq, xb, gt, xt, variants=variants)
 
-if 'plsq' in todo:
+if "plsq" in todo:
     print(f"===== PLSQ{nsplits}x{Msub}x{nbits}")
     plsq = faiss.ProductLocalSearchQuantizer(d, nsplits, Msub, nbits)
     variants = [("encode_ils_iters", i) for i in (2, 3, 4, 8, 16)]
     eval_quantizer(plsq, xq, xb, gt, xt, variants=variants)
 
-if 'rq' in todo:
+if "rq" in todo:
     print("===== RQ")
-    rq = faiss.ResidualQuantizer(d, M, nbits, )
+    rq = faiss.ResidualQuantizer(
+        d,
+        M,
+        nbits,
+    )
     rq.max_beam_size
-    rq.max_beam_size = 30   # for compatibility with older runs
+    rq.max_beam_size = 30  # for compatibility with older runs
     # rq.train_type = faiss.ResidualQuantizer.Train_default
     # rq.verbose = True
     variants = [("max_beam_size", i) for i in (1, 2, 4, 8, 16, 32)]
     eval_quantizer(rq, xq, xb, gt, xt, variants=variants)
 
-if 'rq_lut' in todo:
+if "rq_lut" in todo:
     print("===== RQ")
-    rq = faiss.ResidualQuantizer(d, M, nbits, )
+    rq = faiss.ResidualQuantizer(
+        d,
+        M,
+        nbits,
+    )
     rq.max_beam_size
-    rq.max_beam_size = 30   # for compatibility with older runs
+    rq.max_beam_size = 30  # for compatibility with older runs
     rq.use_beam_LUT
     rq.use_beam_LUT = 1
     # rq.train_type = faiss.ResidualQuantizer.Train_default
@@ -150,7 +165,7 @@ if 'rq_lut' in todo:
     variants = [("max_beam_size", i) for i in (1, 2, 4, 8, 16, 32, 64)]
     eval_quantizer(rq, xq, xb, gt, xt, variants=variants)
 
-if 'lsq' in todo:
+if "lsq" in todo:
     print("===== LSQ")
     lsq = faiss.LocalSearchQuantizer(d, M, nbits)
     variants = [("encode_ils_iters", i) for i in (2, 3, 4, 8, 16)]

--- a/benchs/bench_refine_panorama.py
+++ b/benchs/bench_refine_panorama.py
@@ -74,7 +74,9 @@ nprobe_list = [4, 16, 64, 256]
 kfactor_list = [1, 8, 64, 256, 1024]
 
 print(f"Benchmark on GIST1M with base '{factory}', k={k}, nq={nq}")
-print("nprobe  k_factor   recall_flat   qps_flat   recall_pano   qps_pano   dims_scanned(%)  speedup(x)")
+print(
+    "nprobe  k_factor   recall_flat   qps_flat   recall_pano   qps_pano   dims_scanned(%)  speedup(x)"
+)
 
 faiss.omp_set_num_threads(1)
 
@@ -111,10 +113,16 @@ for nprobe in nprobe_list:
             qps_p_list.append(qps_p)
 
             # Draw speedup and recall
-            plt.plot([kf, kf], [qps_f, qps_p], 'k--', linewidth=1, alpha=0.7)
+            plt.plot([kf, kf], [qps_f, qps_p], "k--", linewidth=1, alpha=0.7)
             mid_y = (qps_f * qps_p) ** 0.5
-            plt.text(kf + 10, mid_y, f"{speedup:.2f}x\nr={recall_p:.2f}", 
-            ha="left", va="center", fontsize=8)
+            plt.text(
+                kf + 10,
+                mid_y,
+                f"{speedup:.2f}x\nr={recall_p:.2f}",
+                ha="left",
+                va="center",
+                fontsize=8,
+            )
 
 plt.plot(kfactor_list, qps_f_list, label="RefineFlat")
 plt.plot(kfactor_list, qps_p_list, label=f"RefineFlatPanorama({nlevels})")
@@ -123,7 +131,9 @@ plt.ylim(bottom=100)
 plt.xlim(right=kfactor_list[-1] * 1.075)
 plt.xlabel("k_factor (k_base = k * k_factor)")
 plt.ylabel("QPS")
-plt.title(f"GIST1M, base={factory}, nprobe={fixed_nprobe}, nlevels={nlevels}, k={k}")
+plt.title(
+    f"GIST1M, base={factory}, nprobe={fixed_nprobe}, nlevels={nlevels}, k={k}"
+)
 plt.legend()
 plt.tight_layout()
 plt.savefig("bench_refine_panorama.png", bbox_inches="tight")

--- a/benchs/bench_scalar_quantizer.py
+++ b/benchs/bench_scalar_quantizer.py
@@ -15,25 +15,27 @@ nq, d = xq.shape
 
 ncent = 256
 
-variants = [(name, getattr(faiss.ScalarQuantizer, name))
-            for name in dir(faiss.ScalarQuantizer)
-            if name.startswith('QT_') and name != 'QT_count']
+variants = [
+    (name, getattr(faiss.ScalarQuantizer, name))
+    for name in dir(faiss.ScalarQuantizer)
+    if name.startswith("QT_") and name != "QT_count"
+]
 
 quantizer = faiss.IndexFlatL2(d)
 # quantizer.add(np.zeros((1, d), dtype='float32'))
 
 if False:
-    for name, qtype in [('flat', 0)] + variants:
+    for name, qtype in [("flat", 0)] + variants:
 
         print("============== test", name)
         t0 = time.time()
 
-        if name == 'flat':
-            index = faiss.IndexIVFFlat(quantizer, d, ncent,
-                                       faiss.METRIC_L2)
+        if name == "flat":
+            index = faiss.IndexIVFFlat(quantizer, d, ncent, faiss.METRIC_L2)
         else:
-            index = faiss.IndexIVFScalarQuantizer(quantizer, d, ncent,
-                                                  qtype, faiss.METRIC_L2)
+            index = faiss.IndexIVFScalarQuantizer(
+                quantizer, d, ncent, qtype, faiss.METRIC_L2
+            )
 
         index.nprobe = 16
         print("[%.3f s] train" % (time.time() - t0))
@@ -46,7 +48,7 @@ if False:
 
         for rank in 1, 10, 100:
             n_ok = (I[:, :rank] == gt[:, :1]).sum()
-            print("%.4f" % (n_ok / float(nq)), end=' ')
+            print("%.4f" % (n_ok / float(nq)), end=" ")
         print()
 
 if True:
@@ -54,18 +56,19 @@ if True:
 
         print("============== test", name)
 
-        for rsname, vals in [('RS_minmax',
-                              [-0.4, -0.2, -0.1, -0.05, 0.0, 0.1, 0.5]),
-                             ('RS_meanstd', [0.8, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0]),
-                             ('RS_quantiles', [0.02, 0.05, 0.1, 0.15]),
-                             ('RS_optim', [0.0])]:
+        for rsname, vals in [
+            ("RS_minmax", [-0.4, -0.2, -0.1, -0.05, 0.0, 0.1, 0.5]),
+            ("RS_meanstd", [0.8, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0]),
+            ("RS_quantiles", [0.02, 0.05, 0.1, 0.15]),
+            ("RS_optim", [0.0]),
+        ]:
             for val in vals:
-                print("%-15s %5g    " % (rsname, val), end=' ')
-                index = faiss.IndexIVFScalarQuantizer(quantizer, d, ncent,
-                                                      qtype, faiss.METRIC_L2)
+                print("%-15s %5g    " % (rsname, val), end=" ")
+                index = faiss.IndexIVFScalarQuantizer(
+                    quantizer, d, ncent, qtype, faiss.METRIC_L2
+                )
                 index.nprobe = 16
-                index.sq.rangestat = getattr(faiss.ScalarQuantizer,
-                                          rsname)
+                index.sq.rangestat = getattr(faiss.ScalarQuantizer, rsname)
 
                 index.sq.rangestat_arg = val
 
@@ -77,5 +80,5 @@ if True:
 
                 for rank in 1, 10, 100:
                     n_ok = (I[:, :rank] == gt[:, :1]).sum()
-                    print("%.4f" % (n_ok / float(nq)), end=' ')
+                    print("%.4f" % (n_ok / float(nq)), end=" ")
                 print("   %.3f s" % (t1 - t0))

--- a/benchs/bench_super_kmeans.py
+++ b/benchs/bench_super_kmeans.py
@@ -87,9 +87,7 @@ def main():
         n, d = args.n, args.d
         x = gaussian_mixture(n, d, args.k, args.seed)
         print("=== bench_super_kmeans ===")
-        print(
-            f"n={n} d={d} k={args.k} niter={args.niter} seed={args.seed}"
-        )
+        print(f"n={n} d={d} k={args.k} niter={args.niter} seed={args.seed}")
 
     print("\n--- faiss.Clustering ---")
     v_dt, v_obj, v_iters = run_vanilla(x, d, args.k, args.niter, args.seed)

--- a/benchs/bench_vector_ops.py
+++ b/benchs/bench_vector_ops.py
@@ -12,12 +12,12 @@ import time
 swig_ptr = faiss.swig_ptr
 
 if False:
-    a = np.arange(10, 14).astype('float32')
-    b = np.arange(20, 24).astype('float32')
+    a = np.arange(10, 14).astype("float32")
+    b = np.arange(20, 24).astype("float32")
 
-    faiss.fvec_inner_product (swig_ptr(a), swig_ptr(b), 4)
+    faiss.fvec_inner_product(swig_ptr(a), swig_ptr(b), 4)
 
-    1/0
+    1 / 0
 
 xd = 100
 yd = 1000000
@@ -26,22 +26,21 @@ np.random.seed(1234)
 
 faiss.omp_set_num_threads(1)
 
-print('xd=%d yd=%d' % (xd, yd))
+print("xd=%d yd=%d" % (xd, yd))
 
-print('Running inner products test..')
+print("Running inner products test..")
 for d in 3, 4, 12, 36, 64:
 
     x = faiss.rand(xd * d).reshape(xd, d)
     y = faiss.rand(yd * d).reshape(yd, d)
 
-    distances = np.empty((xd, yd), dtype='float32')
+    distances = np.empty((xd, yd), dtype="float32")
 
     t0 = time.time()
     for i in range(xd):
-        faiss.fvec_inner_products_ny(swig_ptr(distances[i]),
-                                     swig_ptr(x[i]),
-                                     swig_ptr(y),
-                                     d, yd)
+        faiss.fvec_inner_products_ny(
+            swig_ptr(distances[i]), swig_ptr(x[i]), swig_ptr(y), d, yd
+        )
     t1 = time.time()
 
     # sparse verification
@@ -53,23 +52,22 @@ for d in 3, 4, 12, 36, 64:
         num += abs(distances[xi, yi] - np.dot(x[xi], y[yi]))
         denom += abs(distances[xi, yi])
 
-    print('d=%d t=%.3f s diff=%g' % (d, t1 - t0, num / denom))
+    print("d=%d t=%.3f s diff=%g" % (d, t1 - t0, num / denom))
 
 
-print('Running L2sqr test..')
+print("Running L2sqr test..")
 for d in 3, 4, 12, 36, 64:
 
     x = faiss.rand(xd * d).reshape(xd, d)
     y = faiss.rand(yd * d).reshape(yd, d)
 
-    distances = np.empty((xd, yd), dtype='float32')
+    distances = np.empty((xd, yd), dtype="float32")
 
     t0 = time.time()
     for i in range(xd):
-        faiss.fvec_L2sqr_ny(swig_ptr(distances[i]),
-                            swig_ptr(x[i]),
-                            swig_ptr(y),
-                            d, yd)
+        faiss.fvec_L2sqr_ny(
+            swig_ptr(distances[i]), swig_ptr(x[i]), swig_ptr(y), d, yd
+        )
     t1 = time.time()
 
     # sparse verification
@@ -81,4 +79,4 @@ for d in 3, 4, 12, 36, 64:
         num += abs(distances[xi, yi] - np.sum((x[xi] - y[yi]) ** 2))
         denom += abs(distances[xi, yi])
 
-    print('d=%d t=%.3f s diff=%g' % (d, t1 - t0, num / denom))
+    print("d=%d t=%.3f s diff=%g" % (d, t1 - t0, num / denom))

--- a/benchs/datasets.py
+++ b/benchs/datasets.py
@@ -10,17 +10,17 @@ import numpy as np
 
 
 def ivecs_read(fname):
-    a = np.fromfile(fname, dtype='int32')
+    a = np.fromfile(fname, dtype="int32")
     d = a[0]
     return a.reshape(-1, d + 1)[:, 1:].copy()
 
 
 def fvecs_read(fname):
-    return ivecs_read(fname).view('float32')
+    return ivecs_read(fname).view("float32")
 
 
 def load_sift1M():
-    print("Loading sift1M...", end='', file=sys.stderr)
+    print("Loading sift1M...", end="", file=sys.stderr)
     xt = fvecs_read("sift1M/sift_learn.fvecs")
     xb = fvecs_read("sift1M/sift_base.fvecs")
     xq = fvecs_read("sift1M/sift_query.fvecs")

--- a/benchs/distributed_ondisk/combined_index.py
+++ b/benchs/distributed_ondisk/combined_index.py
@@ -17,15 +17,16 @@ class CombinedIndex:
     the info on how to perform searches
     """
 
-    def __init__(self, invlist_fnames, empty_index_fname,
-                 masked_index_fname=None):
+    def __init__(
+        self, invlist_fnames, empty_index_fname, masked_index_fname=None
+    ):
 
         self.indexes = indexes = []
         ilv = faiss.InvertedListsPtrVector()
 
         for fname in invlist_fnames:
             if os.path.exists(fname):
-                print('reading', fname, end='\r', flush=True)
+                print("reading", fname, end="\r", flush=True)
                 index = faiss.read_index(fname)
                 indexes.append(index)
                 il = faiss.extract_index_ivf(index).invlists
@@ -37,23 +38,24 @@ class CombinedIndex:
         self.big_il = faiss.VStackInvertedLists(ilv.size(), ilv.data())
         if masked_index_fname:
             self.big_il_base = self.big_il
-            print('loading', masked_index_fname)
+            print("loading", masked_index_fname)
             self.masked_index = faiss.read_index(
-                masked_index_fname,
-                faiss.IO_FLAG_MMAP | faiss.IO_FLAG_READ_ONLY)
+                masked_index_fname, faiss.IO_FLAG_MMAP | faiss.IO_FLAG_READ_ONLY
+            )
             self.big_il = faiss.MaskedInvertedLists(
                 faiss.extract_index_ivf(self.masked_index).invlists,
-                self.big_il_base)
+                self.big_il_base,
+            )
 
-        print('loading empty index', empty_index_fname)
+        print("loading empty index", empty_index_fname)
         self.index = faiss.read_index(empty_index_fname)
         ntotal = self.big_il.compute_ntotal()
 
-        print('replace invlists')
+        print("replace invlists")
         index_ivf = faiss.extract_index_ivf(self.index)
         index_ivf.replace_invlists(self.big_il, False)
         index_ivf.ntotal = self.index.ntotal = ntotal
-        index_ivf.parallel_mode = 1   # seems reasonable to do this all the time
+        index_ivf.parallel_mode = 1  # seems reasonable to do this all the time
 
         quantizer = faiss.downcast_index(index_ivf.quantizer)
         quantizer.hnsw.efSearch = 1024
@@ -82,7 +84,6 @@ class CombinedIndex:
         coarse_dis, list_nos = quantizer.search(xq, index_ivf.nprobe)
         return xq, list_nos, coarse_dis
 
-
     def ivf_search_preassigned(self, xq, list_nos, coarse_dis, k):
         index_ivf = faiss.extract_index_ivf(self.index)
         n, d = xq.shape
@@ -91,14 +92,19 @@ class CombinedIndex:
         assert list_nos.shape == coarse_dis.shape
         assert n2 == n
         assert d2 == index_ivf.nprobe
-        D = np.empty((n, k), dtype='float32')
-        I = np.empty((n, k), dtype='int64')
+        D = np.empty((n, k), dtype="float32")
+        I = np.empty((n, k), dtype="int64")
         index_ivf.search_preassigned(
-            n, faiss.swig_ptr(xq), k,
-            faiss.swig_ptr(list_nos), faiss.swig_ptr(coarse_dis),
-            faiss.swig_ptr(D), faiss.swig_ptr(I), False)
+            n,
+            faiss.swig_ptr(xq),
+            k,
+            faiss.swig_ptr(list_nos),
+            faiss.swig_ptr(coarse_dis),
+            faiss.swig_ptr(D),
+            faiss.swig_ptr(I),
+            False,
+        )
         return D, I
-
 
     def ivf_range_search_preassigned(self, xq, list_nos, coarse_dis, radius):
         index_ivf = faiss.extract_index_ivf(self.index)
@@ -111,9 +117,13 @@ class CombinedIndex:
         res = faiss.RangeSearchResult(n)
 
         index_ivf.range_search_preassigned(
-            n, faiss.swig_ptr(xq), radius,
-            faiss.swig_ptr(list_nos), faiss.swig_ptr(coarse_dis),
-            res)
+            n,
+            faiss.swig_ptr(xq),
+            radius,
+            faiss.swig_ptr(list_nos),
+            faiss.swig_ptr(coarse_dis),
+            res,
+        )
 
         lims = faiss.rev_swig_ptr(res.lims, n + 1).copy()
         nd = int(lims[-1])
@@ -135,7 +145,8 @@ class CombinedIndex:
     def set_prefetch_nthread(self, nt):
         for idx in self.indexes:
             il = faiss.downcast_InvertedLists(
-                faiss.extract_index_ivf(idx).invlists)
+                faiss.extract_index_ivf(idx).invlists
+            )
             il.prefetch_nthread = nt
 
     def set_omp_num_threads(self, nt):
@@ -143,38 +154,40 @@ class CombinedIndex:
 
 
 class CombinedIndexDeep1B(CombinedIndex):
-    """ loads a CombinedIndex with the data from the big photodna index """
+    """loads a CombinedIndex with the data from the big photodna index"""
 
     def __init__(self):
         # set some paths
         workdir = "/checkpoint/matthijs/ondisk_distributed/"
 
         # empty index with the proper quantizer
-        indexfname = workdir + 'trained.faissindex'
+        indexfname = workdir + "trained.faissindex"
 
         # index that has some invlists that override the big one
         masked_index_fname = None
         invlist_fnames = [
-            '%s/hslices/slice%d.faissindex' % (workdir, i)
-            for i in range(50)
+            "%s/hslices/slice%d.faissindex" % (workdir, i) for i in range(50)
         ]
-        CombinedIndex.__init__(self, invlist_fnames, indexfname, masked_index_fname)
+        CombinedIndex.__init__(
+            self, invlist_fnames, indexfname, masked_index_fname
+        )
 
 
 def ivecs_read(fname):
-    a = np.fromfile(fname, dtype='int32')
+    a = np.fromfile(fname, dtype="int32")
     d = a[0]
     return a.reshape(-1, d + 1)[:, 1:].copy()
 
 
 def fvecs_read(fname):
-    return ivecs_read(fname).view('float32')
+    return ivecs_read(fname).view("float32")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import time
+
     ci = CombinedIndexDeep1B()
-    print('loaded index of size ', ci.index.ntotal)
+    print("loaded index of size ", ci.index.ntotal)
 
     deep1bdir = "/datasets01_101/simsearch/041218/deep1b/"
 
@@ -187,7 +200,7 @@ if __name__ == '__main__':
         t0 = time.time()
         D, I = ci.search(xq, 100)
         t1 = time.time()
-        print('nprobe=%d 1-recall@1=%.4f t=%.2fs' % (
-            nprobe, (I[:, 0] == gt[:, 0]).sum() / len(xq),
-            t1 - t0
-        ))
+        print(
+            "nprobe=%d 1-recall@1=%.4f t=%.2fs"
+            % (nprobe, (I[:, 0] == gt[:, 0]).sum() / len(xq), t1 - t0)
+        )

--- a/benchs/distributed_ondisk/distributed_kmeans.py
+++ b/benchs/distributed_ondisk/distributed_kmeans.py
@@ -45,8 +45,8 @@ class DatasetAssignDispatch:
         return self.d
 
     def get_subset(self, indices):
-        res = np.zeros((len(indices), self.d), dtype='float32')
-        nos = np.searchsorted(self.cs[1:], indices, side='right')
+        res = np.zeros((len(indices), self.d), dtype="float32")
+        nos = np.searchsorted(self.cs[1:], indices, side="right")
 
         def handle(i):
             mask = nos == i
@@ -58,10 +58,7 @@ class DatasetAssignDispatch:
         return res
 
     def assign_to(self, centroids, weights=None):
-        src = self.imap(
-            lambda x: x.assign_to(centroids, weights),
-            self.xes
-        )
+        src = self.imap(lambda x: x.assign_to(centroids, weights), self.xes)
         I = []
         D = []
         sum_per_centroid = None
@@ -76,9 +73,9 @@ class DatasetAssignDispatch:
 
 
 class AssignServer(rpc.Server):
-    """ Assign version that can be exposed via RPC """
+    """Assign version that can be exposed via RPC"""
 
-    def __init__(self, s, assign, log_prefix=''):
+    def __init__(self, s, assign, log_prefix=""):
         rpc.Server.__init__(self, s, log_prefix=log_prefix)
         self.assign = assign
 
@@ -86,11 +83,9 @@ class AssignServer(rpc.Server):
         return getattr(self.assign, f)
 
 
-
-
 def do_test(todo):
 
-    testdata = '/datasets01_101/simsearch/041218/bigann/bigann_learn.bvecs'
+    testdata = "/datasets01_101/simsearch/041218/bigann/bigann_learn.bvecs"
 
     if os.path.exists(testdata):
         x = bvecs_mmap(testdata)
@@ -108,7 +103,7 @@ def do_test(todo):
     if "0" in todo:
         # reference C++ run
         km = faiss.Kmeans(x.shape[1], 1000, niter=20, verbose=True)
-        km.train(xx.astype('float32'))
+        km.train(xx.astype("float32"))
 
     if "1" in todo:
         # using the Faiss c++ implementation
@@ -117,21 +112,24 @@ def do_test(todo):
 
     if "2" in todo:
         # use the dispatch object (on local datasets)
-        data = DatasetAssignDispatch([
-            DatasetAssign(xx[20000 * i : 20000 * (i + 1)])
-            for i in range(5)
-            ], False
+        data = DatasetAssignDispatch(
+            [DatasetAssign(xx[20000 * i : 20000 * (i + 1)]) for i in range(5)],
+            False,
         )
         kmeans(1000, data, 20)
 
     if "3" in todo:
         # same, with GPU
         ngpu = faiss.get_num_gpus()
-        print('using %d GPUs' % ngpu)
-        data = DatasetAssignDispatch([
-            DatasetAssignGPU(xx[100000 * i // ngpu: 100000 * (i + 1) // ngpu], i)
-            for i in range(ngpu)
-            ], True
+        print("using %d GPUs" % ngpu)
+        data = DatasetAssignDispatch(
+            [
+                DatasetAssignGPU(
+                    xx[100000 * i // ngpu : 100000 * (i + 1) // ngpu], i
+                )
+                for i in range(ngpu)
+            ],
+            True,
         )
         kmeans(1000, data, 20)
 
@@ -142,98 +140,112 @@ def main():
     def aa(*args, **kwargs):
         group.add_argument(*args, **kwargs)
 
-    group = parser.add_argument_group('general options')
-    aa('--test', default='', help='perform tests (comma-separated numbers)')
+    group = parser.add_argument_group("general options")
+    aa("--test", default="", help="perform tests (comma-separated numbers)")
 
-    aa('--k', default=0, type=int, help='nb centroids')
-    aa('--seed', default=1234, type=int, help='random seed')
-    aa('--niter', default=20, type=int, help='nb iterations')
-    aa('--gpu', default=-2, type=int, help='GPU to use (-2:none, -1: all)')
+    aa("--k", default=0, type=int, help="nb centroids")
+    aa("--seed", default=1234, type=int, help="random seed")
+    aa("--niter", default=20, type=int, help="nb iterations")
+    aa("--gpu", default=-2, type=int, help="GPU to use (-2:none, -1: all)")
 
-    group = parser.add_argument_group('I/O options')
-    aa('--indata', default='',
-       help='data file to load (supported formats fvecs, bvecs, npy')
-    aa('--i0', default=0, type=int, help='first vector to keep')
-    aa('--i1', default=-1, type=int, help='last vec to keep + 1')
-    aa('--out', default='', help='file to store centroids')
-    aa('--store_each_iteration', default=False, action='store_true',
-       help='store centroid checkpoints')
+    group = parser.add_argument_group("I/O options")
+    aa(
+        "--indata",
+        default="",
+        help="data file to load (supported formats fvecs, bvecs, npy",
+    )
+    aa("--i0", default=0, type=int, help="first vector to keep")
+    aa("--i1", default=-1, type=int, help="last vec to keep + 1")
+    aa("--out", default="", help="file to store centroids")
+    aa(
+        "--store_each_iteration",
+        default=False,
+        action="store_true",
+        help="store centroid checkpoints",
+    )
 
-    group = parser.add_argument_group('server options')
-    aa('--server', action='store_true', default=False, help='run server')
-    aa('--port', default=12345, type=int, help='server port')
-    aa('--when_ready', default=None, help='store host:port to this file when ready')
-    aa('--ipv4', default=False, action='store_true', help='force ipv4')
+    group = parser.add_argument_group("server options")
+    aa("--server", action="store_true", default=False, help="run server")
+    aa("--port", default=12345, type=int, help="server port")
+    aa(
+        "--when_ready",
+        default=None,
+        help="store host:port to this file when ready",
+    )
+    aa("--ipv4", default=False, action="store_true", help="force ipv4")
 
-    group = parser.add_argument_group('client options')
-    aa('--client', action='store_true', default=False, help='run client')
-    aa('--servers', default='', help='list of server:port separated by spaces')
+    group = parser.add_argument_group("client options")
+    aa("--client", action="store_true", default=False, help="run client")
+    aa("--servers", default="", help="list of server:port separated by spaces")
 
     args = parser.parse_args()
 
     if args.test:
-        do_test(args.test.split(','))
+        do_test(args.test.split(","))
         return
 
     # prepare data matrix (either local or remote)
     if args.indata:
-        print('loading ', args.indata)
-        if args.indata.endswith('.bvecs'):
+        print("loading ", args.indata)
+        if args.indata.endswith(".bvecs"):
             x = bvecs_mmap(args.indata)
-        elif args.indata.endswith('.fvecs'):
+        elif args.indata.endswith(".fvecs"):
             x = fvecs_mmap(args.indata)
-        elif args.indata.endswith('.npy'):
-            x = np.load(args.indata, mmap_mode='r')
+        elif args.indata.endswith(".npy"):
+            x = np.load(args.indata, mmap_mode="r")
         else:
             raise AssertionError
 
         if args.i1 == -1:
             args.i1 = len(x)
-        x = x[args.i0:args.i1]
+        x = x[args.i0 : args.i1]
         if args.gpu == -2:
             data = DatasetAssign(x)
         else:
-            print('moving to GPU')
+            print("moving to GPU")
             data = DatasetAssignGPU(x, args.gpu)
 
     elif args.client:
-        print('connecting to servers')
+        print("connecting to servers")
 
         def connect_client(hostport):
-            host, port = hostport.split(':')
+            host, port = hostport.split(":")
             port = int(port)
-            print('connecting %s:%d' % (host, port))
+            print("connecting %s:%d" % (host, port))
             client = rpc.Client(host, port, v6=not args.ipv4)
-            print('client %s:%d ready' % (host, port))
+            print("client %s:%d ready" % (host, port))
             return client
 
-        hostports = args.servers.strip().split(' ')
+        hostports = args.servers.strip().split(" ")
         # pool = ThreadPool(len(hostports))
 
-        data = DatasetAssignDispatch(
-            list(map(connect_client, hostports)),
-            True
-        )
+        data = DatasetAssignDispatch(list(map(connect_client, hostports)), True)
     else:
         raise AssertionError
 
-
     if args.server:
-        print('starting server')
+        print("starting server")
         log_prefix = f"{rpc.socket.gethostname()}:{args.port}"
         rpc.run_server(
             lambda s: AssignServer(s, data, log_prefix=log_prefix),
-            args.port, report_to_file=args.when_ready,
-            v6=not args.ipv4)
+            args.port,
+            report_to_file=args.when_ready,
+            v6=not args.ipv4,
+        )
 
     else:
-        print('running kmeans')
-        centroids = kmeans(args.k, data, niter=args.niter, seed=args.seed,
-                           checkpoint=args.out if args.store_each_iteration else None)
-        if args.out != '':
-            print('writing centroids to', args.out)
+        print("running kmeans")
+        centroids = kmeans(
+            args.k,
+            data,
+            niter=args.niter,
+            seed=args.seed,
+            checkpoint=args.out if args.store_each_iteration else None,
+        )
+        if args.out != "":
+            print("writing centroids to", args.out)
             np.save(args.out, centroids)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/benchs/distributed_ondisk/distributed_query_demo.py
+++ b/benchs/distributed_ondisk/distributed_query_demo.py
@@ -43,13 +43,13 @@ sindex.set_omp_num_threads(64)
 
 
 def ivecs_read(fname):
-    a = np.fromfile(fname, dtype='int32')
+    a = np.fromfile(fname, dtype="int32")
     d = a[0]
     return a.reshape(-1, d + 1)[:, 1:].copy()
 
 
 def fvecs_read(fname):
-    return ivecs_read(fname).view('float32')
+    return ivecs_read(fname).view("float32")
 
 
 deep1bdir = "/datasets01_101/simsearch/041218/deep1b/"
@@ -64,7 +64,7 @@ for nprobe in 1, 10, 100, 1000:
     t0 = time.time()
     D, I = sindex.search(xq, 100)
     t1 = time.time()
-    print('nprobe=%d 1-recall@1=%.4f t=%.2fs' % (
-        nprobe, (I[:, 0] == gt[:, 0]).sum() / len(xq),
-        t1 - t0
-    ))
+    print(
+        "nprobe=%d 1-recall@1=%.4f t=%.2fs"
+        % (nprobe, (I[:, 0] == gt[:, 0]).sum() / len(xq), t1 - t0)
+    )

--- a/benchs/distributed_ondisk/make_index_vslice.py
+++ b/benchs/distributed_ondisk/make_index_vslice.py
@@ -11,13 +11,13 @@ from multiprocessing.pool import ThreadPool
 
 
 def ivecs_mmap(fname):
-    a = np.memmap(fname, dtype='int32', mode='r')
+    a = np.memmap(fname, dtype="int32", mode="r")
     d = a[0]
     return a.reshape(-1, d + 1)[:, 1:]
 
 
 def fvecs_mmap(fname):
-    return ivecs_mmap(fname).view('float32')
+    return ivecs_mmap(fname).view("float32")
 
 
 def produce_batches(args):
@@ -27,8 +27,10 @@ def produce_batches(args):
     if args.i1 == -1:
         args.i1 = len(x)
 
-    print("Iterating on vectors %d:%d from %s by batches of size %d" % (
-        args.i0, args.i1, args.input, args.bs))
+    print(
+        "Iterating on vectors %d:%d from %s by batches of size %d"
+        % (args.i0, args.i1, args.input, args.bs)
+    )
 
     for j0 in range(args.i0, args.i1, args.bs):
         j1 = min(j0 + args.bs, args.i1)
@@ -36,7 +38,7 @@ def produce_batches(args):
 
 
 def rate_limited_iter(l):
-    'a thread pre-processes the next element'
+    "a thread pre-processes the next element"
     pool = ThreadPool(1)
     res = None
 
@@ -55,42 +57,49 @@ def rate_limited_iter(l):
             yield res
         res = res_next
 
+
 deep1bdir = "/datasets01_101/simsearch/041218/deep1b/"
 workdir = "/checkpoint/matthijs/ondisk_distributed/"
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description='make index for a subset of the data')
+        description="make index for a subset of the data"
+    )
 
     def aa(*args, **kwargs):
         group.add_argument(*args, **kwargs)
 
-    group = parser.add_argument_group('index type')
-    aa('--inputindex',
-       default=workdir + 'trained.faissindex',
-       help='empty input index to fill in')
-    aa('--nt', default=-1, type=int, help='nb of openmp threads to use')
+    group = parser.add_argument_group("index type")
+    aa(
+        "--inputindex",
+        default=workdir + "trained.faissindex",
+        help="empty input index to fill in",
+    )
+    aa("--nt", default=-1, type=int, help="nb of openmp threads to use")
 
-    group = parser.add_argument_group('db options')
-    aa('--input', default=deep1bdir + "base.fvecs")
-    aa('--bs', default=2**18, type=int,
-       help='batch size for db access')
-    aa('--i0', default=0, type=int, help='lower bound to index')
-    aa('--i1', default=-1, type=int, help='upper bound of vectors to index')
+    group = parser.add_argument_group("db options")
+    aa("--input", default=deep1bdir + "base.fvecs")
+    aa("--bs", default=2**18, type=int, help="batch size for db access")
+    aa("--i0", default=0, type=int, help="lower bound to index")
+    aa("--i1", default=-1, type=int, help="upper bound of vectors to index")
 
-    group = parser.add_argument_group('output')
-    aa('-o', default='/tmp/x', help='output index')
-    aa('--keepquantizer', default=False, action='store_true',
-       help='by default we remove the data from the quantizer to save space')
+    group = parser.add_argument_group("output")
+    aa("-o", default="/tmp/x", help="output index")
+    aa(
+        "--keepquantizer",
+        default=False,
+        action="store_true",
+        help="by default we remove the data from the quantizer to save space",
+    )
 
     args = parser.parse_args()
-    print('args=', args)
+    print("args=", args)
 
-    print('start accessing data')
+    print("start accessing data")
     src = produce_batches(args)
 
-    print('loading index', args.inputindex)
+    print("loading index", args.inputindex)
     index = faiss.read_index(args.inputindex)
 
     if args.nt != -1:
@@ -99,21 +108,24 @@ def main():
     t0 = time.time()
     ntot = 0
     for ids, x in rate_limited_iter(src):
-        print('add %d:%d (%.3f s)' % (ntot, ntot + ids.size, time.time() - t0))
-        index.add_with_ids(np.ascontiguousarray(x, dtype='float32'), ids)
+        print("add %d:%d (%.3f s)" % (ntot, ntot + ids.size, time.time() - t0))
+        index.add_with_ids(np.ascontiguousarray(x, dtype="float32"), ids)
         ntot += ids.size
 
     index_ivf = faiss.extract_index_ivf(index)
-    print('invlists stats: imbalance %.3f' % index_ivf.invlists.imbalance_factor())
+    print(
+        "invlists stats: imbalance %.3f" % index_ivf.invlists.imbalance_factor()
+    )
     index_ivf.invlists.print_stats()
 
     if not args.keepquantizer:
-        print('resetting quantizer content')
+        print("resetting quantizer content")
         index_ivf = faiss.extract_index_ivf(index)
         index_ivf.quantizer.reset()
 
-    print('store output', args.o)
+    print("store output", args.o)
     faiss.write_index(index, args.o)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/benchs/distributed_ondisk/make_trained_index.py
+++ b/benchs/distributed_ondisk/make_trained_index.py
@@ -10,45 +10,45 @@ deep1bdir = "/datasets01_101/simsearch/041218/deep1b/"
 workdir = "/checkpoint/matthijs/ondisk_distributed/"
 
 
-print('Load centroids')
-centroids = np.load(workdir + '1M_centroids.npy')
+print("Load centroids")
+centroids = np.load(workdir + "1M_centroids.npy")
 ncent, d = centroids.shape
 
 
-print('apply random rotation')
+print("apply random rotation")
 rrot = faiss.RandomRotationMatrix(d, d)
 rrot.init(1234)
 centroids = rrot.apply_py(centroids)
 
-print('make HNSW index as quantizer')
+print("make HNSW index as quantizer")
 quantizer = faiss.IndexHNSWFlat(d, 32)
 quantizer.hnsw.efSearch = 1024
 quantizer.hnsw.efConstruction = 200
 quantizer.add(centroids)
 
-print('build index')
+print("build index")
 index = faiss.IndexPreTransform(
     rrot,
     faiss.IndexIVFScalarQuantizer(
         quantizer, d, ncent, faiss.ScalarQuantizer.QT_6bit
-        )
-    )
+    ),
+)
 
 
 def ivecs_mmap(fname):
-    a = np.memmap(fname, dtype='int32', mode='r')
+    a = np.memmap(fname, dtype="int32", mode="r")
     d = a[0]
     return a.reshape(-1, d + 1)[:, 1:]
 
 
 def fvecs_mmap(fname):
-    return ivecs_mmap(fname).view('float32')
+    return ivecs_mmap(fname).view("float32")
 
 
-print('finish training index')
-xt = fvecs_mmap(deep1bdir + 'learn.fvecs')
-xt = np.ascontiguousarray(xt[:256 * 1000], dtype='float32')
+print("finish training index")
+xt = fvecs_mmap(deep1bdir + "learn.fvecs")
+xt = np.ascontiguousarray(xt[: 256 * 1000], dtype="float32")
 index.train(xt)
 
-print('write output')
-faiss.write_index(index, workdir + 'trained.faissindex')
+print("write output")
+faiss.write_index(index, workdir + "trained.faissindex")

--- a/benchs/distributed_ondisk/merge_to_ondisk.py
+++ b/benchs/distributed_ondisk/merge_to_ondisk.py
@@ -7,28 +7,25 @@ import faiss
 import argparse
 from multiprocessing.pool import ThreadPool
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('--inputs', nargs='*', required=True,
-                        help='input indexes to merge')
-    parser.add_argument('--l0', type=int, default=0)
-    parser.add_argument('--l1', type=int, default=-1)
+    parser.add_argument(
+        "--inputs", nargs="*", required=True, help="input indexes to merge"
+    )
+    parser.add_argument("--l0", type=int, default=0)
+    parser.add_argument("--l1", type=int, default=-1)
 
-    parser.add_argument('--nt', default=-1,
-                        help='nb threads')
+    parser.add_argument("--nt", default=-1, help="nb threads")
 
-    parser.add_argument('--output', required=True,
-                        help='output index filename')
-    parser.add_argument('--outputIL',
-                        help='output invfile filename')
+    parser.add_argument("--output", required=True, help="output index filename")
+    parser.add_argument("--outputIL", help="output invfile filename")
 
     args = parser.parse_args()
 
     if args.nt != -1:
-        print('set nb of threads to', args.nt)
-
+        print("set nb of threads to", args.nt)
 
     ils = faiss.InvertedListsPtrVector()
     ils_dont_dealloc = []
@@ -38,9 +35,11 @@ if __name__ == '__main__':
     def load_index(fname):
         print("loading", fname)
         try:
-            index = faiss.read_index(fname, faiss.IO_FLAG_MMAP | faiss.IO_FLAG_READ_ONLY)
+            index = faiss.read_index(
+                fname, faiss.IO_FLAG_MMAP | faiss.IO_FLAG_READ_ONLY
+            )
         except RuntimeError as e:
-            print('could not load %s: %s' % (fname, e))
+            print("could not load %s: %s" % (fname, e))
             return fname, None
 
         print("  %d entries" % index.ntotal)
@@ -57,7 +56,7 @@ if __name__ == '__main__':
         il.this.own()
         ils_dont_dealloc.append(il)
         if (args.l0, args.l1) != (0, -1):
-            print('restricting to lists %d:%d' % (args.l0, args.l1))
+            print("restricting to lists %d:%d" % (args.l0, args.l1))
             # il = faiss.SliceInvertedLists(il, args.l0, args.l1)
 
             il.crop_invlists(args.l0, args.l1)
@@ -70,13 +69,11 @@ if __name__ == '__main__':
     print("loaded %d invlists" % ils.size())
 
     if not args.outputIL:
-        args.outputIL = args.output + '_invlists'
+        args.outputIL = args.output + "_invlists"
 
     il0 = ils.at(0)
 
-    il = faiss.OnDiskInvertedLists(
-        il0.nlist, il0.code_size,
-        args.outputIL)
+    il = faiss.OnDiskInvertedLists(il0.nlist, il0.code_size, args.outputIL)
 
     print("perform merge")
 

--- a/benchs/distributed_ondisk/search_server.py
+++ b/benchs/distributed_ondisk/search_server.py
@@ -21,7 +21,8 @@ import numpy as np
 
 
 class MyServer(rpc.Server):
-    """ Assign version that can be exposed via RPC """
+    """Assign version that can be exposed via RPC"""
+
     def __init__(self, s, index):
         rpc.Server.__init__(self, s)
         self.index = index
@@ -36,32 +37,41 @@ def main():
     def aa(*args, **kwargs):
         group.add_argument(*args, **kwargs)
 
-    group = parser.add_argument_group('server options')
-    aa('--port', default=12012, type=int, help='server port')
-    aa('--when_ready_dir', default=None,
-       help='store host:port to this file when ready')
-    aa('--ipv4', default=False, action='store_true', help='force ipv4')
-    aa('--rank', default=0, type=int,
-       help='rank used as index in the client table')
+    group = parser.add_argument_group("server options")
+    aa("--port", default=12012, type=int, help="server port")
+    aa(
+        "--when_ready_dir",
+        default=None,
+        help="store host:port to this file when ready",
+    )
+    aa("--ipv4", default=False, action="store_true", help="force ipv4")
+    aa(
+        "--rank",
+        default=0,
+        type=int,
+        help="rank used as index in the client table",
+    )
 
     args = parser.parse_args()
 
     when_ready = None
     if args.when_ready_dir:
-        when_ready = '%s/%d' % (args.when_ready_dir, args.rank)
+        when_ready = "%s/%d" % (args.when_ready_dir, args.rank)
 
-    print('loading index')
+    print("loading index")
 
     index = combined_index.CombinedIndexDeep1B()
 
-    print('starting server')
+    print("starting server")
     rpc.run_server(
         lambda s: MyServer(s, index),
-        args.port, report_to_file=when_ready,
-        v6=not args.ipv4)
+        args.port,
+        report_to_file=when_ready,
+        v6=not args.ipv4,
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()
 
 
@@ -71,12 +81,12 @@ if __name__ == '__main__':
 
 
 class ResultHeap:
-    """ Combine query results from a sliced dataset (for k-nn search) """
+    """Combine query results from a sliced dataset (for k-nn search)"""
 
     def __init__(self, nq, k):
-        " nq: number of query vectors, k: number of results per query "
-        self.I = np.zeros((nq, k), dtype='int64')
-        self.D = np.zeros((nq, k), dtype='float32')
+        "nq: number of query vectors, k: number of results per query"
+        self.I = np.zeros((nq, k), dtype="int64")
+        self.D = np.zeros((nq, k), dtype="float32")
         self.nq, self.k = nq, k
         heaps = faiss.float_maxheap_array_t()
         heaps.k = k
@@ -91,15 +101,15 @@ class ResultHeap:
         assert I.shape == (self.nq, self.k)
         I += i0
         self.heaps.addn_with_ids(
-            self.k, faiss.swig_ptr(D),
-            faiss.swig_ptr(I), self.k)
+            self.k, faiss.swig_ptr(D), faiss.swig_ptr(I), self.k
+        )
 
     def finalize(self):
         self.heaps.reorder()
 
 
 def distribute_weights(weights, nbin):
-    """ assign a set of weights to a smaller set of bins to balance them """
+    """assign a set of weights to a smaller set of bins to balance them"""
     nw = weights.size
     o = weights.argsort()
     bins = np.zeros(nbin)
@@ -128,40 +138,37 @@ class SplitPerListIndex:
     def set_nprobe(self, nprobe):
         self.index.set_nprobe(nprobe)
         self.pool.map(
-            lambda i: self.sub_indexes[i].set_nprobe(nprobe),
-            range(self.ni)
+            lambda i: self.sub_indexes[i].set_nprobe(nprobe), range(self.ni)
         )
 
     def set_omp_num_threads(self, nt):
         faiss.omp_set_num_threads(nt)
-        self.pool.map(
-            lambda idx: idx.set_omp_num_threads(nt),
-            self.sub_indexes
-        )
+        self.pool.map(lambda idx: idx.set_omp_num_threads(nt), self.sub_indexes)
 
     def set_parallel_mode(self, pm):
         self.index.set_parallel_mode(pm)
-        self.pool.map(
-            lambda idx: idx.set_parallel_mode(pm),
-            self.sub_indexes
-        )
+        self.pool.map(lambda idx: idx.set_parallel_mode(pm), self.sub_indexes)
 
     def set_prefetch_nthread(self, nt):
         self.index.set_prefetch_nthread(nt)
         self.pool.map(
-            lambda idx: idx.set_prefetch_nthread(nt),
-            self.sub_indexes
+            lambda idx: idx.set_prefetch_nthread(nt), self.sub_indexes
         )
 
     def balance_lists(self, list_nos):
         big_il = self.index.big_il
-        weights = np.array([big_il.list_size(int(i))
-                            for i in list_nos.ravel()])
+        weights = np.array([big_il.list_size(int(i)) for i in list_nos.ravel()])
         bins, assign = distribute_weights(weights, self.ni)
         if self.verbose:
-            print('bins weight range %d:%d total %d (%.2f MiB)' % (
-                bins.min(), bins.max(), bins.sum(),
-                bins.sum() * (self.code_size + 8) / 2 ** 20))
+            print(
+                "bins weight range %d:%d total %d (%.2f MiB)"
+                % (
+                    bins.min(),
+                    bins.max(),
+                    bins.sum(),
+                    bins.sum() * (self.code_size + 8) / 2**20,
+                )
+            )
         self.nscan = bins.sum()
         return assign.reshape(list_nos.shape)
 
@@ -175,10 +182,11 @@ class SplitPerListIndex:
             list_nos_i[assign != i] = -1
             t0 = time.time()
             Di, Ii = sub_index.ivf_search_preassigned(
-                xqo, list_nos_i, coarse_dis, k)
+                xqo, list_nos_i, coarse_dis, k
+            )
             # print(list_nos_i, Ii)
             if self.verbose:
-                print('client %d: %.3f s' % (i, time.time() - t0))
+                print("client %d: %.3f s" % (i, time.time() - t0))
             return Di, Ii
 
         rh = ResultHeap(x.shape[0], k)
@@ -200,9 +208,10 @@ class SplitPerListIndex:
             list_nos_i[assign != i] = -1
             t0 = time.time()
             limi, Di, Ii = sub_index.ivf_range_search_preassigned(
-                xqo, list_nos_i, coarse_dis, radius)
+                xqo, list_nos_i, coarse_dis, radius
+            )
             if self.verbose:
-                print('slice %d: %.3f s' % (i, time.time() - t0))
+                print("slice %d: %.3f s" % (i, time.time() - t0))
             return limi, Di, Ii
 
         D = [[] for i in range(nq)]
@@ -211,7 +220,7 @@ class SplitPerListIndex:
         sizes = np.zeros(nq, dtype=int)
         for lims, Di, Ii in self.pool.imap(do_query, range(self.ni)):
             for i in range(nq):
-                l0, l1 = lims[i:i + 2]
+                l0, l1 = lims[i : i + 2]
                 D[i].append(Di[l0:l1])
                 I[i].append(Ii[l0:l1])
                 sizes[i] += l1 - l0

--- a/benchs/kmeans_mnist.py
+++ b/benchs/kmeans_mnist.py
@@ -23,25 +23,25 @@ def load_mnist(fname):
     print("load", fname)
     f = open(fname)
 
-    header = np.fromfile(f, dtype='int8', count=4*4)
-    header = header.reshape(4, 4)[:, ::-1].copy().view('int32')
+    header = np.fromfile(f, dtype="int8", count=4 * 4)
+    header = header.reshape(4, 4)[:, ::-1].copy().view("int32")
     print(header)
     nim, xd, yd = [int(x) for x in header[1:]]
 
-    data = np.fromfile(f, count=nim * xd * yd,
-                       dtype='uint8')
+    data = np.fromfile(f, count=nim * xd * yd, dtype="uint8")
 
     print(data.shape, nim, xd, yd)
     data = data.reshape(nim, xd, yd)
     return data
 
+
 basedir = "/path/to/mnist/data"
 
-x = load_mnist(basedir + 'mnist8m/mnist8m-patterns-idx3-ubyte')
+x = load_mnist(basedir + "mnist8m/mnist8m-patterns-idx3-ubyte")
 
 print("reshape")
 
-x = x.reshape(x.shape[0], -1).astype('float32')
+x = x.reshape(x.shape[0], -1).astype("float32")
 
 
 def train_kmeans(x, k, ngpu):
@@ -66,8 +66,9 @@ def train_kmeans(x, k, ngpu):
     if ngpu == 1:
         index = faiss.GpuIndexFlatL2(res[0], d, flat_config[0])
     else:
-        indexes = [faiss.GpuIndexFlatL2(res[i], d, flat_config[i])
-                   for i in range(ngpu)]
+        indexes = [
+            faiss.GpuIndexFlatL2(res[i], d, flat_config[i]) for i in range(ngpu)
+        ]
         index = faiss.IndexReplicas()
         for sub_index in indexes:
             index.addIndex(sub_index)
@@ -80,6 +81,7 @@ def train_kmeans(x, k, ngpu):
     print("final objective: %.4g" % obj[-1])
 
     return centroids.reshape(k, d)
+
 
 print("run")
 t0 = time.time()

--- a/contrib/big_batch_search.py
+++ b/contrib/big_batch_search.py
@@ -27,11 +27,7 @@ class BigBatchSearcher:
     computation (parallel or not)
     """
 
-    def __init__(
-            self,
-            index, xq, k,
-            verbose=0,
-            use_float16=False):
+    def __init__(self, index, xq, k, verbose=0, use_float16=False):
 
         # verbosity
         self.verbose = verbose
@@ -65,9 +61,8 @@ class BigBatchSearcher:
 
     def report(self, l):
         if self.verbose == 1 or (
-            self.verbose == 2 and (
-                l > 1000 and time.time() < self.t_display + 1.0
-            )
+            self.verbose == 2
+            and (l > 1000 and time.time() < self.t_display + 1.0)
         ):
             return
         t = time.time() - self.t0
@@ -79,8 +74,8 @@ class BigBatchSearcher:
             f"wait out {self.t_accu[5]:.3f} "
             f"eta {datetime.timedelta(seconds=t*self.index.nlist/(l+1)-t)} "
             f"mem {faiss.get_mem_usage_kb()}",
-             end="\r" if self.verbose <= 2 else "\n",
-             flush=True,
+            end="\r" if self.verbose <= 2 else "\n",
+            flush=True,
         )
         self.t_display = time.time()
 
@@ -88,11 +83,12 @@ class BigBatchSearcher:
         self.tic("coarse quantization")
         bs = 65536
         nq = len(self.xq)
-        q_assign = np.empty((nq, self.index.nprobe), dtype='int32')
+        q_assign = np.empty((nq, self.index.nprobe), dtype="int32")
         for i0 in range(0, nq, bs):
             i1 = min(nq, i0 + bs)
             q_dis_i, q_assign_i = self.index.quantizer.search(
-                self.xq[i0:i1], self.index.nprobe)
+                self.xq[i0:i1], self.index.nprobe
+            )
             # q_dis[i0:i1] = q_dis_i
             q_assign[i0:i1] = q_assign_i
         self.toc()
@@ -101,18 +97,19 @@ class BigBatchSearcher:
     def reorder_assign(self):
         self.tic("bucket sort")
         q_assign = self.q_assign
-        q_assign += 1   # move -1 -> 0
+        q_assign += 1  # move -1 -> 0
         self.bucket_lims = faiss.matrix_bucket_sort_inplace(
-            self.q_assign, nbucket=self.index.nlist + 1, nt=16)
+            self.q_assign, nbucket=self.index.nlist + 1, nt=16
+        )
         self.query_ids = self.q_assign.ravel()
         if self.verbose > 0:
-            print('  number of -1s:', self.bucket_lims[1])
+            print("  number of -1s:", self.bucket_lims[1])
         self.bucket_lims = self.bucket_lims[1:]  # shift back to ignore -1s
-        del self.q_assign   # inplace so let's forget about the old version...
+        del self.q_assign  # inplace so let's forget about the old version...
         self.toc()
 
     def prepare_bucket(self, l):
-        """ prepare the queries and database items for bucket l"""
+        """prepare the queries and database items for bucket l"""
         t0 = time.time()
         index = self.index
         # prepare queries
@@ -131,8 +128,8 @@ class BigBatchSearcher:
             xb_l = self.decode_func(xb_l)
 
         if self.use_float16:
-            xb_l = xb_l.astype('float16')
-            xq_l = xq_l.astype('float16')
+            xb_l = xb_l.astype("float16")
+            xq_l = xq_l.astype("float16")
 
         t2 = time.time()
         self.t_accu[0] += t1 - t0
@@ -163,7 +160,10 @@ class BigBatchSearcher:
                     "sizes": self.sizes_in_checkpoint(),
                     "completed": completed,
                     "rh": (self.rh.D, self.rh.I),
-                }, f, -1)
+                },
+                f,
+                -1,
+            )
         os.replace(tmpname, fname)
 
     def read_checkpoint(self, fname):
@@ -176,14 +176,15 @@ class BigBatchSearcher:
 
 
 class BlockComputer:
-    """ computation within one bucket """
+    """computation within one bucket"""
 
     def __init__(
-            self,
-            index,
-            method="knn_function",
-            pairwise_distances=faiss.pairwise_distances,
-            knn=faiss.knn):
+        self,
+        index,
+        method="knn_function",
+        pairwise_distances=faiss.pairwise_distances,
+        knn=faiss.knn,
+    ):
 
         self.index = index
         if index.__class__ == faiss.IndexIVFFlat:
@@ -192,14 +193,16 @@ class BlockComputer:
             by_residual = False
         elif index.__class__ == faiss.IndexIVFPQ:
             index_help = faiss.IndexPQ(
-                index.d, index.pq.M, index.pq.nbits, index.metric_type)
+                index.d, index.pq.M, index.pq.nbits, index.metric_type
+            )
             index_help.pq = index.pq
             decode_func = index_help.pq.decode
             index_help.is_trained = True
             by_residual = index.by_residual
         elif index.__class__ == faiss.IndexIVFScalarQuantizer:
             index_help = faiss.IndexScalarQuantizer(
-                index.d, index.sq.qtype, index.metric_type)
+                index.d, index.sq.qtype, index.metric_type
+            )
             index_help.sq = index.sq
             decode_func = index_help.sq.decode
             index_help.is_trained = True
@@ -232,22 +235,24 @@ class BlockComputer:
 
 
 def big_batch_search(
-        index, xq, k,
-        method="knn_function",
-        pairwise_distances=faiss.pairwise_distances,
-        knn=faiss.knn,
-        verbose=0,
-        threaded=0,
-        use_float16=False,
-        prefetch_threads=1,
-        computation_threads=1,
-        q_assign=None,
-        checkpoint=None,
-        checkpoint_freq=7200,
-        start_list=0,
-        end_list=None,
-        crash_at=-1
-        ):
+    index,
+    xq,
+    k,
+    method="knn_function",
+    pairwise_distances=faiss.pairwise_distances,
+    knn=faiss.knn,
+    verbose=0,
+    threaded=0,
+    use_float16=False,
+    prefetch_threads=1,
+    computation_threads=1,
+    q_assign=None,
+    checkpoint=None,
+    checkpoint_freq=7200,
+    start_list=0,
+    end_list=None,
+    crash_at=-1,
+):
     """
     Search queries xq in the IVF index, with a search function that collects
     batches of query vectors per inverted list. This can be faster than the
@@ -288,10 +293,11 @@ def big_batch_search(
     assert method in ("index", "pairwise_distances", "knn_function")
 
     mem_queries = xq.nbytes
-    mem_assign = len(xq) * nprobe * np.dtype('int32').itemsize
-    mem_res = len(xq) * k * (
-        np.dtype('int64').itemsize
-        + np.dtype('float32').itemsize
+    mem_assign = len(xq) * nprobe * np.dtype("int32").itemsize
+    mem_res = (
+        len(xq)
+        * k
+        * (np.dtype("int64").itemsize + np.dtype("float32").itemsize)
     )
     mem_tot = mem_queries + mem_assign + mem_res
     if verbose > 0:
@@ -301,16 +307,11 @@ def big_batch_search(
         )
 
     bbs = BigBatchSearcher(
-        index, xq, k,
-        verbose=verbose,
-        use_float16=use_float16
+        index, xq, k, verbose=verbose, use_float16=use_float16
     )
 
     comp = BlockComputer(
-        index,
-        method=method,
-        pairwise_distances=pairwise_distances,
-        knn=knn
+        index, method=method, pairwise_distances=pairwise_distances, knn=knn
     )
 
     bbs.decode_func = comp.decode_func
@@ -351,8 +352,8 @@ def big_batch_search(
         # parallel version with granularity 1
 
         def add_results_and_prefetch(to_add, l):
-            """ perform the addition for the previous bucket and
-            prefetch the next (if applicable) """
+            """perform the addition for the previous bucket and
+            prefetch the next (if applicable)"""
             if to_add is not None:
                 bbs.add_results_to_heap(*to_add)
             if l < index.nlist:
@@ -365,7 +366,8 @@ def big_batch_search(
         for l in range(start_list, end_list):
             bbs.report(l)
             prefetched_bucket_a = pool.apply_async(
-                add_results_and_prefetch, (to_add, l + 1))
+                add_results_and_prefetch, (to_add, l + 1)
+            )
             q_subset, xq_l, list_ids, xb_l = prefetched_bucket
             bbs.start_t_accu()
             D, I = comp.block_search(xq_l, xb_l, list_ids, k)
@@ -390,11 +392,13 @@ def big_batch_search(
         ):
             try:
                 with ThreadPool(pool_size) as pool:
-                    res = [pool.apply_async(
-                        task,
-                        args=(i, output_queue, input_queue))
+                    res = [
+                        pool.apply_async(
+                            task, args=(i, output_queue, input_queue)
+                        )
                         for i in range(start_task, end_task)
-                        if i not in completed]
+                        if i not in completed
+                    ]
                     for r in res:
                         r.get()
                     pool.close()
@@ -431,7 +435,7 @@ def big_batch_search(
                 t_wait_out = 0
                 while True:
                     t0 = time.time()
-                    logging.info(f'Compute input: task {task_id}')
+                    logging.info(f"Compute input: task {task_id}")
                     input_value = input_queue.get()
                     t_wait_in = time.time() - t0
                     if input_value is None:
@@ -439,7 +443,9 @@ def big_batch_search(
                         input_queue.put(None)
                         break
                     centroid, q_subset, xq_l, list_ids, xb_l = input_value
-                    logging.info(f'Compute work: task {task_id}, centroid {centroid}')
+                    logging.info(
+                        f"Compute work: task {task_id}, centroid {centroid}"
+                    )
                     t0 = time.time()
                     if computation_threads > 1:
                         D, I = comp.block_search(
@@ -448,10 +454,21 @@ def big_batch_search(
                     else:
                         D, I = comp.block_search(xq_l, xb_l, list_ids, k)
                     t_compute = time.time() - t0
-                    logging.info(f'Compute output: task {task_id}, centroid {centroid}')
+                    logging.info(
+                        f"Compute output: task {task_id}, centroid {centroid}"
+                    )
                     t0 = time.time()
                     output_queue.put(
-                        (centroid, t_wait_in, t_wait_out, t_compute, q_subset, D, list_ids, I)
+                        (
+                            centroid,
+                            t_wait_in,
+                            t_wait_out,
+                            t_compute,
+                            q_subset,
+                            D,
+                            list_ids,
+                            I,
+                        )
                     )
                     t_wait_out = time.time() - t0
                 logging.info(f"Compute end: {task_id}")
@@ -487,7 +504,16 @@ def big_batch_search(
             value = compute_to_main_queue.get()
             if not value:
                 break
-            centroid, t_wait_in, t_wait_out, t_compute, q_subset, D, list_ids, I = value
+            (
+                centroid,
+                t_wait_in,
+                t_wait_out,
+                t_compute,
+                q_subset,
+                D,
+                list_ids,
+                I,
+            ) = value
             # to test checkpointing
             if centroid == crash_at:
                 1 / 0

--- a/contrib/client_server.py
+++ b/contrib/client_server.py
@@ -15,7 +15,7 @@ from . import rpc
 
 
 class SearchServer(rpc.Server):
-    """ Assign version that can be exposed via RPC """
+    """Assign version that can be exposed via RPC"""
 
     def __init__(self, s: int, index: faiss.Index):
         rpc.Server.__init__(self, s)
@@ -23,7 +23,7 @@ class SearchServer(rpc.Server):
         self.index_ivf = faiss.extract_index_ivf(index)
 
     def set_nprobe(self, nprobe: int) -> int:
-        """ set nprobe field """
+        """set nprobe field"""
         self.index_ivf.nprobe = nprobe
 
     def get_ntotal(self) -> int:
@@ -35,15 +35,14 @@ class SearchServer(rpc.Server):
 
 
 def run_index_server(index: faiss.Index, port: int, v6: bool = False):
-    """ serve requests for that index forever """
-    rpc.run_server(
-        lambda s: SearchServer(s, index),
-        port, v6=v6)
+    """serve requests for that index forever"""
+    rpc.run_server(lambda s: SearchServer(s, index), port, v6=v6)
 
 
 ############################################################
 # Client implementation
 ############################################################
+
 
 class ClientIndex:
     """manages a set of distance sub-indexes. The sub_indexes search a
@@ -51,7 +50,7 @@ class ClientIndex:
     """
 
     def __init__(self, machine_ports: List[Tuple[str, int]], v6: bool = False):
-        """ connect to a series of (host, port) pairs """
+        """connect to a series of (host, port) pairs"""
         self.sub_indexes = []
         for machine, port in machine_ports:
             self.sub_indexes.append(rpc.Client(machine, port, v6))
@@ -64,28 +63,23 @@ class ClientIndex:
         self.verbose = False
 
     def set_nprobe(self, nprobe: int) -> None:
-        self.pool.map(
-            lambda idx: idx.set_nprobe(nprobe),
-            self.sub_indexes
-        )
+        self.pool.map(lambda idx: idx.set_nprobe(nprobe), self.sub_indexes)
 
     def set_omp_num_threads(self, nt: int) -> None:
-        self.pool.map(
-            lambda idx: idx.set_omp_num_threads(nt),
-            self.sub_indexes
-        )
+        self.pool.map(lambda idx: idx.set_omp_num_threads(nt), self.sub_indexes)
 
     def get_ntotal(self) -> None:
-        return sum(self.pool.map(
-            lambda idx: idx.get_ntotal(),
-            self.sub_indexes
-        ))
+        return sum(
+            self.pool.map(lambda idx: idx.get_ntotal(), self.sub_indexes)
+        )
 
     def search(self, x, k: int):
 
         rh = faiss.ResultHeap(x.shape[0], k)
 
-        for Di, Ii in self.pool.imap(lambda idx: idx.search(x, k), self.sub_indexes):
+        for Di, Ii in self.pool.imap(
+            lambda idx: idx.search(x, k), self.sub_indexes
+        ):
             rh.add_result(Di, Ii)
         rh.finalize()
         return rh.D, rh.I

--- a/contrib/clustering.py
+++ b/contrib/clustering.py
@@ -23,7 +23,9 @@ def print_nop(*arg, **kwargs):
     pass
 
 
-def two_level_clustering(xt, nc1, nc2, rebalance=True, clustering_niter=25, **args):
+def two_level_clustering(
+    xt, nc1, nc2, rebalance=True, clustering_niter=25, **args
+):
     """
     perform 2-level clustering on a training set xt
     nc1 and nc2 are the number of clusters at each level, the final number of
@@ -38,13 +40,13 @@ def two_level_clustering(xt, nc1, nc2, rebalance=True, clustering_niter=25, **ar
 
     log = print if verbose else print_nop
 
-    log(f"2-level clustering of {xt.shape} nb 1st level clusters = {nc1} total {nc2}")
+    log(
+        f"2-level clustering of {xt.shape} nb 1st level clusters = {nc1} total {nc2}"
+    )
     log("perform coarse training")
 
     km = faiss.Kmeans(
-        d, nc1, niter=clustering_niter,
-        max_points_per_centroid=2000,
-        **args
+        d, nc1, niter=clustering_niter, max_points_per_centroid=2000, **args
     )
     km.train(xt)
 
@@ -58,7 +60,9 @@ def two_level_clustering(xt, nc1, nc2, rebalance=True, clustering_niter=25, **ar
     t0 = time.time()
     _, assign1 = km.assign(xt)
     bc = np.bincount(assign1, minlength=nc1)
-    log(f"done in {time.time() - t0:.2f} s. Sizes of clusters {min(bc)}-{max(bc)}")
+    log(
+        f"done in {time.time() - t0:.2f} s. Sizes of clusters {min(bc)}-{max(bc)}"
+    )
     o = assign1.argsort()
     del km
 
@@ -79,7 +83,11 @@ def two_level_clustering(xt, nc1, nc2, rebalance=True, clustering_niter=25, **ar
     t0 = time.time()
     for c1 in range(nc1):
         nc2 = int(all_nc2[c1])
-        log(f"[{time.time() - t0:.2f} s] training sub-cluster {c1}/{nc1} nc2={nc2}\r", end="", flush=True)
+        log(
+            f"[{time.time() - t0:.2f} s] training sub-cluster {c1}/{nc1} nc2={nc2}\r",
+            end="",
+            flush=True,
+        )
         i1 = i0 + bc[c1]
         subset = o[i0:i1]
         assert np.all(assign1[subset] == c1)
@@ -121,7 +129,9 @@ def train_ivf_index_with_2level(index, xt, **args):
     index.train(xt)
 
 
-def balanced_assignment_with_penalties(x, centroids, alpha = 0.03, num_iter = 20, maxk = 100): 
+def balanced_assignment_with_penalties(
+    x, centroids, alpha=0.03, num_iter=20, maxk=100
+):
     """
     Assign vectors x to centroids with a balance constraint.
 
@@ -164,15 +174,15 @@ def balanced_assignment_with_penalties(x, centroids, alpha = 0.03, num_iter = 20
     n = len(x)
     nopt = n / nc  # targed bin sizes
 
-    # we assign to the top-maxk clusters. The final assignment will pick among these clusters. 
+    # we assign to the top-maxk clusters. The final assignment will pick among these clusters.
     full_d2, full_assign = faiss.knn(x, centroids, maxk)
 
     # scalar penalty for each cluster
     penalties = np.ones(nc, dtype=np.float32)
 
     for it in range(num_iter):
-        # compute penalized assignment 
-        penalties2 = penalties ** 2
+        # compute penalized assignment
+        penalties2 = penalties**2
         full_d2_penalized = full_d2 + penalties2[full_assign]
         a0 = full_d2_penalized.argmin(axis=1)
         assign = np.take_along_axis(full_assign, a0[:, None], axis=1).ravel()
@@ -183,13 +193,13 @@ def balanced_assignment_with_penalties(x, centroids, alpha = 0.03, num_iter = 20
     stats = dict(
         alpha=alpha,
         imf=imbalance_factor(nc, assign),
-        mse = ((x - centroids[assign]) ** 2).sum(1).mean(),  # recompute MSE 
+        mse=((x - centroids[assign]) ** 2).sum(1).mean(),  # recompute MSE
         binsize_min=int(binsizes.min()),
         binsize_max=int(binsizes.max()),
         penalty_min=penalties.min(),
         penalty_max=penalties.max(),
     )
-    
+
     return assign, stats
 
 
@@ -206,7 +216,7 @@ class DatasetAssign:
     to centroids. All other implementations offer the same interface"""
 
     def __init__(self, x):
-        self.x = np.ascontiguousarray(x, dtype='float32')
+        self.x = np.ascontiguousarray(x, dtype="float32")
 
     def count(self):
         return self.x.shape[0]
@@ -226,7 +236,7 @@ class DatasetAssign:
         I = I.ravel()
         D = D.ravel()
         nc, d = centroids.shape
-        sum_per_centroid = np.zeros((nc, d), dtype='float32')
+        sum_per_centroid = np.zeros((nc, d), dtype="float32")
         if weights is None:
             np.add.at(sum_per_centroid, I, self.x)
         else:
@@ -236,15 +246,15 @@ class DatasetAssign:
 
 
 class DatasetAssignGPU(DatasetAssign):
-    """ GPU version of the previous """
+    """GPU version of the previous"""
 
     def __init__(self, x, gpu_id, verbose=False):
         DatasetAssign.__init__(self, x)
         index = faiss.IndexFlatL2(x.shape[1])
         if gpu_id >= 0:
             self.index = faiss.index_cpu_to_gpu(
-                faiss.StandardGpuResources(),
-                gpu_id, index)
+                faiss.StandardGpuResources(), gpu_id, index
+            )
         else:
             # -1 -> assign to all GPUs
             self.index = faiss.index_cpu_to_all_gpus(index)
@@ -256,14 +266,14 @@ class DatasetAssignGPU(DatasetAssign):
 
 
 def sparse_assign_to_dense(xq, xb, xq_norms=None, xb_norms=None):
-    """ assignment function for xq is sparse, xb is dense
+    """assignment function for xq is sparse, xb is dense
     uses a matrix multiplication. The squared norms can be provided if
     available.
     """
     nq = xq.shape[0]
     nb = xb.shape[0]
     if xb_norms is None:
-        xb_norms = (xb ** 2).sum(1)
+        xb_norms = (xb**2).sum(1)
     if xq_norms is None:
         xq_norms = np.array(xq.power(2).sum(1))
     d2 = xb_norms - 2 * xq @ xb.T
@@ -273,7 +283,8 @@ def sparse_assign_to_dense(xq, xb, xq_norms=None, xb_norms=None):
 
 
 def sparse_assign_to_dense_blocks(
-        xq, xb, xq_norms=None, xb_norms=None, qbs=16384, bbs=16384, nt=None):
+    xq, xb, xq_norms=None, xb_norms=None, qbs=16384, bbs=16384, nt=None
+):
     """
     decomposes the sparse_assign_to_dense function into blocks to avoid a
     possible memory blow up. Can be run in multithreaded mode, because scipy's
@@ -286,7 +297,7 @@ def sparse_assign_to_dense_blocks(
     I = -np.ones(nq, dtype=int)
 
     if xb_norms is None:
-        xb_norms = (xb ** 2).sum(1)
+        xb_norms = (xb**2).sum(1)
 
     def handle_query_block(i):
         xq_block = xq[i : i + qbs]
@@ -334,7 +345,8 @@ class DatasetAssignSparse(DatasetAssign):
 
     def perform_search(self, centroids):
         return sparse_assign_to_dense_blocks(
-            self.x, centroids, xq_norms=self.squared_norms)
+            self.x, centroids, xq_norms=self.squared_norms
+        )
 
     def assign_to(self, centroids, weights=None):
         D, I = self.perform_search(centroids)
@@ -343,19 +355,19 @@ class DatasetAssignSparse(DatasetAssign):
         D = D.ravel()
         n = self.x.shape[0]
         if weights is None:
-            weights = np.ones(n, dtype='float32')
+            weights = np.ones(n, dtype="float32")
         nc = len(centroids)
 
         m = scipy.sparse.csc_matrix(
-            (weights, I, np.arange(n + 1)),
-            shape=(nc, n))
+            (weights, I, np.arange(n + 1)), shape=(nc, n)
+        )
         sum_per_centroid = np.array((m * self.x).todense())
 
         return I, D, sum_per_centroid
 
 
 def imbalance_factor(k, assign):
-    assign = np.ascontiguousarray(assign, dtype='int64')
+    assign = np.ascontiguousarray(assign, dtype="int64")
     return faiss.imbalance_factor(len(assign), k, faiss.swig_ptr(assign))
 
 
@@ -363,13 +375,14 @@ def check_if_torch(x):
     if x.__class__ == np.ndarray:
         return False
     import torch
+
     if isinstance(x, torch.Tensor):
         return True
     raise NotImplementedError(f"Unknown tensor type {type(x)}")
 
 
 def reassign_centroids(hassign, centroids, rs=None):
-    """ reassign centroids when some of them collapse """
+    """reassign centroids when some of them collapse"""
     if rs is None:
         rs = np.random
     k, d = centroids.shape
@@ -383,17 +396,18 @@ def reassign_centroids(hassign, centroids, rs=None):
 
     if is_torch:
         import torch
+
         fac = torch.ones_like(centroids[0])
     else:
         fac = np.ones_like(centroids[0])
-    fac[::2] += 1 / 1024.
-    fac[1::2] -= 1 / 1024.
+    fac[::2] += 1 / 1024.0
+    fac[1::2] -= 1 / 1024.0
 
     # this is a single pass unless there are more than k/2
     # empty centroids
     while len(empty_cents) > 0:
         # choose which centroids to split (numpy)
-        probas = hassign.astype('float') - 1
+        probas = hassign.astype("float") - 1
         probas[probas < 0] = 0
         probas /= probas.sum()
         nnz = (probas > 0).sum()
@@ -416,9 +430,15 @@ def reassign_centroids(hassign, centroids, rs=None):
     return nsplit
 
 
-
-def kmeans(k, data, niter=25, seed=1234, checkpoint=None, verbose=True,
-           return_stats=False):
+def kmeans(
+    k,
+    data,
+    niter=25,
+    seed=1234,
+    checkpoint=None,
+    verbose=True,
+    return_stats=False,
+):
     """Pure python kmeans implementation. Follows the Faiss C++ version
     quite closely, but takes a DatasetAssign instead of a training data
     matrix. Also redo is not implemented.
@@ -429,8 +449,13 @@ def kmeans(k, data, niter=25, seed=1234, checkpoint=None, verbose=True,
     n, d = data.count(), data.dim()
     log = print if verbose else print_nop
 
-    log(("Clustering %d points in %dD to %d clusters, " +
-            "%d iterations seed %d") % (n, d, k, niter, seed))
+    log(
+        (
+            "Clustering %d points in %dD to %d clusters, "
+            + "%d iterations seed %d"
+        )
+        % (n, d, k, niter, seed)
+    )
 
     rs = np.random.RandomState(seed)
     print("preproc...")
@@ -448,10 +473,10 @@ def kmeans(k, data, niter=25, seed=1234, checkpoint=None, verbose=True,
     for i in range(niter):
         t0s = time.time()
 
-        log('assigning', end='\r', flush=True)
+        log("assigning", end="\r", flush=True)
         assign, D, sums = data.assign_to(centroids)
 
-        log('compute centroids', end='\r', flush=True)
+        log("compute centroids", end="\r", flush=True)
 
         t_search_tot += time.time() - t0s
 
@@ -462,10 +487,11 @@ def kmeans(k, data, niter=25, seed=1234, checkpoint=None, verbose=True,
 
         hassign = np.bincount(assign, minlength=k)
 
-        fac = hassign.reshape(-1, 1).astype('float32')
+        fac = hassign.reshape(-1, 1).astype("float32")
         fac[fac == 0] = 1  # quiet warning
         if is_torch:
             import torch
+
             fac = torch.from_numpy(fac).to(sums.device)
 
         centroids = sums / fac
@@ -477,21 +503,30 @@ def kmeans(k, data, niter=25, seed=1234, checkpoint=None, verbose=True,
             "time": (time.time() - t0),
             "time_search": t_search_tot,
             "imbalance_factor": imbalance_factor(k, assign),
-            "nsplit": nsplit
+            "nsplit": nsplit,
         }
 
-        log(("  Iteration %d (%.2f s, search %.2f s): "
-             "objective=%g imbalance=%.3f nsplit=%d") % (
-                   i, s["time"], s["time_search"],
-                   err, s["imbalance_factor"],
-                   nsplit)
+        log(
+            (
+                "  Iteration %d (%.2f s, search %.2f s): "
+                "objective=%g imbalance=%.3f nsplit=%d"
+            )
+            % (
+                i,
+                s["time"],
+                s["time_search"],
+                err,
+                s["imbalance_factor"],
+                nsplit,
+            )
         )
         iteration_stats.append(s)
 
         if checkpoint is not None:
-            log('storing centroids in', checkpoint)
+            log("storing centroids in", checkpoint)
             if is_torch:
                 import torch
+
                 torch.save(centroids, checkpoint)
             else:
                 np.save(checkpoint, centroids)

--- a/contrib/datasets.py
+++ b/contrib/datasets.py
@@ -9,31 +9,38 @@ import faiss
 import getpass
 
 
-from .vecs_io import fvecs_read, ivecs_read, bvecs_mmap, fvecs_mmap, bvecs_iter, bvecs_iter_chunked
+from .vecs_io import (
+    fvecs_read,
+    ivecs_read,
+    bvecs_mmap,
+    fvecs_mmap,
+    bvecs_iter,
+    bvecs_iter_chunked,
+)
 from .exhaustive_search import knn
 
 
 class Dataset:
-    """ Generic abstract class for a test dataset """
+    """Generic abstract class for a test dataset"""
 
     def __init__(self):
-        """ the constructor should set the following fields: """
+        """the constructor should set the following fields:"""
         self.d = -1
-        self.metric = 'L2'   # or IP
+        self.metric = "L2"  # or IP
         self.nq = -1
         self.nb = -1
         self.nt = -1
 
     def get_queries(self):
-        """ return the queries as a (nq, d) array """
+        """return the queries as a (nq, d) array"""
         raise NotImplementedError()
 
     def get_train(self, maxtrain=None):
-        """ return the queries as a (nt, d) array """
+        """return the queries as a (nt, d) array"""
         raise NotImplementedError()
 
     def get_database(self):
-        """ return the queries as a (nb, d) array """
+        """return the queries as a (nb, d) array"""
         raise NotImplementedError()
 
     def database_iterator(self, bs=128, split=(1, 0)):
@@ -48,26 +55,28 @@ class Dataset:
         nsplit, rank = split
         i0, i1 = self.nb * rank // nsplit, self.nb * (rank + 1) // nsplit
         for j0 in range(i0, i1, bs):
-            yield xb[j0: min(j0 + bs, i1)]
+            yield xb[j0 : min(j0 + bs, i1)]
 
     def get_groundtruth(self, k=None):
-        """ return the ground truth for k-nearest neighbor search """
+        """return the ground truth for k-nearest neighbor search"""
         raise NotImplementedError()
 
     def get_groundtruth_range(self, thresh=None):
-        """ return the ground truth for range search """
+        """return the ground truth for range search"""
         raise NotImplementedError()
 
     def __str__(self):
-        return (f"dataset in dimension {self.d}, with metric {self.metric}, "
-                f"size: Q {self.nq} B {self.nb} T {self.nt}")
+        return (
+            f"dataset in dimension {self.d}, with metric {self.metric}, "
+            f"size: Q {self.nq} B {self.nb} T {self.nt}"
+        )
 
     def check_sizes(self):
-        """ runs the previous and checks the sizes of the matrices """
+        """runs the previous and checks the sizes of the matrices"""
         assert self.get_queries().shape == (self.nq, self.d)
         if self.nt > 0:
             xt = self.get_train(maxtrain=123)
-            assert xt.shape == (123, self.d), "shape=%s" % (xt.shape, )
+            assert xt.shape == (123, self.d), "shape=%s" % (xt.shape,)
         assert self.get_database().shape == (self.nb, self.d)
         assert self.get_groundtruth(k=13).shape == (self.nq, 13)
 
@@ -77,10 +86,10 @@ class SyntheticDataset(Dataset):
     index
     """
 
-    def __init__(self, d, nt, nb, nq, metric='L2', seed=1338):
+    def __init__(self, d, nt, nb, nq, metric="L2", seed=1338):
         Dataset.__init__(self)
         self.d, self.nt, self.nb, self.nq = d, nt, nb, nq
-        d1 = 10     # intrinsic dimension (more or less)
+        d1 = 10  # intrinsic dimension (more or less)
         n = nb + nt + nq
         rs = np.random.RandomState(seed)
         x = rs.normal(size=(n, d1))
@@ -89,11 +98,11 @@ class SyntheticDataset(Dataset):
         # higher factor (>4) -> higher frequency -> less linear
         x = x * (rs.rand(d) * 4 + 0.1)
         x = np.sin(x)
-        x = x.astype('float32')
+        x = x.astype("float32")
         self.metric = metric
         self.xt = x[:nt]
-        self.xb = x[nt:nt + nb]
-        self.xq = x[nt + nb:]
+        self.xb = x[nt : nt + nb]
+        self.xq = x[nt + nb :]
 
     def get_queries(self):
         return self.xq
@@ -107,8 +116,14 @@ class SyntheticDataset(Dataset):
 
     def get_groundtruth(self, k=100):
         return knn(
-            self.xq, self.xb, k,
-            faiss.METRIC_L2 if self.metric == 'L2' else faiss.METRIC_INNER_PRODUCT
+            self.xq,
+            self.xb,
+            k,
+            (
+                faiss.METRIC_L2
+                if self.metric == "L2"
+                else faiss.METRIC_INNER_PRODUCT
+            ),
         )[1]
 
 
@@ -121,14 +136,15 @@ class SyntheticDataset(Dataset):
 username = getpass.getuser()
 
 for dataset_basedir in (
-        '/datasets01/simsearch/041218/',
-        '/mnt/vol/gfsai-flash3-east/ai-group/datasets/simsearch/',
-        f'/home/{username}/simsearch/data/'):
+    "/datasets01/simsearch/041218/",
+    "/mnt/vol/gfsai-flash3-east/ai-group/datasets/simsearch/",
+    f"/home/{username}/simsearch/data/",
+):
     if os.path.exists(dataset_basedir):
         break
 else:
     # users can link their data directory to `./data`
-    dataset_basedir = 'data/'
+    dataset_basedir = "data/"
 
 
 def set_dataset_basedir(path):
@@ -145,7 +161,7 @@ class DatasetSIFT1M(Dataset):
     def __init__(self):
         Dataset.__init__(self)
         self.d, self.nt, self.nb, self.nq = 128, 100000, 1000000, 10000
-        self.basedir = dataset_basedir + 'sift1M/'
+        self.basedir = dataset_basedir + "sift1M/"
 
     def get_queries(self):
         return fvecs_read(self.basedir + "sift_query.fvecs")
@@ -166,7 +182,7 @@ class DatasetSIFT1M(Dataset):
 
 
 def sanitize(x):
-    return np.ascontiguousarray(x, dtype='float32')
+    return np.ascontiguousarray(x, dtype="float32")
 
 
 class DatasetBigANN(Dataset):
@@ -181,17 +197,19 @@ class DatasetBigANN(Dataset):
         self.nb_M = nb_M
         nb = nb_M * 10**6
         self.d, self.nt, self.nb, self.nq = 128, 10**8, nb, 10000
-        self.basedir = dataset_basedir + 'bigann/'
+        self.basedir = dataset_basedir + "bigann/"
 
     def get_queries(self):
-        return sanitize(bvecs_mmap(self.basedir + 'bigann_query.bvecs')[:])
+        return sanitize(bvecs_mmap(self.basedir + "bigann_query.bvecs")[:])
 
     def get_train(self, maxtrain=None):
         maxtrain = maxtrain if maxtrain is not None else self.nt
-        return sanitize(bvecs_mmap(self.basedir + 'bigann_learn.bvecs')[:maxtrain])
+        return sanitize(
+            bvecs_mmap(self.basedir + "bigann_learn.bvecs")[:maxtrain]
+        )
 
     def get_groundtruth(self, k=None):
-        gt = ivecs_read(self.basedir + 'gnd/idx_%dM.ivecs' % self.nb_M)
+        gt = ivecs_read(self.basedir + "gnd/idx_%dM.ivecs" % self.nb_M)
         if k is not None:
             assert k <= 100
             gt = gt[:, :k]
@@ -199,14 +217,16 @@ class DatasetBigANN(Dataset):
 
     def get_database(self):
         assert self.nb_M < 100, "dataset too large, use iterator"
-        return sanitize(bvecs_mmap(self.basedir + 'bigann_base.bvecs')[:self.nb])
+        return sanitize(
+            bvecs_mmap(self.basedir + "bigann_base.bvecs")[: self.nb]
+        )
 
     def database_iterator(self, bs=128, split=(1, 0)):
-        xb = bvecs_mmap(self.basedir + 'bigann_base.bvecs')
+        xb = bvecs_mmap(self.basedir + "bigann_base.bvecs")
         nsplit, rank = split
         i0, i1 = self.nb * rank // nsplit, self.nb * (rank + 1) // nsplit
         for j0 in range(i0, i1, bs):
-            yield sanitize(xb[j0: min(j0 + bs, i1)])
+            yield sanitize(xb[j0 : min(j0 + bs, i1)])
 
 
 class DatasetDeep1B(Dataset):
@@ -219,17 +239,19 @@ class DatasetDeep1B(Dataset):
     def __init__(self, nb=10**9):
         Dataset.__init__(self)
         nb_to_name = {
-            10**5: '100k',
-            10**6: '1M',
-            10**7: '10M',
-            10**8: '100M',
-            10**9: '1B'
+            10**5: "100k",
+            10**6: "1M",
+            10**7: "10M",
+            10**8: "100M",
+            10**9: "1B",
         }
         assert nb in nb_to_name
         self.d, self.nt, self.nb, self.nq = 96, 358480000, nb, 10000
-        self.basedir = dataset_basedir + 'deep1b/'
+        self.basedir = dataset_basedir + "deep1b/"
         self.gt_fname = "%sdeep%s_groundtruth.ivecs" % (
-            self.basedir, nb_to_name[self.nb])
+            self.basedir,
+            nb_to_name[self.nb],
+        )
 
     def get_queries(self):
         return sanitize(fvecs_read(self.basedir + "deep1B_queries.fvecs"))
@@ -247,14 +269,14 @@ class DatasetDeep1B(Dataset):
 
     def get_database(self):
         assert self.nb <= 10**8, "dataset too large, use iterator"
-        return sanitize(fvecs_mmap(self.basedir + "base.fvecs")[:self.nb])
+        return sanitize(fvecs_mmap(self.basedir + "base.fvecs")[: self.nb])
 
     def database_iterator(self, bs=128, split=(1, 0)):
         xb = fvecs_mmap(self.basedir + "base.fvecs")
         nsplit, rank = split
         i0, i1 = self.nb * rank // nsplit, self.nb * (rank + 1) // nsplit
         for j0 in range(i0, i1, bs):
-            yield sanitize(xb[j0: min(j0 + bs, i1)])
+            yield sanitize(xb[j0 : min(j0 + bs, i1)])
 
 
 class DatasetGlove(Dataset):
@@ -264,28 +286,29 @@ class DatasetGlove(Dataset):
 
     def __init__(self, loc=None, download=False):
         import h5py
+
         assert not download, "not implemented"
         if not loc:
-            loc = dataset_basedir + 'glove/glove-100-angular.hdf5'
-        self.glove_h5py = h5py.File(loc, 'r')
+            loc = dataset_basedir + "glove/glove-100-angular.hdf5"
+        self.glove_h5py = h5py.File(loc, "r")
         # IP and L2 are equivalent in this case, but it is traditionally seen as an IP dataset
-        self.metric = 'IP'
+        self.metric = "IP"
         self.d, self.nt = 100, 0
-        self.nb = self.glove_h5py['train'].shape[0]
-        self.nq = self.glove_h5py['test'].shape[0]
+        self.nb = self.glove_h5py["train"].shape[0]
+        self.nq = self.glove_h5py["test"].shape[0]
 
     def get_queries(self):
-        xq = np.array(self.glove_h5py['test'])
+        xq = np.array(self.glove_h5py["test"])
         faiss.normalize_L2(xq)
         return xq
 
     def get_database(self):
-        xb = np.array(self.glove_h5py['train'])
+        xb = np.array(self.glove_h5py["train"])
         faiss.normalize_L2(xb)
         return xb
 
     def get_groundtruth(self, k=None):
-        gt = self.glove_h5py['neighbors']
+        gt = self.glove_h5py["neighbors"]
         if k is not None:
             assert k <= 100
             gt = gt[:, :k]
@@ -301,21 +324,23 @@ class DatasetMusic100(Dataset):
     def __init__(self):
         Dataset.__init__(self)
         self.d, self.nt, self.nb, self.nq = 100, 0, 10**6, 10000
-        self.metric = 'IP'
-        self.basedir = dataset_basedir + 'music-100/'
+        self.metric = "IP"
+        self.basedir = dataset_basedir + "music-100/"
 
     def get_queries(self):
-        xq = np.fromfile(self.basedir + 'query_music100.bin', dtype='float32')
+        xq = np.fromfile(self.basedir + "query_music100.bin", dtype="float32")
         xq = xq.reshape(-1, 100)
         return xq
 
     def get_database(self):
-        xb = np.fromfile(self.basedir + 'database_music100.bin', dtype='float32')
+        xb = np.fromfile(
+            self.basedir + "database_music100.bin", dtype="float32"
+        )
         xb = xb.reshape(-1, 100)
         return xb
 
     def get_groundtruth(self, k=None):
-        gt = np.load(self.basedir + 'gt.npy')
+        gt = np.load(self.basedir + "gt.npy")
         if k is not None:
             assert k <= 100
             gt = gt[:, :k]
@@ -331,7 +356,7 @@ class DatasetGIST1M(Dataset):
     def __init__(self):
         Dataset.__init__(self)
         self.d, self.nt, self.nb, self.nq = 960, 100000, 1000000, 10000
-        self.basedir = dataset_basedir + 'gist1M/'
+        self.basedir = dataset_basedir + "gist1M/"
 
     def get_queries(self):
         return fvecs_read(self.basedir + "gist_query.fvecs")
@@ -350,6 +375,7 @@ class DatasetGIST1M(Dataset):
             gt = gt[:, :k]
         return gt
 
+
 class DatasetDINO10B(Dataset):
     """
     Data from https://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/
@@ -357,19 +383,52 @@ class DatasetDINO10B(Dataset):
     The dataset is sharded in multiple chunked .bvecs files. Downloading instructions can be obtained with "wget https://dl.fbaipublicfiles.com/large_objects/dino_vitl_10B/README.md".
     Supported sizes : 100k 200k 500k 1M ... 5B 10B listed in supported_nbs (see __init__).
     """
-    def __init__(self, nb, ignore_supported = False):
+
+    def __init__(self, nb, ignore_supported=False):
         Dataset.__init__(self)
-        supported_nbs = [100_000, 200_000, 500_000, 1_000_000, 2_000_000, 5_000_000, 10_000_000, 20_000_000, 50_000_000, 100_000_000, 200_000_000, 500_000_000, 1_000_000_000, 2_000_000_000, 5_000_000_000, 10_000_000_000]
+        supported_nbs = [
+            100_000,
+            200_000,
+            500_000,
+            1_000_000,
+            2_000_000,
+            5_000_000,
+            10_000_000,
+            20_000_000,
+            50_000_000,
+            100_000_000,
+            200_000_000,
+            500_000_000,
+            1_000_000_000,
+            2_000_000_000,
+            5_000_000_000,
+            10_000_000_000,
+        ]
         if nb not in supported_nbs and not ignore_supported:
-            raise ValueError(f"Unsupported dataset size: {nb}, supported values are: {supported_nbs}")
+            raise ValueError(
+                f"Unsupported dataset size: {nb}, supported values are: {supported_nbs}"
+            )
         if not os.path.exists(dataset_basedir):
-            raise ValueError(f"Provided dataset base directory does not exist: {dataset_basedir}")
+            raise ValueError(
+                f"Provided dataset base directory does not exist: {dataset_basedir}"
+            )
         self.basedir = dataset_basedir + "dino_vitl_10B/"
         self.indexdir = self.basedir + "chunked_base_10B"
-        assert os.path.exists(self.indexdir), f"Index path should exist, check your dataset path: {self.indexdir}"
+        assert os.path.exists(
+            self.indexdir
+        ), f"Index path should exist, check your dataset path: {self.indexdir}"
         self.queriesdir = self.basedir + "queries_clean.bvecs"
-        assert os.path.exists(self.queriesdir), f"Queries path should exist as dataset size {nb} is supported: {self.queriesdir}"
-        self.gtsdir = self.basedir + "gts/" + "gts_dino_patch_" + str(nb) + "_" + "k10.npy"
+        assert os.path.exists(
+            self.queriesdir
+        ), f"Queries path should exist as dataset size {nb} is supported: {self.queriesdir}"
+        self.gtsdir = (
+            self.basedir
+            + "gts/"
+            + "gts_dino_patch_"
+            + str(nb)
+            + "_"
+            + "k10.npy"
+        )
         self.train_queriesdir = self.basedir + "train_queries_99M.bvecs"
         self.nb = nb
         self.d = 1024
@@ -377,31 +436,36 @@ class DatasetDINO10B(Dataset):
         self.nt = 99_000_000
         self.metric = "L2"
 
-
     def get_queries(self):
         """Get all vectors as a single array"""
         queries = bvecs_mmap(self.queriesdir)
         return sanitize(queries)
 
-    def get_train(self, maxtrain = None):
+    def get_train(self, maxtrain=None):
         """Get training query vectors as a single array"""
         if maxtrain is None or maxtrain > 10_000_000:
-            raise NotImplementedError("The training set is potentially too large to fit in RAM (400 GB of data). Please use train_iterator or use maxtrain parameter below 10_000_000 to get the first maxtrain training vectors.")
+            raise NotImplementedError(
+                "The training set is potentially too large to fit in RAM (400 GB of data). Please use train_iterator or use maxtrain parameter below 10_000_000 to get the first maxtrain training vectors."
+            )
         return sanitize(bvecs_mmap(self.train_queriesdir)[:maxtrain])
 
     def get_database(self):
         """Get all database vectors as a single array"""
         if self.nb > 10_000_000:
-            raise NotImplementedError("The dataset is potentially too large to fit in RAM. Please use database_iterator or use a dataset size equal to or below 10_000_000.")
+            raise NotImplementedError(
+                "The dataset is potentially too large to fit in RAM. Please use database_iterator or use a dataset size equal to or below 10_000_000."
+            )
         else:
-            return sanitize(bvecs_iter_chunked(self.indexdir, batch_size=self.nb).__next__())
+            return sanitize(
+                bvecs_iter_chunked(self.indexdir, batch_size=self.nb).__next__()
+            )
 
     def database_iterator(self, bs=10_000):
         """Iterator over the database of size nb, corresponding to the first nb vectors in the .bvecs file"""
         total_read = 0
         for batch in bvecs_iter_chunked(self.indexdir, batch_size=bs):
             if total_read + batch.shape[0] > self.nb:
-                batch = batch[:self.nb - total_read]
+                batch = batch[: self.nb - total_read]
             yield sanitize(batch)
             total_read += batch.shape[0]
             if total_read >= self.nb:
@@ -412,10 +476,12 @@ class DatasetDINO10B(Dataset):
         for batch in bvecs_iter(self.train_queriesdir, batch_size=bs):
             yield sanitize(batch)
 
-    def get_groundtruth(self, k = 10):
+    def get_groundtruth(self, k=10):
         """Get ground truth from .npy file"""
         if k > 10:
-            raise NotImplementedError("Ground truth files only available for k<=10")
+            raise NotImplementedError(
+                "Ground truth files only available for k<=10"
+            )
         gts = np.load(self.gtsdir)
         gts = gts[:, :k]
         return gts
@@ -423,29 +489,30 @@ class DatasetDINO10B(Dataset):
     def distance(self):
         return "euclidean"
 
-def dataset_from_name(dataset='deep1M', download=False):
-    """ converts a string describing a dataset to a Dataset object
+
+def dataset_from_name(dataset="deep1M", download=False):
+    """converts a string describing a dataset to a Dataset object
     Supports sift1M, bigann1M..bigann1B, deep1M..deep1B, music-100 and glove
     """
 
-    if dataset == 'sift1M':
+    if dataset == "sift1M":
         return DatasetSIFT1M()
 
-    elif dataset == 'gist1M':
+    elif dataset == "gist1M":
         return DatasetGIST1M()
 
-    elif dataset.startswith('bigann'):
+    elif dataset.startswith("bigann"):
         dbsize = 1000 if dataset == "bigann1B" else int(dataset[6:-1])
         return DatasetBigANN(nb_M=dbsize)
 
     elif dataset.startswith("deep"):
 
         szsuf = dataset[4:]
-        if szsuf[-1] == 'M':
-            dbsize = 10 ** 6 * int(szsuf[:-1])
-        elif szsuf == '1B':
-            dbsize = 10 ** 9
-        elif szsuf[-1] == 'k':
+        if szsuf[-1] == "M":
+            dbsize = 10**6 * int(szsuf[:-1])
+        elif szsuf == "1B":
+            dbsize = 10**9
+        elif szsuf[-1] == "k":
             dbsize = 1000 * int(szsuf[:-1])
         else:
             assert False, "did not recognize suffix " + szsuf

--- a/contrib/evaluation.py
+++ b/contrib/evaluation.py
@@ -15,22 +15,19 @@ from multiprocessing.pool import ThreadPool
 
 
 def knn_intersection_measure(I1, I2):
-    """ computes the intersection measure of two result tables
-    """
+    """computes the intersection measure of two result tables"""
     nq, rank = I1.shape
     assert I2.shape == (nq, rank)
-    ninter = sum(
-        np.intersect1d(I1[i], I2[i]).size
-        for i in range(nq)
-    )
+    ninter = sum(np.intersect1d(I1[i], I2[i]).size for i in range(nq))
     return ninter / I1.size
+
 
 ###############################################################
 # Range search results can be compared with Precision-Recall
 
 
 def filter_range_results(lims, D, I, thresh):
-    """ select a set of results """
+    """select a set of results"""
     nq = lims.size - 1
     mask = D < thresh
     new_lims = np.zeros_like(lims)
@@ -41,13 +38,13 @@ def filter_range_results(lims, D, I, thresh):
 
 def range_PR(lims_ref, Iref, lims_new, Inew, mode="overall"):
     """compute the precision and recall of range search results. The
-    function does not take the distances into account. """
+    function does not take the distances into account."""
 
     def ref_result_for(i):
-        return Iref[lims_ref[i]:lims_ref[i + 1]]
+        return Iref[lims_ref[i] : lims_ref[i + 1]]
 
     def new_result_for(i):
-        return Inew[lims_new[i]:lims_new[i + 1]]
+        return Inew[lims_new[i] : lims_new[i + 1]]
 
     nq = lims_ref.size - 1
     assert lims_new.size - 1 == nq
@@ -75,12 +72,12 @@ def range_PR(lims_ref, Iref, lims_new, Inew, mode="overall"):
         lims_ref[1:] - lims_ref[:-1],
         lims_new[1:] - lims_new[:-1],
         ninter,
-        mode=mode
+        mode=mode,
     )
 
 
 def counts_to_PR(ngt, nres, ninter, mode="overall"):
-    """ computes a  precision-recall for a set of queries.
+    """computes a  precision-recall for a set of queries.
     ngt = nb of GT results per query
     nres = nb of found results per query
     ninter = nb of correct results per query (smaller than nres of course)
@@ -127,7 +124,7 @@ def counts_to_PR(ngt, nres, ninter, mode="overall"):
 
 
 def sort_range_res_2(lims, D, I):
-    """ sort 2 arrays using the first as key """
+    """sort 2 arrays using the first as key"""
     I2 = np.empty_like(I)
     D2 = np.empty_like(D)
     nq = len(lims) - 1
@@ -152,12 +149,16 @@ def sort_range_res_1(lims, I):
 
 
 def range_PR_multiple_thresholds(
-            lims_ref, Iref,
-            lims_new, Dnew, Inew,
-            thresholds,
-            mode="overall", do_sort="ref,new"
-    ):
-    """ compute precision-recall values for range search results
+    lims_ref,
+    Iref,
+    lims_new,
+    Dnew,
+    Inew,
+    thresholds,
+    mode="overall",
+    do_sort="ref,new",
+):
+    """compute precision-recall values for range search results
     for several thresholds on the "new" results.
     This is to plot PR curves
     """
@@ -170,7 +171,7 @@ def range_PR_multiple_thresholds(
         Inew, Dnew = sort_range_res_2(lims_new, Dnew, Inew)
 
     def ref_result_for(i):
-        return Iref[lims_ref[i]:lims_ref[i + 1]]
+        return Iref[lims_ref[i] : lims_ref[i + 1]]
 
     def new_result_for(i):
         l0, l1 = lims_new[i], lims_new[i + 1]
@@ -193,7 +194,7 @@ def range_PR_multiple_thresholds(
             return
 
         # which offsets we are interested in
-        nres= np.searchsorted(res_dis, thresholds)
+        nres = np.searchsorted(res_dis, thresholds)
         counts[q, :, 1] = nres
 
         if gt_ids.size == 0:
@@ -216,8 +217,7 @@ def range_PR_multiple_thresholds(
     recalls = np.zeros(nt)
     for t in range(nt):
         p, r = counts_to_PR(
-                counts[:, t, 0], counts[:, t, 1], counts[:, t, 2],
-                mode=mode
+            counts[:, t, 0], counts[:, t, 1], counts[:, t, 2], mode=mode
         )
         precisions[t] = p
         recalls[t] = r
@@ -229,28 +229,29 @@ def range_PR_multiple_thresholds(
 # Functions that compare search results with a reference result.
 # They are intended for use in tests
 
+
 def _cluster_tables_with_tolerance(tab1, tab2, thr):
-    """ for two tables, cluster them by merging values closer than thr.
-    Returns the cluster ids for each table element """
+    """for two tables, cluster them by merging values closer than thr.
+    Returns the cluster ids for each table element"""
     tab = np.hstack([tab1, tab2])
     tab.sort()
     n = len(tab)
     diffs = np.ones(n)
     diffs[1:] = tab[1:] - tab[:-1]
     unique_vals = tab[diffs > thr]
-    idx1 = np.searchsorted(unique_vals, tab1, side='right') - 1
-    idx2 = np.searchsorted(unique_vals, tab2, side='right') - 1
+    idx1 = np.searchsorted(unique_vals, tab1, side="right") - 1
+    idx2 = np.searchsorted(unique_vals, tab2, side="right") - 1
     return idx1, idx2
 
 
 def check_ref_knn_with_draws(Dref, Iref, Dnew, Inew, rtol=1e-5):
-    """ test that knn search results are identical, with possible ties.
-    Raise if not. """
+    """test that knn search results are identical, with possible ties.
+    Raise if not."""
     np.testing.assert_allclose(Dref, Dnew, rtol=rtol)
     # here we have to be careful because of draws
-    testcase = unittest.TestCase()   # because it makes nice error messages
+    testcase = unittest.TestCase()  # because it makes nice error messages
     for i in range(len(Iref)):
-        if np.all(Iref[i] == Inew[i]): # easy case
+        if np.all(Iref[i] == Inew[i]):  # easy case
             continue
 
         # otherwise collect elements per distance
@@ -265,10 +266,9 @@ def check_ref_knn_with_draws(Dref, Iref, Dnew, Inew, rtol=1e-5):
             testcase.assertEqual(set(Iref[i, mask]), set(Inew[i, mask]))
 
 
-def check_ref_range_results(Lref, Dref, Iref,
-                            Lnew, Dnew, Inew):
-    """ compare range search results wrt. a reference result,
-    throw if it fails """
+def check_ref_range_results(Lref, Dref, Iref, Lnew, Dnew, Inew):
+    """compare range search results wrt. a reference result,
+    throw if it fails"""
     np.testing.assert_array_equal(Lref, Lnew)
     nq = len(Lref) - 1
     for i in range(nq):
@@ -277,12 +277,14 @@ def check_ref_range_results(Lref, Dref, Iref,
         Ii_new = Inew[l0:l1]
         Di_ref = Dref[l0:l1]
         Di_new = Dnew[l0:l1]
-        if np.all(Ii_ref == Ii_new): # easy
+        if np.all(Ii_ref == Ii_new):  # easy
             pass
         else:
+
             def sort_by_ids(I, D):
                 o = I.argsort()
                 return I[o], D[o]
+
             # sort both
             (Ii_ref, Di_ref) = sort_by_ids(Ii_ref, Di_ref)
             (Ii_new, Di_new) = sort_by_ids(Ii_new, Di_new)
@@ -309,11 +311,11 @@ class OperatingPoints:
         self.suboptimal_points = []
 
     def compare_keys(self, k1, k2):
-        """ return -1 if k1 > k2, 1 if k2 > k1, 0 otherwise """
+        """return -1 if k1 > k2, 1 if k2 > k1, 0 otherwise"""
         raise NotImplemented
 
     def do_nothing_key(self):
-        """ parameters to say we do nothing, takes 0 time and has 0 performance"""
+        """parameters to say we do nothing, takes 0 time and has 0 performance"""
         raise NotImplemented
 
     def is_pareto_optimal(self, perf_new, t_new):
@@ -323,15 +325,15 @@ class OperatingPoints:
         return True
 
     def predict_bounds(self, key):
-        """ predicts the bound on time and performance """
+        """predicts the bound on time and performance"""
         min_time = 0.0
         max_perf = 1.0
         for key2, perf, t in self.operating_points + self.suboptimal_points:
             cmp = self.compare_keys(key, key2)
-            if cmp > 0: # key2 > key
+            if cmp > 0:  # key2 > key
                 if t > min_time:
                     min_time = t
-            if cmp < 0: # key2 < key
+            if cmp < 0:  # key2 < key
                 if perf < max_perf:
                     max_perf = perf
         return max_perf, min_time
@@ -347,8 +349,7 @@ class OperatingPoints:
             while i < len(self.operating_points):
                 op_Ls, perf2, t2 = self.operating_points[i]
                 if perf >= perf2 and t < t2:
-                    self.suboptimal_points.append(
-                        self.operating_points.pop(i))
+                    self.suboptimal_points.append(self.operating_points.pop(i))
                 else:
                     i += 1
             self.operating_points.append((key, perf, t))
@@ -388,7 +389,7 @@ class OperatingPointsWithRanges(OperatingPoints):
         return int(np.prod([len(values) for name, values in self.ranges]))
 
     def sample_experiments(self, n_autotune, rs=np.random):
-        """ sample a set of experiments of max size n_autotune
+        """sample a set of experiments of max size n_autotune
         (run all experiments in random order if n_autotune is 0)
         """
         assert n_autotune == 0 or n_autotune >= 2
@@ -398,7 +399,8 @@ class OperatingPointsWithRanges(OperatingPoints):
             experiments = rs.permutation(totex - 2)
         else:
             experiments = rs.choice(
-                totex - 2, size=n_autotune - 2, replace=False)
+                totex - 2, size=n_autotune - 2, replace=False
+            )
 
         experiments = [0, totex - 1] + [int(cno) + 1 for cno in experiments]
         return experiments
@@ -415,12 +417,11 @@ class OperatingPointsWithRanges(OperatingPoints):
     def get_parameters(self, k):
         """Convert a key to a dictionary with parameter values"""
         return {
-            name: values[k[i]]
-            for i, (name, values) in enumerate(self.ranges)
+            name: values[k[i]] for i, (name, values) in enumerate(self.ranges)
         }
 
     def restrict_range(self, name, max_val):
-        """ remove too large values from a range"""
+        """remove too large values from a range"""
         for name2, values in self.ranges:
             if name == name2:
                 val2 = [v for v in values if v < max_val]
@@ -476,6 +477,7 @@ class RepeatTimer:
     enters a loop. It focuses on ms-scale times because for second scale
     it's usually less relevant to repeat the operation.
     """
+
     def __init__(self, warmup=0, nt=-1, runs=1, max_secs=np.inf):
         assert warmup < runs
         self.warmup = warmup
@@ -494,5 +496,5 @@ class RepeatTimer:
         return np.std(self.times) * 1000 if len(self.times) > 1 else 0.0
 
     def nruns(self):
-        """ effective number of runs (may be lower than runs - warmup due to timeout)"""
+        """effective number of runs (may be lower than runs - warmup due to timeout)"""
         return len(self.times)

--- a/contrib/exhaustive_search.py
+++ b/contrib/exhaustive_search.py
@@ -12,7 +12,9 @@ import logging
 LOG = logging.getLogger(__name__)
 
 
-def knn_ground_truth(xq, db_iterator, k, metric_type=faiss.METRIC_L2, shard=False, ngpu=-1):
+def knn_ground_truth(
+    xq, db_iterator, k, metric_type=faiss.METRIC_L2, shard=False, ngpu=-1
+):
     """Computes the exact KNN search results for a dataset that possibly
     does not fit in RAM but for which we have an iterator that
     returns it block by block.
@@ -28,7 +30,7 @@ def knn_ground_truth(xq, db_iterator, k, metric_type=faiss.METRIC_L2, shard=Fals
         ngpu = faiss.get_num_gpus()
 
     if ngpu:
-        LOG.info('running on %d GPUs' % ngpu)
+        LOG.info("running on %d GPUs" % ngpu)
         co = faiss.GpuMultipleClonerOptions()
         co.shard = shard
         index = faiss.index_cpu_to_all_gpus(index, co=co, ngpu=ngpu)
@@ -50,10 +52,9 @@ def knn_ground_truth(xq, db_iterator, k, metric_type=faiss.METRIC_L2, shard=Fals
 
     return rh.D, rh.I
 
+
 # knn function used to be here
 knn = faiss.knn
-
-
 
 
 def range_search_gpu(xq, r2, index_gpu, index_cpu, gpu_k=1024):
@@ -71,13 +72,14 @@ def range_search_gpu(xq, r2, index_gpu, index_cpu, gpu_k=1024):
     r2 = int(r2) if is_binary_index else float(r2)
     k = min(index_gpu.ntotal, gpu_k)
     LOG.debug(
-        f"GPU search {nq} queries with {k=:} {is_binary_index=:} {keep_max=:}")
+        f"GPU search {nq} queries with {k=:} {is_binary_index=:} {keep_max=:}"
+    )
     t0 = time.time()
     D, I = index_gpu.search(xq, k)
     t1 = time.time() - t0
     if is_binary_index:
         assert d * 8 < 32768  # let's compact the distance matrix
-        D = D.astype('int16')
+        D = D.astype("int16")
     t2 = 0
     lim_remain = None
     if index_cpu is not None:
@@ -96,16 +98,19 @@ def range_search_gpu(xq, r2, index_gpu, index_cpu, gpu_k=1024):
                 else:
                     index_cpu = faiss.IndexFlat(d, index_gpu.metric_type)
                 index_cpu.add(xb)
-            lim_remain, D_remain, I_remain = index_cpu.range_search(xq[mask], r2)
+            lim_remain, D_remain, I_remain = index_cpu.range_search(
+                xq[mask], r2
+            )
             if is_binary_index:
-                D_remain = D_remain.astype('int16')
+                D_remain = D_remain.astype("int16")
             t2 = time.time() - t0
     LOG.debug("combine")
     t0 = time.time()
 
     CombinerRangeKNN = (
-        faiss.CombinerRangeKNNint16 if is_binary_index else
-        faiss.CombinerRangeKNNfloat
+        faiss.CombinerRangeKNNint16
+        if is_binary_index
+        else faiss.CombinerRangeKNNfloat
     )
 
     combiner = CombinerRangeKNN(nq, k, r2, keep_max)
@@ -120,11 +125,11 @@ def range_search_gpu(xq, r2, index_gpu, index_cpu, gpu_k=1024):
             combiner.lim_remain = sp(lim_remain.view("int64"))
             combiner.I_remain = sp(I_remain)
             # combiner.set_range_result(sp(mask), sp(lim_remain.view("int64")), sp(D_remain), sp(I_remain))
-        L_res = np.empty(nq + 1, dtype='int64')
+        L_res = np.empty(nq + 1, dtype="int64")
         combiner.compute_sizes(sp(L_res))
         nres = L_res[-1]
         D_res = np.empty(nres, dtype=D.dtype)
-        I_res = np.empty(nres, dtype='int64')
+        I_res = np.empty(nres, dtype="int64")
         combiner.write_result(sp(D_res), sp(I_res))
     else:
         D_res, I_res = [], []
@@ -150,21 +155,27 @@ def range_search_gpu(xq, r2, index_gpu, index_cpu, gpu_k=1024):
     return L_res, D_res, I_res
 
 
-def range_ground_truth(xq, db_iterator, threshold, metric_type=faiss.METRIC_L2,
-                       shard=False, ngpu=-1):
+def range_ground_truth(
+    xq,
+    db_iterator,
+    threshold,
+    metric_type=faiss.METRIC_L2,
+    shard=False,
+    ngpu=-1,
+):
     """Computes the range-search search results for a dataset that possibly
     does not fit in RAM but for which we have an iterator that
     returns it block by block.
     """
     nq, d = xq.shape
     t0 = time.time()
-    xq = np.ascontiguousarray(xq, dtype='float32')
+    xq = np.ascontiguousarray(xq, dtype="float32")
 
     index = faiss.IndexFlat(d, metric_type)
     if ngpu == -1:
         ngpu = faiss.get_num_gpus()
     if ngpu:
-        LOG.info('running on %d GPUs' % ngpu)
+        LOG.info("running on %d GPUs" % ngpu)
         co = faiss.GpuMultipleClonerOptions()
         co.shard = shard
         index_gpu = faiss.index_cpu_to_all_gpus(index, co=co, ngpu=ngpu)
@@ -192,8 +203,8 @@ def range_ground_truth(xq, db_iterator, threshold, metric_type=faiss.METRIC_L2,
         i0 += ni
         LOG.info("%d db elements, %.3f s" % (i0, time.time() - t0))
 
-    empty_I = np.zeros(0, dtype='int64')
-    empty_D = np.zeros(0, dtype='float32')
+    empty_I = np.zeros(0, dtype="int64")
+    empty_D = np.zeros(0, dtype="float32")
     # import pdb; pdb.set_trace()
     D = [(np.hstack(i) if i != [] else empty_D) for i in D]
     I = [(np.hstack(i) if i != [] else empty_I) for i in I]
@@ -205,7 +216,7 @@ def range_ground_truth(xq, db_iterator, threshold, metric_type=faiss.METRIC_L2,
 
 
 def threshold_radius_nres(nres, dis, ids, thresh, keep_max=False):
-    """ select a set of results """
+    """select a set of results"""
     if keep_max:
         mask = dis > thresh
     else:
@@ -213,14 +224,14 @@ def threshold_radius_nres(nres, dis, ids, thresh, keep_max=False):
     new_nres = np.zeros_like(nres)
     o = 0
     for i, nr in enumerate(nres):
-        nr = int(nr)   # avoid issues with int64 + uint64
-        new_nres[i] = mask[o:o + nr].sum()
+        nr = int(nr)  # avoid issues with int64 + uint64
+        new_nres[i] = mask[o : o + nr].sum()
         o += nr
     return new_nres, dis[mask], ids[mask]
 
 
 def threshold_radius(lims, dis, ids, thresh, keep_max=False):
-    """ restrict range-search results to those below a given radius """
+    """restrict range-search results to those below a given radius"""
     if keep_max:
         mask = dis > thresh
     else:
@@ -246,24 +257,32 @@ def apply_maxres(res_batches, target_nres, keep_max=False):
         alldis.partition(target_nres)
         radius = alldis[target_nres]
 
-    if alldis.dtype == 'float32':
+    if alldis.dtype == "float32":
         radius = float(radius)
     else:
         radius = int(radius)
-    LOG.debug('   setting radius to %s' % radius)
+    LOG.debug("   setting radius to %s" % radius)
     totres = 0
     for i, (nres, dis, ids) in enumerate(res_batches):
         nres, dis, ids = threshold_radius_nres(
-            nres, dis, ids, radius, keep_max=keep_max)
+            nres, dis, ids, radius, keep_max=keep_max
+        )
         totres += len(dis)
         res_batches[i] = nres, dis, ids
-    LOG.debug('   updated previous results, new nb results %d' % totres)
+    LOG.debug("   updated previous results, new nb results %d" % totres)
     return radius, totres
 
 
-def range_search_max_results(index, query_iterator, radius,
-                             max_results=None, min_results=None,
-                             shard=False, ngpu=0, clip_to_min=False):
+def range_search_max_results(
+    index,
+    query_iterator,
+    radius,
+    max_results=None,
+    min_results=None,
+    shard=False,
+    ngpu=0,
+    clip_to_min=False,
+):
     """Performs a range search with many queries (given by an iterator)
     and adjusts the threshold on-the-fly so that the total results
     table does not grow larger than max_results.
@@ -287,7 +306,7 @@ def range_search_max_results(index, query_iterator, radius,
         ngpu = faiss.get_num_gpus()
 
     if ngpu:
-        LOG.info('running on %d GPUs' % ngpu)
+        LOG.info("running on %d GPUs" % ngpu)
         co = faiss.GpuMultipleClonerOptions()
         co.shard = shard
         index_gpu = faiss.index_cpu_to_all_gpus(index, co=co, ngpu=ngpu)
@@ -314,54 +333,60 @@ def range_search_max_results(index, query_iterator, radius,
         t1 = time.time()
         if is_binary_index:
             # weird Faiss quirk that returns floats for Hamming distances
-            Di = Di.astype('int16')
+            Di = Di.astype("int16")
 
         totres += len(Di)
         res_batches.append((nres_i, Di, Ii))
 
         if max_results is not None and totres > max_results:
-            LOG.info('too many results %d > %d, scaling back radius' %
-                     (totres, max_results))
+            LOG.info(
+                "too many results %d > %d, scaling back radius"
+                % (totres, max_results)
+            )
             radius, totres = apply_maxres(
-                res_batches, min_results,
-                keep_max=index.metric_type == faiss.METRIC_INNER_PRODUCT
+                res_batches,
+                min_results,
+                keep_max=index.metric_type == faiss.METRIC_INNER_PRODUCT,
             )
         t2 = time.time()
         t_search += t1 - t0
         t_post_process += t2 - t1
-        LOG.debug('   [%.3f s] %d queries done, %d results' % (
-            time.time() - t_start, qtot, totres))
+        LOG.debug(
+            "   [%.3f s] %d queries done, %d results"
+            % (time.time() - t_start, qtot, totres)
+        )
 
     LOG.info(
-        'search done in %.3f s + %.3f s, total %d results, end threshold %g' % (
-            t_search, t_post_process, totres, radius)
+        "search done in %.3f s + %.3f s, total %d results, end threshold %g"
+        % (t_search, t_post_process, totres, radius)
     )
 
     if clip_to_min and totres > min_results:
         radius, totres = apply_maxres(
-            res_batches, min_results,
-            keep_max=index.metric_type == faiss.METRIC_INNER_PRODUCT
+            res_batches,
+            min_results,
+            keep_max=index.metric_type == faiss.METRIC_INNER_PRODUCT,
         )
 
     nres = np.hstack([nres_i for nres_i, dis_i, ids_i in res_batches])
     dis = np.hstack([dis_i for nres_i, dis_i, ids_i in res_batches])
     ids = np.hstack([ids_i for nres_i, dis_i, ids_i in res_batches])
 
-    lims = np.zeros(len(nres) + 1, dtype='uint64')
+    lims = np.zeros(len(nres) + 1, dtype="uint64")
     lims[1:] = np.cumsum(nres)
 
     return radius, lims, dis, ids
 
 
 def exponential_query_iterator(xq, start_bs=32, max_bs=20000):
-    """ produces batches of progressively increasing sizes. This is useful to
+    """produces batches of progressively increasing sizes. This is useful to
     adjust the search radius progressively without overflowing with
-    intermediate results """
+    intermediate results"""
     nq = len(xq)
     bs = start_bs
     i = 0
     while i < nq:
-        xqi = xq[i:i + bs]
+        xqi = xq[i : i + bs]
         yield xqi
         if bs < max_bs:
             bs *= 2

--- a/contrib/factory_tools.py
+++ b/contrib/factory_tools.py
@@ -8,14 +8,14 @@ import re
 
 
 def get_code_size(d, indexkey):
-    """ size of one vector in an index in dimension d
+    """size of one vector in an index in dimension d
     constructed with factory string indexkey"""
 
     if indexkey == "Flat":
         return d * 4
 
     if indexkey.endswith(",RFlat"):
-        return d * 4 + get_code_size(d, indexkey[:-len(",RFlat")])
+        return d * 4 + get_code_size(d, indexkey[: -len(",RFlat")])
 
     mo = re.match("IVF\\d+(_HNSW32)?,(.*)$", indexkey)
     if mo:
@@ -33,42 +33,42 @@ def get_code_size(d, indexkey):
     if mo:
         return get_code_size(d, mo.group(1)) + get_code_size(d, mo.group(2))
 
-    mo = re.match('PQ(\\d+)x(\\d+)(fs|fsr)?$', indexkey)
+    mo = re.match("PQ(\\d+)x(\\d+)(fs|fsr)?$", indexkey)
     if mo:
         return (int(mo.group(1)) * int(mo.group(2)) + 7) // 8
 
-    mo = re.match('PQ(\\d+)\\+(\\d+)$', indexkey)
+    mo = re.match("PQ(\\d+)\\+(\\d+)$", indexkey)
     if mo:
-        return (int(mo.group(1)) + int(mo.group(2)))
+        return int(mo.group(1)) + int(mo.group(2))
 
-    mo = re.match('PQ(\\d+)$', indexkey)
+    mo = re.match("PQ(\\d+)$", indexkey)
     if mo:
         return int(mo.group(1))
 
     if indexkey == "HNSW32" or indexkey == "HNSW32,Flat":
-        return d * 4 + 64 * 4 # roughly
+        return d * 4 + 64 * 4  # roughly
 
-    if indexkey == 'SQ8':
+    if indexkey == "SQ8":
         return d
-    elif indexkey == 'SQ4':
+    elif indexkey == "SQ4":
         return (d + 1) // 2
-    elif indexkey == 'SQ6':
+    elif indexkey == "SQ6":
         return (d * 6 + 7) // 8
-    elif indexkey == 'SQfp16':
+    elif indexkey == "SQfp16":
         return d * 2
-    elif indexkey == 'SQbf16':
+    elif indexkey == "SQbf16":
         return d * 2
 
-    mo = re.match('PCAR?(\\d+),(.*)$', indexkey)
+    mo = re.match("PCAR?(\\d+),(.*)$", indexkey)
     if mo:
         return get_code_size(int(mo.group(1)), mo.group(2))
-    mo = re.match('OPQ\\d+_(\\d+),(.*)$', indexkey)
+    mo = re.match("OPQ\\d+_(\\d+),(.*)$", indexkey)
     if mo:
         return get_code_size(int(mo.group(1)), mo.group(2))
-    mo = re.match('OPQ\\d+,(.*)$', indexkey)
+    mo = re.match("OPQ\\d+,(.*)$", indexkey)
     if mo:
         return get_code_size(d, mo.group(1))
-    mo = re.match('RR(\\d+),(.*)$', indexkey)
+    mo = re.match("RR(\\d+),(.*)$", indexkey)
     if mo:
         return get_code_size(int(mo.group(1)), mo.group(2))
     raise RuntimeError("cannot parse " + indexkey)
@@ -158,7 +158,11 @@ def reverse_index_factory(index):
         return f"PQ{index.pq.M}x{index.pq.nbits}"
 
     elif isinstance(index, faiss.IndexLSH):
-        return "LSH" + ("r" if index.rotate_data else "") + ("t" if index.train_thresholds else "")
+        return (
+            "LSH"
+            + ("r" if index.rotate_data else "")
+            + ("t" if index.train_thresholds else "")
+        )
 
     elif isinstance(index, faiss.IndexScalarQuantizer):
         return sq_names[index.sq.qtype]

--- a/contrib/inspect_tools.py
+++ b/contrib/inspect_tools.py
@@ -8,12 +8,12 @@ import faiss
 
 
 def get_invlist(invlists, l):
-    """ returns the inverted lists content as a pair of (list_ids, list_codes).
+    """returns the inverted lists content as a pair of (list_ids, list_codes).
     The codes are reshaped to a proper size
     """
     invlists = faiss.downcast_InvertedLists(invlists)
     ls = invlists.list_size(l)
-    list_ids = np.zeros(ls, dtype='int64')
+    list_ids = np.zeros(ls, dtype="int64")
     ids = codes = None
     try:
         ids = invlists.get_ids(l)
@@ -21,13 +21,13 @@ def get_invlist(invlists, l):
             faiss.memcpy(faiss.swig_ptr(list_ids), ids, list_ids.nbytes)
         codes = invlists.get_codes(l)
         if invlists.code_size != faiss.InvertedLists.INVALID_CODE_SIZE:
-            list_codes = np.zeros((ls, invlists.code_size), dtype='uint8')
+            list_codes = np.zeros((ls, invlists.code_size), dtype="uint8")
         else:
             # it's a BlockInvertedLists
             npb = invlists.n_per_block
             bs = invlists.block_size
             ls_round = (ls + npb - 1) // npb
-            list_codes = np.zeros((ls_round, bs // npb, npb), dtype='uint8')
+            list_codes = np.zeros((ls_round, bs // npb, npb), dtype="uint8")
         if ls > 0:
             faiss.memcpy(faiss.swig_ptr(list_codes), codes, list_codes.nbytes)
     finally:
@@ -39,28 +39,27 @@ def get_invlist(invlists, l):
 
 
 def get_invlist_sizes(invlists):
-    """ return the array of sizes of the inverted lists """
-    return np.array([
-        invlists.list_size(i)
-        for i in range(invlists.nlist)
-    ], dtype='int64')
+    """return the array of sizes of the inverted lists"""
+    return np.array(
+        [invlists.list_size(i) for i in range(invlists.nlist)], dtype="int64"
+    )
 
 
 def print_object_fields(obj):
-    """ list values all fields of an object known to SWIG """
+    """list values all fields of an object known to SWIG"""
 
     for name in obj.__class__.__swig_getmethods__:
         print(f"{name} = {getattr(obj, name)}")
 
 
 def get_pq_centroids(pq):
-    """ return the PQ centroids as an array """
+    """return the PQ centroids as an array"""
     cen = faiss.vector_to_array(pq.centroids)
     return cen.reshape(pq.M, pq.ksub, pq.dsub)
 
 
 def get_LinearTransform_matrix(pca):
-    """ extract matrix + bias from the PCA object
+    """extract matrix + bias from the PCA object
     works for any linear transform (OPQ, random rotation, etc.)
     """
     b = faiss.vector_to_array(pca.b)
@@ -69,10 +68,10 @@ def get_LinearTransform_matrix(pca):
 
 
 def make_LinearTransform_matrix(A, b=None):
-    """ make a linear transform from a matrix and a bias term (optional)"""
+    """make a linear transform from a matrix and a bias term (optional)"""
     d_out, d_in = A.shape
     if b is not None:
-        assert b.shape == (d_out, )
+        assert b.shape == (d_out,)
     lt = faiss.LinearTransform(d_in, d_out, b is not None)
     faiss.copy_array_to_vector(A.ravel(), lt.A)
     if b is not None:
@@ -83,35 +82,29 @@ def make_LinearTransform_matrix(A, b=None):
 
 
 def get_additive_quantizer_codebooks(aq):
-    """ return to codebooks of an additive quantizer """
+    """return to codebooks of an additive quantizer"""
     codebooks = faiss.vector_to_array(aq.codebooks).reshape(-1, aq.d)
     co = faiss.vector_to_array(aq.codebook_offsets)
-    return [
-        codebooks[co[i]:co[i + 1]]
-        for i in range(aq.M)
-    ]
+    return [codebooks[co[i] : co[i + 1]] for i in range(aq.M)]
 
 
 def get_flat_data(index):
-    """ copy and return the data matrix in an IndexFlat """
+    """copy and return the data matrix in an IndexFlat"""
     xb = faiss.vector_to_array(index.codes).view("float32")
     return xb.reshape(index.ntotal, index.d)
 
 
-def get_flat_codes(index_flat): 
-    """ get the codes from an indexFlatCodes as an array """
+def get_flat_codes(index_flat):
+    """get the codes from an indexFlatCodes as an array"""
     return faiss.vector_to_array(index_flat.codes).reshape(
-        index_flat.ntotal, index_flat.code_size)
+        index_flat.ntotal, index_flat.code_size
+    )
 
 
 def get_NSG_neighbors(nsg):
-    """ get the neighbor list for the vectors stored in the NSG structure, as
-    a N-by-K matrix of indices """
+    """get the neighbor list for the vectors stored in the NSG structure, as
+    a N-by-K matrix of indices"""
     graph = nsg.get_final_graph()
-    neighbors = np.zeros((graph.N, graph.K), dtype='int32')
-    faiss.memcpy(
-        faiss.swig_ptr(neighbors),
-        graph.data,
-        neighbors.nbytes
-    )
+    neighbors = np.zeros((graph.N, graph.K), dtype="int32")
+    faiss.memcpy(faiss.swig_ptr(neighbors), graph.data, neighbors.nbytes)
     return neighbors

--- a/contrib/ivf_tools.py
+++ b/contrib/ivf_tools.py
@@ -14,16 +14,14 @@ def add_preassigned(index_ivf, x, a, ids=None):
     Add elements to an IVF index, where the assignment is already computed
     """
     n, d = x.shape
-    assert a.shape == (n, )
+    assert a.shape == (n,)
     if isinstance(index_ivf, faiss.IndexBinaryIVF):
         d *= 8
     assert d == index_ivf.d
     if ids is not None:
-        assert ids.shape == (n, )
+        assert ids.shape == (n,)
         ids = faiss.swig_ptr(ids)
-    index_ivf.add_core(
-        n, faiss.swig_ptr(x), ids, faiss.swig_ptr(a)
-    )
+    index_ivf.add_core(n, faiss.swig_ptr(x), ids, faiss.swig_ptr(a))
 
 
 def search_preassigned(index_ivf, xq, k, list_nos, coarse_dis=None):
@@ -83,9 +81,7 @@ def range_search_preassigned(index_ivf, x, radius, list_nos, coarse_dis=None):
     sp = faiss.swig_ptr
 
     index_ivf.range_search_preassigned_c(
-        n, sp(x), radius,
-        sp(list_nos), sp(coarse_dis),
-        res
+        n, sp(x), radius, sp(list_nos), sp(coarse_dis), res
     )
     # get pointers and copy them
     lims = faiss.rev_swig_ptr(res.lims, n + 1).copy()
@@ -96,7 +92,7 @@ def range_search_preassigned(index_ivf, x, radius, list_nos, coarse_dis=None):
 
 
 def replace_ivf_quantizer(index_ivf, new_quantizer):
-    """ replace the IVF quantizer with a flat quantizer and return the
+    """replace the IVF quantizer with a flat quantizer and return the
     old quantizer"""
     if new_quantizer.ntotal == 0:
         centroids = index_ivf.quantizer.reconstruct_n()
@@ -120,15 +116,15 @@ def replace_ivf_quantizer(index_ivf, new_quantizer):
 
 
 def permute_invlists(index_ivf, perm):
-    """ Apply some permutation to the inverted lists, and modify the quantizer
+    """Apply some permutation to the inverted lists, and modify the quantizer
     entries accordingly.
     Perm is an array of size nlist, where old_index = perm[new_index]
     """
-    nlist, = perm.shape
+    (nlist,) = perm.shape
     assert index_ivf.nlist == nlist
     quantizer = faiss.downcast_index(index_ivf.quantizer)
     assert quantizer.ntotal == index_ivf.nlist
-    perm = np.ascontiguousarray(perm, dtype='int64')
+    perm = np.ascontiguousarray(perm, dtype="int64")
 
     # just make sure it's a permutation...
     bc = np.bincount(perm, minlength=nlist)

--- a/contrib/ondisk.py
+++ b/contrib/ondisk.py
@@ -11,7 +11,10 @@ LOG = logging.getLogger(__name__)
 
 
 def merge_ondisk(
-    trained_index: faiss.Index, shard_fnames: List[str], ivfdata_fname: str, shift_ids=False
+    trained_index: faiss.Index,
+    shard_fnames: List[str],
+    ivfdata_fname: str,
+    shift_ids=False,
 ) -> None:
     """Add the contents of the indexes stored in shard_fnames into the index
     trained_index. The on-disk data is stored in ivfdata_fname"""
@@ -51,7 +54,9 @@ def merge_ondisk(
         ivf_vector.push_back(ivf)
 
     LOG.info("merge %d inverted lists " % ivf_vector.size())
-    ntotal = invlists.merge_from_multiple(ivf_vector.data(), ivf_vector.size(), shift_ids)
+    ntotal = invlists.merge_from_multiple(
+        ivf_vector.data(), ivf_vector.size(), shift_ids
+    )
 
     # now replace the inverted lists in the output index
     index.ntotal = index_ivf.ntotal = ntotal

--- a/contrib/rpc.py
+++ b/contrib/rpc.py
@@ -27,8 +27,8 @@ LOG = logging.getLogger(__name__)
 PORT = 12032
 
 safe_modules = {
-    'numpy',
-    'numpy.core.multiarray',
+    "numpy",
+    "numpy.core.multiarray",
 }
 
 
@@ -39,49 +39,51 @@ class RestrictedUnpickler(pickle.Unpickler):
         if module in safe_modules:
             return getattr(importlib.import_module(module), name)
         # Forbid everything else.
-        raise pickle.UnpicklingError("global '%s.%s' is forbidden" %
-                                     (module, name))
+        raise pickle.UnpicklingError(
+            "global '%s.%s' is forbidden" % (module, name)
+        )
 
 
 class FileSock:
-    " wraps a socket so that it is usable by pickle/cPickle "
+    "wraps a socket so that it is usable by pickle/cPickle"
 
-    def __init__(self,sock):
+    def __init__(self, sock):
         self.sock = sock
-        self.nr=0
+        self.nr = 0
 
     def write(self, buf):
         # print("sending %d bytes"%len(buf))
-        #self.sock.sendall(buf)
+        # self.sock.sendall(buf)
         # print("...done")
         bs = 512 * 1024
         ns = 0
         while ns < len(buf):
-            sent = self.sock.send(buf[ns:ns + bs])
+            sent = self.sock.send(buf[ns : ns + bs])
             ns += sent
 
-    def read(self,bs=512*1024):
-        #if self.nr==10000: pdb.set_trace()
-        self.nr+=1
+    def read(self, bs=512 * 1024):
+        # if self.nr==10000: pdb.set_trace()
+        self.nr += 1
         # print("read bs=%d"%bs)
         b = []
         nb = 0
-        while len(b)<bs:
+        while len(b) < bs:
             # print('   loop')
             rb = self.sock.recv(bs - nb)
-            if not rb: break
+            if not rb:
+                break
             b.append(rb)
             nb += len(rb)
-        return b''.join(b)
+        return b"".join(b)
 
     def readline(self):
         # print("readline!")
         """may be optimized..."""
-        s=bytes()
+        s = bytes()
         while True:
-            c=self.read(1)
-            s+=c
-        if len(c)==0 or chr(c[0])=='\n':
+            c = self.read(1)
+            s += c
+        if len(c) == 0 or chr(c[0]) == "\n":
             return s
 
 
@@ -99,7 +101,7 @@ class Server:
     transparently from a client
     """
 
-    def __init__(self, s, logf=sys.stderr, log_prefix=''):
+    def __init__(self, s, logf=sys.stderr, log_prefix=""):
         self.logf = logf
         self.log_prefix = log_prefix
 
@@ -107,7 +109,6 @@ class Server:
 
         self.conn = s
         self.fs = FileSock(s)
-
 
     def log(self, s):
         self.logf.write("Server log %s: %s\n" % (self.log_prefix, s))
@@ -130,13 +131,13 @@ class Server:
             (fname, args) = RestrictedUnpickler(self.fs).load()
         except EOFError:
             raise ClientExit("read args")
-        self.log("executing method %s"%(fname))
+        self.log("executing method %s" % (fname))
         st = None
         ret = None
         try:
-            f=getattr(self,fname)
+            f = getattr(self, fname)
         except AttributeError:
-            st = AttributeError("unknown method "+fname)
+            st = AttributeError("unknown method " + fname)
             self.log("unknown method")
 
         try:
@@ -145,38 +146,38 @@ class Server:
             # due to a bug (in mod_python?), ServerException cannot be
             # unpickled, so send the string and make the exception on the client side
 
-            #st=ServerException(
+            # st=ServerException(
             #  "".join(traceback.format_tb(sys.exc_info()[2]))+
             #  str(e))
-            st="".join(traceback.format_tb(sys.exc_info()[2]))+str(e)
+            st = "".join(traceback.format_tb(sys.exc_info()[2])) + str(e)
             self.log("exception in method")
-            traceback.print_exc(50,self.logf)
+            traceback.print_exc(50, self.logf)
             self.logf.flush()
 
         LOG.info("return")
         try:
-            pickle.dump((st ,ret), self.fs, protocol=4)
+            pickle.dump((st, ret), self.fs, protocol=4)
         except EOFError:
             raise ClientExit("function return")
 
     def exec_loop(self):
-        """ main execution loop. Loops and handles exit states"""
+        """main execution loop. Loops and handles exit states"""
 
         self.log("in exec_loop")
         try:
             while True:
                 self.one_function()
         except ClientExit as e:
-            self.log("ClientExit %s"%e)
+            self.log("ClientExit %s" % e)
         except socket.error as e:
-            self.log("socket error %s"%e)
-            traceback.print_exc(50,self.logf)
+            self.log("socket error %s" % e)
+            traceback.print_exc(50, self.logf)
         except EOFError:
             self.log("EOF during communication")
-            traceback.print_exc(50,self.logf)
+            traceback.print_exc(50, self.logf)
         except BaseException:
             # unexpected
-            traceback.print_exc(50,sys.stderr)
+            traceback.print_exc(50, sys.stderr)
             sys.exit(1)
 
         LOG.info("exit server")
@@ -188,14 +189,16 @@ class Server:
     # spying stuff
 
     def get_ps_stats(self):
-        ret=''
-        f=os.popen("echo ============ `hostname` uptime:; uptime;"+
-                   "echo ============ self:; "+
-                   "ps -p %d -o pid,vsize,rss,%%cpu,nlwp,psr; "%os.getpid()+
-                   "echo ============ run queue:;"+
-                   "ps ar -o user,pid,%cpu,%mem,ni,nlwp,psr,vsz,rss,cputime,command")
+        ret = ""
+        f = os.popen(
+            "echo ============ `hostname` uptime:; uptime;"
+            + "echo ============ self:; "
+            + "ps -p %d -o pid,vsize,rss,%%cpu,nlwp,psr; " % os.getpid()
+            + "echo ============ run queue:;"
+            + "ps ar -o user,pid,%cpu,%mem,ni,nlwp,psr,vsz,rss,cputime,command"
+        )
         for l in f:
-            ret+=l
+            ret += l
         return ret
 
 
@@ -204,6 +207,7 @@ class Client:
     Methods of the server object can be called transparently. Exceptions are
     re-raised.
     """
+
     def __init__(self, HOST, port=PORT, v6=False):
         socktype = socket.AF_INET6 if v6 else socket.AF_INET
 
@@ -220,18 +224,18 @@ class Client:
 
     def get_result(self):
         (st, ret) = RestrictedUnpickler(self.fs).load()
-        if st!=None:
+        if st != None:
             raise ServerException(st)
         else:
             return ret
 
-    def __getattr__(self,name):
-        return lambda *x: self.generic_fun(name,x)
+    def __getattr__(self, name):
+        return lambda *x: self.generic_fun(name, x)
 
 
 def run_server(new_handler, port=PORT, report_to_file=None, v6=False):
 
-    HOST = ''                 # Symbolic name meaning the local host
+    HOST = ""  # Symbolic name meaning the local host
     socktype = socket.AF_INET6 if v6 else socket.AF_INET
     s = socket.socket(socktype, socket.SOCK_STREAM)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -242,20 +246,21 @@ def run_server(new_handler, port=PORT, report_to_file=None, v6=False):
 
     LOG.info("accepting connections")
     if report_to_file is not None:
-        LOG.info('storing host+port in %s', report_to_file)
-        open(report_to_file, 'w').write('%s:%d ' % (socket.gethostname(), port))
+        LOG.info("storing host+port in %s", report_to_file)
+        open(report_to_file, "w").write("%s:%d " % (socket.gethostname(), port))
 
     while True:
         try:
             conn, addr = s.accept()
         except socket.error as e:
-            if e[1]=='Interrupted system call': continue
+            if e[1] == "Interrupted system call":
+                continue
             raise
 
-        LOG.info('Connected to %s', addr)
+        LOG.info("Connected to %s", addr)
 
         ibs = new_handler(conn)
 
-        tid = _thread.start_new_thread(ibs.exec_loop,())
+        tid = _thread.start_new_thread(ibs.exec_loop, ())
 
         LOG.debug("Thread ID: %d", tid)

--- a/contrib/torch/clustering.py
+++ b/contrib/torch/clustering.py
@@ -14,7 +14,6 @@ import torch
 from faiss.contrib.clustering import kmeans  # noqa: F401 some libraries import kmeans from here
 
 
-
 class DatasetAssign:
     """Wrapper for a tensor that offers a function to assign the vectors
     to centroids. All other implementations offer the same interface"""

--- a/contrib/torch/quantization.py
+++ b/contrib/torch/quantization.py
@@ -11,6 +11,7 @@ import torch
 import faiss
 import math
 from faiss.contrib.torch import clustering
+
 # the kmeans can produce both torch and numpy centroids
 
 
@@ -57,7 +58,7 @@ class VectorQuantizer(Quantizer):
 
 class ProductQuantizer(Quantizer):
     def __init__(self, d, M, nbits):
-        """ M: number of subvectors, d%M == 0
+        """M: number of subvectors, d%M == 0
         nbits: number of bits that each vector is encoded into
         """
         assert d % M == 0
@@ -69,20 +70,20 @@ class ProductQuantizer(Quantizer):
         self.code_size = code_size
 
     def train(self, x):
-        nc = 2 ** self.nbits
+        nc = 2**self.nbits
         sd = self.d // self.M
         dev = x.device
         dtype = x.dtype
         self.codebook = torch.zeros((self.M, nc, sd), device=dev, dtype=dtype)
         for m in range(self.M):
-            xsub = x[:, m * self.d // self.M: (m + 1) * self.d // self.M]
+            xsub = x[:, m * self.d // self.M : (m + 1) * self.d // self.M]
             data = clustering.DatasetAssign(xsub.contiguous())
-            self.codebook[m] = clustering.kmeans(2 ** self.nbits, data)
+            self.codebook[m] = clustering.kmeans(2**self.nbits, data)
 
     def encode(self, x):
         codes = torch.zeros((x.shape[0], self.code_size), dtype=torch.uint8)
         for m in range(self.M):
-            xsub = x[:, m * self.d // self.M:(m + 1) * self.d // self.M]
+            xsub = x[:, m * self.d // self.M : (m + 1) * self.d // self.M]
             _, I = faiss.knn(xsub.contiguous(), self.codebook[m], 1)
             codes[:, m] = I.ravel()
         return codes

--- a/contrib/torch_utils.py
+++ b/contrib/torch_utils.py
@@ -34,52 +34,59 @@ import numpy as np
 
 
 def swig_ptr_from_UInt8Tensor(x):
-    """ gets a Faiss SWIG pointer from a pytorch tensor (on CPU or GPU) """
+    """gets a Faiss SWIG pointer from a pytorch tensor (on CPU or GPU)"""
     assert x.is_contiguous()
     assert x.dtype == torch.uint8
     return faiss.cast_integer_to_uint8_ptr(
-        x.untyped_storage().data_ptr() + x.storage_offset())
+        x.untyped_storage().data_ptr() + x.storage_offset()
+    )
 
 
 def swig_ptr_from_HalfTensor(x):
-    """ gets a Faiss SWIG pointer from a pytorch tensor (on CPU or GPU) """
+    """gets a Faiss SWIG pointer from a pytorch tensor (on CPU or GPU)"""
     assert x.is_contiguous()
     assert x.dtype == torch.float16
     # no canonical half type in C/C++
     return faiss.cast_integer_to_void_ptr(
-        x.untyped_storage().data_ptr() + x.storage_offset() * 2)
+        x.untyped_storage().data_ptr() + x.storage_offset() * 2
+    )
 
 
 def swig_ptr_from_FloatTensor(x):
-    """ gets a Faiss SWIG pointer from a pytorch tensor (on CPU or GPU) """
+    """gets a Faiss SWIG pointer from a pytorch tensor (on CPU or GPU)"""
     assert x.is_contiguous()
     assert x.dtype == torch.float32
     return faiss.cast_integer_to_float_ptr(
-        x.untyped_storage().data_ptr() + x.storage_offset() * 4)
+        x.untyped_storage().data_ptr() + x.storage_offset() * 4
+    )
 
 
 def swig_ptr_from_BFloat16Tensor(x):
-    """ gets a Faiss SWIG pointer from a pytorch tensor (on CPU or GPU) """
+    """gets a Faiss SWIG pointer from a pytorch tensor (on CPU or GPU)"""
     assert x.is_contiguous()
     assert x.dtype == torch.bfloat16
     return faiss.cast_integer_to_void_ptr(
-        x.untyped_storage().data_ptr() + x.storage_offset() * 2)
+        x.untyped_storage().data_ptr() + x.storage_offset() * 2
+    )
 
 
 def swig_ptr_from_IntTensor(x):
-    """ gets a Faiss SWIG pointer from a pytorch tensor (on CPU or GPU) """
+    """gets a Faiss SWIG pointer from a pytorch tensor (on CPU or GPU)"""
     assert x.is_contiguous()
-    assert x.dtype == torch.int32, 'dtype=%s' % x.dtype
+    assert x.dtype == torch.int32, "dtype=%s" % x.dtype
     return faiss.cast_integer_to_int_ptr(
-        x.untyped_storage().data_ptr() + x.storage_offset() * 4)
+        x.untyped_storage().data_ptr() + x.storage_offset() * 4
+    )
 
 
 def swig_ptr_from_IndicesTensor(x):
-    """ gets a Faiss SWIG pointer from a pytorch tensor (on CPU or GPU) """
+    """gets a Faiss SWIG pointer from a pytorch tensor (on CPU or GPU)"""
     assert x.is_contiguous()
-    assert x.dtype == torch.int64, 'dtype=%s' % x.dtype
+    assert x.dtype == torch.int64, "dtype=%s" % x.dtype
     return faiss.cast_integer_to_idx_t_ptr(
-        x.untyped_storage().data_ptr() + x.storage_offset() * 8)
+        x.untyped_storage().data_ptr() + x.storage_offset() * 8
+    )
+
 
 ##################################################################
 # utilities
@@ -88,10 +95,10 @@ def swig_ptr_from_IndicesTensor(x):
 
 @contextlib.contextmanager
 def using_stream(res, pytorch_stream=None):
-    """ Creates a scoping object to make Faiss GPU use the same stream
-        as pytorch, based on torch.cuda.current_stream().
-        Or, a specific pytorch stream can be passed in as a second
-        argument, in which case we will use that stream.
+    """Creates a scoping object to make Faiss GPU use the same stream
+    as pytorch, based on torch.cuda.current_stream().
+    Or, a specific pytorch stream can be passed in as a second
+    argument, in which case we will use that stream.
     """
 
     if pytorch_stream is None:
@@ -99,7 +106,8 @@ def using_stream(res, pytorch_stream=None):
 
     # This is the cudaStream_t that we wish to use
     cuda_stream_s = faiss.cast_integer_to_cudastream_t(
-        pytorch_stream.cuda_stream)
+        pytorch_stream.cuda_stream
+    )
 
     # So we can revert GpuResources stream state upon exit
     prior_dev = torch.cuda.current_device()
@@ -114,22 +122,24 @@ def using_stream(res, pytorch_stream=None):
         res.setDefaultStream(prior_dev, prior_stream)
 
 
-def torch_replace_method(the_class, name, replacement,
-                         ignore_missing=False, ignore_no_base=False):
+def torch_replace_method(
+    the_class, name, replacement, ignore_missing=False, ignore_no_base=False
+):
     try:
         orig_method = getattr(the_class, name)
     except AttributeError:
         if ignore_missing:
             return
         raise
-    if orig_method.__name__ == 'torch_replacement_' + name:
+    if orig_method.__name__ == "torch_replacement_" + name:
         # replacement was done in parent class
         return
 
     # We should already have the numpy replacement methods patched
-    assert ignore_no_base or (orig_method.__name__ == 'replacement_' + name)
-    setattr(the_class, name + '_numpy', orig_method)
+    assert ignore_no_base or (orig_method.__name__ == "replacement_" + name)
+    setattr(the_class, name + "_numpy", orig_method)
     setattr(the_class, name, replacement)
+
 
 ##################################################################
 # Setup wrappers
@@ -155,8 +165,9 @@ def handle_torch_Index(the_class):
             )
 
         if x.is_cuda:
-            assert hasattr(self, 'getDevice'), \
-                'GPU tensor on CPU index not allowed'
+            assert hasattr(
+                self, "getDevice"
+            ), "GPU tensor on CPU index not allowed"
 
             # On the GPU, use proper stream ordering
             with using_stream(self.getResources()):
@@ -165,8 +176,9 @@ def handle_torch_Index(the_class):
             # CPU torch
             self.add_ex(n, x_ptr, numeric_type)
 
-    def torch_replacement_add_with_ids(self, x, ids,
-                                       numeric_type=faiss.Float32):
+    def torch_replacement_add_with_ids(
+        self, x, ids, numeric_type=faiss.Float32
+    ):
         if type(x) is np.ndarray:
             # forward to faiss __init__.py base method
             return self.add_with_ids_numpy(x, ids)
@@ -184,12 +196,13 @@ def handle_torch_Index(the_class):
             )
 
         assert type(ids) is torch.Tensor
-        assert ids.shape == (n, ), 'not same number of vectors as ids'
+        assert ids.shape == (n,), "not same number of vectors as ids"
         ids_ptr = swig_ptr_from_IndicesTensor(ids)
 
         if x.is_cuda:
-            assert hasattr(self, 'getDevice'), \
-                'GPU tensor on CPU index not allowed'
+            assert hasattr(
+                self, "getDevice"
+            ), "GPU tensor on CPU index not allowed"
 
             # On the GPU, use proper stream ordering
             with using_stream(self.getResources()):
@@ -216,8 +229,9 @@ def handle_torch_Index(the_class):
         L_ptr = swig_ptr_from_IndicesTensor(labels)
 
         if x.is_cuda:
-            assert hasattr(self, 'getDevice'), \
-                'GPU tensor on CPU index not allowed'
+            assert hasattr(
+                self, "getDevice"
+            ), "GPU tensor on CPU index not allowed"
 
             # On the GPU, use proper stream ordering
             with using_stream(self.getResources()):
@@ -246,8 +260,9 @@ def handle_torch_Index(the_class):
             )
 
         if x.is_cuda:
-            assert hasattr(self, 'getDevice'), \
-                'GPU tensor on CPU index not allowed'
+            assert hasattr(
+                self, "getDevice"
+            ), "GPU tensor on CPU index not allowed"
 
             # On the GPU, use proper stream ordering
             with using_stream(self.getResources()):
@@ -283,8 +298,9 @@ def handle_torch_Index(the_class):
 
         return x_ptr, D_ptr, I_ptr, D, I
 
-    def torch_replacement_search(self, x, k, D=None, I=None,
-                                 numeric_type=faiss.Float32):
+    def torch_replacement_search(
+        self, x, k, D=None, I=None, numeric_type=faiss.Float32
+    ):
         if type(x) is np.ndarray:
             # forward to faiss __init__.py base method
             return self.search_numpy(x, k, D=D, I=I)
@@ -296,8 +312,9 @@ def handle_torch_Index(the_class):
         x_ptr, D_ptr, I_ptr, D, I = search_methods_common(x, k, D, I)
 
         if x.is_cuda:
-            assert hasattr(self, 'getDevice'), \
-                'GPU tensor on CPU index not allowed'
+            assert hasattr(
+                self, "getDevice"
+            ), "GPU tensor on CPU index not allowed"
 
             # On the GPU, use proper stream ordering
             with using_stream(self.getResources()):
@@ -308,8 +325,9 @@ def handle_torch_Index(the_class):
 
         return D, I
 
-    def torch_replacement_search_and_reconstruct(self, x, k, D=None, I=None,
-                                                 R=None):
+    def torch_replacement_search_and_reconstruct(
+        self, x, k, D=None, I=None, R=None
+    ):
         if type(x) is np.ndarray:
             # Forward to faiss __init__.py base method
             return self.search_and_reconstruct_numpy(x, k, D=D, I=I, R=R)
@@ -328,21 +346,22 @@ def handle_torch_Index(the_class):
         R_ptr = swig_ptr_from_FloatTensor(R)
 
         if x.is_cuda:
-            assert hasattr(self, 'getDevice'), \
-                'GPU tensor on CPU index not allowed'
+            assert hasattr(
+                self, "getDevice"
+            ), "GPU tensor on CPU index not allowed"
 
             # On the GPU, use proper stream ordering
             with using_stream(self.getResources()):
                 self.search_and_reconstruct_c(n, x_ptr, k, D_ptr, I_ptr, R_ptr)
         else:
             # CPU torch
-            self.search_and_reconstruct_c(n, x_ptr, k, D_ptr, I_ptr,
-                                          R_ptr)
+            self.search_and_reconstruct_c(n, x_ptr, k, D_ptr, I_ptr, R_ptr)
 
         return D, I, R
 
-    def torch_replacement_search_preassigned(self, x, k, Iq, Dq, *,
-                                             D=None, I=None):
+    def torch_replacement_search_preassigned(
+        self, x, k, Iq, Dq, *, D=None, I=None
+    ):
         if type(x) is np.ndarray:
             # forward to faiss __init__.py base method
             return self.search_preassigned_numpy(x, k, Iq, Dq, D=D, I=I)
@@ -365,24 +384,28 @@ def handle_torch_Index(the_class):
             Dq_ptr = None
 
         if x.is_cuda:
-            assert hasattr(self, 'getDevice'), \
-                'GPU tensor on CPU index not allowed'
+            assert hasattr(
+                self, "getDevice"
+            ), "GPU tensor on CPU index not allowed"
 
             # On the GPU, use proper stream ordering
             with using_stream(self.getResources()):
-                self.search_preassigned_c(n, x_ptr, k, Iq_ptr, Dq_ptr,
-                                          D_ptr, I_ptr, False)
+                self.search_preassigned_c(
+                    n, x_ptr, k, Iq_ptr, Dq_ptr, D_ptr, I_ptr, False
+                )
         else:
             # CPU torch
-            self.search_preassigned_c(n, x_ptr, k, Iq_ptr, Dq_ptr,
-                                      D_ptr, I_ptr, False)
+            self.search_preassigned_c(
+                n, x_ptr, k, Iq_ptr, Dq_ptr, D_ptr, I_ptr, False
+            )
 
         return D, I
 
     def torch_replacement_remove_ids(self, x):
         # Not yet implemented
-        assert type(x) is not torch.Tensor, \
-            'remove_ids not yet implemented for torch'
+        assert (
+            type(x) is not torch.Tensor
+        ), "remove_ids not yet implemented for torch"
         return self.remove_ids_numpy(x)
 
     def torch_replacement_reconstruct(self, key, x=None):
@@ -395,21 +418,22 @@ def handle_torch_Index(the_class):
 
         # If the index is a CPU index, the default device is CPU, otherwise we
         # produce a GPU tensor
-        device = torch.device('cpu')
-        if hasattr(self, 'getDevice'):
+        device = torch.device("cpu")
+        if hasattr(self, "getDevice"):
             # same device as the index
-            device = torch.device('cuda', self.getDevice())
+            device = torch.device("cuda", self.getDevice())
 
         if x is None:
             x = torch.empty(self.d, device=device, dtype=torch.float32)
         else:
             assert type(x) is torch.Tensor
-            assert x.shape == (self.d, )
+            assert x.shape == (self.d,)
         x_ptr = swig_ptr_from_FloatTensor(x)
 
         if x.is_cuda:
-            assert hasattr(self, 'getDevice'), \
-                'GPU tensor on CPU index not allowed'
+            assert hasattr(
+                self, "getDevice"
+            ), "GPU tensor on CPU index not allowed"
 
             # On the GPU, use proper stream ordering
             with using_stream(self.getResources()):
@@ -433,10 +457,10 @@ def handle_torch_Index(the_class):
 
         # If the index is a CPU index, the default device is CPU, otherwise we
         # produce a GPU tensor
-        device = torch.device('cpu')
-        if hasattr(self, 'getDevice'):
+        device = torch.device("cpu")
+        if hasattr(self, "getDevice"):
             # same device as the index
-            device = torch.device('cuda', self.getDevice())
+            device = torch.device("cuda", self.getDevice())
 
         if x is None:
             x = torch.empty(ni, self.d, device=device, dtype=torch.float32)
@@ -446,8 +470,9 @@ def handle_torch_Index(the_class):
         x_ptr = swig_ptr_from_FloatTensor(x)
 
         if x.is_cuda:
-            assert hasattr(self, 'getDevice'), \
-                'GPU tensor on CPU index not allowed'
+            assert hasattr(
+                self, "getDevice"
+            ), "GPU tensor on CPU index not allowed"
 
             # On the GPU, use proper stream ordering
             with using_stream(self.getResources()):
@@ -464,7 +489,7 @@ def handle_torch_Index(the_class):
             return self.update_vectors_numpy(keys, x)
 
         assert type(keys) is torch.Tensor
-        (n, ) = keys.shape
+        (n,) = keys.shape
         keys_ptr = swig_ptr_from_IndicesTensor(keys)
 
         assert type(x) is torch.Tensor
@@ -472,8 +497,9 @@ def handle_torch_Index(the_class):
         x_ptr = swig_ptr_from_FloatTensor(x)
 
         if x.is_cuda:
-            assert hasattr(self, 'getDevice'), \
-                'GPU tensor on CPU index not allowed'
+            assert hasattr(
+                self, "getDevice"
+            ), "GPU tensor on CPU index not allowed"
 
             # On the GPU, use proper stream ordering
             with using_stream(self.getResources()):
@@ -494,10 +520,12 @@ def handle_torch_Index(the_class):
         assert d == self.d
         x_ptr = swig_ptr_from_FloatTensor(x)
 
-        assert not x.is_cuda, \
-            'Range search using GPU tensor not yet implemented'
-        assert not hasattr(self, 'getDevice'), \
-            'Range search on GPU index not yet implemented'
+        assert (
+            not x.is_cuda
+        ), "Range search using GPU tensor not yet implemented"
+        assert not hasattr(
+            self, "getDevice"
+        ), "Range search on GPU index not yet implemented"
 
         res = faiss.RangeSearchResult(n)
         self.range_search_c(n, x_ptr, thresh, res)
@@ -507,7 +535,8 @@ def handle_torch_Index(the_class):
         # np to torch
         # NOTE: torch does not support np.uint64, just np.int64
         lims = torch.from_numpy(
-            faiss.rev_swig_ptr(res.lims, n + 1).copy().astype('int64'))
+            faiss.rev_swig_ptr(res.lims, n + 1).copy().astype("int64")
+        )
         nd = int(lims[-1])
         D = torch.from_numpy(faiss.rev_swig_ptr(res.distances, nd).copy())
         I = torch.from_numpy(faiss.rev_swig_ptr(res.labels, nd).copy())
@@ -531,8 +560,9 @@ def handle_torch_Index(the_class):
         codes_ptr = swig_ptr_from_UInt8Tensor(codes)
 
         if x.is_cuda:
-            assert hasattr(self, 'getDevice'), \
-                'GPU tensor on CPU index not allowed'
+            assert hasattr(
+                self, "getDevice"
+            ), "GPU tensor on CPU index not allowed"
 
             # On the GPU, use proper stream ordering
             with using_stream(self.getResources()):
@@ -561,8 +591,9 @@ def handle_torch_Index(the_class):
         x_ptr = swig_ptr_from_FloatTensor(x)
 
         if codes.is_cuda:
-            assert hasattr(self, 'getDevice'), \
-                'GPU tensor on CPU index not allowed'
+            assert hasattr(
+                self, "getDevice"
+            ), "GPU tensor on CPU index not allowed"
 
             # On the GPU, use proper stream ordering
             with using_stream(self.getResources()):
@@ -573,34 +604,46 @@ def handle_torch_Index(the_class):
 
         return x
 
-    torch_replace_method(the_class, 'add', torch_replacement_add)
-    torch_replace_method(the_class, 'add_with_ids',
-                         torch_replacement_add_with_ids)
-    torch_replace_method(the_class, 'assign', torch_replacement_assign)
-    torch_replace_method(the_class, 'train', torch_replacement_train)
-    torch_replace_method(the_class, 'search', torch_replacement_search)
-    torch_replace_method(the_class, 'remove_ids',
-                         torch_replacement_remove_ids)
-    torch_replace_method(the_class, 'reconstruct',
-                         torch_replacement_reconstruct)
-    torch_replace_method(the_class, 'reconstruct_n',
-                         torch_replacement_reconstruct_n)
-    torch_replace_method(the_class, 'range_search',
-                         torch_replacement_range_search)
-    torch_replace_method(the_class, 'update_vectors',
-                         torch_replacement_update_vectors,
-                         ignore_missing=True)
-    torch_replace_method(the_class, 'search_and_reconstruct',
-                         torch_replacement_search_and_reconstruct,
-                         ignore_missing=True)
-    torch_replace_method(the_class, 'search_preassigned',
-                         torch_replacement_search_preassigned,
-                         ignore_missing=True)
-    torch_replace_method(the_class, 'sa_encode', torch_replacement_sa_encode)
-    torch_replace_method(the_class, 'sa_decode', torch_replacement_sa_decode)
+    torch_replace_method(the_class, "add", torch_replacement_add)
+    torch_replace_method(
+        the_class, "add_with_ids", torch_replacement_add_with_ids
+    )
+    torch_replace_method(the_class, "assign", torch_replacement_assign)
+    torch_replace_method(the_class, "train", torch_replacement_train)
+    torch_replace_method(the_class, "search", torch_replacement_search)
+    torch_replace_method(the_class, "remove_ids", torch_replacement_remove_ids)
+    torch_replace_method(
+        the_class, "reconstruct", torch_replacement_reconstruct
+    )
+    torch_replace_method(
+        the_class, "reconstruct_n", torch_replacement_reconstruct_n
+    )
+    torch_replace_method(
+        the_class, "range_search", torch_replacement_range_search
+    )
+    torch_replace_method(
+        the_class,
+        "update_vectors",
+        torch_replacement_update_vectors,
+        ignore_missing=True,
+    )
+    torch_replace_method(
+        the_class,
+        "search_and_reconstruct",
+        torch_replacement_search_and_reconstruct,
+        ignore_missing=True,
+    )
+    torch_replace_method(
+        the_class,
+        "search_preassigned",
+        torch_replacement_search_preassigned,
+        ignore_missing=True,
+    )
+    torch_replace_method(the_class, "sa_encode", torch_replacement_sa_encode)
+    torch_replace_method(the_class, "sa_decode", torch_replacement_sa_decode)
 
 
-faiss_module = sys.modules['faiss']
+faiss_module = sys.modules["faiss"]
 
 # Re-patch anything that inherits from faiss.Index to add the torch bindings
 for symbol in dir(faiss_module):
@@ -615,8 +658,7 @@ for symbol in dir(faiss_module):
 def torch_replacement_knn(xq, xb, k, metric=faiss.METRIC_L2, metric_arg=0):
     if type(xb) is np.ndarray:
         # Forward to faiss __init__.py base method
-        return faiss.knn_numpy(xq, xb, k, metric=metric,
-                               metric_arg=metric_arg)
+        return faiss.knn_numpy(xq, xb, k, metric=metric, metric_arg=metric_arg)
 
     nb, d = xb.size()
     assert xb.is_contiguous()
@@ -637,31 +679,32 @@ def torch_replacement_knn(xq, xb, k, metric=faiss.METRIC_L2, metric_arg=0):
     xq_ptr = swig_ptr_from_FloatTensor(xq)
 
     if metric == faiss.METRIC_L2:
-        faiss.knn_L2sqr(
-            xq_ptr, xb_ptr,
-            d, nq, nb, k, D_ptr, I_ptr
-        )
+        faiss.knn_L2sqr(xq_ptr, xb_ptr, d, nq, nb, k, D_ptr, I_ptr)
     elif metric == faiss.METRIC_INNER_PRODUCT:
-        faiss.knn_inner_product(
-            xq_ptr, xb_ptr,
-            d, nq, nb, k, D_ptr, I_ptr
-        )
+        faiss.knn_inner_product(xq_ptr, xb_ptr, d, nq, nb, k, D_ptr, I_ptr)
     else:
         faiss.knn_extra_metrics(
-            xq_ptr, xb_ptr,
-            d, nq, nb, metric, metric_arg, k, D_ptr, I_ptr
+            xq_ptr, xb_ptr, d, nq, nb, metric, metric_arg, k, D_ptr, I_ptr
         )
 
     return D, I
 
 
-torch_replace_method(faiss_module, 'knn', torch_replacement_knn, True, True)
+torch_replace_method(faiss_module, "knn", torch_replacement_knn, True, True)
 
 
 # allows torch tensor usage with bfKnn
-def torch_replacement_knn_gpu(res, xq, xb, k, D=None, I=None,
-                              metric=faiss.METRIC_L2, device=-1,
-                              use_cuvs=False):
+def torch_replacement_knn_gpu(
+    res,
+    xq,
+    xb,
+    k,
+    D=None,
+    I=None,
+    metric=faiss.METRIC_L2,
+    device=-1,
+    use_cuvs=False,
+):
     if type(xb) is np.ndarray:
         # Forward to faiss __init__.py base method
         return faiss.knn_gpu_numpy(res, xq, xb, k, D, I, metric, device)
@@ -673,7 +716,7 @@ def torch_replacement_knn_gpu(res, xq, xb, k, D=None, I=None,
         xb = xb.t()
         xb_row_major = False
     else:
-        raise TypeError('matrix should be row or column-major')
+        raise TypeError("matrix should be row or column-major")
 
     if xb.dtype == torch.float32:
         xb_type = faiss.DistanceDataType_F32
@@ -685,7 +728,7 @@ def torch_replacement_knn_gpu(res, xq, xb, k, D=None, I=None,
         xb_type = faiss.DistanceDataType_BF16
         xb_ptr = swig_ptr_from_BFloat16Tensor(xb)
     else:
-        raise TypeError('xq must be float32, float16 or bfloat16')
+        raise TypeError("xq must be float32, float16 or bfloat16")
 
     nq, d2 = xq.size()
     assert d2 == d
@@ -695,7 +738,7 @@ def torch_replacement_knn_gpu(res, xq, xb, k, D=None, I=None,
         xq = xq.t()
         xq_row_major = False
     else:
-        raise TypeError('matrix should be row or column-major')
+        raise TypeError("matrix should be row or column-major")
 
     if xq.dtype == torch.float32:
         xq_type = faiss.DistanceDataType_F32
@@ -707,14 +750,14 @@ def torch_replacement_knn_gpu(res, xq, xb, k, D=None, I=None,
         xq_type = faiss.DistanceDataType_BF16
         xq_ptr = swig_ptr_from_BFloat16Tensor(xq)
     else:
-        raise TypeError('xq must be float32, float16 or bfloat16')
+        raise TypeError("xq must be float32, float16 or bfloat16")
 
     if D is None:
         D = torch.empty(nq, k, device=xb.device, dtype=torch.float32)
     else:
         assert D.shape == (nq, k)
         # interface takes void*, we need to check this
-        assert (D.dtype == torch.float32)
+        assert D.dtype == torch.float32
 
     if I is None:
         I = torch.empty(nq, k, device=xb.device, dtype=torch.int64)
@@ -728,7 +771,7 @@ def torch_replacement_knn_gpu(res, xq, xb, k, D=None, I=None,
         I_type = faiss.IndicesDataType_I32
         I_ptr = swig_ptr_from_IntTensor(I)
     else:
-        raise TypeError('I must be i64 or i32')
+        raise TypeError("I must be i64 or i32")
 
     D_ptr = swig_ptr_from_FloatTensor(D)
 
@@ -756,14 +799,15 @@ def torch_replacement_knn_gpu(res, xq, xb, k, D=None, I=None,
     return D, I
 
 
-torch_replace_method(faiss_module, 'knn_gpu', torch_replacement_knn_gpu,
-                     True, True)
+torch_replace_method(
+    faiss_module, "knn_gpu", torch_replacement_knn_gpu, True, True
+)
 
 
 # allows torch tensor usage with bfKnn for all pairwise distances
-def torch_replacement_pairwise_distance_gpu(res, xq, xb, D=None,
-                                            metric=faiss.METRIC_L2,
-                                            device=-1):
+def torch_replacement_pairwise_distance_gpu(
+    res, xq, xb, D=None, metric=faiss.METRIC_L2, device=-1
+):
     if type(xb) is np.ndarray:
         # Forward to faiss __init__.py base method
         return faiss.pairwise_distance_gpu_numpy(res, xq, xb, D, metric)
@@ -775,7 +819,7 @@ def torch_replacement_pairwise_distance_gpu(res, xq, xb, D=None,
         xb = xb.t()
         xb_row_major = False
     else:
-        raise TypeError('xb matrix should be row or column-major')
+        raise TypeError("xb matrix should be row or column-major")
 
     if xb.dtype == torch.float32:
         xb_type = faiss.DistanceDataType_F32
@@ -784,7 +828,7 @@ def torch_replacement_pairwise_distance_gpu(res, xq, xb, D=None,
         xb_type = faiss.DistanceDataType_F16
         xb_ptr = swig_ptr_from_HalfTensor(xb)
     else:
-        raise TypeError('xb must be float32 or float16')
+        raise TypeError("xb must be float32 or float16")
 
     nq, d2 = xq.size()
     assert d2 == d
@@ -794,7 +838,7 @@ def torch_replacement_pairwise_distance_gpu(res, xq, xb, D=None,
         xq = xq.t()
         xq_row_major = False
     else:
-        raise TypeError('xq matrix should be row or column-major')
+        raise TypeError("xq matrix should be row or column-major")
 
     if xq.dtype == torch.float32:
         xq_type = faiss.DistanceDataType_F32
@@ -803,14 +847,14 @@ def torch_replacement_pairwise_distance_gpu(res, xq, xb, D=None,
         xq_type = faiss.DistanceDataType_F16
         xq_ptr = swig_ptr_from_HalfTensor(xq)
     else:
-        raise TypeError('xq must be float32 or float16')
+        raise TypeError("xq must be float32 or float16")
 
     if D is None:
         D = torch.empty(nq, nb, device=xb.device, dtype=torch.float32)
     else:
         assert D.shape == (nq, nb)
         # interface takes void*, we need to check this
-        assert (D.dtype == torch.float32)
+        assert D.dtype == torch.float32
 
     D_ptr = swig_ptr_from_FloatTensor(D)
 
@@ -835,5 +879,10 @@ def torch_replacement_pairwise_distance_gpu(res, xq, xb, D=None,
     return D
 
 
-torch_replace_method(faiss_module, 'pairwise_distance_gpu',
-                     torch_replacement_pairwise_distance_gpu, True, True)
+torch_replace_method(
+    faiss_module,
+    "pairwise_distance_gpu",
+    torch_replacement_pairwise_distance_gpu,
+    True,
+    True,
+)

--- a/contrib/vecs_io.py
+++ b/contrib/vecs_io.py
@@ -14,51 +14,52 @@ definition of the formats here: http://corpus-texmex.irisa.fr/
 
 
 def ivecs_read(fname):
-    a = np.fromfile(fname, dtype='int32')
-    if sys.byteorder == 'big':
+    a = np.fromfile(fname, dtype="int32")
+    if sys.byteorder == "big":
         a.byteswap(inplace=True)
     d = a[0]
     return a.reshape(-1, d + 1)[:, 1:].copy()
 
 
 def fvecs_read(fname):
-    return ivecs_read(fname).view('float32')
+    return ivecs_read(fname).view("float32")
 
 
 def ivecs_mmap(fname):
-    assert sys.byteorder != 'big'
-    a = np.memmap(fname, dtype='int32', mode='r')
+    assert sys.byteorder != "big"
+    a = np.memmap(fname, dtype="int32", mode="r")
     d = a[0]
     return a.reshape(-1, d + 1)[:, 1:]
 
 
 def fvecs_mmap(fname):
-    return ivecs_mmap(fname).view('float32')
+    return ivecs_mmap(fname).view("float32")
 
 
 def bvecs_mmap(fname):
-    x = np.memmap(fname, dtype='uint8', mode='r')
-    if sys.byteorder == 'big':
+    x = np.memmap(fname, dtype="uint8", mode="r")
+    if sys.byteorder == "big":
         da = x[:4][::-1].copy()
-        d = da.view('int32')[0]
+        d = da.view("int32")[0]
     else:
-        d = x[:4].view('int32')[0]
+        d = x[:4].view("int32")[0]
     return x.reshape(-1, d + 4)[:, 4:]
 
 
 def ivecs_write(fname, m):
     n, d = m.shape
-    m1 = np.empty((n, d + 1), dtype='int32')
+    m1 = np.empty((n, d + 1), dtype="int32")
     m1[:, 0] = d
     m1[:, 1:] = m
-    if sys.byteorder == 'big':
+    if sys.byteorder == "big":
         m1.byteswap(inplace=True)
     m1.tofile(fname)
 
 
 def fvecs_write(fname, m):
-    m = m.astype('float32')
-    ivecs_write(fname, m.view('int32'))
+    m = m.astype("float32")
+    ivecs_write(fname, m.view("int32"))
+
 
 def bvecs_iter(filepath, batch_size=100_000):
     """
@@ -66,18 +67,19 @@ def bvecs_iter(filepath, batch_size=100_000):
     """
 
     file_size = os.path.getsize(filepath)
-    with open(filepath, 'rb') as f:
-        dim = np.frombuffer(f.read(4), dtype='<i4')[0]
+    with open(filepath, "rb") as f:
+        dim = np.frombuffer(f.read(4), dtype="<i4")[0]
 
     bytes_per_vec = 4 + dim
     n_vectors = file_size // bytes_per_vec
 
-    mm = np.memmap(filepath, mode='r', dtype=np.uint8)
+    mm = np.memmap(filepath, mode="r", dtype=np.uint8)
     records = mm.reshape(n_vectors, bytes_per_vec)
 
     for start in range(0, n_vectors, batch_size):
         end = np.min([start + batch_size, n_vectors])
         yield records[start:end, 4:]
+
 
 def bvecs_iter_chunked(chunk_folder, batch_size=100_000):
     """
@@ -99,7 +101,11 @@ def bvecs_iter_chunked(chunk_folder, batch_size=100_000):
     # Find all chunk files and sort them
     chunk_files = []
     for entry in os.scandir(chunk_folder):
-        if entry.is_file() and entry.name.startswith("chunk_") and entry.name.endswith(".bvecs"):
+        if (
+            entry.is_file()
+            and entry.name.startswith("chunk_")
+            and entry.name.endswith(".bvecs")
+        ):
             chunk_files.append(entry.path)
     chunk_files.sort()
 
@@ -111,7 +117,7 @@ def bvecs_iter_chunked(chunk_folder, batch_size=100_000):
     for path in chunk_files:
         basename = os.path.basename(path)
         try:
-            num_str = basename.split('_')[1].split('.')[0]
+            num_str = basename.split("_")[1].split(".")[0]
             chunk_numbers.append(int(num_str))
         except (IndexError, ValueError):
             raise ValueError(f"Invalid chunk filename format: {basename}")
@@ -127,8 +133,8 @@ def bvecs_iter_chunked(chunk_folder, batch_size=100_000):
         )
 
     # Get dimension from first chunk
-    with open(chunk_files[0], 'rb') as f:
-        dim = np.frombuffer(f.read(4), dtype='<i4')[0]
+    with open(chunk_files[0], "rb") as f:
+        dim = np.frombuffer(f.read(4), dtype="<i4")[0]
 
     bytes_per_vec = 4 + dim
 
@@ -142,7 +148,7 @@ def bvecs_iter_chunked(chunk_folder, batch_size=100_000):
         n_vectors = file_size // bytes_per_vec
 
         # Memory-map this chunk
-        mm = np.memmap(chunk_path, mode='r', dtype=np.uint8)
+        mm = np.memmap(chunk_path, mode="r", dtype=np.uint8)
         records = mm.reshape(n_vectors, bytes_per_vec)
         vectors = records[:, 4:]  # Skip dimension prefix
 
@@ -166,7 +172,7 @@ def bvecs_iter_chunked(chunk_folder, batch_size=100_000):
 
         # Now process complete batches from this chunk
         while start + batch_size <= n_vectors:
-            yield vectors[start:start + batch_size]
+            yield vectors[start : start + batch_size]
             start += batch_size
 
         remainder = n_vectors - start

--- a/demos/demo_auto_tune.py
+++ b/demos/demo_auto_tune.py
@@ -10,8 +10,10 @@ import numpy as np
 
 try:
     import matplotlib
-    matplotlib.use('Agg')
+
+    matplotlib.use("Agg")
     from matplotlib import pyplot
+
     graphical_output = True
 except ImportError:
     graphical_output = False
@@ -30,21 +32,22 @@ def ivecs_read(fname):
 
 
 def fvecs_read(fname):
-    return ivecs_read(fname).view('float32')
+    return ivecs_read(fname).view("float32")
 
 
 def plot_OperatingPoints(ops, nq, **kwargs):
     ops = ops.optimal_pts
     n = ops.size() * 2 - 1
-    pyplot.plot([ops.at( i      // 2).perf for i in range(n)],
-                [ops.at((i + 1) // 2).t / nq * 1000 for i in range(n)],
-                **kwargs)
+    pyplot.plot(
+        [ops.at(i // 2).perf for i in range(n)],
+        [ops.at((i + 1) // 2).t / nq * 1000 for i in range(n)],
+        **kwargs
+    )
 
 
 #################################################################
 # prepare common data for all indexes
 #################################################################
-
 
 
 t0 = time.time()
@@ -60,7 +63,7 @@ d = xt.shape[1]
 print("load GT")
 
 gt = ivecs_read("sift1M/sift_groundtruth.ivecs")
-gt = gt.astype('int64')
+gt = gt.astype("int64")
 k = gt.shape[1]
 
 print("prepare criterion")
@@ -72,28 +75,41 @@ crit.nnn = k
 
 # indexes that are useful when there is no limitation on memory usage
 unlimited_mem_keys = [
-    "IMI2x10,Flat", "IMI2x11,Flat",
-    "IVF4096,Flat", "IVF16384,Flat",
-    "PCA64,IMI2x10,Flat"]
+    "IMI2x10,Flat",
+    "IMI2x11,Flat",
+    "IVF4096,Flat",
+    "IVF16384,Flat",
+    "PCA64,IMI2x10,Flat",
+]
 
 # memory limited to 16 bytes / vector
 keys_mem_16 = [
-    'IMI2x10,PQ16', 'IVF4096,PQ16',
-    'IMI2x10,PQ8+8', 'OPQ16_64,IMI2x10,PQ16'
-    ]
+    "IMI2x10,PQ16",
+    "IVF4096,PQ16",
+    "IMI2x10,PQ8+8",
+    "OPQ16_64,IMI2x10,PQ16",
+]
 
 # limited to 32 bytes / vector
 keys_mem_32 = [
-    'IMI2x10,PQ32', 'IVF4096,PQ32', 'IVF16384,PQ32',
-    'IMI2x10,PQ16+16',
-    'OPQ32,IVF4096,PQ32', 'IVF4096,PQ16+16', 'OPQ16,IMI2x10,PQ16+16'
-    ]
+    "IMI2x10,PQ32",
+    "IVF4096,PQ32",
+    "IVF16384,PQ32",
+    "IMI2x10,PQ16+16",
+    "OPQ32,IVF4096,PQ32",
+    "IVF4096,PQ16+16",
+    "OPQ16,IMI2x10,PQ16+16",
+]
 
 # indexes that can run on the GPU
 keys_gpu = [
     "PCA64,IVF4096,Flat",
-    "PCA64,Flat", "Flat", "IVF4096,Flat", "IVF16384,Flat",
-    "IVF4096,PQ32"]
+    "PCA64,Flat",
+    "Flat",
+    "IVF4096,Flat",
+    "IVF16384,Flat",
+    "IVF4096,PQ32",
+]
 
 
 keys_to_test = unlimited_mem_keys
@@ -102,8 +118,9 @@ use_gpu = False
 
 if use_gpu:
     # if this fails, it means that the GPU version was not compiled
-    assert faiss.StandardGpuResources, \
-        "Faiss was not compiled with GPU support, or loading _swigfaiss_gpu.so failed"
+    assert (
+        faiss.StandardGpuResources
+    ), "Faiss was not compiled with GPU support, or loading _swigfaiss_gpu.so failed"
     res = faiss.StandardGpuResources()
     dev_no = 0
 
@@ -121,7 +138,6 @@ for index_key in keys_to_test:
 
     # make the index described by the key
     index = faiss.index_factory(d, index_key)
-
 
     if use_gpu:
         # transfer to GPU (may be partial)
@@ -155,14 +171,16 @@ for index_key in keys_to_test:
 
         fig = pyplot.figure(figsize=(12, 9))
         pyplot.xlabel("1-recall at 1")
-        pyplot.ylabel("search time (ms/query, %d threads)" % faiss.omp_get_max_threads())
-        pyplot.gca().set_yscale('log')
+        pyplot.ylabel(
+            "search time (ms/query, %d threads)" % faiss.omp_get_max_threads()
+        )
+        pyplot.gca().set_yscale("log")
         pyplot.grid()
         for i2, opi2 in op_per_key:
-            plot_OperatingPoints(opi2, crit.nq, label = i2, marker = 'o')
+            plot_OperatingPoints(opi2, crit.nq, label=i2, marker="o")
         # plot_OperatingPoints(op, crit.nq, label = 'best', marker = 'o', color = 'r')
         pyplot.legend(loc=2)
-        fig.savefig('tmp/demo_auto_tune.png')
+        fig.savefig("tmp/demo_auto_tune.png")
 
 
 print("[%.3f s] final result:" % (time.time() - t0))

--- a/demos/demo_client_server_ivf.py
+++ b/demos/demo_client_server_ivf.py
@@ -17,13 +17,13 @@ from faiss.contrib.client_server import run_index_server, ClientIndex
 
 
 def ivecs_read(fname):
-    a = np.fromfile(fname, dtype='int32')
+    a = np.fromfile(fname, dtype="int32")
     d = a[0]
     return a.reshape(-1, d + 1)[:, 1:].copy()
 
 
 def fvecs_read(fname):
-    return ivecs_read(fname).view('float32')
+    return ivecs_read(fname).view("float32")
 
 
 #################################################################
@@ -32,7 +32,7 @@ def fvecs_read(fname):
 
 stage = int(sys.argv[1])
 
-tmpdir = '/tmp/'
+tmpdir = "/tmp/"
 
 if stage == 0:
     # train the index
@@ -57,10 +57,10 @@ if 1 <= stage <= 4:
 
 
 machine_ports = [
-    ('localhost', 12010),
-    ('localhost', 12011),
-    ('localhost', 12012),
-    ('localhost', 12013),
+    ("localhost", 12010),
+    ("localhost", 12011),
+    ("localhost", 12012),
+    ("localhost", 12013),
 ]
 v6 = False
 
@@ -78,7 +78,7 @@ if 5 <= stage <= 8:
 
 if stage == 9:
     client_index = ClientIndex(machine_ports)
-    print('index size:', client_index.ntotal)
+    print("index size:", client_index.ntotal)
     client_index.set_nprobe(16)
 
     # load query vectors and ground-truth

--- a/demos/demo_distributed_kmeans_torch.py
+++ b/demos/demo_distributed_kmeans_torch.py
@@ -33,18 +33,19 @@ class DatasetAssignDistributedGPU(clustering.DatasetAssign):
         sizes = torch.zeros(nproc, device=self.device, dtype=torch.int64)
         sizes[rank] = n
         torch.distributed.all_gather(
-            [sizes[i:i + 1] for i in range(nproc)], sizes[rank:rank + 1])
+            [sizes[i : i + 1] for i in range(nproc)], sizes[rank : rank + 1]
+        )
         self.sizes = sizes.cpu().numpy()
 
         # begin & end of each shard
-        self.cs = np.zeros(nproc + 1, dtype='int64')
+        self.cs = np.zeros(nproc + 1, dtype="int64")
         self.cs[1:] = np.cumsum(self.sizes)
 
     def count(self):
         return int(self.sizes.sum())
 
     def int_to_slaves(self, i):
-        " broadcast an int to all workers "
+        "broadcast an int to all workers"
         rank = self.rank
         tab = torch.zeros(1, device=self.device, dtype=torch.int64)
         if rank == 0:
@@ -64,7 +65,8 @@ class DatasetAssignDistributedGPU(clustering.DatasetAssign):
             indices = torch.from_numpy(indices).to(self.device)
         else:
             indices = torch.zeros(
-                len_indices, dtype=torch.int64, device=self.device)
+                len_indices, dtype=torch.int64, device=self.device
+            )
         torch.distributed.broadcast(indices, 0)
 
         # select subset of indices
@@ -73,8 +75,8 @@ class DatasetAssignDistributedGPU(clustering.DatasetAssign):
 
         mask = torch.logical_and(indices < i1, indices >= i0)
         output = torch.zeros(
-            len_indices, self.x.shape[1],
-            dtype=self.x.dtype, device=self.device)
+            len_indices, self.x.shape[1], dtype=self.x.dtype, device=self.device
+        )
         output[mask] = self.x[indices[mask] - i0]
         torch.distributed.reduce(output, 0)  # sum
         if rank == 0:
@@ -94,12 +96,14 @@ class DatasetAssignDistributedGPU(clustering.DatasetAssign):
 
         if rank != 0:
             centroids = torch.zeros(
-                nc, self.x.shape[1], dtype=self.x.dtype, device=self.device)
+                nc, self.x.shape[1], dtype=self.x.dtype, device=self.device
+            )
         torch.distributed.broadcast(centroids, 0)
 
         # perform search
         D, I = faiss.knn_gpu(
-            self.res, self.x, centroids, 1, device=self.device.index)
+            self.res, self.x, centroids, 1, device=self.device.index
+        )
 
         I = I.ravel()
         D = D.ravel()
@@ -120,11 +124,13 @@ class DatasetAssignDistributedGPU(clustering.DatasetAssign):
             all_I = torch.zeros(self.count(), dtype=I.dtype, device=device)
             all_D = torch.zeros(self.count(), dtype=D.dtype, device=device)
             torch.distributed.gather(
-                I, [all_I[self.cs[r]:self.cs[r + 1]] for r in range(nproc)],
+                I,
+                [all_I[self.cs[r] : self.cs[r + 1]] for r in range(nproc)],
                 dst=0,
             )
             torch.distributed.gather(
-                D, [all_D[self.cs[r]:self.cs[r + 1]] for r in range(nproc)],
+                D,
+                [all_D[self.cs[r] : self.cs[r + 1]] for r in range(nproc)],
                 dst=0,
             )
             return all_I.cpu().numpy(), all_D, sum_per_centroid
@@ -160,7 +166,8 @@ if __name__ == "__main__":
     if rank == 0:
         print(f"sizes = {da.sizes}")
         centroids, iteration_stats = clustering.kmeans(
-            k, da, niter=niter, return_stats=True)
+            k, da, niter=niter, return_stats=True
+        )
         print("clusters:", centroids.cpu().numpy())
     else:
         # make sure the iterations are aligned with master

--- a/demos/demo_ondisk_ivf.py
+++ b/demos/demo_ondisk_ivf.py
@@ -15,13 +15,13 @@ from faiss.contrib.ondisk import merge_ondisk
 
 
 def ivecs_read(fname):
-    a = np.fromfile(fname, dtype='int32')
+    a = np.fromfile(fname, dtype="int32")
     d = a[0]
     return a.reshape(-1, d + 1)[:, 1:].copy()
 
 
 def fvecs_read(fname):
-    return ivecs_read(fname).view('float32')
+    return ivecs_read(fname).view("float32")
 
 
 #################################################################
@@ -30,7 +30,7 @@ def fvecs_read(fname):
 
 stage = int(sys.argv[1])
 
-tmpdir = '/tmp/'
+tmpdir = "/tmp/"
 
 if stage == 0:
     # train the index
@@ -55,14 +55,11 @@ if 1 <= stage <= 4:
 
 if stage == 5:
 
-    print('loading trained index')
+    print("loading trained index")
     # construct the output index
     index = faiss.read_index(tmpdir + "trained.index")
 
-    block_fnames = [
-        tmpdir + "block_%d.index" % bno
-        for bno in range(4)
-    ]
+    block_fnames = [tmpdir + "block_%d.index" % bno for bno in range(4)]
 
     merge_ondisk(index, block_fnames, tmpdir + "merged_index.ivfdata")
 

--- a/demos/demo_qinco.py
+++ b/demos/demo_qinco.py
@@ -5,7 +5,7 @@
 
 """
 This demonstrates how to reproduce the QINCo paper results using the Faiss
-QINCo implementation. The code loads the reference model because training 
+QINCo implementation. The code loads the reference model because training
 is not implemented in Faiss.
 
 Prepare the data with
@@ -41,7 +41,7 @@ with torch.no_grad():
         torch.set_num_threads(1)
         faiss.omp_set_num_threads(1)
 
-    x_base = bvecs_mmap("/tmp/bigann1M.bvecs")[:1000].astype('float32')
+    x_base = bvecs_mmap("/tmp/bigann1M.bvecs")[:1000].astype("float32")
     x_scaled = torch.from_numpy(x_base) / qinco.db_scale
 
     t0 = time.time()

--- a/demos/offline_ivf/create_sharded_ssnpp_files.py
+++ b/demos/offline_ivf/create_sharded_ssnpp_files.py
@@ -29,7 +29,7 @@ def main(args: argparse.Namespace):
     ), "num of embeddings per file should divide total num of embeddings"
     for i in range(num_batches):
         xb_batch = ssnpp_data[
-            i * args.data_batch:(i + 1) * args.data_batch, :
+            i * args.data_batch : (i + 1) * args.data_batch, :
         ]
         filename = args.output_dir + f"/ssnpp_{(i):010}.npy"
         np.save(filename, xb_batch)

--- a/demos/offline_ivf/dataset.py
+++ b/demos/offline_ivf/dataset.py
@@ -111,7 +111,7 @@ class MultiFileVectorDataset:
                 xb = xb[start:]
                 start = 0
             req = min(batch_size - rem, xb.shape[0])
-            buffer[rem:rem + req] = xb[:req]
+            buffer[rem : rem + req] = xb[:req]
             rem += req
             if rem == batch_size:
                 if self.normalize:

--- a/demos/offline_ivf/offline_ivf.py
+++ b/demos/offline_ivf/offline_ivf.py
@@ -179,7 +179,9 @@ class OfflineIVF:
             idxs.append(np.empty((0,), dtype=np.uint32))
         bs = 1_000_000
         i = 0
-        for buffer in tqdm(self._iterate_transformed(self.xb_ds, 0, bs, np.float32)):
+        for buffer in tqdm(
+            self._iterate_transformed(self.xb_ds, 0, bs, np.float32)
+        ):
             for j in range(len(codecs)):
                 codec, codeset, idx = codecs[j], codesets[j], idxs[j]
                 uniq = codeset.insert(codec.sa_encode(buffer))
@@ -272,13 +274,17 @@ class OfflineIVF:
                             assert xb_j.shape[1] == index.chain.at(0).d_out
                             index_ivf.add_with_ids(
                                 xb_j,
-                                np.arange(start + jj, start + jj + xb_j.shape[0]),
+                                np.arange(
+                                    start + jj, start + jj + xb_j.shape[0]
+                                ),
                             )
                         else:
                             assert xb_j.shape[1] == index.d
                             index.add_with_ids(
                                 xb_j,
-                                np.arange(start + jj, start + jj + xb_j.shape[0]),
+                                np.arange(
+                                    start + jj, start + jj + xb_j.shape[0]
+                                ),
                             )
                         jj += xb_j.shape[0]
                         logging.info(jj)
@@ -413,7 +419,9 @@ class OfflineIVF:
         D_a_ann_file = (
             f"{self.eval_dir}/D_a_ann_{index_factory_fn}_np{nprobe}.npy"
         )
-        D_a_ann_refined_file = f"{self.eval_dir}/D_a_ann_refined_{index_factory_fn}_np{nprobe}.npy"
+        D_a_ann_refined_file = (
+            f"{self.eval_dir}/D_a_ann_refined_{index_factory_fn}_np{nprobe}.npy"
+        )
         D_b_gt_file = f"{self.eval_dir}/D_b_gt.npy"
         D_b_ann_file = (
             f"{self.eval_dir}/D_b_ann_{index_factory_fn}_np{nprobe}.npy"
@@ -684,26 +692,22 @@ class OfflineIVF:
                 else:
                     d = self.input_d
                 with open(Ifn, "xb") as f, open(Dfn, "xb") as g:
-                    xq_i = np.empty(
-                        shape=(self.xq_bs, d), dtype=np.float16
-                    )
+                    xq_i = np.empty(shape=(self.xq_bs, d), dtype=np.float16)
                     q_assign = np.empty(
                         (self.xq_bs, self.nprobe), dtype=np.int32
                     )
                     j = 0
-                    quantizer = faiss.index_cpu_to_all_gpus(
-                        index_ivf.quantizer
-                    )
+                    quantizer = faiss.index_cpu_to_all_gpus(index_ivf.quantizer)
                     for xq_i_j in tqdm(
                         self._iterate_transformed(
                             self.xq_ds, i, min(100_000, self.xq_bs), np.float16
                         ),
                         file=sys.stdout,
                     ):
-                        xq_i[j:j + xq_i_j.shape[0]] = xq_i_j
+                        xq_i[j : j + xq_i_j.shape[0]] = xq_i_j
                         (
                             _,
-                            q_assign[j:j + xq_i_j.shape[0]],
+                            q_assign[j : j + xq_i_j.shape[0]],
                         ) = quantizer.search(xq_i_j, self.nprobe)
                         j += xq_i_j.shape[0]
                         assert j <= xq_i.shape[0]
@@ -847,7 +851,8 @@ class OfflineIVF:
             for j in range(SMALL_DATA_SAMPLE):
                 assert np.where(I[j] == j + r)[0].size > 0, (
                     f"I[j]: {I[j]}, j: {j}, i: {i}, shard_size:"
-                    f" {self.shard_size}")
+                    f" {self.shard_size}"
+                )
 
         logging.info("search results...")
         index_ivf.nprobe = self.nprobe

--- a/demos/offline_ivf/tests/test_iterate_input.py
+++ b/demos/offline_ivf/tests/test_iterate_input.py
@@ -38,9 +38,9 @@ class TestUtilsMethods(unittest.TestCase):
             data_creator.create_test_data()
             args = data_creator.setup_cli()
             cfg = load_config(args.config)
-            db_iterator = create_dataset_from_oivf_config(
-                cfg, args.xb
-            ).iterate(0, TEST_BATCH_SIZE, np.float32)
+            db_iterator = create_dataset_from_oivf_config(cfg, args.xb).iterate(
+                0, TEST_BATCH_SIZE, np.float32
+            )
 
             for i in range(len(SMALL_FILE_SIZES) - 1):
                 vecs = next(db_iterator)
@@ -65,9 +65,9 @@ class TestUtilsMethods(unittest.TestCase):
             data_creator.create_test_data()
             args = data_creator.setup_cli()
             cfg = load_config(args.config)
-            db_iterator = create_dataset_from_oivf_config(
-                cfg, args.xb
-            ).iterate(0, TEST_BATCH_SIZE, np.float32)
+            db_iterator = create_dataset_from_oivf_config(cfg, args.xb).iterate(
+                0, TEST_BATCH_SIZE, np.float32
+            )
 
             for i in range(len(LARGE_FILE_SIZES) - 1):
                 vecs = next(db_iterator)

--- a/faiss/.flake8
+++ b/faiss/.flake8
@@ -1,3 +1,10 @@
 [flake8]
-# Ignore flakes about ambiguous variable name `I`.
-ignore = E741
+# Match faiss's documented 80-char line length (CONTRIBUTING.md); code is
+# black-formatted at width 80.
+max-line-length = 80
+# Use extend-ignore (not ignore) so pycodestyle's default-disabled checks
+# (E121,E123,E126,E226,E24,E704,W503,W504) stay off. Additionally ignore:
+#   E741 ambiguous name (l/I/O): faiss uses I/D for index/distance arrays.
+#   E203 whitespace before ':' and W503 line break before operator: these
+#   conflict with black formatting (per black's documented recommendations).
+extend-ignore = E741, E203, W503

--- a/faiss/gpu/perf/slow.py
+++ b/faiss/gpu/perf/slow.py
@@ -11,15 +11,16 @@ import numpy as np
 
 def test_slow():
     d = 256
-    index = faiss.index_cpu_to_gpu(faiss.StandardGpuResources(),
-                               0, faiss.IndexFlatL2(d))
-    x = np.random.rand(10 ** 6, d).astype('float32')
-    print('add')
+    index = faiss.index_cpu_to_gpu(
+        faiss.StandardGpuResources(), 0, faiss.IndexFlatL2(d)
+    )
+    x = np.random.rand(10**6, d).astype("float32")
+    print("add")
     index.add(x)
-    print('search')
+    print("search")
     index.search(x, 10)
-    print('done')
+    print("done")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_slow()

--- a/faiss/gpu/test/test_binary_cagra.py
+++ b/faiss/gpu/test/test_binary_cagra.py
@@ -28,8 +28,8 @@ from faiss.contrib import evaluation
 
 
 @unittest.skipIf(
-    "CUVS" not in faiss.get_compile_options(),
-    "only if cuVS is compiled in")
+    "CUVS" not in faiss.get_compile_options(), "only if cuVS is compiled in"
+)
 class TestInterop(unittest.TestCase):
 
     def do_interop(self):
@@ -40,10 +40,12 @@ class TestInterop(unittest.TestCase):
 
         index = faiss.GpuIndexBinaryCagra(res, d)
         xb = np.random.randint(
-            low=0, high=256, size=(1000000, d // 8), dtype=np.uint8)
+            low=0, high=256, size=(1000000, d // 8), dtype=np.uint8
+        )
         index.train(xb)
         queries = np.random.randint(
-            low=0, high=256, size=(1000, d // 8), dtype=np.uint8)
+            low=0, high=256, size=(1000, d // 8), dtype=np.uint8
+        )
         Dnew, Inew = index.search(queries, k)
 
         cpu_index = faiss.index_binary_gpu_to_cpu(index)
@@ -52,7 +54,8 @@ class TestInterop(unittest.TestCase):
         evaluation.check_ref_knn_with_draws(Dref, Iref, Dnew, Inew, k)
 
         deserialized_index = faiss.deserialize_index_binary(
-            faiss.serialize_index_binary(cpu_index))
+            faiss.serialize_index_binary(cpu_index)
+        )
 
         gpu_index = faiss.index_binary_cpu_to_gpu(res, 0, deserialized_index)
         Dnew2, Inew2 = gpu_index.search(queries, k)
@@ -64,8 +67,8 @@ class TestInterop(unittest.TestCase):
 
 
 @unittest.skipIf(
-    "CUVS" not in faiss.get_compile_options(),
-    "only if cuVS is compiled in")
+    "CUVS" not in faiss.get_compile_options(), "only if cuVS is compiled in"
+)
 class TestComputeGT(unittest.TestCase):
 
     def do_compute_GT(self, build_algo=None):
@@ -73,10 +76,12 @@ class TestComputeGT(unittest.TestCase):
         k = 12
         flat_index = faiss.IndexBinaryFlat(d)
         xb = np.random.randint(
-            low=0, high=256, size=(1000000, d // 8), dtype=np.uint8)
+            low=0, high=256, size=(1000000, d // 8), dtype=np.uint8
+        )
         flat_index.add(xb)
         queries = np.random.randint(
-            low=0, high=256, size=(1000, d // 8), dtype=np.uint8)
+            low=0, high=256, size=(1000, d // 8), dtype=np.uint8
+        )
         Dref, Iref = flat_index.search(queries, k)
 
         res = faiss.StandardGpuResources()
@@ -102,8 +107,8 @@ class TestComputeGT(unittest.TestCase):
 
 
 @unittest.skipIf(
-    "CUVS" not in faiss.get_compile_options(),
-    "only if cuVS is compiled in")
+    "CUVS" not in faiss.get_compile_options(), "only if cuVS is compiled in"
+)
 class TestIndexBinaryIDMap(unittest.TestCase):
     """Test IndexBinaryIDMap functionality with GpuIndexBinaryCagra"""
 
@@ -123,14 +128,16 @@ class TestIndexBinaryIDMap(unittest.TestCase):
         index_idmap = faiss.IndexBinaryIDMap(index_gpu)
 
         xb = np.random.randint(
-            low=0, high=256, size=(n, d // 8), dtype=np.uint8)
+            low=0, high=256, size=(n, d // 8), dtype=np.uint8
+        )
         ids = np.arange(1000000, 1000000 + n).astype(np.int64)
 
         index_idmap.add_with_ids(xb, ids)
 
         nq = 1000
         xq = np.random.randint(
-            low=0, high=256, size=(nq, d // 8), dtype=np.uint8)
+            low=0, high=256, size=(nq, d // 8), dtype=np.uint8
+        )
         D, I = index_idmap.search(xq, k)
 
         self.assertTrue(np.all(I >= 1000000))

--- a/faiss/gpu/test/test_cagra.py
+++ b/faiss/gpu/test/test_cagra.py
@@ -21,8 +21,12 @@ class TestComputeGT(unittest.TestCase):
         k = 12
 
         if numeric_type == faiss.Int8:
-            data_base_nt = np.random.randint(-128, 128, size=(10000, d), dtype=np.int8)
-            data_query_nt = np.random.randint(-128, 128, size=(100, d), dtype=np.int8)
+            data_base_nt = np.random.randint(
+                -128, 128, size=(10000, d), dtype=np.int8
+            )
+            data_query_nt = np.random.randint(
+                -128, 128, size=(100, d), dtype=np.int8
+            )
             data_base = data_base_nt.astype(np.float32)
             data_query = data_query_nt.astype(np.float32)
         else:
@@ -32,7 +36,9 @@ class TestComputeGT(unittest.TestCase):
             # Normalize for inner product to avoid duplicate neighbors
             if metric == faiss.METRIC_INNER_PRODUCT:
                 # Normalize database vectors
-                data_base = data_base / np.linalg.norm(data_base, axis=1, keepdims=True)
+                data_base = data_base / np.linalg.norm(
+                    data_base, axis=1, keepdims=True
+                )
                 # Normalize query vectors
                 data_query = data_query / np.linalg.norm(
                     data_query, axis=1, keepdims=True
@@ -95,8 +101,12 @@ class TestInterop(unittest.TestCase):
         d = 64
         k = 12
         if numeric_type == faiss.Int8:
-            data_base_nt = np.random.randint(-128, 128, size=(10000, d), dtype=np.int8)
-            data_query_nt = np.random.randint(-128, 128, size=(100, d), dtype=np.int8)
+            data_base_nt = np.random.randint(
+                -128, 128, size=(10000, d), dtype=np.int8
+            )
+            data_query_nt = np.random.randint(
+                -128, 128, size=(100, d), dtype=np.int8
+            )
             data_base = data_base_nt.astype(np.float32)
             data_query = data_query_nt.astype(np.float32)
         else:
@@ -122,10 +132,14 @@ class TestInterop(unittest.TestCase):
 
         evaluation.check_ref_knn_with_draws(Dref, Iref, Dnew, Inew, k)
 
-        deserialized_index = faiss.deserialize_index(faiss.serialize_index(cpu_index))
+        deserialized_index = faiss.deserialize_index(
+            faiss.serialize_index(cpu_index)
+        )
 
         gpu_index = faiss.index_cpu_to_gpu(res, 0, deserialized_index)
-        Dnew2, Inew2 = gpu_index.search(data_query_nt, k, numeric_type=numeric_type)
+        Dnew2, Inew2 = gpu_index.search(
+            data_query_nt, k, numeric_type=numeric_type
+        )
 
         evaluation.check_ref_knn_with_draws(Dnew2, Inew2, Dnew, Inew, k)
 
@@ -178,8 +192,12 @@ class TestIDMapCagra(unittest.TestCase):
         d = 64
         k = 12
         if numeric_type == faiss.Int8:
-            data_base_nt = np.random.randint(-128, 128, size=(10000, d), dtype=np.int8)
-            data_query_nt = np.random.randint(-128, 128, size=(100, d), dtype=np.int8)
+            data_base_nt = np.random.randint(
+                -128, 128, size=(10000, d), dtype=np.int8
+            )
+            data_query_nt = np.random.randint(
+                -128, 128, size=(100, d), dtype=np.int8
+            )
             data_base = data_base_nt.astype(np.float32)
             data_query = data_query_nt.astype(np.float32)
         else:
@@ -202,7 +220,9 @@ class TestIDMapCagra(unittest.TestCase):
         idMapIndex.train(data_base_nt, numeric_type=numeric_type)
         ids = np.array([i for i in range(10000)])
         idMapIndex.add_with_ids(data_base_nt, ids, numeric_type=numeric_type)
-        Dnew, Inew = idMapIndex.search(data_query_nt, k, numeric_type=numeric_type)
+        Dnew, Inew = idMapIndex.search(
+            data_query_nt, k, numeric_type=numeric_type
+        )
 
         evaluation.check_ref_knn_with_draws(Dref, Iref, Dnew, Inew, k)
 

--- a/faiss/gpu/test/test_contrib_gpu.py
+++ b/faiss/gpu/test/test_contrib_gpu.py
@@ -11,9 +11,13 @@ import numpy as np
 from common_faiss_tests import get_dataset_2
 
 from faiss.contrib import datasets, evaluation, big_batch_search
-from faiss.contrib.exhaustive_search import knn_ground_truth, \
-    range_ground_truth, range_search_gpu, \
-    range_search_max_results, exponential_query_iterator
+from faiss.contrib.exhaustive_search import (
+    knn_ground_truth,
+    range_ground_truth,
+    range_search_gpu,
+    range_search_max_results,
+    exponential_query_iterator,
+)
 
 
 class TestComputeGT(unittest.TestCase):
@@ -30,7 +34,7 @@ class TestComputeGT(unittest.TestCase):
 
         def matrix_iterator(xb, bs):
             for i0 in range(0, xb.shape[0], bs):
-                yield xb[i0:i0 + bs]
+                yield xb[i0 : i0 + bs]
 
         Dnew, Inew = knn_ground_truth(xq, matrix_iterator(xb, 1000), 10)
 
@@ -49,12 +53,11 @@ class TestComputeGT(unittest.TestCase):
         ref_lims, ref_D, ref_I = index.range_search(xq, threshold)
 
         new_lims, new_D, new_I = range_ground_truth(
-            xq, ds.database_iterator(bs=100), threshold,
-            metric_type=metric)
+            xq, ds.database_iterator(bs=100), threshold, metric_type=metric
+        )
 
         evaluation.check_ref_range_results(
-            ref_lims, ref_D, ref_I,
-            new_lims, new_D, new_I
+            ref_lims, ref_D, ref_I, new_lims, new_D, new_I
         )
 
     def test_range_L2(self):
@@ -84,14 +87,16 @@ class TestComputeGT(unittest.TestCase):
         query_iterator = exponential_query_iterator(xq)
 
         radius1, lims_new, Dnew, Inew = range_search_max_results(
-            index, query_iterator, ds.d // 2,
-            min_results=Dref.size, clip_to_min=True,
-            ngpu=1
+            index,
+            query_iterator,
+            ds.d // 2,
+            min_results=Dref.size,
+            clip_to_min=True,
+            ngpu=1,
         )
 
         evaluation.check_ref_range_results(
-            lims_ref, Dref, Iref,
-            lims_new, Dnew, Inew
+            lims_ref, Dref, Iref, lims_new, Dnew, Inew
         )
 
     @unittest.skipIf(faiss.get_num_gpus() < 2, "multiple GPU only test")
@@ -113,17 +118,20 @@ class TestBigBatchSearch(unittest.TestCase):
 
         def pairwise_distances(xq, xb, metric=faiss.METRIC_L2):
             return faiss.pairwise_distance_gpu(
-                res, xq, xb, metric=faiss.METRIC_L2)
+                res, xq, xb, metric=faiss.METRIC_L2
+            )
 
         def knn_function(xq, xb, k, metric=faiss.METRIC_L2):
             return faiss.knn_gpu(res, xq, xb, k, metric=faiss.METRIC_L2)
 
         for method in "pairwise_distances", "knn_function":
             Dnew, Inew = big_batch_search.big_batch_search(
-                index, ds.get_queries(),
-                k, method=method,
+                index,
+                ds.get_queries(),
+                k,
+                method=method,
                 pairwise_distances=pairwise_distances,
-                knn=knn_function
+                knn=knn_function,
             )
             self.assertLess((Inew != Iref).sum() / Iref.size, 1e-4)
             np.testing.assert_almost_equal(Dnew, Dref, decimal=4)
@@ -151,16 +159,22 @@ class TestBigBatchSearchMultiGPU(unittest.TestCase):
 
         def knn_function(xq, xb, k, metric=faiss.METRIC_L2, thread_id=None):
             return faiss.knn_gpu(
-                res[thread_id], xq, xb, k,
-                metric=faiss.METRIC_L2, device=thread_id
+                res[thread_id],
+                xq,
+                xb,
+                k,
+                metric=faiss.METRIC_L2,
+                device=thread_id,
             )
 
         Dnew, Inew = big_batch_search.big_batch_search(
-            index, ds.get_queries(),
-            k, method="knn_function",
+            index,
+            ds.get_queries(),
+            k,
+            method="knn_function",
             knn=knn_function,
             threaded=8,
-            computation_threads=ngpu
+            computation_threads=ngpu,
         )
         self.assertLess((Inew != Iref).sum() / Iref.size, 1e-4)
         np.testing.assert_almost_equal(Dnew, Dref, decimal=4)
@@ -192,18 +206,17 @@ class TestRangeSearchGpu(unittest.TestCase):
 
         # mixed GPU / CPU run
         Lnew, Dnew, Inew = range_search_gpu(
-            ds.get_queries(), threshold, index_gpu, index_cpu, gpu_k=4)
-        evaluation.check_ref_range_results(
-            Lref, Dref, Iref,
-            Lnew, Dnew, Inew
+            ds.get_queries(), threshold, index_gpu, index_cpu, gpu_k=4
         )
+        evaluation.check_ref_range_results(Lref, Dref, Iref, Lnew, Dnew, Inew)
 
         # also test the version without CPU search
         Lnew2, Dnew2, Inew2 = range_search_gpu(
-            ds.get_queries(), threshold, index_gpu, None, gpu_k=4)
+            ds.get_queries(), threshold, index_gpu, None, gpu_k=4
+        )
         for q in range(ds.nq):
-            ref = Iref[Lref[q]:Lref[q+1]]
-            new = Inew2[Lnew2[q]:Lnew2[q+1]]
+            ref = Iref[Lref[q] : Lref[q + 1]]
+            new = Inew2[Lnew2[q] : Lnew2[q + 1]]
             if nres_per_query[q] <= 4:
                 self.assertEqual(set(ref), set(new))
             else:

--- a/faiss/gpu/test/test_cuvs.py
+++ b/faiss/gpu/test/test_cuvs.py
@@ -11,8 +11,8 @@ from faiss.contrib.datasets import SyntheticDataset
 
 
 @unittest.skipIf(
-    "CUVS" not in faiss.get_compile_options(),
-    "only if CUVS is compiled in")
+    "CUVS" not in faiss.get_compile_options(), "only if CUVS is compiled in"
+)
 class TestBfKnn(unittest.TestCase):
 
     def test_large_k_search(self):
@@ -29,7 +29,6 @@ class TestBfKnn(unittest.TestCase):
         _, I = index_gpu.search(ds.get_queries(), k)
         np.testing.assert_equal(I.shape, (ds.nq, k))
 
-
     def test_bfKnn(self):
 
         ds = SyntheticDataset(32, 0, 4321, 1234)
@@ -40,13 +39,15 @@ class TestBfKnn(unittest.TestCase):
 
         # Faiss internal implementation
         Dnew, Inew = faiss.knn_gpu(
-            res, ds.get_queries(), ds.get_database(), 12, use_cuvs=False)
+            res, ds.get_queries(), ds.get_database(), 12, use_cuvs=False
+        )
         np.testing.assert_allclose(Dref, Dnew, atol=1e-4)
         np.testing.assert_array_equal(Iref, Inew)
 
         # cuVS version
         Dnew, Inew = faiss.knn_gpu(
-            res, ds.get_queries(), ds.get_database(), 12, use_cuvs=True)
+            res, ds.get_queries(), ds.get_database(), 12, use_cuvs=True
+        )
         np.testing.assert_allclose(Dref, Dnew, atol=1e-4)
         np.testing.assert_array_equal(Iref, Inew)
 

--- a/faiss/gpu/test/test_gpu_basics.py
+++ b/faiss/gpu/test/test_gpu_basics.py
@@ -3,7 +3,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import unittest
 import numpy as np
@@ -15,12 +20,12 @@ from common_faiss_tests import get_dataset_2
 class ReferencedObject(unittest.TestCase):
 
     d = 16
-    xb = np.random.rand(256, d).astype('float32')
+    xb = np.random.rand(256, d).astype("float32")
     nlist = 128
 
     d_bin = 256
-    xb_bin = np.random.randint(256, size=(10000, d_bin // 8)).astype('uint8')
-    xq_bin = np.random.randint(256, size=(1000, d_bin // 8)).astype('uint8')
+    xb_bin = np.random.randint(256, size=(10000, d_bin // 8)).astype("uint8")
+    xq_bin = np.random.randint(256, size=(1000, d_bin // 8)).astype("uint8")
 
     def test_proxy(self):
         index = faiss.IndexReplicas()
@@ -33,32 +38,33 @@ class ReferencedObject(unittest.TestCase):
 
     def test_resources(self):
         # this used to crash!
-        index = faiss.index_cpu_to_gpu(faiss.StandardGpuResources(), 0,
-                                       faiss.IndexFlatL2(self.d))
+        index = faiss.index_cpu_to_gpu(
+            faiss.StandardGpuResources(), 0, faiss.IndexFlatL2(self.d)
+        )
         index.add(self.xb)
 
     def test_flat(self):
-        index = faiss.GpuIndexFlat(faiss.StandardGpuResources(),
-                                   self.d, faiss.METRIC_L2)
+        index = faiss.GpuIndexFlat(
+            faiss.StandardGpuResources(), self.d, faiss.METRIC_L2
+        )
         index.add(self.xb)
 
     def test_ivfflat(self):
         index = faiss.GpuIndexIVFFlat(
-            faiss.StandardGpuResources(),
-            self.d, self.nlist, faiss.METRIC_L2)
+            faiss.StandardGpuResources(), self.d, self.nlist, faiss.METRIC_L2
+        )
         index.train(self.xb)
 
     def test_ivfpq(self):
         index_cpu = faiss.IndexIVFPQ(
-            faiss.IndexFlatL2(self.d),
-            self.d, self.nlist, 2, 8)
+            faiss.IndexFlatL2(self.d), self.d, self.nlist, 2, 8
+        )
         # speed up test
         index_cpu.pq.cp.niter = 2
         index_cpu.do_polysemous_training = False
         index_cpu.train(self.xb)
 
-        index = faiss.GpuIndexIVFPQ(
-            faiss.StandardGpuResources(), index_cpu)
+        index = faiss.GpuIndexIVFPQ(faiss.StandardGpuResources(), index_cpu)
         index.add(self.xb)
 
     def test_binary_flat(self):
@@ -68,8 +74,9 @@ class ReferencedObject(unittest.TestCase):
         index_ref.add(self.xb_bin)
         D_ref, I_ref = index_ref.search(self.xq_bin, k)
 
-        index = faiss.GpuIndexBinaryFlat(faiss.StandardGpuResources(),
-                                         self.d_bin)
+        index = faiss.GpuIndexBinaryFlat(
+            faiss.StandardGpuResources(), self.d_bin
+        )
         index.add(self.xb_bin)
         D, I = index.search(self.xq_bin, k)
 
@@ -89,21 +96,22 @@ class ReferencedObject(unittest.TestCase):
 
     def test_stress(self):
         # a mixture of the above, from issue #631
-        target = np.random.rand(50, 16).astype('float32')
+        target = np.random.rand(50, 16).astype("float32")
 
         index = faiss.IndexReplicas()
         size, dim = target.shape
         num_gpu = 4
         for _i in range(num_gpu):
             config = faiss.GpuIndexFlatConfig()
-            config.device = 0   # simulate on a single GPU
-            sub_index = faiss.GpuIndexFlatIP(faiss.StandardGpuResources(), dim, config)
+            config.device = 0  # simulate on a single GPU
+            sub_index = faiss.GpuIndexFlatIP(
+                faiss.StandardGpuResources(), dim, config
+            )
             index.addIndex(sub_index)
 
         index = faiss.IndexIDMap(index)
         ids = np.arange(size)
         index.add_with_ids(target, ids)
-
 
 
 class TestGPUKmeans(unittest.TestCase):
@@ -113,7 +121,7 @@ class TestGPUKmeans(unittest.TestCase):
         nb = 1000
         k = 10
         rs = np.random.RandomState(123)
-        xb = rs.rand(nb, d).astype('float32')
+        xb = rs.rand(nb, d).astype("float32")
 
         km1 = faiss.Kmeans(d, k)
         obj1 = km1.train(xb)
@@ -153,8 +161,8 @@ class TestAlternativeDistances(unittest.TestCase):
         nq = 100
 
         rs = np.random.RandomState(123)
-        xb = rs.rand(nb, d).astype('float32')
-        xq = rs.rand(nq, d).astype('float32')
+        xb = rs.rand(nb, d).astype("float32")
+        xq = rs.rand(nq, d).astype("float32")
 
         index_ref = faiss.IndexFlat(d, metric)
         index_ref.metric_arg = metric_arg
@@ -176,8 +184,8 @@ class TestAlternativeDistances(unittest.TestCase):
         np.testing.assert_array_equal(Inew, Iref)
 
     @unittest.skipIf(
-        "CUVS" in faiss.get_compile_options(),
-        "only if CUVS is not compiled in")
+        "CUVS" in faiss.get_compile_options(), "only if CUVS is not compiled in"
+    )
     def do_test_gower(self):
         """Special test for Gower distance with mixed numeric/categorical data"""
         res = faiss.StandardGpuResources()
@@ -188,16 +196,16 @@ class TestAlternativeDistances(unittest.TestCase):
         rs = np.random.RandomState(123)
 
         # Create mixed data: first half numeric [0,1], second half categorical (negative)
-        xb = np.zeros((nb, d), dtype='float32')
-        xq = np.zeros((nq, d), dtype='float32')
+        xb = np.zeros((nb, d), dtype="float32")
+        xq = np.zeros((nq, d), dtype="float32")
 
         # Numeric features in [0,1] range
-        xb[:, :d//2] = rs.rand(nb, d//2)
-        xq[:, :d//2] = rs.rand(nq, d//2)
+        xb[:, : d // 2] = rs.rand(nb, d // 2)
+        xq[:, : d // 2] = rs.rand(nq, d // 2)
 
         # Categorical features (negative integers)
-        xb[:, d//2:] = -rs.randint(1, 5, size=(nb, d//2)).astype('float32')
-        xq[:, d//2:] = -rs.randint(1, 5, size=(nq, d//2)).astype('float32')
+        xb[:, d // 2 :] = -rs.randint(1, 5, size=(nb, d // 2)).astype("float32")
+        xq[:, d // 2 :] = -rs.randint(1, 5, size=(nq, d // 2)).astype("float32")
 
         # CPU reference
         index_ref = faiss.IndexFlat(d, faiss.METRIC_GOWER)
@@ -235,7 +243,9 @@ class TestGpuRef(unittest.TestCase):
     def test_gpu_ref(self):
         # this crashes
         dim = 256
-        training_data = np.random.randint(256, size=(10000, dim // 8)).astype('uint8')
+        training_data = np.random.randint(256, size=(10000, dim // 8)).astype(
+            "uint8"
+        )
         centroids = 330
 
         def create_cpu(dim):
@@ -267,7 +277,7 @@ def make_t(num, d, clamp=False, seed=None):
 
     x = rs.rand(num, d).astype(np.float32)
     if clamp:
-        x = (x * 255).astype('uint8').astype('float32')
+        x = (x * 255).astype("uint8").astype("float32")
     return x
 
 
@@ -315,10 +325,8 @@ class TestKnn(unittest.TestCase):
 
         if vectorsMemoryLimit > 0 or queriesMemoryLimit > 0:
             faiss.bfKnn_tiling(
-                res,
-                params,
-                vectorsMemoryLimit,
-                queriesMemoryLimit)
+                res, params, vectorsMemoryLimit, queriesMemoryLimit
+            )
         else:
             faiss.bfKnn(res, params)
 
@@ -326,9 +334,16 @@ class TestKnn(unittest.TestCase):
         np.testing.assert_array_equal(out_i, ref_i)
 
         faiss.knn_gpu(
-            res, qs, xs, k, out_d, out_i, device=gpu_id,
+            res,
+            qs,
+            xs,
+            k,
+            out_d,
+            out_i,
+            device=gpu_id,
             vectorsMemoryLimit=vectorsMemoryLimit,
-            queriesMemoryLimit=queriesMemoryLimit)
+            queriesMemoryLimit=queriesMemoryLimit,
+        )
 
         np.testing.assert_allclose(ref_d, out_d, atol=1e-5)
         np.testing.assert_array_equal(out_i, ref_i)
@@ -368,8 +383,10 @@ class TestKnn(unittest.TestCase):
 
         faiss.bfKnn(res, params)
 
-        self.assertGreaterEqual((out_i_f16 == ref_i_f16).sum(), ref_i_f16.size - 5)
-        np.testing.assert_allclose(ref_d_f16, out_d_f16, atol = 2e-3)
+        self.assertGreaterEqual(
+            (out_i_f16 == ref_i_f16).sum(), ref_i_f16.size - 5
+        )
+        np.testing.assert_allclose(ref_d_f16, out_d_f16, atol=2e-3)
 
 
 class TestAllPairwiseDistance(unittest.TestCase):
@@ -382,7 +399,7 @@ class TestAllPairwiseDistance(unittest.TestCase):
             faiss.METRIC_Canberra,
             faiss.METRIC_BrayCurtis,
             faiss.METRIC_JensenShannon,
-            faiss.METRIC_Jaccard
+            faiss.METRIC_Jaccard,
         ]
 
         for metric in metrics:
@@ -409,7 +426,7 @@ class TestAllPairwiseDistance(unittest.TestCase):
             # Try f32 data/queries
             params = faiss.GpuDistanceParams()
             params.metric = metric
-            params.k = -1 # all pairwise
+            params.k = -1  # all pairwise
             params.dims = d
             params.vectors = faiss.swig_ptr(xs)
             params.numVectors = nb
@@ -429,7 +446,7 @@ class TestAllPairwiseDistance(unittest.TestCase):
             if faiss.is_similarity_metric(metric):
                 ref_d = np.sort(ref_d, axis=1)
 
-            print('f32', np.abs(ref_d - out_d).max())
+            print("f32", np.abs(ref_d - out_d).max())
 
             np.testing.assert_allclose(ref_d, out_d, atol=1e-5)
 
@@ -462,9 +479,9 @@ class TestAllPairwiseDistance(unittest.TestCase):
             if faiss.is_similarity_metric(metric):
                 ref_d_f16 = np.sort(ref_d_f16, axis=1)
 
-            print('f16', np.abs(ref_d_f16 - out_d_f16).max())
+            print("f16", np.abs(ref_d_f16 - out_d_f16).max())
 
-            np.testing.assert_allclose(ref_d_f16, out_d_f16, atol = 4e-3)
+            np.testing.assert_allclose(ref_d_f16, out_d_f16, atol=4e-3)
 
     def test_gower_pairwise(self):
         """Test Gower distance with GPU pairwise distance computation"""
@@ -474,18 +491,18 @@ class TestAllPairwiseDistance(unittest.TestCase):
         nq = 10
 
         rs = np.random.RandomState(123)
-        
+
         # Create mixed data: first half numeric [0,1], second half categorical (negative)
         xs = np.zeros((nb, d), dtype=np.float32)
         qs = np.zeros((nq, d), dtype=np.float32)
-        
+
         # Numeric features in [0,1] range
-        xs[:, :d//2] = rs.rand(nb, d//2)
-        qs[:, :d//2] = rs.rand(nq, d//2)
-        
+        xs[:, : d // 2] = rs.rand(nb, d // 2)
+        qs[:, : d // 2] = rs.rand(nq, d // 2)
+
         # Categorical features (negative integers)
-        xs[:, d//2:] = -rs.randint(1, 4, size=(nb, d//2)).astype('float32')
-        qs[:, d//2:] = -rs.randint(1, 4, size=(nq, d//2)).astype('float32')
+        xs[:, d // 2 :] = -rs.randint(1, 4, size=(nb, d // 2)).astype("float32")
+        qs[:, d // 2 :] = -rs.randint(1, 4, size=(nq, d // 2)).astype("float32")
 
         res = faiss.StandardGpuResources()
 
@@ -513,9 +530,8 @@ class TestAllPairwiseDistance(unittest.TestCase):
         # IndexFlat will sort the results, so we need to do the same on our end
         out_d = np.sort(out_d, axis=1)
 
-        print('Gower max diff:', np.abs(ref_d - out_d).max())
+        print("Gower max diff:", np.abs(ref_d - out_d).max())
         np.testing.assert_allclose(ref_d, out_d, atol=1e-5)
-
 
 
 def eval_codec(q, xb):
@@ -536,7 +552,7 @@ class TestResidualQuantizer(unittest.TestCase):
     # know there is a problem with it.
     @unittest.skip("Skipped due to ncall memory corruption.")
     def test_with_gpu(self):
-        """ check that we get the same results with a GPU quantizer and a CPU quantizer """
+        """check that we get the same results with a GPU quantizer and a CPU quantizer"""
         d = 32
         nt = 3000
         nb = 1000

--- a/faiss/gpu/test/test_gpu_index.py
+++ b/faiss/gpu/test/test_gpu_index.py
@@ -3,7 +3,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import math
 import unittest
@@ -30,8 +35,8 @@ class TestIVFSearchPreassigned(unittest.TestCase):
         idx_gpu.nprobe = nprobe
 
         rs = np.random.RandomState(567)
-        xb = rs.rand(nb, d).astype('float32')
-        xq = rs.rand(nq, d).astype('float32')
+        xb = rs.rand(nb, d).astype("float32")
+        xq = rs.rand(nq, d).astype("float32")
 
         idx_gpu.train(xb)
         idx_gpu.add(xb)
@@ -40,7 +45,8 @@ class TestIVFSearchPreassigned(unittest.TestCase):
         q_d, q_i = idx_gpu.quantizer.search(xq, nprobe)
 
         preassigned_d, preassigned_i = ivf_tools.search_preassigned(
-            idx_gpu, xq, k, q_i, q_d)
+            idx_gpu, xq, k, q_i, q_d
+        )
 
         # Search using the standard API
         d, i = idx_gpu.search(xq, k)
@@ -60,12 +66,14 @@ class TestIVFSearchPreassigned(unittest.TestCase):
 
         config = faiss.GpuIndexIVFPQConfig()
         config.use_cuvs = False
-        idx_gpu = faiss.GpuIndexIVFPQ(res, d, nlist, 4, 8, faiss.METRIC_L2, config)
+        idx_gpu = faiss.GpuIndexIVFPQ(
+            res, d, nlist, 4, 8, faiss.METRIC_L2, config
+        )
         idx_gpu.nprobe = nprobe
 
         rs = np.random.RandomState(567)
-        xb = rs.rand(nb, d).astype('float32')
-        xq = rs.rand(nq, d).astype('float32')
+        xb = rs.rand(nb, d).astype("float32")
+        xq = rs.rand(nq, d).astype("float32")
 
         idx_gpu.train(xb)
         idx_gpu.add(xb)
@@ -74,7 +82,8 @@ class TestIVFSearchPreassigned(unittest.TestCase):
         q_d, q_i = idx_gpu.quantizer.search(xq, nprobe)
 
         preassigned_d, preassigned_i = ivf_tools.search_preassigned(
-            idx_gpu, xq, k, q_i, q_d)
+            idx_gpu, xq, k, q_i, q_d
+        )
 
         # Search using the standard API
         d, i = idx_gpu.search(xq, k)
@@ -93,14 +102,17 @@ class TestIVFSearchPreassigned(unittest.TestCase):
         k = 50
 
         idx_gpu = faiss.GpuIndexIVFScalarQuantizer(
-            res, d, nlist,
+            res,
+            d,
+            nlist,
             faiss.ScalarQuantizer.QT_6bit,
-            faiss.METRIC_INNER_PRODUCT)
+            faiss.METRIC_INNER_PRODUCT,
+        )
         idx_gpu.nprobe = nprobe
 
         rs = np.random.RandomState(567)
-        xb = rs.rand(nb, d).astype('float32')
-        xq = rs.rand(nq, d).astype('float32')
+        xb = rs.rand(nb, d).astype("float32")
+        xq = rs.rand(nq, d).astype("float32")
 
         idx_gpu.train(xb)
         idx_gpu.add(xb)
@@ -109,7 +121,8 @@ class TestIVFSearchPreassigned(unittest.TestCase):
         q_d, q_i = idx_gpu.quantizer.search(xq, nprobe)
 
         preassigned_d, preassigned_i = ivf_tools.search_preassigned(
-            idx_gpu, xq, k, q_i, q_d)
+            idx_gpu, xq, k, q_i, q_d
+        )
 
         # Search using the standard API
         d, i = idx_gpu.search(xq, k)
@@ -132,8 +145,8 @@ class TestIVFPluggableCoarseQuantizer(unittest.TestCase):
         idx_cpu = faiss.IndexIVFFlat(q, d, nlist)
 
         rs = np.random.RandomState(567)
-        xb = rs.rand(nb, d).astype('float32')
-        xq = rs.rand(nq, d).astype('float32')
+        xb = rs.rand(nb, d).astype("float32")
+        xq = rs.rand(nq, d).astype("float32")
 
         idx_cpu.train(xb)
         idx_cpu.add(xb)
@@ -141,8 +154,10 @@ class TestIVFPluggableCoarseQuantizer(unittest.TestCase):
         # construct a GPU index using the same trained coarse quantizer
         # from the CPU index
         config = faiss.GpuIndexIVFFlatConfig()
-        idx_gpu = faiss.GpuIndexIVFFlat(res, q, d, nlist, faiss.METRIC_L2, config)
-        assert(idx_gpu.is_trained)
+        idx_gpu = faiss.GpuIndexIVFFlat(
+            res, q, d, nlist, faiss.METRIC_L2, config
+        )
+        assert idx_gpu.is_trained
         idx_gpu.add(xb)
 
         k = 20
@@ -154,7 +169,6 @@ class TestIVFPluggableCoarseQuantizer(unittest.TestCase):
         d_c, i_c = idx_cpu.search(xq, k)
         self.assertGreaterEqual((i_g == i_c).sum(), i_g.size * 0.9)
         self.assertTrue(np.allclose(d_g, d_c, rtol=5e-5, atol=5e-5))
-
 
     def test_ivfsq_pu_coarse(self):
         res = faiss.StandardGpuResources()
@@ -168,11 +182,12 @@ class TestIVFPluggableCoarseQuantizer(unittest.TestCase):
 
         q = faiss.IndexFlatL2(d)
         idx_cpu = faiss.IndexIVFScalarQuantizer(
-            q, d, nlist, qtype, faiss.METRIC_L2, use_residual)
+            q, d, nlist, qtype, faiss.METRIC_L2, use_residual
+        )
 
         rs = np.random.RandomState(567)
-        xb = rs.rand(nb, d).astype('float32')
-        xq = rs.rand(nq, d).astype('float32')
+        xb = rs.rand(nb, d).astype("float32")
+        xq = rs.rand(nq, d).astype("float32")
 
         idx_cpu.train(xb)
         idx_cpu.add(xb)
@@ -180,8 +195,9 @@ class TestIVFPluggableCoarseQuantizer(unittest.TestCase):
         # construct a GPU index using the same trained coarse quantizer
         # from the CPU index
         idx_gpu = faiss.GpuIndexIVFScalarQuantizer(
-            res, q, d, nlist, qtype, faiss.METRIC_L2, use_residual)
-        assert(not idx_gpu.is_trained)
+            res, q, d, nlist, qtype, faiss.METRIC_L2, use_residual
+        )
+        assert not idx_gpu.is_trained
         idx_gpu.train(xb)
         idx_gpu.add(xb)
 
@@ -208,11 +224,12 @@ class TestIVFPluggableCoarseQuantizer(unittest.TestCase):
         nprobe_lvl_2 = 10
 
         rs = np.random.RandomState(567)
-        coarse_centroids = rs.rand(nlist_lvl_2, d).astype('float32')
+        coarse_centroids = rs.rand(nlist_lvl_2, d).astype("float32")
 
         # Construct an IVFFlat index for usage as a coarse quantizer
         idx_coarse_cpu = faiss.IndexIVFFlat(
-            faiss.IndexFlatL2(d), d, nlist_lvl_1)
+            faiss.IndexFlatL2(d), d, nlist_lvl_1
+        )
         idx_coarse_cpu.set_direct_map_type(faiss.DirectMap.Hashtable)
         idx_coarse_cpu.nprobe = nprobe_lvl_1
 
@@ -220,12 +237,11 @@ class TestIVFPluggableCoarseQuantizer(unittest.TestCase):
         idx_coarse_cpu.add(coarse_centroids)
         idx_coarse_cpu.make_direct_map()
 
-        assert(idx_coarse_cpu.ntotal == nlist_lvl_2)
+        assert idx_coarse_cpu.ntotal == nlist_lvl_2
 
-        idx_cpu = faiss.IndexIVFPQ(
-            idx_coarse_cpu, d, nlist_lvl_2, 4, 8)
+        idx_cpu = faiss.IndexIVFPQ(idx_coarse_cpu, d, nlist_lvl_2, 4, 8)
 
-        xb = rs.rand(nb, d).astype('float32')
+        xb = rs.rand(nb, d).astype("float32")
         idx_cpu.train(xb)
         idx_cpu.add(xb)
         idx_cpu.nprobe = nprobe_lvl_2
@@ -235,8 +251,9 @@ class TestIVFPluggableCoarseQuantizer(unittest.TestCase):
         config = faiss.GpuIndexIVFPQConfig()
         config.use_cuvs = False
         idx_gpu = faiss.GpuIndexIVFPQ(
-            res, idx_coarse_cpu, d, nlist_lvl_2, 4, 8, faiss.METRIC_L2, config)
-        assert(not idx_gpu.is_trained)
+            res, idx_coarse_cpu, d, nlist_lvl_2, 4, 8, faiss.METRIC_L2, config
+        )
+        assert not idx_gpu.is_trained
 
         idx_gpu.train(xb)
         idx_gpu.add(xb)
@@ -248,7 +265,7 @@ class TestIVFPluggableCoarseQuantizer(unittest.TestCase):
         for use_precomputed in [False, True]:
             idx_gpu.setPrecomputedCodes(use_precomputed)
 
-            xq = rs.rand(nq, d).astype('float32')
+            xq = rs.rand(nq, d).astype("float32")
             d_g, i_g = idx_gpu.search(xq, k)
             d_c, i_c = idx_cpu.search(xq, k)
 
@@ -265,8 +282,8 @@ class TestInterleavedIVFPQLayout(unittest.TestCase):
             nq = 20
 
             rs = np.random.RandomState(123)
-            xb = rs.rand(nb, d).astype('float32')
-            xq = rs.rand(nq, d).astype('float32')
+            xb = rs.rand(nb, d).astype("float32")
+            xq = rs.rand(nq, d).astype("float32")
 
             nlist = int(math.sqrt(nb))
             sub_q = 16
@@ -274,9 +291,13 @@ class TestInterleavedIVFPQLayout(unittest.TestCase):
 
             config = faiss.GpuIndexIVFPQConfig()
             config.interleavedLayout = True
-            idx_gpu = faiss.GpuIndexIVFPQ(res, d, nlist, sub_q, bits_per_code, faiss.METRIC_L2, config)
+            idx_gpu = faiss.GpuIndexIVFPQ(
+                res, d, nlist, sub_q, bits_per_code, faiss.METRIC_L2, config
+            )
             q = faiss.IndexFlatL2(d)
-            idx_cpu = faiss.IndexIVFPQ(q, d, nlist, sub_q, bits_per_code, faiss.METRIC_L2)
+            idx_cpu = faiss.IndexIVFPQ(
+                q, d, nlist, sub_q, bits_per_code, faiss.METRIC_L2
+            )
 
             idx_gpu.train(xb)
             idx_gpu.add(xb)
@@ -309,8 +330,8 @@ class TestInterleavedIVFPQLayout(unittest.TestCase):
             nq = 20
 
             rs = np.random.RandomState(234)
-            xb = rs.rand(nb, d).astype('float32')
-            xq = rs.rand(nq, d).astype('float32')
+            xb = rs.rand(nb, d).astype("float32")
+            xq = rs.rand(nq, d).astype("float32")
 
             nlist = int(math.sqrt(nb))
             sub_q = 16
@@ -319,9 +340,13 @@ class TestInterleavedIVFPQLayout(unittest.TestCase):
 
             config = faiss.GpuIndexIVFPQConfig()
             config.interleavedLayout = True
-            idx_gpu = faiss.GpuIndexIVFPQ(res, d, nlist, sub_q, bits_per_code, faiss.METRIC_L2, config)
+            idx_gpu = faiss.GpuIndexIVFPQ(
+                res, d, nlist, sub_q, bits_per_code, faiss.METRIC_L2, config
+            )
             q = faiss.IndexFlatL2(d)
-            idx_cpu = faiss.IndexIVFPQ(q, d, nlist, sub_q, bits_per_code, faiss.METRIC_L2)
+            idx_cpu = faiss.IndexIVFPQ(
+                q, d, nlist, sub_q, bits_per_code, faiss.METRIC_L2
+            )
 
             idx_gpu.train(xb)
             idx_gpu.add(xb)
@@ -353,8 +378,8 @@ class TestInterleavedIVFPQLayout(unittest.TestCase):
             nq = 20
 
             rs = np.random.RandomState(567)
-            xb = rs.rand(nb, d).astype('float32')
-            xq = rs.rand(nq, d).astype('float32')
+            xb = rs.rand(nb, d).astype("float32")
+            xq = rs.rand(nq, d).astype("float32")
 
             nlist = int(math.sqrt(nb))
             sub_q = 16
@@ -363,9 +388,13 @@ class TestInterleavedIVFPQLayout(unittest.TestCase):
 
             config = faiss.GpuIndexIVFPQConfig()
             config.interleavedLayout = True
-            idx_gpu = faiss.GpuIndexIVFPQ(res, d, nlist, sub_q, bits_per_code, faiss.METRIC_L2, config)
+            idx_gpu = faiss.GpuIndexIVFPQ(
+                res, d, nlist, sub_q, bits_per_code, faiss.METRIC_L2, config
+            )
             q = faiss.IndexFlatL2(d)
-            idx_cpu = faiss.IndexIVFPQ(q, d, nlist, sub_q, bits_per_code, faiss.METRIC_L2)
+            idx_cpu = faiss.IndexIVFPQ(
+                q, d, nlist, sub_q, bits_per_code, faiss.METRIC_L2
+            )
 
             idx_cpu.train(xb)
             idx_cpu.add(xb)
@@ -398,11 +427,11 @@ class TestIVFIndices(unittest.TestCase):
         nlist = 10
 
         rs = np.random.RandomState(567)
-        xb = rs.rand(nb, d).astype('float32')
+        xb = rs.rand(nb, d).astype("float32")
         xb_indices_base = np.arange(nb, dtype=np.int64)
 
         # Force values to not be representable in int32
-        xb_indices = (xb_indices_base + 4294967296).astype('int64')
+        xb_indices = (xb_indices_base + 4294967296).astype("int64")
 
         config = faiss.GpuIndexIVFFlatConfig()
         idx = faiss.GpuIndexIVFFlat(res, d, nlist, faiss.METRIC_L2, config)
@@ -432,15 +461,16 @@ class TestIVFIndices(unittest.TestCase):
         nbits = 8
 
         rs = np.random.RandomState(567)
-        xb = rs.rand(nb, d).astype('float32')
+        xb = rs.rand(nb, d).astype("float32")
         xb_indices_base = np.arange(nb, dtype=np.int64)
 
         # Force values to not be representable in int32
-        xb_indices = (xb_indices_base + 4294967296).astype('int64')
+        xb_indices = (xb_indices_base + 4294967296).astype("int64")
 
         config = faiss.GpuIndexIVFPQConfig()
-        idx = faiss.GpuIndexIVFPQ(res, d, nlist, M, nbits,
-                                  faiss.METRIC_L2, config)
+        idx = faiss.GpuIndexIVFPQ(
+            res, d, nlist, M, nbits, faiss.METRIC_L2, config
+        )
         idx.train(xb)
         idx.add_with_ids(xb, xb_indices)
 
@@ -451,8 +481,9 @@ class TestIVFIndices(unittest.TestCase):
         config.indicesOptions = faiss.INDICES_32_BIT
         # 32-bit indices are not supported with cuVS
         config.use_cuvs = False
-        idx = faiss.GpuIndexIVFPQ(res, d, nlist, M, nbits,
-                                  faiss.METRIC_L2, config)
+        idx = faiss.GpuIndexIVFPQ(
+            res, d, nlist, M, nbits, faiss.METRIC_L2, config
+        )
         idx.train(xb)
         idx.add_with_ids(xb, xb_indices)
 
@@ -468,15 +499,16 @@ class TestIVFIndices(unittest.TestCase):
         qtype = faiss.ScalarQuantizer.QT_4bit
 
         rs = np.random.RandomState(567)
-        xb = rs.rand(nb, d).astype('float32')
+        xb = rs.rand(nb, d).astype("float32")
         xb_indices_base = np.arange(nb, dtype=np.int64)
 
         # Force values to not be representable in int32
-        xb_indices = (xb_indices_base + 4294967296).astype('int64')
+        xb_indices = (xb_indices_base + 4294967296).astype("int64")
 
         config = faiss.GpuIndexIVFScalarQuantizerConfig()
-        idx = faiss.GpuIndexIVFScalarQuantizer(res, d, nlist, qtype,
-                                               faiss.METRIC_L2, True, config)
+        idx = faiss.GpuIndexIVFScalarQuantizer(
+            res, d, nlist, qtype, faiss.METRIC_L2, True, config
+        )
         idx.train(xb)
         idx.add_with_ids(xb, xb_indices)
 
@@ -485,8 +517,9 @@ class TestIVFIndices(unittest.TestCase):
 
         # Store values using 32-bit indices instead
         config.indicesOptions = faiss.INDICES_32_BIT
-        idx = faiss.GpuIndexIVFScalarQuantizer(res, d, nlist, qtype,
-                                               faiss.METRIC_L2, True, config)
+        idx = faiss.GpuIndexIVFScalarQuantizer(
+            res, d, nlist, qtype, faiss.METRIC_L2, True, config
+        )
         idx.train(xb)
         idx.add_with_ids(xb, xb_indices)
 
@@ -518,15 +551,16 @@ class TestInvalidParams(unittest.TestCase):
         nbits = 8
 
         rs = np.random.RandomState(567)
-        xb = rs.rand(nb, d).astype('float32')
+        xb = rs.rand(nb, d).astype("float32")
         xb_indices_base = np.arange(nb, dtype=np.int64)
 
         # Force values to not be representable in int32
-        xb_indices = (xb_indices_base + 4294967296).astype('int64')
+        xb_indices = (xb_indices_base + 4294967296).astype("int64")
 
         config = faiss.GpuIndexIVFPQConfig()
-        idx = faiss.GpuIndexIVFPQ(res, d, nlist, M, nbits,
-                                  faiss.METRIC_L2, config)
+        idx = faiss.GpuIndexIVFPQ(
+            res, d, nlist, M, nbits, faiss.METRIC_L2, config
+        )
         idx.train(xb)
         idx.add_with_ids(xb, xb_indices)
 

--- a/faiss/gpu/test/test_gpu_index_ivfflat.py
+++ b/faiss/gpu/test/test_gpu_index_ivfflat.py
@@ -12,7 +12,7 @@ import numpy as np
 class TestGpuIndexIvfflat(unittest.TestCase):
     def test_reconstruct_n(self):
         index = faiss.index_factory(4, "IVF10,Flat")
-        x = np.random.RandomState(123).rand(10, 4).astype('float32')
+        x = np.random.RandomState(123).rand(10, 4).astype("float32")
         index.train(x)
         index.add(x)
         res = faiss.StandardGpuResources()

--- a/faiss/gpu/test/test_gpu_index_ivfsq.py
+++ b/faiss/gpu/test/test_gpu_index_ivfsq.py
@@ -11,9 +11,9 @@ import faiss
 
 def make_t(num, d, clamp=False):
     rs = np.random.RandomState(123)
-    x = rs.rand(num, d).astype('float32')
+    x = rs.rand(num, d).astype("float32")
     if clamp:
-        x = (x * 255).astype('uint8').astype('float32')
+        x = (x * 255).astype("uint8").astype("float32")
     return x
 
 
@@ -22,7 +22,8 @@ def make_indices_copy_from_cpu(nlist, d, qtype, by_residual, metric, clamp):
 
     quantizer_cp = faiss.IndexFlat(d, metric)
     idx_cpu = faiss.IndexIVFScalarQuantizer(
-        quantizer_cp, d, nlist, qtype, metric, by_residual)
+        quantizer_cp, d, nlist, qtype, metric, by_residual
+    )
 
     idx_cpu.train(to_train)
     idx_cpu.add(to_train)
@@ -44,13 +45,15 @@ def make_indices_copy_from_gpu(nlist, d, qtype, by_residual, metric, clamp):
     config = faiss.GpuIndexIVFScalarQuantizerConfig()
     config.use_cuvs = False
     idx_gpu = faiss.GpuIndexIVFScalarQuantizer(
-        res, d, nlist, qtype, metric, by_residual, config)
+        res, d, nlist, qtype, metric, by_residual, config
+    )
     idx_gpu.train(to_train)
     idx_gpu.add(to_train)
 
     quantizer_cp = faiss.IndexFlat(d, metric)
     idx_cpu = faiss.IndexIVFScalarQuantizer(
-        quantizer_cp, d, nlist, qtype, metric, by_residual)
+        quantizer_cp, d, nlist, qtype, metric, by_residual
+    )
     idx_gpu.copyTo(idx_cpu)
 
     return idx_cpu, idx_gpu
@@ -61,7 +64,8 @@ def make_indices_train(nlist, d, qtype, by_residual, metric, clamp):
 
     quantizer_cp = faiss.IndexFlat(d, metric)
     idx_cpu = faiss.IndexIVFScalarQuantizer(
-        quantizer_cp, d, nlist, qtype, metric, by_residual)
+        quantizer_cp, d, nlist, qtype, metric, by_residual
+    )
     assert by_residual == idx_cpu.by_residual
 
     idx_cpu.train(to_train)
@@ -72,13 +76,15 @@ def make_indices_train(nlist, d, qtype, by_residual, metric, clamp):
     config = faiss.GpuIndexIVFScalarQuantizerConfig()
     config.use_cuvs = False
     idx_gpu = faiss.GpuIndexIVFScalarQuantizer(
-        res, d, nlist, qtype, metric, by_residual, config)
+        res, d, nlist, qtype, metric, by_residual, config
+    )
     assert by_residual == idx_gpu.by_residual
 
     idx_gpu.train(to_train)
     idx_gpu.add(to_train)
 
     return idx_cpu, idx_gpu
+
 
 #
 # Testing functions
@@ -116,8 +122,8 @@ def compare_results(d1, i1, d2, i2):
     # Invalid results should be the same for both
     # (except if we happen to hit different centroids)
     for inv1, inv2 in zip(invalid1, invalid2):
-        if (len(inv1) != len(inv2)):
-            print('mismatch ', len(inv1), len(inv2), inv2[0])
+        if len(inv1) != len(inv2):
+            print("mismatch ", len(inv1), len(inv2), inv2[0])
 
         assert len(inv1) == len(inv2)
         idx_invalid += len(inv2)
@@ -150,8 +156,8 @@ def check_diffs(total_num, in_window_thresh, diffs, diff_inf, invalid):
         if abs(diff) <= diff_window:
             in_window += diffs[diff] / total_num
 
-    if (in_window < in_window_thresh):
-        print('error {} {}'.format(in_window, in_window_thresh))
+    if in_window < in_window_thresh:
+        print("error {} {}".format(in_window, in_window_thresh))
         assert in_window >= in_window_thresh
 
 
@@ -163,27 +169,30 @@ def do_test_with_index(ci, gi, nprobe, k, clamp, in_window_thresh):
     gi.nprobe = gi.nprobe
 
     total_num = num_query * k
-    check_diffs(total_num, in_window_thresh,
-                *compare_results(*ci.search(to_query, k),
-                                 *gi.search(to_query, k)))
+    check_diffs(
+        total_num,
+        in_window_thresh,
+        *compare_results(*ci.search(to_query, k), *gi.search(to_query, k))
+    )
 
 
 def do_test(nlist, d, qtype, by_residual, metric, nprobe, k):
-    clamp = (qtype == faiss.ScalarQuantizer.QT_8bit_direct)
-    ci, gi = make_indices_copy_from_cpu(nlist, d, qtype,
-                                        by_residual, metric, clamp)
+    clamp = qtype == faiss.ScalarQuantizer.QT_8bit_direct
+    ci, gi = make_indices_copy_from_cpu(
+        nlist, d, qtype, by_residual, metric, clamp
+    )
     # A direct copy should be much more closely in agreement
     # (except for fp accumulation order differences)
     do_test_with_index(ci, gi, nprobe, k, clamp, 0.99)
 
-    ci, gi = make_indices_copy_from_gpu(nlist, d, qtype,
-                                        by_residual, metric, clamp)
+    ci, gi = make_indices_copy_from_gpu(
+        nlist, d, qtype, by_residual, metric, clamp
+    )
     # A direct copy should be much more closely in agreement
     # (except for fp accumulation order differences)
     do_test_with_index(ci, gi, nprobe, k, clamp, 0.99)
 
-    ci, gi = make_indices_train(nlist, d, qtype,
-                                by_residual, metric, clamp)
+    ci, gi = make_indices_train(nlist, d, qtype, by_residual, metric, clamp)
     # Separate training can produce a slightly different coarse quantizer
     # and residuals
     do_test_with_index(ci, gi, nprobe, k, clamp, 0.8)
@@ -195,14 +204,15 @@ def do_multi_test(qtype):
     k = 50
 
     for d in [11, 64, 77]:
-        if (qtype != faiss.ScalarQuantizer.QT_8bit_direct):
+        if qtype != faiss.ScalarQuantizer.QT_8bit_direct:
             # residual doesn't make sense here
-            do_test(nlist, d, qtype, True,
-                    faiss.METRIC_L2, nprobe, k)
-            do_test(nlist, d, qtype, True,
-                    faiss.METRIC_INNER_PRODUCT, nprobe, k)
+            do_test(nlist, d, qtype, True, faiss.METRIC_L2, nprobe, k)
+            do_test(
+                nlist, d, qtype, True, faiss.METRIC_INNER_PRODUCT, nprobe, k
+            )
         do_test(nlist, d, qtype, False, faiss.METRIC_L2, nprobe, k)
         do_test(nlist, d, qtype, False, faiss.METRIC_INNER_PRODUCT, nprobe, k)
+
 
 #
 # Test

--- a/faiss/gpu/test/test_gpu_index_refs.py
+++ b/faiss/gpu/test/test_gpu_index_refs.py
@@ -80,8 +80,8 @@ class TestRefs(unittest.TestCase):
 
     def test_GpuIndexIVFPQ(self):
         index_to_delete = faiss.IndexIVFPQ(
-            faiss.IndexFlatL2(self.d),
-            self.d, self.nlist, 2, 8)
+            faiss.IndexFlatL2(self.d), self.d, self.nlist, 2, 8
+        )
         idx = faiss.GpuIndexIVFPQ(self.res, index_to_delete)
         do_multi_test(idx, index_to_delete, self.db)
 
@@ -92,7 +92,7 @@ class TestRefs(unittest.TestCase):
             self.nlist,
             faiss.ScalarQuantizer.QT_8bit_direct,
             faiss.METRIC_L2,
-            False
+            False,
         )
         idx = faiss.GpuIndexIVFScalarQuantizer(self.res, index_to_delete)
         do_multi_test(idx, index_to_delete, self.db)

--- a/faiss/gpu/test/test_gpu_index_serialize.py
+++ b/faiss/gpu/test/test_gpu_index_serialize.py
@@ -10,7 +10,7 @@ import faiss
 
 def make_t(num, d):
     rs = np.random.RandomState(123)
-    return rs.rand(num, d).astype('float32')
+    return rs.rand(num, d).astype("float32")
 
 
 class TestGpuSerialize(unittest.TestCase):
@@ -38,10 +38,22 @@ class TestGpuSerialize(unittest.TestCase):
         # IVFSQ
         config = faiss.GpuIndexIVFScalarQuantizerConfig()
         config.use_cuvs = False
-        indexes.append(faiss.GpuIndexIVFScalarQuantizer(res, d, nlist, faiss.ScalarQuantizer.QT_fp16, faiss.METRIC_L2, True, config))
+        indexes.append(
+            faiss.GpuIndexIVFScalarQuantizer(
+                res,
+                d,
+                nlist,
+                faiss.ScalarQuantizer.QT_fp16,
+                faiss.METRIC_L2,
+                True,
+                config,
+            )
+        )
 
         # IVFPQ
-        indexes.append(faiss.GpuIndexIVFPQ(res, d, nlist, 4, 8, faiss.METRIC_L2))
+        indexes.append(
+            faiss.GpuIndexIVFPQ(res, d, nlist, 4, 8, faiss.METRIC_L2)
+        )
 
         for index in indexes:
             index.train(train)
@@ -51,11 +63,13 @@ class TestGpuSerialize(unittest.TestCase):
 
             ser = faiss.serialize_index(faiss.index_gpu_to_cpu(index))
             cpu_index = faiss.deserialize_index(ser)
-             
+
             gpu_cloner_options = faiss.GpuClonerOptions()
             if isinstance(index, faiss.GpuIndexIVFScalarQuantizer):
                 gpu_cloner_options.use_cuvs = False
-            gpu_index_restore = faiss.index_cpu_to_gpu(res, 0, cpu_index, gpu_cloner_options)
+            gpu_index_restore = faiss.index_cpu_to_gpu(
+                res, 0, cpu_index, gpu_cloner_options
+            )
 
             restore_d, restore_i = gpu_index_restore.search(query, k)
 

--- a/faiss/gpu/test/test_index_cpu_to_gpu.py
+++ b/faiss/gpu/test/test_index_cpu_to_gpu.py
@@ -17,7 +17,7 @@ class TestMoveToGpu(unittest.TestCase):
     def create_index(self, factory_string):
         dimension = 128
         n = 2500
-        db_vectors = np.random.random((n, dimension)).astype('float32')
+        db_vectors = np.random.random((n, dimension)).astype("float32")
         index = faiss.index_factory(dimension, factory_string)
         index.train(db_vectors)
         if factory_string.startswith("IDMap"):
@@ -26,9 +26,9 @@ class TestMoveToGpu(unittest.TestCase):
             index.add(db_vectors)
         return index
 
-    def create_and_clone(self, factory_string,
-                         allowCpuCoarseQuantizer=None,
-                         use_cuvs=None):
+    def create_and_clone(
+        self, factory_string, allowCpuCoarseQuantizer=None, use_cuvs=None
+    ):
         idx = self.create_index(factory_string)
         config = faiss.GpuClonerOptions()
         if allowCpuCoarseQuantizer is not None:
@@ -42,20 +42,25 @@ class TestMoveToGpu(unittest.TestCase):
             self.create_and_clone(factory_string)
         except Exception as e:
             if "not implemented" not in str(e):
-                self.fail("Expected an exception but no exception was "
-                          "thrown for factory_string: %s." % factory_string)
+                self.fail(
+                    "Expected an exception but no exception was "
+                    "thrown for factory_string: %s." % factory_string
+                )
 
-    def verify_clones_successfully(self, factory_string,
-                                   allowCpuCoarseQuantizer=None,
-                                   use_cuvs=None):
+    def verify_clones_successfully(
+        self, factory_string, allowCpuCoarseQuantizer=None, use_cuvs=None
+    ):
         try:
             self.create_and_clone(
                 factory_string,
                 allowCpuCoarseQuantizer=allowCpuCoarseQuantizer,
-                use_cuvs=use_cuvs)
+                use_cuvs=use_cuvs,
+            )
         except Exception as e:
-            self.fail("Unexpected exception thrown factory_string: "
-                      "%s; error message: %s." % (factory_string, str(e)))
+            self.fail(
+                "Unexpected exception thrown factory_string: "
+                "%s; error message: %s." % (factory_string, str(e))
+            )
 
     def test_not_implemented_indices(self):
         self.verify_throws_not_implemented_exception("PQ16")
@@ -76,19 +81,21 @@ class TestMoveToGpu(unittest.TestCase):
 
         # set use_cuvs to false, these index types are not supported on cuVS
         self.verify_clones_successfully("IVF32,SQ8", use_cuvs=False)
-        self.verify_clones_successfully(
-            "PCA32,IVF32,SQ8", use_cuvs=False)
+        self.verify_clones_successfully("PCA32,IVF32,SQ8", use_cuvs=False)
 
     def test_with_flag(self):
-        self.verify_clones_successfully("IVF32_HNSW,Flat",
-                                        allowCpuCoarseQuantizer=True)
-        self.verify_clones_successfully("IVF256(PQ2x4fs),Flat",
-                                        allowCpuCoarseQuantizer=True)
+        self.verify_clones_successfully(
+            "IVF32_HNSW,Flat", allowCpuCoarseQuantizer=True
+        )
+        self.verify_clones_successfully(
+            "IVF256(PQ2x4fs),Flat", allowCpuCoarseQuantizer=True
+        )
 
     def test_with_flag_set_to_false(self):
         try:
-            self.verify_clones_successfully("IVF32_HNSW,Flat",
-                                            allowCpuCoarseQuantizer=False)
+            self.verify_clones_successfully(
+                "IVF32_HNSW,Flat", allowCpuCoarseQuantizer=False
+            )
         except Exception as e:
             if "set the flag to true to allow the CPU fallback" not in str(e):
                 self.fail("Unexepected error message thrown: %s." % str(e))

--- a/faiss/gpu/test/test_lut_dtype_binding.py
+++ b/faiss/gpu/test/test_lut_dtype_binding.py
@@ -9,8 +9,8 @@ import faiss
 
 
 @unittest.skipIf(
-    "CUVS" not in faiss.get_compile_options(),
-    "only if cuVS is compiled in")
+    "CUVS" not in faiss.get_compile_options(), "only if cuVS is compiled in"
+)
 class TestIVFPQSearchCagraConfigDtypes(unittest.TestCase):
     """Regression tests for the SWIG int typemap on cudaDataType_t.
 

--- a/faiss/gpu/test/test_multi_gpu.py
+++ b/faiss/gpu/test/test_multi_gpu.py
@@ -21,8 +21,8 @@ class TestShardedFlat(unittest.TestCase):
         nq = 200
         k = 10
         rs = np.random.RandomState(123)
-        xb = rs.rand(nb, d).astype('float32')
-        xq = rs.rand(nq, d).astype('float32')
+        xb = rs.rand(nb, d).astype("float32")
+        xq = rs.rand(nq, d).astype("float32")
 
         index_cpu = faiss.IndexFlatL2(d)
 
@@ -58,10 +58,11 @@ class TestShardedFlat(unittest.TestCase):
     def do_test_sharded_ivf(self, index_key):
         ds = SyntheticDataset(32, 8000, 10000, 100)
         index = faiss.index_factory(ds.d, index_key)
-        if 'HNSW' in index_key:
+        if "HNSW" in index_key:
             # make a bit more reproducible...
             faiss.ParameterSpace().set_index_parameter(
-                index, 'quantizer_efSearch', 40)
+                index, "quantizer_efSearch", 40
+            )
         index.train(ds.get_train())
         index.add(ds.get_database())
         Dref, Iref = index.search(ds.get_queries(), 10)
@@ -83,7 +84,7 @@ class TestShardedFlat(unittest.TestCase):
         np.testing.assert_array_almost_equal(Dref, Dnew, decimal=4)
 
         # the nprobe is taken from the sub-indexes
-        faiss.GpuParameterSpace().set_index_parameter(index, 'nprobe', 8)
+        faiss.GpuParameterSpace().set_index_parameter(index, "nprobe", 8)
         Dnew8, Inew8 = index.search(ds.get_queries(), 10)
         np.testing.assert_array_equal(Iref8, Inew8)
         np.testing.assert_array_almost_equal(Dref8, Dnew8, decimal=4)
@@ -154,14 +155,13 @@ class EvalIVFPQAccuracy(unittest.TestCase):
         qc = q[:d1, :]
 
         def make_mat(n):
-            return np.dot(
-                np.random.random(size=(nb, d1)), qc).astype('float32')
+            return np.dot(np.random.random(size=(nb, d1)), qc).astype("float32")
 
         return (make_mat(nt), make_mat(nb), make_mat(nq))
 
     def test_mm(self):
         # trouble with MKL+fbmake that appears only at runtime. Check it here
-        x = np.random.random(size=(100, 20)).astype('float32')
+        x = np.random.random(size=(100, 20)).astype("float32")
         mat = faiss.PCAMatrix(20, 10)
         mat.train(x)
         mat.apply_py(x)
@@ -185,7 +185,7 @@ class EvalIVFPQAccuracy(unittest.TestCase):
         # adding some ids because there was a bug in this case;
         # those need to be cast to idx_t(= int64_t), because
         # on windows the numpy int default is int32
-        ids = (np.arange(nb) * 3 + 12345).astype('int64')
+        ids = (np.arange(nb) * 3 + 12345).astype("int64")
         index.add_with_ids(xb, ids)
         ts.append(time.time())
 
@@ -203,15 +203,15 @@ class EvalIVFPQAccuracy(unittest.TestCase):
         mem_info = res.getMemoryInfo()
 
         assert isinstance(mem_info, dict)
-        assert isinstance(mem_info[0]['FlatData'], tuple)
-        assert isinstance(mem_info[0]['FlatData'][0], int)
-        assert isinstance(mem_info[0]['FlatData'][1], int)
+        assert isinstance(mem_info[0]["FlatData"], tuple)
+        assert isinstance(mem_info[0]["FlatData"][0], int)
+        assert isinstance(mem_info[0]["FlatData"][1], int)
 
         gpu_index.nprobe = 4
 
         Dnew, Inew = gpu_index.search(xq, 10)
         ts.append(time.time())
-        print('times:', [t - ts[0] for t in ts])
+        print("times:", [t - ts[0] for t in ts])
 
         # Give us some margin of error
         self.assertGreaterEqual((Iref == Inew).sum(), Iref.size - 50)
@@ -230,7 +230,8 @@ class EvalIVFPQAccuracy(unittest.TestCase):
             gpu_index = faiss.index_cpu_to_gpu_multiple_py(res, index, co)
 
             faiss.GpuParameterSpace().set_index_parameter(
-                gpu_index, 'nprobe', 4)
+                gpu_index, "nprobe", 4
+            )
 
             Dnew, Inew = gpu_index.search(xq, 10)
 
@@ -239,10 +240,10 @@ class EvalIVFPQAccuracy(unittest.TestCase):
             self.assertGreaterEqual((Iref == Inew).sum(), Iref.size * 0.99)
 
     def test_cpu_to_gpu_IVFPQ(self):
-        self.do_cpu_to_gpu('IVF128,PQ4')
+        self.do_cpu_to_gpu("IVF128,PQ4")
 
     def test_cpu_to_gpu_IVFFlat(self):
-        self.do_cpu_to_gpu('IVF128,Flat')
+        self.do_cpu_to_gpu("IVF128,Flat")
 
     def test_set_gpu_param(self):
         index = faiss.index_factory(12, "PCAR8,IVF10,PQ4")

--- a/faiss/gpu/test/torch_test_contrib_gpu.py
+++ b/faiss/gpu/test/torch_test_contrib_gpu.py
@@ -14,7 +14,7 @@ from faiss.contrib.torch import clustering
 
 
 def to_column_major_torch(x):
-    if hasattr(torch, 'contiguous_format'):
+    if hasattr(torch, "contiguous_format"):
         return x.t().clone(memory_format=torch.contiguous_format).t()
     else:
         # was default setting before memory_format was introduced
@@ -35,7 +35,9 @@ class TestTorchUtilsGPU(unittest.TestCase):
         cpu_index.add(xb_torch.numpy())
 
         # Add to CPU index with torch GPU (should fail)
-        xb_torch_gpu = torch.rand(10000, 128, device=torch.device('cuda', 0), dtype=torch.float32)
+        xb_torch_gpu = torch.rand(
+            10000, 128, device=torch.device("cuda", 0), dtype=torch.float32
+        )
         with self.assertRaises(AssertionError):
             cpu_index.add(xb_torch_gpu)
 
@@ -59,8 +61,12 @@ class TestTorchUtilsGPU(unittest.TestCase):
         self.assertTrue(torch.equal(i_torch_cpu.cuda(), i_torch_gpu))
 
         # Search with torch GPU using pre-allocated arrays
-        new_d_torch_gpu = torch.zeros(10, 10, device=torch.device('cuda', 0), dtype=torch.float32)
-        new_i_torch_gpu = torch.zeros(10, 10, device=torch.device('cuda', 0), dtype=torch.int64)
+        new_d_torch_gpu = torch.zeros(
+            10, 10, device=torch.device("cuda", 0), dtype=torch.float32
+        )
+        new_i_torch_gpu = torch.zeros(
+            10, 10, device=torch.device("cuda", 0), dtype=torch.int64
+        )
         gpu_index.search(xq_torch_gpu, 10, new_d_torch_gpu, new_i_torch_gpu)
 
         self.assertTrue(torch.equal(d_torch_cpu.cuda(), new_d_torch_gpu))
@@ -87,10 +93,17 @@ class TestTorchUtilsGPU(unittest.TestCase):
         config.use_cuvs = False
 
         index = faiss.GpuIndexIVFFlat(res, d, nlist, faiss.METRIC_L2, config)
-        xb = torch.rand(1000, d, device=torch.device('cuda', 0), dtype=torch.float32)
+        xb = torch.rand(
+            1000, d, device=torch.device("cuda", 0), dtype=torch.float32
+        )
         index.train(xb)
 
-        ids = torch.arange(1000, 1000 + xb.shape[0], device=torch.device('cuda', 0), dtype=torch.int64)
+        ids = torch.arange(
+            1000,
+            1000 + xb.shape[0],
+            device=torch.device("cuda", 0),
+            dtype=torch.int64,
+        )
 
         # Test add_with_ids with torch gpu
         index.add_with_ids(xb, ids)
@@ -124,7 +137,9 @@ class TestTorchUtilsGPU(unittest.TestCase):
         res.noTempMemory()
         index = faiss.GpuIndexFlatL2(res, d)
 
-        xb = torch.rand(100, d, device=torch.device('cuda', 0), dtype=torch.float32)
+        xb = torch.rand(
+            100, d, device=torch.device("cuda", 0), dtype=torch.float32
+        )
         index.add(xb)
 
         # Test reconstruct with torch gpu (native return)
@@ -133,7 +148,7 @@ class TestTorchUtilsGPU(unittest.TestCase):
         self.assertTrue(torch.equal(xb[7], y))
 
         # Test reconstruct with numpy output provided
-        y = np.empty(d, dtype='float32')
+        y = np.empty(d, dtype="float32")
         index.reconstruct(11, y)
         self.assertTrue(np.array_equal(xb.cpu().numpy()[11], y))
 
@@ -143,7 +158,7 @@ class TestTorchUtilsGPU(unittest.TestCase):
         self.assertTrue(torch.equal(xb[12].cpu(), y))
 
         # Test reconstruct with torch gpu output providesd
-        y = torch.empty(d, device=torch.device('cuda', 0), dtype=torch.float32)
+        y = torch.empty(d, device=torch.device("cuda", 0), dtype=torch.float32)
         index.reconstruct(13, y)
         self.assertTrue(torch.equal(xb[13], y))
 
@@ -153,7 +168,7 @@ class TestTorchUtilsGPU(unittest.TestCase):
         self.assertTrue(torch.equal(xb[10:20], y))
 
         # Test reconstruct with numpy output provided
-        y = np.empty((10, d), dtype='float32')
+        y = np.empty((10, d), dtype="float32")
         index.reconstruct_n(20, 10, y)
         self.assertTrue(np.array_equal(xb.cpu().numpy()[20:30], y))
 
@@ -163,7 +178,9 @@ class TestTorchUtilsGPU(unittest.TestCase):
         self.assertTrue(torch.equal(xb[40:50].cpu(), y))
 
         # Test reconstruct_n with torch gpu output provided
-        y = torch.empty(10, d, device=torch.device('cuda', 0), dtype=torch.float32)
+        y = torch.empty(
+            10, d, device=torch.device("cuda", 0), dtype=torch.float32
+        )
         index.reconstruct_n(50, 10, y)
         self.assertTrue(torch.equal(xb[50:60], y))
 
@@ -177,7 +194,9 @@ class TestTorchUtilsGPU(unittest.TestCase):
 
         index = faiss.GpuIndexIVFFlat(res, d, nlist, faiss.METRIC_L2, config)
 
-        xb = torch.rand(100, d, device=torch.device('cuda', 0), dtype=torch.float32)
+        xb = torch.rand(
+            100, d, device=torch.device("cuda", 0), dtype=torch.float32
+        )
         index.train(xb)
         index.add(xb)
 
@@ -187,7 +206,7 @@ class TestTorchUtilsGPU(unittest.TestCase):
         self.assertTrue(torch.equal(xb[10:20], y))
 
         # Test reconstruct with numpy output provided
-        y = np.empty((10, d), dtype='float32')
+        y = np.empty((10, d), dtype="float32")
         index.reconstruct_n(20, 10, y)
         self.assertTrue(np.array_equal(xb.cpu().numpy()[20:30], y))
 
@@ -197,7 +216,9 @@ class TestTorchUtilsGPU(unittest.TestCase):
         self.assertTrue(torch.equal(xb[40:50].cpu(), y))
 
         # Test reconstruct_n with torch gpu output provided
-        y = torch.empty(10, d, device=torch.device('cuda', 0), dtype=torch.float32)
+        y = torch.empty(
+            10, d, device=torch.device("cuda", 0), dtype=torch.float32
+        )
         index.reconstruct_n(50, 10, y)
         self.assertTrue(torch.equal(xb[50:60], y))
 
@@ -208,7 +229,9 @@ class TestTorchUtilsGPU(unittest.TestCase):
         res.noTempMemory()
 
         index = faiss.GpuIndexFlatL2(res, d)
-        xb = torch.rand(10000, d, device=torch.device('cuda', 0), dtype=torch.float32)
+        xb = torch.rand(
+            10000, d, device=torch.device("cuda", 0), dtype=torch.float32
+        )
         index.add(xb)
 
         index_cpu = faiss.IndexFlatL2(d)
@@ -216,7 +239,9 @@ class TestTorchUtilsGPU(unittest.TestCase):
 
         # Test assign with native gpu output
         # both input as gpu torch and input as cpu torch
-        xq = torch.rand(10, d, device=torch.device('cuda', 0), dtype=torch.float32)
+        xq = torch.rand(
+            10, d, device=torch.device("cuda", 0), dtype=torch.float32
+        )
 
         labels = index.assign(xq, 5)
         labels_cpu = index_cpu.assign(xq.cpu(), 5)
@@ -228,7 +253,7 @@ class TestTorchUtilsGPU(unittest.TestCase):
         self.assertTrue(np.array_equal(labels, labels_cpu))
 
         # Test assign with numpy output provided
-        labels = np.empty((xq.shape[0], 5), dtype='int64')
+        labels = np.empty((xq.shape[0], 5), dtype="int64")
         index.assign(xq.cpu().numpy(), 5, labels)
         self.assertTrue(np.array_equal(labels, labels_cpu))
 
@@ -300,7 +325,9 @@ class TestTorchUtilsKnnGpu(unittest.TestCase):
                     D, I = faiss.knn_gpu(res, xq_c, xb_c, k, use_cuvs=use_cuvs)
 
                     self.assertTrue(torch.equal(torch.from_numpy(I), gt_I))
-                    self.assertLess((torch.from_numpy(D) - gt_D).abs().max(), 1e-4)
+                    self.assertLess(
+                        (torch.from_numpy(D) - gt_D).abs().max(), 1e-4
+                    )
 
             # test torch (cpu, gpu) inputs
             for is_cuda in True, False:
@@ -323,7 +350,9 @@ class TestTorchUtilsKnnGpu(unittest.TestCase):
                             xb_c = to_column_major_torch(xb)
                             assert not xb_c.is_contiguous()
 
-                        D, I = faiss.knn_gpu(res, xq_c, xb_c, k, use_cuvs=use_cuvs)
+                        D, I = faiss.knn_gpu(
+                            res, xq_c, xb_c, k, use_cuvs=use_cuvs
+                        )
 
                         self.assertTrue(torch.equal(I.cpu(), gt_I))
                         self.assertLess((D.cpu() - gt_D).abs().max(), 1e-4)
@@ -331,7 +360,9 @@ class TestTorchUtilsKnnGpu(unittest.TestCase):
                         # test on subset
                         try:
                             # This internally uses the current pytorch stream
-                            D, I = faiss.knn_gpu(res, xq_c[6:8], xb_c, k, use_cuvs=use_cuvs)
+                            D, I = faiss.knn_gpu(
+                                res, xq_c[6:8], xb_c, k, use_cuvs=use_cuvs
+                            )
                         except TypeError:
                             if not xq_row_major:
                                 # then it is expected
@@ -343,8 +374,8 @@ class TestTorchUtilsKnnGpu(unittest.TestCase):
                         self.assertLess((D.cpu() - gt_D[6:8]).abs().max(), 1e-4)
 
     @unittest.skipUnless(
-        "CUVS" in faiss.get_compile_options(),
-        "only if CUVS is compiled in")
+        "CUVS" in faiss.get_compile_options(), "only if CUVS is compiled in"
+    )
     def test_knn_gpu_cuvs(self):
         self.test_knn_gpu(use_cuvs=True)
 
@@ -434,7 +465,9 @@ class TestTorchUtilsPairwiseDistanceGpu(unittest.TestCase):
                     # do the same on our end
                     D = np.sort(D, axis=1)
 
-                    self.assertLess((torch.from_numpy(D) - gt_D).abs().max(), 1e-4)
+                    self.assertLess(
+                        (torch.from_numpy(D) - gt_D).abs().max(), 1e-4
+                    )
 
             # test torch (cpu, gpu) inputs
             for is_cuda in True, False:
@@ -468,7 +501,9 @@ class TestTorchUtilsPairwiseDistanceGpu(unittest.TestCase):
                         # test on subset
                         try:
                             # This internally uses the current pytorch stream
-                            D = faiss.pairwise_distance_gpu(res, xq_c[4:8], xb_c)
+                            D = faiss.pairwise_distance_gpu(
+                                res, xq_c[4:8], xb_c
+                            )
                         except TypeError:
                             if not xq_row_major:
                                 # then it is expected
@@ -487,7 +522,7 @@ class TestTorchUtilsPairwiseDistanceGpu(unittest.TestCase):
 class TestClustering(unittest.TestCase):
 
     def test_python_kmeans(self):
-        """ Test the python implementation of kmeans """
+        """Test the python implementation of kmeans"""
         ds = datasets.SyntheticDataset(32, 10000, 0, 0)
         x = ds.get_train()
 

--- a/faiss/gpu_metal/test/test_metal_python.py
+++ b/faiss/gpu_metal/test/test_metal_python.py
@@ -123,7 +123,8 @@ class TestMetalIVFFlat(unittest.TestCase):
 
         quantizer = faiss.IndexFlatIP(d)
         cpu_index = faiss.IndexIVFFlat(
-            quantizer, d, nlist, faiss.METRIC_INNER_PRODUCT)
+            quantizer, d, nlist, faiss.METRIC_INNER_PRODUCT
+        )
         cpu_index.nprobe = nprobe
         cpu_index.train(xb)
         cpu_index.add(xb)

--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -68,9 +68,9 @@ def _preload_gpu_libs():
     # Order matters: libcudart provides symbols that libcublas* / libcurand depend on.
     _LIBS = [
         (nvidia.cuda_runtime, "libcudart.so.12"),
-        (nvidia.cublas,       "libcublas.so.12"),
-        (nvidia.cublas,       "libcublasLt.so.12"),
-        (nvidia.curand,       "libcurand.so.10"),
+        (nvidia.cublas, "libcublas.so.12"),
+        (nvidia.cublas, "libcublasLt.so.12"),
+        (nvidia.curand, "libcurand.so.10"),
     ]
     for pkg, soname in _LIBS:
         # Use __path__[0] not __file__ — the nvidia-*-cu12 wheels are PEP 420
@@ -98,16 +98,37 @@ from .loader import *
 from faiss import class_wrappers
 from faiss.gpu_wrappers import *
 from faiss.array_conversions import *
-from faiss.extra_wrappers import kmin, kmax, pairwise_distances, rand, randint, \
-    lrand, randn, rand_smooth_vectors, eval_intersection, normalize_L2, \
-    ResultHeap, knn, Kmeans, SuperKmeans, checksum, matrix_bucket_sort_inplace, \
-    bucket_sort, merge_knn_results, MapInt64ToInt64, knn_hamming, \
-    pack_bitstrings, unpack_bitstrings
+from faiss.extra_wrappers import (
+    kmin,
+    kmax,
+    pairwise_distances,
+    rand,
+    randint,
+    lrand,
+    randn,
+    rand_smooth_vectors,
+    eval_intersection,
+    normalize_L2,
+    ResultHeap,
+    knn,
+    Kmeans,
+    SuperKmeans,
+    checksum,
+    matrix_bucket_sort_inplace,
+    bucket_sort,
+    merge_knn_results,
+    MapInt64ToInt64,
+    knn_hamming,
+    pack_bitstrings,
+    unpack_bitstrings,
+)
 
 
-__version__ = "%d.%d.%d" % (FAISS_VERSION_MAJOR,
-                            FAISS_VERSION_MINOR,
-                            FAISS_VERSION_PATCH)
+__version__ = "%d.%d.%d" % (
+    FAISS_VERSION_MAJOR,
+    FAISS_VERSION_MINOR,
+    FAISS_VERSION_PATCH,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +144,9 @@ class_wrappers.handle_NSG(IndexNSG)
 class_wrappers.handle_MapLong2Long(MapLong2Long)
 class_wrappers.handle_IDSelectorSubset(IDSelectorBatch, class_owns=True)
 class_wrappers.handle_IDSelectorSubset(IDSelectorArray, class_owns=False)
-class_wrappers.handle_IDSelectorSubset(IDSelectorBitmap, class_owns=False, force_int64=False)
+class_wrappers.handle_IDSelectorSubset(
+    IDSelectorBitmap, class_owns=False, force_int64=False
+)
 class_wrappers.handle_CodeSet(CodeSet)
 
 class_wrappers.handle_Tensor2D(Tensor2D)
@@ -132,7 +155,9 @@ class_wrappers.handle_Embedding(Embedding)
 class_wrappers.handle_Linear(Linear)
 class_wrappers.handle_QINCo(QINCo)
 class_wrappers.handle_QINCoStep(QINCoStep)
-shard_ivf_index_centroids = class_wrappers.handle_shard_ivf_index_centroids(shard_ivf_index_centroids)
+shard_ivf_index_centroids = class_wrappers.handle_shard_ivf_index_centroids(
+    shard_ivf_index_centroids
+)
 
 
 this_module = sys.modules[__name__]
@@ -155,8 +180,9 @@ for symbol in dir(this_module):
         if issubclass(the_class, Quantizer):
             class_wrappers.handle_Quantizer(the_class)
 
-        if issubclass(the_class, IndexRowwiseMinMax) or \
-                issubclass(the_class, IndexRowwiseMinMaxFP16):
+        if issubclass(the_class, IndexRowwiseMinMax) or issubclass(
+            the_class, IndexRowwiseMinMaxFP16
+        ):
             class_wrappers.handle_IndexRowwiseMinMax(the_class)
 
         if issubclass(the_class, SearchParameters):
@@ -197,8 +223,9 @@ def add_ref_in_constructor(the_class, parameter_no):
     else:
         the_class.__init__ = replacement_init
 
+
 def add_to_referenced_objects(self, ref):
-    if not hasattr(self, 'referenced_objects'):
+    if not hasattr(self, "referenced_objects"):
         self.referenced_objects = [ref]
     else:
         self.referenced_objects.append(ref)
@@ -211,6 +238,7 @@ def add_ref_in_method(the_class, method_name, parameter_no):
         ref = args[parameter_no]
         add_to_referenced_objects(self, ref)
         return original_method(self, *args)
+
     setattr(the_class, method_name, replacement_method)
 
 
@@ -220,7 +248,7 @@ def add_ref_in_method_explicit_own(the_class, method_name):
 
     def replacement_method(self, ref, own=False):
         if not own:
-            if not hasattr(self, 'referenced_objects'):
+            if not hasattr(self, "referenced_objects"):
                 self.referenced_objects = [ref]
             else:
                 self.referenced_objects.append(ref)
@@ -228,6 +256,7 @@ def add_ref_in_method_explicit_own(the_class, method_name):
             # transfer ownership to C++ class
             ref.this.disown()
         return original_method(self, ref, own)
+
     setattr(the_class, method_name, replacement_method)
 
 
@@ -240,6 +269,7 @@ def add_ref_in_function(function_name, parameter_no):
         ref = args[parameter_no]
         result.referenced_objects = [ref]
         return result
+
     setattr(this_module, function_name, replacement_function)
 
 
@@ -254,7 +284,7 @@ add_ref_in_constructor(IndexIVFFlat, 0)
 add_ref_in_constructor(IndexIVFFlatDedup, 0)
 add_ref_in_constructor(IndexIVFFlatPanorama, 0)
 add_ref_in_constructor(IndexPreTransform, {2: [0, 1], 1: [0]})
-add_ref_in_method(IndexPreTransform, 'prepend_transform', 0)
+add_ref_in_method(IndexPreTransform, "prepend_transform", 0)
 add_ref_in_constructor(IndexIVFPQ, 0)
 add_ref_in_constructor(IndexIVFPQR, 0)
 add_ref_in_constructor(IndexIVFPQFastScan, 0)
@@ -273,8 +303,8 @@ add_ref_in_constructor(IndexRowwiseMinMaxFP16, 0)
 add_ref_in_constructor(IndexIDMap, 0)
 add_ref_in_constructor(IndexIDMap2, 0)
 add_ref_in_constructor(IndexHNSW, 0)
-add_ref_in_method(IndexShards, 'add_shard', 0)
-add_ref_in_method(IndexBinaryShards, 'add_shard', 0)
+add_ref_in_method(IndexShards, "add_shard", 0)
+add_ref_in_method(IndexBinaryShards, "add_shard", 0)
 add_ref_in_constructor(IndexRefineFlat, {2: [0], 1: [0]})
 add_ref_in_constructor(IndexRefinePanorama, {2: [0, 1]})
 add_ref_in_constructor(IndexRefine, {2: [0, 1]})
@@ -284,8 +314,8 @@ add_ref_in_constructor(IndexBinaryFromFloat, 0)
 add_ref_in_constructor(IndexBinaryIDMap, 0)
 add_ref_in_constructor(IndexBinaryIDMap2, 0)
 
-add_ref_in_method(IndexReplicas, 'addIndex', 0)
-add_ref_in_method(IndexBinaryReplicas, 'addIndex', 0)
+add_ref_in_method(IndexReplicas, "addIndex", 0)
+add_ref_in_method(IndexBinaryReplicas, "addIndex", 0)
 
 add_ref_in_constructor(BufferedIOWriter, 0)
 add_ref_in_constructor(BufferedIOReader, 0)
@@ -320,7 +350,7 @@ search_with_parameters_c = search_with_parameters
 
 
 def search_with_parameters(index, x, k, params=None, output_stats=False):
-    x = np.ascontiguousarray(x, dtype='float32')
+    x = np.ascontiguousarray(x, dtype="float32")
     n, d = x.shape
     assert d == index.d
     if not params:
@@ -329,24 +359,29 @@ def search_with_parameters(index, x, k, params=None, output_stats=False):
         index_ivf = extract_index_ivf(index)
         params.nprobe = index_ivf.nprobe
         params.max_codes = index_ivf.max_codes
-    nb_dis = np.empty(1, 'uint64')
-    ms_per_stage = np.empty(3, 'float64')
+    nb_dis = np.empty(1, "uint64")
+    ms_per_stage = np.empty(3, "float64")
     distances = np.empty((n, k), dtype=np.float32)
     labels = np.empty((n, k), dtype=np.int64)
     search_with_parameters_c(
-        index, n, swig_ptr(x),
-        k, swig_ptr(distances),
+        index,
+        n,
+        swig_ptr(x),
+        k,
+        swig_ptr(distances),
         swig_ptr(labels),
-        params, swig_ptr(nb_dis), swig_ptr(ms_per_stage)
+        params,
+        swig_ptr(nb_dis),
+        swig_ptr(ms_per_stage),
     )
     if not output_stats:
         return distances, labels
     else:
         stats = {
-            'ndis': nb_dis[0],
-            'pre_transform_ms': ms_per_stage[0],
-            'coarse_quantizer_ms': ms_per_stage[1],
-            'invlist_scan_ms': ms_per_stage[2],
+            "ndis": nb_dis[0],
+            "pre_transform_ms": ms_per_stage[0],
+            "coarse_quantizer_ms": ms_per_stage[1],
+            "invlist_scan_ms": ms_per_stage[2],
         }
         return distances, labels, stats
 
@@ -354,8 +389,10 @@ def search_with_parameters(index, x, k, params=None, output_stats=False):
 range_search_with_parameters_c = range_search_with_parameters
 
 
-def range_search_with_parameters(index, x, radius, params=None, output_stats=False):
-    x = np.ascontiguousarray(x, dtype='float32')
+def range_search_with_parameters(
+    index, x, radius, params=None, output_stats=False
+):
+    x = np.ascontiguousarray(x, dtype="float32")
     n, d = x.shape
     assert d == index.d
     if not params:
@@ -364,13 +401,18 @@ def range_search_with_parameters(index, x, radius, params=None, output_stats=Fal
         index_ivf = extract_index_ivf(index)
         params.nprobe = index_ivf.nprobe
         params.max_codes = index_ivf.max_codes
-    nb_dis = np.empty(1, 'uint64')
-    ms_per_stage = np.empty(3, 'float64')
+    nb_dis = np.empty(1, "uint64")
+    ms_per_stage = np.empty(3, "float64")
     res = RangeSearchResult(n)
     range_search_with_parameters_c(
-        index, n, swig_ptr(x),
-        radius, res,
-        params, swig_ptr(nb_dis), swig_ptr(ms_per_stage)
+        index,
+        n,
+        swig_ptr(x),
+        radius,
+        res,
+        params,
+        swig_ptr(nb_dis),
+        swig_ptr(ms_per_stage),
     )
     lims = rev_swig_ptr(res.lims, n + 1).copy()
     nd = int(lims[-1])
@@ -380,10 +422,10 @@ def range_search_with_parameters(index, x, radius, params=None, output_stats=Fal
         return lims, Dout, Iout
     else:
         stats = {
-            'ndis': nb_dis[0],
-            'pre_transform_ms': ms_per_stage[0],
-            'coarse_quantizer_ms': ms_per_stage[1],
-            'invlist_scan_ms': ms_per_stage[2],
+            "ndis": nb_dis[0],
+            "pre_transform_ms": ms_per_stage[0],
+            "coarse_quantizer_ms": ms_per_stage[1],
+            "invlist_scan_ms": ms_per_stage[2],
         }
         return lims, Dout, Iout, stats
 
@@ -402,7 +444,7 @@ IVFSearchParameters = SearchParametersIVF
 
 
 def serialize_index(index, io_flags=0):
-    """ convert an index to a numpy uint8 array  """
+    """convert an index to a numpy uint8 array"""
     writer = VectorIOWriter()
     write_index(index, writer, io_flags)
     return vector_to_array(writer.data)
@@ -415,7 +457,7 @@ def deserialize_index(data, io_flags=0):
 
 
 def serialize_index_binary(index):
-    """ convert an index to a numpy uint8 array  """
+    """convert an index to a numpy uint8 array"""
     writer = VectorIOWriter()
     write_index_binary(index, writer)
     return vector_to_array(writer.data)

--- a/faiss/python/array_conversions.py
+++ b/faiss/python/array_conversions.py
@@ -19,6 +19,7 @@ from faiss.loader import *
 # classes from the SWIG interface
 ###########################################
 
+
 def _make_deprecated_swig_class(deprecated_name, base_name):
     """
     Dynamically construct deprecated classes as wrappers around renamed ones
@@ -62,58 +63,59 @@ def _make_deprecated_swig_class(deprecated_name, base_name):
 # numpy array / std::vector conversions
 ###########################################
 
-sizeof_long = array.array('l').itemsize
+sizeof_long = array.array("l").itemsize
 deprecated_name_map = {
     # deprecated: replacement
-    'Float': 'Float32',
-    'Double': 'Float64',
-    'Char': 'Int8',
-    'Int': 'Int32',
-    'Long': 'Int32' if sizeof_long == 4 else 'Int64',
-    'LongLong': 'Int64',
-    'Byte': 'UInt8',
+    "Float": "Float32",
+    "Double": "Float64",
+    "Char": "Int8",
+    "Int": "Int32",
+    "Long": "Int32" if sizeof_long == 4 else "Int64",
+    "LongLong": "Int64",
+    "Byte": "UInt8",
     # previously misspelled variant
-    'Uint64': 'UInt64',
+    "Uint64": "UInt64",
 }
 
 for depr_prefix, base_prefix in deprecated_name_map.items():
     _make_deprecated_swig_class(depr_prefix + "Vector", base_prefix + "Vector")
 
     # same for the three legacy *VectorVector classes
-    if depr_prefix in ['Float', 'Long', 'Byte']:
-        _make_deprecated_swig_class(depr_prefix + "VectorVector",
-                                    base_prefix + "VectorVector")
+    if depr_prefix in ["Float", "Long", "Byte"]:
+        _make_deprecated_swig_class(
+            depr_prefix + "VectorVector", base_prefix + "VectorVector"
+        )
 
 # mapping from vector names in swigfaiss.swig and the numpy dtype names
 # TODO: once deprecated classes are removed, remove the dict and just use .lower() below
 vector_name_map = {
-    'Float32': 'float32',
-    'Float64': 'float64',
-    'Int8': 'int8',
-    'Int16': 'int16',
-    'Int32': 'int32',
-    'Int64': 'int64',
-    'UInt8': 'uint8',
-    'UInt16': 'uint16',
-    'UInt32': 'uint32',
-    'UInt64': 'uint64',
-    **{k: v.lower() for k, v in deprecated_name_map.items()}
+    "Float32": "float32",
+    "Float64": "float64",
+    "Int8": "int8",
+    "Int16": "int16",
+    "Int32": "int32",
+    "Int64": "int64",
+    "UInt8": "uint8",
+    "UInt16": "uint16",
+    "UInt32": "uint32",
+    "UInt64": "uint64",
+    **{k: v.lower() for k, v in deprecated_name_map.items()},
 }
 
 
 def vector_to_array(v):
-    """ convert a C++ vector to a numpy array """
+    """convert a C++ vector to a numpy array"""
     classname = v.__class__.__name__
-    if classname.startswith('AlignedTable'):
+    if classname.startswith("AlignedTable"):
         return AlignedTable_to_array(v)
-    if classname.startswith('MaybeOwnedVector'):
+    if classname.startswith("MaybeOwnedVector"):
         dtype = np.dtype(vector_name_map[classname[16:]])
         a = np.empty(v.size(), dtype=dtype)
         if v.size() > 0:
             memcpy(swig_ptr(a), v.data(), a.nbytes)
         return a
 
-    assert classname.endswith('Vector')
+    assert classname.endswith("Vector")
     dtype = np.dtype(vector_name_map[classname[:-6]])
     a = np.empty(v.size(), dtype=dtype)
     if v.size() > 0:
@@ -126,34 +128,41 @@ def vector_float_to_array(v):
 
 
 def copy_array_to_vector(a, v):
-    """ copy a numpy array to a vector """
-    n, = a.shape
+    """copy a numpy array to a vector"""
+    (n,) = a.shape
     classname = v.__class__.__name__
-    if classname.startswith('MaybeOwnedVector'):
-        assert v.is_owned, 'cannot copy to an non-owned MaybeOwnedVector'
+    if classname.startswith("MaybeOwnedVector"):
+        assert v.is_owned, "cannot copy to an non-owned MaybeOwnedVector"
         dtype = np.dtype(vector_name_map[classname[16:]])
-        assert dtype == a.dtype, (
-            'cannot copy a %s array to a %s (should be %s)' % (
-                a.dtype, classname, dtype))
+        assert (
+            dtype == a.dtype
+        ), "cannot copy a %s array to a %s (should be %s)" % (
+            a.dtype,
+            classname,
+            dtype,
+        )
         v.resize(n)
         if n > 0:
             memcpy(v.data(), swig_ptr(a), a.nbytes)
         return
 
-    assert classname.endswith('Vector')
+    assert classname.endswith("Vector")
     dtype = np.dtype(vector_name_map[classname[:-6]])
-    assert dtype == a.dtype, (
-        'cannot copy a %s array to a %s (should be %s)' % (
-            a.dtype, classname, dtype))
+    assert dtype == a.dtype, "cannot copy a %s array to a %s (should be %s)" % (
+        a.dtype,
+        classname,
+        dtype,
+    )
     v.resize(n)
     if n > 0:
         memcpy(v.data(), swig_ptr(a), a.nbytes)
+
 
 # same for AlignedTable
 
 
 def copy_array_to_AlignedTable(a, v):
-    n, = a.shape
+    (n,) = a.shape
     # TODO check class name
     assert v.itemsize() == a.itemsize
     v.resize(n)
@@ -162,9 +171,9 @@ def copy_array_to_AlignedTable(a, v):
 
 
 def array_to_AlignedTable(a):
-    if a.dtype == 'uint16':
+    if a.dtype == "uint16":
         v = AlignedTableUint16(a.size)
-    elif a.dtype == 'uint8':
+    elif a.dtype == "uint8":
         v = AlignedTableUint8(a.size)
     else:
         assert False
@@ -173,9 +182,9 @@ def array_to_AlignedTable(a):
 
 
 def AlignedTable_to_array(v):
-    """ convert an AlignedTable to a numpy array """
+    """convert an AlignedTable to a numpy array"""
     classname = v.__class__.__name__
-    assert classname.startswith('AlignedTable')
+    assert classname.startswith("AlignedTable")
     dtype = classname[12:].lower()
     a = np.empty(v.size(), dtype=dtype)
     if a.size > 0:

--- a/faiss/python/class_wrappers.py
+++ b/faiss/python/class_wrappers.py
@@ -36,36 +36,40 @@ from faiss.loader import (
 
 
 def _check_dtype_uint8(codes):
-    if codes.dtype != 'uint8':
-        raise TypeError("Input argument %s must be ndarray of dtype "
-                        " uint8, but found %s" % ("codes", codes.dtype))
+    if codes.dtype != "uint8":
+        raise TypeError(
+            "Input argument %s must be ndarray of dtype "
+            " uint8, but found %s" % ("codes", codes.dtype)
+        )
     return np.ascontiguousarray(codes)
 
 
 def _numeric_to_str(numeric_type):
     if numeric_type == faiss.Float32:
-        return 'float32'
+        return "float32"
     elif numeric_type == faiss.Float16:
-        return 'float16'
+        return "float16"
     elif numeric_type == faiss.Int8:
-        return 'int8'
+        return "int8"
     else:
-        raise ValueError("numeric type must be either faiss.Float32, faiss.Float16, or faiss.Int8")
+        raise ValueError(
+            "numeric type must be either faiss.Float32, faiss.Float16, or faiss.Int8"
+        )
 
 
 def replace_method(the_class, name, replacement, ignore_missing=False):
-    """ Replaces a method in a class with another version. The old method
-    is renamed to method_name_c (because presumably it was implemented in C) """
+    """Replaces a method in a class with another version. The old method
+    is renamed to method_name_c (because presumably it was implemented in C)"""
     try:
         orig_method = getattr(the_class, name)
     except AttributeError:
         if ignore_missing:
             return
         raise
-    if orig_method.__name__ == 'replacement_' + name:
+    if orig_method.__name__ == "replacement_" + name:
         # replacement was done in parent class
         return
-    setattr(the_class, name + '_c', orig_method)
+    setattr(the_class, name + "_c", orig_method)
     setattr(the_class, name, replacement)
 
 
@@ -85,17 +89,17 @@ def handle_Clustering(the_class):
             average to obtain the centroid (default is 1 for all training vectors).
         """
         n, d = x.shape
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
         assert d == self.d
         if weights is not None:
-            weights = np.ascontiguousarray(weights, dtype='float32')
-            assert weights.shape == (n, )
+            weights = np.ascontiguousarray(weights, dtype="float32")
+            assert weights.shape == (n,)
             self.train_c(n, swig_ptr(x), index, swig_ptr(weights))
         else:
             self.train_c(n, swig_ptr(x), index)
 
     def replacement_train_encoded(self, x, codec, index, weights=None):
-        """ Perform clustering on a set of compressed vectors. The index is used for assignment.
+        """Perform clustering on a set of compressed vectors. The index is used for assignment.
         The decompression is performed on-the-fly.
 
         Parameters
@@ -115,15 +119,16 @@ def handle_Clustering(the_class):
         assert d == codec.sa_code_size()
         assert codec.d == index.d
         if weights is not None:
-            weights = np.ascontiguousarray(weights, dtype='float32')
-            assert weights.shape == (n, )
-            self.train_encoded_c(n, swig_ptr(x), codec,
-                                 index, swig_ptr(weights))
+            weights = np.ascontiguousarray(weights, dtype="float32")
+            assert weights.shape == (n,)
+            self.train_encoded_c(
+                n, swig_ptr(x), codec, index, swig_ptr(weights)
+            )
         else:
             self.train_encoded_c(n, swig_ptr(x), codec, index)
 
-    replace_method(the_class, 'train', replacement_train)
-    replace_method(the_class, 'train_encoded', replacement_train_encoded)
+    replace_method(the_class, "train", replacement_train)
+    replace_method(the_class, "train_encoded", replacement_train_encoded)
 
 
 def handle_SuperKMeans(the_class):
@@ -138,10 +143,10 @@ def handle_SuperKMeans(the_class):
         """
         n, d = x.shape
         assert d == self.d
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
         self.train_c(n, swig_ptr(x))
 
-    replace_method(the_class, 'train', replacement_train)
+    replace_method(the_class, "train", replacement_train)
 
 
 def handle_Clustering1D(the_class):
@@ -155,17 +160,17 @@ def handle_Clustering1D(the_class):
             Training vectors, shape (n, 1). `dtype` must be float32.
         """
         n, d = x.shape
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
         assert d == self.d
         self.train_exact_c(n, swig_ptr(x))
 
-    replace_method(the_class, 'train_exact', replacement_train_exact)
+    replace_method(the_class, "train_exact", replacement_train_exact)
 
 
 def handle_Quantizer(the_class):
 
     def replacement_train(self, x):
-        """ Train the quantizer on a set of training vectors.
+        """Train the quantizer on a set of training vectors.
 
         Parameters
         ----------
@@ -173,12 +178,12 @@ def handle_Quantizer(the_class):
             Training vectors, shape (n, self.d). `dtype` must be float32.
         """
         n, d = x.shape
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
         assert d == self.d
         self.train_c(n, swig_ptr(x))
 
     def replacement_compute_codes(self, x):
-        """ Compute the codes corresponding to a set of vectors.
+        """Compute the codes corresponding to a set of vectors.
 
         Parameters
         ----------
@@ -192,9 +197,9 @@ def handle_Quantizer(the_class):
             and `dtype` uint8.
         """
         n, d = x.shape
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
         assert d == self.d
-        codes = np.empty((n, self.code_size), dtype='uint8')
+        codes = np.empty((n, self.code_size), dtype="uint8")
         self.compute_codes_c(swig_ptr(x), swig_ptr(codes), n)
         return codes
 
@@ -213,13 +218,13 @@ def handle_Quantizer(the_class):
         n, cs = codes.shape
         codes = _check_dtype_uint8(codes)
         assert cs == self.code_size
-        x = np.empty((n, self.d), dtype='float32')
+        x = np.empty((n, self.d), dtype="float32")
         self.decode_c(swig_ptr(codes), swig_ptr(x), n)
         return x
 
-    replace_method(the_class, 'train', replacement_train)
-    replace_method(the_class, 'compute_codes', replacement_compute_codes)
-    replace_method(the_class, 'decode', replacement_decode)
+    replace_method(the_class, "train", replacement_train)
+    replace_method(the_class, "compute_codes", replacement_compute_codes)
+    replace_method(the_class, "decode", replacement_decode)
 
 
 def handle_NSG(the_class):
@@ -230,11 +235,11 @@ def handle_NSG(the_class):
         assert graph.ndim == 2
         assert graph.shape[0] == n
         K = graph.shape[1]
-        x = np.ascontiguousarray(x, dtype='float32')
-        graph = np.ascontiguousarray(graph, dtype='int64')
+        x = np.ascontiguousarray(x, dtype="float32")
+        graph = np.ascontiguousarray(graph, dtype="int64")
         self.build_c(n, swig_ptr(x), swig_ptr(graph), K)
 
-    replace_method(the_class, 'build', replacement_build)
+    replace_method(the_class, "build", replacement_build)
 
 
 def handle_Index(the_class):
@@ -245,11 +250,11 @@ def handle_Index(the_class):
 
         # Allow SWIG internal attributes that are essential for object
         # functionality
-        if name in ['this', 'thisown']:
+        if name in ["this", "thisown"]:
             return original_setattr(self, name, value)
 
         # Allow internal Faiss attributes used during construction/operation
-        if name in ['referenced_objects']:
+        if name in ["referenced_objects"]:
             return original_setattr(self, name, value)
 
         # Check if the attribute already exists (valid attribute)
@@ -293,7 +298,7 @@ def handle_Index(the_class):
         else:
             self.add_ex(n, swig_ptr(x), numeric_type)
 
-    def replacement_add_with_ids(self, x, ids, numeric_type = faiss.Float32):
+    def replacement_add_with_ids(self, x, ids, numeric_type=faiss.Float32):
         """Adds vectors with arbitrary ids to the index (not all indexes support this).
         The index must be trained before vectors can be added to it.
         Vector `i` is stored in `x[i]` and has id `ids[i]`.
@@ -309,14 +314,13 @@ def handle_Index(the_class):
         """
         n, d = x.shape
         assert d == self.d
-        assert ids.shape == (n, ), 'not same nb of vectors as ids'
+        assert ids.shape == (n,), "not same nb of vectors as ids"
         x = np.ascontiguousarray(x, dtype=_numeric_to_str(numeric_type))
-        ids = np.ascontiguousarray(ids, dtype='int64')
+        ids = np.ascontiguousarray(ids, dtype="int64")
         if numeric_type == faiss.Float32:
             self.add_with_ids_c(n, swig_ptr(x), swig_ptr(ids))
         else:
             self.add_with_ids_ex(n, swig_ptr(x), numeric_type, swig_ptr(ids))
-
 
     def replacement_assign(self, x, k, labels=None):
         """Find the k nearest neighbors of the set of vectors x in the index.
@@ -340,7 +344,7 @@ def handle_Index(the_class):
         """
         n, d = x.shape
         assert d == self.d
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
 
         if labels is None:
             labels = np.empty((n, k), dtype=np.int64)
@@ -396,16 +400,15 @@ def handle_Index(the_class):
         # Dispatch to train_c / train_with_queries / train_ex
         if numeric_type == faiss.Float32:
             if train_q is not None:
-                self.train_with_queries(
-                    n, swig_ptr(x), n_train_q, train_q
-                )
+                self.train_with_queries(n, swig_ptr(x), n_train_q, train_q)
             else:
                 self.train_c(n, swig_ptr(x))
         else:
             self.train_ex(n, swig_ptr(x), numeric_type)
 
-
-    def replacement_search(self, x, k, *, params=None, D=None, I=None, numeric_type = faiss.Float32):
+    def replacement_search(
+        self, x, k, *, params=None, D=None, I=None, numeric_type=faiss.Float32
+    ):
         """Find the k nearest neighbors of the set of vectors x in the index.
 
         Parameters
@@ -451,10 +454,20 @@ def handle_Index(the_class):
         if numeric_type == faiss.Float32:
             self.search_c(n, swig_ptr(x), k, swig_ptr(D), swig_ptr(I), params)
         else:
-            self.search_ex(n, swig_ptr(x), numeric_type, k, swig_ptr(D), swig_ptr(I), params)
+            self.search_ex(
+                n,
+                swig_ptr(x),
+                numeric_type,
+                k,
+                swig_ptr(D),
+                swig_ptr(I),
+                params,
+            )
         return D, I
 
-    def replacement_search_and_reconstruct(self, x, k, *, params=None, D=None, I=None, R=None):
+    def replacement_search_and_reconstruct(
+        self, x, k, *, params=None, D=None, I=None, R=None
+    ):
         """Find the k nearest neighbors of the set of vectors x in the index,
         and return an approximation of these vectors.
 
@@ -487,7 +500,7 @@ def handle_Index(the_class):
         """
         n, d = x.shape
         assert d == self.d
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
 
         assert k > 0
 
@@ -507,15 +520,21 @@ def handle_Index(the_class):
             assert R.shape == (n, k, d)
 
         self.search_and_reconstruct_c(
-            n, swig_ptr(x),
-            k, swig_ptr(D),
-            swig_ptr(I), swig_ptr(R), params
+            n, swig_ptr(x), k, swig_ptr(D), swig_ptr(I), swig_ptr(R), params
         )
         return D, I, R
 
     def replacement_search_and_return_codes(
-            self, x, k, *,
-            include_listnos=False, params=None, D=None, I=None, codes=None):
+        self,
+        x,
+        k,
+        *,
+        include_listnos=False,
+        params=None,
+        D=None,
+        I=None,
+        codes=None,
+    ):
         """Find the k nearest neighbors of the set of vectors x in the index,
         and return the codes stored for these vectors
 
@@ -550,7 +569,7 @@ def handle_Index(the_class):
         """
         n, d = x.shape
         assert d == self.d
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
 
         assert k > 0
 
@@ -574,10 +593,14 @@ def handle_Index(the_class):
             assert codes.shape == (n, k, code_size_1)
 
         self.search_and_return_codes_c(
-            n, swig_ptr(x),
-            k, swig_ptr(D),
-            swig_ptr(I), swig_ptr(codes), include_listnos,
-            params
+            n,
+            swig_ptr(x),
+            k,
+            swig_ptr(D),
+            swig_ptr(I),
+            swig_ptr(codes),
+            include_listnos,
+            params,
         )
         return D, I, codes
 
@@ -602,7 +625,7 @@ def handle_Index(the_class):
         else:
             assert x.ndim == 1
             index_ivf = try_extract_index_ivf(self)
-            x = np.ascontiguousarray(x, dtype='int64')
+            x = np.ascontiguousarray(x, dtype="int64")
             if index_ivf and index_ivf.direct_map.type == DirectMap.Hashtable:
                 sel = IDSelectorArray(x.size, swig_ptr(x))
             else:
@@ -626,7 +649,7 @@ def handle_Index(the_class):
         if x is None:
             x = np.empty(self.d, dtype=np.float32)
         else:
-            assert x.shape == (self.d, )
+            assert x.shape == (self.d,)
 
         self.reconstruct_c(key, swig_ptr(x))
         return x
@@ -646,8 +669,8 @@ def handle_Index(the_class):
         x : array_like
             reconstrcuted vectors, size `len(key), self.d`
         """
-        key = np.ascontiguousarray(key, dtype='int64')
-        n, = key.shape
+        key = np.ascontiguousarray(key, dtype="int64")
+        (n,) = key.shape
         if x is None:
             x = np.empty((n, self.d), dtype=np.float32)
         else:
@@ -685,10 +708,10 @@ def handle_Index(the_class):
 
     def replacement_update_vectors(self, keys, x):
         n = keys.size
-        assert keys.shape == (n, )
+        assert keys.shape == (n,)
         assert x.shape == (n, self.d)
-        x = np.ascontiguousarray(x, dtype='float32')
-        keys = np.ascontiguousarray(keys, dtype='int64')
+        x = np.ascontiguousarray(x, dtype="float32")
+        keys = np.ascontiguousarray(keys, dtype="int64")
         self.update_vectors_c(n, swig_ptr(keys), swig_ptr(x))
 
     # No support passed-in for output buffers
@@ -722,7 +745,7 @@ def handle_Index(the_class):
         """
         n, d = x.shape
         assert d == self.d
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
         thresh = float(thresh)
 
         res = RangeSearchResult(n)
@@ -734,7 +757,9 @@ def handle_Index(the_class):
         I = rev_swig_ptr(res.labels, nd).copy()
         return lims, D, I
 
-    def replacement_search_preassigned(self, x, k, Iq, Dq, *, params=None, D=None, I=None):
+    def replacement_search_preassigned(
+        self, x, k, Iq, Dq, *, params=None, D=None, I=None
+    ):
         """Find the k nearest neighbors of the set of vectors x in an IVF index,
         with precalculated coarse quantization assignment.
 
@@ -767,7 +792,7 @@ def handle_Index(the_class):
             When not enough results are found, the label is set to -1
         """
         n, d = x.shape
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
         assert d == self.d
         assert k > 0
 
@@ -781,26 +806,31 @@ def handle_Index(the_class):
         else:
             assert I.shape == (n, k)
 
-        Iq = np.ascontiguousarray(Iq, dtype='int64')
+        Iq = np.ascontiguousarray(Iq, dtype="int64")
         assert params is None, "params not supported"
         assert Iq.shape == (n, self.nprobe)
 
         if Dq is not None:
-            Dq = np.ascontiguousarray(Dq, dtype='float32')
+            Dq = np.ascontiguousarray(Dq, dtype="float32")
             assert Dq.shape == Iq.shape
         else:
-            Dq = np.zeros(Iq.shape, dtype='float32')
+            Dq = np.zeros(Iq.shape, dtype="float32")
 
         self.search_preassigned_c(
-            n, swig_ptr(x),
+            n,
+            swig_ptr(x),
             k,
-            swig_ptr(Iq), swig_ptr(Dq),
-            swig_ptr(D), swig_ptr(I),
-            False
+            swig_ptr(Iq),
+            swig_ptr(Dq),
+            swig_ptr(D),
+            swig_ptr(I),
+            False,
         )
         return D, I
 
-    def replacement_range_search_preassigned(self, x, thresh, Iq, Dq, *, params=None):
+    def replacement_range_search_preassigned(
+        self, x, thresh, Iq, Dq, *, params=None
+    ):
         """Search vectors that are within a distance of the query vectors.
 
         Parameters
@@ -834,24 +864,22 @@ def handle_Index(the_class):
         """
         n, d = x.shape
         assert d == self.d
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
 
-        Iq = np.ascontiguousarray(Iq, dtype='int64')
+        Iq = np.ascontiguousarray(Iq, dtype="int64")
         assert params is None, "params not supported"
         assert Iq.shape == (n, self.nprobe)
 
         if Dq is not None:
-            Dq = np.ascontiguousarray(Dq, dtype='float32')
+            Dq = np.ascontiguousarray(Dq, dtype="float32")
             assert Dq.shape == Iq.shape
         else:
-            Dq = np.zeros(Iq.shape, dtype='float32')
+            Dq = np.zeros(Iq.shape, dtype="float32")
 
         thresh = float(thresh)
         res = RangeSearchResult(n)
         self.range_search_preassigned_c(
-            n, swig_ptr(x), thresh,
-            swig_ptr(Iq), swig_ptr(Dq),
-            res
+            n, swig_ptr(x), thresh, swig_ptr(Iq), swig_ptr(Dq), res
         )
         # get pointers and copy them
         lims = rev_swig_ptr(res.lims, n + 1).copy()
@@ -863,7 +891,7 @@ def handle_Index(the_class):
     def replacement_sa_encode(self, x, codes=None):
         n, d = x.shape
         assert d == self.d
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
         code_size = self.sa_code_size()
 
         if codes is None:
@@ -900,44 +928,71 @@ def handle_Index(the_class):
         self.add_sa_codes_c(n, swig_ptr(codes), ids_ptr)
 
     def replacement_permute_entries(self, perm):
-        n, = perm.shape
+        (n,) = perm.shape
         assert n == self.ntotal
-        perm = np.ascontiguousarray(perm, dtype='int64')
+        perm = np.ascontiguousarray(perm, dtype="int64")
         self.permute_entries_c(faiss.swig_ptr(perm))
 
-    replace_method(the_class, 'add', replacement_add)
-    replace_method(the_class, 'add_with_ids', replacement_add_with_ids)
-    replace_method(the_class, 'assign', replacement_assign)
-    replace_method(the_class, 'train', replacement_train)
-    replace_method(the_class, 'search', replacement_search)
-    replace_method(the_class, 'remove_ids', replacement_remove_ids)
-    replace_method(the_class, 'reconstruct', replacement_reconstruct)
-    replace_method(the_class, 'reconstruct_batch',
-                   replacement_reconstruct_batch)
-    replace_method(the_class, 'reconstruct_n', replacement_reconstruct_n)
-    replace_method(the_class, 'range_search', replacement_range_search)
-    replace_method(the_class, 'update_vectors', replacement_update_vectors,
-                   ignore_missing=True)
-    replace_method(the_class, 'search_and_reconstruct',
-                   replacement_search_and_reconstruct, ignore_missing=True)
-    replace_method(the_class, 'search_and_return_codes',
-                   replacement_search_and_return_codes, ignore_missing=True)
+    replace_method(the_class, "add", replacement_add)
+    replace_method(the_class, "add_with_ids", replacement_add_with_ids)
+    replace_method(the_class, "assign", replacement_assign)
+    replace_method(the_class, "train", replacement_train)
+    replace_method(the_class, "search", replacement_search)
+    replace_method(the_class, "remove_ids", replacement_remove_ids)
+    replace_method(the_class, "reconstruct", replacement_reconstruct)
+    replace_method(
+        the_class, "reconstruct_batch", replacement_reconstruct_batch
+    )
+    replace_method(the_class, "reconstruct_n", replacement_reconstruct_n)
+    replace_method(the_class, "range_search", replacement_range_search)
+    replace_method(
+        the_class,
+        "update_vectors",
+        replacement_update_vectors,
+        ignore_missing=True,
+    )
+    replace_method(
+        the_class,
+        "search_and_reconstruct",
+        replacement_search_and_reconstruct,
+        ignore_missing=True,
+    )
+    replace_method(
+        the_class,
+        "search_and_return_codes",
+        replacement_search_and_return_codes,
+        ignore_missing=True,
+    )
 
     # these ones are IVF-specific
-    replace_method(the_class, 'search_preassigned',
-                   replacement_search_preassigned, ignore_missing=True)
-    replace_method(the_class, 'range_search_preassigned',
-                   replacement_range_search_preassigned, ignore_missing=True)
-    replace_method(the_class, 'sa_encode', replacement_sa_encode)
-    replace_method(the_class, 'sa_decode', replacement_sa_decode)
-    replace_method(the_class, 'add_sa_codes', replacement_add_sa_codes)
-    replace_method(the_class, 'permute_entries', replacement_permute_entries,
-                   ignore_missing=True)
+    replace_method(
+        the_class,
+        "search_preassigned",
+        replacement_search_preassigned,
+        ignore_missing=True,
+    )
+    replace_method(
+        the_class,
+        "range_search_preassigned",
+        replacement_range_search_preassigned,
+        ignore_missing=True,
+    )
+    replace_method(the_class, "sa_encode", replacement_sa_encode)
+    replace_method(the_class, "sa_decode", replacement_sa_decode)
+    replace_method(the_class, "add_sa_codes", replacement_add_sa_codes)
+    replace_method(
+        the_class,
+        "permute_entries",
+        replacement_permute_entries,
+        ignore_missing=True,
+    )
 
     # Store the original __setattr__ method
-    original_setattr = (the_class.__setattr__ if
-                        hasattr(the_class, '__setattr__')
-                        else object.__setattr__)
+    original_setattr = (
+        the_class.__setattr__
+        if hasattr(the_class, "__setattr__")
+        else object.__setattr__
+    )
 
     the_class.__setattr__ = replacement_setattr
 
@@ -949,7 +1004,9 @@ def handle_Index(the_class):
         return {"this": faiss.serialize_index(self).tobytes()}
 
     def index_setstate(self, st):
-        index2 = faiss.deserialize_index(np.frombuffer(st["this"], dtype="uint8"))
+        index2 = faiss.deserialize_index(
+            np.frombuffer(st["this"], dtype="uint8")
+        )
         self.this = index2.this
 
     the_class.__getstate__ = index_getstate
@@ -967,9 +1024,9 @@ def handle_IndexBinary(the_class):
     def replacement_add_with_ids(self, x, ids):
         n, d = x.shape
         x = _check_dtype_uint8(x)
-        ids = np.ascontiguousarray(ids, dtype='int64')
+        ids = np.ascontiguousarray(ids, dtype="int64")
         assert d == self.code_size
-        assert ids.shape == (n, ), 'not same nb of vectors as ids'
+        assert ids.shape == (n,), "not same nb of vectors as ids"
         self.add_with_ids_c(n, swig_ptr(x), swig_ptr(ids))
 
     def replacement_train(self, x):
@@ -1001,10 +1058,9 @@ def handle_IndexBinary(the_class):
         assert k > 0
         distances = np.empty((n, k), dtype=np.int32)
         labels = np.empty((n, k), dtype=np.int64)
-        self.search_c(n, swig_ptr(x),
-                      k, swig_ptr(distances),
-                      swig_ptr(labels),
-                      params)
+        self.search_c(
+            n, swig_ptr(x), k, swig_ptr(distances), swig_ptr(labels), params
+        )
         return distances, labels
 
     def replacement_search_preassigned(self, x, k, Iq, Dq):
@@ -1016,21 +1072,24 @@ def handle_IndexBinary(the_class):
         D = np.empty((n, k), dtype=np.int32)
         I = np.empty((n, k), dtype=np.int64)
 
-        Iq = np.ascontiguousarray(Iq, dtype='int64')
+        Iq = np.ascontiguousarray(Iq, dtype="int64")
         assert Iq.shape == (n, self.nprobe)
 
         if Dq is not None:
-            Dq = np.ascontiguousarray(Dq, dtype='int32')
+            Dq = np.ascontiguousarray(Dq, dtype="int32")
             assert Dq.shape == Iq.shape
         else:
-            Dq = np.zeros(Iq.shape, dtype='int32')
+            Dq = np.zeros(Iq.shape, dtype="int32")
 
         self.search_preassigned_c(
-            n, swig_ptr(x),
+            n,
+            swig_ptr(x),
             k,
-            swig_ptr(Iq), swig_ptr(Dq),
-            swig_ptr(D), swig_ptr(I),
-            False
+            swig_ptr(Iq),
+            swig_ptr(Dq),
+            swig_ptr(D),
+            swig_ptr(I),
+            False,
         )
         return D, I
 
@@ -1047,27 +1106,27 @@ def handle_IndexBinary(the_class):
         I = rev_swig_ptr(res.labels, nd).copy()
         return lims, D, I
 
-    def replacement_range_search_preassigned(self, x, thresh, Iq, Dq, *, params=None):
+    def replacement_range_search_preassigned(
+        self, x, thresh, Iq, Dq, *, params=None
+    ):
         n, d = x.shape
         x = _check_dtype_uint8(x)
         assert d == self.code_size
 
-        Iq = np.ascontiguousarray(Iq, dtype='int64')
+        Iq = np.ascontiguousarray(Iq, dtype="int64")
         assert params is None, "params not supported"
         assert Iq.shape == (n, self.nprobe)
 
         if Dq is not None:
-            Dq = np.ascontiguousarray(Dq, dtype='int32')
+            Dq = np.ascontiguousarray(Dq, dtype="int32")
             assert Dq.shape == Iq.shape
         else:
-            Dq = np.zeros(Iq.shape, dtype='int32')
+            Dq = np.zeros(Iq.shape, dtype="int32")
 
         thresh = int(thresh)
         res = RangeSearchResult(n)
         self.range_search_preassigned_c(
-            n, swig_ptr(x), thresh,
-            swig_ptr(Iq), swig_ptr(Dq),
-            res
+            n, swig_ptr(x), thresh, swig_ptr(Iq), swig_ptr(Dq), res
         )
         # get pointers and copy them
         lims = rev_swig_ptr(res.lims, n + 1).copy()
@@ -1081,7 +1140,7 @@ def handle_IndexBinary(the_class):
             sel = x
         else:
             assert x.ndim == 1
-            x = np.ascontiguousarray(x, dtype='int64')
+            x = np.ascontiguousarray(x, dtype="int64")
             sel = IDSelectorBatch(x.size, swig_ptr(x))
         return self.remove_ids_c(sel)
 
@@ -1118,26 +1177,34 @@ def handle_IndexBinary(the_class):
         self.assign_c(n, swig_ptr(x), swig_ptr(labels), k)
         return labels
 
-    replace_method(the_class, 'add', replacement_add)
-    replace_method(the_class, 'add_with_ids', replacement_add_with_ids)
-    replace_method(the_class, 'train', replacement_train)
-    replace_method(the_class, 'search', replacement_search)
-    replace_method(the_class, 'assign', replacement_assign)
-    replace_method(the_class, 'range_search', replacement_range_search)
-    replace_method(the_class, 'reconstruct', replacement_reconstruct)
-    replace_method(the_class, 'reconstruct_n', replacement_reconstruct_n)
-    replace_method(the_class, 'remove_ids', replacement_remove_ids)
-    replace_method(the_class, 'search_preassigned',
-                   replacement_search_preassigned, ignore_missing=True)
-    replace_method(the_class, 'range_search_preassigned',
-                   replacement_range_search_preassigned, ignore_missing=True)
+    replace_method(the_class, "add", replacement_add)
+    replace_method(the_class, "add_with_ids", replacement_add_with_ids)
+    replace_method(the_class, "train", replacement_train)
+    replace_method(the_class, "search", replacement_search)
+    replace_method(the_class, "assign", replacement_assign)
+    replace_method(the_class, "range_search", replacement_range_search)
+    replace_method(the_class, "reconstruct", replacement_reconstruct)
+    replace_method(the_class, "reconstruct_n", replacement_reconstruct_n)
+    replace_method(the_class, "remove_ids", replacement_remove_ids)
+    replace_method(
+        the_class,
+        "search_preassigned",
+        replacement_search_preassigned,
+        ignore_missing=True,
+    )
+    replace_method(
+        the_class,
+        "range_search_preassigned",
+        replacement_range_search_preassigned,
+        ignore_missing=True,
+    )
 
 
 def handle_VectorTransform(the_class):
 
     def apply_method(self, x):
         n, d = x.shape
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
         assert d == self.d_in
         y = np.empty((n, self.d_out), dtype=np.float32)
         self.apply_noalloc(n, swig_ptr(x), swig_ptr(y))
@@ -1145,7 +1212,7 @@ def handle_VectorTransform(the_class):
 
     def replacement_reverse_transform(self, x):
         n, d = x.shape
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
         assert d == self.d_out
         y = np.empty((n, self.d_in), dtype=np.float32)
         self.reverse_transform_c(n, swig_ptr(x), swig_ptr(y))
@@ -1153,16 +1220,17 @@ def handle_VectorTransform(the_class):
 
     def replacement_vt_train(self, x):
         n, d = x.shape
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
         assert d == self.d_in
         self.train_c(n, swig_ptr(x))
 
-    replace_method(the_class, 'train', replacement_vt_train)
+    replace_method(the_class, "train", replacement_vt_train)
     # apply is reserved in Python...
     the_class.apply_py = apply_method
     the_class.apply = apply_method
-    replace_method(the_class, 'reverse_transform',
-                   replacement_reverse_transform)
+    replace_method(
+        the_class, "reverse_transform", replacement_reverse_transform
+    )
 
 
 def handle_AutoTuneCriterion(the_class):
@@ -1171,26 +1239,27 @@ def handle_AutoTuneCriterion(the_class):
             assert I.shape == D.shape
         self.nq, self.gt_nnn = I.shape
         self.set_groundtruth_c(
-            self.gt_nnn, swig_ptr(D) if D is not None else None, swig_ptr(I))
+            self.gt_nnn, swig_ptr(D) if D is not None else None, swig_ptr(I)
+        )
 
     def replacement_evaluate(self, D, I):
         assert I.shape == D.shape
         assert I.shape == (self.nq, self.nnn)
         return self.evaluate_c(swig_ptr(D), swig_ptr(I))
 
-    replace_method(the_class, 'set_groundtruth', replacement_set_groundtruth)
-    replace_method(the_class, 'evaluate', replacement_evaluate)
+    replace_method(the_class, "set_groundtruth", replacement_set_groundtruth)
+    replace_method(the_class, "evaluate", replacement_evaluate)
 
 
 def handle_ParameterSpace(the_class):
     def replacement_explore(self, index, xq, crit):
         assert xq.shape == (crit.nq, index.d)
-        xq = np.ascontiguousarray(xq, dtype='float32')
+        xq = np.ascontiguousarray(xq, dtype="float32")
         ops = OperatingPoints()
-        self.explore_c(index, crit.nq, swig_ptr(xq),
-                       crit, ops)
+        self.explore_c(index, crit.nq, swig_ptr(xq), crit, ops)
         return ops
-    replace_method(the_class, 'explore', replacement_explore)
+
+    replace_method(the_class, "explore", replacement_explore)
 
 
 def handle_MatrixStats(the_class):
@@ -1198,14 +1267,15 @@ def handle_MatrixStats(the_class):
 
     def replacement_init(self, m):
         assert len(m.shape) == 2
-        m = np.ascontiguousarray(m, dtype='float32')
+        m = np.ascontiguousarray(m, dtype="float32")
         original_init(self, m.shape[0], m.shape[1], swig_ptr(m))
 
     the_class.__init__ = replacement_init
 
 
 def handle_IOWriter(the_class):
-    """ add a write_bytes method """
+    """add a write_bytes method"""
+
     def write_bytes(self, b):
         return self(swig_ptr(b), 1, len(b))
 
@@ -1213,7 +1283,7 @@ def handle_IOWriter(the_class):
 
 
 def handle_IOReader(the_class):
-    """ add a read_bytes method """
+    """add a read_bytes method"""
 
     def read_bytes(self, totsz):
         buf = bytearray(totsz)
@@ -1239,10 +1309,10 @@ def handle_IndexRowwiseMinMax(the_class):
         """
         n, d = x.shape
         assert d == self.d
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
         self.train_inplace_c(n, swig_ptr(x))
 
-    replace_method(the_class, 'train_inplace', replacement_train_inplace)
+    replace_method(the_class, "train_inplace", replacement_train_inplace)
 
 
 def handle_CodePacker(the_class):
@@ -1258,12 +1328,13 @@ def handle_CodePacker(the_class):
         nblock, block_size = block.shape
         assert block_size == self.block_size
         assert 0 <= offset < block_size * self.nvec
-        x = np.zeros(self.code_size, dtype='uint8')
+        x = np.zeros(self.code_size, dtype="uint8")
         self.unpack_1_c(faiss.swig_ptr(block), offset, swig_ptr(x))
         return x
 
-    replace_method(the_class, 'pack_1', replacement_pack_1)
-    replace_method(the_class, 'unpack_1', replacement_unpack_1)
+    replace_method(the_class, "pack_1", replacement_pack_1)
+    replace_method(the_class, "unpack_1", replacement_unpack_1)
+
 
 ######################################################
 # MapLong2Long interface
@@ -1273,22 +1344,23 @@ def handle_CodePacker(the_class):
 def handle_MapLong2Long(the_class):
 
     def replacement_map_add(self, keys, vals):
-        n, = keys.shape
+        (n,) = keys.shape
         assert (n,) == vals.shape
-        keys = np.ascontiguousarray(keys, dtype='int64')
-        vals = np.ascontiguousarray(vals, dtype='int64')
+        keys = np.ascontiguousarray(keys, dtype="int64")
+        vals = np.ascontiguousarray(vals, dtype="int64")
         self.add_c(n, swig_ptr(keys), swig_ptr(vals))
 
     def replacement_map_search_multiple(self, keys):
-        n, = keys.shape
-        keys = np.ascontiguousarray(keys, dtype='int64')
-        vals = np.empty(n, dtype='int64')
+        (n,) = keys.shape
+        keys = np.ascontiguousarray(keys, dtype="int64")
+        vals = np.empty(n, dtype="int64")
         self.search_multiple_c(n, swig_ptr(keys), swig_ptr(vals))
         return vals
 
-    replace_method(the_class, 'add', replacement_map_add)
-    replace_method(the_class, 'search_multiple',
-                   replacement_map_search_multiple)
+    replace_method(the_class, "add", replacement_map_add)
+    replace_method(
+        the_class, "search_multiple", replacement_map_search_multiple
+    )
 
 
 ######################################################
@@ -1297,7 +1369,7 @@ def handle_MapLong2Long(the_class):
 
 
 def add_to_referenced_objects(self, ref):
-    if not hasattr(self, 'referenced_objects'):
+    if not hasattr(self, "referenced_objects"):
         self.referenced_objects = [ref]
     else:
         self.referenced_objects.append(ref)
@@ -1371,9 +1443,9 @@ def handle_IDSelectorSubset(the_class, class_owns, force_int64=True):
     def replacement_init(self, *args):
         if len(args) == 1:
             # assume it's an array
-            subset, = args
+            (subset,) = args
             if force_int64:
-                subset = np.ascontiguousarray(subset, dtype='int64')
+                subset = np.ascontiguousarray(subset, dtype="int64")
             args = (len(subset), faiss.swig_ptr(subset))
             if not class_owns:
                 add_to_referenced_objects(self, subset)
@@ -1392,12 +1464,13 @@ def handle_CodeSet(the_class):
         if inserted is None:
             inserted = np.empty(n, dtype=bool)
         else:
-            assert inserted.shape == (n, )
+            assert inserted.shape == (n,)
 
         self.insert_c(n, swig_ptr(codes), swig_ptr(inserted))
         return inserted
 
-    replace_method(the_class, 'insert', replacement_insert)
+    replace_method(the_class, "insert", replacement_insert)
+
 
 ######################################################
 # Syntactic sugar for NeuralNet classes
@@ -1409,11 +1482,12 @@ def handle_Tensor2D(the_class):
 
     def replacement_init(self, *args):
         if len(args) == 1:
-            array, = args
+            (array,) = args
             n, d = array.shape
             self.original_init(n, d)
             faiss.copy_array_to_vector(
-                np.ascontiguousarray(array).ravel(), self.v)
+                np.ascontiguousarray(array).ravel(), self.v
+            )
         else:
             self.original_init(*args)
 
@@ -1439,16 +1513,18 @@ def handle_Embedding(the_class):
         self.from_torch(emb)
 
     def from_torch(self, emb):
-        """ copy weights from torch.Embedding """
+        """copy weights from torch.Embedding"""
         assert emb.weight.shape == (self.num_embeddings, self.embedding_dim)
         faiss.copy_array_to_vector(
-            np.ascontiguousarray(emb.weight.data).ravel(), self.weight)
+            np.ascontiguousarray(emb.weight.data).ravel(), self.weight
+        )
 
     def from_array(self, array):
-        """ copy weights from numpy array """
+        """copy weights from numpy array"""
         assert array.shape == (self.num_embeddings, self.embedding_dim)
         faiss.copy_array_to_vector(
-            np.ascontiguousarray(array).ravel(), self.weight)
+            np.ascontiguousarray(array).ravel(), self.weight
+        )
 
     the_class.from_array = from_array
     the_class.from_torch = from_torch
@@ -1469,19 +1545,21 @@ def handle_Linear(the_class):
         self.from_torch(linear)
 
     def from_torch(self, linear):
-        """ copy weights from torch.Linear """
+        """copy weights from torch.Linear"""
         assert linear.weight.shape == (self.out_features, self.in_features)
         faiss.copy_array_to_vector(
-            linear.weight.data.numpy().ravel(), self.weight)
+            linear.weight.data.numpy().ravel(), self.weight
+        )
         if linear.bias is not None:
             assert linear.bias.shape == (self.out_features,)
             faiss.copy_array_to_vector(linear.bias.data.numpy(), self.bias)
 
     def from_array(self, array, bias=None):
-        """ copy weights from numpy array """
+        """copy weights from numpy array"""
         assert array.shape == (self.out_features, self.in_features)
         faiss.copy_array_to_vector(
-            np.ascontiguousarray(array).ravel(), self.weight)
+            np.ascontiguousarray(array).ravel(), self.weight
+        )
         if bias is not None:
             assert bias.shape == (self.out_features,)
             faiss.copy_array_to_vector(bias, self.bias)
@@ -1489,6 +1567,7 @@ def handle_Linear(the_class):
     the_class.__init__ = replacement_init
     the_class.from_array = from_array
     the_class.from_torch = from_torch
+
 
 ######################################################
 # Syntactic sugar for QINCo and QINCoStep
@@ -1508,8 +1587,13 @@ def handle_QINCoStep(the_class):
         self.from_torch(step)
 
     def from_torch(self, step):
-        """ copy weights from torch.QINCoStep """
-        assert (step.d, step.K, step.L, step.h) == (self.d, self.K, self.L, self.h)
+        """copy weights from torch.QINCoStep"""
+        assert (step.d, step.K, step.L, step.h) == (
+            self.d,
+            self.K,
+            self.L,
+            self.h,
+        )
         self.codebook.from_torch(step.codebook)
         self.MLPconcat.from_torch(step.MLPconcat)
 
@@ -1537,10 +1621,13 @@ def handle_QINCo(the_class):
         self.from_torch(qinco)
 
     def from_torch(self, qinco):
-        """ copy weights from torch.QINCo """
-        assert (
-            (qinco.d, qinco.K, qinco.L, qinco.M, qinco.h) ==
-            (self.d, self.K, self.L, self.M, self.h)
+        """copy weights from torch.QINCo"""
+        assert (qinco.d, qinco.K, qinco.L, qinco.M, qinco.h) == (
+            self.d,
+            self.K,
+            self.L,
+            self.M,
+            self.h,
         )
         self.codebook0.from_torch(qinco.codebook0)
         for m in range(qinco.M - 1):
@@ -1556,4 +1643,5 @@ def handle_shard_ivf_index_centroids(func):
         if len(args) > 3 and args[3] is not None:
             args[3] = faiss.PyCallbackShardingFunction(args[3])
         return func(*args, **kwargs)
+
     return wrapper

--- a/faiss/python/extra_wrappers.py
+++ b/faiss/python/extra_wrappers.py
@@ -25,10 +25,10 @@ import collections.abc
 def kmin(array, k):
     """return k smallest values (and their indices) of the lines of a
     float32 array"""
-    array = np.ascontiguousarray(array, dtype='float32')
+    array = np.ascontiguousarray(array, dtype="float32")
     m, n = array.shape
-    I = np.zeros((m, k), dtype='int64')
-    D = np.zeros((m, k), dtype='float32')
+    I = np.zeros((m, k), dtype="int64")
+    D = np.zeros((m, k), dtype="float32")
     ha = faiss.float_maxheap_array_t()
     ha.ids = swig_ptr(I)
     ha.val = swig_ptr(D)
@@ -43,10 +43,10 @@ def kmin(array, k):
 def kmax(array, k):
     """return k largest values (and their indices) of the lines of a
     float32 array"""
-    array = np.ascontiguousarray(array, dtype='float32')
+    array = np.ascontiguousarray(array, dtype="float32")
     m, n = array.shape
-    I = np.zeros((m, k), dtype='int64')
-    D = np.zeros((m, k), dtype='float32')
+    I = np.zeros((m, k), dtype="int64")
+    D = np.zeros((m, k), dtype="float32")
     ha = faiss.float_minheap_array_t()
     ha.ids = swig_ptr(I)
     ha.val = swig_ptr(D)
@@ -61,36 +61,38 @@ def kmax(array, k):
 def pairwise_distances(xq, xb, metric=METRIC_L2, metric_arg=0):
     """compute the whole pairwise distance matrix between two sets of
     vectors"""
-    xq = np.ascontiguousarray(xq, dtype='float32')
-    xb = np.ascontiguousarray(xb, dtype='float32')
+    xq = np.ascontiguousarray(xq, dtype="float32")
+    xb = np.ascontiguousarray(xb, dtype="float32")
     nq, d = xq.shape
     nb, d2 = xb.shape
     assert d == d2
-    dis = np.empty((nq, nb), dtype='float32')
+    dis = np.empty((nq, nb), dtype="float32")
     if metric == METRIC_L2:
-        pairwise_L2sqr(
-            d, nq, swig_ptr(xq),
-            nb, swig_ptr(xb),
-            swig_ptr(dis))
+        pairwise_L2sqr(d, nq, swig_ptr(xq), nb, swig_ptr(xb), swig_ptr(dis))
     elif metric == METRIC_INNER_PRODUCT:
         dis[:] = xq @ xb.T
     else:
         pairwise_extra_distances(
-            d, nq, swig_ptr(xq),
-            nb, swig_ptr(xb),
-            metric, metric_arg,
-            swig_ptr(dis))
+            d,
+            nq,
+            swig_ptr(xq),
+            nb,
+            swig_ptr(xb),
+            metric,
+            metric_arg,
+            swig_ptr(dis),
+        )
     return dis
 
 
 def rand(n, seed=12345):
-    res = np.empty(n, dtype='float32')
+    res = np.empty(n, dtype="float32")
     float_rand(swig_ptr(res), res.size, seed)
     return res
 
 
 def randint(n, seed=12345, vmax=None):
-    res = np.empty(n, dtype='int64')
+    res = np.empty(n, dtype="int64")
     if vmax is None:
         int64_rand(swig_ptr(res), res.size, seed)
     else:
@@ -102,47 +104,52 @@ lrand = randint
 
 
 def randn(n, seed=12345):
-    res = np.empty(n, dtype='float32')
+    res = np.empty(n, dtype="float32")
     float_randn(swig_ptr(res), res.size, seed)
     return res
 
 
 def checksum(a):
-    """ compute a checksum for quick-and-dirty comparisons of arrays """
-    a = a.view('uint8')
+    """compute a checksum for quick-and-dirty comparisons of arrays"""
+    a = a.view("uint8")
     if a.ndim == 1:
         return bvec_checksum(a.size, swig_ptr(a))
     n, d = a.shape
-    cs = np.zeros(n, dtype='uint64')
+    cs = np.zeros(n, dtype="uint64")
     bvecs_checksum(n, d, swig_ptr(a), swig_ptr(cs))
     return cs
 
+
 rand_smooth_vectors_c = rand_smooth_vectors
 
+
 def rand_smooth_vectors(n, d, seed=1234):
-    res = np.empty((n, d), dtype='float32')
+    res = np.empty((n, d), dtype="float32")
     rand_smooth_vectors_c(n, d, swig_ptr(res), seed)
     return res
 
 
 def eval_intersection(I1, I2):
-    """ size of intersection between each line of two result tables"""
-    I1 = np.ascontiguousarray(I1, dtype='int64')
-    I2 = np.ascontiguousarray(I2, dtype='int64')
+    """size of intersection between each line of two result tables"""
+    I1 = np.ascontiguousarray(I1, dtype="int64")
+    I2 = np.ascontiguousarray(I2, dtype="int64")
     n = I1.shape[0]
     assert I2.shape[0] == n
     k1, k2 = I1.shape[1], I2.shape[1]
     ninter = 0
     for i in range(n):
         ninter += ranklist_intersection_size(
-            k1, swig_ptr(I1[i]), k2, swig_ptr(I2[i]))
+            k1, swig_ptr(I1[i]), k2, swig_ptr(I2[i])
+        )
     return ninter
 
 
 def normalize_L2(x):
     fvec_renorm_L2(x.shape[1], x.shape[0], swig_ptr(x))
 
+
 bucket_sort_c = bucket_sort
+
 
 def bucket_sort(tab, nbucket=None, nt=0):
     """Perform a bucket sort on a table of integers.
@@ -166,16 +173,21 @@ def bucket_sort(tab, nbucket=None, nt=0):
     tab = np.ascontiguousarray(tab, dtype="int64")
     if nbucket is None:
         nbucket = int(tab.max() + 1)
-    lims = np.empty(nbucket + 1, dtype='int64')
-    perm = np.empty(tab.size, dtype='int64')
+    lims = np.empty(nbucket + 1, dtype="int64")
+    perm = np.empty(tab.size, dtype="int64")
     bucket_sort_c(
-        tab.size, faiss.swig_ptr(tab.view('uint64')),
-        nbucket, faiss.swig_ptr(lims), faiss.swig_ptr(perm),
-        nt
+        tab.size,
+        faiss.swig_ptr(tab.view("uint64")),
+        nbucket,
+        faiss.swig_ptr(lims),
+        faiss.swig_ptr(perm),
+        nt,
     )
     return lims, perm
 
+
 matrix_bucket_sort_inplace_c = matrix_bucket_sort_inplace
+
 
 def matrix_bucket_sort_inplace(tab, nbucket=None, nt=0):
     """Perform a bucket sort on a matrix, recording the original
@@ -199,15 +211,13 @@ def matrix_bucket_sort_inplace(tab, nbucket=None, nt=0):
     lims : array_like
         cumulative sum of bucket sizes (size vmax + 1)
     """
-    assert tab.dtype == 'int32' or tab.dtype == 'int64'
+    assert tab.dtype == "int32" or tab.dtype == "int64"
     nrow, ncol = tab.shape
     if nbucket is None:
         nbucket = int(tab.max() + 1)
-    lims = np.empty(nbucket + 1, dtype='int64')
+    lims = np.empty(nbucket + 1, dtype="int64")
     matrix_bucket_sort_inplace_c(
-        nrow, ncol, faiss.swig_ptr(tab),
-        nbucket, faiss.swig_ptr(lims),
-        nt
+        nrow, ncol, faiss.swig_ptr(tab), nbucket, faiss.swig_ptr(lims), nt
     )
     return lims
 
@@ -215,6 +225,7 @@ def matrix_bucket_sort_inplace(tab, nbucket=None, nt=0):
 ###########################################
 # ResultHeap
 ###########################################
+
 
 class ResultHeap:
     """Accumulate query results from a sliced dataset. The final result will
@@ -226,8 +237,8 @@ class ResultHeap:
         k: number of results per query
         keep_max: keep the top-k maximum values instead of the minima
         """
-        self.I = np.zeros((nq, k), dtype='int64')
-        self.D = np.zeros((nq, k), dtype='float32')
+        self.I = np.zeros((nq, k), dtype="int64")
+        self.D = np.zeros((nq, k), dtype="float32")
         self.nq, self.k = nq, k
         if keep_max:
             heaps = float_minheap_array_t()
@@ -247,13 +258,11 @@ class ResultHeap:
         D, I do not need to be in a particular order (heap or sorted)
         """
         nq, kd = D.shape
-        D = np.ascontiguousarray(D, dtype='float32')
-        I = np.ascontiguousarray(I, dtype='int64')
+        D = np.ascontiguousarray(D, dtype="float32")
+        I = np.ascontiguousarray(I, dtype="int64")
         assert I.shape == (nq, kd)
         assert nq == self.nq
-        self.heaps.addn_with_ids(
-            kd, swig_ptr(D),
-            swig_ptr(I), kd)
+        self.heaps.addn_with_ids(kd, swig_ptr(D), swig_ptr(I), kd)
 
     def add_result_subset(self, subset, D, I):
         """
@@ -264,16 +273,17 @@ class ResultHeap:
         nsubset, kd = D.shape
         assert nsubset == len(subset)
         assert (
-            I.ndim == 2 and D.shape == I.shape or
-            I.ndim == 1 and I.shape == (kd, )
+            I.ndim == 2
+            and D.shape == I.shape
+            or I.ndim == 1
+            and I.shape == (kd,)
         )
-        D = np.ascontiguousarray(D, dtype='float32')
-        I = np.ascontiguousarray(I, dtype='int64')
-        subset = np.ascontiguousarray(subset, dtype='int64')
+        D = np.ascontiguousarray(D, dtype="float32")
+        I = np.ascontiguousarray(I, dtype="int64")
+        subset = np.ascontiguousarray(subset, dtype="int64")
         id_stride = 0 if I.ndim == 1 else kd
         self.heaps.addn_query_subset_with_ids(
-            nsubset, swig_ptr(subset),
-            kd, swig_ptr(D), swig_ptr(I), id_stride
+            nsubset, swig_ptr(subset), kd, swig_ptr(D), swig_ptr(I), id_stride
         )
 
     def finalize(self):
@@ -292,43 +302,61 @@ def merge_knn_results(Dall, Iall, keep_max=False):
     Inew = np.empty((n, k), dtype=Iall.dtype)
     func = merge_knn_results_CMax if keep_max else merge_knn_results_CMin
     func(
-        n, k, nshard,
-        swig_ptr(Dall), swig_ptr(Iall),
-        swig_ptr(Dnew), swig_ptr(Inew)
+        n,
+        k,
+        nshard,
+        swig_ptr(Dall),
+        swig_ptr(Iall),
+        swig_ptr(Dnew),
+        swig_ptr(Inew),
     )
     return Dnew, Inew
+
 
 ######################################################
 # Efficient ID to ID map
 ######################################################
 
+
 class MapInt64ToInt64:
 
     def __init__(self, capacity):
         self.log2_capacity = int(np.log2(capacity))
-        assert capacity == 2 ** self.log2_capacity, "need power of 2 capacity"
+        assert capacity == 2**self.log2_capacity, "need power of 2 capacity"
         self.capacity = capacity
-        self.tab = np.empty((capacity, 2), dtype='int64')
-        faiss.hashtable_int64_to_int64_init(self.log2_capacity, swig_ptr(self.tab))
+        self.tab = np.empty((capacity, 2), dtype="int64")
+        faiss.hashtable_int64_to_int64_init(
+            self.log2_capacity, swig_ptr(self.tab)
+        )
 
     def add(self, keys, vals):
-        n, = keys.shape
+        (n,) = keys.shape
         assert vals.shape == (n,)
         faiss.hashtable_int64_to_int64_add(
-            self.log2_capacity, swig_ptr(self.tab),
-            n, swig_ptr(keys), swig_ptr(vals))
+            self.log2_capacity,
+            swig_ptr(self.tab),
+            n,
+            swig_ptr(keys),
+            swig_ptr(vals),
+        )
 
     def lookup(self, keys):
-        n, = keys.shape
-        vals = np.empty((n,), dtype='int64')
+        (n,) = keys.shape
+        vals = np.empty((n,), dtype="int64")
         faiss.hashtable_int64_to_int64_lookup(
-            self.log2_capacity, swig_ptr(self.tab),
-            n, swig_ptr(keys), swig_ptr(vals))
+            self.log2_capacity,
+            swig_ptr(self.tab),
+            n,
+            swig_ptr(keys),
+            swig_ptr(vals),
+        )
         return vals
+
 
 ######################################################
 # KNN function
 ######################################################
+
 
 def knn(xq, xb, k, metric=METRIC_L2, metric_arg=0.0):
     """
@@ -355,30 +383,35 @@ def knn(xq, xb, k, metric=METRIC_L2, metric_arg=0.0):
     I : array_like
         Labels of the nearest neighbors, shape (nq, k)
     """
-    xq = np.ascontiguousarray(xq, dtype='float32')
-    xb = np.ascontiguousarray(xb, dtype='float32')
+    xq = np.ascontiguousarray(xq, dtype="float32")
+    xb = np.ascontiguousarray(xb, dtype="float32")
     nq, d = xq.shape
     nb, d2 = xb.shape
     assert d == d2
 
-    I = np.empty((nq, k), dtype='int64')
-    D = np.empty((nq, k), dtype='float32')
+    I = np.empty((nq, k), dtype="int64")
+    D = np.empty((nq, k), dtype="float32")
 
     if metric == METRIC_L2:
         knn_L2sqr(
-            swig_ptr(xq), swig_ptr(xb),
-            d, nq, nb, k, swig_ptr(D), swig_ptr(I)
+            swig_ptr(xq), swig_ptr(xb), d, nq, nb, k, swig_ptr(D), swig_ptr(I)
         )
     elif metric == METRIC_INNER_PRODUCT:
         knn_inner_product(
-            swig_ptr(xq), swig_ptr(xb),
-            d, nq, nb, k, swig_ptr(D), swig_ptr(I)
+            swig_ptr(xq), swig_ptr(xb), d, nq, nb, k, swig_ptr(D), swig_ptr(I)
         )
-    else: 
+    else:
         knn_extra_metrics(
-            swig_ptr(xq), swig_ptr(xb),
-            d, nq, nb, metric, metric_arg, k, 
-            swig_ptr(D), swig_ptr(I)
+            swig_ptr(xq),
+            swig_ptr(xb),
+            d,
+            nq,
+            nb,
+            metric,
+            metric_arg,
+            k,
+            swig_ptr(D),
+            swig_ptr(I),
         )
 
     return D, I
@@ -412,8 +445,8 @@ def knn_hamming(xq, xb, k, variant="hc"):
     nq, d = xq.shape
     nb, d2 = xb.shape
     assert d == d2
-    D = np.empty((nq, k), dtype='int32')
-    I = np.empty((nq, k), dtype='int64')
+    D = np.empty((nq, k), dtype="int32")
+    I = np.empty((nq, k), dtype="int64")
 
     if variant == "hc":
         heap = faiss.int_maxheap_array_t()
@@ -422,13 +455,18 @@ def knn_hamming(xq, xb, k, variant="hc"):
         heap.ids = faiss.swig_ptr(I)
         heap.val = faiss.swig_ptr(D)
         faiss.hammings_knn_hc(
-            heap, faiss.swig_ptr(xq), faiss.swig_ptr(xb), nb,
-            d, 1
+            heap, faiss.swig_ptr(xq), faiss.swig_ptr(xb), nb, d, 1
         )
     elif variant == "mc":
         faiss.hammings_knn_mc(
-            faiss.swig_ptr(xq), faiss.swig_ptr(xb), nq, nb, k, d,
-            faiss.swig_ptr(D), faiss.swig_ptr(I)
+            faiss.swig_ptr(xq),
+            faiss.swig_ptr(xb),
+            nq,
+            nb,
+            k,
+            d,
+            faiss.swig_ptr(D),
+            faiss.swig_ptr(I),
         )
     else:
         raise NotImplementedError
@@ -487,8 +525,8 @@ class Kmeans:
 
     def __init__(self, d, k, **kwargs):
         """d: input dimension, k: nb of centroids. Additional
-         parameters are passed on the ClusteringParameters object,
-         including niter=25, verbose=False, spherical = False
+        parameters are passed on the ClusteringParameters object,
+        including niter=25, verbose=False, spherical = False
         """
         self.d = d
         self.reset(k)
@@ -498,7 +536,7 @@ class Kmeans:
         else:
             self.cp = ClusteringParameters()
         for k, v in kwargs.items():
-            if k == 'gpu':
+            if k == "gpu":
                 if v == True or v == -1:
                     v = get_num_gpus()
                 self.gpu = v
@@ -516,7 +554,9 @@ class Kmeans:
             else:
                 self.index = IndexFlatL2(d)
             if self.gpu:
-                self.index = faiss.index_cpu_to_all_gpus(self.index, ngpu=self.gpu)
+                self.index = faiss.index_cpu_to_all_gpus(
+                    self.index, ngpu=self.gpu
+                )
         else:
             if self.gpu:
                 fac = GpuProgressiveDimIndexFactory(ngpu=self.gpu)
@@ -525,8 +565,8 @@ class Kmeans:
             self.fac = fac
 
     def reset(self, k=None):
-        """ prepare k-means object to perform a new clustering, possibly
-        with another number of centroids """
+        """prepare k-means object to perform a new clustering, possibly
+        with another number of centroids"""
         if k is not None:
             self.k = int(k)
         self.centroids = None
@@ -534,7 +574,7 @@ class Kmeans:
         self.iteration_stats = None
 
     def train(self, x, weights=None, init_centroids=None):
-        """ Perform k-means clustering.
+        """Perform k-means clustering.
         On output of the function call:
 
         - the centroids are in the centroids field of size (`k`, `d`).
@@ -559,7 +599,7 @@ class Kmeans:
             final optimization objective
 
         """
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
         n, d = x.shape
         assert d == self.d
 
@@ -569,7 +609,9 @@ class Kmeans:
             if init_centroids is not None:
                 nc, d2 = init_centroids.shape
                 assert d2 == d
-                faiss.copy_array_to_vector(init_centroids.ravel(), clus.centroids)
+                faiss.copy_array_to_vector(
+                    init_centroids.ravel(), clus.centroids
+                )
             clus.train(x, self.index, weights)
         else:
             # not supported for progressive dim
@@ -586,15 +628,14 @@ class Kmeans:
         stats = [stats.at(i) for i in range(stats.size())]
         self.obj = np.array([st.obj for st in stats])
         # copy all the iteration_stats objects to a python array
-        stat_fields = 'obj time time_search imbalance_factor nsplit'.split()
+        stat_fields = "obj time time_search imbalance_factor nsplit".split()
         self.iteration_stats = [
-            {field: getattr(st, field) for field in stat_fields}
-            for st in stats
+            {field: getattr(st, field) for field in stat_fields} for st in stats
         ]
         return self.obj[-1] if self.obj.size > 0 else 0.0
 
     def assign(self, x):
-        x = np.ascontiguousarray(x, dtype='float32')
+        x = np.ascontiguousarray(x, dtype="float32")
         assert self.centroids is not None, "should train before assigning"
         self.index.reset()
         self.index.add(self.centroids)
@@ -629,9 +670,10 @@ class SuperKmeans(Kmeans):
 
     def train(self, x, weights=None, init_centroids=None):
         assert weights is None, "SuperKmeans does not support weights"
-        assert init_centroids is None, \
-            "SuperKmeans does not support init_centroids"
-        x = np.ascontiguousarray(x, dtype='float32')
+        assert (
+            init_centroids is None
+        ), "SuperKmeans does not support init_centroids"
+        x = np.ascontiguousarray(x, dtype="float32")
         n, d = x.shape
         assert d == self.d
 
@@ -643,10 +685,9 @@ class SuperKmeans(Kmeans):
         stats = sc.iteration_stats
         stats = [stats.at(i) for i in range(stats.size())]
         self.obj = np.array([st.obj for st in stats])
-        stat_fields = 'obj time time_search imbalance_factor nsplit'.split()
+        stat_fields = "obj time time_search imbalance_factor nsplit".split()
         self.iteration_stats = [
-            {field: getattr(st, field) for field in stat_fields}
-            for st in stats
+            {field: getattr(st, field) for field in stat_fields} for st in stats
         ]
         self.gemm_pruning_rates = faiss.vector_to_array(sc.gemm_pruning_rates)
         return self.obj[-1] if self.obj.size > 0 else 0.0
@@ -656,10 +697,13 @@ class SuperKmeans(Kmeans):
 # Packing and unpacking bitstrings
 ###########################################
 
+
 def is_sequence(x):
     return isinstance(x, collections.abc.Sequence)
 
+
 pack_bitstrings_c = pack_bitstrings
+
 
 def pack_bitstrings(a, nbit):
     """
@@ -672,21 +716,24 @@ def pack_bitstrings(a, nbit):
     If nbit is an array: entry (i, j) takes nbit[j] bits.
     """
     n, M = a.shape
-    a = np.ascontiguousarray(a, dtype='int32')
+    a = np.ascontiguousarray(a, dtype="int32")
     if is_sequence(nbit):
-        nbit = np.ascontiguousarray(nbit, dtype='int32')
+        nbit = np.ascontiguousarray(nbit, dtype="int32")
         assert nbit.shape == (M,)
         code_size = int((nbit.sum() + 7) // 8)
-        b = np.empty((n, code_size), dtype='uint8')
+        b = np.empty((n, code_size), dtype="uint8")
         pack_bitstrings_c(
-            n, M, swig_ptr(nbit), swig_ptr(a), swig_ptr(b), code_size)
+            n, M, swig_ptr(nbit), swig_ptr(a), swig_ptr(b), code_size
+        )
     else:
         code_size = (M * nbit + 7) // 8
-        b = np.empty((n, code_size), dtype='uint8')
+        b = np.empty((n, code_size), dtype="uint8")
         pack_bitstrings_c(n, M, nbit, swig_ptr(a), swig_ptr(b), code_size)
     return b
 
+
 unpack_bitstrings_c = unpack_bitstrings
+
 
 def unpack_bitstrings(b, M_or_nbits, nbit=None):
     """
@@ -703,19 +750,18 @@ def unpack_bitstrings(b, M_or_nbits, nbit=None):
     """
     n, code_size = b.shape
     if nbit is None:
-        nbit = np.ascontiguousarray(M_or_nbits, dtype='int32')
+        nbit = np.ascontiguousarray(M_or_nbits, dtype="int32")
         M = len(nbit)
         min_code_size = int((nbit.sum() + 7) // 8)
         assert code_size >= min_code_size
-        a = np.empty((n, M), dtype='int32')
+        a = np.empty((n, M), dtype="int32")
         unpack_bitstrings_c(
-            n, M, swig_ptr(nbit),
-            swig_ptr(b), code_size, swig_ptr(a))
+            n, M, swig_ptr(nbit), swig_ptr(b), code_size, swig_ptr(a)
+        )
     else:
         M = M_or_nbits
         min_code_size = (M * nbit + 7) // 8
         assert code_size >= min_code_size
-        a = np.empty((n, M), dtype='int32')
-        unpack_bitstrings_c(
-            n, M, nbit, swig_ptr(b), code_size, swig_ptr(a))
+        a = np.empty((n, M), dtype="int32")
+        unpack_bitstrings_c(n, M, nbit, swig_ptr(b), code_size, swig_ptr(a))
     return a

--- a/faiss/python/gpu_wrappers.py
+++ b/faiss/python/gpu_wrappers.py
@@ -19,9 +19,9 @@ from faiss.loader import *
 
 
 def index_cpu_to_gpu_multiple_py(resources, index, co=None, gpus=None):
-    """ builds the C++ vectors for the GPU indices and the
+    """builds the C++ vectors for the GPU indices and the
     resources. Handles the case where the resources are assigned to
-    the list of GPUs """
+    the list of GPUs"""
     if gpus is None:
         gpus = range(len(resources))
     vres = GpuResourcesVector()
@@ -41,7 +41,7 @@ def index_cpu_to_all_gpus(index, co=None, ngpu=-1):
 
 
 def index_cpu_to_gpus_list(index, co=None, gpus=None, ngpu=-1):
-    """ Here we can pass list of GPU ids as a parameter or ngpu to
+    """Here we can pass list of GPU ids as a parameter or ngpu to
     use first n GPU's. gpus mut be a list or None.
     co is a GpuMultipleClonerOptions
     """
@@ -53,10 +53,23 @@ def index_cpu_to_gpus_list(index, co=None, gpus=None, ngpu=-1):
     index_gpu = index_cpu_to_gpu_multiple_py(res, index, co, gpus)
     return index_gpu
 
+
 # allows numpy ndarray usage with bfKnn
 
 
-def knn_gpu(res, xq, xb, k, D=None, I=None, metric=METRIC_L2, device=-1, use_cuvs=False, vectorsMemoryLimit=0, queriesMemoryLimit=0):
+def knn_gpu(
+    res,
+    xq,
+    xb,
+    k,
+    D=None,
+    I=None,
+    metric=METRIC_L2,
+    device=-1,
+    use_cuvs=False,
+    vectorsMemoryLimit=0,
+    queriesMemoryLimit=0,
+):
     """
     Compute the k nearest neighbors of a vector on one GPU without constructing an index
 
@@ -107,7 +120,7 @@ def knn_gpu(res, xq, xb, k, D=None, I=None, metric=METRIC_L2, device=-1, use_cuv
         xq = xq.T
         xq_row_major = False
     else:
-        xq = np.ascontiguousarray(xq, dtype='float32')
+        xq = np.ascontiguousarray(xq, dtype="float32")
         xq_row_major = True
 
     xq_ptr = swig_ptr(xq)
@@ -117,7 +130,7 @@ def knn_gpu(res, xq, xb, k, D=None, I=None, metric=METRIC_L2, device=-1, use_cuv
     elif xq.dtype == np.float16:
         xq_type = DistanceDataType_F16
     else:
-        raise TypeError('xq must be f32 or f16')
+        raise TypeError("xq must be f32 or f16")
 
     nb, d2 = xb.shape
     assert d2 == d
@@ -127,7 +140,7 @@ def knn_gpu(res, xq, xb, k, D=None, I=None, metric=METRIC_L2, device=-1, use_cuv
         xb = xb.T
         xb_row_major = False
     else:
-        xb = np.ascontiguousarray(xb, dtype='float32')
+        xb = np.ascontiguousarray(xb, dtype="float32")
         xb_row_major = True
 
     xb_ptr = swig_ptr(xb)
@@ -137,7 +150,7 @@ def knn_gpu(res, xq, xb, k, D=None, I=None, metric=METRIC_L2, device=-1, use_cuv
     elif xb.dtype == np.float16:
         xb_type = DistanceDataType_F16
     else:
-        raise TypeError('xb must be float32 or float16')
+        raise TypeError("xb must be float32 or float16")
 
     if D is None:
         D = np.empty((nq, k), dtype=np.float32)
@@ -160,7 +173,7 @@ def knn_gpu(res, xq, xb, k, D=None, I=None, metric=METRIC_L2, device=-1, use_cuv
     elif I.dtype == I.dtype == np.int32:
         I_type = IndicesDataType_I32
     else:
-        raise TypeError('I must be i64 or i32')
+        raise TypeError("I must be i64 or i32")
 
     args = GpuDistanceParams()
     args.metric = metric
@@ -188,6 +201,7 @@ def knn_gpu(res, xq, xb, k, D=None, I=None, metric=METRIC_L2, device=-1, use_cuv
         bfKnn(res, args)
 
     return D, I
+
 
 # allows numpy ndarray usage with bfKnn for all pairwise distances
 
@@ -229,8 +243,7 @@ def pairwise_distance_gpu(res, xq, xb, D=None, metric=METRIC_L2, device=-1):
         xq = xq.T
         xq_row_major = False
     else:
-        raise TypeError(
-            'xq matrix should be row (C) or column-major (Fortran)')
+        raise TypeError("xq matrix should be row (C) or column-major (Fortran)")
 
     xq_ptr = swig_ptr(xq)
 
@@ -239,7 +252,7 @@ def pairwise_distance_gpu(res, xq, xb, D=None, metric=METRIC_L2, device=-1):
     elif xq.dtype == np.float16:
         xq_type = DistanceDataType_F16
     else:
-        xq = np.ascontiguousarray(xb, dtype='float32')
+        xq = np.ascontiguousarray(xb, dtype="float32")
         xq_row_major = True
 
     nb, d2 = xb.shape
@@ -250,7 +263,7 @@ def pairwise_distance_gpu(res, xq, xb, D=None, metric=METRIC_L2, device=-1):
         xb = xb.T
         xb_row_major = False
     else:
-        xb = np.ascontiguousarray(xb, dtype='float32')
+        xb = np.ascontiguousarray(xb, dtype="float32")
         xb_row_major = True
 
     xb_ptr = swig_ptr(xb)
@@ -260,7 +273,7 @@ def pairwise_distance_gpu(res, xq, xb, D=None, metric=METRIC_L2, device=-1):
     elif xb.dtype == np.float16:
         xb_type = DistanceDataType_F16
     else:
-        raise TypeError('xb must be float32 or float16')
+        raise TypeError("xb must be float32 or float16")
 
     if D is None:
         D = np.empty((nq, nb), dtype=np.float32)

--- a/faiss/python/loader.py
+++ b/faiss/python/loader.py
@@ -37,23 +37,34 @@ def supported_instruction_sets():
             return False
         # Numpy 2.0 supports SVE detection by __cpu_features__, so just skip
         import numpy
+
         if Version(numpy.__version__) >= Version("2.0"):
             return False
         # platform-dependent legacy fallback using numpy.distutils.cpuinfo
         try:
             import numpy.distutils.cpuinfo
-            return "sve" in numpy.distutils.cpuinfo.cpu.info[0].get('Features', "").split()
+
+            return (
+                "sve"
+                in numpy.distutils.cpuinfo.cpu.info[0]
+                .get("Features", "")
+                .split()
+            )
         except ImportError:
             # check if SVE is supported by checking the auxval
             # using values defined as:
             # #define AT_HWCAP 16
             # #define HWCAP_SVE  (1 << 22)
-            return bool(__import__('ctypes').CDLL(None).getauxval(16) & (1<<22))
+            return bool(
+                __import__("ctypes").CDLL(None).getauxval(16) & (1 << 22)
+            )
 
     import numpy
+
     if Version(numpy.__version__) >= Version("1.19"):
         # use private API as next-best thing until numpy/numpy#18058 is solved
         from numpy._core._multiarray_umath import __cpu_features__
+
         # __cpu_features__ is a dictionary with CPU features
         # as keys, and True / False as values
         supported = {k for k, v in __cpu_features__.items() if v}
@@ -65,16 +76,24 @@ def supported_instruction_sets():
 
     # platform-dependent legacy fallback before numpy 1.19, no windows
     if platform.system() == "Darwin":
-        if subprocess.check_output(["/usr/sbin/sysctl", "hw.optional.avx2_0"])[-1] == '1':
+        if (
+            subprocess.check_output(["/usr/sbin/sysctl", "hw.optional.avx2_0"])[
+                -1
+            ]
+            == "1"
+        ):
             return {"AVX2"}
     elif platform.system() == "Linux":
         import numpy.distutils.cpuinfo
+
         result = set()
-        if "avx2" in numpy.distutils.cpuinfo.cpu.info[0].get('flags', ""):
+        if "avx2" in numpy.distutils.cpuinfo.cpu.info[0].get("flags", ""):
             result.add("AVX2")
-        if "avx512" in numpy.distutils.cpuinfo.cpu.info[0].get('flags', ""):
+        if "avx512" in numpy.distutils.cpuinfo.cpu.info[0].get("flags", ""):
             result.add("AVX512")
-        if "avx512_fp16" in numpy.distutils.cpuinfo.cpu.info[0].get('flags', ""):
+        if "avx512_fp16" in numpy.distutils.cpuinfo.cpu.info[0].get(
+            "flags", ""
+        ):
             # avx512_fp16 is supported starting SPR
             result.add("AVX512_SPR")
         if is_sve_supported():
@@ -83,6 +102,7 @@ def supported_instruction_sets():
             result.discard(f)
         return result
     return set()
+
 
 logger = logging.getLogger(__name__)
 
@@ -93,8 +113,10 @@ opt_env_variable_name = "FAISS_OPT_LEVEL"
 opt_level = os.environ.get(opt_env_variable_name, None)
 
 if opt_level is None:
-    logger.debug(f"Environment variable {opt_env_variable_name} is not set, " \
-                "so let's pick the instruction set according to the current CPU")
+    logger.debug(
+        f"Environment variable {opt_env_variable_name} is not set, "
+        "so let's pick the instruction set according to the current CPU"
+    )
     instruction_sets = supported_instruction_sets()
 else:
     logger.debug(f"Using {opt_level} as an instruction set.")
@@ -107,10 +129,13 @@ if has_AVX512_SPR:
     try:
         logger.info("Loading faiss with AVX512-SPR support.")
         from .swigfaiss_avx512_spr import *
+
         logger.info("Successfully loaded faiss with AVX512-SPR support.")
         loaded = True
     except ImportError as e:
-        logger.info(f"Could not load library with AVX512-SPR support due to:\n{e!r}")
+        logger.info(
+            f"Could not load library with AVX512-SPR support due to:\n{e!r}"
+        )
         # reset so that we load without AVX512 below
         loaded = False
 
@@ -119,10 +144,13 @@ if has_AVX512 and not loaded:
     try:
         logger.info("Loading faiss with AVX512 support.")
         from .swigfaiss_avx512 import *
+
         logger.info("Successfully loaded faiss with AVX512 support.")
         loaded = True
     except ImportError as e:
-        logger.info(f"Could not load library with AVX512 support due to:\n{e!r}")
+        logger.info(
+            f"Could not load library with AVX512 support due to:\n{e!r}"
+        )
         # reset so that we load without AVX512 below
         loaded = False
 
@@ -131,6 +159,7 @@ if has_AVX2 and not loaded:
     try:
         logger.info("Loading faiss with AVX2 support.")
         from .swigfaiss_avx2 import *
+
         logger.info("Successfully loaded faiss with AVX2 support.")
         loaded = True
     except ImportError as e:
@@ -143,6 +172,7 @@ if has_SVE and not loaded:
     try:
         logger.info("Loading faiss with SVE support.")
         from .swigfaiss_sve import *
+
         logger.info("Successfully loaded faiss with SVE support.")
         loaded = True
     except ImportError as e:
@@ -155,6 +185,7 @@ if not loaded:
         # we import * so that the symbol X can be accessed as faiss.X
         logger.info("Loading faiss.")
         from .swigfaiss import *
+
         logger.info("Successfully loaded faiss.")
     except ModuleNotFoundError:
         formatted_ins_sets = ", ".join(supported_instruction_sets())
@@ -165,7 +196,6 @@ if not loaded:
             f"A) Set the correct FAISS_OPT_LEVEL value when executing "
             f"'cmake'.\n"
             f"B) Build the correct SWIG wrapper.\n\n"
-
             f"These are the supported instruction sets on your system:\n"
             f"{formatted_ins_sets}\n"
             f"- If 'AVX512_SPR' (case insensitive) is supported on your "

--- a/faiss/python/setup.py
+++ b/faiss/python/setup.py
@@ -83,7 +83,9 @@ if found_swigfaiss_avx512:
 if found_swigfaiss_avx512_spr:
     print(f"Copying {swigfaiss_avx512_spr_lib}")
     shutil.copyfile("swigfaiss_avx512_spr.py", "faiss/swigfaiss_avx512_spr.py")
-    shutil.copyfile(swigfaiss_avx512_spr_lib, f"faiss/_swigfaiss_avx512_spr{ext}")
+    shutil.copyfile(
+        swigfaiss_avx512_spr_lib, f"faiss/_swigfaiss_avx512_spr{ext}"
+    )
 
 if found_callbacks:
     print(f"Copying {callbacks_lib}")
@@ -97,7 +99,8 @@ if found_swigfaiss_sve:
 if found_faiss_example_external_module_lib:
     print(f"Copying {faiss_example_external_module_lib}")
     shutil.copyfile(
-        "faiss_example_external_module.py", "faiss/faiss_example_external_module.py"
+        "faiss_example_external_module.py",
+        "faiss/faiss_example_external_module.py",
     )
     shutil.copyfile(
         faiss_example_external_module_lib,

--- a/perf_tests/bench_hnsw.py
+++ b/perf_tests/bench_hnsw.py
@@ -45,9 +45,7 @@ def is_perf_counter(key: str) -> bool:
 
 
 def accumulate_perf_counter(
-    phase: str,
-    t: PerfCounters,
-    counters: Dict[str, int]
+    phase: str, t: PerfCounters, counters: Dict[str, int]
 ):
     counters[f"{phase}_wall_time_us"] = int(t.wall_time_s * US_IN_S)
     counters[f"{phase}_user_time_us"] = int(t.user_time_s * US_IN_S)
@@ -198,8 +196,8 @@ def main():
     for counter, values in result.items():
         if is_perf_counter(counter):
             print(
-                "%s t=%.3f us (± %.4f)" % 
-                (counter, np.mean(values), np.std(values))
+                "%s t=%.3f us (± %.4f)"
+                % (counter, np.mean(values), np.std(values))
             )
 
 

--- a/tests/common_faiss_tests.py
+++ b/tests/common_faiss_tests.py
@@ -5,7 +5,12 @@
 
 # a few common functions for the tests
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import sys
 import unittest
@@ -50,8 +55,9 @@ class Randu10k:
         D, I = DI
         e = {}
         for rank in 1, 10, 100:
-            e[rank] = ((I[:, :rank] == self.gt.reshape(-1, 1)).sum() /
-                       float(self.nq))
+            e[rank] = (I[:, :rank] == self.gt.reshape(-1, 1)).sum() / float(
+                self.nq
+            )
         return e
 
 
@@ -77,9 +83,9 @@ class Randu10kUnbalanced(Randu10k):
 
 def get_dataset(d, nb, nt, nq):
     rs = np.random.RandomState(123)
-    xb = rs.rand(nb, d).astype('float32')
-    xt = rs.rand(nt, d).astype('float32')
-    xq = rs.rand(nq, d).astype('float32')
+    xb = rs.rand(nb, d).astype("float32")
+    xt = rs.rand(nt, d).astype("float32")
+    xq = rs.rand(nq, d).astype("float32")
 
     return (xt, xb, xq)
 
@@ -88,7 +94,7 @@ def get_dataset_2(d, nt, nb, nq):
     """A dataset that is not completely random but still challenging to
     index
     """
-    d1 = 10     # intrinsic dimension (more or less)
+    d1 = 10  # intrinsic dimension (more or less)
     n = nb + nt + nq
     rs = np.random.RandomState(1338)
     x = rs.normal(size=(n, d1))
@@ -97,14 +103,14 @@ def get_dataset_2(d, nt, nb, nq):
     # higher factor (>4) -> higher frequency -> less linear
     x = x * (rs.rand(d) * 4 + 0.1)
     x = np.sin(x)
-    x = x.astype('float32')
-    return x[:nt], x[nt:nt + nb], x[nt + nb:]
+    x = x.astype("float32")
+    return x[:nt], x[nt : nt + nb], x[nt + nb :]
 
 
 def make_binary_dataset(d, nt, nb, nq):
     assert d % 8 == 0
     rs = np.random.RandomState(123)
-    x = rs.randint(256, size=(nb + nq + nt, int(d / 8))).astype('uint8')
+    x = rs.randint(256, size=(nb + nq + nt, int(d / 8))).astype("uint8")
     return x[:nt], x[nt:-nq], x[-nq:]
 
 
@@ -115,19 +121,22 @@ def compare_binary_result_lists(D1, I1, D2, I2):
     assert D1.shape == I1.shape == D2.shape == I2.shape
     n, k = D1.shape
     ndiff = (D1 != D2).sum()
-    assert ndiff == 0, '%d differences in distance matrix %s' % (
-        ndiff, D1.shape)
+    assert ndiff == 0, "%d differences in distance matrix %s" % (
+        ndiff,
+        D1.shape,
+    )
 
     def normalize_DI(D, I):
         norm = I.max() + 1.0
-        Dr = D.astype('float64') + I / norm
+        Dr = D.astype("float64") + I / norm
         # ignore -1s and elements on last column
         Dr[I1 == -1] = 1e20
         Dr[D == D[:, -1:]] = 1e20
         Dr.sort(axis=1)
         return Dr
+
     ndiff = (normalize_DI(D1, I1) != normalize_DI(D2, I2)).sum()
-    assert ndiff == 0, '%d differences in normalized D matrix' % ndiff
+    assert ndiff == 0, "%d differences in normalized D matrix" % ndiff
 
 
 # Map SIMDLevel enum values to their string names.
@@ -218,7 +227,8 @@ def for_all_simd_levels(cls):
                 def tearDown(self):
                     super().tearDown()
                     faiss.SIMDConfig.set_level(
-                        faiss.SIMDConfig.get_dispatched_level())
+                        faiss.SIMDConfig.get_dispatched_level()
+                    )
 
             Parameterized.__name__ = f"{cls.__name__}_{ln}"
             Parameterized.__qualname__ = f"{cls.__qualname__}_{ln}"

--- a/tests/index_io_backward_compatibility/cmake_conda_io_utils.py
+++ b/tests/index_io_backward_compatibility/cmake_conda_io_utils.py
@@ -121,9 +121,7 @@ INDEX_BINARY_TYPES = [
 
 
 def sanitize_index_key(index_key: str) -> str:
-    return (
-        index_key.replace(",", "__").replace("(", "--").replace(")", "--")
-    )
+    return index_key.replace(",", "__").replace("(", "--").replace(")", "--")
 
 
 def generate_vectors(d: int, nb: int, seed: int) -> np.ndarray:
@@ -133,17 +131,13 @@ def generate_vectors(d: int, nb: int, seed: int) -> np.ndarray:
     return xb
 
 
-def write_vectors(
-    output_dir: str, vectors: np.ndarray, filename: str
-) -> None:
+def write_vectors(output_dir: str, vectors: np.ndarray, filename: str) -> None:
     path = os.path.join(output_dir, filename)
     print(f"Writing vectors to: {path}")
     np.save(path, vectors)
 
 
-def create_and_populate_index(
-    index_key: str, xb: np.ndarray
-) -> faiss.Index:
+def create_and_populate_index(index_key: str, xb: np.ndarray) -> faiss.Index:
     d = xb.shape[1]
     index = faiss.index_factory(d, index_key)
     print(f"Created index type: {type(index).__name__}")
@@ -156,9 +150,7 @@ def create_and_populate_index(
     # IDMap indexes require add_with_ids() instead of add()
     if "IDMap" in index_key:
         ids = np.arange(xb.shape[0], dtype=np.int64)
-        print(
-            f"Using add_with_ids() with IDs from 0 to {xb.shape[0] - 1}"
-        )
+        print(f"Using add_with_ids() with IDs from 0 to {xb.shape[0] - 1}")
         index.add_with_ids(xb, ids)
     else:
         index.add(xb)
@@ -182,9 +174,7 @@ def create_and_populate_binary_index(
     # IDMap indexes require add_with_ids() instead of add()
     if "IDMap" in index_key:
         ids = np.arange(xb.shape[0], dtype=np.int64)
-        print(
-            f"Using add_with_ids() with IDs from 0 to {xb.shape[0] - 1}"
-        )
+        print(f"Using add_with_ids() with IDs from 0 to {xb.shape[0] - 1}")
         index.add_with_ids(xb, ids)
     else:
         index.add(xb)
@@ -193,9 +183,7 @@ def create_and_populate_binary_index(
     return index
 
 
-def write_index(
-    index: faiss.Index, output_dir: str, filename: str
-) -> None:
+def write_index(index: faiss.Index, output_dir: str, filename: str) -> None:
     index_path = os.path.join(output_dir, filename)
 
     # Delete existing file if present
@@ -359,9 +347,7 @@ def test_write_binary_index_type(
         }
 
 
-def write_test_all_files(
-    writer: str, output_dir: str, seed: int
-) -> int:
+def write_test_all_files(writer: str, output_dir: str, seed: int) -> int:
     print(f"{writer.capitalize()} Writer: Testing index serialization")
 
     os.makedirs(output_dir, exist_ok=True)
@@ -401,13 +387,12 @@ def write_test_all_files(
 
     # Now write binary indexes
     print(
-        f"\n{writer.capitalize()} Writer: "
-        "Testing binary index serialization"
+        f"\n{writer.capitalize()} Writer: " "Testing binary index serialization"
     )
     print(f"\nGenerating binary vectors: {nb} database vectors, dimension {d}")
     assert d % 8 == 0
     np.random.seed(seed)
-    xb_binary = np.random.randint(256, size=(nb, int(d / 8))).astype('uint8')
+    xb_binary = np.random.randint(256, size=(nb, int(d / 8))).astype("uint8")
     write_vectors(output_dir, xb_binary, f"vectors_db_binary_{writer}.npy")
 
     binary_results = []
@@ -508,9 +493,7 @@ def read_test_all_files(reader: str, writer: str, input_dir: str) -> int:
 
     # Now read binary indexes
     print(f"\n{reader} Reader: Testing binary index deserialization")
-    binary_metadata = read_metadata(
-        input_dir, f"{writer}_binary_metadata.json"
-    )
+    binary_metadata = read_metadata(input_dir, f"{writer}_binary_metadata.json")
 
     print(f"Binary metadata from {writer} build:")
     print_metadata(binary_metadata)

--- a/tests/test_binary_hashindex.py
+++ b/tests/test_binary_hashindex.py
@@ -12,12 +12,16 @@ from common_faiss_tests import for_all_simd_levels, make_binary_dataset
 
 def bitvec_shuffle(a, order):
     n, d = a.shape
-    db, = order.shape
-    b = np.empty((n, db // 8), dtype='uint8')
+    (db,) = order.shape
+    b = np.empty((n, db // 8), dtype="uint8")
     faiss.bitvec_shuffle(
-        n, d * 8, db,
+        n,
+        d * 8,
+        db,
         faiss.swig_ptr(order),
-        faiss.swig_ptr(a), faiss.swig_ptr(b))
+        faiss.swig_ptr(a),
+        faiss.swig_ptr(b),
+    )
     return b
 
 
@@ -27,15 +31,15 @@ class TestSmallFuncs(unittest.TestCase):
         d = 256
         n = 1000
         rs = np.random.RandomState(123)
-        o = rs.permutation(d).astype('int32')
+        o = rs.permutation(d).astype("int32")
 
-        x = rs.randint(256, size=(n, d // 8)).astype('uint8')
+        x = rs.randint(256, size=(n, d // 8)).astype("uint8")
 
         y1 = bitvec_shuffle(x, o[:128])
         y2 = bitvec_shuffle(x, o[128:])
         y = np.hstack((y1, y2))
 
-        oinv = np.empty(d, dtype='int32')
+        oinv = np.empty(d, dtype="int32")
         oinv[o] = np.arange(d)
         z = bitvec_shuffle(y, oinv)
 
@@ -70,8 +74,8 @@ class TestRange(unittest.TestCase):
             stats.reset()
             Lnew, Dnew, Inew = index.range_search(xq, radius)
             for i in range(nq):
-                ref = Iref[Lref[i]:Lref[i + 1]]
-                new = Inew[Lnew[i]:Lnew[i + 1]]
+                ref = Iref[Lref[i] : Lref[i + 1]]
+                new = Inew[Lnew[i] : Lnew[i + 1]]
                 snew = set(new)
                 # no duplicates
                 self.assertTrue(len(new) == len(snew))
@@ -109,8 +113,8 @@ class TestRange(unittest.TestCase):
             stats.reset()
             Lnew, Dnew, Inew = index.range_search(xq, radius)
             for i in range(nq):
-                ref = Iref[Lref[i]:Lref[i + 1]]
-                new = Inew[Lnew[i]:Lnew[i + 1]]
+                ref = Iref[Lref[i] : Lref[i + 1]]
+                new = Inew[Lnew[i] : Lnew[i + 1]]
                 snew = set(new)
                 # no duplicates
                 self.assertTrue(len(new) == len(snew))
@@ -162,7 +166,8 @@ class TestKnn(unittest.TestCase):
 
             # test serialization
             index2 = faiss.deserialize_index_binary(
-                faiss.serialize_index_binary(index))
+                faiss.serialize_index_binary(index)
+            )
 
             D2, I2 = index2.search(xq, k)
             np.testing.assert_array_equal(Inew, I2)
@@ -170,7 +175,8 @@ class TestKnn(unittest.TestCase):
 
             # Verify deserialized index is serializable again
             index3 = faiss.deserialize_index_binary(
-                faiss.serialize_index_binary(index2))
+                faiss.serialize_index_binary(index2)
+            )
             D3, I3 = index3.search(xq, k)
             np.testing.assert_array_equal(Inew, I3)
             np.testing.assert_array_equal(Dnew, D3)
@@ -196,17 +202,13 @@ class TestKnn(unittest.TestCase):
         index.nflip = 5
         k = 10
         Do, Io = index.search(xq, k)
-        self.assertTrue(
-            np.all(Do[:, 1:] >= Do[:, :-1])
-        )
+        self.assertTrue(np.all(Do[:, 1:] >= Do[:, :-1]))
 
     def test_result_order_binhash(self):
         self.subtest_result_order(0)
 
     def test_result_order_multihash(self):
         self.subtest_result_order(3)
-
-
 
 
 """

--- a/tests/test_binary_io.py
+++ b/tests/test_binary_io.py
@@ -5,7 +5,12 @@
 
 """Binary indexes (de)serialization"""
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import numpy as np
 import unittest
@@ -14,7 +19,7 @@ import faiss
 
 def make_binary_dataset(d, nb, nt, nq):
     assert d % 8 == 0
-    x = np.random.randint(256, size=(nb + nq + nt, int(d / 8))).astype('uint8')
+    x = np.random.randint(256, size=(nb + nq + nt, int(d / 8))).astype("uint8")
     return x[:nt], x[nt:-nq], x[-nq:]
 
 
@@ -35,7 +40,9 @@ class TestBinaryFlat(unittest.TestCase):
         index = faiss.IndexBinaryFlat(d)
         index.add(self.xb)
         D, I = index.search(self.xq, 3)
-        index2 = faiss.deserialize_index_binary(faiss.serialize_index_binary(index))
+        index2 = faiss.deserialize_index_binary(
+            faiss.serialize_index_binary(index)
+        )
 
         D2, I2 = index2.search(self.xq, 3)
 
@@ -44,7 +51,8 @@ class TestBinaryFlat(unittest.TestCase):
 
         # Verify deserialized index is serializable again
         index3 = faiss.deserialize_index_binary(
-            faiss.serialize_index_binary(index2))
+            faiss.serialize_index_binary(index2)
+        )
         D3, I3 = index3.search(self.xq, 3)
         assert (I3 == I).all()
         assert (D3 == D).all()
@@ -66,13 +74,15 @@ class TestBinaryIVF(unittest.TestCase):
 
         quantizer = faiss.IndexBinaryFlat(d)
         index = faiss.IndexBinaryIVF(quantizer, d, 8)
-        index.cp.min_points_per_centroid = 5    # quiet warning
+        index.cp.min_points_per_centroid = 5  # quiet warning
         index.nprobe = 4
         index.train(self.xt)
         index.add(self.xb)
         D, I = index.search(self.xq, 3)
 
-        index2 = faiss.deserialize_index_binary(faiss.serialize_index_binary(index))
+        index2 = faiss.deserialize_index_binary(
+            faiss.serialize_index_binary(index)
+        )
 
         D2, I2 = index2.search(self.xq, 3)
 
@@ -81,7 +91,8 @@ class TestBinaryIVF(unittest.TestCase):
 
         # Verify deserialized index is serializable again
         index3 = faiss.deserialize_index_binary(
-            faiss.serialize_index_binary(index2))
+            faiss.serialize_index_binary(index2)
+        )
         D3, I3 = index3.search(self.xq, 3)
         assert (I3 == I).all()
         assert (D3 == D).all()
@@ -105,13 +116,16 @@ class TestObjectOwnership(unittest.TestCase):
         index.add(self.xb)
 
         # this is the output of read_index_binary (==> checks ownership)
-        index2 = faiss.deserialize_index_binary(faiss.serialize_index_binary(index))
+        index2 = faiss.deserialize_index_binary(
+            faiss.serialize_index_binary(index)
+        )
 
         assert index2.thisown
 
         # Verify deserialized index is serializable again
         index3 = faiss.deserialize_index_binary(
-            faiss.serialize_index_binary(index2))
+            faiss.serialize_index_binary(index2)
+        )
         assert index3.thisown
 
 
@@ -134,7 +148,9 @@ class TestBinaryFromFloat(unittest.TestCase):
         index.add(self.xb)
         D, I = index.search(self.xq, 3)
 
-        index2 = faiss.deserialize_index_binary(faiss.serialize_index_binary(index))
+        index2 = faiss.deserialize_index_binary(
+            faiss.serialize_index_binary(index)
+        )
         D2, I2 = index2.search(self.xq, 3)
 
         assert (I2 == I).all()
@@ -142,10 +158,12 @@ class TestBinaryFromFloat(unittest.TestCase):
 
         # Verify deserialized index is serializable again
         index3 = faiss.deserialize_index_binary(
-            faiss.serialize_index_binary(index2))
+            faiss.serialize_index_binary(index2)
+        )
         D3, I3 = index3.search(self.xq, 3)
         assert (I3 == I).all()
         assert (D3 == D).all()
+
 
 class TestBinaryHNSW(unittest.TestCase):
 
@@ -165,7 +183,9 @@ class TestBinaryHNSW(unittest.TestCase):
         index.add(self.xb)
         D, I = index.search(self.xq, 3)
 
-        index2 = faiss.deserialize_index_binary(faiss.serialize_index_binary(index))
+        index2 = faiss.deserialize_index_binary(
+            faiss.serialize_index_binary(index)
+        )
 
         D2, I2 = index2.search(self.xq, 3)
 
@@ -174,7 +194,8 @@ class TestBinaryHNSW(unittest.TestCase):
 
         # Verify deserialized index is serializable again
         index3 = faiss.deserialize_index_binary(
-            faiss.serialize_index_binary(index2))
+            faiss.serialize_index_binary(index2)
+        )
         D3, I3 = index3.search(self.xq, 3)
         assert (I3 == I).all()
         assert (D3 == D).all()
@@ -184,13 +205,15 @@ class TestBinaryHNSW(unittest.TestCase):
 
         quantizer = faiss.IndexBinaryHNSW(d)
         index = faiss.IndexBinaryIVF(quantizer, d, 8)
-        index.cp.min_points_per_centroid = 5    # quiet warning
+        index.cp.min_points_per_centroid = 5  # quiet warning
         index.nprobe = 4
         index.train(self.xt)
         index.add(self.xb)
         D, I = index.search(self.xq, 3)
 
-        index2 = faiss.deserialize_index_binary(faiss.serialize_index_binary(index))
+        index2 = faiss.deserialize_index_binary(
+            faiss.serialize_index_binary(index)
+        )
 
         D2, I2 = index2.search(self.xq, 3)
 
@@ -199,7 +222,8 @@ class TestBinaryHNSW(unittest.TestCase):
 
         # Verify deserialized index is serializable again
         index3 = faiss.deserialize_index_binary(
-            faiss.serialize_index_binary(index2))
+            faiss.serialize_index_binary(index2)
+        )
         D3, I3 = index3.search(self.xq, 3)
         assert (I3 == I).all()
         assert (D3 == D).all()

--- a/tests/test_binary_search_params.py
+++ b/tests/test_binary_search_params.py
@@ -15,7 +15,8 @@ from common_faiss_tests import for_all_simd_levels
 class TestBinarySearchParams(unittest.TestCase):
 
     def do_test_with_param(
-            self, index, ps_params, params, d=64, nb=500, nq=20, k=5):
+        self, index, ps_params, params, d=64, nb=500, nq=20, k=5
+    ):
         """
         Test equivalence between setting
         1. param_name = value with ParameterSpace
@@ -38,8 +39,7 @@ class TestBinarySearchParams(unittest.TestCase):
         self.assertFalse(np.all(Inew == I0))
 
         for param_name, value in ps_params.items():
-            faiss.ParameterSpace().set_index_parameter(
-                index, param_name, value)
+            faiss.ParameterSpace().set_index_parameter(index, param_name, value)
         Dref, Iref = index.search(xq, k)
 
         np.testing.assert_array_equal(Iref, Inew)
@@ -50,10 +50,14 @@ class TestBinarySearchParams(unittest.TestCase):
         quantizer = faiss.IndexBinaryFlat(d)
         index = faiss.IndexBinaryIVF(quantizer, d, 32)
         self.do_test_with_param(
-                index,
-                {"nprobe": 3},
-                faiss.SearchParametersIVF(nprobe=3),
-                d=d, nb=500, nq=20, k=5)
+            index,
+            {"nprobe": 3},
+            faiss.SearchParametersIVF(nprobe=3),
+            d=d,
+            nb=500,
+            nq=20,
+            k=5,
+        )
 
     def test_efSearch(self):
         d = 64
@@ -62,7 +66,11 @@ class TestBinarySearchParams(unittest.TestCase):
             index,
             {"efSearch": 4},
             faiss.SearchParametersHNSW(efSearch=4),
-            d=d, nb=500, nq=20, k=5)
+            d=d,
+            nb=500,
+            nq=20,
+            k=5,
+        )
 
     def test_quantizer_hnsw(self):
         d = 64
@@ -73,10 +81,13 @@ class TestBinarySearchParams(unittest.TestCase):
             {"quantizer_efSearch": 5, "nprobe": 10},
             faiss.SearchParametersIVF(
                 nprobe=10,
-                quantizer_params=faiss.SearchParametersHNSW(
-                    efSearch=5)
+                quantizer_params=faiss.SearchParametersHNSW(efSearch=5),
             ),
-            d=d, nb=500, nq=20, k=5)
+            d=d,
+            nb=500,
+            nq=20,
+            k=5,
+        )
 
     def test_max_codes(self):
         d = 64
@@ -95,19 +106,17 @@ class TestBinarySearchParams(unittest.TestCase):
 
         stats = faiss.cvar.indexIVF_stats
         stats.reset()
-        D0, I0 = index.search(
-            xq, k,
-            params=faiss.SearchParametersIVF(nprobe=8)
-        )
+        D0, I0 = index.search(xq, k, params=faiss.SearchParametersIVF(nprobe=8))
         ndis0 = stats.ndis
         target_ndis = ndis0 // nq
         for q in range(nq):
             stats.reset()
             Dq, Iq = index.search(
-                xq[q:q + 1], k,
+                xq[q : q + 1],
+                k,
                 params=faiss.SearchParametersIVF(
                     nprobe=8, max_codes=target_ndis
-                )
+                ),
             )
             self.assertLessEqual(stats.ndis, target_ndis)
             if stats.ndis < target_ndis:
@@ -127,13 +136,11 @@ class TestBinarySearchParams(unittest.TestCase):
         index.add(xb)
 
         D1, I1 = index.search(
-            xq, k,
-            params=faiss.SearchParametersHNSW(efSearch=4)
+            xq, k, params=faiss.SearchParametersHNSW(efSearch=4)
         )
 
         D2, I2 = index.search(
-            xq, k,
-            params=faiss.SearchParametersHNSW(efSearch=16)
+            xq, k, params=faiss.SearchParametersHNSW(efSearch=16)
         )
 
         self.assertFalse(np.all(I1 == I2))
@@ -153,14 +160,8 @@ class TestBinarySearchParams(unittest.TestCase):
         index.train(xb)
         index.add(xb)
 
-        D1, I1 = index.search(
-            xq, k,
-            params=faiss.SearchParametersIVF(nprobe=1)
-        )
+        D1, I1 = index.search(xq, k, params=faiss.SearchParametersIVF(nprobe=1))
 
-        D2, I2 = index.search(
-            xq, k,
-            params=faiss.SearchParametersIVF(nprobe=8)
-        )
+        D2, I2 = index.search(xq, k, params=faiss.SearchParametersIVF(nprobe=8))
 
         self.assertFalse(np.all(I1 == I2))

--- a/tests/test_build_blocks.py
+++ b/tests/test_build_blocks.py
@@ -19,7 +19,7 @@ class TestPCA(unittest.TestCase):
         d = 64
         n = 1000
         np.random.seed(123)
-        x = np.random.random(size=(n, d)).astype('float32')
+        x = np.random.random(size=(n, d)).astype("float32")
 
         pca = faiss.PCAMatrix(d, 10)
         pca.train(x)
@@ -43,7 +43,7 @@ class TestPCA(unittest.TestCase):
         d = 64
         n = 20  # n < d_in exercises the Gram-matrix branch
         np.random.seed(123)
-        x = np.random.random(size=(n, d)).astype('float32')
+        x = np.random.random(size=(n, d)).astype("float32")
 
         pca = faiss.PCAMatrix(d, 8)
         pca.train(x)
@@ -53,15 +53,13 @@ class TestPCA(unittest.TestCase):
         y_second = pca.apply_py(x)
 
         # Eigenvectors are unique up to per-component sign; compare abs.
-        np.testing.assert_allclose(
-            np.abs(y_first), np.abs(y_second), atol=1e-4
-        )
+        np.testing.assert_allclose(np.abs(y_first), np.abs(y_second), atol=1e-4)
 
     def test_pca_epsilon(self):
         d = 64
         n = 1000
         np.random.seed(123)
-        x = np.random.random(size=(n, d)).astype('float32')
+        x = np.random.random(size=(n, d)).astype("float32")
 
         # make sure data is in a sub-space
         x[:, ::2] = 0
@@ -110,7 +108,7 @@ class TestHadamardRotation(unittest.TestCase):
         d = 128
         n = 100
         np.random.seed(123)
-        x = np.random.randn(n, d).astype('float32')
+        x = np.random.randn(n, d).astype("float32")
 
         fr = faiss.HadamardRotation(d)
         y = fr.apply(x)
@@ -122,7 +120,7 @@ class TestHadamardRotation(unittest.TestCase):
         cases = {192: 256, 384: 512, 768: 1024, 1536: 2048}
         for d, expected_out in cases.items():
             np.random.seed(42)
-            x = np.random.randn(20, d).astype('float32')
+            x = np.random.randn(20, d).astype("float32")
             fr = faiss.HadamardRotation(d)
             self.assertEqual(fr.d_out, expected_out)
             y = fr.apply(x)
@@ -135,7 +133,7 @@ class TestHadamardRotation(unittest.TestCase):
         d = 64
         n = 20
         np.random.seed(789)
-        x = np.random.randn(n, d).astype('float32')
+        x = np.random.randn(n, d).astype("float32")
 
         fr1 = faiss.HadamardRotation(d, 42)
         fr2 = faiss.HadamardRotation(d, 42)
@@ -147,7 +145,7 @@ class TestHadamardRotation(unittest.TestCase):
         d = 64
         n = 20
         np.random.seed(101)
-        x = np.random.randn(n, d).astype('float32')
+        x = np.random.randn(n, d).astype("float32")
 
         fr1 = faiss.HadamardRotation(d, 1)
         fr2 = faiss.HadamardRotation(d, 2)
@@ -159,7 +157,7 @@ class TestHadamardRotation(unittest.TestCase):
         """Hadamard transform preserves L2 norms for power-of-2 dims."""
         d = 256
         np.random.seed(42)
-        x = np.random.randn(100, d).astype('float32')
+        x = np.random.randn(100, d).astype("float32")
         fr = faiss.HadamardRotation(d)
         y = fr.apply(x)
         norms_in = np.linalg.norm(x, axis=1)
@@ -170,7 +168,7 @@ class TestHadamardRotation(unittest.TestCase):
         d = 64
         n = 500
         np.random.seed(202)
-        x = np.random.randn(n, d).astype('float32')
+        x = np.random.randn(n, d).astype("float32")
 
         index = faiss.index_factory(d, "HR,Flat")
         index.train(x)
@@ -186,42 +184,42 @@ class TestOrthogonalReconstruct(unittest.TestCase):
         lt = faiss.LinearTransform(20, 10, True)
         rs = np.random.RandomState(10)
         A, _ = np.linalg.qr(rs.randn(20, 20))
-        A = A[:10].astype('float32')
+        A = A[:10].astype("float32")
         faiss.copy_array_to_vector(A.ravel(), lt.A)
-        faiss.copy_array_to_vector(rs.randn(10).astype('float32'), lt.b)
+        faiss.copy_array_to_vector(rs.randn(10).astype("float32"), lt.b)
 
         lt.set_is_orthonormal()
         lt.is_trained = True
         assert lt.is_orthonormal
 
-        x = rs.rand(30, 20).astype('float32')
+        x = rs.rand(30, 20).astype("float32")
         xt = lt.apply_py(x)
         xtt = lt.reverse_transform(xt)
         xttt = lt.apply_py(xtt)
 
-        err = ((xt - xttt)**2).sum()
+        err = ((xt - xttt) ** 2).sum()
 
         self.assertGreater(1e-5, err)
 
     def test_recons_orthogonal_impossible(self):
         lt = faiss.LinearTransform(20, 10, True)
         rs = np.random.RandomState(10)
-        A = rs.randn(10 * 20).astype('float32')
+        A = rs.randn(10 * 20).astype("float32")
         faiss.copy_array_to_vector(A.ravel(), lt.A)
-        faiss.copy_array_to_vector(rs.randn(10).astype('float32'), lt.b)
+        faiss.copy_array_to_vector(rs.randn(10).astype("float32"), lt.b)
         lt.is_trained = True
 
         lt.set_is_orthonormal()
         assert not lt.is_orthonormal
 
-        x = rs.rand(30, 20).astype('float32')
+        x = rs.rand(30, 20).astype("float32")
         xt = lt.apply_py(x)
         try:
             lt.reverse_transform(xt)
         except Exception:
             pass
         else:
-            self.assertFalse('should do an exception')
+            self.assertFalse("should do an exception")
 
 
 class TestMAdd(unittest.TestCase):
@@ -232,13 +230,13 @@ class TestMAdd(unittest.TestCase):
         swig_ptr = faiss.swig_ptr
         for dim in 16, 32, 20, 25:
             for _repeat in 1, 2, 3, 4, 5:
-                a = rs.rand(dim).astype('float32')
-                b = rs.rand(dim).astype('float32')
-                c = np.zeros(dim, dtype='float32')
+                a = rs.rand(dim).astype("float32")
+                b = rs.rand(dim).astype("float32")
+                c = np.zeros(dim, dtype="float32")
                 bf = rs.uniform(5.0) - 2.5
                 idx = faiss.fvec_madd_and_argmin(
-                    dim, swig_ptr(a), bf, swig_ptr(b),
-                    swig_ptr(c))
+                    dim, swig_ptr(a), bf, swig_ptr(b), swig_ptr(c)
+                )
                 ref_c = a + b * bf
                 assert np.abs(c - ref_c).max() < 1e-5
                 assert idx == ref_c.argmin()
@@ -250,13 +248,14 @@ class TestNyFuncs(unittest.TestCase):
         rs = np.random.RandomState(123)
         swig_ptr = faiss.swig_ptr
         for d in 1, 2, 4, 8, 12, 16:
-            x = rs.rand(d).astype('float32')
+            x = rs.rand(d).astype("float32")
             for ny in 128, 129, 130:
-                y = rs.rand(ny, d).astype('float32')
+                y = rs.rand(ny, d).astype("float32")
                 ref = ((x - y) ** 2).sum(1)
-                new = np.zeros(ny, dtype='float32')
-                faiss.fvec_L2sqr_ny(swig_ptr(new), swig_ptr(x),
-                                    swig_ptr(y), d, ny)
+                new = np.zeros(ny, dtype="float32")
+                faiss.fvec_L2sqr_ny(
+                    swig_ptr(new), swig_ptr(x), swig_ptr(y), d, ny
+                )
                 assert np.abs(ref - new).max() < 1e-4
 
     def test_IP(self):
@@ -264,13 +263,14 @@ class TestNyFuncs(unittest.TestCase):
         rs = np.random.RandomState(123)
         swig_ptr = faiss.swig_ptr
         for d in 1, 2, 4, 8, 12, 16:
-            x = rs.rand(d).astype('float32')
+            x = rs.rand(d).astype("float32")
             for ny in 128, 129, 130:
-                y = rs.rand(ny, d).astype('float32')
+                y = rs.rand(ny, d).astype("float32")
                 ref = (x * y).sum(1)
-                new = np.zeros(ny, dtype='float32')
+                new = np.zeros(ny, dtype="float32")
                 faiss.fvec_inner_products_ny(
-                    swig_ptr(new), swig_ptr(x), swig_ptr(y), d, ny)
+                    swig_ptr(new), swig_ptr(x), swig_ptr(y), d, ny
+                )
                 assert np.abs(ref - new).max() < 1e-4
 
 
@@ -278,45 +278,45 @@ class TestMatrixStats(unittest.TestCase):
 
     def test_0s(self):
         rs = np.random.RandomState(123)
-        m = rs.rand(40, 20).astype('float32')
+        m = rs.rand(40, 20).astype("float32")
         m[5:10] = 0
         comments = faiss.MatrixStats(m).comments
-        assert 'has 5 copies' in comments
-        assert '5 null vectors' in comments
+        assert "has 5 copies" in comments
+        assert "5 null vectors" in comments
 
     def test_copies(self):
         rs = np.random.RandomState(123)
-        m = rs.rand(40, 20).astype('float32')
+        m = rs.rand(40, 20).astype("float32")
         m[::2] = m[1::2]
         comments = faiss.MatrixStats(m).comments
-        assert '20 vectors are distinct' in comments
+        assert "20 vectors are distinct" in comments
 
     def test_dead_dims(self):
         rs = np.random.RandomState(123)
-        m = rs.rand(40, 20).astype('float32')
+        m = rs.rand(40, 20).astype("float32")
         m[:, 5:10] = 0
         comments = faiss.MatrixStats(m).comments
-        assert '5 dimensions are constant' in comments
+        assert "5 dimensions are constant" in comments
 
     def test_rogue_means(self):
         rs = np.random.RandomState(123)
-        m = rs.rand(40, 20).astype('float32')
+        m = rs.rand(40, 20).astype("float32")
         m[:, 5:10] += 12345
         comments = faiss.MatrixStats(m).comments
-        assert '5 dimensions are too large wrt. their variance' in comments
+        assert "5 dimensions are too large wrt. their variance" in comments
 
     def test_normalized(self):
         rs = np.random.RandomState(123)
-        m = rs.rand(40, 20).astype('float32')
+        m = rs.rand(40, 20).astype("float32")
         faiss.normalize_L2(m)
         comments = faiss.MatrixStats(m).comments
-        assert 'vectors are normalized' in comments
+        assert "vectors are normalized" in comments
 
     def test_hash(self):
         cc = []
         for _ in range(2):
             rs = np.random.RandomState(123)
-            m = rs.rand(40, 20).astype('float32')
+            m = rs.rand(40, 20).astype("float32")
             cc.append(faiss.MatrixStats(m).hash_value)
         self.assertTrue(cc[0] == cc[1])
 
@@ -328,7 +328,7 @@ class TestScalarQuantizer(unittest.TestCase):
         rs = np.random.RandomState(123)
         for _it in range(20):
             for d in 13, 16, 24:
-                x = np.floor(rs.rand(5, d) * 256).astype('float32')
+                x = np.floor(rs.rand(5, d) * 256).astype("float32")
                 x[0] = 0
                 x[1] = 255
 
@@ -339,18 +339,21 @@ class TestScalarQuantizer(unittest.TestCase):
                 x[3, 1] = 0
 
                 ref_index = faiss.IndexScalarQuantizer(
-                    d, faiss.ScalarQuantizer.QT_8bit)
+                    d, faiss.ScalarQuantizer.QT_8bit
+                )
                 ref_index.train(x[:2])
                 ref_index.add(x[2:3])
 
                 index = faiss.IndexScalarQuantizer(
-                    d, faiss.ScalarQuantizer.QT_8bit_direct)
+                    d, faiss.ScalarQuantizer.QT_8bit_direct
+                )
                 assert index.is_trained
                 index.add(x[2:3])
 
                 assert np.all(
-                    faiss.vector_to_array(ref_index.codes) ==
-                    faiss.vector_to_array(index.codes))
+                    faiss.vector_to_array(ref_index.codes)
+                    == faiss.vector_to_array(index.codes)
+                )
 
                 # Note that distances are not the same because ref_index
                 # reconstructs x as x + 0.5
@@ -362,15 +365,14 @@ class TestScalarQuantizer(unittest.TestCase):
     def test_6bit_equiv(self):
         rs = np.random.RandomState(123)
         for d in 3, 6, 8, 16, 36:
-            trainset = np.zeros((2, d), dtype='float32')
+            trainset = np.zeros((2, d), dtype="float32")
             trainset[0, :] = 0
             trainset[0, :] = 63
 
-            index = faiss.IndexScalarQuantizer(
-                d, faiss.ScalarQuantizer.QT_6bit)
+            index = faiss.IndexScalarQuantizer(d, faiss.ScalarQuantizer.QT_6bit)
             index.train(trainset)
 
-            x = rs.randint(64, size=(100, d)).astype('float32')
+            x = rs.randint(64, size=(100, d)).astype("float32")
 
             # verify encoder / decoder
             index.add(x)
@@ -378,7 +380,7 @@ class TestScalarQuantizer(unittest.TestCase):
             assert np.all(x == x2 - 0.5)
 
             # verify AVX decoder (used only for search)
-            y = 63 * rs.rand(20, d).astype('float32')
+            y = 63 * rs.rand(20, d).astype("float32")
 
             D, I = index.search(y, 10)
             for i in range(20):
@@ -406,9 +408,7 @@ class TestScalarQuantizer(unittest.TestCase):
         for i in range(5):
             for j in range(4):
                 self.assertAlmostEqual(
-                    ((xq[i] - xb2[I[i, j]]) ** 2).sum(),
-                    D[i, j],
-                    places=4
+                    ((xq[i] - xb2[I[i, j]]) ** 2).sum(), D[i, j], places=4
                 )
 
 
@@ -427,8 +427,8 @@ class TestRandom(unittest.TestCase):
         assert c.max() - c.min() < 50 * 2
 
     def test_rand_vector(self):
-        """ test if the smooth_vectors function is reasonably compressible with
-        a small PQ """
+        """test if the smooth_vectors function is reasonably compressible with
+        a small PQ"""
         x = faiss.rand_smooth_vectors(1300, 32)
         xt = x[:1000]
         xb = x[1000:1200]
@@ -453,16 +453,19 @@ class TestPairwiseDis(unittest.TestCase):
         y = faiss.rand((200, 10), seed=2)
         ix = faiss.randint(50, vmax=100)
         iy = faiss.randint(50, vmax=200)
-        dis = np.empty(50, dtype='float32')
+        dis = np.empty(50, dtype="float32")
         faiss.pairwise_indexed_L2sqr(
-            10, 50,
-            swig_ptr(x), swig_ptr(ix),
-            swig_ptr(y), swig_ptr(iy),
-            swig_ptr(dis))
+            10,
+            50,
+            swig_ptr(x),
+            swig_ptr(ix),
+            swig_ptr(y),
+            swig_ptr(iy),
+            swig_ptr(dis),
+        )
 
         for i in range(50):
-            assert np.allclose(
-                dis[i], ((x[ix[i]] - y[iy[i]]) ** 2).sum())
+            assert np.allclose(dis[i], ((x[ix[i]] - y[iy[i]]) ** 2).sum())
 
     def test_IP(self):
         swig_ptr = faiss.swig_ptr
@@ -470,16 +473,19 @@ class TestPairwiseDis(unittest.TestCase):
         y = faiss.rand((200, 10), seed=2)
         ix = faiss.randint(50, vmax=100)
         iy = faiss.randint(50, vmax=200)
-        dis = np.empty(50, dtype='float32')
+        dis = np.empty(50, dtype="float32")
         faiss.pairwise_indexed_inner_product(
-            10, 50,
-            swig_ptr(x), swig_ptr(ix),
-            swig_ptr(y), swig_ptr(iy),
-            swig_ptr(dis))
+            10,
+            50,
+            swig_ptr(x),
+            swig_ptr(ix),
+            swig_ptr(y),
+            swig_ptr(iy),
+            swig_ptr(dis),
+        )
 
         for i in range(50):
-            assert np.allclose(
-                dis[i], np.dot(x[ix[i]], y[iy[i]]))
+            assert np.allclose(dis[i], np.dot(x[ix[i]], y[iy[i]]))
 
 
 class TestResultHeap(unittest.TestCase):
@@ -534,7 +540,7 @@ class TestReconstructBatch(unittest.TestCase):
         subset = np.zeros(1200, dtype=int)
         self.assertRaises(
             RuntimeError,
-            lambda : index.reconstruct_batch(subset),
+            lambda: index.reconstruct_batch(subset),
         )
 
 
@@ -542,10 +548,10 @@ class TestBucketSort(unittest.TestCase):
 
     def do_test_bucket_sort(self, nt):
         rs = np.random.RandomState(123)
-        tab = rs.randint(100, size=1000, dtype='int64')
+        tab = rs.randint(100, size=1000, dtype="int64")
         lims, perm = faiss.bucket_sort(tab, nt=nt)
         for i in range(max(tab) + 1):
-            assert np.all(tab[perm[lims[i]: lims[i + 1]]] == i)
+            assert np.all(tab[perm[lims[i] : lims[i + 1]]] == i)
 
     def test_bucket_sort(self):
         self.do_test_bucket_sort(0)
@@ -554,8 +560,8 @@ class TestBucketSort(unittest.TestCase):
         self.do_test_bucket_sort(4)
 
     def do_test_bucket_sort_inplace(
-            self, nt, nrow=500, ncol=20, nbucket=300, repro=False,
-            dtype='int32'):
+        self, nt, nrow=500, ncol=20, nbucket=300, repro=False, dtype="int32"
+    ):
         rs = np.random.RandomState(123)
         tab = rs.randint(nbucket, size=(nrow, ncol), dtype=dtype)
 
@@ -569,9 +575,9 @@ class TestBucketSort(unittest.TestCase):
         for b in range(nbucket):
             rows, _ = np.where(tab == b)
             rows.sort()
-            tab2[lims[b]:lims[b + 1]].sort()
+            tab2[lims[b] : lims[b + 1]].sort()
             rows = set(rows)
-            self.assertEqual(rows, set(tab2[lims[b]:lims[b + 1]]))
+            self.assertEqual(rows, set(tab2[lims[b] : lims[b + 1]]))
 
     def test_bucket_sort_inplace(self):
         self.do_test_bucket_sort_inplace(0)
@@ -586,10 +592,10 @@ class TestBucketSort(unittest.TestCase):
         self.do_test_bucket_sort_inplace(4, nbucket=5)
 
     def test_bucket_sort_inplace_int64(self):
-        self.do_test_bucket_sort_inplace(0, dtype='int64')
+        self.do_test_bucket_sort_inplace(0, dtype="int64")
 
     def test_bucket_sort_inplace_parallel_int64(self):
-        self.do_test_bucket_sort_inplace(4, dtype='int64')
+        self.do_test_bucket_sort_inplace(4, dtype="int64")
 
 
 class TestMergeKNNResults(unittest.TestCase):
@@ -597,9 +603,9 @@ class TestMergeKNNResults(unittest.TestCase):
     def do_test(self, ismax, dtype):
         rs = np.random.RandomState()
         n, k, nshard = 10, 5, 3
-        all_ids = rs.randint(100000, size=(nshard, n, k)).astype('int64')
+        all_ids = rs.randint(100000, size=(nshard, n, k)).astype("int64")
         all_dis = rs.rand(nshard, n, k)
-        if dtype == 'int32':
+        if dtype == "int32":
             all_dis = (all_dis * 1000000).astype("int32")
         else:
             all_dis = all_dis.astype(dtype)
@@ -609,7 +615,7 @@ class TestMergeKNNResults(unittest.TestCase):
                 if ismax:
                     all_dis[i, j] = all_dis[i, j][::-1]
         Dref = np.zeros((n, k), dtype=dtype)
-        Iref = np.zeros((n, k), dtype='int64')
+        Iref = np.zeros((n, k), dtype="int64")
 
         for i in range(n):
             dis = all_dis[:, i, :].ravel()
@@ -625,25 +631,25 @@ class TestMergeKNNResults(unittest.TestCase):
         np.testing.assert_array_equal(Inew, Iref)
 
     def test_min_float(self):
-        self.do_test(ismax=False, dtype='float32')
+        self.do_test(ismax=False, dtype="float32")
 
     def test_max_int(self):
-        self.do_test(ismax=True, dtype='int32')
+        self.do_test(ismax=True, dtype="int32")
 
     def test_max_float(self):
-        self.do_test(ismax=True, dtype='float32')
+        self.do_test(ismax=True, dtype="float32")
 
 
 class TestMapInt64ToInt64(unittest.TestCase):
 
     def do_test(self, capacity, n):
-        """ test that we are able to lookup """
+        """test that we are able to lookup"""
         rs = np.random.RandomState(123)
         # make sure we have unique values
-        keys = np.unique(rs.choice(2 ** 29, size=n).astype("int64"))
+        keys = np.unique(rs.choice(2**29, size=n).astype("int64"))
         rs.shuffle(keys)
         n = keys.size
-        vals = rs.choice(2 ** 30, size=n).astype('int64')
+        vals = rs.choice(2**30, size=n).astype("int64")
         tab = faiss.MapInt64ToInt64(capacity)
         tab.add(keys, vals)
 
@@ -653,7 +659,7 @@ class TestMapInt64ToInt64(unittest.TestCase):
 
         # make a few keys that we know are not there
         mask = rs.rand(n) < 0.3
-        keys[mask] = rs.choice(2 ** 29, size=n)[mask] + 2 ** 29
+        keys[mask] = rs.choice(2**29, size=n)[mask] + 2**29
         vals2 = tab.lookup(keys)
         np.testing.assert_array_equal(-1, vals2[mask])
         np.testing.assert_array_equal(vals[~mask], vals2[~mask])
@@ -663,4 +669,4 @@ class TestMapInt64ToInt64(unittest.TestCase):
 
     def xx_test_large(self):
         # don't run by default because it's slow
-        self.do_test(2 ** 21, 10 ** 6)
+        self.do_test(2**21, 10**6)

--- a/tests/test_callback_py.py
+++ b/tests/test_callback_py.py
@@ -18,7 +18,7 @@ class TestCallbackPy(unittest.TestCase):
         d = 128
         niter = 1_000_000_000
 
-        x = np.random.rand(n, d).astype('float32')
+        x = np.random.rand(n, d).astype("float32")
         index = faiss.IndexFlat(d)
 
         cp = faiss.ClusteringParameters()

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -27,8 +27,9 @@ class TestClone(unittest.TestCase):
         index1 = faiss.index_factory(d, factory)
         index1.train(ds.get_train())
         if with_ids:
-            index1.add_with_ids(ds.get_database(),
-                                np.arange(ds.nb).astype("int64"))
+            index1.add_with_ids(
+                ds.get_database(), np.arange(ds.nb).astype("int64")
+            )
         else:
             index1.add(ds.get_database())
         k = 5

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -19,7 +19,7 @@ class TestClustering(unittest.TestCase):
         d = 64
         n = 1000
         rs = np.random.RandomState(123)
-        x = rs.uniform(size=(n, d)).astype('float32')
+        x = rs.uniform(size=(n, d)).astype("float32")
 
         x *= 10
 
@@ -45,24 +45,20 @@ class TestClustering(unittest.TestCase):
         self.assertGreater(err_int, err32)
         self.assertTrue(np.all(km.centroids == np.floor(km.centroids)))
 
-
     def test_nasty_clustering(self):
         d = 2
         rs = np.random.RandomState(123)
-        x = np.zeros((100, d), dtype='float32')
+        x = np.zeros((100, d), dtype="float32")
         for i in range(5):
-            x[i * 20:i * 20 + 20] = rs.uniform(size=d)
+            x[i * 20 : i * 20 + 20] = rs.uniform(size=d)
 
         # we have 5 distinct points but ask for 10 centroids...
         km = faiss.Kmeans(d, 10, niter=10, verbose=True)
         km.train(x)
 
-
-
-
     def test_1ptpercluster(self):
         # https://github.com/facebookresearch/faiss/issues/842
-        X = np.random.randint(0, 1, (5, 10)).astype('float32')
+        X = np.random.randint(0, 1, (5, 10)).astype("float32")
         k = 5
         niter = 10
         verbose = True
@@ -81,8 +77,13 @@ class TestClustering(unittest.TestCase):
 
         ccent = faiss.randn((10, d), 123)
         faiss.normalize_L2(ccent)
-        x = [ccent[i] + sigma * faiss.randn((100, d), 1234 + i) for i in range(5)]
-        x += [ccent[i] + sigma * faiss.randn((10, d), 1234 + i) for i in range(5, 10)]
+        x = [
+            ccent[i] + sigma * faiss.randn((100, d), 1234 + i) for i in range(5)
+        ]
+        x += [
+            ccent[i] + sigma * faiss.randn((10, d), 1234 + i)
+            for i in range(5, 10)
+        ]
         x = np.vstack(x)
 
         clus = faiss.Clustering(d, 5)
@@ -96,9 +97,9 @@ class TestClustering(unittest.TestCase):
 
         # now assign weight 0.1 to the 5 first clusters and weight 10
         # to the 5 last ones and re-run k-means
-        weights = np.ones(100 * 5 + 10 * 5, dtype='float32')
-        weights[:100 * 5] = 0.1
-        weights[100 * 5:] = 10
+        weights = np.ones(100 * 5 + 10 * 5, dtype="float32")
+        weights[: 100 * 5] = 0.1
+        weights[100 * 5 :] = 10
 
         clus = faiss.Clustering(d, 5)
         index = faiss.IndexFlatL2(d)
@@ -169,7 +170,7 @@ class TestClustering(unittest.TestCase):
         xt, xb, xq = get_dataset_2(d, 1000, 0, 0)
         km = faiss.Kmeans(d, k, niter=4)
         km.train(xt)
-        assert list(km.obj) == [st['obj'] for st in km.iteration_stats]
+        assert list(km.obj) == [st["obj"] for st in km.iteration_stats]
 
 
 class TestCompositeClustering(unittest.TestCase):
@@ -179,7 +180,7 @@ class TestCompositeClustering(unittest.TestCase):
         n = 1000
 
         rs = np.random.RandomState(123)
-        x = rs.uniform(size=(n, d)).astype('float32')
+        x = rs.uniform(size=(n, d)).astype("float32")
 
         # make sure that doing 10 redos yields a better objective than just 1
 
@@ -201,7 +202,7 @@ class TestCompositeClustering(unittest.TestCase):
         n = 1000
 
         rs = np.random.RandomState(123)
-        x = rs.uniform(size=(n, d)).astype('float32')
+        x = rs.uniform(size=(n, d)).astype("float32")
         faiss.normalize_L2(x)
 
         # make sure that doing 10 redos yields a better objective than just 1
@@ -259,7 +260,7 @@ class TestClustering1D(unittest.TestCase):
 
     def subtest_cluster1d(self, n, k):
         rs = np.random.RandomState(123)
-        x = rs.uniform(size=(n, 1)).astype('float32')
+        x = rs.uniform(size=(n, 1)).astype("float32")
 
         clus = faiss.Clustering1D(k)
         clus.train_exact(x)
@@ -278,15 +279,188 @@ class TestClustering1D(unittest.TestCase):
 
     def test_smawk(self):
         # example in http://web.cs.unlv.edu/larmore/Courses/CSC477/monge.pdf.
-        A = [[ 25, 21, 13,10,20,13,19,35,37,41,58,66,82,99,124,133,156,178],
-             [ 42, 35, 26,20,29,21,25,37,36,39,56,64,76,91,116,125,146,164],
-             [ 57, 48, 35,28,33,24,28,40,37,37,54,61,72,83,107,113,131,146],
-             [ 78, 65, 51,42,44,35,38,48,42,42,55,61,70,80,100,106,120,135],
-             [ 90, 76, 58,48,49,39,42,48,39,35,47,51,56,63, 80, 86, 97,110],
-             [103, 85, 67,56,55,44,44,49,39,33,41,44,49,56, 71, 75, 84, 96],
-             [123,105, 86,75,73,59,57,62,51,44,50,52,55,59, 72, 74, 80, 92],
-             [142,123,100,86,82,65,61,62,50,43,47,45,46,46, 58, 59, 65, 73],
-             [151,130,104,88,80,59,52,49,37,29,29,24,23,20, 28, 25, 31, 39]];
+        A = [
+            [
+                25,
+                21,
+                13,
+                10,
+                20,
+                13,
+                19,
+                35,
+                37,
+                41,
+                58,
+                66,
+                82,
+                99,
+                124,
+                133,
+                156,
+                178,
+            ],
+            [
+                42,
+                35,
+                26,
+                20,
+                29,
+                21,
+                25,
+                37,
+                36,
+                39,
+                56,
+                64,
+                76,
+                91,
+                116,
+                125,
+                146,
+                164,
+            ],
+            [
+                57,
+                48,
+                35,
+                28,
+                33,
+                24,
+                28,
+                40,
+                37,
+                37,
+                54,
+                61,
+                72,
+                83,
+                107,
+                113,
+                131,
+                146,
+            ],
+            [
+                78,
+                65,
+                51,
+                42,
+                44,
+                35,
+                38,
+                48,
+                42,
+                42,
+                55,
+                61,
+                70,
+                80,
+                100,
+                106,
+                120,
+                135,
+            ],
+            [
+                90,
+                76,
+                58,
+                48,
+                49,
+                39,
+                42,
+                48,
+                39,
+                35,
+                47,
+                51,
+                56,
+                63,
+                80,
+                86,
+                97,
+                110,
+            ],
+            [
+                103,
+                85,
+                67,
+                56,
+                55,
+                44,
+                44,
+                49,
+                39,
+                33,
+                41,
+                44,
+                49,
+                56,
+                71,
+                75,
+                84,
+                96,
+            ],
+            [
+                123,
+                105,
+                86,
+                75,
+                73,
+                59,
+                57,
+                62,
+                51,
+                44,
+                50,
+                52,
+                55,
+                59,
+                72,
+                74,
+                80,
+                92,
+            ],
+            [
+                142,
+                123,
+                100,
+                86,
+                82,
+                65,
+                61,
+                62,
+                50,
+                43,
+                47,
+                45,
+                46,
+                46,
+                58,
+                59,
+                65,
+                73,
+            ],
+            [
+                151,
+                130,
+                104,
+                88,
+                80,
+                59,
+                52,
+                49,
+                37,
+                29,
+                29,
+                24,
+                23,
+                20,
+                28,
+                25,
+                31,
+                39,
+            ],
+        ]
 
         sp = faiss.swig_ptr
         A = np.array(A).astype(np.float32)
@@ -307,7 +481,7 @@ class TestEarlyStopping(unittest.TestCase):
         max_iter = 1000
 
         rs = np.random.RandomState(42)
-        x = rs.uniform(size=(n, d)).astype('float32')
+        x = rs.uniform(size=(n, d)).astype("float32")
 
         clus = faiss.Clustering(d, k)
         clus.niter = max_iter

--- a/tests/test_clustering_initialization.py
+++ b/tests/test_clustering_initialization.py
@@ -105,8 +105,12 @@ class TestClusteringInitialization(unittest.TestCase):
             total_obj = 0.0
             for trial_seed in range(n_trials):
                 centroids = run_init(
-                    faiss.ClusteringInitMethod_AFK_MC2, xt, d, k,
-                    seed=42 + trial_seed, chain_length=chain_length
+                    faiss.ClusteringInitMethod_AFK_MC2,
+                    xt,
+                    d,
+                    k,
+                    seed=42 + trial_seed,
+                    chain_length=chain_length,
                 )
                 D, _ = faiss.knn(xt, centroids, 1)
                 total_obj += np.sum(D)
@@ -116,8 +120,9 @@ class TestClusteringInitialization(unittest.TestCase):
         for i in range(1, len(chain_lengths)):
             prev, curr = chain_lengths[i - 1], chain_lengths[i]
             self.assertLessEqual(
-                results[curr], results[prev] * 1.05,
-                f"Chain {curr} should not be worse than chain {prev}"
+                results[curr],
+                results[prev] * 1.05,
+                f"Chain {curr} should not be worse than chain {prev}",
             )
 
     def test_with_existing_centroids(self):
@@ -160,9 +165,7 @@ class TestClusteringInitialization(unittest.TestCase):
                 D_without, _ = faiss.knn(xt, all_baseline, 1)
                 distortion_without = np.sum(D_without)
 
-                self.assertLessEqual(
-                    distortion_with, distortion_without * 1.05
-                )
+                self.assertLessEqual(distortion_with, distortion_without * 1.05)
 
 
 if __name__ == "__main__":

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -49,10 +49,11 @@ class TestComputeGT(unittest.TestCase):
 
         def matrix_iterator(xb, bs):
             for i0 in range(0, xb.shape[0], bs):
-                yield xb[i0:i0 + bs]
+                yield xb[i0 : i0 + bs]
 
         Dnew, Inew = knn_ground_truth(
-            xq, matrix_iterator(xb, 1000), 10, metric, ngpu=ngpu)
+            xq, matrix_iterator(xb, 1000), 10, metric, ngpu=ngpu
+        )
 
         np.testing.assert_array_equal(Iref, Inew)
         # decimal = 4 required when run on GPU
@@ -90,8 +91,7 @@ class TestDatasets(unittest.TestCase):
         index = faiss.IndexFlatIP(32)
         index.add(ds.get_database())
         np.testing.assert_array_equal(
-            ds.get_groundtruth(100),
-            index.search(ds.get_queries(), 100)[1]
+            ds.get_groundtruth(100), index.search(ds.get_queries(), 100)[1]
         )
 
     def test_synthetic_iterator(self):
@@ -107,8 +107,8 @@ class TestDatasets(unittest.TestCase):
 class TestExhaustiveSearch(unittest.TestCase):
 
     def test_knn_cpu(self):
-        xb = np.random.rand(200, 32).astype('float32')
-        xq = np.random.rand(100, 32).astype('float32')
+        xb = np.random.rand(200, 32).astype("float32")
+        xq = np.random.rand(100, 32).astype("float32")
 
         index = faiss.IndexFlatL2(32)
         index.add(xb)
@@ -140,12 +140,15 @@ class TestExhaustiveSearch(unittest.TestCase):
         ref_lims, ref_D, ref_I = index.range_search(xq, threshold)
 
         new_lims, new_D, new_I = range_ground_truth(
-            xq, ds.database_iterator(bs=100), threshold, ngpu=0,
-            metric_type=metric)
+            xq,
+            ds.database_iterator(bs=100),
+            threshold,
+            ngpu=0,
+            metric_type=metric,
+        )
 
         evaluation.check_ref_range_results(
-            ref_lims, ref_D, ref_I,
-            new_lims, new_D, new_I
+            ref_lims, ref_D, ref_I, new_lims, new_D, new_I
         )
 
     def test_range_L2(self):
@@ -167,29 +170,29 @@ class TestExhaustiveSearch(unittest.TestCase):
 
         def matrix_iterator(xb, bs):
             for i0 in range(0, xb.shape[0], bs):
-                yield xb[i0:i0 + bs]
+                yield xb[i0 : i0 + bs]
 
         # check repro OK
         _, new_lims, new_D, new_I = range_search_max_results(
-            index, matrix_iterator(xq, 100), threshold, max_results=1e10)
+            index, matrix_iterator(xq, 100), threshold, max_results=1e10
+        )
 
         evaluation.check_ref_range_results(
-            ref_lims, ref_D, ref_I,
-            new_lims, new_D, new_I
+            ref_lims, ref_D, ref_I, new_lims, new_D, new_I
         )
 
         max_res = ref_lims[-1] // 2
 
         new_threshold, new_lims, new_D, new_I = range_search_max_results(
-            index, matrix_iterator(xq, 100), threshold, max_results=max_res)
+            index, matrix_iterator(xq, 100), threshold, max_results=max_res
+        )
 
         self.assertLessEqual(new_lims[-1], max_res)
 
         ref_lims, ref_D, ref_I = index.range_search(xq, new_threshold)
 
         evaluation.check_ref_range_results(
-            ref_lims, ref_D, ref_I,
-            new_lims, new_D, new_I
+            ref_lims, ref_D, ref_I, new_lims, new_D, new_I
         )
 
 
@@ -197,9 +200,9 @@ class TestInspect(unittest.TestCase):
 
     def test_LinearTransform(self):
         # training data
-        xt = np.random.rand(1000, 20).astype('float32')
+        xt = np.random.rand(1000, 20).astype("float32")
         # test data
-        x = np.random.rand(10, 20).astype('float32')
+        x = np.random.rand(10, 20).astype("float32")
         # make the PCA matrix
         pca = faiss.PCAMatrix(20, 10)
         pca.train(xt)
@@ -213,18 +216,16 @@ class TestInspect(unittest.TestCase):
         np.testing.assert_array_almost_equal(yref, ynew)
 
     def test_IndexFlat(self):
-        xb = np.random.rand(13, 20).astype('float32')
+        xb = np.random.rand(13, 20).astype("float32")
         index = faiss.IndexFlatL2(20)
         index.add(xb)
-        np.testing.assert_array_equal(
-            xb, inspect_tools.get_flat_data(index)
-        )
+        np.testing.assert_array_equal(xb, inspect_tools.get_flat_data(index))
 
     def test_make_LT(self):
         rs = np.random.RandomState(123)
-        X = rs.rand(13, 20).astype('float32')
-        A = rs.rand(5, 20).astype('float32')
-        b = rs.rand(5).astype('float32')
+        X = rs.rand(13, 20).astype("float32")
+        A = rs.rand(5, 20).astype("float32")
+        b = rs.rand(5).astype("float32")
         Yref = X @ A.T + b
         lt = inspect_tools.make_LinearTransform_matrix(A, b)
         Ynew = lt.apply(X)
@@ -244,18 +245,8 @@ class TestInspect(unittest.TestCase):
 class TestRangeEval(unittest.TestCase):
 
     def test_precision_recall(self):
-        Iref = [
-            [1, 2, 3],
-            [5, 6],
-            [],
-            []
-        ]
-        Inew = [
-            [1, 2],
-            [6, 7],
-            [1],
-            []
-        ]
+        Iref = [[1, 2, 3], [5, 6], [], []]
+        Inew = [[1, 2], [6, 7], [1], []]
 
         lims_ref = np.cumsum([0] + [len(x) for x in Iref])
         Iref = np.hstack(Iref)
@@ -296,18 +287,18 @@ class TestRangeEval(unittest.TestCase):
             for i, thr in enumerate(all_thr):
 
                 lims2, _, I2 = evaluation.filter_range_results(
-                    new_lims, new_D, new_I, thr)
+                    new_lims, new_D, new_I, thr
+                )
 
                 prec, recall = evaluation.range_PR(
-                    ref_lims, ref_I, lims2, I2, mode=mode)
+                    ref_lims, ref_I, lims2, I2, mode=mode
+                )
 
                 ref_precisions[i] = prec
                 ref_recalls[i] = recall
 
             precisions, recalls = evaluation.range_PR_multiple_thresholds(
-                ref_lims, ref_I,
-                new_lims, new_D, new_I, all_thr,
-                mode=mode
+                ref_lims, ref_I, new_lims, new_D, new_I, all_thr, mode=mode
             )
 
             np.testing.assert_array_almost_equal(ref_precisions, precisions)
@@ -322,7 +313,7 @@ class TestPreassigned(unittest.TestCase):
         xt = ds.get_train()
         xq = ds.get_queries()
         xb = ds.get_database()
-        index = faiss.index_factory(128, 'PCA64,IVF64,PQ4np')
+        index = faiss.index_factory(128, "PCA64,IVF64,PQ4np")
         index.train(xt)
         index.add(xb)
         index_downcasted = faiss.extract_index_ivf(index)
@@ -371,8 +362,7 @@ class TestPreassigned(unittest.TestCase):
             index.nprobe = nprobe
             a = alt_quantizer.search(xq[:, :20].copy(), index.nprobe)[1]
             D, I = ivf_tools.search_preassigned(index, xq, 4, a)
-            inter_perf = faiss.eval_intersection(
-                I, ds.get_groundtruth()[:, :4])
+            inter_perf = faiss.eval_intersection(I, ds.get_groundtruth()[:, :4])
             self.assertTrue(inter_perf >= prev_inter_perf)
             prev_inter_perf = inter_perf
 
@@ -386,7 +376,9 @@ class TestPreassigned(unittest.TestCase):
         D, I = ivf_tools.search_preassigned(index, xq, 4, a)
         radius = D.max() * 1.01
 
-        lims, DR, IR = ivf_tools.range_search_preassigned(index, xq, radius.item(), a)
+        lims, DR, IR = ivf_tools.range_search_preassigned(
+            index, xq, radius.item(), a
+        )
 
         # with that radius the k-NN results are a subset of the range search
         # results
@@ -395,8 +387,8 @@ class TestPreassigned(unittest.TestCase):
             self.assertTrue(set(I[q]) <= set(IR[l0:l1]))
 
     @unittest.skipIf(
-        platform.system() == 'Windows',
-        'test_binary hangs for Windows on newer versions of MKL.'
+        platform.system() == "Windows",
+        "test_binary hangs for Windows on newer versions of MKL.",
     )
     def test_binary(self):
         ds = datasets.SyntheticDataset(128, 2000, 2000, 200)
@@ -457,7 +449,8 @@ class TestPreassigned(unittest.TestCase):
         radius = int(D.max() + 1)
 
         lims, DR, IR = ivf_tools.range_search_preassigned(
-            index, xq_bin, radius, a)
+            index, xq_bin, radius, a
+        )
 
         # with that radius the k-NN results are a subset of the range
         # search results
@@ -509,13 +502,15 @@ class TestRangeSearchMaxResults(unittest.TestCase):
 
         init_radius = 1e10 if metric_type == faiss.METRIC_L2 else -1e10
         radius1, lims_new, Dnew, Inew = range_search_max_results(
-            index, query_iterator, init_radius,
-            min_results=Dref.size, clip_to_min=True
+            index,
+            query_iterator,
+            init_radius,
+            min_results=Dref.size,
+            clip_to_min=True,
         )
 
         evaluation.check_ref_range_results(
-            lims_ref, Dref, Iref,
-            lims_new, Dnew, Inew
+            lims_ref, Dref, Iref, lims_new, Dnew, Inew
         )
 
     def test_L2(self):
@@ -545,20 +540,22 @@ class TestRangeSearchMaxResults(unittest.TestCase):
         query_iterator = exponential_query_iterator(xq)
 
         radius1, lims_new, Dnew, Inew = range_search_max_results(
-            index, query_iterator, ds.d // 2,
-            min_results=Dref.size, clip_to_min=True
+            index,
+            query_iterator,
+            ds.d // 2,
+            min_results=Dref.size,
+            clip_to_min=True,
         )
 
         evaluation.check_ref_range_results(
-            lims_ref, Dref, Iref,
-            lims_new, Dnew, Inew
+            lims_ref, Dref, Iref, lims_new, Dnew, Inew
         )
 
 
 class TestClustering(unittest.TestCase):
 
     def test_python_kmeans(self):
-        """ Test the python implementation of kmeans """
+        """Test the python implementation of kmeans"""
         ds = datasets.SyntheticDataset(32, 5000, 0, 0)
         x = ds.get_train()
 
@@ -578,7 +575,7 @@ class TestClustering(unittest.TestCase):
         self.assertLess(err2, err * 1.1)
 
     def test_2level(self):
-        " verify that 2-level clustering is not too sub-optimal "
+        "verify that 2-level clustering is not too sub-optimal"
         ds = datasets.SyntheticDataset(32, 10000, 0, 0)
         xt = ds.get_train()
         km_ref = faiss.Kmeans(ds.d, 100)
@@ -591,7 +588,7 @@ class TestClustering(unittest.TestCase):
         self.assertLess(err2, err * 1.1)
 
     def test_ivf_train_2level(self):
-        " check 2-level clustering with IVF training "
+        "check 2-level clustering with IVF training"
         ds = datasets.SyntheticDataset(32, 10000, 1000, 200)
         index = faiss.index_factory(ds.d, "PCA16,IVF100,SQ8")
         faiss.extract_index_ivf(index).nprobe = 10
@@ -602,7 +599,8 @@ class TestClustering(unittest.TestCase):
         index = faiss.index_factory(ds.d, "PCA16,IVF100,SQ8")
         faiss.extract_index_ivf(index).nprobe = 10
         clustering.train_ivf_index_with_2level(
-            index, ds.get_train(), verbose=True, rebalance=False)
+            index, ds.get_train(), verbose=True, rebalance=False
+        )
         index.add(ds.get_database())
         Dnew, Inew = index.search(ds.get_queries(), 1)
 
@@ -663,9 +661,7 @@ class TestBigBatchSearch(unittest.TestCase):
         for method in ("pairwise_distances", "knn_function"):
             for threaded in 0, 2:
                 Dnew, Inew = big_batch_search.big_batch_search(
-                    index, ds.get_queries(),
-                    k, method=method,
-                    threaded=threaded
+                    index, ds.get_queries(), k, method=method, threaded=threaded
                 )
                 self.assertLess((Inew != Iref).sum() / Iref.size, 1e-4)
                 np.testing.assert_almost_equal(Dnew, Dref, decimal=4)
@@ -697,11 +693,14 @@ class TestBigBatchSearch(unittest.TestCase):
             # First big batch search
             try:
                 Dnew, Inew = big_batch_search.big_batch_search(
-                    index, ds.get_queries(),
-                    k, method="knn_function",
+                    index,
+                    ds.get_queries(),
+                    k,
+                    method="knn_function",
                     threaded=2,
-                    checkpoint=checkpoint, checkpoint_freq=0.1,
-                    crash_at=20
+                    checkpoint=checkpoint,
+                    checkpoint_freq=0.1,
+                    crash_at=20,
                 )
             except ZeroDivisionError:
                 pass
@@ -709,10 +708,13 @@ class TestBigBatchSearch(unittest.TestCase):
                 self.assertFalse("should have crashed")
             # Second big batch search
             Dnew, Inew = big_batch_search.big_batch_search(
-                index, ds.get_queries(),
-                k, method="knn_function",
+                index,
+                ds.get_queries(),
+                k,
+                method="knn_function",
                 threaded=2,
-                checkpoint=checkpoint, checkpoint_freq=5
+                checkpoint=checkpoint,
+                checkpoint_freq=5,
             )
             self.assertLess((Inew != Iref).sum() / Iref.size, 1e-4)
             np.testing.assert_almost_equal(Dnew, Dref, decimal=4)
@@ -724,8 +726,8 @@ class TestBigBatchSearch(unittest.TestCase):
 class TestInvlistSort(unittest.TestCase):
 
     def test_sort(self):
-        """ make sure that the search results do not change
-        after sorting the inverted lists """
+        """make sure that the search results do not change
+        after sorting the inverted lists"""
         ds = datasets.SyntheticDataset(32, 2000, 200, 20)
         index = faiss.index_factory(ds.d, "IVF50,SQ8")
         index.train(ds.get_train())
@@ -743,8 +745,8 @@ class TestInvlistSort(unittest.TestCase):
 
     def test_hnsw_permute(self):
         """
-            make sure HNSW permutation works
-            (useful when used as coarse quantizer)
+        make sure HNSW permutation works
+        (useful when used as coarse quantizer)
         """
         ds = datasets.SyntheticDataset(32, 0, 1000, 50)
         index = faiss.index_factory(ds.d, "HNSW32,Flat")
@@ -762,7 +764,7 @@ class TestInvlistSort(unittest.TestCase):
 class TestCodeSet(unittest.TestCase):
 
     def test_code_set(self):
-        """ CodeSet and np.unique should produce the same output """
+        """CodeSet and np.unique should produce the same output"""
         d = 8
         n = 1000  # > 256 and using only 0 or 1 so there must be duplicates
         codes = np.random.randint(0, 2, (n, d), dtype=np.uint8)
@@ -770,15 +772,14 @@ class TestCodeSet(unittest.TestCase):
         inserted = s.insert(codes)
         np.testing.assert_equal(
             np.sort(np.unique(codes, axis=0), axis=None),
-            np.sort(codes[inserted], axis=None))
+            np.sort(codes[inserted], axis=None),
+        )
 
 
 @unittest.skipIf(
-    platform.system() == 'Windows',
-    'OnDiskInvertedLists is unsupported on Windows.'
+    platform.system() == "Windows",
+    "OnDiskInvertedLists is unsupported on Windows.",
 )
-
-
 class TestMerge(unittest.TestCase):
     @contextmanager
     def temp_directory(self):
@@ -811,7 +812,9 @@ class TestMerge(unittest.TestCase):
 
             # construct the output index and merge them on disk
             index = faiss.read_index(tmpdir + "/trained.index")
-            block_fnames = [tmpdir + "/block_%d.index" % bno for bno in range(4)]
+            block_fnames = [
+                tmpdir + "/block_%d.index" % bno for bno in range(4)
+            ]
 
             merge_ondisk(
                 index, block_fnames, tmpdir + "/merged_index.ivfdata", shift_ids
@@ -877,7 +880,9 @@ class TestFactoryTools(unittest.TestCase):
             index = faiss.IndexIVFScalarQuantizer(
                 faiss.IndexFlatL2(d), d, 32, qtype
             )
-            self.assertEqual(factory_tools.reverse_index_factory(index), expected)
+            self.assertEqual(
+                factory_tools.reverse_index_factory(index), expected
+            )
 
     def test_scalar_quantizer_types(self):
         d = 32
@@ -903,4 +908,6 @@ class TestFactoryTools(unittest.TestCase):
         }
         for qtype, expected in sq_types.items():
             index = faiss.IndexScalarQuantizer(d, qtype)
-            self.assertEqual(factory_tools.reverse_index_factory(index), expected)
+            self.assertEqual(
+                factory_tools.reverse_index_factory(index), expected
+            )

--- a/tests/test_contrib_with_scipy.py
+++ b/tests/test_contrib_with_scipy.py
@@ -18,7 +18,7 @@ import scipy.sparse
 class TestClustering(unittest.TestCase):
 
     def test_sparse_routines(self):
-        """ the sparse assignment routine """
+        """the sparse assignment routine"""
         ds = datasets.SyntheticDataset(1000, 2000, 0, 200)
         xt = ds.get_train().copy()
         faiss.normalize_L2(xt)
@@ -38,13 +38,14 @@ class TestClustering(unittest.TestCase):
         np.testing.assert_array_almost_equal(Dref.ravel(), D, decimal=3)
 
         D, I = clustering.sparse_assign_to_dense_blocks(
-            xsparse, centroids, qbs=123, bbs=33, nt=4)
+            xsparse, centroids, qbs=123, bbs=33, nt=4
+        )
 
         np.testing.assert_array_equal(Iref.ravel(), I)
         np.testing.assert_array_almost_equal(Dref.ravel(), D, decimal=3)
 
     def test_sparse_kmeans(self):
-        """ demo on how to cluster sparse data into dense clusters """
+        """demo on how to cluster sparse data into dense clusters"""
 
         ds = datasets.SyntheticDataset(1000, 1500, 0, 0)
         xt = ds.get_train().copy()
@@ -60,7 +61,8 @@ class TestClustering(unittest.TestCase):
         xsparse = scipy.sparse.csr_matrix(xt)
 
         centroids, iteration_stats = clustering.kmeans(
-            50, clustering.DatasetAssignSparse(xsparse), return_stats=True)
+            50, clustering.DatasetAssignSparse(xsparse), return_stats=True
+        )
 
         new_err = iteration_stats[-1]["obj"]
 

--- a/tests/test_extra_distances.py
+++ b/tests/test_extra_distances.py
@@ -20,96 +20,102 @@ import scipy.spatial.distance
 
 @for_all_simd_levels
 class TestExtraDistances(unittest.TestCase):
-    """ check wrt. the scipy implementation """
+    """check wrt. the scipy implementation"""
 
     def make_example(self):
         rs = np.random.RandomState(123)
-        x = rs.rand(5, 32).astype('float32')
-        y = rs.rand(3, 32).astype('float32')
+        x = rs.rand(5, 32).astype("float32")
+        y = rs.rand(3, 32).astype("float32")
         return x, y
 
     def run_simple_dis_test(self, ref_func, metric_type):
         xq, yb = self.make_example()
-        ref_dis = np.array([
-            [ref_func(x, y) for y in yb]
-            for x in xq
-        ])
+        ref_dis = np.array([[ref_func(x, y) for y in yb] for x in xq])
         new_dis = faiss.pairwise_distances(xq, yb, metric_type)
         self.assertTrue(np.allclose(ref_dis, new_dis))
 
     def test_L1(self):
-        self.run_simple_dis_test(scipy.spatial.distance.cityblock,
-                                 faiss.METRIC_L1)
+        self.run_simple_dis_test(
+            scipy.spatial.distance.cityblock, faiss.METRIC_L1
+        )
 
     def test_Linf(self):
-        self.run_simple_dis_test(scipy.spatial.distance.chebyshev,
-                                 faiss.METRIC_Linf)
+        self.run_simple_dis_test(
+            scipy.spatial.distance.chebyshev, faiss.METRIC_Linf
+        )
 
     def test_L2(self):
         xq, yb = self.make_example()
-        ref_dis = np.array([
-            [scipy.spatial.distance.sqeuclidean(x, y) for y in yb]
-            for x in xq
-        ])
+        ref_dis = np.array(
+            [[scipy.spatial.distance.sqeuclidean(x, y) for y in yb] for x in xq]
+        )
         new_dis = faiss.pairwise_distances(xq, yb, faiss.METRIC_L2)
         self.assertTrue(np.allclose(ref_dis, new_dis))
 
-        ref_dis = np.array([
-            [scipy.spatial.distance.euclidean(x, y) for y in yb]
-            for x in xq
-        ])
-        new_dis = np.sqrt(new_dis)        # post processing
+        ref_dis = np.array(
+            [[scipy.spatial.distance.euclidean(x, y) for y in yb] for x in xq]
+        )
+        new_dis = np.sqrt(new_dis)  # post processing
         self.assertTrue(np.allclose(ref_dis, new_dis))
 
     def test_Lp(self):
         p = 1.5
         xq, yb = self.make_example()
-        ref_dis = np.array([
-            [scipy.spatial.distance.minkowski(x, y, p) for y in yb]
-            for x in xq
-        ])
+        ref_dis = np.array(
+            [
+                [scipy.spatial.distance.minkowski(x, y, p) for y in yb]
+                for x in xq
+            ]
+        )
         new_dis = faiss.pairwise_distances(xq, yb, faiss.METRIC_Lp, p)
-        new_dis = new_dis ** (1 / p)     # post processing
+        new_dis = new_dis ** (1 / p)  # post processing
         self.assertTrue(np.allclose(ref_dis, new_dis))
 
     def test_canberra(self):
-        self.run_simple_dis_test(scipy.spatial.distance.canberra,
-                                 faiss.METRIC_Canberra)
+        self.run_simple_dis_test(
+            scipy.spatial.distance.canberra, faiss.METRIC_Canberra
+        )
 
     def test_braycurtis(self):
-        self.run_simple_dis_test(scipy.spatial.distance.braycurtis,
-                                 faiss.METRIC_BrayCurtis)
+        self.run_simple_dis_test(
+            scipy.spatial.distance.braycurtis, faiss.METRIC_BrayCurtis
+        )
 
     def xx_test_jensenshannon(self):
         # this distance does not seem to be implemented in scipy
         # vectors should probably be L1 normalized
-        self.run_simple_dis_test(scipy.spatial.distance.jensenshannon,
-                                 faiss.METRIC_JensenShannon)
+        self.run_simple_dis_test(
+            scipy.spatial.distance.jensenshannon, faiss.METRIC_JensenShannon
+        )
 
     def test_jaccard(self):
         xq, yb = self.make_example()
-        ref_dis = np.array([
+        ref_dis = np.array(
             [
-                (np.min([x, y], axis=0).sum() / np.max([x, y], axis=0).sum())
-                for y in yb
+                [
+                    (
+                        np.min([x, y], axis=0).sum()
+                        / np.max([x, y], axis=0).sum()
+                    )
+                    for y in yb
+                ]
+                for x in xq
             ]
-            for x in xq
-        ])
+        )
         new_dis = faiss.pairwise_distances(xq, yb, faiss.METRIC_Jaccard)
         self.assertTrue(np.allclose(ref_dis, new_dis))
 
     def test_nan_euclidean(self):
         xq, yb = self.make_example()
-        ref_dis = np.array([
-            [scipy.spatial.distance.sqeuclidean(x, y) for y in yb]
-            for x in xq
-        ])
+        ref_dis = np.array(
+            [[scipy.spatial.distance.sqeuclidean(x, y) for y in yb] for x in xq]
+        )
         new_dis = faiss.pairwise_distances(xq, yb, faiss.METRIC_NaNEuclidean)
         self.assertTrue(np.allclose(ref_dis, new_dis))
 
         x = [[3, np.nan, np.nan, 6]]
         q = [[1, np.nan, np.nan, 5]]
-        dis = [(4 / 2 * ((3 - 1)**2 + (6 - 5)**2))]
+        dis = [4 / 2 * ((3 - 1) ** 2 + (6 - 5) ** 2)]
         new_dis = faiss.pairwise_distances(x, q, faiss.METRIC_NaNEuclidean)
         self.assertTrue(np.allclose(new_dis, dis))
 
@@ -219,7 +225,9 @@ class TestExtraDistances(unittest.TestCase):
             dtype="float32",
         )
 
-        dis_mixed = faiss.pairwise_distances(xq_mixed, yb_mixed, faiss.METRIC_GOWER)
+        dis_mixed = faiss.pairwise_distances(
+            xq_mixed, yb_mixed, faiss.METRIC_GOWER
+        )
 
         self.assertTrue(np.all(np.isnan(dis_mixed)))
 
@@ -247,7 +255,7 @@ class TestExtraDistances(unittest.TestCase):
 
 @for_all_simd_levels
 class TestKNN(unittest.TestCase):
-    """ test that the knn search gives the same as distance matrix + argmin """
+    """test that the knn search gives the same as distance matrix + argmin"""
 
     def do_test_knn(self, mt):
         d = 10
@@ -283,7 +291,7 @@ class TestKNN(unittest.TestCase):
 
 @for_all_simd_levels
 class TestHNSW(unittest.TestCase):
-    """ since it has a distance computer, HNSW should work """
+    """since it has a distance computer, HNSW should work"""
 
     def test_hnsw(self):
 
@@ -308,7 +316,7 @@ class TestHNSW(unittest.TestCase):
 
 @for_all_simd_levels
 class TestIVF(unittest.TestCase):
-    """ since it has a distance computer, IVF should work """
+    """since it has a distance computer, IVF should work"""
 
     def test_ivf(self):
 
@@ -325,7 +333,7 @@ class TestIVF(unittest.TestCase):
         inter = faiss.eval_intersection(Iref, Inew)
         self.assertGreater(inter, Iref.size * 0.9)
 
-        index.nprobe = index.nlist 
+        index.nprobe = index.nlist
         Dnew, Inew = index.search(ds.get_queries(), 10)
 
-        check_ref_knn_with_draws(Dref, Iref, Dnew, Inew) 
+        check_ref_knn_with_draws(Dref, Iref, Dnew, Inew)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -82,8 +82,9 @@ class TestFactory(unittest.TestCase):
     def test_factory_HNSW_newstyle(self):
         index = faiss.index_factory(12, "HNSW32,Flat")
         assert index.storage.sa_code_size() == 12 * 4
-        index = faiss.index_factory(12, "HNSW32,SQ8",
-                                    faiss.METRIC_INNER_PRODUCT)
+        index = faiss.index_factory(
+            12, "HNSW32,SQ8", faiss.METRIC_INNER_PRODUCT
+        )
         assert index.storage.sa_code_size() == 12
         assert index.metric_type == faiss.METRIC_INNER_PRODUCT
         index = faiss.index_factory(12, "HNSW,PQ4")
@@ -130,9 +131,9 @@ class TestFactory(unittest.TestCase):
         assert index.pq.M == 2 and index.pq.nbits == 8
 
     def test_factory_lsh(self):
-        index = faiss.index_factory(128, 'LSHrt')
+        index = faiss.index_factory(128, "LSHrt")
         self.assertEqual(index.nbits, 128)
-        index = faiss.index_factory(128, 'LSH16rt')
+        index = faiss.index_factory(128, "LSH16rt")
         self.assertEqual(index.nbits, 16)
 
     def test_factory_fast_scan(self):
@@ -141,8 +142,9 @@ class TestFactory(unittest.TestCase):
         self.assertEqual(index.pq.nbits, 4)
         index = faiss.index_factory(56, "PQ28x4fs_64")
         self.assertEqual(index.bbs, 64)
-        index = faiss.index_factory(56, "IVF50,PQ28x4fs_64",
-                                    faiss.METRIC_INNER_PRODUCT)
+        index = faiss.index_factory(
+            56, "IVF50,PQ28x4fs_64", faiss.METRIC_INNER_PRODUCT
+        )
         self.assertEqual(index.bbs, 64)
         self.assertEqual(index.nlist, 50)
         self.assertTrue(index.cp.spherical)
@@ -192,14 +194,14 @@ class TestCodeSize(unittest.TestCase):
     def test_1(self):
         self.assertEqual(
             factory_tools.get_code_size(50, "IVF32,Flat,Refine(PQ25x12)"),
-            50 * 4 + (25 * 12 + 7) // 8
+            50 * 4 + (25 * 12 + 7) // 8,
         )
 
 
 class TestCloneSize(unittest.TestCase):
 
     def test_clone_size(self):
-        index = faiss.index_factory(20, 'PCA10,Flat')
+        index = faiss.index_factory(20, "PCA10,Flat")
         xb = faiss.rand((100, 20))
         index.train(xb)
         index.add(xb)
@@ -210,7 +212,7 @@ class TestCloneSize(unittest.TestCase):
 class TestCloneIVFPQ(unittest.TestCase):
 
     def test_clone(self):
-        index = faiss.index_factory(16, 'IVF10,PQ4np')
+        index = faiss.index_factory(16, "IVF10,PQ4np")
         xb = faiss.rand((1000, 16))
         index.train(xb)
         index.add(xb)
@@ -304,7 +306,7 @@ class TestAdditive(unittest.TestCase):
         index = faiss.index_factory(12, "IVF256(RCQ2x4),RQ3x4")
         self.assertEqual(
             faiss.downcast_index(index.quantizer).__class__,
-            faiss.ResidualCoarseQuantizer
+            faiss.ResidualCoarseQuantizer,
         )
 
     def test_rq3(self):
@@ -312,14 +314,14 @@ class TestAdditive(unittest.TestCase):
 
         np.testing.assert_array_equal(
             faiss.vector_to_array(index.rq.nbits),
-            np.array([16, 16, 8, 8, 8, 4, 4, 4, 4, 4, 4])
+            np.array([16, 16, 8, 8, 8, 4, 4, 4, 4, 4, 4]),
         )
 
     def test_norm(self):
         index = faiss.index_factory(5, "RQ8x8_Nqint8")
         self.assertEqual(
-            index.rq.search_type,
-            faiss.AdditiveQuantizer.ST_norm_qint8)
+            index.rq.search_type, faiss.AdditiveQuantizer.ST_norm_qint8
+        )
 
 
 @for_all_simd_levels
@@ -372,7 +374,7 @@ class TestIVFSpectralHashOwnership(unittest.TestCase):
     def test_constructor(self):
         index = faiss.IndexIVFSpectralHash(faiss.IndexFlat(10), 10, 20, 10, 1)
         gc.collect()
-        index.quantizer.ntotal   # this should not crash
+        index.quantizer.ntotal  # this should not crash
 
     def test_replace_vt(self):
         index = faiss.IndexIVFSpectralHash(faiss.IndexFlat(10), 10, 20, 10, 1)

--- a/tests/test_fast_scan.py
+++ b/tests/test_fast_scan.py
@@ -32,7 +32,7 @@ class TestSearch(unittest.TestCase):
         index_gt.add(ds.get_database())
         Dref, Iref = index_gt.search(ds.get_queries(), 10)
 
-        index = faiss.index_factory(32, 'PQ16x4fs')
+        index = faiss.index_factory(32, "PQ16x4fs")
         index.train(ds.get_train())
         index.add(ds.get_database())
         Da, Ia = index.search(ds.get_queries(), 10)
@@ -58,7 +58,7 @@ class TestSearch(unittest.TestCase):
         In both cases, fall back to a recall@1 check.
         """
         ds = datasets.SyntheticDataset(32, 2000, 5000, 200)
-        index = faiss.index_factory(32, 'PQ16x4fs')
+        index = faiss.index_factory(32, "PQ16x4fs")
         index.train(ds.get_train())
         index.add(ds.get_database())
 
@@ -66,15 +66,17 @@ class TestSearch(unittest.TestCase):
         nq = xq.shape[0]
         M, ksub = index.pq.M, index.pq.ksub
 
-        tab = np.zeros((nq, M, ksub), dtype='float32')
+        tab = np.zeros((nq, M, ksub), dtype="float32")
         index.pq.compute_distance_tables(
-            nq, faiss.swig_ptr(xq), faiss.swig_ptr(tab))
+            nq, faiss.swig_ptr(xq), faiss.swig_ptr(tab)
+        )
         D, I = index.search(xq, 10)
 
         with NoneSIMDLevel():
-            tab_none = np.zeros((nq, M, ksub), dtype='float32')
+            tab_none = np.zeros((nq, M, ksub), dtype="float32")
             index.pq.compute_distance_tables(
-                nq, faiss.swig_ptr(xq), faiss.swig_ptr(tab_none))
+                nq, faiss.swig_ptr(xq), faiss.swig_ptr(tab_none)
+            )
             D_none, I_none = index.search(xq, 10)
 
         lut_diffs = int((tab != tab_none).sum())
@@ -84,9 +86,11 @@ class TestSearch(unittest.TestCase):
         else:
             recall_at_1 = (I[:, 0] == I_none[:, 0]).mean()
             self.assertGreater(
-                recall_at_1, 0.95,
+                recall_at_1,
+                0.95,
                 f"LUT diverges ({lut_diffs} entries differ, DD={dd_mode}); "
-                f"recall@1 vs NONE = {recall_at_1:.3f}")
+                f"recall@1 vs NONE = {recall_at_1:.3f}",
+            )
 
 
 class TestFastScanDDSpeed(unittest.TestCase):
@@ -119,9 +123,9 @@ class TestFastScanDDSpeed(unittest.TestCase):
         # 2x is conservative: scalar-to-AVX2 theoretical max is ~32x,
         # observed 5-27x in isolation. 2x leaves margin for CI noise.
         self.assertGreater(
-            speedup, 2.0,
-            f"{label} should be >2x faster than NONE, "
-            f"got {speedup:.1f}x",
+            speedup,
+            2.0,
+            f"{label} should be >2x faster than NONE, " f"got {speedup:.1f}x",
         )
 
     @unittest.skipUnless(
@@ -134,8 +138,7 @@ class TestFastScanDDSpeed(unittest.TestCase):
         index, xq, k = self._build_index()
         none_t = self._bench(index, xq, k, faiss.SIMDLevel_NONE)
         avx2_t = self._bench(index, xq, k, faiss.SIMDLevel_AVX2)
-        faiss.SIMDConfig.set_level(
-            faiss.SIMDConfig.get_dispatched_level())
+        faiss.SIMDConfig.set_level(faiss.SIMDConfig.get_dispatched_level())
         self._check_speedup(none_t, avx2_t, "AVX2")
 
     @unittest.skipUnless(
@@ -147,10 +150,8 @@ class TestFastScanDDSpeed(unittest.TestCase):
     def test_dd_fastscan_avx512_faster_than_none(self):
         index, xq, k = self._build_index()
         none_t = self._bench(index, xq, k, faiss.SIMDLevel_NONE)
-        avx512_t = self._bench(
-            index, xq, k, faiss.SIMDLevel_AVX512)
-        faiss.SIMDConfig.set_level(
-            faiss.SIMDConfig.get_dispatched_level())
+        avx512_t = self._bench(index, xq, k, faiss.SIMDLevel_AVX512)
+        faiss.SIMDConfig.set_level(faiss.SIMDConfig.get_dispatched_level())
         self._check_speedup(none_t, avx512_t, "AVX512")
 
 
@@ -160,7 +161,7 @@ class TestRounding(unittest.TestCase):
     def do_test_rounding(self, implem=4, metric=faiss.METRIC_L2):
         ds = datasets.SyntheticDataset(32, 2000, 5000, 200)
 
-        index = faiss.index_factory(32, 'PQ16x4', metric)
+        index = faiss.index_factory(32, "PQ16x4", metric)
         index.train(ds.get_train())
         index.add(ds.get_database())
         Dref, Iref = index.search(ds.get_queries(), 10)
@@ -188,7 +189,7 @@ class TestRounding(unittest.TestCase):
         # check accuracy of distances
         # err3 = ((D3 - D2) ** 2).sum()
         err4 = ((D4 - D2) ** 2).sum()
-        nf = (D2 ** 2).sum()
+        nf = (D2**2).sum()
         self.assertLess(err4, nf * 1e-4)
 
     def test_implem_4(self):
@@ -216,7 +217,7 @@ class TestReconstruct(unittest.TestCase):
     def test_pqfastscan(self):
         ds = datasets.SyntheticDataset(20, 1000, 1000, 0)
 
-        index = faiss.index_factory(20, 'PQ5x4')
+        index = faiss.index_factory(20, "PQ5x4")
         index.train(ds.get_train())
         index.add(ds.get_database())
         recons = index.reconstruct_n(0, index.ntotal)
@@ -229,7 +230,7 @@ class TestReconstruct(unittest.TestCase):
     def test_aqfastscan(self):
         ds = datasets.SyntheticDataset(20, 1000, 1000, 0)
 
-        index = faiss.index_factory(20, 'RQ5x4_Nrq2x4')
+        index = faiss.index_factory(20, "RQ5x4_Nrq2x4")
         index.train(ds.get_train())
         index.add(ds.get_database())
         recons = index.reconstruct_n(0, index.ntotal)
@@ -250,14 +251,14 @@ def reference_accu(codes, LUT):
     nb, nsp_2 = codes.shape
     assert is_16 == 16
     assert nsp_2 == nsp // 2
-    accu = np.zeros((nq, nb), 'uint16')
+    accu = np.zeros((nq, nb), "uint16")
     for i in range(nq):
         for j in range(nb):
             a = np.uint16(0)
             for sp in range(0, nsp, 2):
                 c = codes[j, sp // 2]
-                a += LUT[i, sp, c & 15].astype('uint16')
-                a += LUT[i, sp + 1, c >> 4].astype('uint16')
+                a += LUT[i, sp, c & 15].astype("uint16")
+                a += LUT[i, sp + 1, c >> 4].astype("uint16")
             accu[i, j] = a
     return accu
 
@@ -265,16 +266,16 @@ def reference_accu(codes, LUT):
 # disabled because the function to write to mem is not implemented currently
 
 
-class ThisIsNotATestLoop5:    # (unittest.TestCase):
+class ThisIsNotATestLoop5:  # (unittest.TestCase):
 
     def do_loop5_kernel(self, nq, bb):
-        """ unit test for the accumulation kernel """
+        """unit test for the accumulation kernel"""
         nb = bb * 32  # databse size
-        nsp = 24     # number of sub-quantizers
+        nsp = 24  # number of sub-quantizers
 
         rs = np.random.RandomState(123)
-        codes = rs.randint(256, size=(nb, nsp // 2)).astype('uint8')
-        LUT = rs.randint(256, size=(nq, nsp, 16)).astype('uint8')
+        codes = rs.randint(256, size=(nb, nsp // 2)).astype("uint8")
+        LUT = rs.randint(256, size=(nq, nsp, 16)).astype("uint8")
         accu_ref = reference_accu(codes, LUT)
 
         def to_A(x):
@@ -283,17 +284,10 @@ class ThisIsNotATestLoop5:    # (unittest.TestCase):
         sp = faiss.swig_ptr
 
         LUT_a = faiss.AlignedTableUint8(LUT.size)
-        faiss.pq4_pack_LUT(
-            nq, nsp, sp(LUT),
-            LUT_a.get()
-        )
+        faiss.pq4_pack_LUT(nq, nsp, sp(LUT), LUT_a.get())
 
         codes_a = faiss.AlignedTableUint8(codes.size)
-        faiss.pq4_pack_codes(
-            sp(codes),
-            nb, nsp, nb, nb, nsp,
-            codes_a.get()
-        )
+        faiss.pq4_pack_codes(sp(codes), nb, nsp, nb, nb, nsp, codes_a.get())
 
         accu_a = faiss.AlignedTableUint16(nq * nb)
         accu_a.clear()
@@ -319,6 +313,7 @@ class ThisIsNotATestLoop5:    # (unittest.TestCase):
 ##########################################################
 # Tests for various IndexPQFastScan implementations
 ##########################################################
+
 
 def verify_with_draws(testcase, Dref, Iref, Dnew, Inew):
     """Verify a list of results where there are draws in the distances
@@ -348,7 +343,7 @@ class TestImplems(unittest.TestCase):
         if (d, metric) not in self.cache:
             ds = datasets.SyntheticDataset(d, 1000, 2000, 200)
             target_size = d // 2
-            index = faiss.index_factory(d, 'PQ%dx4' % target_size, metric)
+            index = faiss.index_factory(d, "PQ%dx4" % target_size, metric)
             index.train(ds.get_train())
             index.add(ds.get_database())
 
@@ -379,8 +374,8 @@ class TestImplems(unittest.TestCase):
 
         Dnew, Inew = index2.search(ds.get_queries(), self.k)
 
-        Dref = Dref[:, :self.k]
-        Iref = Iref[:, :self.k]
+        Dref = Dref[:, : self.k]
+        Iref = Iref[:, : self.k]
 
         verify_with_draws(self, Dref, Iref, Dnew, Inew)
 
@@ -497,7 +492,7 @@ class TestAdd(unittest.TestCase):
 
         ds = datasets.SyntheticDataset(d, 2000, 5000, 200)
 
-        index = faiss.index_factory(d, f'PQ{d // 2}x4np')
+        index = faiss.index_factory(d, f"PQ{d // 2}x4np")
         index.train(ds.get_train())
 
         xb = ds.get_database()
@@ -527,7 +522,7 @@ class TestAdd(unittest.TestCase):
         d = 32
         ds = datasets.SyntheticDataset(d, 2000, 5000, 200)
 
-        index = faiss.index_factory(d, f'PQ{d // 2}x4np')
+        index = faiss.index_factory(d, f"PQ{d // 2}x4np")
         index.train(ds.get_train())
         index.add(ds.get_database())
         Dref, Iref = index.search(ds.get_queries(), 10)
@@ -554,7 +549,7 @@ class TestAdd(unittest.TestCase):
 
 class TestAQFastScan(unittest.TestCase):
 
-    def subtest_accuracy(self, aq, st, implem, metric_type='L2'):
+    def subtest_accuracy(self, aq, st, implem, metric_type="L2"):
         """
         Compare IndexAdditiveQuantizerFastScan with IndexAQ (qint8)
         """
@@ -562,20 +557,20 @@ class TestAQFastScan(unittest.TestCase):
         ds = datasets.SyntheticDataset(d, 1000, 1000, 500, metric_type)
         gt = ds.get_groundtruth(k=1)
 
-        if metric_type == 'L2':
+        if metric_type == "L2":
             metric = faiss.METRIC_L2
-            postfix1 = '_Nqint8'
-            postfix2 = f'_N{st}2x4'
+            postfix1 = "_Nqint8"
+            postfix2 = f"_N{st}2x4"
         else:
             metric = faiss.METRIC_INNER_PRODUCT
-            postfix1 = postfix2 = ''
+            postfix1 = postfix2 = ""
 
-        index = faiss.index_factory(d, f'{aq}3x4{postfix1}', metric)
+        index = faiss.index_factory(d, f"{aq}3x4{postfix1}", metric)
         index.train(ds.get_train())
         index.add(ds.get_database())
         Dref, Iref = index.search(ds.get_queries(), 1)
 
-        indexfs = faiss.index_factory(d, f'{aq}3x4fs_32{postfix2}', metric)
+        indexfs = faiss.index_factory(d, f"{aq}3x4fs_32{postfix2}", metric)
         indexfs.train(ds.get_train())
         indexfs.add(ds.get_database())
         indexfs.implem = implem
@@ -588,23 +583,23 @@ class TestAQFastScan(unittest.TestCase):
         assert abs(recall_ref - recall) < 0.05
 
     def xx_test_accuracy(self):
-        for metric in 'L2', 'IP':
+        for metric in "L2", "IP":
             for implem in 0, 12, 13, 14, 15:
-                self.subtest_accuracy('RQ', 'rq', implem, metric)
-                self.subtest_accuracy('LSQ', 'lsq', implem, metric)
+                self.subtest_accuracy("RQ", "rq", implem, metric)
+                self.subtest_accuracy("LSQ", "lsq", implem, metric)
 
     def subtest_from_idxaq(self, implem, metric):
-        if metric == 'L2':
+        if metric == "L2":
             metric_type = faiss.METRIC_L2
-            st = '_Nrq2x4'
+            st = "_Nrq2x4"
         else:
             metric_type = faiss.METRIC_INNER_PRODUCT
-            st = ''
+            st = ""
 
         d = 16
         ds = datasets.SyntheticDataset(d, 1000, 2000, 1000, metric=metric)
         gt = ds.get_groundtruth(k=1)
-        index = faiss.index_factory(d, 'RQ8x4' + st, metric_type)
+        index = faiss.index_factory(d, "RQ8x4" + st, metric_type)
         index.train(ds.get_train())
         index.add(ds.get_database())
         Dref, Iref = index.search(ds.get_queries(), 1)
@@ -620,8 +615,8 @@ class TestAQFastScan(unittest.TestCase):
 
     def xx_test_from_idxaq(self):
         for implem in 2, 3, 4:
-            self.subtest_from_idxaq(implem, 'L2')
-            self.subtest_from_idxaq(implem, 'IP')
+            self.subtest_from_idxaq(implem, "L2")
+            self.subtest_from_idxaq(implem, "IP")
 
     def subtest_factory(self, aq, M, bbs, st):
         """
@@ -636,31 +631,31 @@ class TestAQFastScan(unittest.TestCase):
         d = 16
 
         if bbs > 0:
-            index = faiss.index_factory(d, f'{aq}{M}x4fs_{bbs}_N{st}2x4')
+            index = faiss.index_factory(d, f"{aq}{M}x4fs_{bbs}_N{st}2x4")
         else:
-            index = faiss.index_factory(d, f'{aq}{M}x4fs_N{st}2x4')
+            index = faiss.index_factory(d, f"{aq}{M}x4fs_N{st}2x4")
             bbs = 32
 
         assert index.bbs == bbs
         aq = faiss.downcast_AdditiveQuantizer(index.aq)
         assert aq.M == M
 
-        if aq == 'LSQ':
+        if aq == "LSQ":
             assert isinstance(aq, faiss.LocalSearchQuantizer)
-        if aq == 'RQ':
+        if aq == "RQ":
             assert isinstance(aq, faiss.ResidualQuantizer)
 
-        if st == 'lsq':
+        if st == "lsq":
             assert aq.search_type == AQ.ST_norm_lsq2x4
-        if st == 'rq':
+        if st == "rq":
             assert aq.search_type == AQ.ST_norm_rq2x4
 
     def test_factory(self):
-        self.subtest_factory('LSQ', 16, 64, 'lsq')
-        self.subtest_factory('LSQ', 16, 64, 'rq')
-        self.subtest_factory('RQ', 16, 64, 'rq')
-        self.subtest_factory('RQ', 16, 64, 'lsq')
-        self.subtest_factory('LSQ', 64, 0, 'lsq')
+        self.subtest_factory("LSQ", 16, 64, "lsq")
+        self.subtest_factory("LSQ", 16, 64, "rq")
+        self.subtest_factory("RQ", 16, 64, "rq")
+        self.subtest_factory("RQ", 16, 64, "lsq")
+        self.subtest_factory("LSQ", 64, 0, "lsq")
 
     def subtest_io(self, factory_str):
         d = 8
@@ -676,39 +671,40 @@ class TestAQFastScan(unittest.TestCase):
         np.testing.assert_array_equal(I1, I2)
 
     def test_io(self):
-        self.subtest_io('LSQ4x4fs_Nlsq2x4')
-        self.subtest_io('LSQ4x4fs_Nrq2x4')
-        self.subtest_io('RQ4x4fs_Nrq2x4')
-        self.subtest_io('RQ4x4fs_Nlsq2x4')
+        self.subtest_io("LSQ4x4fs_Nlsq2x4")
+        self.subtest_io("LSQ4x4fs_Nrq2x4")
+        self.subtest_io("RQ4x4fs_Nrq2x4")
+        self.subtest_io("RQ4x4fs_Nlsq2x4")
 
 
 # programatically generate tests to get finer test granularity.
+
 
 def add_TestAQFastScan_subset_accuracy(aq, st, implem, metric):
     setattr(
         TestAQFastScan,
         f"test_accuracy_{metric}_{aq}_implem{implem}",
-        lambda self: self.subtest_accuracy(aq, st, implem, metric)
+        lambda self: self.subtest_accuracy(aq, st, implem, metric),
     )
 
 
-for metric in 'L2', 'IP':
+for metric in "L2", "IP":
     for implem in 0, 12, 13, 14, 15:
-        add_TestAQFastScan_subset_accuracy('LSQ', 'lsq', implem, metric)
-        add_TestAQFastScan_subset_accuracy('RQ', 'rq', implem, metric)
+        add_TestAQFastScan_subset_accuracy("LSQ", "lsq", implem, metric)
+        add_TestAQFastScan_subset_accuracy("RQ", "rq", implem, metric)
 
 
 def add_TestAQFastScan_subtest_from_idxaq(implem, metric):
     setattr(
         TestAQFastScan,
         f"test_from_idxaq_{metric}_implem{implem}",
-        lambda self: self.subtest_from_idxaq(implem, metric)
+        lambda self: self.subtest_from_idxaq(implem, metric),
     )
 
 
 for implem in 2, 3, 4:
-    add_TestAQFastScan_subtest_from_idxaq(implem, 'L2')
-    add_TestAQFastScan_subtest_from_idxaq(implem, 'IP')
+    add_TestAQFastScan_subtest_from_idxaq(implem, "L2")
+    add_TestAQFastScan_subtest_from_idxaq(implem, "IP")
 
 # Apply decorator after dynamic method generation.
 TestAQFastScan = for_all_simd_levels(TestAQFastScan)
@@ -725,12 +721,12 @@ class TestPAQFastScan(unittest.TestCase):
         ds = datasets.SyntheticDataset(d, 1000, 1000, 500)
         gt = ds.get_groundtruth(k=1)
 
-        index = faiss.index_factory(d, f'{paq}2x3x4_Nqint8')
+        index = faiss.index_factory(d, f"{paq}2x3x4_Nqint8")
         index.train(ds.get_train())
         index.add(ds.get_database())
         Dref, Iref = index.search(ds.get_queries(), 1)
 
-        indexfs = faiss.index_factory(d, f'{paq}2x3x4fs_Nlsq2x4')
+        indexfs = faiss.index_factory(d, f"{paq}2x3x4fs_Nlsq2x4")
         indexfs.train(ds.get_train())
         indexfs.add(ds.get_database())
         Da, Ia = indexfs.search(ds.get_queries(), 1)
@@ -748,14 +744,14 @@ class TestPAQFastScan(unittest.TestCase):
         self.subtest_accuracy("PRQ")
 
     def subtest_factory(self, paq):
-        index = faiss.index_factory(16, f'{paq}2x3x4fs_Nlsq2x4')
+        index = faiss.index_factory(16, f"{paq}2x3x4fs_Nlsq2x4")
         q = faiss.downcast_Quantizer(index.aq)
         self.assertEqual(q.nsplits, 2)
         self.assertEqual(q.subquantizer(0).M, 3)
 
     def test_factory(self):
-        self.subtest_factory('PRQ')
-        self.subtest_factory('PLSQ')
+        self.subtest_factory("PRQ")
+        self.subtest_factory("PLSQ")
 
     def subtest_io(self, factory_str):
         d = 8
@@ -771,8 +767,8 @@ class TestPAQFastScan(unittest.TestCase):
         np.testing.assert_array_equal(I1, I2)
 
     def test_io(self):
-        self.subtest_io('PLSQ2x3x4fs_Nlsq2x4')
-        self.subtest_io('PRQ2x3x4fs_Nrq2x4')
+        self.subtest_io("PLSQ2x3x4fs_Nlsq2x4")
+        self.subtest_io("PRQ2x3x4fs_Nrq2x4")
 
 
 @for_all_simd_levels
@@ -785,7 +781,7 @@ class TestBlockDecode(unittest.TestCase):
         index.train(ds.get_train())
         index.add(ds.get_database())
 
-        decoded = index.pq.decode(
-            index.pq.compute_codes(ds.get_database())
-        )[0, ::100]
+        decoded = index.pq.decode(index.pq.compute_codes(ds.get_database()))[
+            0, ::100
+        ]
         np.testing.assert_array_equal(decoded, index.reconstruct(0)[::100])

--- a/tests/test_fast_scan_ivf.py
+++ b/tests/test_fast_scan_ivf.py
@@ -23,7 +23,7 @@ class TestLUTQuantization(unittest.TestCase):
 
     def compute_dis_float(self, codes, LUT, bias):
         nprobe, nt, M = codes.shape
-        dis = np.zeros((nprobe, nt), dtype='float32')
+        dis = np.zeros((nprobe, nt), dtype="float32")
         if bias is not None:
             dis[:] = bias.reshape(-1, 1)
 
@@ -41,7 +41,7 @@ class TestLUTQuantization(unittest.TestCase):
 
     def compute_dis_quant(self, codes, LUT, bias, a, b):
         nprobe, nt, M = codes.shape
-        dis = np.zeros((nprobe, nt), dtype='uint16')
+        dis = np.zeros((nprobe, nt), dtype="uint16")
         if bias is not None:
             dis[:] = bias.reshape(-1, 1)
 
@@ -53,7 +53,9 @@ class TestLUTQuantization(unittest.TestCase):
                 LUTp = LUT[p]
 
             for i in range(nt):
-                dis[p, i] += LUTp[np.arange(M), codes[p, i]].astype('uint16').sum()
+                dis[p, i] += (
+                    LUTp[np.arange(M), codes[p, i]].astype("uint16").sum()
+                )
 
         return dis / a + b
 
@@ -62,25 +64,34 @@ class TestLUTQuantization(unittest.TestCase):
         nt = 200
 
         rs = np.random.RandomState(123)
-        codes = rs.randint(ksub, size=(nprobe, nt, M)).astype('uint8')
+        codes = rs.randint(ksub, size=(nprobe, nt, M)).astype("uint8")
 
         dis_ref = self.compute_dis_float(codes, LUT, bias)
 
-        LUTq = np.zeros(LUT.shape, dtype='uint8')
+        LUTq = np.zeros(LUT.shape, dtype="uint8")
         biasq = (
-            np.zeros(bias.shape, dtype='uint16')
-            if (bias is not None) and not alt_3d else None
+            np.zeros(bias.shape, dtype="uint16")
+            if (bias is not None) and not alt_3d
+            else None
         )
-        atab = np.zeros(1, dtype='float32')
-        btab = np.zeros(1, dtype='float32')
+        atab = np.zeros(1, dtype="float32")
+        btab = np.zeros(1, dtype="float32")
 
         def sp(x):
             return faiss.swig_ptr(x) if x is not None else None
 
         faiss.quantize_LUT_and_bias(
-                nprobe, M, ksub, LUT.ndim == 3,
-                sp(LUT), sp(bias), sp(LUTq), M, sp(biasq),
-                sp(atab), sp(btab)
+            nprobe,
+            M,
+            ksub,
+            LUT.ndim == 3,
+            sp(LUT),
+            sp(bias),
+            sp(LUTq),
+            M,
+            sp(biasq),
+            sp(atab),
+            sp(btab),
         )
         a = atab[0]
         b = btab[0]
@@ -94,7 +105,7 @@ class TestLUTQuantization(unittest.TestCase):
         M = 20
         nprobe = 10
         rs = np.random.RandomState(1234)
-        LUT = rs.rand(M, ksub).astype('float32')
+        LUT = rs.rand(M, ksub).astype("float32")
         bias = None
 
         self.do_test(LUT, bias, nprobe)
@@ -104,8 +115,8 @@ class TestLUTQuantization(unittest.TestCase):
         M = 20
         nprobe = 10
         rs = np.random.RandomState(1234)
-        LUT = rs.rand(M, ksub).astype('float32')
-        bias = rs.rand(nprobe).astype('float32')
+        LUT = rs.rand(M, ksub).astype("float32")
+        bias = rs.rand(nprobe).astype("float32")
         bias *= 10
 
         self.do_test(LUT, bias, nprobe)
@@ -115,8 +126,8 @@ class TestLUTQuantization(unittest.TestCase):
         M = 20
         nprobe = 10
         rs = np.random.RandomState(1234)
-        LUT = rs.rand(nprobe, M, ksub).astype('float32')
-        bias = rs.rand(nprobe).astype('float32')
+        LUT = rs.rand(nprobe, M, ksub).astype("float32")
+        bias = rs.rand(nprobe).astype("float32")
         bias *= 10
 
         self.do_test(LUT, bias, nprobe)
@@ -126,8 +137,8 @@ class TestLUTQuantization(unittest.TestCase):
         M = 20
         nprobe = 10
         rs = np.random.RandomState(1234)
-        LUT = rs.rand(nprobe, M, ksub).astype('float32')
-        bias = rs.rand(nprobe).astype('float32')
+        LUT = rs.rand(nprobe, M, ksub).astype("float32")
+        bias = rs.rand(nprobe).astype("float32")
         bias *= 10
 
         self.do_test(LUT, bias, nprobe, alt_3d=True)
@@ -137,18 +148,20 @@ class TestLUTQuantization(unittest.TestCase):
 # Tests for various IndexPQFastScan implementations
 ##########################################################
 
+
 def verify_with_draws(testcase, Dref, Iref, Dnew, Inew):
-    """ verify a list of results where there are draws in the distances (because
-    they are integer). """
+    """verify a list of results where there are draws in the distances (because
+    they are integer)."""
     np.testing.assert_array_almost_equal(Dref, Dnew, decimal=5)
     # here we have to be careful because of draws
     for i in range(len(Iref)):
-        if np.all(Iref[i] == Inew[i]): # easy case
+        if np.all(Iref[i] == Inew[i]):  # easy case
             continue
         # we can deduce nothing about the latest line
         skip_dis = Dref[i, -1]
         for dis in np.unique(Dref):
-            if dis == skip_dis: continue
+            if dis == skip_dis:
+                continue
             mask = Dref[i, :] == dis
             testcase.assertEqual(set(Iref[i, mask]), set(Inew[i, mask]))
 
@@ -171,12 +184,13 @@ def three_metrics(Dref, Iref, Dnew, Inew):
 
 @for_all_simd_levels
 class TestIVFImplem1(unittest.TestCase):
-    """ Verify implem 1 (search from original invlists)
-    against IndexIVFPQ """
+    """Verify implem 1 (search from original invlists)
+    against IndexIVFPQ"""
 
-    def do_test(self, by_residual, metric_type=faiss.METRIC_L2,
-                use_precomputed_table=0):
-        ds  = datasets.SyntheticDataset(32, 2000, 5000, 1000)
+    def do_test(
+        self, by_residual, metric_type=faiss.METRIC_L2, use_precomputed_table=0
+    ):
+        ds = datasets.SyntheticDataset(32, 2000, 5000, 1000)
 
         index = faiss.index_factory(32, "IVF32,PQ16x4np", metric_type)
         index.use_precomputed_table
@@ -212,11 +226,11 @@ class TestIVFImplem1(unittest.TestCase):
 
 @for_all_simd_levels
 class TestIVFImplem2(unittest.TestCase):
-    """ Verify implem 2 (search with original invlists with uint8 LUTs)
-    against IndexIVFPQ. Entails some loss in accuracy. """
+    """Verify implem 2 (search with original invlists with uint8 LUTs)
+    against IndexIVFPQ. Entails some loss in accuracy."""
 
     def eval_quant_loss(self, by_residual, metric=faiss.METRIC_L2):
-        ds  = datasets.SyntheticDataset(32, 2000, 5000, 1000)
+        ds = datasets.SyntheticDataset(32, 2000, 5000, 1000)
 
         index = faiss.index_factory(32, "IVF32,PQ16x4np", metric)
         index.train(ds.get_train())
@@ -234,7 +248,7 @@ class TestIVFImplem2(unittest.TestCase):
 
         ref_results = {
             (True, 1): [0.985, 1.0, 9.872],
-            (True, 0): [ 0.987, 1.0, 9.914],
+            (True, 0): [0.987, 1.0, 9.914],
             (False, 1): [0.991, 1.0, 9.907],
             (False, 0): [0.986, 1.0, 9.917],
         }
@@ -244,7 +258,6 @@ class TestIVFImplem2(unittest.TestCase):
         self.assertGreaterEqual(m3[0], ref[0] * 0.995)
         self.assertGreaterEqual(m3[1], ref[1] * 0.995)
         self.assertGreaterEqual(m3[2], ref[2] * 0.995)
-
 
     def test_qloss_no_residual(self):
         self.eval_quant_loss(False)
@@ -263,13 +276,13 @@ class TestIVFImplem2(unittest.TestCase):
 class TestEquivPQ(unittest.TestCase):
 
     def test_equiv_pq(self):
-        ds  = datasets.SyntheticDataset(32, 2000, 200, 4)
+        ds = datasets.SyntheticDataset(32, 2000, 200, 4)
         xq = ds.get_queries()
 
         index = faiss.index_factory(32, "IVF1,PQ16x4np")
         index.by_residual = False
         # force coarse quantizer
-        index.quantizer.add(np.zeros((1, 32), dtype='float32'))
+        index.quantizer.add(np.zeros((1, 32), dtype="float32"))
         index.train(ds.get_train())
         index.add(ds.get_database())
         Dref, Iref = index.search(xq, 4)
@@ -277,8 +290,7 @@ class TestEquivPQ(unittest.TestCase):
         index_pq = faiss.index_factory(32, "PQ16x4np")
         index_pq.pq = index.pq
         index_pq.is_trained = True
-        codevec = faiss.downcast_InvertedLists(
-            index.invlists).codes.at(0)
+        codevec = faiss.downcast_InvertedLists(index.invlists).codes.at(0)
         index_pq.codes = faiss.MaybeOwnedVectorUInt8(codevec)
         index_pq.ntotal = index.ntotal
         Dnew, Inew = index_pq.search(xq, 4)
@@ -299,18 +311,17 @@ class TestEquivPQ(unittest.TestCase):
         # test encode and decode
 
         np.testing.assert_array_equal(
-            index_pq.sa_encode(xq),
-            index2.sa_encode(xq)
+            index_pq.sa_encode(xq), index2.sa_encode(xq)
         )
 
         np.testing.assert_array_equal(
             index_pq.sa_decode(index_pq.sa_encode(xq)),
-            index2.sa_decode(index2.sa_encode(xq))
+            index2.sa_decode(index2.sa_encode(xq)),
         )
 
         np.testing.assert_array_equal(
             ((index_pq.sa_decode(index_pq.sa_encode(xq)) - xq) ** 2).sum(1),
-            ((index2.sa_decode(index2.sa_encode(xq)) - xq) ** 2).sum(1)
+            ((index2.sa_decode(index2.sa_encode(xq)) - xq) ** 2).sum(1),
         )
 
     def test_equiv_pq_encode_decode(self):
@@ -323,20 +334,21 @@ class TestEquivPQ(unittest.TestCase):
         index_ivfpqfs = faiss.IndexIVFPQFastScan(index_ivfpq)
 
         np.testing.assert_array_equal(
-            index_ivfpq.sa_encode(xq),
-            index_ivfpqfs.sa_encode(xq)
+            index_ivfpq.sa_encode(xq), index_ivfpqfs.sa_encode(xq)
         )
 
         np.testing.assert_array_equal(
             index_ivfpq.sa_decode(index_ivfpq.sa_encode(xq)),
-            index_ivfpqfs.sa_decode(index_ivfpqfs.sa_encode(xq))
+            index_ivfpqfs.sa_decode(index_ivfpqfs.sa_encode(xq)),
         )
 
         np.testing.assert_array_equal(
-            ((index_ivfpq.sa_decode(index_ivfpq.sa_encode(xq)) - xq) ** 2)
-            .sum(1),
-            ((index_ivfpqfs.sa_decode(index_ivfpqfs.sa_encode(xq)) - xq) ** 2)
-            .sum(1)
+            ((index_ivfpq.sa_decode(index_ivfpq.sa_encode(xq)) - xq) ** 2).sum(
+                1
+            ),
+            (
+                (index_ivfpqfs.sa_decode(index_ivfpqfs.sa_encode(xq)) - xq) ** 2
+            ).sum(1),
         )
 
 
@@ -509,7 +521,8 @@ class TestTraining(unittest.TestCase):
         Dref, Iref = index.search(ds.get_queries(), 10)
 
         index2 = faiss.IndexIVFPQFastScan(
-            index.quantizer, d, 32, d // 2, 4, metric, bbs)
+            index.quantizer, d, 32, d // 2, 4, metric, bbs
+        )
         index2.by_residual = by_residual
         index2.train(ds.get_train())
 
@@ -524,7 +537,7 @@ class TestTraining(unittest.TestCase):
             (True, 1, 30): (0.989, 1.0, 9.885),
             (False, 1, 32): (0.99, 1.0, 9.875),
             (False, 0, 32): (0.99, 1.0, 9.92),
-            (False, 1, 30): (1.0, 1.0, 9.895)
+            (False, 1, 30): (1.0, 1.0, 9.895),
         }
         ref_m3 = ref_m3_tab[(by_residual, metric, d)]
         self.assertGreaterEqual(m3[0], ref_m3[0] * 0.99)
@@ -560,8 +573,8 @@ class TestTraining(unittest.TestCase):
 
 @for_all_simd_levels
 class TestReconstruct(unittest.TestCase):
-    """ test reconstruct and sa_encode / sa_decode
-    (also for a few additive quantizer variants) """
+    """test reconstruct and sa_encode / sa_decode
+    (also for a few additive quantizer variants)"""
 
     def do_test(self, by_residual=False):
         d = 32
@@ -570,7 +583,8 @@ class TestReconstruct(unittest.TestCase):
         ds = datasets.SyntheticDataset(d, 250, 200, 10)
 
         index = faiss.IndexIVFPQFastScan(
-            faiss.IndexFlatL2(d), d, 50, d // 2, 4, metric)
+            faiss.IndexFlatL2(d), d, 50, d // 2, 4, metric
+        )
         index.by_residual = by_residual
         index.make_direct_map(True)
         index.train(ds.get_train())
@@ -585,13 +599,13 @@ class TestReconstruct(unittest.TestCase):
 
         # Test original list reconstruction
         index.orig_invlists = faiss.ArrayInvertedLists(
-            index.nlist, index.code_size)
+            index.nlist, index.code_size
+        )
         index.reconstruct_orig_invlists()
         assert index.orig_invlists.compute_ntotal() == index.ntotal
 
         # compare with non fast-scan index
-        index2 = faiss.IndexIVFPQ(
-            index.quantizer, d, 50, d // 2, 4, metric)
+        index2 = faiss.IndexIVFPQ(index.quantizer, d, 50, d // 2, 4, metric)
         index2.by_residual = by_residual
         index2.pq = index.pq
         index2.is_trained = True
@@ -606,8 +620,9 @@ class TestReconstruct(unittest.TestCase):
     def test_by_residual(self):
         self.do_test(by_residual=True)
 
-    def do_test_generic(self, factory_string,
-                        by_residual=False, metric=faiss.METRIC_L2):
+    def do_test_generic(
+        self, factory_string, by_residual=False, metric=faiss.METRIC_L2
+    ):
         d = 32
         ds = datasets.SyntheticDataset(d, 250, 200, 10)
         index = faiss.index_factory(ds.d, factory_string, metric)
@@ -618,7 +633,7 @@ class TestReconstruct(unittest.TestCase):
         index.add(ds.get_database())
 
         # Test reconstruction
-        v123 = index.reconstruct(123) # single id
+        v123 = index.reconstruct(123)  # single id
         v120_10 = index.reconstruct_n(120, 10)
         np.testing.assert_array_equal(v120_10[3], v123)
         v120_10 = index.reconstruct_batch(np.arange(120, 130))
@@ -630,7 +645,6 @@ class TestReconstruct(unittest.TestCase):
         index2 = faiss.deserialize_index(faiss.serialize_index(index))
         codes2 = index2.sa_encode(ds.get_database()[120:130])
         np.testing.assert_array_equal(codes, codes2)
-
 
     def test_ivfpq_residual(self):
         self.do_test_generic("IVF20,PQ16x4fs", by_residual=True)
@@ -645,10 +659,18 @@ class TestReconstruct(unittest.TestCase):
         self.do_test_generic("RQ4x4fs", metric=faiss.METRIC_INNER_PRODUCT)
 
     def test_ivfprq(self):
-        self.do_test_generic("IVF20,PRQ8x2x4fs", by_residual=True, metric=faiss.METRIC_INNER_PRODUCT)
+        self.do_test_generic(
+            "IVF20,PRQ8x2x4fs",
+            by_residual=True,
+            metric=faiss.METRIC_INNER_PRODUCT,
+        )
 
     def test_ivfprq_no_residual(self):
-        self.do_test_generic("IVF20,PRQ8x2x4fs", by_residual=False, metric=faiss.METRIC_INNER_PRODUCT)
+        self.do_test_generic(
+            "IVF20,PRQ8x2x4fs",
+            by_residual=False,
+            metric=faiss.METRIC_INNER_PRODUCT,
+        )
 
     def test_prq(self):
         self.do_test_generic("PRQ8x2x4fs", metric=faiss.METRIC_INNER_PRODUCT)
@@ -659,8 +681,7 @@ class TestIsTrained(unittest.TestCase):
 
     def test_issue_2019(self):
         index = faiss.index_factory(
-            32,
-            "PCAR16,IVF200(IVF10,PQ2x4fs,RFlat),PQ4x4fsr"
+            32, "PCAR16,IVF200(IVF10,PQ2x4fs,RFlat),PQ4x4fsr"
         )
         des = faiss.rand((1000, 32))
         index.train(des)
@@ -668,7 +689,7 @@ class TestIsTrained(unittest.TestCase):
 
 class TestIVFAQFastScan(unittest.TestCase):
 
-    def subtest_accuracy(self, aq, st, by_residual, implem, metric_type='L2'):
+    def subtest_accuracy(self, aq, st, by_residual, implem, metric_type="L2"):
         """
         Compare IndexIVFAdditiveQuantizerFastScan with
         IndexIVFAdditiveQuantizer
@@ -677,15 +698,15 @@ class TestIVFAQFastScan(unittest.TestCase):
         ds = datasets.SyntheticDataset(d, 1000, 1000, 500, metric_type)
         gt = ds.get_groundtruth(k=1)
 
-        if metric_type == 'L2':
+        if metric_type == "L2":
             metric = faiss.METRIC_L2
-            postfix1 = '_Nqint8'
-            postfix2 = f'_N{st}2x4'
+            postfix1 = "_Nqint8"
+            postfix2 = f"_N{st}2x4"
         else:
             metric = faiss.METRIC_INNER_PRODUCT
-            postfix1 = postfix2 = ''
+            postfix1 = postfix2 = ""
 
-        index = faiss.index_factory(d, f'IVF{nlist},{aq}3x4{postfix1}', metric)
+        index = faiss.index_factory(d, f"IVF{nlist},{aq}3x4{postfix1}", metric)
         index.by_residual = by_residual
         index.train(ds.get_train())
         index.add(ds.get_database())
@@ -693,7 +714,8 @@ class TestIVFAQFastScan(unittest.TestCase):
         Dref, Iref = index.search(ds.get_queries(), 1)
 
         indexfs = faiss.index_factory(
-            d, f'IVF{nlist},{aq}3x4fs_32{postfix2}', metric)
+            d, f"IVF{nlist},{aq}3x4fs_32{postfix2}", metric
+        )
         indexfs.by_residual = by_residual
         indexfs.train(ds.get_train())
         indexfs.add(ds.get_database())
@@ -709,11 +731,11 @@ class TestIVFAQFastScan(unittest.TestCase):
 
     def xx_test_accuracy(self):
         # generated programatically below
-        for metric in 'L2', 'IP':
+        for metric in "L2", "IP":
             for byr in True, False:
                 for implem in 0, 10, 11, 12, 13, 14, 15:
-                    self.subtest_accuracy('RQ', 'rq', byr, implem, metric)
-                    self.subtest_accuracy('LSQ', 'lsq', byr, implem, metric)
+                    self.subtest_accuracy("RQ", "rq", byr, implem, metric)
+                    self.subtest_accuracy("LSQ", "lsq", byr, implem, metric)
 
     def subtest_rescale_accuracy(self, aq, st, by_residual, implem):
         """
@@ -724,11 +746,10 @@ class TestIVFAQFastScan(unittest.TestCase):
         gt = ds.get_groundtruth(k=1)
 
         metric = faiss.METRIC_L2
-        postfix1 = '_Nqint8'
-        postfix2 = f'_N{st}2x4'
+        postfix1 = "_Nqint8"
+        postfix2 = f"_N{st}2x4"
 
-        index = faiss.index_factory(
-            d, f'IVF{nlist},{aq}3x4{postfix1}', metric)
+        index = faiss.index_factory(d, f"IVF{nlist},{aq}3x4{postfix1}", metric)
         index.by_residual = by_residual
         index.train(ds.get_train())
         index.add(ds.get_database())
@@ -736,7 +757,8 @@ class TestIVFAQFastScan(unittest.TestCase):
         Dref, Iref = index.search(ds.get_queries(), 1)
 
         indexfs = faiss.index_factory(
-            d, f'IVF{nlist},{aq}3x4fs_32{postfix2}', metric)
+            d, f"IVF{nlist},{aq}3x4fs_32{postfix2}", metric
+        )
         indexfs.by_residual = by_residual
         indexfs.norm_scale = 2
         indexfs.train(ds.get_train())
@@ -754,14 +776,16 @@ class TestIVFAQFastScan(unittest.TestCase):
     def xx_test_rescale_accuracy(self):
         for byr in True, False:
             for implem in 0, 10, 11, 12, 13, 14, 15:
-                self.subtest_accuracy('RQ', 'rq', byr, implem, 'L2')
-                self.subtest_accuracy('LSQ', 'lsq', byr, implem, 'L2')
+                self.subtest_accuracy("RQ", "rq", byr, implem, "L2")
+                self.subtest_accuracy("LSQ", "lsq", byr, implem, "L2")
 
     def subtest_from_ivfaq(self, implem):
         d = 8
-        ds = datasets.SyntheticDataset(d, 1000, 2000, 1000, metric='IP')
+        ds = datasets.SyntheticDataset(d, 1000, 2000, 1000, metric="IP")
         gt = ds.get_groundtruth(k=1)
-        index = faiss.index_factory(d, 'IVF16,RQ8x4', faiss.METRIC_INNER_PRODUCT)
+        index = faiss.index_factory(
+            d, "IVF16,RQ8x4", faiss.METRIC_INNER_PRODUCT
+        )
         index.train(ds.get_train())
         index.add(ds.get_database())
         index.nprobe = 16
@@ -779,7 +803,7 @@ class TestIVFAQFastScan(unittest.TestCase):
         for implem in 0, 1, 2:
             self.subtest_from_ivfaq(implem)
 
-    def subtest_factory(self, aq, M, bbs, st, r='r'):
+    def subtest_factory(self, aq, M, bbs, st, r="r"):
         """
         Format: IVF{nlist},{AQ}{M}x4fs{r}_{bbs}_N{st}
 
@@ -795,10 +819,12 @@ class TestIVFAQFastScan(unittest.TestCase):
 
         if bbs > 0:
             index = faiss.index_factory(
-                d, f'IVF{nlist},{aq}{M}x4fs{r}_{bbs}_N{st}2x4')
+                d, f"IVF{nlist},{aq}{M}x4fs{r}_{bbs}_N{st}2x4"
+            )
         else:
             index = faiss.index_factory(
-                d, f'IVF{nlist},{aq}{M}x4fs{r}_N{st}2x4')
+                d, f"IVF{nlist},{aq}{M}x4fs{r}_N{st}2x4"
+            )
             bbs = 32
 
         assert index.nlist == nlist
@@ -806,26 +832,26 @@ class TestIVFAQFastScan(unittest.TestCase):
         q = faiss.downcast_Quantizer(index.aq)
         assert q.M == M
 
-        if aq == 'LSQ':
+        if aq == "LSQ":
             assert isinstance(q, faiss.LocalSearchQuantizer)
-        if aq == 'RQ':
+        if aq == "RQ":
             assert isinstance(q, faiss.ResidualQuantizer)
 
-        if st == 'lsq':
+        if st == "lsq":
             assert q.search_type == AQ.ST_norm_lsq2x4
-        if st == 'rq':
+        if st == "rq":
             assert q.search_type == AQ.ST_norm_rq2x4
 
-        assert index.by_residual == (r == 'r')
+        assert index.by_residual == (r == "r")
 
     def test_factory(self):
-        self.subtest_factory('LSQ', 16, 64, 'lsq')
-        self.subtest_factory('LSQ', 16, 64, 'rq')
-        self.subtest_factory('RQ', 16, 64, 'rq')
-        self.subtest_factory('RQ', 16, 64, 'lsq')
-        self.subtest_factory('LSQ', 64, 0, 'lsq')
+        self.subtest_factory("LSQ", 16, 64, "lsq")
+        self.subtest_factory("LSQ", 16, 64, "rq")
+        self.subtest_factory("RQ", 16, 64, "rq")
+        self.subtest_factory("RQ", 16, 64, "lsq")
+        self.subtest_factory("LSQ", 64, 0, "lsq")
 
-        self.subtest_factory('LSQ', 64, 0, 'lsq', r='')
+        self.subtest_factory("LSQ", 64, 0, "lsq", r="")
 
     def subtest_io(self, factory_str):
         d = 8
@@ -841,21 +867,22 @@ class TestIVFAQFastScan(unittest.TestCase):
         np.testing.assert_array_equal(I1, I2)
 
     def test_io(self):
-        self.subtest_io('IVF16,LSQ4x4fs_Nlsq2x4')
-        self.subtest_io('IVF16,LSQ4x4fs_Nrq2x4')
-        self.subtest_io('IVF16,RQ4x4fs_Nrq2x4')
-        self.subtest_io('IVF16,RQ4x4fs_Nlsq2x4')
+        self.subtest_io("IVF16,LSQ4x4fs_Nlsq2x4")
+        self.subtest_io("IVF16,LSQ4x4fs_Nrq2x4")
+        self.subtest_io("IVF16,RQ4x4fs_Nrq2x4")
+        self.subtest_io("IVF16,RQ4x4fs_Nlsq2x4")
 
 
 # add more tests programatically
 
+
 def add_TestIVFAQFastScan_subtest_accuracy(
-        aq, st, by_residual, implem, metric='L2'):
+    aq, st, by_residual, implem, metric="L2"
+):
     setattr(
         TestIVFAQFastScan,
         f"test_accuracy_{metric}_{aq}_implem{implem}_residual{by_residual}",
-        lambda self:
-        self.subtest_accuracy(aq, st, by_residual, implem, metric)
+        lambda self: self.subtest_accuracy(aq, st, by_residual, implem, metric),
     )
 
 
@@ -863,18 +890,22 @@ def add_TestIVFAQFastScan_subtest_rescale_accuracy(aq, st, by_residual, implem):
     setattr(
         TestIVFAQFastScan,
         f"test_rescale_accuracy_{aq}_implem{implem}_residual{by_residual}",
-        lambda self:
-        self.subtest_rescale_accuracy(aq, st, by_residual, implem)
+        lambda self: self.subtest_rescale_accuracy(aq, st, by_residual, implem),
     )
+
 
 for byr in True, False:
     for implem in 0, 10, 11, 12, 13, 14, 15:
-        for mt in 'L2', 'IP':
-            add_TestIVFAQFastScan_subtest_accuracy('RQ', 'rq', byr, implem, mt)
-            add_TestIVFAQFastScan_subtest_accuracy('LSQ', 'lsq', byr, implem, mt)
+        for mt in "L2", "IP":
+            add_TestIVFAQFastScan_subtest_accuracy("RQ", "rq", byr, implem, mt)
+            add_TestIVFAQFastScan_subtest_accuracy(
+                "LSQ", "lsq", byr, implem, mt
+            )
 
-        add_TestIVFAQFastScan_subtest_rescale_accuracy('LSQ', 'lsq', byr, implem)
-        add_TestIVFAQFastScan_subtest_rescale_accuracy('RQ', 'rq', byr, implem)
+        add_TestIVFAQFastScan_subtest_rescale_accuracy(
+            "LSQ", "lsq", byr, implem
+        )
+        add_TestIVFAQFastScan_subtest_rescale_accuracy("RQ", "rq", byr, implem)
 
 # Apply decorator after dynamic method generation.
 TestIVFAQFastScan = for_all_simd_levels(TestIVFAQFastScan)
@@ -892,13 +923,13 @@ class TestIVFPAQFastScan(unittest.TestCase):
         ds = datasets.SyntheticDataset(d, 1000, 1000, 500)
         gt = ds.get_groundtruth(k=1)
 
-        index = faiss.index_factory(d, f'IVF{nlist},{paq}2x3x4_Nqint8')
+        index = faiss.index_factory(d, f"IVF{nlist},{paq}2x3x4_Nqint8")
         index.train(ds.get_train())
         index.add(ds.get_database())
         index.nprobe = 4
         Dref, Iref = index.search(ds.get_queries(), 1)
 
-        indexfs = faiss.index_factory(d, f'IVF{nlist},{paq}2x3x4fsr_Nlsq2x4')
+        indexfs = faiss.index_factory(d, f"IVF{nlist},{paq}2x3x4fsr_Nlsq2x4")
         indexfs.train(ds.get_train())
         indexfs.add(ds.get_database())
         indexfs.nprobe = 4
@@ -918,7 +949,7 @@ class TestIVFPAQFastScan(unittest.TestCase):
 
     def subtest_factory(self, paq):
         nlist, d = 128, 16
-        index = faiss.index_factory(d, f'IVF{nlist},{paq}2x3x4fsr_Nlsq2x4')
+        index = faiss.index_factory(d, f"IVF{nlist},{paq}2x3x4fsr_Nlsq2x4")
         q = faiss.downcast_Quantizer(index.aq)
 
         self.assertEqual(index.nlist, nlist)
@@ -927,8 +958,8 @@ class TestIVFPAQFastScan(unittest.TestCase):
         self.assertTrue(index.by_residual)
 
     def test_factory(self):
-        self.subtest_factory('PLSQ')
-        self.subtest_factory('PRQ')
+        self.subtest_factory("PLSQ")
+        self.subtest_factory("PRQ")
 
     def subtest_io(self, factory_str):
         d = 8
@@ -944,8 +975,8 @@ class TestIVFPAQFastScan(unittest.TestCase):
         np.testing.assert_array_equal(I1, I2)
 
     def test_io(self):
-        self.subtest_io('IVF16,PLSQ2x3x4fsr_Nlsq2x4')
-        self.subtest_io('IVF16,PRQ2x3x4fs_Nrq2x4')
+        self.subtest_io("IVF16,PLSQ2x3x4fsr_Nlsq2x4")
+        self.subtest_io("IVF16,PRQ2x3x4fs_Nrq2x4")
 
 
 @for_all_simd_levels
@@ -966,7 +997,8 @@ class TestSearchParams(unittest.TestCase):
 
         index.nprobe = 1
         Dnew4, Inew4 = index.search(
-            ds.get_queries(), 10, params=faiss.IVFSearchParameters(nprobe=4))
+            ds.get_queries(), 10, params=faiss.IVFSearchParameters(nprobe=4)
+        )
         np.testing.assert_array_equal(Dref4, Dnew4)
         np.testing.assert_array_equal(Iref4, Inew4)
 
@@ -995,8 +1027,8 @@ class TestRangeSearchImplem12(unittest.TestCase):
         nextra = 0
 
         for i in range(ds.nq):
-            ref = set(I1[lims1[i]: lims1[i + 1]])
-            new = set(I2[lims2[i]: lims2[i + 1]])
+            ref = set(I1[lims1[i] : lims1[i + 1]])
+            new = set(I2[lims2[i] : lims2[i + 1]])
             nmiss += len(ref - new)
             nextra += len(new - ref)
 

--- a/tests/test_fastscan_filter.py
+++ b/tests/test_fastscan_filter.py
@@ -59,10 +59,12 @@ class TestFastScanFiltering(unittest.TestCase):
             allowed = set(range(lo, hi))
         elif id_selector_type == "not_batch":
             # Exclude entire 32-vector blocks to test block-skip
-            excluded = np.concatenate([
-                np.arange(0, 32, dtype="int64"),
-                np.arange(64, 96, dtype="int64"),
-            ])
+            excluded = np.concatenate(
+                [
+                    np.arange(0, 32, dtype="int64"),
+                    np.arange(64, 96, dtype="int64"),
+                ]
+            )
             inner_sel = faiss.IDSelectorBatch(excluded)
             sel = faiss.IDSelectorNot(inner_sel)
             allowed = {i for i in range(nb) if i not in excluded}
@@ -87,16 +89,15 @@ class TestFastScanFiltering(unittest.TestCase):
                 idx = int(Ifs[q, j])
                 if idx >= 0:
                     self.assertIn(
-                        idx, allowed,
-                        f"Query {q}, rank {j}: got id {idx} not in allowed set"
+                        idx,
+                        allowed,
+                        f"Query {q}, rank {j}: got id {idx} not in allowed set",
                     )
 
         # If allowed set is large enough, expect some valid results
         if len(allowed) > k:
             valid = np.sum(Ifs >= 0)
-            self.assertGreater(
-                valid, 0, "Expected some valid results"
-            )
+            self.assertGreater(valid, 0, "Expected some valid results")
 
         return Ifs
 
@@ -207,10 +208,12 @@ class TestBlockSkipConsistency(unittest.TestCase):
         ds = datasets.SyntheticDataset(d, 2000, nb, 20)
 
         # Exclude entire blocks: IDs 0-31 and 64-95
-        excluded = np.concatenate([
-            np.arange(0, 32, dtype="int64"),
-            np.arange(64, 96, dtype="int64"),
-        ])
+        excluded = np.concatenate(
+            [
+                np.arange(0, 32, dtype="int64"),
+                np.arange(64, 96, dtype="int64"),
+            ]
+        )
         inner_sel = faiss.IDSelectorBatch(excluded)
         sel = faiss.IDSelectorNot(inner_sel)
         allowed = {i for i in range(nb) if i not in excluded}
@@ -235,11 +238,17 @@ class TestBlockSkipConsistency(unittest.TestCase):
         for q in range(ds.nq):
             for j in range(k):
                 if Ifs[q, j] >= 0:
-                    self.assertIn(int(Ifs[q, j]), allowed,
-                        f"FastScan q={q} j={j}: id {Ifs[q, j]} is excluded")
+                    self.assertIn(
+                        int(Ifs[q, j]),
+                        allowed,
+                        f"FastScan q={q} j={j}: id {Ifs[q, j]} is excluded",
+                    )
                 if Ipq[q, j] >= 0:
-                    self.assertIn(int(Ipq[q, j]), allowed,
-                        f"IVFPQ q={q} j={j}: id {Ipq[q, j]} is excluded")
+                    self.assertIn(
+                        int(Ipq[q, j]),
+                        allowed,
+                        f"IVFPQ q={q} j={j}: id {Ipq[q, j]} is excluded",
+                    )
 
     def test_partial_vs_whole_block_filter(self):
         """
@@ -332,8 +341,9 @@ class TestFastScanRangeSearchFilter(unittest.TestCase):
             for idx in I:
                 if idx >= 0:
                     self.assertIn(
-                        int(idx), allowed,
-                        f"Range search returned id {idx} not in allowed set"
+                        int(idx),
+                        allowed,
+                        f"Range search returned id {idx} not in allowed set",
                     )
         except RuntimeError:
             # range_search may not be supported for all fastscan variants

--- a/tests/test_flat_panorama.py
+++ b/tests/test_flat_panorama.py
@@ -97,14 +97,15 @@ class TestIndexFlatPanorama(unittest.TestCase):
         for i in range(nq):
             n_results = lims_regular[i + 1] - lims_regular[i]
             if n_results > 0:
-                ids_reg = I_regular[lims_regular[i]: lims_regular[i + 1]]
-                dist_reg = D_regular[lims_regular[i]: lims_regular[i + 1]]
-                ids_pan = I_panorama[lims_panorama[i]: lims_panorama[i + 1]]
-                dist_pan = D_panorama[lims_panorama[i]: lims_panorama[i + 1]]
+                ids_reg = I_regular[lims_regular[i] : lims_regular[i + 1]]
+                dist_reg = D_regular[lims_regular[i] : lims_regular[i + 1]]
+                ids_pan = I_panorama[lims_panorama[i] : lims_panorama[i + 1]]
+                dist_pan = D_panorama[lims_panorama[i] : lims_panorama[i + 1]]
 
                 sort_reg, sort_pan = np.argsort(ids_reg), np.argsort(ids_pan)
                 np.testing.assert_array_equal(
-                    ids_reg[sort_reg], ids_pan[sort_pan])
+                    ids_reg[sort_reg], ids_pan[sort_pan]
+                )
                 np.testing.assert_allclose(
                     dist_reg[sort_reg], dist_pan[sort_pan], rtol=1e-5
                 )
@@ -120,7 +121,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(d, xb, metric=metric)
                 index_panorama = self.create_panorama(
-                    d, nlevels, xb, metric=metric)
+                    d, nlevels, xb, metric=metric
+                )
 
                 D_regular, I_regular = index_regular.search(xq, k)
                 D_panorama, I_panorama = index_panorama.search(xq, k)
@@ -138,7 +140,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(d, xb, metric=metric)
                 index_panorama = self.create_panorama(
-                    d, nlevels, xb, metric=metric)
+                    d, nlevels, xb, metric=metric
+                )
 
                 D_regular, I_regular = index_regular.search(xq, k)
                 D_panorama, I_panorama = index_panorama.search(xq, k)
@@ -154,15 +157,16 @@ class TestIndexFlatPanorama(unittest.TestCase):
 
         for metric in self.METRICS:
             index_regular = self.create_flat(d, xb, metric=metric)
-            index_panorama = self.create_panorama(
-                d, nlevels, xb, metric=metric)
+            index_panorama = self.create_panorama(d, nlevels, xb, metric=metric)
 
             for radius in [0.5, 1.0, 2.0, 5.0]:
                 with self.subTest(metric=metric, radius=radius):
                     lims_reg, D_reg, I_reg = index_regular.range_search(
-                        xq, radius)
+                        xq, radius
+                    )
                     lims_pan, D_pan, I_pan = index_panorama.range_search(
-                        xq, radius)
+                        xq, radius
+                    )
 
                     is_valid = (
                         (D_pan <= radius)
@@ -201,8 +205,7 @@ class TestIndexFlatPanorama(unittest.TestCase):
 
                     stats = faiss.cvar.indexPanorama_stats
                     ratio_dims_scanned = stats.ratio_dims_scanned
-                    self.assertLess(ratio_dims_scanned,
-                                    prev_ratio_dims_scanned)
+                    self.assertLess(ratio_dims_scanned, prev_ratio_dims_scanned)
                     prev_ratio_dims_scanned = ratio_dims_scanned
 
             faiss.omp_set_num_threads(nt)
@@ -219,7 +222,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
 
                     index_regular = self.create_flat(d, xb, metric=metric)
                     index_panorama = self.create_panorama(
-                        d, nlevels, xb, metric=metric)
+                        d, nlevels, xb, metric=metric
+                    )
 
                     D_regular, I_regular = index_regular.search(xq, k)
                     D_panorama, I_panorama = index_panorama.search(xq, k)
@@ -237,13 +241,15 @@ class TestIndexFlatPanorama(unittest.TestCase):
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(d, xb, metric=metric)
                 index_panorama = self.create_panorama(
-                    d, nlevels, xb, metric=metric)
+                    d, nlevels, xb, metric=metric
+                )
 
                 D_regular, I_regular = index_regular.search(xq, k)
                 D_panorama, I_panorama = index_panorama.search(xq, k)
 
                 self.assert_search_results_equal(
-                    D_regular, I_regular, D_panorama, I_panorama)
+                    D_regular, I_regular, D_panorama, I_panorama
+                )
 
     def test_multiple_levels_small_dimension(self):
         """Test edge case: more levels than dimension naturally supports"""
@@ -254,13 +260,15 @@ class TestIndexFlatPanorama(unittest.TestCase):
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(d, xb, metric=metric)
                 index_panorama = self.create_panorama(
-                    d, nlevels, xb, metric=metric)
+                    d, nlevels, xb, metric=metric
+                )
 
                 D_regular, I_regular = index_regular.search(xq, k)
                 D_panorama, I_panorama = index_panorama.search(xq, k)
 
                 self.assert_search_results_equal(
-                    D_regular, I_regular, D_panorama, I_panorama)
+                    D_regular, I_regular, D_panorama, I_panorama
+                )
 
     # ID selector tests
 
@@ -273,15 +281,18 @@ class TestIndexFlatPanorama(unittest.TestCase):
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(d, xb, metric=metric)
                 index_panorama = self.create_panorama(
-                    d, nlevels, xb, metric=metric)
+                    d, nlevels, xb, metric=metric
+                )
 
                 params = faiss.SearchParameters()
                 params.sel = faiss.IDSelectorRange(10000, 50000)
 
                 D_regular, I_regular = index_regular.search(
-                    xq, k, params=params)
+                    xq, k, params=params
+                )
                 D_panorama, I_panorama = index_panorama.search(
-                    xq, k, params=params)
+                    xq, k, params=params
+                )
 
                 self.assertTrue(np.all(I_panorama >= 10000))
                 self.assertTrue(np.all(I_panorama < 50000))
@@ -298,17 +309,21 @@ class TestIndexFlatPanorama(unittest.TestCase):
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(d, xb, metric=metric)
                 index_panorama = self.create_panorama(
-                    d, nlevels, xb, metric=metric)
+                    d, nlevels, xb, metric=metric
+                )
 
                 allowed_ids = np.array(
-                    [i * 100 for i in range(500)], dtype=np.int64)
+                    [i * 100 for i in range(500)], dtype=np.int64
+                )
                 params = faiss.SearchParameters()
                 params.sel = faiss.IDSelectorBatch(allowed_ids)
 
                 D_regular, I_regular = index_regular.search(
-                    xq, k, params=params)
+                    xq, k, params=params
+                )
                 D_panorama, I_panorama = index_panorama.search(
-                    xq, k, params=params)
+                    xq, k, params=params
+                )
 
                 allowed_set = set(allowed_ids)
                 for id_val in I_panorama.flatten():
@@ -326,15 +341,18 @@ class TestIndexFlatPanorama(unittest.TestCase):
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(d, xb, metric=metric)
                 index_panorama = self.create_panorama(
-                    d, nlevels, xb, metric=metric)
+                    d, nlevels, xb, metric=metric
+                )
 
                 params = faiss.SearchParameters()
                 params.sel = faiss.IDSelectorRange(20, 60)
 
                 D_regular, I_regular = index_regular.search(
-                    xq, k, params=params)
+                    xq, k, params=params
+                )
                 D_panorama, I_panorama = index_panorama.search(
-                    xq, k, params=params)
+                    xq, k, params=params
+                )
 
                 self.assertTrue(np.all(I_panorama >= 20))
                 self.assertTrue(np.all(I_panorama < 60))
@@ -350,7 +368,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index_panorama = self.create_panorama(
-                    d, nlevels, xb, metric=metric)
+                    d, nlevels, xb, metric=metric
+                )
 
                 params = faiss.SearchParameters()
                 params.sel = faiss.IDSelectorRange(nb + 100, nb + 200)
@@ -387,7 +406,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
 
                     index_regular = self.create_flat(d, xb, metric=metric)
                     index_panorama = self.create_panorama(
-                        d, nlevels=8, xb=xb, metric=metric)
+                        d, nlevels=8, xb=xb, metric=metric
+                    )
 
                     D_regular, I_regular = index_regular.search(xq, k)
                     D_panorama, I_panorama = index_panorama.search(xq, k)
@@ -407,7 +427,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
             for k, bs in [(1, 1), (10, 128), (100, 4096)]:
                 with self.subTest(metric=metric, k=k, batch_size=bs):
                     index_panorama = self.create_panorama(
-                        d, nlevels, xb=xb, batch_size=bs, metric=metric)
+                        d, nlevels, xb=xb, batch_size=bs, metric=metric
+                    )
                     D_regular, I_regular = index_regular.search(xq, k)
                     D_panorama, I_panorama = index_panorama.search(xq, k)
                     self.assert_search_results_equal(
@@ -418,8 +439,9 @@ class TestIndexFlatPanorama(unittest.TestCase):
         """Test handling of empty search results (shapes only)"""
         d, nb, nt, nq, nlevels, k = 32, 100, 200, 10, 4, 10
         _, xb, _ = self.generate_data(d, nt, nb, nq, seed=111)
-        xq = np.random.rand(nq, d).astype("float32") + \
-            10.0  # Queries far from database
+        xq = (
+            np.random.rand(nq, d).astype("float32") + 10.0
+        )  # Queries far from database
 
         for metric in self.METRICS:
             with self.subTest(metric=metric):
@@ -438,12 +460,12 @@ class TestIndexFlatPanorama(unittest.TestCase):
                 with self.subTest(metric=metric, nb=nb):
                     d, nt, nlevels, nq = 32, max(nb, 100), 4, 10
                     k = min(3, nb)
-                    _, xb, xq = self.generate_data(
-                        d, nt, nb, nq, seed=666 + nb)
+                    _, xb, xq = self.generate_data(d, nt, nb, nq, seed=666 + nb)
 
                     index_regular = self.create_flat(d, xb, metric=metric)
                     index_panorama = self.create_panorama(
-                        d, nlevels, xb, metric=metric)
+                        d, nlevels, xb, metric=metric
+                    )
 
                     D_regular, I_regular = index_regular.search(xq, k)
                     D_panorama, I_panorama = index_panorama.search(xq, k)
@@ -464,9 +486,11 @@ class TestIndexFlatPanorama(unittest.TestCase):
             for radius in [0.01, 0.1, 100.0, 1000.0]:
                 with self.subTest(metric=metric, radius=radius):
                     lims_reg, D_reg, I_reg = index_regular.range_search(
-                        xq, radius)
+                        xq, radius
+                    )
                     lims_pan, D_pan, I_pan = index_panorama.range_search(
-                        xq, radius)
+                        xq, radius
+                    )
 
                     np.testing.assert_array_equal(lims_reg, lims_pan)
 
@@ -484,8 +508,7 @@ class TestIndexFlatPanorama(unittest.TestCase):
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(d, metric=metric)
-                index_panorama = self.create_panorama(
-                    d, nlevels, metric=metric)
+                index_panorama = self.create_panorama(d, nlevels, metric=metric)
 
                 # Keep total nb under 100k
                 batch_sizes = [5000, 10000, 15000, 20000]
@@ -501,7 +524,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
                 D_panorama, I_panorama = index_panorama.search(xq, k)
 
                 self.assert_search_results_equal(
-                    D_regular, I_regular, D_panorama, I_panorama)
+                    D_regular, I_regular, D_panorama, I_panorama
+                )
 
     def test_add_search_add_search(self):
         """Test interleaved add and search operations"""
@@ -511,8 +535,7 @@ class TestIndexFlatPanorama(unittest.TestCase):
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(d, metric=metric)
-                index_panorama = self.create_panorama(
-                    d, nlevels, metric=metric)
+                index_panorama = self.create_panorama(d, nlevels, metric=metric)
 
                 # First add and search
                 xb1 = np.random.rand(200, d).astype("float32")
@@ -524,7 +547,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
                 D_reg_1, I_reg_1 = index_regular.search(xq1, k)
                 D_pan_1, I_pan_1 = index_panorama.search(xq1, k)
                 self.assert_search_results_equal(
-                    D_reg_1, I_reg_1, D_pan_1, I_pan_1)
+                    D_reg_1, I_reg_1, D_pan_1, I_pan_1
+                )
 
                 # Second add and search
                 xb2 = np.random.rand(300, d).astype("float32")
@@ -535,7 +559,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
                 D_reg_2, I_reg_2 = index_regular.search(xq2, k)
                 D_pan_2, I_pan_2 = index_panorama.search(xq2, k)
                 self.assert_search_results_equal(
-                    D_reg_2, I_reg_2, D_pan_2, I_pan_2)
+                    D_reg_2, I_reg_2, D_pan_2, I_pan_2
+                )
 
     def test_reconstruct(self):
         """Test reconstruct and reconstruct_n return original vectors"""
@@ -545,7 +570,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index_panorama = self.create_panorama(
-                    d, nlevels, xb, metric=metric)
+                    d, nlevels, xb, metric=metric
+                )
 
                 # Test reconstruct for single vector
                 idx = 123
@@ -554,24 +580,25 @@ class TestIndexFlatPanorama(unittest.TestCase):
 
                 # Test reconstruct_n for range of vectors
                 start_idx, n_vectors = 120, 10
-                vn_panorama = index_panorama.reconstruct_n(
-                    start_idx, n_vectors)
+                vn_panorama = index_panorama.reconstruct_n(start_idx, n_vectors)
                 np.testing.assert_array_equal(
-                    xb[start_idx:start_idx + n_vectors], vn_panorama)
+                    xb[start_idx : start_idx + n_vectors], vn_panorama
+                )
 
     def test_remove_ids_then_add(self):
         """Test removing vectors with remove_ids() then adding more vectors"""
         d, nb, nt, nq, nlevels, k = 964, 50000, 0, 10, 128, 15
         _, xb, xq = self.generate_data(d, nt, nb, nq, seed=2026)
 
-        xb1 = xb[:nb // 2]
-        xb2 = xb[nb // 2:]
+        xb1 = xb[: nb // 2]
+        xb2 = xb[nb // 2 :]
 
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(d, xb1, metric=metric)
                 index_panorama = self.create_panorama(
-                    d, nlevels, xb1, metric=metric)
+                    d, nlevels, xb1, metric=metric
+                )
 
                 # Remove every even ID
                 ids_to_remove = np.arange(0, nb, 2, dtype=np.int64)
@@ -589,7 +616,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
                 D_reg_1, I_reg_1 = index_regular.search(xq, k)
                 D_pan_1, I_pan_1 = index_panorama.search(xq, k)
                 self.assert_search_results_equal(
-                    D_reg_1, I_reg_1, D_pan_1, I_pan_1)
+                    D_reg_1, I_reg_1, D_pan_1, I_pan_1
+                )
 
                 # Second add and search
                 index_regular.add(xb2)
@@ -602,7 +630,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
                 D_reg_2, I_reg_2 = index_regular.search(xq, k)
                 D_pan_2, I_pan_2 = index_panorama.search(xq, k)
                 self.assert_search_results_equal(
-                    D_reg_2, I_reg_2, D_pan_2, I_pan_2)
+                    D_reg_2, I_reg_2, D_pan_2, I_pan_2
+                )
 
     def test_merge_from(self):
         """Test merging indexes with merge_from()"""
@@ -620,9 +649,11 @@ class TestIndexFlatPanorama(unittest.TestCase):
                 index2_regular = self.create_flat(d, xb2, metric=metric)
 
                 index1_panorama = self.create_panorama(
-                    d, nlevels, xb1, batch_size, metric=metric)
+                    d, nlevels, xb1, batch_size, metric=metric
+                )
                 index2_panorama = self.create_panorama(
-                    d, nlevels * 2, xb2, batch_size // 2, metric=metric)
+                    d, nlevels * 2, xb2, batch_size // 2, metric=metric
+                )
 
                 # Merge second index into first
                 index1_regular.merge_from(index2_regular, 0)
@@ -636,7 +667,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
                 D_regular, I_regular = index1_regular.search(xq, k)
                 D_panorama, I_panorama = index1_panorama.search(xq, k)
                 self.assert_search_results_equal(
-                    D_regular, I_regular, D_panorama, I_panorama)
+                    D_regular, I_regular, D_panorama, I_panorama
+                )
 
     def test_permute_entries(self):
         """Test permuting entries with permute_entries()"""
@@ -647,7 +679,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(d, xb, metric=metric)
                 index_panorama = self.create_panorama(
-                    d, nlevels, xb, metric=metric)
+                    d, nlevels, xb, metric=metric
+                )
 
                 # Create a random permutation
                 np.random.seed(1234)
@@ -663,7 +696,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
 
                 # Verify permuted indexes match each other
                 self.assert_search_results_equal(
-                    D_regular, I_regular, D_panorama, I_panorama)
+                    D_regular, I_regular, D_panorama, I_panorama
+                )
 
     def test_serialization(self):
         """Test write/read Panorama indexes preserves search results"""
@@ -676,7 +710,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
 
                 D_before, I_before = index.search(xq, k)
                 index_after = faiss.deserialize_index(
-                    faiss.serialize_index(index))
+                    faiss.serialize_index(index)
+                )
                 D_after, I_after = index_after.search(xq, k)
 
                 np.testing.assert_array_equal(I_before, I_after)
@@ -714,7 +749,8 @@ class TestIndexFlatPanorama(unittest.TestCase):
                         self.assert_search_results_equal(D_base, I_base, D, I)
 
                         ratios.append(
-                            faiss.cvar.indexPanorama_stats.ratio_dims_scanned)
+                            faiss.cvar.indexPanorama_stats.ratio_dims_scanned
+                        )
 
                 expected_ratios = [1 / nlevels for nlevels in nlevels_list]
                 np.testing.assert_allclose(ratios, expected_ratios, atol=1e-3)

--- a/tests/test_graph_based.py
+++ b/tests/test_graph_based.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-""" a few tests for graph-based indices (HNSW, nndescent and NSG)"""
+"""a few tests for graph-based indices (HNSW, nndescent and NSG)"""
 
 import numpy as np
 import unittest
@@ -53,8 +53,8 @@ class TestHNSW(unittest.TestCase):
         nmiss = 0
         # check if returned results are a subset of the reference results
         for i in range(len(self.xq)):
-            ref = Iref[lims_ref[i]: lims_ref[i + 1]]
-            new = I[lims[i]: lims[i + 1]]
+            ref = Iref[lims_ref[i] : lims_ref[i + 1]]
+            new = I[lims[i] : lims[i + 1]]
             self.assertLessEqual(set(new), set(ref))
             nmiss += len(ref) - len(new)
         # currently we miss 405 / 6019 neighbors
@@ -140,7 +140,7 @@ class TestHNSW(unittest.TestCase):
 
     def test_add_0_vecs(self):
         index = faiss.IndexHNSWFlat(10, 16)
-        zero_vecs = np.zeros((0, 10), dtype='float32')
+        zero_vecs = np.zeros((0, 10), dtype="float32")
         # infinite loop
         index.add(zero_vecs)
 
@@ -182,13 +182,10 @@ class TestHNSW(unittest.TestCase):
             faiss.serialize_index(index, faiss.IO_FLAG_SKIP_STORAGE)
         )
         self.assertEqual(index2.storage, None)
-        self.assertRaises(
-            RuntimeError,
-            index2.search, self.xb, 1)
+        self.assertRaises(RuntimeError, index2.search, self.xb, 1)
 
         # make sure we can store an index with empty storage
-        index4 = faiss.deserialize_index(
-            faiss.serialize_index(index2))
+        index4 = faiss.deserialize_index(faiss.serialize_index(index2))
 
         # add storage afterwards
         index.storage = faiss.clone_index(index.storage)
@@ -350,15 +347,15 @@ class TestHNSWNaN(unittest.TestCase):
         d = 64
         nt = 2000
         nb = 1000
-        xt = np.random.default_rng(42).random((nt, d), dtype='float32')
-        xb = np.random.default_rng(43).random((nb, d), dtype='float32')
+        xt = np.random.default_rng(42).random((nt, d), dtype="float32")
+        xb = np.random.default_rng(43).random((nb, d), dtype="float32")
 
         index = faiss.index_factory(d, "IVF256_HNSW32,SQ8")
         index.train(xt)
         index.add(xb)
 
         # Create a vector with NaN in the first component
-        vec = np.zeros((1, d), dtype='float32')
+        vec = np.zeros((1, d), dtype="float32")
         vec[0, 0] = np.nan
 
         # This should not crash
@@ -372,9 +369,9 @@ class Issue3684(unittest.TestCase):
         np.random.seed(1234)  # For reproducibility
         d = 256  # Example dimension
         nb = 10  # Number of database vectors
-        nq = 2   # Number of query vectors
-        xb = np.random.random((nb, d)).astype('float32')
-        xq = np.random.random((nq, d)).astype('float32')
+        nq = 2  # Number of query vectors
+        xb = np.random.random((nb, d)).astype("float32")
+        xq = np.random.random((nq, d)).astype("float32")
 
         faiss.normalize_L2(xb)  # Normalize both query and database vectors
         faiss.normalize_L2(xq)
@@ -472,8 +469,7 @@ class TestNSG(unittest.TestCase):
 
     def subtest_build(self, knn_graph, thresh, metric=faiss.METRIC_L2):
         d = self.xq.shape[1]
-        metrics = {faiss.METRIC_L2: 'L2',
-                   faiss.METRIC_INNER_PRODUCT: 'IP'}
+        metrics = {faiss.METRIC_L2: "L2", faiss.METRIC_INNER_PRODUCT: "IP"}
 
         flat_index = faiss.IndexFlat(d, metric)
         flat_index.add(self.xb)
@@ -591,8 +587,7 @@ class TestNSG(unittest.TestCase):
             index.add(self.xb)
 
         self.assertIn(
-            "NSG does not support incremental addition",
-            str(context.exception)
+            "NSG does not support incremental addition", str(context.exception)
         )
 
     def test_nsg_rebuild_throws_with_pre_built_knn_graph(self):
@@ -739,8 +734,8 @@ class TestNNDescentGenRandom(unittest.TestCase):
         """
         d = 32
         nb = 200  # just above NUM_EVAL_POINTS=100
-        xb = np.random.default_rng(42).random((nb, d)).astype('float32')
-        xq = np.random.default_rng(43).random((10, d)).astype('float32')
+        xb = np.random.default_rng(42).random((nb, d)).astype("float32")
+        xq = np.random.default_rng(43).random((10, d)).astype("float32")
 
         index = faiss.IndexNNDescentFlat(d, 32)
         index.nndescent.search_L = nb  # triggers gen_random(size=nb, N=nb)
@@ -789,7 +784,7 @@ class TestNNDescentKNNG(unittest.TestCase):
         assert recall > 0.99
 
     def test_small_nndescent(self):
-        """ building a too small graph used to crash, make sure it raises
+        """building a too small graph used to crash, make sure it raises
         an exception instead.
         TODO: build the exact knn graph for small cases
         """
@@ -802,5 +797,5 @@ class TestNNDescentKNNG(unittest.TestCase):
         index.nndescent.iter = 5
         index.verbose = True
 
-        xb = np.zeros((78, d), dtype='float32')
+        xb = np.zeros((78, d), dtype="float32")
         self.assertRaises(RuntimeError, index.add, xb)

--- a/tests/test_hamming_utils.py
+++ b/tests/test_hamming_utils.py
@@ -29,8 +29,11 @@ from common_faiss_tests import for_all_simd_levels
 
 def _popcount_xor(a, b):
     """Reference Hamming distance via NumPy; bit-exact across platforms."""
-    return np.unpackbits(np.bitwise_xor(a, b), axis=-1).sum(axis=-1).astype(
-        np.int32)
+    return (
+        np.unpackbits(np.bitwise_xor(a, b), axis=-1)
+        .sum(axis=-1)
+        .astype(np.int32)
+    )
 
 
 def _make_codes(n, ncodes, seed):
@@ -60,8 +63,13 @@ class TestHammingUtils(unittest.TestCase):
                 b = _make_codes(nb, ncodes, seed=2 + ncodes)
                 dis = np.empty((na, nb), dtype=np.int32)
                 faiss.hammings(
-                    faiss.swig_ptr(a), faiss.swig_ptr(b),
-                    na, nb, ncodes, faiss.swig_ptr(dis))
+                    faiss.swig_ptr(a),
+                    faiss.swig_ptr(b),
+                    na,
+                    nb,
+                    ncodes,
+                    faiss.swig_ptr(dis),
+                )
                 expected = _popcount_xor(a[:, None, :], b[None, :, :])
                 np.testing.assert_array_equal(dis, expected)
 
@@ -74,9 +82,15 @@ class TestHammingUtils(unittest.TestCase):
                 D = np.empty((na, k), dtype=np.int32)
                 I = np.empty((na, k), dtype=np.int64)
                 faiss.hammings_knn_mc(
-                    faiss.swig_ptr(a), faiss.swig_ptr(b),
-                    na, nb, k, ncodes,
-                    faiss.swig_ptr(D), faiss.swig_ptr(I))
+                    faiss.swig_ptr(a),
+                    faiss.swig_ptr(b),
+                    na,
+                    nb,
+                    k,
+                    ncodes,
+                    faiss.swig_ptr(D),
+                    faiss.swig_ptr(I),
+                )
 
                 full = _popcount_xor(a[:, None, :], b[None, :, :])
                 # Distance-at-returned-index agrees with the reference.
@@ -85,7 +99,7 @@ class TestHammingUtils(unittest.TestCase):
                 # Each returned distance is no greater than the true k-th
                 # smallest, so the result really is a top-k (with ties
                 # broken in some impl-defined way).
-                kth = np.partition(full, k - 1, axis=1)[:, k - 1:k]
+                kth = np.partition(full, k - 1, axis=1)[:, k - 1 : k]
                 self.assertTrue(np.all(D <= kth))
                 # IDs within a row are unique.
                 for i in range(na):
@@ -99,10 +113,17 @@ class TestHammingUtils(unittest.TestCase):
                 b = _make_codes(n2, ncodes, seed=21 + ncodes)
                 count = np.zeros(1, dtype=np.uint64)
                 faiss.hamming_count_thres(
-                    faiss.swig_ptr(a), faiss.swig_ptr(b),
-                    n1, n2, ht, ncodes, faiss.swig_ptr(count))
-                expected = int((_popcount_xor(
-                    a[:, None, :], b[None, :, :]) <= ht).sum())
+                    faiss.swig_ptr(a),
+                    faiss.swig_ptr(b),
+                    n1,
+                    n2,
+                    ht,
+                    ncodes,
+                    faiss.swig_ptr(count),
+                )
+                expected = int(
+                    (_popcount_xor(a[:, None, :], b[None, :, :]) <= ht).sum()
+                )
                 # Sanity: thresholds chosen so the count is non-trivial
                 # (otherwise the test passes vacuously).
                 self.assertGreater(expected, 0)
@@ -123,13 +144,19 @@ class TestHammingUtils(unittest.TestCase):
                 idx = np.empty(2 * expected_count + 4, dtype=np.int64)
                 dis = np.empty(expected_count + 4, dtype=np.int32)
                 got = faiss.match_hamming_thres(
-                    faiss.swig_ptr(a), faiss.swig_ptr(b),
-                    n1, n2, ht, ncodes,
-                    faiss.swig_ptr(idx), faiss.swig_ptr(dis))
+                    faiss.swig_ptr(a),
+                    faiss.swig_ptr(b),
+                    n1,
+                    n2,
+                    ht,
+                    ncodes,
+                    faiss.swig_ptr(idx),
+                    faiss.swig_ptr(dis),
+                )
                 self.assertEqual(got, expected_count)
                 # Decode the (i, j) pairs.
-                i_idx = idx[0:2 * got:2]
-                j_idx = idx[1:2 * got:2]
+                i_idx = idx[0 : 2 * got : 2]
+                j_idx = idx[1 : 2 * got : 2]
                 dis = dis[:got]
                 # Every reported pair is within threshold and matches the
                 # reference distance at (i, j).
@@ -148,8 +175,8 @@ class TestHammingUtils(unittest.TestCase):
                 dbs = _make_codes(n, ncodes, seed=40 + ncodes)
                 count = np.zeros(1, dtype=np.uint64)
                 faiss.crosshamming_count_thres(
-                    faiss.swig_ptr(dbs), n, ht, ncodes,
-                    faiss.swig_ptr(count))
+                    faiss.swig_ptr(dbs), n, ht, ncodes, faiss.swig_ptr(count)
+                )
                 full = _popcount_xor(dbs[:, None, :], dbs[None, :, :])
                 # crosshamming counts unordered pairs i < j.
                 triu = np.triu(full <= ht, k=1)
@@ -172,19 +199,24 @@ class TestHammingUtils(unittest.TestCase):
                 heap.ids = faiss.swig_ptr(I)
                 heap.val = faiss.swig_ptr(D)
                 faiss.generalized_hammings_knn_hc(
-                    heap, faiss.swig_ptr(a), faiss.swig_ptr(b),
-                    nb, code_size, True)
+                    heap,
+                    faiss.swig_ptr(a),
+                    faiss.swig_ptr(b),
+                    nb,
+                    code_size,
+                    True,
+                )
 
                 # Reference distance: number of bytes that differ.
-                ref_dist = code_size - (
-                    a[:, None, :] == b[None, :, :]).sum(axis=-1).astype(
-                        np.int32)
+                ref_dist = code_size - (a[:, None, :] == b[None, :, :]).sum(
+                    axis=-1
+                ).astype(np.int32)
                 # Distance at returned index matches the reference.
                 returned = np.take_along_axis(ref_dist, I, axis=1)
                 np.testing.assert_array_equal(D, returned)
                 # Each returned distance is no greater than the true k-th
                 # smallest -- catches an impl that returns I=[0..k-1].
-                kth = np.partition(ref_dist, k - 1, axis=1)[:, k - 1:k]
+                kth = np.partition(ref_dist, k - 1, axis=1)[:, k - 1 : k]
                 self.assertTrue(np.all(D <= kth))
                 # ordered=True was passed: distances within each row are
                 # non-decreasing.

--- a/tests/test_hnsw_panorama.py
+++ b/tests/test_hnsw_panorama.py
@@ -45,10 +45,7 @@ class TestIndexHNSWFlatPanorama(unittest.TestCase):
     def compute_recall(self, gt_I, test_I):
         """Compute recall@k - fraction of ground truth results found in test results."""
         nq, k = gt_I.shape
-        recalls = [
-            np.isin(gt_I[i], test_I[i]).sum() 
-            for i in range(nq)
-        ]
+        recalls = [np.isin(gt_I[i], test_I[i]).sum() for i in range(nq)]
         return sum(recalls) / (nq * k)
 
     # Core functionality tests
@@ -64,7 +61,9 @@ class TestIndexHNSWFlatPanorama(unittest.TestCase):
         self.assertEqual(index.d, d)
         self.assertEqual(index.ntotal, 0)
         self.assertTrue(index.is_trained)
-        self.assertEqual(index.hnsw.nb_neighbors(0), 2 * M)  # Level 0 has 2*M neighbors
+        self.assertEqual(
+            index.hnsw.nb_neighbors(0), 2 * M
+        )  # Level 0 has 2*M neighbors
         self.assertEqual(index.num_panorama_levels, num_levels)
         self.assertEqual(index.metric_type, faiss.METRIC_L2)
 
@@ -176,7 +175,8 @@ class TestIndexHNSWFlatPanorama(unittest.TestCase):
 
                 recall = self.compute_recall(gt_I, I)
                 self.assertGreaterEqual(
-                    recall, 0.80,
+                    recall,
+                    0.80,
                     f"Recall too low for d={d}, nlevels={nlevels}: "
                     f"{recall:.4f}",
                 )
@@ -222,7 +222,7 @@ class TestIndexHNSWFlatPanorama(unittest.TestCase):
         D_before, I_before = index.search(xq, k)
 
         # Save and load using temporary file
-        fname = tempfile.mktemp(suffix='.index')
+        fname = tempfile.mktemp(suffix=".index")
         try:
             faiss.write_index(index, fname)
             loaded_index = faiss.read_index(fname)
@@ -284,14 +284,18 @@ class TestIndexHNSWFlatPanorama(unittest.TestCase):
         index1 = faiss.index_factory(d, "HNSW32_FlatPanorama")
         self.assertIsInstance(index1, faiss.IndexHNSWFlatPanorama)
         self.assertEqual(index1.d, d)
-        self.assertEqual(index1.hnsw.nb_neighbors(0), 2 * 32)  # Level 0 has 2*M neighbors
+        self.assertEqual(
+            index1.hnsw.nb_neighbors(0), 2 * 32
+        )  # Level 0 has 2*M neighbors
         self.assertEqual(index1.num_panorama_levels, 8)  # default
 
         # Test factory creation with explicit levels
         index2 = faiss.index_factory(d, "HNSW16_FlatPanorama12")
         self.assertIsInstance(index2, faiss.IndexHNSWFlatPanorama)
         self.assertEqual(index2.d, d)
-        self.assertEqual(index2.hnsw.nb_neighbors(0), 2 * 16)  # Level 0 has 2*M neighbors
+        self.assertEqual(
+            index2.hnsw.nb_neighbors(0), 2 * 16
+        )  # Level 0 has 2*M neighbors
         self.assertEqual(index2.num_panorama_levels, 12)
 
         # Test that it works
@@ -357,7 +361,9 @@ class TestIndexHNSWFlatPanorama(unittest.TestCase):
         k = 5
 
         # Generate data
-        _, xb_initial, xq = self.generate_data(d, nt_initial, nb_initial, nq, seed=1111)
+        _, xb_initial, xq = self.generate_data(
+            d, nt_initial, nb_initial, nq, seed=1111
+        )
         _, xb_add, _ = self.generate_data(d, nt_add, nb_add, 1, seed=2222)
 
         index = faiss.IndexHNSWFlatPanorama(d, 16, 8)
@@ -374,7 +380,7 @@ class TestIndexHNSWFlatPanorama(unittest.TestCase):
         self.assertEqual(index.ntotal, nb_initial + nb_add)
         self.assertEqual(
             index.cum_sums.size(),
-            (nb_initial + nb_add) * (index.num_panorama_levels + 1)
+            (nb_initial + nb_add) * (index.num_panorama_levels + 1),
         )
 
         # Search again - should work correctly with all vectors
@@ -438,19 +444,23 @@ class TestIndexHNSWFlatPanorama(unittest.TestCase):
         for i in range(nb):
             src = perm[i]
             for j in range(index.num_panorama_levels + 1):
-                expected = cum_sums_before[src * (index.num_panorama_levels + 1) + j]
+                expected = cum_sums_before[
+                    src * (index.num_panorama_levels + 1) + j
+                ]
                 actual = cum_sums_after[i * (index.num_panorama_levels + 1) + j]
                 self.assertEqual(
-                    actual, expected,
-                    f"cum_sums not permuted correctly at i={i}, j={j}"
+                    actual,
+                    expected,
+                    f"cum_sums not permuted correctly at i={i}, j={j}",
                 )
 
         # Search after permutation
         D_after, I_after = index.search(xq, k)
 
         # Results should be identical (with permuted IDs)
-        np.testing.assert_allclose(D_before, D_after,
-                                   err_msg="Distance changed after permutation")
+        np.testing.assert_allclose(
+            D_before, D_after, err_msg="Distance changed after permutation"
+        )
 
         # The ID should be the permuted version
         # If before we found vector j, after permutation we should find
@@ -462,8 +472,9 @@ class TestIndexHNSWFlatPanorama(unittest.TestCase):
                     old_id = I_before[i, j]
                     new_id = np.where(perm == old_id)[0][0]
                     self.assertEqual(
-                        I_after[i, j], new_id,
-                        f"Permuted ID mismatch at position ({i}, {j})"
+                        I_after[i, j],
+                        new_id,
+                        f"Permuted ID mismatch at position ({i}, {j})",
                     )
 
         # Verify overall recall is maintained
@@ -543,8 +554,7 @@ class TestIndexHNSWFlatPanorama(unittest.TestCase):
             for j in range(k):
                 if I[i, j] != -1:
                     self.assertIn(
-                        I[i, j], allowed_set,
-                        f"ID {I[i, j]} not in allowed set"
+                        I[i, j], allowed_set, f"ID {I[i, j]} not in allowed set"
                     )
                     count += 1
 
@@ -578,7 +588,8 @@ class TestIndexHNSWFlatPanorama(unittest.TestCase):
 
             for i in range(1, len(ratios)):
                 self.assertLessEqual(
-                    ratios[i], ratios[i - 1],
+                    ratios[i],
+                    ratios[i - 1],
                     f"ratio should decrease: nlevels={nlevels_list[i]} "
                     f"ratio={ratios[i]:.4f} > prev={ratios[i-1]:.4f}",
                 )

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -5,6 +5,7 @@
 
 """this is a basic test script for simple indices work"""
 from __future__ import absolute_import, division, print_function
+
 # no unicode_literals because it messes up in py2
 
 import numpy as np
@@ -19,8 +20,8 @@ from faiss.contrib.evaluation import check_ref_knn_with_draws
 class TestModuleInterface(unittest.TestCase):
 
     def test_version_attribute(self):
-        assert hasattr(faiss, '__version__')
-        assert re.match('^\\d+\\.\\d+\\.\\d+$', faiss.__version__)
+        assert hasattr(faiss, "__version__")
+        assert re.match("^\\d+\\.\\d+\\.\\d+$", faiss.__version__)
 
 
 @for_all_simd_levels
@@ -40,7 +41,9 @@ class TestIndexFlat(unittest.TestCase):
         D1, I1 = index.search(xq, k)
 
         if metric_type == faiss.METRIC_L2:
-            all_dis = ((xq.reshape(nq, 1, d) - xb.reshape(1, nb, d)) ** 2).sum(2)
+            all_dis = ((xq.reshape(nq, 1, d) - xb.reshape(1, nb, d)) ** 2).sum(
+                2
+            )
             Iref = all_dis.argsort(axis=1)[:, :k]
         else:
             all_dis = np.dot(xq, xb.T)
@@ -60,18 +63,17 @@ class TestIndexFlat(unittest.TestCase):
         lims, D2, I2 = index.range_search(xq, radius)
 
         for i in range(nq):
-            l0, l1 = lims[i:i + 2]
+            l0, l1 = lims[i : i + 2]
             _, Il = D2[l0:l1], I2[l0:l1]
             if metric_type == faiss.METRIC_L2:
-                Ilref, = np.where(all_dis[i] < radius)
+                (Ilref,) = np.where(all_dis[i] < radius)
             else:
-                Ilref, = np.where(all_dis[i] > radius)
+                (Ilref,) = np.where(all_dis[i] > radius)
             Il.sort()
             Ilref.sort()
             np.testing.assert_equal(Il, Ilref)
             np.testing.assert_almost_equal(
-                all_dis[i, Ilref], D2[l0:l1],
-                decimal=5
+                all_dis[i, Ilref], D2[l0:l1], decimal=5
             )
 
     def set_blas_blocks(self, small):
@@ -121,8 +123,8 @@ class TestDbParallelSearch(unittest.TestCase):
     def _check(self, metric_type, nq, nb, k):
         d = 64
         np.random.seed(1234)
-        xb = np.random.random((nb, d)).astype('float32')
-        xq = np.random.random((nq, d)).astype('float32')
+        xb = np.random.random((nb, d)).astype("float32")
+        xq = np.random.random((nq, d)).astype("float32")
 
         index = faiss.IndexFlat(d, metric_type)
         index.add(xb)
@@ -130,9 +132,9 @@ class TestDbParallelSearch(unittest.TestCase):
 
         # compute ground truth with numpy
         if metric_type == faiss.METRIC_L2:
-            all_dis = (
-                (xq.reshape(nq, 1, d) - xb.reshape(1, nb, d)) ** 2
-            ).sum(2)
+            all_dis = ((xq.reshape(nq, 1, d) - xb.reshape(1, nb, d)) ** 2).sum(
+                2
+            )
             Iref = all_dis.argsort(axis=1)[:, :k]
         else:
             all_dis = np.dot(xq, xb.T)
@@ -176,8 +178,8 @@ class TestDbParallelSearch(unittest.TestCase):
         nq = 2
         k = 10
         np.random.seed(42)
-        xb = np.random.random((nb, d)).astype('float32')
-        xq = np.random.random((nq, d)).astype('float32')
+        xb = np.random.random((nb, d)).astype("float32")
+        xq = np.random.random((nq, d)).astype("float32")
 
         index = faiss.IndexFlatIP(d)
         index.add(xb)
@@ -267,15 +269,14 @@ class TestIndexFlatL2Panorama(unittest.TestCase):
         lims, D2, I2 = index.range_search(xq, radius)
 
         for i in range(nq):
-            l0, l1 = lims[i:i + 2]
+            l0, l1 = lims[i : i + 2]
             _, Il = D2[l0:l1], I2[l0:l1]
-            Ilref, = np.where(all_dis[i] < radius)
+            (Ilref,) = np.where(all_dis[i] < radius)
             Il.sort()
             Ilref.sort()
             np.testing.assert_equal(Il, Ilref)
             np.testing.assert_almost_equal(
-                all_dis[i, Ilref], D2[l0:l1],
-                decimal=5
+                all_dis[i, Ilref], D2[l0:l1], decimal=5
             )
 
 
@@ -296,7 +297,7 @@ class EvalIVFPQAccuracy(unittest.TestCase):
 
         coarse_quantizer = faiss.IndexFlatL2(d)
         index = faiss.IndexIVFPQ(coarse_quantizer, d, 32, 8, 8)
-        index.cp.min_points_per_centroid = 5    # quiet warning
+        index.cp.min_points_per_centroid = 5  # quiet warning
         index.train(xt)
         index.add(xb)
         index.nprobe = 4
@@ -319,7 +320,6 @@ class EvalIVFPQAccuracy(unittest.TestCase):
         ref_recons = index.reconstruct_n(0, nb)
         new_recons = index2.reconstruct_n(0, nb)
         self.assertTrue(np.all(ref_recons == new_recons))
-
 
     def test_IMI(self):
         d = 32
@@ -372,7 +372,6 @@ class EvalIVFPQAccuracy(unittest.TestCase):
         # should return the same result
         self.assertGreater(n_ok, 165)
 
-
     def test_IMI_2(self):
         d = 32
         nb = 1000
@@ -402,9 +401,6 @@ class EvalIVFPQAccuracy(unittest.TestCase):
 
         # should return the same result
         self.assertGreater(n_ok, 165)
-
-
-
 
 
 class TestMultiIndexQuantizer(unittest.TestCase):
@@ -455,19 +451,21 @@ class TestScalarQuantizer(unittest.TestCase):
         nok = {}
 
         nprobe = 64  # Probe all centroids, only exercise residual quantizer.
-        index = faiss.IndexIVFFlat(quantizer, d, ncent,
-                                   faiss.METRIC_L2)
-        index.cp.min_points_per_centroid = 5    # quiet warning
+        index = faiss.IndexIVFFlat(quantizer, d, ncent, faiss.METRIC_L2)
+        index.cp.min_points_per_centroid = 5  # quiet warning
         index.nprobe = nprobe
         index.train(xt)
         index.add(xb)
         D, I = index.search(xq, 10)
-        nok['flat'] = (I[:, 0] == I_ref[:, 0]).sum()
+        nok["flat"] = (I[:, 0] == I_ref[:, 0]).sum()
 
-        for qname in "QT_4bit QT_4bit_uniform QT_8bit QT_8bit_uniform QT_fp16 QT_bf16".split():
+        for (
+            qname
+        ) in "QT_4bit QT_4bit_uniform QT_8bit QT_8bit_uniform QT_fp16 QT_bf16".split():
             qtype = getattr(faiss.ScalarQuantizer, qname)
-            index = faiss.IndexIVFScalarQuantizer(quantizer, d, ncent,
-                                                  qtype, faiss.METRIC_L2)
+            index = faiss.IndexIVFScalarQuantizer(
+                quantizer, d, ncent, qtype, faiss.METRIC_L2
+            )
 
             index.nprobe = nprobe
             index.train(xt)
@@ -476,17 +474,17 @@ class TestScalarQuantizer(unittest.TestCase):
 
             nok[qname] = (I[:, 0] == I_ref[:, 0]).sum()
 
-        self.assertGreaterEqual(nok['flat'], nq * 0.6)
+        self.assertGreaterEqual(nok["flat"], nq * 0.6)
         # The tests below are a bit fragile, it happens that the
         # ordering between uniform and non-uniform are reverted,
         # probably because the dataset is small, which introduces
         # jitter
-        self.assertGreaterEqual(nok['flat'], nok['QT_8bit'])
-        self.assertGreaterEqual(nok['QT_8bit'], nok['QT_4bit'])
+        self.assertGreaterEqual(nok["flat"], nok["QT_8bit"])
+        self.assertGreaterEqual(nok["QT_8bit"], nok["QT_4bit"])
         # flaky: self.assertGreaterEqual(nok['QT_8bit'], nok['QT_8bit_uniform'])
-        self.assertGreaterEqual(nok['QT_4bit'], nok['QT_4bit_uniform'])
-        self.assertGreaterEqual(nok['QT_fp16'], nok['QT_8bit'])
-        self.assertGreaterEqual(nok['QT_bf16'], nok['QT_8bit'])
+        self.assertGreaterEqual(nok["QT_4bit"], nok["QT_4bit_uniform"])
+        self.assertGreaterEqual(nok["QT_fp16"], nok["QT_8bit"])
+        self.assertGreaterEqual(nok["QT_bf16"], nok["QT_8bit"])
 
     def test_4variants(self):
         d = 32
@@ -502,7 +500,9 @@ class TestScalarQuantizer(unittest.TestCase):
 
         nok = {}
 
-        for qname in "QT_4bit QT_4bit_uniform QT_8bit QT_8bit_uniform QT_fp16 QT_bf16".split():
+        for (
+            qname
+        ) in "QT_4bit QT_4bit_uniform QT_8bit QT_8bit_uniform QT_fp16 QT_bf16".split():
             qtype = getattr(faiss.ScalarQuantizer, qname)
             index = faiss.IndexScalarQuantizer(d, qtype, faiss.METRIC_L2)
             index.train(xt)
@@ -510,12 +510,12 @@ class TestScalarQuantizer(unittest.TestCase):
             D, I = index.search(xq, 10)
             nok[qname] = (I[:, 0] == I_ref[:, 0]).sum()
 
-        self.assertGreaterEqual(nok['QT_8bit'], nq * 0.9)
-        self.assertGreaterEqual(nok['QT_8bit'], nok['QT_4bit'])
+        self.assertGreaterEqual(nok["QT_8bit"], nq * 0.9)
+        self.assertGreaterEqual(nok["QT_8bit"], nok["QT_4bit"])
         # flaky: self.assertGreaterEqual(nok['QT_8bit'], nok['QT_8bit_uniform'])
-        self.assertGreaterEqual(nok['QT_4bit'], nok['QT_4bit_uniform'])
-        self.assertGreaterEqual(nok['QT_fp16'], nok['QT_8bit'])
-        self.assertGreaterEqual(nok['QT_bf16'], nq * 0.9)
+        self.assertGreaterEqual(nok["QT_4bit"], nok["QT_4bit_uniform"])
+        self.assertGreaterEqual(nok["QT_fp16"], nok["QT_8bit"])
+        self.assertGreaterEqual(nok["QT_bf16"], nq * 0.9)
 
 
 class TestRangeSearch(unittest.TestCase):
@@ -533,15 +533,15 @@ class TestRangeSearch(unittest.TestCase):
 
         Dref, Iref = index.search(xq, 5)
 
-        thresh = 0.1   # *squared* distance
+        thresh = 0.1  # *squared* distance
         lims, D, I = index.range_search(xq, thresh)
 
         for i in range(nq):
-            Iline = I[lims[i]:lims[i + 1]]
-            Dline = D[lims[i]:lims[i + 1]]
+            Iline = I[lims[i] : lims[i + 1]]
+            Dline = D[lims[i] : lims[i + 1]]
             for j, dis in zip(Iref[i], Dref[i]):
                 if dis < thresh:
-                    li, = np.where(Iline == j)
+                    (li,) = np.where(Iline == j)
                     self.assertTrue(li.size == 1)
                     idx = li[0]
                     self.assertGreaterEqual(1e-4, abs(Dline[idx] - dis))
@@ -574,7 +574,7 @@ class TestSearchAndReconstruct(unittest.TestCase):
         self.assertLessEqual(recons_ref_err, 1e-6)
 
         def norm1(x):
-            return np.sqrt((x ** 2).sum(axis=1))
+            return np.sqrt((x**2).sum(axis=1))
 
         recons_err = np.mean(norm1(R_flat - xb[I_flat]))
 
@@ -606,7 +606,7 @@ class TestSearchAndReconstruct(unittest.TestCase):
 
         quantizer = faiss.IndexFlatL2(d)
         index = faiss.IndexIVFFlat(quantizer, d, 32, faiss.METRIC_L2)
-        index.cp.min_points_per_centroid = 5    # quiet warning
+        index.cp.min_points_per_centroid = 5  # quiet warning
         index.nprobe = 4
         index.train(xt)
         index.add(xb)
@@ -624,7 +624,7 @@ class TestSearchAndReconstruct(unittest.TestCase):
 
         quantizer = faiss.IndexFlatL2(d)
         index = faiss.IndexIVFFlatPanorama(quantizer, d, 32, nlevels)
-        index.cp.min_points_per_centroid = 5    # quiet warning
+        index.cp.min_points_per_centroid = 5  # quiet warning
         index.nprobe = 4
         index.train(xt)
         index.add(xb)
@@ -641,7 +641,7 @@ class TestSearchAndReconstruct(unittest.TestCase):
 
         quantizer = faiss.IndexFlatL2(d)
         index = faiss.IndexIVFPQ(quantizer, d, 32, 8, 8)
-        index.cp.min_points_per_centroid = 5    # quiet warning
+        index.cp.min_points_per_centroid = 5  # quiet warning
         index.nprobe = 4
         index.train(xt)
         index.add(xb)
@@ -658,7 +658,7 @@ class TestSearchAndReconstruct(unittest.TestCase):
 
         quantizer = faiss.IndexFlatL2(d)
         index = faiss.IndexIVFResidualQuantizer(quantizer, d, 32, 8, 8)
-        index.cp.min_points_per_centroid = 5    # quiet warning
+        index.cp.min_points_per_centroid = 5  # quiet warning
         index.nprobe = 4
         index.train(xt)
         index.add(xb)
@@ -696,7 +696,6 @@ class TestSearchAndReconstruct(unittest.TestCase):
         self.run_search_and_reconstruct(index, xb, xq)
 
 
-
 class TestDistancesPositive(unittest.TestCase):
 
     def test_l2_pos(self):
@@ -710,7 +709,7 @@ class TestDistancesPositive(unittest.TestCase):
         n = 5000
 
         rs = np.random.RandomState(1234)
-        x = rs.rand(n, d).astype('float32')
+        x = rs.rand(n, d).astype("float32")
 
         index = faiss.IndexFlatL2(d)
         index.add(x)
@@ -722,10 +721,10 @@ class TestDistancesPositive(unittest.TestCase):
 
 class TestShardReplicas(unittest.TestCase):
     def test_shard_flag_propagation(self):
-        d = 64                           # dimension
+        d = 64  # dimension
         nb = 1000
         rs = np.random.RandomState(1234)
-        xb = rs.rand(nb, d).astype('float32')
+        xb = rs.rand(nb, d).astype("float32")
         nlist = 10
         quantizer1 = faiss.IndexFlatL2(d)
         quantizer2 = faiss.IndexFlatL2(d)
@@ -750,10 +749,10 @@ class TestShardReplicas(unittest.TestCase):
         self.assertEqual(index.ntotal, 0)
 
     def test_replica_flag_propagation(self):
-        d = 64                           # dimension
+        d = 64  # dimension
         nb = 1000
         rs = np.random.RandomState(1234)
-        xb = rs.rand(nb, d).astype('float32')
+        xb = rs.rand(nb, d).astype("float32")
         nlist = 10
         quantizer1 = faiss.IndexFlatL2(d)
         quantizer2 = faiss.IndexFlatL2(d)
@@ -782,10 +781,10 @@ class TestReconsException(unittest.TestCase):
 
     def test_recons_exception(self):
 
-        d = 64                           # dimension
+        d = 64  # dimension
         nb = 1000
         rs = np.random.RandomState(1234)
-        xb = rs.rand(nb, d).astype('float32')
+        xb = rs.rand(nb, d).astype("float32")
         nlist = 10
         quantizer = faiss.IndexFlatL2(d)  # the other index
         index = faiss.IndexIVFFlat(quantizer, d, nlist)
@@ -795,13 +794,10 @@ class TestReconsException(unittest.TestCase):
 
         index.reconstruct(9)
 
-        self.assertRaises(
-            RuntimeError,
-            index.reconstruct, 100001
-        )
+        self.assertRaises(RuntimeError, index.reconstruct, 100001)
 
     def test_reconstruct_after_add(self):
-        index = faiss.index_factory(10, 'IVF5,SQfp16')
+        index = faiss.index_factory(10, "IVF5,SQfp16")
         index.train(faiss.randn((100, 10), 123))
         index.add(faiss.randn((100, 10), 345))
         index.make_direct_map()
@@ -826,10 +822,7 @@ class TestReconsException(unittest.TestCase):
         index.reconstruct(9)
 
         # Reconstruct >= ntotal (10), assert exception raise
-        self.assertRaises(
-            RuntimeError,
-            index.reconstruct, 10
-        )
+        self.assertRaises(RuntimeError, index.reconstruct, 10)
 
 
 class TestReconsHash(unittest.TestCase):
@@ -879,19 +872,13 @@ class TestReconsHash(unittest.TestCase):
 
         for i in range(0, 200, 13):
             if i % 3 == 0:
-                self.assertRaises(
-                    RuntimeError,
-                    index2.reconstruct, int(ids[i])
-                )
+                self.assertRaises(RuntimeError, index2.reconstruct, int(ids[i]))
             else:
                 recons = index2.reconstruct(int(ids[i]))
                 self.assertTrue(np.all(recons == ref_recons[i]))
 
         # index error should raise
-        self.assertRaises(
-            RuntimeError,
-            index.reconstruct, 20000
-        )
+        self.assertRaises(RuntimeError, index.reconstruct, 20000)
 
     def test_IVFFlat(self):
         self.do_test("IVF5,Flat")
@@ -915,7 +902,7 @@ class TestValidIndexParams(unittest.TestCase):
 
         coarse_quantizer = faiss.IndexFlatL2(d)
         index = faiss.IndexIVFPQ(coarse_quantizer, d, 32, 8, 8)
-        index.cp.min_points_per_centroid = 5    # quiet warning
+        index.cp.min_points_per_centroid = 5  # quiet warning
         index.train(xt)
         index.add(xb)
 
@@ -984,8 +971,8 @@ class TestLargeRangeSearch(unittest.TestCase):
 class TestRandomIndex(unittest.TestCase):
 
     def test_random(self):
-        """ just check if several runs of search retrieve the
-        same results """
+        """just check if several runs of search retrieve the
+        same results"""
         index = faiss.IndexRandom(32, 1000000000)
         (xt, xb, xq) = get_dataset_2(32, 0, 0, 10)
 

--- a/tests/test_index_accuracy.py
+++ b/tests/test_index_accuracy.py
@@ -14,7 +14,11 @@ import faiss
 
 import numpy as np
 from common_faiss_tests import (
-    for_all_simd_levels, get_dataset_2, Randu10k, Randu10kUnbalanced)
+    for_all_simd_levels,
+    get_dataset_2,
+    Randu10k,
+    Randu10kUnbalanced,
+)
 
 ev = Randu10k()
 
@@ -200,8 +204,9 @@ class TestSQFlavors(unittest.TestCase):
             nt = trained.shape[1]
             # 2 lines: vmins and vdiffs
             new_nt = int(nt * d2 / d)
-            trained2 = np.hstack((trained, np.zeros((2, new_nt - nt),
-                                  dtype="float32")))
+            trained2 = np.hstack(
+                (trained, np.zeros((2, new_nt - nt), dtype="float32"))
+            )
             trained2[1, nt:] = 1.0  # set vdiff to 1 to avoid div by 0
             faiss.copy_array_to_vector(trained2.ravel(), index2.sq.trained)
         else:
@@ -239,8 +244,9 @@ class TestSQFlavors(unittest.TestCase):
         quantizer = faiss.IndexFlat(d, mt)
         for qname in "8bit 4bit 8bit_uniform 4bit_uniform fp16 6bit".split():
             qtype = getattr(faiss.ScalarQuantizer, "QT_" + qname)
-            index = faiss.IndexIVFScalarQuantizer(quantizer, d, nlist, qtype,
-                                                  mt)
+            index = faiss.IndexIVFScalarQuantizer(
+                quantizer, d, nlist, qtype, mt
+            )
             index.train(xt)
             index.add(xb)
             index.nprobe = 4  # hopefully more robust than 1
@@ -280,8 +286,8 @@ class TestSQFlavors(unittest.TestCase):
                 index.parallel_mode = pm
                 lims4, D4, I4 = index.range_search(xq, radius)
                 for qno in range(len(lims) - 1):
-                    Iref = I3[lims[qno]: lims[qno + 1]]
-                    Inew = I4[lims4[qno]: lims4[qno + 1]]
+                    Iref = I3[lims[qno] : lims[qno + 1]]
+                    Inew = I4[lims4[qno] : lims4[qno + 1]]
                     assert set(Iref) == set(Inew), "q %d ref %s new %s" % (
                         qno,
                         Iref,
@@ -345,9 +351,7 @@ class TestSQByte(unittest.TestCase):
         gt_index.add(xb)
         Dref, Iref = gt_index.search(xq, 10)
 
-        index = faiss.IndexScalarQuantizer(
-            d, quantizer_type, metric_type
-        )
+        index = faiss.IndexScalarQuantizer(d, quantizer_type, metric_type)
         index.add(xb)
         D, I = index.search(xq, 10)
 
@@ -366,8 +370,7 @@ class TestSQByte(unittest.TestCase):
         Dref, Iref = gt_index.search(xq, 10)
 
         index = faiss.IndexIVFScalarQuantizer(
-            quantizer, d, nlist, quantizer_type,
-            metric_type
+            quantizer, d, nlist, quantizer_type, metric_type
         )
         index.nprobe = 4
         index.by_residual = False
@@ -379,7 +382,10 @@ class TestSQByte(unittest.TestCase):
         np.testing.assert_array_equal(I, Iref)
 
     def test_8bit_direct(self):
-        for quantizer in faiss.ScalarQuantizer.QT_8bit_direct, faiss.ScalarQuantizer.QT_8bit_direct_signed:
+        for quantizer in (
+            faiss.ScalarQuantizer.QT_8bit_direct,
+            faiss.ScalarQuantizer.QT_8bit_direct_signed,
+        ):
             for d in 13, 16, 24:
                 for metric_type in faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT:
                     self.subtest_8bit_direct(metric_type, d, quantizer)
@@ -402,7 +408,9 @@ class TestNNDescent(unittest.TestCase):
         search_Ls = [10, 20, 30]
         thresholds = [0.80, 0.90, 0.93]
         for search_L, threshold in zip(search_Ls, thresholds):
-            self.subtest(32, faiss.METRIC_INNER_PRODUCT, 10, search_L, threshold)
+            self.subtest(
+                32, faiss.METRIC_INNER_PRODUCT, 10, search_L, threshold
+            )
 
     def subtest(self, d, metric, topk, search_L, threshold):
         metric_names = {
@@ -507,8 +515,9 @@ class TestPQFlavors(unittest.TestCase):
 
                 # polysemous behaves bizarrely on ARM
                 assert (
-                    ninter >= self.ref_results[mt, by_residual,
-                                               index.polysemous_ht] - 4
+                    ninter
+                    >= self.ref_results[mt, by_residual, index.polysemous_ht]
+                    - 4
                 )
 
             # also test range search
@@ -586,7 +595,7 @@ class TestFlat1D(unittest.TestCase):
         ndiff = (np.abs(ref_I - new_I) != 0).sum()
 
         assert ndiff < 100
-        new_D = new_D ** 2
+        new_D = new_D**2
         max_diff_D = np.abs(ref_D - new_D).max()
         assert max_diff_D < 1e-5
 
@@ -683,8 +692,9 @@ class TestRoundoff(unittest.TestCase):
             # this does not work
             assert not np.all(I.ravel() == np.arange(nq))
 
-            index = faiss.IndexPreTransform(faiss.CenteringTransform(d),
-                                            faiss.IndexFlat(d))
+            index = faiss.IndexPreTransform(
+                faiss.CenteringTransform(d), faiss.IndexFlat(d)
+            )
 
             index.train(xb)
             index.add(xb)

--- a/tests/test_index_binary.py
+++ b/tests/test_index_binary.py
@@ -11,16 +11,17 @@ import unittest
 import faiss
 
 from common_faiss_tests import (
-    compare_binary_result_lists, for_all_simd_levels, make_binary_dataset
+    compare_binary_result_lists,
+    for_all_simd_levels,
+    make_binary_dataset,
 )
-
 
 
 def binary_to_float(x):
     n, d = x.shape
     x8 = x.reshape(n * d, -1)
-    c8 = 2 * ((x8 >> np.arange(8)) & 1).astype('int8') - 1
-    return c8.astype('float32').reshape(n, d * 8)
+    c8 = 2 * ((x8 >> np.arange(8)) & 1).astype("int8") - 1
+    return c8.astype("float32").reshape(n, d * 8)
 
 
 def binary_dis(x, y):
@@ -29,7 +30,7 @@ def binary_dis(x, y):
 
 @for_all_simd_levels
 class TestBinaryPQ(unittest.TestCase):
-    """ Use a PQ that mimicks a binary encoder """
+    """Use a PQ that mimicks a binary encoder"""
 
     def test_encode_to_binary(self):
         d = 256
@@ -40,7 +41,8 @@ class TestBinaryPQ(unittest.TestCase):
         pq = faiss.ProductQuantizer(d, int(d / 8), 8)
 
         centroids = binary_to_float(
-            np.tile(np.arange(256), int(d / 8)).astype('uint8').reshape(-1, 1))
+            np.tile(np.arange(256), int(d / 8)).astype("uint8").reshape(-1, 1)
+        )
 
         faiss.copy_array_to_vector(centroids.ravel(), pq.centroids)
         pq.is_trained = True
@@ -124,8 +126,8 @@ class TestBinaryFlat(unittest.TestCase):
             index.use_heap = use_heap
             Dflat, Iflat = index.search(self.xq, 10)
 
-            assert(np.all(Iflat == -1))
-            assert(np.all(Dflat == 2147483647)) # NOTE(hoss): int32_t max
+            assert np.all(Iflat == -1)
+            assert np.all(Dflat == 2147483647)  # NOTE(hoss): int32_t max
 
     def test_range_search(self):
         d = self.xq.shape[1] * 8
@@ -138,7 +140,7 @@ class TestBinaryFlat(unittest.TestCase):
         lims, D2, I2 = index.range_search(self.xq, thresh)
         nt1 = nt2 = 0
         for i in range(len(self.xq)):
-            range_res = I2[lims[i]:lims[i + 1]]
+            range_res = I2[lims[i] : lims[i + 1]]
             if thresh > D[i, -1]:
                 self.assertTrue(set(I[i]) <= set(range_res))
                 nt1 += 1
@@ -151,7 +153,9 @@ class TestBinaryFlat(unittest.TestCase):
 
     def test_reconstruct(self):
         index = faiss.IndexBinaryFlat(64)
-        input_vector = np.random.randint(0, 255, size=(10, index.code_size)).astype("uint8")
+        input_vector = np.random.randint(
+            0, 255, size=(10, index.code_size)
+        ).astype("uint8")
         index.add(input_vector)
 
         reconstructed_vector = index.reconstruct_n(0, 4)
@@ -180,7 +184,7 @@ class TestBinaryIVF(unittest.TestCase):
 
         quantizer = faiss.IndexBinaryFlat(d)
         index = faiss.IndexBinaryIVF(quantizer, d, 8)
-        index.cp.min_points_per_centroid = 5    # quiet warning
+        index.cp.min_points_per_centroid = 5  # quiet warning
         index.nprobe = 8
         index.train(self.xt)
         index.add(self.xb)
@@ -193,7 +197,7 @@ class TestBinaryIVF(unittest.TestCase):
 
         quantizer = faiss.IndexBinaryFlat(d)
         index = faiss.IndexBinaryIVF(quantizer, d, 8)
-        index.cp.min_points_per_centroid = 5    # quiet warning
+        index.cp.min_points_per_centroid = 5  # quiet warning
         index.nprobe = 4
         index.train(self.xt)
         index.add(self.xb)
@@ -208,7 +212,7 @@ class TestBinaryIVF(unittest.TestCase):
 
         quantizer = faiss.IndexBinaryFlat(d)
         index = faiss.IndexBinaryIVF(quantizer, d, 8)
-        index.cp.min_points_per_centroid = 5    # quiet warning
+        index.cp.min_points_per_centroid = 5  # quiet warning
         index.nprobe = 4
         index.train(self.xt)
         index.add(self.xb)
@@ -218,13 +222,12 @@ class TestBinaryIVF(unittest.TestCase):
         Lr, Dr, Ir = index.range_search(self.xq, radius)
 
         for i in range(len(self.xq)):
-            res = Ir[Lr[i]:Lr[i + 1]]
+            res = Ir[Lr[i] : Lr[i + 1]]
             if D[i, -1] < radius:
                 self.assertTrue(set(I[i]) <= set(res))
             else:
                 subset = I[i, D[i, :] < radius]
                 self.assertTrue(set(subset) == set(res))
-
 
     def test_ivf_flat_empty(self):
         d = self.xq.shape[1] * 8
@@ -236,14 +239,14 @@ class TestBinaryIVF(unittest.TestCase):
             index.use_heap = use_heap
             Divfflat, Iivfflat = index.search(self.xq, 10)
 
-            assert(np.all(Iivfflat == -1))
-            assert(np.all(Divfflat == 2147483647)) # NOTE(hoss): int32_t max
+            assert np.all(Iivfflat == -1)
+            assert np.all(Divfflat == 2147483647)  # NOTE(hoss): int32_t max
 
     def test_ivf_reconstruction(self):
         d = self.xq.shape[1] * 8
         quantizer = faiss.IndexBinaryFlat(d)
         index = faiss.IndexBinaryIVF(quantizer, d, 8)
-        index.cp.min_points_per_centroid = 5    # quiet warning
+        index.cp.min_points_per_centroid = 5  # quiet warning
         index.nprobe = 4
         index.train(self.xt)
 
@@ -251,22 +254,20 @@ class TestBinaryIVF(unittest.TestCase):
         index.set_direct_map_type(faiss.DirectMap.Array)
 
         for i in range(0, len(self.xb), 13):
-            np.testing.assert_array_equal(
-                index.reconstruct(i),
-                self.xb[i]
-            )
+            np.testing.assert_array_equal(index.reconstruct(i), self.xb[i])
 
         # try w/ hashtable
         index = faiss.IndexBinaryIVF(quantizer, d, 8)
         rs = np.random.RandomState(123)
-        ids = rs.choice(10000, size=len(self.xb), replace=False).astype(np.int64)
+        ids = rs.choice(10000, size=len(self.xb), replace=False).astype(
+            np.int64
+        )
         index.add_with_ids(self.xb, ids)
         index.set_direct_map_type(faiss.DirectMap.Hashtable)
 
         for i in range(0, len(self.xb), 13):
             np.testing.assert_array_equal(
-                index.reconstruct(int(ids[i])),
-                self.xb[i]
+                index.reconstruct(int(ids[i])), self.xb[i]
             )
 
     def test_ivf_nprobe(self):
@@ -295,7 +296,7 @@ class TestBinaryIVF(unittest.TestCase):
         # assert np.all(I == ref_I)  # id may be different
 
         # test range search
-        thresh = 5   # *squared* distance
+        thresh = 5  # *squared* distance
         lims, D, I = index.range_search(xq, thresh)
         ref_lims, ref_D, ref_I = ref_index.range_search(xq, thresh)
         assert np.all(lims == ref_lims)
@@ -307,7 +308,7 @@ class TestBinaryIVF(unittest.TestCase):
 
         quantizer = faiss.IndexBinaryFlat(d)
         index = faiss.IndexBinaryIVF(quantizer, d, 10)
-        index.cp.min_points_per_centroid = 5    # quiet warning
+        index.cp.min_points_per_centroid = 5  # quiet warning
         index.train(self.xt)
         index.add(self.xb)
         index.nprobe = 3
@@ -369,8 +370,10 @@ class TestHNSW(unittest.TestCase):
 @for_all_simd_levels
 class TestReplicasAndShards(unittest.TestCase):
 
-    @unittest.skipIf(os.name == "posix" and os.uname().sysname == "Darwin",
-                     "There is a bug in the OpenMP implementation on OSX.")
+    @unittest.skipIf(
+        os.name == "posix" and os.uname().sysname == "Darwin",
+        "There is a bug in the OpenMP implementation on OSX.",
+    )
     def test_replicas(self):
         d = 32
         nq = 100
@@ -443,5 +446,5 @@ class TestReplicasAndShards(unittest.TestCase):
         compare_binary_result_lists(Dref, Iref, D2, I2)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_index_binary_from_float.py
+++ b/tests/test_index_binary_from_float.py
@@ -15,15 +15,15 @@ from common_faiss_tests import for_all_simd_levels
 def make_binary_dataset(d, nb, nt, nq):
     assert d % 8 == 0
     rs = np.random.RandomState(123)
-    x = rs.randint(256, size=(nb + nq + nt, int(d / 8))).astype('uint8')
+    x = rs.randint(256, size=(nb + nq + nt, int(d / 8))).astype("uint8")
     return x[:nt], x[nt:-nq], x[-nq:]
 
 
 def binary_to_float(x):
     n, d = x.shape
     x8 = x.reshape(n * d, -1)
-    c8 = 2 * ((x8 >> np.arange(8)) & 1).astype('int8') - 1
-    return c8.astype('float32').reshape(n, d * 8)
+    c8 = 2 * ((x8 >> np.arange(8)) & 1).astype("int8") - 1
+    return c8.astype("float32").reshape(n, d * 8)
 
 
 @for_all_simd_levels
@@ -47,7 +47,7 @@ class TestIndexBinaryFromFloat(unittest.TestCase):
         D_ref, I_ref = index_ref.search(binary_to_float(xq), 10)
         D, I = index_bin.search(xq, 10)
 
-        np.testing.assert_allclose((D_ref / 4.0).astype('int32'), D)
+        np.testing.assert_allclose((D_ref / 4.0).astype("int32"), D)
 
     def test_wrapped_quantizer(self):
         d = 256
@@ -95,8 +95,9 @@ class TestIndexBinaryFromFloat(unittest.TestCase):
 
         assert nlist == float_quantizer.ntotal
 
-        index = faiss.IndexBinaryIVF(wrapped_quantizer, d,
-                                     float_quantizer.ntotal)
+        index = faiss.IndexBinaryIVF(
+            wrapped_quantizer, d, float_quantizer.ntotal
+        )
         index.nprobe = 2048
         assert index.is_trained
 
@@ -105,8 +106,9 @@ class TestIndexBinaryFromFloat(unittest.TestCase):
         D_ref, I_ref = index_ref.search(xq, 10)
         D, I = index.search(xq, 10)
 
-        recall = sum(gti[0] in Di[:10] for gti, Di in zip(D_ref, D)) \
-                 / float(D_ref.shape[0])
+        recall = sum(gti[0] in Di[:10] for gti, Di in zip(D_ref, D)) / float(
+            D_ref.shape[0]
+        )
 
         assert recall > 0.82, "recall = %g" % recall
 
@@ -146,8 +148,9 @@ class TestIndexBinaryFromFloat(unittest.TestCase):
         assert nlist == wrapped_quantizer.ntotal
         assert wrapped_quantizer.is_trained
 
-        index = faiss.IndexBinaryIVF(wrapped_quantizer, d,
-                                     hnsw_quantizer.ntotal)
+        index = faiss.IndexBinaryIVF(
+            wrapped_quantizer, d, hnsw_quantizer.ntotal
+        )
         index.nprobe = 128
 
         assert index.is_trained
@@ -157,8 +160,9 @@ class TestIndexBinaryFromFloat(unittest.TestCase):
         D_ref, I_ref = index_ref.search(xq, 10)
         D, I = index.search(xq, 10)
 
-        recall = sum(gti[0] in Di[:10] for gti, Di in zip(D_ref, D)) \
-                 / float(D_ref.shape[0])
+        recall = sum(gti[0] in Di[:10] for gti, Di in zip(D_ref, D)) / float(
+            D_ref.shape[0]
+        )
 
         assert recall >= 0.77, "recall = %g" % recall
 

--- a/tests/test_index_composite.py
+++ b/tests/test_index_composite.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-""" more elaborate that test_index.py """
+"""more elaborate that test_index.py"""
 
 import numpy as np
 import unittest
@@ -23,7 +23,7 @@ class TestRemoveFastScan(unittest.TestCase):
     def do_test(self, ntotal, removed):
         d = 20
         xt, xb, _ = get_dataset_2(d, ntotal, ntotal, 0)
-        index = faiss.index_factory(20, 'IDMap2,PQ5x4fs')
+        index = faiss.index_factory(20, "IDMap2,PQ5x4fs")
         index.train(xt)
         index.add_with_ids(xb, np.arange(ntotal).astype("int64"))
         before = index.reconstruct_n(0, ntotal)
@@ -75,15 +75,15 @@ class TestRemove(unittest.TestCase):
         if ondisk:
             filename = tempfile.mkstemp()[1]
             invlists = faiss.OnDiskInvertedLists(
-                index1.nlist, index1.code_size,
-                filename)
+                index1.nlist, index1.code_size, filename
+            )
             index1.replace_invlists(invlists)
 
-        index1.add(xb[:int(nb / 2)])
+        index1.add(xb[: int(nb / 2)])
 
         index2 = faiss.IndexIVFFlat(quantizer, d, 20)
         assert index2.is_trained
-        index2.add(xb[int(nb / 2):])
+        index2.add(xb[int(nb / 2) :])
 
         Dref, Iref = index1.search(xq, 10)
         index1.merge_from(index2, int(nb / 2))
@@ -104,8 +104,10 @@ class TestRemove(unittest.TestCase):
     def test_remove_regular(self):
         self.do_merge_then_remove(False)
 
-    @unittest.skipIf(platform.system() == 'Windows',
-                     'OnDiskInvertedLists is unsupported on Windows.')
+    @unittest.skipIf(
+        platform.system() == "Windows",
+        "OnDiskInvertedLists is unsupported on Windows.",
+    )
     def test_remove_ondisk(self):
         self.do_merge_then_remove(True)
 
@@ -113,48 +115,48 @@ class TestRemove(unittest.TestCase):
         # only tests the python interface
 
         index = faiss.IndexFlat(5)
-        xb = np.zeros((10, 5), dtype='float32')
-        xb[:, 0] = np.arange(10, dtype='int64') + 1000
+        xb = np.zeros((10, 5), dtype="float32")
+        xb[:, 0] = np.arange(10, dtype="int64") + 1000
         index.add(xb)
-        index.remove_ids(np.arange(5, dtype='int64') * 2)
+        index.remove_ids(np.arange(5, dtype="int64") * 2)
         xb2 = faiss.vector_float_to_array(index.codes)
         xb2 = xb2.view("float32").reshape(5, 5)
         assert np.all(xb2[:, 0] == xb[np.arange(5) * 2 + 1, 0])
 
     def test_remove_id_map(self):
         sub_index = faiss.IndexFlat(5)
-        xb = np.zeros((10, 5), dtype='float32')
+        xb = np.zeros((10, 5), dtype="float32")
         xb[:, 0] = np.arange(10) + 1000
         index = faiss.IndexIDMap2(sub_index)
-        index.add_with_ids(xb, np.arange(10, dtype='int64') + 100)
+        index.add_with_ids(xb, np.arange(10, dtype="int64") + 100)
         assert index.reconstruct(104)[0] == 1004
-        index.remove_ids(np.array([103], dtype='int64'))
+        index.remove_ids(np.array([103], dtype="int64"))
         assert index.reconstruct(104)[0] == 1004
         try:
             index.reconstruct(103)
         except RuntimeError:
             pass
         else:
-            assert False, 'should have raised an exception'
+            assert False, "should have raised an exception"
 
     def test_factory_idmap2_suffix(self):
-        xb = np.zeros((10, 5), dtype='float32')
+        xb = np.zeros((10, 5), dtype="float32")
         xb[:, 0] = np.arange(10) + 1000
         index = faiss.index_factory(5, "Flat,IDMap2")
-        ids = np.arange(10, dtype='int64') + 100
+        ids = np.arange(10, dtype="int64") + 100
         index.add_with_ids(xb, ids)
         assert index.reconstruct(104)[0] == 1004
-        index.remove_ids(np.array([103], dtype='int64'))
+        index.remove_ids(np.array([103], dtype="int64"))
         assert index.reconstruct(104)[0] == 1004
 
     def test_factory_idmap2_prefix(self):
-        xb = np.zeros((10, 5), dtype='float32')
+        xb = np.zeros((10, 5), dtype="float32")
         xb[:, 0] = np.arange(10) + 1000
         index = faiss.index_factory(5, "IDMap2,Flat")
-        ids = np.arange(10, dtype='int64') + 100
+        ids = np.arange(10, dtype="int64") + 100
         index.add_with_ids(xb, ids)
         assert index.reconstruct(109)[0] == 1009
-        index.remove_ids(np.array([100], dtype='int64'))
+        index.remove_ids(np.array([100], dtype="int64"))
         assert index.reconstruct(109)[0] == 1009
 
     def test_remove_id_map_2(self):
@@ -163,13 +165,13 @@ class TestRemove(unittest.TestCase):
         X = rs.randn(10, 10).astype(np.float32)
         idx = np.array([0, 10, 20, 30, 40, 5, 15, 25, 35, 45], np.int64)
         remove_set = np.array([10, 30], dtype=np.int64)
-        index = faiss.index_factory(10, 'IDMap,Flat')
+        index = faiss.index_factory(10, "IDMap,Flat")
         index.add_with_ids(X[:5, :], idx[:5])
         index.remove_ids(remove_set)
         index.add_with_ids(X[5:, :], idx[5:])
 
         for i in range(10):
-            _, searchres = index.search(X[i:i + 1, :], 1)
+            _, searchres = index.search(X[i : i + 1, :], 1)
             if idx[i] in remove_set:
                 assert searchres[0] != idx[i]
             else:
@@ -177,22 +179,24 @@ class TestRemove(unittest.TestCase):
 
     def test_remove_id_map_binary(self):
         sub_index = faiss.IndexBinaryFlat(40)
-        xb = np.zeros((10, 5), dtype='uint8')
+        xb = np.zeros((10, 5), dtype="uint8")
         xb[:, 0] = np.arange(10) + 100
         index = faiss.IndexBinaryIDMap2(sub_index)
-        index.add_with_ids(xb, np.arange(10, dtype='int64') + 1000)
+        index.add_with_ids(xb, np.arange(10, dtype="int64") + 1000)
         assert index.reconstruct(1004)[0] == 104
-        index.remove_ids(np.array([1003], dtype='int64'))
+        index.remove_ids(np.array([1003], dtype="int64"))
         assert index.reconstruct(1004)[0] == 104
         try:
             index.reconstruct(1003)
         except RuntimeError:
             pass
         else:
-            assert False, 'should have raised an exception'
+            assert False, "should have raised an exception"
 
         # while we are there, let's test I/O as well...
-        index = faiss.deserialize_index_binary(faiss.serialize_index_binary(index))
+        index = faiss.deserialize_index_binary(
+            faiss.serialize_index_binary(index)
+        )
 
         assert index.reconstruct(1004)[0] == 104
         try:
@@ -200,11 +204,12 @@ class TestRemove(unittest.TestCase):
         except RuntimeError:
             pass
         else:
-            assert False, 'should have raised an exception'
+            assert False, "should have raised an exception"
 
         # Verify deserialized index is serializable again
         index2 = faiss.deserialize_index_binary(
-            faiss.serialize_index_binary(index))
+            faiss.serialize_index_binary(index)
+        )
         assert index2.reconstruct(1004)[0] == 104
 
 
@@ -212,7 +217,7 @@ class TestRangeSearch(unittest.TestCase):
 
     def test_range_search_id_map(self):
         sub_index = faiss.IndexFlat(5, 1)  # L2 search instead of inner product
-        xb = np.zeros((10, 5), dtype='float32')
+        xb = np.zeros((10, 5), dtype="float32")
         xb[:, 0] = np.arange(10) + 1000
         index = faiss.IndexIDMap2(sub_index)
         index.add_with_ids(xb, np.arange(10, dtype=np.int64) + 100)
@@ -231,9 +236,9 @@ class TestUpdate(unittest.TestCase):
         nt = 1500
         nq = 100
         np.random.seed(123)
-        xb = np.random.random(size=(nb, d)).astype('float32')
-        xt = np.random.random(size=(nt, d)).astype('float32')
-        xq = np.random.random(size=(nq, d)).astype('float32')
+        xb = np.random.random(size=(nb, d)).astype("float32")
+        xt = np.random.random(size=(nt, d)).astype("float32")
+        xq = np.random.random(size=(nq, d)).astype("float32")
 
         index = faiss.index_factory(d, "IVF64,Flat")
         index.train(xt)
@@ -246,13 +251,14 @@ class TestUpdate(unittest.TestCase):
 
         # revert order of the 200 first vectors
         nu = 200
-        index.update_vectors(np.arange(nu).astype('int64'),
-                             xb[nu - 1::-1].copy())
+        index.update_vectors(
+            np.arange(nu).astype("int64"), xb[nu - 1 :: -1].copy()
+        )
 
         recons_after = np.vstack([index.reconstruct(i) for i in range(nb)])
 
         # make sure reconstructions remain the same
-        diff_recons = recons_before[:nu] - recons_after[nu - 1::-1]
+        diff_recons = recons_before[:nu] - recons_after[nu - 1 :: -1]
         assert np.abs(diff_recons).max() == 0
 
         D2, I2 = index.search(xq, 5)
@@ -279,7 +285,7 @@ class TestPCAWhite(unittest.TestCase):
         # normal distribition
         x = faiss.randn((nt + nb + nq) * d, 1234).reshape(nt + nb + nq, d)
 
-        index = faiss.index_factory(d, 'Flat')
+        index = faiss.index_factory(d, "Flat")
 
         xt = x[:nt]
         xb = x[nt:-nq]
@@ -292,20 +298,20 @@ class TestPCAWhite(unittest.TestCase):
         # make distribution very skewed
         x *= [10, 4, 1, 0.5]
         rr, _ = np.linalg.qr(faiss.randn(d * d).reshape(d, d))
-        x = np.dot(x, rr).astype('float32')
+        x = np.dot(x, rr).astype("float32")
 
         xt = x[:nt]
         xb = x[nt:-nq]
         xq = x[-nq:]
 
         # L2 search on skewed distribution
-        index = faiss.index_factory(d, 'Flat')
+        index = faiss.index_factory(d, "Flat")
 
         index.add(xb)
         Dl2, Il2 = index.search(xq, 5)
 
         # whiten + L2 search on L2 distribution
-        index = faiss.index_factory(d, 'PCAW%d,Flat' % d)
+        index = faiss.index_factory(d, "PCAW%d,Flat" % d)
 
         index.train(xt)
         index.add(xb)
@@ -314,8 +320,9 @@ class TestPCAWhite(unittest.TestCase):
         # make sure correlation of whitened results with original
         # results is much better than simple L2 distances
         # should be 961 vs. 264
-        assert (faiss.eval_intersection(Io, Iw) >
-                2 * faiss.eval_intersection(Io, Il2))
+        assert faiss.eval_intersection(Io, Iw) > 2 * faiss.eval_intersection(
+            Io, Il2
+        )
 
 
 class TestTransformChain(unittest.TestCase):
@@ -334,7 +341,7 @@ class TestTransformChain(unittest.TestCase):
         # make distribution very skewed
         x *= [10, 4, 1, 0.5]
         rr, _ = np.linalg.qr(faiss.randn(d * d).reshape(d, d))
-        x = np.dot(x, rr).astype('float32')
+        x = np.dot(x, rr).astype("float32")
 
         xt = x[:nt]
         xb = x[nt:-nq]
@@ -368,10 +375,9 @@ class TestTransformChain(unittest.TestCase):
         assert np.all(I == I2)
 
 
-@unittest.skipIf(platform.system() == 'Windows', \
-                 'Mmap not supported on Windows.')
-
-
+@unittest.skipIf(
+    platform.system() == "Windows", "Mmap not supported on Windows."
+)
 class TestRareIO(unittest.TestCase):
 
     def compare_results(self, index1, index2, xq):
@@ -394,7 +400,7 @@ class TestRareIO(unittest.TestCase):
         if sparse:
             # makes the inverted lists sparse because all elements get
             # assigned to the same invlist
-            xt += (np.ones(10) * 1000).astype('float32')
+            xt += (np.ones(10) * 1000).astype("float32")
 
         if in_pretransform:
             # make sure it still works when wrapped in an IndexPreTransform
@@ -527,10 +533,10 @@ class TestSerialize(unittest.TestCase):
         assert np.all(Dnew == Dref) and np.all(Inew == Iref)
 
 
-@unittest.skipIf(platform.system() == 'Windows',
-                 'OnDiskInvertedLists is unsupported on Windows.')
-
-
+@unittest.skipIf(
+    platform.system() == "Windows",
+    "OnDiskInvertedLists is unsupported on Windows.",
+)
 class TestRenameOndisk(unittest.TestCase):
 
     def test_rename(self):
@@ -552,30 +558,30 @@ class TestRenameOndisk(unittest.TestCase):
 
             # make an index with ondisk invlists
             invlists = faiss.OnDiskInvertedLists(
-                index1.nlist, index1.code_size,
-                dirname + '/aa.ondisk')
+                index1.nlist, index1.code_size, dirname + "/aa.ondisk"
+            )
             index1.replace_invlists(invlists)
             index1.add(xb)
             D1, I1 = index1.search(xq, 10)
-            faiss.write_index(index1, dirname + '/aa.ivf')
+            faiss.write_index(index1, dirname + "/aa.ivf")
 
             # move the index elsewhere
-            os.mkdir(dirname + '/1')
-            for fname in 'aa.ondisk', 'aa.ivf':
-                os.rename(dirname + '/' + fname,
-                          dirname + '/1/' + fname)
+            os.mkdir(dirname + "/1")
+            for fname in "aa.ondisk", "aa.ivf":
+                os.rename(dirname + "/" + fname, dirname + "/1/" + fname)
 
             # try to read it: fails!
             try:
-                index2 = faiss.read_index(dirname + '/1/aa.ivf')
+                index2 = faiss.read_index(dirname + "/1/aa.ivf")
             except RuntimeError:
-                pass   # normal
+                pass  # normal
             else:
                 assert False
 
             # read it with magic flag
-            index2 = faiss.read_index(dirname + '/1/aa.ivf',
-                                      faiss.IO_FLAG_ONDISK_SAME_DIR)
+            index2 = faiss.read_index(
+                dirname + "/1/aa.ivf", faiss.IO_FLAG_ONDISK_SAME_DIR
+            )
             D2, I2 = index2.search(xq, 10)
             assert np.all(I1 == I2)
 
@@ -729,8 +735,11 @@ class TestSplitMerge(unittest.TestCase):
                 index.copy_subset_to(sub_indexes[i], subset_type, j0, j1)
             elif subset_type == 4:
                 index.copy_subset_to(
-                    sub_indexes[i], subset_type,
-                    i * nlist // nsplit, (i + 1) * nlist // nsplit)
+                    sub_indexes[i],
+                    subset_type,
+                    i * nlist // nsplit,
+                    (i + 1) * nlist // nsplit,
+                )
 
         index_shards = faiss.IndexShards(False, False)
         for i in range(nsplit):
@@ -758,8 +767,8 @@ class TestSplitMerge(unittest.TestCase):
 class TestIndependentQuantizer(unittest.TestCase):
 
     def test_sidebyside(self):
-        """ provide double-sized vectors to the index, where each vector
-        is the concatenation of twice the same vector """
+        """provide double-sized vectors to the index, where each vector
+        is the concatenation of twice the same vector"""
         ds = SyntheticDataset(32, 1000, 500, 50)
 
         index = faiss.index_factory(ds.d, "IVF32,SQ8")
@@ -769,19 +778,17 @@ class TestIndependentQuantizer(unittest.TestCase):
         Dref, Iref = index.search(ds.get_queries(), 10)
 
         select32first = make_LinearTransform_matrix(
-            np.eye(64, dtype='float32')[:32])
-
-        select32last = make_LinearTransform_matrix(
-            np.eye(64, dtype='float32')[32:])
-
-        quantizer = faiss.IndexPreTransform(
-            select32first,
-            index.quantizer
+            np.eye(64, dtype="float32")[:32]
         )
 
+        select32last = make_LinearTransform_matrix(
+            np.eye(64, dtype="float32")[32:]
+        )
+
+        quantizer = faiss.IndexPreTransform(select32first, index.quantizer)
+
         index2 = faiss.IndexIVFIndependentQuantizer(
-            quantizer,
-            index, select32last
+            quantizer, index, select32last
         )
 
         xq2 = np.hstack([ds.get_queries()] * 2)
@@ -801,13 +808,14 @@ class TestIndependentQuantizer(unittest.TestCase):
         np.testing.assert_array_equal(Iref, Inew)
 
     def test_half_store(self):
-        """ the index stores only the first half of each vector
-        but the coarse quantizer sees them entirely """
+        """the index stores only the first half of each vector
+        but the coarse quantizer sees them entirely"""
         ds = SyntheticDataset(32, 1000, 500, 50)
         gt = ds.get_groundtruth(10)
 
         select32first = make_LinearTransform_matrix(
-            np.eye(32, dtype='float32')[:16])
+            np.eye(32, dtype="float32")[:16]
+        )
 
         index_ivf = faiss.index_factory(ds.d // 2, "IVF32,Flat")
         index_ivf.nprobe = 4
@@ -821,8 +829,7 @@ class TestIndependentQuantizer(unittest.TestCase):
         index_ivf = faiss.index_factory(ds.d // 2, "IVF32,Flat")
         index_ivf.nprobe = 4
         index = faiss.IndexIVFIndependentQuantizer(
-            faiss.IndexFlatL2(ds.d),
-            index_ivf, select32first
+            faiss.IndexFlatL2(ds.d), index_ivf, select32first
         )
         index.train(ds.get_train())
         index.add(ds.get_database())
@@ -833,15 +840,15 @@ class TestIndependentQuantizer(unittest.TestCase):
         self.assertLess(perf_ref, perf_new)
 
     def test_precomputed_tables(self):
-        """ see how precomputed tables behave with centroid distance estimates from a mismatching
-        coarse quantizer """
+        """see how precomputed tables behave with centroid distance estimates from a mismatching
+        coarse quantizer"""
         ds = SyntheticDataset(48, 2000, 500, 250)
         gt = ds.get_groundtruth(10)
 
         index = faiss.IndexIVFIndependentQuantizer(
             faiss.IndexFlatL2(48),
             faiss.index_factory(16, "IVF64,PQ4np"),
-            faiss.PCAMatrix(48, 16)
+            faiss.PCAMatrix(48, 16),
         )
         index.train(ds.get_train())
         index.add(ds.get_database())
@@ -875,7 +882,6 @@ class TestIndependentQuantizer(unittest.TestCase):
         np.testing.assert_array_equal(Inew, I3)
 
 
-
 class TestSearchAndReconstruct(unittest.TestCase):
 
     def run_search_and_reconstruct(self, index, xb, xq, k=10, eps=None):
@@ -903,11 +909,11 @@ class TestSearchAndReconstruct(unittest.TestCase):
         self.assertLessEqual(recons_ref_err, 1e-6)
 
         def norm1(x):
-            return np.sqrt((x ** 2).sum(axis=1))
+            return np.sqrt((x**2).sum(axis=1))
 
         recons_err = np.mean(norm1(R_flat - xb[I_flat]))
 
-        print('Reconstruction error = %.3f' % recons_err)
+        print("Reconstruction error = %.3f" % recons_err)
         if eps is not None:
             self.assertLessEqual(recons_err, eps)
 
@@ -936,7 +942,7 @@ class TestSearchAndReconstruct(unittest.TestCase):
 
         quantizer = faiss.IndexFlatL2(d)
         index = faiss.IndexIVFFlat(quantizer, d, 32, faiss.METRIC_L2)
-        index.cp.min_points_per_centroid = 5    # quiet warning
+        index.cp.min_points_per_centroid = 5  # quiet warning
         index.nprobe = 4
         index.train(xt)
         index.add(xb)
@@ -953,7 +959,7 @@ class TestSearchAndReconstruct(unittest.TestCase):
 
         quantizer = faiss.IndexFlatL2(d)
         index = faiss.IndexIVFPQ(quantizer, d, 32, 8, 8)
-        index.cp.min_points_per_centroid = 5    # quiet warning
+        index.cp.min_points_per_centroid = 5  # quiet warning
         index.nprobe = 4
         index.train(xt)
         index.add(xb)
@@ -1006,7 +1012,8 @@ class TestSearchAndGetCodes(unittest.TestCase):
         Dref, Iref = index.search(ds.get_queries(), 10)
 
         D, I, codes = index.search_and_return_codes(
-            ds.get_queries(), 10, include_listnos=True)
+            ds.get_queries(), 10, include_listnos=True
+        )
 
         np.testing.assert_array_equal(I, Iref)
         np.testing.assert_array_equal(D, Dref)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -27,7 +27,7 @@ class TestIOVariants(unittest.TestCase):
 
     def test_io_error(self):
         d, n = 32, 1000
-        x = np.random.uniform(size=(n, d)).astype('float32')
+        x = np.random.uniform(size=(n, d)).astype("float32")
         index = faiss.IndexFlatL2(d)
         index.add(x)
         fd, fname = tempfile.mkstemp()
@@ -38,11 +38,11 @@ class TestIOVariants(unittest.TestCase):
             # should be fine
             faiss.read_index(fname)
 
-            with open(fname, 'rb') as f:
+            with open(fname, "rb") as f:
                 data = f.read()
             # now damage file
-            with open(fname, 'wb') as f:
-                f.write(data[:int(len(data) / 2)])
+            with open(fname, "wb") as f:
+                f.write(data[: int(len(data) / 2)])
 
             # should make a nice readable exception that mentions the filename
             try:
@@ -62,7 +62,7 @@ class TestCallbacks(unittest.TestCase):
 
     def do_write_callback(self, bsz):
         d, n = 32, 1000
-        x = np.random.uniform(size=(n, d)).astype('float32')
+        x = np.random.uniform(size=(n, d)).astype("float32")
         index = faiss.IndexFlatL2(d)
         index.add(x)
 
@@ -74,27 +74,24 @@ class TestCallbacks(unittest.TestCase):
             writer = faiss.BufferedIOWriter(writer, bsz)
 
         faiss.write_index(index, writer)
-        del writer   # make sure all writes committed
+        del writer  # make sure all writes committed
 
         if sys.version_info[0] < 3:
             buf = f.getvalue()
         else:
             buf = f.getbuffer()
 
-        index2 = faiss.deserialize_index(np.frombuffer(buf, dtype='uint8'))
+        index2 = faiss.deserialize_index(np.frombuffer(buf, dtype="uint8"))
 
         self.assertEqual(index.d, index2.d)
         np.testing.assert_array_equal(
             faiss.vector_to_array(index.codes),
-            faiss.vector_to_array(index2.codes)
+            faiss.vector_to_array(index2.codes),
         )
 
         # This is not a callable function: should raise an exception
         writer = faiss.PyCallbackIOWriter("blabla")
-        self.assertRaises(
-            Exception,
-            faiss.write_index, index, writer
-        )
+        self.assertRaises(Exception, faiss.write_index, index, writer)
 
     def test_buf_read(self):
         x = np.random.uniform(size=20)
@@ -104,7 +101,7 @@ class TestCallbacks(unittest.TestCase):
         try:
             x.tofile(fname)
 
-            with open(fname, 'rb') as f:
+            with open(fname, "rb") as f:
                 reader = faiss.PyCallbackIOReader(f.read, 1234)
 
                 bsz = 123
@@ -120,7 +117,7 @@ class TestCallbacks(unittest.TestCase):
 
     def do_read_callback(self, bsz):
         d, n = 32, 1000
-        x = np.random.uniform(size=(n, d)).astype('float32')
+        x = np.random.uniform(size=(n, d)).astype("float32")
         index = faiss.IndexFlatL2(d)
         index.add(x)
 
@@ -129,7 +126,7 @@ class TestCallbacks(unittest.TestCase):
         try:
             faiss.write_index(index, fname)
 
-            with open(fname, 'rb') as f:
+            with open(fname, "rb") as f:
                 reader = faiss.PyCallbackIOReader(f.read, 1234)
 
                 if bsz > 0:
@@ -140,15 +137,12 @@ class TestCallbacks(unittest.TestCase):
             self.assertEqual(index.d, index2.d)
             np.testing.assert_array_equal(
                 faiss.vector_to_array(index.codes),
-                faiss.vector_to_array(index2.codes)
+                faiss.vector_to_array(index2.codes),
             )
 
             # This is not a callable function: should raise an exception
             reader = faiss.PyCallbackIOReader("blabla")
-            self.assertRaises(
-                Exception,
-                faiss.read_index, reader
-            )
+            self.assertRaises(Exception, faiss.read_index, reader)
         finally:
             if os.path.exists(fname):
                 os.unlink(fname)
@@ -169,7 +163,7 @@ class TestCallbacks(unittest.TestCase):
 
     def test_read_buffer(self):
         d, n = 32, 1000
-        x = np.random.uniform(size=(n, d)).astype('float32')
+        x = np.random.uniform(size=(n, d)).astype("float32")
         index = faiss.IndexFlatL2(d)
         index.add(x)
 
@@ -178,15 +172,14 @@ class TestCallbacks(unittest.TestCase):
         try:
             faiss.write_index(index, fname)
 
-            reader = faiss.BufferedIOReader(
-                faiss.FileIOReader(fname), 1234)
+            reader = faiss.BufferedIOReader(faiss.FileIOReader(fname), 1234)
 
             index2 = faiss.read_index(reader)
 
             self.assertEqual(index.d, index2.d)
             np.testing.assert_array_equal(
                 faiss.vector_to_array(index.codes),
-                faiss.vector_to_array(index2.codes)
+                faiss.vector_to_array(index2.codes),
             )
 
         finally:
@@ -195,10 +188,10 @@ class TestCallbacks(unittest.TestCase):
                 os.unlink(fname)
 
     def test_transfer_pipe(self):
-        """ transfer an index through a Unix pipe """
+        """transfer an index through a Unix pipe"""
 
         d, n = 32, 1000
-        x = np.random.uniform(size=(n, d)).astype('float32')
+        x = np.random.uniform(size=(n, d)).astype("float32")
         index = faiss.IndexFlatL2(d)
         index.add(x)
         Dref, Iref = index.search(x, 10)
@@ -231,7 +224,7 @@ class TestCallbacks(unittest.TestCase):
 
 
 class PyOndiskInvertedLists:
-    """ wraps an OnDisk object for use from C++ """
+    """wraps an OnDisk object for use from C++"""
 
     def __init__(self, oil):
         self.oil = oil
@@ -243,7 +236,7 @@ class PyOndiskInvertedLists:
         oil = self.oil
         assert 0 <= list_no < oil.lists.size()
         l = oil.lists.at(list_no)
-        with open(oil.filename, 'rb') as f:
+        with open(oil.filename, "rb") as f:
             f.seek(l.offset)
             return f.read(l.size * oil.code_size)
 
@@ -251,7 +244,7 @@ class PyOndiskInvertedLists:
         oil = self.oil
         assert 0 <= list_no < oil.lists.size()
         l = oil.lists.at(list_no)
-        with open(oil.filename, 'rb') as f:
+        with open(oil.filename, "rb") as f:
             f.seek(l.offset + l.capacity * oil.code_size)
             return f.read(l.size * 8)
 
@@ -301,9 +294,10 @@ class Test_IO_VectorTransform(unittest.TestCase):
     test write_VectorTransform using IOWriter Pointer
     and read_VectorTransform using file name
     """
+
     def test_write_vector_transform(self):
         d, n = 32, 1000
-        x = np.random.uniform(size=(n, d)).astype('float32')
+        x = np.random.uniform(size=(n, d)).astype("float32")
         quantizer = faiss.IndexFlatL2(d)
         index = faiss.IndexIVFSpectralHash(quantizer, d, n, 8, 1.0)
         index.train(x)
@@ -343,9 +337,10 @@ class Test_IO_VectorTransform(unittest.TestCase):
     test write_VectorTransform using file name
     and read_VectorTransform using IOWriter Pointer
     """
+
     def test_read_vector_transform(self):
         d, n = 32, 1000
-        x = np.random.uniform(size=(n, d)).astype('float32')
+        x = np.random.uniform(size=(n, d)).astype("float32")
         quantizer = faiss.IndexFlatL2(d)
         index = faiss.IndexIVFSpectralHash(quantizer, d, n, 8, 1.0)
         index.train(x)
@@ -372,6 +367,7 @@ class Test_IO_PQ(unittest.TestCase):
     """
     test read and write PQ.
     """
+
     def test_io_pq(self):
         xt, xb, xq = get_dataset_2(d, nt, nb, nq)
         index = faiss.IndexPQ(d, 4, 4)
@@ -392,7 +388,7 @@ class Test_IO_PQ(unittest.TestCase):
         self.assertEqual(index.pq.ksub, read_pq.ksub)
         np.testing.assert_array_equal(
             faiss.vector_to_array(index.pq.centroids),
-            faiss.vector_to_array(read_pq.centroids)
+            faiss.vector_to_array(read_pq.centroids),
         )
 
         # Verify deserialized PQ is serializable again
@@ -408,15 +404,15 @@ class Test_IO_PQ(unittest.TestCase):
         self.assertEqual(index.pq.nbits, read_pq2.nbits)
         np.testing.assert_array_equal(
             faiss.vector_to_array(index.pq.centroids),
-            faiss.vector_to_array(read_pq2.centroids)
+            faiss.vector_to_array(read_pq2.centroids),
         )
-
 
 
 class Test_IO_IndexLSH(unittest.TestCase):
     """
     test read and write IndexLSH.
     """
+
     def test_io_lsh(self):
         xt, xb, xq = get_dataset_2(d, nt, nb, nq)
         index_lsh = faiss.IndexLSH(d, 32, True, True)
@@ -430,8 +426,7 @@ class Test_IO_IndexLSH(unittest.TestCase):
         try:
             faiss.write_index(index_lsh, fname)
 
-            reader = faiss.BufferedIOReader(
-                faiss.FileIOReader(fname), 1234)
+            reader = faiss.BufferedIOReader(faiss.FileIOReader(fname), 1234)
             read_index_lsh = faiss.read_index(reader)
             # Delete reader to prevent [WinError 32] The process cannot
             # access the file because it is being used by another process
@@ -440,7 +435,7 @@ class Test_IO_IndexLSH(unittest.TestCase):
             self.assertEqual(index_lsh.d, read_index_lsh.d)
             np.testing.assert_array_equal(
                 faiss.vector_to_array(index_lsh.codes),
-                faiss.vector_to_array(read_index_lsh.codes)
+                faiss.vector_to_array(read_index_lsh.codes),
             )
             D_read, I_read = read_index_lsh.search(xq, 10)
 
@@ -463,6 +458,7 @@ class Test_IO_IndexIVFSpectralHash(unittest.TestCase):
     """
     test read and write IndexIVFSpectralHash.
     """
+
     def test_io_ivf_spectral_hash(self):
         nlist = 1000
         xt, xb, xq = get_dataset_2(d, nt, nb, nq)
@@ -478,8 +474,7 @@ class Test_IO_IndexIVFSpectralHash(unittest.TestCase):
         try:
             faiss.write_index(index, fname)
 
-            reader = faiss.BufferedIOReader(
-                faiss.FileIOReader(fname), 1234)
+            reader = faiss.BufferedIOReader(faiss.FileIOReader(fname), 1234)
             read_index = faiss.read_index(reader)
             del reader
 
@@ -507,8 +502,8 @@ class Test_IO_IndexIVFSpectralHash(unittest.TestCase):
 class TestIVFPQRead(unittest.TestCase):
     def test_reader(self):
         d, n = 32, 1000
-        xq = np.random.uniform(size=(n, d)).astype('float32')
-        xb = np.random.uniform(size=(n, d)).astype('float32')
+        xq = np.random.uniform(size=(n, d)).astype("float32")
+        xb = np.random.uniform(size=(n, d)).astype("float32")
 
         index = faiss.index_factory(32, "IVF32,PQ16np", faiss.METRIC_L2)
         index.train(xb)
@@ -521,7 +516,8 @@ class TestIVFPQRead(unittest.TestCase):
 
             index_a = faiss.read_index(fname)
             index_b = faiss.read_index(
-                fname, faiss.IO_FLAG_SKIP_PRECOMPUTE_TABLE)
+                fname, faiss.IO_FLAG_SKIP_PRECOMPUTE_TABLE
+            )
 
             Da, Ia = index_a.search(xq, 10)
             Db, Ib = index_b.search(xq, 10)
@@ -547,7 +543,7 @@ class TestIVFPQRead(unittest.TestCase):
 class TestIOFlatMMap(unittest.TestCase):
     @unittest.skipIf(
         platform.system() not in ["Windows", "Linux", "Darwin"],
-        "supported OSes only"
+        "supported OSes only",
     )
     def test_mmap(self):
         xt, xb, xq = get_dataset_2(32, 0, 100, 50)
@@ -580,7 +576,7 @@ class TestIOFlatMMap(unittest.TestCase):
 
     @unittest.skipIf(
         platform.system() not in ["Windows", "Linux", "Darwin"],
-        "supported OSes only"
+        "supported OSes only",
     )
     def test_mmap_ivf(self):
         d, nlist = 32, 64
@@ -619,7 +615,8 @@ class TestIOFlatMMap(unittest.TestCase):
 
         serialized_index = faiss.serialize_index(index)
         reader = faiss.ZeroCopyIOReader(
-            faiss.swig_ptr(serialized_index), serialized_index.size)
+            faiss.swig_ptr(serialized_index), serialized_index.size
+        )
         index2 = faiss.read_index(reader)
         Dnew, Inew = index2.search(xq, 10)
         np.testing.assert_array_equal(Iref, Inew)
@@ -674,7 +671,8 @@ class TestIORoundTrip(unittest.TestCase):
 
         reader = faiss.VectorIOReader()
         faiss.copy_array_to_vector(
-            np.array(faiss.vector_to_array(writer.data)), reader.data)
+            np.array(faiss.vector_to_array(writer.data)), reader.data
+        )
         pca2 = faiss.read_VectorTransform(reader)
 
         self.assertEqual(pca2.d_in, d)
@@ -694,7 +692,8 @@ class TestIORoundTrip(unittest.TestCase):
 
         reader = faiss.VectorIOReader()
         faiss.copy_array_to_vector(
-            np.array(faiss.vector_to_array(writer.data)), reader.data)
+            np.array(faiss.vector_to_array(writer.data)), reader.data
+        )
         fr2 = faiss.read_VectorTransform(reader)
 
         self.assertEqual(fr2.d_in, d)
@@ -724,7 +723,8 @@ class TestIORoundTrip(unittest.TestCase):
 
         reader = faiss.VectorIOReader()
         faiss.copy_array_to_vector(
-            np.array(faiss.vector_to_array(writer.data)), reader.data)
+            np.array(faiss.vector_to_array(writer.data)), reader.data
+        )
         index2 = faiss.read_index(reader)
 
         self.assertIsNone(index2)
@@ -740,7 +740,8 @@ class Test_IO_HNSW(unittest.TestCase):
             read_index = faiss.deserialize_index(faiss.serialize_index(index))
             self.assertEqual(index.hnsw.efSearch, read_index.hnsw.efSearch)
             self.assertEqual(
-                index.hnsw.efConstruction, read_index.hnsw.efConstruction)
+                index.hnsw.efConstruction, read_index.hnsw.efConstruction
+            )
             D, I = index.search(self.xq, 10)
             D_read, I_read = read_index.search(self.xq, 10)
             np.testing.assert_array_equal(D, D_read)

--- a/tests/test_ivf_flat_panorama.py
+++ b/tests/test_ivf_flat_panorama.py
@@ -46,7 +46,9 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
         metric=faiss.METRIC_L2,
     ):
         quantizer = (
-            faiss.IndexFlatL2(d) if metric == faiss.METRIC_L2 else faiss.IndexFlatIP(d)
+            faiss.IndexFlatL2(d)
+            if metric == faiss.METRIC_L2
+            else faiss.IndexFlatIP(d)
         )
         index = faiss.IndexIVFFlat(quantizer, d, nlist, metric)
         index.train(xt)
@@ -71,7 +73,9 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
     ):
         """Create and initialize IndexIVFFlatPanorama."""
         quantizer = (
-            faiss.IndexFlatL2(d) if metric == faiss.METRIC_L2 else faiss.IndexFlatIP(d)
+            faiss.IndexFlatL2(d)
+            if metric == faiss.METRIC_L2
+            else faiss.IndexFlatIP(d)
         )
         index = faiss.IndexIVFFlatPanorama(quantizer, d, nlist, nlevels, metric)
         index.train(xt)
@@ -104,7 +108,11 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
             f"Overlap rate {overlap_rate:.6f} is not > {1-otol:.3f}. ",
         )
         np.testing.assert_allclose(
-            D_regular, D_panorama, rtol=rtol, atol=atol, err_msg="Distances mismatch"
+            D_regular,
+            D_panorama,
+            rtol=rtol,
+            atol=atol,
+            err_msg="Distances mismatch",
         )
 
     def assert_range_results_equal(
@@ -132,7 +140,9 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
 
             if len(common) > 0:
                 # Extract and sort distances for common IDs
-                mask_reg, mask_pan = np.isin(ids_reg, common), np.isin(ids_pan, common)
+                mask_reg, mask_pan = np.isin(ids_reg, common), np.isin(
+                    ids_pan, common
+                )
                 dist_reg = D_regular[lims_regular[i] : lims_regular[i + 1]]
                 dist_pan = D_panorama[lims_panorama[i] : lims_panorama[i + 1]]
 
@@ -160,11 +170,13 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
         """Helper to validate range search results match between regular and panorama."""
         if metric == faiss.METRIC_L2:
             self.assertTrue(
-                np.all(D_pan <= radius), f"Some L2 distances exceed radius={radius}"
+                np.all(D_pan <= radius),
+                f"Some L2 distances exceed radius={radius}",
             )
         else:
             self.assertTrue(
-                np.all(D_pan >= radius), f"Some IP distances below radius={radius}"
+                np.all(D_pan >= radius),
+                f"Some IP distances below radius={radius}",
             )
         self.assert_range_results_equal(
             lims_reg, D_reg, I_reg, lims_pan, D_pan, I_pan, nq
@@ -231,8 +243,12 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
 
             for radius in [0.5, 1.0, 2.0, 5.0]:
                 with self.subTest(metric=metric, radius=radius):
-                    lims_reg, D_reg, I_reg = index_regular.range_search(xq, radius)
-                    lims_pan, D_pan, I_pan = index_panorama.range_search(xq, radius)
+                    lims_reg, D_reg, I_reg = index_regular.range_search(
+                        xq, radius
+                    )
+                    lims_pan, D_pan, I_pan = index_panorama.range_search(
+                        xq, radius
+                    )
                     self.validate_and_compare_range_results(
                         metric,
                         radius,
@@ -272,7 +288,9 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
                     self.assert_search_results_equal(D_base, I_base, D, I)
 
             # Verify ratio_dims_scanned decreases as n_levels increases
-            ratio_dims_scanned = faiss.cvar.indexPanorama_stats.ratio_dims_scanned
+            ratio_dims_scanned = (
+                faiss.cvar.indexPanorama_stats.ratio_dims_scanned
+            )
             self.assertLess(ratio_dims_scanned, prev_ratio_dims_scanned)
             prev_ratio_dims_scanned = ratio_dims_scanned
 
@@ -365,8 +383,12 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
                 params = faiss.SearchParametersIVF()
                 params.sel = faiss.IDSelectorRange(10000, 50000)
 
-                D_regular, I_regular = index_regular.search(xq, k, params=params)
-                D_panorama, I_panorama = index_panorama.search(xq, k, params=params)
+                D_regular, I_regular = index_regular.search(
+                    xq, k, params=params
+                )
+                D_panorama, I_panorama = index_panorama.search(
+                    xq, k, params=params
+                )
 
                 self.assertTrue(np.all(I_panorama >= 10000))
                 self.assertTrue(np.all(I_panorama < 50000))
@@ -388,12 +410,18 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
                     d, nlist, nlevels, xt, xb, nprobe=32, metric=metric
                 )
 
-                allowed_ids = np.array([i * 100 for i in range(500)], dtype=np.int64)
+                allowed_ids = np.array(
+                    [i * 100 for i in range(500)], dtype=np.int64
+                )
                 params = faiss.SearchParametersIVF()
                 params.sel = faiss.IDSelectorBatch(allowed_ids)
 
-                D_regular, I_regular = index_regular.search(xq, k, params=params)
-                D_panorama, I_panorama = index_panorama.search(xq, k, params=params)
+                D_regular, I_regular = index_regular.search(
+                    xq, k, params=params
+                )
+                D_panorama, I_panorama = index_panorama.search(
+                    xq, k, params=params
+                )
 
                 allowed_set = set(allowed_ids) | set([-1])
                 for id_val in I_panorama.flatten():
@@ -419,8 +447,12 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
                 params = faiss.SearchParametersIVF()
                 params.sel = faiss.IDSelectorRange(20, 60)
 
-                D_regular, I_regular = index_regular.search(xq, k, params=params)
-                D_panorama, I_panorama = index_panorama.search(xq, k, params=params)
+                D_regular, I_regular = index_regular.search(
+                    xq, k, params=params
+                )
+                D_panorama, I_panorama = index_panorama.search(
+                    xq, k, params=params
+                )
 
                 self.assertTrue(np.all(I_panorama >= 20))
                 self.assertTrue(np.all(I_panorama < 60))
@@ -477,7 +509,9 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
         """Test handling of empty search results"""
         d, nb, nt, nq, nlist, nlevels, k = 32, 100, 200, 5, 8, 4, 10
         xt, xb, _ = self.generate_data(d, nt, nb, nq, seed=111)
-        xq = np.random.rand(nq, d).astype("float32") + 10.0  # Queries far from database
+        xq = (
+            np.random.rand(nq, d).astype("float32") + 10.0
+        )  # Queries far from database
 
         for metric in self.METRICS:
             with self.subTest(metric=metric):
@@ -498,7 +532,9 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
                 with self.subTest(metric=metric, nb=nb):
                     d, nt, nlist, nlevels, nq = 32, max(nb, 100), 4, 4, 5
                     k = min(3, nb)
-                    xt, xb, xq = self.generate_data(d, nt, nb, nq, seed=666 + nb)
+                    xt, xb, xq = self.generate_data(
+                        d, nt, nb, nq, seed=666 + nb
+                    )
 
                     index_regular = self.create_ivf_flat(
                         d, nlist, xt, xb, nprobe=nlist, metric=metric
@@ -569,8 +605,12 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
 
             for radius in [0.01, 0.1, 100.0, 1000.0]:
                 with self.subTest(metric=metric, radius=radius):
-                    lims_reg, D_reg, I_reg = index_regular.range_search(xq, radius)
-                    lims_pan, D_pan, I_pan = index_panorama.range_search(xq, radius)
+                    lims_reg, D_reg, I_reg = index_regular.range_search(
+                        xq, radius
+                    )
+                    lims_pan, D_pan, I_pan = index_panorama.range_search(
+                        xq, radius
+                    )
                     self.validate_and_compare_range_results(
                         metric,
                         radius,
@@ -624,7 +664,9 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
 
         for metric in self.METRICS:
             with self.subTest(metric=metric):
-                index_regular = self.create_ivf_flat(d, nlist, xt, metric=metric)
+                index_regular = self.create_ivf_flat(
+                    d, nlist, xt, metric=metric
+                )
                 index_panorama = self.create_panorama(
                     d, nlist, nlevels, xt, metric=metric
                 )
@@ -640,7 +682,9 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
 
                 D_reg_1, I_reg_1 = index_regular.search(xq1, k)
                 D_pan_1, I_pan_1 = index_panorama.search(xq1, k)
-                self.assert_search_results_equal(D_reg_1, I_reg_1, D_pan_1, I_pan_1)
+                self.assert_search_results_equal(
+                    D_reg_1, I_reg_1, D_pan_1, I_pan_1
+                )
 
                 # Second add and search
                 xb2 = np.random.rand(300, d).astype("float32")
@@ -650,7 +694,9 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
                 xq2 = np.random.rand(10, d).astype("float32")
                 D_reg_2, I_reg_2 = index_regular.search(xq2, k)
                 D_pan_2, I_pan_2 = index_panorama.search(xq2, k)
-                self.assert_search_results_equal(D_reg_2, I_reg_2, D_pan_2, I_pan_2)
+                self.assert_search_results_equal(
+                    D_reg_2, I_reg_2, D_pan_2, I_pan_2
+                )
 
     def test_update_vectors(self):
         """Test update operations (single, batch, and interleaved with search)"""
@@ -660,7 +706,13 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index_regular = self.create_ivf_flat(
-                    d, nlist, xt, xb, nprobe=32, make_direct_map=True, metric=metric
+                    d,
+                    nlist,
+                    xt,
+                    xb,
+                    nprobe=32,
+                    make_direct_map=True,
+                    metric=metric,
                 )
                 index_panorama = self.create_panorama(
                     d,
@@ -687,13 +739,17 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
 
                 # Test interleaved update/search
                 update_ids_2 = np.array([50, 500, 2500, 15000], dtype=np.int64)
-                xb_new_2 = np.random.rand(len(update_ids_2), d).astype("float32")
+                xb_new_2 = np.random.rand(len(update_ids_2), d).astype(
+                    "float32"
+                )
                 index_regular.update_vectors(update_ids_2, xb_new_2)
                 index_panorama.update_vectors(update_ids_2, xb_new_2)
 
                 D_reg_2, I_reg_2 = index_regular.search(xq, k)
                 D_pan_2, I_pan_2 = index_panorama.search(xq, k)
-                self.assert_search_results_equal(D_reg_2, I_reg_2, D_pan_2, I_pan_2)
+                self.assert_search_results_equal(
+                    D_reg_2, I_reg_2, D_pan_2, I_pan_2
+                )
 
     def test_serialization(self):
         """Test that writing and reading Panorama indexes preserves search results"""
@@ -707,7 +763,9 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
                 )
 
                 D_before, I_before = index.search(xq, k)
-                index_after = faiss.deserialize_index(faiss.serialize_index(index))
+                index_after = faiss.deserialize_index(
+                    faiss.serialize_index(index)
+                )
                 D_after, I_after = index_after.search(xq, k)
 
                 np.testing.assert_array_equal(I_before, I_after)
@@ -747,7 +805,9 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
                         D, I = index.search(xq, k)
                         self.assert_search_results_equal(D_base, I_base, D, I)
 
-                        ratios.append(faiss.cvar.indexPanorama_stats.ratio_dims_scanned)
+                        ratios.append(
+                            faiss.cvar.indexPanorama_stats.ratio_dims_scanned
+                        )
 
                 expected_ratios = [1 / nlevels for nlevels in nlevels_list]
                 np.testing.assert_allclose(ratios, expected_ratios, atol=1e-3)

--- a/tests/test_ivflib.py
+++ b/tests/test_ivflib.py
@@ -15,10 +15,16 @@ import random
 class TestIVFlib(unittest.TestCase):
 
     def test_methods_exported(self):
-        methods = ['check_compatible_for_merge', 'extract_index_ivf',
-                   'merge_into', 'search_centroid',
-                   'search_and_return_centroids', 'get_invlist_range',
-                   'set_invlist_range', 'search_with_parameters']
+        methods = [
+            "check_compatible_for_merge",
+            "extract_index_ivf",
+            "merge_into",
+            "search_centroid",
+            "search_and_return_centroids",
+            "get_invlist_range",
+            "set_invlist_range",
+            "search_with_parameters",
+        ]
 
         for method in methods:
             assert callable(getattr(faiss, method, None))
@@ -49,10 +55,7 @@ def search_single_scan(index, xq, k, bs=128):
         sub_assign = assign.copy()
         sub_assign[skip_rows, skip_cols] = -1
 
-        index.search_preassigned(
-            xq, k, sub_assign, coarse_dis,
-            D=rh.D, I=rh.I
-        )
+        index.search_preassigned(xq, k, sub_assign, coarse_dis, D=rh.D, I=rh.I)
 
     rh.finalize()
 
@@ -63,15 +66,15 @@ class TestSequentialScan(unittest.TestCase):
 
     def test_sequential_scan(self):
         d = 20
-        index = faiss.index_factory(d, 'IVF100,SQ8')
+        index = faiss.index_factory(d, "IVF100,SQ8")
 
         rs = np.random.RandomState(123)
-        xt = rs.rand(5000, d).astype('float32')
-        xb = rs.rand(10000, d).astype('float32')
+        xt = rs.rand(5000, d).astype("float32")
+        xb = rs.rand(10000, d).astype("float32")
         index.train(xt)
         index.add(xb)
         k = 15
-        xq = rs.rand(200, d).astype('float32')
+        xq = rs.rand(200, d).astype("float32")
 
         ref_D, ref_I = index.search(xq, k)
         D, I = search_single_scan(index, xq, k, bs=10)
@@ -84,16 +87,16 @@ class TestSearchWithParameters(unittest.TestCase):
 
     def test_search_with_parameters(self):
         d = 20
-        index = faiss.index_factory(d, 'IVF100,SQ8')
+        index = faiss.index_factory(d, "IVF100,SQ8")
 
         rs = np.random.RandomState(123)
-        xt = rs.rand(5000, d).astype('float32')
-        xb = rs.rand(10000, d).astype('float32')
+        xt = rs.rand(5000, d).astype("float32")
+        xb = rs.rand(10000, d).astype("float32")
         index.train(xt)
         index.nprobe = 3
         index.add(xb)
         k = 15
-        xq = rs.rand(200, d).astype('float32')
+        xq = rs.rand(200, d).astype("float32")
 
         stats = faiss.cvar.indexIVF_stats
         stats.reset()
@@ -107,7 +110,8 @@ class TestSearchWithParameters(unittest.TestCase):
         params.nprobe = 3
 
         Dnew, Inew, stats2 = faiss.search_with_parameters(
-            index, xq, k, params, output_stats=True)
+            index, xq, k, params, output_stats=True
+        )
 
         np.testing.assert_array_equal(Inew, Iref)
         np.testing.assert_array_equal(Dnew, Dref)
@@ -116,15 +120,15 @@ class TestSearchWithParameters(unittest.TestCase):
 
     def test_range_search_with_parameters(self):
         d = 20
-        index = faiss.index_factory(d, 'IVF100,SQ8')
+        index = faiss.index_factory(d, "IVF100,SQ8")
 
         rs = np.random.RandomState(123)
-        xt = rs.rand(5000, d).astype('float32')
-        xb = rs.rand(10000, d).astype('float32')
+        xt = rs.rand(5000, d).astype("float32")
+        xb = rs.rand(10000, d).astype("float32")
         index.train(xt)
         index.nprobe = 3
         index.add(xb)
-        xq = rs.rand(200, d).astype('float32')
+        xq = rs.rand(200, d).astype("float32")
 
         Dpre, _ = index.search(xq, 15)
         radius = float(np.median(Dpre[:, -1]))
@@ -140,7 +144,8 @@ class TestSearchWithParameters(unittest.TestCase):
         params.nprobe = 3
 
         Lnew, Dnew, Inew, stats2 = faiss.range_search_with_parameters(
-            index, xq, radius, params, output_stats=True)
+            index, xq, radius, params, output_stats=True
+        )
 
         np.testing.assert_array_equal(Lnew, Lref)
         np.testing.assert_array_equal(Inew, Iref)
@@ -155,18 +160,18 @@ class TestSmallData(unittest.TestCase):
     def test_small_data(self):
         d = 20
         # nlist = (2^4)^2 = 256
-        index = faiss.index_factory(d, 'IMI2x4,Flat')
+        index = faiss.index_factory(d, "IMI2x4,Flat")
 
         # When nprobe >= nlist, it is equivalent to an IndexFlat.
         rs = np.random.RandomState(123)
-        xt = rs.rand(100, d).astype('float32')
-        xb = rs.rand(1000, d).astype('float32')
+        xt = rs.rand(100, d).astype("float32")
+        xb = rs.rand(1000, d).astype("float32")
 
         index.train(xt)
         index.add(xb)
         index.nprobe = 2048
         k = 5
-        xq = rs.rand(10, d).astype('float32')
+        xq = rs.rand(10, d).astype("float32")
 
         # test kNN search
         D, I = index.search(xq, k)
@@ -175,7 +180,7 @@ class TestSmallData(unittest.TestCase):
         assert np.all(I == ref_I)
 
         # test range search
-        thresh = 0.1   # *squared* distance
+        thresh = 0.1  # *squared* distance
         lims, D, I = index.range_search(xq, thresh)
         ref_index = faiss.IndexFlat(d)
         ref_index.add(xb)
@@ -199,11 +204,12 @@ class TestIvfSharding(unittest.TestCase):
         return i % shard_count
 
     def verify_sharded_ivf_indexes(
-            self, template, xb, shard_count, sharding_function, generate_ids=True):
+        self, template, xb, shard_count, sharding_function, generate_ids=True
+    ):
         sharded_indexes_counters = [0] * shard_count
         sharded_indexes = []
         for i in range(shard_count):
-            if xb[0].dtype.name == 'uint8':
+            if xb[0].dtype.name == "uint8":
                 index = faiss.read_index_binary(template % i)
             else:
                 index = faiss.read_index(template % i)
@@ -213,13 +219,16 @@ class TestIvfSharding(unittest.TestCase):
         if generate_ids:
             for i in range(len(xb)):
                 shard_id = sharding_function(i, shard_count)
-                reconstructed = sharded_indexes[shard_id].quantizer.reconstruct(i)
+                reconstructed = sharded_indexes[shard_id].quantizer.reconstruct(
+                    i
+                )
                 np.testing.assert_array_equal(reconstructed, xb[i])
         else:
             for i in range(len(xb)):
                 shard_id = sharding_function(i, shard_count)
                 reconstructed = sharded_indexes[shard_id].quantizer.reconstruct(
-                    sharded_indexes_counters[shard_id])
+                    sharded_indexes_counters[shard_id]
+                )
                 sharded_indexes_counters[shard_id] += 1
                 np.testing.assert_array_equal(reconstructed, xb[i])
 
@@ -231,16 +240,12 @@ class TestIvfSharding(unittest.TestCase):
         quantizer = faiss.IndexFlatL2(self.d)
         index = faiss.IndexIVFFlat(quantizer, self.d, self.nlist)
         with self.assertRaises(RuntimeError):
-            faiss.shard_ivf_index_centroids(
-                index,
-                10,
-                "shard.%d.index",
-                None
-            )
+            faiss.shard_ivf_index_centroids(index, 10, "shard.%d.index", None)
 
     def test_save_index_shards_by_centroids_flat_quantizer_default_sharding(
-            self):
-        xb = np.random.rand(self.nb, self.d).astype('float32')
+        self,
+    ):
+        xb = np.random.rand(self.nb, self.d).astype("float32")
         quantizer = faiss.IndexFlatL2(self.d)
         index = faiss.IndexIVFFlat(quantizer, self.d, self.nlist)
         shard_count = 3
@@ -249,18 +254,16 @@ class TestIvfSharding(unittest.TestCase):
 
         template = str(random.randint(0, 100000)) + "shard.%d.index"
         faiss.shard_ivf_index_centroids(
-            index,
-            shard_count,
-            template,
-            None,
-            True
+            index, shard_count, template, None, True
         )
         self.verify_sharded_ivf_indexes(
-            template, xb, shard_count, self.default_sharding_function)
+            template, xb, shard_count, self.default_sharding_function
+        )
 
     def test_save_index_shards_by_centroids_flat_quantizer_custom_sharding(
-            self):
-        xb = np.random.rand(self.nb, self.d).astype('float32')
+        self,
+    ):
+        xb = np.random.rand(self.nb, self.d).astype("float32")
         quantizer = faiss.IndexFlatL2(self.d)
         index = faiss.IndexIVFFlat(quantizer, self.d, self.nlist)
         shard_count = 20
@@ -269,17 +272,14 @@ class TestIvfSharding(unittest.TestCase):
 
         template = str(random.randint(0, 100000)) + "shard.%d.index"
         faiss.shard_ivf_index_centroids(
-            index,
-            shard_count,
-            template,
-            self.custom_sharding_function,
-            True
+            index, shard_count, template, self.custom_sharding_function, True
         )
         self.verify_sharded_ivf_indexes(
-            template, xb, shard_count, self.custom_sharding_function)
+            template, xb, shard_count, self.custom_sharding_function
+        )
 
     def test_save_index_shards_by_centroids_hnsw_quantizer(self):
-        xb = np.random.rand(self.nb, self.d).astype('float32')
+        xb = np.random.rand(self.nb, self.d).astype("float32")
         quantizer = faiss.IndexHNSWFlat(self.d, 32)
         index = faiss.IndexIVFFlat(quantizer, self.d, self.nlist)
         shard_count = 17
@@ -288,17 +288,16 @@ class TestIvfSharding(unittest.TestCase):
 
         template = str(random.randint(0, 100000)) + "shard.%d.index"
         faiss.shard_ivf_index_centroids(
-            index,
-            shard_count,
-            template,
-            None,
-            True
+            index, shard_count, template, None, True
         )
         self.verify_sharded_ivf_indexes(
-            template, xb, shard_count, self.default_sharding_function)
+            template, xb, shard_count, self.default_sharding_function
+        )
 
     def test_save_index_shards_by_centroids_binary_flat_quantizer(self):
-        xb = np.random.randint(256, size=(self.nb, int(self.d / 8))).astype('uint8')
+        xb = np.random.randint(256, size=(self.nb, int(self.d / 8))).astype(
+            "uint8"
+        )
         quantizer = faiss.IndexBinaryFlat(self.d)
         index = faiss.IndexBinaryIVF(quantizer, self.d, self.nlist)
         shard_count = 11
@@ -307,17 +306,16 @@ class TestIvfSharding(unittest.TestCase):
 
         template = str(random.randint(0, 100000)) + "shard.%d.index"
         faiss.shard_binary_ivf_index_centroids(
-            index,
-            shard_count,
-            template,
-            None,
-            True
+            index, shard_count, template, None, True
         )
         self.verify_sharded_ivf_indexes(
-            template, xb, shard_count, self.default_sharding_function)
+            template, xb, shard_count, self.default_sharding_function
+        )
 
     def test_save_index_shards_by_centroids_binary_hnsw_quantizer(self):
-        xb = np.random.randint(256, size=(self.nb, int(self.d / 8))).astype('uint8')
+        xb = np.random.randint(256, size=(self.nb, int(self.d / 8))).astype(
+            "uint8"
+        )
         quantizer = faiss.IndexBinaryHNSW(self.d, 32)
         index = faiss.IndexBinaryIVF(quantizer, self.d, self.nlist)
         shard_count = 13
@@ -326,17 +324,16 @@ class TestIvfSharding(unittest.TestCase):
 
         template = str(random.randint(0, 100000)) + "shard.%d.index"
         faiss.shard_binary_ivf_index_centroids(
-            index,
-            shard_count,
-            template,
-            None,
-            True
+            index, shard_count, template, None, True
         )
         self.verify_sharded_ivf_indexes(
-            template, xb, shard_count, self.default_sharding_function)
+            template, xb, shard_count, self.default_sharding_function
+        )
 
     def test_save_index_shards_without_id_generation(self):
-        xb = np.random.randint(256, size=(self.nb, int(self.d / 8))).astype('uint8')
+        xb = np.random.randint(256, size=(self.nb, int(self.d / 8))).astype(
+            "uint8"
+        )
         quantizer = faiss.IndexBinaryHNSW(self.d, 32)
         index = faiss.IndexBinaryIVF(quantizer, self.d, self.nlist)
         shard_count = 5
@@ -345,16 +342,13 @@ class TestIvfSharding(unittest.TestCase):
 
         template = str(random.randint(0, 100000)) + "shard.%d.index"
         faiss.shard_binary_ivf_index_centroids(
-            index,
-            shard_count,
-            template,
-            None,
-            False
+            index, shard_count, template, None, False
         )
         self.verify_sharded_ivf_indexes(
-            template, xb, shard_count, self.default_sharding_function, False)
+            template, xb, shard_count, self.default_sharding_function, False
+        )
 
-        xb = np.random.rand(self.nb, self.d).astype('float32')
+        xb = np.random.rand(self.nb, self.d).astype("float32")
         quantizer = faiss.IndexHNSWFlat(self.d, 32)
         index = faiss.IndexIVFFlat(quantizer, self.d, self.nlist)
         shard_count = 23
@@ -363,18 +357,15 @@ class TestIvfSharding(unittest.TestCase):
 
         template = str(random.randint(0, 100000)) + "shard.%d.index"
         faiss.shard_ivf_index_centroids(
-            index,
-            shard_count,
-            template,
-            None,
-            False
+            index, shard_count, template, None, False
         )
         self.verify_sharded_ivf_indexes(
-            template, xb, shard_count, self.default_sharding_function, False)
+            template, xb, shard_count, self.default_sharding_function, False
+        )
 
     def test_save_index_shards_by_centroids_rabitq(self):
         """Test sharding for IndexIVFRaBitQ."""
-        xb = np.random.rand(self.nb, self.d).astype('float32')
+        xb = np.random.rand(self.nb, self.d).astype("float32")
         quantizer = faiss.IndexFlatL2(self.d)
         index = faiss.IndexIVFRaBitQ(quantizer, self.d, self.nlist)
         shard_count = 7
@@ -386,18 +377,15 @@ class TestIvfSharding(unittest.TestCase):
 
         template = str(random.randint(0, 100000)) + "shard.%d.rabitq.index"
         faiss.shard_ivf_index_centroids(
-            index,
-            shard_count,
-            template,
-            None,
-            True
+            index, shard_count, template, None, True
         )
         self.verify_sharded_ivf_indexes(
-            template, xb, shard_count, self.default_sharding_function)
+            template, xb, shard_count, self.default_sharding_function
+        )
 
     def test_save_index_shards_by_centroids_rabitq_fastscan(self):
         """Test sharding for IndexIVFRaBitQFastScan."""
-        xb = np.random.rand(self.nb, self.d).astype('float32')
+        xb = np.random.rand(self.nb, self.d).astype("float32")
         quantizer = faiss.IndexFlatL2(self.d)
         index = faiss.IndexIVFRaBitQFastScan(quantizer, self.d, self.nlist)
         shard_count = 5
@@ -409,18 +397,15 @@ class TestIvfSharding(unittest.TestCase):
 
         template = str(random.randint(0, 100000)) + "shard.%d.rabitqfs.index"
         faiss.shard_ivf_index_centroids(
-            index,
-            shard_count,
-            template,
-            None,
-            True
+            index, shard_count, template, None, True
         )
         self.verify_sharded_ivf_indexes(
-            template, xb, shard_count, self.default_sharding_function)
+            template, xb, shard_count, self.default_sharding_function
+        )
 
     def test_save_index_shards_by_centroids_rabitq_custom_sharding(self):
         """Test sharding for IndexIVFRaBitQ with custom sharding function."""
-        xb = np.random.rand(self.nb, self.d).astype('float32')
+        xb = np.random.rand(self.nb, self.d).astype("float32")
         quantizer = faiss.IndexFlatL2(self.d)
         index = faiss.IndexIVFRaBitQ(quantizer, self.d, self.nlist)
         shard_count = 20
@@ -432,33 +417,27 @@ class TestIvfSharding(unittest.TestCase):
 
         template = str(random.randint(0, 100000)) + "shard.%d.rabitq.index"
         faiss.shard_ivf_index_centroids(
-            index,
-            shard_count,
-            template,
-            self.custom_sharding_function,
-            True
+            index, shard_count, template, self.custom_sharding_function, True
         )
         self.verify_sharded_ivf_indexes(
-            template, xb, shard_count, self.custom_sharding_function)
+            template, xb, shard_count, self.custom_sharding_function
+        )
 
     def test_save_index_shards_by_centroids_panorama(self):
         """Test sharding for IndexIVFFlatPanorama."""
-        xb = np.random.rand(self.nb, self.d).astype('float32')
+        xb = np.random.rand(self.nb, self.d).astype("float32")
         quantizer = faiss.IndexFlatL2(self.d)
         n_levels = 4
         index = faiss.IndexIVFFlatPanorama(
-            quantizer, self.d, self.nlist, n_levels)
+            quantizer, self.d, self.nlist, n_levels
+        )
         shard_count = 5
 
         index.quantizer.add(xb)
 
         template = str(random.randint(0, 100000)) + "shard.%d.panorama.index"
         faiss.shard_ivf_index_centroids(
-            index,
-            shard_count,
-            template,
-            None,
-            True
+            index, shard_count, template, None, True
         )
 
         # Verify shards are IndexIVFFlatPanorama after read-back
@@ -468,4 +447,5 @@ class TestIvfSharding(unittest.TestCase):
             self.assertIsInstance(shard, faiss.IndexIVFFlatPanorama)
 
         self.verify_sharded_ivf_indexes(
-            template, xb, shard_count, self.default_sharding_function)
+            template, xb, shard_count, self.default_sharding_function
+        )

--- a/tests/test_local_search_quantizer.py
+++ b/tests/test_local_search_quantizer.py
@@ -51,8 +51,8 @@ def compute_binary_terms_ref(codebooks):
     M, K, d = codebooks.shape
 
     codebooks_t = np.swapaxes(codebooks, 1, 2)  # [M, d, K]
-    binaries = 2 * codebooks.dot(codebooks_t)   # [M, K, M, K]
-    binaries = np.swapaxes(binaries, 1, 2)      # [M, M, K, K]
+    binaries = 2 * codebooks.dot(codebooks_t)  # [M, K, M, K]
+    binaries = np.swapaxes(binaries, 1, 2)  # [M, M, K, K]
 
     return binaries
 
@@ -127,7 +127,7 @@ class TestComponents(unittest.TestCase):
         n = 500
         M = 4
         nbits = 6
-        K = (1 << nbits)
+        K = 1 << nbits
 
         rs = np.random.RandomState(123)
         x = rs.rand(n, d).astype(np.float32)
@@ -148,15 +148,17 @@ class TestComponents(unittest.TestCase):
 
         np.testing.assert_allclose(decoded_x, decoded_x_ref, rtol=1e-6)
 
-    @unittest.skipIf(platform.system() == 'Windows',
-                     'Does not work on Windows after numpy 2 upgrade.')
+    @unittest.skipIf(
+        platform.system() == "Windows",
+        "Does not work on Windows after numpy 2 upgrade.",
+    )
     def test_update_codebooks(self):
         """Test codebooks updatation."""
         d = 16
         n = 500
         M = 4
         nbits = 6
-        K = (1 << nbits)
+        K = 1 << nbits
 
         # set a larger value to make the updating process more stable
         lambd = 1e-2
@@ -178,7 +180,9 @@ class TestComponents(unittest.TestCase):
 
         ref_codebooks = update_codebooks_ref(x, codes, K, lambd)
 
-        np.testing.assert_allclose(new_codebooks, ref_codebooks, rtol=1e-3, atol=1e-3)
+        np.testing.assert_allclose(
+            new_codebooks, ref_codebooks, rtol=1e-3, atol=1e-3
+        )
 
     def test_update_codebooks_with_double(self):
         """If the data is not zero-centering, it would be more accurate to
@@ -208,7 +212,7 @@ class TestComponents(unittest.TestCase):
         n = 500
         M = 4
         nbits = 6
-        K = (1 << nbits)
+        K = 1 << nbits
 
         rs = np.random.RandomState(123)
         x = rs.rand(n, d).astype(np.float32)
@@ -223,16 +227,14 @@ class TestComponents(unittest.TestCase):
         codebooks = codebooks.reshape(M, K, d).copy()
         ref_binaries = compute_binary_terms_ref(codebooks)
 
-        np.testing.assert_allclose(
-            binaries, ref_binaries, rtol=1e-4, atol=1e-4
-        )
+        np.testing.assert_allclose(binaries, ref_binaries, rtol=1e-4, atol=1e-4)
 
     def test_compute_unary_terms(self):
         d = 16
         n = 500
         M = 4
         nbits = 6
-        K = (1 << nbits)
+        K = 1 << nbits
 
         rs = np.random.RandomState(123)
         x = rs.rand(n, d).astype(np.float32)
@@ -254,7 +256,7 @@ class TestComponents(unittest.TestCase):
         n = 500
         M = 4
         nbits = 6
-        K = (1 << nbits)
+        K = 1 << nbits
 
         rs = np.random.RandomState(123)
 
@@ -276,12 +278,7 @@ class TestComponents(unittest.TestCase):
 
         # do icm encoding given binary and unary terms
         lsq = faiss.LocalSearchQuantizer(d, M, nbits)
-        lsq.icm_encode_step(
-            sp(new_codes),
-            sp(unaries),
-            sp(binaries),
-            n,
-            1)
+        lsq.icm_encode_step(sp(new_codes), sp(unaries), sp(binaries), n, 1)
 
         # do icm encoding given binary and unary terms in Python
         ref_codes = icm_encode_step_ref(unaries, binaries, codes)
@@ -292,7 +289,7 @@ class TestComponents(unittest.TestCase):
         n = 500
         M = 4
         nbits = 4
-        K = (1 << nbits)
+        K = 1 << nbits
 
         rs = np.random.RandomState(123)
         x = rs.rand(n, d).astype(np.float32)
@@ -313,12 +310,7 @@ class TestComponents(unittest.TestCase):
         new_codes = codes.copy()
 
         # do icm encoding given binary and unary terms
-        lsq.icm_encode_step(
-            sp(new_codes),
-            sp(unaries),
-            sp(binaries),
-            n,
-            1)
+        lsq.icm_encode_step(sp(new_codes), sp(unaries), sp(binaries), n, 1)
 
         # do icm encoding without pre-computed unary and binary terms in Python
         codebooks = faiss.vector_float_to_array(lsq.codebooks)
@@ -375,7 +367,8 @@ class TestIndexLocalSearchQuantizer(unittest.TestCase):
 
         AQ = faiss.AdditiveQuantizer
         ir2 = faiss.IndexLocalSearchQuantizer(
-            ds.d, 4, 5, faiss.METRIC_L2, AQ.ST_norm_float)
+            ds.d, 4, 5, faiss.METRIC_L2, AQ.ST_norm_float
+        )
 
         ir2.train(ds.get_train())  # just to set flags properly
         ir2.lsq.codebooks = ir.lsq.codebooks
@@ -419,22 +412,18 @@ class TestIndexLocalSearchQuantizer(unittest.TestCase):
         self.assertEqual(index.lsq.M, 5)
         self.assertEqual(index.lsq.K, 1 << 6)
         self.assertEqual(
-            index.lsq.search_type,
-            faiss.AdditiveQuantizer.ST_norm_qint8
+            index.lsq.search_type, faiss.AdditiveQuantizer.ST_norm_qint8
         )
 
         index = faiss.index_factory(20, "LSQ5x6_Ncqint8")
         self.assertEqual(
-            index.lsq.search_type,
-            faiss.AdditiveQuantizer.ST_norm_cqint8
+            index.lsq.search_type, faiss.AdditiveQuantizer.ST_norm_cqint8
         )
 
         index = faiss.index_factory(20, "LSQ5x6_Ncqint4")
         self.assertEqual(
-            index.lsq.search_type,
-            faiss.AdditiveQuantizer.ST_norm_cqint4
+            index.lsq.search_type, faiss.AdditiveQuantizer.ST_norm_cqint4
         )
-
 
 
 class TestIndexIVFLocalSearchQuantizer(unittest.TestCase):
@@ -445,14 +434,12 @@ class TestIndexIVFLocalSearchQuantizer(unittest.TestCase):
         self.assertEqual(index.lsq.M, 5)
         self.assertEqual(index.lsq.K, 1 << 6)
         self.assertEqual(
-            index.lsq.search_type,
-            faiss.AdditiveQuantizer.ST_norm_qint8
+            index.lsq.search_type, faiss.AdditiveQuantizer.ST_norm_qint8
         )
 
         index = faiss.index_factory(20, "IVF1024,LSQ5x6_Ncqint8")
         self.assertEqual(
-            index.lsq.search_type,
-            faiss.AdditiveQuantizer.ST_norm_cqint8
+            index.lsq.search_type, faiss.AdditiveQuantizer.ST_norm_cqint8
         )
 
     def eval_index_accuracy(self, factory_key):
@@ -663,8 +650,9 @@ class TestIndexIVFProductLocalSearchQuantizer(unittest.TestCase):
     def test_index_accuracy(self):
         self.eval_index_accuracy("IVF32,PLSQ2x2x5_Nqint8")
 
-    @unittest.skipIf(platform.system() == 'Windows',
-                     'Does not work on Windows-2022+.')
+    @unittest.skipIf(
+        platform.system() == "Windows", "Does not work on Windows-2022+."
+    )
     def test_index_accuracy2(self):
         """check that the error is in the same ballpark as LSQ."""
         inter1 = self.eval_index_accuracy("IVF32,PLSQ2x2x5_Nqint8")

--- a/tests/test_merge_index.py
+++ b/tests/test_merge_index.py
@@ -50,7 +50,7 @@ class TestMerge1(unittest.TestCase):
         # trains the quantizer
         ref_index.train(xt)
 
-        print('ref search')
+        print("ref search")
         ref_index.add(xb)
         _Dref, Iref = ref_index.search(xq, k)
         print(Iref[:5, :6])
@@ -68,15 +68,17 @@ class TestMerge1(unittest.TestCase):
         index = indexes[0]
 
         for i in range(1, ni):
-            print('merge ntotal=%d other.ntotal=%d ' % (
-                index.ntotal, indexes[i].ntotal))
+            print(
+                "merge ntotal=%d other.ntotal=%d "
+                % (index.ntotal, indexes[i].ntotal)
+            )
             index.merge_from(indexes[i], index.ntotal)
 
         _D, I = index.search(xq, k)
 
         ndiff = (I != Iref).sum()
-        print('%d / %d differences' % (ndiff, nq * k))
-        assert (ndiff < nq * k / 1000.)
+        print("%d / %d differences" % (ndiff, nq * k))
+        assert ndiff < nq * k / 1000.0
 
     def test_merge(self):
         self.do_test_merge(1)
@@ -98,13 +100,13 @@ class TestMerge1(unittest.TestCase):
             index.add(xb)
         else:
             gen = np.random.RandomState(1234)
-            id_list = gen.permutation(nb * 7)[:nb].astype('int64')
+            id_list = gen.permutation(nb * 7)[:nb].astype("int64")
             index.add_with_ids(xb, id_list)
 
-        print('ref search ntotal=%d' % index.ntotal)
+        print("ref search ntotal=%d" % index.ntotal)
         Dref, Iref = index.search(xq, k)
 
-        toremove = np.zeros(nq * k, dtype='int64')
+        toremove = np.zeros(nq * k, dtype="int64")
         nr = 0
         for i in range(nq):
             for j in range(k):
@@ -114,17 +116,16 @@ class TestMerge1(unittest.TestCase):
                     nr = nr + 1
                     toremove[nr] = Iref[i, j]
 
-        print('nr=', nr)
+        print("nr=", nr)
 
-        idsel = faiss.IDSelectorBatch(
-            nr, faiss.swig_ptr(toremove))
+        idsel = faiss.IDSelectorBatch(nr, faiss.swig_ptr(toremove))
 
         for i in range(nr):
-            assert (idsel.is_member(int(toremove[i])))
+            assert idsel.is_member(int(toremove[i]))
 
         nremoved = index.remove_ids(idsel)
 
-        print('nremoved=%d ntotal=%d' % (nremoved, index.ntotal))
+        print("nremoved=%d ntotal=%d" % (nremoved, index.ntotal))
 
         D, I = index.search(xq, k)
 
@@ -187,7 +188,8 @@ class TestMerge2(unittest.TestCase):
         # test both clone and index_read/write
         if True:
             index1 = faiss.deserialize_index(
-                faiss.serialize_index(index_trained))
+                faiss.serialize_index(index_trained)
+            )
         else:
             index1 = faiss.clone_index(index_trained)
         # assert index1.aq.qnorm.ntotal == index_trained.aq.qnorm.ntotal
@@ -223,7 +225,7 @@ class TestMerge2(unittest.TestCase):
     def do_test_with_ids(self, factory_key):
         ds = SyntheticDataset(32, 300, 300, 100)
         rs = np.random.RandomState(123)
-        ids = rs.choice(10000, ds.nb, replace=False).astype('int64')
+        ids = rs.choice(10000, ds.nb, replace=False).astype("int64")
         index1 = faiss.index_factory(ds.d, factory_key)
         index1.train(ds.get_train())
         index1.add_with_ids(ds.get_database(), ids)
@@ -248,10 +250,9 @@ class TestMerge2(unittest.TestCase):
 @for_all_simd_levels
 class TestRemoveFastScan(unittest.TestCase):
 
-    def do_fast_scan_test(self,
-                          factory_key,
-                          with_ids=False,
-                          direct_map_type=faiss.DirectMap.NoMap):
+    def do_fast_scan_test(
+        self, factory_key, with_ids=False, direct_map_type=faiss.DirectMap.NoMap
+    ):
         ds = SyntheticDataset(110, 1000, 1000, 100)
         index = faiss.index_factory(ds.d, factory_key)
         index.train(ds.get_train())
@@ -259,7 +260,9 @@ class TestRemoveFastScan(unittest.TestCase):
         index.reset()
         tokeep = [i % 3 == 0 for i in range(ds.nb)]
         if with_ids:
-            index.add_with_ids(ds.get_database()[tokeep], np.arange(ds.nb)[tokeep])
+            index.add_with_ids(
+                ds.get_database()[tokeep], np.arange(ds.nb)[tokeep]
+            )
             faiss.extract_index_ivf(index).nprobe = 5
         else:
             index.add(ds.get_database()[tokeep])
@@ -284,9 +287,11 @@ class TestRemoveFastScan(unittest.TestCase):
         self.do_fast_scan_test("IVF20,PQ5x4fs", True)
 
     def test_remove_IVFPQFastScan_2(self):
-        self.assertRaisesRegex(Exception,
-                               ".*not supported.*",
-                               self.do_fast_scan_test,
-                               "IVF20,PQ5x4fs",
-                               True,
-                               faiss.DirectMap.Hashtable)
+        self.assertRaisesRegex(
+            Exception,
+            ".*not supported.*",
+            self.do_fast_scan_test,
+            "IVF20,PQ5x4fs",
+            True,
+            faiss.DirectMap.Hashtable,
+        )

--- a/tests/test_meta_index.py
+++ b/tests/test_meta_index.py
@@ -33,7 +33,7 @@ class IDRemap(unittest.TestCase):
         _Dref, Iref = index.search(xq, k)
 
         # try a remapping
-        ids = np.arange(nb)[::-1].copy().astype('int64')
+        ids = np.arange(nb)[::-1].copy().astype("int64")
 
         sub_index = faiss.IndexPQ(d, 8, 8)
         index2 = faiss.IndexIDMap(sub_index)
@@ -52,8 +52,7 @@ class IDRemap(unittest.TestCase):
 
         # reference: index without remapping
 
-        index = faiss.IndexIVFPQ(coarse_quantizer, d,
-                                        ncentroids, 8, 8)
+        index = faiss.IndexIVFPQ(coarse_quantizer, d, ncentroids, 8, 8)
         index.nprobe = 5
         k = 10
         index.train(xt)
@@ -61,10 +60,9 @@ class IDRemap(unittest.TestCase):
         _Dref, Iref = index.search(xq, k)
 
         # try a remapping
-        ids = np.arange(nb)[::-1].copy().astype('int64')
+        ids = np.arange(nb)[::-1].copy().astype("int64")
 
-        index2 = faiss.IndexIVFPQ(coarse_quantizer, d,
-                                        ncentroids, 8, 8)
+        index2 = faiss.IndexIVFPQ(coarse_quantizer, d, ncentroids, 8, 8)
         index2.nprobe = 5
 
         index2.train(xt)
@@ -76,8 +74,10 @@ class IDRemap(unittest.TestCase):
 
 class Shards(unittest.TestCase):
 
-    @unittest.skipIf(os.name == "posix" and os.uname().sysname == "Darwin",
-                     "There is a bug in the OpenMP implementation on OSX.")
+    @unittest.skipIf(
+        os.name == "posix" and os.uname().sysname == "Darwin",
+        "There is a bug in the OpenMP implementation on OSX.",
+    )
     def test_shards(self):
         k = 32
         ref_index = faiss.IndexFlatL2(d)
@@ -87,9 +87,9 @@ class Shards(unittest.TestCase):
 
         # Create both threaded and non-threaded shard indexes
         shard_index_nonthreaded = faiss.IndexShards(
-            d, False)  # explicitly non-threaded
-        shard_index_threaded = faiss.IndexShards(
-            d, True)  # explicitly threaded
+            d, False
+        )  # explicitly non-threaded
+        shard_index_threaded = faiss.IndexShards(d, True)  # explicitly threaded
         shard_index_2 = faiss.IndexShards(d, True, False)
 
         ni = 3
@@ -138,7 +138,7 @@ class Shards(unittest.TestCase):
                 faiss.omp_set_num_threads(remember_nt)
 
             ndiff = (I != Iref).sum()
-            assert (ndiff < nq * k / 1000.)
+            assert ndiff < nq * k / 1000.0
 
     def test_shards_ivf(self):
         ds = SyntheticDataset(32, 1000, 100, 20)
@@ -151,10 +151,11 @@ class Shards(unittest.TestCase):
         ref_index.reset()
 
         sharded_index = faiss.IndexShardsIVF(
-            ref_index.quantizer, ref_index.nlist, False, True)
+            ref_index.quantizer, ref_index.nlist, False, True
+        )
         for shard in range(3):
             index_i = faiss.clone_index(ref_index)
-            index_i.add(xb[shard * nb // 3: (shard + 1)* nb // 3])
+            index_i.add(xb[shard * nb // 3 : (shard + 1) * nb // 3])
             sharded_index.add_shard(index_i)
 
         Dnew, Inew = sharded_index.search(ds.get_database(), 10)

--- a/tests/test_omp_threads_py.py
+++ b/tests/test_omp_threads_py.py
@@ -3,7 +3,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import faiss
 import unittest

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -11,7 +11,6 @@ import unittest
 from common_faiss_tests import for_all_simd_levels
 
 
-
 class PartitionTests:
 
     def test_partition(self):
@@ -43,7 +42,7 @@ class PartitionTests:
 
 
 def pointer_to_minus1():
-    return np.array([-1], dtype='int64').view("uint64")
+    return np.array([-1], dtype="int64").view("uint64")
 
 
 @for_all_simd_levels
@@ -55,27 +54,23 @@ class TestPartitioningFloat(unittest.TestCase, PartitionTests):
                 self.do_partition(n, q, maxval, i + 1234)
         rs = np.random.RandomState(seed)
         if maxval is None:
-            vals = rs.rand(n).astype('float32')
+            vals = rs.rand(n).astype("float32")
         else:
-            vals = rs.randint(maxval, size=n).astype('float32')
+            vals = rs.randint(maxval, size=n).astype("float32")
 
-        ids = (rs.permutation(n) + 12345).astype('int64')
+        ids = (rs.permutation(n) + 12345).astype("int64")
         dic = dict(zip(ids, vals))
 
         vals_orig = vals.copy()
 
         sp = faiss.swig_ptr
         if isinstance(q, int):
-            faiss.CMax_float_partition_fuzzy(
-                sp(vals), sp(ids), n,
-                q, q, None
-            )
+            faiss.CMax_float_partition_fuzzy(sp(vals), sp(ids), n, q, q, None)
         else:
             q_min, q_max = q
             q = pointer_to_minus1()
             faiss.CMax_float_partition_fuzzy(
-                sp(vals), sp(ids), n,
-                q_min, q_max, sp(q)
+                sp(vals), sp(ids), n, q_min, q_max, sp(q)
             )
             q = q[0]
             assert q_min <= q <= q_max
@@ -101,13 +96,13 @@ class TestPartitioningFloatMin(unittest.TestCase, PartitionTests):
                 self.do_partition(n, q, maxval, i + 1234)
         rs = np.random.RandomState(seed)
         if maxval is None:
-            vals = rs.rand(n).astype('float32')
+            vals = rs.rand(n).astype("float32")
             mirval = 1.0
         else:
-            vals = rs.randint(maxval, size=n).astype('float32')
+            vals = rs.randint(maxval, size=n).astype("float32")
             mirval = 65536
 
-        ids = (rs.permutation(n) + 12345).astype('int64')
+        ids = (rs.permutation(n) + 12345).astype("int64")
         dic = dict(zip(ids, vals))
 
         vals_orig = vals.copy()
@@ -116,16 +111,12 @@ class TestPartitioningFloatMin(unittest.TestCase, PartitionTests):
 
         sp = faiss.swig_ptr
         if isinstance(q, int):
-            faiss.CMin_float_partition_fuzzy(
-                sp(vals), sp(ids), n,
-                q, q, None
-            )
+            faiss.CMin_float_partition_fuzzy(sp(vals), sp(ids), n, q, q, None)
         else:
             q_min, q_max = q
             q = pointer_to_minus1()
             faiss.CMin_float_partition_fuzzy(
-                sp(vals), sp(ids), n,
-                q_min, q_max, sp(q)
+                sp(vals), sp(ids), n, q_min, q_max, sp(q)
             )
             q = q[0]
             assert q_min <= q <= q_max
@@ -153,8 +144,8 @@ class TestPartitioningUint16(unittest.TestCase, PartitionTests):
                 self.do_partition(n, q, maxval, i + 1234)
 
         rs = np.random.RandomState(seed)
-        vals = rs.randint(maxval, size=n).astype('uint16')
-        ids = (rs.permutation(n) + 12345).astype('int64')
+        vals = rs.randint(maxval, size=n).astype("uint16")
+        ids = (rs.permutation(n) + 12345).astype("int64")
         dic = dict(zip(ids, vals))
 
         sp = faiss.swig_ptr
@@ -165,13 +156,13 @@ class TestPartitioningUint16(unittest.TestCase, PartitionTests):
 
         if isinstance(q, int):
             faiss.CMax_uint16_partition_fuzzy(
-                tab_a.get(), sp(ids), n, q, q, None)
+                tab_a.get(), sp(ids), n, q, q, None
+            )
         else:
             q_min, q_max = q
             q = pointer_to_minus1()
             faiss.CMax_uint16_partition_fuzzy(
-                tab_a.get(), sp(ids), n,
-                q_min, q_max, sp(q)
+                tab_a.get(), sp(ids), n, q_min, q_max, sp(q)
             )
             q = q[0]
             assert q_min <= q <= q_max
@@ -194,31 +185,31 @@ class TestPartitioningUint16(unittest.TestCase, PartitionTests):
 class TestPartitioningUint16Min(unittest.TestCase, PartitionTests):
 
     def do_partition(self, n, q, maxval=65536, seed=None):
-        #seed = 1235
+        # seed = 1235
         if seed is None:
             for i in range(50):
                 self.do_partition(n, q, maxval, i + 1234)
         rs = np.random.RandomState(seed)
-        vals = rs.randint(maxval, size=n).astype('uint16')
-        ids = (rs.permutation(n) + 12345).astype('int64')
+        vals = rs.randint(maxval, size=n).astype("uint16")
+        ids = (rs.permutation(n) + 12345).astype("int64")
         dic = dict(zip(ids, vals))
 
         sp = faiss.swig_ptr
         vals_orig = vals.copy()
 
         tab_a = faiss.AlignedTableUint16()
-        vals_inv = (65535 - vals).astype('uint16')
+        vals_inv = (65535 - vals).astype("uint16")
         faiss.copy_array_to_AlignedTable(vals_inv, tab_a)
 
         if isinstance(q, int):
             faiss.CMin_uint16_partition_fuzzy(
-                tab_a.get(), sp(ids), n, q, q, None)
+                tab_a.get(), sp(ids), n, q, q, None
+            )
         else:
             q_min, q_max = q
             q = pointer_to_minus1()
             thresh2 = faiss.CMin_uint16_partition_fuzzy(
-                tab_a.get(), sp(ids), n,
-                q_min, q_max, sp(q)
+                tab_a.get(), sp(ids), n, q_min, q_max, sp(q)
             )
             q = q[0]
             assert q_min <= q <= q_max
@@ -243,14 +234,14 @@ class TestHistograms(unittest.TestCase):
 
     def do_test(self, nbin, n):
         rs = np.random.RandomState(123)
-        tab = rs.randint(nbin, size=n).astype('uint16')
+        tab = rs.randint(nbin, size=n).astype("uint16")
         ref_histogram = np.bincount(tab, minlength=nbin)
 
         tab_a = faiss.AlignedTableUint16()
         faiss.copy_array_to_AlignedTable(tab, tab_a)
 
         sp = faiss.swig_ptr
-        hist = np.zeros(nbin, 'int32')
+        hist = np.zeros(nbin, "int32")
         if nbin == 8:
             faiss.simd_histogram_8(tab_a.get(), n, 0, -1, sp(hist))
         elif nbin == 16:
@@ -271,11 +262,14 @@ class TestHistograms(unittest.TestCase):
     def test_16bin_odd(self):
         self.do_test(16, 123)
 
-
-    def do_test_bounded(self, nbin, n, shift=2, minv=500, rspan=None, seed=None):
+    def do_test_bounded(
+        self, nbin, n, shift=2, minv=500, rspan=None, seed=None
+    ):
         if seed is None:
             for run in range(50):
-                self.do_test_bounded(nbin, n, shift, minv, rspan, seed=123 + run)
+                self.do_test_bounded(
+                    nbin, n, shift, minv, rspan, seed=123 + run
+                )
             return
 
         if rspan is None:
@@ -284,7 +278,7 @@ class TestHistograms(unittest.TestCase):
             rmin, rmax = rspan
 
         rs = np.random.RandomState(seed)
-        tab = rs.randint(rmin, rmax, size=n).astype('uint16')
+        tab = rs.randint(rmin, rmax, size=n).astype("uint16")
         bc = np.bincount(tab, minlength=65536)
 
         binsize = 1 << shift
@@ -292,7 +286,7 @@ class TestHistograms(unittest.TestCase):
 
         def pad_and_reshape(x, m, n):
             xout = np.zeros(m * n, dtype=x.dtype)
-            xout[:x.size] = x
+            xout[: x.size] = x
             return xout.reshape(m, n)
 
         ref_histogram = pad_and_reshape(ref_histogram, nbin, binsize)
@@ -302,15 +296,11 @@ class TestHistograms(unittest.TestCase):
         faiss.copy_array_to_AlignedTable(tab, tab_a)
         sp = faiss.swig_ptr
 
-        hist = np.zeros(nbin, 'int32')
+        hist = np.zeros(nbin, "int32")
         if nbin == 8:
-            faiss.simd_histogram_8(
-                tab_a.get(), n, minv, shift, sp(hist)
-            )
+            faiss.simd_histogram_8(tab_a.get(), n, minv, shift, sp(hist))
         elif nbin == 16:
-            faiss.simd_histogram_16(
-                tab_a.get(), n, minv, shift, sp(hist)
-            )
+            faiss.simd_histogram_16(tab_a.get(), n, minv, shift, sp(hist))
         else:
             raise AssertionError()
 

--- a/tests/test_product_quantizer.py
+++ b/tests/test_product_quantizer.py
@@ -21,12 +21,12 @@ class TestProductQuantizer(unittest.TestCase):
         n = 2000
         cs = 4
         np.random.seed(123)
-        x = np.random.random(size=(n, d)).astype('float32')
+        x = np.random.random(size=(n, d)).astype("float32")
         pq = faiss.ProductQuantizer(d, cs, 8)
         pq.train(x)
         codes = pq.compute_codes(x)
         x2 = pq.decode(codes)
-        diff = ((x - x2)**2).sum()
+        diff = ((x - x2) ** 2).sum()
 
         # diff= 4418.0562
         self.assertGreater(5000, diff)
@@ -39,7 +39,7 @@ class TestProductQuantizer(unittest.TestCase):
         codes = pq10.compute_codes(x)
 
         x10 = pq10.decode(codes)
-        diff10 = ((x - x10)**2).sum()
+        diff10 = ((x - x10) ** 2).sum()
         self.assertGreater(diff, diff10)
 
     def do_test_codec(self, nbit):
@@ -47,15 +47,12 @@ class TestProductQuantizer(unittest.TestCase):
 
         # simulate training
         rs = np.random.RandomState(123)
-        centroids = rs.rand(2, 1 << nbit, 8).astype('float32')
+        centroids = rs.rand(2, 1 << nbit, 8).astype("float32")
         faiss.copy_array_to_vector(centroids.ravel(), pq.centroids)
 
         idx = rs.randint(1 << nbit, size=(100, 2))
         # can be encoded exactly
-        x = np.hstack((
-            centroids[0, idx[:, 0]],
-            centroids[1, idx[:, 1]]
-        ))
+        x = np.hstack((centroids[0, idx[:, 0]], centroids[1, idx[:, 1]]))
 
         # encode / decode
         codes = pq.compute_codes(x)
@@ -65,9 +62,10 @@ class TestProductQuantizer(unittest.TestCase):
         # encode w/ external index
         assign_index = faiss.IndexFlatL2(8)
         pq.assign_index = assign_index
-        codes2 = np.empty((100, pq.code_size), dtype='uint8')
+        codes2 = np.empty((100, pq.code_size), dtype="uint8")
         pq.compute_codes_with_assign_index(
-            faiss.swig_ptr(x), faiss.swig_ptr(codes2), 100)
+            faiss.swig_ptr(x), faiss.swig_ptr(codes2), 100
+        )
         assert np.all(codes == codes2)
 
     def test_codec(self):
@@ -81,7 +79,7 @@ class TestProductQuantizer(unittest.TestCase):
             self.skipTest("SIMDLevel.NONE not available")
         d, cs = 64, 4
         np.random.seed(123)
-        x = np.random.random(size=(2000, d)).astype('float32')
+        x = np.random.random(size=(2000, d)).astype("float32")
         for nbits in (4, 6, 8):
             with self.subTest(nbits=nbits):
                 pq = faiss.ProductQuantizer(d, cs, nbits)
@@ -99,7 +97,7 @@ class TestPQTransposedCentroids(unittest.TestCase):
         M = d // dsub
         pq = faiss.ProductQuantizer(d, M, 8)
         xt = faiss.randn((max(1000, pq.ksub * 50), d), 123)
-        pq.cp.niter = 4    # to avoid timeouts in tests
+        pq.cp.niter = 4  # to avoid timeouts in tests
         pq.train(xt)
 
         codes = pq.compute_codes(xt)
@@ -144,7 +142,7 @@ class TestPQTables(unittest.TestCase):
         M = d // dsub
         pq = faiss.ProductQuantizer(d, M, nbit)
         xt = faiss.randn((max(1000, pq.ksub * 50), d), 123)
-        pq.cp.niter = 4    # to avoid timeouts in tests
+        pq.cp.niter = 4  # to avoid timeouts in tests
         pq.train(xt)
 
         centroids = faiss.vector_to_array(pq.centroids)
@@ -189,7 +187,9 @@ class TestPQTables(unittest.TestCase):
         new_sdc_tab = new_sdc_tab.reshape(M, pq.ksub, pq.ksub)
 
         np.testing.assert_array_almost_equal(ref_tab, new_tab, decimal=5)
-        np.testing.assert_array_almost_equal(ref_sdc_tab, new_sdc_tab, decimal=5)
+        np.testing.assert_array_almost_equal(
+            ref_sdc_tab, new_sdc_tab, decimal=5
+        )
 
     def test_dsub2(self):
         self.do_test(16, 2)
@@ -207,7 +207,7 @@ class TestPQTables(unittest.TestCase):
         self.do_test(36, 4)
 
     # too slow
-    #def test_12bit(self):
+    # def test_12bit(self):
     #    self.do_test(32, 4, nbit=12)
 
     def test_4bit(self):

--- a/tests/test_rabitq.py
+++ b/tests/test_rabitq.py
@@ -487,9 +487,7 @@ def create_index_ivf_rabitq_with_rotation(
 ):
     """Helper: Create IndexIVFRaBitQ with random rotation."""
     quantizer = faiss.IndexFlat(d, metric)
-    index_rbq = faiss.IndexIVFRaBitQ(
-        quantizer, d, nlist, metric, True, nb_bits
-    )
+    index_rbq = faiss.IndexIVFRaBitQ(quantizer, d, nlist, metric, True, nb_bits)
     index_rbq.qb = qb
     index_rbq.nprobe = nprobe
     rrot = faiss.RandomRotationMatrix(d, d)
@@ -587,13 +585,9 @@ class TestMultiBitRaBitQ(unittest.TestCase):
         # Invalid nb_bits
         quantizer = faiss.IndexFlat(d, faiss.METRIC_L2)
         with self.assertRaises(RuntimeError):
-            faiss.IndexIVFRaBitQ(
-                quantizer, d, nlist, faiss.METRIC_L2, True, 0
-            )
+            faiss.IndexIVFRaBitQ(quantizer, d, nlist, faiss.METRIC_L2, True, 0)
         with self.assertRaises(RuntimeError):
-            faiss.IndexIVFRaBitQ(
-                quantizer, d, nlist, faiss.METRIC_L2, True, 10
-            )
+            faiss.IndexIVFRaBitQ(quantizer, d, nlist, faiss.METRIC_L2, True, 10)
 
     # ==================== Basic Operations Tests ====================
 
@@ -626,7 +620,7 @@ class TestMultiBitRaBitQ(unittest.TestCase):
     def test_recall_quality(self):
         """Test that recall is reasonable for various configurations."""
         for metric in [faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT]:
-            metric_str = 'L2' if metric == faiss.METRIC_L2 else 'IP'
+            metric_str = "L2" if metric == faiss.METRIC_L2 else "IP"
             ds = datasets.SyntheticDataset(
                 128, 500, 1000, 50, metric=metric_str
             )
@@ -641,15 +635,13 @@ class TestMultiBitRaBitQ(unittest.TestCase):
                         index.train(ds.get_train())
                         index.add(ds.get_database())
                         _, I = index.search(ds.get_queries(), 10)
-                        recall = faiss.eval_intersection(
-                            I, I_gt
-                        ) / (ds.nq * 10)
+                        recall = faiss.eval_intersection(I, I_gt) / (ds.nq * 10)
                         self.assertGreater(recall, 0.10)
 
     def test_recall_monotonic_improvement(self):
         """Test that recall improves with more bits."""
         for metric in [faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT]:
-            metric_str = 'L2' if metric == faiss.METRIC_L2 else 'IP'
+            metric_str = "L2" if metric == faiss.METRIC_L2 else "IP"
             ds = datasets.SyntheticDataset(
                 128, 500, 1000, 50, metric=metric_str
             )
@@ -665,9 +657,9 @@ class TestMultiBitRaBitQ(unittest.TestCase):
                         index.train(ds.get_train())
                         index.add(ds.get_database())
                         _, I = index.search(ds.get_queries(), 10)
-                        recalls[nb_bits] = faiss.eval_intersection(
-                            I, I_gt
-                        ) / (ds.nq * 10)
+                        recalls[nb_bits] = faiss.eval_intersection(I, I_gt) / (
+                            ds.nq * 10
+                        )
 
                     # Monotonic improvement with tolerance
                     tolerance = 0.03
@@ -745,7 +737,7 @@ class TestMultiBitRaBitQ(unittest.TestCase):
     def test_ivf_nprobe_improves_recall(self):
         """Test that higher nprobe improves recall."""
         for metric in [faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT]:
-            metric_str = 'L2' if metric == faiss.METRIC_L2 else 'IP'
+            metric_str = "L2" if metric == faiss.METRIC_L2 else "IP"
             ds = datasets.SyntheticDataset(
                 128, 500, 1000, 50, metric=metric_str
             )
@@ -767,9 +759,9 @@ class TestMultiBitRaBitQ(unittest.TestCase):
                     for nprobe in [1, 2, 4, 8]:
                         index_rbq.nprobe = nprobe
                         _, I = index.search(ds.get_queries(), 10)
-                        recalls[nprobe] = faiss.eval_intersection(
-                            I, I_gt
-                        ) / (ds.nq * 10)
+                        recalls[nprobe] = faiss.eval_intersection(I, I_gt) / (
+                            ds.nq * 10
+                        )
 
                     self.assertGreaterEqual(recalls[2], recalls[1])
                     self.assertGreaterEqual(recalls[4], recalls[2])
@@ -835,9 +827,7 @@ class TestMultiBitRaBitQ(unittest.TestCase):
                         params = faiss.RaBitQSearchParameters()
                         params.qb = qb
                         params.centered = False
-                        D, I = index.search(
-                            ds.get_queries(), 10, params=params
-                        )
+                        D, I = index.search(ds.get_queries(), 10, params=params)
 
                         self.assertEqual(D.shape, (ds.nq, 10))
                         self.assertTrue(np.all(I >= 0))
@@ -938,9 +928,11 @@ class TestMultiBitRaBitQ(unittest.TestCase):
                         true_dist = float(np.sum((query - centroid) ** 2))
 
                     np.testing.assert_allclose(
-                        D[0, 0], true_dist, atol=0.15,
-                        err_msg=f"nb_bits={nb_bits}")
-
+                        D[0, 0],
+                        true_dist,
+                        atol=0.15,
+                        err_msg=f"nb_bits={nb_bits}",
+                    )
 
 
 if __name__ == "__main__":

--- a/tests/test_rabitq_fastscan.py
+++ b/tests/test_rabitq_fastscan.py
@@ -26,15 +26,19 @@ def compute_expected_code_size(d, nb_bits):
 
 
 def _create_fastscan_index(
-    d, metric, use_ivf=False,
-    nlist=16, nprobe=4, bbs=32, nb_bits=1,
+    d,
+    metric,
+    use_ivf=False,
+    nlist=16,
+    nprobe=4,
+    bbs=32,
+    nb_bits=1,
 ):
     """Create FastScan index (IVF or non-IVF)."""
     if use_ivf:
         quantizer = faiss.IndexFlat(d, metric)
         index = faiss.IndexIVFRaBitQFastScan(
-            quantizer, d, nlist, metric, bbs,
-            True, nb_bits
+            quantizer, d, nlist, metric, bbs, True, nb_bits
         )
         index.nprobe = nprobe
     else:
@@ -50,13 +54,22 @@ class TestRaBitQFastScan(unittest.TestCase):
     NPROBE = 4
 
     def _create_index(
-        self, d, metric, use_ivf=False,
-        nlist=None, bbs=32, nb_bits=1,
+        self,
+        d,
+        metric,
+        use_ivf=False,
+        nlist=None,
+        bbs=32,
+        nb_bits=1,
     ):
         return _create_fastscan_index(
-            d, metric, use_ivf=use_ivf,
-            nlist=nlist or self.NLIST, nprobe=self.NPROBE,
-            bbs=bbs, nb_bits=nb_bits,
+            d,
+            metric,
+            use_ivf=use_ivf,
+            nlist=nlist or self.NLIST,
+            nprobe=self.NPROBE,
+            bbs=bbs,
+            nb_bits=nb_bits,
         )
 
     def _create_baseline(self, d, metric, use_ivf=False, nlist=None):
@@ -134,9 +147,7 @@ class TestRaBitQFastScan(unittest.TestCase):
                     )
                 else:
                     # Non-IVF: use sa_encode + sa_decode
-                    index_fs = faiss.IndexRaBitQFastScan(
-                        ds.d, faiss.METRIC_L2
-                    )
+                    index_fs = faiss.IndexRaBitQFastScan(ds.d, faiss.METRIC_L2)
                     index_fs.train(ds.get_train())
 
                     codes_fs = np.empty(
@@ -145,7 +156,7 @@ class TestRaBitQFastScan(unittest.TestCase):
                     index_fs.compute_codes(
                         faiss.swig_ptr(codes_fs),
                         len(test_vectors),
-                        faiss.swig_ptr(test_vectors)
+                        faiss.swig_ptr(test_vectors),
                     )
                     decoded_fs = index_fs.sa_decode(codes_fs)
 
@@ -174,7 +185,9 @@ class TestRaBitQFastScan(unittest.TestCase):
                     ds = datasets.SyntheticDataset(128, 1000, 200, 20)
 
                     index = self._create_index(
-                        128, faiss.METRIC_L2, use_ivf,
+                        128,
+                        faiss.METRIC_L2,
+                        use_ivf,
                         nb_bits=nb_bits,
                     )
                     index.train(ds.get_train())
@@ -224,7 +237,7 @@ class TestRaBitQFastScan(unittest.TestCase):
 
                 I_gt = ds.get_groundtruth(5)
                 recall = faiss.eval_intersection(I[:, :5], I_gt[:, :5])
-                recall /= (ds.nq * 5)
+                recall /= ds.nq * 5
                 np.testing.assert_(recall > 0.1)
 
     # ==================== Thread Safety Tests ====================
@@ -260,7 +273,8 @@ class TestRaBitQFastScan(unittest.TestCase):
             with self.subTest(use_ivf=use_ivf):
                 factory_str = f"IVF{nlist},RaBitQfs" if use_ivf else "RaBitQfs"
                 expected_type = (
-                    faiss.IndexIVFRaBitQFastScan if use_ivf
+                    faiss.IndexIVFRaBitQFastScan
+                    if use_ivf
                     else faiss.IndexRaBitQFastScan
                 )
 
@@ -397,16 +411,14 @@ class TestRaBitQFastScan(unittest.TestCase):
 
                 params_fs = faiss.IVFSearchParameters()
                 params_fs.nprobe = nprobe
-                _, I_fs = index_fs.search(
-                    ds.get_queries(), k, params=params_fs
-                )
+                _, I_fs = index_fs.search(ds.get_queries(), k, params=params_fs)
 
                 eval_base = faiss.eval_intersection(
                     I_base[:, :k], I_gt[:, :k]
                 ) / (ds.nq * k)
-                eval_fs = faiss.eval_intersection(
-                    I_fs[:, :k], I_gt[:, :k]
-                ) / (ds.nq * k)
+                eval_fs = faiss.eval_intersection(I_fs[:, :k], I_gt[:, :k]) / (
+                    ds.nq * k
+                )
 
                 np.testing.assert_(abs(eval_base - eval_fs) < 0.01)
 
@@ -434,9 +446,9 @@ class TestRaBitQFastScan(unittest.TestCase):
         params_base.centered = False
         _, I_base = index_base.search(ds.get_queries(), k, params=params_base)
 
-        eval_base = faiss.eval_intersection(
-            I_base[:, :k], I_gt[:, :k]
-        ) / (ds.nq * k)
+        eval_base = faiss.eval_intersection(I_base[:, :k], I_gt[:, :k]) / (
+            ds.nq * k
+        )
 
         # FastScan with specific implementation
         quantizer2 = faiss.IndexFlat(ds.d, faiss.METRIC_L2)
@@ -454,9 +466,9 @@ class TestRaBitQFastScan(unittest.TestCase):
         params_fs.nprobe = nprobe
         _, I_fs = index_fs.search(ds.get_queries(), k, params=params_fs)
 
-        eval_fs = faiss.eval_intersection(
-            I_fs[:, :k], I_gt[:, :k]
-        ) / (ds.nq * k)
+        eval_fs = faiss.eval_intersection(I_fs[:, :k], I_gt[:, :k]) / (
+            ds.nq * k
+        )
 
         np.testing.assert_(abs(eval_base - eval_fs) < 0.05)
 
@@ -488,9 +500,7 @@ class TestRaBitQFastScan(unittest.TestCase):
         params = faiss.IVFSearchParameters()
         params.nprobe = nprobe
 
-        D, I = faiss.search_with_parameters(
-            index, ds.get_queries(), k, params
-        )
+        D, I = faiss.search_with_parameters(index, ds.get_queries(), k, params)
 
         self.assertEqual(D.shape, (nq, k))
         self.assertEqual(I.shape, (nq, k))
@@ -536,10 +546,12 @@ class TestIVFRaBitQFastScanFiltering(unittest.TestCase):
             sel = faiss.IDSelectorBatch(subset)
             allowed = set(subset.tolist())
         elif selector_type == "whole_block_not":
-            excluded = np.concatenate([
-                np.arange(0, min(32, nb), dtype="int64"),
-                np.arange(64, min(96, nb), dtype="int64"),
-            ])
+            excluded = np.concatenate(
+                [
+                    np.arange(0, min(32, nb), dtype="int64"),
+                    np.arange(64, min(96, nb), dtype="int64"),
+                ]
+            )
             inner_sel = faiss.IDSelectorBatch(excluded)
             sel = faiss.IDSelectorNot(inner_sel)
             allowed = {i for i in range(nb) if i not in excluded}
@@ -633,8 +645,7 @@ class TestMultiBitRaBitQFastScan(unittest.TestCase):
             self.assertEqual(index.code_size, expected_size)
 
     def test_ivf_construction(self):
-        """Test IndexIVFRaBitQFastScan construction with valid/invalid nb_bits.
-        """
+        """Test IndexIVFRaBitQFastScan construction with valid/invalid nb_bits."""
         d, nlist = 128, 16
         # Valid nb_bits
         for nb_bits in [1, 2, 4, 8]:
@@ -711,7 +722,7 @@ class TestMultiBitRaBitQFastScan(unittest.TestCase):
     def test_recall_monotonic_improvement(self):
         """Test that recall improves with more bits."""
         for metric in [faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT]:
-            metric_str = 'L2' if metric == faiss.METRIC_L2 else 'IP'
+            metric_str = "L2" if metric == faiss.METRIC_L2 else "IP"
             ds = datasets.SyntheticDataset(
                 128, 500, 1000, 50, metric=metric_str
             )
@@ -728,9 +739,9 @@ class TestMultiBitRaBitQFastScan(unittest.TestCase):
                         index.train(ds.get_train())
                         index.add(ds.get_database())
                         _, I = index.search(ds.get_queries(), 10)
-                        recalls[nb_bits] = faiss.eval_intersection(
-                            I, I_gt
-                        ) / (ds.nq * 10)
+                        recalls[nb_bits] = faiss.eval_intersection(I, I_gt) / (
+                            ds.nq * 10
+                        )
 
                     tolerance = 0.03
                     self.assertGreaterEqual(recalls[2], recalls[1] - tolerance)
@@ -754,9 +765,7 @@ class TestMultiBitRaBitQFastScan(unittest.TestCase):
             index.train(ds.get_train())
             index.add(ds.get_database())
             _, I = index.search(ds.get_queries(), 10)
-            recalls[nb_bits] = faiss.eval_intersection(
-                I, I_gt
-            ) / (ds.nq * 10)
+            recalls[nb_bits] = faiss.eval_intersection(I, I_gt) / (ds.nq * 10)
 
         self.assertGreater(recalls[2], recalls[1])
         self.assertGreater(recalls[4], recalls[2])
@@ -808,8 +817,7 @@ class TestMultiBitRaBitQFastScan(unittest.TestCase):
         d, nlist, nprobe, k = 128, 16, 4, 10
         ds = datasets.SyntheticDataset(d, 1000, 1000, 50)
 
-        if not faiss.SIMDConfig.is_simd_level_available(
-                faiss.SIMDLevel_NONE):
+        if not faiss.SIMDConfig.is_simd_level_available(faiss.SIMDLevel_NONE):
             self.skipTest("SIMDLevel.NONE not available")
 
         for metric in [faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT]:
@@ -834,10 +842,8 @@ class TestMultiBitRaBitQFastScan(unittest.TestCase):
                     _, I_fs_simd = index_fs.search(ds.get_queries(), k)
 
                     with NoneSIMDLevel():
-                        _, I_rbq_none = index_rbq.search(
-                            ds.get_queries(), k)
-                        _, I_fs_none = index_fs.search(
-                            ds.get_queries(), k)
+                        _, I_rbq_none = index_rbq.search(ds.get_queries(), k)
+                        _, I_fs_none = index_fs.search(ds.get_queries(), k)
 
                     np.testing.assert_array_equal(I_rbq_simd, I_rbq_none)
                     np.testing.assert_array_equal(I_fs_simd, I_fs_none)
@@ -928,9 +934,7 @@ class TestMultiBitRaBitQFastScan(unittest.TestCase):
                     index.add(test_vectors)
 
                     reconstructed = index.reconstruct_n(0, len(test_vectors))
-                    errors = np.sum(
-                        (test_vectors - reconstructed) ** 2, axis=1
-                    )
+                    errors = np.sum((test_vectors - reconstructed) ** 2, axis=1)
                     avg_error = np.mean(errors)
 
                     self.assertTrue(np.all(np.isfinite(reconstructed)))
@@ -946,16 +950,17 @@ class TestMultiBitRaBitQFastScan(unittest.TestCase):
                     with self.subTest(
                         use_ivf=use_ivf, nb_bits=nb_bits, metric=metric
                     ):
-                        metric_str = (
-                            "L2" if metric == faiss.METRIC_L2 else "IP"
-                        )
+                        metric_str = "L2" if metric == faiss.METRIC_L2 else "IP"
                         ds = datasets.SyntheticDataset(
                             d, 500, 100, 10, metric=metric_str
                         )
 
                         index = _create_fastscan_index(
-                            d, metric, use_ivf=use_ivf,
-                            nlist=nlist, nb_bits=nb_bits,
+                            d,
+                            metric,
+                            use_ivf=use_ivf,
+                            nlist=nlist,
+                            nb_bits=nb_bits,
                         )
                         if use_ivf:
                             index.nprobe = nlist
@@ -1108,19 +1113,18 @@ class TestRaBitQFastScanSearchParams(unittest.TestCase):
         _, I_qb4 = index.search(ds.get_queries(), k, params=params_qb4)
 
         # Compute recall@k
-        recall_qb1 = np.mean([
-            len(np.intersect1d(I_qb1[i], I_gt[i])) / k
-            for i in range(ds.nq)
-        ])
-        recall_qb4 = np.mean([
-            len(np.intersect1d(I_qb4[i], I_gt[i])) / k
-            for i in range(ds.nq)
-        ])
+        recall_qb1 = np.mean(
+            [len(np.intersect1d(I_qb1[i], I_gt[i])) / k for i in range(ds.nq)]
+        )
+        recall_qb4 = np.mean(
+            [len(np.intersect1d(I_qb4[i], I_gt[i])) / k for i in range(ds.nq)]
+        )
 
         self.assertGreater(
-            recall_qb4, recall_qb1,
+            recall_qb4,
+            recall_qb1,
             f"qb=4 recall ({recall_qb4:.3f}) should be higher "
-            f"than qb=1 recall ({recall_qb1:.3f})"
+            f"than qb=1 recall ({recall_qb1:.3f})",
         )
 
 

--- a/tests/test_referenced_objects.py
+++ b/tests/test_referenced_objects.py
@@ -4,7 +4,12 @@
 # LICENSE file in the root directory of this source tree.
 
 """make sure that the referenced objects are kept"""
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import numpy as np
 import unittest
@@ -13,8 +18,8 @@ import sys
 import gc
 
 d = 10
-xt = np.random.rand(100, d).astype('float32')
-xb = np.random.rand(20, d).astype('float32')
+xt = np.random.rand(100, d).astype("float32")
+xb = np.random.rand(20, d).astype("float32")
 
 
 class TestReferenced(unittest.TestCase):
@@ -70,10 +75,10 @@ class TestReferenced(unittest.TestCase):
     def test_IDMap(self):
         sub_index = faiss.IndexFlatL2(d)
         index = faiss.IndexIDMap(sub_index)
-        index.add_with_ids(xb, np.arange(len(xb), dtype='int64'))
+        index.add_with_ids(xb, np.arange(len(xb), dtype="int64"))
         del sub_index
         gc.collect()
-        index.add_with_ids(xb, np.arange(len(xb), dtype='int64'))
+        index.add_with_ids(xb, np.arange(len(xb), dtype="int64"))
 
     def test_shards(self):
         index = faiss.IndexShards(d)
@@ -157,8 +162,8 @@ class TestReferenced(unittest.TestCase):
 
 
 dbin = 32
-xtbin = np.random.randint(256, size=(100, int(dbin / 8))).astype('uint8')
-xbbin = np.random.randint(256, size=(20, int(dbin / 8))).astype('uint8')
+xtbin = np.random.randint(256, size=(100, int(dbin / 8))).astype("uint8")
+xbbin = np.random.randint(256, size=(20, int(dbin / 8))).astype("uint8")
 
 
 class TestReferencedBinary(unittest.TestCase):
@@ -173,5 +178,6 @@ class TestReferencedBinary(unittest.TestCase):
         gc.collect()
         index.add(xbbin)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_refine.py
+++ b/tests/test_refine.py
@@ -37,8 +37,7 @@ class TestDistanceComputer(unittest.TestCase):
                 for j in range(10):
                     ref_dis = Dref[q, j]
                     new_dis = dc(int(Iref[q, j]))
-                    np.testing.assert_almost_equal(
-                        new_dis, ref_dis, decimal=5)
+                    np.testing.assert_almost_equal(new_dis, ref_dis, decimal=5)
 
     def test_distance_computer_PQ(self):
         self.do_test("PQ8np")
@@ -59,10 +58,10 @@ class TestDistanceComputer(unittest.TestCase):
         self.do_test("PCA20,SQ8")
 
     def test_distance_computer_AQ_decompress(self):
-        self.do_test("RQ3x4")    # test decompress path
+        self.do_test("RQ3x4")  # test decompress path
 
     def test_distance_computer_AQ_LUT(self):
-        self.do_test("RQ3x4_Nqint8")    # test LUT path
+        self.do_test("RQ3x4_Nqint8")  # test LUT path
 
     def test_distance_computer_AQ_LUT_IP(self):
         self.do_test("RQ3x4_Nqint8", faiss.METRIC_INNER_PRODUCT)
@@ -80,10 +79,9 @@ class TestIndexRefineSearchParams(unittest.TestCase):
 
         # Set nprobe on the base index (for IndexRefine, nprobe belongs to
         # the IVF base index)
-        if hasattr(index, 'base_index') and hasattr(
-                index.base_index, 'nprobe'):
+        if hasattr(index, "base_index") and hasattr(index.base_index, "nprobe"):
             index.base_index.nprobe = 4
-        elif hasattr(index, 'nprobe'):
+        elif hasattr(index, "nprobe"):
             index.nprobe = 4
 
         xq = ds.get_queries()
@@ -111,12 +109,16 @@ class TestIndexRefineSearchParams(unittest.TestCase):
 
         # try passing params for the baseline index, change nprobe
         base_params = faiss.IVFSearchParameters(nprobe=10)
-        params = faiss.IndexRefineSearchParameters(k_factor=1, base_index_params=base_params)
+        params = faiss.IndexRefineSearchParameters(
+            k_factor=1, base_index_params=base_params
+        )
         D4, I4 = index.search(xq, 10, params=params)
         inter4 = faiss.eval_intersection(I4, ds.get_groundtruth(10))
 
         base_params = faiss.IVFSearchParameters(nprobe=2)
-        params = faiss.IndexRefineSearchParameters(k_factor=1, base_index_params=base_params)
+        params = faiss.IndexRefineSearchParameters(
+            k_factor=1, base_index_params=base_params
+        )
         D5, I5 = index.search(xq, 10, params=params)
         inter5 = faiss.eval_intersection(I5, ds.get_groundtruth(10))
 
@@ -174,10 +176,11 @@ class TestIndexRefineRangeSearch(unittest.TestCase):
             end_lim = lims_2[iq + 1]
             for i_lim in range(start_lim, end_lim):
                 idx = I2[i_lim]
-                l2_dis = np.sum(np.square(xq[iq : iq + 1,] - xb[idx : idx + 1,]))
+                l2_dis = np.sum(
+                    np.square(xq[iq : iq + 1,] - xb[idx : idx + 1,])
+                )
 
                 self.assertAlmostEqual(l2_dis, D2[i_lim], places=4)
-
 
     def test_refine_1(self):
         self.do_test("SQ4")

--- a/tests/test_refine_panorama.py
+++ b/tests/test_refine_panorama.py
@@ -116,13 +116,16 @@ class TestIndexRefinePanorama(unittest.TestCase):
                 # Build two identical refine indexes
                 base_cfg = "Flat"
                 index_flat = self.create_flat(
-                    d, base_cfg, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, xt=xt, xb=xb, metric=metric
+                )
                 index_pan = self.create_panorama(
-                    d, base_cfg, n_levels, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, n_levels, xt=xt, xb=xb, metric=metric
+                )
 
                 for k_factor in [1, 8, 64, 256, 1024, 50000]:
                     params = faiss.IndexRefineSearchParameters(
-                        k_factor=float(k_factor))
+                        k_factor=float(k_factor)
+                    )
 
                     D_flat, I_flat = index_flat.search(xq, k, params=params)
                     D_pano, I_pano = index_pan.search(xq, k, params=params)
@@ -140,7 +143,8 @@ class TestIndexRefinePanorama(unittest.TestCase):
 
         for metric in self.METRICS:
             index_base = self.create_flat(
-                d, base_cfg, xt=xt, xb=xb, metric=metric)
+                d, base_cfg, xt=xt, xb=xb, metric=metric
+            )
             D_base, I_base = index_base.search(xq, k)
 
             params = faiss.IndexRefineSearchParameters(k_factor=1000)
@@ -153,14 +157,14 @@ class TestIndexRefinePanorama(unittest.TestCase):
                 with self.subTest(metric=metric, nlevels=nlevels):
                     faiss.cvar.indexPanorama_stats.reset()
                     index = self.create_panorama(
-                        d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                        d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                    )
                     D, I = index.search(xq, k, params=params)
                     self.assert_search_results_equal(D_base, I_base, D, I)
 
                     stats = faiss.cvar.indexPanorama_stats
                     ratio_dims_scanned = stats.ratio_dims_scanned
-                    self.assertLess(ratio_dims_scanned,
-                                    prev_ratio_dims_scanned)
+                    self.assertLess(ratio_dims_scanned, prev_ratio_dims_scanned)
                     prev_ratio_dims_scanned = ratio_dims_scanned
 
             faiss.omp_set_num_threads(nt_threads)
@@ -177,9 +181,11 @@ class TestIndexRefinePanorama(unittest.TestCase):
 
                     base_cfg = "Flat"
                     index_regular = self.create_flat(
-                        d, base_cfg, xt=xt, xb=xb, metric=metric)
+                        d, base_cfg, xt=xt, xb=xb, metric=metric
+                    )
                     index_panorama = self.create_panorama(
-                        d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                        d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                    )
 
                     D_regular, I_regular = index_regular.search(xq, k)
                     D_panorama, I_panorama = index_panorama.search(xq, k)
@@ -198,15 +204,18 @@ class TestIndexRefinePanorama(unittest.TestCase):
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(
-                    d, base_cfg, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, xt=xt, xb=xb, metric=metric
+                )
                 index_panorama = self.create_panorama(
-                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                )
 
                 D_regular, I_regular = index_regular.search(xq, k)
                 D_panorama, I_panorama = index_panorama.search(xq, k)
 
                 self.assert_search_results_equal(
-                    D_regular, I_regular, D_panorama, I_panorama)
+                    D_regular, I_regular, D_panorama, I_panorama
+                )
 
     def test_multiple_levels_small_dimension(self):
         """Test edge case: more levels than dimension naturally supports"""
@@ -218,15 +227,18 @@ class TestIndexRefinePanorama(unittest.TestCase):
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(
-                    d, base_cfg, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, xt=xt, xb=xb, metric=metric
+                )
                 index_panorama = self.create_panorama(
-                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                )
 
                 D_regular, I_regular = index_regular.search(xq, k)
                 D_panorama, I_panorama = index_panorama.search(xq, k)
 
                 self.assert_search_results_equal(
-                    D_regular, I_regular, D_panorama, I_panorama)
+                    D_regular, I_regular, D_panorama, I_panorama
+                )
 
     def test_id_selector_range(self):
         """Test ID filtering with range selector"""
@@ -238,19 +250,24 @@ class TestIndexRefinePanorama(unittest.TestCase):
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(
-                    d, base_cfg, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, xt=xt, xb=xb, metric=metric
+                )
                 index_panorama = self.create_panorama(
-                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                )
 
                 base_params = faiss.SearchParameters()
                 base_params.sel = faiss.IDSelectorRange(10000, 50000)
                 params = faiss.IndexRefineSearchParameters(
-                    k_factor=1, base_index_params=base_params)
+                    k_factor=1, base_index_params=base_params
+                )
 
                 D_regular, I_regular = index_regular.search(
-                    xq, k, params=params)
+                    xq, k, params=params
+                )
                 D_panorama, I_panorama = index_panorama.search(
-                    xq, k, params=params)
+                    xq, k, params=params
+                )
 
                 self.assertTrue(np.all(I_panorama >= 10000))
                 self.assertTrue(np.all(I_panorama < 50000))
@@ -268,21 +285,27 @@ class TestIndexRefinePanorama(unittest.TestCase):
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(
-                    d, base_cfg, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, xt=xt, xb=xb, metric=metric
+                )
                 index_panorama = self.create_panorama(
-                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                )
 
                 allowed_ids = np.array(
-                    [i * 100 for i in range(500)], dtype=np.int64)
+                    [i * 100 for i in range(500)], dtype=np.int64
+                )
                 base_params = faiss.SearchParameters()
                 base_params.sel = faiss.IDSelectorBatch(allowed_ids)
                 params = faiss.IndexRefineSearchParameters(
-                    k_factor=1, base_index_params=base_params)
+                    k_factor=1, base_index_params=base_params
+                )
 
                 D_regular, I_regular = index_regular.search(
-                    xq, k, params=params)
+                    xq, k, params=params
+                )
                 D_panorama, I_panorama = index_panorama.search(
-                    xq, k, params=params)
+                    xq, k, params=params
+                )
 
                 allowed_set = set(allowed_ids)
                 for id_val in I_panorama.flatten():
@@ -301,19 +324,24 @@ class TestIndexRefinePanorama(unittest.TestCase):
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(
-                    d, base_cfg, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, xt=xt, xb=xb, metric=metric
+                )
                 index_panorama = self.create_panorama(
-                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                )
 
                 base_params = faiss.SearchParameters()
                 base_params.sel = faiss.IDSelectorRange(20, 60)
                 params = faiss.IndexRefineSearchParameters(
-                    k_factor=1, base_index_params=base_params)
+                    k_factor=1, base_index_params=base_params
+                )
 
                 D_regular, I_regular = index_regular.search(
-                    xq, k, params=params)
+                    xq, k, params=params
+                )
                 D_panorama, I_panorama = index_panorama.search(
-                    xq, k, params=params)
+                    xq, k, params=params
+                )
 
                 self.assertTrue(np.all(I_panorama >= 20))
                 self.assertTrue(np.all(I_panorama < 60))
@@ -325,15 +353,17 @@ class TestIndexRefinePanorama(unittest.TestCase):
         """Test handling of empty search results (shapes only)"""
         d, nb, nt, nq, nlevels, k = 32, 100, 200, 10, 4, 10
         xt, xb, _ = self.generate_data(d, nt, nb, nq, seed=111)
-        xq = np.random.rand(nq, d).astype("float32") + \
-            10.0  # Queries far from database
+        xq = (
+            np.random.rand(nq, d).astype("float32") + 10.0
+        )  # Queries far from database
 
         base_cfg = "Flat"
 
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index = self.create_panorama(
-                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                )
                 D, I = index.search(xq, k)
 
                 self.assertEqual(D.shape, (nq, k))
@@ -349,7 +379,8 @@ class TestIndexRefinePanorama(unittest.TestCase):
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(d, base_cfg, metric=metric)
                 index_panorama = self.create_panorama(
-                    d, base_cfg, nlevels, metric=metric)
+                    d, base_cfg, nlevels, metric=metric
+                )
 
                 # Keep total nb under 100k
                 batch_sizes = [5000, 10000, 15000, 20000]
@@ -365,7 +396,8 @@ class TestIndexRefinePanorama(unittest.TestCase):
                 D_panorama, I_panorama = index_panorama.search(xq, k)
 
                 self.assert_search_results_equal(
-                    D_regular, I_regular, D_panorama, I_panorama)
+                    D_regular, I_regular, D_panorama, I_panorama
+                )
 
     def test_add_search_add_search(self):
         """Test interleaved add and search operations"""
@@ -378,7 +410,8 @@ class TestIndexRefinePanorama(unittest.TestCase):
             with self.subTest(metric=metric):
                 index_regular = self.create_flat(d, base_cfg, metric=metric)
                 index_panorama = self.create_panorama(
-                    d, base_cfg, nlevels, metric=metric)
+                    d, base_cfg, nlevels, metric=metric
+                )
 
                 # First add and search
                 xb1 = np.random.rand(200, d).astype("float32")
@@ -390,7 +423,8 @@ class TestIndexRefinePanorama(unittest.TestCase):
                 D_reg_1, I_reg_1 = index_regular.search(xq1, k)
                 D_pan_1, I_pan_1 = index_panorama.search(xq1, k)
                 self.assert_search_results_equal(
-                    D_reg_1, I_reg_1, D_pan_1, I_pan_1)
+                    D_reg_1, I_reg_1, D_pan_1, I_pan_1
+                )
 
                 # Second add and search
                 xb2 = np.random.rand(300, d).astype("float32")
@@ -401,7 +435,8 @@ class TestIndexRefinePanorama(unittest.TestCase):
                 D_reg_2, I_reg_2 = index_regular.search(xq2, k)
                 D_pan_2, I_pan_2 = index_panorama.search(xq2, k)
                 self.assert_search_results_equal(
-                    D_reg_2, I_reg_2, D_pan_2, I_pan_2)
+                    D_reg_2, I_reg_2, D_pan_2, I_pan_2
+                )
 
     def test_serialization(self):
         """Test write/read Panorama indexes preserves search results"""
@@ -413,11 +448,13 @@ class TestIndexRefinePanorama(unittest.TestCase):
         for metric in self.METRICS:
             with self.subTest(metric=metric):
                 index = self.create_panorama(
-                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric)
+                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                )
 
                 D_before, I_before = index.search(xq, k)
                 index_after = faiss.deserialize_index(
-                    faiss.serialize_index(index))
+                    faiss.serialize_index(index)
+                )
                 D_after, I_after = index_after.search(xq, k)
 
                 np.testing.assert_array_equal(I_before, I_after)
@@ -448,36 +485,36 @@ class TestIndexRefinePanorama(unittest.TestCase):
                 # Force k_base = nb
                 k_factor = nb // k  # 500000 // 10 = 50000
                 params = faiss.IndexRefineSearchParameters(
-                    k_factor=float(k_factor))
+                    k_factor=float(k_factor)
+                )
 
                 ratios = []
                 nlevels_list = [1, 2, 4, 8, 16, 32]
                 for nlevels in nlevels_list:
                     with self.subTest(nlevels=nlevels):
-                        metric_str = (
-                            "L2" if metric == faiss.METRIC_L2 else "IP"
-                        )
+                        metric_str = "L2" if metric == faiss.METRIC_L2 else "IP"
                         factory_str = f"Flat{metric_str}Panorama{nlevels}_1"
                         refine_index = faiss.index_factory(
                             d, factory_str, metric
                         )
                         refine_index.add(xb)
                         index = faiss.IndexRefinePanorama(
-                            index_base, refine_index)
+                            index_base, refine_index
+                        )
 
                         faiss.cvar.indexPanorama_stats.reset()
                         D, I = index.search(xq, k, params=params)
                         self.assert_search_results_equal(
-                            D_base, I_base, D, I, atol=1e-4)
+                            D_base, I_base, D, I, atol=1e-4
+                        )
 
                         ratios.append(
-                            faiss.cvar.indexPanorama_stats.ratio_dims_scanned)
+                            faiss.cvar.indexPanorama_stats.ratio_dims_scanned
+                        )
 
                 expected_ratios = [1 / nlevels for nlevels in nlevels_list]
 
                 # Extra low tolerance for point-wise Panorama refinement
-                np.testing.assert_allclose(
-                    ratios, expected_ratios, atol=1e-5
-                )
+                np.testing.assert_allclose(ratios, expected_ratios, atol=1e-5)
 
                 faiss.omp_set_num_threads(nt)

--- a/tests/test_residual_quantizer.py
+++ b/tests/test_residual_quantizer.py
@@ -22,13 +22,13 @@ faiss.omp_set_num_threads(4)
 
 
 def pairwise_distances(a, b):
-    anorms = (a ** 2).sum(1)
-    bnorms = (b ** 2).sum(1)
+    anorms = (a**2).sum(1)
+    bnorms = (b**2).sum(1)
     return anorms.reshape(-1, 1) + bnorms - 2 * a @ b.T
 
 
 def beam_search_encode_step_ref(cent, residuals, codes, L):
-    """ Reference beam search implementation
+    """Reference beam search implementation
     encodes a residual table.
     """
     K, d = cent.shape
@@ -38,7 +38,9 @@ def beam_search_encode_step_ref(cent, residuals, codes, L):
     assert n2 == n and beam_size_2 == beam_size
 
     # compute all possible new residuals
-    cent_distances = pairwise_distances(residuals.reshape(n * beam_size, d), cent)
+    cent_distances = pairwise_distances(
+        residuals.reshape(n * beam_size, d), cent
+    )
     cent_distances = cent_distances.reshape(n, beam_size, K)
 
     # TODO write in vector form
@@ -47,7 +49,7 @@ def beam_search_encode_step_ref(cent, residuals, codes, L):
         # then keep all the results
         new_beam_size = beam_size * K
         new_codes = np.zeros((n, beam_size, K, m + 1), dtype=int)
-        new_residuals = np.zeros((n, beam_size, K, d), dtype='float32')
+        new_residuals = np.zeros((n, beam_size, K, d), dtype="float32")
         for i in range(n):
             new_codes[i, :, :, :-1] = codes[i]
             new_codes[i, :, :, -1] = np.arange(K)
@@ -59,13 +61,13 @@ def beam_search_encode_step_ref(cent, residuals, codes, L):
         # keep top-L results
         new_beam_size = L
         new_codes = np.zeros((n, L, m + 1), dtype=int)
-        new_residuals = np.zeros((n, L, d), dtype='float32')
-        new_distances = np.zeros((n, L), dtype='float32')
+        new_residuals = np.zeros((n, L, d), dtype="float32")
+        new_distances = np.zeros((n, L), dtype="float32")
         for i in range(n):
             cd = cent_distances[i].ravel()
-            jl = np.argsort(cd)[:L]    # TODO argpartition
-            js = jl // K     # input beam index
-            ls = jl % K      # centroid index
+            jl = np.argsort(cd)[:L]  # TODO argpartition
+            js = jl // K  # input beam index
+            ls = jl % K  # centroid index
             new_codes[i, :, :-1] = codes[i, js, :]
             new_codes[i, :, -1] = ls
             new_residuals[i, :, :] = residuals[i, js, :] - cent[ls, :]
@@ -75,7 +77,7 @@ def beam_search_encode_step_ref(cent, residuals, codes, L):
 
 
 def beam_search_encode_step(cent, residuals, codes, L, assign_index=None):
-    """ Wrapper of the C++ function with the same interface """
+    """Wrapper of the C++ function with the same interface"""
     K, d = cent.shape
     n, beam_size, d2 = residuals.shape
     assert d == d2
@@ -84,16 +86,26 @@ def beam_search_encode_step(cent, residuals, codes, L, assign_index=None):
 
     assert L <= beam_size * K
 
-    new_codes = np.zeros((n, L, m + 1), dtype='int32')
-    new_residuals = np.zeros((n, L, d), dtype='float32')
-    new_distances = np.zeros((n, L), dtype='float32')
+    new_codes = np.zeros((n, L, m + 1), dtype="int32")
+    new_residuals = np.zeros((n, L, d), dtype="float32")
+    new_distances = np.zeros((n, L), dtype="float32")
 
     sp = faiss.swig_ptr
-    codes = np.ascontiguousarray(codes, dtype='int32')
+    codes = np.ascontiguousarray(codes, dtype="int32")
     faiss.beam_search_encode_step(
-        d, K, sp(cent), n, beam_size, sp(residuals),
-        m, sp(codes), L, sp(new_codes), sp(new_residuals), sp(new_distances),
-        assign_index
+        d,
+        K,
+        sp(cent),
+        n,
+        beam_size,
+        sp(residuals),
+        m,
+        sp(codes),
+        L,
+        sp(new_codes),
+        sp(new_residuals),
+        sp(new_distances),
+        assign_index,
     )
 
     return new_codes, new_residuals, new_distances
@@ -107,11 +119,12 @@ def beam_search_encoding_ref(centroids, x, L):
     beam_size = 1
     codes = np.zeros((n, beam_size, 0), dtype=int)
     residuals = x.reshape((n, beam_size, d))
-    distances = (x ** 2).sum(1).reshape(n, beam_size)
+    distances = (x**2).sum(1).reshape(n, beam_size)
 
     for cent in centroids:
         codes, residuals, distances = beam_search_encode_step_ref(
-            cent, residuals, codes, L)
+            cent, residuals, codes, L
+        )
 
     return (codes, residuals, distances)
 
@@ -124,15 +137,15 @@ def beam_search_encoding_ref(centroids, x, L):
 class TestBeamSearch(unittest.TestCase):
 
     def do_test(self, K=70, L=10, use_assign_index=False):
-        """ compare C++ beam search with reference python implementation """
+        """compare C++ beam search with reference python implementation"""
         d = 32
         n = 500
-        L = 10 # beam size
+        L = 10  # beam size
 
         rs = np.random.RandomState(123)
-        x = rs.rand(n, d).astype('float32')
+        x = rs.rand(n, d).astype("float32")
 
-        cent = rs.rand(K, d).astype('float32')
+        cent = rs.rand(K, d).astype("float32")
 
         # first quant step --> input beam size is 1
         codes = np.zeros((n, 1, 0), dtype=int)
@@ -154,7 +167,7 @@ class TestBeamSearch(unittest.TestCase):
 
         # second quant step:
         K = 50
-        cent = rs.rand(K, d).astype('float32')
+        cent = rs.rand(K, d).astype("float32")
 
         codes, residuals = ref_codes, ref_residuals
 
@@ -193,7 +206,7 @@ def eval_codec(q, xb):
 class TestResidualQuantizer(unittest.TestCase):
 
     def test_training(self):
-        """check that the error is in the same ballpark as PQ """
+        """check that the error is in the same ballpark as PQ"""
         ds = datasets.SyntheticDataset(32, 3000, 1000, 0)
 
         xt = ds.get_train()
@@ -218,7 +231,7 @@ class TestResidualQuantizer(unittest.TestCase):
         self.assertLess(err_rq, err_pq * 1.2)
 
     def test_beam_size(self):
-        """ check that a larger beam gives a lower error """
+        """check that a larger beam gives a lower error"""
         ds = datasets.SyntheticDataset(32, 3000, 1000, 0)
 
         xt = ds.get_train()
@@ -239,7 +252,7 @@ class TestResidualQuantizer(unittest.TestCase):
         self.assertLess(err_rq1, err_rq0)
 
     def test_training_with_limited_mem(self):
-        """ make sure a different batch size gives the same result"""
+        """make sure a different batch size gives the same result"""
         ds = datasets.SyntheticDataset(32, 3000, 1000, 0)
 
         xt = ds.get_train()
@@ -281,8 +294,8 @@ class TestResidualQuantizer(unittest.TestCase):
         np.testing.assert_array_equal(codes, codes_none)
 
     def test_clipping(self):
-        """ verify that a clipped residual quantizer gives the same
-        code prefix + suffix as the full RQ """
+        """verify that a clipped residual quantizer gives the same
+        code prefix + suffix as the full RQ"""
         ds = datasets.SyntheticDataset(32, 1000, 100, 0)
 
         rq = faiss.ResidualQuantizer(ds.d, 5, 4)
@@ -290,7 +303,7 @@ class TestResidualQuantizer(unittest.TestCase):
         rq.max_beam_size = 5
         rq.train(ds.get_train())
 
-        rq.max_beam_size = 1   # is not he same for a large beam size
+        rq.max_beam_size = 1  # is not he same for a large beam size
         codes = rq.compute_codes(ds.get_database())
 
         rq2 = faiss.ResidualQuantizer(ds.d, 2, 4)
@@ -307,15 +320,20 @@ class TestResidualQuantizer(unittest.TestCase):
         # verify that prefixes are the same
         for i in range(ds.nb):
             br = faiss.BitstringReader(faiss.swig_ptr(codes[i]), rq.code_size)
-            br2 = faiss.BitstringReader(faiss.swig_ptr(codes2[i]), rq2.code_size)
+            br2 = faiss.BitstringReader(
+                faiss.swig_ptr(codes2[i]), rq2.code_size
+            )
             self.assertEqual(br.read(rq2.tot_bits), br2.read(rq2.tot_bits))
-            br3 = faiss.BitstringReader(faiss.swig_ptr(codes3[i]), rq3.code_size)
+            br3 = faiss.BitstringReader(
+                faiss.swig_ptr(codes3[i]), rq3.code_size
+            )
             self.assertEqual(br.read(rq3.tot_bits), br3.read(rq3.tot_bits))
 
 
 ###########################################################
 # Test index, index factory sa_encode / sa_decode
 ###########################################################
+
 
 def unpack_codes(rq, packed_codes):
     nbits = faiss.vector_to_array(rq.nbits)
@@ -333,7 +351,7 @@ def unpack_codes(rq, packed_codes):
 
 
 def retrain_AQ_codebook(index, xt):
-    """ reference implementation of codebook retraining """
+    """reference implementation of codebook retraining"""
     rq = index.rq
 
     codes_packed = index.sa_encode(xt)
@@ -358,7 +376,11 @@ def retrain_AQ_codebook(index, xt):
         B, residuals, rank, singvals = np.linalg.lstsq(C, xt, rcond=None)
     else:
         import scipy.linalg
-        B, residuals, rank, singvals = scipy.linalg.lstsq(C, xt, )
+
+        B, residuals, rank, singvals = scipy.linalg.lstsq(
+            C,
+            xt,
+        )
 
     MSE = ((C @ B - xt) ** 2).sum() / n
 
@@ -415,8 +437,7 @@ class TestIndexResidualQuantizer(unittest.TestCase):
         # initialize the codebooks
         rcq = faiss.downcast_index(ivf.quantizer)
         faiss.copy_array_to_vector(
-            np.vstack(codebooks[:rcq.rq.M]).ravel(),
-            rcq.rq.codebooks
+            np.vstack(codebooks[: rcq.rq.M]).ravel(), rcq.rq.codebooks
         )
         rcq.rq.is_trained = True
         # translation of AdditiveCoarseQuantizer::train
@@ -426,8 +447,7 @@ class TestIndexResidualQuantizer(unittest.TestCase):
         rcq.is_trained = True
 
         faiss.copy_array_to_vector(
-            np.vstack(codebooks[rcq.rq.M:]).ravel(),
-            ivf.rq.codebooks
+            np.vstack(codebooks[rcq.rq.M :]).ravel(), ivf.rq.codebooks
         )
         ivf.rq.is_trained = True
         ivf.is_trained = True
@@ -448,14 +468,14 @@ class TestIndexResidualQuantizer(unittest.TestCase):
 
         np.testing.assert_array_equal(
             faiss.vector_to_array(index.rq.nbits),
-            np.array([16, 16, 8, 8, 8, 4, 4, 4, 4, 4, 4])
+            np.array([16, 16, 8, 8, 8, 4, 4, 4, 4, 4, 4]),
         )
 
     def test_factory_norm(self):
         index = faiss.index_factory(5, "RQ8x8_Nqint8")
         self.assertEqual(
-            index.rq.search_type,
-            faiss.AdditiveQuantizer.ST_norm_qint8)
+            index.rq.search_type, faiss.AdditiveQuantizer.ST_norm_qint8
+        )
 
     def test_search_decompress(self):
         ds = datasets.SyntheticDataset(32, 1000, 1000, 100)
@@ -479,9 +499,9 @@ class TestIndexResidualQuantizer(unittest.TestCase):
         self.assertGreater(recalls[10], 0.35)
 
     def do_exact_search_equiv(self, norm_type):
-        """ searching with this normalization should yield
+        """searching with this normalization should yield
         exactly the same results as decompression (because the
-        norms are exact) """
+        norms are exact)"""
         ds = datasets.SyntheticDataset(32, 1000, 1000, 100)
 
         # decompresses by default
@@ -492,7 +512,8 @@ class TestIndexResidualQuantizer(unittest.TestCase):
         Dref, Iref = ir.search(ds.get_queries(), 10)
 
         ir2 = faiss.IndexResidualQuantizer(
-            ds.d, 3, 6, faiss.METRIC_L2, norm_type)
+            ds.d, 3, 6, faiss.METRIC_L2, norm_type
+        )
 
         # assumes training is reproducible
         ir2.rq.train_type = faiss.ResidualQuantizer.Train_default
@@ -553,9 +574,6 @@ class TestIndexResidualQuantizer(unittest.TestCase):
 
         # ref run 7474.98 / 7006.1777
         self.assertGreater(err_before, err_after_refined * 1.06)
-
-
-
 
 
 ###########################################################
@@ -696,7 +714,7 @@ class TestIVFResidualCoarseQuantizer(unittest.TestCase):
         self.assertNotEqual(quantizer.rq.codebook_cross_products.size(), 0)
         quantizer3 = faiss.deserialize_index(
             faiss.serialize_index(quantizer),
-            faiss.IO_FLAG_SKIP_PRECOMPUTE_TABLE
+            faiss.IO_FLAG_SKIP_PRECOMPUTE_TABLE,
         )
         self.assertEqual(quantizer3.rq.codebook_cross_products.size(), 0)
         CD3, CI3 = quantizer3.search(ds.get_queries(), 10)
@@ -726,7 +744,7 @@ class TestAdditiveQuantizerWithLUT(unittest.TestCase):
 
         # test norms computation
 
-        norms_ref = (cents ** 2).sum(1)
+        norms_ref = (cents**2).sum(1)
         norms = np.zeros(1 << aq.tot_bits, dtype="float32")
         aq.compute_centroid_norms(sp(norms))
 
@@ -734,10 +752,7 @@ class TestAdditiveQuantizerWithLUT(unittest.TestCase):
 
         # test IP search
 
-        Dref, Iref = faiss.knn(
-            xq, cents, 10,
-            metric=faiss.METRIC_INNER_PRODUCT
-        )
+        Dref, Iref = faiss.knn(xq, cents, 10, metric=faiss.METRIC_INNER_PRODUCT)
 
         Dnew = np.zeros_like(Dref)
         Inew = np.zeros_like(Iref)
@@ -771,7 +786,8 @@ class TestIndexResidualQuantizerSearch(unittest.TestCase):
         xq = ds.get_queries()
 
         ir = faiss.IndexResidualQuantizer(
-            ds.d, 3, 4, faiss.METRIC_INNER_PRODUCT)
+            ds.d, 3, 4, faiss.METRIC_INNER_PRODUCT
+        )
         ir.rq.train_type = faiss.ResidualQuantizer.Train_default
         ir.train(xt)
 
@@ -781,8 +797,9 @@ class TestIndexResidualQuantizerSearch(unittest.TestCase):
 
         AQ = faiss.AdditiveQuantizer
         ir2 = faiss.IndexResidualQuantizer(
-            ds.d, 3, 4, faiss.METRIC_INNER_PRODUCT, AQ.ST_LUT_nonorm)
-        ir2.rq.codebooks = ir.rq.codebooks    # fake training
+            ds.d, 3, 4, faiss.METRIC_INNER_PRODUCT, AQ.ST_LUT_nonorm
+        )
+        ir2.rq.codebooks = ir.rq.codebooks  # fake training
         ir2.rq.is_trained = True
         ir2.is_trained = True
         ir2.add(xb)
@@ -813,13 +830,18 @@ class TestIndexResidualQuantizerSearch(unittest.TestCase):
         inter_ref = faiss.eval_intersection(Iref, gt)
 
         AQ = faiss.AdditiveQuantizer
-        for st in AQ.ST_norm_float, AQ.ST_norm_qint8, AQ.ST_norm_qint4, \
-                AQ.ST_norm_cqint8, AQ.ST_norm_cqint4:
+        for st in (
+            AQ.ST_norm_float,
+            AQ.ST_norm_qint8,
+            AQ.ST_norm_qint4,
+            AQ.ST_norm_cqint8,
+            AQ.ST_norm_cqint4,
+        ):
 
             ir2 = faiss.IndexResidualQuantizer(ds.d, 3, 4, faiss.METRIC_L2, st)
             ir2.rq.max_beam_size = 30
-            ir2.train(xt)   # to get the norm bounds
-            ir2.rq.codebooks = ir.rq.codebooks    # fake training
+            ir2.train(xt)  # to get the norm bounds
+            ir2.rq.codebooks = ir.rq.codebooks  # fake training
             ir2.add(xb)
 
             D2, I2 = ir2.search(xq, 10)
@@ -845,8 +867,7 @@ class TestIVFResidualQuantizer(unittest.TestCase):
         quantizer = faiss.IndexFlatL2(ds.d)
 
         index = faiss.IndexIVFResidualQuantizer(
-            quantizer, ds.d, 100, 3, 4,
-            faiss.METRIC_L2, st
+            quantizer, ds.d, 100, 3, 4, faiss.METRIC_L2, st
         )
         index.by_residual = by_residual
 
@@ -880,7 +901,8 @@ class TestIVFResidualQuantizer(unittest.TestCase):
             self.assertTrue(np.all(inters[1:3] >= inters[:2]))
             # check that we have the same result as the flat residual quantizer
             iflat = faiss.IndexResidualQuantizer(
-                ds.d, 3, 4, faiss.METRIC_L2, st)
+                ds.d, 3, 4, faiss.METRIC_L2, st
+            )
             iflat.rq.train_type
             iflat.rq.train_type = faiss.ResidualQuantizer.Train_default
             iflat.rq.max_beam_size = 30
@@ -919,19 +941,16 @@ class TestIVFResidualQuantizer(unittest.TestCase):
         index = faiss.index_factory(12, "IVF1024,RQ8x8_Nfloat")
         self.assertEqual(index.nlist, 1024)
         self.assertEqual(
-            index.rq.search_type,
-            faiss.AdditiveQuantizer.ST_norm_float
+            index.rq.search_type, faiss.AdditiveQuantizer.ST_norm_float
         )
 
         index = faiss.index_factory(12, "IVF1024,RQ8x8_Ncqint8")
         self.assertEqual(
-            index.rq.search_type,
-            faiss.AdditiveQuantizer.ST_norm_cqint8
+            index.rq.search_type, faiss.AdditiveQuantizer.ST_norm_cqint8
         )
         index = faiss.index_factory(12, "IVF1024,RQ8x8_Ncqint4")
         self.assertEqual(
-            index.rq.search_type,
-            faiss.AdditiveQuantizer.ST_norm_cqint4
+            index.rq.search_type, faiss.AdditiveQuantizer.ST_norm_cqint4
         )
 
     def do_test_accuracy_IP(self, by_residual):
@@ -940,8 +959,13 @@ class TestIVFResidualQuantizer(unittest.TestCase):
         quantizer = faiss.IndexFlatIP(ds.d)
 
         index = faiss.IndexIVFResidualQuantizer(
-            quantizer, ds.d, 100, 3, 4,
-            faiss.METRIC_INNER_PRODUCT, faiss.AdditiveQuantizer.ST_decompress
+            quantizer,
+            ds.d,
+            100,
+            3,
+            4,
+            faiss.METRIC_INNER_PRODUCT,
+            faiss.AdditiveQuantizer.ST_decompress,
         )
         index.cp.spherical = True
         index.by_residual = by_residual
@@ -986,10 +1010,7 @@ def precomp_codebooks(codebooks):
     codebook_cross_prods = [
         [codebooks[m1] @ codebooks[m].T for m1 in range(m)] for m in range(M)
     ]
-    cent_norms = [
-        (c ** 2).sum(1)
-        for c in codebooks
-    ]
+    cent_norms = [(c**2).sum(1) for c in codebooks]
     return codebook_cross_prods, cent_norms
 
 
@@ -997,9 +1018,11 @@ def precomp_codebooks(codebooks):
 # Reference implementation of table-based beam search (use_beam_LUT=1)
 ############################################################
 
-def beam_search_encode_step_tab(codes, L, distances, codebook_cross_prods_i,
-                                query_cp_i, cent_norms_i):
-    """ Reference beam search implementation
+
+def beam_search_encode_step_tab(
+    codes, L, distances, codebook_cross_prods_i, query_cp_i, cent_norms_i
+):
+    """Reference beam search implementation
     encodes a residual table.
     """
     n, beam_size, m = codes.shape
@@ -1008,7 +1031,7 @@ def beam_search_encode_step_tab(codes, L, distances, codebook_cross_prods_i,
     assert n2 == n and beam_size_2 == beam_size
     n2, K = query_cp_i.shape
     assert n2 == n
-    K2, = cent_norms_i.shape
+    (K2,) = cent_norms_i.shape
     assert K == K2
     assert len(codebook_cross_prods_i) == m
 
@@ -1042,12 +1065,12 @@ def beam_search_encode_step_tab(codes, L, distances, codebook_cross_prods_i,
         # keep top-L results
         new_beam_size = L
         new_codes = np.zeros((n, L, m + 1), dtype=int)
-        new_distances = np.zeros((n, L), dtype='float32')
+        new_distances = np.zeros((n, L), dtype="float32")
         for i in range(n):
             cd = cent_distances[i].ravel()
-            jl = np.argsort(cd)[:L]    # TODO argpartition
-            js = jl // K     # input beam index
-            ls = jl % K      # centroid index
+            jl = np.argsort(cd)[:L]  # TODO argpartition
+            js = jl // K  # input beam index
+            ls = jl % K  # centroid index
             new_codes[i, :, :-1] = codes[i, js, :]
             new_codes[i, :, -1] = ls
             new_distances[i, :] = cd[jl]
@@ -1061,26 +1084,27 @@ def beam_search_encoding_tab(codebooks, x, L, precomp, implem="ref"):
     """
     compare_implem = "ref" in implem and "cpp" in implem
 
-    query_cross_prods = [
-        x @ c.T for c in codebooks
-    ]
+    query_cross_prods = [x @ c.T for c in codebooks]
 
     M = len(codebooks)
-    codebook_offsets = np.zeros(M + 1, dtype='uint64')
+    codebook_offsets = np.zeros(M + 1, dtype="uint64")
     codebook_offsets[1:] = np.cumsum([len(cb) for cb in codebooks])
     codebook_cross_prods, cent_norms = precomp
     n, d = x.shape
     beam_size = 1
-    codes = np.zeros((n, beam_size, 0), dtype='int32')
-    distances = (x ** 2).sum(1).reshape(n, beam_size)
+    codes = np.zeros((n, beam_size, 0), dtype="int32")
+    distances = (x**2).sum(1).reshape(n, beam_size)
 
     for m, cent in enumerate(codebooks):
 
         if "ref" in implem:
             new_codes, new_distances = beam_search_encode_step_tab(
-                codes, L,
-                distances, codebook_cross_prods[m][:m],
-                query_cross_prods[m], cent_norms[m]
+                codes,
+                L,
+                distances,
+                codebook_cross_prods[m][:m],
+                query_cross_prods[m],
+                cent_norms[m],
             )
             new_beam_size = codes.shape[1]
 
@@ -1091,31 +1115,37 @@ def beam_search_encoding_tab(codebooks, x, L, precomp, implem="ref"):
         if "cpp" in implem:
             K = len(cent)
             new_beam_size = min(beam_size * K, L)
-            new_codes = np.zeros((n, new_beam_size, m + 1), dtype='int32')
+            new_codes = np.zeros((n, new_beam_size, m + 1), dtype="int32")
             new_distances = np.zeros((n, new_beam_size), dtype="float32")
             if m > 0:
                 cp = np.vstack(codebook_cross_prods[m][:m])
             else:
-                cp = np.zeros((0, K), dtype='float32')
+                cp = np.zeros((0, K), dtype="float32")
 
             sp = faiss.swig_ptr
             faiss.beam_search_encode_step_tab(
-                K, n, beam_size,
-                sp(cp), cp.shape[1],
+                K,
+                n,
+                beam_size,
+                sp(cp),
+                cp.shape[1],
                 sp(codebook_offsets),
-                sp(query_cross_prods[m]), query_cross_prods[m].shape[1],
+                sp(query_cross_prods[m]),
+                query_cross_prods[m].shape[1],
                 sp(cent_norms[m]),
                 m,
-                sp(codes), sp(distances),
+                sp(codes),
+                sp(distances),
                 new_beam_size,
-                sp(new_codes), sp(new_distances)
+                sp(new_codes),
+                sp(new_distances),
             )
 
         if compare_implem:
             np.testing.assert_array_almost_equal(
-                new_distances, distances_ref, decimal=5)
-            np.testing.assert_array_equal(
-                new_codes, codes_ref)
+                new_distances, distances_ref, decimal=5
+            )
+            np.testing.assert_array_equal(new_codes, codes_ref)
 
         codes = new_codes
         distances = new_distances
@@ -1151,20 +1181,20 @@ class TestCrossCodebookComputations(unittest.TestCase):
 
         # check C++ precomp tables
         rq.compute_codebook_tables()
-        codebook_cross_prods = faiss.vector_to_array(
-            rq.codebook_cross_products)
+        codebook_cross_prods = faiss.vector_to_array(rq.codebook_cross_products)
         ofs = 0
         for m in range(1, rq.M):
             py_table = np.vstack(codebook_cross_prods_ref[m])
             kk = rq.codebook_offsets.at(m)
             K = 1 << rq.nbits.at(m)
-            cpp_table = codebook_cross_prods[ofs:ofs + K * kk].reshape(kk, K)
+            cpp_table = codebook_cross_prods[ofs : ofs + K * kk].reshape(kk, K)
             ofs += kk * K
             np.testing.assert_allclose(py_table, cpp_table, atol=1e-5)
 
         cent_norms = faiss.vector_to_array(rq.centroid_norms)
         np.testing.assert_array_almost_equal(
-            np.hstack(cent_norms_ref), cent_norms, decimal=5)
+            np.hstack(cent_norms_ref), cent_norms, decimal=5
+        )
 
         # validate the C++ beam_search_encode_step_tab function
         beam_search_encoding_tab(codebooks, xb, 7, precomp, implem="ref cpp")
@@ -1172,11 +1202,13 @@ class TestCrossCodebookComputations(unittest.TestCase):
         # check implem w/ residuals
         n = ref_codes.shape[0]
         sp = faiss.swig_ptr
-        ref_codes_packed = np.zeros((n, rq.code_size), dtype='uint8')
-        ref_codes_int32 = ref_codes.astype('int32')
+        ref_codes_packed = np.zeros((n, rq.code_size), dtype="uint8")
+        ref_codes_int32 = ref_codes.astype("int32")
         rq.pack_codes(
-            n, sp(ref_codes_int32),
-            sp(ref_codes_packed), rq.M * ref_codes.shape[1]
+            n,
+            sp(ref_codes_int32),
+            sp(ref_codes_packed),
+            rq.M * ref_codes.shape[1],
         )
 
         rq.max_beam_size = 7

--- a/tests/test_scalar_quantizer_correctness.py
+++ b/tests/test_scalar_quantizer_correctness.py
@@ -74,11 +74,12 @@ class TestScalarQuantizerEncodeDecode(unittest.TestCase):
         if not faiss.SIMDConfig.is_simd_level_available(faiss.SIMDLevel_NONE):
             self.skipTest("SIMDLevel.NONE not available")
         for qtype in (
-                faiss.ScalarQuantizer.QT_8bit,
-                faiss.ScalarQuantizer.QT_4bit,
-                faiss.ScalarQuantizer.QT_8bit_uniform,
-                faiss.ScalarQuantizer.QT_4bit_uniform,
-                faiss.ScalarQuantizer.QT_fp16):
+            faiss.ScalarQuantizer.QT_8bit,
+            faiss.ScalarQuantizer.QT_4bit,
+            faiss.ScalarQuantizer.QT_8bit_uniform,
+            faiss.ScalarQuantizer.QT_4bit_uniform,
+            faiss.ScalarQuantizer.QT_fp16,
+        ):
             with self.subTest(qtype=qtype):
                 sq = faiss.ScalarQuantizer(self.d, qtype)
                 sq.train(self.xb)
@@ -115,10 +116,10 @@ class TestScalarQuantizerSearch(unittest.TestCase):
         self.assertGreater(recall, min_recall)
 
     def test_SQ4(self):
-        self.do_search('SQ4', 0.5)
+        self.do_search("SQ4", 0.5)
 
     def test_SQfp16(self):
-        self.do_search('SQfp16', 0.99)
+        self.do_search("SQfp16", 0.99)
 
     def test_tqmse_search(self):
         index_gt = faiss.IndexFlatL2(self.d)
@@ -126,17 +127,17 @@ class TestScalarQuantizerSearch(unittest.TestCase):
         _, I_gt = index_gt.search(self.xq_unit, 10)
 
         recalls = {}
-        for factory_str in ['L2norm,RR,SQtqmse4', 'L2norm,RR,SQtqmse8']:
+        for factory_str in ["L2norm,RR,SQtqmse4", "L2norm,RR,SQtqmse8"]:
             index = faiss.index_factory(self.d, factory_str)
             index.train(self.xb)
             index.add(self.xb)
             _, I = index.search(self.xq, 10)
             recalls[factory_str] = (I_gt[:, 0] == I[:, 0]).mean()
 
-        self.assertGreater(recalls['L2norm,RR,SQtqmse4'], 0.2)
+        self.assertGreater(recalls["L2norm,RR,SQtqmse4"], 0.2)
         self.assertGreaterEqual(
-            recalls['L2norm,RR,SQtqmse8'],
-            recalls['L2norm,RR,SQtqmse4'])
+            recalls["L2norm,RR,SQtqmse8"], recalls["L2norm,RR,SQtqmse4"]
+        )
 
 
 @for_all_simd_levels
@@ -148,7 +149,7 @@ class TestScalarQuantizerDistances(unittest.TestCase):
         x = ds.get_queries()
         xb = ds.get_database()
 
-        index = faiss.index_factory(d, 'SQ8')
+        index = faiss.index_factory(d, "SQ8")
         index.train(xb)
         index.add(xb)
 
@@ -167,7 +168,7 @@ class TestScalarQuantizerDistances(unittest.TestCase):
         faiss.normalize_L2(x)
         faiss.normalize_L2(xb)
 
-        index = faiss.index_factory(d, 'SQtqmse8')
+        index = faiss.index_factory(d, "SQtqmse8")
         index.train(xb)
         index.add(xb)
 
@@ -184,20 +185,20 @@ class TestScalarQuantizerEdgeCases(unittest.TestCase):
 
     def test_zero_vectors(self):
         d = 32
-        xb = np.zeros((100, d), dtype='float32')
-        index = faiss.index_factory(d, 'SQ8')
+        xb = np.zeros((100, d), dtype="float32")
+        index = faiss.index_factory(d, "SQ8")
         index.train(xb)
         index.add(xb)
-        D, _ = index.search(np.zeros((1, d), dtype='float32'), 10)
+        D, _ = index.search(np.zeros((1, d), dtype="float32"), 10)
         self.assertTrue(np.allclose(D, 0, atol=1e-5))
 
     def test_constant_vectors(self):
         d = 32
-        xb = np.ones((100, d), dtype='float32') * 0.5
-        index = faiss.index_factory(d, 'SQ8')
+        xb = np.ones((100, d), dtype="float32") * 0.5
+        index = faiss.index_factory(d, "SQ8")
         index.train(xb)
         index.add(xb)
-        D, _ = index.search(np.ones((1, d), dtype='float32') * 0.5, 10)
+        D, _ = index.search(np.ones((1, d), dtype="float32") * 0.5, 10)
         self.assertTrue(np.allclose(D, 0, atol=1e-3))
 
     def test_extreme_dims(self):
@@ -207,7 +208,7 @@ class TestScalarQuantizerEdgeCases(unittest.TestCase):
                 ds = SyntheticDataset(d=d, nt=0, nb=100, nq=10, seed=42)
                 xb = ds.get_database()
                 xq = ds.get_queries()
-                index = faiss.index_factory(d, 'SQ8')
+                index = faiss.index_factory(d, "SQ8")
                 index.train(xb)
                 index.add(xb)
                 D, I = index.search(xq, 10)
@@ -221,7 +222,7 @@ class TestScalarQuantizerEdgeCases(unittest.TestCase):
                 ds = SyntheticDataset(d=d, nt=0, nb=100, nq=5, seed=42)
                 xb = ds.get_database()
                 xq = ds.get_queries()
-                index = faiss.index_factory(d, 'SQ8')
+                index = faiss.index_factory(d, "SQ8")
                 index.train(xb)
                 index.add(xb)
                 D, I = index.search(xq, 10)
@@ -230,11 +231,11 @@ class TestScalarQuantizerEdgeCases(unittest.TestCase):
 
     def test_tqmse_non_simd_dims(self):
         factory_strings = [
-            'SQtqmse1',
-            'SQtqmse2',
-            'SQtqmse3',
-            'SQtqmse4',
-            'SQtqmse8',
+            "SQtqmse1",
+            "SQtqmse2",
+            "SQtqmse3",
+            "SQtqmse4",
+            "SQtqmse8",
         ]
         for d in [7, 9, 15, 17, 31, 33, 63, 65]:
             for factory_str in factory_strings:
@@ -263,7 +264,7 @@ class TestScalarQuantizerIP(unittest.TestCase):
         faiss.normalize_L2(xb)
         faiss.normalize_L2(xq)
 
-        index = faiss.index_factory(d, 'SQ8', faiss.METRIC_INNER_PRODUCT)
+        index = faiss.index_factory(d, "SQ8", faiss.METRIC_INNER_PRODUCT)
         index.train(xb)
         index.add(xb)
         D, _ = index.search(xq, 10)
@@ -284,7 +285,7 @@ class TestTurboQUnbiasedness(unittest.TestCase):
 
         for d in [128, 256, 384, 512, 768]:
             n = 500
-            xb = rng.randn(n, d).astype('float32')
+            xb = rng.randn(n, d).astype("float32")
             faiss.normalize_L2(xb)
 
             for qt_name, qt in [
@@ -303,10 +304,9 @@ class TestTurboQUnbiasedness(unittest.TestCase):
 
                 # Cosine similarity
                 xr_norms = np.linalg.norm(xr, axis=1)
-                cos_sim = np.array([
-                    xb[i] @ xr[i] / (xr_norms[i] + 1e-30)
-                    for i in range(n)
-                ]).mean()
+                cos_sim = np.array(
+                    [xb[i] @ xr[i] / (xr_norms[i] + 1e-30) for i in range(n)]
+                ).mean()
 
                 print(
                     f"{d:>6} {qt_name:>8} "
@@ -315,8 +315,9 @@ class TestTurboQUnbiasedness(unittest.TestCase):
 
                 # Reconstruction should point in the right direction
                 self.assertGreater(
-                    mean_self_ip, 0.1,
-                    msg=f"d={d} {qt_name}: self IP {mean_self_ip:.4f} too low"
+                    mean_self_ip,
+                    0.1,
+                    msg=f"d={d} {qt_name}: self IP {mean_self_ip:.4f} too low",
                 )
 
 

--- a/tests/test_search_params.py
+++ b/tests/test_search_params.py
@@ -29,9 +29,9 @@ class TestSelector(unittest.TestCase):
         id_selector_type="batch",
         mt=faiss.METRIC_L2,
         k=10,
-        use_heap=True
+        use_heap=True,
     ):
-        """ Verify that the id selector returns the subset of results that are
+        """Verify that the id selector returns the subset of results that are
         members according to the IDSelector.
         Supports id_selector_type="batch", "bitmap", "range", "range_sorted", "and", "or", "xor"
         """
@@ -40,8 +40,8 @@ class TestSelector(unittest.TestCase):
 
         if index_key == "BinaryFlat":
             rs = np.random.RandomState(123)
-            xb = rs.randint(256, size=(ds.nb, d // 8), dtype='uint8')
-            xq = rs.randint(256, size=(ds.nq, d // 8), dtype='uint8')
+            xb = rs.randint(256, size=(ds.nb, d // 8), dtype="uint8")
+            xq = rs.randint(256, size=(ds.nq, d // 8), dtype="uint8")
             index = faiss.IndexBinaryFlat(d)
             index.use_heap = use_heap
             # Use smaller radius for Hamming distance
@@ -53,12 +53,12 @@ class TestSelector(unittest.TestCase):
             xt = ds.get_train()
             index = faiss.index_factory(d, index_key, mt)
             index.train(xt)
-            base_radius = float('inf')  # Will be set based on results
+            base_radius = float("inf")  # Will be set based on results
             is_binary = False
 
         # reference result
         if "range" in id_selector_type:
-            subset = np.arange(30, 80).astype('int64')
+            subset = np.arange(30, 80).astype("int64")
         elif id_selector_type == "or":
             lhs_rs = np.random.RandomState(123)
             lhs_subset = lhs_rs.choice(ds.nb, 50, replace=False).astype("int64")
@@ -79,7 +79,7 @@ class TestSelector(unittest.TestCase):
             subset = np.setxor1d(lhs_subset, rhs_subset)
         else:
             rs = np.random.RandomState(123)
-            subset = rs.choice(ds.nb, 50, replace=False).astype('int64')
+            subset = rs.choice(ds.nb, 50, replace=False).astype("int64")
 
         index.add(xb[subset])
         if "IVF" in index_key and id_selector_type == "range_sorted":
@@ -88,7 +88,7 @@ class TestSelector(unittest.TestCase):
         Iref = subset[Iref0]
         Iref[Iref0 < 0] = -1
 
-        if base_radius == float('inf'):
+        if base_radius == float("inf"):
             radius = float(Dref[Iref > 0].max()) * 1.01
         else:
             radius = base_radius
@@ -118,37 +118,40 @@ class TestSelector(unittest.TestCase):
         elif id_selector_type == "bitmap":
             bitmap = np.zeros(ds.nb, dtype=bool)
             bitmap[subset] = True
-            bitmap = np.packbits(bitmap, bitorder='little')
+            bitmap = np.packbits(bitmap, bitorder="little")
             sel = faiss.IDSelectorBitmap(bitmap)
         elif id_selector_type == "not":
             ssubset = set(subset)
-            inverse_subset = np.array([
-                i for i in range(ds.nb)
-                if i not in ssubset
-            ]).astype('int64')
+            inverse_subset = np.array(
+                [i for i in range(ds.nb) if i not in ssubset]
+            ).astype("int64")
             sel = faiss.IDSelectorNot(faiss.IDSelectorBatch(inverse_subset))
         elif id_selector_type == "or":
             sel = faiss.IDSelectorOr(
                 faiss.IDSelectorBatch(lhs_subset),
-                faiss.IDSelectorBatch(rhs_subset)
+                faiss.IDSelectorBatch(rhs_subset),
             )
         elif id_selector_type == "and":
             sel = faiss.IDSelectorAnd(
                 faiss.IDSelectorBatch(lhs_subset),
-                faiss.IDSelectorBatch(rhs_subset)
+                faiss.IDSelectorBatch(rhs_subset),
             )
         elif id_selector_type == "xor":
             sel = faiss.IDSelectorXOr(
                 faiss.IDSelectorBatch(lhs_subset),
-                faiss.IDSelectorBatch(rhs_subset)
+                faiss.IDSelectorBatch(rhs_subset),
             )
         else:
             sel = faiss.IDSelectorBatch(subset)
 
         params = (
-            faiss.SearchParametersIVF(sel=sel) if "IVF" in index_key else
-            faiss.SearchParametersPQ(sel=sel) if "PQ" in index_key else
-            faiss.SearchParameters(sel=sel)
+            faiss.SearchParametersIVF(sel=sel)
+            if "IVF" in index_key
+            else (
+                faiss.SearchParametersPQ(sel=sel)
+                if "PQ" in index_key
+                else faiss.SearchParameters(sel=sel)
+            )
         )
 
         Dnew, Inew = index.search(xq, k, params=params)
@@ -164,11 +167,12 @@ class TestSelector(unittest.TestCase):
             subset_set = set(subset)  # Convert to set for O(1) lookups
             # Handle -1 values separately (they're always valid)
             valid_ids = np.logical_or(
-                Inew == -1,
-                np.isin(Inew, list(subset_set))
+                Inew == -1, np.isin(Inew, list(subset_set))
             )
 
-            self.assertTrue(np.all(valid_ids), "Some returned IDs are not in the subset")
+            self.assertTrue(
+                np.all(valid_ids), "Some returned IDs are not in the subset"
+            )
 
             # Check that distances match
             np.testing.assert_almost_equal(Dref, Dnew, decimal=5)
@@ -178,7 +182,9 @@ class TestSelector(unittest.TestCase):
             np.testing.assert_almost_equal(Dref, Dnew, decimal=5)
 
         if have_range_search:
-            Rlims_new, RDnew, RInew = index.range_search(xq, radius, params=params)
+            Rlims_new, RDnew, RInew = index.range_search(
+                xq, radius, params=params
+            )
             np.testing.assert_array_equal(Rlims_ref, Rlims_new)
             RDref, RIref = sort_range_res_2(Rlims_ref, RDref, RIref)
 
@@ -189,7 +195,10 @@ class TestSelector(unittest.TestCase):
                 subset_set = set(subset)  # Convert to set for O(1) lookups
                 valid_ids = np.isin(RInew, list(subset_set))
 
-                self.assertTrue(np.all(valid_ids), "Some range search IDs are not in the subset")
+                self.assertTrue(
+                    np.all(valid_ids),
+                    "Some range search IDs are not in the subset",
+                )
 
                 # Check that distances match
                 np.testing.assert_almost_equal(RDref, RDnew, decimal=5)
@@ -237,8 +246,7 @@ class TestSelector(unittest.TestCase):
 
     def test_Flat_IP_id_range(self):
         self.do_test_id_selector(
-            "Flat", id_selector_type="range",
-            mt=faiss.METRIC_INNER_PRODUCT
+            "Flat", id_selector_type="range", mt=faiss.METRIC_INNER_PRODUCT
         )
 
     def test_Flat_id_array(self):
@@ -246,8 +254,7 @@ class TestSelector(unittest.TestCase):
 
     def test_Flat_IP_id_array(self):
         self.do_test_id_selector(
-            "Flat", id_selector_type="array",
-            mt=faiss.METRIC_INNER_PRODUCT
+            "Flat", id_selector_type="array", mt=faiss.METRIC_INNER_PRODUCT
         )
 
     def test_Flat_id_bitmap(self):
@@ -268,7 +275,7 @@ class TestSelector(unittest.TestCase):
     #    self.do_test_id_selector("RQ3x4")
 
     def do_test_id_selector_weak(self, index_key):
-        """ verify that the selected subset is the subset  in the list"""
+        """verify that the selected subset is the subset  in the list"""
         ds = datasets.SyntheticDataset(32, 1000, 100, 20)
         index = faiss.index_factory(ds.d, index_key)
         index.train(ds.get_train())
@@ -286,7 +293,7 @@ class TestSelector(unittest.TestCase):
         mask = np.zeros(ds.nb, dtype=bool)
         mask[subset] = True
         for q in range(len(Iref)):
-            mask_q, = np.where(mask[Iref[q]])
+            (mask_q,) = np.where(mask[Iref[q]])
             l = len(mask_q)
             np.testing.assert_array_equal(Iref[q, mask_q], Inew[q, :l])
             np.testing.assert_array_equal(Dref[q, mask_q], Dnew[q, :l])
@@ -312,19 +319,20 @@ class TestSelector(unittest.TestCase):
 
         valid_ids = ids[mask]
         sel = faiss.IDSelectorTranslated(
-            index, faiss.IDSelectorBatch(valid_ids))
+            index, faiss.IDSelectorBatch(valid_ids)
+        )
 
         Dnew, Inew = index.search(
-            ds.get_queries(), 10,
-            params=faiss.SearchParameters(sel=sel)
+            ds.get_queries(), 10, params=faiss.SearchParameters(sel=sel)
         )
         np.testing.assert_array_equal(Iref, Inew)
         np.testing.assert_array_almost_equal(Dref, Dnew, decimal=5)
 
         # let the IDMap::search add the translation...
         Dnew, Inew = index.search(
-            ds.get_queries(), 10,
-            params=faiss.SearchParameters(sel=faiss.IDSelectorBatch(valid_ids))
+            ds.get_queries(),
+            10,
+            params=faiss.SearchParameters(sel=faiss.IDSelectorBatch(valid_ids)),
         )
         np.testing.assert_array_equal(Iref, Inew)
         np.testing.assert_array_almost_equal(Dref, Dnew, decimal=5)
@@ -363,8 +371,7 @@ class TestSelector(unittest.TestCase):
 @for_all_simd_levels
 class TestSearchParams(unittest.TestCase):
 
-    def do_test_with_param(
-            self, index_key, ps_params, params):
+    def do_test_with_param(self, index_key, ps_params, params):
         """
         Test equivalence between setting
         1. param_name_2 = value with ParameterSpace
@@ -386,8 +393,7 @@ class TestSearchParams(unittest.TestCase):
         self.assertFalse(np.all(Inew == I0))
 
         for param_name, value in ps_params.items():
-            faiss.ParameterSpace().set_index_parameter(
-                index, param_name, value)
+            faiss.ParameterSpace().set_index_parameter(index, param_name, value)
         Dref, Iref = index.search(ds.get_queries(), 10)
 
         np.testing.assert_array_equal(Iref, Inew)
@@ -395,13 +401,13 @@ class TestSearchParams(unittest.TestCase):
 
     def test_nprobe(self):
         self.do_test_with_param(
-                "IVF32,Flat", {"nprobe": 3},
-                faiss.SearchParametersIVF(nprobe=3))
+            "IVF32,Flat", {"nprobe": 3}, faiss.SearchParametersIVF(nprobe=3)
+        )
 
     def test_efSearch(self):
         self.do_test_with_param(
-            "HNSW", {"efSearch": 4},
-            faiss.SearchParametersHNSW(efSearch=4))
+            "HNSW", {"efSearch": 4}, faiss.SearchParametersHNSW(efSearch=4)
+        )
 
     def test_quantizer_hnsw(self):
         self.do_test_with_param(
@@ -409,9 +415,8 @@ class TestSearchParams(unittest.TestCase):
             {"quantizer_efSearch": 5, "nprobe": 10},
             faiss.SearchParametersIVF(
                 nprobe=10,
-                quantizer_params=faiss.SearchParametersHNSW(
-                    efSearch=5)
-            )
+                quantizer_params=faiss.SearchParametersHNSW(efSearch=5),
+            ),
         )
 
     def test_PQ_polysemous_ht(self):
@@ -419,13 +424,12 @@ class TestSearchParams(unittest.TestCase):
             "PQ4x8",
             {"ht": 10},
             faiss.SearchParametersPQ(
-                polysemous_ht=10,
-                search_type=faiss.IndexPQ.ST_polysemous
-            )
+                polysemous_ht=10, search_type=faiss.IndexPQ.ST_polysemous
+            ),
         )
 
     def test_max_codes(self):
-        " tests whether the max nb codes is taken into account "
+        "tests whether the max nb codes is taken into account"
         ds = datasets.SyntheticDataset(32, 1000, 100, 20)
         index = faiss.index_factory(ds.d, "IVF32,Flat")
         index.train(ds.get_train())
@@ -434,18 +438,18 @@ class TestSearchParams(unittest.TestCase):
         stats = faiss.cvar.indexIVF_stats
         stats.reset()
         D0, I0 = index.search(
-            ds.get_queries(), 10,
-            params=faiss.SearchParametersIVF(nprobe=8)
+            ds.get_queries(), 10, params=faiss.SearchParametersIVF(nprobe=8)
         )
         ndis0 = stats.ndis
         target_ndis = ndis0 // ds.nq  # a few queries will be below, a few above
         for q in range(ds.nq):
             stats.reset()
             Dq, Iq = index.search(
-                ds.get_queries()[q:q + 1], 10,
+                ds.get_queries()[q : q + 1],
+                10,
                 params=faiss.SearchParametersIVF(
                     nprobe=8, max_codes=target_ndis
-                )
+                ),
             )
             self.assertLessEqual(stats.ndis, target_ndis)
             if stats.ndis < target_ndis:
@@ -485,8 +489,7 @@ class TestSelectorCallback(unittest.TestCase):
         subset = rs.choice(ds.nb, 50, replace=False)
 
         params = faiss.SearchParametersIVF(
-            sel=faiss.IDSelectorBatch(subset),
-            nprobe=4
+            sel=faiss.IDSelectorBatch(subset), nprobe=4
         )
 
         Dref, Iref = index.search(ds.get_queries(), k, params=params)
@@ -495,8 +498,7 @@ class TestSelectorCallback(unittest.TestCase):
             return idx in subset
 
         params = faiss.SearchParametersIVF(
-            sel=faiss.PyCallbackIDSelector(is_member),
-            nprobe=4
+            sel=faiss.PyCallbackIDSelector(is_member), nprobe=4
         )
 
         Dnew, Inew = index.search(ds.get_queries(), k, params=params)
@@ -506,20 +508,21 @@ class TestSelectorCallback(unittest.TestCase):
 
 
 class TestSortedIDSelectorRange(unittest.TestCase):
-    """ to test the sorted id bounds, there are a few cases to consider """
+    """to test the sorted id bounds, there are a few cases to consider"""
 
     def do_test_sorted(self, imin, imax, n=100):
         selr = faiss.IDSelectorRange(imin, imax, True)
         sp = faiss.swig_ptr
         for seed in range(10):
             rs = np.random.RandomState(seed)
-            ids = rs.choice(30, n).astype('int64')
+            ids = rs.choice(30, n).astype("int64")
             ids.sort()
-            j01 = np.zeros(2, dtype='uint64')
+            j01 = np.zeros(2, dtype="uint64")
             selr.find_sorted_ids_bounds(
-                len(ids), sp(ids), sp(j01[:1]), sp(j01[1:]))
+                len(ids), sp(ids), sp(j01[:1]), sp(j01[1:])
+            )
             j0, j1 = j01.astype(int)
-            ref_idx, = np.where((ids >= imin) & (ids < imax))
+            (ref_idx,) = np.where((ids >= imin) & (ids < imax))
             np.testing.assert_array_equal(ref_idx, np.arange(j0, j1))
 
     def test_sorted_in_range(self):
@@ -536,11 +539,10 @@ class TestSortedIDSelectorRange(unittest.TestCase):
 
     def test_12_92(self):
         selr = faiss.IDSelectorRange(30, 80, True)
-        ids = np.array([12, 92], dtype='int64')
-        j01 = np.zeros(2, dtype='uint64')
+        ids = np.array([12, 92], dtype="int64")
+        j01 = np.zeros(2, dtype="uint64")
         sp = faiss.swig_ptr
-        selr.find_sorted_ids_bounds(
-            len(ids), sp(ids), sp(j01[:1]), sp(j01[1:]))
+        selr.find_sorted_ids_bounds(len(ids), sp(ids), sp(j01[:1]), sp(j01[1:]))
         assert j01[0] >= j01[1]
 
 
@@ -562,13 +564,12 @@ class TestPrecomputed(unittest.TestCase):
         if range:
             r2 = float(np.median(Dref[:, 5]))
             Lref, Dref, Iref = index.range_search(ds.get_queries(), r2)
-            assert Lref.size > 10   # make sure there is something to test...
+            assert Lref.size > 10  # make sure there is something to test...
 
-            Lnew, Dnew, Inew = index.range_search_preassigned(ds.get_queries(), r2, Iq, Dq)
-            check_ref_range_results(
-                Lref, Dref, Iref,
-                Lnew, Dnew, Inew
+            Lnew, Dnew, Inew = index.range_search_preassigned(
+                ds.get_queries(), r2, Iq, Dq
             )
+            check_ref_range_results(Lref, Dref, Iref, Lnew, Dnew, Inew)
 
     def test_knn_and_range_Flat(self):
         self.do_test_knn_and_range("IVF32,Flat")
@@ -603,7 +604,7 @@ class TestIVFEarlyTermination(unittest.TestCase):
         k = 10
         params = faiss.SearchParametersIVF()
         params.nprobe = 32
-        params.max_codes = k // 2    # tight budget: forces truncation
+        params.max_codes = k // 2  # tight budget: forces truncation
         params.ensure_topk_full = False
         _, I_tight = index.search(ds.get_queries(), k, params=params)
 
@@ -637,14 +638,18 @@ class TestIVFEarlyTermination(unittest.TestCase):
         # Per-query (id, distance) pairs must match as sorted sets since
         # within-query order is not guaranteed across OMP threads.
         for q in range(ds.nq):
-            a = sorted(zip(
-                Iref[Lref[q]: Lref[q + 1]].tolist(),
-                Dref[Lref[q]: Lref[q + 1]].tolist(),
-            ))
-            b = sorted(zip(
-                Inew[Lnew[q]: Lnew[q + 1]].tolist(),
-                Dnew[Lnew[q]: Lnew[q + 1]].tolist(),
-            ))
+            a = sorted(
+                zip(
+                    Iref[Lref[q] : Lref[q + 1]].tolist(),
+                    Dref[Lref[q] : Lref[q + 1]].tolist(),
+                )
+            )
+            b = sorted(
+                zip(
+                    Inew[Lnew[q] : Lnew[q + 1]].tolist(),
+                    Dnew[Lnew[q] : Lnew[q + 1]].tolist(),
+                )
+            )
             self.assertEqual(a, b)
 
     def test_range_early_exit_is_subset(self):
@@ -657,14 +662,12 @@ class TestIVFEarlyTermination(unittest.TestCase):
         radius = 15.0
         p_full = faiss.SearchParametersIVF()
         p_full.nprobe = 32
-        p_full.max_empty_result_buckets = 0    # disabled
-        Lf, Df, If = index.range_search(
-            ds.get_queries(), radius, params=p_full
-        )
+        p_full.max_empty_result_buckets = 0  # disabled
+        Lf, Df, If = index.range_search(ds.get_queries(), radius, params=p_full)
 
         p_early = faiss.SearchParametersIVF()
         p_early.nprobe = 32
-        p_early.max_empty_result_buckets = 1   # aggressive early-exit
+        p_early.max_empty_result_buckets = 1  # aggressive early-exit
         Le, De, Ie = index.range_search(
             ds.get_queries(), radius, params=p_early
         )
@@ -673,8 +676,8 @@ class TestIVFEarlyTermination(unittest.TestCase):
         self.assertTrue(np.all(np.diff(Le) <= np.diff(Lf)))
         # And each per-query id-set must be a subset of the full result.
         for q in range(ds.nq):
-            full = set(If[Lf[q]: Lf[q + 1]].tolist())
-            early = set(Ie[Le[q]: Le[q + 1]].tolist())
+            full = set(If[Lf[q] : Lf[q + 1]].tolist())
+            early = set(Ie[Le[q] : Le[q + 1]].tolist())
             self.assertTrue(early.issubset(full))
         # At least one query must strictly shrink.
         any_shrunk = bool(np.any(np.diff(Le) < np.diff(Lf)))
@@ -694,9 +697,7 @@ class TestIVFEarlyTermination(unittest.TestCase):
         p_tight = faiss.SearchParametersIVF()
         p_tight.nprobe = 32
         p_tight.max_empty_result_buckets = 1
-        Lt, _, _ = index.range_search(
-            ds.get_queries(), radius, params=p_tight
-        )
+        Lt, _, _ = index.range_search(ds.get_queries(), radius, params=p_tight)
 
         p_relaxed = faiss.SearchParametersIVF()
         p_relaxed.nprobe = 32
@@ -757,7 +758,7 @@ class TestIVFEarlyTermination(unittest.TestCase):
 
         params = faiss.SearchParametersIVF()
         params.nprobe = 32
-        params.max_codes = 5            # tight pre-filter budget
+        params.max_codes = 5  # tight pre-filter budget
         params.ensure_topk_full = True  # post-filter soft cap
         params.sel = sel
         _, I = index.search(ds.get_queries(), 10, params=params)

--- a/tests/test_simd_dispatch.py
+++ b/tests/test_simd_dispatch.py
@@ -102,7 +102,9 @@ class TestSIMDDispatch(unittest.TestCase):
             import faiss
 
             if "DD" not in faiss.get_compile_options():
-                self.skipTest("Not a DD build - SIMD level is fixed at compile time")
+                self.skipTest(
+                    "Not a DD build - SIMD level is fixed at compile time"
+                )
         except ImportError:
             self.skipTest("faiss not available")
 
@@ -161,7 +163,9 @@ print(f"OK: SIMD level {level_name} dispatched correctly")
             import faiss
 
             if "DD" not in faiss.get_compile_options():
-                self.skipTest("Not a DD build - SIMD level is fixed at compile time")
+                self.skipTest(
+                    "Not a DD build - SIMD level is fixed at compile time"
+                )
         except ImportError:
             self.skipTest("faiss not available")
 
@@ -227,7 +231,9 @@ for lvl in range(int(faiss.SIMDLevel_COUNT)):
             import faiss
 
             if "DD" not in faiss.get_compile_options():
-                self.skipTest("Not a DD build - SIMD level is fixed at compile time")
+                self.skipTest(
+                    "Not a DD build - SIMD level is fixed at compile time"
+                )
         except ImportError:
             self.skipTest("faiss not available")
 
@@ -239,9 +245,17 @@ for lvl in range(int(faiss.SIMDLevel_COUNT)):
             self.skipTest("/proc/cpuinfo not available")
 
         # The exact feature set faiss requires before selecting AVX512_SPR.
-        avx512_core = {"avx512f", "avx512cd", "avx512vl", "avx512dq", "avx512bw"}
+        avx512_core = {
+            "avx512f",
+            "avx512cd",
+            "avx512vl",
+            "avx512dq",
+            "avx512bw",
+        }
         spr_capable = (
-            avx512_core <= flags and "avx512_bf16" in flags and "avx512_fp16" in flags
+            avx512_core <= flags
+            and "avx512_bf16" in flags
+            and "avx512_fp16" in flags
         )
 
         spr_detected = faiss.SIMDConfig.is_simd_level_available(

--- a/tests/test_standalone_codec.py
+++ b/tests/test_standalone_codec.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-""" test byte codecs """
+"""test byte codecs"""
 
 from __future__ import print_function
 import numpy as np
@@ -37,7 +37,7 @@ class TestEncodeDecode(unittest.TestCase):
 
         codes2 = codec.sa_encode(x2)
 
-        if 'IVF' in factory_key or 'RQ' in factory_key:
+        if "IVF" in factory_key or "RQ" in factory_key:
             # some rows are not reconstructed exactly because they
             # flip into another quantization cell
             nrowdiff = (codes != codes2).any(axis=1).sum()
@@ -47,7 +47,7 @@ class TestEncodeDecode(unittest.TestCase):
 
         x3 = codec.sa_decode(codes2)
 
-        if 'IVF' in factory_key or 'RQ' in factory_key:
+        if "IVF" in factory_key or "RQ" in factory_key:
             diffs = np.abs(x2 - x3).sum(axis=1)
             avg = np.abs(x2).sum(axis=1).mean()
             diffs.sort()
@@ -56,43 +56,43 @@ class TestEncodeDecode(unittest.TestCase):
             self.assertTrue(np.allclose(x2, x3))
 
     def test_SQ8(self):
-        self.do_encode_twice('SQ8')
+        self.do_encode_twice("SQ8")
 
     def test_SQtqmse1(self):
-        self.do_encode_twice('SQtqmse1')
+        self.do_encode_twice("SQtqmse1")
 
     def test_SQtqmse2(self):
-        self.do_encode_twice('SQtqmse2')
+        self.do_encode_twice("SQtqmse2")
 
     def test_SQtqmse3(self):
-        self.do_encode_twice('SQtqmse3')
+        self.do_encode_twice("SQtqmse3")
 
     def test_SQtqmse4(self):
-        self.do_encode_twice('SQtqmse4')
+        self.do_encode_twice("SQtqmse4")
 
     def test_SQtqmse8(self):
-        self.do_encode_twice('SQtqmse8')
+        self.do_encode_twice("SQtqmse8")
 
     def test_IVFSQ8(self):
-        self.do_encode_twice('IVF256,SQ8')
+        self.do_encode_twice("IVF256,SQ8")
 
     def test_PCAIVFSQ8(self):
-        self.do_encode_twice('PCAR32,IVF256,SQ8')
+        self.do_encode_twice("PCAR32,IVF256,SQ8")
 
     def test_PQ6x8(self):
-        self.do_encode_twice('PQ6np')
+        self.do_encode_twice("PQ6np")
 
     def test_PQ6x6(self):
-        self.do_encode_twice('PQ6x6np')
+        self.do_encode_twice("PQ6x6np")
 
     def test_IVFPQ6x8np(self):
-        self.do_encode_twice('IVF512,PQ6np')
+        self.do_encode_twice("IVF512,PQ6np")
 
     def test_LSH(self):
-        self.do_encode_twice('LSHrt')
+        self.do_encode_twice("LSHrt")
 
     def test_RQ6x8(self):
-        self.do_encode_twice('RQ6x8')
+        self.do_encode_twice("RQ6x8")
 
 
 class TestIndexEquiv(unittest.TestCase):
@@ -127,8 +127,7 @@ class TestIndexEquiv(unittest.TestCase):
         self.assertTrue(np.all(code_new == code_ref))
         self.assertTrue(np.all(x_recons_new == x_recons_ref))
 
-        codec_new_2 = faiss.deserialize_index(
-            faiss.serialize_index(codec_new))
+        codec_new_2 = faiss.deserialize_index(faiss.serialize_index(codec_new))
 
         code_new = codec_new_2.sa_encode(x)
         x_recons_new = codec_new_2.sa_decode(code_new)
@@ -138,7 +137,8 @@ class TestIndexEquiv(unittest.TestCase):
 
         # Verify deserialized index is serializable again
         codec_new_3 = faiss.deserialize_index(
-            faiss.serialize_index(codec_new_2))
+            faiss.serialize_index(codec_new_2)
+        )
         code_new_3 = codec_new_3.sa_encode(x)
         self.assertTrue(np.all(code_new_3 == code_ref))
 
@@ -150,7 +150,7 @@ class TestIndexEquiv(unittest.TestCase):
 
 
 class TestAccuracy(unittest.TestCase):
-    """ comparative accuracy of a few types of indexes """
+    """comparative accuracy of a few types of indexes"""
 
     def compare_accuracy(self, lowac, highac, max_errs=(1e10, 1e10)):
         d = 96
@@ -165,7 +165,7 @@ class TestAccuracy(unittest.TestCase):
         for factory_string in lowac, highac:
 
             codec = faiss.index_factory(d, factory_string)
-            print('sa codec: code size %d' % codec.sa_code_size())
+            print("sa codec: code size %d" % codec.sa_code_size())
             codec.train(xt)
 
             codes = codec.sa_encode(x)
@@ -180,34 +180,32 @@ class TestAccuracy(unittest.TestCase):
         self.assertGreater(max_errs[1], errs[1])
 
         # just a small IndexLattice I/O test
-        if 'Lattice' in highac:
-            codec2 = faiss.deserialize_index(
-                faiss.serialize_index(codec))
+        if "Lattice" in highac:
+            codec2 = faiss.deserialize_index(faiss.serialize_index(codec))
             codes = codec2.sa_encode(x)
             x3 = codec2.sa_decode(codes)
             self.assertTrue(np.all(x2 == x3))
 
             # Verify deserialized index is serializable again
-            codec3 = faiss.deserialize_index(
-                faiss.serialize_index(codec2))
+            codec3 = faiss.deserialize_index(faiss.serialize_index(codec2))
             codes3 = codec3.sa_encode(x)
             x4 = codec3.sa_decode(codes3)
             self.assertTrue(np.all(x2 == x4))
 
     def test_SQ(self):
-        self.compare_accuracy('SQ4', 'SQ8')
+        self.compare_accuracy("SQ4", "SQ8")
 
     def test_SQ2(self):
-        self.compare_accuracy('SQ6', 'SQ8')
+        self.compare_accuracy("SQ6", "SQ8")
 
     def test_SQ3(self):
-        self.compare_accuracy('SQ8', 'SQfp16')
+        self.compare_accuracy("SQ8", "SQfp16")
 
     def test_SQ4(self):
-        self.compare_accuracy('SQ8', 'SQbf16')
+        self.compare_accuracy("SQ8", "SQbf16")
 
     def test_SQtqmse(self):
-        self.compare_accuracy('SQtqmse4', 'SQtqmse8')
+        self.compare_accuracy("SQtqmse4", "SQtqmse8")
 
     def test_SQtqmse_ordering(self):
         d = 96
@@ -219,11 +217,12 @@ class TestAccuracy(unittest.TestCase):
 
         errs = []
         for factory_string in (
-                'SQtqmse1',
-                'SQtqmse2',
-                'SQtqmse3',
-                'SQtqmse4',
-                'SQtqmse8'):
+            "SQtqmse1",
+            "SQtqmse2",
+            "SQtqmse3",
+            "SQtqmse4",
+            "SQtqmse8",
+        ):
             codec = faiss.index_factory(d, factory_string)
             codec.train(xt)
             codes = codec.sa_encode(x)
@@ -234,44 +233,44 @@ class TestAccuracy(unittest.TestCase):
             self.assertGreaterEqual(errs[i], errs[i + 1])
 
     def test_PQ(self):
-        self.compare_accuracy('PQ6x8np', 'PQ8x8np')
+        self.compare_accuracy("PQ6x8np", "PQ8x8np")
 
     def test_PQ2(self):
-        self.compare_accuracy('PQ8x6np', 'PQ8x8np')
+        self.compare_accuracy("PQ8x6np", "PQ8x8np")
 
     def test_IVFvsPQ(self):
-        self.compare_accuracy('PQ8np', 'IVF256,PQ8np')
+        self.compare_accuracy("PQ8np", "IVF256,PQ8np")
 
     def test_Lattice(self):
         # measured low/high: 20946.244, 5277.483
-        self.compare_accuracy('ZnLattice3x10_4',
-                              'ZnLattice3x20_4',
-                              (22000, 5400))
+        self.compare_accuracy(
+            "ZnLattice3x10_4", "ZnLattice3x20_4", (22000, 5400)
+        )
 
     def test_Lattice2(self):
         # here the difference is actually tiny
         # measured errs: [16403.072, 15967.735]
-        self.compare_accuracy('ZnLattice3x12_1',
-                              'ZnLattice3x12_7',
-                              (18000, 16000))
+        self.compare_accuracy(
+            "ZnLattice3x12_1", "ZnLattice3x12_7", (18000, 16000)
+        )
 
 
 swig_ptr = faiss.swig_ptr
 
 
 class LatticeTest(unittest.TestCase):
-    """ Low-level lattice tests """
+    """Low-level lattice tests"""
 
     def test_repeats(self):
         rs = np.random.RandomState(123)
         dim = 32
         for _i in range(1000):
-            vec = np.floor((rs.rand(dim) ** 7) * 3).astype('float32')
+            vec = np.floor((rs.rand(dim) ** 7) * 3).astype("float32")
             vecs = vec.copy()
             vecs.sort()
             repeats = faiss.Repeats(dim, swig_ptr(vecs))
             code = repeats.encode(swig_ptr(vec))
-            vec2 = np.zeros(dim, dtype='float32')
+            vec2 = np.zeros(dim, dtype="float32")
             repeats.decode(code, swig_ptr(vec2))
             assert np.all(vec == vec2)
 
@@ -283,7 +282,7 @@ class LatticeTest(unittest.TestCase):
         assert ref_codec.nv == codec.nv
         s = set()
         for i in range(ref_codec.nv):
-            c = np.zeros(dim, dtype='float32')
+            c = np.zeros(dim, dtype="float32")
             ref_codec.decode(i, swig_ptr(c))
             code = codec.encode_centroid(swig_ptr(c))
             assert 0 <= code < codec.nv
@@ -295,7 +294,7 @@ class LatticeTest(unittest.TestCase):
         r2 = 6
         codec = faiss.ZnSphereCodecRec(dim, r2)
         for i in range(codec.nv):
-            c = np.zeros(dim, dtype='float32')
+            c = np.zeros(dim, dtype="float32")
             codec.decode(i, swig_ptr(c))
             code = codec.encode_centroid(swig_ptr(c))
             assert code == i
@@ -306,10 +305,10 @@ class LatticeTest(unittest.TestCase):
         codec = faiss.ZnSphereCodecAlt(dim, r2)
         rs = np.random.RandomState(123)
         n = 100
-        codes = rs.randint(codec.nv, size=n, dtype='uint64')
-        x = np.empty((n, dim), dtype='float32')
+        codes = rs.randint(codec.nv, size=n, dtype="uint64")
+        x = np.empty((n, dim), dtype="float32")
         codec.decode_multi(n, swig_ptr(codes), swig_ptr(x))
-        codes2 = np.empty(n, dtype='uint64')
+        codes2 = np.empty(n, dtype="uint64")
         codec.encode_multi(n, swig_ptr(x), swig_ptr(codes2))
 
         assert np.all(codes == codes2)
@@ -323,8 +322,8 @@ class LatticeTest(unittest.TestCase):
     def test_lattice_index(self):
         index = faiss.index_factory(96, "ZnLattice3x10_4")
         rs = np.random.RandomState(123)
-        xq = rs.randn(10, 96).astype('float32')
-        xb = rs.randn(20, 96).astype('float32')
+        xq = rs.randn(10, 96).astype("float32")
+        xb = rs.randn(20, 96).astype("float32")
         index.train(xb)
         index.add(xb)
         D, I = index.search(xq, 5)
@@ -337,16 +336,16 @@ class LatticeTest(unittest.TestCase):
 class TestBitstring(unittest.TestCase):
 
     def test_rw(self):
-        """ Low-level bit string tests """
+        """Low-level bit string tests"""
         rs = np.random.RandomState(1234)
         nbyte = 1000
         sz = 0
 
-        bs = np.ones(nbyte, dtype='uint8')
+        bs = np.ones(nbyte, dtype="uint8")
         bw = faiss.BitstringWriter(swig_ptr(bs), nbyte)
 
         if False:
-            ctrl = [(7, 0x35), (13, 0x1d74)]
+            ctrl = [(7, 0x35), (13, 0x1D74)]
             for nbit, x in ctrl:
                 bw.write(x, nbit)
         else:
@@ -355,7 +354,7 @@ class TestBitstring(unittest.TestCase):
                 nbit = int(1 + 62 * rs.rand() ** 4)
                 if sz + nbit > nbyte * 8:
                     break
-                x = int(rs.randint(1 << nbit, dtype='int64'))
+                x = int(rs.randint(1 << nbit, dtype="int64"))
                 bw.write(x, nbit)
                 ctrl.append((nbit, x))
                 sz += nbit
@@ -380,7 +379,7 @@ class TestBitstring(unittest.TestCase):
         M = 10
         n = 20
         rs = np.random.RandomState(123)
-        a = rs.randint(1<<nbit, size=(n, M), dtype='int32')
+        a = rs.randint(1 << nbit, size=(n, M), dtype="int32")
         b = faiss.pack_bitstrings(a, nbit)
         c = faiss.unpack_bitstrings(b, M, nbit)
         np.testing.assert_array_equal(a, c)
@@ -389,7 +388,7 @@ class TestBitstring(unittest.TestCase):
         nbits = [10, 5, 3, 12, 6, 7, 4]
         n = 20
         rs = np.random.RandomState(123)
-        a = rs.randint(1<<16, size=(n, len(nbits)), dtype='int32')
+        a = rs.randint(1 << 16, size=(n, len(nbits)), dtype="int32")
         a &= (1 << np.array(nbits)) - 1
         b = faiss.pack_bitstrings(a, nbits)
         c = faiss.unpack_bitstrings(b, nbits)
@@ -419,7 +418,7 @@ class TestIVFTransfer(unittest.TestCase):
 class TestIDMap(unittest.TestCase):
     def test_idmap(self):
         ds = SyntheticDataset(32, 2000, 200, 100)
-        ids = np.random.randint(10000, size=ds.nb, dtype='int64')
+        ids = np.random.randint(10000, size=ds.nb, dtype="int64")
         index = faiss.index_factory(ds.d, "IDMap2,PQ8x2")
         index.train(ds.get_train())
         index.add_with_ids(ds.get_database(), ids)
@@ -434,13 +433,12 @@ class TestIDMap(unittest.TestCase):
 
         np.testing.assert_array_equal(Iref, Inew)
         np.testing.assert_array_equal(Dref, Dnew)
-        
 
 
 class TestRefine(unittest.TestCase):
 
     def test_refine(self):
-        """ Make sure that IndexRefine can function as a standalone codec """
+        """Make sure that IndexRefine can function as a standalone codec"""
 
         ds = SyntheticDataset(32, 500, 100, 0)
         index = faiss.index_factory(ds.d, "RQ2x5,Refine(ITQ,LSHt)")
@@ -453,13 +451,10 @@ class TestRefine(unittest.TestCase):
         codes1 = index1.sa_encode(ds.get_database())
         codes2 = index2.sa_encode(ds.get_database())
 
-        np.testing.assert_array_equal(
-            codes12,
-            np.hstack((codes1, codes2))
-        )
+        np.testing.assert_array_equal(codes12, np.hstack((codes1, codes2)))
 
     def test_refine_sa_decode(self):
-        """ Make sure IndexRefine.sa_decode correctly extracts refine codes """
+        """Make sure IndexRefine.sa_decode correctly extracts refine codes"""
 
         ds = SyntheticDataset(32, 500, 100, 0)
         index = faiss.index_factory(ds.d, "PQ4,Refine(SQ8)")
@@ -475,7 +470,7 @@ class TestRefine(unittest.TestCase):
         np.testing.assert_allclose(x_decoded, x_decoded_ref)
 
     def test_equiv_rcq_rq(self):
-        """ make sure that the codes generated by the standalone codec are the same
+        """make sure that the codes generated by the standalone codec are the same
         between an
            IndexRefine with ResidualQuantizer
         and
@@ -500,11 +495,13 @@ class TestRefine(unittest.TestCase):
 
         np.testing.assert_array_equal(codes1, codes2)
 
-    @unittest.skipIf(platform.system() == 'Windows',
-                     'Does not work on Windows after numpy 2 upgrade.')
+    @unittest.skipIf(
+        platform.system() == "Windows",
+        "Does not work on Windows after numpy 2 upgrade.",
+    )
     def test_equiv_sh(self):
-        """ make sure that the IVFSpectralHash sa_encode function gives the same
-        result as the concatenated RQ + LSH index sa_encode """
+        """make sure that the IVFSpectralHash sa_encode function gives the same
+        result as the concatenated RQ + LSH index sa_encode"""
         ds = SyntheticDataset(32, 500, 100, 0)
         index1 = faiss.index_factory(ds.d, "RQ1x4,Refine(ITQ16,LSH)")
         index1.train(ds.get_train())
@@ -526,7 +523,7 @@ class TestRefine(unittest.TestCase):
             ds.d,
             coarse_quantizer.ntotal,
             encoder.sa_code_size() * 8,
-            period
+            period,
         )
 
         # replace with the vt of the encoder. Binarization is performed by

--- a/tests/test_svs_py.py
+++ b/tests/test_svs_py.py
@@ -55,8 +55,8 @@ class TestSVSAdapter(unittest.TestCase):
         cls.nb = 500
         cls.nq = 50
         np.random.seed(1234)
-        cls.xb = np.random.random((cls.nb, cls.d)).astype('float32')
-        cls.xq = np.random.random((cls.nq, cls.d)).astype('float32')
+        cls.xb = np.random.random((cls.nb, cls.d)).astype("float32")
+        cls.xq = np.random.random((cls.nq, cls.d)).astype("float32")
 
     def test_svs_construction(self):
         """Test construction and basic properties"""
@@ -229,7 +229,7 @@ class TestSVSAdapter(unittest.TestCase):
         index = self._create_instance()
 
         # Test wrong dimension
-        wrong_dim_data = np.random.random((100, self.d + 1)).astype('float32')
+        wrong_dim_data = np.random.random((100, self.d + 1)).astype("float32")
         with self.assertRaises(AssertionError):
             index.add(wrong_dim_data)
 
@@ -340,6 +340,7 @@ class TestSVSIVFCoarseQuantizerFactory(unittest.TestCase):
 @unittest.skipIf(_SKIP_SVS, _SKIP_REASON)
 class TestSVSAdapterFP16(TestSVSAdapter):
     """Repeat all tests for SVS Float16 variant"""
+
     def _create_instance(self):
         idx = self.target_class(self.d, 64)
         idx.storage_kind = faiss.SVS_FP16
@@ -349,6 +350,7 @@ class TestSVSAdapterFP16(TestSVSAdapter):
 @unittest.skipIf(_SKIP_SVS, _SKIP_REASON)
 class TestSVSAdapterSQ8(TestSVSAdapter):
     """Repeat all tests for SVS SQ int8 variant"""
+
     def _create_instance(self):
         idx = self.target_class(self.d, 64)
         idx.storage_kind = faiss.SVS_SQ8
@@ -466,8 +468,8 @@ class TestSVSVamanaParameters(unittest.TestCase):
         cls.nb = 500
         cls.nq = 50
         np.random.seed(1234)
-        cls.xb = np.random.random((cls.nb, cls.d)).astype('float32')
-        cls.xq = np.random.random((cls.nq, cls.d)).astype('float32')
+        cls.xb = np.random.random((cls.nb, cls.d)).astype("float32")
+        cls.xq = np.random.random((cls.nq, cls.d)).astype("float32")
 
     def _create_instance(self):
         """Create an instance of the SVS Vamana index"""
@@ -552,6 +554,7 @@ class TestSVSVamanaParameters(unittest.TestCase):
 @unittest.skipIf(_SKIP_SVS, _SKIP_REASON)
 class TestSVSVamanaParametersFP16(TestSVSVamanaParameters):
     """Repeat Vamana parameter tests for SVS Float16 variant"""
+
     def _create_instance(self):
         idx = self.target_class(self.d, 64)
         idx.storage_kind = faiss.SVS_FP16
@@ -561,6 +564,7 @@ class TestSVSVamanaParametersFP16(TestSVSVamanaParameters):
 @unittest.skipIf(_SKIP_SVS, _SKIP_REASON)
 class TestSVSVamanaParametersSQ8(TestSVSVamanaParameters):
     """Repeat Vamana parameter tests for SVS SQ int8 variant"""
+
     def _create_instance(self):
         idx = self.target_class(self.d, 64)
         idx.storage_kind = faiss.SVS_SQ8
@@ -669,8 +673,8 @@ class TestSVSIVFAdapter(unittest.TestCase):
         self.nq = 100
         self.nlist = 4
         np.random.seed(1234)
-        self.xb = np.random.random((self.nb, self.d)).astype('float32')
-        self.xq = np.random.random((self.nq, self.d)).astype('float32')
+        self.xb = np.random.random((self.nb, self.d)).astype("float32")
+        self.xq = np.random.random((self.nq, self.d)).astype("float32")
 
     def _create_instance(self):
         idx = self.target_class(self.d, self.nlist)
@@ -694,7 +698,7 @@ class TestSVSIVFAdapter(unittest.TestCase):
         self.assertTrue(index.is_trained)
 
         # Add more data
-        extra = np.random.random((200, self.d)).astype('float32')
+        extra = np.random.random((200, self.d)).astype("float32")
         index.add(extra)
 
         # Search
@@ -714,7 +718,7 @@ class TestSVSIVFAdapter(unittest.TestCase):
         index = self._create_instance()
         index.train(self.xb)
 
-        extra = np.random.random((200, self.d)).astype('float32')
+        extra = np.random.random((200, self.d)).astype("float32")
         index.add(extra)
 
         D_before, I_before = index.search(self.xq, 4)
@@ -734,7 +738,7 @@ class TestSVSIVFAdapter(unittest.TestCase):
         index = self._create_instance()
         index.train(self.xb)
 
-        extra = np.random.random((200, self.d)).astype('float32')
+        extra = np.random.random((200, self.d)).astype("float32")
         index.add(extra)
         before = index.ntotal
 
@@ -749,7 +753,7 @@ class TestSVSIVFAdapter(unittest.TestCase):
         index = self._create_instance()
         index.train(self.xb)
 
-        extra = np.random.random((100, self.d)).astype('float32')
+        extra = np.random.random((100, self.d)).astype("float32")
         index.add(extra)
         self.assertGreater(index.ntotal, 0)
 
@@ -761,9 +765,11 @@ class TestSVSIVFAdapter(unittest.TestCase):
 @unittest.skipIf(_SKIP_SVS, _SKIP_REASON)
 class TestSVSIVFAdapterFP16(TestSVSIVFAdapter):
     """Repeat IVF tests for FP16 variant"""
+
     def _create_instance(self):
-        idx = self.target_class(self.d, self.nlist, faiss.METRIC_L2,
-                                faiss.SVS_FP16)
+        idx = self.target_class(
+            self.d, self.nlist, faiss.METRIC_L2, faiss.SVS_FP16
+        )
         idx.num_threads = 4
         return idx
 
@@ -771,9 +777,11 @@ class TestSVSIVFAdapterFP16(TestSVSIVFAdapter):
 @unittest.skipIf(_SKIP_SVS, _SKIP_REASON)
 class TestSVSIVFAdapterSQ8(TestSVSIVFAdapter):
     """Repeat IVF tests for SQ8 variant"""
+
     def _create_instance(self):
-        idx = self.target_class(self.d, self.nlist, faiss.METRIC_L2,
-                                faiss.SVS_SQ8)
+        idx = self.target_class(
+            self.d, self.nlist, faiss.METRIC_L2, faiss.SVS_SQ8
+        )
         idx.num_threads = 4
         return idx
 
@@ -833,8 +841,8 @@ class TestSVSIVFAdapterLeanVec4x4(TestSVSIVFAdapter):
 
     def _create_instance(self):
         idx = self.target_class(
-            self.d, self.nlist, faiss.METRIC_L2, 0,
-            faiss.SVS_LeanVec4x4)
+            self.d, self.nlist, faiss.METRIC_L2, 0, faiss.SVS_LeanVec4x4
+        )
         idx.num_threads = 4
         return idx
 
@@ -891,8 +899,8 @@ class TestSVSIVFParameters(unittest.TestCase):
         self.nq = 50
         self.nlist = 100
         np.random.seed(1234)
-        self.xb = np.random.random((self.nb, self.d)).astype('float32')
-        self.xq = np.random.random((self.nq, self.d)).astype('float32')
+        self.xb = np.random.random((self.nb, self.d)).astype("float32")
+        self.xq = np.random.random((self.nq, self.d)).astype("float32")
 
     def test_ivf_parameter_setting(self):
         """Test that IVF parameters can be set and retrieved"""
@@ -936,7 +944,7 @@ class TestSVSIVFParameters(unittest.TestCase):
 
         # Train and add
         index.train(self.xb)
-        extra = np.random.random((100, self.d)).astype('float32')
+        extra = np.random.random((100, self.d)).astype("float32")
         index.add(extra)
 
         loaded = faiss.deserialize_index(faiss.serialize_index(index))
@@ -971,8 +979,11 @@ class TestSVSIVFLeanVecOOD(unittest.TestCase):
 
     def _create_instance(self):
         idx = faiss.IndexSVSIVFLeanVec(
-            self.d, self.nlist, faiss.METRIC_L2,
-            self.leanvec_d, faiss.SVS_LeanVec4x8
+            self.d,
+            self.nlist,
+            faiss.METRIC_L2,
+            self.leanvec_d,
+            faiss.SVS_LeanVec4x8,
         )
         idx.num_threads = 4
         return idx
@@ -1001,9 +1012,7 @@ class TestSVSIVFLeanVecOOD(unittest.TestCase):
         """OOD training rejects non-Float32 numeric_type with xq_train"""
         idx = self._create_instance()
         with self.assertRaises(TypeError):
-            idx.train(
-                self.x, xq_train=self.tq, numeric_type=faiss.Float16
-            )
+            idx.train(self.x, xq_train=self.tq, numeric_type=faiss.Float16)
 
     def test_ivf_leanvec_ood_search(self):
         """OOD-trained IVF LeanVec index returns valid search results"""
@@ -1123,14 +1132,15 @@ class TestSVSStaticIVF(unittest.TestCase):
         self.nq = 100
         self.nlist = 4
         np.random.seed(1234)
-        self.xb = np.random.random((self.nb, self.d)).astype('float32')
-        self.xq = np.random.random((self.nq, self.d)).astype('float32')
+        self.xb = np.random.random((self.nb, self.d)).astype("float32")
+        self.xq = np.random.random((self.nq, self.d)).astype("float32")
 
     def _create_static(self, storage=None):
         if storage is None:
             storage = faiss.SVS_FP32
         idx = faiss.IndexSVSIVF(
-            self.d, self.nlist, faiss.METRIC_L2, storage, True)
+            self.d, self.nlist, faiss.METRIC_L2, storage, True
+        )
         idx.num_threads = 4
         return idx
 
@@ -1156,7 +1166,7 @@ class TestSVSStaticIVF(unittest.TestCase):
         """add() must raise on a static index"""
         index = self._create_static()
         index.train(self.xb)
-        extra = np.random.random((100, self.d)).astype('float32')
+        extra = np.random.random((100, self.d)).astype("float32")
         with self.assertRaises(RuntimeError):
             index.add(extra)
 
@@ -1220,12 +1230,13 @@ class TestSVSStaticIVFLVQ(unittest.TestCase):
         self.nq = 100
         self.nlist = 4
         np.random.seed(1234)
-        self.xb = np.random.random((self.nb, self.d)).astype('float32')
-        self.xq = np.random.random((self.nq, self.d)).astype('float32')
+        self.xb = np.random.random((self.nb, self.d)).astype("float32")
+        self.xq = np.random.random((self.nq, self.d)).astype("float32")
 
     def _create_static_lvq(self):
         idx = faiss.IndexSVSIVFLVQ(
-            self.d, self.nlist, faiss.METRIC_L2, faiss.SVS_LVQ4x4, True)
+            self.d, self.nlist, faiss.METRIC_L2, faiss.SVS_LVQ4x4, True
+        )
         idx.num_threads = 4
         return idx
 
@@ -1271,13 +1282,13 @@ class TestSVSStaticIVFLeanVec(unittest.TestCase):
         self.nq = 100
         self.nlist = 10
         np.random.seed(1234)
-        self.xb = np.random.random((self.nb, self.d)).astype('float32')
-        self.xq = np.random.random((self.nq, self.d)).astype('float32')
+        self.xb = np.random.random((self.nb, self.d)).astype("float32")
+        self.xq = np.random.random((self.nq, self.d)).astype("float32")
 
     def _create_static_leanvec(self):
         idx = faiss.IndexSVSIVFLeanVec(
-            self.d, self.nlist, faiss.METRIC_L2, 0,
-            faiss.SVS_LeanVec4x4, True)
+            self.d, self.nlist, faiss.METRIC_L2, 0, faiss.SVS_LeanVec4x4, True
+        )
         idx.num_threads = 4
         return idx
 
@@ -1333,14 +1344,15 @@ class TestSVSStaticVamana(unittest.TestCase):
         self.nq = 100
         self.degree = 32
         np.random.seed(1234)
-        self.xb = np.random.random((self.nb, self.d)).astype('float32')
-        self.xq = np.random.random((self.nq, self.d)).astype('float32')
+        self.xb = np.random.random((self.nb, self.d)).astype("float32")
+        self.xq = np.random.random((self.nq, self.d)).astype("float32")
 
     def _create_static(self, storage=None):
         if storage is None:
             storage = faiss.SVS_FP32
         return faiss.IndexSVSVamana(
-            self.d, self.degree, faiss.METRIC_L2, storage, True)
+            self.d, self.degree, faiss.METRIC_L2, storage, True
+        )
 
     def test_static_construction(self):
         """is_static is set on the constructed index"""
@@ -1363,7 +1375,7 @@ class TestSVSStaticVamana(unittest.TestCase):
         """A second add() must raise on a static Vamana index"""
         index = self._create_static()
         index.add(self.xb)
-        extra = np.random.random((100, self.d)).astype('float32')
+        extra = np.random.random((100, self.d)).astype("float32")
         with self.assertRaises(RuntimeError):
             index.add(extra)
 
@@ -1443,12 +1455,13 @@ class TestSVSStaticVamanaLVQ(unittest.TestCase):
         self.nq = 100
         self.degree = 32
         np.random.seed(1234)
-        self.xb = np.random.random((self.nb, self.d)).astype('float32')
-        self.xq = np.random.random((self.nq, self.d)).astype('float32')
+        self.xb = np.random.random((self.nb, self.d)).astype("float32")
+        self.xq = np.random.random((self.nq, self.d)).astype("float32")
 
     def _create_static_lvq(self):
         return faiss.IndexSVSVamanaLVQ(
-            self.d, self.degree, faiss.METRIC_L2, faiss.SVS_LVQ4x4, True)
+            self.d, self.degree, faiss.METRIC_L2, faiss.SVS_LVQ4x4, True
+        )
 
     def test_static_lvq_add_search(self):
         index = self._create_static_lvq()
@@ -1489,13 +1502,13 @@ class TestSVSStaticVamanaLeanVec(unittest.TestCase):
         self.nq = 100
         self.degree = 32
         np.random.seed(1234)
-        self.xb = np.random.random((self.nb, self.d)).astype('float32')
-        self.xq = np.random.random((self.nq, self.d)).astype('float32')
+        self.xb = np.random.random((self.nb, self.d)).astype("float32")
+        self.xq = np.random.random((self.nq, self.d)).astype("float32")
 
     def _create_static_leanvec(self):
         return faiss.IndexSVSVamanaLeanVec(
-            self.d, self.degree, faiss.METRIC_L2, 0,
-            faiss.SVS_LeanVec4x4, True)
+            self.d, self.degree, faiss.METRIC_L2, 0, faiss.SVS_LeanVec4x4, True
+        )
 
     def test_static_leanvec_train_add_search(self):
         index = self._create_static_leanvec()
@@ -1540,5 +1553,5 @@ class TestSVSStaticVamanaLeanVec(unittest.TestCase):
         np.testing.assert_allclose(D_before, D_after, rtol=1e-4)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_swig_wrapper.py
+++ b/tests/test_swig_wrapper.py
@@ -11,15 +11,15 @@ import numpy as np
 
 
 class TestSWIGWrap(unittest.TestCase):
-    """ various regressions with the SWIG wrapper """
+    """various regressions with the SWIG wrapper"""
 
     def test_size_t_ptr(self):
         # issue 1064
         index = faiss.IndexHNSWFlat(10, 32)
 
         hnsw = index.hnsw
-        index.add(np.random.rand(100, 10).astype('float32'))
-        be = np.empty(2, 'uint64')
+        index.add(np.random.rand(100, 10).astype("float32"))
+        be = np.empty(2, "uint64")
         hnsw.neighbor_range(23, 0, faiss.swig_ptr(be), faiss.swig_ptr(be[1:]))
 
     def test_id_map_at(self):
@@ -27,7 +27,9 @@ class TestSWIGWrap(unittest.TestCase):
         n_features = 100
         feature_dims = 10
 
-        features = np.random.random((n_features, feature_dims)).astype(np.float32)
+        features = np.random.random((n_features, feature_dims)).astype(
+            np.float32
+        )
         idx = np.arange(n_features).astype(np.int64)
 
         index = faiss.IndexFlatL2(feature_dims)
@@ -43,36 +45,32 @@ class TestSWIGWrap(unittest.TestCase):
         )
 
         # serialize and deserialize
-        index2 = faiss.deserialize_index(
-            faiss.serialize_index(index)
-        )
+        index2 = faiss.deserialize_index(faiss.serialize_index(index))
 
         assert isinstance(index2, faiss.IndexRefineFlat)
 
         # Verify deserialized index is serializable again
-        index3 = faiss.deserialize_index(
-            faiss.serialize_index(index2)
-        )
+        index3 = faiss.deserialize_index(faiss.serialize_index(index2))
         assert isinstance(index3, faiss.IndexRefineFlat)
 
     def do_test_array_type(self, dtype):
-        """ tests swig_ptr and rev_swig_ptr for this type of array """
+        """tests swig_ptr and rev_swig_ptr for this type of array"""
         a = np.arange(12).astype(dtype)
         ptr = faiss.swig_ptr(a)
         a2 = faiss.rev_swig_ptr(ptr, 12)
         np.testing.assert_array_equal(a, a2)
 
     def test_all_array_types(self):
-        self.do_test_array_type('float32')
-        self.do_test_array_type('float64')
-        self.do_test_array_type('int8')
-        self.do_test_array_type('uint8')
-        self.do_test_array_type('int16')
-        self.do_test_array_type('uint16')
-        self.do_test_array_type('int32')
-        self.do_test_array_type('uint32')
-        self.do_test_array_type('int64')
-        self.do_test_array_type('uint64')
+        self.do_test_array_type("float32")
+        self.do_test_array_type("float64")
+        self.do_test_array_type("int8")
+        self.do_test_array_type("uint8")
+        self.do_test_array_type("int16")
+        self.do_test_array_type("uint16")
+        self.do_test_array_type("int32")
+        self.do_test_array_type("uint32")
+        self.do_test_array_type("int64")
+        self.do_test_array_type("uint64")
 
     def test_int64(self):
         # see https://github.com/facebookresearch/faiss/issues/1529
@@ -81,21 +79,21 @@ class TestSWIGWrap(unittest.TestCase):
         for i in range(10):
             v.push_back(i)
         a = faiss.vector_to_array(v)
-        assert a.dtype == 'int64'
-        np.testing.assert_array_equal(a, np.arange(10, dtype='int64'))
+        assert a.dtype == "int64"
+        np.testing.assert_array_equal(a, np.arange(10, dtype="int64"))
 
         # check if it works in an IDMap
         idx = faiss.IndexIDMap(faiss.IndexFlatL2(32))
         idx.add_with_ids(
-            np.random.rand(10, 32).astype('float32'),
-            np.random.randint(1000, size=10, dtype='int64')
+            np.random.rand(10, 32).astype("float32"),
+            np.random.randint(1000, size=10, dtype="int64"),
         )
         faiss.vector_to_array(idx.id_map)
 
     def test_asan(self):
         # this test should fail with ASAN
         index = faiss.IndexFlatL2(32)
-        index.this.own(False)   # this is a mem leak, should be catched by ASAN
+        index.this.own(False)  # this is a mem leak, should be catched by ASAN
 
     def test_SWIG_version(self):
         self.assertLess(faiss.swig_version(), 0x050000)
@@ -176,9 +174,9 @@ class TestRevSwigPtr(unittest.TestCase):
     def test_rev_swig_ptr(self):
 
         index = faiss.IndexFlatL2(4)
-        xb0 = np.vstack([
-            i * 10 + np.array([1, 2, 3, 4], dtype='float32')
-            for i in range(5)])
+        xb0 = np.vstack(
+            [i * 10 + np.array([1, 2, 3, 4], dtype="float32") for i in range(5)]
+        )
         index.add(xb0)
         xb = faiss.rev_swig_ptr(index.get_xb(), 4 * 5).reshape(5, 4)
         self.assertEqual(np.abs(xb0 - xb).sum(), 0)
@@ -190,20 +188,16 @@ class TestException(unittest.TestCase):
 
         index = faiss.IndexFlatL2(10)
 
-        a = np.zeros((5, 10), dtype='float32')
-        b = np.zeros(5, dtype='int64')
+        a = np.zeros((5, 10), dtype="float32")
+        b = np.zeros(5, dtype="int64")
 
         # an unsupported operation for IndexFlat
-        self.assertRaises(
-            RuntimeError,
-            index.add_with_ids, a, b
-        )
+        self.assertRaises(RuntimeError, index.add_with_ids, a, b)
         # assert 'add_with_ids not implemented' in str(e)
 
     def test_exception_2(self):
         self.assertRaises(
-            RuntimeError,
-            faiss.index_factory, 12, 'IVF256,Flat,PQ8'
+            RuntimeError, faiss.index_factory, 12, "IVF256,Flat,PQ8"
         )
         #    assert 'could not parse' in str(e)
 
@@ -301,14 +295,19 @@ class TestSearchPreassignedDqNone(unittest.TestCase):
         self._check(index, xq, Iq, k=5, thresh=20, zero_dtype=np.int32)
 
 
-@unittest.skipIf(faiss.swig_version() < 0x040000, "swig < 4 does not support Doxygen comments")
+@unittest.skipIf(
+    faiss.swig_version() < 0x040000,
+    "swig < 4 does not support Doxygen comments",
+)
 class TestDoxygen(unittest.TestCase):
 
     def test_doxygen_comments(self):
         maxheap_array = faiss.float_maxheap_array_t()
 
-        self.assertTrue("a template structure for a set of [min|max]-heaps"
-                        in maxheap_array.__doc__)
+        self.assertTrue(
+            "a template structure for a set of [min|max]-heaps"
+            in maxheap_array.__doc__
+        )
 
 
 class TestMapLong2Long(unittest.TestCase):

--- a/tests/test_wheel_smoke.py
+++ b/tests/test_wheel_smoke.py
@@ -195,6 +195,6 @@ class TestSIMD(unittest.TestCase):
         if "DD" not in opts:
             raise unittest.SkipTest("Not a Dynamic Dispatch build")
         # DD builds should select at least AVX2 on modern x86_64
-        assert "AVX2" in opts or "AVX512" in opts, (
-            f"DD build did not select a SIMD path: {opts}"
-        )
+        assert (
+            "AVX2" in opts or "AVX512" in opts
+        ), f"DD build did not select a SIMD path: {opts}"

--- a/tests/test_wheel_smoke_gpu.py
+++ b/tests/test_wheel_smoke_gpu.py
@@ -36,11 +36,13 @@ _skip_unless_gpu_build = unittest.skipUnless(
 
 def skip_if_no_gpu(test_func):
     """Skip test if no GPU is available."""
+
     @functools.wraps(test_func)
     def wrapper(*args, **kwargs):
         if faiss.get_num_gpus() == 0:
             raise unittest.SkipTest("No GPU available")
         return test_func(*args, **kwargs)
+
     return wrapper
 
 

--- a/tests/torch_test_contrib.py
+++ b/tests/torch_test_contrib.py
@@ -13,8 +13,6 @@ from faiss.contrib import datasets
 from faiss.contrib.torch import clustering, quantization
 
 
-
-
 class TestTorchUtilsCPU(unittest.TestCase):
     # tests add, search
     def test_lookup(self):
@@ -147,7 +145,7 @@ class TestTorchUtilsCPU(unittest.TestCase):
         self.assertTrue(np.array_equal(labels, labels_ref))
 
         # Test assign with numpy output provided
-        labels = np.empty((xq.shape[0], 5), dtype='int64')
+        labels = np.empty((xq.shape[0], 5), dtype="int64")
         index.assign(xq.numpy(), 5, labels)
         self.assertTrue(np.array_equal(labels, labels_ref))
 
@@ -303,7 +301,7 @@ class TestTorchUtilsCPU(unittest.TestCase):
 
         # mutilate the index' quantizer
         index.quantizer.reset()
-        index.quantizer.add(np.zeros((20, 32), dtype='float32'))
+        index.quantizer.add(np.zeros((20, 32), dtype="float32"))
 
         # test numpy codepath
         Dq, Iq = quantizer.search(ds.get_queries(), 4)
@@ -339,7 +337,9 @@ class TestTorchUtilsCPU(unittest.TestCase):
         decoded_torch = index.sa_decode(encoded_torch)
         decoded_np = index.sa_decode(encoded_np)
 
-        self.assertTrue(torch.equal(decoded_torch, torch.from_numpy(decoded_np)))
+        self.assertTrue(
+            torch.equal(decoded_torch, torch.from_numpy(decoded_np))
+        )
 
         # torch cpu as output parameter
         encoded_torch_param = torch.zeros(nq, d, dtype=torch.uint8)
@@ -380,7 +380,7 @@ class TestTorchUtilsCPU(unittest.TestCase):
 class TestClustering(unittest.TestCase):
 
     def test_python_kmeans(self):
-        """ Test the python implementation of kmeans """
+        """Test the python implementation of kmeans"""
         ds = datasets.SyntheticDataset(32, 10000, 0, 0)
         x = ds.get_train()
 
@@ -405,23 +405,23 @@ class TestClustering(unittest.TestCase):
 
 class TestQuantization(unittest.TestCase):
     def test_python_product_quantization(self):
-        """ Test the python implementation of product quantization """
+        """Test the python implementation of product quantization"""
         d = 64
         n = 10000
         cs = 4
         nbits = 8
         M = 4
-        x = np.random.random(size=(n, d)).astype('float32')
+        x = np.random.random(size=(n, d)).astype("float32")
         pq = faiss.ProductQuantizer(d, cs, nbits)
         pq.train(x)
         codes = pq.compute_codes(x)
         x2 = pq.decode(codes)
-        diff = ((x - x2)**2).sum()
+        diff = ((x - x2) ** 2).sum()
         # vs pure pytorch impl
         xt = torch.from_numpy(x)
         my_pq = quantization.ProductQuantizer(d, M, nbits)
         my_pq.train(xt)
         my_codes = my_pq.encode(xt)
         xt2 = my_pq.decode(my_codes)
-        my_diff = ((xt - xt2)**2).sum()
+        my_diff = ((xt - xt2) ** 2).sum()
         self.assertLess(abs(diff - my_diff), 100)

--- a/tests/torch_test_neural_net.py
+++ b/tests/torch_test_neural_net.py
@@ -11,18 +11,20 @@ import numpy as np  # usort: skip
 import faiss  # usort: skip
 
 from faiss.contrib import datasets  # usort: skip
-from faiss.contrib.inspect_tools import get_additive_quantizer_codebooks  # usort: skip
+from faiss.contrib.inspect_tools import (
+    get_additive_quantizer_codebooks,
+)  # usort: skip
 
 
 class TestLayer(unittest.TestCase):
 
     @torch.no_grad()
     def test_Embedding(self):
-        """ verify that the Faiss Embedding works the same as in Pytorch """
+        """verify that the Faiss Embedding works the same as in Pytorch"""
         torch.manual_seed(123)
 
         emb = nn.Embedding(40, 50)
-        idx = torch.randint(40, (25, ))
+        idx = torch.randint(40, (25,))
         ref_batch = emb(idx)
 
         emb2 = faiss.Embedding(emb)
@@ -34,7 +36,7 @@ class TestLayer(unittest.TestCase):
 
     @torch.no_grad()
     def do_test_Linear(self, bias):
-        """ verify that the Faiss Linear works the same as in Pytorch """
+        """verify that the Faiss Linear works the same as in Pytorch"""
         torch.manual_seed(123)
         linear = nn.Linear(50, 40, bias=bias)
         x = torch.randn(25, 50)
@@ -50,6 +52,7 @@ class TestLayer(unittest.TestCase):
 
     def test_Linear_nobias(self):
         self.do_test_Linear(False)
+
 
 ######################################################
 # QINCo Pytorch implementation copied from
@@ -70,7 +73,9 @@ def compute_batch_distances(a, b):
     anorms = (a**2).sum(-1)
     bnorms = (b**2).sum(-1)
     return (
-        anorms.unsqueeze(-1) + bnorms.unsqueeze(1) - 2 * torch.bmm(a, b.transpose(2, 1))
+        anorms.unsqueeze(-1)
+        + bnorms.unsqueeze(1)
+        - 2 * torch.bmm(a, b.transpose(2, 1))
     )
 
 
@@ -78,9 +83,13 @@ def assign_batch_multiple(x, zqs):
     bs, d = x.shape
     bs, K, d = zqs.shape
 
-    L2distances = compute_batch_distances(x.unsqueeze(1), zqs).squeeze(1)  # [bs x ksq]
+    L2distances = compute_batch_distances(x.unsqueeze(1), zqs).squeeze(
+        1
+    )  # [bs x ksq]
     idx = torch.argmin(L2distances, dim=1).unsqueeze(1)  # [bsx1]
-    quantized = torch.gather(zqs, dim=1, index=idx.unsqueeze(-1).repeat(1, 1, d))
+    quantized = torch.gather(
+        zqs, dim=1, index=idx.unsqueeze(-1).repeat(1, 1, d)
+    )
     return idx.squeeze(1), quantized.squeeze(1)
 
 
@@ -99,7 +108,11 @@ def assign_to_codebook(x, c, bs=16384):
     for i in range(0, nq, bs):
         xnorms = (x[i : i + bs] ** 2).sum(1, keepdim=True)
         for j in range(0, nb, bs):
-            dis = xnorms + cnorms[j : j + bs] - 2 * x[i : i + bs] @ c[j : j + bs].T
+            dis = (
+                xnorms
+                + cnorms[j : j + bs]
+                - 2 * x[i : i + bs] @ c[j : j + bs].T
+            )
             dmini, imini = dis.min(1)
             if j == 0:
                 dmin = dmini
@@ -129,7 +142,9 @@ class QINCoStep(nn.Module):
         self.residual_blocks = []
         for l in range(L):
             residual_block = nn.Sequential(
-                nn.Linear(d, h, bias=False), nn.ReLU(), nn.Linear(h, d, bias=False)
+                nn.Linear(d, h, bias=False),
+                nn.ReLU(),
+                nn.Linear(h, d, bias=False),
             )
             self.add_module(f"residual_block{l}", residual_block)
             self.residual_blocks.append(residual_block)
@@ -220,6 +235,7 @@ class QINCo(nn.Module):
 # QINCo tests
 ######################################################
 
+
 def copy_QINCoStep(step):
     step2 = faiss.QINCoStep(step.d, step.K, step.L, step.h)
     step2.codebook.from_torch(step.codebook)
@@ -239,7 +255,7 @@ class TestQINCoStep(unittest.TestCase):
         torch.manual_seed(123)
         step = QINCoStep(d=16, K=20, L=2, h=8)
 
-        codes = torch.randint(0, 20, (10, ))
+        codes = torch.randint(0, 20, (10,))
         xhat = torch.randn(10, 16)
         ref_decode = step.decode(xhat, codes)
 
@@ -248,8 +264,7 @@ class TestQINCoStep(unittest.TestCase):
         codes2 = faiss.Int32Tensor2D(codes[:, None].to(dtype=torch.int32))
 
         np.testing.assert_array_equal(
-            step.codebook(codes).numpy(),
-            step2.codebook(codes2).numpy()
+            step.codebook(codes).numpy(), step2.codebook(codes2).numpy()
         )
 
         xhat2 = faiss.Tensor2D(xhat)
@@ -258,9 +273,7 @@ class TestQINCoStep(unittest.TestCase):
         new_decode = step2.decode(xhat2, codes2)
 
         np.testing.assert_allclose(
-            ref_decode.numpy(),
-            new_decode.numpy(),
-            atol=2e-6
+            ref_decode.numpy(), new_decode.numpy(), atol=2e-6
         )
 
     @torch.no_grad()
@@ -269,7 +282,7 @@ class TestQINCoStep(unittest.TestCase):
         step = QINCoStep(d=16, K=20, L=2, h=8)
 
         # create plausible x for testing starting from actual codes
-        codes = torch.randint(0, 20, (10, ))
+        codes = torch.randint(0, 20, (10,))
         xhat = torch.zeros(10, 16)
         x = step.decode(xhat, codes)
         del codes
@@ -283,12 +296,9 @@ class TestQINCoStep(unittest.TestCase):
         new_codes = step2.encode(xhat2, x2, toadd2)
 
         np.testing.assert_allclose(
-            ref_codes.numpy(),
-            new_codes.numpy().ravel(),
-            atol=2e-6
+            ref_codes.numpy(), new_codes.numpy().ravel(), atol=2e-6
         )
         np.testing.assert_allclose(toadd.numpy(), toadd2.numpy(), atol=2e-6)
-
 
 
 class TestQINCo(unittest.TestCase):
@@ -321,18 +331,21 @@ class TestQINCo(unittest.TestCase):
 
         new_codes = qinco2.encode(x2)
 
-        np.testing.assert_allclose(ref_codes.numpy(), new_codes.numpy(), atol=2e-6)
+        np.testing.assert_allclose(
+            ref_codes.numpy(), new_codes.numpy(), atol=2e-6
+        )
 
 
 ######################################################
 # Test index
 ######################################################
 
+
 class TestIndexQINCo(unittest.TestCase):
 
     def test_search(self):
         """
-        We can't train qinco with just Faiss so we just train a RQ and use the 
+        We can't train qinco with just Faiss so we just train a RQ and use the
         codebooks in QINCo with L = 0 residual blocks
         """
         ds = datasets.SyntheticDataset(32, 1000, 100, 0)
@@ -343,7 +356,7 @@ class TestIndexQINCo(unittest.TestCase):
         rq = index_ref.rq
         # rq = faiss.ResidualQuantizer(ds.d, M, 4)
         rq.train_type = faiss.ResidualQuantizer.Train_default
-        rq.max_beam_size = 1    # beam search not implemented for QINCo (yet)
+        rq.max_beam_size = 1  # beam search not implemented for QINCo (yet)
         index_ref.train(ds.get_train())
         codebooks = get_additive_quantizer_codebooks(rq)
 

--- a/tutorial/python/1-Flat.py
+++ b/tutorial/python/1-Flat.py
@@ -5,25 +5,26 @@
 
 import numpy as np
 
-d = 64                           # dimension
-nb = 100000                      # database size
-nq = 10000                       # nb of queries
-np.random.seed(1234)             # make reproducible
-xb = np.random.random((nb, d)).astype('float32')
-xb[:, 0] += np.arange(nb) / 1000.
-xq = np.random.random((nq, d)).astype('float32')
-xq[:, 0] += np.arange(nq) / 1000.
+d = 64  # dimension
+nb = 100000  # database size
+nq = 10000  # nb of queries
+np.random.seed(1234)  # make reproducible
+xb = np.random.random((nb, d)).astype("float32")
+xb[:, 0] += np.arange(nb) / 1000.0
+xq = np.random.random((nq, d)).astype("float32")
+xq[:, 0] += np.arange(nq) / 1000.0
 
-import faiss                   # make faiss available
-index = faiss.IndexFlatL2(d)   # build the index
+import faiss  # make faiss available
+
+index = faiss.IndexFlatL2(d)  # build the index
 print(index.is_trained)
-index.add(xb)                  # add vectors to the index
+index.add(xb)  # add vectors to the index
 print(index.ntotal)
 
-k = 4                          # we want to see 4 nearest neighbors
-D, I = index.search(xb[:5], k) # sanity check
+k = 4  # we want to see 4 nearest neighbors
+D, I = index.search(xb[:5], k)  # sanity check
 print(I)
 print(D)
-D, I = index.search(xq, k)     # actual search
-print(I[:5])                   # neighbors of the 5 first queries
-print(I[-5:])                  # neighbors of the 5 last queries
+D, I = index.search(xq, k)  # actual search
+print(I[:5])  # neighbors of the 5 first queries
+print(I[-5:])  # neighbors of the 5 last queries

--- a/tutorial/python/11-SVS.py
+++ b/tutorial/python/11-SVS.py
@@ -19,65 +19,79 @@
 #
 
 import numpy as np
-import faiss                     # make faiss available
+import faiss  # make faiss available
 
-d = 64                           # dimension
-nb = 100000                      # database size
-nq = 10000                       # nb of queries
-np.random.seed(1234)             # make reproducible
-xb = np.random.random((nb, d)).astype('float32')
-xb[:, 0] += np.arange(nb) / 1000.
-xq = np.random.random((nq, d)).astype('float32')
-xq[:, 0] += np.arange(nq) / 1000.
+d = 64  # dimension
+nb = 100000  # database size
+nq = 10000  # nb of queries
+np.random.seed(1234)  # make reproducible
+xb = np.random.random((nb, d)).astype("float32")
+xb[:, 0] += np.arange(nb) / 1000.0
+xq = np.random.random((nq, d)).astype("float32")
+xq[:, 0] += np.arange(nq) / 1000.0
 
-index = faiss.IndexSVSVamana(d, 64) # build the index (DynamicVamana, float32)
+index = faiss.IndexSVSVamana(d, 64)  # build the index (DynamicVamana, float32)
 
 print(index.is_trained)
-index.add(xb)                  # add vectors to the index
+index.add(xb)  # add vectors to the index
 print(index.ntotal)
 
-k = 4                          # we want to see 4 nearest neighbors
+k = 4  # we want to see 4 nearest neighbors
 
 print(f"{k} nearest neighbors of the first 5 vectors")
-D, I = index.search(xb[:5], k) # sanity check
+D, I = index.search(xb[:5], k)  # sanity check
 print(I)
 print(D)
-D, I = index.search(xq, k)     # actual search
+D, I = index.search(xq, k)  # actual search
 print(f"{k} nearest neighbors of the 5 first query vectors")
-print(I[:5])                   # neighbors of the 5 first queries
+print(I[:5])  # neighbors of the 5 first queries
 print(f"{k} nearest neighbors of the 5 last query vectors")
-print(I[-5:])                  # neighbors of the 5 last queries
+print(I[-5:])  # neighbors of the 5 last queries
 
 faiss.write_index(index, "index.faiss")
 reloaded = faiss.read_index("index.faiss")
 
 D, I = reloaded.search(xq, k)  # search with the reloaded
 print(f"{k} nearest neighbors of the 5 first query vectors (after reloading)")
-print(I[:5])                   # neighbors of the 5 first queries
+print(I[:5])  # neighbors of the 5 first queries
 print(f"{k} nearest neighbors of the 5 last query vectors (after reloading)")
-print(I[-5:])                  # neighbors of the 5 last queries
+print(I[-5:])  # neighbors of the 5 last queries
 
-flat_idx_fac = faiss.index_factory(d, 'SVSFlat', faiss.METRIC_L2)                       # example of using factory for SVS Flat
+flat_idx_fac = faiss.index_factory(
+    d, "SVSFlat", faiss.METRIC_L2
+)  # example of using factory for SVS Flat
 flat_idx_fac.add(xb)
 flat_idx_fac.search(xq, k)
 
-uncompressed_idx_fac = faiss.index_factory(d, 'SVSVamana64', faiss.METRIC_L2)           # example of using factory for SVS Vamana uncompressed
+uncompressed_idx_fac = faiss.index_factory(
+    d, "SVSVamana64", faiss.METRIC_L2
+)  # example of using factory for SVS Vamana uncompressed
 uncompressed_idx_fac.add(xb)
 uncompressed_idx_fac.search(xq, k)
 
-lvq_idx = faiss.IndexSVSVamanaLVQ(d, 32, faiss.METRIC_L2, faiss.SVS_LVQ4x8)                     # example of using SVS Vamana LVQ
-lvq_idx_fac_2 = faiss.index_factory(d, 'SVSVamana32,LVQ4x4', faiss.METRIC_L2)           # example of using factory for SVS Vamana LVQ
+lvq_idx = faiss.IndexSVSVamanaLVQ(
+    d, 32, faiss.METRIC_L2, faiss.SVS_LVQ4x8
+)  # example of using SVS Vamana LVQ
+lvq_idx_fac_2 = faiss.index_factory(
+    d, "SVSVamana32,LVQ4x4", faiss.METRIC_L2
+)  # example of using factory for SVS Vamana LVQ
 lvq_idx_fac_2.add(xb)
 lvq_idx_fac_2.search(xq, k)
 
 
-leanvec_idx = faiss.IndexSVSVamanaLeanVec(d, 32, faiss.METRIC_L2, 0, faiss.SVS_LeanVec4x4)      # example of using SVS Vamana LeanVec
-leanvec_idx_fac = faiss.index_factory(d, 'SVSVamana32,LeanVec4x4', faiss.METRIC_L2)     # example of using factory for SVS Vamana LeanVec
+leanvec_idx = faiss.IndexSVSVamanaLeanVec(
+    d, 32, faiss.METRIC_L2, 0, faiss.SVS_LeanVec4x4
+)  # example of using SVS Vamana LeanVec
+leanvec_idx_fac = faiss.index_factory(
+    d, "SVSVamana32,LeanVec4x4", faiss.METRIC_L2
+)  # example of using factory for SVS Vamana LeanVec
 leanvec_idx_fac.train(xb)
 leanvec_idx_fac.add(xb)
 leanvec_idx_fac.search(xq, k)
 
-leanvec_idx_fac2 = faiss.index_factory(d, 'SVSVamana64,LeanVec4x4_16', faiss.METRIC_L2) # example of using factory for SVS Vamana LeanVec. leanvec_dims is 16
+leanvec_idx_fac2 = faiss.index_factory(
+    d, "SVSVamana64,LeanVec4x4_16", faiss.METRIC_L2
+)  # example of using factory for SVS Vamana LeanVec. leanvec_dims is 16
 leanvec_idx_fac2.train(xb)
 leanvec_idx_fac2.add(xb)
 leanvec_idx_fac2.search(xq, k)

--- a/tutorial/python/2-IVFFlat.py
+++ b/tutorial/python/2-IVFFlat.py
@@ -5,14 +5,14 @@
 
 import numpy as np
 
-d = 64                           # dimension
-nb = 100000                      # database size
-nq = 10000                       # nb of queries
-np.random.seed(1234)             # make reproducible
-xb = np.random.random((nb, d)).astype('float32')
-xb[:, 0] += np.arange(nb) / 1000.
-xq = np.random.random((nq, d)).astype('float32')
-xq[:, 0] += np.arange(nq) / 1000.
+d = 64  # dimension
+nb = 100000  # database size
+nq = 10000  # nb of queries
+np.random.seed(1234)  # make reproducible
+xb = np.random.random((nb, d)).astype("float32")
+xb[:, 0] += np.arange(nb) / 1000.0
+xq = np.random.random((nq, d)).astype("float32")
+xq[:, 0] += np.arange(nq) / 1000.0
 
 import faiss
 
@@ -26,9 +26,9 @@ assert not index.is_trained
 index.train(xb)
 assert index.is_trained
 
-index.add(xb)                  # add may be a bit slower as well
-D, I = index.search(xq, k)     # actual search
-print(I[-5:])                  # neighbors of the 5 last queries
-index.nprobe = 10              # default nprobe is 1, try a few more
+index.add(xb)  # add may be a bit slower as well
+D, I = index.search(xq, k)  # actual search
+print(I[-5:])  # neighbors of the 5 last queries
+index.nprobe = 10  # default nprobe is 1, try a few more
 D, I = index.search(xq, k)
-print(I[-5:])                  # neighbors of the 5 last queries
+print(I[-5:])  # neighbors of the 5 last queries

--- a/tutorial/python/3-IVFPQ.py
+++ b/tutorial/python/3-IVFPQ.py
@@ -5,14 +5,14 @@
 
 import numpy as np
 
-d = 64                           # dimension
-nb = 100000                      # database size
-nq = 10000                       # nb of queries
-np.random.seed(1234)             # make reproducible
-xb = np.random.random((nb, d)).astype('float32')
-xb[:, 0] += np.arange(nb) / 1000.
-xq = np.random.random((nq, d)).astype('float32')
-xq[:, 0] += np.arange(nq) / 1000.
+d = 64  # dimension
+nb = 100000  # database size
+nq = 10000  # nb of queries
+np.random.seed(1234)  # make reproducible
+xb = np.random.random((nb, d)).astype("float32")
+xb[:, 0] += np.arange(nb) / 1000.0
+xq = np.random.random((nq, d)).astype("float32")
+xq[:, 0] += np.arange(nq) / 1000.0
 
 import faiss
 
@@ -21,12 +21,12 @@ m = 8
 k = 4
 quantizer = faiss.IndexFlatL2(d)  # this remains the same
 index = faiss.IndexIVFPQ(quantizer, d, nlist, m, 8)
-                                  # 8 specifies that each sub-vector is encoded as 8 bits
+# 8 specifies that each sub-vector is encoded as 8 bits
 index.train(xb)
 index.add(xb)
-D, I = index.search(xb[:5], k) # sanity check
+D, I = index.search(xb[:5], k)  # sanity check
 print(I)
 print(D)
-index.nprobe = 10              # make comparable with experiment above
-D, I = index.search(xq, k)     # search
+index.nprobe = 10  # make comparable with experiment above
+D, I = index.search(xq, k)  # search
 print(I[-5:])

--- a/tutorial/python/4-GPU.py
+++ b/tutorial/python/4-GPU.py
@@ -5,16 +5,16 @@
 
 import numpy as np
 
-d = 64                           # dimension
-nb = 100000                      # database size
-nq = 10000                       # nb of queries
-np.random.seed(1234)             # make reproducible
-xb = np.random.random((nb, d)).astype('float32')
-xb[:, 0] += np.arange(nb) / 1000.
-xq = np.random.random((nq, d)).astype('float32')
-xq[:, 0] += np.arange(nq) / 1000.
+d = 64  # dimension
+nb = 100000  # database size
+nq = 10000  # nb of queries
+np.random.seed(1234)  # make reproducible
+xb = np.random.random((nb, d)).astype("float32")
+xb[:, 0] += np.arange(nb) / 1000.0
+xq = np.random.random((nq, d)).astype("float32")
+xq[:, 0] += np.arange(nq) / 1000.0
 
-import faiss                     # make faiss available
+import faiss  # make faiss available
 
 res = faiss.StandardGpuResources()  # use a single GPU
 
@@ -25,13 +25,13 @@ index_flat = faiss.IndexFlatL2(d)  # build a flat (CPU) index
 # make it a flat GPU index
 gpu_index_flat = faiss.index_cpu_to_gpu(res, 0, index_flat)
 
-gpu_index_flat.add(xb)         # add vectors to the index
+gpu_index_flat.add(xb)  # add vectors to the index
 print(gpu_index_flat.ntotal)
 
-k = 4                          # we want to see 4 nearest neighbors
+k = 4  # we want to see 4 nearest neighbors
 D, I = gpu_index_flat.search(xq, k)  # actual search
-print(I[:5])                   # neighbors of the 5 first queries
-print(I[-5:])                  # neighbors of the 5 last queries
+print(I[:5])  # neighbors of the 5 first queries
+print(I[-5:])  # neighbors of the 5 last queries
 
 
 ## Using an IVF index
@@ -45,13 +45,13 @@ index_ivf = faiss.IndexIVFFlat(quantizer, d, nlist, faiss.METRIC_L2)
 gpu_index_ivf = faiss.index_cpu_to_gpu(res, 0, index_ivf)
 
 assert not gpu_index_ivf.is_trained
-gpu_index_ivf.train(xb)        # add vectors to the index
+gpu_index_ivf.train(xb)  # add vectors to the index
 assert gpu_index_ivf.is_trained
 
-gpu_index_ivf.add(xb)          # add vectors to the index
+gpu_index_ivf.add(xb)  # add vectors to the index
 print(gpu_index_ivf.ntotal)
 
-k = 4                          # we want to see 4 nearest neighbors
+k = 4  # we want to see 4 nearest neighbors
 D, I = gpu_index_ivf.search(xq, k)  # actual search
-print(I[:5])                   # neighbors of the 5 first queries
-print(I[-5:])                  # neighbors of the 5 last queries
+print(I[:5])  # neighbors of the 5 first queries
+print(I[-5:])  # neighbors of the 5 last queries

--- a/tutorial/python/5-Multiple-GPUs.py
+++ b/tutorial/python/5-Multiple-GPUs.py
@@ -5,16 +5,16 @@
 
 import numpy as np
 
-d = 64                           # dimension
-nb = 100000                      # database size
-nq = 10000                       # nb of queries
-np.random.seed(1234)             # make reproducible
-xb = np.random.random((nb, d)).astype('float32')
-xb[:, 0] += np.arange(nb) / 1000.
-xq = np.random.random((nq, d)).astype('float32')
-xq[:, 0] += np.arange(nq) / 1000.
+d = 64  # dimension
+nb = 100000  # database size
+nq = 10000  # nb of queries
+np.random.seed(1234)  # make reproducible
+xb = np.random.random((nb, d)).astype("float32")
+xb[:, 0] += np.arange(nb) / 1000.0
+xq = np.random.random((nq, d)).astype("float32")
+xq[:, 0] += np.arange(nq) / 1000.0
 
-import faiss                     # make faiss available
+import faiss  # make faiss available
 
 ngpus = faiss.get_num_gpus()
 
@@ -22,14 +22,12 @@ print("number of GPUs:", ngpus)
 
 cpu_index = faiss.IndexFlatL2(d)
 
-gpu_index = faiss.index_cpu_to_all_gpus(  # build the index
-    cpu_index
-)
+gpu_index = faiss.index_cpu_to_all_gpus(cpu_index)  # build the index
 
-gpu_index.add(xb)              # add vectors to the index
+gpu_index.add(xb)  # add vectors to the index
 print(gpu_index.ntotal)
 
-k = 4                          # we want to see 4 nearest neighbors
-D, I = gpu_index.search(xq, k) # actual search
-print(I[:5])                   # neighbors of the 5 first queries
-print(I[-5:])                  # neighbors of the 5 last queries
+k = 4  # we want to see 4 nearest neighbors
+D, I = gpu_index.search(xq, k)  # actual search
+print(I[:5])  # neighbors of the 5 first queries
+print(I[-5:])  # neighbors of the 5 last queries

--- a/tutorial/python/6-HNSW.py
+++ b/tutorial/python/6-HNSW.py
@@ -8,9 +8,9 @@ import numpy as np
 import faiss
 
 
-d = 64       # dimension
+d = 64  # dimension
 nb = 100000  # database size
-nq = 10000   # number of queries
+nq = 10000  # number of queries
 
 np.random.seed(1234)
 
@@ -23,9 +23,9 @@ xq[:, 0] += np.arange(nq) / 1000.0
 k = 4
 
 index = faiss.IndexHNSWFlat(d, 32)  # M=32: neighbors per node
-index.hnsw.efConstruction = 40      # graph construction quality
+index.hnsw.efConstruction = 40  # graph construction quality
 index.add(xb)
-index.hnsw.efSearch = 64            # higher = better recall, slower
+index.hnsw.efSearch = 64  # higher = better recall, slower
 
 # sanity check
 D, I = index.search(xb[:5], k)

--- a/tutorial/python/7-PQFastScan.py
+++ b/tutorial/python/7-PQFastScan.py
@@ -6,30 +6,30 @@
 import faiss
 import numpy as np
 
-d = 64                           # dimension
-nb = 100000                      # database size
-nq = 10000                       # nb of queries
-np.random.seed(1234)             # make reproducible
-xb = np.random.random((nb, d)).astype('float32')    # 64-dim *nb queries
-xb[:, 0] += np.arange(nb) / 1000.
-xq = np.random.random((nq, d)).astype('float32')
-xq[:, 0] += np.arange(nq) / 1000.
+d = 64  # dimension
+nb = 100000  # database size
+nq = 10000  # nb of queries
+np.random.seed(1234)  # make reproducible
+xb = np.random.random((nb, d)).astype("float32")  # 64-dim *nb queries
+xb[:, 0] += np.arange(nb) / 1000.0
+xq = np.random.random((nq, d)).astype("float32")
+xq[:, 0] += np.arange(nq) / 1000.0
 
-m = 8   # 8 specifies that the number of sub-vector is 8
+m = 8  # 8 specifies that the number of sub-vector is 8
 k = 4  # number of dimension in extracted vector
-n_bit = 4   # 4 specifies that each sub-vector is encoded as 4 bits
-bbs = 32    # build block size ( bbs % 32 == 0 ) for PQ
+n_bit = 4  # 4 specifies that each sub-vector is encoded as 4 bits
+bbs = 32  # build block size ( bbs % 32 == 0 ) for PQ
 index = faiss.IndexPQFastScan(d, m, n_bit, faiss.METRIC_L2, bbs)
 # construct FastScan Index
 
 assert not index.is_trained
-index.train(xb)     # Train vectors data index within mockup database
+index.train(xb)  # Train vectors data index within mockup database
 assert index.is_trained
 
 index.add(xb)
 D, I = index.search(xb[:5], k)  # sanity check
 print(I)
 print(D)
-index.nprobe = 10              # make comparable with experiment above
-D, I = index.search(xq, k)     # search
-print(I[-5:])               # neighbors of the 5 last queries
+index.nprobe = 10  # make comparable with experiment above
+D, I = index.search(xq, k)  # search
+print(I[-5:])  # neighbors of the 5 last queries

--- a/tutorial/python/8-PQFastScanRefine.py
+++ b/tutorial/python/8-PQFastScanRefine.py
@@ -6,14 +6,14 @@
 import faiss
 import numpy as np
 
-d = 64                           # dimension
-nb = 100000                      # database size
-nq = 10000                       # nb of queries
-np.random.seed(1234)             # make reproducible
-xb = np.random.random((nb, d)).astype('float32')    # 64-dim *nb queries
-xb[:, 0] += np.arange(nb) / 1000.
-xq = np.random.random((nq, d)).astype('float32')
-xq[:, 0] += np.arange(nq) / 1000.
+d = 64  # dimension
+nb = 100000  # database size
+nq = 10000  # nb of queries
+np.random.seed(1234)  # make reproducible
+xb = np.random.random((nb, d)).astype("float32")  # 64-dim *nb queries
+xb[:, 0] += np.arange(nb) / 1000.0
+xq = np.random.random((nq, d)).astype("float32")
+xq[:, 0] += np.arange(nq) / 1000.0
 
 m = 8  # 8 specifies that the number of sub-vector is 8
 k = 4  # number of dimension in extracted vector

--- a/tutorial/python/9-RefineComparison.py
+++ b/tutorial/python/9-RefineComparison.py
@@ -11,15 +11,15 @@ from faiss.contrib import datasets
 # 64-dim vectors, 50000 vectors in the training, 100000 in database,
 # 10000 in queries, dtype ('float32')
 ds = datasets.SyntheticDataset(64, 50000, 100000, 10000)
-d = 64                           # dimension
+d = 64  # dimension
 
 # Constructing the refine PQ index with SQfp16 with index factory
-index_fp16 = faiss.index_factory(d, 'PQ32x4fs,Refine(SQfp16)')
+index_fp16 = faiss.index_factory(d, "PQ32x4fs,Refine(SQfp16)")
 index_fp16.train(ds.get_train())
 index_fp16.add(ds.get_database())
 
 # Constructing the refine PQ index with SQ8
-index_sq8 = faiss.index_factory(d, 'PQ32x4fs,Refine(SQ8)')
+index_sq8 = faiss.index_factory(d, "PQ32x4fs,Refine(SQ8)")
 index_sq8.train(ds.get_train())
 index_sq8.add(ds.get_database())
 
@@ -36,7 +36,7 @@ KIM_fp16 = knn_intersection_measure(I_fp16, ds.get_groundtruth())
 KIM_sq8 = knn_intersection_measure(I_sq8, ds.get_groundtruth())
 
 # KNN intersection measure accuracy shows that choosing SQ8 impacts accuracy
-assert (KIM_fp16 > KIM_sq8)
+assert KIM_fp16 > KIM_sq8
 
 print(I_sq8[:5])
 print(I_fp16[:5])


### PR DESCRIPTION
Summary:
Fixes the faiss flake8 configuration so it matches the project's documented style and stops flagging code that black deliberately formats.

- Sets `max-line-length = 80` to match faiss's documented coding style (`CONTRIBUTING.md`: "80 character line length"); Python is black-formatted at width 80 in the base of this stack.
- Switches `ignore` to `extend-ignore`. The previous `ignore = E741` silently *replaced* pycodestyle's default-disabled list, which re-enabled checks black intentionally violates (`W503`/`W504` line-break placement, `E226` arithmetic spacing, `E121`/`E123`/`E126` continuation indent). `extend-ignore` keeps those defaults off.
- Adds `E203` (whitespace before `:`) and `W503` (line break before binary operator) — the two documented black-vs-pycodestyle conflicts.

Pure config change; no source files touched.

Differential Revision: D109739446
