### PR TITLE
De-flake bench_transposed_encode (CI timeout)

### DIFF
--- a/tests/bench_transposed_encode.py
+++ b/tests/bench_transposed_encode.py
@@ -103,11 +103,14 @@ def main() -> None:
     # Single-threaded for a clean per-core kernel signal.
     faiss.omp_set_num_threads(1)
 
+    # Sizes stay small so the run finishes well under the CI test deadline even
+    # in dynamic-dispatch mode, where the slow scalar NONE level is also timed
+    # on every case.
     # dsub in {1,2,4,8} -> the fast _D specialization is taken.
-    run_case(d=128, m=32, nbits=8, nb=1_000_000, ntrain=100_000, n_repeat=5)
-    run_case(d=64, m=16, nbits=8, nb=1_000_000, ntrain=100_000, n_repeat=5)
+    run_case(d=128, m=32, nbits=8, nb=50_000, ntrain=20_000, n_repeat=2)
+    run_case(d=64, m=16, nbits=8, nb=50_000, ntrain=20_000, n_repeat=2)
     # dsub=16 -> _D fast path NOT taken (control: no AVX512 vs NONE gap).
-    run_case(d=128, m=8, nbits=8, nb=1_000_000, ntrain=100_000, n_repeat=5)
+    run_case(d=128, m=8, nbits=8, nb=50_000, ntrain=20_000, n_repeat=2)
     sys.stdout.flush()
 
 


### PR DESCRIPTION
Summary:
`bench_transposed_encode` is an ad-hoc microbenchmark wired into CI as a plain `python_unittest`. It encodes 1,000,000 vectors with `ProductQuantizer.compute_codes`, single-threaded, repeated 5x, across all SIMD levels (`NONE`/`AVX2`/`AVX512`). Under `-c faiss.dynamic_dispatch=true` all three levels are available (the slow scalar `NONE` path is always available), so all three are timed — roughly tripling the work and pushing wall-clock right at the 600s test deadline (TestInfra showed `duration_min == duration_max == 600s`, avg 424s). It intermittently tripped the deadline, so TestWarden auto-disabled it (T277674127, dups T277525456 / T277525454).

Fix: shrink the deterministic workload (`nb` 1,000,000 -> 50,000, `ntrain` 100,000 -> 20,000, `n_repeat` 5 -> 2) so the run finishes well under the deadline even when DD mode times all three SIMD levels, and add the `tpx_labels.long_running` label for extra timeout headroom. The cross-level `compute_codes` coverage is preserved. The "codes identical across levels" line stays a diagnostic print (not an assertion), because scalar vs FMA reduction-order differences legitimately change nearest-centroid tie-breaks, so exact code equality across SIMD levels is not guaranteed.

Differential Revision: D110092205


