### PR TITLE
De-flake test_flat_panorama across SIMD levels (#5361)

### DIFF
--- a/tests/bench_transposed_encode.py
+++ b/tests/bench_transposed_encode.py
@@ -103,11 +103,14 @@ def main() -> None:
     # Single-threaded for a clean per-core kernel signal.
     faiss.omp_set_num_threads(1)
 
+    # Sizes stay small so the run finishes well under the CI test deadline even
+    # in dynamic-dispatch mode, where the slow scalar NONE level is also timed
+    # on every case.
     # dsub in {1,2,4,8} -> the fast _D specialization is taken.
-    run_case(d=128, m=32, nbits=8, nb=1_000_000, ntrain=100_000, n_repeat=5)
-    run_case(d=64, m=16, nbits=8, nb=1_000_000, ntrain=100_000, n_repeat=5)
+    run_case(d=128, m=32, nbits=8, nb=50_000, ntrain=20_000, n_repeat=2)
+    run_case(d=64, m=16, nbits=8, nb=50_000, ntrain=20_000, n_repeat=2)
     # dsub=16 -> _D fast path NOT taken (control: no AVX512 vs NONE gap).
-    run_case(d=128, m=8, nbits=8, nb=1_000_000, ntrain=100_000, n_repeat=5)
+    run_case(d=128, m=8, nbits=8, nb=50_000, ntrain=20_000, n_repeat=2)
     sys.stdout.flush()
 
 

--- a/tests/test_flat_panorama.py
+++ b/tests/test_flat_panorama.py
@@ -20,6 +20,7 @@ import faiss
 import numpy as np
 from common_faiss_tests import for_all_simd_levels
 from faiss.contrib.datasets import SyntheticDataset
+from faiss.contrib.evaluation import check_ref_knn_with_draws
 
 
 @for_all_simd_levels
@@ -58,26 +59,26 @@ class TestIndexFlatPanorama(unittest.TestCase):
         I_panorama,
         rtol=1e-5,
         atol=1e-4,
-        otol=1e-3,
     ):
-        # Allow small tolerance in overlap rate to account for
-        # floating-point errors in distance computations that can affect
-        # ordering when distances are nearly equal.
-        # Faiss: (a - b) * (a - b) vs. Panorama: a * a + b * b - 2(a * b);
-        # these differ at the float32 ULP level, so atol absorbs the gap.
-        overlap_rate = np.mean(I_regular == I_panorama)
-
-        self.assertGreater(
-            overlap_rate,
-            1 - otol,
-            f"Overlap rate {overlap_rate:.6f} is not > {1 - otol:.3f}. ",
-        )
+        # The reference IndexFlat kernel is SIMD-dispatched, so its float
+        # reduction order changes with the runtime SIMD level (wide FMA under
+        # AVX512_SPR), while the Panorama kernel is compiled once at baseline
+        # and uses the algebraically equivalent a * a + b * b - 2(a * b)
+        # decomposition instead of (a - b) * (a - b). Both are exact but round
+        # differently, so near-tied neighbors can swap order. Compare with the
+        # tie-aware kNN comparator: distances must match within tolerance and
+        # ids only need to agree as sets within each distance tie-group. This is
+        # variant-agnostic (NONE / AVX2 / AVX512 / AVX512_SPR) rather than tuned
+        # to one dispatch level's gap.
         np.testing.assert_allclose(
             D_regular,
             D_panorama,
             rtol=rtol,
             atol=atol,
             err_msg="Distances mismatch",
+        )
+        check_ref_knn_with_draws(
+            D_regular, I_regular, D_panorama, I_panorama, rtol=rtol
         )
 
     def assert_range_results_equal(


### PR DESCRIPTION
Summary:

`test_batch_boundaries` flaked (~36%) on the `AVX512_SPR` dispatch variant. The reference `IndexFlat` distance kernel is SIMD-dispatched, so its float reduction order changes with the runtime SIMD level (wide FMA under `AVX512_SPR`), while the `IndexFlatPanorama` kernel is compiled once at baseline and uses the algebraically-equivalent `a*a + b*b - 2ab` decomposition instead of `(a-b)^2`. Both are exact but round differently, so near-tied neighbors reorder at batch boundaries. The earlier scalar de-flake (D109488316 / D109488320, T276491016) only widened the `atol`/`otol` tolerance for the `_NONE` gap, leaving the larger `AVX512_SPR` gap.

Fix: replace the brittle exact-id overlap-rate gate in `assert_search_results_equal` with the tie-aware comparator `faiss.contrib.evaluation.check_ref_knn_with_draws`, which requires distances to match within `rtol` and ids to agree only as sets within each distance tie-group. This is variant-agnostic (covers `NONE` / `AVX2` / `AVX512` / `AVX512_SPR`) and is the standard faiss kNN comparison helper used across the suite.

Differential Revision: D110092203


