### PR TITLE
faiss/gpu/perf: check cudaProfilerStop() return (fix clang21 -Wunused-value)

### DIFF
--- a/faiss/gpu/perf/PerfClustering.cpp
+++ b/faiss/gpu/perf/PerfClustering.cpp
@@ -42,7 +42,7 @@ using namespace faiss::gpu;
 int main(int argc, char** argv) {
     gflags::ParseCommandLineFlags(&argc, &argv, true);
 
-    cudaProfilerStop();
+    CUDA_VERIFY(cudaProfilerStop());
 
     auto seed = FLAGS_seed != -1 ? FLAGS_seed : time(nullptr);
     printf("using seed %ld\n", seed);


### PR DESCRIPTION
Summary:
Under clang21, this fails to compile in the
HIP-ified build with -Werror,-Wunused-value: the leading cudaProfilerStop() in
PerfClustering.cpp ignores its return value, which clang21 (via HIP's
hipProfilerStop -> hipError_t) treats as [[nodiscard]]:

  PerfClustering.cpp:46:5: error: ignoring return value of type 'hipError_t'
  declared with 'nodiscard' attribute [-Werror,-Wunused-value]
      hipProfilerStop();

Wrap it in CUDA_VERIFY(...) so the return code is inspected, exactly like every
other CUDA-profiler / sync call in this same file (lines 91, 121, 124). This is
the file's own convention; no behavior change for the success path.

Differential Revision: D110109331


