### PR TITLE
Reuse faiss.ResultHeap in benchs instead of duplicating it (#5363)

### DIFF
--- a/benchs/bench_for_interrupt.py
+++ b/benchs/bench_for_interrupt.py
@@ -83,34 +83,6 @@ print("set nprobe=", nprobe)
 faiss.ParameterSpace().set_index_parameter(index_1, "nprobe", nprobe)
 
 
-class ResultHeap:
-    """Combine query results from a sliced dataset"""
-
-    def __init__(self, nq, k):
-        "nq: number of query vectors, k: number of results per query"
-        self.I = np.zeros((nq, k), dtype="int64")
-        self.D = np.zeros((nq, k), dtype="float32")
-        self.nq, self.k = nq, k
-        heaps = faiss.float_maxheap_array_t()
-        heaps.k = k
-        heaps.nh = nq
-        heaps.val = faiss.swig_ptr(self.D)
-        heaps.ids = faiss.swig_ptr(self.I)
-        heaps.heapify()
-        self.heaps = heaps
-
-    def add_batch_result(self, D, I, i0):
-        assert D.shape == (self.nq, self.k)
-        assert I.shape == (self.nq, self.k)
-        I += i0
-        self.heaps.addn_with_ids(
-            self.k, faiss.swig_ptr(D), faiss.swig_ptr(I), self.k
-        )
-
-    def finalize(self):
-        self.heaps.reorder()
-
-
 stats = faiss.cvar.indexIVF_stats
 stats.reset()
 
@@ -137,7 +109,7 @@ if args.twostage:
         index.add(xb[i : i + subset_len])
         indexes[i] = index
 
-rh = ResultHeap(nq, k)
+rh = faiss.ResultHeap(nq, k)
 sum_time = tq = ts = 0
 for i in range(0, nb, subset_len):
     if not args.twostage:
@@ -154,7 +126,8 @@ for i in range(0, nb, subset_len):
     sum_time = sum_time + time.time() - start
     tq += stats.quantization_time
     ts += stats.search_time
-    rh.add_batch_result(Di, Ii, i)
+    Ii += i
+    rh.add_result(Di, Ii)
 
 print(
     "time of searching separately: %.3f s = %.3f + %.3f ms" % (sum_time, tq, ts)

--- a/benchs/distributed_ondisk/search_server.py
+++ b/benchs/distributed_ondisk/search_server.py
@@ -80,34 +80,6 @@ if __name__ == "__main__":
 ############################################################
 
 
-class ResultHeap:
-    """Combine query results from a sliced dataset (for k-nn search)"""
-
-    def __init__(self, nq, k):
-        "nq: number of query vectors, k: number of results per query"
-        self.I = np.zeros((nq, k), dtype="int64")
-        self.D = np.zeros((nq, k), dtype="float32")
-        self.nq, self.k = nq, k
-        heaps = faiss.float_maxheap_array_t()
-        heaps.k = k
-        heaps.nh = nq
-        heaps.val = faiss.swig_ptr(self.D)
-        heaps.ids = faiss.swig_ptr(self.I)
-        heaps.heapify()
-        self.heaps = heaps
-
-    def add_batch_result(self, D, I, i0):
-        assert D.shape == (self.nq, self.k)
-        assert I.shape == (self.nq, self.k)
-        I += i0
-        self.heaps.addn_with_ids(
-            self.k, faiss.swig_ptr(D), faiss.swig_ptr(I), self.k
-        )
-
-    def finalize(self):
-        self.heaps.reorder()
-
-
 def distribute_weights(weights, nbin):
     """assign a set of weights to a smaller set of bins to balance them"""
     nw = weights.size
@@ -189,11 +161,11 @@ class SplitPerListIndex:
                 print("client %d: %.3f s" % (i, time.time() - t0))
             return Di, Ii
 
-        rh = ResultHeap(x.shape[0], k)
+        rh = faiss.ResultHeap(x.shape[0], k)
 
         for Di, Ii in self.pool.imap(do_query, range(self.ni)):
             # print("ADD", Ii, rh.I)
-            rh.add_batch_result(Di, Ii, 0)
+            rh.add_result(Di, Ii)
         rh.finalize()
         return rh.D, rh.I
 


### PR DESCRIPTION
Summary:

`ResultHeap` is now part of the faiss Python package: it is defined in `faiss/python/extra_wrappers.py` and re-exported into the top-level namespace from `faiss/python/__init__.py`, so it is importable as `faiss.ResultHeap`. The `faiss.contrib` modules (`big_batch_search.py`, `exhaustive_search.py`, `client_server.py`) already consume the packaged class.

Two benchmark scripts still carried their own older, byte-for-byte-duplicated copy of the class:
- `benchs/bench_for_interrupt.py`
- `benchs/distributed_ondisk/search_server.py`

This removes both local copies and uses `faiss.ResultHeap` instead.

The packaged class exposes a slightly different (and richer) API than the old copies: it has `add_result(D, I)` rather than `add_batch_result(D, I, i0)`. The old `add_batch_result` simply applied an id offset (`I += i0`) before pushing the batch onto the heaps, so the call sites are translated as:
- `rh.add_batch_result(Di, Ii, i)` -> `Ii += i; rh.add_result(Di, Ii)`
- `rh.add_batch_result(Di, Ii, 0)` -> `rh.add_result(Di, Ii)` (offset was 0)

This is the code half of task T276876996. The other half is the broken wiki link on the "Brute force search without an index" page, which points at `benchs/bench_all_ivf/datasets.py#L75` on `master`. Now that `ResultHeap` lives in the package, the link is best repointed at the canonical implementation: `faiss/python/extra_wrappers.py`. That edit is on the GitHub wiki (a separate repo) and is not part of this diff.

Reviewed By: mnorris11

Differential Revision: D110118635


