### PR TITLE
Fix BLAS L2 cancellation with zero padding (#5327)

### DIFF
--- a/faiss/utils/distances.cpp
+++ b/faiss/utils/distances.cpp
@@ -442,6 +442,13 @@ void exhaustive_L2sqr_blas_default_impl(
         y_norms = y_norms2;
     }
 
+    // Heuristic threshold used to detect catastrophic cancellation in the
+    // L2-from-IP decomposition:
+    //   ||x||^2 + ||y||^2 - 2<x, y>.
+    // For suspiciously small results relative to the norm scale, recompute
+    // exact L2 directly from vector components.
+    constexpr float kBlasL2CancellationRelTol = 1e-6f;
+
     for (size_t i0 = 0; i0 < nx; i0 += bs_x) {
         size_t i1 = i0 + bs_x;
         if (i1 > nx) {
@@ -474,19 +481,29 @@ void exhaustive_L2sqr_blas_default_impl(
                        &nyi);
             }
             for (size_t i = i0; i < i1; i++) {
+                const float* x_i = x + i * d;
                 float* ip_line = ip_block.get() + (i - i0) * (j1 - j0);
 
                 for (size_t j = j0; j < j1; j++) {
+                    if (!res.is_in_selection(j)) {
+                        *ip_line = HUGE_VALF;
+                        ip_line++;
+                        continue;
+                    }
+
                     float ip = *ip_line;
                     float dis = x_norms[i] + y_norms[j] - 2 * ip;
+                    const float norm_sum = x_norms[i] + y_norms[j];
 
-                    if (!res.is_in_selection(j)) {
-                        dis = HUGE_VALF;
+                    // For near-cancellation cases, avoid decomposition and
+                    // recompute the distance directly.
+                    if (dis < 0 || dis < kBlasL2CancellationRelTol * norm_sum) {
+                        dis = fvec_L2sqr(x_i, y + j * d, d);
                     }
-                    // negative values can occur for identical vectors
-                    // due to roundoff errors
-                    if (dis < 0) {
-                        dis = 0;
+
+                    // Clamp tiny negative values from rounding to zero.
+                    if (dis < 0.0f) {
+                        dis = 0.0f;
                     }
 
                     *ip_line = dis;
@@ -610,6 +627,7 @@ static void knn_db_parallel_impl(
 
     int nt = omp_get_max_threads();
     const size_t bs_y = distance_compute_blas_database_bs;
+    constexpr float kBlasL2CancellationRelTol = 1e-6f;
 
     // Per-thread result heaps: nt threads x nx queries x k results
     std::vector<T> all_dis(static_cast<size_t>(nt) * nx * k);
@@ -697,8 +715,17 @@ static void knn_db_parallel_impl(
 
                         if constexpr (C::is_max) {
                             dis = x_norms[i] + y_norms[global_j] - 2 * ip;
-                            if (dis < 0) {
-                                dis = 0;
+                            const float norm_sum = x_norms[i] + y_norms[global_j];
+                            if (
+                                    dis < 0 ||
+                                    dis <
+                                            kBlasL2CancellationRelTol *
+                                                    norm_sum) {
+                                dis = fvec_L2sqr(
+                                        x + i * d, y + global_j * d, d);
+                            }
+                            if (dis < 0.0f) {
+                                dis = 0.0f;
                             }
                         } else {
                             dis = ip;

--- a/tests/test_index_accuracy.py
+++ b/tests/test_index_accuracy.py
@@ -706,6 +706,63 @@ class TestRoundoff(unittest.TestCase):
         finally:
             faiss.cvar.distance_compute_blas_threshold = saved_threshold
 
+    def test_zero_padding_invariance(self):
+        """Repro for #5327: zero-padding should preserve exact L2 results."""
+        d = 2
+        nq = 2
+        pad_dims = 63999
+        radius = 1.0
+
+        xb = np.array(
+            [
+                [10100.0, 10100.0],
+                [10004.0, 10006.0],
+                [10001.0, 10002.0],
+                [9997.0, 10007.0],
+            ],
+            dtype=np.float32,
+        )
+        xq = np.tile(np.array([[10000.0, 10000.0]], dtype=np.float32), (nq, 1))
+
+        xb_pad = np.pad(xb, ((0, 0), (0, pad_dims))).astype(np.float32)
+        xq_pad = np.pad(xq, ((0, 0), (0, pad_dims))).astype(np.float32)
+
+        # Ensure this case crosses the BLAS path threshold with default config.
+        self.assertGreaterEqual(
+            nq * (d + pad_dims), faiss.cvar.distance_compute_blas_threshold
+        )
+
+        index = faiss.IndexFlatL2(d)
+        index.add(xb)
+        D, I = index.search(xq, 4)
+        lims, RD, RI = index.range_search(xq, radius)
+
+        index_pad = faiss.IndexFlatL2(d + pad_dims)
+        index_pad.add(xb_pad)
+        Dp, Ip = index_pad.search(xq_pad, 4)
+        limsp, RDp, RIp = index_pad.range_search(xq_pad, radius)
+
+        exact = np.sum(
+            (xb.astype(np.float64) - xq[0].astype(np.float64)) ** 2,
+            axis=1,
+        )
+        exact_pad = np.sum(
+            (xb_pad.astype(np.float64) - xq_pad[0].astype(np.float64)) ** 2,
+            axis=1,
+        )
+        np.testing.assert_allclose(exact_pad, exact)
+
+        # Zero-padding should preserve distances and hit sets.
+        np.testing.assert_array_equal(I[0], Ip[0])
+        np.testing.assert_allclose(D[0], Dp[0], rtol=0, atol=1e-5)
+
+        np.testing.assert_array_equal(
+            RI[lims[0] : lims[1]], RIp[limsp[0] : limsp[1]]
+        )
+        np.testing.assert_allclose(
+            RD[lims[0] : lims[1]], RDp[limsp[0] : limsp[1]], rtol=0, atol=1e-5
+        )
+
 
 @for_all_simd_levels
 class TestSpectralHash(unittest.TestCase):


### PR DESCRIPTION
## Summary
This PR fixes a numerical cancellation issue in the BLAS L2 path where
`||x||^2 + ||y||^2 - 2<x,y>` can lose precision for large norms and small true distances
(e.g., zero-padded vectors), producing incorrect distances and range-search hits.

## Changes
- Added near-cancellation detection in BLAS-based L2 computation paths.
- For suspicious results (negative or very small relative to norm scale), recompute exact L2 with `fvec_L2sqr`.
- Kept tiny-negative clamping to `0`.
- Added regression test `test_zero_padding_invariance` reproducing #5327.

## Validation
- `pytest tests/test_index_accuracy.py -k zero_padding_invariance -q` passed.
- Full Python test suite passed locally with this patch.
