### PR TITLE
Add prefetch for vector code

### DIFF
--- a/faiss/impl/DistanceComputer.h
+++ b/faiss/impl/DistanceComputer.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <faiss/Index.h>
+#include <faiss/utils/prefetch.h>
 
 namespace faiss {
 
@@ -29,6 +30,9 @@ struct DistanceComputer {
 
     /// compute distance of vector i to current query
     virtual float operator()(idx_t i) = 0;
+
+    /// prefetch data for vector i, if the implementation supports it
+    virtual void prefetch(idx_t i) {}
 
     /// compute distances of current query to 4 stored vectors.
     /// certain DistanceComputer implementations may benefit
@@ -71,6 +75,10 @@ struct NegativeDistanceComputer : DistanceComputer {
 
     void set_query(const float* x) override {
         basedis->set_query(x);
+    }
+
+    void prefetch(idx_t i) override {
+        basedis->prefetch(i);
     }
 
     /// compute distance of vector i to current query
@@ -148,6 +156,27 @@ struct FlatCodesDistanceComputer : DistanceComputer {
                 dis1,
                 dis2,
                 dis3);
+    }
+
+    void prefetch(idx_t i) override {
+        if (codes == nullptr || code_size == 0) {
+            return;
+        }
+
+        const uint8_t* code = codes + i * code_size;
+
+        // Prefetch a few cache lines. Do not prefetch the whole vector/code;
+        // the distance loop itself will stream through the rest.
+        prefetch_L2(code);
+        if (code_size > 64) {
+            prefetch_L2(code + 64);
+        }
+        if (code_size > 128) {
+            prefetch_L2(code + 128);
+        }
+        if (code_size > 192) {
+            prefetch_L2(code + 192);
+        }
     }
 
     /// Computes a partial dot product over a slice of the query vector.

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -869,6 +869,8 @@ void HNSW::add_with_locks(
 
 namespace {
 
+static constexpr size_t kHNSWCodePrefetchAhead = 1;
+
 /** Helper to extract search parameters from HNSW and SearchParameters */
 inline void extract_search_params(
         const HNSW& hnsw,
@@ -980,6 +982,13 @@ int search_from_candidates_fixVT(
         };
 
         for (size_t j = begin; j < jmax; j++) {
+            if (j + kHNSWCodePrefetchAhead < jmax) {
+                int vp = hnsw.neighbors[j + kHNSWCodePrefetchAhead];
+                if (vp >= 0) {
+                    qdis.prefetch(vp);
+                }
+            }
+
             int v1 = hnsw.neighbors[j];
 
             saved_j[counter] = v1;
@@ -1420,6 +1429,13 @@ TopCandidatesQueue<C> search_from_candidate_unbounded_fixVT(
         };
 
         for (size_t j = begin; j < jmax; j++) {
+            if (j + kHNSWCodePrefetchAhead < jmax) {
+                int vp = hnsw.neighbors[j + kHNSWCodePrefetchAhead];
+                if (vp >= 0) {
+                    qdis.prefetch(vp);
+                }
+            }
+
             int v1 = hnsw.neighbors[j];
 
             saved_j[counter] = v1;


### PR DESCRIPTION
## Summary

This PR adds an optional `DistanceComputer::prefetch(idx_t)` hook and uses it in HNSW search to prefetch vector codes before distance computation.

The default implementation is a no-op, so existing distance computers are unaffected. `NegativeDistanceComputer` forwards the call to the wrapped distance computer, and `FlatCodesDistanceComputer` prefetches the first few cache lines of the target code.

HNSW search now prefetches the next neighbor's vector code while iterating over neighbor candidates. This is intended to reduce memory access latency for flat-code-backed HNSW indexes without changing search results.

On sift-128-euclidean, this improves HNSW search QPS by 10% to 15% with no recall change.

<img width="2706" height="1378" alt="faiss_prefetch_vs_baseline_qps_sift_128" src="https://github.com/user-attachments/assets/cd7b84fe-7c5b-47ba-a105-6f5abca71a5d" />
