### PR TITLE
faiss/gpu/perf: check CUDA return in PerfIVFPQAdd (clang21 nodiscard)

### DIFF
--- a/faiss/gpu/perf/PerfIVFPQAdd.cpp
+++ b/faiss/gpu/perf/PerfIVFPQAdd.cpp
@@ -31,7 +31,7 @@ DEFINE_bool(reserve_memory, false, "whether or not to pre-reserve memory");
 int main(int argc, char** argv) {
     gflags::ParseCommandLineFlags(&argc, &argv, true);
 
-    cudaProfilerStop();
+    CUDA_VERIFY(cudaProfilerStop());
 
     int dim = FLAGS_dim;
     int numCentroids = FLAGS_centroids;
@@ -72,7 +72,7 @@ int main(int argc, char** argv) {
         }
     }
 
-    cudaDeviceSynchronize();
+    CUDA_VERIFY(cudaDeviceSynchronize());
     CUDA_VERIFY(cudaProfilerStart());
 
     float totalGpuTime = 0.0f;


### PR DESCRIPTION
Summary:
Under Clang 21 (and its HIP/hipify path for AMD GPU builds), the AMD GPU build of the FAISS GPU perf benchmark fails `-Werror,-Wunused-value`:

  error: ignoring return value of type 'hipError_t' declared with 'nodiscard' attribute [-Werror,-Wunused-value]

`cudaProfilerStop()` / `cudaDeviceSynchronize()` return `cudaError_t`/`hipError_t`, which is `[[nodiscard]]`; the two bare calls -- at the top of `main()` and just before the timing loop -- silently dropped that. Both are wrapped in `CUDA_VERIFY()`, exactly as the rest of this same file already does, so a real device error surfaces rather than being masked.

Differential Revision: D110259824


