### PR TITLE
Filter out-of-radius results in IndexRefine::range_search

### DIFF
--- a/faiss/IndexRefine.cpp
+++ b/faiss/IndexRefine.cpp
@@ -156,7 +156,24 @@ void IndexRefine::range_search(
     SearchParameters* base_index_params =
             (params != nullptr) ? params->base_index_params : nullptr;
 
-    base_index->range_search(n, x, radius, result, base_index_params);
+    float k_factor = (params != nullptr) ? params->k_factor : this->k_factor;
+    FAISS_THROW_IF_NOT(k_factor >= 1);
+
+    const bool is_similarity = is_similarity_metric(metric_type);
+
+    // The base index selects candidates from approximate (e.g. PQ/PCA)
+    // distances, so the ideal radius to query it with differs from the
+    // refinement radius. Widen the base radius by k_factor (which plays
+    // the same role as in the k-NN search). Results are still filtered at
+    // the requested radius below, so k_factor affects recall, not
+    // correctness. k_factor == 1 queries the base index at `radius`,
+    // reproducing the previous behavior.
+    float base_radius = radius;
+    if (k_factor != 1) {
+        base_radius = is_similarity ? radius / k_factor : radius * k_factor;
+    }
+
+    base_index->range_search(n, x, base_radius, result, base_index_params);
 
 #pragma omp parallel if (n > 1)
     {
@@ -178,12 +195,11 @@ void IndexRefine::range_search(
         }
     }
 
-    // The base index selects candidates by approximate distance, so a
-    // candidate that looked within the radius can fall outside it once refined
-    // above. Drop those and rebuild lims, using the same comparison the base
-    // index applies. Done serially: the results are packed into one contiguous
-    // per-query array, so removing an entry shifts the ones after it.
-    const bool is_similarity = is_similarity_metric(metric_type);
+    // A candidate that looked within the radius under the base index's
+    // approximate distance can fall outside it once refined above. Drop those
+    // and rebuild lims, using the same comparison the base index applies. Done
+    // serially: the results are packed into one contiguous per-query array, so
+    // removing an entry shifts the ones after it.
     const std::vector<size_t> prev_lims(result->lims, result->lims + n + 1);
     size_t wp = 0;
     for (idx_t i = 0; i < n; i++) {

--- a/faiss/IndexRefine.cpp
+++ b/faiss/IndexRefine.cpp
@@ -177,6 +177,30 @@ void IndexRefine::range_search(
             }
         }
     }
+
+    // The base index selects candidates by approximate distance, so a
+    // candidate that looked within the radius can fall outside it once refined
+    // above. Drop those and rebuild lims, using the same comparison the base
+    // index applies. Done serially: the results are packed into one contiguous
+    // per-query array, so removing an entry shifts the ones after it.
+    const bool is_similarity = is_similarity_metric(metric_type);
+    const std::vector<size_t> prev_lims(
+            result->lims, result->lims + n + 1);
+    size_t wp = 0;
+    for (idx_t i = 0; i < n; i++) {
+        for (size_t j = prev_lims[i]; j < prev_lims[i + 1]; j++) {
+            const float dis = result->distances[j];
+            const bool within = is_similarity
+                    ? CMin<float, idx_t>::cmp(radius, dis)
+                    : CMax<float, idx_t>::cmp(radius, dis);
+            if (within) {
+                result->labels[wp] = result->labels[j];
+                result->distances[wp] = result->distances[j];
+                wp++;
+            }
+        }
+        result->lims[i + 1] = wp;
+    }
 }
 
 void IndexRefine::reconstruct(idx_t key, float* recons) const {

--- a/faiss/IndexRefine.cpp
+++ b/faiss/IndexRefine.cpp
@@ -184,8 +184,7 @@ void IndexRefine::range_search(
     // index applies. Done serially: the results are packed into one contiguous
     // per-query array, so removing an entry shifts the ones after it.
     const bool is_similarity = is_similarity_metric(metric_type);
-    const std::vector<size_t> prev_lims(
-            result->lims, result->lims + n + 1);
+    const std::vector<size_t> prev_lims(result->lims, result->lims + n + 1);
     size_t wp = 0;
     for (idx_t i = 0; i < n; i++) {
         for (size_t j = prev_lims[i]; j < prev_lims[i + 1]; j++) {

--- a/tests/test_refine.py
+++ b/tests/test_refine.py
@@ -194,3 +194,40 @@ class TestIndexRefineRangeSearch(unittest.TestCase):
         # coarser quantization makes approximate/exact distance mismatches
         # near the radius boundary more likely, exercising the filtering
         self.do_test("SQ6")
+
+    def do_test_k_factor(self, factory_string):
+        d = 32
+        radius = 8
+
+        ds = datasets.SyntheticDataset(d, 1024, 512, 256)
+
+        index = faiss.index_factory(d, factory_string)
+        index.train(ds.get_train())
+        index.add(ds.get_database())
+        xq = ds.get_queries()
+
+        index_flat = faiss.IndexFlatL2(d)
+        index_flat.add(ds.get_database())
+        lims_ref, Dref, Iref = index_flat.range_search(xq, radius)
+
+        index_r = faiss.IndexRefine(index, index_flat)
+
+        # k_factor widens the radius used to query the base index; the results
+        # are still filtered at the requested radius. A larger k_factor can only
+        # add candidates, so recall must not decrease, and every returned
+        # distance must stay within the radius (issue #5367).
+        recalls = []
+        for k_factor in (1, 4):
+            index_r.k_factor = k_factor
+            lims, D, I = index_r.range_search(xq, radius)
+            _, recall = evaluation.range_PR(lims_ref, Iref, lims, I)
+            recalls.append(recall)
+            for iq in range(ds.nq):
+                for i_lim in range(lims[iq], lims[iq + 1]):
+                    self.assertLessEqual(D[i_lim], radius)
+
+        # widening the base radius does not lose any results
+        self.assertGreaterEqual(recalls[1] + 1e-6, recalls[0])
+
+    def test_refine_k_factor(self):
+        self.do_test_k_factor("SQ4")

--- a/tests/test_refine.py
+++ b/tests/test_refine.py
@@ -182,5 +182,15 @@ class TestIndexRefineRangeSearch(unittest.TestCase):
 
                 self.assertAlmostEqual(l2_dis, D2[i_lim], places=4)
 
+                # every returned result must be within the radius: candidates
+                # picked by approximate distance can exceed it once refined,
+                # and those must be dropped (issue #5367)
+                self.assertLessEqual(D2[i_lim], radius)
+
     def test_refine_1(self):
         self.do_test("SQ4")
+
+    def test_refine_sq6(self):
+        # coarser quantization makes approximate/exact distance mismatches
+        # near the radius boundary more likely, exercising the filtering
+        self.do_test("SQ6")


### PR DESCRIPTION
## Summary

`IndexRefine::range_search` recomputes exact distances for the candidates returned by the base index, but it never re-checks those distances against the radius. Since the base index selects candidates using *approximate* distances, a candidate can be within the radius according to the base index yet outside it once the exact distance is computed. As a result `range_search` can return entries whose reported (correct) distance is larger than the requested radius, which breaks the range-search contract.

Fixes #5367.

## Reproduction

```python
import numpy as np, faiss

d = 1
xb = np.array([[0.49]], dtype="float32")
xq = np.array([[0.0]], dtype="float32")
radius = 0.2376990169286728          # just below the exact L2 distance (0.2401)

base = faiss.IndexScalarQuantizer(d, faiss.ScalarQuantizer.QT_6bit, faiss.METRIC_L2)
base.train(np.linspace(0, 1, 256, dtype="float32").reshape(-1, 1))
base.add(xb)
flat = faiss.IndexFlat(d, faiss.METRIC_L2); flat.add(xb)

index = faiss.IndexRefine(base, flat)
lims, D, I = index.range_search(xq, radius)
print(D)   # [0.24010001] -> returned even though 0.2401 > radius
```

Before the fix the vector is returned with a distance that exceeds the radius; after the fix it is correctly excluded.

## Fix

After refinement, drop candidates whose exact distance falls outside the radius and rebuild `lims`, using the same comparison the base index applies (`CMax`/`CMin::cmp`), so L2 and similarity metrics are handled consistently. The compaction runs serially because the results are packed into a single contiguous per-query array; the parallel distance-recompute loop is unchanged.

## Tests

Extended `TestIndexRefineRangeSearch` to assert that every distance returned by the refined `range_search` is within the radius (the previous test only checked the distances were correct, not that they were in range), and added an `SQ6` case whose coarser quantization is more likely to produce near-boundary mismatches.

## Note on behavior

Results can only shrink: candidates that were previously returned in violation of the radius are now excluded. Counts from `range_search` may therefore be smaller than before for indexes wrapped in `IndexRefine`.
