### PR TITLE
Support IndexFlat range search for extra metrics

### DIFF
--- a/faiss/IndexFlat.cpp
+++ b/faiss/IndexFlat.cpp
@@ -77,6 +77,7 @@ void IndexFlat::range_search(
             range_search_L2sqr(x, get_xb(), d, n, ntotal, radius, result, sel);
             break;
         default:
+            metric_type_from_int(static_cast<int>(metric_type));
             range_search_extra_metrics(
                     x,
                     get_xb(),

--- a/faiss/IndexFlat.cpp
+++ b/faiss/IndexFlat.cpp
@@ -77,7 +77,17 @@ void IndexFlat::range_search(
             range_search_L2sqr(x, get_xb(), d, n, ntotal, radius, result, sel);
             break;
         default:
-            FAISS_THROW_MSG("metric type not supported");
+            range_search_extra_metrics(
+                    x,
+                    get_xb(),
+                    d,
+                    n,
+                    ntotal,
+                    metric_type,
+                    metric_arg,
+                    radius,
+                    result,
+                    sel);
     }
 }
 

--- a/faiss/utils/extra_distances.cpp
+++ b/faiss/utils/extra_distances.cpp
@@ -12,6 +12,7 @@
 
 #include <omp.h>
 #include <algorithm>
+#include <limits>
 
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/DistanceComputer.h>
@@ -59,20 +60,32 @@ void range_search_extra_metrics_impl(
         BlockResultHandler& res) {
     using SingleResultHandler =
             typename BlockResultHandler::SingleResultHandler;
-    [[maybe_unused]] int nt = std::min(int(nx), omp_get_max_threads());
+    FAISS_THROW_IF_NOT_FMT(
+            nx <= static_cast<size_t>((std::numeric_limits<idx_t>::max)()),
+            "nx %zu overflows idx_t",
+            nx);
+    FAISS_THROW_IF_NOT_FMT(
+            ny <= static_cast<size_t>((std::numeric_limits<idx_t>::max)()),
+            "ny %zu overflows idx_t",
+            ny);
+
+    const idx_t nx_i = static_cast<idx_t>(nx);
+    const idx_t ny_i = static_cast<idx_t>(ny);
+    [[maybe_unused]] int nt = static_cast<int>(std::max<size_t>(
+            1, std::min(nx, static_cast<size_t>(omp_get_max_threads()))));
 
 #pragma omp parallel num_threads(nt)
     {
         SingleResultHandler resi(res);
 
 #pragma omp for
-        for (int64_t i = 0; i < static_cast<int64_t>(nx); i++) {
-            const float* x_i = x + i * vd.d;
+        for (idx_t i = 0; i < nx_i; i++) {
+            const float* x_i = x + static_cast<size_t>(i) * vd.d;
             const float* y_j = y;
 
-            resi.begin(i);
+            resi.begin(static_cast<size_t>(i));
 
-            for (size_t j = 0; j < ny; j++, y_j += vd.d) {
+            for (idx_t j = 0; j < ny_i; j++, y_j += vd.d) {
                 if (!res.is_in_selection(j)) {
                     continue;
                 }

--- a/faiss/utils/extra_distances.cpp
+++ b/faiss/utils/extra_distances.cpp
@@ -16,6 +16,7 @@
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/DistanceComputer.h>
 #include <faiss/impl/IDSelector.h>
+#include <faiss/impl/ResultHandler.h>
 #include <faiss/utils/utils.h>
 
 namespace faiss {
@@ -45,6 +46,56 @@ struct ExtraDistanceComputer : FlatCodesDistanceComputer {
 
     void set_query(const float* x) override {
         q = x;
+    }
+};
+
+template <class VD, class BlockResultHandler>
+void range_search_extra_metrics_impl(
+        const VD& vd,
+        const float* x,
+        const float* y,
+        size_t nx,
+        size_t ny,
+        BlockResultHandler& res) {
+    using SingleResultHandler =
+            typename BlockResultHandler::SingleResultHandler;
+    [[maybe_unused]] int nt = std::min(int(nx), omp_get_max_threads());
+
+#pragma omp parallel num_threads(nt)
+    {
+        SingleResultHandler resi(res);
+
+#pragma omp for
+        for (int64_t i = 0; i < static_cast<int64_t>(nx); i++) {
+            const float* x_i = x + i * vd.d;
+            const float* y_j = y;
+
+            resi.begin(i);
+
+            for (size_t j = 0; j < ny; j++, y_j += vd.d) {
+                if (!res.is_in_selection(j)) {
+                    continue;
+                }
+                float disij = vd(x_i, y_j);
+                resi.add_result(disij, j);
+            }
+            resi.end();
+        }
+    }
+}
+
+template <class VD>
+struct Run_range_search_extra_metrics {
+    using T = void;
+    const VD& vd;
+
+    template <class BlockResultHandler>
+    void f(BlockResultHandler& res,
+           const float* x,
+           const float* y,
+           size_t nx,
+           size_t ny) {
+        range_search_extra_metrics_impl(vd, x, y, nx, ny, res);
     }
 };
 
@@ -133,6 +184,23 @@ void knn_extra_metrics(
             }
             InterruptCallback::check();
         }
+    });
+}
+
+void range_search_extra_metrics(
+        const float* x,
+        const float* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        MetricType mt,
+        float metric_arg,
+        float radius,
+        RangeSearchResult* result,
+        const IDSelector* sel) {
+    with_VectorDistance(d, mt, metric_arg, [&](auto vd) {
+        Run_range_search_extra_metrics<decltype(vd)> r{vd};
+        dispatch_range_ResultHandler(result, radius, mt, sel, r, x, y, nx, ny);
     });
 }
 

--- a/faiss/utils/extra_distances.h
+++ b/faiss/utils/extra_distances.h
@@ -21,6 +21,7 @@
 namespace faiss {
 
 struct FlatCodesDistanceComputer;
+struct RangeSearchResult;
 
 void pairwise_extra_distances(
         int64_t d,
@@ -46,6 +47,18 @@ void knn_extra_metrics(
         size_t k,
         float* distances,
         int64_t* indexes,
+        const IDSelector* sel = nullptr);
+
+void range_search_extra_metrics(
+        const float* x,
+        const float* y,
+        size_t d,
+        size_t nx,
+        size_t ny,
+        MetricType mt,
+        float metric_arg,
+        float radius,
+        RangeSearchResult* result,
         const IDSelector* sel = nullptr);
 
 /** get a DistanceComputer that refers to this type of distance and

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -546,6 +546,30 @@ class TestRangeSearch(unittest.TestCase):
                     idx = li[0]
                     self.assertGreaterEqual(1e-4, abs(Dline[idx] - dis))
 
+    def test_range_search_l1(self):
+        xb = np.array(
+            [[0.0, 0.0], [2.0, 0.0], [0.0, 3.0], [5.0, 0.0]],
+            dtype="float32",
+        )
+        xq = np.array([[0.0, 0.0]], dtype="float32")
+
+        index = faiss.IndexFlat(2, faiss.METRIC_L1)
+        index.add(xb)
+
+        lims, D, I = index.range_search(xq, 3.0)
+
+        np.testing.assert_array_equal(lims, [0, 2])
+        np.testing.assert_array_equal(I, [0, 1])
+        np.testing.assert_array_equal(D, [0.0, 2.0])
+
+        params = faiss.SearchParameters()
+        params.sel = faiss.IDSelectorBatch(np.array([1, 2], dtype="int64"))
+        lims, D, I = index.range_search(xq, 3.0, params=params)
+
+        np.testing.assert_array_equal(lims, [0, 1])
+        np.testing.assert_array_equal(I, [1])
+        np.testing.assert_array_equal(D, [2.0])
+
 
 class TestSearchAndReconstruct(unittest.TestCase):
 


### PR DESCRIPTION
Summary:
- add range_search support for IndexFlat metrics handled by VectorDistance, including METRIC_L1
- preserve existing range result handler semantics for distance and similarity metrics, including ID selectors
- add a METRIC_L1 regression test for the strict radius boundary from #5353

Fixes #5353.

Test Plan:
- PYTHONPATH=tests python -m pytest -q tests/test_index.py::TestRangeSearch tests/test_extra_distances.py::TestKNN_NONE
- manual issue reproducer: IndexFlat(2, METRIC_L1).range_search(xq, 3.0) returns labels [0, 1] and distances [0.0, 2.0]
- git diff --check