### PR TITLE
Keep distances_simdlib256.h include in distances_simd.cpp (unused-include false positive)

### DIFF
--- a/faiss/utils/distances_simd.cpp
+++ b/faiss/utils/distances_simd.cpp
@@ -18,8 +18,11 @@
 // NOLINTNEXTLINE(facebook-hte-InlineHeader)
 #include <faiss/utils/simd_impl/distances_autovec-inl.h>
 
+// This TU is the SIMDLevel::NONE build of the specializations that
+// distances_simdlib256.h emits, so the include is required despite no symbol
+// being named directly here.
 // NOLINTNEXTLINE(facebook-hte-InlineHeader)
-#include <faiss/utils/simd_impl/distances_simdlib256.h>
+#include <faiss/utils/simd_impl/distances_simdlib256.h> // IWYU pragma: keep
 
 namespace faiss {
 


### PR DESCRIPTION
Summary:
`facebook-unused-include-check` flags `#include <faiss/utils/simd_impl/distances_simdlib256.h>` in `faiss/utils/distances_simd.cpp` as unused (T278317194), but this is a false positive.

`distances_simd.cpp` sets `#define THE_SIMD_LEVEL SIMDLevel::NONE` and then includes `distances_simdlib256.h`, which contains explicit template specializations parameterized on `THE_SIMD_LEVEL` — `fvec_sub`, `fvec_add` (both overloads), and `compute_PQ_dis_tables_dsub2`. This translation unit is the *sole* place the `SIMDLevel::NONE` versions of those specializations are defined; the primary templates in `distances.h` are pure declarations with no generic body, and the sibling TUs (`distances_avx2.cpp`, `distances_aarch64.cpp`) only emit the AVX2 / ARM_NEON specializations for their own `THE_SIMD_LEVEL`. The NONE path is always reachable through `with_simd_level_256bit` dispatch (it is the scalar fallback), so removing the include would leave those specializations undefined and break the link.

No symbol from the header is referenced *by name* in the .cpp, which is why the checker flags it — this is the standard per-level codegen idiom in faiss. Resolve the false positive by marking the include `// IWYU pragma: keep` (which the checker honors) plus a short comment explaining why it must stay, rather than deleting it.

Differential Revision: D110781200


