### PR TITLE
Guard constant/zero-norm query in RaBitQ query quantization (#5381)

### DIFF
--- a/faiss/impl/RaBitQUtils.cpp
+++ b/faiss/impl/RaBitQUtils.cpp
@@ -209,7 +209,13 @@ QueryFactorsData compute_query_factors(
     // Quantize the query
     const uint8_t max_code = (1 << qb) - 1;
     const float delta = (v_max - v_min) / max_code;
-    const float inv_delta = 1.0f / delta;
+    // A constant (or zero-norm) query has v_max == v_min, so delta == 0.
+    // Without this guard inv_delta would be +inf and (v_q - v_min) * inv_delta
+    // == NaN, which then float-casts to uint8_t below -- undefined behavior
+    // (UBSan float-cast-overflow) and garbage codes. A constant query carries
+    // no directional signal, so quantizing every component to 0 is correct;
+    // inv_delta = 0 achieves that.
+    const float inv_delta = (delta > 0.0f) ? (1.0f / delta) : 0.0f;
 
     rotated_qq.resize(d);
     size_t sum_qq = 0;


### PR DESCRIPTION
Summary:

In `ScalarQuantizer`/RaBitQ query quantization (`RaBitQUtils.cpp`), a constant query vector -- all components equal, e.g. the zero vector -- has `v_max == v_min`, so the per-component `delta` is 0. `inv_delta = 1/delta` was then `+inf`, making `(v_q - v_min) * inv_delta == 0 * inf == NaN`, which is rounded and cast to `uint8_t` -- undefined behavior (UBSan: float-cast-overflow) and garbage query codes.

Guard it: `inv_delta = (delta > 0) ? 1/delta : 0`. A constant query carries no directional signal, so quantizing every component to 0 is the correct degenerate result; downstream distance estimation and (in callers) reranking then behave sanely instead of hitting UB.

Found via UBSan on a MyRocks XDB-V RaBitQ KNN query with a zero query vector.

Reviewed By: mnorris11

Differential Revision: D110242938


