### PR TITLE
Parallelize inverted-list append loop in IndexIVFPQ::add_core_o

### DIFF
--- a/faiss/IndexIVFPQ.cpp
+++ b/faiss/IndexIVFPQ.cpp
@@ -14,6 +14,8 @@
 #include <cstdint>
 #include <cstdio>
 
+#include <omp.h>
+
 #include <algorithm>
 
 #include <faiss/utils/distances_dispatch.h>
@@ -292,34 +294,49 @@ void IndexIVFPQ::add_core_o(
     pq.compute_codes(to_encode, xcodes.get(), n);
 
     double t2 = getmillisecs();
-    // TODO: parallelize?
     size_t n_ignore = 0;
-    for (idx_t i = 0; i < n; i++) {
-        idx_t key = idx[i];
-        idx_t id = xids ? xids[i] : ntotal + i;
-        if (key < 0) {
-            direct_map.add_single_id(id, -1, 0);
-            n_ignore++;
+    DirectMapAdd dm_adder(direct_map, n, xids);
+
+#pragma omp parallel reduction(+ : n_ignore)
+    {
+        int nt = omp_get_num_threads();
+        int rank = omp_get_thread_num();
+
+        // each thread takes care of a subset of lists
+        for (idx_t i = 0; i < n; i++) {
+            idx_t key = idx[i];
+            if (key < 0) {
+                if (rank == 0) {
+                    dm_adder.add(i, -1, 0);
+                    n_ignore++;
+                    if (residuals_2) {
+                        memset(residuals_2 + i * d,
+                               0,
+                               sizeof(*residuals_2) * d);
+                    }
+                }
+                continue;
+            }
+            if (key % nt != rank) {
+                continue;
+            }
+
+            idx_t id = xids ? xids[i] : ntotal + i;
+            uint8_t* code = xcodes.get() + i * code_size;
+            size_t offset =
+                    invlists->add_entry(key, id, code, inverted_list_context);
+
             if (residuals_2) {
-                memset(residuals_2, 0, sizeof(*residuals_2) * d);
+                float* res2 = residuals_2 + i * d;
+                const float* xi = to_encode + i * d;
+                pq.decode(code, res2);
+                for (int j = 0; j < d; j++) {
+                    res2[j] = xi[j] - res2[j];
+                }
             }
-            continue;
+
+            dm_adder.add(i, key, offset);
         }
-
-        uint8_t* code = xcodes.get() + i * code_size;
-        size_t offset =
-                invlists->add_entry(key, id, code, inverted_list_context);
-
-        if (residuals_2) {
-            float* res2 = residuals_2 + i * d;
-            const float* xi = to_encode + i * d;
-            pq.decode(code, res2);
-            for (int j = 0; j < d; j++) {
-                res2[j] = xi[j] - res2[j];
-            }
-        }
-
-        direct_map.add_single_id(id, key, offset);
     }
 
     double t3 = getmillisecs();


### PR DESCRIPTION
The bulk-add path in `IndexIVFPQ::add_core_o` appended encoded vectors to the inverted lists in a serial loop (marked `TODO: parallelize?`), while the base `IndexIVF::add_core` has sharded this work across threads. The result is that `add()` throughput stopped scaling with thread count with the serial append becoming the bottleneck at high thread counts.

This PR applies the same pattern already used in `IndexIVF::add_core`:

- **Shard lists across threads** by `key % num_threads == rank`, so each inverted list is only ever appended to by one thread. Per-list append order (and hence the resulting index) is identical to the serial version.
- **Replace non-thread-safe `direct_map.add_single_id()` calls** with the existing thread-safe `DirectMapAdd` helper.
- **Count ignored (`key < 0`) entries via an OpenMP reduction**; rank 0 handles their direct-map entries and residual zeroing.

**Bug Fix**

Also fixes a bug on the `key < 0` path: the `residuals_2` memset zeroed row 0 (`residuals_2`) instead of row `i` (`residuals_2 + i * d`).

**Benchmark**

```bash
numactl -N 0 -m 0 python benchs/bench_all_ivf/bench_all_ivf.py --db sift1M --indexkey IVF4096,PQ32
```

Times are for the append phase as reported by verbose `add_core` timings, with coarse assignment precomputed.

```
+---------+------------+-----------+---------+
| threads | before (s) | after (s) | speedup |
+---------+------------+-----------+---------+
|       1 |      0.052 |     0.052 |    1.0x |
|       4 |      0.053 |     0.033 |    1.6x |
|      16 |      0.054 |     0.015 |    3.6x |
|      60 |      0.116 |     0.018 |    6.4x |
+---------+------------+-----------+---------+
```

The gain grows with higher thread counts, and would be expected to grow further with cheaper encodes (smaller M) or larger batches, where the append phase is a larger share of total add time.
