### PR TITLE
fix: bs add n fix valid counter skip

### DIFF
--- a/faiss/utils/approx_topk_hamming/approx_topk_hamming.h
+++ b/faiss/utils/approx_topk_hamming/approx_topk_hamming.h
@@ -118,7 +118,7 @@ struct HeapWithBucketsForHamming32<
                         }
                     }
 
-                    if (valid_counter == 8) {
+                    if (valid_counter == 0) {
                         continue; // Skip if all vectors are filtered out
                     }
 


### PR DESCRIPTION
isn't valid counter == 0 means all vectors are filtered out?