### PR TITLE
Vectorize RaBitQ fast-scan handler adjustment (1 bit, no filter)

### DIFF
--- a/faiss/IndexIVFRaBitQFastScan.h
+++ b/faiss/IndexIVFRaBitQFastScan.h
@@ -9,6 +9,9 @@
 
 #include <memory>
 #include <vector>
+#if defined(__AVX512F__) && defined(__AVX512BW__) && defined(__AVX512VL__)
+#include <immintrin.h>
+#endif
 
 #include <faiss/IndexIVFFastScan.h>
 #include <faiss/IndexIVFRaBitQ.h>
@@ -279,63 +282,146 @@ void IVFRaBitQHeapHandler<C, SL>::handle(
     const size_t qb = context->qb > 0 ? context->qb : index->qb;
     const size_t d = index->d;
 
-    for (size_t j = 0; j < max_positions; j++) {
-        const int64_t result_id = this->adjust_id(b, j);
-        if (result_id < 0) {
-            continue;
-        }
-        if (this->sel != nullptr && !this->sel->is_member(result_id)) {
-            continue;
-        }
+#if defined(__AVX512F__) && defined(__AVX512BW__) && defined(__AVX512VL__)
+    if (!is_multibit && this->sel == nullptr && max_positions == 32 &&
+        index->bbs == 32 && (idx_base % index->bbs) == 0 && !centered &&
+        storage_size == sizeof(SignBitFactors)) {
+        ALIGNED(64) float adjusted_tab[32];
+        const __m512 one_a_v = _mm512_set1_ps(one_a);
+        const __m512 bias_v = _mm512_set1_ps(bias);
+        const __m512 c34_v = _mm512_set1_ps(query_factors.c34);
+        const __m512 qr_to_c_v = _mm512_set1_ps(query_factors.qr_to_c_L2sqr);
+        const __m512 two_v = _mm512_set1_ps(2.0f);
+        const __m512 zero_v = _mm512_setzero_ps();
+        const __m512 qr_norm_v = _mm512_set1_ps(query_factors.qr_norm_L2sqr);
+        const __m512 neg_half_v = _mm512_set1_ps(-0.5f);
+        const __m512i even_idx = _mm512_setr_epi32(
+                0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30);
+        const __m512i odd_idx = _mm512_setr_epi32(
+                1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31);
 
-        this->scan_cnt++;
+        this->scan_cnt += 32;
 
-        const float normalized_distance = d32tab[j] * one_a + bias;
-        const uint8_t* base_ptr = aux_base + j * storage_size;
+        uint32_t candidate_mask = 0;
+        for (size_t base = 0; base < 32; base += 16) {
+            const __m256i d16 = _mm256_loadu_si256(
+                    reinterpret_cast<const __m256i*>(d32tab + base));
+            __m512 normalized = _mm512_cvtepi32_ps(_mm512_cvtepu16_epi32(d16));
+            normalized =
+                    _mm512_add_ps(_mm512_mul_ps(normalized, one_a_v), bias_v);
 
-        if (is_multibit) {
-            const SignBitFactorsWithError& full_factors =
-                    *reinterpret_cast<const SignBitFactorsWithError*>(base_ptr);
+            const float* factors = reinterpret_cast<const float*>(
+                    aux_base + base * storage_size);
+            const __m512 packed0 = _mm512_loadu_ps(factors);
+            const __m512 packed1 = _mm512_loadu_ps(factors + 16);
+            const __m512 or_minus_c =
+                    _mm512_permutex2var_ps(packed0, even_idx, packed1);
+            const __m512 dp_multiplier =
+                    _mm512_permutex2var_ps(packed0, odd_idx, packed1);
 
-            float dist_1bit = rabitq_utils::compute_1bit_adjusted_distance(
-                    normalized_distance,
-                    full_factors,
-                    query_factors,
-                    centered,
-                    qb,
-                    d);
-
-            bool should_refine = rabitq_utils::should_refine_candidate(
-                    dist_1bit,
-                    full_factors.f_error,
-                    query_factors.g_error,
-                    heap_dis[0],
-                    is_similarity);
-            if (should_refine) {
-                size_t local_offset = idx_base + j;
-                float dist_full = compute_full_multibit_distance(
-                        local_q, q, local_offset, base_ptr);
-                if (Cfloat::cmp(heap_dis[0], dist_full)) {
-                    heap_replace_top<Cfloat>(
-                            k, heap_dis, heap_ids, dist_full, result_id);
-                    nup++;
-                }
+            const __m512 final_dot = _mm512_sub_ps(normalized, c34_v);
+            __m512 adjusted = _mm512_sub_ps(
+                    _mm512_add_ps(or_minus_c, qr_to_c_v),
+                    _mm512_mul_ps(
+                            two_v, _mm512_mul_ps(dp_multiplier, final_dot)));
+            if (query_factors.qr_norm_L2sqr != 0.0f) {
+                adjusted = _mm512_mul_ps(
+                        neg_half_v, _mm512_sub_ps(adjusted, qr_norm_v));
+            } else {
+                adjusted = _mm512_max_ps(zero_v, adjusted);
             }
-        } else {
-            const auto& db_factors =
-                    *reinterpret_cast<const SignBitFactors*>(base_ptr);
-            float adjusted_distance =
-                    rabitq_utils::compute_1bit_adjusted_distance(
-                            normalized_distance,
-                            db_factors,
-                            query_factors,
-                            centered,
-                            qb,
-                            d);
+
+            _mm512_storeu_ps(adjusted_tab + base, adjusted);
+            const __m512 heap_top = _mm512_set1_ps(heap_dis[0]);
+            __mmask16 mask;
+            if constexpr (Cfloat::is_max) {
+                mask = _mm512_cmp_ps_mask(heap_top, adjusted, _CMP_GT_OQ);
+            } else {
+                mask = _mm512_cmp_ps_mask(heap_top, adjusted, _CMP_LT_OQ);
+            }
+            candidate_mask |= uint32_t(mask) << base;
+        }
+
+        while (candidate_mask) {
+            const int j = __builtin_ctz(candidate_mask);
+            candidate_mask &= candidate_mask - 1;
+            const int64_t result_id = this->adjust_id(b, j);
+            if (result_id < 0) {
+                continue;
+            }
+            const float adjusted_distance = adjusted_tab[j];
             if (Cfloat::cmp(heap_dis[0], adjusted_distance)) {
                 heap_replace_top<Cfloat>(
                         k, heap_dis, heap_ids, adjusted_distance, result_id);
                 nup++;
+            }
+        }
+    } else
+#endif
+    {
+        for (size_t j = 0; j < max_positions; j++) {
+            const int64_t result_id = this->adjust_id(b, j);
+            if (result_id < 0) {
+                continue;
+            }
+            if (this->sel != nullptr && !this->sel->is_member(result_id)) {
+                continue;
+            }
+
+            this->scan_cnt++;
+
+            const float normalized_distance = d32tab[j] * one_a + bias;
+            const uint8_t* base_ptr = aux_base + j * storage_size;
+
+            if (is_multibit) {
+                const SignBitFactorsWithError& full_factors =
+                        *reinterpret_cast<const SignBitFactorsWithError*>(
+                                base_ptr);
+
+                float dist_1bit = rabitq_utils::compute_1bit_adjusted_distance(
+                        normalized_distance,
+                        full_factors,
+                        query_factors,
+                        centered,
+                        qb,
+                        d);
+
+                bool should_refine = rabitq_utils::should_refine_candidate(
+                        dist_1bit,
+                        full_factors.f_error,
+                        query_factors.g_error,
+                        heap_dis[0],
+                        is_similarity);
+                if (should_refine) {
+                    size_t local_offset = idx_base + j;
+                    float dist_full = compute_full_multibit_distance(
+                            local_q, q, local_offset, base_ptr);
+                    if (Cfloat::cmp(heap_dis[0], dist_full)) {
+                        heap_replace_top<Cfloat>(
+                                k, heap_dis, heap_ids, dist_full, result_id);
+                        nup++;
+                    }
+                }
+            } else {
+                const auto& db_factors =
+                        *reinterpret_cast<const SignBitFactors*>(base_ptr);
+                float adjusted_distance =
+                        rabitq_utils::compute_1bit_adjusted_distance(
+                                normalized_distance,
+                                db_factors,
+                                query_factors,
+                                centered,
+                                qb,
+                                d);
+                if (Cfloat::cmp(heap_dis[0], adjusted_distance)) {
+                    heap_replace_top<Cfloat>(
+                            k,
+                            heap_dis,
+                            heap_ids,
+                            adjusted_distance,
+                            result_id);
+                    nup++;
+                }
             }
         }
     }

--- a/faiss/IndexIVFRaBitQFastScan.h
+++ b/faiss/IndexIVFRaBitQFastScan.h
@@ -9,9 +9,6 @@
 
 #include <memory>
 #include <vector>
-#if defined(__AVX512F__) && defined(__AVX512BW__) && defined(__AVX512VL__)
-#include <immintrin.h>
-#endif
 
 #include <faiss/IndexIVFFastScan.h>
 #include <faiss/IndexIVFRaBitQ.h>
@@ -21,6 +18,7 @@
 #include <faiss/impl/fast_scan/rabitq_result_handler.h>
 #include <faiss/utils/AlignedTable.h>
 #include <faiss/utils/Heap.h>
+#include <faiss/utils/rabitq_simd.h>
 
 namespace faiss {
 
@@ -282,65 +280,25 @@ void IVFRaBitQHeapHandler<C, SL>::handle(
     const size_t qb = context->qb > 0 ? context->qb : index->qb;
     const size_t d = index->d;
 
-#if defined(__AVX512F__) && defined(__AVX512BW__) && defined(__AVX512VL__)
     if (!is_multibit && this->sel == nullptr && max_positions == 32 &&
         index->bbs == 32 && (idx_base % index->bbs) == 0 && !centered &&
         storage_size == sizeof(SignBitFactors)) {
         ALIGNED(64) float adjusted_tab[32];
-        const __m512 one_a_v = _mm512_set1_ps(one_a);
-        const __m512 bias_v = _mm512_set1_ps(bias);
-        const __m512 c34_v = _mm512_set1_ps(query_factors.c34);
-        const __m512 qr_to_c_v = _mm512_set1_ps(query_factors.qr_to_c_L2sqr);
-        const __m512 two_v = _mm512_set1_ps(2.0f);
-        const __m512 zero_v = _mm512_setzero_ps();
-        const __m512 qr_norm_v = _mm512_set1_ps(query_factors.qr_norm_L2sqr);
-        const __m512 neg_half_v = _mm512_set1_ps(-0.5f);
-        const __m512i even_idx = _mm512_setr_epi32(
-                0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30);
-        const __m512i odd_idx = _mm512_setr_epi32(
-                1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31);
 
         this->scan_cnt += 32;
-
-        uint32_t candidate_mask = 0;
-        for (size_t base = 0; base < 32; base += 16) {
-            const __m256i d16 = _mm256_loadu_si256(
-                    reinterpret_cast<const __m256i*>(d32tab + base));
-            __m512 normalized = _mm512_cvtepi32_ps(_mm512_cvtepu16_epi32(d16));
-            normalized =
-                    _mm512_add_ps(_mm512_mul_ps(normalized, one_a_v), bias_v);
-
-            const float* factors = reinterpret_cast<const float*>(
-                    aux_base + base * storage_size);
-            const __m512 packed0 = _mm512_loadu_ps(factors);
-            const __m512 packed1 = _mm512_loadu_ps(factors + 16);
-            const __m512 or_minus_c =
-                    _mm512_permutex2var_ps(packed0, even_idx, packed1);
-            const __m512 dp_multiplier =
-                    _mm512_permutex2var_ps(packed0, odd_idx, packed1);
-
-            const __m512 final_dot = _mm512_sub_ps(normalized, c34_v);
-            __m512 adjusted = _mm512_sub_ps(
-                    _mm512_add_ps(or_minus_c, qr_to_c_v),
-                    _mm512_mul_ps(
-                            two_v, _mm512_mul_ps(dp_multiplier, final_dot)));
-            if (query_factors.qr_norm_L2sqr != 0.0f) {
-                adjusted = _mm512_mul_ps(
-                        neg_half_v, _mm512_sub_ps(adjusted, qr_norm_v));
-            } else {
-                adjusted = _mm512_max_ps(zero_v, adjusted);
-            }
-
-            _mm512_storeu_ps(adjusted_tab + base, adjusted);
-            const __m512 heap_top = _mm512_set1_ps(heap_dis[0]);
-            __mmask16 mask;
-            if constexpr (Cfloat::is_max) {
-                mask = _mm512_cmp_ps_mask(heap_top, adjusted, _CMP_GT_OQ);
-            } else {
-                mask = _mm512_cmp_ps_mask(heap_top, adjusted, _CMP_LT_OQ);
-            }
-            candidate_mask |= uint32_t(mask) << base;
-        }
+        uint32_t candidate_mask =
+                rabitq::ivf_rabitq_fastscan_adjust_1bit_32_dispatch(
+                        d32tab,
+                        aux_base,
+                        storage_size,
+                        one_a,
+                        bias,
+                        query_factors.c34,
+                        query_factors.qr_to_c_L2sqr,
+                        query_factors.qr_norm_L2sqr,
+                        heap_dis[0],
+                        Cfloat::is_max,
+                        adjusted_tab);
 
         while (candidate_mask) {
             const int j = __builtin_ctz(candidate_mask);
@@ -356,9 +314,7 @@ void IVFRaBitQHeapHandler<C, SL>::handle(
                 nup++;
             }
         }
-    } else
-#endif
-    {
+    } else {
         for (size_t j = 0; j < max_positions; j++) {
             const int64_t result_id = this->adjust_id(b, j);
             if (result_id < 0) {

--- a/faiss/impl/RaBitQUtils.cpp
+++ b/faiss/impl/RaBitQUtils.cpp
@@ -17,6 +17,40 @@
 #include <limits>
 
 namespace faiss {
+namespace rabitq {
+
+uint32_t ivf_rabitq_fastscan_adjust_1bit_32_dispatch(
+        const uint16_t* distances32,
+        const uint8_t* aux_base,
+        size_t storage_size,
+        float one_a,
+        float bias,
+        float c34,
+        float qr_to_c_l2sqr,
+        float qr_norm_l2sqr,
+        float heap_top,
+        bool c_is_max,
+        float* adjusted32) {
+    constexpr int available_levels =
+            AVAILABLE_SIMD_LEVELS_NONE | (1 << int(SIMDLevel::AVX512));
+    return with_selected_simd_levels<available_levels>([&]<SIMDLevel SL>() {
+        return ivf_rabitq_fastscan_adjust_1bit_32<SL>(
+                distances32,
+                aux_base,
+                storage_size,
+                one_a,
+                bias,
+                c34,
+                qr_to_c_l2sqr,
+                qr_norm_l2sqr,
+                heap_top,
+                c_is_max,
+                adjusted32);
+    });
+}
+
+} // namespace rabitq
+
 namespace rabitq_utils {
 
 // Verify no unexpected padding in structures used for per-vector storage.

--- a/faiss/utils/rabitq_simd.h
+++ b/faiss/utils/rabitq_simd.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -77,6 +78,42 @@ void rearrange_bit_planes(
         size_t d,
         size_t qb,
         uint8_t* out);
+
+/**
+ * Adjust 32 1-bit RaBitQ fast-scan distances and return lanes that beat the
+ * current heap threshold.
+ *
+ * aux_base points at 32 consecutive SignBitFactors records with
+ * storage_size == 2 * sizeof(float). This interface intentionally exposes only
+ * byte/scalar types so SIMD implementations stay hidden in per-ISA translation
+ * units.
+ */
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
+uint32_t ivf_rabitq_fastscan_adjust_1bit_32(
+        const uint16_t* distances32,
+        const uint8_t* aux_base,
+        size_t storage_size,
+        float one_a,
+        float bias,
+        float c34,
+        float qr_to_c_l2sqr,
+        float qr_norm_l2sqr,
+        float heap_top,
+        bool c_is_max,
+        float* adjusted32);
+
+uint32_t ivf_rabitq_fastscan_adjust_1bit_32_dispatch(
+        const uint16_t* distances32,
+        const uint8_t* aux_base,
+        size_t storage_size,
+        float one_a,
+        float bias,
+        float c34,
+        float qr_to_c_l2sqr,
+        float qr_norm_l2sqr,
+        float heap_top,
+        bool c_is_max,
+        float* adjusted32);
 
 // NONE specializations — scalar fallbacks
 
@@ -159,6 +196,40 @@ inline void rearrange_bit_planes<SIMDLevel::NONE>(
             out[iv * offset + idim / 8] |= bit ? (1 << (idim % 8)) : 0;
         }
     }
+}
+
+template <>
+inline uint32_t ivf_rabitq_fastscan_adjust_1bit_32<SIMDLevel::NONE>(
+        const uint16_t* distances32,
+        const uint8_t* aux_base,
+        size_t storage_size,
+        float one_a,
+        float bias,
+        float c34,
+        float qr_to_c_l2sqr,
+        float qr_norm_l2sqr,
+        float heap_top,
+        bool c_is_max,
+        float* adjusted32) {
+    uint32_t candidate_mask = 0;
+    for (size_t j = 0; j < 32; j++) {
+        const float normalized = distances32[j] * one_a + bias;
+        const float* factors =
+                reinterpret_cast<const float*>(aux_base + j * storage_size);
+        const float final_dot = normalized - c34;
+        float adjusted =
+                factors[0] + qr_to_c_l2sqr - 2.0f * factors[1] * final_dot;
+        if (qr_norm_l2sqr != 0.0f) {
+            adjusted = -0.5f * (adjusted - qr_norm_l2sqr);
+        } else {
+            adjusted = std::max(0.0f, adjusted);
+        }
+        adjusted32[j] = adjusted;
+        if (c_is_max ? heap_top > adjusted : heap_top < adjusted) {
+            candidate_mask |= uint32_t(1) << j;
+        }
+    }
+    return candidate_mask;
 }
 
 } // namespace faiss::rabitq

--- a/faiss/utils/simd_impl/rabitq_avx512.cpp
+++ b/faiss/utils/simd_impl/rabitq_avx512.cpp
@@ -7,6 +7,7 @@
 
 #ifdef COMPILE_SIMD_AVX512
 
+#include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/rabitq_simd.h>
 #include <immintrin.h>
 
@@ -377,6 +378,71 @@ void rearrange_bit_planes<SIMDLevel::AVX512>(
             out[iv * offset + idim / 8] |= bit ? (1 << (idim % 8)) : 0;
         }
     }
+}
+
+template <>
+uint32_t ivf_rabitq_fastscan_adjust_1bit_32<SIMDLevel::AVX512>(
+        const uint16_t* distances32,
+        const uint8_t* aux_base,
+        size_t storage_size,
+        float one_a,
+        float bias,
+        float c34,
+        float qr_to_c_l2sqr,
+        float qr_norm_l2sqr,
+        float heap_top_scalar,
+        bool c_is_max,
+        float* adjusted32) {
+    FAISS_ASSERT(storage_size == 2 * sizeof(float));
+
+    const __m512 one_a_v = _mm512_set1_ps(one_a);
+    const __m512 bias_v = _mm512_set1_ps(bias);
+    const __m512 c34_v = _mm512_set1_ps(c34);
+    const __m512 qr_to_c_v = _mm512_set1_ps(qr_to_c_l2sqr);
+    const __m512 two_v = _mm512_set1_ps(2.0f);
+    const __m512 zero_v = _mm512_setzero_ps();
+    const __m512 qr_norm_v = _mm512_set1_ps(qr_norm_l2sqr);
+    const __m512 neg_half_v = _mm512_set1_ps(-0.5f);
+    const __m512 heap_top = _mm512_set1_ps(heap_top_scalar);
+    const __m512i even_idx = _mm512_setr_epi32(
+            0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30);
+    const __m512i odd_idx = _mm512_setr_epi32(
+            1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31);
+
+    uint32_t candidate_mask = 0;
+    for (size_t base = 0; base < 32; base += 16) {
+        const __m256i d16 = _mm256_loadu_si256(
+                reinterpret_cast<const __m256i*>(distances32 + base));
+        __m512 normalized = _mm512_cvtepi32_ps(_mm512_cvtepu16_epi32(d16));
+        normalized = _mm512_add_ps(_mm512_mul_ps(normalized, one_a_v), bias_v);
+
+        const float* factors =
+                reinterpret_cast<const float*>(aux_base + base * storage_size);
+        const __m512 packed0 = _mm512_loadu_ps(factors);
+        const __m512 packed1 = _mm512_loadu_ps(factors + 16);
+        const __m512 or_minus_c =
+                _mm512_permutex2var_ps(packed0, even_idx, packed1);
+        const __m512 dp_multiplier =
+                _mm512_permutex2var_ps(packed0, odd_idx, packed1);
+
+        const __m512 final_dot = _mm512_sub_ps(normalized, c34_v);
+        __m512 adjusted = _mm512_sub_ps(
+                _mm512_add_ps(or_minus_c, qr_to_c_v),
+                _mm512_mul_ps(two_v, _mm512_mul_ps(dp_multiplier, final_dot)));
+        if (qr_norm_l2sqr != 0.0f) {
+            adjusted = _mm512_mul_ps(
+                    neg_half_v, _mm512_sub_ps(adjusted, qr_norm_v));
+        } else {
+            adjusted = _mm512_max_ps(adjusted, zero_v);
+        }
+
+        _mm512_storeu_ps(adjusted32 + base, adjusted);
+        const __mmask16 mask = c_is_max
+                ? _mm512_cmp_ps_mask(heap_top, adjusted, _CMP_GT_OQ)
+                : _mm512_cmp_ps_mask(heap_top, adjusted, _CMP_LT_OQ);
+        candidate_mask |= uint32_t(mask) << base;
+    }
+    return candidate_mask;
 }
 
 } // namespace faiss::rabitq


### PR DESCRIPTION
This patch adds an AVX512 fast path for the 1-bit IndexIVFRaBitQFastScan result handler.

The PQ4 fast-scan kernel already computes distances for 32 candidates at a time, but the RaBitQ handler was converting those 32 uint16 distances back into a scalar per-candidate loop to apply the 1-bit distance correction and heap threshold check.

  For the common 1-bit, non-centered, no-selector, full-block path, this patch keeps the correction step vectorized:

  - converts 16 uint16 distances to float at a time
  - loads/deinterleaves the per-vector RaBitQ aux factors
  - computes adjusted distances with AVX512
  - compares all lanes against the current heap threshold
  - drains only surviving lanes into the scalar heap update path

  The scalar fallback is unchanged for multibit, selectors, partial blocks, centered mode, and non-AVX512 builds.

  ## Validation

  Tested on AWS Sapphire Rapids with a 1M Cohere IVF_RABITQ_FASTSCAN index.

  Config:

  - nprobe=64
  - k=100
  - nq=1000
  - 5 rounds
  - 8 search threads

  Results:
  baseline 312.87
  patched 322.61


  This is about a 3% end-to-end QPS improvement with unchanged results.
