### PR TITLE
faiss: support METRIC_L1 and extra metrics in IndexFlat range_search

### DIFF
--- a/faiss/IndexFlat.cpp
+++ b/faiss/IndexFlat.cpp
@@ -77,7 +77,8 @@ void IndexFlat::range_search(
             range_search_L2sqr(x, get_xb(), d, n, ntotal, radius, result, sel);
             break;
         default:
-            FAISS_THROW_MSG("metric type not supported");
+            IndexFlatCodes::range_search(n, x, radius, result, params);
+            break;
     }
 }
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -528,23 +528,26 @@ class TestRangeSearch(unittest.TestCase):
 
         (xt, xb, xq) = get_dataset(d, nb, nt, nq)
 
-        index = faiss.IndexFlatL2(d)
-        index.add(xb)
+        for metric, thresh in [
+            (faiss.METRIC_L2, 0.1),
+            (faiss.METRIC_L1, 0.5),
+        ]:
+            index = faiss.IndexFlat(d, metric)
+            index.add(xb)
 
-        Dref, Iref = index.search(xq, 5)
+            Dref, Iref = index.search(xq, 5)
 
-        thresh = 0.1  # *squared* distance
-        lims, D, I = index.range_search(xq, thresh)
+            lims, D, I = index.range_search(xq, thresh)
 
-        for i in range(nq):
-            Iline = I[lims[i] : lims[i + 1]]
-            Dline = D[lims[i] : lims[i + 1]]
-            for j, dis in zip(Iref[i], Dref[i]):
-                if dis < thresh:
-                    (li,) = np.where(Iline == j)
-                    self.assertTrue(li.size == 1)
-                    idx = li[0]
-                    self.assertGreaterEqual(1e-4, abs(Dline[idx] - dis))
+            for i in range(nq):
+                Iline = I[lims[i] : lims[i + 1]]
+                Dline = D[lims[i] : lims[i + 1]]
+                for j, dis in zip(Iref[i], Dref[i]):
+                    if dis < thresh:
+                        (li,) = np.where(Iline == j)
+                        self.assertTrue(li.size == 1)
+                        idx = li[0]
+                        self.assertGreaterEqual(1e-4, abs(Dline[idx] - dis))
 
 
 class TestSearchAndReconstruct(unittest.TestCase):


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebookresearch/faiss/issues/5353

it is marginally less performant than implementing in extra_distances to avoid the decode memcpy, but it keeps the change simple.

Differential Revision: D111062845


