### PR TITLE
RaBitQ SIMD-optimized bit-plane operation (#5392)

### DIFF
--- a/benchs/bench_rabitq_simd.cpp
+++ b/benchs/bench_rabitq_simd.cpp
@@ -82,6 +82,38 @@ void bench_rabitq_and_dot_product_with_sum(benchmark::State& state) {
             });
 }
 
+template <SIMDLevel SL>
+void bench_rabitq_rearrange_impl(benchmark::State& state) {
+    size_t qb = state.range(0);
+    size_t d = state.range(1);
+    size_t offset = (d + 7) / 8;
+
+    AlignedTable<uint8_t> rotated_qq(d);
+    byte_rand(rotated_qq.data(), rotated_qq.size(), 10996);
+    // codes are qb-bit values, one per dimension
+    const uint8_t code_mask = static_cast<uint8_t>((1u << qb) - 1);
+    for (size_t i = 0; i < d; i++) {
+        rotated_qq[i] &= code_mask;
+    }
+    AlignedTable<uint8_t> out(offset * qb);
+
+    for (auto _ : state) {
+        rabitq::rearrange_bit_planes<SL>(rotated_qq.data(), d, qb, out.data());
+        benchmark::DoNotOptimize(out.data());
+    }
+    state.SetItemsProcessed(state.iterations() * d);
+}
+
+void bench_rabitq_rearrange_scalar(benchmark::State& state) {
+    bench_rabitq_rearrange_impl<SIMDLevel::NONE>(state);
+}
+
+#if defined(__x86_64__)
+void bench_rabitq_rearrange_avx2(benchmark::State& state) {
+    bench_rabitq_rearrange_impl<SIMDLevel::AVX2>(state);
+}
+#endif
+
 const std::vector<int64_t> qbs{1, 2, 4, 8};
 const std::vector<int64_t> dims{64, 100, 256, 512, 1000, 1024, 3072};
 
@@ -95,6 +127,14 @@ BENCHMARK(bench_rabitq_xor_dot_product)
 BENCHMARK(bench_rabitq_and_dot_product_with_sum)
         ->ArgsProduct({qbs, dims})
         ->ArgNames({"qb", "d"});
+BENCHMARK(bench_rabitq_rearrange_scalar)
+        ->ArgsProduct({qbs, dims})
+        ->ArgNames({"qb", "d"});
+#if defined(__x86_64__)
+BENCHMARK(bench_rabitq_rearrange_avx2)
+        ->ArgsProduct({qbs, dims})
+        ->ArgNames({"qb", "d"});
+#endif
 BENCHMARK_MAIN();
 
 } // namespace faiss

--- a/faiss/impl/RaBitQuantizer.cpp
+++ b/faiss/impl/RaBitQuantizer.cpp
@@ -14,7 +14,6 @@
 #include <faiss/utils/distances.h>
 #include <faiss/utils/rabitq_simd.h>
 
-#include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <memory>
@@ -526,16 +525,12 @@ struct RaBitQDistanceComputerQ : RaBitQDistanceComputer {
         size_t offset = (d + 7) / 8;
 
         rearranged_rotated_qq.resize(offset * qb);
-        std::fill(
-                rearranged_rotated_qq.begin(), rearranged_rotated_qq.end(), 0);
-
-        for (size_t idim = 0; idim < d; idim++) {
-            for (size_t iv = 0; iv < qb; iv++) {
-                const bool bit = ((rotated_qq[idim] & (1 << iv)) != 0);
-                rearranged_rotated_qq[iv * offset + idim / 8] |=
-                        bit ? (1 << (idim % 8)) : 0;
-            }
-        }
+        with_selected_simd_levels<
+                AVAILABLE_SIMD_LEVELS_NONE | (1 << int(SIMDLevel::AVX2)) |
+                (1 << int(SIMDLevel::AVX512))>([&]<SIMDLevel RSL>() {
+            rabitq::rearrange_bit_planes<RSL>(
+                    rotated_qq.data(), d, qb, rearranged_rotated_qq.data());
+        });
     }
 };
 

--- a/faiss/utils/rabitq_simd.h
+++ b/faiss/utils/rabitq_simd.h
@@ -58,6 +58,26 @@ uint64_t bitwise_xor_dot_product(
 template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
 uint64_t popcount(const uint8_t* data, size_t size);
 
+/**
+ * Rearrange per-dimension quantized query codes into bit-plane layout.
+ *
+ * @p rotated_qq holds one qb-bit code per dimension (one byte each, value in
+ * [0, 2^qb)). @p out receives qb bit-planes of ((d + 7) / 8) bytes each:
+ * bit-plane j packs bit j of code i into bit (i % 8) of byte (i / 8). @p out
+ * must have room for qb * ((d + 7) / 8) bytes and is fully overwritten.
+ *
+ * @param rotated_qq  per-dimension codes (d bytes)
+ * @param d           dimensionality
+ * @param qb          quantization bits per dimension (1..8)
+ * @param out         bit-plane output buffer (qb * ((d + 7) / 8) bytes)
+ */
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
+void rearrange_bit_planes(
+        const uint8_t* rotated_qq,
+        size_t d,
+        size_t qb,
+        uint8_t* out);
+
 // NONE specializations — scalar fallbacks
 
 template <>
@@ -123,6 +143,22 @@ inline uint64_t popcount<SIMDLevel::NONE>(const uint8_t* data, size_t size) {
         sum += popcount32(yv);
     }
     return sum;
+}
+
+template <>
+inline void rearrange_bit_planes<SIMDLevel::NONE>(
+        const uint8_t* rotated_qq,
+        size_t d,
+        size_t qb,
+        uint8_t* out) {
+    const size_t offset = (d + 7) / 8;
+    memset(out, 0, offset * qb);
+    for (size_t idim = 0; idim < d; idim++) {
+        for (size_t iv = 0; iv < qb; iv++) {
+            const bool bit = ((rotated_qq[idim] & (1 << iv)) != 0);
+            out[iv * offset + idim / 8] |= bit ? (1 << (idim % 8)) : 0;
+        }
+    }
 }
 
 } // namespace faiss::rabitq

--- a/faiss/utils/simd_impl/rabitq_avx2.cpp
+++ b/faiss/utils/simd_impl/rabitq_avx2.cpp
@@ -220,6 +220,34 @@ uint64_t popcount<SIMDLevel::AVX2>(const uint8_t* data, size_t size) {
     return sum;
 }
 
+template <>
+void rearrange_bit_planes<SIMDLevel::AVX2>(
+        const uint8_t* rotated_qq,
+        size_t d,
+        size_t qb,
+        uint8_t* out) {
+    const size_t offset = (d + 7) / 8;
+    memset(out, 0, offset * qb);
+    const size_t nchunks = d / 32;
+    for (size_t chunk = 0; chunk < nchunks; chunk++) {
+        __m256i vals =
+                _mm256_loadu_si256((const __m256i*)(rotated_qq + chunk * 32));
+        for (size_t iv = 0; iv < qb; iv++) {
+            __m256i mask = _mm256_set1_epi8(static_cast<char>(1 << iv));
+            __m256i bits =
+                    _mm256_cmpeq_epi8(_mm256_and_si256(vals, mask), mask);
+            uint32_t packed = static_cast<uint32_t>(_mm256_movemask_epi8(bits));
+            memcpy(&out[iv * offset + chunk * 4], &packed, 4);
+        }
+    }
+    for (size_t idim = nchunks * 32; idim < d; idim++) {
+        for (size_t iv = 0; iv < qb; iv++) {
+            const bool bit = ((rotated_qq[idim] & (1 << iv)) != 0);
+            out[iv * offset + idim / 8] |= bit ? (1 << (idim % 8)) : 0;
+        }
+    }
+}
+
 } // namespace faiss::rabitq
 
 namespace faiss::rabitq::multibit {

--- a/faiss/utils/simd_impl/rabitq_avx512.cpp
+++ b/faiss/utils/simd_impl/rabitq_avx512.cpp
@@ -344,6 +344,41 @@ uint64_t popcount<SIMDLevel::AVX512>(const uint8_t* data, size_t size) {
     return sum;
 }
 
+template <>
+void rearrange_bit_planes<SIMDLevel::AVX512>(
+        const uint8_t* rotated_qq,
+        size_t d,
+        size_t qb,
+        uint8_t* out) {
+    const size_t offset = (d + 7) / 8;
+    memset(out, 0, offset * qb);
+    size_t idim = 0;
+    for (; idim + 64 <= d; idim += 64) {
+        __m512i vals = _mm512_loadu_si512((const __m512i*)(rotated_qq + idim));
+        for (size_t iv = 0; iv < qb; iv++) {
+            __m512i mask = _mm512_set1_epi8(static_cast<char>(1 << iv));
+            __mmask64 bits = _mm512_test_epi8_mask(vals, mask);
+            memcpy(&out[iv * offset + idim / 8], &bits, 8);
+        }
+    }
+    for (; idim + 32 <= d; idim += 32) {
+        __m256i vals = _mm256_loadu_si256((const __m256i*)(rotated_qq + idim));
+        for (size_t iv = 0; iv < qb; iv++) {
+            __m256i mask = _mm256_set1_epi8(static_cast<char>(1 << iv));
+            __m256i bits =
+                    _mm256_cmpeq_epi8(_mm256_and_si256(vals, mask), mask);
+            uint32_t packed = static_cast<uint32_t>(_mm256_movemask_epi8(bits));
+            memcpy(&out[iv * offset + idim / 8], &packed, 4);
+        }
+    }
+    for (; idim < d; idim++) {
+        for (size_t iv = 0; iv < qb; iv++) {
+            const bool bit = ((rotated_qq[idim] & (1 << iv)) != 0);
+            out[iv * offset + idim / 8] |= bit ? (1 << (idim % 8)) : 0;
+        }
+    }
+}
+
 } // namespace faiss::rabitq
 
 namespace faiss::rabitq::multibit {

--- a/tests/test_rabitq_simd.cpp
+++ b/tests/test_rabitq_simd.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include <faiss/utils/rabitq_simd.h>
+#include <faiss/utils/simd_levels.h>
+
+using faiss::SIMDLevel;
+
+// Random qb-bit-per-dimension query codes (one byte each, value in [0, 2^qb)).
+static std::vector<uint8_t> random_codes(size_t d, size_t qb, uint32_t seed) {
+    std::mt19937 rng(seed);
+    const uint8_t code_mask = static_cast<uint8_t>((1u << qb) - 1);
+    std::vector<uint8_t> q(d);
+    for (size_t i = 0; i < d; i++) {
+        q[i] = static_cast<uint8_t>(rng()) & code_mask;
+    }
+    return q;
+}
+
+// 32-d chunks and chunk boundaries.
+static const std::vector<size_t> kDims =
+        {1, 8, 16, 31, 32, 33, 255, 256, 257, 512, 1024, 2048};
+
+// Note: scalar kernel's own correctness is covered end-to-end by
+// tests/test_rabitq.py. This target is x86-only (see BUCK).
+TEST(RaBitQRearrangeBitPlanes, Avx2MatchesScalar) {
+    for (size_t d : kDims) {
+        for (size_t qb = 1; qb <= 8; qb++) {
+            const auto q = random_codes(d, qb, 10996);
+            const size_t out_bytes = ((d + 7) / 8) * qb;
+
+            std::vector<uint8_t> scalar(out_bytes);
+            faiss::rabitq::rearrange_bit_planes<SIMDLevel::NONE>(
+                    q.data(), d, qb, scalar.data());
+
+            std::vector<uint8_t> avx2(out_bytes);
+            faiss::rabitq::rearrange_bit_planes<SIMDLevel::AVX2>(
+                    q.data(), d, qb, avx2.data());
+
+            EXPECT_EQ(avx2, scalar) << "d=" << d << " qb=" << qb;
+        }
+    }
+}


### PR DESCRIPTION
Summary:

{F1991891064}

RaBitQ distance computation needs the quantized query bits laid out in "bit-plane" format.  The transformation operation for this has to happen for every single residual therefore it is a fixed cost per-iterator.  I noticed that this was quite significant for very high cluster counts.

the code for it is:
```
for (size_t idim = 0; idim < d; idim++) {
  for (size_t iv = 0; iv < qb; iv++) {
    const bool bit = ((rotated_qq[idim] & (1 << iv)) != 0);
    rearranged_rotated_qq[iv * offset + idim / 8] |=
      bit ? (1 << (idim % 8)) : 0;
  }
}
```

When qb=4, each dimension is 4-bits wide representing values 0-15.  `rotated_qq[i]` is all 4 bits for dimension i.  We need to rotate into bit-plan so that `bit_plane_j` is all the j-bits.  That is, `bit_plane_3` is `d` bits, each one the 3rd bit of its qb=4 dimension.  Right now this is done with a for-each-dimension for-each-bit double loop as seen above.

Instead of going one-dimension-at-a-time we can do SIMD 32 dimensions at once with a 256-bit AVX2 register.  Turn those 0-15 into uint8 (this way it works for any qb <= 8, the higher bits are just set to 0) and load 32 into a register, then for each bit plane j, mask every uint8 with 1 << j and check if the bit is set.  Then use `movemask` to compress just the 1/0 result from 256 bits down to 32 bits.  That's the block the plane needs.

Number of operations is reduced by 32.

Reviewed By: alibeklfc

Differential Revision: D101289092


