### PR TITLE
Include Python type stubs (__init__.pyi, py.typed) in conda packages

### DIFF
--- a/faiss/python/CMakeLists.txt
+++ b/faiss/python/CMakeLists.txt
@@ -378,6 +378,8 @@ configure_file(class_wrappers.py class_wrappers.py COPYONLY)
 configure_file(gpu_wrappers.py gpu_wrappers.py COPYONLY)
 configure_file(extra_wrappers.py extra_wrappers.py COPYONLY)
 configure_file(array_conversions.py array_conversions.py COPYONLY)
+configure_file(__init__.pyi __init__.pyi COPYONLY)
+configure_file(py.typed py.typed COPYONLY)
 
 # file(GLOB files "${PROJECT_SOURCE_DIR}/../../contrib/*.py")
 file(COPY ${PROJECT_SOURCE_DIR}/../../contrib  DESTINATION .)


### PR DESCRIPTION
Summary:
## Summary

see https://github.com/facebookresearch/faiss/issues/5261

The type stubs added in PR #4840 (`__init__.pyi` and `py.typed`) ship in the pip wheel but are missing from the conda packages, as reported on GitHub for faiss 1.14.2. Users installing `faiss-cpu`/`faiss-gpu` from conda get no type hints.

Faiss has two independent Python packaging paths:

- The **pip/wheel** build is driven by `pyproject.toml` (scikit-build-core) and packages files from CMake `install()` directives, which already handle the stubs (`python/CMakeLists.txt`), so the wheel gets them.
- The **conda** build (`conda/*/build-pkg.sh`) instead `cd`s into the CMake build dir and runs `setup.py install`. `setup.py` only copies the stubs if they exist in the cwd (`os.path.exists("__init__.pyi")`), but the `configure_file(... COPYONLY)` block in `python/CMakeLists.txt` that stages the hand-written Python sources into the build dir did not include `__init__.pyi` or `py.typed`. So the stubs were never staged, the `os.path.exists` checks returned False, and conda silently dropped them.

This adds the two stub files to that `configure_file` staging block so the conda `setup.py install` flow can see them, mirroring how the `.py` sources are staged. `setup.py` already lists `*.pyi`/`py.typed` in `package_data`, so no change is needed there.

To prevent silent regressions, the conda `test:` sections (which previously only ran unit tests and checked the `.so` files) now assert both stub files are present in the installed `faiss` package.

## Test Plan

tried it on my machine:
```
$ cmake -B _build \
       -DBUILD_SHARED_LIBS=ON \
       -DFAISS_ENABLE_GPU=OFF \
       -DFAISS_ENABLE_METAL=OFF \
       -DFAISS_ENABLE_PYTHON=OFF \
       -DBUILD_TESTING=OFF \
       -DCMAKE_BUILD_TYPE=Release .
$ cmake --build _build -j$(sysctl -n hw.ncpu) --target faiss
$ cmake --install _build --prefix _libfaiss_stage/
$ cmake -B /tmp/faiss_py \
       -Dfaiss_ROOT=_libfaiss_stage/ \
       -DFAISS_ENABLE_GPU=OFF \
       -DPython_EXECUTABLE=$(which python) \
       faiss/python
$ ls /tmp/faiss_py/__init__.pyi /tmp/faiss_py/py.typed
/tmp/faiss_py/__init__.pyi  /tmp/faiss_py/py.typed
```

Differential Revision: D111144696


