### PR TITLE
Always widen IndexRefine::range_search base radius by k_factor

### DIFF
--- a/faiss/IndexRefine.cpp
+++ b/faiss/IndexRefine.cpp
@@ -157,19 +157,14 @@ void IndexRefine::range_search(
             (params != nullptr) ? params->base_index_params : nullptr;
 
     const float kf = (params != nullptr) ? params->k_factor : this->k_factor;
-    FAISS_THROW_IF_NOT(kf >= 1);
 
     const bool is_similarity = is_similarity_metric(metric_type);
 
-    // Widen base_index search radius by k_factor.
-    // Filtered to exact radius below; k_factor affects recall, not correctness.
-    // For similarity metrics a negative radius widens by multiplying, not
-    // dividing, so branch on the sign to always loosen the base threshold.
-    float base_radius = radius;
-    if (kf != 1) {
-        base_radius = is_similarity ? (radius >= 0 ? radius / kf : radius * kf)
-                                    : radius * kf;
-    }
+    // Scale the base_index search radius by k_factor. Results are filtered to
+    // the exact radius below, so this only affects recall, not correctness; it
+    // is up to the user to pick a k_factor that widens the base search for
+    // their metric.
+    const float base_radius = radius * kf;
 
     base_index->range_search(n, x, base_radius, result, base_index_params);
 

--- a/tests/test_refine.py
+++ b/tests/test_refine.py
@@ -225,10 +225,13 @@ class TestIndexRefineRangeSearch(unittest.TestCase):
 
         index_r = faiss.IndexRefine(index, index_flat)
 
-        # k_factor widens the radius used to query the base index; the results
-        # are still filtered at the requested radius. A larger k_factor can only
-        # add candidates, so recall must not decrease, and every returned
-        # distance must stay on the correct side of the radius (issue #5367).
+        # k_factor scales the radius used to query the base index (base_radius =
+        # radius * k_factor); the results are still filtered at the requested
+        # radius, so every returned distance must stay on the correct side of it
+        # regardless of k_factor (issue #5367). For an L2 base a larger k_factor
+        # widens the base search and can only add candidates, so recall must not
+        # decrease; for a similarity base radius * k_factor does not necessarily
+        # widen the search, so no recall guarantee is asserted there.
         recalls = []
         for k_factor in (1, 4):
             index_r.k_factor = k_factor
@@ -242,16 +245,16 @@ class TestIndexRefineRangeSearch(unittest.TestCase):
                     else:
                         self.assertLessEqual(D[i_lim], radius)
 
-        # widening the base radius does not lose any results
-        self.assertGreaterEqual(recalls[1] + 1e-6, recalls[0])
+        if not is_similarity:
+            # widening the L2 base radius does not lose any results
+            self.assertGreaterEqual(recalls[1] + 1e-6, recalls[0])
 
     def test_refine_k_factor(self):
         self.do_test_k_factor("SQ4")
 
     def test_refine_k_factor_ip(self):
-        # an inner-product base exercises the is_similarity branch of the
-        # base-radius widening; the negative radius additionally covers the
-        # sign-dependent path (radius < 0 widens by multiplying, not dividing).
+        # an inner-product base exercises the is_similarity (CMin) branch of the
+        # exact radius filter, with both a positive and a negative radius.
         # Inner products on this dataset span roughly [-5, +5], so these radii
         # select non-trivial result sets on either side of zero.
         self.do_test_k_factor("SQ4", faiss.METRIC_INNER_PRODUCT, radius=4)


### PR DESCRIPTION
Summary:
Addresses mdouze's review feedback on D110513829.

`IndexRefine::range_search` scaled the base index's search radius by `k_factor` using a metric- and sign-dependent formula (`radius / k_factor` for non-negative similarity radii, `radius * k_factor` otherwise) and rejected `k_factor < 1` via `FAISS_THROW_IF_NOT(kf >= 1)`. Per reviewer guidance, remove both: always compute `base_radius = radius * k_factor` and let the user choose a `k_factor` that widens the base search for their metric.

Correctness is unaffected: the exact radius filter added in D110513829 still drops every candidate whose refined distance falls outside the requested radius, so `k_factor` only trades off recall vs. work, never returns out-of-radius results.

Differential Revision: D111286236


