### PR TITLE
RaBitQ fastscan avx512 lut quant

### DIFF
--- a/faiss/IndexIVFRaBitQFastScan.cpp
+++ b/faiss/IndexIVFRaBitQFastScan.cpp
@@ -19,8 +19,10 @@
 #include <faiss/impl/ResultHandler.h>
 #include <faiss/impl/fast_scan/FastScanDistancePostProcessing.h>
 #include <faiss/impl/fast_scan/fast_scan.h>
+#include <faiss/impl/simd_dispatch.h>
 #include <faiss/invlists/BlockInvertedLists.h>
 #include <faiss/utils/distances.h>
+#include <faiss/utils/rabitq_simd.h>
 #include <faiss/utils/utils.h>
 
 namespace faiss {
@@ -29,7 +31,6 @@ namespace faiss {
 using rabitq_utils::ExtraBitsFactors;
 using rabitq_utils::QueryFactorsData;
 using rabitq_utils::round_nonnegative_to_uint16;
-using rabitq_utils::round_nonnegative_to_uint8;
 using rabitq_utils::SignBitFactors;
 using rabitq_utils::SignBitFactorsWithError;
 
@@ -455,6 +456,7 @@ void IndexIVFRaBitQFastScan::compute_LUT(
         const FastScanDistancePostProcessing& context) const {
     FAISS_THROW_IF_NOT(is_trained);
     FAISS_THROW_IF_NOT(by_residual);
+    FAISS_ASSERT(ksub == 16);
 
     // Use overridden qb/centered from context if provided, else index defaults
     const uint8_t used_qb = context.qb > 0 ? context.qb : qb;
@@ -517,6 +519,7 @@ void IndexIVFRaBitQFastScan::compute_LUT_uint8(
         const FastScanDistancePostProcessing& context) const {
     FAISS_THROW_IF_NOT(is_trained);
     FAISS_THROW_IF_NOT(by_residual);
+    FAISS_ASSERT(ksub == 16);
 
     const uint8_t used_qb = context.qb > 0 ? context.qb : qb;
     const bool used_centered = context.qb > 0 ? context.centered : centered;
@@ -574,44 +577,53 @@ void IndexIVFRaBitQFastScan::compute_LUT_uint8(
             float glob_max_span = -HUGE_VAL;
             float glob_max_dis = -HUGE_VAL;
             float glob_b = HUGE_VAL;
-            for (size_t j2 = 0; j2 < cur_nprobe; j2++) {
-                float b_j = 0;
-                float span_j = 0;
-                for (size_t m = 0; m < M; m++) {
-                    const float* tab = lut_float.get() + j2 * dim12 + m * ksub;
-                    float mn = tab[0], mx = tab[0];
-                    for (size_t s = 1; s < ksub; s++) {
-                        mn = std::min(mn, tab[s]);
-                        mx = std::max(mx, tab[s]);
-                    }
-                    all_mins[j2 * M + m] = mn;
-                    float span = mx - mn;
-                    glob_max_span = std::max(glob_max_span, span);
-                    b_j += mn;
-                    span_j += span;
-                }
-                probe_b[j2] = b_j;
-                glob_max_dis = std::max(glob_max_dis, span_j);
-                glob_b = std::min(glob_b, b_j);
-            }
-            float a = std::min(255.0f / glob_max_span, 65535.0f / glob_max_dis);
+            float a;
+            with_selected_simd_levels<rabitq::RABITQ_QUANTIZATION_SIMD_LEVELS>(
+                    [&]<SIMDLevel SL>() {
+                        for (size_t j2 = 0; j2 < cur_nprobe; j2++) {
+                            float b_j = 0;
+                            float span_j = 0;
+                            for (size_t m = 0; m < M; m++) {
+                                const float* tab =
+                                        lut_float.get() + j2 * dim12 + m * ksub;
+                                float mn, mx;
+                                rabitq::lut_minmax_16<SL>(tab, mn, mx);
+                                all_mins[j2 * M + m] = mn;
+                                float span = mx - mn;
+                                glob_max_span = std::max(glob_max_span, span);
+                                b_j += mn;
+                                span_j += span;
+                            }
+                            probe_b[j2] = b_j;
+                            glob_max_dis = std::max(glob_max_dis, span_j);
+                            glob_b = std::min(glob_b, b_j);
+                        }
 
-            // Second pass: quantize LUT and compute biasq
-            uint8_t* out_base = dis_tables.get() + i * cur_nprobe * dim12_2;
-            uint16_t* bq = biases.get() + i * cur_nprobe;
-            for (size_t j2 = 0; j2 < cur_nprobe; j2++) {
-                for (size_t m = 0; m < M; m++) {
-                    const float* tab = lut_float.get() + j2 * dim12 + m * ksub;
-                    float mn = all_mins[j2 * M + m];
-                    uint8_t* out = out_base + j2 * dim12_2 + m * ksub;
-                    for (size_t s = 0; s < ksub; s++) {
-                        out[s] = round_nonnegative_to_uint8(a * (tab[s] - mn));
-                    }
-                }
-                memset(out_base + j2 * dim12_2 + M * ksub, 0, (M2 - M) * ksub);
-                bq[j2] =
-                        round_nonnegative_to_uint16(a * (probe_b[j2] - glob_b));
-            }
+                        a = std::min(
+                                255.0f / glob_max_span,
+                                65535.0f / glob_max_dis);
+
+                        // Second pass: quantize LUT and compute biasq.
+                        uint8_t* out_base =
+                                dis_tables.get() + i * cur_nprobe * dim12_2;
+                        uint16_t* bq = biases.get() + i * cur_nprobe;
+                        for (size_t j2 = 0; j2 < cur_nprobe; j2++) {
+                            for (size_t m = 0; m < M; m++) {
+                                const float* tab =
+                                        lut_float.get() + j2 * dim12 + m * ksub;
+                                const float mn = all_mins[j2 * M + m];
+                                uint8_t* out =
+                                        out_base + j2 * dim12_2 + m * ksub;
+                                rabitq::lut_quantize_16_to_uint8<SL>(
+                                        tab, mn, a, out);
+                            }
+                            memset(out_base + j2 * dim12_2 + M * ksub,
+                                   0,
+                                   (M2 - M) * ksub);
+                            bq[j2] = round_nonnegative_to_uint16(
+                                    a * (probe_b[j2] - glob_b));
+                        }
+                    });
             normalizers[2 * i] = a;
             normalizers[2 * i + 1] = glob_b;
         }
@@ -827,35 +839,35 @@ struct IVFRaBitQFastScanScanner : InvertedListScanner {
         const size_t M = index.M;
         const size_t M2 = index.M2;
         const size_t ksub = index.ksub;
+        FAISS_ASSERT(ksub == 16);
 
         float max_span = -HUGE_VAL;
         float max_dis = 0;
         float b = 0;
         float* mins = mins_buf.data();
 
-        for (size_t m = 0; m < M; m++) {
-            const float* tab = lut_float.get() + m * ksub;
-            float mn = tab[0], mx = tab[0];
-            for (size_t s = 1; s < ksub; s++) {
-                mn = std::min(mn, tab[s]);
-                mx = std::max(mx, tab[s]);
-            }
-            mins[m] = mn;
-            float span = mx - mn;
-            max_span = std::max(max_span, span);
-            max_dis += span;
-            b += mn;
-        }
-
-        float a = std::min(255.0f / max_span, 65535.0f / max_dis);
+        float a;
         uint8_t* out = dis_tables.get();
-        for (size_t m = 0; m < M; m++) {
-            const float* tab = lut_float.get() + m * ksub;
-            for (size_t s = 0; s < ksub; s++) {
-                out[m * ksub + s] =
-                        round_nonnegative_to_uint8(a * (tab[s] - mins[m]));
-            }
-        }
+        with_selected_simd_levels<rabitq::RABITQ_QUANTIZATION_SIMD_LEVELS>(
+                [&]<SIMDLevel SL>() {
+                    for (size_t m = 0; m < M; m++) {
+                        const float* tab = lut_float.get() + m * ksub;
+                        float mn, mx;
+                        rabitq::lut_minmax_16<SL>(tab, mn, mx);
+                        mins[m] = mn;
+                        float span = mx - mn;
+                        max_span = std::max(max_span, span);
+                        max_dis += span;
+                        b += mn;
+                    }
+
+                    a = std::min(255.0f / max_span, 65535.0f / max_dis);
+                    for (size_t m = 0; m < M; m++) {
+                        const float* tab = lut_float.get() + m * ksub;
+                        rabitq::lut_quantize_16_to_uint8<SL>(
+                                tab, mins[m], a, out + m * ksub);
+                    }
+                });
         memset(out + M * ksub, 0, (M2 - M) * ksub);
         biases[0] = 0;
         normalizers[0] = a;

--- a/faiss/impl/RaBitQUtils.cpp
+++ b/faiss/impl/RaBitQUtils.cpp
@@ -188,52 +188,54 @@ QueryFactorsData compute_query_factors(
 
     const float inv_d_sqrt = 1.0f / std::sqrt(static_cast<float>(d));
 
-    // Compute quantization range
-    float v_min = std::numeric_limits<float>::max();
-    float v_max = std::numeric_limits<float>::lowest();
-
     const float* rq = rotated_q.data();
-    if (centered) {
-        float z_max = Z_MAX_BY_QB[qb - 1];
-        float v_radius = z_max * std::sqrt(query_factors.qr_to_c_L2sqr / d);
-        v_min = -v_radius;
-        v_max = v_radius;
-    } else {
-        for (size_t i = 0; i < d; i++) {
-            const float v_q = rq[i];
-            v_min = std::min(v_min, v_q);
-            v_max = std::max(v_max, v_q);
-        }
-    }
-
-    // Quantize the query
-    const uint8_t max_code = (1 << qb) - 1;
-    const float delta = (v_max - v_min) / max_code;
-    // A constant (or zero-norm) query has v_max == v_min, so delta == 0.
-    // Without this guard inv_delta would be +inf and (v_q - v_min) * inv_delta
-    // == NaN, which then float-casts to uint8_t below -- undefined behavior
-    // (UBSan float-cast-overflow) and garbage codes. A constant query carries
-    // no directional signal, so quantizing every component to 0 is correct;
-    // inv_delta = 0 achieves that.
-    const float inv_delta = (delta > 0.0f) ? (1.0f / delta) : 0.0f;
-
-    rotated_qq.resize(d);
+    float v_min;
+    float v_max;
+    float delta;
     size_t sum_qq = 0;
     int64_t sum2_signed_odd_int = 0;
-
+    const uint8_t max_code = (1 << qb) - 1;
+    rotated_qq.resize(d);
     uint8_t* rqq = rotated_qq.data();
-    for (size_t i = 0; i < d; i++) {
-        const float v_q = rq[i];
-        const uint8_t v_qq =
-                round_clamped_to_uint8((v_q - v_min) * inv_delta, max_code);
-        rqq[i] = v_qq;
-        sum_qq += v_qq;
 
-        if (centered) {
-            int64_t signed_odd_int = int64_t(v_qq) * 2 - max_code;
-            sum2_signed_odd_int += signed_odd_int * signed_odd_int;
-        }
-    }
+    // Select the SIMD implementation once for both range computation and
+    // quantization. This function runs once per query/probe pair.
+    with_selected_simd_levels<rabitq::RABITQ_QUANTIZATION_SIMD_LEVELS>(
+            [&]<SIMDLevel SL>() {
+                if (centered) {
+                    const float z_max = Z_MAX_BY_QB[qb - 1];
+                    const float v_radius =
+                            z_max * std::sqrt(query_factors.qr_to_c_L2sqr / d);
+                    v_min = -v_radius;
+                    v_max = v_radius;
+                } else {
+                    v_min = std::numeric_limits<float>::max();
+                    v_max = std::numeric_limits<float>::lowest();
+                    rabitq::minmax_values<SL>(rq, d, v_min, v_max);
+                }
+
+                delta = (v_max - v_min) / max_code;
+                // A constant (or zero-norm) query has delta == 0. Preserve the
+                // scalar path's centered correction terms while avoiding
+                // 0 * inf during quantization.
+                if (delta <= 0.0f) {
+                    memset(rqq, 0, d * sizeof(uint8_t));
+                    if (centered) {
+                        sum2_signed_odd_int = int64_t(d) * max_code * max_code;
+                    }
+                } else {
+                    rabitq::quantize_query_values<SL>(
+                            rq,
+                            d,
+                            v_min,
+                            1.0f / delta,
+                            max_code,
+                            centered,
+                            rqq,
+                            sum_qq,
+                            sum2_signed_odd_int);
+                }
+            });
 
     // Compute query factors
     query_factors.c1 = 2 * delta * inv_d_sqrt;

--- a/faiss/impl/RaBitQUtils.h
+++ b/faiss/impl/RaBitQUtils.h
@@ -99,7 +99,7 @@ inline uint8_t round_nonnegative_to_uint8(float x) {
     assert(x == x);
     assert(x >= 0.0f);
     assert(x < 255.5f);
-    return static_cast<uint8_t>(static_cast<int>(x + 0.5f));
+    return rabitq::round_nonnegative_byte_scalar(x);
 }
 
 /** Same as round_nonnegative_to_uint8 for uint16 RaBitQ bias values. */
@@ -118,17 +118,7 @@ inline uint16_t round_nonnegative_to_uint16(float x) {
  */
 inline uint8_t round_clamped_to_uint8(float x, uint8_t max_code) {
     assert(x == x);
-
-    if (x <= 0.0f) {
-        return 0;
-    }
-
-    const float max_code_f = static_cast<float>(max_code);
-    if (x >= max_code_f) {
-        return max_code;
-    }
-
-    return static_cast<uint8_t>(static_cast<int>(x + 0.5f));
+    return rabitq::round_clamped_byte_scalar(x, max_code);
 }
 
 /** Compute factors for a single database vector using RaBitQ algorithm.

--- a/faiss/utils/rabitq_simd.h
+++ b/faiss/utils/rabitq_simd.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -15,6 +16,10 @@
 #include <faiss/utils/simd_levels.h>
 
 namespace faiss::rabitq {
+
+/// SIMD levels with RaBitQ query/LUT quantization implementations.
+constexpr int RABITQ_QUANTIZATION_SIMD_LEVELS = (1 << int(SIMDLevel::NONE)) |
+        (1 << int(SIMDLevel::AVX2)) | (1 << int(SIMDLevel::AVX512));
 
 /**
  * Compute dot product between query and binary data using popcount on AND.
@@ -77,6 +82,36 @@ void rearrange_bit_planes(
         size_t d,
         size_t qb,
         uint8_t* out);
+
+/// Find min/max of one 16-entry FastScan LUT row.
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
+void lut_minmax_16(const float* tab, float& mn, float& mx);
+
+/// Find min/max of an arbitrary-length float vector. For n == 0, mn and mx
+/// are left unchanged.
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
+void minmax_values(const float* values, size_t n, float& mn, float& mx);
+
+/// Quantize one 16-entry FastScan LUT row with non-negative half-up rounding.
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
+void lut_quantize_16_to_uint8(
+        const float* tab,
+        float mn,
+        float a,
+        uint8_t* out);
+
+/// Quantize rotated query values and accumulate query correction terms.
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
+void quantize_query_values(
+        const float* rq,
+        size_t d,
+        float v_min,
+        float inv_delta,
+        uint8_t max_code,
+        bool centered,
+        uint8_t* rqq,
+        size_t& sum_qq,
+        int64_t& sum2_signed_odd_int);
 
 // NONE specializations — scalar fallbacks
 
@@ -157,6 +192,92 @@ inline void rearrange_bit_planes<SIMDLevel::NONE>(
         for (size_t iv = 0; iv < qb; iv++) {
             const bool bit = ((rotated_qq[idim] & (1 << iv)) != 0);
             out[iv * offset + idim / 8] |= bit ? (1 << (idim % 8)) : 0;
+        }
+    }
+}
+
+inline uint8_t round_clamped_byte_scalar(float x, uint8_t max_code) {
+    if (x <= 0.0f) {
+        return 0;
+    }
+    if (x >= max_code) {
+        return max_code;
+    }
+    return static_cast<uint8_t>(static_cast<int>(x + 0.5f));
+}
+
+inline uint8_t round_nonnegative_byte_scalar(float x) {
+    return round_clamped_byte_scalar(x, 255);
+}
+
+template <>
+inline void lut_minmax_16<SIMDLevel::NONE>(
+        const float* tab,
+        float& mn,
+        float& mx) {
+    mn = tab[0];
+    mx = tab[0];
+    for (size_t s = 1; s < 16; s++) {
+        mn = std::min(mn, tab[s]);
+        mx = std::max(mx, tab[s]);
+    }
+}
+
+template <>
+inline void minmax_values<SIMDLevel::NONE>(
+        const float* values,
+        size_t n,
+        float& mn,
+        float& mx) {
+    if (n == 0) {
+        return;
+    }
+    mn = values[0];
+    mx = values[0];
+    for (size_t i = 1; i < n; i++) {
+        mn = std::min(mn, values[i]);
+        mx = std::max(mx, values[i]);
+    }
+}
+
+template <>
+inline void lut_quantize_16_to_uint8<SIMDLevel::NONE>(
+        const float* tab,
+        float mn,
+        float a,
+        uint8_t* out) {
+    for (size_t s = 0; s < 16; s++) {
+        out[s] = round_nonnegative_byte_scalar(a * (tab[s] - mn));
+    }
+}
+
+template <>
+inline void quantize_query_values<SIMDLevel::NONE>(
+        const float* rq,
+        size_t d,
+        float v_min,
+        float inv_delta,
+        uint8_t max_code,
+        bool centered,
+        uint8_t* rqq,
+        size_t& sum_qq,
+        int64_t& sum2_signed_odd_int) {
+    if (centered) {
+        for (size_t i = 0; i < d; i++) {
+            const uint8_t v_qq = round_clamped_byte_scalar(
+                    (rq[i] - v_min) * inv_delta, max_code);
+            rqq[i] = v_qq;
+            sum_qq += v_qq;
+
+            const int64_t signed_odd_int = int64_t(v_qq) * 2 - max_code;
+            sum2_signed_odd_int += signed_odd_int * signed_odd_int;
+        }
+    } else {
+        for (size_t i = 0; i < d; i++) {
+            const uint8_t v_qq = round_clamped_byte_scalar(
+                    (rq[i] - v_min) * inv_delta, max_code);
+            rqq[i] = v_qq;
+            sum_qq += v_qq;
         }
     }
 }

--- a/faiss/utils/simd_impl/rabitq_avx2.cpp
+++ b/faiss/utils/simd_impl/rabitq_avx2.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/utils/rabitq_simd.h>
 #include <immintrin.h>
+#include <limits>
 
 namespace faiss::rabitq {
 
@@ -82,7 +83,160 @@ inline uint64_t reduce_add_128(__m128i v) {
     return lanes[0] + lanes[1];
 }
 
+inline float reduce_min_256(__m256 v) {
+    __m128 x =
+            _mm_min_ps(_mm256_castps256_ps128(v), _mm256_extractf128_ps(v, 1));
+    x = _mm_min_ps(x, _mm_movehl_ps(x, x));
+    x = _mm_min_ss(x, _mm_shuffle_ps(x, x, 1));
+    return _mm_cvtss_f32(x);
+}
+
+inline float reduce_max_256(__m256 v) {
+    __m128 x =
+            _mm_max_ps(_mm256_castps256_ps128(v), _mm256_extractf128_ps(v, 1));
+    x = _mm_max_ps(x, _mm_movehl_ps(x, x));
+    x = _mm_max_ss(x, _mm_shuffle_ps(x, x, 1));
+    return _mm_cvtss_f32(x);
+}
+
+inline __m256i round_nonnegative_ps_to_i32(__m256 x) {
+    return _mm256_cvttps_epi32(_mm256_add_ps(x, _mm256_set1_ps(0.5f)));
+}
+
+inline void store_i32_as_u8_8(__m256i values, uint8_t* out) {
+    const __m128i packed16 = _mm_packus_epi32(
+            _mm256_castsi256_si128(values),
+            _mm256_extracti128_si256(values, 1));
+    const __m128i packed8 = _mm_packus_epi16(packed16, _mm_setzero_si128());
+    _mm_storel_epi64(reinterpret_cast<__m128i*>(out), packed8);
+}
+
+inline void accumulate_i32_as_i64(
+        __m256i values,
+        __m256i& low_acc,
+        __m256i& high_acc) {
+    low_acc = _mm256_add_epi64(
+            low_acc, _mm256_cvtepi32_epi64(_mm256_castsi256_si128(values)));
+    high_acc = _mm256_add_epi64(
+            high_acc,
+            _mm256_cvtepi32_epi64(_mm256_extracti128_si256(values, 1)));
+}
+
 } // namespace
+
+template <>
+void lut_minmax_16<SIMDLevel::AVX2>(const float* tab, float& mn, float& mx) {
+    const __m256 lo = _mm256_loadu_ps(tab);
+    const __m256 hi = _mm256_loadu_ps(tab + 8);
+    const __m256 min_vec = _mm256_min_ps(lo, hi);
+    const __m256 max_vec = _mm256_max_ps(lo, hi);
+    mn = reduce_min_256(min_vec);
+    mx = reduce_max_256(max_vec);
+}
+
+template <>
+void minmax_values<SIMDLevel::AVX2>(
+        const float* values,
+        size_t n,
+        float& mn,
+        float& mx) {
+    if (n == 0) {
+        return;
+    }
+
+    size_t i = 0;
+    __m256 min_vec = _mm256_set1_ps(std::numeric_limits<float>::max());
+    __m256 max_vec = _mm256_set1_ps(std::numeric_limits<float>::lowest());
+    for (; i + 8 <= n; i += 8) {
+        const __m256 values_vec = _mm256_loadu_ps(values + i);
+        min_vec = _mm256_min_ps(min_vec, values_vec);
+        max_vec = _mm256_max_ps(max_vec, values_vec);
+    }
+
+    mn = reduce_min_256(min_vec);
+    mx = reduce_max_256(max_vec);
+    for (; i < n; i++) {
+        mn = std::min(mn, values[i]);
+        mx = std::max(mx, values[i]);
+    }
+}
+
+template <>
+void lut_quantize_16_to_uint8<SIMDLevel::AVX2>(
+        const float* tab,
+        float mn,
+        float a,
+        uint8_t* out) {
+    const __m256 a_vec = _mm256_set1_ps(a);
+    const __m256 mn_times_a_vec = _mm256_set1_ps(mn * a);
+    const __m256i zero = _mm256_setzero_si256();
+    for (size_t i = 0; i < 16; i += 8) {
+        const __m256 values = _mm256_loadu_ps(tab + i);
+        const __m256 scaled = _mm256_fmsub_ps(values, a_vec, mn_times_a_vec);
+        const __m256i rounded =
+                _mm256_max_epi32(round_nonnegative_ps_to_i32(scaled), zero);
+        store_i32_as_u8_8(rounded, out + i);
+    }
+}
+
+template <>
+void quantize_query_values<SIMDLevel::AVX2>(
+        const float* rq,
+        size_t d,
+        float v_min,
+        float inv_delta,
+        uint8_t max_code,
+        bool centered,
+        uint8_t* rqq,
+        size_t& sum_qq,
+        int64_t& sum2_signed_odd_int) {
+    const __m256 inv_delta_vec = _mm256_set1_ps(inv_delta);
+    const __m256 v_min_times_inv_delta_vec = _mm256_set1_ps(v_min * inv_delta);
+    const __m256 zero = _mm256_setzero_ps();
+    const __m256 max_code_ps = _mm256_set1_ps(max_code);
+    const __m256i max_code_i32 = _mm256_set1_epi32(max_code);
+    const __m256i two = _mm256_set1_epi32(2);
+    __m256i sum_acc_lo = _mm256_setzero_si256();
+    __m256i sum_acc_hi = _mm256_setzero_si256();
+    __m256i sq_acc_lo = _mm256_setzero_si256();
+    __m256i sq_acc_hi = _mm256_setzero_si256();
+
+    size_t i = 0;
+    for (; i + 8 <= d; i += 8) {
+        const __m256 values = _mm256_loadu_ps(rq + i);
+        __m256 scaled = _mm256_fmsub_ps(
+                values, inv_delta_vec, v_min_times_inv_delta_vec);
+        scaled = _mm256_min_ps(_mm256_max_ps(scaled, zero), max_code_ps);
+        const __m256i rounded = round_nonnegative_ps_to_i32(scaled);
+        accumulate_i32_as_i64(rounded, sum_acc_lo, sum_acc_hi);
+
+        if (centered) {
+            const __m256i signed_odd = _mm256_sub_epi32(
+                    _mm256_mullo_epi32(rounded, two), max_code_i32);
+            const __m256i signed_odd_sqr =
+                    _mm256_mullo_epi32(signed_odd, signed_odd);
+            accumulate_i32_as_i64(signed_odd_sqr, sq_acc_lo, sq_acc_hi);
+        }
+        store_i32_as_u8_8(rounded, rqq + i);
+    }
+
+    sum_qq += reduce_add_256(sum_acc_lo) + reduce_add_256(sum_acc_hi);
+    if (centered) {
+        sum2_signed_odd_int +=
+                reduce_add_256(sq_acc_lo) + reduce_add_256(sq_acc_hi);
+    }
+
+    for (; i < d; i++) {
+        const uint8_t v_qq = round_clamped_byte_scalar(
+                (rq[i] - v_min) * inv_delta, max_code);
+        rqq[i] = v_qq;
+        sum_qq += v_qq;
+        if (centered) {
+            const int64_t signed_odd_int = int64_t(v_qq) * 2 - max_code;
+            sum2_signed_odd_int += signed_odd_int * signed_odd_int;
+        }
+    }
+}
 
 template <>
 uint64_t bitwise_and_dot_product<SIMDLevel::AVX2>(

--- a/faiss/utils/simd_impl/rabitq_avx512.cpp
+++ b/faiss/utils/simd_impl/rabitq_avx512.cpp
@@ -9,6 +9,7 @@
 
 #include <faiss/utils/rabitq_simd.h>
 #include <immintrin.h>
+#include <limits>
 
 namespace faiss::rabitq {
 
@@ -167,7 +168,163 @@ inline uint64_t reduce_add_128(__m128i v) {
     return lanes[0] + lanes[1];
 }
 
+inline __m512i round_nonnegative_ps_to_i32(__m512 x) {
+    return _mm512_cvttps_epi32(_mm512_add_ps(x, _mm512_set1_ps(0.5f)));
+}
+
+inline void store_i32_as_u8_16(__m512i values, uint8_t* out) {
+    const __m128i packed = _mm512_cvtusepi32_epi8(values);
+    _mm_storeu_si128(reinterpret_cast<__m128i*>(out), packed);
+}
+
 } // namespace
+
+template <>
+void lut_minmax_16<SIMDLevel::AVX512>(const float* tab, float& mn, float& mx) {
+    const __m512 v = _mm512_loadu_ps(tab);
+    mn = _mm512_reduce_min_ps(v);
+    mx = _mm512_reduce_max_ps(v);
+}
+
+template <>
+void minmax_values<SIMDLevel::AVX512>(
+        const float* values,
+        size_t n,
+        float& mn,
+        float& mx) {
+    if (n == 0) {
+        return;
+    }
+
+    size_t i = 0;
+    __m512 mn_vec = _mm512_set1_ps(std::numeric_limits<float>::max());
+    __m512 mx_vec = _mm512_set1_ps(std::numeric_limits<float>::lowest());
+    for (; i + 16 <= n; i += 16) {
+        const __m512 v = _mm512_loadu_ps(values + i);
+        mn_vec = _mm512_min_ps(mn_vec, v);
+        mx_vec = _mm512_max_ps(mx_vec, v);
+    }
+
+    if (i < n) {
+        const __mmask16 mask =
+                static_cast<__mmask16>((uint32_t(1) << (n - i)) - 1);
+        const __m512 v = _mm512_maskz_loadu_ps(mask, values + i);
+        mn_vec = _mm512_mask_min_ps(mn_vec, mask, mn_vec, v);
+        mx_vec = _mm512_mask_max_ps(mx_vec, mask, mx_vec, v);
+    }
+
+    mn = _mm512_reduce_min_ps(mn_vec);
+    mx = _mm512_reduce_max_ps(mx_vec);
+}
+
+template <>
+void lut_quantize_16_to_uint8<SIMDLevel::AVX512>(
+        const float* tab,
+        float mn,
+        float a,
+        uint8_t* out) {
+    const __m512 values = _mm512_loadu_ps(tab);
+    const __m512 a_vec = _mm512_set1_ps(a);
+    const __m512 scaled =
+            _mm512_fmsub_ps(values, a_vec, _mm512_set1_ps(mn * a));
+    __m512i rounded = round_nonnegative_ps_to_i32(scaled);
+    rounded = _mm512_max_epi32(rounded, _mm512_setzero_si512());
+    store_i32_as_u8_16(rounded, out);
+}
+
+template <>
+void quantize_query_values<SIMDLevel::AVX512>(
+        const float* rq,
+        size_t d,
+        float v_min,
+        float inv_delta,
+        uint8_t max_code,
+        bool centered,
+        uint8_t* rqq,
+        size_t& sum_qq,
+        int64_t& sum2_signed_odd_int) {
+    const __m512 inv_delta_vec = _mm512_set1_ps(inv_delta);
+    const __m512 v_min_times_inv_delta_vec = _mm512_set1_ps(v_min * inv_delta);
+    const __m512 zero = _mm512_setzero_ps();
+    const __m512 max_code_ps = _mm512_set1_ps(static_cast<float>(max_code));
+    const __m512i max_code_i32 = _mm512_set1_epi32(max_code);
+    const __m512i two = _mm512_set1_epi32(2);
+
+    size_t i = 0;
+    if (centered) {
+        __m512i sum_acc_lo = _mm512_setzero_si512();
+        __m512i sum_acc_hi = _mm512_setzero_si512();
+        __m512i sq_acc_lo = _mm512_setzero_si512();
+        __m512i sq_acc_hi = _mm512_setzero_si512();
+        for (; i + 16 <= d; i += 16) {
+            const __m512 values = _mm512_loadu_ps(rq + i);
+            __m512 scaled = _mm512_fmsub_ps(
+                    values, inv_delta_vec, v_min_times_inv_delta_vec);
+            scaled = _mm512_min_ps(_mm512_max_ps(scaled, zero), max_code_ps);
+            __m512i rounded = round_nonnegative_ps_to_i32(scaled);
+
+            sum_acc_lo = _mm512_add_epi64(
+                    sum_acc_lo,
+                    _mm512_cvtepi32_epi64(_mm512_castsi512_si256(rounded)));
+            sum_acc_hi = _mm512_add_epi64(
+                    sum_acc_hi,
+                    _mm512_cvtepi32_epi64(
+                            _mm512_extracti64x4_epi64(rounded, 1)));
+            const __m512i signed_odd = _mm512_sub_epi32(
+                    _mm512_mullo_epi32(rounded, two), max_code_i32);
+            const __m512i signed_odd_sqr =
+                    _mm512_mullo_epi32(signed_odd, signed_odd);
+            sq_acc_lo = _mm512_add_epi64(
+                    sq_acc_lo,
+                    _mm512_cvtepi32_epi64(
+                            _mm512_castsi512_si256(signed_odd_sqr)));
+            sq_acc_hi = _mm512_add_epi64(
+                    sq_acc_hi,
+                    _mm512_cvtepi32_epi64(
+                            _mm512_extracti64x4_epi64(signed_odd_sqr, 1)));
+            store_i32_as_u8_16(rounded, rqq + i);
+        }
+        sum_qq += static_cast<uint64_t>(
+                _mm512_reduce_add_epi64(sum_acc_lo) +
+                _mm512_reduce_add_epi64(sum_acc_hi));
+        sum2_signed_odd_int += _mm512_reduce_add_epi64(sq_acc_lo);
+        sum2_signed_odd_int += _mm512_reduce_add_epi64(sq_acc_hi);
+    } else {
+        __m512i sum_acc_lo = _mm512_setzero_si512();
+        __m512i sum_acc_hi = _mm512_setzero_si512();
+        for (; i + 16 <= d; i += 16) {
+            const __m512 values = _mm512_loadu_ps(rq + i);
+            __m512 scaled = _mm512_fmsub_ps(
+                    values, inv_delta_vec, v_min_times_inv_delta_vec);
+            scaled = _mm512_min_ps(_mm512_max_ps(scaled, zero), max_code_ps);
+            __m512i rounded = round_nonnegative_ps_to_i32(scaled);
+
+            sum_acc_lo = _mm512_add_epi64(
+                    sum_acc_lo,
+                    _mm512_cvtepi32_epi64(_mm512_castsi512_si256(rounded)));
+            sum_acc_hi = _mm512_add_epi64(
+                    sum_acc_hi,
+                    _mm512_cvtepi32_epi64(
+                            _mm512_extracti64x4_epi64(rounded, 1)));
+            store_i32_as_u8_16(rounded, rqq + i);
+        }
+        sum_qq += static_cast<uint64_t>(
+                _mm512_reduce_add_epi64(sum_acc_lo) +
+                _mm512_reduce_add_epi64(sum_acc_hi));
+    }
+
+    for (; i < d; i++) {
+        const uint8_t v_qq = round_clamped_byte_scalar(
+                (rq[i] - v_min) * inv_delta, max_code);
+        rqq[i] = v_qq;
+        sum_qq += v_qq;
+
+        if (centered) {
+            const int64_t signed_odd_int = int64_t(v_qq) * 2 - max_code;
+            sum2_signed_odd_int += signed_odd_int * signed_odd_int;
+        }
+    }
+}
 
 template <>
 uint64_t bitwise_and_dot_product<SIMDLevel::AVX512>(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,7 @@ if(FAISS_OPT_LEVEL STREQUAL "dd")
   )
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|amd64|AMD64)")
     list(APPEND FAISS_TEST_SRC
+      test_rabitq_simd.cpp
       test_simd_levels_x86_avx2.cpp
       test_simd_levels_x86_avx512.cpp
     )

--- a/tests/test_rabitq_simd.cpp
+++ b/tests/test_rabitq_simd.cpp
@@ -12,6 +12,7 @@
 #include <random>
 #include <vector>
 
+#include <faiss/impl/RaBitQUtils.h>
 #include <faiss/utils/rabitq_simd.h>
 #include <faiss/utils/simd_levels.h>
 
@@ -32,9 +33,81 @@ static std::vector<uint8_t> random_codes(size_t d, size_t qb, uint32_t seed) {
 static const std::vector<size_t> kDims =
         {1, 8, 16, 31, 32, 33, 255, 256, 257, 512, 1024, 2048};
 
+template <SIMDLevel SL>
+static void check_quantization_matches_scalar() {
+    constexpr size_t d = 257;
+    constexpr float v_min = -2.0f;
+    constexpr float inv_delta = 16.0f;
+
+    for (uint8_t max_code : {uint8_t(1), uint8_t(15), uint8_t(255)}) {
+        std::vector<float> values(d);
+        for (size_t i = 0; i < d; i++) {
+            const uint8_t code = i % (size_t(max_code) + 1);
+            values[i] = v_min + code / inv_delta;
+        }
+
+        for (bool centered : {false, true}) {
+            std::vector<uint8_t> scalar_codes(d);
+            size_t scalar_sum = 0;
+            int64_t scalar_sum2 = 0;
+            faiss::rabitq::quantize_query_values<SIMDLevel::NONE>(
+                    values.data(),
+                    d,
+                    v_min,
+                    inv_delta,
+                    max_code,
+                    centered,
+                    scalar_codes.data(),
+                    scalar_sum,
+                    scalar_sum2);
+
+            std::vector<uint8_t> simd_codes(d);
+            size_t simd_sum = 0;
+            int64_t simd_sum2 = 0;
+            faiss::rabitq::quantize_query_values<SL>(
+                    values.data(),
+                    d,
+                    v_min,
+                    inv_delta,
+                    max_code,
+                    centered,
+                    simd_codes.data(),
+                    simd_sum,
+                    simd_sum2);
+
+            EXPECT_EQ(simd_codes, scalar_codes)
+                    << "max_code=" << int(max_code) << " centered=" << centered;
+            EXPECT_EQ(simd_sum, scalar_sum);
+            EXPECT_EQ(simd_sum2, scalar_sum2);
+        }
+    }
+
+    constexpr float lut_min = -2.0f;
+    constexpr float lut_scale = 4.0f;
+    float lut[16];
+    for (size_t i = 0; i < 16; i++) {
+        lut[i] = lut_min + i / lut_scale;
+    }
+    uint8_t scalar_lut[16];
+    uint8_t simd_lut[16];
+    faiss::rabitq::lut_quantize_16_to_uint8<SIMDLevel::NONE>(
+            lut, lut_min, lut_scale, scalar_lut);
+    faiss::rabitq::lut_quantize_16_to_uint8<SL>(
+            lut, lut_min, lut_scale, simd_lut);
+    EXPECT_EQ(
+            std::vector<uint8_t>(simd_lut, simd_lut + 16),
+            std::vector<uint8_t>(scalar_lut, scalar_lut + 16));
+}
+
 // Note: scalar kernel's own correctness is covered end-to-end by
 // tests/test_rabitq.py. This target is x86-only (see BUCK).
 TEST(RaBitQRearrangeBitPlanes, Avx2MatchesScalar) {
+#ifdef FAISS_ENABLE_DD
+    if (!faiss::SIMDConfig::is_simd_level_available(SIMDLevel::AVX2)) {
+        GTEST_SKIP() << "AVX2 is not available on this CPU";
+    }
+#endif
+
     for (size_t d : kDims) {
         for (size_t qb = 1; qb <= 8; qb++) {
             const auto q = random_codes(d, qb, 10996);
@@ -52,3 +125,210 @@ TEST(RaBitQRearrangeBitPlanes, Avx2MatchesScalar) {
         }
     }
 }
+
+TEST(RaBitQQuantization, ZeroCenteredQueryPreservesCorrectionScale) {
+    constexpr size_t d = 64;
+    std::vector<float> query(d, 0.0f);
+    std::vector<float> rotated_query;
+    std::vector<uint8_t> quantized_query;
+
+    const auto factors = faiss::rabitq_utils::compute_query_factors(
+            query.data(),
+            d,
+            nullptr,
+            8,
+            true,
+            faiss::METRIC_L2,
+            rotated_query,
+            quantized_query);
+
+    EXPECT_EQ(factors.int_dot_scale, 0.0f);
+    EXPECT_EQ(quantized_query, std::vector<uint8_t>(d, 0));
+}
+
+#ifdef COMPILE_SIMD_AVX2
+
+TEST(RaBitQQuantization, Avx2MinmaxMatchesScalar) {
+#ifdef FAISS_ENABLE_DD
+    if (!faiss::SIMDConfig::is_simd_level_available(SIMDLevel::AVX2)) {
+        GTEST_SKIP() << "AVX2 is not available on this CPU";
+    }
+#endif
+
+    std::mt19937 rng(123);
+    std::uniform_real_distribution<float> dist(-100.0f, 100.0f);
+    float scalar_min = 1.0f;
+    float scalar_max = 2.0f;
+    float avx2_min = scalar_min;
+    float avx2_max = scalar_max;
+    faiss::rabitq::minmax_values<SIMDLevel::NONE>(
+            nullptr, 0, scalar_min, scalar_max);
+    faiss::rabitq::minmax_values<SIMDLevel::AVX2>(
+            nullptr, 0, avx2_min, avx2_max);
+    EXPECT_EQ(avx2_min, scalar_min);
+    EXPECT_EQ(avx2_max, scalar_max);
+
+    for (size_t d : {1, 7, 8, 9, 15, 16, 17, 255}) {
+        std::vector<float> values(d);
+        for (float& value : values) {
+            value = dist(rng);
+        }
+
+        faiss::rabitq::minmax_values<SIMDLevel::NONE>(
+                values.data(), d, scalar_min, scalar_max);
+        faiss::rabitq::minmax_values<SIMDLevel::AVX2>(
+                values.data(), d, avx2_min, avx2_max);
+        EXPECT_EQ(avx2_min, scalar_min) << "d=" << d;
+        EXPECT_EQ(avx2_max, scalar_max) << "d=" << d;
+    }
+}
+
+TEST(RaBitQQuantization, Avx2LargeCenteredAccumulationMatchesScalar) {
+#ifdef FAISS_ENABLE_DD
+    if (!faiss::SIMDConfig::is_simd_level_available(SIMDLevel::AVX2)) {
+        GTEST_SKIP() << "AVX2 is not available on this CPU";
+    }
+#endif
+
+    constexpr size_t d = 40000;
+    constexpr uint8_t max_code = 255;
+    std::vector<float> values(d);
+    for (size_t i = 0; i < d; i++) {
+        values[i] = (i & 1) ? 1.0f : 0.0f;
+    }
+
+    std::vector<uint8_t> scalar_codes(d);
+    size_t scalar_sum = 0;
+    int64_t scalar_sum2 = 0;
+    faiss::rabitq::quantize_query_values<SIMDLevel::NONE>(
+            values.data(),
+            d,
+            0.0f,
+            255.0f,
+            max_code,
+            true,
+            scalar_codes.data(),
+            scalar_sum,
+            scalar_sum2);
+
+    std::vector<uint8_t> avx2_codes(d);
+    size_t avx2_sum = 0;
+    int64_t avx2_sum2 = 0;
+    faiss::rabitq::quantize_query_values<SIMDLevel::AVX2>(
+            values.data(),
+            d,
+            0.0f,
+            255.0f,
+            max_code,
+            true,
+            avx2_codes.data(),
+            avx2_sum,
+            avx2_sum2);
+
+    EXPECT_EQ(avx2_codes, scalar_codes);
+    EXPECT_EQ(avx2_sum, scalar_sum);
+    EXPECT_EQ(avx2_sum2, scalar_sum2);
+    EXPECT_EQ(avx2_sum2, int64_t(d) * max_code * max_code);
+}
+
+TEST(RaBitQQuantization, Avx2MatchesScalarAcrossCodeRange) {
+#ifdef FAISS_ENABLE_DD
+    if (!faiss::SIMDConfig::is_simd_level_available(SIMDLevel::AVX2)) {
+        GTEST_SKIP() << "AVX2 is not available on this CPU";
+    }
+#endif
+    check_quantization_matches_scalar<SIMDLevel::AVX2>();
+}
+
+#endif
+
+#ifdef COMPILE_SIMD_AVX512
+
+TEST(RaBitQQuantization, Avx512MinmaxMatchesScalar) {
+    if (!faiss::SIMDConfig::is_simd_level_available(SIMDLevel::AVX512)) {
+        GTEST_SKIP() << "AVX512 is not available on this CPU";
+    }
+
+    float scalar_min = 1.0f;
+    float scalar_max = 2.0f;
+    float avx512_min = scalar_min;
+    float avx512_max = scalar_max;
+    faiss::rabitq::minmax_values<SIMDLevel::NONE>(
+            nullptr, 0, scalar_min, scalar_max);
+    faiss::rabitq::minmax_values<SIMDLevel::AVX512>(
+            nullptr, 0, avx512_min, avx512_max);
+    EXPECT_EQ(avx512_min, scalar_min);
+    EXPECT_EQ(avx512_max, scalar_max);
+
+    std::mt19937 rng(123);
+    std::uniform_real_distribution<float> dist(-100.0f, 100.0f);
+    for (size_t d : {1, 7, 15, 16, 17, 31, 32, 33, 255}) {
+        std::vector<float> values(d);
+        for (float& value : values) {
+            value = dist(rng);
+        }
+
+        faiss::rabitq::minmax_values<SIMDLevel::NONE>(
+                values.data(), d, scalar_min, scalar_max);
+        faiss::rabitq::minmax_values<SIMDLevel::AVX512>(
+                values.data(), d, avx512_min, avx512_max);
+        EXPECT_EQ(avx512_min, scalar_min) << "d=" << d;
+        EXPECT_EQ(avx512_max, scalar_max) << "d=" << d;
+    }
+}
+
+TEST(RaBitQQuantization, Avx512LargeCenteredAccumulationMatchesScalar) {
+    if (!faiss::SIMDConfig::is_simd_level_available(SIMDLevel::AVX512)) {
+        GTEST_SKIP() << "AVX512 is not available on this CPU";
+    }
+
+    // 65025 * d exceeds INT32_MAX and catches 32-bit SIMD reductions.
+    constexpr size_t d = 40000;
+    constexpr uint8_t max_code = 255;
+    std::vector<float> values(d);
+    for (size_t i = 0; i < d; i++) {
+        values[i] = (i & 1) ? 1.0f : 0.0f;
+    }
+
+    std::vector<uint8_t> scalar_codes(d);
+    size_t scalar_sum = 0;
+    int64_t scalar_sum2 = 0;
+    faiss::rabitq::quantize_query_values<SIMDLevel::NONE>(
+            values.data(),
+            d,
+            0.0f,
+            255.0f,
+            max_code,
+            true,
+            scalar_codes.data(),
+            scalar_sum,
+            scalar_sum2);
+
+    std::vector<uint8_t> avx512_codes(d);
+    size_t avx512_sum = 0;
+    int64_t avx512_sum2 = 0;
+    faiss::rabitq::quantize_query_values<SIMDLevel::AVX512>(
+            values.data(),
+            d,
+            0.0f,
+            255.0f,
+            max_code,
+            true,
+            avx512_codes.data(),
+            avx512_sum,
+            avx512_sum2);
+
+    EXPECT_EQ(avx512_codes, scalar_codes);
+    EXPECT_EQ(avx512_sum, scalar_sum);
+    EXPECT_EQ(avx512_sum2, scalar_sum2);
+    EXPECT_EQ(avx512_sum2, int64_t(d) * max_code * max_code);
+}
+
+TEST(RaBitQQuantization, Avx512MatchesScalarAcrossCodeRange) {
+    if (!faiss::SIMDConfig::is_simd_level_available(SIMDLevel::AVX512)) {
+        GTEST_SKIP() << "AVX512 is not available on this CPU";
+    }
+    check_quantization_matches_scalar<SIMDLevel::AVX512>();
+}
+
+#endif


### PR DESCRIPTION
Vectorize RaBitQ FastScan LUT quantization with AVX-512 to reduce query setup overhead

<img width="1672" height="941" alt="exec-4dd00ef0-e5cf-4d1e-bc4f-2757cba24840" src="https://github.com/user-attachments/assets/1ab6b779-c9c2-4a03-82fe-d5ffa4ae9d14" />
