### PR TITLE
Fix binary IVF reconstruct_n stride

### DIFF
--- a/faiss/IndexBinaryIVF.cpp
+++ b/faiss/IndexBinaryIVF.cpp
@@ -192,7 +192,7 @@ void IndexBinaryIVF::reconstruct_n(idx_t i0, idx_t ni, uint8_t* recons) const {
                 continue;
             }
 
-            uint8_t* reconstructed = recons + (id - i0) * d;
+            uint8_t* reconstructed = recons + (id - i0) * code_size;
             reconstruct_from_offset(list_no, offset, reconstructed);
         }
     }

--- a/tests/test_index_binary.py
+++ b/tests/test_index_binary.py
@@ -269,6 +269,20 @@ class TestBinaryIVF(unittest.TestCase):
                 self.xb[i]
             )
 
+    def test_ivf_reconstruct_n_compact_output(self):
+        d = 64
+        code_size = d // 8
+        xb = np.arange(3 * code_size, dtype="uint8").reshape(3, code_size)
+
+        quantizer = faiss.IndexBinaryFlat(d)
+        quantizer.add(np.zeros((1, code_size), dtype="uint8"))
+
+        index = faiss.IndexBinaryIVF(quantizer, d, 1)
+        index.is_trained = True
+        index.add(xb)
+
+        np.testing.assert_array_equal(index.reconstruct_n(0, 3), xb)
+
     def test_ivf_nprobe(self):
         """Test in case of nprobe > nlist."""
         d = self.xq.shape[1] * 8


### PR DESCRIPTION
Fixes #5386.

## Summary

Fix `IndexBinaryIVF::reconstruct_n` to write reconstructed binary codes using `code_size` as the byte stride instead of `d`, which is the binary dimension in bits.

This matches the documented `IndexBinary` output layout (`ni * d / 8` bytes) and the Python wrapper allocation shape `(ni, self.code_size)`.

## Root cause

`IndexBinaryIVF::reconstruct_n` computed each output pointer as:

```cpp
recons + (id - i0) * d
```

For binary indexes, `d` is measured in bits, so this skipped `d` bytes per row and left compact Python output rows unwritten, with possible writes past the caller-provided buffer.

## Validation

- Added a regression test for compact `IndexBinaryIVF.reconstruct_n(0, 3)` output.
- Verified the new test fails against the pre-fix local extension with only the first row reconstructed.
- Ran `git diff --check -- faiss\IndexBinaryIVF.cpp tests\test_index_binary.py` successfully.

I could not complete a local post-fix Python run because this checkout has no local FAISS build and the Python interpreter loads the installed Anaconda `faiss` package; this environment also lacks `cmake` and `ninja` commands for rebuilding the extension.