### PR TITLE
Stand up parallel cuVS 26.02 IVF-PQ targets (rmm/raft/cuvs) at CUDA 12.8 (#5414)

### DIFF
--- a/faiss/gpu/GpuCloner.cpp
+++ b/faiss/gpu/GpuCloner.cpp
@@ -14,7 +14,7 @@
 
 #include <faiss/IndexBinaryFlat.h>
 #include <faiss/IndexFlat.h>
-#if defined USE_NVIDIA_CUVS
+#if defined(USE_NVIDIA_CUVS) && !defined(FAISS_CUVS_NO_CAGRA)
 #include <faiss/IndexBinaryHNSW.h>
 #include <faiss/IndexHNSW.h>
 #endif
@@ -28,7 +28,7 @@
 #include <faiss/MetaIndexes.h>
 #include <faiss/gpu/GpuIndex.h>
 #include <faiss/gpu/GpuIndexBinaryFlat.h>
-#if defined USE_NVIDIA_CUVS
+#if defined(USE_NVIDIA_CUVS) && !defined(FAISS_CUVS_NO_CAGRA)
 #include <faiss/gpu/GpuIndexBinaryCagra.h>
 #include <faiss/gpu/GpuIndexCagra.h>
 #endif
@@ -92,7 +92,7 @@ Index* ToCPUCloner::clone_Index(const Index* index) {
         // (inverse op of ToGpuClonerMultiple)
 
     }
-#if defined USE_NVIDIA_CUVS
+#if defined(USE_NVIDIA_CUVS) && !defined(FAISS_CUVS_NO_CAGRA)
     else if (auto icg = dynamic_cast<const GpuIndexCagra*>(index)) {
         IndexHNSWCagra* res = new IndexHNSWCagra();
         if (icg->get_numeric_type() != faiss::NumericType::Float32) {
@@ -233,7 +233,7 @@ Index* ToGpuCloner::clone_Index(const Index* index) {
 
         return res;
     }
-#if defined USE_NVIDIA_CUVS
+#if defined(USE_NVIDIA_CUVS) && !defined(FAISS_CUVS_NO_CAGRA)
     else if (auto icg = dynamic_cast<const faiss::IndexHNSWCagra*>(index)) {
         GpuIndexCagraConfig config;
         config.device = device;
@@ -533,7 +533,7 @@ faiss::IndexBinary* index_binary_gpu_to_cpu(
         ii->copyTo(ret);
         return ret;
     }
-#if defined USE_NVIDIA_CUVS
+#if defined(USE_NVIDIA_CUVS) && !defined(FAISS_CUVS_NO_CAGRA)
     else if (auto ii = dynamic_cast<const GpuIndexBinaryCagra*>(gpu_index)) {
         IndexBinaryHNSWCagra* ret = new IndexBinaryHNSWCagra();
         ii->copyTo(ret);
@@ -555,7 +555,7 @@ faiss::IndexBinary* index_binary_cpu_to_gpu(
         config.device = device;
         return new GpuIndexBinaryFlat(provider, ii, config);
     }
-#if defined USE_NVIDIA_CUVS
+#if defined(USE_NVIDIA_CUVS) && !defined(FAISS_CUVS_NO_CAGRA)
     else if (
             auto ii = dynamic_cast<const faiss::IndexBinaryHNSWCagra*>(index)) {
         GpuIndexCagraConfig config;

--- a/faiss/gpu/GpuIndexIVFScalarQuantizer.cu
+++ b/faiss/gpu/GpuIndexIVFScalarQuantizer.cu
@@ -13,7 +13,7 @@
 #include <faiss/gpu/impl/IVFFlat.cuh>
 #include <faiss/gpu/utils/CopyUtils.cuh>
 
-#if defined USE_NVIDIA_CUVS
+#if defined(USE_NVIDIA_CUVS) && !defined(FAISS_CUVS_NO_IVFSQ)
 #include <cuvs/neighbors/ivf_sq.hpp>
 #include <faiss/gpu/utils/CuvsUtils.h>
 #include <faiss/gpu/impl/CuvsIVFSQ.cuh>
@@ -124,9 +124,15 @@ void GpuIndexIVFScalarQuantizer::verifySQSettings_() const {
 }
 
 bool GpuIndexIVFScalarQuantizer::shouldUseCuvs_() const {
+#if defined(FAISS_CUVS_NO_IVFSQ)
+    // cuVS IVF-SQ backend compiled out (e.g. against cuVS 26.02, which has no
+    // ivf_sq); fall back to the classic (non-cuVS) GPU scalar-quantizer impl.
+    return false;
+#else
     return should_use_cuvs(config_) &&
             sq.qtype == faiss::ScalarQuantizer::QT_8bit && by_residual &&
             ivfSQConfig_.indicesOptions == INDICES_64_BIT;
+#endif
 }
 
 void GpuIndexIVFScalarQuantizer::setIndex_(
@@ -141,7 +147,7 @@ void GpuIndexIVFScalarQuantizer::setIndex_(
         IndicesOptions indicesOptions,
         MemorySpace space) {
     if (shouldUseCuvs_()) {
-#if defined USE_NVIDIA_CUVS
+#if defined(USE_NVIDIA_CUVS) && !defined(FAISS_CUVS_NO_IVFSQ)
         if (!ivfSQConfig_.interleavedLayout) {
             fprintf(stderr,
                     "WARN: interleavedLayout is set to False with cuVS enabled. This will be ignored.\n");
@@ -245,7 +251,7 @@ void GpuIndexIVFScalarQuantizer::copyTo(
 
     GpuIndexIVF::copyTo(index);
     auto sqCopy = sq;
-#if defined USE_NVIDIA_CUVS
+#if defined(USE_NVIDIA_CUVS) && !defined(FAISS_CUVS_NO_IVFSQ)
     if (index_) {
         auto cuvsIndex = dynamic_cast<const CuvsIVFSQ*>(index_.get());
         if (cuvsIndex) {
@@ -328,7 +334,7 @@ void GpuIndexIVFScalarQuantizer::train(idx_t n, const float* x) {
 
     if (shouldUseCuvs_() &&
         !(quantizer->is_trained && quantizer->ntotal == nlist)) {
-#if defined USE_NVIDIA_CUVS
+#if defined(USE_NVIDIA_CUVS) && !defined(FAISS_CUVS_NO_IVFSQ)
         setIndex_(
                 resources_.get(),
                 this->d,


### PR DESCRIPTION
Summary:

TLDR: go back to cuVS 26.02 for Quark, until deps upgrade (may take some time)
--
