### PR TITLE
Fix OperatingPoints::add prune loop leaving dominated points at equal time (#5415)

### DIFF
--- a/faiss/AutoTune.cpp
+++ b/faiss/AutoTune.cpp
@@ -150,7 +150,7 @@ bool OperatingPoints::add(
     }
     // remove non-optimal points from array
     for (size_t i = a.size() - 1; i > 0; --i) {
-        if (a[i].t < a[i - 1].t) {
+        if (a[i].t <= a[i - 1].t) {
             a.erase(a.begin() + (i - 1));
         }
     }

--- a/tests/test_autotune.py
+++ b/tests/test_autotune.py
@@ -72,3 +72,54 @@ class TestAutoTuneCriterion(unittest.TestCase):
         crit.set_groundtruth(None, gt_I)
         self.assertEqual(crit.gt_nnn, gt_nnn)
         self.assertEqual(crit.gt_I.size(), nq * gt_nnn)
+
+
+class TestOperatingPoints(unittest.TestCase):
+    def _keys(self, ops):
+        n = ops.optimal_pts.size()
+        return [ops.optimal_pts.at(i).key for i in range(n)]
+
+    def test_equal_time_better_perf_removes_dominated(self):
+        # B (perf=0.9, t=1.0) dominates A (perf=0.5, t=1.0) — same time,
+        # strictly better perf.  A must be pruned from the optimal frontier.
+        ops = faiss.OperatingPoints()
+        self.assertTrue(ops.add(0.5, 1.0, "A"))
+        self.assertTrue(ops.add(0.9, 1.0, "B"))
+        keys = self._keys(ops)
+        # origin ("") + B only — A must not survive
+        self.assertEqual(len(keys), 2)
+        self.assertNotIn("A", keys, "A dominated by B; must not remain")
+        self.assertIn("B", keys)
+
+    def test_middle_insert_equal_time_removes_dominated(self):
+        # Frontier has P1=(0.5, t=1.0) and P2=(0.9, t=2.0).  Adding
+        # P3=(0.7, t=1.0) inserts P3 in the middle and must prune P1 (same
+        # time, worse perf) — exercises the else-branch insertion path.
+        ops = faiss.OperatingPoints()
+        self.assertTrue(ops.add(0.5, 1.0, "P1"))
+        self.assertTrue(ops.add(0.9, 2.0, "P2"))
+        self.assertTrue(ops.add(0.7, 1.0, "P3"))
+        keys = self._keys(ops)
+        # origin ("") + P3 + P2 — P1 dominated by P3 at equal time
+        self.assertEqual(len(keys), 3)
+        self.assertNotIn("P1", keys, "P1 dominated by P3; must not remain")
+        self.assertIn("P3", keys)
+        self.assertIn("P2", keys)
+
+    def test_normal_pareto_frontier_preserved(self):
+        # Two points where neither dominates the other: higher perf at higher
+        # cost vs lower perf at lower cost.  Both must remain on the frontier.
+        ops = faiss.OperatingPoints()
+        self.assertTrue(ops.add(0.5, 0.5, "approximate"))
+        self.assertTrue(ops.add(0.9, 2.0, "accurate"))
+        keys = self._keys(ops)
+        self.assertIn("approximate", keys)
+        self.assertIn("accurate", keys)
+
+    def test_worse_perf_at_equal_time_rejected(self):
+        # A point with worse perf and equal time is not admitted.
+        ops = faiss.OperatingPoints()
+        self.assertTrue(ops.add(0.9, 1.0, "good"))
+        admitted = ops.add(0.5, 1.0, "bad")
+        self.assertFalse(admitted)
+        self.assertNotIn("bad", self._keys(ops))


### PR DESCRIPTION
Summary:

The post-admission prune loop in `OperatingPoints::add` used a strict
`<` comparison on time to detect dominated points:

    if (a[i].t < a[i - 1].t)

When a new point B has strictly better performance than an existing point
A at exactly the same search time, B is admitted (perf > a.back().perf),
pushed to the back, and the prune loop runs. The condition evaluates
`B.t < A.t` — false when times are equal — so A is left on the frontier.
The optimal set then contains A which B strictly dominates (B.perf >
A.perf, B.t == A.t), breaking the Pareto invariant.

Fix: change `<` to `<=`. This is safe: the admission branches prevent
duplicate (perf, t) pairs from being stored, so the prune loop never
encounters equal time AND equal perf simultaneously. The `<=` condition
only activates for the genuinely dominated case: higher-perf point at
lower-or-equal time.

D110116217 (2026-06-30) fixed the identical bug in the Python port of
this function (`contrib/evaluation.py::add_operating_point`), changing
`t < t2` to `t <= t2` in its prune loop. This diff fixes the C++ source
that the Python version was documented to port.

Reviewed By: mdouze

Differential Revision: D110586087


