### PR TITLE
Fix get_code_size to handle HNSW coarse quantizers with any M value

### DIFF
--- a/contrib/factory_tools.py
+++ b/contrib/factory_tools.py
@@ -17,7 +17,7 @@ def get_code_size(d, indexkey):
     if indexkey.endswith(",RFlat"):
         return d * 4 + get_code_size(d, indexkey[: -len(",RFlat")])
 
-    mo = re.match("IVF\\d+(_HNSW32)?,(.*)$", indexkey)
+    mo = re.match("IVF\\d+(_HNSW\\d+)?,(.*)$", indexkey)
     if mo:
         return get_code_size(d, mo.group(2))
 
@@ -45,8 +45,10 @@ def get_code_size(d, indexkey):
     if mo:
         return int(mo.group(1))
 
-    if indexkey == "HNSW32" or indexkey == "HNSW32,Flat":
-        return d * 4 + 64 * 4  # roughly
+    mo = re.match("HNSW(\\d+)(,Flat)?$", indexkey)
+    if mo:
+        M = int(mo.group(1))
+        return d * 4 + M * 2 * 4  # roughly
 
     if indexkey == "SQ8":
         return d

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -929,3 +929,33 @@ class TestFactoryTools(unittest.TestCase):
             self.assertEqual(
                 factory_tools.reverse_index_factory(index), expected
             )
+
+    def test_get_code_size_hnsw_non_default_m(self):
+        d = 128
+        # Non-default M values previously raised RuntimeError("cannot parse HNSW16")
+        self.assertEqual(factory_tools.get_code_size(d, "HNSW16"), d * 4 + 16 * 2 * 4)
+        self.assertEqual(factory_tools.get_code_size(d, "HNSW64"), d * 4 + 64 * 2 * 4)
+        self.assertEqual(
+            factory_tools.get_code_size(d, "HNSW16,Flat"), d * 4 + 16 * 2 * 4
+        )
+        # HNSW32 backward compat: formula generalizes correctly
+        self.assertEqual(factory_tools.get_code_size(d, "HNSW32"), d * 4 + 32 * 2 * 4)
+
+    def test_get_code_size_ivf_hnsw_non_default_m(self):
+        d = 128
+        # IVF+HNSW coarse quantizer with non-default M: code size is inner type only
+        self.assertEqual(
+            factory_tools.get_code_size(d, "IVF64_HNSW16,Flat"), d * 4
+        )
+        self.assertEqual(
+            factory_tools.get_code_size(d, "IVF64_HNSW64,PQ8x8"), (8 * 8 + 7) // 8
+        )
+
+    def test_get_code_size_hnsw_roundtrip(self):
+        d = 128
+        index = faiss.index_factory(d, "HNSW16,Flat")
+        factory_str = factory_tools.reverse_index_factory(index)
+        self.assertEqual(factory_str, "HNSW16")
+        # get_code_size(reverse_index_factory(index)) must not raise for any M
+        code_size = factory_tools.get_code_size(d, factory_str)
+        self.assertEqual(code_size, d * 4 + 16 * 2 * 4)


### PR DESCRIPTION
Summary:
We fix two bugs in `get_code_size` (`contrib/factory_tools.py`) that raise
`RuntimeError` for any valid HNSW factory string with M≠32.

**Bug 1 — IVF+HNSW regex hardcodes M=32 (line 20):**
`re.match("IVF\\d+(_HNSW32)?,(.*)")` — `_HNSW8`, `_HNSW16`, `_HNSW64` do
not match. Execution falls through all branches to
`raise RuntimeError("cannot parse IVF64_HNSW16,Flat")`.
Fix: change `_HNSW32` to `_HNSW\\d+`.

**Bug 2 — Standalone HNSW string comparison hardcodes M=32 (lines 48–49):**
`if indexkey == "HNSW32" or indexkey == "HNSW32,Flat"` — any other M falls
through to `RuntimeError`. Fix: replace with
`re.match("HNSW(\\d+)(,Flat)?$")` and generalized formula
`d * 4 + M * 2 * 4` (equivalent to the original `d * 4 + 64 * 4` for M=32;
the `# roughly` comment is preserved since HNSW graph overhead depends on
ntotal and level distribution).

**Root cause:** `reverse_index_factory` already correctly handles any M via
`get_hnsw_M()` — line 96 produces `"IVF{n}_HNSW{M},..."`, line 125 produces
`"HNSW{M}"`. The standard roundtrip
`get_code_size(d, reverse_index_factory(index))` crashes for every
IVF+HNSW or standalone HNSW index with M≠32. HNSW M=16 and M=64 are common
production configurations.

Reviewed By: limqiying

Differential Revision: D109142320


