### PR TITLE
black -l 80: tests/ formatting (2/3)

### DIFF
--- a/faiss/gpu/test/bench_approaches.py
+++ b/faiss/gpu/test/bench_approaches.py
@@ -84,7 +84,7 @@ def load_from_hive(
         if xb is None:
             xb = np.empty((n, arr.shape[1]), dtype=np.float32)
         m = min(arr.shape[0], n - i)
-        xb[i:i+m] = arr[:m]
+        xb[i : i + m] = arr[:m]
         i += m
         if i % (batch_size * 50) == 0:
             elapsed = time.time() - t0
@@ -398,12 +398,10 @@ def main():
         "(not needed when --hive-table is set)",
     )
     parser.add_argument(
-        "--n", type=int, default=0,
-        help="Use first N vectors (0=all)"
+        "--n", type=int, default=0, help="Use first N vectors (0=all)"
     )
     parser.add_argument(
-        "--nq", type=int, default=1000,
-        help="Number of queries"
+        "--nq", type=int, default=1000, help="Number of queries"
     )
     parser.add_argument("--num-gpus", type=int, default=0)
     parser.add_argument("--graph-degree", type=int, default=32)
@@ -413,7 +411,7 @@ def main():
         "--n-clusters",
         type=int,
         default=0,
-        help="all_neighbors n_clusters (0=auto)"
+        help="all_neighbors n_clusters (0=auto)",
     )
     parser.add_argument(
         "--overlap-factor",
@@ -462,8 +460,10 @@ def main():
         "--approaches",
         type=str,
         default="A,B,C,D",
-        help=("A (IndexShards), B (GPU stitch), "
-                "C (CPU stitch), D (all_neighbors)"),
+        help=(
+            "A (IndexShards), B (GPU stitch), "
+            "C (CPU stitch), D (all_neighbors)"
+        ),
     )
     parser.add_argument(
         "--index-dir",

--- a/faiss/gpu/test/test_cagra.py
+++ b/faiss/gpu/test/test_cagra.py
@@ -246,11 +246,11 @@ class TestIDMapCagra(unittest.TestCase):
 
 
 @unittest.skipIf(
-    "CUVS" not in faiss.get_compile_options(),
-    "only if cuVS is compiled in")
+    "CUVS" not in faiss.get_compile_options(), "only if cuVS is compiled in"
+)
 @unittest.skipIf(
-    faiss.get_num_gpus() < 2,
-    "need at least 2 GPUs for multi-GPU test")
+    faiss.get_num_gpus() < 2, "need at least 2 GPUs for multi-GPU test"
+)
 class TestMultiGpuCagra(unittest.TestCase):
 
     def test_multi_gpu_build_and_search(self):
@@ -285,11 +285,12 @@ class TestMultiGpuCagra(unittest.TestCase):
         cpu_index.hnsw.efSearch = 128
         Dnew, Inew = cpu_index.search(xq, k)
 
-        recall = np.mean([
-            len(set(Inew[i]) & set(Iref[i])) / k for i in range(ds.nq)
-        ])
-        self.assertGreater(recall, 0.80,
-                           f"Multi-GPU recall@{k} too low: {recall:.4f}")
+        recall = np.mean(
+            [len(set(Inew[i]) & set(Iref[i])) / k for i in range(ds.nq)]
+        )
+        self.assertGreater(
+            recall, 0.80, f"Multi-GPU recall@{k} too low: {recall:.4f}"
+        )
 
         # Serialization roundtrip
         data = faiss.serialize_index(cpu_index)
@@ -317,11 +318,10 @@ class TestMultiGpuCagra(unittest.TestCase):
         config = faiss.GpuIndexCagraConfig()
         config.graph_degree = 32
         config.intermediate_graph_degree = 48
-        index = faiss.GpuIndexCagra(
-            res, ds.d, faiss.METRIC_L2, config)
+        index = faiss.GpuIndexCagra(res, ds.d, faiss.METRIC_L2, config)
         index.trainAllNeighbors(
-            ds.nb, faiss.swig_ptr(xb), devices,
-            0, 0, True, 0)
+            ds.nb, faiss.swig_ptr(xb), devices, 0, 0, True, 0
+        )
 
         cpu_index = faiss.IndexHNSWCagra()
         cpu_index.base_level_only = True
@@ -332,11 +332,8 @@ class TestMultiGpuCagra(unittest.TestCase):
         Dnew, Inew = cpu_index.search(xq, k)
 
         recall = np.mean(
-            [
-                len(set(Inew[i]) & set(Iref[i])) / k
-                for i in range(ds.nq)
-            ]
+            [len(set(Inew[i]) & set(Iref[i])) / k for i in range(ds.nq)]
         )
         self.assertGreater(
-            recall, 0.70,
-            f"all_neighbors recall@{k} too low: {recall:.4f}")
+            recall, 0.70, f"all_neighbors recall@{k} too low: {recall:.4f}"
+        )

--- a/faiss/gpu/test/test_gpu_index_ivfsq.py
+++ b/faiss/gpu/test/test_gpu_index_ivfsq.py
@@ -243,8 +243,8 @@ class TestSQ(unittest.TestCase):
 
 
 @unittest.skipIf(
-    "CUVS" not in faiss.get_compile_options(),
-    "only if CUVS is compiled in")
+    "CUVS" not in faiss.get_compile_options(), "only if CUVS is compiled in"
+)
 class TestCuvsSQ8(unittest.TestCase):
 
     def make_gpu_index(self, metric):
@@ -261,8 +261,8 @@ class TestCuvsSQ8(unittest.TestCase):
         config.indicesOptions = faiss.INDICES_64_BIT
 
         idx_gpu = faiss.GpuIndexIVFScalarQuantizer(
-            res, d, nlist, faiss.ScalarQuantizer.QT_8bit,
-            metric, True, config)
+            res, d, nlist, faiss.ScalarQuantizer.QT_8bit, metric, True, config
+        )
         idx_gpu.train(xt)
         idx_gpu.add(xb)
         idx_gpu.nprobe = nprobe
@@ -278,8 +278,13 @@ class TestCuvsSQ8(unittest.TestCase):
 
         quantizer = faiss.IndexFlat(idx_gpu.d, metric)
         idx_cpu = faiss.IndexIVFScalarQuantizer(
-            quantizer, idx_gpu.d, nlist,
-            faiss.ScalarQuantizer.QT_8bit, metric, True)
+            quantizer,
+            idx_gpu.d,
+            nlist,
+            faiss.ScalarQuantizer.QT_8bit,
+            metric,
+            True,
+        )
         idx_gpu.copyTo(idx_cpu)
         idx_cpu.nprobe = nprobe
 
@@ -288,8 +293,7 @@ class TestCuvsSQ8(unittest.TestCase):
         self.assertEqual(idx_cpu.sq.trained.size(), 2 * idx_gpu.d)
         do_test_with_index(idx_cpu, idx_gpu, nprobe, k, False, 0.8)
 
-        idx_gpu_copy = faiss.GpuIndexIVFScalarQuantizer(
-            res, idx_cpu, config)
+        idx_gpu_copy = faiss.GpuIndexIVFScalarQuantizer(res, idx_cpu, config)
         idx_gpu_copy.nprobe = nprobe
         self.assertEqual(idx_gpu_copy.ntotal, idx_cpu.ntotal)
         do_test_with_index(idx_cpu, idx_gpu_copy, nprobe, k, False, 0.8)
@@ -297,9 +301,10 @@ class TestCuvsSQ8(unittest.TestCase):
         xq_nan = make_t(2, idx_gpu.d)
         xq_nan[1, 0] = np.nan
         D_nan, I_nan = idx_gpu.search(xq_nan, k)
-        np.testing.assert_array_equal(I_nan[1], -np.ones(k, dtype='int64'))
+        np.testing.assert_array_equal(I_nan[1], -np.ones(k, dtype="int64"))
         np.testing.assert_allclose(
-            D_nan[1], np.full(k, np.finfo('float32').max, dtype='float32'))
+            D_nan[1], np.full(k, np.finfo("float32").max, dtype="float32")
+        )
 
         idx_gpu.reset()
         self.assertEqual(idx_gpu.ntotal, 0)

--- a/tests/test_build_blocks.py
+++ b/tests/test_build_blocks.py
@@ -669,14 +669,14 @@ class TestMapInt64ToInt64(unittest.TestCase):
 
     def xx_test_large(self):
         # don't run by default because it's slow
-        self.do_test(2 ** 21, 10 ** 6)
+        self.do_test(2**21, 10**6)
 
 
 class TestRanklistIntersectionSize(unittest.TestCase):
 
     def _intersect(self, v1, v2):
-        a = np.array(v1, dtype='int64')
-        b = np.array(v2, dtype='int64')
+        a = np.array(v1, dtype="int64")
+        b = np.array(v2, dtype="int64")
         return faiss.ranklist_intersection_size(
             len(a), faiss.swig_ptr(a), len(b), faiss.swig_ptr(b)
         )
@@ -706,5 +706,5 @@ class TestRanklistIntersectionSize(unittest.TestCase):
 
     def test_ids_above_2_pow_60(self):
         # the old bit-flag trick corrupted IDs with bit 60 set
-        v1, v2 = [2 ** 60, 2 ** 61, 2 ** 62], [2 ** 61, 2 ** 62, 2 ** 63 - 1]
+        v1, v2 = [2**60, 2**61, 2**62], [2**61, 2**62, 2**63 - 1]
         self.assertEqual(self._intersect(v1, v2), self._expected(v1, v2))

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -319,8 +319,7 @@ class TestOperatingPoints(unittest.TestCase):
         pts = op.operating_points
         for _, pi, ti in pts:
             for _, pj, tj in pts:
-                self.assertFalse(
-                    pj >= pi and tj <= ti and (pj > pi or tj < ti))
+                self.assertFalse(pj >= pi and tj <= ti and (pj > pi or tj < ti))
 
 
 class TestPreassigned(unittest.TestCase):
@@ -933,13 +932,19 @@ class TestFactoryTools(unittest.TestCase):
     def test_get_code_size_hnsw_non_default_m(self):
         d = 128
         # Non-default M values previously raised RuntimeError("cannot parse HNSW16")
-        self.assertEqual(factory_tools.get_code_size(d, "HNSW16"), d * 4 + 16 * 2 * 4)
-        self.assertEqual(factory_tools.get_code_size(d, "HNSW64"), d * 4 + 64 * 2 * 4)
+        self.assertEqual(
+            factory_tools.get_code_size(d, "HNSW16"), d * 4 + 16 * 2 * 4
+        )
+        self.assertEqual(
+            factory_tools.get_code_size(d, "HNSW64"), d * 4 + 64 * 2 * 4
+        )
         self.assertEqual(
             factory_tools.get_code_size(d, "HNSW16,Flat"), d * 4 + 16 * 2 * 4
         )
         # HNSW32 backward compat: formula generalizes correctly
-        self.assertEqual(factory_tools.get_code_size(d, "HNSW32"), d * 4 + 32 * 2 * 4)
+        self.assertEqual(
+            factory_tools.get_code_size(d, "HNSW32"), d * 4 + 32 * 2 * 4
+        )
 
     def test_get_code_size_ivf_hnsw_non_default_m(self):
         d = 128
@@ -948,7 +953,8 @@ class TestFactoryTools(unittest.TestCase):
             factory_tools.get_code_size(d, "IVF64_HNSW16,Flat"), d * 4
         )
         self.assertEqual(
-            factory_tools.get_code_size(d, "IVF64_HNSW64,PQ8x8"), (8 * 8 + 7) // 8
+            factory_tools.get_code_size(d, "IVF64_HNSW64,PQ8x8"),
+            (8 * 8 + 7) // 8,
         )
 
     def test_get_code_size_hnsw_roundtrip(self):

--- a/tests/test_eden.py
+++ b/tests/test_eden.py
@@ -63,7 +63,9 @@ def eden_reference_reconstruct(x, bits, center=None, scale_type="unbiased"):
     return out
 
 
-def eden_reference_l2_distances(x, query, bits, center=None, scale_type="unbiased"):
+def eden_reference_l2_distances(
+    x, query, bits, center=None, scale_type="unbiased"
+):
     x = np.asarray(x, dtype="float32")
     query = np.asarray(query, dtype="float32")
     if center is None:
@@ -205,9 +207,7 @@ class TestEDENScalarQuantizer(unittest.TestCase):
         self.assertTrue(np.any(I >= 0))
 
     def test_search_matches_none_simd_level(self):
-        if not faiss.SIMDConfig.is_simd_level_available(
-            faiss.SIMDLevel_NONE
-        ):
+        if not faiss.SIMDConfig.is_simd_level_available(faiss.SIMDLevel_NONE):
             self.skipTest("SIMDLevel.NONE not available")
 
         levels = [

--- a/tests/test_ivf_flat_panorama.py
+++ b/tests/test_ivf_flat_panorama.py
@@ -104,7 +104,9 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
             atol=atol,
             err_msg="Distances mismatch",
         )
-        check_ref_knn_with_draws(D_regular, I_regular, D_regular, I_panorama, rtol=rtol)
+        check_ref_knn_with_draws(
+            D_regular, I_regular, D_regular, I_panorama, rtol=rtol
+        )
 
     def assert_range_results_equal(
         self,


### PR DESCRIPTION
Summary:
# this is a no-op change

Part 2 of a 3-diff split of the faiss `black -l 80` reformat into small, reviewable diffs (each 3-4 files, <100 changed lines). Follow-up to D109736099 (landed), which formatted the faiss Python tree; these files drifted or are new.

Ran `black -l 80` (line length 80, matching faiss's `CONTRIBUTING.md`: "80 character line length (both for C++ and Python)") over the test files: `tests/test_build_blocks.py`, `tests/test_contrib.py`, `tests/test_eden.py`, `tests/test_ivf_flat_panorama.py`.

Pure-formatting only. `black`'s AST-equivalence safety check guarantees no identifier, string/numeric value, operator, or control-flow change — only whitespace, wrapping, trailing commas, and quote normalization. Independently verified: `ast.dump` equality (docstrings normalized) and comment-content preservation. `fbcode/faiss/` is excluded from Meta's standard Python autoformatter (it mirrors to public GitHub), so `black -l 80` is the correct tool.

Differential Revision: D112191719


