### PR TITLE
black -l 80: python/__init__.pyi formatting (4/4)

### DIFF
--- a/benchs/bench_eden.py
+++ b/benchs/bench_eden.py
@@ -229,9 +229,9 @@ def rabitq_reconstruction_errors(index, xb):
         center = np.zeros(d, dtype="float32")
 
     cb = -(float(1 << ex_bits) - 0.5)
-    signs = np.unpackbits(
-        codes[:, :binary_size], axis=1, bitorder="little"
-    )[:, :d].astype("float32")
+    signs = np.unpackbits(codes[:, :binary_size], axis=1, bitorder="little")[
+        :, :d
+    ].astype("float32")
     ex_bitplanes = np.unpackbits(
         codes[:, ex_code_offset:ex_factors_offset],
         axis=1,
@@ -414,9 +414,13 @@ def print_markdown_tables(
             values = f"| {row.bits} |"
             for index_name in indexes:
                 metric = row.metrics.get(index_name)
-                values += f" {format_float(metric.recall if metric else None)} |"
+                values += (
+                    f" {format_float(metric.recall if metric else None)} |"
+                )
                 if include_ci:
-                    values += f" {format_ci(metric.recall_ci) if metric else ''} |"
+                    values += (
+                        f" {format_ci(metric.recall_ci) if metric else ''} |"
+                    )
             if target is not None:
                 for baseline in baselines:
                     recall_delta = result_delta(row, target, baseline, "recall")

--- a/faiss/gpu/test/bench_approaches.py
+++ b/faiss/gpu/test/bench_approaches.py
@@ -84,7 +84,7 @@ def load_from_hive(
         if xb is None:
             xb = np.empty((n, arr.shape[1]), dtype=np.float32)
         m = min(arr.shape[0], n - i)
-        xb[i:i+m] = arr[:m]
+        xb[i : i + m] = arr[:m]
         i += m
         if i % (batch_size * 50) == 0:
             elapsed = time.time() - t0
@@ -398,12 +398,10 @@ def main():
         "(not needed when --hive-table is set)",
     )
     parser.add_argument(
-        "--n", type=int, default=0,
-        help="Use first N vectors (0=all)"
+        "--n", type=int, default=0, help="Use first N vectors (0=all)"
     )
     parser.add_argument(
-        "--nq", type=int, default=1000,
-        help="Number of queries"
+        "--nq", type=int, default=1000, help="Number of queries"
     )
     parser.add_argument("--num-gpus", type=int, default=0)
     parser.add_argument("--graph-degree", type=int, default=32)
@@ -413,7 +411,7 @@ def main():
         "--n-clusters",
         type=int,
         default=0,
-        help="all_neighbors n_clusters (0=auto)"
+        help="all_neighbors n_clusters (0=auto)",
     )
     parser.add_argument(
         "--overlap-factor",
@@ -462,8 +460,10 @@ def main():
         "--approaches",
         type=str,
         default="A,B,C,D",
-        help=("A (IndexShards), B (GPU stitch), "
-                "C (CPU stitch), D (all_neighbors)"),
+        help=(
+            "A (IndexShards), B (GPU stitch), "
+            "C (CPU stitch), D (all_neighbors)"
+        ),
     )
     parser.add_argument(
         "--index-dir",

--- a/faiss/gpu/test/test_cagra.py
+++ b/faiss/gpu/test/test_cagra.py
@@ -246,11 +246,11 @@ class TestIDMapCagra(unittest.TestCase):
 
 
 @unittest.skipIf(
-    "CUVS" not in faiss.get_compile_options(),
-    "only if cuVS is compiled in")
+    "CUVS" not in faiss.get_compile_options(), "only if cuVS is compiled in"
+)
 @unittest.skipIf(
-    faiss.get_num_gpus() < 2,
-    "need at least 2 GPUs for multi-GPU test")
+    faiss.get_num_gpus() < 2, "need at least 2 GPUs for multi-GPU test"
+)
 class TestMultiGpuCagra(unittest.TestCase):
 
     def test_multi_gpu_build_and_search(self):
@@ -285,11 +285,12 @@ class TestMultiGpuCagra(unittest.TestCase):
         cpu_index.hnsw.efSearch = 128
         Dnew, Inew = cpu_index.search(xq, k)
 
-        recall = np.mean([
-            len(set(Inew[i]) & set(Iref[i])) / k for i in range(ds.nq)
-        ])
-        self.assertGreater(recall, 0.80,
-                           f"Multi-GPU recall@{k} too low: {recall:.4f}")
+        recall = np.mean(
+            [len(set(Inew[i]) & set(Iref[i])) / k for i in range(ds.nq)]
+        )
+        self.assertGreater(
+            recall, 0.80, f"Multi-GPU recall@{k} too low: {recall:.4f}"
+        )
 
         # Serialization roundtrip
         data = faiss.serialize_index(cpu_index)
@@ -317,11 +318,10 @@ class TestMultiGpuCagra(unittest.TestCase):
         config = faiss.GpuIndexCagraConfig()
         config.graph_degree = 32
         config.intermediate_graph_degree = 48
-        index = faiss.GpuIndexCagra(
-            res, ds.d, faiss.METRIC_L2, config)
+        index = faiss.GpuIndexCagra(res, ds.d, faiss.METRIC_L2, config)
         index.trainAllNeighbors(
-            ds.nb, faiss.swig_ptr(xb), devices,
-            0, 0, True, 0)
+            ds.nb, faiss.swig_ptr(xb), devices, 0, 0, True, 0
+        )
 
         cpu_index = faiss.IndexHNSWCagra()
         cpu_index.base_level_only = True
@@ -332,11 +332,8 @@ class TestMultiGpuCagra(unittest.TestCase):
         Dnew, Inew = cpu_index.search(xq, k)
 
         recall = np.mean(
-            [
-                len(set(Inew[i]) & set(Iref[i])) / k
-                for i in range(ds.nq)
-            ]
+            [len(set(Inew[i]) & set(Iref[i])) / k for i in range(ds.nq)]
         )
         self.assertGreater(
-            recall, 0.70,
-            f"all_neighbors recall@{k} too low: {recall:.4f}")
+            recall, 0.70, f"all_neighbors recall@{k} too low: {recall:.4f}"
+        )

--- a/faiss/gpu/test/test_gpu_index_ivfsq.py
+++ b/faiss/gpu/test/test_gpu_index_ivfsq.py
@@ -243,8 +243,8 @@ class TestSQ(unittest.TestCase):
 
 
 @unittest.skipIf(
-    "CUVS" not in faiss.get_compile_options(),
-    "only if CUVS is compiled in")
+    "CUVS" not in faiss.get_compile_options(), "only if CUVS is compiled in"
+)
 class TestCuvsSQ8(unittest.TestCase):
 
     def make_gpu_index(self, metric):
@@ -261,8 +261,8 @@ class TestCuvsSQ8(unittest.TestCase):
         config.indicesOptions = faiss.INDICES_64_BIT
 
         idx_gpu = faiss.GpuIndexIVFScalarQuantizer(
-            res, d, nlist, faiss.ScalarQuantizer.QT_8bit,
-            metric, True, config)
+            res, d, nlist, faiss.ScalarQuantizer.QT_8bit, metric, True, config
+        )
         idx_gpu.train(xt)
         idx_gpu.add(xb)
         idx_gpu.nprobe = nprobe
@@ -278,8 +278,13 @@ class TestCuvsSQ8(unittest.TestCase):
 
         quantizer = faiss.IndexFlat(idx_gpu.d, metric)
         idx_cpu = faiss.IndexIVFScalarQuantizer(
-            quantizer, idx_gpu.d, nlist,
-            faiss.ScalarQuantizer.QT_8bit, metric, True)
+            quantizer,
+            idx_gpu.d,
+            nlist,
+            faiss.ScalarQuantizer.QT_8bit,
+            metric,
+            True,
+        )
         idx_gpu.copyTo(idx_cpu)
         idx_cpu.nprobe = nprobe
 
@@ -288,8 +293,7 @@ class TestCuvsSQ8(unittest.TestCase):
         self.assertEqual(idx_cpu.sq.trained.size(), 2 * idx_gpu.d)
         do_test_with_index(idx_cpu, idx_gpu, nprobe, k, False, 0.8)
 
-        idx_gpu_copy = faiss.GpuIndexIVFScalarQuantizer(
-            res, idx_cpu, config)
+        idx_gpu_copy = faiss.GpuIndexIVFScalarQuantizer(res, idx_cpu, config)
         idx_gpu_copy.nprobe = nprobe
         self.assertEqual(idx_gpu_copy.ntotal, idx_cpu.ntotal)
         do_test_with_index(idx_cpu, idx_gpu_copy, nprobe, k, False, 0.8)
@@ -297,9 +301,10 @@ class TestCuvsSQ8(unittest.TestCase):
         xq_nan = make_t(2, idx_gpu.d)
         xq_nan[1, 0] = np.nan
         D_nan, I_nan = idx_gpu.search(xq_nan, k)
-        np.testing.assert_array_equal(I_nan[1], -np.ones(k, dtype='int64'))
+        np.testing.assert_array_equal(I_nan[1], -np.ones(k, dtype="int64"))
         np.testing.assert_allclose(
-            D_nan[1], np.full(k, np.finfo('float32').max, dtype='float32'))
+            D_nan[1], np.full(k, np.finfo("float32").max, dtype="float32")
+        )
 
         idx_gpu.reset()
         self.assertEqual(idx_gpu.ntotal, 0)

--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -84,7 +84,9 @@ def _preload_gpu_libs():
         def _nvidia_lib_dir(import_name, pip_spec):
             """Return the lib/ dir of an nvidia-*-cu12 wheel, or raise a fix-it."""
             try:
-                mod = __import__("nvidia." + import_name, fromlist=[import_name])
+                mod = __import__(
+                    "nvidia." + import_name, fromlist=[import_name]
+                )
             except ImportError as e:
                 pip_name = pip_spec.split(">")[0].split("<")[0].split("=")[0]
                 raise RuntimeError(
@@ -94,7 +96,9 @@ def _preload_gpu_libs():
             # __path__[0] not __file__: PEP 420 namespace pkgs have __file__ = None.
             return os.path.join(mod.__path__[0], "lib")
 
-        _cudart = _nvidia_lib_dir("cuda_runtime", "nvidia-cuda-runtime-cu12>=12.6,<13")
+        _cudart = _nvidia_lib_dir(
+            "cuda_runtime", "nvidia-cuda-runtime-cu12>=12.6,<13"
+        )
         _cublas = _nvidia_lib_dir("cublas", "nvidia-cublas-cu12>=12.6,<13")
         _curand = _nvidia_lib_dir("curand", "nvidia-curand-cu12>=10.3.7,<11")
         _load(os.path.join(_cudart, "libcudart.so.12"))

--- a/faiss/python/__init__.pyi
+++ b/faiss/python/__init__.pyi
@@ -44,8 +44,12 @@ IO_FLAG_SKIP_STORAGE: int  # skip the storage for graph-based indexes
 IO_FLAG_READ_ONLY: int  # read-only mode
 IO_FLAG_ONDISK_SAME_DIR: int  # strip directory component from ondisk filename
 IO_FLAG_SKIP_IVF_DATA: int  # don't load IVF data to RAM, only list sizes
-IO_FLAG_SKIP_PRECOMPUTE_TABLE: int  # don't initialize precomputed table after loading
-IO_FLAG_PQ_SKIP_SDC_TABLE: int  # don't compute the sdc table for PQ-based indices
+IO_FLAG_SKIP_PRECOMPUTE_TABLE: (
+    int  # don't initialize precomputed table after loading
+)
+IO_FLAG_PQ_SKIP_SDC_TABLE: (
+    int  # don't compute the sdc table for PQ-based indices
+)
 IO_FLAG_MMAP: int  # try to memmap data (useful to load as OnDiskInvertedLists)
 IO_FLAG_MMAP_IFC: int  # mmap for IndexFlatCodes-derived indices and HNSW
 
@@ -66,15 +70,21 @@ def bucket_sort(
     tab: npt.NDArray[np.int64], nbucket: int | None = None, nt: int = 0
 ) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int64]]: ...
 def matrix_bucket_sort_inplace(
-    tab: npt.NDArray[np.int32 | np.int64], nbucket: int | None = None, nt: int = 0
+    tab: npt.NDArray[np.int32 | np.int64],
+    nbucket: int | None = None,
+    nt: int = 0,
 ) -> npt.NDArray[np.int64]: ...
-def eval_intersection(I1: npt.NDArray[np.int64], I2: npt.NDArray[np.int64]) -> int: ...
+def eval_intersection(
+    I1: npt.NDArray[np.int64], I2: npt.NDArray[np.int64]
+) -> int: ...
 def checksum(a: npt.NDArray[np.uint8]) -> int | npt.NDArray[np.uint64]: ...
 def rand_smooth_vectors(
     n: int, d: int, seed: int = 1234
 ) -> npt.NDArray[np.float32]: ...
 def merge_knn_results(
-    Dall: npt.NDArray[np.float32], Iall: npt.NDArray[np.int64], keep_max: bool = False
+    Dall: npt.NDArray[np.float32],
+    Iall: npt.NDArray[np.int64],
+    keep_max: bool = False,
 ) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.int64]]: ...
 @overload
 def knn(
@@ -339,7 +349,9 @@ class Index:
     def reset(self) -> None: ...
     def remove_ids(self, sel: IDSelector) -> int: ...
     @overload
-    def reconstruct(self, key: int, x: torch.Tensor | None = None) -> torch.Tensor: ...
+    def reconstruct(
+        self, key: int, x: torch.Tensor | None = None
+    ) -> torch.Tensor: ...
     @overload
     def reconstruct(
         self, key: int, x: npt.NDArray[np.float32] | None = None
@@ -360,7 +372,10 @@ class Index:
     ) -> torch.Tensor: ...
     @overload
     def reconstruct_n(
-        self, n0: int = 0, ni: int = -1, x: npt.NDArray[np.float32] | None = None
+        self,
+        n0: int = 0,
+        ni: int = -1,
+        x: npt.NDArray[np.float32] | None = None,
     ) -> npt.NDArray[np.float32]: ...
     @overload
     def search_and_reconstruct(
@@ -387,7 +402,10 @@ class Index:
         npt.NDArray[np.float32], npt.NDArray[np.int64], npt.NDArray[np.float32]
     ]: ...
     def compute_residual(
-        self, x: npt.NDArray[np.float32], residual: npt.NDArray[np.float32], key: int
+        self,
+        x: npt.NDArray[np.float32],
+        residual: npt.NDArray[np.float32],
+        key: int,
     ) -> None: ...
     def compute_residual_n(
         self,
@@ -426,7 +444,9 @@ class Index:
     ) -> None: ...
     @overload
     def add_sa_codes(
-        self, codes: npt.NDArray[np.uint8], ids: npt.NDArray[np.int64] | None = None
+        self,
+        codes: npt.NDArray[np.uint8],
+        ids: npt.NDArray[np.int64] | None = None,
     ) -> None: ...
     def merge_from(self, other_index: Index, add_id: int = 0) -> None: ...
     def check_compatible_for_merge(self, other_index: Index) -> None: ...
@@ -483,7 +503,9 @@ class VectorTransform:
     @overload
     def apply_py(self, x: torch.Tensor) -> torch.Tensor: ...
     @overload
-    def apply_py(self, x: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]: ...
+    def apply_py(
+        self, x: npt.NDArray[np.float32]
+    ) -> npt.NDArray[np.float32]: ...
     @overload
     def reverse_transform(
         self, xt: torch.Tensor, x: torch.Tensor | None = None
@@ -563,7 +585,9 @@ class ITQTransform(VectorTransform):
     max_train_per_dim: int
     pca_then_itq: LinearTransform
 
-    def __init__(self, d_in: int = 0, d_out: int = 0, do_pca: bool = False) -> None: ...
+    def __init__(
+        self, d_in: int = 0, d_out: int = 0, do_pca: bool = False
+    ) -> None: ...
     def check_identical(self, other: VectorTransform) -> None: ...
 
 class OPQMatrix(LinearTransform):
@@ -606,7 +630,9 @@ class IndexFlatCodes(Index):
     code_size: int
     codes: Any  # MaybeOwnedVector<uint8_t>
 
-    def __init__(self, code_size: int = 0, d: int = 0, metric: MetricType = METRIC_L2) -> None: ...
+    def __init__(
+        self, code_size: int = 0, d: int = 0, metric: MetricType = METRIC_L2
+    ) -> None: ...
     def sa_code_size(self) -> int: ...
     def permute_entries(self, perm: npt.NDArray[np.int64]) -> None: ...
 
@@ -770,7 +796,9 @@ class IndexPreTransform(Index):
         npt.NDArray[np.int64], npt.NDArray[np.float32], npt.NDArray[np.int64]
     ]: ...
     @overload
-    def reconstruct(self, key: int, x: torch.Tensor | None = None) -> torch.Tensor: ...
+    def reconstruct(
+        self, key: int, x: torch.Tensor | None = None
+    ) -> torch.Tensor: ...
     @overload
     def reconstruct(
         self, key: int, x: npt.NDArray[np.float32] | None = None
@@ -781,7 +809,10 @@ class IndexPreTransform(Index):
     ) -> torch.Tensor: ...
     @overload
     def reconstruct_n(
-        self, n0: int = 0, ni: int = -1, x: npt.NDArray[np.float32] | None = None
+        self,
+        n0: int = 0,
+        ni: int = -1,
+        x: npt.NDArray[np.float32] | None = None,
     ) -> npt.NDArray[np.float32]: ...
     @overload
     def search_and_reconstruct(
@@ -807,7 +838,9 @@ class IndexPreTransform(Index):
     ) -> tuple[
         npt.NDArray[np.float32], npt.NDArray[np.int64], npt.NDArray[np.float32]
     ]: ...
-    def apply_chain(self, x: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]: ...
+    def apply_chain(
+        self, x: npt.NDArray[np.float32]
+    ) -> npt.NDArray[np.float32]: ...
     def reverse_chain(
         self, xt: npt.NDArray[np.float32], x: npt.NDArray[np.float32]
     ) -> None: ...
@@ -850,11 +883,15 @@ class Quantizer:
     @overload
     def compute_codes(self, x: torch.Tensor) -> torch.Tensor: ...
     @overload
-    def compute_codes(self, x: npt.NDArray[np.float32]) -> npt.NDArray[np.uint8]: ...
+    def compute_codes(
+        self, x: npt.NDArray[np.float32]
+    ) -> npt.NDArray[np.uint8]: ...
     @overload
     def decode(self, codes: torch.Tensor) -> torch.Tensor: ...
     @overload
-    def decode(self, codes: npt.NDArray[np.uint8]) -> npt.NDArray[np.float32]: ...
+    def decode(
+        self, codes: npt.NDArray[np.uint8]
+    ) -> npt.NDArray[np.float32]: ...
 
 class ProductQuantizer(Quantizer):
     # Core attributes from C++ struct
@@ -907,10 +944,16 @@ class ProductQuantizer(Quantizer):
         self, x: npt.NDArray[np.float32], dis_table: npt.NDArray[np.float32]
     ) -> None: ...
     def compute_distance_tables(
-        self, nx: int, x: npt.NDArray[np.float32], dis_tables: npt.NDArray[np.float32]
+        self,
+        nx: int,
+        x: npt.NDArray[np.float32],
+        dis_tables: npt.NDArray[np.float32],
     ) -> None: ...
     def compute_inner_prod_tables(
-        self, nx: int, x: npt.NDArray[np.float32], dis_tables: npt.NDArray[np.float32]
+        self,
+        nx: int,
+        x: npt.NDArray[np.float32],
+        dis_tables: npt.NDArray[np.float32],
     ) -> None: ...
 
     # Advanced encoding methods
@@ -949,7 +992,9 @@ class ProductQuantizer(Quantizer):
 
     # Centroid management
     def set_derived_values(self) -> None: ...
-    def set_params(self, centroids: npt.NDArray[np.float32], m: int) -> None: ...
+    def set_params(
+        self, centroids: npt.NDArray[np.float32], m: int
+    ) -> None: ...
     def get_centroids(self, m: int, i: int) -> npt.NDArray[np.float32]: ...
     def sync_transposed_centroids(self) -> None: ...
     def clear_transposed_centroids(self) -> None: ...
@@ -975,7 +1020,9 @@ class AdditiveQuantizer(Quantizer):
     norm_tabs: Float32Vector  # norms of codebook entries for 4-bit fastscan
     qnorm: IndexFlat1D  # store and search norms
     centroid_norms: Float32Vector  # norms of all codebook entries
-    codebook_cross_products: Float32Vector  # dot products with previous codebooks
+    codebook_cross_products: (
+        Float32Vector  # dot products with previous codebooks
+    )
     max_mem_distances: int  # memory limit for beam search
 
     # Search type configuration
@@ -996,7 +1043,9 @@ class AdditiveQuantizer(Quantizer):
     ST_norm_rq2x4: int
 
     @overload
-    def __init__(self, d: int, nbits: list[int], search_type: int = 0) -> None: ...
+    def __init__(
+        self, d: int, nbits: list[int], search_type: int = 0
+    ) -> None: ...
     @overload
     def __init__(self) -> None: ...
     def set_derived_values(self) -> None: ...
@@ -1055,7 +1104,9 @@ class AdditiveQuantizer(Quantizer):
         distances: npt.NDArray[np.float32],
         labels: npt.NDArray[np.int64],
     ) -> None: ...
-    def compute_centroid_norms(self, norms: npt.NDArray[np.float32]) -> None: ...
+    def compute_centroid_norms(
+        self, norms: npt.NDArray[np.float32]
+    ) -> None: ...
     def knn_centroids_L2(
         self,
         n: int,
@@ -1090,16 +1141,24 @@ class ResidualQuantizer(AdditiveQuantizer):
     assign_index_factory: ProgressiveDimIndexFactory
 
     @overload
-    def __init__(self, d: int, nbits: list[int], search_type: int = 0) -> None: ...
+    def __init__(
+        self, d: int, nbits: list[int], search_type: int = 0
+    ) -> None: ...
     @overload
-    def __init__(self, d: int, M: int, nbits: int, search_type: int = 0) -> None: ...
+    def __init__(
+        self, d: int, M: int, nbits: int, search_type: int = 0
+    ) -> None: ...
     @overload
     def __init__(self) -> None: ...
-    def initialize_from(self, other: ResidualQuantizer, skip_M: int = 0) -> None: ...
+    def initialize_from(
+        self, other: ResidualQuantizer, skip_M: int = 0
+    ) -> None: ...
     @overload
     def retrain_AQ_codebook(self, n: int, x: torch.Tensor) -> float: ...
     @overload
-    def retrain_AQ_codebook(self, n: int, x: npt.NDArray[np.float32]) -> float: ...
+    def retrain_AQ_codebook(
+        self, n: int, x: npt.NDArray[np.float32]
+    ) -> float: ...
     def refine_beam(
         self,
         n: int,
@@ -1124,10 +1183,12 @@ class ResidualQuantizer(AdditiveQuantizer):
 
 class IcmEncoder:
     """ICM (Iterated Conditional Modes) encoder for LSQ"""
+
     def __init__(self, lsq: LocalSearchQuantizer) -> None: ...
 
 class IcmEncoderFactory:
     """Factory class for ICM (Iterated Conditional Modes) encoders in LSQ"""
+
     def __init__(self) -> None: ...
     def get(self, lsq: LocalSearchQuantizer) -> IcmEncoder: ...
 
@@ -1154,7 +1215,9 @@ class LocalSearchQuantizer(AdditiveQuantizer):
     update_codebooks_with_double: bool
 
     @overload
-    def __init__(self, d: int, M: int, nbits: int, search_type: int = 0) -> None: ...
+    def __init__(
+        self, d: int, M: int, nbits: int, search_type: int = 0
+    ) -> None: ...
     @overload
     def __init__(self) -> None: ...
     @overload
@@ -1203,14 +1266,19 @@ class LocalSearchQuantizer(AdditiveQuantizer):
         stddev: list[float],
         gen: Any,  # std::mt19937&
     ) -> None: ...
-    def compute_binary_terms(self, binaries: npt.NDArray[np.float32]) -> None: ...
+    def compute_binary_terms(
+        self, binaries: npt.NDArray[np.float32]
+    ) -> None: ...
     @overload
     def compute_unary_terms(
         self, x: torch.Tensor, unaries: npt.NDArray[np.float32], n: int
     ) -> None: ...
     @overload
     def compute_unary_terms(
-        self, x: npt.NDArray[np.float32], unaries: npt.NDArray[np.float32], n: int
+        self,
+        x: npt.NDArray[np.float32],
+        unaries: npt.NDArray[np.float32],
+        n: int,
     ) -> None: ...
     @overload
     def evaluate(
@@ -1412,7 +1480,9 @@ class IndexScalarQuantizer(IndexFlatCodes):
     sq: ScalarQuantizer
     codes: UInt8Vector
 
-    def __init__(self, d: int, qtype: int, metric: MetricType = METRIC_L2) -> None: ...
+    def __init__(
+        self, d: int, qtype: int, metric: MetricType = METRIC_L2
+    ) -> None: ...
 
 # IVF classes
 class InvertedLists:
@@ -1538,7 +1608,9 @@ class OnDiskInvertedLists(InvertedLists):
     ) -> int: ...
     def merge_from_1(self, il: InvertedLists, verbose: bool = False) -> int: ...
     def crop_invlists(self, l0: int, l1: int) -> None: ...
-    def prefetch_lists(self, list_nos: npt.NDArray[np.int64], nlist: int) -> None: ...
+    def prefetch_lists(
+        self, list_nos: npt.NDArray[np.int64], nlist: int
+    ) -> None: ...
 
     # Memory management methods
     def do_mmap(self) -> None: ...
@@ -1576,14 +1648,20 @@ class IndexIVF(Index):
     quantizer: Index
     nprobe: int
     nlist: int
-    quantizer_trains_alone: str  # char in C++ -> single character string in Python
+    quantizer_trains_alone: (
+        str  # char in C++ -> single character string in Python
+    )
     own_fields: bool
     cp: ClusteringParameters
     clustering_index: Index
     max_codes: int
 
     def __init__(
-        self, quantizer: Index, d: int, nlist: int, metric: MetricType = METRIC_L2
+        self,
+        quantizer: Index,
+        d: int,
+        nlist: int,
+        metric: MetricType = METRIC_L2,
     ) -> None: ...
 
     # Core IndexIVF methods from C++
@@ -1670,7 +1748,9 @@ class IndexIVF(Index):
     def check_ids_sorted(self) -> bool: ...
     def make_direct_map(self, new_maintain_direct_map: bool = True) -> None: ...
     def set_direct_map_type(self, type: int) -> None: ...  # DirectMap::Type
-    def replace_invlists(self, invlists: InvertedLists, own: bool = False) -> None: ...
+    def replace_invlists(
+        self, invlists: InvertedLists, own: bool = False
+    ) -> None: ...
     @overload
     def search_preassigned(
         self,
@@ -1698,7 +1778,11 @@ class IndexIVF(Index):
 
 class IndexIVFFlat(IndexIVF):
     def __init__(
-        self, quantizer: Index, d: int, nlist: int, metric: MetricType = METRIC_L2
+        self,
+        quantizer: Index,
+        d: int,
+        nlist: int,
+        metric: MetricType = METRIC_L2,
     ) -> None: ...
 
 class IndexIVFFlatPanorama(IndexIVFFlat):
@@ -1838,10 +1922,14 @@ class IndexHNSW(Index):
         [int, npt.NDArray[np.float32], npt.NDArray[np.float32]], None
     ]
 
-    def __init__(self, d: int, M: int, metric: MetricType = METRIC_L2) -> None: ...
+    def __init__(
+        self, d: int, M: int, metric: MetricType = METRIC_L2
+    ) -> None: ...
 
 class IndexHNSWFlat(IndexHNSW):
-    def __init__(self, d: int, M: int, metric: MetricType = METRIC_L2) -> None: ...
+    def __init__(
+        self, d: int, M: int, metric: MetricType = METRIC_L2
+    ) -> None: ...
 
 class IndexHNSWFlatPanorama(IndexHNSWFlat):
     """Panorama implementation of IndexHNSWFlat.
@@ -1862,14 +1950,22 @@ class IndexHNSWPQ(IndexHNSW):
     pq: ProductQuantizer
 
     def __init__(
-        self, d: int, pq: ProductQuantizer, M: int, metric: MetricType = METRIC_L2
+        self,
+        d: int,
+        pq: ProductQuantizer,
+        M: int,
+        metric: MetricType = METRIC_L2,
     ) -> None: ...
 
 class IndexHNSWSQ(IndexHNSW):
     sq: ScalarQuantizer
 
     def __init__(
-        self, d: int, sq: ScalarQuantizer, M: int, metric: MetricType = METRIC_L2
+        self,
+        d: int,
+        sq: ScalarQuantizer,
+        M: int,
+        metric: MetricType = METRIC_L2,
     ) -> None: ...
 
 class IndexHNSW2Level(IndexHNSW):
@@ -1936,7 +2032,9 @@ class IndexBinary:
         x: npt.NDArray[np.uint8],
         thresh: int,
         params: SearchParameters | None = None,
-    ) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int32], npt.NDArray[np.int64]]: ...
+    ) -> tuple[
+        npt.NDArray[np.int64], npt.NDArray[np.int32], npt.NDArray[np.int64]
+    ]: ...
     @overload
     def reconstruct(self, key: int) -> torch.Tensor: ...
     @overload
@@ -1959,7 +2057,9 @@ class IndexBinary:
     @overload
     def assign(self, x: torch.Tensor, k: int = 1) -> torch.Tensor: ...
     @overload
-    def assign(self, x: npt.NDArray[np.uint8], k: int = 1) -> npt.NDArray[np.int64]: ...
+    def assign(
+        self, x: npt.NDArray[np.uint8], k: int = 1
+    ) -> npt.NDArray[np.int64]: ...
     @overload
     def search_preassigned(
         self,
@@ -1993,7 +2093,9 @@ class IndexBinary:
         Iq: npt.NDArray[np.int64],
         Dq: npt.NDArray[np.int32] | None,
         params: SearchParameters | None = None,
-    ) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int32], npt.NDArray[np.int64]]: ...
+    ) -> tuple[
+        npt.NDArray[np.int64], npt.NDArray[np.int32], npt.NDArray[np.int64]
+    ]: ...
 
 class IndexBinaryFlat(IndexBinary):
     def __init__(self, d: int) -> None: ...
@@ -2055,13 +2157,20 @@ class IndexBinaryIVF(IndexBinary):
         Dq: npt.NDArray[np.int32] | None = None,
         *,
         params: SearchParameters | None = None,
-    ) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int32], npt.NDArray[np.int64]]: ...
+    ) -> tuple[
+        npt.NDArray[np.int64], npt.NDArray[np.int32], npt.NDArray[np.int64]
+    ]: ...
     def reconstruct_from_offset(
-        self, list_no: int, offset: int, key: npt.NDArray[np.uint8] | None = None
+        self,
+        list_no: int,
+        offset: int,
+        key: npt.NDArray[np.uint8] | None = None,
     ) -> npt.NDArray[np.uint8]: ...
     def make_direct_map(self, new_maintain_direct_map: bool = True) -> None: ...
     def set_direct_map_type(self, type: int) -> None: ...
-    def replace_invlists(self, invlists: InvertedLists, own: bool = False) -> None: ...
+    def replace_invlists(
+        self, invlists: InvertedLists, own: bool = False
+    ) -> None: ...
     def get_list_size(self, list_no: int) -> int: ...
     def merge_from(self, other: IndexBinaryIVF, add_id: int = 0) -> None: ...
     def check_compatible_for_merge(self, other: IndexBinaryIVF) -> None: ...
@@ -2108,7 +2217,9 @@ class IndexRefine(Index):
 
 class IndexRefineFlat(IndexRefine):
     def __init__(
-        self, base_index: Index | None = None, xb: npt.NDArray[np.float32] | None = None
+        self,
+        base_index: Index | None = None,
+        xb: npt.NDArray[np.float32] | None = None,
     ) -> None: ...
 
 class IndexRefinePanorama(IndexRefine):
@@ -2162,8 +2273,12 @@ class IndexResidualQuantizerFastScan(IndexAdditiveQuantizerFastScan):
 
     @overload
     def __init__(
-        self, d: int, M: int, nbits: int,
-        metric: MetricType = METRIC_L2, bbs: int = 32,
+        self,
+        d: int,
+        M: int,
+        nbits: int,
+        metric: MetricType = METRIC_L2,
+        bbs: int = 32,
     ) -> None: ...
     @overload
     def __init__(self) -> None: ...
@@ -2173,8 +2288,12 @@ class IndexLocalSearchQuantizerFastScan(IndexAdditiveQuantizerFastScan):
 
     @overload
     def __init__(
-        self, d: int, M: int, nbits: int,
-        metric: MetricType = METRIC_L2, bbs: int = 32,
+        self,
+        d: int,
+        M: int,
+        nbits: int,
+        metric: MetricType = METRIC_L2,
+        bbs: int = 32,
     ) -> None: ...
     @overload
     def __init__(self) -> None: ...
@@ -2213,8 +2332,12 @@ class FileIOReader(IOReader):
     def __init__(self, fname: str) -> None: ...
 
 # Index serialization functions (THE MAIN ONES FROM __init__.py)
-def serialize_index(index: Index, io_flags: int = 0) -> npt.NDArray[np.uint8]: ...
-def deserialize_index(data: npt.NDArray[np.uint8], io_flags: int = 0) -> Index: ...
+def serialize_index(
+    index: Index, io_flags: int = 0
+) -> npt.NDArray[np.uint8]: ...
+def deserialize_index(
+    data: npt.NDArray[np.uint8], io_flags: int = 0
+) -> Index: ...
 def serialize_index_binary(index: IndexBinary) -> npt.NDArray[np.uint8]: ...
 def deserialize_index_binary(data: npt.NDArray[np.uint8]) -> IndexBinary: ...
 
@@ -2240,7 +2363,9 @@ def read_VectorTransform(fname: str) -> VectorTransform: ...
 
 # InvertedLists I/O functions
 def write_InvertedLists(invlists: InvertedLists, writer: IOWriter) -> None: ...
-def read_InvertedLists(reader: IOReader, io_flags: int = 0) -> InvertedLists: ...
+def read_InvertedLists(
+    reader: IOReader, io_flags: int = 0
+) -> InvertedLists: ...
 
 # Deserialization safety limits
 def get_deserialization_loop_limit() -> int: ...
@@ -2343,7 +2468,9 @@ class TimeoutGuard:
     timeout: float
     def __init__(self, timeout_in_seconds: float) -> None: ...
     def __enter__(self) -> None: ...
-    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None: ...
+    def __exit__(
+        self, exc_type: Any, exc_value: Any, traceback: Any
+    ) -> None: ...
 
 # Callback classes for timeout handling
 class TimeoutCallback:
@@ -2560,7 +2687,9 @@ class ProgressiveDimClustering(ProgressiveDimClusteringParameters):
         self, d: int, k: int, cp: ProgressiveDimClusteringParameters
     ) -> None: ...
     @overload
-    def train(self, x: torch.Tensor, factory: ProgressiveDimIndexFactory) -> None: ...
+    def train(
+        self, x: torch.Tensor, factory: ProgressiveDimIndexFactory
+    ) -> None: ...
     @overload
     def train(
         self, x: npt.NDArray[np.float32], factory: ProgressiveDimIndexFactory
@@ -2779,7 +2908,9 @@ class IDSelectorRange(IDSelector):
     imax: int
     assume_sorted: bool
 
-    def __init__(self, imin: int, imax: int, assume_sorted: bool = False) -> None: ...
+    def __init__(
+        self, imin: int, imax: int, assume_sorted: bool = False
+    ) -> None: ...
     def is_member(self, id: int) -> bool: ...
     def find_sorted_ids_bounds(
         self,
@@ -3098,7 +3229,9 @@ class IndexBinaryIDMap(IndexBinary):
         thresh: int,
         *,
         params: SearchParameters | None = None,
-    ) -> tuple[npt.NDArray[np.int64], npt.NDArray[np.int32], npt.NDArray[np.int64]]: ...
+    ) -> tuple[
+        npt.NDArray[np.int64], npt.NDArray[np.int32], npt.NDArray[np.int64]
+    ]: ...
     @overload
     def reconstruct(self, key: int) -> torch.Tensor: ...
     @overload
@@ -3119,7 +3252,9 @@ class IndexIDMap2(IndexIDMap):
     def merge_from(self, other_index: Index, add_id: int = 0) -> None: ...
     def remove_ids(self, sel: IDSelector) -> int: ...
     @overload
-    def reconstruct(self, key: int, x: torch.Tensor | None = None) -> torch.Tensor: ...
+    def reconstruct(
+        self, key: int, x: torch.Tensor | None = None
+    ) -> torch.Tensor: ...
     @overload
     def reconstruct(
         self, key: int, x: npt.NDArray[np.float32] | None = None
@@ -3152,7 +3287,9 @@ class IndexNSG(Index):
     build_type: int
     verbose: bool
 
-    def __init__(self, d: int, R: int, metric: MetricType = METRIC_L2) -> None: ...
+    def __init__(
+        self, d: int, R: int, metric: MetricType = METRIC_L2
+    ) -> None: ...
     @overload
     def build(self, x: torch.Tensor, graph: torch.Tensor) -> None: ...
     @overload
@@ -3179,10 +3316,14 @@ class IndexNNDescent(Index):
     storage: Index
     own_fields: bool
 
-    def __init__(self, d: int, K: int, metric: MetricType = METRIC_L2) -> None: ...
+    def __init__(
+        self, d: int, K: int, metric: MetricType = METRIC_L2
+    ) -> None: ...
 
 class IndexNNDescentFlat(IndexNNDescent):
-    def __init__(self, d: int, K: int, metric: MetricType = METRIC_L2) -> None: ...
+    def __init__(
+        self, d: int, K: int, metric: MetricType = METRIC_L2
+    ) -> None: ...
 
 # Index2Layer
 class Index2Layer(Index):
@@ -3286,7 +3427,10 @@ class IndexResidualQuantizer(IndexAdditiveQuantizer):
 
     @overload
     def __init__(
-        self, d: int, M: int, nbits: int,
+        self,
+        d: int,
+        M: int,
+        nbits: int,
         metric: MetricType = METRIC_L2,
     ) -> None: ...
     @overload
@@ -3297,7 +3441,10 @@ class IndexLocalSearchQuantizer(IndexAdditiveQuantizer):
 
     @overload
     def __init__(
-        self, d: int, M: int, nbits: int,
+        self,
+        d: int,
+        M: int,
+        nbits: int,
         metric: MetricType = METRIC_L2,
     ) -> None: ...
     @overload
@@ -3453,7 +3600,9 @@ class IndexProductLocalSearchQuantizerFastScan(IndexAdditiveQuantizerFastScan):
         bbs: int = 32,
     ) -> None: ...
 
-class IndexIVFProductResidualQuantizerFastScan(IndexIVFAdditiveQuantizerFastScan):
+class IndexIVFProductResidualQuantizerFastScan(
+    IndexIVFAdditiveQuantizerFastScan
+):
     prq: ProductResidualQuantizer
 
     def __init__(
@@ -3468,7 +3617,9 @@ class IndexIVFProductResidualQuantizerFastScan(IndexIVFAdditiveQuantizerFastScan
         bbs: int = 32,
     ) -> None: ...
 
-class IndexIVFProductLocalSearchQuantizerFastScan(IndexIVFAdditiveQuantizerFastScan):
+class IndexIVFProductLocalSearchQuantizerFastScan(
+    IndexIVFAdditiveQuantizerFastScan
+):
     plsq: ProductLocalSearchQuantizer
 
     def __init__(
@@ -3494,7 +3645,12 @@ class AdditiveCoarseQuantizer(Index):
     aq: AdditiveQuantizer
     centroid_norms: Float32Vector
 
-    def __init__(self, d: int = 0, aq: AdditiveQuantizer | None = None, metric: MetricType = METRIC_L2) -> None: ...
+    def __init__(
+        self,
+        d: int = 0,
+        aq: AdditiveQuantizer | None = None,
+        metric: MetricType = METRIC_L2,
+    ) -> None: ...
 
 class SearchParametersResidualCoarseQuantizer(SearchParameters):
     beam_factor: float
@@ -3707,7 +3863,9 @@ class IndexIVFInterface:
     nprobe: int  # number of probes at query time
     max_codes: int  # max nb of codes to visit to do a query
 
-    def __init__(self, quantizer: Index | None = None, nlist: int = 0) -> None: ...
+    def __init__(
+        self, quantizer: Index | None = None, nlist: int = 0
+    ) -> None: ...
     def search_preassigned(
         self,
         n: int,
@@ -3751,7 +3909,9 @@ class ParameterSpace:
     def initialize(self, index: Index) -> None: ...
     def set_index_parameters(self, index: Index, cno: int) -> None: ...
     def set_index_parameters(self, index: Index, param_string: str) -> None: ...
-    def set_index_parameter(self, index: Index, name: str, val: float) -> None: ...
+    def set_index_parameter(
+        self, index: Index, name: str, val: float
+    ) -> None: ...
     def update_bounds(
         self,
         cno: int,
@@ -3791,6 +3951,7 @@ class GpuIndexIVF(GpuIndex, IndexIVFInterface): ...
 
 class GpuIndexIVFConfig(GpuIndexConfig):
     """Configuration for GPU IVF indices"""
+
     def __init__(self) -> None: ...
 
 class GpuIndexIVFPQConfig(GpuIndexIVFConfig):
@@ -3860,7 +4021,9 @@ class GpuParameterSpace(ParameterSpace):
     """GPU-specific parameter space for auto-tuning"""
 
     def initialize(self, index: Index) -> None: ...
-    def set_index_parameter(self, index: Index, name: str, val: float) -> None: ...
+    def set_index_parameter(
+        self, index: Index, name: str, val: float
+    ) -> None: ...
 
 class OperatingPoints:
     all_pts: OperatingPointVector
@@ -3951,7 +4114,6 @@ def range_search_inner_product(
     result: RangeSearchResult,
     sel: IDSelector | None = None,
 ) -> None: ...
-
 @overload
 def imbalance_factor(k: int, hist: int) -> float: ...
 @overload
@@ -3959,7 +4121,10 @@ def imbalance_factor(n: int, k: int, assign: int) -> float: ...
 
 # Index factory functions
 def index_factory(
-    d: int, description: str, metric: MetricType = METRIC_L2, own_invlists: bool = True
+    d: int,
+    description: str,
+    metric: MetricType = METRIC_L2,
+    own_invlists: bool = True,
 ) -> Index: ...
 def index_binary_factory(
     d: int, description: str, own_invlists: bool = True
@@ -3987,7 +4152,9 @@ class MapLong2Long:
     def __init__(self) -> None: ...
     def add(self, n: int, keys: np.ndarray, vals: np.ndarray) -> None: ...
     def search(self, key: int) -> int: ...
-    def search_multiple(self, n: int, keys: np.ndarray, vals: np.ndarray) -> None: ...
+    def search_multiple(
+        self, n: int, keys: np.ndarray, vals: np.ndarray
+    ) -> None: ...
 
 # Additional utilities
 def get_num_gpus() -> int: ...
@@ -4033,14 +4200,18 @@ class StandardGpuResourcesImpl:
     def noTempMemory(self) -> None: ...
     def setTempMemory(self, size: int) -> None: ...
     def setPinnedMemory(self, size: int) -> None: ...
-    def setDefaultStream(self, device: int, stream: Any) -> None: ...  # cudaStream_t
+    def setDefaultStream(
+        self, device: int, stream: Any
+    ) -> None: ...  # cudaStream_t
     def revertDefaultStream(self, device: int) -> None: ...
     def getDefaultStream(self, device: int) -> Any: ...  # cudaStream_t
     def setDefaultNullStreamAllDevices(self) -> None: ...
     def setLogMemoryAllocations(self, enable: bool) -> None: ...
     def initializeForDevice(self, device: int) -> None: ...
     def getBlasHandle(self, device: int) -> Any: ...  # cublasHandle_t
-    def getAlternateStreams(self, device: int) -> list[Any]: ...  # vector<cudaStream_t>
+    def getAlternateStreams(
+        self, device: int
+    ) -> list[Any]: ...  # vector<cudaStream_t>
     def allocMemory(self, req: Any) -> Any: ...  # AllocRequest -> void*
     def deallocMemory(self, device: int, ptr: Any) -> None: ...
     def getTempMemoryAvailable(self, device: int) -> int: ...
@@ -4058,7 +4229,9 @@ class StandardGpuResources:
     def noTempMemory(self) -> None: ...
     def setTempMemory(self, size: int) -> None: ...
     def setPinnedMemory(self, size: int) -> None: ...
-    def setDefaultStream(self, device: int, stream: Any) -> None: ...  # cudaStream_t
+    def setDefaultStream(
+        self, device: int, stream: Any
+    ) -> None: ...  # cudaStream_t
     def revertDefaultStream(self, device: int) -> None: ...
     def setDefaultNullStreamAllDevices(self) -> None: ...
     def getMemoryInfo(self) -> dict[int, dict[str, tuple[int, int]]]: ...
@@ -4143,7 +4316,9 @@ class GpuMultipleClonerOptions(GpuClonerOptions):
 
 # GPU Cloner classes (from gpu/GpuCloner.h)
 class ToCPUCloner(Cloner):
-    def merge_index(self, dst: Index, src: Index, successive_ids: bool) -> None: ...
+    def merge_index(
+        self, dst: Index, src: Index, successive_ids: bool
+    ) -> None: ...
     def clone_Index(self, index: Index) -> Index: ...
 
 class ToGpuCloner(Cloner, GpuClonerOptions):
@@ -4456,7 +4631,9 @@ def rand_smooth_vectors(
 @overload
 def eval_intersection(I1: torch.Tensor, I2: torch.Tensor) -> int: ...
 @overload
-def eval_intersection(I1: npt.NDArray[np.int64], I2: npt.NDArray[np.int64]) -> int: ...
+def eval_intersection(
+    I1: npt.NDArray[np.int64], I2: npt.NDArray[np.int64]
+) -> int: ...
 @overload
 def normalize_L2(x: torch.Tensor) -> None: ...
 @overload
@@ -4501,7 +4678,10 @@ def knn_hamming(
 ) -> tuple[torch.Tensor, torch.Tensor]: ...
 @overload
 def knn_hamming(
-    xq: npt.NDArray[np.uint8], xb: npt.NDArray[np.uint8], k: int, variant: str = "hc"
+    xq: npt.NDArray[np.uint8],
+    xb: npt.NDArray[np.uint8],
+    k: int,
+    variant: str = "hc",
 ) -> tuple[npt.NDArray[np.int32], npt.NDArray[np.int64]]: ...
 @overload
 def merge_knn_results(
@@ -4509,12 +4689,16 @@ def merge_knn_results(
 ) -> tuple[torch.Tensor, torch.Tensor]: ...
 @overload
 def merge_knn_results(
-    Dall: npt.NDArray[np.float32], Iall: npt.NDArray[np.int64], keep_max: bool = False
+    Dall: npt.NDArray[np.float32],
+    Iall: npt.NDArray[np.int64],
+    keep_max: bool = False,
 ) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.int64]]: ...
 
 # Pack/unpack bitstring functions from extra_wrappers.py
 @overload
-def pack_bitstrings(a: npt.NDArray[np.int32], nbit: int) -> npt.NDArray[np.uint8]: ...
+def pack_bitstrings(
+    a: npt.NDArray[np.int32], nbit: int
+) -> npt.NDArray[np.uint8]: ...
 @overload
 def pack_bitstrings(
     a: npt.NDArray[np.int32], nbit: npt.NDArray[np.int32]
@@ -4611,9 +4795,17 @@ class float_minheap_array_t:
     def __init__(self) -> None: ...
     def heapify(self) -> None: ...
     def addn(self, n: int, vals: Any) -> None: ...
-    def addn_with_ids(self, n: int, vals: Any, ids: Any, id_stride: int) -> None: ...
+    def addn_with_ids(
+        self, n: int, vals: Any, ids: Any, id_stride: int
+    ) -> None: ...
     def addn_query_subset_with_ids(
-        self, nsubset: int, subset: Any, n: int, vals: Any, ids: Any, id_stride: int
+        self,
+        nsubset: int,
+        subset: Any,
+        n: int,
+        vals: Any,
+        ids: Any,
+        id_stride: int,
     ) -> None: ...
     def reorder(self) -> None: ...
 
@@ -4626,9 +4818,17 @@ class float_maxheap_array_t:
     def __init__(self) -> None: ...
     def heapify(self) -> None: ...
     def addn(self, n: int, vals: Any) -> None: ...
-    def addn_with_ids(self, n: int, vals: Any, ids: Any, id_stride: int) -> None: ...
+    def addn_with_ids(
+        self, n: int, vals: Any, ids: Any, id_stride: int
+    ) -> None: ...
     def addn_query_subset_with_ids(
-        self, nsubset: int, subset: Any, n: int, vals: Any, ids: Any, id_stride: int
+        self,
+        nsubset: int,
+        subset: Any,
+        n: int,
+        vals: Any,
+        ids: Any,
+        id_stride: int,
     ) -> None: ...
     def reorder(self) -> None: ...
 
@@ -4704,7 +4904,9 @@ class MapInt64ToInt64:
     tab: npt.NDArray[np.int64]
 
     def __init__(self, capacity: int) -> None: ...
-    def add(self, keys: npt.NDArray[np.int64], vals: npt.NDArray[np.int64]) -> None: ...
+    def add(
+        self, keys: npt.NDArray[np.int64], vals: npt.NDArray[np.int64]
+    ) -> None: ...
     def lookup(self, keys: npt.NDArray[np.int64]) -> npt.NDArray[np.int64]: ...
 
 # Additional hash table functions

--- a/tests/test_build_blocks.py
+++ b/tests/test_build_blocks.py
@@ -669,14 +669,14 @@ class TestMapInt64ToInt64(unittest.TestCase):
 
     def xx_test_large(self):
         # don't run by default because it's slow
-        self.do_test(2 ** 21, 10 ** 6)
+        self.do_test(2**21, 10**6)
 
 
 class TestRanklistIntersectionSize(unittest.TestCase):
 
     def _intersect(self, v1, v2):
-        a = np.array(v1, dtype='int64')
-        b = np.array(v2, dtype='int64')
+        a = np.array(v1, dtype="int64")
+        b = np.array(v2, dtype="int64")
         return faiss.ranklist_intersection_size(
             len(a), faiss.swig_ptr(a), len(b), faiss.swig_ptr(b)
         )
@@ -706,5 +706,5 @@ class TestRanklistIntersectionSize(unittest.TestCase):
 
     def test_ids_above_2_pow_60(self):
         # the old bit-flag trick corrupted IDs with bit 60 set
-        v1, v2 = [2 ** 60, 2 ** 61, 2 ** 62], [2 ** 61, 2 ** 62, 2 ** 63 - 1]
+        v1, v2 = [2**60, 2**61, 2**62], [2**61, 2**62, 2**63 - 1]
         self.assertEqual(self._intersect(v1, v2), self._expected(v1, v2))

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -319,8 +319,7 @@ class TestOperatingPoints(unittest.TestCase):
         pts = op.operating_points
         for _, pi, ti in pts:
             for _, pj, tj in pts:
-                self.assertFalse(
-                    pj >= pi and tj <= ti and (pj > pi or tj < ti))
+                self.assertFalse(pj >= pi and tj <= ti and (pj > pi or tj < ti))
 
 
 class TestPreassigned(unittest.TestCase):
@@ -933,13 +932,19 @@ class TestFactoryTools(unittest.TestCase):
     def test_get_code_size_hnsw_non_default_m(self):
         d = 128
         # Non-default M values previously raised RuntimeError("cannot parse HNSW16")
-        self.assertEqual(factory_tools.get_code_size(d, "HNSW16"), d * 4 + 16 * 2 * 4)
-        self.assertEqual(factory_tools.get_code_size(d, "HNSW64"), d * 4 + 64 * 2 * 4)
+        self.assertEqual(
+            factory_tools.get_code_size(d, "HNSW16"), d * 4 + 16 * 2 * 4
+        )
+        self.assertEqual(
+            factory_tools.get_code_size(d, "HNSW64"), d * 4 + 64 * 2 * 4
+        )
         self.assertEqual(
             factory_tools.get_code_size(d, "HNSW16,Flat"), d * 4 + 16 * 2 * 4
         )
         # HNSW32 backward compat: formula generalizes correctly
-        self.assertEqual(factory_tools.get_code_size(d, "HNSW32"), d * 4 + 32 * 2 * 4)
+        self.assertEqual(
+            factory_tools.get_code_size(d, "HNSW32"), d * 4 + 32 * 2 * 4
+        )
 
     def test_get_code_size_ivf_hnsw_non_default_m(self):
         d = 128
@@ -948,7 +953,8 @@ class TestFactoryTools(unittest.TestCase):
             factory_tools.get_code_size(d, "IVF64_HNSW16,Flat"), d * 4
         )
         self.assertEqual(
-            factory_tools.get_code_size(d, "IVF64_HNSW64,PQ8x8"), (8 * 8 + 7) // 8
+            factory_tools.get_code_size(d, "IVF64_HNSW64,PQ8x8"),
+            (8 * 8 + 7) // 8,
         )
 
     def test_get_code_size_hnsw_roundtrip(self):

--- a/tests/test_eden.py
+++ b/tests/test_eden.py
@@ -63,7 +63,9 @@ def eden_reference_reconstruct(x, bits, center=None, scale_type="unbiased"):
     return out
 
 
-def eden_reference_l2_distances(x, query, bits, center=None, scale_type="unbiased"):
+def eden_reference_l2_distances(
+    x, query, bits, center=None, scale_type="unbiased"
+):
     x = np.asarray(x, dtype="float32")
     query = np.asarray(query, dtype="float32")
     if center is None:
@@ -205,9 +207,7 @@ class TestEDENScalarQuantizer(unittest.TestCase):
         self.assertTrue(np.any(I >= 0))
 
     def test_search_matches_none_simd_level(self):
-        if not faiss.SIMDConfig.is_simd_level_available(
-            faiss.SIMDLevel_NONE
-        ):
+        if not faiss.SIMDConfig.is_simd_level_available(faiss.SIMDLevel_NONE):
             self.skipTest("SIMDLevel.NONE not available")
 
         levels = [

--- a/tests/test_ivf_flat_panorama.py
+++ b/tests/test_ivf_flat_panorama.py
@@ -104,7 +104,9 @@ class TestIndexIVFFlatPanorama(unittest.TestCase):
             atol=atol,
             err_msg="Distances mismatch",
         )
-        check_ref_knn_with_draws(D_regular, I_regular, D_regular, I_panorama, rtol=rtol)
+        check_ref_knn_with_draws(
+            D_regular, I_regular, D_regular, I_panorama, rtol=rtol
+        )
 
     def assert_range_results_equal(
         self,

--- a/tests/test_refine_panorama.py
+++ b/tests/test_refine_panorama.py
@@ -90,7 +90,9 @@ class TestIndexRefinePanorama(unittest.TestCase):
             atol=atol,
             err_msg="Distances mismatch",
         )
-        check_ref_knn_with_draws(D_regular, I_regular, D_regular, I_panorama, rtol=rtol)
+        check_ref_knn_with_draws(
+            D_regular, I_regular, D_regular, I_panorama, rtol=rtol
+        )
 
     def test_refine_panorama_correctness(self):
         d = 128


### PR DESCRIPTION
Summary:
# this is a no-op change

Part 4 of the faiss `black -l 80` reformat, split out on its own because `python/__init__.pyi` is a single generated type-stub whose formatting delta is ~374 lines — it cannot be split under the 100-line-per-diff budget without splitting a single file, so it is isolated here. Follow-up to D109736099 (landed).

Ran `black -l 80` (line length 80, matching faiss's `CONTRIBUTING.md`: "80 character line length (both for C++ and Python)") over `python/__init__.pyi`.

Pure-formatting only. `black`'s AST-equivalence safety check guarantees no identifier, string/numeric value, operator, or type-annotation change — only whitespace, wrapping, trailing commas, and quote normalization. Independently verified: `ast.dump` equality (docstrings normalized) and comment-content preservation. `fbcode/faiss/` is excluded from Meta's standard Python autoformatter (it mirrors to public GitHub), so `black -l 80` is the correct tool.

Differential Revision: D112191718


