### PR TITLE
Validate code_size against compute_code_size in RaBitQ flat deserialization

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -2715,6 +2715,11 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
 
         // rabitq.nb_bits is already set to 1 by read_RaBitQuantizer
         idxq->code_size = idxq->rabitq.code_size;
+        validate_code_size_match(
+                idxq->code_size,
+                idxq->rabitq.compute_code_size(
+                        idxq->rabitq.d, idxq->rabitq.nb_bits),
+                "IndexRaBitQ");
         idx = std::move(idxq);
     } else if (h == fourcc("Ixrr")) {
         // Ixrr = multi-bit format (new)
@@ -2733,6 +2738,11 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
                 idxq->qb);
 
         idxq->code_size = idxq->rabitq.code_size;
+        validate_code_size_match(
+                idxq->code_size,
+                idxq->rabitq.compute_code_size(
+                        idxq->rabitq.d, idxq->rabitq.nb_bits),
+                "IndexRaBitQ");
         idx = std::move(idxq);
     } else if (h == fourcc("Iwrq")) {
         auto ivrq = std::make_unique<IndexIVFRaBitQ>();

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -2175,19 +2175,24 @@ TEST(ReadIndexDeserialize, ITQTransformMeanTooSmall) {
 // RaBitQ qb deserialization validation tests
 // -----------------------------------------------------------------------
 
+/// Single-bit RaBitQ code_size == compute_code_size(d, 1): (d+7)/8 + 8.
+static size_t rabitq_single_bit_code_size(size_t d) {
+    return (d + 7) / 8 + 8;
+}
+
 /// Helper: push a minimal RaBitQuantizer (single-bit format, multi_bit=false).
 static void push_rabitq(std::vector<uint8_t>& buf, size_t d) {
-    push_val<size_t>(buf, d); // d
-    push_val<size_t>(buf, 1); // code_size
-    push_val<int>(buf, 1);    // metric_type (L2)
+    push_val<size_t>(buf, d);                              // d
+    push_val<size_t>(buf, rabitq_single_bit_code_size(d)); // code_size
+    push_val<int>(buf, 1);                                 // metric_type (L2)
 }
 
 /// Helper: push a minimal RaBitQuantizer (multi-bit format, multi_bit=true).
 static void push_rabitq_multibit(std::vector<uint8_t>& buf, size_t d) {
-    push_val<size_t>(buf, d); // d
-    push_val<size_t>(buf, 1); // code_size
-    push_val<int>(buf, 1);    // metric_type (L2)
-    push_val<size_t>(buf, 1); // nb_bits
+    push_val<size_t>(buf, d);                              // d
+    push_val<size_t>(buf, rabitq_single_bit_code_size(d)); // code_size (nb_bits=1)
+    push_val<int>(buf, 1);                                 // metric_type (L2)
+    push_val<size_t>(buf, 1);                              // nb_bits
 }
 
 /// Helper: push an IVF header (index_header + nlist + nprobe + flat quantizer
@@ -2285,6 +2290,46 @@ TEST(ReadIndexDeserialize, RaBitQQbZeroAccepted_Ixrr) {
     VectorIOReader reader;
     reader.data = buf;
     EXPECT_NO_THROW(read_index_up(&reader));
+}
+
+// -----------------------------------------------------------------------
+// Test: IndexRaBitQ code_size field mismatch. The flat readers take
+// rabitq.code_size straight from the file. If it does not match
+// compute_code_size(d, nb_bits), decode_core still reads the per-code
+// factor block at offset (d+7)/8 -- derived from d, not code_size -- so a
+// too-small code_size makes search()/sa_decode() read past the codes
+// buffer (heap OOB), even when codes.size() == ntotal * code_size holds.
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, RaBitQCodeSizeFieldMismatch_Ixrq) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "Ixrq");
+    push_index_header(buf, /*d=*/8, /*ntotal=*/0);
+    // RaBitQuantizer with a code_size that does not match
+    // compute_code_size(8, 1) == (8+7)/8 + 8 == 9.
+    push_val<size_t>(buf, (size_t)8); // d
+    push_val<size_t>(buf, (size_t)1); // code_size = 1 (forged; real = 9)
+    push_val<int>(buf, 1);            // metric_type (L2)
+    push_vector<uint8_t>(buf, {});    // codes
+    push_vector<float>(buf, std::vector<float>(8, 0.0f)); // center
+    push_val<uint8_t>(buf, 0);        // qb = 0
+
+    expect_read_throws_with(buf, "code_size mismatch");
+}
+
+TEST(ReadIndexDeserialize, RaBitQCodeSizeFieldMismatch_Ixrr) {
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "Ixrr");
+    push_index_header(buf, /*d=*/8, /*ntotal=*/0);
+    // Multi-bit form: code_size must match compute_code_size(8, nb_bits).
+    push_val<size_t>(buf, (size_t)8); // d
+    push_val<size_t>(buf, (size_t)1); // code_size = 1 (forged; real = 9 for nb_bits=1)
+    push_val<int>(buf, 1);            // metric_type (L2)
+    push_val<size_t>(buf, 1);         // nb_bits = 1
+    push_vector<uint8_t>(buf, {});    // codes
+    push_vector<float>(buf, std::vector<float>(8, 0.0f)); // center
+    push_val<uint8_t>(buf, 0);        // qb = 0
+
+    expect_read_throws_with(buf, "code_size mismatch");
 }
 
 // -- Irfn (IndexRaBitQFastScan, new format) --


### PR DESCRIPTION
### Summary

The flat RaBitQ readers (`fourcc("Ixrq")` / `fourcc("Ixrr")` in `read_index`, `faiss/impl/index_read.cpp`) take `rabitq.code_size` straight from the file and use it as the per-vector stride, without checking it against `compute_code_size(d, nb_bits)`. The IVF RaBitQ readers (`Iwrq`/`Iwrr`) already recompute `code_size` after reading (`ivrq->rabitq.code_size = ivrq->rabitq.compute_code_size(...)`), so only the flat readers trust the stored value.

`RaBitQuantizer::decode_core` strides by `code_size` but locates the per-code factor block at offset `(d + 7) / 8`, derived from `d` rather than `code_size`. A file with a too-small `code_size` therefore makes `search()` / `sa_decode()` read the factor block past the end of the `codes` buffer.

This is **independent of** the `codes.size() == ntotal * code_size` buffer-length check (added for these arms in #5293): a `codes` buffer sized to `ntotal * (forged code_size)` satisfies that check yet still overruns, because the factor read within the final code slot extends past the buffer end.

### Reproduce (heap OOB under AddressSanitizer, public API only)

A self-contained program that builds a crafted `Ixrq` payload (`d=8`, forged `code_size=1` vs real `9`, `codes` buffer = `ntotal` bytes so the `codes.size()` check passes), then `read_index` + `sa_decode`:

```
read_index SUCCEEDED. loaded code_size=1, codes.size()=64
calling sa_decode ...
==ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 4 at 0x... 0 bytes after 64-byte region
  #0 faiss::RaBitQuantizer::decode_core(...)      faiss/impl/RaBitQuantizer.cpp:219
  #1 faiss::IndexRaBitQ::sa_decode(...)           faiss/IndexRaBitQ.cpp:61
0x...120 is located 0 bytes after 64-byte region
  allocated by read_index_up                      faiss/impl/index_read.cpp (codes buffer)
```

With this patch, `read_index` rejects the file up front:

```
FaissException: IndexRaBitQ code_size mismatch: stored 1 vs derived 9
  at validate_code_size_match  faiss/impl/index_read.cpp
```

### Fix

Validate the stored `code_size` against `compute_code_size(d, nb_bits)` in both flat arms, using the existing `validate_code_size_match` helper (this is the scalar stored-vs-derived case that helper is for).

Also add `RaBitQCodeSizeFieldMismatch_Ixrq` / `_Ixrr` regression tests, and fix the `push_rabitq` / `push_rabitq_multibit` test helpers to emit a valid `code_size` — they previously wrote a placeholder that only passed because the reader did not validate it.

Validated locally: new tests pass with the change and fail without it; the full `ReadIndexDeserialize` suite passes; and the ASAN reproduction above is rejected instead of overrunning.

Related to #5293 (same flat readers, complementary buffer-length check). The two are independent: #5293 bounds `codes.size()`; this PR fixes `code_size` itself, which #5293 alone does not cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
