### PR TITLE
Bounds-check decoded direct_map entry in IndexIVF::reconstruct

### DIFF
--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -1055,7 +1055,19 @@ InvertedListScanner* IndexIVF::get_InvertedListScanner(
 
 void IndexIVF::reconstruct(idx_t key, float* recons) const {
     idx_t lo = direct_map.get(key);
-    reconstruct_from_offset(lo_listno(lo), lo_offset(lo), recons);
+    const size_t list_no = lo_listno(lo);
+    const size_t offset = lo_offset(lo);
+    FAISS_THROW_IF_NOT_FMT(
+            list_no < nlist,
+            "IndexIVF::reconstruct: list_no %zd out of range (nlist=%zd)",
+            list_no,
+            nlist);
+    FAISS_THROW_IF_NOT_FMT(
+            offset < invlists->list_size(list_no),
+            "IndexIVF::reconstruct: offset %zd out of range (list_size=%zd)",
+            offset,
+            invlists->list_size(list_no));
+    reconstruct_from_offset(list_no, offset, recons);
 }
 
 void IndexIVF::reconstruct_n(idx_t i0, idx_t ni, float* recons) const {


### PR DESCRIPTION
Summary:
`IndexIVF::reconstruct` decodes a packed `(list_no, offset)` from
`direct_map.get(key)` and passes it straight to `reconstruct_from_offset`.
`DirectMap::get` validates the map key and rejects a negative `lo`, but
never checks that the decoded `list_no`/`offset` are consistent with the
inverted lists. A deserialized index whose `direct_map` is inconsistent
with its `invlists` (e.g. `list_no >= nlist`, or an empty `codes`) makes
`ArrayInvertedLists::get_codes(list_no)` index out of bounds — the
`assert(list_no < nlist)` guard is compiled out in opt builds — and
`reconstruct_from_offset`'s `memcpy` faults on a near-null read.

Adds the `list_no < nlist` and `offset < list_size(list_no)` checks that
the sibling `IndexIVFPQR::reconstruct_from_offset` (and the Metal backend)
already perform, at the shared `IndexIVF::reconstruct` entry so every IVF
subtype is covered. Indexes built via `add()` always satisfy these, so no
valid index is rejected. Found by agentic fuzzing.

Reviewed By: bshethmeta

Differential Revision: D112368335


