### PR TITLE
Harden FastScan deserialization: enforce ksub==16 and bound reconstruct()

### DIFF
--- a/faiss/IndexFastScan.cpp
+++ b/faiss/IndexFastScan.cpp
@@ -8,6 +8,7 @@
 #include <faiss/IndexFastScan.h>
 
 #include <omp.h>
+#include <algorithm>
 #include <cstring>
 #include <memory>
 
@@ -617,8 +618,19 @@ template void IndexFastScan::search_dispatch_implem<false>(
         const FastScanDistancePostProcessing& context) const;
 
 void IndexFastScan::reconstruct(idx_t key, float* recons) const {
-    std::vector<uint8_t> code(code_size, 0);
+    FAISS_THROW_IF_NOT_FMT(
+            key >= 0 && key < ntotal,
+            "IndexFastScan::reconstruct: key %zd out of range (ntotal=%zd)",
+            (size_t)key,
+            (size_t)ntotal);
     std::unique_ptr<CodePacker> packer(get_CodePacker());
+    size_t block_no = (size_t)key / packer->nvec;
+    FAISS_THROW_IF_NOT_MSG(
+            mul_no_overflow(
+                    block_no + 1, packer->block_size, "IndexFastScan codes") <=
+                    codes.size(),
+            "IndexFastScan::reconstruct: packed codes buffer too small");
+    std::vector<uint8_t> code(std::max(code_size, packer->code_size), 0);
     packer->unpack_1(codes.data(), key, code.data());
     sa_decode(1, code.data(), recons);
 }

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -866,6 +866,11 @@ static void validate_fastscan_fields(
             M,
             ksub);
     FAISS_THROW_IF_NOT_FMT(
+            ksub == 16,
+            "%s: invalid ksub=%zd (fast-scan requires nbits=4 / ksub=16)",
+            index_type,
+            ksub);
+    FAISS_THROW_IF_NOT_FMT(
             bbs > 0 && bbs % 32 == 0,
             "%s: invalid bbs=%d (must be > 0 and a multiple of 32)",
             index_type,


### PR DESCRIPTION
Summary:
Fast-scan indexes are a 4-bit layout by construction (`init_fastscan`
enforces `nbits == 4` -> `ksub == 16`, `code_size == (M*4+7)/8`), and the
`pq4_*` kernels hardcode a 16-entry / 16-byte sub-LUT stride. The
deserializer, however, reconstructs these fields from the stream without
re-establishing that invariant, allowing three OOB accesses:

1. `validate_fastscan_fields` checks `M`/`M2`/`bbs` but not `ksub`. An
   index with `nbits != 4` (`ksub != 16`) makes `IndexFastScan::search`
   size the LUT buffers as `n*ksub*M2` while `pq4_pack_LUT` copies at a
   hardcoded 16-byte stride -> heap OOB read/write. Now rejects `ksub != 16`.

2. `IndexFastScan::reconstruct` unpacks a block for `key` from `codes`
   with no bounds check; a crafted index declaring `ntotal > 0` with an
   empty/undersized `codes` blob reads OOB in `pq4_get_packed_element`.

3. The reconstruct staging buffer is sized from the deserialized
   `code_size`, while `CodePackerPQ4::unpack_1` writes `packer->code_size`
   bytes; a smaller `code_size` (e.g. `nbits==0`) yields an OOB write.

`reconstruct` now bounds `key` against `ntotal`, verifies the packed block
lies within `codes`, and sizes the staging buffer to `max(code_size,
packer->code_size)`. Valid indexes are unaffected (`ksub==16`,
`code_size==packer->code_size`, full blocks). Found by agentic fuzzing.

Differential Revision: D112368331


