### PR TITLE
Reject degenerate code_size==0 IndexPQ with ntotal>0 on deserialization

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -1702,6 +1702,10 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         read_ProductQuantizer(&idxp->pq, f);
         idxp->code_size = idxp->pq.code_size;
         read_vector(idxp->codes, f);
+        FAISS_THROW_IF_NOT_MSG(
+                idxp->code_size > 0 || idxp->ntotal == 0,
+                "IndexPQ with ntotal > 0 must have code_size > 0 "
+                "(corrupt ProductQuantizer nbits?)");
         FAISS_THROW_IF_NOT(
                 idxp->codes.size() ==
                 mul_no_overflow(


### PR DESCRIPTION
Summary:
`read_ProductQuantizer` accepts `nbits == 0` (only `nbits <= 24` is
enforced), which derives `code_size == 0`. The `IxPq` codes-consistency
check `codes.size() == ntotal * code_size` then degenerates to
`0 == ntotal * 0`, satisfied by an empty `codes` vector for any `ntotal`.
A crafted index with `ntotal >= 1`, `nbits == 0`, and empty codes passes
deserialization, and the first `reconstruct()` hands
`codes.data() == nullptr` to `PQDecoderGeneric::decode` (`reg = *code`) —
a null read that kills the process.

Guards the degenerate `code_size == 0 && ntotal > 0` combination in the
`IxPq` branch (before the existing size check), converting the SIGSEGV
into a clean FaissException. A default-constructed, untrained PQ
(`nbits == 0`, `ntotal == 0`) still deserializes, so no legitimate index
is rejected. Found by agentic fuzzing.

Differential Revision: D112368333


