### PR TITLE
Validate codes/ntotal consistency in Ix2L and IxLa deserialization

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -2118,6 +2118,16 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
                     r2);
         }
         read_index_header(*idxl, f);
+        FAISS_THROW_IF_NOT_FMT(
+                idxl->ntotal == 0,
+                "IndexLattice deserialization carries no code storage; "
+                "ntotal=%zd != 0 is corrupt",
+                (size_t)idxl->ntotal);
+        FAISS_THROW_IF_NOT_FMT(
+                idxl->d == d,
+                "IndexLattice header d=%d inconsistent with encoded d=%d",
+                idxl->d,
+                d);
         READVECTOR(idxl->trained);
         idx = std::move(idxl);
     } else if (h == fourcc("IvSQ")) { // legacy
@@ -2354,6 +2364,10 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         READ1(idxp->code_size_2);
         READ1(idxp->code_size);
         validate_code_size_match(
+                idxp->code_size_1,
+                idxp->q1.coarse_code_size(),
+                "Index2Layer code_size_1");
+        validate_code_size_match(
                 idxp->code_size_2,
                 idxp->pq.code_size,
                 "Index2Layer code_size_2");
@@ -2362,6 +2376,12 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
                 idxp->code_size_1 + idxp->code_size_2,
                 "Index2Layer");
         read_vector(idxp->codes, f);
+        FAISS_THROW_IF_NOT(
+                idxp->codes.size() ==
+                mul_no_overflow(
+                        (size_t)idxp->ntotal,
+                        idxp->code_size,
+                        "Index2Layer codes"));
         idx = std::move(idxp);
     } else if (
             h == fourcc("IHNf") || h == fourcc("IHNp") || h == fourcc("IHNs") ||


### PR DESCRIPTION
Summary:
Two faiss deserialization branches accept an index whose `ntotal` is
inconsistent with its stored `codes`, so the first `reconstruct()` reads
through a null (or out-of-bounds) `codes.data()`:

- `Ix2L` (Index2Layer): reads `ntotal` (header), `code_size_1`,
  `code_size_2`, `code_size`, and `codes` independently. Unlike every
  sibling `IndexFlatCodes` reader it never checked
  `codes.size() == ntotal * code_size`. It also never checked that the
  coarse-code width `code_size_1` matches `q1.nlist` -- and because a PQ
  with `nbits == 0` yields `code_size_2 == 0`, a forged
  `code_size_1 == code_size == 0` made the size check vacuous
  (`0 == ntotal * 0`) while `Level1Quantizer::decode_listno` still reads
  `coarse_code_size(nlist)` bytes from an empty `codes` buffer
  (near-null read at IndexIVF.cpp:148).

- `IxLa` (IndexLattice): the writer persists the header (including
  `ntotal`) but never writes the `codes` vector, so a well-formed IxLa
  index is always empty. A forged `ntotal > 0` leaves `codes` empty and
  `IndexLattice::sa_decode` hands `codes.data() == nullptr` to
  `BitstringReader::read`.

Adds to Ix2L both the standard `mul_no_overflow` codes-size check and a
`code_size_1 == q1.coarse_code_size()` check (so the coarse width matches
nlist and the size check can no longer be made vacuous). For IxLa enforces
`ntotal == 0` plus header/encoded `d` consistency. All convert a SIGSEGV
into a clean FaissException, matching the existing hardening on this
surface. Found by agentic fuzzing.

Differential Revision: D112368337


