### PR TITLE
Harden reconstruct()/reset() against null storage in composite indexes

### DIFF
--- a/faiss/IndexNNDescent.cpp
+++ b/faiss/IndexNNDescent.cpp
@@ -183,11 +183,19 @@ void IndexNNDescent::add(idx_t n, const float* x) {
 
 void IndexNNDescent::reset() {
     nndescent.reset();
+    FAISS_THROW_IF_NOT_MSG(
+            storage,
+            "Please use IndexNNDescentFlat (or variants) "
+            "instead of IndexNNDescent directly");
     storage->reset();
     ntotal = 0;
 }
 
 void IndexNNDescent::reconstruct(idx_t key, float* recons) const {
+    FAISS_THROW_IF_NOT_MSG(
+            storage,
+            "Please use IndexNNDescentFlat (or variants) "
+            "instead of IndexNNDescent directly");
     storage->reconstruct(key, recons);
 }
 

--- a/faiss/IndexNSG.cpp
+++ b/faiss/IndexNSG.cpp
@@ -245,12 +245,18 @@ void IndexNSG::add(idx_t n, const float* x) {
 
 void IndexNSG::reset() {
     nsg.reset();
+    FAISS_THROW_IF_NOT_MSG(
+            storage,
+            "Please use IndexNSGFlat (or variants) instead of IndexNSG directly");
     storage->reset();
     ntotal = 0;
     is_built = false;
 }
 
 void IndexNSG::reconstruct(idx_t key, float* recons) const {
+    FAISS_THROW_IF_NOT_MSG(
+            storage,
+            "Please use IndexNSGFlat (or variants) instead of IndexNSG directly");
     storage->reconstruct(key, recons);
 }
 

--- a/faiss/IndexPreTransform.cpp
+++ b/faiss/IndexPreTransform.cpp
@@ -229,6 +229,7 @@ size_t IndexPreTransform::remove_ids(const IDSelector& sel) {
 }
 
 void IndexPreTransform::reconstruct(idx_t key, float* recons) const {
+    FAISS_THROW_IF_NOT_MSG(index, "IndexPreTransform: null sub-index");
     float* x = chain.empty() ? recons : new float[index->d];
     std::unique_ptr<float[]> del(recons == x ? nullptr : x);
     // Initial reconstruction
@@ -239,6 +240,7 @@ void IndexPreTransform::reconstruct(idx_t key, float* recons) const {
 }
 
 void IndexPreTransform::reconstruct_n(idx_t i0, idx_t ni, float* recons) const {
+    FAISS_THROW_IF_NOT_MSG(index, "IndexPreTransform: null sub-index");
     float* x = chain.empty() ? recons : new float[ni * index->d];
     std::unique_ptr<float[]> del(recons == x ? nullptr : x);
     // Initial reconstruction


### PR DESCRIPTION
Summary:
`IndexNSG`, `IndexNNDescent`, and `IndexPreTransform` dereference a
sub-index (`storage` / `index`) in `reconstruct()` (and `reset()` /
`reconstruct_n()`) with no null check. Every sibling method on these
classes (`search`/`add`/`build`/`train`) already guards the same pointer
with `FAISS_THROW_IF_NOT_MSG(...)`, but the reconstruct/reset paths were
missed.

A serialized index whose sub-index slot carries the `fourcc("null")`
marker deserializes with the pointer left null (a legal deserialization
outcome — the reader returns `nullptr` for that marker, and the
cross-checks are skipped when the pointer is null). The first
`reconstruct()` call then makes a virtual call through the null pointer
and SIGSEGVs the process instead of raising a catchable `FaissException`.

This adds the same guard the sibling methods already use, so a missing
storage sub-index fails with a clean `FaissException` on this widely
hardened deserialization surface. Found by agentic fuzzing.

Differential Revision: D112368330


