### PR TITLE
Guard exhaustive_{inner_product,L2sqr}_seq against empty query batches (nx=0)

### DIFF
--- a/faiss/IndexFlat.cpp
+++ b/faiss/IndexFlat.cpp
@@ -581,6 +581,10 @@ inline void flat_pano_search_core(
         const SearchParameters* params) {
     using SingleResultHandler = typename BlockHandler::SingleResultHandler;
 
+    if (n <= 0) {
+        return;
+    }
+
     IDSelector* sel = params ? params->sel : nullptr;
     bool use_sel = sel != nullptr;
 
@@ -800,6 +804,10 @@ void IndexFlatPanorama::search_subset(
 
             FAISS_THROW_IF_NOT(k > 0);
             FAISS_THROW_IF_NOT(batch_size == 1);
+
+            if (n <= 0) {
+                return;
+            }
 
             [[maybe_unused]] int nt = std::min(int(n), omp_get_max_threads());
 

--- a/faiss/utils/distances.cpp
+++ b/faiss/utils/distances.cpp
@@ -291,6 +291,11 @@ void exhaustive_inner_product_seq(
         BlockResultHandler& res) {
     using SingleResultHandler =
             typename BlockResultHandler::SingleResultHandler;
+
+    if (nx == 0) {
+        return;
+    }
+
     [[maybe_unused]] int nt = std::min(int(nx), omp_get_max_threads());
 
 #pragma omp parallel num_threads(nt)
@@ -327,6 +332,11 @@ void exhaustive_L2sqr_seq(
         BlockResultHandler& res) {
     using SingleResultHandler =
             typename BlockResultHandler::SingleResultHandler;
+
+    if (nx == 0) {
+        return;
+    }
+
     [[maybe_unused]] int nt = std::min(int(nx), omp_get_max_threads());
 
 #pragma omp parallel num_threads(nt)

--- a/tests/test_flat_panorama.py
+++ b/tests/test_flat_panorama.py
@@ -452,6 +452,25 @@ class TestIndexFlatPanorama(unittest.TestCase):
                 self.assertEqual(D.shape, (nq, k))
                 self.assertEqual(I.shape, (nq, k))
 
+    def test_empty_query_batch(self):
+        """Test search() and range_search() with an empty query batch
+        (nq=0). This must not enter the OpenMP parallel region with
+        num_threads(0), which is unspecified behavior."""
+        d, nb, nt, nlevels, k = 32, 500, 700, 4, 5
+        _, xb, _ = self.generate_data(d, nt, nb, nq=1, seed=1414)
+        xq_empty = np.empty((0, d)).astype("float32")
+
+        for metric in self.METRICS:
+            with self.subTest(metric=metric):
+                index = self.create_panorama(d, nlevels, xb, metric=metric)
+
+                D, I = index.search(xq_empty, k)
+                self.assertEqual(D.shape, (0, k))
+                self.assertEqual(I.shape, (0, k))
+
+                lims, _, _ = index.range_search(xq_empty, 1.0)
+                np.testing.assert_array_equal(lims, np.zeros(1, dtype=np.int64))
+
     def test_very_small_dataset(self):
         """Test with dataset smaller than batch size (< 128 vectors)"""
         test_cases = [10, 50, 100]

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -112,6 +112,31 @@ class TestIndexFlat(unittest.TestCase):
     def test_with_blas_reservoir_ip(self):
         self.do_test(200, faiss.METRIC_INNER_PRODUCT, k=150)
 
+    def test_empty_query_batch(self):
+        """search()/range_search() with nq=0 must not enter an OpenMP
+        parallel region with num_threads(0), which is unspecified
+        behavior. An empty batch always has nq * d below
+        distance_compute_blas_threshold, so this exercises the non-BLAS
+        exhaustive_{inner_product,L2sqr}_seq path unconditionally."""
+        d = 32
+        nb = 1000
+        _, xb, _ = get_dataset_2(d, 0, nb, 1)
+        xq_empty = np.empty((0, d), dtype="float32")
+
+        for metric_type in (faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT):
+            with self.subTest(metric_type=metric_type):
+                index = faiss.IndexFlat(d, metric_type)
+                index.add(xb)
+
+                D, I = index.search(xq_empty, 10)
+                self.assertEqual(D.shape, (0, 10))
+                self.assertEqual(I.shape, (0, 10))
+
+                lims, _, _ = index.range_search(xq_empty, 1.0)
+                np.testing.assert_array_equal(
+                    lims, np.zeros(1, dtype=np.int64)
+                )
+
 
 @for_all_simd_levels
 class TestDbParallelSearch(unittest.TestCase):

--- a/tests/test_refine_panorama.py
+++ b/tests/test_refine_panorama.py
@@ -233,6 +233,27 @@ class TestIndexRefinePanorama(unittest.TestCase):
                     D_regular, I_regular, D_panorama, I_panorama
                 )
 
+    def test_empty_query_batch(self):
+        """Test search() with an empty query batch (nq=0), which is routed
+        through IndexFlatPanorama::search_subset. This must not enter the
+        OpenMP parallel region with num_threads(0), which is unspecified
+        behavior."""
+        d, nb, nt, nlevels, k = 32, 500, 700, 1, 5
+        xt, xb, _ = self.generate_data(d, nt, nb, nq=1, seed=1515)
+        xq_empty = np.empty((0, d)).astype("float32")
+
+        base_cfg = "Flat"
+
+        for metric in self.METRICS:
+            with self.subTest(metric=metric):
+                index_panorama = self.create_panorama(
+                    d, base_cfg, nlevels, xt=xt, xb=xb, metric=metric
+                )
+
+                D, I = index_panorama.search(xq_empty, k)
+                self.assertEqual(D.shape, (0, k))
+                self.assertEqual(I.shape, (0, k))
+
     def test_id_selector_range(self):
         """Test ID filtering with range selector"""
         d, nb, nt, nq, nlevels, k = 128, 80000, 120000, 500, 8, 20


### PR DESCRIPTION
Summary:
Found while self-reviewing the sibling IndexFlatPanorama fix in this
stack: `exhaustive_inner_product_seq` and `exhaustive_L2sqr_seq` in
`utils/distances.cpp` compute
`int nt = std::min(int(nx), omp_get_max_threads())` and then open
`#pragma omp parallel num_threads(nt)`, with no `nx > 0` guard -- the
identical bug class just fixed for `IndexFlatPanorama`, but here backing
plain `IndexFlat::search`/`IndexFlat::range_search` (`IndexFlatL2`,
`IndexFlatIP`, and anything composing them: `IndexIDMap`,
`IndexPreTransform`, `IndexRefineFlat`, etc.) -- the single most widely
used search path in FAISS.

`IndexFlat::search` has no `n > 0` guard before dispatching to
`knn_inner_product`/`knn_L2sqr` (`IndexFlat.cpp:29-59`). Those route to
`Run_search_inner_product::f`/`Run_search_L2sqr::f`
(`utils/distances.cpp:545-580`), which call the `_seq` (non-BLAS) path
whenever `res.sel` is set (any ID selector) OR `nx * d` is below
`distance_compute_blas_threshold` (default 128000) -- always true when
`nx == 0`. So `IndexFlat::search(0, x, k, ...)` reaches `nt =
std::min(0, omp_get_max_threads()) == 0` and
`#pragma omp parallel num_threads(0)` unconditionally, every time.

Per the OpenMP specification, `num_threads` "must evaluate to a positive
integer" -- 0 is unspecified behavior. This devserver's runtime tolerates
it (see below), but is not guaranteed to on every OpenMP implementation
FAISS's production toolchain may link.

Fix: add `if (nx == 0) { return; }` before `nt` is computed, in both
functions -- mirroring the exact guard style already used two functions
below in the same file, in the BLAS counterparts
`exhaustive_inner_product_blas`/`exhaustive_L2sqr_blas_default_impl`
("BLAS does not like empty matrices", `nx == 0 || ny == 0`). Deliberately
NOT copying the `ny == 0` half of that guard here: the BLAS path's
`ny == 0` early return is itself a separate, already-tracked bug (see
finding #6 in the improver findings log -- it skips `begin_multiple`/
`end_multiple` entirely, leaving `distances`/`labels` uninitialized for
`nx > 0, ny == 0`). The `_seq` path does not have that problem: each
query's `resi.begin(i)` already heap-heapifies (or reservoir/range-inits)
to neutral/-1 values per query regardless of `ny`, so `ny == 0` with
`nx > 0` already produces correct "no results" output today. Only the
`nx == 0` case needed a guard, and it needed one specifically to avoid
`num_threads(0)`, not to fix an output-correctness gap.

Verified empirically (temporarily reverted both guards, rebuilt, reran
the new test): on this devserver's OpenMP runtime, `num_threads(0)` does
not crash and the test passes either way -- consistent with the sibling
Panorama diff in this stack. Recording this explicitly rather than
claiming a crash we did not observe; the fix closes real, spec-defined
undefined behavior on FAISS's single most-used search entry point
regardless of whether it reproduces on this specific box.

Swept the rest of the tree for the same `std::min(int(n...),
omp_get_max_threads())` -> `num_threads(nt)` pattern: only two other
sites exist in all of fbcode/faiss/, both in `IndexFlat.cpp`, both
already fixed by the previous diff in this stack. Two adjacent
`num_threads(nt)` sites with different `nt` derivations
(`impl/PolysemousTraining.cpp`, `utils/sorting.cpp`'s
`fvec_argsort_parallel`/`parallel_merge`) were also inspected; both
derive `nt` from internal, not directly user-controlled, values (`pq.M`,
recursive thread-count splitting) and are lower-confidence/harder to
reach -- logged in the findings log for future investigation rather than
folded into this diff.

Reviewed By: trang-nm-nguyen

Differential Revision: D112314349
