### PR TITLE
Raise HNSW visited-table hash-set threshold from 500k to 10M (#5446)

### DIFF
--- a/faiss/impl/VisitedTable.cpp
+++ b/faiss/impl/VisitedTable.cpp
@@ -15,8 +15,12 @@ namespace faiss {
 // advance() is O(1) except every 250 calls, which are O(size).
 // The hash set strategy is a constant factor slower for get()/set(),
 // but O(1) to construct and O(visits) to advance.
-// A size of ~1M seems to be the threshold where the hash set wins.
-size_t visited_table_hashset_threshold = 500000;
+// 10M is only a current estimated threshold, not a proven crossover: we are not
+// sure the array still wins at 10M. The point where the array stops paying off
+// varies by dataset (it shifts with dimension, working-set / cache pressure,
+// etc.), so this is a coarse default that should eventually be replaced by
+// smarter per-index tuning.
+size_t visited_table_hashset_threshold = 10000000;
 
 std::unique_ptr<VisitedTable> VisitedTable::create(
         size_t size,


### PR DESCRIPTION
## Summary

`HNSW` search maintains a per-thread visited set, and `faiss` chooses its implementation by index size via `visited_table_hashset_threshold`: below the threshold it uses a version-stamped byte array (`VisitedTableVector`, O(1) direct-index `get`/`set`, O(n) memory); at/above it, a hash set (`VisitedTableSet`, hash-and-probe per access, memory proportional to nodes visited).

The current 500k cutoff is too low. It forces million-scale in-memory indexes onto the hash set, whose hash-and-probe on every visited neighbor is markedly slower than the array's single indexed access - while the array's footprint (~1 byte/node, ~1 MB/thread at 1M) is entirely affordable for in-memory HNSW. **This raises the cutoff to 10M so ~1M–10M indexes get the faster array. Callers can still force either implementation per index via `HNSW::use_visited_hashset`**.

Note: 10M is a heuristic estimate, not a tuned optimum. The real array-vs-hash-set crossover is dataset-dependent - in particular it shrinks with vector dimension: at very high dimension the distance computation dominates per-node cost, so the array's access advantage vanishes and its larger cache footprint can even make it marginally slower (see test plan: dbpedia at 3072d is ~neutral, while 128d–960d gain clearly). A follow-up should make this smarter - e.g. tune the threshold per index accounting for dimension / vector byte-size, or use a lossy / more compact visited structure that trades a little accuracy for lower access + memory cost.

Reviewed By: mnorris11, pankajsingh88

Differential Revision: D112025912

## Evaluation
This change alone (versioned array vs. untouched hash-set) on 3 1M-scale datasets — `sift-1M` (128d L2), `gist-1M` (960d L2), `dbpedia-openai-1M` (3072d IP). HNSW32, efConstruction 40, efSearch sweep [16, 32, 64, 128, 256], batch size [1, full query set], 8 search threads, dynamic dispatch on AVX-512, best-of-10 search repeats. Recall is identical base-vs-fixed (search-time change only).

Plot: top row = single-query QPS vs recall (base dashed, fixed solid); bottom row = speedup (fixed / base) vs recall, single-query and full-batch, shared y-scale.
<img width="1540" height="860" alt="faiss_fix1_3ds" src="https://github.com/user-attachments/assets/64b2d7e7-5b5b-49ba-9897-6ef229a50f5a" />

Speedup (fixed / base) at matched recall:
- `sift-1M` (128d): single-query 1.07–1.75x, full-batch 1.45–1.76x
- `gist-1M` (960d): single-query 1.06–1.28x, full-batch 1.08–1.16x
- `dbpedia-openai-1M` (3072d): single-query 0.92–1.02x, full-batch 0.97–0.98x

Takeaway: raising the threshold improves 1M-scale performance for low/mid-dimensional datasets (up to ~1.8x) at zero recall cost.

On `dbpedia-openai-1M` (3072d) there is a minor regression (~2-8%). At very high dimension the array's fast-access advantage disappears (the distance computation dominates per-node cost), while the versioned array's memory behavior costs a little: the per-`search()` allocation + zeroing of the whole array (frequent memory operations), and a degraded cache-hit rate for the array's scattered accesses (the ~1 MB array gets evicted by the large 12 KB/vector streams, causing cache contention). This is minor and specific to very-high-dimensional data.


