### PR TITLE
pyfaiss_gpu_cuvs_2602: cuVS faiss Python for aarch64/GH200 (26.02, CUDA 12.4)

### DIFF
--- a/faiss/gpu/GpuDistance.cu
+++ b/faiss/gpu/GpuDistance.cu
@@ -233,7 +233,10 @@ void bfKnn(GpuResourcesProvider* prov, const GpuDistanceParams& args) {
             "limitation: both vectorType and queryType must currently "
             "be the same (F32 / F16 / BF16");
 
-#if defined USE_NVIDIA_CUVS
+// cuVS brute-force (flat) lives in the full cuVS build only; the aarch64
+// cuvs-ivfpq subset omits neighbors/brute_force, so FAISS_CUVS_NO_FLAT compiles
+// this branch out and bfKnn falls back to faiss's own kernels below.
+#if defined(USE_NVIDIA_CUVS) && !defined(FAISS_CUVS_NO_FLAT)
     // Note: For now, cuVS bfknn requires queries and vectors to be same layout
     if (should_use_cuvs(args) && args.queriesRowMajor == args.vectorsRowMajor &&
         args.outIndicesType == IndicesDataType::I64 &&

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -437,7 +437,10 @@ int64_t cast_cudastream_t_to_integer(hipStream_t x) {
 
 #else // FAISS_ENABLE_ROCM
 
-#ifdef FAISS_ENABLE_CUVS
+// CAGRA is absent from the aarch64 cuVS build (cuvs-ivfpq subset), so gate the
+// CAGRA bindings on FAISS_CUVS_NO_CAGRA too, else the wrapper references
+// undefined GpuIndexCagra symbols when linked against the aarch64 faiss_cuvs.
+#if defined(FAISS_ENABLE_CUVS) && !defined(FAISS_CUVS_NO_CAGRA)
 %shared_ptr(faiss::gpu::IVFPQBuildCagraConfig);
 %shared_ptr(faiss::gpu::IVFPQSearchCagraConfig);
 
@@ -447,7 +450,7 @@ int64_t cast_cudastream_t_to_integer(hipStream_t x) {
 #include <faiss/gpu/GpuIndexBinaryCagra.h>
 
 %}
-#endif // FAISS_ENABLE_CUVS
+#endif // FAISS_ENABLE_CUVS && !FAISS_CUVS_NO_CAGRA
 
 typedef CUstream_st* cudaStream_t;
 
@@ -774,7 +777,7 @@ void gpu_sync_all_devices()
 %include  <faiss/gpu/GpuIndicesOptions.h>
 %include  <faiss/gpu/GpuClonerOptions.h>
 %include  <faiss/gpu/GpuIndex.h>
-#ifdef FAISS_ENABLE_CUVS
+#if defined(FAISS_ENABLE_CUVS) && !defined(FAISS_CUVS_NO_CAGRA)
 // IVFPQSearchCagraConfig.lut_dtype and .internal_distance_dtype are typed as
 // cudaDataType_t (a C enum from <library_types.h>). Without an int typemap
 // SWIG generates accessors that read/write a cudaDataType_t* SwigPyObject,
@@ -931,7 +934,7 @@ typedef int cudaDataType_t;
     DOWNCAST ( IndexSVSIVF )
 #endif // FAISS_ENABLE_SVS
 #ifdef GPU_WRAPPER
-#ifdef FAISS_ENABLE_CUVS
+#if defined(FAISS_ENABLE_CUVS) && !defined(FAISS_CUVS_NO_CAGRA)
     DOWNCAST_GPU ( GpuIndexCagra )
     DOWNCAST_GPU ( GpuIndexBinaryCagra )
 #endif


### PR DESCRIPTION
Summary: get python bindings working when compiling out various parts of cuVS

Differential Revision: D112825740


