### PR TITLE
Throw instead of abort on null buffer in RaBitQuantizer::decode_core (#5465)

### DIFF
--- a/faiss/impl/RaBitQuantizer.cpp
+++ b/faiss/impl/RaBitQuantizer.cpp
@@ -185,8 +185,10 @@ void RaBitQuantizer::decode_core(
         float* x,
         size_t n,
         const float* centroid_in) const {
-    FAISS_ASSERT(codes != nullptr);
-    FAISS_ASSERT(x != nullptr);
+    FAISS_THROW_IF_MSG(
+            codes == nullptr, "RaBitQuantizer::decode_core: null codes buffer");
+    FAISS_THROW_IF_MSG(
+            x == nullptr, "RaBitQuantizer::decode_core: null output buffer");
 
     const float inv_d_sqrt = (d == 0) ? 1.0f : (1.0f / std::sqrt((float)d));
     const size_t ex_bits = nb_bits - 1;


### PR DESCRIPTION
Summary:

Agentic fuzzing (T279738382) found that deserializing an `IndexRaBitQ`
whose `codes` vector is empty while the header-declared `ntotal >= 1`
reaches `RaBitQuantizer::decode_core` with a null `codes` pointer
(`IndexFlatCodes::codes.data()` is null for an empty vector). The two
`FAISS_ASSERT` guards there print to stderr and call `abort()` — a
process-killing SIGABRT (DoS) rather than a recoverable error.

Convert the two fatal asserts to `FAISS_THROW_IF_NOT_MSG`, which raises a
catchable `FaissException`. This matches faiss's documented failure mode
for malformed input on the reconstruct path (and is already handled by
deserializing consumers and by the fuzz harness `run_fuzz_iteration`).
The checks sit at function entry, outside the decode loop, so there is no
hot-path cost. The sibling encode guard in `compute_codes_core` is left
as-is: it is reached via `add()`, not from untrusted deserialized input.

Differential Revision: D113119667


