### PR TITLE
Bound decode-cache compute in ZnSphereCodecRec deserialization

### DIFF
--- a/faiss/impl/lattice_Zn.cpp
+++ b/faiss/impl/lattice_Zn.cpp
@@ -557,12 +557,11 @@ ZnSphereCodecRec::ZnSphereCodecRec(int dim_in, int r2_in)
 
     decode_cache.resize((r2 + 1));
 
-    // The decode cache stores total_cache_entries * dimsub floats.
-    // Cap at 2^27 total floats (~512 MB), aligned with the nv_cum
-    // memory cap above which also uses 2^27 entries.  The entry count
-    // grows as the number of lattice points in dimension
-    // 2^cache_level, which is O(r2^(dim/2)) -- much faster than the
-    // O(r2^2) growth of nv_cum.
+    // The decode cache stores total_cache_entries * dimsub floats and is
+    // built with one decode() call per entry. The entry count grows as the
+    // number of lattice points in dimension 2^cache_level, which is
+    // O(r2^(dim/2)) -- much faster than the O(r2^2) growth of nv_cum, so it
+    // is bounded per-r2sub in the loop below.
     size_t total_cache_entries = 0;
     int dimsub = (1 << cache_level);
 
@@ -571,9 +570,9 @@ ZnSphereCodecRec::ZnSphereCodecRec(int dim_in, int r2_in)
         uint64_t nvi = get_nv(ld, r2sub);
         total_cache_entries += nvi;
         FAISS_THROW_IF_NOT_MSG(
-                total_cache_entries <= (size_t(1) << 27) / dimsub,
-                "ZnSphereCodecRec: r2 too large, decode cache "
-                "would require excessive memory");
+                total_cache_entries <= (size_t(1) << 27) / (size_t)dim,
+                "ZnSphereCodecRec: r2/dim too large, decode cache "
+                "would require excessive memory and computation");
         std::vector<float>& cache = decode_cache[r2sub];
         cache.resize(nvi * dimsub);
         std::vector<float> c(dim);


### PR DESCRIPTION
Summary:
Agentic fuzzing (T279545561, T279518049 — the same signature via two
harnesses) found a multi-second timeout in `ZnSphereCodecRec::decode`
reached while deserializing an `IndexLattice`. The `ZnSphereCodecRec`
constructor builds a decode cache by calling `decode()` once per cache
entry, and each `decode()` costs O(`dim`). The pre-existing cap bounded
only stored cache memory (`total_cache_entries * dimsub <= 2^27`, with
`dimsub = 2^min(3, log2_dim-1)` clamped at 8 ), so a crafted index with
large `dim`/`r2` stayed under it while driving billions of `decode`
operations, exceeding the fuzzer's 10s per-input timeout.

Replace that memory-only cap with a single bound `total_cache_entries *
dim <= 2^27`. One check covers both cost dimensions at once:

- Construction cost is one O(`dim`) `decode()` per entry, i.e.
  `entries * dim` operations (~1.3e8 at the cap, sub-second).
- Cache memory is `entries * dimsub` floats. Because `dimsub < dim`
  always (`dimsub = 2^min(3, log2_dim-1) < 2^log2_dim = dim`),
  `entries * dim <= 2^27` implies `entries * dimsub <= 2^27`. So the
  single compute check subsumes the old memory bound — a separate memory
  check would be strictly redundant.

`dim >= 1` is guaranteed by the constructor's power-of-two check, so
there is no divide-by-zero, and the `2^27` constant is reused for
alignment with the `nv_cum` cap above. Placing the check in the
constructor protects every construction path (deserialization,
`index_factory`, direct construction) and runs once at construction, not
on the search hot path. Real lattice configs (the `ZnSphereCodecAlt`
fallback is dim=8/r2=14; factory configs use small power-of-two dim with
small r2) are orders of magnitude under the bound; only crafted blow-ups
are rejected, now with a catchable `FaissException` that
`run_fuzz_iteration` already swallows.

Differential Revision: D113405533


