### PR TITLE
Remove confusing double-negative throw-macro conditions

### DIFF
--- a/faiss/IndexAdditiveQuantizer.cpp
+++ b/faiss/IndexAdditiveQuantizer.cpp
@@ -235,8 +235,7 @@ void IndexAdditiveQuantizer::search(
         float* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
 
     if (aq->search_type == AdditiveQuantizer::ST_decompress) {
         with_VectorDistance(d, metric_type, metric_arg, [&](auto vd) {
@@ -459,8 +458,7 @@ void AdditiveCoarseQuantizer::search(
         float* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
 
     if (metric_type == METRIC_INNER_PRODUCT) {
         aq->knn_centroids_inner_product(n, x, k, distances, labels);

--- a/faiss/IndexAdditiveQuantizerFastScan.cpp
+++ b/faiss/IndexAdditiveQuantizerFastScan.cpp
@@ -36,7 +36,7 @@ void IndexAdditiveQuantizerFastScan::init(
         MetricType metric,
         int bbs_) {
     FAISS_THROW_IF_NOT(aq_init != nullptr);
-    FAISS_THROW_IF_NOT(!aq_init->nbits.empty());
+    FAISS_THROW_IF_MSG(aq_init->nbits.empty(), "nbits must not be empty");
     FAISS_THROW_IF_NOT(aq_init->nbits[0] == 4);
     if (metric == METRIC_INNER_PRODUCT) {
         FAISS_THROW_IF_NOT_MSG(
@@ -192,8 +192,7 @@ void IndexAdditiveQuantizerFastScan::search(
         float* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
     FAISS_THROW_IF_NOT(k > 0);
     bool rescale = (rescale_norm && norm_scale > 1 && metric_type == METRIC_L2);
     if (!rescale) {

--- a/faiss/IndexBinaryFromFloat.cpp
+++ b/faiss/IndexBinaryFromFloat.cpp
@@ -55,8 +55,7 @@ void IndexBinaryFromFloat::search(
         int32_t* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
     FAISS_THROW_IF_NOT(k > 0);
 
     constexpr idx_t bs = 32768;

--- a/faiss/IndexBinaryHNSW.cpp
+++ b/faiss/IndexBinaryHNSW.cpp
@@ -292,8 +292,8 @@ void IndexBinaryHNSW::reconstruct(idx_t key, uint8_t* recons) const {
 
 DistanceComputer* IndexBinaryHNSW::get_distance_computer() const {
     IndexBinaryFlat* flat_storage = dynamic_cast<IndexBinaryFlat*>(storage);
-    FAISS_THROW_IF_NOT_MSG(
-            flat_storage != nullptr,
+    FAISS_THROW_IF_MSG(
+            flat_storage == nullptr,
             "IndexBinaryHNSW requires IndexBinaryFlat storage");
     return with_simd_level([&]<SIMDLevel SL>() {
         return make_binary_hnsw_distance_computer_fixSL<SL>(
@@ -316,8 +316,8 @@ IndexBinaryHNSWCagra::IndexBinaryHNSWCagra(int d_, int M)
 }
 
 void IndexBinaryHNSWCagra::add(idx_t n, const uint8_t* x) {
-    FAISS_THROW_IF_NOT_MSG(
-            !base_level_only,
+    FAISS_THROW_IF_MSG(
+            base_level_only,
             "Cannot add vectors when base_level_only is set to True");
 
     IndexBinaryHNSW::add(n, x);

--- a/faiss/IndexBinaryHash.cpp
+++ b/faiss/IndexBinaryHash.cpp
@@ -83,8 +83,7 @@ void IndexBinaryHash::range_search(
         int radius,
         RangeSearchResult* result,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
     size_t nlist = 0, ndis = 0, n0 = 0;
 
 #pragma omp parallel if (n > 100) reduction(+ : ndis, n0, nlist)
@@ -116,8 +115,7 @@ void IndexBinaryHash::search(
         int32_t* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
     FAISS_THROW_IF_NOT(k > 0);
 
     using HeapForL2 = CMax<int32_t, idx_t>;
@@ -216,8 +214,7 @@ void IndexBinaryMultiHash::range_search(
         int radius,
         RangeSearchResult* result,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
     size_t nlist = 0, ndis = 0, n0 = 0;
 
 #pragma omp parallel if (n > 100) reduction(+ : ndis, n0, nlist)
@@ -249,8 +246,7 @@ void IndexBinaryMultiHash::search(
         int32_t* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
     FAISS_THROW_IF_NOT(k > 0);
 
     using HeapForL2 = CMax<int32_t, idx_t>;

--- a/faiss/IndexBinaryIVF.cpp
+++ b/faiss/IndexBinaryIVF.cpp
@@ -206,8 +206,7 @@ void IndexBinaryIVF::search_and_reconstruct(
         idx_t* __restrict labels,
         uint8_t* __restrict recons,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
     const size_t nprobe_2 = std::min(nlist, this->nprobe);
     FAISS_THROW_IF_NOT(k > 0);
     FAISS_THROW_IF_NOT(nprobe_2 > 0);
@@ -524,8 +523,7 @@ void IndexBinaryIVF::range_search(
         int radius,
         RangeSearchResult* __restrict res,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
     const size_t nprobe_2 = std::min(nlist, this->nprobe);
     std::unique_ptr<idx_t[]> idx(new idx_t[n * nprobe_2]);
     std::unique_ptr<int32_t[]> coarse_dis(new int32_t[n * nprobe_2]);

--- a/faiss/IndexFastScan.cpp
+++ b/faiss/IndexFastScan.cpp
@@ -267,8 +267,7 @@ void IndexFastScan::search(
         float* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
     FAISS_THROW_IF_NOT(k > 0);
 
     FastScanDistancePostProcessing empty_context{};
@@ -317,7 +316,7 @@ void IndexFastScan::search_dispatch_implem(
     if (implem == 1) {
         FAISS_THROW_MSG("not implemented");
     } else if (implem == 2 || implem == 3 || implem == 4) {
-        FAISS_THROW_IF_NOT(orig_codes != nullptr);
+        FAISS_THROW_IF_NOT(orig_codes);
         search_implem_234<Cfloat>(n, x, k, distances, labels, context);
     } else if (impl >= 12 && impl <= 15) {
         FAISS_THROW_IF_NOT(ntotal < INT_MAX);

--- a/faiss/IndexFlat.cpp
+++ b/faiss/IndexFlat.cpp
@@ -451,8 +451,7 @@ void IndexFlat1D::search(
         float* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
     FAISS_THROW_IF_NOT(k > 0);
     FAISS_THROW_IF_NOT_MSG(
             perm.size() == static_cast<size_t>(ntotal),

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -903,8 +903,7 @@ void IndexHNSW2Level::search(
         idx_t* labels,
         const SearchParameters* params) const {
     FAISS_THROW_IF_NOT(k > 0);
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
 
     if (dynamic_cast<const Index2Layer*>(storage)) {
         IndexHNSW::search(n, x, k, distances, labels);
@@ -1084,8 +1083,8 @@ IndexHNSWCagra::IndexHNSWCagra(
 }
 
 void IndexHNSWCagra::add(idx_t n, const float* x) {
-    FAISS_THROW_IF_NOT_MSG(
-            !base_level_only,
+    FAISS_THROW_IF_MSG(
+            base_level_only,
             "Cannot add vectors when base_level_only is set to True");
 
     IndexHNSW::add(n, x);

--- a/faiss/IndexIVFAdditiveQuantizer.cpp
+++ b/faiss/IndexIVFAdditiveQuantizer.cpp
@@ -283,7 +283,7 @@ InvertedListScanner* IndexIVFAdditiveQuantizer::get_InvertedListScanner(
         bool store_pairs,
         const IDSelector* sel,
         const IVFSearchParameters*) const {
-    FAISS_THROW_IF_NOT(!sel);
+    FAISS_THROW_IF_MSG(sel, "id selector not supported for this index");
     if (metric_type == METRIC_INNER_PRODUCT) {
         if (aq->search_type == AdditiveQuantizer::ST_decompress) {
             return new AQInvertedListScannerDecompress<true>(

--- a/faiss/IndexIVFAdditiveQuantizerFastScan.cpp
+++ b/faiss/IndexIVFAdditiveQuantizerFastScan.cpp
@@ -48,8 +48,8 @@ void IndexIVFAdditiveQuantizerFastScan::init(
         MetricType metric,
         int bbs_,
         bool own_invlists_) {
-    FAISS_THROW_IF_NOT(aq_ != nullptr);
-    FAISS_THROW_IF_NOT(!aq_->nbits.empty());
+    FAISS_THROW_IF_NOT(aq_);
+    FAISS_THROW_IF_MSG(aq_->nbits.empty(), "quantizer nbits must not be empty");
     FAISS_THROW_IF_NOT(aq_->nbits[0] == 4);
     if (metric == METRIC_INNER_PRODUCT) {
         FAISS_THROW_IF_NOT_MSG(
@@ -310,8 +310,7 @@ void IndexIVFAdditiveQuantizerFastScan::search(
         float* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
 
     FAISS_THROW_IF_NOT(k > 0);
     bool rescale = (rescale_norm && norm_scale > 1 && metric_type == METRIC_L2);

--- a/faiss/IndexIVFFastScan.cpp
+++ b/faiss/IndexIVFFastScan.cpp
@@ -376,9 +376,8 @@ void IndexIVFFastScan::search_preassigned(
         cur_nprobe = params->nprobe;
     }
 
-    FAISS_THROW_IF_NOT_MSG(
-            !store_pairs, "store_pairs not supported for this index");
-    FAISS_THROW_IF_NOT_MSG(!stats, "stats not supported for this index");
+    FAISS_THROW_IF_MSG(store_pairs, "store_pairs not supported for this index");
+    FAISS_THROW_IF_MSG(stats, "stats not supported for this index");
     FAISS_THROW_IF_NOT(k > 0);
     FastScanDistancePostProcessing empty_context{};
 
@@ -404,8 +403,8 @@ void IndexIVFFastScan::range_search(
                 params->max_lists_num == 0,
                 "max_lists_num is a knn knob and is not honored by "
                 "fastscan range search");
-        FAISS_THROW_IF_NOT_MSG(
-                !params->ensure_topk_full,
+        FAISS_THROW_IF_MSG(
+                params->ensure_topk_full,
                 "ensure_topk_full is a knn knob and is not honored by "
                 "fastscan range search");
         FAISS_THROW_IF_NOT_MSG(
@@ -1592,7 +1591,7 @@ void IndexIVFFastScan::reconstruct_from_offset(
 }
 
 void IndexIVFFastScan::reconstruct_orig_invlists() {
-    FAISS_THROW_IF_NOT(orig_invlists != nullptr);
+    FAISS_THROW_IF_NOT(orig_invlists);
     FAISS_THROW_IF_NOT(orig_invlists->list_size(0) == 0);
 
 #pragma omp parallel for if (nlist > 100)

--- a/faiss/IndexIVFFlat.cpp
+++ b/faiss/IndexIVFFlat.cpp
@@ -65,7 +65,7 @@ void IndexIVFFlat::add_core(
         void* inverted_list_context) {
     FAISS_THROW_IF_NOT(is_trained);
     FAISS_THROW_IF_NOT(coarse_idx);
-    FAISS_THROW_IF_NOT(!by_residual);
+    FAISS_THROW_IF_MSG(by_residual, "by_residual not supported for this index");
     FAISS_THROW_IF_NOT_MSG(invlists, "invlists not initialized");
     direct_map.check_can_add(xids);
 
@@ -110,7 +110,7 @@ void IndexIVFFlat::encode_vectors(
         const idx_t* list_nos,
         uint8_t* codes,
         bool include_listnos) const {
-    FAISS_THROW_IF_NOT(!by_residual);
+    FAISS_THROW_IF_MSG(by_residual, "by_residual not supported for this index");
     if (!include_listnos) {
         memcpy(codes, x, code_size * n);
     } else {
@@ -291,8 +291,7 @@ void IndexIVFFlatDedup::search_preassigned(
         bool store_pairs,
         const IVFSearchParameters* params,
         IndexIVFStats* /*stats*/) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !store_pairs, "store_pairs not supported in IVFDedup");
+    FAISS_THROW_IF_MSG(store_pairs, "store_pairs not supported in IVFDedup");
 
     IndexIVFFlat::search_preassigned(
             n, x, k, assign, centroid_dis, distances, labels, false, params);

--- a/faiss/IndexIVFIndependentQuantizer.cpp
+++ b/faiss/IndexIVFIndependentQuantizer.cpp
@@ -90,7 +90,7 @@ void IndexIVFIndependentQuantizer::search(
         float* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(!params, "search parameters not supported");
+    FAISS_THROW_IF_MSG(params, "search parameters not supported");
     size_t nprobe = index_ivf->nprobe;
     std::vector<float> D(n * nprobe);
     std::vector<idx_t> I(n * nprobe);

--- a/faiss/IndexIVFRaBitQFastScan.cpp
+++ b/faiss/IndexIVFRaBitQFastScan.cpp
@@ -65,7 +65,7 @@ IndexIVFRaBitQFastScan::IndexIVFRaBitQFastScan(
             "RaBitQ only supports L2 and Inner Product metrics");
     FAISS_THROW_IF_NOT_MSG(
             bbs_in % 32 == 0, "Batch size must be multiple of 32");
-    FAISS_THROW_IF_NOT_MSG(quantizer_in != nullptr, "Quantizer cannot be null");
+    FAISS_THROW_IF_MSG(quantizer_in == nullptr, "Quantizer cannot be null");
 
     by_residual = true;
     qb = 8; // RaBitQ quantization bits
@@ -163,8 +163,10 @@ void IndexIVFRaBitQFastScan::train_encoder(
         const float* x,
         const idx_t* assign) {
     FAISS_THROW_IF_NOT(n > 0);
-    FAISS_THROW_IF_NOT(x != nullptr);
-    FAISS_THROW_IF_NOT(assign != nullptr || !by_residual);
+    FAISS_THROW_IF_NOT(x);
+    FAISS_THROW_IF_MSG(
+            assign == nullptr && by_residual,
+            "assign is required when by_residual is set");
 
     rabitq.train(n, x);
     is_trained = true;
@@ -178,9 +180,9 @@ void IndexIVFRaBitQFastScan::encode_vectors(
         uint8_t* codes,
         bool include_listnos) const {
     FAISS_THROW_IF_NOT(n > 0);
-    FAISS_THROW_IF_NOT(x != nullptr);
-    FAISS_THROW_IF_NOT(list_nos != nullptr);
-    FAISS_THROW_IF_NOT(codes != nullptr);
+    FAISS_THROW_IF_NOT(x);
+    FAISS_THROW_IF_NOT(list_nos);
+    FAISS_THROW_IF_NOT(codes);
     FAISS_THROW_IF_NOT(is_trained);
 
     size_t coarse_size = include_listnos ? coarse_code_size() : 0;
@@ -418,9 +420,9 @@ void IndexIVFRaBitQFastScan::search_preassigned(
         IndexIVFStats* stats) const {
     FAISS_THROW_IF_NOT(is_trained);
     FAISS_THROW_IF_NOT(k > 0);
-    FAISS_THROW_IF_NOT_MSG(
-            !store_pairs, "store_pairs not supported for RaBitQFastScan");
-    FAISS_THROW_IF_NOT_MSG(!stats, "stats not supported for this index");
+    FAISS_THROW_IF_MSG(
+            store_pairs, "store_pairs not supported for RaBitQFastScan");
+    FAISS_THROW_IF_MSG(stats, "stats not supported for this index");
 
     size_t cur_nprobe = this->nprobe;
     uint8_t used_qb = qb;
@@ -677,8 +679,8 @@ void IndexIVFRaBitQFastScan::sa_decode(idx_t n, const uint8_t* bytes, float* x)
         const {
     FAISS_THROW_IF_NOT(is_trained);
     FAISS_THROW_IF_NOT(n > 0);
-    FAISS_THROW_IF_NOT(bytes != nullptr);
-    FAISS_THROW_IF_NOT(x != nullptr);
+    FAISS_THROW_IF_NOT(bytes);
+    FAISS_THROW_IF_NOT(x);
 
     size_t coarse_size = coarse_code_size();
     size_t total_code_size = code_size + coarse_size;

--- a/faiss/IndexIVFSpectralHash.cpp
+++ b/faiss/IndexIVFSpectralHash.cpp
@@ -87,7 +87,7 @@ void IndexIVFSpectralHash::train_encoder(
     if (!vt->is_trained) {
         vt->train(n, x);
     }
-    FAISS_THROW_IF_NOT(!by_residual);
+    FAISS_THROW_IF_MSG(by_residual, "by_residual not supported for this index");
 
     if (threshold_type == Thresh_global) {
         // nothing to do
@@ -184,7 +184,7 @@ void IndexIVFSpectralHash::encode_vectors(
         uint8_t* codes,
         bool include_listnos) const {
     FAISS_THROW_IF_NOT(is_trained);
-    FAISS_THROW_IF_NOT(!by_residual);
+    FAISS_THROW_IF_MSG(by_residual, "by_residual not supported for this index");
     float freq = 2.0 / period;
     size_t coarse_size = include_listnos ? coarse_code_size() : 0;
 
@@ -221,7 +221,7 @@ InvertedListScanner* IndexIVFSpectralHash::get_InvertedListScanner(
         bool store_pairs,
         const IDSelector* sel,
         const IVFSearchParameters*) const {
-    FAISS_THROW_IF_NOT(!sel);
+    FAISS_THROW_IF_MSG(sel, "id selector not supported for this index");
     return with_simd_level([&]<SIMDLevel SL>() {
         return make_spectral_hash_scanner_fixSL<SL>(
                 code_size, this, store_pairs);
@@ -253,8 +253,11 @@ void IndexIVFSpectralHash::replace_vt(IndexPreTransform* encoder, bool own) {
     auto sub_index = dynamic_cast<IndexLSH*>(encoder->index);
     FAISS_THROW_IF_NOT_MSG(sub_index, "final index should be LSH");
     FAISS_THROW_IF_NOT(sub_index->nbits == nbit);
-    FAISS_THROW_IF_NOT(!sub_index->rotate_data);
-    FAISS_THROW_IF_NOT(!sub_index->train_thresholds);
+    FAISS_THROW_IF_MSG(
+            sub_index->rotate_data, "LSH sub-index must not rotate data");
+    FAISS_THROW_IF_MSG(
+            sub_index->train_thresholds,
+            "LSH sub-index thresholds must already be trained");
     replace_vt(encoder->chain[0], own);
 }
 

--- a/faiss/IndexLSH.cpp
+++ b/faiss/IndexLSH.cpp
@@ -119,8 +119,7 @@ void IndexLSH::search(
         float* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
     FAISS_THROW_IF_NOT(k > 0);
     FAISS_THROW_IF_NOT(is_trained);
     const float* xt = apply_preprocess(n, x);
@@ -151,7 +150,7 @@ void IndexLSH::transfer_thresholds(LinearTransform* vt) {
         vt->b.resize(nbits, 0);
         vt->have_bias = true;
     }
-    FAISS_THROW_IF_NOT(!vt->b.empty());
+    FAISS_THROW_IF_MSG(vt->b.empty(), "bias vector must not be empty");
     for (int i = 0; i < nbits; i++) {
         vt->b[i] -= thresholds[i];
     }

--- a/faiss/IndexNNDescent.cpp
+++ b/faiss/IndexNNDescent.cpp
@@ -101,8 +101,7 @@ void IndexNNDescent::search(
         float* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
     FAISS_THROW_IF_NOT_MSG(
             storage,
             "Please use IndexNNDescentFlat (or variants) "

--- a/faiss/IndexNSG.cpp
+++ b/faiss/IndexNSG.cpp
@@ -62,8 +62,7 @@ void IndexNSG::search(
         float* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
     FAISS_THROW_IF_NOT_MSG(
             storage,
             "Please use IndexNSGFlat (or variants) instead of IndexNSG directly");

--- a/faiss/IndexPQ.cpp
+++ b/faiss/IndexPQ.cpp
@@ -107,7 +107,7 @@ void IndexPQ::search(
     if (iparams) {
         params = dynamic_cast<const SearchParametersPQ*>(iparams);
         FAISS_THROW_IF_NOT_MSG(params, "invalid search params");
-        FAISS_THROW_IF_NOT_MSG(!params->sel, "selector not supported");
+        FAISS_THROW_IF_MSG(params->sel, "selector not supported");
         param_search_type = params->search_type;
     }
 
@@ -459,7 +459,7 @@ struct SortedArray {
 
     void init(const T* x_2) {
         this->x = x_2;
-        FAISS_THROW_IF_NOT(!perm.empty());
+        FAISS_THROW_IF_MSG(perm.empty(), "permutation array must not be empty");
         for (int n = 0; n < N; n++) {
             perm[n] = n;
         }
@@ -543,7 +543,7 @@ struct SemiSortedArray {
 
     void init(const T* x_2) {
         this->x = x_2;
-        FAISS_THROW_IF_NOT(!perm.empty());
+        FAISS_THROW_IF_MSG(perm.empty(), "permutation array must not be empty");
         for (int n = 0; n < N; n++) {
             perm[n] = n;
         }
@@ -665,7 +665,7 @@ struct MinSumK {
 
     void mark_seen(int64_t i) {
         if (use_seen) {
-            FAISS_THROW_IF_NOT(!seen.empty());
+            FAISS_THROW_IF_MSG(seen.empty(), "seen bitmap must not be empty");
             seen[i >> 3] |= 1 << (i & 7);
         }
     }
@@ -795,8 +795,7 @@ void MultiIndexQuantizer::search(
         float* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
     if (n == 0) {
         return;
     }
@@ -943,8 +942,7 @@ void MultiIndexQuantizer2::search(
         float* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
 
     if (n == 0) {
         return;

--- a/faiss/IndexRaBitQ.cpp
+++ b/faiss/IndexRaBitQ.cpp
@@ -122,8 +122,8 @@ struct Run_search_with_dc_res {
                     // RaBitQuantizer.cpp for details.
                     auto* dc = dynamic_cast<RaBitQDistanceComputer*>(
                             dc_base.get());
-                    FAISS_THROW_IF_NOT_MSG(
-                            dc != nullptr,
+                    FAISS_THROW_IF_MSG(
+                            dc == nullptr,
                             "Failed to cast to RaBitQDistanceComputer for two-stage search");
 
                     bool is_similarity =

--- a/faiss/IndexRaBitQFastScan.cpp
+++ b/faiss/IndexRaBitQFastScan.cpp
@@ -512,8 +512,7 @@ void IndexRaBitQFastScan::search(
         float* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
 
     // Create query factors array on stack - memory managed by caller
     std::vector<rabitq_utils::QueryFactorsData> query_factors_storage(n);

--- a/faiss/IndexReplicas.cpp
+++ b/faiss/IndexReplicas.cpp
@@ -127,8 +127,7 @@ void IndexReplicasTemplate<IndexT>::search(
         distance_t* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
     FAISS_THROW_IF_NOT(k > 0);
     FAISS_THROW_IF_NOT_MSG(this->count() > 0, "no replicas in index");
 

--- a/faiss/IndexShards.cpp
+++ b/faiss/IndexShards.cpp
@@ -143,8 +143,8 @@ void IndexShardsTemplate<IndexT>::add_with_ids(
             "request them to be shifted");
 
     if (successive_ids) {
-        FAISS_THROW_IF_NOT_MSG(
-                !xids,
+        FAISS_THROW_IF_MSG(
+                xids,
                 "It makes no sense to pass in ids and "
                 "request them to be shifted");
         FAISS_THROW_IF_NOT_MSG(

--- a/faiss/IndexShardsIVF.cpp
+++ b/faiss/IndexShardsIVF.cpp
@@ -106,8 +106,8 @@ void IndexShardsIVF::add_with_ids(
             "request them to be shifted");
 
     if (successive_ids) {
-        FAISS_THROW_IF_NOT_MSG(
-                !xids,
+        FAISS_THROW_IF_MSG(
+                xids,
                 "It makes no sense to pass in ids and "
                 "request them to be shifted");
         FAISS_THROW_IF_NOT_MSG(

--- a/faiss/MetaIndexes.cpp
+++ b/faiss/MetaIndexes.cpp
@@ -63,8 +63,7 @@ void IndexSplitVectors::search(
         float* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
     FAISS_THROW_IF_NOT_MSG(k == 1, "search implemented only for k=1");
     FAISS_THROW_IF_NOT_MSG(
             sum_d == d, "not enough indexes compared to # dimensions");
@@ -187,8 +186,7 @@ void IndexRandom::search(
         float* distances,
         idx_t* labels,
         const SearchParameters* params) const {
-    FAISS_THROW_IF_NOT_MSG(
-            !params, "search params not supported for this index");
+    FAISS_THROW_IF_MSG(params, "search params not supported for this index");
     FAISS_THROW_IF_NOT(k <= ntotal);
 #pragma omp parallel for if (n > 1000)
     for (idx_t i = 0; i < n; i++) {

--- a/faiss/SuperKMeans.cpp
+++ b/faiss/SuperKMeans.cpp
@@ -392,7 +392,7 @@ SuperKMeans::SuperKMeans(int d, int k, const SuperKMeansParameters& cp_in)
 
 void SuperKMeans::train(idx_t n, const float* x) {
     FAISS_THROW_IF_NOT_MSG(n > 0, "SuperKMeans: n must be positive");
-    FAISS_THROW_IF_NOT_MSG(x != nullptr, "SuperKMeans: x must not be null");
+    FAISS_THROW_IF_MSG(x == nullptr, "SuperKMeans: x must not be null");
     FAISS_THROW_IF_NOT_MSG(
             n >= static_cast<idx_t>(k), "SuperKMeans: n must be >= k");
     if (cp.check_input_data_for_NaNs) {
@@ -514,14 +514,14 @@ void super_kmeans_assign_iteration(
             "super_kmeans_assign_iteration: d_prime must be >= 1");
     FAISS_THROW_IF_NOT_MSG(
             d_prime < d, "super_kmeans_assign_iteration: d_prime must be < d");
-    FAISS_THROW_IF_NOT_MSG(
-            ad_coeff != nullptr,
+    FAISS_THROW_IF_MSG(
+            ad_coeff == nullptr,
             "super_kmeans_assign_iteration: ad_coeff must not be null");
-    FAISS_THROW_IF_NOT_MSG(
-            tau != nullptr,
+    FAISS_THROW_IF_MSG(
+            tau == nullptr,
             "super_kmeans_assign_iteration: tau must not be null");
-    FAISS_THROW_IF_NOT_MSG(
-            assignments != nullptr,
+    FAISS_THROW_IF_MSG(
+            assignments == nullptr,
             "super_kmeans_assign_iteration: assignments must not be null");
 
     const int d_trail = d - d_prime;

--- a/faiss/VectorTransform.cpp
+++ b/faiss/VectorTransform.cpp
@@ -1096,8 +1096,7 @@ ITQTransform::ITQTransform(int din, int dout, bool do_pca_in)
 }
 
 void ITQTransform::train(idx_t n, const float* x_in) {
-    FAISS_THROW_IF_NOT_MSG(
-            !is_trained, "ITQTransform has already been trained");
+    FAISS_THROW_IF_MSG(is_trained, "ITQTransform has already been trained");
 
     size_t max_train_points = std::max(d_in * max_train_per_dim, 32768);
     const float* x =

--- a/faiss/gpu/GpuCloner.cpp
+++ b/faiss/gpu/GpuCloner.cpp
@@ -150,8 +150,8 @@ Index* ToGpuCloner::clone_Index(const Index* index) {
         GpuIndexFlatConfig config;
         config.device = device;
         config.useFloat16 = true;
-        FAISS_THROW_IF_NOT_MSG(
-                !use_cuvs, "this type of index is not implemented for cuVS");
+        FAISS_THROW_IF_MSG(
+                use_cuvs, "this type of index is not implemented for cuVS");
         GpuIndexFlat* gif = new GpuIndexFlat(
                 provider, index->d, index->metric_type, config);
         // transfer data by blocks

--- a/faiss/gpu/GpuIndexBinaryFlat.cu
+++ b/faiss/gpu/GpuIndexBinaryFlat.cu
@@ -146,7 +146,7 @@ void GpuIndexBinaryFlat::search(
         return;
     }
 
-    FAISS_THROW_IF_NOT_MSG(!params, "params not implemented");
+    FAISS_THROW_IF_MSG(params, "params not implemented");
 
     validateKSelect(k, binaryFlatConfig_.use_cuvs);
 

--- a/faiss/gpu/GpuIndexCagra.cu
+++ b/faiss/gpu/GpuIndexCagra.cu
@@ -378,8 +378,8 @@ void GpuIndexCagra::trainMultiGpu(
         idx_t stitch_per_shard,
         int stitch_k,
         int stitch_mode) {
-    FAISS_THROW_IF_NOT_MSG(!is_trained, "index is already trained");
-    FAISS_THROW_IF_NOT_MSG(!devices.empty(), "must provide at least one GPU");
+    FAISS_THROW_IF_MSG(is_trained, "index is already trained");
+    FAISS_THROW_IF_MSG(devices.empty(), "must provide at least one GPU");
     FAISS_THROW_IF_NOT_MSG(stitch_k >= 1, "stitch_k must be >= 1");
 
     numeric_type_ = NumericType::Float32;
@@ -763,8 +763,8 @@ void GpuIndexCagra::trainAllNeighbors(
         int build_algo,
         float refinement_rate,
         int ivfpq_search_batch) {
-    FAISS_THROW_IF_NOT_MSG(!is_trained, "index is already trained");
-    FAISS_THROW_IF_NOT_MSG(!devices.empty(), "must provide at least one GPU");
+    FAISS_THROW_IF_MSG(is_trained, "index is already trained");
+    FAISS_THROW_IF_MSG(devices.empty(), "must provide at least one GPU");
 
     numeric_type_ = NumericType::Float32;
     idx_t graph_degree = static_cast<idx_t>(cagraConfig_.graph_degree);

--- a/faiss/gpu/GpuIndexFlat.cu
+++ b/faiss/gpu/GpuIndexFlat.cu
@@ -207,7 +207,7 @@ void GpuIndexFlat::addImpl_(idx_t n, const float* x, const idx_t* ids) {
     FAISS_ASSERT(n > 0);
 
     // We do not support add_with_ids
-    FAISS_THROW_IF_NOT_MSG(!ids, "add_with_ids not supported");
+    FAISS_THROW_IF_MSG(ids, "add_with_ids not supported");
 
     data_->add(x, n, resources_->getDefaultStream(config_.device));
     this->ntotal += n;

--- a/faiss/gpu/GpuIndexIVF.cu
+++ b/faiss/gpu/GpuIndexIVF.cu
@@ -420,8 +420,8 @@ void GpuIndexIVF::search_preassigned(
     DeviceScope scope(config_.device);
     auto stream = resources_->getDefaultStream(config_.device);
 
-    FAISS_THROW_IF_NOT_MSG(
-            !store_pairs,
+    FAISS_THROW_IF_MSG(
+            store_pairs,
             "GpuIndexIVF::search_preassigned does not "
             "currently support store_pairs");
     FAISS_THROW_IF_NOT_MSG(this->is_trained, "GpuIndexIVF not trained");

--- a/faiss/gpu/GpuIndexIVFFlat.cu
+++ b/faiss/gpu/GpuIndexIVFFlat.cu
@@ -154,8 +154,8 @@ void GpuIndexIVFFlat::copyTo(faiss::IndexIVFFlat* index) const {
     DeviceScope scope(config_.device);
 
     // We must have the indices in order to copy to ourselves
-    FAISS_THROW_IF_NOT_MSG(
-            ivfFlatConfig_.indicesOptions != INDICES_IVF,
+    FAISS_THROW_IF_MSG(
+            ivfFlatConfig_.indicesOptions == INDICES_IVF,
             "Cannot copy to CPU as GPU index doesn't retain "
             "indices (INDICES_IVF)");
 

--- a/faiss/gpu/GpuIndexIVFPQ.cu
+++ b/faiss/gpu/GpuIndexIVFPQ.cu
@@ -93,8 +93,8 @@ GpuIndexIVFPQ::GpuIndexIVFPQ(
     // instance
     this->is_trained = false;
 
-    FAISS_THROW_IF_NOT_MSG(
-            !config.use_cuvs,
+    FAISS_THROW_IF_MSG(
+            config.use_cuvs,
             "GpuIndexIVFPQ: cuVS does not support separate coarseQuantizer");
 
     verifyPQSettings_();
@@ -171,8 +171,8 @@ void GpuIndexIVFPQ::copyTo(faiss::IndexIVFPQ* index) const {
     DeviceScope scope(config_.device);
 
     // We must have the indices in order to copy to ourselves
-    FAISS_THROW_IF_NOT_MSG(
-            ivfpqConfig_.indicesOptions != INDICES_IVF,
+    FAISS_THROW_IF_MSG(
+            ivfpqConfig_.indicesOptions == INDICES_IVF,
             "Cannot copy to CPU as GPU index doesn't retain "
             "indices (INDICES_IVF)");
 

--- a/faiss/gpu/GpuIndexIVFScalarQuantizer.cu
+++ b/faiss/gpu/GpuIndexIVFScalarQuantizer.cu
@@ -244,8 +244,8 @@ void GpuIndexIVFScalarQuantizer::copyTo(
     DeviceScope scope(config_.device);
 
     // We must have the indices in order to copy to ourselves
-    FAISS_THROW_IF_NOT_MSG(
-            ivfSQConfig_.indicesOptions != INDICES_IVF,
+    FAISS_THROW_IF_MSG(
+            ivfSQConfig_.indicesOptions == INDICES_IVF,
             "Cannot copy to CPU as GPU index doesn't retain "
             "indices (INDICES_IVF)");
 

--- a/faiss/gpu/impl/CuvsIVFSQ.cu
+++ b/faiss/gpu/impl/CuvsIVFSQ.cu
@@ -796,8 +796,8 @@ idx_t CuvsIVFSQ::getBitsetSizeForFiltering_() const {
 
     // maxVectorId_ / hasNegativeVectorId_ are maintained incrementally as
     // vectors are added, so no per-search readback of the index is needed.
-    FAISS_THROW_IF_NOT_MSG(
-            !hasNegativeVectorId_,
+    FAISS_THROW_IF_MSG(
+            hasNegativeVectorId_,
             "cuVS IVF-SQ IDSelector filtering does not support "
             "negative vector ids");
 

--- a/faiss/gpu/test/TestGpuDistance.cu
+++ b/faiss/gpu/test/TestGpuDistance.cu
@@ -202,8 +202,8 @@ void testTransposition(
 #if defined USE_NVIDIA_CUVS
     args.use_cuvs = use_cuvs;
 #else
-    FAISS_THROW_IF_NOT_MSG(
-            !use_cuvs,
+    FAISS_THROW_IF_MSG(
+            use_cuvs,
             "cuVS has not been compiled into the current version so it cannot be used.");
 #endif
 

--- a/faiss/gpu_metal/MetalCloner.mm
+++ b/faiss/gpu_metal/MetalCloner.mm
@@ -29,8 +29,8 @@ faiss::Index* index_cpu_to_metal_gpu(
         StandardMetalResources* res,
         int device,
         const faiss::Index* index) {
-    FAISS_THROW_IF_NOT(res != nullptr);
-    FAISS_THROW_IF_NOT(res->getResources() != nullptr);
+    FAISS_THROW_IF_NOT(res);
+    FAISS_THROW_IF_NOT(res->getResources());
     FAISS_THROW_IF_NOT(res->getResources()->isAvailable());
     FAISS_THROW_IF_NOT_MSG(device == 0, "Metal backend supports only device 0");
 

--- a/faiss/gpu_metal/MetalIndex.mm
+++ b/faiss/gpu_metal/MetalIndex.mm
@@ -25,7 +25,7 @@ MetalIndex::MetalIndex(
     FAISS_THROW_IF_NOT_MSG(
             config_.device >= 0 && config_.device < 1,
             "Metal backend supports only device 0 (single GPU).");
-    FAISS_THROW_IF_NOT(resources_ != nullptr);
+    FAISS_THROW_IF_NOT(resources_);
     FAISS_THROW_IF_NOT(resources_->isAvailable());
 }
 

--- a/faiss/gpu_metal/MetalIndexFlat.mm
+++ b/faiss/gpu_metal/MetalIndexFlat.mm
@@ -167,7 +167,7 @@ void MetalIndexFlat::search(
 }
 
 void MetalIndexFlat::copyTo(faiss::IndexFlat* index) const {
-    FAISS_THROW_IF_NOT(index != nullptr);
+    FAISS_THROW_IF_NOT(index);
     FAISS_THROW_IF_NOT(index->d == d);
     FAISS_THROW_IF_NOT(index->metric_type == metric_type);
     if (ntotal == 0 || vectorsBuffer_ == nil) {

--- a/faiss/gpu_metal/MetalIndexIVFFlat.mm
+++ b/faiss/gpu_metal/MetalIndexIVFFlat.mm
@@ -462,8 +462,8 @@ MetalIndexIVFFlat::MetalIndexIVFFlat(
         : MetalIndex(resources, dims, metric, metricArg, config),
           indicesOptions_(config.indicesOptions),
           interleavedLayout_(config.interleavedLayout) {
-    FAISS_THROW_IF_NOT_MSG(
-            coarseQuantizer != nullptr,
+    FAISS_THROW_IF_MSG(
+            coarseQuantizer == nullptr,
             "MetalIndexIVFFlat: coarseQuantizer must be non-null");
     cpuIndex_ = std::make_unique<faiss::IndexIVFFlat>(
             coarseQuantizer, (size_t)d, (size_t)nlist, metric);
@@ -629,7 +629,7 @@ void MetalIndexIVFFlat::add_with_ids(
     if (n == 0) {
         return;
     }
-    FAISS_THROW_IF_NOT(xids != nullptr);
+    FAISS_THROW_IF_NOT(xids);
 
     idx_t oldNt = cpuIndex_->ntotal;
     const idx_t autoReserveMinBatch = getIvfAutoReserveMinBatch();
@@ -1487,8 +1487,8 @@ void MetalIndexIVFFlat::search_preassigned(
     FAISS_THROW_IF_NOT(k > 0);
     FAISS_THROW_IF_NOT(assign);
     FAISS_THROW_IF_NOT_MSG(stats == nullptr, "IVF stats not supported");
-    FAISS_THROW_IF_NOT_MSG(
-            !store_pairs,
+    FAISS_THROW_IF_MSG(
+            store_pairs,
             "MetalIndexIVFFlat::search_preassigned does not currently support store_pairs");
     if (params) {
         FAISS_THROW_IF_NOT_FMT(

--- a/faiss/gpu_metal/MetalIndexIVFPQ.mm
+++ b/faiss/gpu_metal/MetalIndexIVFPQ.mm
@@ -182,7 +182,7 @@ void MetalIndexIVFPQ::add(idx_t n, const float* x) {
 
 void MetalIndexIVFPQ::add_with_ids(idx_t n, const float* x, const idx_t* xids) {
     FAISS_THROW_IF_NOT(cpuIndex_);
-    FAISS_THROW_IF_NOT(xids != nullptr);
+    FAISS_THROW_IF_NOT(xids);
     if (n == 0)
         return;
 

--- a/faiss/gpu_metal/impl/MetalIVFFlat.mm
+++ b/faiss/gpu_metal/impl/MetalIVFFlat.mm
@@ -156,7 +156,7 @@ void MetalIVFFlatImpl::appendVectors(
     if (n == 0) {
         return;
     }
-    FAISS_THROW_IF_NOT(list_nos != nullptr);
+    FAISS_THROW_IF_NOT(list_nos);
 
     // Count how many vectors go to each list.
     std::vector<size_t> addPerList(nlist_, 0);

--- a/faiss/gpu_metal/impl/MetalIVFPQ.mm
+++ b/faiss/gpu_metal/impl/MetalIVFPQ.mm
@@ -94,8 +94,8 @@ void MetalIVFPQImpl::appendCodes(
         const idx_t* xids) {
     if (n == 0)
         return;
-    FAISS_THROW_IF_NOT(list_nos != nullptr);
-    FAISS_THROW_IF_NOT(codes != nullptr);
+    FAISS_THROW_IF_NOT(list_nos);
+    FAISS_THROW_IF_NOT(codes);
 
     std::vector<size_t> addPerList(nlist_, 0);
     for (idx_t i = 0; i < n; ++i) {
@@ -170,7 +170,7 @@ void MetalIVFPQImpl::appendCodes(
 }
 
 void MetalIVFPQImpl::setPQCentroids(const float* centroids) {
-    FAISS_THROW_IF_NOT(centroids != nullptr);
+    FAISS_THROW_IF_NOT(centroids);
     size_t bytes = (size_t)M_ * (size_t)ksub_ * (size_t)dsub_ * sizeof(float);
     if (pqCentroidsBuf_ != nil) {
         resources_->deallocBuffer(pqCentroidsBuf_, MetalAllocType::IVFLists);

--- a/faiss/impl/ClusteringInitialization.cpp
+++ b/faiss/impl/ClusteringInitialization.cpp
@@ -157,8 +157,8 @@ void ClusteringInitialization::init_centroids(
             n,
             k);
     FAISS_THROW_IF_NOT(d > 0);
-    FAISS_THROW_IF_NOT(x != nullptr);
-    FAISS_THROW_IF_NOT(centroids != nullptr);
+    FAISS_THROW_IF_NOT(x);
+    FAISS_THROW_IF_NOT(centroids);
     FAISS_THROW_IF_NOT(
             n_existing_centroids == 0 || existing_centroids != nullptr);
 

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -1097,8 +1097,8 @@ int hnsw_detail::search_from_candidates_panorama(
         const SearchParameters* params) {
     // Panorama's progressive-bound math is L2-specific: refuse to run in
     // similarity mode.
-    FAISS_THROW_IF_NOT_MSG(
-            !hnsw.is_similarity,
+    FAISS_THROW_IF_MSG(
+            hnsw.is_similarity,
             "search_from_candidates_panorama does not support is_similarity=true");
 
     using C = HNSW::C_distance;

--- a/faiss/impl/LocalSearchQuantizer.cpp
+++ b/faiss/impl/LocalSearchQuantizer.cpp
@@ -597,8 +597,8 @@ void LocalSearchQuantizer::icm_encode_step(
         const float* binaries,
         size_t n,
         size_t n_iters) const {
-    FAISS_THROW_IF_NOT(M != 0 && K != 0);
-    FAISS_THROW_IF_NOT(binaries != nullptr);
+    FAISS_THROW_IF_MSG(M == 0 || K == 0, "M and K must be nonzero");
+    FAISS_THROW_IF_NOT(binaries);
 
     // Resolve SIMD level once, not per iteration of the n × n_iters × M loop.
     with_simd_level_256bit([&]<SIMDLevel SL>() {

--- a/faiss/impl/NSG.cpp
+++ b/faiss/impl/NSG.cpp
@@ -142,7 +142,9 @@ void NSG::build(
         idx_t n,
         const nsg::Graph<idx_t>& knn_graph,
         bool verbose) {
-    FAISS_THROW_IF_NOT(!is_built && ntotal == 0);
+    FAISS_THROW_IF_MSG(
+            is_built || ntotal != 0,
+            "NSG graph must be empty and not yet built");
 
     if (verbose) {
         printf("NSG::build R=%d, L=%d, C=%d\n", R, L, C);

--- a/faiss/impl/RaBitQuantizerMultiBit.cpp
+++ b/faiss/impl/RaBitQuantizerMultiBit.cpp
@@ -257,8 +257,8 @@ void quantize_ex_bits(
     const size_t ex_bits = nb_bits - 1;
     FAISS_THROW_IF_NOT_MSG(
             ex_bits >= 1 && ex_bits <= 8, "ex_bits must be in range [1, 8]");
-    FAISS_THROW_IF_NOT_MSG(residual != nullptr, "residual cannot be null");
-    FAISS_THROW_IF_NOT_MSG(ex_code != nullptr, "ex_code cannot be null");
+    FAISS_THROW_IF_MSG(residual == nullptr, "residual cannot be null");
+    FAISS_THROW_IF_MSG(ex_code == nullptr, "ex_code cannot be null");
 
     // Step 1: Compute L2 norm of residual
     float norm_sqr = fvec_norm_L2sqr(residual, d);

--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -427,7 +427,7 @@ const LloydMaxTable kLloydMaxTables[] = {
 
 void populate_lloyd_max_trained(size_t mse_bits, std::vector<float>& trained) {
     FAISS_THROW_IF_NOT(mse_bits >= 1 && mse_bits <= 8);
-    FAISS_THROW_IF_NOT(kLloydMaxTables[mse_bits].centroids != nullptr);
+    FAISS_THROW_IF_NOT(kLloydMaxTables[mse_bits].centroids);
     size_t k = size_t(1) << mse_bits;
     const auto& t = kLloydMaxTables[mse_bits];
     trained.resize(k + (k - 1));
@@ -548,7 +548,7 @@ void ScalarQuantizer::train(size_t n, const float* x) {
         case QT_4bit_uniform:
         case QT_8bit_uniform:
             FAISS_THROW_IF_NOT(n > 0);
-            FAISS_THROW_IF_NOT(x != nullptr);
+            FAISS_THROW_IF_NOT(x);
             train_Uniform(
                     rangestat,
                     rangestat_arg,
@@ -561,7 +561,7 @@ void ScalarQuantizer::train(size_t n, const float* x) {
         case QT_8bit:
         case QT_6bit:
             FAISS_THROW_IF_NOT(n > 0);
-            FAISS_THROW_IF_NOT(x != nullptr);
+            FAISS_THROW_IF_NOT(x);
             train_NonUniform(
                     rangestat,
                     rangestat_arg,

--- a/faiss/impl/ThreadedIndex-inl.h
+++ b/faiss/impl/ThreadedIndex-inl.h
@@ -70,8 +70,8 @@ void ThreadedIndex<IndexT>::addIndex(IndexT* index) {
 
         // Make sure this index is not duplicated
         for (auto& p : indices_) {
-            FAISS_THROW_IF_NOT_MSG(
-                    p.first != index,
+            FAISS_THROW_IF_MSG(
+                    p.first == index,
                     "addIndex: attempting to add index "
                     "that is already in the collection");
         }

--- a/faiss/impl/binary_hamming/IndexBinaryIVF_impl.h
+++ b/faiss/impl/binary_hamming/IndexBinaryIVF_impl.h
@@ -292,7 +292,7 @@ void search_knn_hamming_per_invlist(
     nprobe = std::min((idx_t)ivf->nlist, nprobe);
     idx_t max_codes = params ? params->max_codes : ivf->max_codes;
     FAISS_THROW_IF_NOT(max_codes == 0);
-    FAISS_THROW_IF_NOT(!store_pairs);
+    FAISS_THROW_IF_MSG(store_pairs, "store_pairs is not supported here");
 
     // reorder buckets
     std::vector<int64_t> lims(n + 1);

--- a/faiss/impl/hnsw/LockVector.cpp
+++ b/faiss/impl/hnsw/LockVector.cpp
@@ -30,7 +30,7 @@ void LockVector::prepare(size_t new_size) {
         // Just destroy old and init fresh; omp_lock_t is not copyable.
         clear();
         data_ = static_cast<omp_lock_t*>(malloc(new_cap * sizeof(omp_lock_t)));
-        FAISS_THROW_IF_NOT(data_ != nullptr);
+        FAISS_THROW_IF_NOT(data_);
         capacity_ = new_cap;
     }
     for (size_t i = size_; i < new_size; i++) {

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -340,7 +340,9 @@ std::unique_ptr<VectorTransform> read_VectorTransform_up(IOReader* f) {
         READVECTOR(lt->b);
         FAISS_THROW_IF_NOT(
                 lt->A.size() >= size_t(lt->d_in) * size_t(lt->d_out));
-        FAISS_THROW_IF_NOT(!lt->have_bias || lt->b.size() >= size_t(lt->d_out));
+        FAISS_THROW_IF_MSG(
+                lt->have_bias && lt->b.size() < size_t(lt->d_out),
+                "bias vector smaller than d_out");
         lt->set_is_orthonormal();
         vt = std::move(lt);
     } else if (h == fourcc("RmDT")) {

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -921,7 +921,8 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
                 : dynamic_cast<const IndexNSGPQ*>(idx)      ? fourcc("INSp")
                 : dynamic_cast<const IndexNSGSQ*>(idx)      ? fourcc("INSs")
                                                             : 0;
-        FAISS_THROW_IF_NOT(h != 0);
+        FAISS_THROW_IF_MSG(
+                h == 0, "don't know how to serialize this IndexNSG subtype");
         WRITE1(h);
         write_index_header(idxnsg, f);
         WRITE1(idxnsg->GK);
@@ -936,9 +937,11 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
             const IndexNNDescent* idxnnd =
                     dynamic_cast<const IndexNNDescent*>(idx)) {
         auto idxnndflat = dynamic_cast<const IndexNNDescentFlat*>(idx);
-        FAISS_THROW_IF_NOT(idxnndflat != nullptr);
+        FAISS_THROW_IF_NOT(idxnndflat);
         uint32_t h = fourcc("INNf");
-        FAISS_THROW_IF_NOT(h != 0);
+        FAISS_THROW_IF_MSG(
+                h == 0,
+                "don't know how to serialize this IndexNNDescent subtype");
         WRITE1(h);
         write_index_header(idxnnd, f);
         write_NNDescent(&idxnnd->nndescent, f);

--- a/faiss/invlists/DirectMap.cpp
+++ b/faiss/invlists/DirectMap.cpp
@@ -80,7 +80,7 @@ idx_t DirectMap::get(idx_t key) const {
         return lo;
     } else if (type == Hashtable) {
         auto res = hashtable.find(key);
-        FAISS_THROW_IF_NOT_MSG(res != hashtable.end(), "key not found");
+        FAISS_THROW_IF_MSG(res == hashtable.end(), "key not found");
         return res->second;
     } else {
         FAISS_THROW_MSG("direct map not initialized");

--- a/faiss/invlists/InvertedLists.cpp
+++ b/faiss/invlists/InvertedLists.cpp
@@ -371,8 +371,8 @@ ArrayInvertedListsPanorama::ArrayInvertedListsPanorama(
           pano(code_size_in, n_levels_in, batch_size) {
     FAISS_THROW_IF_NOT(n_levels_in > 0);
     FAISS_THROW_IF_NOT(code_size_in % sizeof(float) == 0);
-    FAISS_THROW_IF_NOT_MSG(
-            !use_iterator,
+    FAISS_THROW_IF_MSG(
+            use_iterator,
             "IndexIVFFlatPanorama does not support iterators, use vanilla IndexIVFFlat instead");
     FAISS_ASSERT(level_width % sizeof(float) == 0);
 

--- a/faiss/invlists/OnDiskInvertedLists.cpp
+++ b/faiss/invlists/OnDiskInvertedLists.cpp
@@ -405,7 +405,8 @@ void OnDiskInvertedLists::update_entries(
         size_t n_entry,
         const idx_t* ids_in,
         const uint8_t* codes_in) {
-    FAISS_THROW_IF_NOT(!read_only);
+    FAISS_THROW_IF_MSG(
+            read_only, "cannot modify a read-only OnDiskInvertedLists");
     if (n_entry == 0) {
         return;
     }
@@ -422,7 +423,8 @@ size_t OnDiskInvertedLists::add_entries(
         size_t n_entry,
         const idx_t* ids,
         const uint8_t* code) {
-    FAISS_THROW_IF_NOT(!read_only);
+    FAISS_THROW_IF_MSG(
+            read_only, "cannot modify a read-only OnDiskInvertedLists");
     locks->lock_1(list_no);
     size_t o = list_size(list_no);
     resize_locked(list_no, n_entry + o);
@@ -432,7 +434,8 @@ size_t OnDiskInvertedLists::add_entries(
 }
 
 void OnDiskInvertedLists::resize(size_t list_no, size_t new_size) {
-    FAISS_THROW_IF_NOT(!read_only);
+    FAISS_THROW_IF_MSG(
+            read_only, "cannot modify a read-only OnDiskInvertedLists");
     locks->lock_1(list_no);
     resize_locked(list_no, new_size);
     locks->unlock_1(list_no);

--- a/faiss/svs/IndexSVSIVF.cpp
+++ b/faiss/svs/IndexSVSIVF.cpp
@@ -222,7 +222,7 @@ size_t IndexSVSIVF::remove_ids(const IDSelector& sel) {
 }
 
 void IndexSVSIVF::create_impl(idx_t n, const float* x) {
-    FAISS_THROW_IF_NOT(!impl);
+    FAISS_THROW_IF_MSG(impl, "impl already created");
     ntotal = 0;
     auto svs_metric = to_svs_metric(metric_type);
     auto svs_storage_kind = to_svs_storage_kind(storage_kind);

--- a/faiss/svs/IndexSVSIVFLeanVec.cpp
+++ b/faiss/svs/IndexSVSIVFLeanVec.cpp
@@ -119,7 +119,7 @@ void IndexSVSIVFLeanVec::deserialize_training_data(std::istream& in) {
 }
 
 void IndexSVSIVFLeanVec::create_impl(idx_t n, const float* x) {
-    FAISS_THROW_IF_NOT(!impl);
+    FAISS_THROW_IF_MSG(impl, "impl already created");
     ntotal = 0;
     auto svs_metric = to_svs_metric(metric_type);
     auto svs_storage_kind = to_svs_storage_kind(storage_kind);

--- a/faiss/svs/IndexSVSVamana.cpp
+++ b/faiss/svs/IndexSVSVamana.cpp
@@ -268,7 +268,7 @@ size_t IndexSVSVamana::remove_ids(const IDSelector& sel) {
 }
 
 void IndexSVSVamana::create_impl(idx_t n, const float* x) {
-    FAISS_THROW_IF_NOT(!impl);
+    FAISS_THROW_IF_MSG(impl, "impl already created");
     ntotal = 0;
     auto svs_metric = to_svs_metric(metric_type);
     auto svs_storage_kind = to_svs_storage_kind(storage_kind);

--- a/faiss/svs/IndexSVSVamanaLeanVec.cpp
+++ b/faiss/svs/IndexSVSVamanaLeanVec.cpp
@@ -121,7 +121,7 @@ void IndexSVSVamanaLeanVec::deserialize_training_data(std::istream& in) {
 }
 
 void IndexSVSVamanaLeanVec::create_impl(idx_t n, const float* x) {
-    FAISS_THROW_IF_NOT(!impl);
+    FAISS_THROW_IF_MSG(impl, "impl already created");
     ntotal = 0;
     auto svs_metric = to_svs_metric(metric_type);
     auto svs_storage_kind = to_svs_storage_kind(storage_kind);

--- a/faiss/utils/quantize_lut.cpp
+++ b/faiss/utils/quantize_lut.cpp
@@ -143,7 +143,8 @@ void quantize_LUT_and_bias(
         float* b_out) {
     float a, b;
     if (!bias) {
-        FAISS_THROW_IF_NOT(!lut_is_3d);
+        FAISS_THROW_IF_MSG(
+                lut_is_3d, "3d LUT is not supported when bias is null");
         std::vector<float> mins(M);
         float max_span_LUT = -HUGE_VAL, max_span_dis = 0;
         b = 0;

--- a/tests/test_threaded_index.cpp
+++ b/tests/test_threaded_index.cpp
@@ -47,7 +47,7 @@ struct MockIndex : public faiss::Index {
             float* distances,
             idx_t* labels,
             const faiss::SearchParameters* params) const override {
-        FAISS_THROW_IF_NOT(!params);
+        FAISS_THROW_IF_MSG(params, "search params not supported");
         nCalled = n;
         xCalled = x;
         kCalled = k;


### PR DESCRIPTION
Summary:
Audited `fbcode/faiss` for uses of the `FAISS_THROW_IF_NOT*` macros whose
condition itself contains a negation (`!` or `!=`). Because `FAISS_THROW_IF_NOT(X)`
throws when `X` is *false*, a negated condition reads as a double negative — e.g.
`FAISS_THROW_IF_NOT_MSG(!params, "...")` actually throws when `params` *is* set, and
`FAISS_THROW_IF_NOT(ptr != nullptr)` throws when `ptr` *is* null.

Rewrites (all behavior-preserving):
- `FAISS_THROW_IF_NOT_MSG(!X, MSG)` -> `FAISS_THROW_IF_MSG(X, MSG)`
- `FAISS_THROW_IF_NOT_MSG(A != B, MSG)` -> `FAISS_THROW_IF_MSG(A == B, MSG)`
- `FAISS_THROW_IF_NOT(ptr != nullptr)` -> `FAISS_THROW_IF_NOT(ptr)` (pointer truthiness)
- `FAISS_THROW_IF_NOT(!X)` / `FAISS_THROW_IF_NOT(A != B)` -> `FAISS_THROW_IF_MSG(...)`
  with a concise message (there is no bare `FAISS_THROW_IF` / `FAISS_THROW_IF_FMT`, so
  positive-polarity throws must carry a message).
- Compound conditions were rewritten via De Morgan's law so the surviving condition
  has no `!`/`!=` where practical (e.g. `M != 0 && K != 0` -> throw on `M == 0 || K == 0`).

Also documented this convention in `faiss/.claude/CLAUDE.md` so future changes avoid
reintroducing double negatives.

Not changed: three `FAISS_THROW_IF_NOT_FMT(...)` sites with negated conditions
(`impl/index_read.cpp`, `impl/index_write.cpp`, `invlists/OnDiskInvertedLists.cpp`).
There is no `FAISS_THROW_IF_FMT` macro, so their printf-style format arguments cannot
move to `FAISS_THROW_IF_MSG` without adding a new macro.

Differential Revision: D113577769
