### PR TITLE
Don't redefine __PRETTY_FUNCTION__ under clang-cl

### DIFF
--- a/faiss/impl/platform_macros.h
+++ b/faiss/impl/platform_macros.h
@@ -25,7 +25,9 @@
 
 #define strtok_r strtok_s
 
-#ifdef _MSC_VER
+// clang-cl defines _MSC_VER but provides __PRETTY_FUNCTION__ itself, in
+// clang's format. Redefining it there breaks code that parses it.
+#if defined(_MSC_VER) && !defined(__clang__)
 #define __PRETTY_FUNCTION__ __FUNCSIG__
 #endif // _MSC_VER
 


### PR DESCRIPTION
`platform_macros.h` redefines `__PRETTY_FUNCTION__` to `__FUNCSIG__` whenever `_MSC_VER` is defined. That is right for MSVC, which has no `__PRETTY_FUNCTION__`, but clang-cl also defines `_MSC_VER` while already providing `__PRETTY_FUNCTION__` in clang's own format. The macro therefore replaces a working definition with one in a different format.

Anything that parses it then misbehaves, and does so far from the cause. magic_enum derives enumerator names from `__PRETTY_FUNCTION__`, so with clang-cl every translation unit that includes any FAISS header silently loses enum reflection. The failure surfaces as a static assertion about an unrelated enum, with nothing pointing back at FAISS.

Found while building a project that embeds FAISS with clang-cl on Windows. Bisecting the include list showed reflection failing with any FAISS header present and succeeding with none; restricting the shim to Microsoft's compiler fixes it, and FAISS itself builds unchanged.

MSVC is unaffected: it does not define `__clang__`, so it still gets the shim. Non-Windows targets never reach this branch.