### PR TITLE
faiss DD: SQ AVX-512 falls back to AVX2 when d%16!=0

### DIFF
--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -641,17 +641,14 @@ void ScalarQuantizer::TurboQuantRefine::init_projection(size_t d) {
 }
 
 ScalarQuantizer::SQuantizer* ScalarQuantizer::select_quantizer() const {
-    return with_simd_level_spr([&]<SIMDLevel SL>() -> SQuantizer* {
-        if constexpr (SL != SIMDLevel::NONE) {
-            auto* q = scalar_quantizer::sq_select_quantizer<SL>(
-                    qtype, d, trained);
-            if (q) {
-                return q;
-            }
-        }
-        return scalar_quantizer::sq_select_quantizer<SIMDLevel::NONE>(
-                qtype, d, trained);
-    });
+    // A SIMD level's factory returns nullptr when the dimension is
+    // incompatible (e.g. AVX-512 needs d % 16 == 0); the dispatcher then falls
+    // back to the next-lower level (AVX-512 -> AVX2 -> scalar).
+    return with_simd_level_fallback<AVAILABLE_SIMD_LEVELS_A0_SPR>(
+            [&]<SIMDLevel SL>() -> SQuantizer* {
+                return scalar_quantizer::sq_select_quantizer<SL>(
+                        qtype, d, trained);
+            });
 }
 
 void ScalarQuantizer::compute_codes(const float* x, uint8_t* codes, size_t n)
@@ -684,17 +681,11 @@ void ScalarQuantizer::decode(const uint8_t* codes, float* x, size_t n) const {
 ScalarQuantizer::SQDistanceComputer* ScalarQuantizer::get_distance_computer(
         MetricType metric) const {
     FAISS_THROW_IF_NOT(metric == METRIC_L2 || metric == METRIC_INNER_PRODUCT);
-    return with_simd_level_spr([&]<SIMDLevel SL>() -> SQDistanceComputer* {
-        if constexpr (SL != SIMDLevel::NONE) {
-            auto* dc = scalar_quantizer::sq_select_distance_computer<SL>(
-                    metric, qtype, d, trained);
-            if (dc) {
-                return dc;
-            }
-        }
-        return scalar_quantizer::sq_select_distance_computer<SIMDLevel::NONE>(
-                metric, qtype, d, trained);
-    });
+    return with_simd_level_fallback<AVAILABLE_SIMD_LEVELS_A0_SPR>(
+            [&]<SIMDLevel SL>() -> SQDistanceComputer* {
+                return scalar_quantizer::sq_select_distance_computer<SL>(
+                        metric, qtype, d, trained);
+            });
 }
 
 InvertedListScanner* ScalarQuantizer::select_InvertedListScanner(
@@ -703,33 +694,19 @@ InvertedListScanner* ScalarQuantizer::select_InvertedListScanner(
         bool store_pairs,
         const IDSelector* sel,
         bool by_residual) const {
-    return with_simd_level_spr([&]<SIMDLevel SL>() -> InvertedListScanner* {
-        if constexpr (SL != SIMDLevel::NONE) {
-            auto* s = scalar_quantizer::sq_select_InvertedListScanner<SL>(
-                    qtype,
-                    mt,
-                    d,
-                    code_size,
-                    trained,
-                    quantizer,
-                    store_pairs,
-                    sel,
-                    by_residual);
-            if (s) {
-                return s;
-            }
-        }
-        return scalar_quantizer::sq_select_InvertedListScanner<SIMDLevel::NONE>(
-                qtype,
-                mt,
-                d,
-                code_size,
-                trained,
-                quantizer,
-                store_pairs,
-                sel,
-                by_residual);
-    });
+    return with_simd_level_fallback<AVAILABLE_SIMD_LEVELS_A0_SPR>(
+            [&]<SIMDLevel SL>() -> InvertedListScanner* {
+                return scalar_quantizer::sq_select_InvertedListScanner<SL>(
+                        qtype,
+                        mt,
+                        d,
+                        code_size,
+                        trained,
+                        quantizer,
+                        store_pairs,
+                        sel,
+                        by_residual);
+            });
 }
 
 } // namespace faiss

--- a/faiss/impl/simd_dispatch.h
+++ b/faiss/impl/simd_dispatch.h
@@ -84,6 +84,24 @@ inline auto dispatch_with_fallback(LambdaType&& action) {
     }
 }
 
+/** Run action at current_level; on a null result, retry the next-lower level,
+ * down to NONE (terminal). action is called per level tried, so never moved. */
+template <int available_levels, SIMDLevel current_level, typename LambdaType>
+inline auto dispatch_simd_level_or_lower(LambdaType& action) {
+    if constexpr (current_level == SIMDLevel::NONE) {
+        return action.template operator()<SIMDLevel::NONE>();
+    } else {
+        if constexpr (available_levels & (1 << int(current_level))) {
+            if (auto result = action.template operator()<current_level>()) {
+                return result;
+            }
+        }
+        return dispatch_simd_level_or_lower<
+                available_levels,
+                get_simd_fallback(current_level)>(action);
+    }
+}
+
 /** The complete dispatching function. It takes into account:
  * - the currently selected SIMD level
  * - the compiled in SIMD levels (given by COMPILE_SIMD_XXX)
@@ -163,6 +181,18 @@ inline auto with_selected_simd_levels(LambdaType&& action) {
 #endif
 }
 
+/** Like with_selected_simd_levels, but for factory actions that return null to
+ * decline a level (e.g. AVX-512 needing d % 16 == 0). Falls back to the next
+ * lower level, down to NONE. */
+template <int available_levels, typename LambdaType>
+inline auto with_simd_level_fallback(const LambdaType& action) {
+    return with_selected_simd_levels<available_levels>(
+            [&action]<SIMDLevel SL>() {
+                return dispatch_simd_level_or_lower<available_levels, SL>(
+                        action);
+            });
+}
+
 /**
  * Dispatch to a lambda with SIMDLevel as a compile-time constant.
  *
@@ -195,15 +225,6 @@ inline auto with_selected_simd_levels(LambdaType&& action) {
 template <typename LambdaType>
 inline auto with_simd_level(LambdaType&& action) {
     return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A0>(
-            std::forward<LambdaType>(action));
-}
-
-/**
- * Use for functions with AVX512_SPR-specific implementations.
- */
-template <typename LambdaType>
-inline auto with_simd_level_spr(LambdaType&& action) {
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A0_SPR>(
             std::forward<LambdaType>(action));
 }
 


### PR DESCRIPTION
Summary:
TLDR: missed a DD fallback of AVX512 to sequential when d was not divisible by 16. No unit test because too hard to measure timing in fallback without flakiness.
-

Under dynamic dispatch, scalar-quantizer (SQ) search is catastrophically slow
for vector dimensions that are not a multiple of 16. Measured on
`ai_infra.vench_benchmark_results` (nq=1), AVX-512-vs-AVX2 median speedup by
dimension:

  dim 128 -> 1.13x    dim 512 -> 1.31x    dim 1024 -> 1.42x
  dim 200 -> 0.199x   dim 768 -> 1.42x    dim 2048 -> 1.39x
  (worst `IVF*,SQfp16` at d=200: ~0.05x, i.e. ~19x slower than AVX2)

dim=200 is the only benchmarked dimension that is not a multiple of 16, and it
is the only one that regresses; every multiple-of-16 dim gets a 1.1-1.4x gain.
This affects all x86 microarchitectures (not just one CPU).

Root cause: `is_dimension_compatible<AVX512>()` (`sq-dispatch.h`) requires
`d % 16 == 0`, so for d=200 the AVX-512 SQ factory returns `nullptr`. The
dispatch in `ScalarQuantizer::get_distance_computer` /
`select_InvertedListScanner` / `select_quantizer` then falls back directly from
AVX-512 to the scalar `SIMDLevel::NONE` path, skipping AVX2. `with_simd_level_spr`
dispatches once at the host's top level (AVX-512), so the `nullptr` from the
AVX-512 factory drops straight to NONE rather than trying AVX2. On an AVX-512
host, d=200 therefore runs a scalar per-component loop, while an AVX2 host runs
the fast 8-wide kernel (d=200 is a multiple of 8).

Fix: in all three SQ dispatch sites, when the top level is an AVX-512 variant
and its factory declines, try AVX2 before the scalar path. AVX2 needs only
`d % 8 == 0` (satisfied by d=200), is always available on an AVX-512 host, and
is dramatically faster than scalar. This recovers d=200 SQ from ~0.2x to ~1.0x
(parity with AVX2, which is what non-DD prod already uses).

Chose the AVX2 fallback over adding a masked 512-bit tail to the float SQ
distance/decode loops (`DCTemplate<...,AVX512>`): the masked-tail approach
would touch the decode path of every codec (8/4/6-bit, fp16, bf16) with fiddly
masked loads over packed sub-byte codes, a much larger and riskier change, for
only a marginal gain over AVX2 at these dimensions. The AVX2 fallback is
minimal and fully removes the regression.

My questions:
--

Why can't we replace with_simd_level and always fall back?
--
```
  They are not interchangeable with with_simd_level_fallback. There are two independent differences, and the
  first is the disqualifying one:

  a) Null-decline semantics + multiple invocation. with_simd_level_fallback is built for selection/factory
  actions that return a nullable pointer, where null means "this level declines, drop down a level." That's the
  whole point of dispatch_simd_level_or_lower (simd_dispatch.h:89-103):

  if (auto result = action.template operator()<current_level>()) {
      return result;   // non-null: accept
  }                    // null: recurse to get_simd_fallback(level)

  This (i) requires the return value to be truthiness-testable, and (ii) may call the action multiple times (once
  per level until one accepts). Your three SQ sites fit perfectly — they return SQuantizer* /
  SQDistanceComputer* / InvertedListScanner* and the old code hand-rolled the exact if (q) return q; else NONE
  fallback that this now encapsulates.

  with_simd_level / with_simd_level_256bit back work kernels — e.g. the fvec_L2sqr<level>(...) compute loop in
  the with_simd_level doc example (simd_dispatch.h:209-216). Those:
  - often return void or a non-pointer — if (auto result = ...) is ill-formed on void and would misread a
  legitimate 0.0/false as "declined," and
  - must run exactly once at the selected level; re-invoking a side-effecting loop across levels would be wrong.

  So you can't fold them in without breaking every void/compute caller.
```

Did we miss any call sites?
--
```
  No remaining migration candidates — your diff already covers the whole pattern

  The audit traced every pointer-returning dispatch site in fbcode/faiss/ down to its underlying <SL> factory to
  check for the nullable-decline semantics (return nullptr to reject a SIMD level → fall back lower). Findings:

  1. The manual decline pattern existed only in ScalarQuantizer.cpp — the three sites your diff already migrated
  (select_quantizer, get_distance_computer, select_InvertedListScanner). The declining factories they call live
  in impl/scalar_quantizer/sq-dispatch.h and are the only return nullptr-to-decline factories in the entire tree
  (each does if (!is_dimension_compatible<SL>(d)) return nullptr; plus per-qtype declines for eden 5/6/7-bit).

  2. with_simd_level_spr is fully removed — zero references remain anywhere in fbcode/faiss/.

  3. Every other pointer-returning dispatch site is not a candidate — the factory always returns a valid object,
  so wrapping it in with_simd_level_fallback would be a no-op. Notable ones:

  ┌───────────────────────────────────┬──────────────────────────────────────────────┬────────────────────────┐
  │               Site                │                   Factory                    │        Why not         │
  ├───────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────┤
  │ IndexPQ.cpp:85                    │ get_PQFlatCodesDistanceComputer<SL>          │ never null             │
  ├───────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────┤
  │ IndexIVFPQ.cpp:529                │ make_IVFPQInvertedListScanner<SL>            │ never null             │
  ├───────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────┤
  │ IndexBinaryIVF.cpp:470            │ make_binary_ivf_scanner_fixSL<SL>            │ never null             │
  ├───────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────┤
  │ IndexBinaryHNSW.cpp:298           │ make_binary_hnsw_distance_computer_fixSL<SL> │ never null             │
  ├───────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────┤
  │ IndexIVFSpectralHash.cpp:225      │ make_spectral_hash_scanner_fixSL<SL>         │ never null             │
  ├───────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────┤
  │ EDENQuantizer.cpp:873             │ make_distance_computer_for_level<SL>         │ every specialization   │
  │                                   │                                              │ returns valid          │
  ├───────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────┤
  │ RaBitQuantizer.cpp:662            │ inline new RaBitQDistanceComputer…<SL>       │ always dc.release()    │
  ├───────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────┤
  │ fast_scan.cpp:449/461/474/490/514 │ make_*_scanner_impl<SL>                      │ always valid           │
  │                                   │                                              │ unique_ptr             │
  ├───────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────┤
  │                                   │                                              │ returns bool compute   │
  │ distances_fused.cpp:54            │ exhaustive_L2sqr_fused_cmax<SL>              │ result, NONE is a real │
  │                                   │                                              │  specialization        │
  └───────────────────────────────────┴──────────────────────────────────────────────┴────────────────────────┘

  4. All the with_simd_level / with_simd_level_256bit / with_simd_level_a0_spr bulk callers (dozens across
  utils/distances.cpp, hamming.cpp, ProductQuantizer.cpp, ResidualQuantizer.cpp, etc.) are run-once void/scalar
  compute kernels — correctly left alone, as we discussed.
```

Differential Revision: D113787304


