### PR TITLE
Avoid signed int overflow in VStackInvertedLists binary search

### DIFF
--- a/faiss/invlists/InvertedLists.cpp
+++ b/faiss/invlists/InvertedLists.cpp
@@ -669,10 +669,10 @@ namespace {
 int translate_list_no(const VStackInvertedLists* vil, idx_t list_no) {
     FAISS_THROW_IF_NOT(
             list_no >= 0 && static_cast<size_t>(list_no) < vil->nlist);
-    int i0 = 0, i1 = vil->ils.size();
+    size_t i0 = 0, i1 = vil->ils.size();
     const idx_t* cumsz = vil->cumsz.data();
     while (i0 + 1 < i1) {
-        int imed = (i0 + i1) / 2;
+        size_t imed = i0 + (i1 - i0) / 2;
         if (list_no >= cumsz[imed]) {
             i0 = imed;
         } else {


### PR DESCRIPTION
translate_list_no() for VStackInvertedLists used int indices for the binary search over vil->ils, with i1 initialized from the size_t ils.size() (a narrowing conversion). The midpoint computation (i0 + i1) / 2 could overflow int, which is undefined behavior.

Use size_t indices and compute the midpoint as i0 + (i1 - i0) / 2, which cannot overflow.