### PR TITLE
Bound lattice_nbit loop in IndexLattice ctor to fix deserialization timeout (T277092535)

### DIFF
--- a/faiss/IndexLattice.cpp
+++ b/faiss/IndexLattice.cpp
@@ -26,6 +26,11 @@ IndexLattice::IndexLattice(idx_t d_in, int nsq_in, int scale_nbit_in, int r2)
     lattice_nbit = 0;
     while (!(((uint64_t)1 << lattice_nbit) >= zn_sphere_codec.nv)) {
         lattice_nbit++;
+        FAISS_THROW_IF_NOT_FMT(
+                lattice_nbit < 64,
+                "IndexLattice: nv=%zu too large, lattice code would exceed "
+                "63 bits (likely corrupt r2/dsq)",
+                (size_t)zn_sphere_codec.nv);
     }
 
     int total_nbit = (lattice_nbit + scale_nbit_in) * nsq_in;


### PR DESCRIPTION
Summary:
Agentic fuzzing (faiss_read_index_binary_fuzzer) found a multi-second
timeout while deserializing an IndexLattice. After D113405533 bounded the
ZnSphereCodecRec decode-cache build, the same crafted input now hangs one
frame up, in the IndexLattice constructor:

  lattice_nbit = 0;
  while (!(((uint64_t)1 << lattice_nbit) >= zn_sphere_codec.nv)) {
      lattice_nbit++;
  }

zn_sphere_codec.nv (number of Zn lattice points) grows as O(r2^(dsq/2))
and is a uint64_t; a crafted r2/dsq makes it exceed 2^63 (and overflow).
Once lattice_nbit reaches 64 the shift '(uint64_t)1 << lattice_nbit' is
undefined -- on x86 the shift count is masked mod 64 so it wraps to a
small value that stays < nv, and the loop never terminates. That is an
effectively infinite loop reached purely from attacker-controlled bytes,
exceeding the fuzzer's 10s per-input timeout.

Fix: reject nv > 2^63 inside the loop with a catchable FAISS_THROW_IF_NOT.
A lattice code wider than 63 bits is never valid, and real lattice configs
(the ZnSphereCodecAlt fallback is dsq=8/r2=14; factory configs use small
power-of-two dsq with small r2) need only a handful of bits, so they are
orders of magnitude under the bound. run_fuzz_iteration already swallows
FaissException.

Differential Revision: D113834749


