### PR TITLE
faiss HNSW: add opt-in deterministic lock-free graph build (faiss::hnsw_deterministic_build) (#5486)

### DIFF
--- a/faiss/IndexBinaryHNSW.cpp
+++ b/faiss/IndexBinaryHNSW.cpp
@@ -270,13 +270,25 @@ void IndexBinaryHNSW::add(idx_t n, const uint8_t* x) {
     storage->add(n, x);
     ntotal = storage->ntotal;
 
-    hnsw_add_vertices(
-            *this,
-            n0,
-            n,
-            x,
-            verbose,
-            hnsw.levels.size() == static_cast<size_t>(ntotal));
+    bool preset_levels = hnsw.levels.size() == static_cast<size_t>(ntotal);
+
+    if (hnsw_deterministic_build) {
+        hnsw_add_vertices_deterministic(
+                hnsw,
+                n0,
+                n,
+                d,
+                init_level0,
+                keep_max_size_level0,
+                preset_levels,
+                verbose,
+                [this] { return get_distance_computer(); },
+                [this, x, n0](DistanceComputer& dc, HNSW::storage_idx_t pt_id) {
+                    dc.set_query((const float*)(x + (pt_id - n0) * code_size));
+                });
+    } else {
+        hnsw_add_vertices(*this, n0, n, x, verbose, preset_levels);
+    }
 }
 
 void IndexBinaryHNSW::reset() {

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -41,6 +41,8 @@ using NodeDistFarther = HNSW::NodeDistFarther;
 
 HNSWStats hnsw_stats;
 
+bool hnsw_deterministic_build = false;
+
 /**************************************************************
  * add / search blocks of descriptors
  **************************************************************/
@@ -214,6 +216,300 @@ void hnsw_add_vertices(
 
 } // namespace
 
+// Deterministic HNSW graph build: points are bucketed by level and inserted in
+// prefix-doubling batches. Phase A computes forward links against a frozen
+// snapshot and records reverse edges; phase B merges those in a fixed order.
+void hnsw_add_vertices_deterministic(
+        HNSW& hnsw,
+        size_t n0,
+        size_t n,
+        int d,
+        bool init_level0,
+        bool keep_max_size_level0,
+        bool preset_levels,
+        bool verbose,
+        const std::function<DistanceComputer*()>& make_distance_computer,
+        const std::function<void(DistanceComputer&, HNSW::storage_idx_t)>&
+                set_query) {
+    size_t ntotal = n0 + n;
+    double t0 = getmillisecs();
+    if (verbose) {
+        printf("hnsw_add_vertices_deterministic: adding %zd elements on top of %zd "
+               "(preset_levels=%d)\n",
+               n,
+               n0,
+               int(preset_levels));
+    }
+
+    if (n == 0) {
+        return;
+    }
+
+    // init_level0=false (CAGRA import) skips the level-0-only bucket; higher-
+    // level points still build their own level-0 links.
+    const int min_bucket_level = init_level0 ? 0 : 1;
+
+    int max_level = hnsw.prepare_level_tab(n, preset_levels);
+    if (verbose) {
+        printf("  max_level = %d\n", max_level);
+    }
+
+    // Bucket the new points by level, highest first.
+    std::vector<int> hist;
+    std::vector<int> order(n);
+
+    { // make buckets with vectors of the same level
+
+        // build histogram
+        for (size_t i = 0; i < n; i++) {
+            storage_idx_t pt_id = static_cast<storage_idx_t>(i + n0);
+            int pt_level = hnsw.levels[pt_id] - 1;
+            while (pt_level >= static_cast<int>(hist.size())) {
+                hist.push_back(0);
+            }
+            hist[pt_level]++;
+        }
+
+        // accumulate
+        std::vector<int> offsets(hist.size() + 1, 0);
+        for (size_t i = 0; i < hist.size() - 1; i++) {
+            offsets[i + 1] = offsets[i] + hist[i];
+        }
+
+        // bucket sort
+        for (size_t i = 0; i < n; i++) {
+            storage_idx_t pt_id = static_cast<storage_idx_t>(i + n0);
+            int pt_level = hnsw.levels[pt_id] - 1;
+            order[offsets[pt_level]++] = pt_id;
+        }
+    }
+
+    // Upper bound on batch size (ParlayANN's theta), 2% of the index.
+    const size_t theta =
+            std::max<size_t>(1, static_cast<size_t>(0.02 * ntotal));
+
+    // Polled inside phase A: a batch can be 2% of ntotal, so cancelling only
+    // at batch boundaries would take minutes on large indexes.
+    const idx_t check_period = InterruptCallback::get_period_hint(
+            max_level * d * hnsw.efConstruction);
+
+    RandomGenerator rng2(789);
+    size_t i1 = n;
+
+    for (int pt_level = static_cast<int>(hist.size()) - 1;
+         pt_level >= min_bucket_level;
+         pt_level--) {
+        size_t i0 = i1 - hist[pt_level];
+        if (i0 == i1) {
+            continue;
+        }
+
+        if (verbose) {
+            printf("Adding %zu elements at level %d\n", i1 - i0, pt_level);
+        }
+
+        // random permutation to get rid of dataset order bias
+        for (size_t j = i0; j < i1; j++) {
+            std::swap(
+                    order[j],
+                    order[j + rng2.rand_int(static_cast<int>(i1 - j))]);
+        }
+
+        // Bootstrap/raise the entry point: the top bucket runs first, so its
+        // first (shuffled) point is a valid max-level entry point.
+        if (hnsw.entry_point == -1 || pt_level > hnsw.max_level) {
+            hnsw.max_level = pt_level;
+            hnsw.entry_point = order[i0];
+        }
+
+        // Prefix-doubling batches within this bucket.
+        size_t s = i0;
+        while (s < i1) {
+            size_t done = s - i0;
+            size_t grow = std::min(done == 0 ? size_t(1) : done, theta);
+            size_t e = std::min(i1, s + grow);
+
+            // Phase A: compute forward links against the snapshot
+            // A reverse edge: `dest` gains an incoming link from `src`.
+            struct Edge {
+                int level;
+                HNSW::storage_idx_t dest;
+                HNSW::storage_idx_t src;
+            };
+
+            // One buffer, sized to an upper bound so it never reallocates.
+            // The fill order is nondeterministic but harmless: phase B
+            // regroups by destination.
+            size_t cap_sum = 0;
+            for (int64_t i = s; i < static_cast<int64_t>(e); i++) {
+                storage_idx_t pid = order[i];
+                cap_sum += hnsw.offsets[pid + 1] - hnsw.offsets[pid];
+            }
+            // Default-initialised to skip a memset per sub-batch; safe because
+            // edge_counter only hands out slots that are written before read.
+            std::unique_ptr<Edge[]> reverse_edges(new Edge[cap_sum]);
+            std::atomic<size_t> edge_counter{0};
+
+            // Thrown after the region (cannot throw out of one); the
+            // unsynchronized write costs at most one extra poll.
+            bool interrupt = false;
+
+#pragma omp parallel if (e - s > 100)
+            {
+                std::unique_ptr<VisitedTable> vt =
+                        VisitedTable::create(ntotal, hnsw.use_visited_hashset);
+
+                std::unique_ptr<DistanceComputer> dis(make_distance_computer());
+                std::vector<std::pair<HNSW::storage_idx_t, int>>
+                        pt_reverse_edges;
+                size_t counter = 0;
+
+#pragma omp for schedule(static)
+                for (int64_t i = s; i < static_cast<int64_t>(e); i++) {
+                    if (interrupt) {
+                        continue; // cannot break out of an OpenMP for loop
+                    }
+                    storage_idx_t pt_id = order[i];
+                    int lvl = hnsw.levels[pt_id] - 1;
+                    set_query(*dis, pt_id);
+
+                    pt_reverse_edges.clear();
+                    hnsw.compute_forward_links_deterministic(
+                            *dis,
+                            lvl,
+                            pt_id,
+                            *vt,
+                            pt_reverse_edges,
+                            keep_max_size_level0);
+
+                    size_t off = edge_counter.fetch_add(
+                            pt_reverse_edges.size(), std::memory_order_relaxed);
+                    for (size_t k = 0; k < pt_reverse_edges.size(); k++) {
+                        reverse_edges[off + k] = {
+                                pt_reverse_edges[k].second,
+                                pt_reverse_edges[k].first,
+                                pt_id};
+                    }
+
+                    if (counter++ % check_period == 0 &&
+                        InterruptCallback::is_interrupted()) {
+                        interrupt = true;
+                    }
+                }
+            }
+            if (interrupt) {
+                FAISS_THROW_MSG("computation interrupted");
+            }
+
+            // Phase B: merge the reverse edges
+            // Group by destination so each node is merged by exactly one
+            // thread: lock-free and thread-count-independent.
+            const size_t total = edge_counter.load();
+
+            constexpr int kBucketBits = 8;
+            constexpr uint32_t kNumBuckets = 1u << kBucketBits;
+            constexpr uint32_t kBucketMask = kNumBuckets - 1;
+
+            // bstart[b]..bstart[b+1] delimits bucket b after partitioning.
+            std::vector<size_t> bstart(kNumBuckets + 1, 0);
+            for (size_t idx = 0; idx < total; idx++) {
+                bstart[(static_cast<uint32_t>(reverse_edges[idx].dest) &
+                        kBucketMask) +
+                       1]++;
+            }
+            for (uint32_t b = 0; b < kNumBuckets; b++) {
+                bstart[b + 1] += bstart[b];
+            }
+
+            // In-place partition (cycle sort): each step lands at least one
+            // edge in its bucket, so O(total) with no auxiliary buffer.
+            {
+                std::vector<size_t> head(bstart.begin(), bstart.end() - 1);
+                for (uint32_t b = 0; b < kNumBuckets; b++) {
+                    size_t end_b = bstart[b + 1];
+                    while (head[b] < end_b) {
+                        Edge cur_e = reverse_edges[head[b]];
+                        if ((static_cast<uint32_t>(cur_e.dest) & kBucketMask) ==
+                            b) {
+                            head[b]++;
+                            continue;
+                        }
+                        while ((static_cast<uint32_t>(cur_e.dest) &
+                                kBucketMask) != b) {
+                            uint32_t tb = static_cast<uint32_t>(cur_e.dest) &
+                                    kBucketMask;
+                            std::swap(cur_e, reverse_edges[head[tb]]);
+                            head[tb]++;
+                        }
+                        reverse_edges[head[b]] = cur_e;
+                        head[b]++;
+                    }
+                }
+            }
+            Edge* base = reverse_edges.get();
+
+#pragma omp parallel if (total > 100)
+            {
+                std::unique_ptr<DistanceComputer> dis(make_distance_computer());
+                // Not schedule(dynamic): the libomp dynamic dispatcher
+                // segfaults in some build configs.
+#pragma omp for schedule(static)
+                for (int64_t b = 0; b < static_cast<int64_t>(kNumBuckets);
+                     b++) {
+                    Edge* p = base + bstart[b];
+                    size_t m = bstart[b + 1] - bstart[b];
+                    if (m == 0) {
+                        continue;
+                    }
+                    // src order does not matter; the merge re-sorts each set.
+                    std::sort(p, p + m, [](const Edge& a, const Edge& c) {
+                        if (a.level != c.level) {
+                            return a.level < c.level;
+                        }
+                        return a.dest < c.dest;
+                    });
+                    std::vector<HNSW::storage_idx_t> incoming;
+                    size_t g = 0;
+                    while (g < m) {
+                        size_t h = g + 1;
+                        while (h < m && p[h].level == p[g].level &&
+                               p[h].dest == p[g].dest) {
+                            h++;
+                        }
+                        incoming.clear();
+                        incoming.reserve(h - g);
+                        for (size_t kk = g; kk < h; kk++) {
+                            incoming.push_back(p[kk].src);
+                        }
+                        hnsw.merge_reverse_links_deterministic(
+                                *dis,
+                                p[g].dest,
+                                p[g].level,
+                                incoming,
+                                keep_max_size_level0 && (p[g].level == 0));
+                        g = h;
+                    }
+                }
+            }
+
+            InterruptCallback::check();
+            s = e;
+        }
+
+        i1 = i0;
+    }
+
+    if (init_level0) {
+        FAISS_ASSERT(i1 == 0);
+    } else {
+        FAISS_ASSERT((i1 - hist[0]) == 0);
+    }
+
+    if (verbose) {
+        printf("Done in %.3f ms\n", getmillisecs() - t0);
+    }
+}
+
 /**************************************************************
  * IndexHNSW implementation
  **************************************************************/
@@ -384,13 +680,25 @@ void IndexHNSW::add(idx_t n, const float* x) {
     storage->add(n, x);
     ntotal = storage->ntotal;
 
-    hnsw_add_vertices(
-            *this,
-            n0,
-            n,
-            x,
-            verbose,
-            hnsw.levels.size() == static_cast<size_t>(ntotal));
+    bool preset_levels = hnsw.levels.size() == static_cast<size_t>(ntotal);
+
+    if (hnsw_deterministic_build) {
+        hnsw_add_vertices_deterministic(
+                hnsw,
+                n0,
+                n,
+                d,
+                init_level0,
+                keep_max_size_level0,
+                preset_levels,
+                verbose,
+                [this] { return storage_distance_computer(storage); },
+                [this, x, n0](DistanceComputer& dc, HNSW::storage_idx_t pt_id) {
+                    dc.set_query(x + (pt_id - n0) * d);
+                });
+    } else {
+        hnsw_add_vertices(*this, n0, n, x, verbose, preset_levels);
+    }
 }
 
 void IndexHNSW::reset() {

--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -41,6 +41,8 @@ using NodeDistFarther = HNSW::NodeDistFarther;
 
 HNSWStats hnsw_stats;
 
+bool hnsw_deterministic_build = false;
+
 /**************************************************************
  * add / search blocks of descriptors
  **************************************************************/
@@ -214,6 +216,302 @@ void hnsw_add_vertices(
 
 } // namespace
 
+// Deterministic HNSW graph build inspired by ParlayANN: points are bucketed by
+// level and inserted in prefix-doubling batches. Phase A computes forward
+// links against a frozen snapshot and records reverse edges; phase B merges
+// those in a fixed order.
+// https://arxiv.org/abs/2305.04359
+void hnsw_add_vertices_deterministic(
+        HNSW& hnsw,
+        size_t n0,
+        size_t n,
+        int d,
+        bool init_level0,
+        bool keep_max_size_level0,
+        bool preset_levels,
+        bool verbose,
+        const std::function<DistanceComputer*()>& make_distance_computer,
+        const std::function<void(DistanceComputer&, HNSW::storage_idx_t)>&
+                set_query) {
+    size_t ntotal = n0 + n;
+    double t0 = getmillisecs();
+    if (verbose) {
+        printf("hnsw_add_vertices_deterministic: adding %zd elements on top of %zd "
+               "(preset_levels=%d)\n",
+               n,
+               n0,
+               int(preset_levels));
+    }
+
+    if (n == 0) {
+        return;
+    }
+
+    // init_level0=false (CAGRA import) skips the level-0-only bucket; higher-
+    // level points still build their own level-0 links.
+    const int min_bucket_level = init_level0 ? 0 : 1;
+
+    int max_level = hnsw.prepare_level_tab(n, preset_levels);
+    if (verbose) {
+        printf("  max_level = %d\n", max_level);
+    }
+
+    // Bucket the new points by level, highest first.
+    std::vector<int> hist;
+    std::vector<int> order(n);
+
+    { // make buckets with vectors of the same level
+
+        // build histogram
+        for (size_t i = 0; i < n; i++) {
+            storage_idx_t pt_id = static_cast<storage_idx_t>(i + n0);
+            int pt_level = hnsw.levels[pt_id] - 1;
+            while (pt_level >= static_cast<int>(hist.size())) {
+                hist.push_back(0);
+            }
+            hist[pt_level]++;
+        }
+
+        // accumulate
+        std::vector<int> offsets(hist.size() + 1, 0);
+        for (size_t i = 0; i < hist.size() - 1; i++) {
+            offsets[i + 1] = offsets[i] + hist[i];
+        }
+
+        // bucket sort
+        for (size_t i = 0; i < n; i++) {
+            storage_idx_t pt_id = static_cast<storage_idx_t>(i + n0);
+            int pt_level = hnsw.levels[pt_id] - 1;
+            order[offsets[pt_level]++] = pt_id;
+        }
+    }
+
+    // Upper bound on batch size (ParlayANN's theta), 2% of the index.
+    const size_t theta =
+            std::max<size_t>(1, static_cast<size_t>(0.02 * ntotal));
+
+    // Polled inside phase A: a batch can be 2% of ntotal, so cancelling only
+    // at batch boundaries would take minutes on large indexes.
+    const idx_t check_period = InterruptCallback::get_period_hint(
+            max_level * d * hnsw.efConstruction);
+
+    RandomGenerator rng2(789);
+    size_t i1 = n;
+
+    for (int pt_level = static_cast<int>(hist.size()) - 1;
+         pt_level >= min_bucket_level;
+         pt_level--) {
+        size_t i0 = i1 - hist[pt_level];
+        if (i0 == i1) {
+            continue;
+        }
+
+        if (verbose) {
+            printf("Adding %zu elements at level %d\n", i1 - i0, pt_level);
+        }
+
+        // random permutation to get rid of dataset order bias
+        for (size_t j = i0; j < i1; j++) {
+            std::swap(
+                    order[j],
+                    order[j + rng2.rand_int(static_cast<int>(i1 - j))]);
+        }
+
+        // Bootstrap/raise the entry point: the top bucket runs first, so its
+        // first (shuffled) point is a valid max-level entry point.
+        if (hnsw.entry_point == -1 || pt_level > hnsw.max_level) {
+            hnsw.max_level = pt_level;
+            hnsw.entry_point = order[i0];
+        }
+
+        // Prefix-doubling batches within this bucket.
+        size_t s = i0;
+        while (s < i1) {
+            size_t done = s - i0;
+            size_t grow = std::min(done == 0 ? size_t(1) : done, theta);
+            size_t e = std::min(i1, s + grow);
+
+            // Phase A: compute forward links against the snapshot
+            // A reverse edge: `dest` gains an incoming link from `src`.
+            struct Edge {
+                int level;
+                HNSW::storage_idx_t dest;
+                HNSW::storage_idx_t src;
+            };
+
+            // One buffer, sized to an upper bound so it never reallocates.
+            // The fill order is nondeterministic but harmless: phase B
+            // regroups by destination.
+            size_t cap_sum = 0;
+            for (int64_t i = s; i < static_cast<int64_t>(e); i++) {
+                storage_idx_t pid = order[i];
+                cap_sum += hnsw.offsets[pid + 1] - hnsw.offsets[pid];
+            }
+            // Default-initialised to skip a memset per sub-batch; safe because
+            // edge_counter only hands out slots that are written before read.
+            std::unique_ptr<Edge[]> reverse_edges(new Edge[cap_sum]);
+            std::atomic<size_t> edge_counter{0};
+
+            // Thrown after the region (cannot throw out of one); the
+            // unsynchronized write costs at most one extra poll.
+            bool interrupt = false;
+
+#pragma omp parallel if (e - s > 100)
+            {
+                std::unique_ptr<VisitedTable> vt =
+                        VisitedTable::create(ntotal, hnsw.use_visited_hashset);
+
+                std::unique_ptr<DistanceComputer> dis(make_distance_computer());
+                std::vector<std::pair<HNSW::storage_idx_t, int>>
+                        pt_reverse_edges;
+                size_t counter = 0;
+
+#pragma omp for schedule(static)
+                for (int64_t i = s; i < static_cast<int64_t>(e); i++) {
+                    if (interrupt) {
+                        continue; // cannot break out of an OpenMP for loop
+                    }
+                    storage_idx_t pt_id = order[i];
+                    int lvl = hnsw.levels[pt_id] - 1;
+                    set_query(*dis, pt_id);
+
+                    pt_reverse_edges.clear();
+                    hnsw.compute_forward_links_deterministic(
+                            *dis,
+                            lvl,
+                            pt_id,
+                            *vt,
+                            pt_reverse_edges,
+                            keep_max_size_level0);
+
+                    size_t off = edge_counter.fetch_add(
+                            pt_reverse_edges.size(), std::memory_order_relaxed);
+                    for (size_t k = 0; k < pt_reverse_edges.size(); k++) {
+                        reverse_edges[off + k] = {
+                                pt_reverse_edges[k].second,
+                                pt_reverse_edges[k].first,
+                                pt_id};
+                    }
+
+                    if (counter++ % check_period == 0 &&
+                        InterruptCallback::is_interrupted()) {
+                        interrupt = true;
+                    }
+                }
+            }
+            if (interrupt) {
+                FAISS_THROW_MSG("computation interrupted");
+            }
+
+            // Phase B: merge the reverse edges
+            // Group by destination so each node is merged by exactly one
+            // thread: lock-free and thread-count-independent.
+            const size_t total = edge_counter.load();
+
+            constexpr int kBucketBits = 8;
+            constexpr uint32_t kNumBuckets = 1u << kBucketBits;
+            constexpr uint32_t kBucketMask = kNumBuckets - 1;
+
+            // bstart[b]..bstart[b+1] delimits bucket b after partitioning.
+            std::vector<size_t> bstart(kNumBuckets + 1, 0);
+            for (size_t idx = 0; idx < total; idx++) {
+                bstart[(static_cast<uint32_t>(reverse_edges[idx].dest) &
+                        kBucketMask) +
+                       1]++;
+            }
+            for (uint32_t b = 0; b < kNumBuckets; b++) {
+                bstart[b + 1] += bstart[b];
+            }
+
+            // In-place partition (cycle sort): each step lands at least one
+            // edge in its bucket, so O(total) with no auxiliary buffer.
+            {
+                std::vector<size_t> head(bstart.begin(), bstart.end() - 1);
+                for (uint32_t b = 0; b < kNumBuckets; b++) {
+                    size_t end_b = bstart[b + 1];
+                    while (head[b] < end_b) {
+                        Edge cur_e = reverse_edges[head[b]];
+                        if ((static_cast<uint32_t>(cur_e.dest) & kBucketMask) ==
+                            b) {
+                            head[b]++;
+                            continue;
+                        }
+                        while ((static_cast<uint32_t>(cur_e.dest) &
+                                kBucketMask) != b) {
+                            uint32_t tb = static_cast<uint32_t>(cur_e.dest) &
+                                    kBucketMask;
+                            std::swap(cur_e, reverse_edges[head[tb]]);
+                            head[tb]++;
+                        }
+                        reverse_edges[head[b]] = cur_e;
+                        head[b]++;
+                    }
+                }
+            }
+            Edge* base = reverse_edges.get();
+
+#pragma omp parallel if (total > 100)
+            {
+                std::unique_ptr<DistanceComputer> dis(make_distance_computer());
+                // Not schedule(dynamic): the libomp dynamic dispatcher
+                // segfaults in some build configs.
+#pragma omp for schedule(static)
+                for (int64_t b = 0; b < static_cast<int64_t>(kNumBuckets);
+                     b++) {
+                    Edge* p = base + bstart[b];
+                    size_t m = bstart[b + 1] - bstart[b];
+                    if (m == 0) {
+                        continue;
+                    }
+                    // src order does not matter; the merge re-sorts each set.
+                    std::sort(p, p + m, [](const Edge& a, const Edge& c) {
+                        if (a.level != c.level) {
+                            return a.level < c.level;
+                        }
+                        return a.dest < c.dest;
+                    });
+                    std::vector<HNSW::storage_idx_t> incoming;
+                    size_t g = 0;
+                    while (g < m) {
+                        size_t h = g + 1;
+                        while (h < m && p[h].level == p[g].level &&
+                               p[h].dest == p[g].dest) {
+                            h++;
+                        }
+                        incoming.clear();
+                        incoming.reserve(h - g);
+                        for (size_t kk = g; kk < h; kk++) {
+                            incoming.push_back(p[kk].src);
+                        }
+                        hnsw.merge_reverse_links_deterministic(
+                                *dis,
+                                p[g].dest,
+                                p[g].level,
+                                incoming,
+                                keep_max_size_level0 && (p[g].level == 0));
+                        g = h;
+                    }
+                }
+            }
+
+            InterruptCallback::check();
+            s = e;
+        }
+
+        i1 = i0;
+    }
+
+    if (init_level0) {
+        FAISS_ASSERT(i1 == 0);
+    } else {
+        FAISS_ASSERT((i1 - hist[0]) == 0);
+    }
+
+    if (verbose) {
+        printf("Done in %.3f ms\n", getmillisecs() - t0);
+    }
+}
+
 /**************************************************************
  * IndexHNSW implementation
  **************************************************************/
@@ -384,13 +682,25 @@ void IndexHNSW::add(idx_t n, const float* x) {
     storage->add(n, x);
     ntotal = storage->ntotal;
 
-    hnsw_add_vertices(
-            *this,
-            n0,
-            n,
-            x,
-            verbose,
-            hnsw.levels.size() == static_cast<size_t>(ntotal));
+    bool preset_levels = hnsw.levels.size() == static_cast<size_t>(ntotal);
+
+    if (hnsw_deterministic_build) {
+        hnsw_add_vertices_deterministic(
+                hnsw,
+                n0,
+                n,
+                d,
+                init_level0,
+                keep_max_size_level0,
+                preset_levels,
+                verbose,
+                [this] { return storage_distance_computer(storage); },
+                [this, x, n0](DistanceComputer& dc, HNSW::storage_idx_t pt_id) {
+                    dc.set_query(x + (pt_id - n0) * d);
+                });
+    } else {
+        hnsw_add_vertices(*this, n0, n, x, verbose, preset_levels);
+    }
 }
 
 void IndexHNSW::reset() {

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -19,6 +19,7 @@
 #include <faiss/impl/IDSelector.h>
 #include <faiss/impl/ResultHandler.h>
 #include <faiss/impl/VisitedTable.h>
+#include <faiss/impl/hnsw/LockVector.h>
 #include <faiss/impl/hnsw/MinimaxHeap.h>
 
 namespace faiss {
@@ -222,17 +223,17 @@ int HNSW::prepare_level_tab(size_t n, bool preset_levels) {
         }
     }
 
-    int max_level_2 = 0;
+    int local_max_level = 0;
     for (size_t i = 0; i < n; i++) {
         int pt_level = levels[i + n0] - 1;
-        if (pt_level > max_level_2) {
-            max_level_2 = pt_level;
+        if (pt_level > local_max_level) {
+            local_max_level = pt_level;
         }
         offsets.push_back(offsets.back() + cum_nb_neighbors(pt_level + 1));
     }
     neighbors.resize(offsets.back(), -1);
 
-    return max_level_2;
+    return local_max_level;
 }
 
 /** Enumerate vertices from nearest to farthest from query, keep a
@@ -304,6 +305,11 @@ template void HNSW::shrink_neighbor_list<HNSW::C_similarity>(
 namespace {
 
 using storage_idx_t = HNSW::storage_idx_t;
+
+inline size_t pruned_neighbor_size(size_t max_size, float prune_headroom) {
+    return static_cast<size_t>(
+            max_size - max_size * std::clamp(prune_headroom, 0.0f, 0.5f));
+}
 
 // Map a (high-level) HNSW comparator C — which uses int64_t IDs — to the
 // (low-level) MinimaxHeap comparator HC, which uses int32_t IDs.
@@ -784,7 +790,183 @@ HNSWStats hnsw_detail::greedy_update_nearest(
             hnsw, qdis, level, nearest, d_nearest);
 }
 
+/**************************************************************
+ * Deterministic addition subroutines
+ **************************************************************/
+
 namespace {
+
+template <class C>
+void compute_forward_links_impl(
+        HNSW& hnsw,
+        DistanceComputer& ptdis,
+        int pt_level,
+        storage_idx_t pt_id,
+        VisitedTable& vt,
+        std::vector<std::pair<storage_idx_t, int>>& pt_reverse_edges,
+        bool keep_max_size_level0) {
+    storage_idx_t nearest = hnsw.entry_point;
+    FAISS_ASSERT(nearest >= 0);
+    float d_nearest = ptdis(nearest);
+
+    int level = hnsw.max_level;
+    // greedy descent on the upper levels the point does not live on
+    for (; level > pt_level; level--) {
+        greedy_update_nearest_impl<C>(hnsw, ptdis, level, nearest, d_nearest);
+    }
+
+    // levels the point lives on: search from the same entry point
+    for (; level >= 0; level--) {
+        std::priority_queue<HNSW::NodeDistCloserT<C>> link_targets;
+        search_neighbors_to_add_dispatch<C>(
+                hnsw,
+                ptdis,
+                link_targets,
+                nearest,
+                d_nearest,
+                level,
+                vt,
+                false);
+
+        int M = hnsw.nb_neighbors(level);
+        shrink_neighbor_list_inner<C>(
+                ptdis, link_targets, M, keep_max_size_level0 && (level == 0));
+
+        // pt_id is not reachable yet, so the snapshot stays immutable for the
+        // other points in this batch
+        size_t begin, end;
+        hnsw.neighbor_range(pt_id, level, &begin, &end);
+        size_t i = begin;
+        while (!link_targets.empty()) {
+            storage_idx_t other_id = link_targets.top().id;
+            link_targets.pop();
+            // pt_id is in its own candidate list when it is the entry point
+            if (other_id == pt_id) {
+                continue;
+            }
+            FAISS_ASSERT(i < end);
+            hnsw.neighbors[i++] = other_id;
+            pt_reverse_edges.emplace_back(other_id, level);
+        }
+        while (i < end) {
+            hnsw.neighbors[i++] = -1;
+        }
+    }
+}
+
+template <class C>
+void merge_reverse_links_impl(
+        HNSW& hnsw,
+        DistanceComputer& dis,
+        storage_idx_t node,
+        int level,
+        std::vector<storage_idx_t>& incoming,
+        bool keep_max_size_level0) {
+    size_t begin, end;
+    hnsw.neighbor_range(node, level, &begin, &end);
+    size_t max_size = end - begin;
+
+    std::vector<storage_idx_t> cands;
+    cands.reserve(max_size + incoming.size());
+    for (size_t i = begin; i < end; i++) {
+        if (hnsw.neighbors[i] < 0) {
+            break;
+        }
+        cands.push_back(hnsw.neighbors[i]);
+    }
+    size_t n_existing = cands.size();
+
+    std::sort(incoming.begin(), incoming.end());
+    incoming.erase(
+            std::unique(incoming.begin(), incoming.end()), incoming.end());
+    for (storage_idx_t v : incoming) {
+        if (v == node) {
+            continue;
+        }
+        bool present = false;
+        for (size_t i = 0; i < n_existing; i++) {
+            if (cands[i] == v) {
+                present = true;
+                break;
+            }
+        }
+        if (!present) {
+            cands.push_back(v);
+        }
+    }
+
+    if (cands.size() <= max_size) {
+        size_t i = begin;
+        for (storage_idx_t v : cands) {
+            hnsw.neighbors[i++] = v;
+        }
+        while (i < end) {
+            hnsw.neighbors[i++] = -1;
+        }
+        return;
+    }
+
+    // Ties broken by id, so the result is independent of collection order.
+    std::vector<std::pair<float, storage_idx_t>> arr;
+    arr.reserve(cands.size());
+    for (storage_idx_t v : cands) {
+        arr.emplace_back(dis.symmetric_dis(node, v), v);
+    }
+    std::sort(
+            arr.begin(),
+            arr.end(),
+            [](const std::pair<float, storage_idx_t>& a,
+               const std::pair<float, storage_idx_t>& b) {
+                if (a.first != b.first) {
+                    // C::cmp(x, y) is true when y is "better" than x, so
+                    // a before b iff a is better than b.
+                    return C::cmp(b.first, a.first);
+                }
+                return a.second < b.second;
+            });
+
+    // Same headroom as add_link's reciprocal pruning, so degrees stay
+    // comparable between the two builds.
+    size_t pruned_size = pruned_neighbor_size(max_size, hnsw.prune_headroom);
+    if (pruned_size < 1) {
+        pruned_size = 1;
+    }
+
+    std::vector<std::pair<float, storage_idx_t>> kept;
+    std::vector<std::pair<float, storage_idx_t>> outsiders;
+    for (const auto& cand : arr) {
+        float dist_v1_q = cand.first;
+        bool good = true;
+        for (const auto& k : kept) {
+            float dist_v1_v2 = dis.symmetric_dis(k.second, cand.second);
+            if (C::cmp(dist_v1_q, dist_v1_v2)) {
+                good = false;
+                break;
+            }
+        }
+        if (good) {
+            kept.push_back(cand);
+            if (kept.size() >= pruned_size) {
+                break;
+            }
+        } else if (keep_max_size_level0) {
+            outsiders.push_back(cand);
+        }
+    }
+    for (size_t idx = 0; keep_max_size_level0 && kept.size() < max_size &&
+         idx < outsiders.size();
+         idx++) {
+        kept.push_back(outsiders[idx]);
+    }
+
+    size_t i = begin;
+    for (const auto& k : kept) {
+        hnsw.neighbors[i++] = k.second;
+    }
+    while (i < end) {
+        hnsw.neighbors[i++] = -1;
+    }
+}
 
 template <class C>
 void add_with_locks_impl(
@@ -861,6 +1043,49 @@ void HNSW::add_with_locks(
     } else {
         add_with_locks_impl<C_distance>(
                 *this, ptdis, pt_level, pt_id, locks, vt, keep_max_size_level0);
+    }
+}
+
+void HNSW::compute_forward_links_deterministic(
+        DistanceComputer& ptdis,
+        int pt_level,
+        storage_idx_t pt_id,
+        VisitedTable& vt,
+        std::vector<std::pair<storage_idx_t, int>>& pt_reverse_edges,
+        bool keep_max_size_level0) {
+    if (is_similarity) {
+        compute_forward_links_impl<C_similarity>(
+                *this,
+                ptdis,
+                pt_level,
+                pt_id,
+                vt,
+                pt_reverse_edges,
+                keep_max_size_level0);
+    } else {
+        compute_forward_links_impl<C_distance>(
+                *this,
+                ptdis,
+                pt_level,
+                pt_id,
+                vt,
+                pt_reverse_edges,
+                keep_max_size_level0);
+    }
+}
+
+void HNSW::merge_reverse_links_deterministic(
+        DistanceComputer& dis,
+        storage_idx_t node,
+        int level,
+        std::vector<storage_idx_t>& incoming,
+        bool keep_max_size_level0) {
+    if (is_similarity) {
+        merge_reverse_links_impl<C_similarity>(
+                *this, dis, node, level, incoming, keep_max_size_level0);
+    } else {
+        merge_reverse_links_impl<C_distance>(
+                *this, dis, node, level, incoming, keep_max_size_level0);
     }
 }
 

--- a/faiss/impl/HNSW.h
+++ b/faiss/impl/HNSW.h
@@ -7,8 +7,10 @@
 
 #pragma once
 
+#include <functional>
 #include <optional>
 #include <queue>
+#include <utility>
 #include <vector>
 
 #include <omp.h>
@@ -214,6 +216,29 @@ struct HNSW {
             VisitedTable& vt,
             bool keep_max_size_level0 = false);
 
+    /** Deterministic build, phase A: write pt_id's forward links against an
+     * immutable snapshot, touching only pt_id's own slots. Reciprocal edges
+     * are collected in `pt_reverse_edges` for phase B, not applied. Requires
+     * entry_point set. */
+    void compute_forward_links_deterministic(
+            DistanceComputer& ptdis,
+            int pt_level,
+            storage_idx_t pt_id,
+            VisitedTable& vt,
+            std::vector<std::pair<storage_idx_t, int>>& pt_reverse_edges,
+            bool keep_max_size_level0 = false);
+
+    /** Deterministic build, phase B: merge `incoming` into `node` and
+     * re-prune in a total order (distance, ties by id) so the result is
+     * order-independent. Touches only `node`'s slots; `incoming` is sorted
+     * and deduplicated in place. */
+    void merge_reverse_links_deterministic(
+            DistanceComputer& dis,
+            storage_idx_t node,
+            int level,
+            std::vector<storage_idx_t>& incoming,
+            bool keep_max_size_level0 = false);
+
     /// Search interface for 1 point, single thread
     ///
     /// NOTE: We pass a reference to the index itself to allow for additional
@@ -257,6 +282,23 @@ struct HNSW {
     void permute_entries(const idx_t* map);
 };
 
+/** Deterministic, lock-free HNSW graph build, shared by IndexHNSW and
+ * IndexBinaryHNSW. The callbacks let both share the algorithm:
+ * `make_distance_computer()` returns a fresh DistanceComputer per thread
+ * (caller-owned) and `set_query(dc, pt_id)` points it at pt_id's vector. */
+void hnsw_add_vertices_deterministic(
+        HNSW& hnsw,
+        size_t n0,
+        size_t n,
+        int d,
+        bool init_level0,
+        bool keep_max_size_level0,
+        bool preset_levels,
+        bool verbose,
+        const std::function<DistanceComputer*()>& make_distance_computer,
+        const std::function<void(DistanceComputer&, HNSW::storage_idx_t)>&
+                set_query);
+
 struct HNSWStats {
     size_t n1 = 0; /// number of vectors searched
     size_t n2 =
@@ -280,6 +322,12 @@ struct HNSWStats {
 
 // global var that collects them all
 FAISS_API extern HNSWStats hnsw_stats;
+
+/** Use the lock-free deterministic graph build in add() rather than the
+ * lock-based one. Transitional: it will become the only path.
+ *
+ * NOT thread-safe: set before calling add(). Sampled once per add(). */
+FAISS_API extern bool hnsw_deterministic_build;
 
 /// Internal HNSW algorithm helpers. These are not part of the public API; they
 /// are exposed here only so that unit tests (and a few cross-TU callers such as

--- a/faiss/python/__init__.pyi
+++ b/faiss/python/__init__.pyi
@@ -4318,6 +4318,18 @@ distance_compute_min_k_reservoir: int
 # Index factory verbose flag
 index_factory_verbose: int
 
+# SWIG exposes mutable C++ globals here rather than as module attributes,
+# which could not write through to C++. Access as `faiss.cvar.<name>`.
+class _SwigGlobals:
+    distance_compute_blas_threshold: int
+    distance_compute_blas_query_bs: int
+    distance_compute_blas_database_bs: int
+    distance_compute_min_k_reservoir: int
+    index_factory_verbose: int
+    hnsw_deterministic_build: bool
+
+cvar: _SwigGlobals
+
 # GPU-specific types and functions
 class GpuDistanceParams:
     metric: MetricType

--- a/tests/bench_hnsw_deterministic.py
+++ b/tests/bench_hnsw_deterministic.py
@@ -1,0 +1,274 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Microbenchmark for the HNSW graph build (deterministic, lock-free). Two modes:
+#
+#   summary (default): build the index FAISS_DET_NBUILDS times, reporting build
+#     time (min/mean) + peak RSS, graph reproducibility (blake2b of
+#     neighbors+offsets across builds), and the recall/QPS tradeoff vs
+#     brute-force ground truth.
+#
+#   timing study (FAISS_DET_ROUNDS > 0): time the build FAISS_DET_ROUNDS times,
+#     reporting per-round times and min/mean/median/max/std.
+#
+# Memory: a single HNSWFlat index at large nb is tens of GB, so only one index
+# is alive at a time, the dataset is serialized once and memory-mapped
+# (file-backed pages are evictable instead of hitting swap), and ground truth
+# uses faiss.knn (no second full-size index copy).
+#
+# Env (all optional): FAISS_DET_NB (default 40_000_000), FAISS_DET_NBUILDS (3),
+#   FAISS_DET_ROUNDS (0), FAISS_DET_M (32), FAISS_DET_EFC (64), FAISS_DET_NQ
+#   (1_000), FAISS_DET_SEED (1234), FAISS_DET_DATA_DIR (a tempdir, reused across
+#   runs), FAISS_DET_GRAPH_OUT (dump last graph), FAISS_DET_TAG.
+#
+# Run with:
+#   buck2 run fbcode//faiss/tests:bench_hnsw_deterministic
+
+from __future__ import annotations
+
+import gc
+import hashlib
+import os
+import tempfile
+import threading
+import time
+import unittest
+
+import faiss
+import numpy as np
+
+from faiss.contrib.datasets import SyntheticDataset
+
+
+def _envint(name: str, default: int) -> int:
+    v = os.environ.get(name)
+    return int(v) if v else default
+
+
+class RSSPeak:
+    # Samples VmRSS in a daemon thread; reset() rebases the peak to "now" so the
+    # peak during a single build interval can be captured.
+    def __init__(self, interval: float = 0.25) -> None:
+        self._peak = 0
+        self._stop = False
+        self._lock = threading.Lock()
+        self._interval = interval
+        self._t = threading.Thread(target=self._run, daemon=True)
+
+    @staticmethod
+    def _rss_kb() -> int:
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1])
+        return 0
+
+    def _run(self) -> None:
+        while not self._stop:
+            r = self._rss_kb()
+            with self._lock:
+                self._peak = max(self._peak, r)
+            time.sleep(self._interval)
+
+    def start(self) -> None:
+        self._t.start()
+
+    def reset(self) -> None:
+        with self._lock:
+            self._peak = self._rss_kb()
+
+    def peak_gb(self) -> float:
+        with self._lock:
+            return self._peak / 1048576.0
+
+    def stop(self) -> None:
+        self._stop = True
+        # Join the sampler so no in-flight `self._peak = max(...)` update can
+        # race a subsequent peak_gb() read.
+        self._t.join()
+
+
+def dataset_paths(d: int, nb: int, nq: int, seed: int) -> tuple[str, str]:
+    base = os.environ.get("FAISS_DET_DATA_DIR") or os.path.join(
+        tempfile.gettempdir(), "faiss_det_bench"
+    )
+    os.makedirs(base, exist_ok=True)
+    tag = f"d{d}_nb{nb}_nq{nq}_s{seed}"
+    return (
+        os.path.join(base, f"xb_{tag}.npy"),
+        os.path.join(base, f"xq_{tag}.npy"),
+    )
+
+
+def make_dataset(d: int, nb: int, nq: int, seed: int):
+    # SyntheticDataset: a low-intrinsic-dimensional ellipsoid so recall is
+    # meaningful; HNSWFlat needs no training (nt=0). Serialized once and
+    # returned as a copy-on-write memmap so its pages stay file-backed (a build
+    # still makes its own resident copy, but the source can be evicted under
+    # pressure rather than swapped). Queries are tiny and kept in memory.
+    xb_path, xq_path = dataset_paths(d, nb, nq, seed)
+    if not (os.path.exists(xb_path) and os.path.exists(xq_path)):
+        ds = SyntheticDataset(d, 0, nb, nq, seed=seed)
+        np.save(xb_path, ds.get_database())
+        np.save(xq_path, ds.get_queries())
+        del ds
+        gc.collect()
+    xb = np.load(xb_path, mmap_mode="c")
+    xq = np.load(xq_path)
+    return xb, xq
+
+
+def ground_truth(xb, xq, k):
+    # Block-wise brute force: streams over xb without a second full-size copy.
+    _, gt = faiss.knn(xq, xb, k, metric=faiss.METRIC_L2)
+    return gt
+
+
+def dump_graph(index, path):
+    neighbors = faiss.vector_to_array(index.hnsw.neighbors)
+    offsets = faiss.vector_to_array(index.hnsw.offsets)
+    with open(path, "wb") as f:
+        f.write(neighbors.tobytes())
+        f.write(offsets.tobytes())
+    return neighbors.nbytes + offsets.nbytes
+
+
+def build_index(xb, d, M, efc, rss):
+    index = faiss.IndexHNSWFlat(d, M)
+    index.hnsw.efConstruction = efc
+    rss.reset()
+    t0 = time.perf_counter()
+    index.add(xb)
+    return index, time.perf_counter() - t0, rss.peak_gb()
+
+
+def recall_at_k(index, xq, gt, k, efSearch):
+    index.hnsw.efSearch = efSearch
+    t0 = time.perf_counter()
+    _, ids = index.search(xq, k)
+    dt = time.perf_counter() - t0
+    nq = xq.shape[0]
+    hits = 0
+    for i in range(nq):
+        hits += len(set(ids[i]).intersection(set(gt[i])))
+    return hits / (nq * k), nq / dt
+
+
+def graph_hash(index) -> str:
+    # blake2b of neighbors+offsets, no copy beyond vector_to_array.
+    h = hashlib.blake2b()
+    neighbors = faiss.vector_to_array(index.hnsw.neighbors)
+    h.update(memoryview(neighbors))
+    del neighbors
+    offsets = faiss.vector_to_array(index.hnsw.offsets)
+    h.update(memoryview(offsets))
+    return h.hexdigest()
+
+
+def _stats(xs):
+    xs2 = sorted(xs)
+    n = len(xs2)
+    mean = sum(xs2) / n
+    median = xs2[n // 2] if n % 2 else (xs2[n // 2 - 1] + xs2[n // 2]) / 2
+    std = (sum((x - mean) ** 2 for x in xs2) / n) ** 0.5
+    return min(xs2), mean, median, max(xs2), std
+
+
+EF_SEARCH = (16, 32, 64, 128)
+
+
+def summary(xb, xq, gt, d, nb, M, efc, k, nbuilds, rss, threads):
+    print(
+        f"\n=== d={d} nb={nb:,} M={M} efC={efc} k={k} nbuilds={nbuilds} "
+        f"(threads={threads}) ==="
+    )
+    times, peaks, hashes = [], [], []
+    idx = None
+    for _ in range(nbuilds):
+        if idx is not None:
+            del idx
+            gc.collect()
+        idx, t, peak = build_index(xb, d, M, efc, rss)
+        times.append(t)
+        peaks.append(peak)
+        hashes.append(graph_hash(idx))
+    out = os.environ.get("FAISS_DET_GRAPH_OUT")
+    if out:
+        dump_graph(idx, out)
+
+    tmin, tmean = min(times), sum(times) / len(times)
+    print(
+        f"build time: min={tmin:7.2f}s mean={tmean:7.2f}s "
+        f"peak={max(peaks):.1f}GB"
+    )
+    print(
+        f"graph reproducible across {nbuilds} builds: "
+        f"{'YES' if len(set(hashes)) == 1 else 'NO'}"
+    )
+    print(f"{'efSearch':>9} | {'recall':>8} {'QPS':>9}")
+    for efs in EF_SEARCH:
+        r, q = recall_at_k(idx, xq, gt, k, efs)
+        print(f"{efs:>9} | {r:>8.4f} {q:>9.0f}")
+    del idx
+    gc.collect()
+
+
+def timing_study(xb, d, M, efc, rounds, rss, tag, threads):
+    print(
+        f"\n=== timing study: {rounds} rounds, threads={threads}, "
+        f"tag={tag!r} ==="
+    )
+    ts = []
+    for r in range(rounds):
+        idx, t, peak = build_index(xb, d, M, efc, rss)
+        ts.append(t)
+        del idx
+        gc.collect()
+        print(f"round {r + 1:>2}/{rounds}  {t:7.2f}s  peak={peak:.1f}GB")
+    mn, mean, med, mx, std = _stats(ts)
+    print("build s: " + " ".join(f"{x:.2f}" for x in ts))
+    print(
+        f"build: min={mn:.2f} mean={mean:.2f} median={med:.2f} "
+        f"max={mx:.2f} std={std:.2f}"
+    )
+
+
+def main() -> None:
+    d = 128
+    nb = _envint("FAISS_DET_NB", 40_000_000)
+    nq = _envint("FAISS_DET_NQ", 1_000)
+    M = _envint("FAISS_DET_M", 32)
+    efc = _envint("FAISS_DET_EFC", 64)
+    seed = _envint("FAISS_DET_SEED", 1234)
+    nbuilds = _envint("FAISS_DET_NBUILDS", 3)
+    rounds = _envint("FAISS_DET_ROUNDS", 0)
+    k = 10
+    tag = os.environ.get("FAISS_DET_TAG", "")
+
+    # Fixed thread count: the build guarantees reproducibility at a fixed
+    # thread count.
+    faiss.omp_set_num_threads(faiss.omp_get_max_threads())
+    threads = faiss.omp_get_max_threads()
+    faiss.cvar.hnsw_deterministic_build = True
+    print("faiss HNSW deterministic-build benchmark")
+
+    rss = RSSPeak()
+    rss.start()
+    xb, xq = make_dataset(d, nb, nq, seed)
+    if rounds > 0:
+        timing_study(xb, d, M, efc, rounds, rss, tag, threads)
+    else:
+        gt = ground_truth(xb, xq, k)
+        summary(xb, xq, gt, d, nb, M, efc, k, nbuilds, rss, threads)
+    rss.stop()
+
+
+class BenchHNSWDeterministic(unittest.TestCase):
+    def test_bench(self) -> None:
+        main()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_graph_based.py
+++ b/tests/test_graph_based.py
@@ -39,6 +39,82 @@ class TestHNSW(unittest.TestCase):
 
         self.io_and_retest(index, Dhnsw, Ihnsw)
 
+    def test_deterministic_build(self):
+        # The HNSW build is deterministic and lock-free: repeated builds, and
+        # builds at different thread counts, produce byte-identical graphs.
+        # nb must be large enough that the batch-size cap (2% of n) exceeds
+        # the >100 threshold gating the parallel build region; otherwise the
+        # build runs single-threaded and determinism is trivially untested.
+        d = 32
+        nb = 20000
+        xb = np.random.RandomState(123).random((nb, d)).astype("float32")
+
+        # build() mutates the process-global OpenMP thread count and the
+        # deterministic-build flag; restore both so they do not leak into
+        # subsequent tests.
+        self.addCleanup(faiss.omp_set_num_threads, faiss.omp_get_max_threads())
+        self.addCleanup(
+            setattr,
+            faiss.cvar,
+            "hnsw_deterministic_build",
+            faiss.cvar.hnsw_deterministic_build,
+        )
+        faiss.cvar.hnsw_deterministic_build = True
+
+        def build(nthreads):
+            faiss.omp_set_num_threads(nthreads)
+            index = faiss.IndexHNSWFlat(d, 16)
+            index.add(xb)
+            return index
+
+        # `index.hnsw` returns a fresh (copied) proxy and `.neighbors` /
+        # `.offsets` are views into it, so chaining `index.hnsw.neighbors`
+        # inline reads a freed temporary. Bind the hnsw proxy to keep it alive
+        # across the (copying) vector_to_array calls.
+        def graph_of(index):
+            hnsw = index.hnsw
+            return (
+                hnsw.max_level,
+                faiss.vector_to_array(hnsw.neighbors),
+                faiss.vector_to_array(hnsw.offsets),
+            )
+
+        idx8 = build(8)
+        max_level, g8a, offs = graph_of(idx8)
+
+        # graph is non-trivial: multi-level, many real edges
+        self.assertGreaterEqual(max_level, 1)
+        self.assertGreater(int((g8a >= 0).sum()), nb)
+
+        # reproducible across repeated builds and across thread counts
+        g8b = graph_of(build(8))[1]
+        g1 = graph_of(build(1))[1]
+        np.testing.assert_array_equal(g8a, g8b)
+        np.testing.assert_array_equal(g8a, g1)
+
+        # no self-loops
+        for i in range(nb):
+            seg = g8a[int(offs[i]) : int(offs[i + 1])]
+            self.assertNotIn(i, seg[seg >= 0].tolist())
+
+    def test_deterministic_build_recall(self):
+        # Same recall bar as test_hnsw (which exercises the lock-based default),
+        # so the deterministic graph is not merely reproducible but as good.
+        self.addCleanup(
+            setattr,
+            faiss.cvar,
+            "hnsw_deterministic_build",
+            faiss.cvar.hnsw_deterministic_build,
+        )
+        faiss.cvar.hnsw_deterministic_build = True
+
+        index = faiss.IndexHNSWFlat(self.xq.shape[1], 16)
+        index.add(self.xb)
+        Dhnsw, Ihnsw = index.search(self.xq, 1)
+
+        self.assertGreaterEqual((self.Iref == Ihnsw).sum(), 460)
+        self.io_and_retest(index, Dhnsw, Ihnsw)
+
     def test_range_search(self):
         index_flat = faiss.IndexFlat(self.xb.shape[1])
         index_flat.add(self.xb)
@@ -143,6 +219,7 @@ class TestHNSW(unittest.TestCase):
         zero_vecs = np.zeros((0, 10), dtype="float32")
         # infinite loop
         index.add(zero_vecs)
+        self.assertEqual(index.ntotal, 0)
 
     def test_hnsw_IP(self):
         d = self.xq.shape[1]
@@ -158,7 +235,7 @@ class TestHNSW(unittest.TestCase):
         self.assertGreaterEqual((Iref == Ihnsw).sum(), 470)
 
         mask = Iref[:, 0] == Ihnsw[:, 0]
-        assert np.allclose(Dref[mask, 0], Dhnsw[mask, 0])
+        self.assertTrue(np.allclose(Dref[mask, 0], Dhnsw[mask, 0]))
 
     def test_ndis_stats(self):
         d = self.xq.shape[1]
@@ -194,14 +271,6 @@ class TestHNSW(unittest.TestCase):
         Dnew, Inew = index.search(self.xq, 5)
         np.testing.assert_array_equal(Dnew, Dref)
         np.testing.assert_array_equal(Inew, Iref)
-
-        if False:
-            # test reading without storage
-            # not implemented because it is hard to skip over an index
-            index3 = faiss.deserialize_index(
-                faiss.serialize_index(index), faiss.IO_FLAG_SKIP_STORAGE
-            )
-            self.assertEqual(index3.storage, None)
 
     def test_hnsw_reset(self):
         d = self.xb.shape[1]
@@ -607,9 +676,10 @@ class TestNSG(unittest.TestCase):
         d = self.xq.shape[1]
         R, pq_M = 32, 4
         index = faiss.index_factory(d, f"NSG{R}_PQ{pq_M}np")
-        assert isinstance(index, faiss.IndexNSGPQ)
+        self.assertIsInstance(index, faiss.IndexNSGPQ)
         idxpq = faiss.downcast_index(index.storage)
-        assert index.nsg.R == R and idxpq.pq.M == pq_M
+        self.assertEqual(index.nsg.R, R)
+        self.assertEqual(idxpq.pq.M, pq_M)
 
         flat_index = faiss.IndexFlat(d)
         flat_index.add(self.xb)
@@ -634,10 +704,10 @@ class TestNSG(unittest.TestCase):
         d = self.xq.shape[1]
         R = 32
         index = faiss.index_factory(d, f"NSG{R}_SQ8")
-        assert isinstance(index, faiss.IndexNSGSQ)
+        self.assertIsInstance(index, faiss.IndexNSGSQ)
         idxsq = faiss.downcast_index(index.storage)
-        assert index.nsg.R == R
-        assert idxsq.sq.qtype == faiss.ScalarQuantizer.QT_8bit
+        self.assertEqual(index.nsg.R, R)
+        self.assertEqual(idxsq.sq.qtype, faiss.ScalarQuantizer.QT_8bit)
 
         flat_index = faiss.IndexFlat(d)
         flat_index.add(self.xb)
@@ -743,6 +813,8 @@ class TestNNDescentGenRandom(unittest.TestCase):
 
         # This crashed with division by zero before the fix
         D, I = index.search(xq, k=1)
+        self.assertEqual(I.shape, (xq.shape[0], 1))
+        self.assertEqual(D.shape, (xq.shape[0], 1))
 
 
 class TestNNDescentKNNG(unittest.TestCase):
@@ -780,7 +852,7 @@ class TestNNDescentKNNG(unittest.TestCase):
                         recalls += 1
                         break
         recall = 1.0 * recalls / (nb * K)
-        assert recall > 0.99
+        self.assertGreater(recall, 0.99)
 
     def test_small_nndescent(self):
         """building a too small graph used to crash, make sure it raises


### PR DESCRIPTION
Summary:

TLDR: adds deterministic HNSW build inspired by ParlayANN. The deterministic build is reproducible AND faster than the lock-based build at every scale and thread count we measured. This is gated behind `faiss::hnsw_deterministic_build`. We plan to test internally, then make this the default flow and remove the existing flow.
--

https://arxiv.org/abs/2305.04359
--

HOW TO ENABLE
--
```
C++:     faiss::hnsw_deterministic_build = true;
Python:  faiss.cvar.hnsw_deterministic_build = True
```
Nothing else is needed, and nothing changes until you do it: the flag defaults
to false, so this diff is a no-op on its own.

An embedder driving this from its own configuration system should resolve the
value once at startup and assign the global, rather than per index: changing it
between two `add()` calls would leave one index built by each algorithm.

`python/__init__.pyi` now declares `faiss.cvar`. It was missing, so any Python
consumer assigning a faiss global failed Pyre with "No attribute `cvar` in
module `faiss`" -- fixed here rather than with a `pyre-ignore` in each consumer.

WHEN IT IS WORTH ENABLING
--
Only for builds that run multi-threaded. At one thread the existing lock-based
build is *already* deterministic, so the flag buys nothing beyond ~6% build
time. Verified: lock-based at OMP=1 is byte-identical across runs, while at
OMP=8 46% of neighbor slots differ. A consumer that pins
`omp_set_num_threads(1)` should not bother.

similarities to parlayANN:
- add vertices in doubling batches against frozen snapshot
- defer adding reciprocal edges immediately, add them later after parallel phase

differences from ParlayANN:
- re-uses Faiss HNSW pruning in `shrink_neighbor_list`

---

AI (with a bunch of edits) explanation in more detail:
--

What changed
- `IndexHNSW::add` and `IndexBinaryHNSW::add` pick the build at runtime. Both paths are compiled in and **the default is unchanged** (lock-based); nothing switches until the flag or the hook says so.
- Turning it on:
```
C++:     faiss::hnsw_deterministic_build = true;
Python:  faiss.cvar.hnsw_deterministic_build = True
```
- A single plain `bool` is the whole API: libfaiss takes no dependency on any configuration system, and an embedder that wants one resolves it itself and assigns the global:
```
faiss.cvar.hnsw_deterministic_build = <your config lookup>
```
- Resolve it once at startup, not per index. `add()` reads the flag each call, so changing it between two `add()` calls on one index would build part of the graph with each algorithm -- reproducible in neither.
- **This flag is transitional.** Once the deterministic build is validated in production, the follow-up makes it the only path and deletes the lock-based build and the flag.
- The deterministic path now supports the CAGRA level-0 import configuration: `init_level0=false` skips the level-0-only bucket (level 0 is supplied by the imported CAGRA graph), and `keep_max_size_level0` fills the base layer to 2*M. So `IndexHNSWCagra` (CPU) and `GpuIndexCagra::copyTo(IndexHNSWCagra*)` build through the deterministic path.
- `IndexBinaryHNSW::add` is gated by the same flag and shares the same deterministic implementation: `hnsw_add_vertices_deterministic` takes `make_distance_computer` / `set_query` callbacks, so the binary index just supplies its own Hamming distance computer. It keeps its own lock-based `hnsw_add_vertices` for the default path.

Background
--
HNSW construction in Faiss was non-deterministic under parallel builds: multiple runs of `IndexHNSW::add` with the same data and seeds could produce different graphs, a problem for persistence, crash recovery, and replication (the ParlayANN motivation, https://arxiv.org/abs/2305.04359). Sources of non-determinism were: (1) the reciprocal-link write race in `add_links_starting_from_impl`; (2) floating-point distance ties resolved in heap/visitation order; (3) the entry-point bootstrap `#pragma omp critical` race.

Algorithm (adapted from ParlayANN to Faiss's level-batched structure):
- Per level bucket (highest first, deterministic shuffle), points are inserted in prefix-doubling sub-batches (batch sizes 1, 2, 4, ... capped at 2% of the index).
- Phase A (`HNSW::compute_forward_links_deterministic`, parallel): each point greedily descends and computes its forward links against the immutable snapshot from the end of the previous sub-batch, writing only its own neighbor slots. Reciprocal-edge requests are collected, not applied, so this phase is race-free.
- Phase B (`HNSW::merge_reverse_links_deterministic`, parallel): reverse edges are grouped by destination with a fixed-size 256-bucket radix partition on the low bits of `dest` (a small constant bucket count, independent of `ntotal` and thread count, so grouping stays O(edges) in memory), each bucket sorted by `(level, dest)` and merged in parallel. Every affected node is merged exactly once in a total order (distance, ties by id) and re-pruned with the same RNG heuristic. Because every `dest` maps to exactly one bucket, distinct nodes touch disjoint slots (no locks) and the merge is order- and thread-count-independent. The Phase-B parallel-for uses `schedule(static)` — the libomp dynamic dispatcher segfaults in some build configs (the pre-existing lock-based build carried the same warning).

Guarantee: the resulting graph is reproducible across runs at a fixed thread count and, in practice, across thread counts (the merge is fully order-independent). Recall matches the previous default at every efSearch.

## Performance: build time (40M, d=128, M=32, efC=64, 166 threads)
10-round interleaved timing study (one deterministic + one lock-based build per round, so both see identical host conditions):
  deterministic per-round s: 285.58 275.03 280.84 272.62 273.73 272.61 272.05 272.90 269.87 272.29
  lock-based    per-round s: 306.23 352.97 322.76 294.23 339.32 303.04 291.46 341.96 359.31 282.92
  deterministic: min=269.87 mean=274.75 median=272.76 max=285.58 std=4.53
  lock-based:    min=282.92 mean=319.42 median=314.50 max=359.31 std=26.12
  det/lock: mean=0.860 (deterministic ~14% faster), median=0.867
The deterministic build is ~14% faster than the lock-based build at 40M and ~6x more stable run-to-run (std 4.53s vs 26.12s), since it does not depend on lock-contention timing. Peak RSS ~66GB vs ~56GB. Recall matches at every efSearch (byte-identical graph across builds).

## Performance: search time

Back on the deterministic HEAD, tree clean. Here's the matched A/B — same 40M synthetic data, same machine (AMD Genoa, 166 cores),
  search_repeat=100, deterministic (my HEAD) vs lock-based (parent commit). Since my diff doesn't touch search() at all, any difference is
  purely graph structure + measurement noise.

  Search QPS: deterministic vs lock-based (40M synthetic, repeat=100)

  HNSW16
```
  ┌──────────┬─────────────────┬─────────┬──────────┬───────┐
  │ efSearch │ recall det/lock │ QPS det │ QPS lock │   Δ   │
  ├──────────┼─────────────────┼─────────┼──────────┼───────┤
  │       64 │ 0.828/0.820     │ 170,329 │  177,995 │ −4.3% │
  ├──────────┼─────────────────┼─────────┼──────────┼───────┤
  │      128 │ 0.866/0.862     │ 112,727 │  110,727 │ +1.8% │
  ├──────────┼─────────────────┼─────────┼──────────┼───────┤
  │      256 │ 0.886/0.888     │  59,815 │   56,784 │ +5.3% │
  └──────────┴─────────────────┴─────────┴──────────┴───────┘
```
  HNSW32
```
  ┌──────────┬─────────────────┬─────────┬──────────┬───────┐
  │ efSearch │ recall det/lock │ QPS det │ QPS lock │   Δ   │
  ├──────────┼─────────────────┼─────────┼──────────┼───────┤
  │       64 │ 0.935/0.930     │ 110,186 │  108,411 │ +1.6% │
  ├──────────┼─────────────────┼─────────┼──────────┼───────┤
  │      128 │ 0.958/0.953     │  68,019 │   66,308 │ +2.6% │
  ├──────────┼─────────────────┼─────────┼──────────┼───────┤
  │      256 │ 0.965/0.960     │  37,624 │   35,828 │ +5.0% │
  └──────────┴─────────────────┴─────────┴──────────┴───────┘
```
  HNSW32,SQ8
```
  ┌──────────┬─────────────────┬─────────┬──────────┬────────┐
  │ efSearch │ recall det/lock │ QPS det │ QPS lock │   Δ    │
  ├──────────┼─────────────────┼─────────┼──────────┼────────┤
  │       64 │ 0.926/0.934     │ 220,713 │  198,325 │ +11.3% │
  ├──────────┼─────────────────┼─────────┼──────────┼────────┤
  │      128 │ 0.948/0.953     │ 117,504 │  129,173 │  −9.0% │
  ├──────────┼─────────────────┼─────────┼──────────┼────────┤
  │      256 │ 0.961/0.963     │  58,582 │   65,551 │ −10.6% │
  └──────────┴─────────────────┴─────────┴──────────┴────────┘
```
(Low-ef points ef16/32 omitted from the verdict — even at 100 repeats their std is ~8–20%, too noisy; ef128/256 std is ~3–5%.)

Verdict: no search-QPS regression
- Pure HNSW (16, 32): QPS at parity — within ±5%, and actually slightly faster deterministic at the high-recall points (ef128/256), with
  equal-or-better recall.
- HNSW32,SQ8: more scatter (±10%, mixed direction) — but it tracks small correlated recall differences (det ef256 is 0.961 vs 0.963),
  i.e. the two different graphs sit at slightly different recall/QPS operating points, not a systematic slowdown. Search code is
  identical, so this is graph-structure + noise, not a code regression. If you want it pinned down, a recall-matched (interpolated)
  comparison would remove the operating-point confound.
- Bonus: the deterministic build was 2–3× faster in every case (e.g. HNSW32: 277 s vs 527 s; HNSW16: 164 s vs 429 s) — consistent with
  all prior results.

## Single-threaded (OMP_NUM_THREADS=1)
Customers frequently build with OMP=1 or OpenMP disabled, so this case matters. Measured at 1M / d=128 / M=32 / efC=64, single-threaded:
  build time: lock-based 188.36s vs deterministic 176.40s  (0.94x -> deterministic ~6% FASTER)
  peak RSS:   1.6 GB (both, identical)
  recall@10 ef 16/32/64/128: lock-based .8830/.9387/.9676/.9853 vs deterministic .8832/.9381/.9625/.9798
No single-threaded regression: the deterministic build is slightly faster (it avoids the per-node OpenMP lock ops), uses the same memory, and matches recall within noise. Note the lock-based build was already deterministic at a single thread, so single-threaded users lose nothing and gain a small speedup.

## Serialization compatibility
No on-disk format change, verified in `index_read.cpp` / `index_write.cpp`:
- `hnsw_deterministic_build` is a namespace-scope global, not a field on `HNSW` or `IndexHNSW`, so it is not part of any serialized struct. Like `retain_locks`, it is a pure runtime build flag.
- `write_HNSW` / `read_HNSW` and the `IndexHNSW` field layout are unchanged. The subtype fourcc tags, header, CAGRA block, graph CSR (entry_point / max_level / levels / offsets / neighbors / efC / efS), and storage are all as before.
- `keep_max_size_level0` is still serialized only for the CAGRA subtype (`IHc2`/`IHNc`); `init_level0` is build-only (not serialized).
- The deterministic build emits the same HNSW CSR structure (only neighbor content differs), so old indexes read unchanged and new indexes remain readable by older Faiss.
- Verified by the `io_and_retest` serialize -> deserialize -> re-search round-trips in `test_graph_based.py` / `test_hnsw.cpp` (all pass).
- Measured on a 1M index: written with the flag off, flag flipped on, read back
  -> `neighbors`, `offsets`, `entry_point`, `max_level` byte-identical and
  search ids+distances identical. The flag is read only inside `add()`.
- Mixed-mode append (lock-built graph extended by a deterministic `add()`) was
  measured against brute-force ground truth at 220k and is indistinguishable
  from either pure build -- recall@10 within +-0.02 of both at ef 32/64/128. No
  existing test covers this, since every test builds one way in one process.

## CAGRA API for HNSW build on multi-GPU (aka D106837134) — MAST verification
Verified end-to-end on MAST (8x H100 Grand Teton, Approach D, 100M vectors) with this change in the build — the multi-GPU CAGRA -> HNSW graph-build time is comparable to the D106837134 baseline (no regression):
  all_neighbors build: 367.4s   optimize: 231.7s   copyTo: 18.4s   serialize: 28.9s (66 GB)
  INDEX build -> serialize total: 661.7s (11.0 min)   [D106837134 baseline: 721s]
  recall@10 (tiled 100M): ef64 0.7746, ef128 0.8830, ef256 0.9429
- This confirms this CPU-side change builds, links, and runs in the GPU CAGRA binary at scale and does not regress the pipeline. Note the Approach-D run uses copyTo(base_level_only=True), which imports the CAGRA graph directly as HNSW level 0 and skips add(), so it does not itself route through the deterministic add().
- The deterministic CAGRA level-0 import this change adds (the copyTo path with base_level_only=False: init_level0=false skips the level-0 bucket; keep_max_size_level0 fills the base layer) is covered by passing unit tests: `Test_IndexHNSWCagra_BaseLevelOnly_RangeSearch` (C++), `test_hnsw_no_init_level0`, and `test_hnsw_cagra_IP` / `_base_level_only` (Python).


## Behavioral note: level-0 base layer under keep_max_size_level0 (reviewers, please note)
One deliberate difference from the lock-based build, in the CAGRA base-layer case only: the old build gated the "fill the level-0 list up to 2*M" behavior on the inserted point's OWN top level (`keep_max_size_level0 && pt_level == 0`), so a level>=1 node's level-0 list could be pruned below 2*M. The deterministic build gates on the LINK level (`keep_max_size_level0 && level == 0`), so EVERY node's level-0 list is filled to 2*M when `keep_max_size_level0` is set (not only the level-0-only points). This is a strict superset of the old coverage -- it fills exactly to the 2*M slot capacity (no overflow) and yields a fuller/denser base layer for CPU `IndexHNSWCagra`, which is what `GpuIndexCagra::copyFrom(IndexHNSWCagra*)` reads back. It is INERT for the default build (`keep_max_size_level0` defaults to false, so the gate is never true) and never affects a non-CAGRA graph. Called out explicitly so reviewers know the CPU `IndexHNSWCagra` base-layer graph is intentionally denser than the pre-diff build; worth a sanity check against GPU `copyFrom` expectations.

Reviewed By: pankajsingh88

Differential Revision: D112025877


