### PR TITLE
Add type stubs for SVS index classes + IndexIVFFlatPanorama.batch_size

### DIFF
--- a/faiss/python/__init__.pyi
+++ b/faiss/python/__init__.pyi
@@ -39,6 +39,20 @@ ClusteringInitMethod_RANDOM: int
 ClusteringInitMethod_KMEANS_PLUS_PLUS: int
 ClusteringInitMethod_AFK_MC2: int
 
+# Storage kind for SVS (Intel Scalable Vector Search) indexes
+SVSStorageKind = int
+SVS_FP32: int
+SVS_FP16: int
+SVS_SQ8: int
+SVS_LVQ4x0: int
+SVS_LVQ4x4: int
+SVS_LVQ4x8: int
+SVS_LVQ8x0: int
+SVS_LeanVec4x4: int
+SVS_LeanVec4x8: int
+SVS_LeanVec8x8: int
+SVS_count: int
+
 # I/O flag constants for reading/writing indexes
 IO_FLAG_SKIP_STORAGE: int  # skip the storage for graph-based indexes
 IO_FLAG_READ_ONLY: int  # read-only mode
@@ -275,6 +289,16 @@ class SearchParameters:
 
 class SearchParametersPreTransform(SearchParameters):
     index_params: SearchParameters | None
+    def __init__(self) -> None: ...
+
+class SearchParametersSVSVamana(SearchParameters):
+    search_window_size: int
+    search_buffer_capacity: int
+    def __init__(self) -> None: ...
+
+class SearchParametersSVSIVF(SearchParameters):
+    n_probes: int
+    k_reorder: float
     def __init__(self) -> None: ...
 
 # Base Index class
@@ -1803,6 +1827,7 @@ class IndexIVFFlatPanorama(IndexIVFFlat):
     """Panorama adaptation of IndexIVFFlat following https://arxiv.org/abs/2510.00566"""
 
     n_levels: int
+    batch_size: int
 
     def __init__(
         self,
@@ -1812,6 +1837,7 @@ class IndexIVFFlatPanorama(IndexIVFFlat):
         n_levels: int,
         metric: MetricType = METRIC_L2,
         own_invlists: bool = True,
+        batch_size: int = ...,
     ) -> None: ...
 
 class IndexIVFPQ(IndexIVF):
@@ -3832,6 +3858,106 @@ class IndexIVFRaBitQFastScan(IndexIVFFastScan):
     ) -> None: ...
     @overload
     def __init__(self, orig: IndexIVFRaBitQ, bbs: int = 32) -> None: ...
+
+# SVS (Intel Scalable Vector Search) indexes
+class IndexSVSFlat(Index):
+    nlabels: int
+    def __init__(self, d: int, metric: MetricType = METRIC_L2) -> None: ...
+
+class IndexSVSVamana(Index):
+    graph_max_degree: int
+    prune_to: int
+    alpha: float
+    search_window_size: int
+    search_buffer_capacity: int
+    construction_window_size: int
+    max_candidate_pool_size: int
+    use_full_search_history: bool
+    is_static: bool
+    storage_kind: SVSStorageKind
+
+    def __init__(
+        self,
+        d: int,
+        degree: int,
+        metric: MetricType = METRIC_L2,
+        storage: SVSStorageKind = SVS_FP32,
+        is_static: bool = False,
+    ) -> None: ...
+    @staticmethod
+    def is_lvq_leanvec_enabled() -> bool: ...
+
+class IndexSVSVamanaLVQ(IndexSVSVamana):
+    def __init__(
+        self,
+        d: int,
+        degree: int,
+        metric: MetricType = METRIC_L2,
+        storage: SVSStorageKind = SVS_LVQ4x0,
+        is_static: bool = False,
+    ) -> None: ...
+
+class IndexSVSVamanaLeanVec(IndexSVSVamana):
+    leanvec_d: int
+
+    def __init__(
+        self,
+        d: int,
+        degree: int,
+        metric: MetricType = METRIC_L2,
+        leanvec_dims: int = 0,
+        storage: SVSStorageKind = SVS_LeanVec4x4,
+        is_static: bool = False,
+    ) -> None: ...
+
+class IndexSVSIVF(Index):
+    num_centroids: int
+    minibatch_size: int
+    num_iterations: int
+    is_hierarchical: bool
+    training_fraction: float
+    hierarchical_level1_clusters: int
+    seed: int
+    n_probes: int
+    k_reorder: float
+    num_threads: int
+    intra_query_threads: int
+    is_static: bool
+    storage_kind: SVSStorageKind
+
+    def __init__(
+        self,
+        d: int,
+        nlist: int,
+        metric: MetricType = METRIC_L2,
+        storage: SVSStorageKind = SVS_FP32,
+        is_static: bool = False,
+    ) -> None: ...
+    @staticmethod
+    def is_lvq_leanvec_enabled() -> bool: ...
+
+class IndexSVSIVFLVQ(IndexSVSIVF):
+    def __init__(
+        self,
+        d: int,
+        nlist: int,
+        metric: MetricType = METRIC_L2,
+        storage: SVSStorageKind = SVS_LVQ4x0,
+        is_static: bool = False,
+    ) -> None: ...
+
+class IndexSVSIVFLeanVec(IndexSVSIVF):
+    leanvec_d: int
+
+    def __init__(
+        self,
+        d: int,
+        nlist: int,
+        metric: MetricType = METRIC_L2,
+        leanvec_dims: int = 0,
+        storage: SVSStorageKind = SVS_LeanVec4x4,
+        is_static: bool = False,
+    ) -> None: ...
 
 # Independent quantizer
 class IndexIVFIndependentQuantizer(Index):


### PR DESCRIPTION
Summary:
Fbcode/faiss/python/__init__.pyi is missing type stubs for 7 SWIG-exposed
SVS (Intel Scalable Vector Search) index classes and one field on
IndexIVFFlatPanorama, causing Pyre `[missing-attribute]` errors for any
Python caller that constructs or type-annotates these classes.

`swigfaiss.swig` `%include`s and `DOWNCAST`s `IndexSVSFlat`,
`IndexSVSVamana`, `IndexSVSVamanaLVQ`, `IndexSVSVamanaLeanVec`,
`IndexSVSIVF`, `IndexSVSIVFLVQ`, and `IndexSVSIVFLeanVec` (lines 763-769,
928-934) -- all 7 classes are live, constructible Python types today. None
of the 7 appear anywhere in `__init__.pyi`: 0 matches for each. Verified
against current trunk before implementing, not from a stale backlog
snapshot.

This diff adds:
- `SVSStorageKind = int` module-level type alias plus the 10 constant
  values (`SVS_FP32`, `SVS_FP16`, `SVS_SQ8`, `SVS_LVQ4x0/4x4/4x8`,
  `SVS_LVQ8x0`, `SVS_LeanVec4x4/4x8/8x8`, `SVS_count`), matching the
  existing `MetricType = int` / `METRIC_L2: int` convention used for
  every other plain (non-`enum class`) C++ enum in this file --
  `SVSStorageKind` is declared as an unscoped `enum` in
  `svs/IndexSVSVamana.h`, so SWIG exposes its values as bare top-level
  names, not `SVSStorageKind_`-prefixed names (that prefix convention
  only applies to C++11 `enum class` types, e.g. `ClusteringInitMethod`).
- `SearchParametersSVSVamana` and `SearchParametersSVSIVF` stubs
  (`search_window_size`/`search_buffer_capacity`, `n_probes`/`k_reorder`
  respectively), the two `SearchParameters` subclasses defined alongside
  the SVS index headers that were equally unstubbed.
- `IndexSVSFlat`, `IndexSVSVamana` (+ `is_lvq_leanvec_enabled()` static
  method), `IndexSVSVamanaLVQ`, `IndexSVSVamanaLeanVec` (+
  `train_with_queries` support surfaced via the base `Index.train()`
  Python wrapper, not a separate stub method -- see below),
  `IndexSVSIVF` (+ `is_lvq_leanvec_enabled()`), `IndexSVSIVFLVQ`, and
  `IndexSVSIVFLeanVec`, each with the constructor signature and public
  config fields read directly from their C++ headers
  (`svs/IndexSVS*.h`). Internal implementation-detail members
  (`impl`, `mmap_owner`, `stored_vectors`, `stored_vectors_valid`,
  `training_data` -- raw pointers into the unwrapped `svs_runtime::*`
  library, or reconstruction-cache storage) are deliberately excluded,
  matching this file's existing convention of omitting internal storage
  fields even when technically public (e.g. `IndexIVFFlatPanorama.cum_sums`
  is similarly excluded today).
- `IndexIVFFlatPanorama.batch_size: int` field and constructor parameter
  (default `Panorama::kDefaultBatchSize` = 128, expressed as `= ...` per
  this file's existing convention for non-literal defaults). The class
  already had `n_levels` stubbed but was missing `batch_size`, added in
  the same commit (D111132644-era) as the class itself.

Confirmed `train_with_queries` (a raw SWIG-exposed C++ method used
internally by `Index`'s Python `train()` wrapper for out-of-distribution
training data, per `class_wrappers.py`) does not need its own stub entry:
the same pattern already excludes `train_c`/`train_ex`, the other two raw
per-numeric-type dispatch targets of the same wrapper -- callers use
`index.train(x, xq_train=...)`, not the raw method name directly.

This is a stub-only change: `python/__init__.pyi` is consumed exclusively
by static type checkers (Pyre, mypy, pyright) and IDE autocompletion, not
by the Python runtime, so no behavior change is possible. Validated with
`python3 -c "import ast; ast.parse(open('python/__init__.pyi').read())"`
(0 syntax errors) and a full-file identifier-occurrence grep confirming
each new symbol appears exactly where intended with no accidental
duplicate class/constant definitions. `buck2 build fbcode//faiss:faiss`
and `fbcode//faiss/python:pyfaiss` both build clean (0 warnings, 0
errors); `buck2 test fbcode//faiss/tests:test_io` (Friday rotation
target) passes 30/30.

Differential Revision: D114349814


