### PR TITLE
Reject AdditiveQuantizer with zero-bit code size on deserialization

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -821,6 +821,10 @@ static void read_AdditiveQuantizer(AdditiveQuantizer& aq, IOReader* f) {
     }
 
     aq.set_derived_values();
+    FAISS_THROW_IF_NOT_FMT(
+            aq.code_size > 0,
+            "invalid AdditiveQuantizer: nbits sum to 0 bits, code_size %zd",
+            aq.code_size);
 
     // Sanity-check codebooks size without knowing the effective dimension.
     // codebooks stores effective_d * total_codebook_size floats, so its


### PR DESCRIPTION
Summary:
Deserializing an AdditiveQuantizer-based index (residual quantizer,
local-search quantizer, and their product variants) validated that the
number of sub-quantizers M is positive, but not that the resulting
per-vector code size is nonzero. A crafted index can set every
sub-quantizer's bit width to 0, which makes the derived code size 0
while the index still declares a positive vector count.

Such an index ends up with an empty codes buffer whose data pointer is
null/unspecified. Decoding any vector then dereferences that pointer
inside the bitstring reader used to unpack per-vector codes, causing a
segfault on fully attacker-controlled input.

Reject this configuration right where the code size is derived, with a
descriptive exception. A quantizer that stores zero bits per vector
cannot decode anything and is never produced by real training, so this
only rejects malformed/crafted inputs.

Differential Revision: D115173394


