### PR TITLE
Fix SIMD level detection in Faiss (#5507)

### DIFF
--- a/conda/faiss-gpu-cuvs/meta.yaml
+++ b/conda/faiss-gpu-cuvs/meta.yaml
@@ -61,14 +61,14 @@ outputs:
       host:
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
         - mkl >=2024.2.2,<2026  # [x86_64]
-        - openblas =0.3.33 # [not x86_64]
+        - openblas =0.3.34 # [not x86_64]
         - libcuvs =26.06
         - cuda-version {{ cuda_constraints }}
         - libsvs-runtime =0.4.0  # [x86_64 and linux]
       run:
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
         - mkl >=2024.2.2,<2026  # [x86_64]
-        - openblas =0.3.33 # [not x86_64]
+        - openblas =0.3.34 # [not x86_64]
         - cuda-cudart {{ cuda_constraints }}
         - libcublas {{ libcublas_constraints }}
         - libcuvs =26.06

--- a/conda/faiss-gpu/meta.yaml
+++ b/conda/faiss-gpu/meta.yaml
@@ -60,11 +60,11 @@ outputs:
         - cuda-toolkit {{ cudatoolkit }}
       host:
         - mkl >=2024.2.2,<2026  # [x86_64]
-        - openblas =0.3.33 # [not x86_64]
+        - openblas =0.3.34 # [not x86_64]
         - libsvs-runtime =0.4.0  # [x86_64 and linux]
       run:
         - mkl >=2024.2.2,<2026  # [x86_64]
-        - openblas =0.3.33 # [not x86_64]
+        - openblas =0.3.34 # [not x86_64]
         - cuda-cudart {{ cuda_constraints }}
         - libcublas {{ libcublas_constraints }}
         - libsvs-runtime =0.4.0  # [x86_64 and linux]

--- a/conda/faiss/meta.yaml
+++ b/conda/faiss/meta.yaml
@@ -69,7 +69,7 @@ outputs:
         - mkl >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
-        - openblas =0.3.33  # [not x86_64]
+        - openblas =0.3.34  # [not x86_64]
         - libopenblas =0.3.33  # [osx]
       run:
         - python {{ python }}
@@ -83,7 +83,7 @@ outputs:
         - mkl >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
-        - openblas =0.3.33  # [not x86_64]
+        - openblas =0.3.34  # [not x86_64]
         - libopenblas =0.3.33  # [osx]
     test:
       requires:

--- a/faiss/utils/simd_levels.cpp
+++ b/faiss/utils/simd_levels.cpp
@@ -24,6 +24,16 @@ uint64_t SIMDConfig::supported_simd_levels = 0;
 // detect_x86_uarch_flags() at load time.
 bool SIMDConfig::avx512_split = false;
 
+// Resolved here rather than in the header so that dependents, which never see
+// FAISS_ENABLE_DD, still get the answer for the faiss they link against.
+bool SIMDConfig::has_dynamic_dispatch() {
+#ifdef FAISS_ENABLE_DD
+    return true;
+#else
+    return false;
+#endif
+}
+
 // ARM SVE runtime detection
 #if defined(__aarch64__) || defined(_M_ARM64)
 

--- a/faiss/utils/simd_levels.h
+++ b/faiss/utils/simd_levels.h
@@ -169,13 +169,8 @@ struct FAISS_API SIMDConfig {
 
     static SIMDLevel auto_detect_simd_level();
 
-    static constexpr bool has_dynamic_dispatch() {
-#ifdef FAISS_ENABLE_DD
-        return true;
-#else
-        return false;
-#endif
-    }
+    /// Whether this faiss build dispatches SIMD at runtime.
+    static bool has_dynamic_dispatch();
 
     SIMDConfig(const char** faiss_simd_level_env = nullptr);
 


### PR DESCRIPTION
Summary:

`SIMDConfig::has_dynamic_dispatch()` was defined inline in `simd_levels.h`, where it resolved `#ifdef FAISS_ENABLE_DD` at include time. That macro is only set while faiss itself is compiled, so any code outside the library that included the header always evaluated it to `false` — reporting that dynamic dispatch was unavailable even when linked against a faiss built with it enabled.

Callers using it to decide whether `SIMDConfig::set_level()` will do anything would therefore skip setting the SIMD level, and silently fall back to the auto-detected one.

Move the definition into `simd_levels.cpp`, which is compiled as part of the library and does see the macro. Callers now get the answer for the faiss they actually link against.

The function is no longer `constexpr` and so cannot be used in constant expressions. It had no such uses.

Also bumps the conda `openblas` pin for non-x86_64 platforms from 0.3.33 to 0.3.34, which is required to get the `Linux arm64 (conda)` build green. conda-forge now serves `libopenblas 0.3.34`, which depends on `openblas >=0.3.34,<0.3.35`, so the old pin left the environment unsolvable:

```
ExplainedDependencyNeedsBuildingError: Unsatisfiable dependencies for platform linux-aarch64
  - package libfaiss-1.15.0-py3.12_h3f4af3b_10_cpu requires openblas 0.3.33.*,
    but none of the providers can be installed
```

The separate `libopenblas` pins for osx are left at 0.3.33, since that package is resolving fine.

Reviewed By: junjieqi

Differential Revision: D115218647


