### PR TITLE
Merge shard results by metric type rather than assuming similarity

### DIFF
--- a/faiss/IndexShards.cpp
+++ b/faiss/IndexShards.cpp
@@ -243,8 +243,11 @@ void IndexShardsTemplate<IndexT>::search(
 
     this->runOnIndex(fn);
 
-    if (this->metric_type == METRIC_L2) {
-        merge_knn_results<idx_t, CMin<distance_t, int>>(
+    // Only similarity metrics rank larger values first. Testing for METRIC_L2 alone merged every
+    // other metric as a similarity, so distance metrics such as METRIC_L1, METRIC_Linf and METRIC_Lp
+    // came back worst-first once results crossed shard boundaries.
+    if (is_similarity_metric(this->metric_type)) {
+        merge_knn_results<idx_t, CMax<distance_t, int>>(
                 n,
                 k,
                 nshard,
@@ -253,7 +256,7 @@ void IndexShardsTemplate<IndexT>::search(
                 distances,
                 labels);
     } else {
-        merge_knn_results<idx_t, CMax<distance_t, int>>(
+        merge_knn_results<idx_t, CMin<distance_t, int>>(
                 n,
                 k,
                 nshard,

--- a/tests/test_meta_index.py
+++ b/tests/test_meta_index.py
@@ -145,6 +145,34 @@ class Shards(unittest.TestCase):
             # thousands of the nq*k cells, far above this floor.
             assert ndiff < nq * k / 100.0, f"too many mismatches: {ndiff}"
 
+    def test_shards_distance_metric_ordering(self):
+        # METRIC_L1 returns distances, so the shard merge must rank smaller values first.
+        # Testing only for METRIC_L2 treated every other metric as a similarity, which put the
+        # FARTHEST vectors first as soon as results crossed a shard boundary.
+        k = 10
+        ref_index = faiss.IndexFlat(d, faiss.METRIC_L1)
+        ref_index.add(xb)
+        Dref, _Iref = ref_index.search(xq, k)
+
+        shard_index = faiss.IndexShards(d, False, True)
+        shards = []
+        ni = 3
+        for i in range(ni):
+            i0 = int(i * nb / ni)
+            i1 = int((i + 1) * nb / ni)
+            shard = faiss.IndexFlat(d, faiss.METRIC_L1)
+            shard.add(xb[i0:i1])
+            shards.append(shard)  # keep the shards alive for the duration of the test
+            shard_index.add_shard(shard)
+
+        D, _I = shard_index.search(xq, k)
+
+        # Nearest first within each result row...
+        assert np.all(D[:, :-1] <= D[:, 1:]), "sharded METRIC_L1 results are not sorted by distance"
+        # ...and the same neighbors the unsharded index finds. Distances are compared rather than
+        # labels so that equidistant neighbors may be returned in either order.
+        np.testing.assert_array_almost_equal(D, Dref, decimal=5)
+
     def test_shards_ivf(self):
         ds = SyntheticDataset(32, 1000, 100, 20)
         ref_index = faiss.index_factory(ds.d, "IVF32,SQ8")


### PR DESCRIPTION
## Summary

`IndexShardsTemplate::search` picked the comparator for merging per-shard results by testing for `METRIC_L2`:

```cpp
if (this->metric_type == METRIC_L2) {
    merge_knn_results<idx_t, CMin<distance_t, int>>(...);   // smaller is better
} else {
    merge_knn_results<idx_t, CMax<distance_t, int>>(...);   // larger is better
}
```

Everything that is not `METRIC_L2` was therefore merged as a similarity. `METRIC_L1`, `METRIC_Linf` and `METRIC_Lp` return distances, so once results crossed a shard boundary they came back farthest-first, while the same vectors in a single unsharded index came back nearest-first.

This PR selects the comparator with the existing `is_similarity_metric()` helper from `MetricType.h`, which is exactly the distinction the branch needs.

Fixes #5503

## Behaviour change

`is_similarity_metric()` is true only for `METRIC_INNER_PRODUCT` and `METRIC_Jaccard`, so:

| metric | before | after |
| --- | --- | --- |
| `METRIC_L2` | `CMin` | `CMin` (unchanged) |
| `METRIC_INNER_PRODUCT` | `CMax` | `CMax` (unchanged) |
| `METRIC_L1`, `METRIC_Linf`, `METRIC_Lp`, `METRIC_Canberra`, `METRIC_BrayCurtis`, `METRIC_JensenShannon` | `CMax` | **`CMin`** |
| `METRIC_Jaccard` | `CMax` | `CMax` (unchanged) |

`IndexShardsTemplate<IndexBinary>` is also unaffected: `IndexBinary::metric_type` defaults to `METRIC_L2`, which keeps `CMin` as before.

## Reproduction

Against the released `faiss-cpu` 1.15.0 wheel, using the reporter's example:

```python
import faiss, numpy as np

xb0 = np.array([[0., 0.]], dtype='float32')
xb1 = np.array([[10., 0.]], dtype='float32')
xq  = np.array([[1., 0.]], dtype='float32')

flat = faiss.IndexFlat(2, faiss.METRIC_L1)
flat.add(np.vstack([xb0, xb1]))
print(flat.search(xq, 2))

s0 = faiss.IndexFlat(2, faiss.METRIC_L1); s0.add(xb0)
s1 = faiss.IndexFlat(2, faiss.METRIC_L1); s1.add(xb1)
shards = faiss.IndexShards(2, False, True)
shards.add_shard(s0); shards.add_shard(s1)
print(shards.search(xq, 2))
```

```
single IndexFlat  D,I = [[1. 9.]] [[0 1]]     # nearest first, correct
IndexShards       D,I = [[9. 1.]] [[1 0]]     # farthest first, reversed
```

## Test

Adds `Shards::test_shards_distance_metric_ordering` to `tests/test_meta_index.py`. It splits the dataset across three `METRIC_L1` shards and checks that each result row is ordered nearest-first and matches the distances an unsharded `IndexFlat(METRIC_L1)` returns. Distances rather than labels are compared so that equidistant neighbours may be returned in either order.

The test fails on `main` (the rows come back reversed) and passes with this change.

## Testing notes

I reproduced the bug against the released 1.15.0 wheel as shown above, but I was not able to build faiss from source on this machine (Windows, no local C++ toolchain), so I have not executed the C++ build or run the test suite locally. The added test's pass/fail claim above follows from the comparator change rather than from a local run. Please treat CI as the gate, and I am happy to adjust if anything in the suite disagrees.
