### PR TITLE
c_api: fix IndexReplicas own_indices getter/setter name mismatch

### DIFF
--- a/c_api/IndexReplicas_c.h
+++ b/c_api/IndexReplicas_c.h
@@ -22,7 +22,7 @@ extern "C" {
 FAISS_DECLARE_CLASS_INHERITED(IndexReplicas, Index)
 FAISS_DECLARE_DESTRUCTOR(IndexReplicas)
 
-FAISS_DECLARE_GETTER_SETTER(IndexReplicas, int, own_fields)
+FAISS_DECLARE_GETTER_SETTER(IndexReplicas, int, own_indices)
 
 int faiss_IndexReplicas_new(FaissIndexReplicas** p_index, idx_t d);
 


### PR DESCRIPTION
`IndexReplicas_c.cpp` defines:

```cpp
DEFINE_GETTER(IndexReplicas, int, own_indices)
DEFINE_SETTER(IndexReplicas, int, own_indices)
```

while `IndexReplicas_c.h` defines

```cpp
FAISS_DECLARE_GETTER_SETTER(IndexReplicas, int, own_fields)
```

this mismatch causes neither `faiss_IndexReplicas_set_own_indices` and `faiss_IndexReplicas_set_own_fields` to be exported in the c_api. This patch completes the migration to `indices` instead of `fields` in the c_api.

1 to 1 same problem/fix as in #5165 