### PR TITLE
feat(IndexReplicas): Exported replica count in c_api

### DIFF
--- a/c_api/IndexReplicas_c.cpp
+++ b/c_api/IndexReplicas_c.cpp
@@ -56,6 +56,10 @@ int faiss_IndexReplicas_remove_replica(
     CATCH_AND_HANDLE
 }
 
+int faiss_IndexReplicas_count(const FaissIndexReplicas* index) {
+    return reinterpret_cast<const IndexReplicas*>(index)->count();
+}
+
 FaissIndex* faiss_IndexReplicas_at(FaissIndexReplicas* index, int i) {
     auto replica = reinterpret_cast<IndexReplicas*>(index)->at(i);
     return reinterpret_cast<FaissIndex*>(replica);

--- a/c_api/IndexReplicas_c.h
+++ b/c_api/IndexReplicas_c.h
@@ -39,6 +39,8 @@ int faiss_IndexReplicas_remove_replica(
         FaissIndexReplicas* index,
         FaissIndex* replica);
 
+int faiss_IndexReplicas_count(const FaissIndexReplicas* index);
+
 FaissIndex* faiss_IndexReplicas_at(FaissIndexReplicas* index, int i);
 
 #ifdef __cplusplus


### PR DESCRIPTION
`IndexReplicas` are missing a way to get the actual current replica count through the c api.

I've added the count method in this PR.