### PR TITLE
feat(IndexShards): Exported shard count in c_api

### DIFF
--- a/c_api/IndexShards_c.cpp
+++ b/c_api/IndexShards_c.cpp
@@ -59,6 +59,10 @@ int faiss_IndexShards_remove_shard(FaissIndexShards* index, FaissIndex* shard) {
     CATCH_AND_HANDLE
 }
 
+int faiss_IndexShards_count(const FaissIndexShards* index) {
+    return reinterpret_cast<const IndexShards*>(index)->count();
+}
+
 FaissIndex* faiss_IndexShards_at(FaissIndexShards* index, int i) {
     auto shard = reinterpret_cast<IndexShards*>(index)->at(i);
     return reinterpret_cast<FaissIndex*>(shard);

--- a/c_api/IndexShards_c.h
+++ b/c_api/IndexShards_c.h
@@ -37,6 +37,9 @@ int faiss_IndexShards_add_shard(FaissIndexShards* index, FaissIndex* shard);
 
 int faiss_IndexShards_remove_shard(FaissIndexShards* index, FaissIndex* shard);
 
+/// Returns the number of sub-indices (shards)
+int faiss_IndexShards_count(const FaissIndexShards* index);
+
 FaissIndex* faiss_IndexShards_at(FaissIndexShards* index, int i);
 
 #ifdef __cplusplus


### PR DESCRIPTION
`IndexShards` are missing a way to get the actual current shard count through the c api.

I've added the count method in this PR.
Same as #5512