### PR TITLE
feat(IndexRefineFlat): Exported base index in c_api

### DIFF
--- a/c_api/IndexFlat_c.cpp
+++ b/c_api/IndexFlat_c.cpp
@@ -125,6 +125,11 @@ int faiss_IndexRefineFlat_new(
 DEFINE_DESTRUCTOR(IndexRefineFlat)
 DEFINE_INDEX_DOWNCAST(IndexRefineFlat)
 
+FaissIndex* faiss_IndexRefineFlat_base_index(FaissIndexRefineFlat* index) {
+    return reinterpret_cast<FaissIndex*>(
+            reinterpret_cast<faiss::IndexRefineFlat*>(index)->base_index);
+}
+
 DEFINE_GETTER(IndexRefineFlat, int, own_fields)
 DEFINE_SETTER(IndexRefineFlat, int, own_fields)
 

--- a/c_api/IndexFlat_c.h
+++ b/c_api/IndexFlat_c.h
@@ -100,6 +100,10 @@ int faiss_IndexRefineFlat_new(
 FAISS_DECLARE_DESTRUCTOR(IndexRefineFlat)
 FAISS_DECLARE_INDEX_DOWNCAST(IndexRefineFlat)
 
+/// Get a pointer to the base index.
+/// The returned pointer is borrowed, do not free.
+FaissIndex* faiss_IndexRefineFlat_base_index(FaissIndexRefineFlat* index);
+
 FAISS_DECLARE_GETTER_SETTER(IndexRefineFlat, int, own_fields)
 
 /// factor between k requested in search and the k requested from


### PR DESCRIPTION
In the c api there is currently no way to access the base index of `IndexRefineFlat`, so I've added it.

`faiss_IndexRefineFlat_base_index` returns a borrowed pointer to the base index now.