### PR TITLE
c_api: Added gpu device getter for gpu indexes

### DIFF
--- a/c_api/gpu/GpuIndex_c.cpp
+++ b/c_api/gpu/GpuIndex_c.cpp
@@ -14,3 +14,7 @@
 using faiss::gpu::GpuIndexConfig;
 
 DEFINE_GETTER(GpuIndexConfig, int, device)
+
+int faiss_GpuIndex_getDevice(const FaissGpuIndex* index) {
+    return reinterpret_cast<const faiss::gpu::GpuIndex*>(index)->getDevice();
+}

--- a/c_api/gpu/GpuIndex_c.h
+++ b/c_api/gpu/GpuIndex_c.h
@@ -22,6 +22,8 @@ FAISS_DECLARE_GETTER(GpuIndexConfig, int, device)
 
 FAISS_DECLARE_CLASS_INHERITED(GpuIndex, Index)
 
+int faiss_GpuIndex_getDevice(const FaissGpuIndex* index);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
I've exposed the device getter of gpu indexes in the c api which was missing but already existing on C++ side.