### PR TITLE
Add AVX512 bitplane kernel for multi-bit RaBitQ inner product

### DIFF
--- a/faiss/utils/simd_impl/rabitq_avx512.cpp
+++ b/faiss/utils/simd_impl/rabitq_avx512.cpp
@@ -623,16 +623,6 @@ namespace faiss::rabitq::multibit {
 
 namespace {
 
-inline float hsum_avx2(__m256 v) {
-    __m128 hi = _mm256_extractf128_ps(v, 1);
-    __m128 lo = _mm256_castps256_ps128(v);
-    lo = _mm_add_ps(lo, hi);
-    __m128 shuf = _mm_movehdup_ps(lo);
-    lo = _mm_add_ps(lo, shuf);
-    shuf = _mm_movehl_ps(shuf, lo);
-    return _mm_cvtss_f32(_mm_add_ss(lo, shuf));
-}
-
 inline float ip_1exbit_avx512(
         const uint8_t* __restrict sign_bits,
         const uint8_t* __restrict ex_code,
@@ -664,60 +654,96 @@ inline float ip_1exbit_avx512(
     return result;
 }
 
-// AVX2+BMI2 bitplane kernel used as fallback for ex_bits >= 2.
-// AVX512 TU has AVX2 available. BMI2 guarded separately since
-// VIA Eden X4 has AVX2 without BMI2.
+// Guarded on BMI2 because FAISS_BMI2_FLAGS may be empty (see
+// faiss/CMakeLists.txt), in which case _pext_u64 is unavailable and the
+// dispatcher falls back to the scalar path.
 #ifdef __BMI2__
-inline float ip_bitplane_avx2(
+// AVX512 bitplane kernel for ex_bits >= 2, replacing the AVX2 fallback this
+// translation unit used to carry (the AVX2 TU keeps its own copy).
+//
+// A bitplane is already a bitmask, so it can be moved into a mask register and
+// consumed by a masked add. That takes the per-plane work from 5 uops
+// (broadcast, and, cmpgt, and, fmadd) down to 2 (kmov, masked add). Note this
+// does not relieve port 5: kmov r32->k and vpbroadcastd r32->zmm both issue
+// there. The win is uop count, plus 16 dims per iteration instead of 8.
+//
+// _pext_u64 still runs once per 8 dims per plane, i.e. the same count as the
+// AVX2 kernel; only the vector side gets cheaper. Memory access pattern is
+// unchanged, including the over-read past the ex-code section (at most
+// 8 - ex_bits bytes), which always lands inside the trailing ExtraBitsFactors
+// of the same record.
+inline float ip_bitplane_avx512(
         const uint8_t* __restrict sign_bits,
         const uint8_t* __restrict ex_code,
         const float* __restrict rotated_q,
         size_t d,
         size_t ex_bits,
         float cb) {
-    __m256 acc = _mm256_setzero_ps();
-    const __m256 v_one = _mm256_set1_ps(1.0f);
-    const __m256i bit_pos = _mm256_setr_epi32(1, 2, 4, 8, 16, 32, 64, 128);
-    const __m256i zero = _mm256_setzero_si256();
-    const __m256 v_cb = _mm256_set1_ps(cb);
+    __m512 acc = _mm512_setzero_ps();
+    const __m512 v_cb = _mm512_set1_ps(cb);
 
     uint64_t pext_masks[7];
-    __m256 v_weights[8];
+    __m512 v_weights[8];
     for (size_t b = 0; b < ex_bits; b++) {
         uint64_t m = 0;
         for (int j = 0; j < 8; j++) {
             m |= (1ULL << (b + j * ex_bits));
         }
         pext_masks[b] = m;
-        v_weights[b] = _mm256_set1_ps(static_cast<float>(1u << b));
+        v_weights[b] = _mm512_set1_ps(static_cast<float>(1u << b));
     }
-    v_weights[ex_bits] = _mm256_set1_ps(static_cast<float>(1u << ex_bits));
+    v_weights[ex_bits] = _mm512_set1_ps(static_cast<float>(1u << ex_bits));
 
     size_t i = 0;
-    for (; i + 8 <= d; i += 8) {
-        __m256i sb_cmp = _mm256_cmpgt_epi32(
-                _mm256_and_si256(_mm256_set1_epi32(sign_bits[i / 8]), bit_pos),
-                zero);
-        __m256 recon = _mm256_mul_ps(
-                _mm256_and_ps(_mm256_castsi256_ps(sb_cmp), v_one),
-                v_weights[ex_bits]);
+    for (; i + 16 <= d; i += 16) {
+        uint16_t sb = 0;
+        memcpy(&sb, sign_bits + (i / 8), sizeof(uint16_t));
+        __m512 recon = _mm512_maskz_mov_ps(
+                static_cast<__mmask16>(sb), v_weights[ex_bits]);
 
-        uint64_t ex64 = 0;
-        memcpy(&ex64, ex_code + (i / 8) * ex_bits, sizeof(uint64_t));
+        uint64_t lo64 = 0;
+        uint64_t hi64 = 0;
+        memcpy(&lo64, ex_code + (i / 8) * ex_bits, sizeof(uint64_t));
+        memcpy(&hi64, ex_code + ((i / 8) + 1) * ex_bits, sizeof(uint64_t));
 
         for (size_t b = 0; b < ex_bits; b++) {
-            auto plane = static_cast<uint8_t>(_pext_u64(ex64, pext_masks[b]));
-            __m256i p_cmp = _mm256_cmpgt_epi32(
-                    _mm256_and_si256(_mm256_set1_epi32(plane), bit_pos), zero);
-            __m256 p_f = _mm256_and_ps(_mm256_castsi256_ps(p_cmp), v_one);
-            recon = _mm256_fmadd_ps(p_f, v_weights[b], recon);
+            const uint32_t plane =
+                    static_cast<uint32_t>(_pext_u64(lo64, pext_masks[b])) |
+                    (static_cast<uint32_t>(_pext_u64(hi64, pext_masks[b]))
+                     << 8);
+            recon = _mm512_mask_add_ps(
+                    recon, static_cast<__mmask16>(plane), recon, v_weights[b]);
         }
 
-        __m256 rq = _mm256_loadu_ps(rotated_q + i);
-        acc = _mm256_fmadd_ps(rq, _mm256_add_ps(recon, v_cb), acc);
+        __m512 rq = _mm512_loadu_ps(rotated_q + i);
+        acc = _mm512_fmadd_ps(rq, _mm512_add_ps(recon, v_cb), acc);
     }
 
-    float result = hsum_avx2(acc);
+    // Half-width step so the scalar tail stays under 8 dims, as it was with the
+    // 8-wide AVX2 kernel. Without this, a d that is a multiple of 8 but not of
+    // 16 (e.g. 200, 1000) would push 8 dims into ip_scalar that used to be
+    // vectorized. The upper 8 lanes are masked off everywhere, and rotated_q is
+    // loaded masked so nothing is read past the end.
+    if (i + 8 <= d) {
+        __m512 recon = _mm512_maskz_mov_ps(
+                static_cast<__mmask16>(sign_bits[i / 8]), v_weights[ex_bits]);
+
+        uint64_t lo64 = 0;
+        memcpy(&lo64, ex_code + (i / 8) * ex_bits, sizeof(uint64_t));
+
+        for (size_t b = 0; b < ex_bits; b++) {
+            const uint32_t plane =
+                    static_cast<uint32_t>(_pext_u64(lo64, pext_masks[b]));
+            recon = _mm512_mask_add_ps(
+                    recon, static_cast<__mmask16>(plane), recon, v_weights[b]);
+        }
+
+        __m512 rq = _mm512_maskz_loadu_ps(0x00ff, rotated_q + i);
+        acc = _mm512_fmadd_ps(rq, _mm512_add_ps(recon, v_cb), acc);
+        i += 8;
+    }
+
+    float result = _mm512_reduce_add_ps(acc);
     result += ip_scalar(sign_bits, ex_code, rotated_q, i, d, ex_bits, cb);
     return result;
 }
@@ -739,7 +765,8 @@ float compute_inner_product<SIMDLevel::AVX512>(
 
 #ifdef __BMI2__
     if (ex_bits <= 7) {
-        return ip_bitplane_avx2(sign_bits, ex_code, rotated_q, d, ex_bits, cb);
+        return ip_bitplane_avx512(
+                sign_bits, ex_code, rotated_q, d, ex_bits, cb);
     }
 #endif
     return ip_scalar(sign_bits, ex_code, rotated_q, 0, d, ex_bits, cb);


### PR DESCRIPTION
`compute_inner_product<AVX512>` only had a dedicated kernel for `ex_bits == 1`; every wider configuration fell through to `ip_bitplane_avx2`, so AVX512 builds ran 256-bit code for the RaBitQ widths used in practice (`nb_bits` 4-5). This adds `ip_bitplane_avx512`: a bitplane is already a bitmask, so it goes straight into a mask register and is consumed by a single masked add instead of the AVX2 broadcast/and/cmpgt/and/fmadd sequence, which also takes the GPR->vector broadcast off the dependency chain; and it processes 16 dimensions per iteration instead of 8. `_pext_u64` still runs once per 8 dims per plane, so only the vector side gets cheaper, and the memory access pattern is unchanged. The now-unreachable copy of `ip_bitplane_avx2` in this translation unit is removed; the AVX2 translation unit keeps its own. Top-10 labels are unchanged across `nb_bits` in {2,3,4,5,7,8} and both metrics, with distance deviation at the level expected from reassociating the accumulation from 8 to 16 lanes; `nb_bits == 2` stays bit-identical since that path is untouched.