### PR TITLE
Don't raise HNSW entry_point to a point that isn't linked yet (#5524)

### DIFF
--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -317,11 +317,16 @@ void hnsw_add_vertices_deterministic(
                     order[j + rng2.rand_int(static_cast<int>(i1 - j))]);
         }
 
-        // Bootstrap/raise the entry point: the top bucket runs first, so its
-        // first (shuffled) point is a valid max-level entry point.
-        if (hnsw.entry_point == -1 || pt_level > hnsw.max_level) {
+        // Bootstrap only when the graph is empty. Raising entry_point to a
+        // point that is not yet linked orphans everything already inserted,
+        // which on an incremental add() is the entire prior graph. order[i0]
+        // is the sole member of the first batch below, so defer until then.
+        bool raise_entry_point = false;
+        if (hnsw.entry_point == -1) {
             hnsw.max_level = pt_level;
             hnsw.entry_point = order[i0];
+        } else if (pt_level > hnsw.max_level) {
+            raise_entry_point = true;
         }
 
         // Prefix-doubling batches within this bucket.
@@ -496,6 +501,12 @@ void hnsw_add_vertices_deterministic(
 
             InterruptCallback::check();
             s = e;
+
+            if (raise_entry_point) {
+                hnsw.max_level = pt_level;
+                hnsw.entry_point = order[i0];
+                raise_entry_point = false;
+            }
         }
 
         i1 = i0;


### PR DESCRIPTION
Summary:

`hnsw_add_vertices_deterministic` promoted `entry_point` to `order[i0]`
before that point had any links. Within a single add() the promoted point
gets linked moments later by the same bucket's batches, so nothing is
lost. Across add() calls it orphans the whole graph built by earlier
calls: the new entry point has no path back to any of it, and every
subsequent search starts there.

Defer the raise by one prefix-doubling batch. The first batch is exactly
{order[i0]} (grow = done == 0 ? 1 : done), so once it returns the point is
linked into the existing graph and is a valid entry point. Later batches
in the same bucket then see the raised max_level, which preserves
upper-level connectivity -- deferring to the end of the bucket instead
would lose that.

Bootstrap (entry_point == -1) is unchanged: with an empty graph there is
nothing to orphan and nothing to link to.

entry_point and max_level end up at the same values as before; only the
moment of promotion moves. Indexes built with a single add() are
bit-identical. Determinism is preserved.

Found via OVIS Search, which builds 4.15B-vector HNSW32 shards 1M vectors
per add(). Recall against exhaustive ground truth sat at 68% and would not
respond to efConstruction 40/256/512 or efSearch 120..1600. Modelling it
as "the first P vectors of each shard are unreachable" gives
recall = (N-P)/N and fits five independent production indexes at
P = 62.2M +/- 1.3M, across 2x in N and both fp32 and SQ8.

Why this survived so long: it is only reachable through repeated add().
Both existing deterministic-build tests, test_graph_based.py and
bench_hnsw_deterministic.py, call add() exactly once.

Differential Revision: D116192917


