### PR TITLE
  Speed up HNSW RaBitQ search with code prefetching

### DIFF
--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -7,6 +7,8 @@
 
 #include <faiss/IndexHNSW.h>
 
+#include <faiss/IndexRaBitQ.h>
+
 #include <omp.h>
 #include <atomic>
 #include <cinttypes>
@@ -39,6 +41,7 @@ using storage_idx_t = HNSW::storage_idx_t;
 using NodeDistFarther = HNSW::NodeDistFarther;
 
 HNSWStats hnsw_stats;
+RaBitQHNSWStats rabitq_hnsw_stats;
 
 bool hnsw_deterministic_build = false;
 
@@ -577,6 +580,7 @@ void hnsw_search(
         }
     }
     size_t n1 = 0, n2 = 0, ndis = 0, nhops = 0;
+    size_t n_rabitq_1bit = 0, n_rabitq_refine = 0;
 
     idx_t check_period = InterruptCallback::get_period_hint(
             hnsw.max_level * index->d * efSearch);
@@ -602,7 +606,9 @@ void hnsw_search(
                 omp_capture_exception(ex, [&] { interrupt = true; });
             }
 
-#pragma omp for reduction(+ : n1, n2, ndis, nhops) schedule(guided)
+#pragma omp for reduction(                                               \
+                + : n1, n2, ndis, nhops, n_rabitq_1bit, n_rabitq_refine) \
+        schedule(guided)
             for (idx_t i = i0; i < i1; i++) {
                 if (interrupt.load(std::memory_order_relaxed)) {
                     continue;
@@ -617,6 +623,8 @@ void hnsw_search(
                     n2 += stats.n2;
                     ndis += stats.ndis;
                     nhops += stats.nhops;
+                    n_rabitq_1bit += stats.n_rabitq_1bit;
+                    n_rabitq_refine += stats.n_rabitq_refine;
                     res->end();
                     vt->advance();
                 } catch (...) {
@@ -629,6 +637,7 @@ void hnsw_search(
     }
 
     hnsw_stats.combine({n1, n2, ndis, nhops});
+    rabitq_hnsw_stats.add({n_rabitq_1bit, n_rabitq_refine});
 }
 
 } // anonymous namespace
@@ -1127,6 +1136,107 @@ IndexHNSWSQ::IndexHNSWSQ(
 }
 
 IndexHNSWSQ::IndexHNSWSQ() = default;
+
+/**************************************************************
+ * IndexHNSWRaBitQ implementation
+ **************************************************************/
+
+IndexHNSWRaBitQ::IndexHNSWRaBitQ() = default;
+
+IndexHNSWRaBitQ::IndexHNSWRaBitQ(
+        int d,
+        int M,
+        uint8_t nb_bits,
+        MetricType metric)
+        : IndexHNSW(new IndexRaBitQ(d, metric, nb_bits), M),
+          build_storage(
+                  (metric == METRIC_L2) ? new IndexFlatL2(d)
+                                        : new IndexFlat(d, metric)) {
+    own_fields = true;
+    // 1-bit codes store plain SignBitFactors with no f_error, so there is no
+    // bound to prune with and the staged path does not apply.
+    hnsw.is_rabitq = nb_bits >= 2;
+}
+
+IndexHNSWRaBitQ::IndexHNSWRaBitQ(const IndexHNSWRaBitQ& other)
+        : IndexHNSW(other), build_storage(nullptr) {
+    // IndexHNSW's implicit copy shares storage. Keep a direct copy non-owning;
+    // clone_index() replaces storage with a deep copy and restores ownership.
+    own_fields = false;
+}
+
+IndexHNSWRaBitQ::~IndexHNSWRaBitQ() {
+    delete build_storage;
+}
+
+void IndexHNSWRaBitQ::train(idx_t n, const float* x) {
+    FAISS_THROW_IF_NOT_MSG(storage, "storage not initialized");
+    FAISS_THROW_IF_NOT_MSG(
+            build_storage, "index is finalized and cannot be trained again");
+    build_storage->train(n, x);
+    storage->train(n, x);
+    is_trained = true;
+}
+
+void IndexHNSWRaBitQ::add(idx_t n, const float* x) {
+    FAISS_THROW_IF_NOT_MSG(
+            build_storage,
+            "index is finalized; rebuild it from scratch to add more vectors");
+    FAISS_THROW_IF_NOT(is_trained);
+    size_t n0 = ntotal;
+    storage->add(n, x);
+    build_storage->add(n, x);
+    ntotal = storage->ntotal;
+
+    const bool preset_levels =
+            hnsw.levels.size() == static_cast<size_t>(ntotal);
+
+    // The graph must be built from exact distances because RaBitQ has no
+    // symmetric_dis(). The deterministic builder accepts a distance-computer
+    // callback directly, so it can read build_storage without changing the
+    // index's searchable storage.
+    if (hnsw_deterministic_build) {
+        hnsw_add_vertices_deterministic(
+                hnsw,
+                n0,
+                n,
+                d,
+                init_level0,
+                keep_max_size_level0,
+                preset_levels,
+                verbose,
+                [this] { return storage_distance_computer(build_storage); },
+                [this, x, n0](DistanceComputer& dc, HNSW::storage_idx_t pt_id) {
+                    dc.set_query(x + (pt_id - n0) * d);
+                });
+        return;
+    }
+
+    // The legacy builder obtains its distance computer from index.storage, so
+    // point that field at the exact vectors only for the duration of the build.
+    Index* compressed = storage;
+    storage = build_storage;
+    try {
+        hnsw_add_vertices(*this, n0, n, x, verbose, preset_levels);
+    } catch (...) {
+        // Never leave search pointing at the temporary FP32 build storage.
+        storage = compressed;
+        throw;
+    }
+    storage = compressed;
+}
+
+void IndexHNSWRaBitQ::reset() {
+    IndexHNSW::reset();
+    if (build_storage) {
+        build_storage->reset();
+    }
+}
+
+void IndexHNSWRaBitQ::finalize() {
+    delete build_storage;
+    build_storage = nullptr;
+}
 
 /**************************************************************
  * IndexHNSW2Level implementation

--- a/faiss/IndexHNSW.h
+++ b/faiss/IndexHNSW.h
@@ -216,6 +216,47 @@ struct IndexHNSWSQ : IndexHNSW {
             MetricType metric = METRIC_L2);
 };
 
+/** HNSW index whose storage is RaBitQ-compressed.
+ *
+ * RaBitQ does not implement symmetric_dis(), which HNSW's neighbor-diversity
+ * pruning needs, so the graph cannot be built from the codes. Instead the exact
+ * vectors are kept in `build_storage` for the duration of the build, the graph
+ * is built from them, and finalize() drops them. Search then runs entirely on
+ * the compressed codes.
+ *
+ * With nb_bits >= 2 the codes carry a per-vector error factor, so search uses
+ * the staged path (`HNSW::is_rabitq`): a 1-bit estimate for every neighbor and
+ * the full multi-bit distance only for candidates the error bound cannot rule
+ * out. nb_bits = 1 has no error factor and falls back to plain search.
+ */
+struct IndexHNSWRaBitQ : IndexHNSW {
+    /// exact vectors, needed only to build the graph; null once finalized
+    IndexFlat* build_storage = nullptr;
+
+    IndexHNSWRaBitQ();
+    IndexHNSWRaBitQ(
+            int d,
+            int M,
+            uint8_t nb_bits = 4,
+            MetricType metric = METRIC_L2);
+
+    /// The copy does NOT inherit build_storage: copies are made to be searched,
+    /// and duplicating the exact vectors would silently double peak memory. A
+    /// copied index is therefore finalized and cannot be added to. Defining
+    /// this is also what keeps the default shallow copy from double-freeing
+    /// storage or build_storage via clone_index()'s TRYCLONE.
+    IndexHNSWRaBitQ(const IndexHNSWRaBitQ& other);
+
+    ~IndexHNSWRaBitQ() override;
+
+    void train(idx_t n, const float* x) override;
+    void add(idx_t n, const float* x) override;
+    void reset() override;
+
+    /// release the exact vectors; the index becomes compressed and read-only
+    void finalize();
+};
+
 /** 2-level code structure with fast random access
  */
 struct IndexHNSW2Level : IndexHNSW {

--- a/faiss/clone_index.cpp
+++ b/faiss/clone_index.cpp
@@ -38,6 +38,7 @@
 #include <faiss/IndexPQ.h>
 #include <faiss/IndexPQFastScan.h>
 #include <faiss/IndexPreTransform.h>
+#include <faiss/IndexRaBitQ.h>
 #include <faiss/IndexRefine.h>
 #include <faiss/IndexRowwiseMinMax.h>
 #include <faiss/IndexScalarQuantizer.h>
@@ -139,6 +140,7 @@ IndexIDMap* clone_IndexIDMap(const IndexIDMap* im) {
 IndexHNSW* clone_IndexHNSW(const IndexHNSW* ihnsw) {
     TRYCLONE(IndexHNSW2Level, ihnsw)
     TRYCLONE(IndexHNSWFlatPanorama, ihnsw)
+    TRYCLONE(IndexHNSWRaBitQ, ihnsw)
     TRYCLONE(IndexHNSWFlat, ihnsw)
     TRYCLONE(IndexHNSWPQ, ihnsw)
     TRYCLONE(IndexHNSWSQ, ihnsw)
@@ -294,6 +296,7 @@ Index* Cloner::clone_Index(const Index* index) {
     TRYCLONE(IndexEDEN, index)
 
     TRYCLONE(IndexScalarQuantizer, index)
+    TRYCLONE(IndexRaBitQ, index)
     TRYCLONE(MultiIndexQuantizer, index)
 
     if (const IndexIVF* ivf = dynamic_cast<const IndexIVF*>(index)) {

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -17,6 +17,8 @@
 
 #include <faiss/impl/DistanceComputer.h>
 #include <faiss/impl/IDSelector.h>
+#include <faiss/impl/RaBitQUtils.h>
+#include <faiss/impl/RaBitQuantizer.h>
 #include <faiss/impl/ResultHandler.h>
 #include <faiss/impl/VisitedTable.h>
 #include <faiss/impl/hnsw/LockVector.h>
@@ -1290,6 +1292,171 @@ int search_from_candidates_dispatch(
     return call(vts);
 }
 
+/** Staged RaBitQ level-0 search.
+ *
+ * Every neighbor gets a cheap 1-bit estimate; the full multi-bit distance is
+ * computed only when the error bound leaves the candidate able to enter the
+ * result heap. Deliberately mirrors `search_from_candidates_fixVT` step for
+ * step apart from how a neighbor's distance is obtained, so that any recall
+ * difference is attributable to the staged distance rather than to a different
+ * traversal.
+ *
+ * Both the beam and the result heap receive the same value per candidate, which
+ * means the beam mixes 1-bit estimates with refined distances. That is the
+ * reference implementation's behavior and it is why recall is not guaranteed to
+ * match vanilla HNSW.
+ */
+template <typename VTType, class C>
+int search_from_candidates_rabitq_fixVT(
+        const HNSW& hnsw,
+        DistanceComputer& qdis,
+        ResultHandler& res,
+        MinimaxHeapT<HC_for<C>>& candidates,
+        VTType& vt,
+        HNSWStats& stats,
+        int level,
+        int nres_in,
+        const SearchParameters* params) {
+    int nres = nres_in;
+    int ndis = 0;
+
+    bool do_dis_check;
+    int efSearch;
+    const IDSelector* sel;
+    extract_search_params(hnsw, params, do_dis_check, efSearch, sel);
+
+    // Resolved once per query: this must never happen inside the neighbor loop.
+    auto* rq = dynamic_cast<RaBitQDistanceComputer*>(&qdis);
+    FAISS_THROW_IF_NOT_MSG(
+            rq, "staged RaBitQ search requires an IndexRaBitQ storage");
+    FAISS_THROW_IF_NOT_MSG(
+            rq->nb_bits >= 2,
+            "staged RaBitQ search requires nb_bits >= 2: 1-bit codes store "
+            "plain SignBitFactors with no f_error, so there is no bound");
+
+    const uint8_t* all_codes = rq->codes;
+    const size_t code_size = rq->code_size;
+    const size_t sign_bytes = (rq->d + 7) / 8;
+    const bool is_sim = hnsw.is_similarity;
+
+    vt.reserve(efSearch);
+
+    typename C::T threshold = res.threshold;
+    for (int i = 0; i < candidates.size(); i++) {
+        idx_t v1 = candidates.ids[i];
+        float d = candidates.dis[i];
+        FAISS_ASSERT(v1 >= 0);
+        if (!sel || sel->is_member(v1)) {
+            if (C::cmp(threshold, d)) {
+                if (res.add_result(d, v1)) {
+                    threshold = res.threshold;
+                }
+            }
+        }
+        vt.set(v1);
+    }
+
+    int nstep = 0;
+
+    while (candidates.size() > 0) {
+        float d0 = 0;
+        int v0 = candidates.pop_min(&d0);
+
+        if (do_dis_check) {
+            int n_dis_below = candidates.count_below(d0);
+            if (n_dis_below >= efSearch) {
+                break;
+            }
+        }
+
+        size_t begin, end;
+        hnsw.neighbor_range(v0, level, &begin, &end);
+
+        threshold = res.threshold;
+
+        for (size_t j = begin; j < end; j++) {
+            int v1 = hnsw.neighbors[j];
+            if (v1 < 0) {
+                break;
+            }
+            if (!vt.set(v1)) {
+                continue;
+            }
+
+            const uint8_t* code =
+                    all_codes + static_cast<size_t>(v1) * code_size;
+            const float est = rq->distance_to_code_1bit(code);
+            stats.n_rabitq_1bit++;
+
+            float dis = est;
+            const auto* fac = reinterpret_cast<
+                    const rabitq_utils::SignBitFactorsWithError*>(
+                    code + sign_bytes);
+            if (rabitq_utils::should_refine_candidate(
+                        est, fac->f_error, rq->g_error, threshold, is_sim)) {
+                dis = rq->distance_to_code_full(code);
+                stats.n_rabitq_refine++;
+            }
+            ndis++;
+
+            if (!sel || sel->is_member(v1)) {
+                if (C::cmp(threshold, dis)) {
+                    if (res.add_result(dis, v1)) {
+                        threshold = res.threshold;
+                        nres += 1;
+                    }
+                }
+            }
+            candidates.push(v1, dis);
+        }
+
+        nstep++;
+        if (!do_dis_check && nstep > efSearch) {
+            break;
+        }
+    }
+
+    if (level == 0) {
+        stats.n1++;
+        if (candidates.size() == 0) {
+            stats.n2++;
+        }
+        stats.ndis += ndis;
+        stats.nhops += nstep;
+    }
+    return nres;
+}
+
+template <class C>
+int search_from_candidates_rabitq_dispatch(
+        const HNSW& hnsw,
+        DistanceComputer& qdis,
+        ResultHandler& res,
+        MinimaxHeapT<HC_for<C>>& candidates,
+        VisitedTable& vt,
+        HNSWStats& stats,
+        int level,
+        int nres_in,
+        const SearchParameters* params) {
+    auto call = [&]<typename VTType>(VTType& vt_concrete) -> int {
+        return search_from_candidates_rabitq_fixVT<VTType, C>(
+                hnsw,
+                qdis,
+                res,
+                candidates,
+                vt_concrete,
+                stats,
+                level,
+                nres_in,
+                params);
+    };
+    if (VisitedTableVector* vtv = dynamic_cast<VisitedTableVector*>(&vt)) {
+        return call(*vtv);
+    }
+    VisitedTableSet& vts = dynamic_cast<VisitedTableSet&>(vt);
+    return call(vts);
+}
+
 } // namespace
 
 /** Do a BFS on the candidates list. Public dispatcher: only handles the
@@ -1722,7 +1889,12 @@ HNSWStats search_impl(
 
         candidates.push(nearest, d_nearest);
 
-        if (!hnsw.is_panorama) {
+        if (hnsw.is_rabitq) {
+            // Works for both L2 and IP: should_refine_candidate() applies a
+            // lower bound for L2 and an upper bound for IP.
+            search_from_candidates_rabitq_dispatch<C>(
+                    hnsw, qdis, res, candidates, vt, stats, 0, 0, params);
+        } else if (!hnsw.is_panorama) {
             search_from_candidates_dispatch<C>(
                     hnsw, qdis, res, candidates, vt, stats, 0, 0, params);
         } else {

--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -23,6 +23,7 @@
 #include <faiss/impl/VisitedTable.h>
 #include <faiss/impl/hnsw/LockVector.h>
 #include <faiss/impl/hnsw/MinimaxHeap.h>
+#include <faiss/utils/prefetch.h>
 
 namespace faiss {
 
@@ -1337,6 +1338,8 @@ int search_from_candidates_rabitq_fixVT(
     const uint8_t* all_codes = rq->codes;
     const size_t code_size = rq->code_size;
     const size_t sign_bytes = (rq->d + 7) / 8;
+    const size_t filter_bytes =
+            sign_bytes + sizeof(rabitq_utils::SignBitFactorsWithError);
     const bool is_sim = hnsw.is_similarity;
 
     vt.reserve(efSearch);
@@ -1374,7 +1377,23 @@ int search_from_candidates_rabitq_fixVT(
 
         threshold = res.threshold;
 
+        // RaBitQ codes are random accesses during graph traversal. Prefetch
+        // the bytes needed by both the 1-bit estimate and its error bound.
+        constexpr size_t kCacheLineBytes = 64;
+        constexpr size_t kPrefetchDistance = 4;
         for (size_t j = begin; j < end; j++) {
+            if (j + kPrefetchDistance < end) {
+                int next = hnsw.neighbors[j + kPrefetchDistance];
+                if (next >= 0) {
+                    const uint8_t* next_code =
+                            all_codes + static_cast<size_t>(next) * code_size;
+                    for (size_t offset = 0; offset < filter_bytes;
+                         offset += kCacheLineBytes) {
+                        prefetch_L1(next_code + offset);
+                    }
+                }
+            }
+
             int v1 = hnsw.neighbors[j];
             if (v1 < 0) {
                 break;

--- a/faiss/impl/HNSW.h
+++ b/faiss/impl/HNSW.h
@@ -157,6 +157,12 @@ struct HNSW {
     /// use Panorama progressive pruning in search
     bool is_panorama = false;
 
+    /// use staged RaBitQ search: a 1-bit estimate for every neighbor, and the
+    /// full multi-bit distance only where the error bound leaves the candidate
+    /// able to enter the result heap. Requires an IndexRaBitQ storage with
+    /// nb_bits >= 2 (1-bit codes carry no f_error, so there is no bound).
+    bool is_rabitq = false;
+
     /// distance comparison semantics: when true, distances are treated as
     /// similarity scores (larger is better). Default false matches the
     /// historical L2/Hamming behavior (smaller is better).
@@ -305,11 +311,15 @@ struct HNSWStats {
             0; /// number of queries for which the candidate list is exhausted
     size_t ndis = 0;  /// number of distances computed
     size_t nhops = 0; /// number of hops aka number of edges traversed
+    size_t n_rabitq_1bit = 0;
+    size_t n_rabitq_refine = 0;
 
     void reset() {
         n1 = n2 = 0;
         ndis = 0;
         nhops = 0;
+        n_rabitq_1bit = 0;
+        n_rabitq_refine = 0;
     }
 
     void combine(const HNSWStats& other) {
@@ -317,6 +327,8 @@ struct HNSWStats {
         n2 += other.n2;
         ndis += other.ndis;
         nhops += other.nhops;
+        n_rabitq_1bit += other.n_rabitq_1bit;
+        n_rabitq_refine += other.n_rabitq_refine;
     }
 };
 
@@ -328,6 +340,30 @@ FAISS_API extern HNSWStats hnsw_stats;
  *
  * NOT thread-safe: set before calling add(). Sampled once per add(). */
 FAISS_API extern bool hnsw_deterministic_build;
+
+/// Instrumentation for the staged RaBitQ search. The refine ratio is the number
+/// that decides whether staged search can pay for itself: every candidate costs
+/// a 1-bit estimate, and only the refined ones additionally cost a full
+/// multi-bit distance.
+struct RaBitQHNSWStats {
+    uint64_t n_1bit = 0;   /// candidates given a 1-bit estimate
+    uint64_t n_refine = 0; /// of those, ones that needed the full distance
+
+    void reset() {
+        n_1bit = n_refine = 0;
+    }
+
+    void add(const RaBitQHNSWStats& other) {
+        n_1bit += other.n_1bit;
+        n_refine += other.n_refine;
+    }
+
+    double refine_ratio() const {
+        return n_1bit ? double(n_refine) / double(n_1bit) : 0.0;
+    }
+};
+
+FAISS_API extern RaBitQHNSWStats rabitq_hnsw_stats;
 
 /// Internal HNSW algorithm helpers. These are not part of the public API; they
 /// are exposed here only so that unit tests (and a few cross-TU callers such as

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -2501,7 +2501,7 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
     } else if (
             h == fourcc("IHNf") || h == fourcc("IHNp") || h == fourcc("IHNs") ||
             h == fourcc("IHN2") || h == fourcc("IHNc") || h == fourcc("IHc2") ||
-            h == fourcc("IHfP") || h == fourcc("IH00")) {
+            h == fourcc("IHfP") || h == fourcc("IHNr") || h == fourcc("IH00")) {
         std::unique_ptr<IndexHNSW> idxhnsw;
         if (h == fourcc("IH00")) {
             idxhnsw = std::make_unique<IndexHNSW>();
@@ -2519,6 +2519,10 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
             idxhnsw = std::make_unique<IndexHNSWCagra>();
         } else if (h == fourcc("IHc2")) {
             idxhnsw = std::make_unique<IndexHNSWCagra>();
+        } else if (h == fourcc("IHNr")) {
+            // A serialized index is always finalized: build_storage stays null
+            // and the storage read below is the RaBitQ one.
+            idxhnsw = std::make_unique<IndexHNSWRaBitQ>();
         }
         read_index_header(*idxhnsw, f);
         if (h == fourcc("IHfP")) {
@@ -2574,6 +2578,22 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
                     "HNSW storage d %d != index d %d",
                     idxhnsw->storage->d,
                     idxhnsw->d);
+        }
+        if (h == fourcc("IHNr")) {
+            auto* idx_rabitq = dynamic_cast<IndexHNSWRaBitQ*>(idxhnsw.get());
+            FAISS_THROW_IF_NOT_MSG(
+                    idx_rabitq, "IHNr must deserialize to an IndexHNSWRaBitQ");
+            if (idxhnsw->storage) {
+                auto* rq = dynamic_cast<IndexRaBitQ*>(idxhnsw->storage);
+                FAISS_THROW_IF_NOT_MSG(
+                        rq, "IndexHNSWRaBitQ storage must be an IndexRaBitQ");
+                // Like is_similarity, is_rabitq is not serialized: re-derive
+                // it, so that a reloaded index still takes the staged search
+                // path. 1-bit codes have no f_error and fall back to plain
+                // search. IO_FLAG_SKIP_STORAGE leaves it false because the
+                // resulting index is not searchable.
+                idxhnsw->hnsw.is_rabitq = rq->rabitq.nb_bits >= 2;
+            }
         }
         if (h == fourcc("IHN2")) {
             FAISS_THROW_IF_NOT_MSG(

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -873,6 +873,7 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
                 : dynamic_cast<const IndexHNSWSQ*>(idx)     ? fourcc("IHNs")
                 : dynamic_cast<const IndexHNSW2Level*>(idx) ? fourcc("IHN2")
                 : dynamic_cast<const IndexHNSWCagra*>(idx)  ? fourcc("IHc2")
+                : dynamic_cast<const IndexHNSWRaBitQ*>(idx) ? fourcc("IHNr")
                 : typeid(*idx) == typeid(IndexHNSW)         ? fourcc("IH00")
                                                             : 0;
         FAISS_THROW_IF_NOT_FMT(

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -575,6 +575,13 @@ IndexHNSW* parse_IndexHNSW(
     if (match(sq_pattern)) {
         return new IndexHNSWSQ(d, sq_types[sm[1].str()], hnsw_M, mt);
     }
+    // "RaBitQ" defaults to 4 bits (1 sign + 3 extra). Explicit widths from 1
+    // through 9 match RaBitQuantizer's supported range.
+    if (match("RaBitQ([1-9])?")) {
+        // the capture is the bare digit, so no substr offset here
+        int nb_bits = mres_to_int(sm[1], 4);
+        return new IndexHNSWRaBitQ(d, hnsw_M, nb_bits, mt);
+    }
     if (match("([0-9]+)\\+PQ([0-9]+)?")) {
         int ncent = mres_to_int(sm[1]);
         int pq_m = mres_to_int(sm[2]);

--- a/faiss/python/__init__.pyi
+++ b/faiss/python/__init__.pyi
@@ -1939,12 +1939,23 @@ class HNSWStats:
     n3: int
     ndis: int
     nreorder: int
+    n_rabitq_1bit: int
+    n_rabitq_refine: int
+
+class RaBitQHNSWStats:
+    n_1bit: int
+    n_refine: int
+
+    def reset(self) -> None: ...
+    def add(self, other: RaBitQHNSWStats) -> None: ...
+    def refine_ratio(self) -> float: ...
 
 class HNSW:
     max_level: int
     entry_point: int
     efConstruction: int
     efSearch: int
+    is_rabitq: bool
     hnsw_stats: HNSWStats
     assign_probas: Float32Vector
     cum_nneighbor_per_level: Int32Vector
@@ -2007,6 +2018,18 @@ class IndexHNSWSQ(IndexHNSW):
         M: int,
         metric: MetricType = METRIC_L2,
     ) -> None: ...
+
+class IndexHNSWRaBitQ(IndexHNSW):
+    build_storage: IndexFlat | None
+
+    def __init__(
+        self,
+        d: int,
+        M: int,
+        nb_bits: int = 4,
+        metric: MetricType = METRIC_L2,
+    ) -> None: ...
+    def finalize(self) -> None: ...
 
 class IndexHNSW2Level(IndexHNSW):
     q1: Any  # Level1Quantizer

--- a/faiss/python/swigfaiss.swig
+++ b/faiss/python/swigfaiss.swig
@@ -914,6 +914,7 @@ typedef int cudaDataType_t;
     DOWNCAST ( IndexHNSWPQ )
     DOWNCAST ( IndexHNSWSQ )
     DOWNCAST ( IndexHNSWCagra )
+    DOWNCAST ( IndexHNSWRaBitQ )
     DOWNCAST ( IndexHNSW )
     DOWNCAST ( IndexHNSW2Level )
     DOWNCAST ( IndexNNDescentFlat )

--- a/tests/test_hnsw_rabitq.py
+++ b/tests/test_hnsw_rabitq.py
@@ -1,0 +1,99 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import faiss
+import numpy as np
+
+
+class TestHNSWRaBitQ(unittest.TestCase):
+    def make_data(self, d=32, nt=400, nb=600, nq=20):
+        rs = np.random.RandomState(123)
+        xt = rs.randn(nt, d).astype("float32")
+        xb = rs.randn(nb, d).astype("float32")
+        xq = rs.randn(nq, d).astype("float32")
+        return xt, xb, xq
+
+    def make_index(self, metric=faiss.METRIC_L2, nb_bits=3):
+        xt, xb, xq = self.make_data()
+        if metric == faiss.METRIC_INNER_PRODUCT:
+            faiss.normalize_L2(xt)
+            faiss.normalize_L2(xb)
+            faiss.normalize_L2(xq)
+        index = faiss.IndexHNSWRaBitQ(xt.shape[1], 8, nb_bits, metric)
+        index.hnsw.efConstruction = 40
+        index.hnsw.efSearch = 32
+        index.train(xt)
+        index.add(xb)
+        return index, xb, xq
+
+    def test_staged_search_finalize_clone_and_io(self):
+        index, xb, xq = self.make_index(nb_bits=3)
+
+        faiss.cvar.rabitq_hnsw_stats.reset()
+        Dref, Iref = index.search(xq, 10)
+        stats = faiss.cvar.rabitq_hnsw_stats
+        self.assertGreater(stats.n_1bit, 0)
+        self.assertGreaterEqual(stats.n_1bit, stats.n_refine)
+        self.assertTrue(np.all(Iref >= 0))
+        self.assertTrue(np.all(np.isfinite(Dref)))
+
+        # Clones and serialized indexes are search-only and do not retain the
+        # exact FP32 build storage.
+        cloned = faiss.clone_index(index)
+        self.assertIsInstance(cloned, faiss.IndexHNSWRaBitQ)
+        Dclone, Iclone = cloned.search(xq, 10)
+        np.testing.assert_array_equal(Iclone, Iref)
+        np.testing.assert_array_equal(Dclone, Dref)
+
+        loaded = faiss.deserialize_index(faiss.serialize_index(index))
+        self.assertIsInstance(loaded, faiss.IndexHNSWRaBitQ)
+        Dloaded, Iloaded = loaded.search(xq, 10)
+        np.testing.assert_array_equal(Iloaded, Iref)
+        np.testing.assert_array_equal(Dloaded, Dref)
+
+        index.finalize()
+        with self.assertRaises(RuntimeError):
+            index.add(xb[:1])
+
+    def test_one_bit_fallback(self):
+        index, _, xq = self.make_index(nb_bits=1)
+        self.assertFalse(index.hnsw.is_rabitq)
+        faiss.cvar.rabitq_hnsw_stats.reset()
+        D, I = index.search(xq, 10)
+        self.assertTrue(np.all(I >= 0))
+        self.assertTrue(np.all(np.isfinite(D)))
+        self.assertEqual(faiss.cvar.rabitq_hnsw_stats.n_1bit, 0)
+        self.assertEqual(faiss.cvar.rabitq_hnsw_stats.n_refine, 0)
+
+    def test_inner_product_and_reset(self):
+        index, xb, xq = self.make_index(
+            metric=faiss.METRIC_INNER_PRODUCT, nb_bits=3
+        )
+        D, I = index.search(xq, 10)
+        self.assertTrue(np.all(I >= 0))
+        self.assertTrue(np.all(np.isfinite(D)))
+        self.assertTrue(np.all(D[:, :-1] >= D[:, 1:]))
+
+        index.reset()
+        self.assertEqual(index.ntotal, 0)
+        index.add(xb)
+        self.assertEqual(index.ntotal, len(xb))
+
+    def test_factory(self):
+        default_index = faiss.index_factory(32, "HNSW8,RaBitQ")
+        self.assertIsInstance(default_index, faiss.IndexHNSWRaBitQ)
+        default_storage = faiss.downcast_index(default_index.storage)
+        self.assertIsInstance(default_storage, faiss.IndexRaBitQ)
+        self.assertEqual(default_storage.rabitq.nb_bits, 4)
+
+        one_bit = faiss.index_factory(32, "HNSW8,RaBitQ1")
+        self.assertIsInstance(one_bit, faiss.IndexHNSWRaBitQ)
+        self.assertFalse(one_bit.hnsw.is_rabitq)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
 Prefetch RaBitQ sign bits and error factors four neighbors ahead during
  level-0 HNSW traversal.

  RaBitQ codes are accessed through irregular graph edges. Prefetching the bytes
  needed by the 1-bit filter hides part of this memory latency without loading the
  extra multi-bit code that most candidates never refine into.

  This does not change search results or distance calculations.

  ## Benchmark

  Cohere 1M, d=1024, IP, HNSW32,RaBitQ4, k=10, single thread.

  AWS Graviton4 (m8g.4xlarge), warm runs interleaved across control and patched
  builds for five rounds:
     efSearch      Before       After    Improvement
   16    1905 QPS    2093 QPS          +9.8%
   64    1224 QPS    1513 QPS         +23.6%
   256     564 QPS     794 QPS         +40.7%


  Lookahead 4 also outperformed 8 and 16 on the same workload.

  Complete result ID and distance arrays were bit-identical between builds.
  The implementation uses Faiss's portable prefetch_L1 helper and was validated
  on both AArch64 and x86-64.