### PR TITLE
Fix empty-index BLAS search results

### DIFF
--- a/faiss/utils/distances.cpp
+++ b/faiss/utils/distances.cpp
@@ -554,6 +554,16 @@ void exhaustive_L2sqr_blas<Top1BlockResultHandler<CMax<float, int64_t>>>(
     });
 }
 
+template <class BlockResultHandler>
+void initialize_empty_results(size_t nx, BlockResultHandler& res) {
+    const size_t bs_x = distance_compute_blas_query_bs;
+    for (size_t i0 = 0; i0 < nx; i0 += bs_x) {
+        const size_t i1 = std::min(i0 + bs_x, nx);
+        res.begin_multiple(i0, i1);
+        res.end_multiple();
+    }
+}
+
 struct Run_search_inner_product {
     using T = void;
     template <class BlockResultHandler>
@@ -563,8 +573,11 @@ struct Run_search_inner_product {
            size_t d,
            size_t nx,
            size_t ny) {
-        if (res.sel ||
-            nx * d < static_cast<size_t>(distance_compute_blas_threshold)) {
+        if (ny == 0) {
+            initialize_empty_results(nx, res);
+        } else if (
+                res.sel ||
+                nx * d < static_cast<size_t>(distance_compute_blas_threshold)) {
             exhaustive_inner_product_seq(x, y, d, nx, ny, res);
         } else {
             exhaustive_inner_product_blas(x, y, d, nx, ny, res);
@@ -582,8 +595,11 @@ struct Run_search_L2sqr {
            size_t nx,
            size_t ny,
            const float* y_norm2) {
-        if (res.sel ||
-            nx * d < static_cast<size_t>(distance_compute_blas_threshold)) {
+        if (ny == 0) {
+            initialize_empty_results(nx, res);
+        } else if (
+                res.sel ||
+                nx * d < static_cast<size_t>(distance_compute_blas_threshold)) {
             exhaustive_L2sqr_seq(x, y, d, nx, ny, res);
         } else {
             exhaustive_L2sqr_blas(x, y, d, nx, ny, res, y_norm2);

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -137,6 +137,31 @@ class TestIndexFlat(unittest.TestCase):
                     lims, np.zeros(1, dtype=np.int64)
                 )
 
+    def test_empty_index_with_blas(self):
+        saved_threshold = faiss.cvar.distance_compute_blas_threshold
+        saved_query_bs = faiss.cvar.distance_compute_blas_query_bs
+        faiss.cvar.distance_compute_blas_threshold = 1
+        faiss.cvar.distance_compute_blas_query_bs = 2
+        try:
+            xq = np.arange(5, dtype="float32").reshape(-1, 1)
+            for metric_type in (faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT):
+                expected_distance = (
+                    np.finfo("float32").max
+                    if metric_type == faiss.METRIC_L2
+                    else np.finfo("float32").min
+                )
+                index = faiss.IndexFlat(1, metric_type)
+                for k in (1, 10, 150):
+                    with self.subTest(metric_type=metric_type, k=k):
+                        D = np.full((len(xq), k), 42, dtype="float32")
+                        I = np.full((len(xq), k), 99, dtype="int64")
+                        index.search(xq, k, D=D, I=I)
+                        np.testing.assert_array_equal(D, expected_distance)
+                        np.testing.assert_array_equal(I, -1)
+        finally:
+            faiss.cvar.distance_compute_blas_threshold = saved_threshold
+            faiss.cvar.distance_compute_blas_query_bs = saved_query_bs
+
 
 @for_all_simd_levels
 class TestDbParallelSearch(unittest.TestCase):


### PR DESCRIPTION
## Summary

- initialize result handlers when an exhaustive search has no database vectors
- process empty results in the configured query block size, preserving bounded temporary memory for large query batches
- cover L2 and inner-product search across top-1, heap, and reservoir result handlers

## Problem

Searching an empty `IndexFlat` produced correct sentinel values for small query batches, but could leave the caller's distance and label buffers untouched once `nq * d` selected the BLAS path. The BLAS helpers return early for `ny == 0` before the result handler's `begin_multiple` / `end_multiple` lifecycle initializes and finalizes the output.

This change handles an empty database before choosing the sequential or BLAS implementation. It uses the existing result-handler lifecycle so each handler supplies its own correct neutral distance and `-1` label semantics.

Fixes #3830.

## Validation

- `python -m unittest test_index.TestIndexFlat_ARM_NEON.test_empty_index_with_blas`
- `python -m unittest test_index` (49 tests passed)
- `faiss_test --gtest_brief=1` (290 passed, 1 platform-specific skip)
- `clang-format 21 --dry-run --Werror faiss/utils/distances.cpp`
