### PR TITLE
Make cuVS dispatch opt-in rather than build-implied

### DIFF
--- a/faiss/gpu/GpuClonerOptions.h
+++ b/faiss/gpu/GpuClonerOptions.h
@@ -39,12 +39,8 @@ struct GpuClonerOptions {
     /// Set verbose options on the index
     bool verbose = false;
 
-    /// use the cuVS implementation
-#if defined USE_NVIDIA_CUVS
-    bool use_cuvs = true;
-#else
+    /// Use the cuVS implementation. Opt-in: see GpuIndexConfig::use_cuvs.
     bool use_cuvs = false;
-#endif
 
     /// This flag controls the CPU fallback logic for coarse quantizer
     /// component of the index. When set to false (default), the cloner will

--- a/faiss/gpu/GpuDistance.h
+++ b/faiss/gpu/GpuDistance.h
@@ -107,12 +107,9 @@ struct GpuDistanceParams {
     /// execution
     int device = -1;
 
-    /// Should the index dispatch down to cuVS?
-#if defined USE_NVIDIA_CUVS
-    bool use_cuvs = true;
-#else
+    /// Should the search dispatch down to cuVS? Opt-in: see
+    /// GpuIndexConfig::use_cuvs.
     bool use_cuvs = false;
-#endif
 };
 
 /// A function that determines whether cuVS should be used based on various

--- a/faiss/gpu/GpuIndex.h
+++ b/faiss/gpu/GpuIndex.h
@@ -38,12 +38,11 @@ struct GpuIndexConfig {
     /// more memory than is available on the GPU.
     MemorySpace memorySpace = MemorySpace::Device;
 
-    /// Should the index dispatch down to cuVS?
-#if defined USE_NVIDIA_CUVS
-    bool use_cuvs = true;
-#else
+    /// Should the index dispatch down to cuVS? Opt-in: dispatching to cuVS
+    /// selects a different implementation with its own numerical behaviour, so
+    /// it must be an explicit choice by the caller rather than a consequence of
+    /// how the binary happened to be built.
     bool use_cuvs = false;
-#endif
 };
 
 /// A centralized function that determines whether cuVS should


### PR DESCRIPTION
Summary:
`GpuIndexConfig::use_cuvs`, `GpuClonerOptions::use_cuvs` and
`GpuDistanceParams::use_cuvs` each defaulted to `true` whenever the library was
compiled with `USE_NVIDIA_CUVS`, and to `false` otherwise.

That makes the choice of backend a property of how the binary was built rather
than a choice the caller made. Code that constructs a default
`GpuIndexFlatConfig()` and never mentions cuVS starts dispatching to a different
implementation, with its own numerical behaviour, the moment it is linked
against a cuVS-enabled build -- and there is no process-wide way to opt back
out, since the flag lives per-object with no environment variable or global
setter behind it.

Default all three to `false`, so an unset flag means "no". The flag is otherwise
unchanged: callers that want cuVS set it explicitly, which is what every cuVS
test already does. Builds without cuVS are unaffected, since the flag was
already `false` there.

`GpuIndexCagra` never consults `use_cuvs` -- it is unconditionally cuVS-backed
-- so CAGRA is unaffected.

One knock-on worth flagging: `test_gpu_index_ivfsq.py` and
`test_index_cpu_to_gpu.py` were picking up cuVS from the default rather than
setting it, so when built against a cuVS-enabled library they now exercise the
classical path. Neither asserts which backend ran, so both still pass. Threading
an explicit `use_cuvs=True` through them, so those variants keep earning their
name, is a follow-up.

Differential Revision: D116567346


