### PR TITLE
Add SVE low-dimensional nearest fast path and spherical SuperKMeans support

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -64,6 +64,7 @@ set(FAISS_SIMD_NEON_SRC
 set(FAISS_SIMD_SVE_SRC
   impl/pq_code_distance/pq_code_distance-sve.cpp
   utils/simd_impl/distances_arm_sve.cpp
+  utils/simd_impl/super_kmeans_kernels_sve.cpp
 )
 set(FAISS_SIMD_RVV_SRC
   impl/fast_scan/impl-riscv.cpp

--- a/faiss/Clustering.h
+++ b/faiss/Clustering.h
@@ -75,6 +75,11 @@ struct ClusteringParameters {
     /// so the training process stops only if an error
     /// is unchanged from the previous iteration.
     double early_stop_threshold = 0.0;
+
+    /// Whether to use the SuperKMeans (super fast k-means) variant instead of
+    /// the vanilla Clustering implementation. Only honored by callers that
+    /// explicitly support it (e.g. IVF level-1 quantizer training).
+    bool use_super_kmeans = false;
 };
 
 struct ClusteringIterationStats {

--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <faiss/IndexIVF.h>
+#include <faiss/SuperKMeans.h>
 
 #include <omp.h>
 #include <atomic>
@@ -78,13 +79,22 @@ void Level1Quantizer::train_q1(
             printf("Training level-1 quantizer on %zd vectors in %zdD\n", n, d);
         }
 
-        Clustering clus(static_cast<int>(d), static_cast<int>(nlist), cp);
         quantizer->reset();
-        if (clustering_index) {
-            clus.train(n, x, *clustering_index);
+        if (cp.use_super_kmeans && clustering_index == nullptr) {
+            SuperKMeansParameters super_cp;
+            static_cast<ClusteringParameters&>(super_cp) = cp;
+            SuperKMeans clus(
+                    static_cast<int>(d), static_cast<int>(nlist), super_cp);
+            clus.train(n, x);
             quantizer->add(nlist, clus.centroids.data());
         } else {
-            clus.train(n, x, *quantizer);
+            Clustering clus(static_cast<int>(d), static_cast<int>(nlist), cp);
+            if (clustering_index) {
+                clus.train(n, x, *clustering_index);
+                quantizer->add(nlist, clus.centroids.data());
+            } else {
+                clus.train(n, x, *quantizer);
+            }
         }
         quantizer->is_trained = true;
     } else if (quantizer_trains_alone == 2) {

--- a/faiss/SuperKMeans.cpp
+++ b/faiss/SuperKMeans.cpp
@@ -57,7 +57,7 @@ namespace faiss {
 namespace {
 
 struct TrainState {
-    /// Fast orthogonal rotation. Train in rotated space;
+    /// Orthogonal rotation. Train in rotated space (X_tilde = X * R);
     /// un-rotate centroids before return.
     std::unique_ptr<faiss::VectorTransform> R;
 
@@ -208,8 +208,7 @@ int update_centroids_and_split(
         int k,
         TrainState& state,
         std::vector<int64_t>& labels64,
-        std::vector<float>& hassign,
-        bool spherical) {
+        std::vector<float>& hassign) {
     std::fill(hassign.begin(), hassign.end(), 0.0f);
     assert(!labels64.empty());
     assert(!state.assignments.empty());
@@ -227,23 +226,16 @@ int update_centroids_and_split(
             /*weights=*/nullptr,
             hassign.data(),
             state.Y_tilde.data());
-    if (spherical) {
-        fvec_renorm_L2(d, k, state.Y_tilde.data());
-    }
     if (state.n <= k) {
         return 0;
     }
-    const int nsplit = detail::split_clusters(
+    return detail::split_clusters(
             d,
             k,
             state.n,
             /*k_frozen=*/0,
             hassign.data(),
             state.Y_tilde.data());
-    if (spherical) {
-        fvec_renorm_L2(d, k, state.Y_tilde.data());
-    }
-    return nsplit;
 }
 
 /// Stay-in-band controller: nudge state.d_prime based on observed pruning
@@ -472,8 +464,11 @@ void SuperKMeans::train(idx_t n, const float* x) {
                     pruned_at_gemm);
         }
 
-        const int nsplit = update_centroids_and_split(
-                d, k, state, labels64, hassign, cp.spherical);
+        const int nsplit =
+                update_centroids_and_split(d, k, state, labels64, hassign);
+        if (cp.spherical) {
+            fvec_renorm_L2(d, k, state.Y_tilde.data());
+        }
         const float pruning_rate = (iter == 0)
                 ? 0.0f
                 : adapt_d_prime(d, cp, state, total_pairs, pruned_at_gemm);

--- a/faiss/SuperKMeans.cpp
+++ b/faiss/SuperKMeans.cpp
@@ -57,9 +57,9 @@ namespace faiss {
 namespace {
 
 struct TrainState {
-    /// Orthogonal rotation. Train in rotated space (X_tilde = X * R);
+    /// Fast orthogonal rotation. Train in rotated space;
     /// un-rotate centroids before return.
-    faiss::RandomRotationMatrix R;
+    std::unique_ptr<faiss::VectorTransform> R;
 
     std::vector<float> X_tilde; // (n, d) row-major
     int n = 0;
@@ -77,7 +77,17 @@ struct TrainState {
     int low_pruning_streak = 0;
     bool low_pruning_warning_printed = false;
 
-    explicit TrainState(int d) : R(d, d) {}
+    explicit TrainState(int d, bool spherical)
+            : R([d, spherical]() -> std::unique_ptr<faiss::VectorTransform> {
+                  // Spherical (inner-product) clustering only: a power-of-two
+                  // dimension can use the fast Hadamard rotation instead of
+                  // the generic random rotation. L2 training keeps the
+                  // original RandomRotationMatrix path unchanged.
+                  if (spherical && d > 0 && (d & (d - 1)) == 0) {
+                      return std::make_unique<faiss::HadamardRotation>(d);
+                  }
+                  return std::make_unique<faiss::RandomRotationMatrix>(d, d);
+              }()) {}
 };
 
 /// PDX block layout for the trailing pruning sweep: block b covers original
@@ -198,7 +208,8 @@ int update_centroids_and_split(
         int k,
         TrainState& state,
         std::vector<int64_t>& labels64,
-        std::vector<float>& hassign) {
+        std::vector<float>& hassign,
+        bool spherical) {
     std::fill(hassign.begin(), hassign.end(), 0.0f);
     assert(!labels64.empty());
     assert(!state.assignments.empty());
@@ -216,16 +227,23 @@ int update_centroids_and_split(
             /*weights=*/nullptr,
             hassign.data(),
             state.Y_tilde.data());
+    if (spherical) {
+        fvec_renorm_L2(d, k, state.Y_tilde.data());
+    }
     if (state.n <= k) {
         return 0;
     }
-    return detail::split_clusters(
+    const int nsplit = detail::split_clusters(
             d,
             k,
             state.n,
             /*k_frozen=*/0,
             hassign.data(),
             state.Y_tilde.data());
+    if (spherical) {
+        fvec_renorm_L2(d, k, state.Y_tilde.data());
+    }
+    return nsplit;
 }
 
 /// Stay-in-band controller: nudge state.d_prime based on observed pruning
@@ -295,10 +313,17 @@ std::unique_ptr<uint8_t[]> setup_train_state(
             "SuperKMeans: training set size exceeds INT_MAX after sampling");
     state.n = static_cast<int>(nx);
 
-    state.R.init(cp.seed);
+    if (auto* R = dynamic_cast<HadamardRotation*>(state.R.get())) {
+        R->init(cp.seed);
+    } else {
+        auto* dense_rotation =
+                dynamic_cast<RandomRotationMatrix*>(state.R.get());
+        FAISS_ASSERT(dense_rotation != nullptr);
+        dense_rotation->init(cp.seed);
+    }
 
     state.X_tilde.resize(static_cast<size_t>(state.n) * d);
-    state.R.apply_noalloc(state.n, x_sampled, state.X_tilde.data());
+    state.R->apply_noalloc(state.n, x_sampled, state.X_tilde.data());
 
     // Forgy init: pick k random rows from the rotated pool as initial
     // centroids. These remain in rotated space; un-rotation happens
@@ -312,6 +337,9 @@ std::unique_ptr<uint8_t[]> setup_train_state(
                     state.Y_tilde.data() + static_cast<size_t>(j) * d,
                     state.X_tilde.data() + static_cast<size_t>(perm[j]) * d,
                     sizeof(float) * d);
+        }
+        if (cp.spherical) {
+            fvec_renorm_L2(d, k, state.Y_tilde.data());
         }
     }
 
@@ -339,7 +367,7 @@ std::unique_ptr<uint8_t[]> setup_train_state(
 /// reverse_transform applies R^T = R^-1.
 void untransform_centroids(
         std::vector<float>& centroids,
-        const RandomRotationMatrix& R,
+        const VectorTransform& R,
         int d,
         int k,
         const float* Y_tilde) {
@@ -411,7 +439,7 @@ void SuperKMeans::train(idx_t n, const float* x) {
                static_cast<idx_t>(k) * cp.min_points_per_centroid);
     }
 
-    TrainState state(d);
+    TrainState state(d, cp.spherical);
     std::vector<int64_t> labels64;
     SuperKMeansAssignScratch assign_scratch;
     std::vector<float> hassign;
@@ -444,8 +472,8 @@ void SuperKMeans::train(idx_t n, const float* x) {
                     pruned_at_gemm);
         }
 
-        const int nsplit =
-                update_centroids_and_split(d, k, state, labels64, hassign);
+        const int nsplit = update_centroids_and_split(
+                d, k, state, labels64, hassign, cp.spherical);
         const float pruning_rate = (iter == 0)
                 ? 0.0f
                 : adapt_d_prime(d, cp, state, total_pairs, pruned_at_gemm);
@@ -492,7 +520,7 @@ void SuperKMeans::train(idx_t n, const float* x) {
                (getmillisecs() - t_train_start) / 1000.0);
     }
 
-    untransform_centroids(centroids, state.R, d, k, state.Y_tilde.data());
+    untransform_centroids(centroids, *state.R, d, k, state.Y_tilde.data());
 }
 
 void super_kmeans_assign_iteration(

--- a/faiss/SuperKMeans.h
+++ b/faiss/SuperKMeans.h
@@ -13,8 +13,9 @@
 //   "A Super Fast K-means for Indexing Vector Embeddings."
 //   arXiv preprint arXiv:2603.20009.
 //
-// Use when: L2 metric, k >= 1024, d >= 128, dense float embeddings.
-// Do not use for: IP/cosine (use Clustering with cp.spherical=true), small k,
+// Use when: L2 metric, or spherical inner-product clustering with
+// cp.spherical=true, k >= 1024, d >= 128, dense float embeddings.
+// Do not use for: small k,
 // binary data (use IndexBinaryIVF), or near-unit-sphere embeddings with
 // k < 4096 (chi-squared assumption breaks down).
 //

--- a/faiss/VectorTransform.cpp
+++ b/faiss/VectorTransform.cpp
@@ -513,6 +513,44 @@ void HadamardRotation::apply_noalloc(idx_t n, const float* x, float* xt) const {
     }
 }
 
+void HadamardRotation::reverse_transform(idx_t n, const float* xt, float* x)
+        const {
+    FAISS_THROW_IF_NOT_MSG(is_trained, "Transformation not trained yet");
+    FAISS_THROW_IF_NOT_MSG(
+            d_in == d_out,
+            "HadamardRotation inverse requires equal input/output dimensions");
+
+    const size_t p = d_out;
+    // Reverse of apply_noalloc: three unnormalized FWHT rounds scale norms
+    // by (sqrt(p))^3 = p*sqrt(p); the forward pass cancels this with
+    // total_scale = 1/(p*sqrt(p)), so the inverse applies the same factor.
+    const float inverse_scale = 1.0f / (p * std::sqrt(static_cast<float>(p)));
+
+#pragma omp parallel for schedule(dynamic)
+    for (idx_t i = 0; i < n; i++) {
+        const float* xi = xt + i * p;
+        float* xo = x + i * p;
+
+        // The inverse reverses the three sign-flip/Hadamard factors.
+        std::memcpy(xo, xi, p * sizeof(float));
+        fwht_inplace(xo, p);
+
+        for (size_t j = 0; j < p; j++) {
+            xo[j] *= signs3[j];
+        }
+        fwht_inplace(xo, p);
+
+        for (size_t j = 0; j < p; j++) {
+            xo[j] *= signs2[j];
+        }
+        fwht_inplace(xo, p);
+
+        for (size_t j = 0; j < p; j++) {
+            xo[j] *= signs1[j] * inverse_scale;
+        }
+    }
+}
+
 void HadamardRotation::check_identical(const VectorTransform& other) const {
     auto* hr = dynamic_cast<const HadamardRotation*>(&other);
     FAISS_THROW_IF_NOT_MSG(hr, "failed to cast to HadamardRotation");

--- a/faiss/VectorTransform.h
+++ b/faiss/VectorTransform.h
@@ -144,6 +144,9 @@ struct HadamardRotation : VectorTransform {
 
     void apply_noalloc(idx_t n, const float* x, float* xt) const override;
 
+    /// Apply the inverse transform when d_in == d_out.
+    void reverse_transform(idx_t n, const float* xt, float* x) const override;
+
     void check_identical(const VectorTransform& other) const override;
 
     HadamardRotation() {}

--- a/faiss/python/__init__.pyi
+++ b/faiss/python/__init__.pyi
@@ -2628,6 +2628,7 @@ class ClusteringParameters:
     init_method: ClusteringInitMethod
     afkmc2_chain_length: int  # chain length for AFK-MC² initialization
     early_stop_threshold: float  # early stop threshold [0, 1]
+    use_super_kmeans: bool  # route through SuperKMeans when supported
 
     def __init__(self) -> None: ...
 

--- a/faiss/python/extra_wrappers.py
+++ b/faiss/python/extra_wrappers.py
@@ -656,8 +656,10 @@ class SuperKmeans(Kmeans):
     `iteration_stats`, and `assign()` surface; additionally exposes
     `gemm_pruning_rates`.
 
-    kwargs are forwarded to `SuperKMeansParameters`. Fields not present on it
-    (e.g. `spherical`, `int_centroids`, `nredo`, `frozen_centroids`,
+    kwargs are forwarded to `SuperKMeansParameters`. Fields inherited from
+    `ClusteringParameters` such as `spherical` are supported (unit-normalized
+    centroids enable inner-product clustering). Fields not present on it
+    (e.g. `int_centroids`, `nredo`, `frozen_centroids`,
     `init_method`, `update_index`, `early_stop_threshold`,
     `progressive_dim_steps`, `gpu`) raise `AttributeError`.
     """

--- a/faiss/utils/simd_impl/distances_arm_sve.cpp
+++ b/faiss/utils/simd_impl/distances_arm_sve.cpp
@@ -574,11 +574,9 @@ void fvec_L2sqr_ny<SIMDLevel::ARM_SVE>(
 namespace {
 
 /// Low-dimensional L2sqr nearest (D in {2,4,8}). The data is row-major
-/// (centroid c is y[c*D .. c*D+D]); each centroid's D components are loaded
-/// with a single svld1 into one SVE vector and reduced with svaddv. A scalar
-/// loop tracks the global minimum index. This avoids SVE gather/structure
-/// loads, which are not available on all toolchains. The scratch buffer is
-/// not written, matching the AVX2/AVX512 D2/D4/D8 implementations.
+/// (centroid c is y[c*D .. c*D+D]). Each SVE lane tracks one centroid across
+/// batches, keeping the lane-local minimum and index in registers. The scratch
+/// buffer is not written, matching the AVX2/AVX512 D2/D4/D8 implementations.
 template <int D>
 size_t fvec_L2sqr_ny_nearest_lowdim(
         float* /*distances_tmp_buffer*/,
@@ -586,42 +584,31 @@ size_t fvec_L2sqr_ny_nearest_lowdim(
         const float* y,
         size_t ny) {
     const size_t lanes = svcntw();
-    // When D exceeds the vector width, fall back to the generic path.
-    if (static_cast<size_t>(D) > lanes) {
-        float global_min = HUGE_VALF;
-        size_t global_idx = 0;
-        for (size_t c = 0; c < ny; ++c) {
-            const float* yc = y + c * D;
-            float dis = 0.0f;
-            for (int j = 0; j < D; ++j) {
-                const float df = x[j] - yc[j];
-                dis += df * df;
-            }
-            if (dis < global_min) {
-                global_min = dis;
-                global_idx = c;
-            }
+    svfloat32_t global_mins = svdup_n_f32(HUGE_VALF);
+    svuint32_t global_ids = svdup_n_u32(0);
+    svuint32_t current_ids = svindex_u32(0, 1);
+
+    for (size_t c = 0; c < ny; c += lanes) {
+        const svbool_t pg = svwhilelt_b32_u64(c, ny);
+        svfloat32_t distances = svdup_n_f32(0.0f);
+        for (uint32_t j = 0; j < D; ++j) {
+            const svuint32_t offsets = svindex_u32(j, D);
+            const svfloat32_t yv =
+                    svld1_gather_u32index_f32(pg, y + c * D, offsets);
+            const svfloat32_t diff = svsub_n_f32_x(pg, yv, x[j]);
+            distances = svmla_f32_m(pg, distances, diff, diff);
         }
-        return global_idx;
+
+        const svbool_t closer = svcmplt_f32(pg, distances, global_mins);
+        global_mins = svsel_f32(closer, distances, global_mins);
+        global_ids = svsel_u32(closer, current_ids, global_ids);
+        current_ids =
+                svadd_n_u32_x(pg, current_ids, static_cast<uint32_t>(lanes));
     }
-    const svbool_t pg = svwhilelt_b32(size_t(0), size_t(D));
-    // Broadcast x's D components into a vector (padding lanes are unused).
-    svfloat32_t xv = svdup_n_f32(0.0f);
-    svfloat32_t xacc = svld1_f32(pg, x);
-    xv = svsel_f32(pg, xacc, xv);
-    float global_min = HUGE_VALF;
-    size_t global_idx = 0;
-    for (size_t c = 0; c < ny; ++c) {
-        svfloat32_t yv = svld1_f32(pg, y + c * D);
-        svfloat32_t diff = svsub_f32_x(pg, yv, xv);
-        svfloat32_t sq = svmul_f32_x(pg, diff, diff);
-        const float dis = svaddv_f32(pg, sq);
-        if (dis < global_min) {
-            global_min = dis;
-            global_idx = c;
-        }
-    }
-    return global_idx;
+
+    const svbool_t all = svptrue_b32();
+    const float global_min = svminv_f32(all, global_mins);
+    return svminv_u32(svcmpeq_n_f32(all, global_mins, global_min), global_ids);
 }
 
 } // namespace
@@ -684,11 +671,11 @@ size_t fvec_L2sqr_ny_nearest<SIMDLevel::ARM_SVE>(
         const float* y,
         size_t d,
         size_t ny) {
-    // Low-dimensional L2sqr nearest (d in {2,4,8}): each centroid is a D-float
-    // vector, one SVE lane per centroid via D svld1 loads. d is the SIMD
-    // layout condition; ny is the generic loop bound. The scratch buffer is
-    // not written (matching the x86 D2/D4/D8 implementations); the min index
-    // is tracked entirely in registers.
+    // Low-dimensional L2sqr nearest (d in {2,4,8}): each SVE lane tracks one
+    // centroid while D gathers load its components. d is the SIMD layout
+    // condition; ny is the generic loop bound. The scratch buffer is not
+    // written (matching the x86 D2/D4/D8 implementations); minima and indices
+    // remain in registers.
     if (d == 2 || d == 4 || d == 8) {
         switch (d) {
             case 2:

--- a/faiss/utils/simd_impl/distances_arm_sve.cpp
+++ b/faiss/utils/simd_impl/distances_arm_sve.cpp
@@ -7,6 +7,9 @@
 
 #include <arm_sve.h>
 
+#include <initializer_list>
+#include <utility>
+
 #include <faiss/utils/distances.h>
 
 #include <faiss/impl/AuxIndexStructures.h>
@@ -568,6 +571,112 @@ void fvec_L2sqr_ny<SIMDLevel::ARM_SVE>(
     }
 }
 
+namespace {
+
+/// Low-dimensional L2sqr nearest (D in {2,4,8}). The data is row-major
+/// (centroid c is y[c*D .. c*D+D]); each centroid's D components are loaded
+/// with a single svld1 into one SVE vector and reduced with svaddv. A scalar
+/// loop tracks the global minimum index. This avoids SVE gather/structure
+/// loads, which are not available on all toolchains. The scratch buffer is
+/// not written, matching the AVX2/AVX512 D2/D4/D8 implementations.
+template <int D>
+size_t fvec_L2sqr_ny_nearest_lowdim(
+        float* /*distances_tmp_buffer*/,
+        const float* x,
+        const float* y,
+        size_t ny) {
+    const size_t lanes = svcntw();
+    // When D exceeds the vector width, fall back to the generic path.
+    if (static_cast<size_t>(D) > lanes) {
+        float global_min = HUGE_VALF;
+        size_t global_idx = 0;
+        for (size_t c = 0; c < ny; ++c) {
+            const float* yc = y + c * D;
+            float dis = 0.0f;
+            for (int j = 0; j < D; ++j) {
+                const float df = x[j] - yc[j];
+                dis += df * df;
+            }
+            if (dis < global_min) {
+                global_min = dis;
+                global_idx = c;
+            }
+        }
+        return global_idx;
+    }
+    const svbool_t pg = svwhilelt_b32(size_t(0), size_t(D));
+    // Broadcast x's D components into a vector (padding lanes are unused).
+    svfloat32_t xv = svdup_n_f32(0.0f);
+    svfloat32_t xacc = svld1_f32(pg, x);
+    xv = svsel_f32(pg, xacc, xv);
+    float global_min = HUGE_VALF;
+    size_t global_idx = 0;
+    for (size_t c = 0; c < ny; ++c) {
+        svfloat32_t yv = svld1_f32(pg, y + c * D);
+        svfloat32_t diff = svsub_f32_x(pg, yv, xv);
+        svfloat32_t sq = svmul_f32_x(pg, diff, diff);
+        const float dis = svaddv_f32(pg, sq);
+        if (dis < global_min) {
+            global_min = dis;
+            global_idx = c;
+        }
+    }
+    return global_idx;
+}
+
+} // namespace
+
+// Specializations for low-dimensional L2sqr nearest, mirroring the
+// fvec_L2sqr_ny_nearest_D2/D4/D8 declarations used by the SSE/AVX
+// implementations. One SVE lane covers one D-float centroid.
+template <SIMDLevel>
+size_t fvec_L2sqr_ny_nearest_D2(
+        float* distances_tmp_buffer,
+        const float* x,
+        const float* y,
+        size_t ny);
+
+template <SIMDLevel>
+size_t fvec_L2sqr_ny_nearest_D4(
+        float* distances_tmp_buffer,
+        const float* x,
+        const float* y,
+        size_t ny);
+
+template <SIMDLevel>
+size_t fvec_L2sqr_ny_nearest_D8(
+        float* distances_tmp_buffer,
+        const float* x,
+        const float* y,
+        size_t ny);
+
+template <>
+size_t fvec_L2sqr_ny_nearest_D2<SIMDLevel::ARM_SVE>(
+        float* distances_tmp_buffer,
+        const float* x,
+        const float* y,
+        size_t ny) {
+    return fvec_L2sqr_ny_nearest_lowdim<2>(distances_tmp_buffer, x, y, ny);
+}
+
+template <>
+size_t fvec_L2sqr_ny_nearest_D4<SIMDLevel::ARM_SVE>(
+        float* distances_tmp_buffer,
+        const float* x,
+        const float* y,
+        size_t ny) {
+    return fvec_L2sqr_ny_nearest_lowdim<4>(distances_tmp_buffer, x, y, ny);
+}
+
+template <>
+size_t fvec_L2sqr_ny_nearest_D8<SIMDLevel::ARM_SVE>(
+        float* distances_tmp_buffer,
+        const float* x,
+        const float* y,
+        size_t ny) {
+    return fvec_L2sqr_ny_nearest_lowdim<8>(distances_tmp_buffer, x, y, ny);
+}
+
 template <>
 size_t fvec_L2sqr_ny_nearest<SIMDLevel::ARM_SVE>(
         float* distances_tmp_buffer,
@@ -575,6 +684,25 @@ size_t fvec_L2sqr_ny_nearest<SIMDLevel::ARM_SVE>(
         const float* y,
         size_t d,
         size_t ny) {
+    // Low-dimensional L2sqr nearest (d in {2,4,8}): each centroid is a D-float
+    // vector, one SVE lane per centroid via D svld1 loads. d is the SIMD
+    // layout condition; ny is the generic loop bound. The scratch buffer is
+    // not written (matching the x86 D2/D4/D8 implementations); the min index
+    // is tracked entirely in registers.
+    if (d == 2 || d == 4 || d == 8) {
+        switch (d) {
+            case 2:
+                return fvec_L2sqr_ny_nearest_D2<SIMDLevel::ARM_SVE>(
+                        distances_tmp_buffer, x, y, ny);
+            case 4:
+                return fvec_L2sqr_ny_nearest_D4<SIMDLevel::ARM_SVE>(
+                        distances_tmp_buffer, x, y, ny);
+            default:
+                return fvec_L2sqr_ny_nearest_D8<SIMDLevel::ARM_SVE>(
+                        distances_tmp_buffer, x, y, ny);
+        }
+    }
+
     const size_t lanes = static_cast<size_t>(svcntw());
 
     size_t nearest_idx = 0;

--- a/faiss/utils/simd_impl/super_kmeans_kernels.h
+++ b/faiss/utils/simd_impl/super_kmeans_kernels.h
@@ -39,5 +39,10 @@ template <>
 float block_l2<SIMDLevel::AVX512>(const float* x, const float* y, int n);
 #endif
 
+#ifdef COMPILE_SIMD_ARM_SVE
+template <>
+float block_l2<SIMDLevel::ARM_SVE>(const float* x, const float* y, int n);
+#endif
+
 } // namespace detail
 } // namespace faiss

--- a/faiss/utils/simd_impl/super_kmeans_kernels_sve.cpp
+++ b/faiss/utils/simd_impl/super_kmeans_kernels_sve.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifdef COMPILE_SIMD_ARM_SVE
+
+#include <faiss/utils/simd_impl/super_kmeans_kernels.h>
+
+#include <arm_sve.h>
+
+namespace faiss {
+namespace detail {
+
+template <>
+float block_l2<SIMDLevel::ARM_SVE>(const float* x, const float* y, int n) {
+    svfloat32_t acc = svdup_n_f32(0.0f);
+    const int lanes = static_cast<int>(svcntw());
+    for (int m = 0; m < n; m += lanes) {
+        const svbool_t pg = svwhilelt_b32(m, n);
+        const svfloat32_t xv = svld1_f32(pg, x + m);
+        const svfloat32_t yv = svld1_f32(pg, y + m);
+        const svfloat32_t diff = svsub_f32_x(pg, xv, yv);
+        acc = svmla_f32_m(pg, acc, diff, diff);
+    }
+    return svaddv_f32(svptrue_b32(), acc);
+}
+
+} // namespace detail
+} // namespace faiss
+
+#endif // COMPILE_SIMD_ARM_SVE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,9 +62,10 @@ if(FAISS_ENABLE_SVS)
   list(APPEND FAISS_TEST_SRC test_svs.cpp)
 endif()
 
-# DD-only tests: x86-specific tests containing raw AVX2/AVX512 intrinsics
+# DD-only tests; x86-specific raw-intrinsic tests are added separately below.
 if(FAISS_OPT_LEVEL STREQUAL "dd")
   list(APPEND FAISS_TEST_SRC
+    test_distances_dispatch.cpp
     test_simd_perf.cpp
   )
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|amd64|AMD64)")

--- a/tests/test_distances_dispatch.cpp
+++ b/tests/test_distances_dispatch.cpp
@@ -299,3 +299,27 @@ TEST(DistancesDispatch, FvecL2sqrNyNearest_AllLevels) {
                 levels);
     }
 }
+
+// The low-dimensional nearest path (d in {2,4,8}, one SIMD lane per
+// centroid) must agree with the generic implementation for any ny, including
+// values that are not multiples of the SIMD width.
+TEST(DistancesDispatch, FvecL2sqrNyNearest_LowDim) {
+    SIMDLevelGuard guard;
+    auto levels = available_levels();
+    SKIP_IF_SINGLE_LEVEL(levels);
+    constexpr size_t kLowDims[] = {2, 4, 8};
+    constexpr size_t kNy[] = {1, 2, 3, 16, 17, 23, 32};
+    for (size_t d : kLowDims) {
+        for (size_t ny : kNy) {
+            auto x = rand_vec(d, 40);
+            auto y = rand_vec(d * ny, 41);
+            check_index_at_levels(
+                    [&]() {
+                        std::vector<float> tmp(ny);
+                        return fvec_L2sqr_ny_nearest(
+                                tmp.data(), x.data(), y.data(), d, ny);
+                    },
+                    levels);
+        }
+    }
+}

--- a/tests/test_distances_dispatch.cpp
+++ b/tests/test_distances_dispatch.cpp
@@ -32,6 +32,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cmath>
 #include <random>
 #include <vector>
@@ -302,13 +303,32 @@ TEST(DistancesDispatch, FvecL2sqrNyNearest_AllLevels) {
 
 // The low-dimensional nearest path (d in {2,4,8}, one SIMD lane per
 // centroid) must agree with the generic implementation for any ny, including
-// values that are not multiples of the SIMD width.
+// values around common SIMD widths and non-multiple tails.
 TEST(DistancesDispatch, FvecL2sqrNyNearest_LowDim) {
     SIMDLevelGuard guard;
     auto levels = available_levels();
     SKIP_IF_SINGLE_LEVEL(levels);
     constexpr size_t kLowDims[] = {2, 4, 8};
-    constexpr size_t kNy[] = {1, 2, 3, 16, 17, 23, 32};
+    constexpr size_t kNy[] = {
+            1,
+            2,
+            3,
+            7,
+            8,
+            9,
+            15,
+            16,
+            17,
+            23,
+            31,
+            32,
+            33,
+            63,
+            64,
+            65,
+            255,
+            256,
+            257};
     for (size_t d : kLowDims) {
         for (size_t ny : kNy) {
             auto x = rand_vec(d, 40);
@@ -321,5 +341,27 @@ TEST(DistancesDispatch, FvecL2sqrNyNearest_LowDim) {
                     },
                     levels);
         }
+    }
+}
+
+TEST(DistancesDispatch, FvecL2sqrNyNearest_LowDimKeepsFirstTie) {
+    SIMDLevelGuard guard;
+    auto levels = available_levels();
+    SKIP_IF_SINGLE_LEVEL(levels);
+    constexpr size_t kLowDims[] = {2, 4, 8};
+    constexpr size_t ny = 23;
+    constexpr size_t expected = 3;
+    for (size_t d : kLowDims) {
+        std::vector<float> x(d, 0.0f);
+        std::vector<float> y(d * ny, 1.0f);
+        std::fill_n(y.data() + expected * d, d, 0.0f);
+        std::fill_n(y.data() + 17 * d, d, 0.0f);
+        auto nearest = [&]() {
+            std::vector<float> tmp(ny);
+            return fvec_L2sqr_ny_nearest(tmp.data(), x.data(), y.data(), d, ny);
+        };
+        SIMDConfig::set_level(SIMDLevel::NONE);
+        EXPECT_EQ(expected, nearest());
+        check_index_at_levels(nearest, levels);
     }
 }

--- a/tests/test_super_kmeans.py
+++ b/tests/test_super_kmeans.py
@@ -53,6 +53,55 @@ class SuperKMeansTest(unittest.TestCase):
         v_final = v_stats.at(v_stats.size() - 1).obj
         self.assertLess(abs(sc_final - v_final) / v_final, 0.05)
 
+    def test_spherical_objective_close_to_vanilla_spherical(self):
+        # With cp.spherical=true, SuperKMeans unit-normalizes centroids so the
+        # L2 assignment it computes is equivalent to inner-product assignment.
+        # The final objective must track vanilla spherical Clustering.
+        d, k, n = 64, 16, 2000
+        x = SyntheticDataset(d, n, 0, 0).get_train()
+
+        p = faiss.SuperKMeansParameters()
+        p.seed = 42
+        p.niter = 10
+        p.spherical = True
+        sc = faiss.SuperKMeans(d, k, p)
+        sc.train(x)
+
+        quant = faiss.IndexFlatL2(d)
+        vanilla = faiss.Clustering(d, k)
+        vanilla.seed = 42
+        vanilla.niter = 10
+        vanilla.spherical = True
+        vanilla.train(x, quant)
+
+        sc_final = sc.iteration_stats.at(sc.iteration_stats.size() - 1).obj
+        v_stats = vanilla.iteration_stats
+        v_final = v_stats.at(v_stats.size() - 1).obj
+        self.assertLess(abs(sc_final - v_final) / v_final, 0.05)
+
+    def test_spherical_produces_unit_centroids(self):
+        d, k, n = 64, 16, 2000
+        x = SyntheticDataset(d, n, 0, 0).get_train()
+
+        p = faiss.SuperKMeansParameters()
+        p.seed = 42
+        p.niter = 10
+        p.spherical = True
+        sc = faiss.SuperKMeans(d, k, p)
+        sc.train(x)
+
+        centroids = faiss.vector_to_array(sc.centroids).reshape(k, d)
+        norms = np.linalg.norm(centroids, axis=1)
+        np.testing.assert_allclose(norms, 1.0, atol=1e-4)
+
+    def test_use_super_kmeans_field_is_inherited(self):
+        # use_super_kmeans lives on ClusteringParameters and is inherited by
+        # SuperKMeansParameters; it must be settable from Python.
+        p = faiss.SuperKMeansParameters()
+        self.assertFalse(p.use_super_kmeans)
+        p.use_super_kmeans = True
+        self.assertTrue(p.use_super_kmeans)
+
     def test_pruning_rate_in_expected_range(self):
         # The 10-d intrinsic manifold of SyntheticDataset gives ADSampling
         # the assigned-vs-other distance gap it needs to prune effectively.


### PR DESCRIPTION
## Summary

This PR adds two related changes for the SCANN coarse quantizer / PQ encoding path on ARM SVE: a low-dimensional nearest-neighbor fast path and spherical SuperKMeans support.

### 1. Low-dimensional L2sqr nearest fast path (d in {2,4,8})

`fvec_L2sqr_ny_nearest<ARM_SVE>` previously wrote all `ny` distances to the scratch buffer and then performed a separate linear scan. For PQ encoding (`compute_1_code`) each call has `d = dsub` and `ny = ksub`, making this the hot path. The new path maps one centroid to each SVE lane, gathers its `D` components, and keeps lane-local minimum distances and ids across batches. A predicated tail handles non-multiple `ny` values, equal distances preserve the first index, and only one final horizontal reduction is needed. The scratch buffer is not written, matching the x86 AVX2/AVX512 `D2/D4/D8` implementations.

`ProductQuantizer::compute_code` already uses the A1 dispatch on current `main`, so the ARM_SVE specialization remains reachable from PQ encoding after this rebase.

### 2. SuperKMeans spherical (inner-product) support

SuperKMeans previously only supported L2 clustering; the header explicitly excluded IP/cosine. With `cp.spherical=true`:
- `TrainState::R` becomes `std::unique_ptr<VectorTransform>`; power-of-two `d` uses the fast `HadamardRotation`, L2 keeps `RandomRotationMatrix`.
- Forgy initialization produces unit centroids before the first assignment. Each iteration computes and splits centroids first, then applies spherical centroid post-processing once, matching the `Clustering` flow.
- `HadamardRotation::reverse_transform` fills the missing inverse.
- `ClusteringParameters::use_super_kmeans` (default false) lets `Level1Quantizer::train_q1` route coarse quantizer training through SuperKMeans when explicitly enabled; the Python type stubs expose the new option.
- `block_l2<ARM_SVE>` completes the SuperKMeans SIMD kernels for the ADSampling pruning loop.

## Tests

- Low-dim nearest across SIMD levels: `d` in `{2,4,8}` and `ny` around common SIMD widths through 257, including non-multiple tails and first-index tie behavior. The dispatch test source is included in DD builds.
- Spherical objective close to vanilla spherical Clustering; unit-norm centroids.
- `use_super_kmeans` field inherited from `ClusteringParameters`.

## Benchmark

qwen 4096-dim, IP, nlist=1024, sub_dim=4, 1 thread, 50k rows:

| stage | baseline | optimized | change |
| --- | ---: | ---: | --- |
| Train | 67.73s | 24.36s | -64% |
| Add | 10.86s | 7.17s | -34% |
| Build | 78.59s | 31.52s | -60% |

Train speedup comes from SuperKMeans spherical coarse quantizer training; Add speedup comes from the low-dim SVE nearest fast path in PQ encoding. recall@10 unchanged vs Clustering baseline (diff <= 0.0002).

## Notes

This change targets ARM SVE. The x86 (AVX2/AVX512) implementations already have equivalent low-dim nearest specializations. The generic ARM SVE distance path comes from current `main`; this PR adds the low-dimensional nearest specializations on top of it.
