### PR TITLE
Fix range_search_max_results to respect all similarity metrics

### DIFF
--- a/contrib/exhaustive_search.py
+++ b/contrib/exhaustive_search.py
@@ -347,7 +347,7 @@ def range_search_max_results(
             radius, totres = apply_maxres(
                 res_batches,
                 min_results,
-                keep_max=index.metric_type == faiss.METRIC_INNER_PRODUCT,
+                keep_max=faiss.is_similarity_metric(index.metric_type),
             )
         t2 = time.time()
         t_search += t1 - t0
@@ -366,7 +366,7 @@ def range_search_max_results(
         radius, totres = apply_maxres(
             res_batches,
             min_results,
-            keep_max=index.metric_type == faiss.METRIC_INNER_PRODUCT,
+            keep_max=faiss.is_similarity_metric(index.metric_type),
         )
 
     nres = np.hstack([nres_i for nres_i, dis_i, ids_i in res_batches])

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -194,6 +194,57 @@ class TestExhaustiveSearch(unittest.TestCase):
             ref_lims, ref_D, ref_I, new_lims, new_D, new_I
         )
 
+    def test_query_iterator_similarity_metric(self):
+        """range_search_max_results must keep the highest-scoring results
+        (and raise the radius) for any similarity metric, not just
+        METRIC_INNER_PRODUCT. Regression test for a bug where pruning
+        for METRIC_Jaccard (also a similarity metric, see
+        faiss.is_similarity_metric) kept the lowest-scoring results
+        instead of the highest-scoring ones."""
+
+        class FakeSimilarityIndex:
+            """Stands in for an Index using a similarity metric (higher
+            score = better match), exposing only what
+            range_search_max_results touches."""
+
+            def __init__(self, sims, metric_type):
+                self.sims = sims
+                self.metric_type = metric_type
+
+            def range_search(self, xq, radius):
+                lims = [0]
+                D = []
+                I = []
+                for i in range(len(xq)):
+                    s = self.sims[i]
+                    idx = np.nonzero(s > radius)[0]
+                    D.append(s[idx])
+                    I.append(idx.astype("int64"))
+                    lims.append(lims[-1] + len(idx))
+                return (
+                    np.array(lims, dtype="uint64"),
+                    np.hstack(D).astype("float32"),
+                    np.hstack(I).astype("int64"),
+                )
+
+        rs = np.random.RandomState(1)
+        nq, ndb = 5, 200
+        sims = [rs.rand(ndb).astype("float32") for _ in range(nq)]
+        index = FakeSimilarityIndex(sims, faiss.METRIC_Jaccard)
+
+        xq = np.zeros((nq, 1), dtype="float32")  # unused by the fake index
+        radius = 0.0  # keep everything initially
+        total = sum(len(s) for s in sims)
+        max_results = total // 2
+
+        new_radius, lims, D, I = range_search_max_results(
+            index, iter([xq]), radius, max_results=max_results
+        )
+
+        self.assertGreaterEqual(new_radius, radius)
+        self.assertGreater(len(D), 0)
+        self.assertGreaterEqual(D.min(), new_radius - 1e-6)
+
 
 class TestInspect(unittest.TestCase):
 


### PR DESCRIPTION
## Bug

`range_search_max_results()` (and its helper `apply_maxres()`) in `contrib/exhaustive_search.py` decide whether to keep the highest- or lowest-scoring results when pruning the accumulated results down to `max_results`, based on:

```python
keep_max=index.metric_type == faiss.METRIC_INNER_PRODUCT
```

This hardcodes the assumption that `METRIC_INNER_PRODUCT` is the only "similarity" metric (higher = better). But `faiss.is_similarity_metric()` (see `faiss/MetricType.h`) also treats `METRIC_Jaccard` as a similarity metric, and this same, correct check is already used a few lines above in `range_search_gpu()` in the very same file (`keep_max = faiss.is_similarity_metric(index_gpu.metric_type)`).

As a result, when `range_search_max_results` is used with a `METRIC_Jaccard` index and the result set grows past `max_results`, the pruning logic incorrectly discards the *highest*-similarity matches and keeps the *lowest*-similarity ones, and moves the returned radius in the wrong direction.

## Root cause

Two call sites in `contrib/exhaustive_search.py` compare `index.metric_type` directly against `faiss.METRIC_INNER_PRODUCT` instead of using the library's own `faiss.is_similarity_metric()` helper, which is the single source of truth for which metrics are "larger is better".

## Fix

Replace both occurrences of `index.metric_type == faiss.METRIC_INNER_PRODUCT` with `faiss.is_similarity_metric(index.metric_type)`, matching the existing pattern used in `range_search_gpu` in the same module.

## Test plan

Added `test_query_iterator_similarity_metric` to `tests/test_contrib.py`. It exercises `range_search_max_results` against a lightweight fake index using `METRIC_Jaccard` (real `IndexFlat.range_search` doesn't support `METRIC_Jaccard` directly, so a fake index is used to isolate the pruning logic under test) and asserts that pruning keeps the highest-scoring results and raises the radius accordingly.

- Confirmed the new test fails on `main` (old code keeps the *lowest*-similarity results and lowers the radius) and passes after the fix, by swapping the module in-place against an installed `faiss-cpu` and running the assertions directly (full repo `pytest` collection isn't possible in this environment without rebuilding the C++ extension for `main`, since the installed wheel is older and `tests/common_faiss_tests.py` on `main` references APIs from a newer build).
- The fix is a pure two-line change that only affects the boolean passed to `apply_maxres`, verified by direct comparison of before/after behavior with the reproduction script.