### PR TITLE
Fix HNSW concurrent race segfault on RISC-V

### DIFF
--- a/faiss/impl/HNSW.cpp
+++ b/faiss/impl/HNSW.cpp
@@ -419,7 +419,13 @@ void add_link_tpl(
     }
     // they may have shrunk more than just by 1 element
     while (i < end) {
+#ifdef __riscv
+        __atomic_store_n(
+                &hnsw.neighbors[i], (storage_idx_t)-1, __ATOMIC_RELAXED);
+        i++;
+#else
         hnsw.neighbors[i++] = -1;
+#endif
     }
 }
 
@@ -513,9 +519,16 @@ static void search_neighbors_to_add_fixVT(
 
             for (size_t j = begin; j < end; j++) {
                 HNSW::storage_idx_t nodeId = hnsw.neighbors[j];
+#ifdef __riscv
+                if (nodeId < 0 ||
+                    static_cast<size_t>(nodeId) >= hnsw.levels.size()) {
+                    break;
+                }
+#else
                 if (nodeId < 0) {
                     break;
                 }
+#endif
                 if (!vt.set(nodeId)) {
                     continue;
                 }


### PR DESCRIPTION
On RISC-V, GCC -O2 optimizes the `while (i < end) neighbors[i++] = -1` loop in add_link_tpl into a memset(0xFF) call, which writes byte-by-byte (`sb`). The reader in search_neighbors_to_add_fixVT does a lock-free `lw` on the same neighbor slot while the writer holds the other_id lock but the reader does not. A torn read yields 0x00FFFFFF (a half-finished write), which passes the `nodeId < 0` check and is used as a valid id, eventually driving an out-of-bounds vector access and segfault.

Fix the writer to store -1 with a relaxed atomic store so the reader sees either the old valid id or a complete -1, and add a bounds check on the reader as a defensive backstop. Both guarded by __riscv so other architectures are untouched.