### PR TITLE
Fix IndexIDMap range search parameters

### DIFF
--- a/faiss/IndexIDMap.cpp
+++ b/faiss/IndexIDMap.cpp
@@ -229,15 +229,20 @@ void IndexIDMapTemplate<IndexT>::range_search(
         typename IndexT::distance_t radius,
         RangeSearchResult* result,
         const SearchParameters* params) const {
-    if (params && params->sel) {
-        SearchParameters internal_search_parameters;
-        IDSelectorTranslated id_selector_translated(id_map, params->sel);
-        internal_search_parameters.sel = &id_selector_translated;
+    IDSelectorTranslated this_idtrans(this->id_map, nullptr);
+    ScopedSelChange sel_change;
 
-        index->range_search(n, x, radius, result, &internal_search_parameters);
-    } else {
-        index->range_search(n, x, radius, result, params);
+    if (params && params->sel) {
+        auto idtrans = dynamic_cast<const IDSelectorTranslated*>(params->sel);
+
+        if (!idtrans) {
+            // Preserve the concrete params type and its index-specific fields.
+            auto params_non_const = const_cast<SearchParameters*>(params);
+            this_idtrans.sel = params->sel;
+            sel_change.set(params_non_const, &this_idtrans);
+        }
     }
+    index->range_search(n, x, radius, result, params);
 
     const idx_t id_map_size = static_cast<idx_t>(id_map.size());
 #pragma omp parallel for

--- a/tests/test_search_params.py
+++ b/tests/test_search_params.py
@@ -364,6 +364,35 @@ class TestSelector(unittest.TestCase):
         np.testing.assert_array_equal(sorted(I_ref), sorted(I))
         np.testing.assert_array_equal(sorted(D_ref), sorted(D))
 
+    def test_idmap_range_ivf_params(self):
+        quantizer = faiss.IndexFlatL2(1)
+        quantizer.add(np.array([[0.0], [100.0]], dtype="float32"))
+        base = faiss.IndexIVFFlat(quantizer, 1, 2, faiss.METRIC_L2)
+        base.nprobe = 1
+        index = faiss.IndexIDMap(base)
+
+        index.add_with_ids(
+            np.array([[0.0], [100.0]], dtype="float32"),
+            np.array([10, 20], dtype="int64"),
+        )
+
+        params = faiss.SearchParametersIVF(nprobe=2)
+        params.sel = faiss.IDSelectorBatch(
+            np.array([10, 20], dtype="int64")
+        )
+        lims, distances, labels = index.range_search(
+            np.array([[0.0]], dtype="float32"),
+            10001.0,
+            params=params,
+        )
+        order = np.argsort(labels)
+        labels = labels[order]
+        distances = distances[order]
+
+        np.testing.assert_array_equal(lims, [0, 2])
+        np.testing.assert_array_equal(distances, [0.0, 10000.0])
+        np.testing.assert_array_equal(labels, [10, 20])
+
     def test_bounds(self):
         # https://github.com/facebookresearch/faiss/issues/3156
         d = 64  # dimension


### PR DESCRIPTION
## Summary

- preserve the concrete search-parameter type when `IndexIDMap::range_search` translates an external-ID selector
- retain IVF-specific per-query fields such as `nprobe` by temporarily replacing only `sel`, using the same scoped restoration pattern as `search_ex`
- add a deterministic regression test with two IVF lists and external IDs

## Testing

- confirmed the new test fails against FAISS 1.14.2 with `IndexIVF params have incorrect type`
- built the current source on macOS arm64 with Python bindings (`FAISS_OPT_LEVEL=generic`, GPU and Metal disabled)
- `python -m pytest -q tests/test_search_params.py` (51 passed)
- `clang-format 21 --dry-run --Werror faiss/IndexIDMap.cpp`
- `git diff --check`

Closes #5523