### PR TITLE
Fix OSX arm64 nightly: bump libopenblas from 0.3.33 to 0.3.34

### DIFF
--- a/conda/faiss/meta.yaml
+++ b/conda/faiss/meta.yaml
@@ -56,7 +56,7 @@ outputs:
         - mkl-devel >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi
         {% endif %}
-        - libopenblas =0.3.33  # [osx]
+        - libopenblas =0.3.34  # [osx]
       host:
         - python {{ python }}
         - libcxx =20.1.1  # [osx and arm64]
@@ -70,7 +70,7 @@ outputs:
         - python_abi =3.12
         {% endif %}
         - openblas =0.3.34  # [not x86_64]
-        - libopenblas =0.3.33  # [osx]
+        - libopenblas =0.3.34  # [osx]
       run:
         - python {{ python }}
         - libcxx =20.1.1  # [osx and arm64]
@@ -84,7 +84,7 @@ outputs:
         - python_abi =3.12
         {% endif %}
         - openblas =0.3.34  # [not x86_64]
-        - libopenblas =0.3.33  # [osx]
+        - libopenblas =0.3.34  # [osx]
     test:
       requires:
         - conda-build =25.3.1
@@ -122,7 +122,7 @@ outputs:
         - mkl >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
-        - libopenblas =0.3.33  # [osx]
+        - libopenblas =0.3.34  # [osx]
       host:
         - python {{ python }}
         - numpy >=2.0,<3.0
@@ -138,7 +138,7 @@ outputs:
         - mkl >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
-        - libopenblas =0.3.33  # [osx]
+        - libopenblas =0.3.34  # [osx]
       run:
         - python {{ python }}
         - numpy >=2.0,<3.0
@@ -153,7 +153,7 @@ outputs:
         - mkl >=2024.2.2,<2026  # [x86_64 and win]
         - python_abi =3.12
         {% endif %}
-        - libopenblas =0.3.33  # [osx]
+        - libopenblas =0.3.34  # [osx]
     test:
       requires:
         - numpy >=2.0,<3.0


### PR DESCRIPTION
Summary:
The `OSX arm64 nightlies` job has been failing to solve the `libfaiss`
environment since D115218647:

```
ExplainedDependencyNeedsBuildingError: Unsatisfiable dependencies for platform osx-arm64: {MatchSpec("openblas==0.3.34=openmp_hea878ba_0")}
  - package libopenblas-0.3.33-pthreads_hddb8425_0 has constraint
    openblas >=0.3.33,<0.3.34.0a0 conflicting with openblas-0.3.34-openmp_hea878ba_0
```

`conda/faiss/meta.yaml` pins both outputs of the OpenBLAS feedstock, and on
osx-arm64 both selectors apply at once: `openblas =0.3.34  # [not x86_64]` and
`libopenblas =0.3.33  # [osx]`. Since `libopenblas 0.3.33` constrains
`openblas >=0.3.33,<0.3.34.0a0`, the two specs are mutually exclusive and the
recipe can never solve.

D115218647 bumped `openblas` to 0.3.34 to get `Linux arm64 (conda)` green and
left the osx `libopenblas` pins at 0.3.33 on the grounds that that package was
resolving fine. It was — in isolation. But the two pins are version-coupled, so
the bump broke Mac. The pins also land on different platforms, which is why only
OSX fails: `# [not x86_64]` gives linux-arm64 the `openblas` pin on its own.

Bump the six osx `libopenblas` pins to 0.3.34 so both feedstock outputs agree.
This matches how the same breakage was fixed the last time `openblas` moved:
D98293081 bumped `openblas` 0.3.30 to 0.3.32 and broke this job, D98718117 fixed
it by bumping `libopenblas` to match, and D104902441 moved both together when
going 0.3.32 to 0.3.33 and stayed green.

Reverting `openblas` to 0.3.33 is not an option here — it would re-break
`linux-arm64-nightly`.

The GPU recipes need no change: they carry no osx `libopenblas` pins, since GPU
builds are Linux-only.

Differential Revision: D117300512


