### PR TITLE
Validate IndexScalarQuantizer codes buffer size on deserialization

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -2167,6 +2167,12 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         read_ScalarQuantizer(&idxs->sq, f, *idxs);
         read_vector(idxs->codes, f);
         idxs->code_size = idxs->sq.code_size;
+        FAISS_THROW_IF_NOT(
+                idxs->codes.size() ==
+                mul_no_overflow(
+                        (size_t)idxs->ntotal,
+                        idxs->code_size,
+                        "IndexScalarQuantizer codes"));
         idx = std::move(idxs);
     } else if (h == fourcc("IxLa")) {
         int d, nsq, scale_nbit, r2;


### PR DESCRIPTION
Summary:
When reading a serialized ScalarQuantizer-based flat index, the codes
buffer length was not checked against ntotal * code_size, unlike the
equivalent read paths for other flat-codes index types. A crafted
index file with an inflated ntotal but a short codes buffer causes
out-of-bounds reads during decode/reconstruct.

Add the same size check used by the other index types right after the
codes buffer is read.

Differential Revision: D117319393


