### PR TITLE
fix(faiss): use is_similarity_metric for IndexShardsIVF merge

### DIFF
--- a/faiss/IndexShardsIVF.cpp
+++ b/faiss/IndexShardsIVF.cpp
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <functional>
 
+#include <faiss/MetricType.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/Heap.h>
 #include <faiss/utils/WorkerThread.h>
@@ -227,7 +228,7 @@ void IndexShardsIVF::search(
 
     this->runOnIndex(fn);
 
-    if (this->metric_type == METRIC_L2) {
+    if (!is_similarity_metric(metric_type)) {
         merge_knn_results<idx_t, CMin<distance_t, int>>(
                 n,
                 k,


### PR DESCRIPTION
IndexShardsIVF merges non-L2 distance metrics as similarities, reversing L1 and other metrics at IndexShardsIVF.cpp:230.

The search method checked only METRIC_L2 for CMin and used CMax for everything else. Metrics such as L1, Linf, Lp, Canberra and BrayCurtis are distances and require CMin. Only inner product and Jaccard are similarities.

Fix: replace the METRIC_L2 check with !is_similarity_metric(metric_type) so all distance metrics use CMin and only similarities use CMax. Add the MetricType header for the helper.

Verified by syntax check and inspecting merge logic. The diff is minimal and does not change formatting elsewhere.