### PR TITLE
Add RVV SIMD specialization for product quantizer distance-table computation

### DIFF
--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -489,7 +489,7 @@ void ProductQuantizer::compute_distance_tables(
         const float* x,
         float* dis_tables) const {
     int64_t nx_signed = nx;
-#if defined(COMPILE_SIMD_AVX2) || defined(COMPILE_SIMD_ARM_NEON)
+#if defined(COMPILE_SIMD_AVX2) || defined(COMPILE_SIMD_ARM_NEON) || defined(COMPILE_SIMD_RISCV_RVV)
     if (dsub == 2 && nbits < 8) { // interesting for a narrow range of settings
         compute_PQ_dis_tables_dsub2(
                 d, ksub, centroids.data(), nx, x, false, dis_tables);
@@ -524,7 +524,7 @@ void ProductQuantizer::compute_inner_prod_tables(
         const float* x,
         float* dis_tables) const {
     int64_t nx_signed = nx;
-#if defined(COMPILE_SIMD_AVX2) || defined(COMPILE_SIMD_ARM_NEON)
+#if defined(COMPILE_SIMD_AVX2) || defined(COMPILE_SIMD_ARM_NEON) || defined(COMPILE_SIMD_RISCV_RVV)
     if (dsub == 2 && nbits < 8) {
         compute_PQ_dis_tables_dsub2(
                 d, ksub, centroids.data(), nx, x, true, dis_tables);
@@ -862,44 +862,32 @@ void ProductQuantizer::search_sdc(
     size_t k = res->k;
     int64_t nq_signed = nq;
 
-#pragma omp parallel
-    {
-        // One allocation per OMP thread instead of one per query.
-        std::vector<const float*> q_row(M);
-#pragma omp for
-        for (int64_t i = 0; i < nq_signed; i++) {
-            idx_t* heap_ids = res->ids + i * k;
-            float* heap_dis = res->val + i * k;
-            const uint8_t* qcode = qcodes + i * code_size;
+#pragma omp parallel for
+    for (int64_t i = 0; i < nq_signed; i++) {
+        /* Compute distances and keep smallest values */
+        idx_t* heap_ids = res->ids + i * k;
+        float* heap_dis = res->val + i * k;
+        const uint8_t* qcode = qcodes + i * code_size;
 
-            if (init_finalize_heap)
-                maxheap_heapify(k, heap_dis, heap_ids);
+        if (init_finalize_heap)
+            maxheap_heapify(k, heap_dis, heap_ids);
 
-            // Precompute per-subquantizer row pointers: q_row[m] points to
-            // sdc_table[m*ksub^2 + qcode[m]*ksub], eliminating M
-            // multiplications and M pointer advances per database vector in the
-            // j-loop.
-            const float* sdc = sdc_table.data();
+        const uint8_t* bcode = bcodes;
+        for (size_t j = 0; j < nb; j++) {
+            float dis = 0;
+            const float* tab = sdc_table.data();
             for (size_t m = 0; m < M; m++) {
-                q_row[m] = sdc + m * (size_t)(ksub * ksub) +
-                        (size_t)qcode[m] * ksub;
+                dis += tab[bcode[m] + qcode[m] * ksub];
+                tab += ksub * ksub;
             }
-
-            const uint8_t* bcode = bcodes;
-            for (size_t j = 0; j < nb; j++) {
-                float dis = 0;
-                for (size_t m = 0; m < M; m++) {
-                    dis += q_row[m][bcode[m]];
-                }
-                if (dis < heap_dis[0]) {
-                    maxheap_replace_top(k, heap_dis, heap_ids, dis, j);
-                }
-                bcode += code_size;
+            if (dis < heap_dis[0]) {
+                maxheap_replace_top(k, heap_dis, heap_ids, dis, j);
             }
-
-            if (init_finalize_heap)
-                maxheap_reorder(k, heap_dis, heap_ids);
+            bcode += code_size;
         }
+
+        if (init_finalize_heap)
+            maxheap_reorder(k, heap_dis, heap_ids);
     }
 }
 

--- a/faiss/utils/distances_dispatch.h
+++ b/faiss/utils/distances_dispatch.h
@@ -208,7 +208,10 @@ inline void compute_PQ_dis_tables_dsub2_dispatch(
         const float* x,
         bool is_inner_product,
         float* dis_tables) {
-    with_simd_level_256bit([&]<SIMDLevel level>() {
+    constexpr int dsub2_mask =
+            AVAILABLE_SIMD_LEVELS_AVX2_NEON |
+            (1 << int(SIMDLevel::RISCV_RVV));
+    with_selected_simd_levels<dsub2_mask>([&]<SIMDLevel level>() {
         compute_PQ_dis_tables_dsub2<level>(
                 d, ksub, centroids, nx, x, is_inner_product, dis_tables);
     });

--- a/faiss/utils/simd_impl/distances_rvv.cpp
+++ b/faiss/utils/simd_impl/distances_rvv.cpp
@@ -11,65 +11,75 @@
 
 #ifdef COMPILE_SIMD_RISCV_RVV
 
-#include <riscv_vector.h>
 #include <faiss/utils/extra_distances.h>
+#include <riscv_vector.h>
 
 namespace faiss {
 
+template <typename Vec, typename Reduce>
+static inline float rvv_reduce(
+        Vec value,
+        size_t vl,
+        float identity,
+        Reduce reduce) {
+    vfloat32m1_t init = __riscv_vfmv_s_f_f32m1(identity, 1);
+    vfloat32m1_t result = reduce(value, init, vl);
+    return __riscv_vfmv_f_s_f32m1_f32(result);
+}
+
+static inline size_t rvv_argmin(const float* values, size_t n) {
+    size_t vlmax = __riscv_vsetvlmax_e32m8();
+    vfloat32m8_t vmin = __riscv_vfmv_v_f_f32m8(__builtin_inff(), vlmax);
+    size_t i = 0;
+    while (i < n) {
+        size_t vl = __riscv_vsetvl_e32m8(n - i);
+        vfloat32m8_t vd = __riscv_vle32_v_f32m8(values + i, vl);
+        vmin = __riscv_vfmin_vv_f32m8_tu(vmin, vmin, vd, vl);
+        i += vl;
+    }
+    float min_val = rvv_reduce(
+            vmin, vlmax, __builtin_inff(), __riscv_vfredmin_vs_f32m8_f32m1);
+    i = 0;
+    while (i < n) {
+        size_t vl = __riscv_vsetvl_e32m8(n - i);
+        vfloat32m8_t vd = __riscv_vle32_v_f32m8(values + i, vl);
+        long j = __riscv_vfirst_m_b4(
+                __riscv_vmfeq_vf_f32m8_b4(vd, min_val, vl), vl);
+        if (j >= 0)
+            return i + static_cast<size_t>(j);
+        i += vl;
+    }
+    return n;
+}
 
 template <>
 void compute_PQ_dis_tables_dsub2<SIMDLevel::RISCV_RVV>(
-        size_t d,                    
-        size_t ksub,                 
-        const float* all_centroids,  
-        size_t nx,                   
-        const float* x,              
-        bool is_inner_product,       
-        float* dis_tables) {         
-    size_t M = d / 2;                
-    FAISS_THROW_IF_NOT(ksub % 8 == 0); 
-    float* c0_all = new float[M * ksub];  
-    float* c1_all = new float[M * ksub];  
+        size_t d,
+        size_t ksub,
+        const float* all_centroids,
+        size_t nx,
+        const float* x,
+        bool is_inner_product,
+        float* dis_tables) {
+    size_t M = d / 2;
+    FAISS_THROW_IF_NOT(ksub % 8 == 0);
+
+    float* c0_all = new float[M * ksub];
+    float* c1_all = new float[M * ksub];
     for (size_t m = 0; m < M; m++) {
-        const float* cm = all_centroids + m * ksub * 2;  
-        float* c0m = c0_all + m * ksub;                  
-        float* c1m = c1_all + m * ksub;                 
+        const float* cm = all_centroids + m * ksub * 2;
+        float* c0m = c0_all + m * ksub;
+        float* c1m = c1_all + m * ksub;
         for (size_t k = 0; k < ksub; k++) {
-            c0m[k] = cm[2 * k];       
-            c1m[k] = cm[2 * k + 1];   
+            c0m[k] = cm[2 * k];
+            c1m[k] = cm[2 * k + 1];
         }
     }
 
-    size_t vl = __riscv_vsetvl_e32m1(ksub); 
+    size_t vl = __riscv_vsetvl_e32m1(ksub);
 
     if (is_inner_product) {
-        for (size_t i = 0; i < nx; i++) {
-            const float* xi = x + i * d;                    
-            float* oi = dis_tables + i * M * ksub;          
-            for (size_t m = 0; m + 1 < M; m += 2) {         
-                float x0a = xi[2 * m], x1a = xi[2 * m + 1];          
-                float x0b = xi[2 * (m + 1)], x1b = xi[2 * (m + 1) + 1]; 
-                const float* c0a = c0_all + m * ksub;        
-                const float* c1a = c1_all + m * ksub;        
-                const float* c0b = c0_all + (m + 1) * ksub;  
-                const float* c1b = c1_all + (m + 1) * ksub;  
-                float* oa = oi + m * ksub;                   
-                float* ob = oi + (m + 1) * ksub;             
-                for (size_t k = 0; k < ksub; k += vl) {      
-                    vfloat32m1_t vc0 = __riscv_vle32_v_f32m1(c0a + k, vl); 
-                    vfloat32m1_t vc1 = __riscv_vle32_v_f32m1(c1a + k, vl); 
-                    vfloat32m1_t ra = __riscv_vfmacc_vf_f32m1(
-                            __riscv_vfmul_vf_f32m1(vc0, x0a, vl), x1a, vc1, vl);
-                    __riscv_vse32_v_f32m1(oa + k, ra, vl); 
-                    vc0 = __riscv_vle32_v_f32m1(c0b + k, vl);
-                    vc1 = __riscv_vle32_v_f32m1(c1b + k, vl);
-                    vfloat32m1_t rb = __riscv_vfmacc_vf_f32m1(
-                            __riscv_vfmul_vf_f32m1(vc0, x0b, vl), x1b, vc1, vl);
-                    __riscv_vse32_v_f32m1(ob + k, rb, vl);  
-                }
-            }
-        }
-    } else {
+        // --- x0*c0 + x1*c1---  unroll x2
         for (size_t i = 0; i < nx; i++) {
             const float* xi = x + i * d;
             float* oi = dis_tables + i * M * ksub;
@@ -83,14 +93,50 @@ void compute_PQ_dis_tables_dsub2<SIMDLevel::RISCV_RVV>(
                 float* oa = oi + m * ksub;
                 float* ob = oi + (m + 1) * ksub;
                 for (size_t k = 0; k < ksub; k += vl) {
+                    //  m：ra = vc0*x0a + x1a*vc1（
                     vfloat32m1_t vc0 = __riscv_vle32_v_f32m1(c0a + k, vl);
                     vfloat32m1_t vc1 = __riscv_vle32_v_f32m1(c1a + k, vl);
-                    vfloat32m1_t d0 = __riscv_vfsub_vf_f32m1(vc0, x0a, vl); // d0 = c0 - x0a
-                    vfloat32m1_t d1 = __riscv_vfsub_vf_f32m1(vc1, x1a, vl); // d1 = c1 - x1a
-                    d0 = __riscv_vfmul_vv_f32m1(d0, d0, vl);                // d0 = d0²
-                    d1 = __riscv_vfmul_vv_f32m1(d1, d1, vl);                // d1 = d1²
-                    vfloat32m1_t r = __riscv_vfadd_vv_f32m1(d0, d1, vl);    // r = d0 + d1
-                    __riscv_vse32_v_f32m1(oa + k, r, vl);  
+                    vfloat32m1_t ra = __riscv_vfmacc_vf_f32m1(
+                            __riscv_vfmul_vf_f32m1(vc0, x0a, vl), x1a, vc1, vl);
+                    //   └─ vfmul：vc0*x0a；vfmacc：acc + x1a*vc1 →
+                    //   x0a*c0+x1a*c1
+                    __riscv_vse32_v_f32m1(oa + k, ra, vl);
+
+                    vc0 = __riscv_vle32_v_f32m1(c0b + k, vl);
+                    vc1 = __riscv_vle32_v_f32m1(c1b + k, vl);
+                    vfloat32m1_t rb = __riscv_vfmacc_vf_f32m1(
+                            __riscv_vfmul_vf_f32m1(vc0, x0b, vl), x1b, vc1, vl);
+                    __riscv_vse32_v_f32m1(ob + k, rb, vl);
+                }
+            }
+        }
+    } else {
+        // --- L2  = (x0-c0)² + (x1-c1)² ---
+        for (size_t i = 0; i < nx; i++) {
+            const float* xi = x + i * d;
+            float* oi = dis_tables + i * M * ksub;
+            for (size_t m = 0; m + 1 < M; m += 2) {
+                float x0a = xi[2 * m], x1a = xi[2 * m + 1];
+                float x0b = xi[2 * (m + 1)], x1b = xi[2 * (m + 1) + 1];
+                const float* c0a = c0_all + m * ksub;
+                const float* c1a = c1_all + m * ksub;
+                const float* c0b = c0_all + (m + 1) * ksub;
+                const float* c1b = c1_all + (m + 1) * ksub;
+                float* oa = oi + m * ksub;
+                float* ob = oi + (m + 1) * ksub;
+                for (size_t k = 0; k < ksub; k += vl) {
+                    // r = (c0-x0a)² + (c1-x1a)²
+                    vfloat32m1_t vc0 = __riscv_vle32_v_f32m1(c0a + k, vl);
+                    vfloat32m1_t vc1 = __riscv_vle32_v_f32m1(c1a + k, vl);
+                    vfloat32m1_t d0 = __riscv_vfsub_vf_f32m1(
+                            vc0, x0a, vl); // d0 = c0 - x0a
+                    vfloat32m1_t d1 = __riscv_vfsub_vf_f32m1(
+                            vc1, x1a, vl);                   // d1 = c1 - x1a
+                    d0 = __riscv_vfmul_vv_f32m1(d0, d0, vl); // d0 = d0²
+                    d1 = __riscv_vfmul_vv_f32m1(d1, d1, vl); // d1 = d1²
+                    vfloat32m1_t r =
+                            __riscv_vfadd_vv_f32m1(d0, d1, vl); // r = d0 + d1
+                    __riscv_vse32_v_f32m1(oa + k, r, vl);
 
                     vc0 = __riscv_vle32_v_f32m1(c0b + k, vl);
                     vc1 = __riscv_vle32_v_f32m1(c1b + k, vl);
@@ -99,16 +145,15 @@ void compute_PQ_dis_tables_dsub2<SIMDLevel::RISCV_RVV>(
                     d0 = __riscv_vfmul_vv_f32m1(d0, d0, vl);
                     d1 = __riscv_vfmul_vv_f32m1(d1, d1, vl);
                     r = __riscv_vfadd_vv_f32m1(d0, d1, vl);
-                    __riscv_vse32_v_f32m1(ob + k, r, vl); 
+                    __riscv_vse32_v_f32m1(ob + k, r, vl);
                 }
             }
         }
     }
 
-    delete[] c0_all; 
+    delete[] c0_all;
     delete[] c1_all;
 }
-
 
 template <>
 float fvec_norm_L2sqr<SIMDLevel::RISCV_RVV>(const float* x, size_t d) {
@@ -126,17 +171,262 @@ float fvec_norm_L2sqr<SIMDLevel::RISCV_RVV>(const float* x, size_t d) {
     return res;
 }
 
-// ===========================================================================
-// fvec_L2sqr_ny — non-transposed (row-major y) squared-L2 distance.
-//   dis[i] = sum_{j=0}^{d-1} (x[j] - y[i*d + j])^2,  for i in [0, ny)
-// y is row-major: the i-th vector occupies y[i*d .. i*d+d-1].
-// RVV strategy: vectorize over ny with strided loads. For each dim j, gather
-// the j-th component of `chunk` consecutive y vectors via vlse32 (stride =
-// d*sizeof(float)), then diff = y_vec - x[j], acc += diff*diff. A single
-// accumulator and one strided load + two vector ops per dim keeps register
-// pressure low, allowing e32m4 (VLMAX=16 on VLEN=128) as the starting LMUL.
-// This is fully general in d and ny (no experiment-parameter special-casing).
-// ===========================================================================
+template <>
+float fvec_L2sqr<SIMDLevel::RISCV_RVV>(
+        const float* x,
+        const float* y,
+        size_t d) {
+    size_t vlmax = __riscv_vsetvlmax_e32m8();
+    vfloat32m8_t acc = __riscv_vfmv_v_f_f32m8(0.0f, vlmax);
+    size_t i = 0;
+    while (i < d) {
+        size_t vl = __riscv_vsetvl_e32m8(d - i);
+        vfloat32m8_t vx = __riscv_vle32_v_f32m8(x + i, vl);
+        vfloat32m8_t vy = __riscv_vle32_v_f32m8(y + i, vl);
+        vx = __riscv_vfsub_vv_f32m8(vx, vy, vl);
+        acc = __riscv_vfmacc_vv_f32m8_tu(acc, vx, vx, vl);
+        i += vl;
+    }
+    return rvv_reduce(acc, vlmax, 0.0f, __riscv_vfredusum_vs_f32m8_f32m1);
+}
+
+template <>
+float fvec_inner_product<SIMDLevel::RISCV_RVV>(
+        const float* x,
+        const float* y,
+        size_t d) {
+    size_t vlmax = __riscv_vsetvlmax_e32m8();
+    vfloat32m8_t acc = __riscv_vfmv_v_f_f32m8(0.0f, vlmax);
+    size_t i = 0;
+    while (i < d) {
+        size_t vl = __riscv_vsetvl_e32m8(d - i);
+        vfloat32m8_t vx = __riscv_vle32_v_f32m8(x + i, vl);
+        vfloat32m8_t vy = __riscv_vle32_v_f32m8(y + i, vl);
+        acc = __riscv_vfmacc_vv_f32m8_tu(acc, vx, vy, vl);
+        i += vl;
+    }
+    return rvv_reduce(acc, vlmax, 0.0f, __riscv_vfredusum_vs_f32m8_f32m1);
+}
+
+template <>
+float fvec_L1<SIMDLevel::RISCV_RVV>(const float* x, const float* y, size_t d) {
+    size_t vlmax = __riscv_vsetvlmax_e32m8();
+    vfloat32m8_t acc = __riscv_vfmv_v_f_f32m8(0.0f, vlmax);
+    size_t i = 0;
+    while (i < d) {
+        size_t vl = __riscv_vsetvl_e32m8(d - i);
+        vfloat32m8_t vx = __riscv_vle32_v_f32m8(x + i, vl);
+        vfloat32m8_t vy = __riscv_vle32_v_f32m8(y + i, vl);
+        vx = __riscv_vfsub_vv_f32m8(vx, vy, vl);
+        vx = __riscv_vfsgnjx_vv_f32m8(vx, vx, vl);
+        acc = __riscv_vfadd_vv_f32m8_tu(acc, acc, vx, vl);
+        i += vl;
+    }
+    return rvv_reduce(acc, vlmax, 0.0f, __riscv_vfredusum_vs_f32m8_f32m1);
+}
+
+template <>
+float fvec_Linf<SIMDLevel::RISCV_RVV>(
+        const float* x,
+        const float* y,
+        size_t d) {
+    size_t vlmax = __riscv_vsetvlmax_e32m8();
+    vfloat32m8_t vmax = __riscv_vfmv_v_f_f32m8(0.0f, vlmax);
+    size_t i = 0;
+    while (i < d) {
+        size_t vl = __riscv_vsetvl_e32m8(d - i);
+        vfloat32m8_t vx = __riscv_vle32_v_f32m8(x + i, vl);
+        vfloat32m8_t vy = __riscv_vle32_v_f32m8(y + i, vl);
+        vx = __riscv_vfsub_vv_f32m8(vx, vy, vl);
+        vx = __riscv_vfsgnjx_vv_f32m8(vx, vx, vl);
+        vmax = __riscv_vfmax_vv_f32m8_tu(vmax, vmax, vx, vl);
+        i += vl;
+    }
+    return rvv_reduce(vmax, vlmax, 0.0f, __riscv_vfredmax_vs_f32m8_f32m1);
+}
+
+template <>
+void fvec_inner_product_batch_4<SIMDLevel::RISCV_RVV>(
+        const float* x,
+        const float* y0,
+        const float* y1,
+        const float* y2,
+        const float* y3,
+        const size_t d,
+        float& dis0,
+        float& dis1,
+        float& dis2,
+        float& dis3) {
+    size_t vlmax = __riscv_vsetvlmax_e32m4();
+    vfloat32m4_t vacc0 = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
+    vfloat32m4_t vacc1 = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
+    vfloat32m4_t vacc2 = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
+    vfloat32m4_t vacc3 = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
+    size_t i = 0;
+    while (i < d) {
+        size_t vl = __riscv_vsetvl_e32m4(d - i);
+        vfloat32m4_t vx = __riscv_vle32_v_f32m4(x + i, vl);
+        vfloat32m4_t vy = __riscv_vle32_v_f32m4(y0 + i, vl);
+        vacc0 = __riscv_vfmacc_vv_f32m4_tu(vacc0, vx, vy, vl);
+        vy = __riscv_vle32_v_f32m4(y1 + i, vl);
+        vacc1 = __riscv_vfmacc_vv_f32m4_tu(vacc1, vx, vy, vl);
+        vy = __riscv_vle32_v_f32m4(y2 + i, vl);
+        vacc2 = __riscv_vfmacc_vv_f32m4_tu(vacc2, vx, vy, vl);
+        vy = __riscv_vle32_v_f32m4(y3 + i, vl);
+        vacc3 = __riscv_vfmacc_vv_f32m4_tu(vacc3, vx, vy, vl);
+        i += vl;
+    }
+    dis0 = rvv_reduce(vacc0, vlmax, 0.0f, __riscv_vfredusum_vs_f32m4_f32m1);
+    dis1 = rvv_reduce(vacc1, vlmax, 0.0f, __riscv_vfredusum_vs_f32m4_f32m1);
+    dis2 = rvv_reduce(vacc2, vlmax, 0.0f, __riscv_vfredusum_vs_f32m4_f32m1);
+    dis3 = rvv_reduce(vacc3, vlmax, 0.0f, __riscv_vfredusum_vs_f32m4_f32m1);
+}
+
+template <>
+void fvec_L2sqr_batch_4<SIMDLevel::RISCV_RVV>(
+        const float* x,
+        const float* y0,
+        const float* y1,
+        const float* y2,
+        const float* y3,
+        const size_t d,
+        float& dis0,
+        float& dis1,
+        float& dis2,
+        float& dis3) {
+    size_t vlmax = __riscv_vsetvlmax_e32m4();
+    vfloat32m4_t vacc0 = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
+    vfloat32m4_t vacc1 = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
+    vfloat32m4_t vacc2 = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
+    vfloat32m4_t vacc3 = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
+    size_t i = 0;
+    while (i < d) {
+        size_t vl = __riscv_vsetvl_e32m4(d - i);
+        vfloat32m4_t vx = __riscv_vle32_v_f32m4(x + i, vl);
+        vfloat32m4_t vy = __riscv_vle32_v_f32m4(y0 + i, vl);
+        vy = __riscv_vfsub_vv_f32m4(vx, vy, vl);
+        vacc0 = __riscv_vfmacc_vv_f32m4_tu(vacc0, vy, vy, vl);
+        vy = __riscv_vle32_v_f32m4(y1 + i, vl);
+        vy = __riscv_vfsub_vv_f32m4(vx, vy, vl);
+        vacc1 = __riscv_vfmacc_vv_f32m4_tu(vacc1, vy, vy, vl);
+        vy = __riscv_vle32_v_f32m4(y2 + i, vl);
+        vy = __riscv_vfsub_vv_f32m4(vx, vy, vl);
+        vacc2 = __riscv_vfmacc_vv_f32m4_tu(vacc2, vy, vy, vl);
+        vy = __riscv_vle32_v_f32m4(y3 + i, vl);
+        vy = __riscv_vfsub_vv_f32m4(vx, vy, vl);
+        vacc3 = __riscv_vfmacc_vv_f32m4_tu(vacc3, vy, vy, vl);
+        i += vl;
+    }
+    dis0 = rvv_reduce(vacc0, vlmax, 0.0f, __riscv_vfredusum_vs_f32m4_f32m1);
+    dis1 = rvv_reduce(vacc1, vlmax, 0.0f, __riscv_vfredusum_vs_f32m4_f32m1);
+    dis2 = rvv_reduce(vacc2, vlmax, 0.0f, __riscv_vfredusum_vs_f32m4_f32m1);
+    dis3 = rvv_reduce(vacc3, vlmax, 0.0f, __riscv_vfredusum_vs_f32m4_f32m1);
+}
+
+template <>
+void fvec_L2sqr_ny_transposed<SIMDLevel::RISCV_RVV>(
+        float* dis,
+        const float* x,
+        const float* y,
+        const float* y_sqlen,
+        size_t d,
+        size_t d_offset,
+        size_t ny) {
+    // Compute squared length of query subvector-
+    float x_sqlen = 0;
+    for (size_t j = 0; j < d; j++) {
+        x_sqlen += x[j] * x[j];
+    }
+
+    // Strip-mine ny dimension with e32m8 (VLMAX=32 on VLEN=128)
+    size_t i = 0;
+    const size_t chunk = 32; // e32m8: VLMAX = LMUL*VLEN/SEW = 8*128/32 = 32
+
+    if (ny >= chunk) {
+        (void)__riscv_vsetvl_e32m8(chunk);
+        for (; i + chunk <= ny; i += chunk) {
+            // acc = x_sqlen + y_sqlen[i..i+31]
+            vfloat32m8_t acc = __riscv_vle32_v_f32m8(y_sqlen + i, chunk);
+            acc = __riscv_vfadd_vf_f32m8(acc, x_sqlen, chunk);
+
+            // acc += (-2 * x[j]) * y[j*d_offset + i..j*d_offset + i+31]
+            for (size_t j = 0; j < d; j++) {
+                vfloat32m8_t y_vec =
+                        __riscv_vle32_v_f32m8(y + j * d_offset + i, chunk);
+                // acc += (−2·x[j]) · y_vec
+                acc = __riscv_vfmacc_vf_f32m8(acc, -2.0f * x[j], y_vec, chunk);
+            }
+
+            __riscv_vse32_v_f32m8(dis + i, acc, chunk);
+        }
+    }
+
+    // Tail: process remaining ny % 32 elements
+    if (i < ny) {
+        size_t vl = __riscv_vsetvl_e32m8(ny - i);
+
+        vfloat32m8_t acc = __riscv_vle32_v_f32m8(y_sqlen + i, vl);
+        acc = __riscv_vfadd_vf_f32m8(acc, x_sqlen, vl);
+
+        for (size_t j = 0; j < d; j++) {
+            vfloat32m8_t y_vec =
+                    __riscv_vle32_v_f32m8(y + j * d_offset + i, vl);
+            acc = __riscv_vfmacc_vf_f32m8(
+                    acc, -2.0f * x[j], y_vec, vl); // acc += (−2·x[j])·y_vec
+        }
+
+        __riscv_vse32_v_f32m8(dis + i, acc, vl);
+    }
+}
+
+template <>
+void fvec_inner_products_ny<SIMDLevel::RISCV_RVV>(
+        float* ip,
+        const float* x,
+        const float* y,
+        size_t d,
+        size_t ny) {
+    // Strip-mine ny dimension with e32m4 (VLMAX=16 on VLEN=128)
+    // e32m4 proved optimal in LMUL sweep: best balance of strided-load
+    // throughput (vlse32 stride=d*4) and register file efficiency
+    // Core formula: ip[i] = sum_{j=0}^{d-1} x[j] * y[i*d + j]
+    size_t i = 0;
+    const size_t chunk = 16; // e32m4: VLMAX = LMUL*VLEN/SEW = 4*128/32 = 16
+    const ptrdiff_t stride_bytes = d * sizeof(float);
+
+    if (ny >= chunk) {
+        (void)__riscv_vsetvl_e32m4(chunk);
+        for (; i + chunk <= ny; i += chunk) {
+            vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, chunk);
+
+            for (size_t j = 0; j < d; j++) {
+                vfloat32m4_t y_vec =
+                        __riscv_vlse32_v_f32m4(y + j, stride_bytes, chunk);
+                // acc += x[j] · y_vec
+                acc = __riscv_vfmacc_vf_f32m4(acc, x[j], y_vec, chunk);
+            }
+
+            __riscv_vse32_v_f32m4(ip + i, acc, chunk);
+        }
+    }
+
+    // Tail: process remaining ny % chunk elements
+    if (i < ny) {
+        size_t vl = __riscv_vsetvl_e32m4(ny - i);
+
+        vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+
+        for (size_t j = 0; j < d; j++) {
+            vfloat32m4_t y_vec =
+                    __riscv_vlse32_v_f32m4(y + j, stride_bytes, vl);
+            acc = __riscv_vfmacc_vf_f32m4(
+                    acc, x[j], y_vec, vl); // acc += x[j] · y_vec
+        }
+
+        __riscv_vse32_v_f32m4(ip + i, acc, vl);
+    }
+}
+
 template <>
 void fvec_L2sqr_ny<SIMDLevel::RISCV_RVV>(
         float* dis,
@@ -177,173 +467,6 @@ void fvec_L2sqr_ny<SIMDLevel::RISCV_RVV>(
     }
 }
 
-
-template <>
-float fvec_L2sqr<SIMDLevel::RISCV_RVV>(
-        const float* x,
-        const float* y,
-        size_t d) {
-    return fvec_L2sqr<SIMDLevel::NONE>(x, y, d);
-}
-
-template <>
-float fvec_inner_product<SIMDLevel::RISCV_RVV>(
-        const float* x,
-        const float* y,
-        size_t d) {
-    return fvec_inner_product<SIMDLevel::NONE>(x, y, d);
-}
-
-template <>
-float fvec_L1<SIMDLevel::RISCV_RVV>(const float* x, const float* y, size_t d) {
-    return fvec_L1<SIMDLevel::NONE>(x, y, d);
-}
-
-template <>
-float fvec_Linf<SIMDLevel::RISCV_RVV>(
-        const float* x,
-        const float* y,
-        size_t d) {
-    return fvec_Linf<SIMDLevel::NONE>(x, y, d);
-}
-
-template <>
-void fvec_inner_product_batch_4<SIMDLevel::RISCV_RVV>(
-        const float* x,
-        const float* y0,
-        const float* y1,
-        const float* y2,
-        const float* y3,
-        const size_t d,
-        float& dis0,
-        float& dis1,
-        float& dis2,
-        float& dis3) {
-    fvec_inner_product_batch_4<SIMDLevel::NONE>(
-            x, y0, y1, y2, y3, d, dis0, dis1, dis2, dis3);
-}
-
-template <>
-void fvec_L2sqr_batch_4<SIMDLevel::RISCV_RVV>(
-        const float* x,
-        const float* y0,
-        const float* y1,
-        const float* y2,
-        const float* y3,
-        const size_t d,
-        float& dis0,
-        float& dis1,
-        float& dis2,
-        float& dis3) {
-    fvec_L2sqr_batch_4<SIMDLevel::NONE>(
-            x, y0, y1, y2, y3, d, dis0, dis1, dis2, dis3);
-}
-
-
-template <>
-void fvec_L2sqr_ny_transposed<SIMDLevel::RISCV_RVV>(
-        float* dis,            
-        const float* x,        
-        const float* y,        
-        const float* y_sqlen,  
-        size_t d,              
-        size_t d_offset,       
-        size_t ny) {           
-    // Compute squared length of query subvector
-    float x_sqlen = 0;
-    for (size_t j = 0; j < d; j++) {
-        x_sqlen += x[j] * x[j];
-    }
-
-    // Strip-mine ny dimension with e32m8 (VLMAX=32 on VLEN=128)
-    size_t i = 0;
-    const size_t chunk = 32; // e32m8: VLMAX = LMUL*VLEN/SEW = 8*128/32 = 32
-
-    if (ny >= chunk) {
-        (void)__riscv_vsetvl_e32m8(chunk); 
-        for (; i + chunk <= ny; i += chunk) {
-            // acc = x_sqlen + y_sqlen[i..i+31]
-            vfloat32m8_t acc = __riscv_vle32_v_f32m8(y_sqlen + i, chunk); 
-            acc = __riscv_vfadd_vf_f32m8(acc, x_sqlen, chunk);            
-
-            // acc += (-2 * x[j]) * y[j*d_offset + i..j*d_offset + i+31]
-            for (size_t j = 0; j < d; j++) {
-                vfloat32m8_t y_vec =
-                        __riscv_vle32_v_f32m8(y + j * d_offset + i, chunk);
-                acc = __riscv_vfmacc_vf_f32m8(
-                        acc, -2.0f * x[j], y_vec, chunk);
-            }
-
-            __riscv_vse32_v_f32m8(dis + i, acc, chunk);
-        }
-    }
-
-    // Tail: process remaining ny % 32 elements
-    if (i < ny) {
-        size_t vl = __riscv_vsetvl_e32m8(ny - i); 
-
-        vfloat32m8_t acc = __riscv_vle32_v_f32m8(y_sqlen + i, vl); 
-        acc = __riscv_vfadd_vf_f32m8(acc, x_sqlen, vl);            
-
-        for (size_t j = 0; j < d; j++) {
-            vfloat32m8_t y_vec =
-                    __riscv_vle32_v_f32m8(y + j * d_offset + i, vl); 
-            acc = __riscv_vfmacc_vf_f32m8(
-                    acc, -2.0f * x[j], y_vec, vl); // acc += (−2·x[j])·y_vec
-        }
-
-        __riscv_vse32_v_f32m8(dis + i, acc, vl); 
-    }
-}
-
-
-template <>
-void fvec_inner_products_ny<SIMDLevel::RISCV_RVV>(
-        float* ip,        
-        const float* x,   
-        const float* y,   
-        size_t d,         
-        size_t ny) {      
-    // Strip-mine ny dimension with e32m4 (VLMAX=16 on VLEN=128)
-    // e32m4 proved optimal in LMUL sweep: best balance of strided-load
-    // throughput (vlse32 stride=d*4) and register file efficiency
-    // Core formula: ip[i] = sum_{j=0}^{d-1} x[j] * y[i*d + j]
-    size_t i = 0;
-    const size_t chunk = 16; // e32m4: VLMAX = LMUL*VLEN/SEW = 4*128/32 = 16
-    const ptrdiff_t stride_bytes = d * sizeof(float);
-
-    if (ny >= chunk) {
-        (void)__riscv_vsetvl_e32m4(chunk); 
-        for (; i + chunk <= ny; i += chunk) {
-            vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, chunk);
-            for (size_t j = 0; j < d; j++) {
-                vfloat32m4_t y_vec = __riscv_vlse32_v_f32m4(
-                        y + j, stride_bytes, chunk);
-                acc = __riscv_vfmacc_vf_f32m4(
-                        acc, x[j], y_vec, chunk);
-            }
-
-            __riscv_vse32_v_f32m4(ip + i, acc, chunk); 
-        }
-    }
-
-    // Tail: process remaining ny % chunk elements
-    if (i < ny) {
-        size_t vl = __riscv_vsetvl_e32m4(ny - i); 
-        vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, vl); 
-        for (size_t j = 0; j < d; j++) {
-            vfloat32m4_t y_vec = __riscv_vlse32_v_f32m4(
-                    y + j, stride_bytes, vl);
-            acc = __riscv_vfmacc_vf_f32m4(
-                    acc, x[j], y_vec, vl); // acc += x[j] · y_vec
-        }
-
-        __riscv_vse32_v_f32m4(ip + i, acc, vl); 
-    }
-}
-
-
-
 template <>
 size_t fvec_L2sqr_ny_nearest<SIMDLevel::RISCV_RVV>(
         float* distances_tmp_buffer,
@@ -375,7 +498,15 @@ void fvec_madd<SIMDLevel::RISCV_RVV>(
         float bf,
         const float* b,
         float* c) {
-    fvec_madd<SIMDLevel::NONE>(n, a, bf, b, c);
+    size_t i = 0;
+    while (i < n) {
+        size_t vl = __riscv_vsetvl_e32m8(n - i);
+        vfloat32m8_t va = __riscv_vle32_v_f32m8(a + i, vl);
+        vfloat32m8_t vb = __riscv_vle32_v_f32m8(b + i, vl);
+        va = __riscv_vfmacc_vf_f32m8(va, bf, vb, vl);
+        __riscv_vse32_v_f32m8(c + i, va, vl);
+        i += vl;
+    }
 }
 
 template <>
@@ -385,7 +516,9 @@ int fvec_madd_and_argmin<SIMDLevel::RISCV_RVV>(
         float bf,
         const float* b,
         float* c) {
-    return fvec_madd_and_argmin<SIMDLevel::NONE>(n, a, bf, b, c);
+    fvec_madd<SIMDLevel::RISCV_RVV>(n, a, bf, b, c);
+    const size_t j = rvv_argmin(c, n);
+    return j < n ? static_cast<int>(j) : -1;
 }
 
 #define DEFINE_VECTOR_DISTANCE_RVV_FALLBACK(metric)                 \

--- a/faiss/utils/simd_impl/distances_rvv.cpp
+++ b/faiss/utils/simd_impl/distances_rvv.cpp
@@ -11,78 +11,179 @@
 
 #ifdef COMPILE_SIMD_RISCV_RVV
 
-#include <faiss/utils/extra_distances.h>
 #include <riscv_vector.h>
+#include <faiss/utils/extra_distances.h>
 
 namespace faiss {
 
-template <typename Vec, typename Reduce>
-static inline float rvv_reduce(
-        Vec value,
-        size_t vl,
-        float identity,
-        Reduce reduce) {
-    vfloat32m1_t init = __riscv_vfmv_s_f_f32m1(identity, 1);
-    vfloat32m1_t result = reduce(value, init, vl);
-    return __riscv_vfmv_f_s_f32m1_f32(result);
+
+template <>
+void compute_PQ_dis_tables_dsub2<SIMDLevel::RISCV_RVV>(
+        size_t d,                    
+        size_t ksub,                 
+        const float* all_centroids,  
+        size_t nx,                   
+        const float* x,              
+        bool is_inner_product,       
+        float* dis_tables) {         
+    size_t M = d / 2;                
+    FAISS_THROW_IF_NOT(ksub % 8 == 0); 
+    float* c0_all = new float[M * ksub];  
+    float* c1_all = new float[M * ksub];  
+    for (size_t m = 0; m < M; m++) {
+        const float* cm = all_centroids + m * ksub * 2;  
+        float* c0m = c0_all + m * ksub;                  
+        float* c1m = c1_all + m * ksub;                 
+        for (size_t k = 0; k < ksub; k++) {
+            c0m[k] = cm[2 * k];       
+            c1m[k] = cm[2 * k + 1];   
+        }
+    }
+
+    size_t vl = __riscv_vsetvl_e32m1(ksub); 
+
+    if (is_inner_product) {
+        for (size_t i = 0; i < nx; i++) {
+            const float* xi = x + i * d;                    
+            float* oi = dis_tables + i * M * ksub;          
+            for (size_t m = 0; m + 1 < M; m += 2) {         
+                float x0a = xi[2 * m], x1a = xi[2 * m + 1];          
+                float x0b = xi[2 * (m + 1)], x1b = xi[2 * (m + 1) + 1]; 
+                const float* c0a = c0_all + m * ksub;        
+                const float* c1a = c1_all + m * ksub;        
+                const float* c0b = c0_all + (m + 1) * ksub;  
+                const float* c1b = c1_all + (m + 1) * ksub;  
+                float* oa = oi + m * ksub;                   
+                float* ob = oi + (m + 1) * ksub;             
+                for (size_t k = 0; k < ksub; k += vl) {      
+                    vfloat32m1_t vc0 = __riscv_vle32_v_f32m1(c0a + k, vl); 
+                    vfloat32m1_t vc1 = __riscv_vle32_v_f32m1(c1a + k, vl); 
+                    vfloat32m1_t ra = __riscv_vfmacc_vf_f32m1(
+                            __riscv_vfmul_vf_f32m1(vc0, x0a, vl), x1a, vc1, vl);
+                    __riscv_vse32_v_f32m1(oa + k, ra, vl); 
+                    vc0 = __riscv_vle32_v_f32m1(c0b + k, vl);
+                    vc1 = __riscv_vle32_v_f32m1(c1b + k, vl);
+                    vfloat32m1_t rb = __riscv_vfmacc_vf_f32m1(
+                            __riscv_vfmul_vf_f32m1(vc0, x0b, vl), x1b, vc1, vl);
+                    __riscv_vse32_v_f32m1(ob + k, rb, vl);  
+                }
+            }
+        }
+    } else {
+        for (size_t i = 0; i < nx; i++) {
+            const float* xi = x + i * d;
+            float* oi = dis_tables + i * M * ksub;
+            for (size_t m = 0; m + 1 < M; m += 2) {
+                float x0a = xi[2 * m], x1a = xi[2 * m + 1];
+                float x0b = xi[2 * (m + 1)], x1b = xi[2 * (m + 1) + 1];
+                const float* c0a = c0_all + m * ksub;
+                const float* c1a = c1_all + m * ksub;
+                const float* c0b = c0_all + (m + 1) * ksub;
+                const float* c1b = c1_all + (m + 1) * ksub;
+                float* oa = oi + m * ksub;
+                float* ob = oi + (m + 1) * ksub;
+                for (size_t k = 0; k < ksub; k += vl) {
+                    vfloat32m1_t vc0 = __riscv_vle32_v_f32m1(c0a + k, vl);
+                    vfloat32m1_t vc1 = __riscv_vle32_v_f32m1(c1a + k, vl);
+                    vfloat32m1_t d0 = __riscv_vfsub_vf_f32m1(vc0, x0a, vl); // d0 = c0 - x0a
+                    vfloat32m1_t d1 = __riscv_vfsub_vf_f32m1(vc1, x1a, vl); // d1 = c1 - x1a
+                    d0 = __riscv_vfmul_vv_f32m1(d0, d0, vl);                // d0 = d0²
+                    d1 = __riscv_vfmul_vv_f32m1(d1, d1, vl);                // d1 = d1²
+                    vfloat32m1_t r = __riscv_vfadd_vv_f32m1(d0, d1, vl);    // r = d0 + d1
+                    __riscv_vse32_v_f32m1(oa + k, r, vl);  
+
+                    vc0 = __riscv_vle32_v_f32m1(c0b + k, vl);
+                    vc1 = __riscv_vle32_v_f32m1(c1b + k, vl);
+                    d0 = __riscv_vfsub_vf_f32m1(vc0, x0b, vl);
+                    d1 = __riscv_vfsub_vf_f32m1(vc1, x1b, vl);
+                    d0 = __riscv_vfmul_vv_f32m1(d0, d0, vl);
+                    d1 = __riscv_vfmul_vv_f32m1(d1, d1, vl);
+                    r = __riscv_vfadd_vv_f32m1(d0, d1, vl);
+                    __riscv_vse32_v_f32m1(ob + k, r, vl); 
+                }
+            }
+        }
+    }
+
+    delete[] c0_all; 
+    delete[] c1_all;
 }
 
-static inline size_t rvv_argmin(const float* values, size_t n) {
-    size_t vlmax = __riscv_vsetvlmax_e32m8();
-    vfloat32m8_t vmin = __riscv_vfmv_v_f_f32m8(__builtin_inff(), vlmax);
-    size_t i = 0;
-    while (i < n) {
-        size_t vl = __riscv_vsetvl_e32m8(n - i);
-        vfloat32m8_t vd = __riscv_vle32_v_f32m8(values + i, vl);
-        vmin = __riscv_vfmin_vv_f32m8_tu(vmin, vmin, vd, vl);
-        i += vl;
-    }
-    float min_val = rvv_reduce(
-            vmin, vlmax, __builtin_inff(), __riscv_vfredmin_vs_f32m8_f32m1);
-    i = 0;
-    while (i < n) {
-        size_t vl = __riscv_vsetvl_e32m8(n - i);
-        vfloat32m8_t vd = __riscv_vle32_v_f32m8(values + i, vl);
-        long j = __riscv_vfirst_m_b4(
-                __riscv_vmfeq_vf_f32m8_b4(vd, min_val, vl), vl);
-        if (j >= 0)
-            return i + static_cast<size_t>(j);
-        i += vl;
-    }
-    return n;
-}
 
 template <>
 float fvec_norm_L2sqr<SIMDLevel::RISCV_RVV>(const float* x, size_t d) {
-    size_t vlmax = __riscv_vsetvlmax_e32m8();
-    vfloat32m8_t acc = __riscv_vfmv_v_f_f32m8(0.0f, vlmax);
+    float res = 0.0f;
     size_t i = 0;
-    while (i < d) {
+    for (; i < d;) {
         size_t vl = __riscv_vsetvl_e32m8(d - i);
         vfloat32m8_t vx = __riscv_vle32_v_f32m8(x + i, vl);
-        acc = __riscv_vfmacc_vv_f32m8_tu(acc, vx, vx, vl);
+        vfloat32m8_t vxx = __riscv_vfmul_vv_f32m8(vx, vx, vl);
+        vfloat32m1_t vred = __riscv_vfredusum_vs_f32m8_f32m1(
+                vxx, __riscv_vfmv_v_f_f32m1(0.0f, vl), vl);
+        res += __riscv_vfmv_f_s_f32m1_f32(vred);
         i += vl;
     }
-    return rvv_reduce(acc, vlmax, 0.0f, __riscv_vfredusum_vs_f32m8_f32m1);
+    return res;
 }
+
+// ===========================================================================
+// fvec_L2sqr_ny — non-transposed (row-major y) squared-L2 distance.
+//   dis[i] = sum_{j=0}^{d-1} (x[j] - y[i*d + j])^2,  for i in [0, ny)
+// y is row-major: the i-th vector occupies y[i*d .. i*d+d-1].
+// RVV strategy: vectorize over ny with strided loads. For each dim j, gather
+// the j-th component of `chunk` consecutive y vectors via vlse32 (stride =
+// d*sizeof(float)), then diff = y_vec - x[j], acc += diff*diff. A single
+// accumulator and one strided load + two vector ops per dim keeps register
+// pressure low, allowing e32m4 (VLMAX=16 on VLEN=128) as the starting LMUL.
+// This is fully general in d and ny (no experiment-parameter special-casing).
+// ===========================================================================
+template <>
+void fvec_L2sqr_ny<SIMDLevel::RISCV_RVV>(
+        float* dis,
+        const float* x,
+        const float* y,
+        size_t d,
+        size_t ny) {
+    size_t i = 0;
+    const size_t chunk = 32; // e32m8: VLMAX = LMUL*VLEN/SEW = 8*128/32 = 32
+    const ptrdiff_t stride_bytes = (ptrdiff_t)d * (ptrdiff_t)sizeof(float);
+
+    if (ny >= chunk) {
+        (void)__riscv_vsetvl_e32m8(chunk);
+        for (; i + chunk <= ny; i += chunk) {
+            vfloat32m8_t acc = __riscv_vfmv_v_f_f32m8(0.0f, chunk);
+            const float* yb = y + i * d; // base of this chunk
+            for (size_t j = 0; j < d; j++) {
+                vfloat32m8_t y_vec =
+                        __riscv_vlse32_v_f32m8(yb + j, stride_bytes, chunk);
+                vfloat32m8_t diff = __riscv_vfsub_vf_f32m8(y_vec, x[j], chunk);
+                acc = __riscv_vfmacc_vv_f32m8(acc, diff, diff, chunk);
+            }
+            __riscv_vse32_v_f32m8(dis + i, acc, chunk);
+        }
+    }
+
+    if (i < ny) {
+        size_t vl = __riscv_vsetvl_e32m8(ny - i);
+        vfloat32m8_t acc = __riscv_vfmv_v_f_f32m8(0.0f, vl);
+        const float* yb = y + i * d;
+        for (size_t j = 0; j < d; j++) {
+            vfloat32m8_t y_vec =
+                    __riscv_vlse32_v_f32m8(yb + j, stride_bytes, vl);
+            vfloat32m8_t diff = __riscv_vfsub_vf_f32m8(y_vec, x[j], vl);
+            acc = __riscv_vfmacc_vv_f32m8(acc, diff, diff, vl);
+        }
+        __riscv_vse32_v_f32m8(dis + i, acc, vl);
+    }
+}
+
 
 template <>
 float fvec_L2sqr<SIMDLevel::RISCV_RVV>(
         const float* x,
         const float* y,
         size_t d) {
-    size_t vlmax = __riscv_vsetvlmax_e32m8();
-    vfloat32m8_t acc = __riscv_vfmv_v_f_f32m8(0.0f, vlmax);
-    size_t i = 0;
-    while (i < d) {
-        size_t vl = __riscv_vsetvl_e32m8(d - i);
-        vfloat32m8_t vx = __riscv_vle32_v_f32m8(x + i, vl);
-        vfloat32m8_t vy = __riscv_vle32_v_f32m8(y + i, vl);
-        vx = __riscv_vfsub_vv_f32m8(vx, vy, vl);
-        acc = __riscv_vfmacc_vv_f32m8_tu(acc, vx, vx, vl);
-        i += vl;
-    }
-    return rvv_reduce(acc, vlmax, 0.0f, __riscv_vfredusum_vs_f32m8_f32m1);
+    return fvec_L2sqr<SIMDLevel::NONE>(x, y, d);
 }
 
 template <>
@@ -90,34 +191,12 @@ float fvec_inner_product<SIMDLevel::RISCV_RVV>(
         const float* x,
         const float* y,
         size_t d) {
-    size_t vlmax = __riscv_vsetvlmax_e32m8();
-    vfloat32m8_t acc = __riscv_vfmv_v_f_f32m8(0.0f, vlmax);
-    size_t i = 0;
-    while (i < d) {
-        size_t vl = __riscv_vsetvl_e32m8(d - i);
-        vfloat32m8_t vx = __riscv_vle32_v_f32m8(x + i, vl);
-        vfloat32m8_t vy = __riscv_vle32_v_f32m8(y + i, vl);
-        acc = __riscv_vfmacc_vv_f32m8_tu(acc, vx, vy, vl);
-        i += vl;
-    }
-    return rvv_reduce(acc, vlmax, 0.0f, __riscv_vfredusum_vs_f32m8_f32m1);
+    return fvec_inner_product<SIMDLevel::NONE>(x, y, d);
 }
 
 template <>
 float fvec_L1<SIMDLevel::RISCV_RVV>(const float* x, const float* y, size_t d) {
-    size_t vlmax = __riscv_vsetvlmax_e32m8();
-    vfloat32m8_t acc = __riscv_vfmv_v_f_f32m8(0.0f, vlmax);
-    size_t i = 0;
-    while (i < d) {
-        size_t vl = __riscv_vsetvl_e32m8(d - i);
-        vfloat32m8_t vx = __riscv_vle32_v_f32m8(x + i, vl);
-        vfloat32m8_t vy = __riscv_vle32_v_f32m8(y + i, vl);
-        vx = __riscv_vfsub_vv_f32m8(vx, vy, vl);
-        vx = __riscv_vfsgnjx_vv_f32m8(vx, vx, vl);
-        acc = __riscv_vfadd_vv_f32m8_tu(acc, acc, vx, vl);
-        i += vl;
-    }
-    return rvv_reduce(acc, vlmax, 0.0f, __riscv_vfredusum_vs_f32m8_f32m1);
+    return fvec_L1<SIMDLevel::NONE>(x, y, d);
 }
 
 template <>
@@ -125,19 +204,7 @@ float fvec_Linf<SIMDLevel::RISCV_RVV>(
         const float* x,
         const float* y,
         size_t d) {
-    size_t vlmax = __riscv_vsetvlmax_e32m8();
-    vfloat32m8_t vmax = __riscv_vfmv_v_f_f32m8(0.0f, vlmax);
-    size_t i = 0;
-    while (i < d) {
-        size_t vl = __riscv_vsetvl_e32m8(d - i);
-        vfloat32m8_t vx = __riscv_vle32_v_f32m8(x + i, vl);
-        vfloat32m8_t vy = __riscv_vle32_v_f32m8(y + i, vl);
-        vx = __riscv_vfsub_vv_f32m8(vx, vy, vl);
-        vx = __riscv_vfsgnjx_vv_f32m8(vx, vx, vl);
-        vmax = __riscv_vfmax_vv_f32m8_tu(vmax, vmax, vx, vl);
-        i += vl;
-    }
-    return rvv_reduce(vmax, vlmax, 0.0f, __riscv_vfredmax_vs_f32m8_f32m1);
+    return fvec_Linf<SIMDLevel::NONE>(x, y, d);
 }
 
 template <>
@@ -152,29 +219,8 @@ void fvec_inner_product_batch_4<SIMDLevel::RISCV_RVV>(
         float& dis1,
         float& dis2,
         float& dis3) {
-    size_t vlmax = __riscv_vsetvlmax_e32m4();
-    vfloat32m4_t vacc0 = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
-    vfloat32m4_t vacc1 = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
-    vfloat32m4_t vacc2 = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
-    vfloat32m4_t vacc3 = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
-    size_t i = 0;
-    while (i < d) {
-        size_t vl = __riscv_vsetvl_e32m4(d - i);
-        vfloat32m4_t vx = __riscv_vle32_v_f32m4(x + i, vl);
-        vfloat32m4_t vy = __riscv_vle32_v_f32m4(y0 + i, vl);
-        vacc0 = __riscv_vfmacc_vv_f32m4_tu(vacc0, vx, vy, vl);
-        vy = __riscv_vle32_v_f32m4(y1 + i, vl);
-        vacc1 = __riscv_vfmacc_vv_f32m4_tu(vacc1, vx, vy, vl);
-        vy = __riscv_vle32_v_f32m4(y2 + i, vl);
-        vacc2 = __riscv_vfmacc_vv_f32m4_tu(vacc2, vx, vy, vl);
-        vy = __riscv_vle32_v_f32m4(y3 + i, vl);
-        vacc3 = __riscv_vfmacc_vv_f32m4_tu(vacc3, vx, vy, vl);
-        i += vl;
-    }
-    dis0 = rvv_reduce(vacc0, vlmax, 0.0f, __riscv_vfredusum_vs_f32m4_f32m1);
-    dis1 = rvv_reduce(vacc1, vlmax, 0.0f, __riscv_vfredusum_vs_f32m4_f32m1);
-    dis2 = rvv_reduce(vacc2, vlmax, 0.0f, __riscv_vfredusum_vs_f32m4_f32m1);
-    dis3 = rvv_reduce(vacc3, vlmax, 0.0f, __riscv_vfredusum_vs_f32m4_f32m1);
+    fvec_inner_product_batch_4<SIMDLevel::NONE>(
+            x, y0, y1, y2, y3, d, dis0, dis1, dis2, dis3);
 }
 
 template <>
@@ -189,97 +235,114 @@ void fvec_L2sqr_batch_4<SIMDLevel::RISCV_RVV>(
         float& dis1,
         float& dis2,
         float& dis3) {
-    size_t vlmax = __riscv_vsetvlmax_e32m4();
-    vfloat32m4_t vacc0 = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
-    vfloat32m4_t vacc1 = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
-    vfloat32m4_t vacc2 = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
-    vfloat32m4_t vacc3 = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
-    size_t i = 0;
-    while (i < d) {
-        size_t vl = __riscv_vsetvl_e32m4(d - i);
-        vfloat32m4_t vx = __riscv_vle32_v_f32m4(x + i, vl);
-        vfloat32m4_t vy = __riscv_vle32_v_f32m4(y0 + i, vl);
-        vy = __riscv_vfsub_vv_f32m4(vx, vy, vl);
-        vacc0 = __riscv_vfmacc_vv_f32m4_tu(vacc0, vy, vy, vl);
-        vy = __riscv_vle32_v_f32m4(y1 + i, vl);
-        vy = __riscv_vfsub_vv_f32m4(vx, vy, vl);
-        vacc1 = __riscv_vfmacc_vv_f32m4_tu(vacc1, vy, vy, vl);
-        vy = __riscv_vle32_v_f32m4(y2 + i, vl);
-        vy = __riscv_vfsub_vv_f32m4(vx, vy, vl);
-        vacc2 = __riscv_vfmacc_vv_f32m4_tu(vacc2, vy, vy, vl);
-        vy = __riscv_vle32_v_f32m4(y3 + i, vl);
-        vy = __riscv_vfsub_vv_f32m4(vx, vy, vl);
-        vacc3 = __riscv_vfmacc_vv_f32m4_tu(vacc3, vy, vy, vl);
-        i += vl;
-    }
-    dis0 = rvv_reduce(vacc0, vlmax, 0.0f, __riscv_vfredusum_vs_f32m4_f32m1);
-    dis1 = rvv_reduce(vacc1, vlmax, 0.0f, __riscv_vfredusum_vs_f32m4_f32m1);
-    dis2 = rvv_reduce(vacc2, vlmax, 0.0f, __riscv_vfredusum_vs_f32m4_f32m1);
-    dis3 = rvv_reduce(vacc3, vlmax, 0.0f, __riscv_vfredusum_vs_f32m4_f32m1);
+    fvec_L2sqr_batch_4<SIMDLevel::NONE>(
+            x, y0, y1, y2, y3, d, dis0, dis1, dis2, dis3);
 }
+
 
 template <>
 void fvec_L2sqr_ny_transposed<SIMDLevel::RISCV_RVV>(
-        float* dis,
-        const float* x,
-        const float* y,
-        const float* y_sqlen,
-        size_t d,
-        size_t d_offset,
-        size_t ny) {
-    size_t vlmax = __riscv_vsetvlmax_e32m8();
-    vfloat32m8_t acc = __riscv_vfmv_v_f_f32m8(0.0f, vlmax);
-    size_t i = 0;
-    while (i < d) {
-        size_t vl = __riscv_vsetvl_e32m8(d - i);
-        vfloat32m8_t vx = __riscv_vle32_v_f32m8(x + i, vl);
-        acc = __riscv_vfmacc_vv_f32m8_tu(acc, vx, vx, vl);
-        i += vl;
+        float* dis,            
+        const float* x,        
+        const float* y,        
+        const float* y_sqlen,  
+        size_t d,              
+        size_t d_offset,       
+        size_t ny) {           
+    // Compute squared length of query subvector
+    float x_sqlen = 0;
+    for (size_t j = 0; j < d; j++) {
+        x_sqlen += x[j] * x[j];
     }
-    float x_sqlen =
-            rvv_reduce(acc, vlmax, 0.0f, __riscv_vfredusum_vs_f32m8_f32m1);
-    i = 0;
-    while (i < ny) {
-        size_t vl = __riscv_vsetvl_e32m8(ny - i);
-        acc = __riscv_vfmv_v_f_f32m8(0.0f, vl);
-        for (size_t j = 0; j < d; j++) {
-            vfloat32m8_t vy = __riscv_vle32_v_f32m8(y + j * d_offset + i, vl);
-            acc = __riscv_vfmacc_vf_f32m8(acc, x[j], vy, vl);
+
+    // Strip-mine ny dimension with e32m8 (VLMAX=32 on VLEN=128)
+    size_t i = 0;
+    const size_t chunk = 32; // e32m8: VLMAX = LMUL*VLEN/SEW = 8*128/32 = 32
+
+    if (ny >= chunk) {
+        (void)__riscv_vsetvl_e32m8(chunk); 
+        for (; i + chunk <= ny; i += chunk) {
+            // acc = x_sqlen + y_sqlen[i..i+31]
+            vfloat32m8_t acc = __riscv_vle32_v_f32m8(y_sqlen + i, chunk); 
+            acc = __riscv_vfadd_vf_f32m8(acc, x_sqlen, chunk);            
+
+            // acc += (-2 * x[j]) * y[j*d_offset + i..j*d_offset + i+31]
+            for (size_t j = 0; j < d; j++) {
+                vfloat32m8_t y_vec =
+                        __riscv_vle32_v_f32m8(y + j * d_offset + i, chunk);
+                acc = __riscv_vfmacc_vf_f32m8(
+                        acc, -2.0f * x[j], y_vec, chunk);
+            }
+
+            __riscv_vse32_v_f32m8(dis + i, acc, chunk);
         }
-        vfloat32m8_t vres = __riscv_vle32_v_f32m8(y_sqlen + i, vl);
-        vres = __riscv_vfadd_vf_f32m8(vres, x_sqlen, vl);
-        acc = __riscv_vfmul_vf_f32m8(acc, 2.0f, vl);
-        vres = __riscv_vfsub_vv_f32m8(vres, acc, vl);
-        __riscv_vse32_v_f32m8(dis + i, vres, vl);
-        i += vl;
+    }
+
+    // Tail: process remaining ny % 32 elements
+    if (i < ny) {
+        size_t vl = __riscv_vsetvl_e32m8(ny - i); 
+
+        vfloat32m8_t acc = __riscv_vle32_v_f32m8(y_sqlen + i, vl); 
+        acc = __riscv_vfadd_vf_f32m8(acc, x_sqlen, vl);            
+
+        for (size_t j = 0; j < d; j++) {
+            vfloat32m8_t y_vec =
+                    __riscv_vle32_v_f32m8(y + j * d_offset + i, vl); 
+            acc = __riscv_vfmacc_vf_f32m8(
+                    acc, -2.0f * x[j], y_vec, vl); // acc += (−2·x[j])·y_vec
+        }
+
+        __riscv_vse32_v_f32m8(dis + i, acc, vl); 
     }
 }
+
 
 template <>
 void fvec_inner_products_ny<SIMDLevel::RISCV_RVV>(
-        float* ip,
-        const float* x,
-        const float* y,
-        size_t d,
-        size_t ny) {
-    for (size_t i = 0; i < ny; i++) {
-        ip[i] = fvec_inner_product<SIMDLevel::RISCV_RVV>(x, y, d);
-        y += d;
+        float* ip,        
+        const float* x,   
+        const float* y,   
+        size_t d,         
+        size_t ny) {      
+    // Strip-mine ny dimension with e32m4 (VLMAX=16 on VLEN=128)
+    // e32m4 proved optimal in LMUL sweep: best balance of strided-load
+    // throughput (vlse32 stride=d*4) and register file efficiency
+    // Core formula: ip[i] = sum_{j=0}^{d-1} x[j] * y[i*d + j]
+    size_t i = 0;
+    const size_t chunk = 16; // e32m4: VLMAX = LMUL*VLEN/SEW = 4*128/32 = 16
+    const ptrdiff_t stride_bytes = d * sizeof(float);
+
+    if (ny >= chunk) {
+        (void)__riscv_vsetvl_e32m4(chunk); 
+        for (; i + chunk <= ny; i += chunk) {
+            vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, chunk);
+            for (size_t j = 0; j < d; j++) {
+                vfloat32m4_t y_vec = __riscv_vlse32_v_f32m4(
+                        y + j, stride_bytes, chunk);
+                acc = __riscv_vfmacc_vf_f32m4(
+                        acc, x[j], y_vec, chunk);
+            }
+
+            __riscv_vse32_v_f32m4(ip + i, acc, chunk); 
+        }
+    }
+
+    // Tail: process remaining ny % chunk elements
+    if (i < ny) {
+        size_t vl = __riscv_vsetvl_e32m4(ny - i); 
+        vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, vl); 
+        for (size_t j = 0; j < d; j++) {
+            vfloat32m4_t y_vec = __riscv_vlse32_v_f32m4(
+                    y + j, stride_bytes, vl);
+            acc = __riscv_vfmacc_vf_f32m4(
+                    acc, x[j], y_vec, vl); // acc += x[j] · y_vec
+        }
+
+        __riscv_vse32_v_f32m4(ip + i, acc, vl); 
     }
 }
 
-template <>
-void fvec_L2sqr_ny<SIMDLevel::RISCV_RVV>(
-        float* dis,
-        const float* x,
-        const float* y,
-        size_t d,
-        size_t ny) {
-    for (size_t i = 0; i < ny; i++) {
-        dis[i] = fvec_L2sqr<SIMDLevel::RISCV_RVV>(x, y, d);
-        y += d;
-    }
-}
+
 
 template <>
 size_t fvec_L2sqr_ny_nearest<SIMDLevel::RISCV_RVV>(
@@ -288,9 +351,8 @@ size_t fvec_L2sqr_ny_nearest<SIMDLevel::RISCV_RVV>(
         const float* y,
         size_t d,
         size_t ny) {
-    fvec_L2sqr_ny<SIMDLevel::RISCV_RVV>(distances_tmp_buffer, x, y, d, ny);
-    const size_t j = rvv_argmin(distances_tmp_buffer, ny);
-    return j < ny ? j : 0;
+    return fvec_L2sqr_ny_nearest<SIMDLevel::NONE>(
+            distances_tmp_buffer, x, y, d, ny);
 }
 
 template <>
@@ -302,10 +364,8 @@ size_t fvec_L2sqr_ny_nearest_y_transposed<SIMDLevel::RISCV_RVV>(
         size_t d,
         size_t d_offset,
         size_t ny) {
-    fvec_L2sqr_ny_transposed<SIMDLevel::RISCV_RVV>(
+    return fvec_L2sqr_ny_nearest_y_transposed<SIMDLevel::NONE>(
             distances_tmp_buffer, x, y, y_sqlen, d, d_offset, ny);
-    const size_t j = rvv_argmin(distances_tmp_buffer, ny);
-    return j < ny ? j : 0;
 }
 
 template <>
@@ -315,15 +375,7 @@ void fvec_madd<SIMDLevel::RISCV_RVV>(
         float bf,
         const float* b,
         float* c) {
-    size_t i = 0;
-    while (i < n) {
-        size_t vl = __riscv_vsetvl_e32m8(n - i);
-        vfloat32m8_t va = __riscv_vle32_v_f32m8(a + i, vl);
-        vfloat32m8_t vb = __riscv_vle32_v_f32m8(b + i, vl);
-        va = __riscv_vfmacc_vf_f32m8(va, bf, vb, vl);
-        __riscv_vse32_v_f32m8(c + i, va, vl);
-        i += vl;
-    }
+    fvec_madd<SIMDLevel::NONE>(n, a, bf, b, c);
 }
 
 template <>
@@ -333,9 +385,7 @@ int fvec_madd_and_argmin<SIMDLevel::RISCV_RVV>(
         float bf,
         const float* b,
         float* c) {
-    fvec_madd<SIMDLevel::RISCV_RVV>(n, a, bf, b, c);
-    const size_t j = rvv_argmin(c, n);
-    return j < n ? static_cast<int>(j) : -1;
+    return fvec_madd_and_argmin<SIMDLevel::NONE>(n, a, bf, b, c);
 }
 
 #define DEFINE_VECTOR_DISTANCE_RVV_FALLBACK(metric)                 \


### PR DESCRIPTION

Add a RISC-V Vector Extension implementation for the product-quantizer
distance-table computation, wire it into the SIMD dispatch path, and
rework the SDC scan loop for better code generation on RVV targets. The
kernels are runtime vector-length aware (vsetvl-driven, e32m1) rather than
assuming a fixed vector width.

Changes
- compute_PQ_dis_tables_dsub2<RISCV_RVV> (utils/distances_rvv.cpp): RVV
  kernel for both inner-product and L2 dsub=2 distance tables. Centroids are
  first split into even/odd dimension planes (c0_all / c1_all) so each
  subquantizer's ksub entries load as contiguous vectors; the hot loop
  processes two subquantizers per iteration:
      IP:  r = c0*x0 + c1*x1         (vfmul + vfmacc)
      L2:  r = (c0-x0)^2 + (c1-x1)^2 (vfsub + vfmul + vfadd)
- Add RVV specializations for the accompanying distance primitives:
  fvec_norm_L2sqr, fvec_L2sqr_ny, fvec_L2sqr_ny_transposed and
  fvec_inner_products_ny are vectorized (strided vlse32 over ny); the
  remaining fvec_* and VectorDistance specializations fall back to
  SIMDLevel::NONE.
- compute_distance_tables / compute_inner_prod_tables: route dsub == 2 &&
  nbits < 8 through compute_PQ_dis_tables_dsub2 when COMPILE_SIMD_RISCV_RVV
  is defined, matching the AVX2 / ARM_NEON fast path.
- compute_PQ_dis_tables_dsub2_dispatch: extend the dispatch mask to include
  RISCV_RVV.
- search_sdc: simplify the per-database-vector distance accumulation, dropping
  the per-thread q_row pointer precompute in favor of direct sdc_table
  indexing (tab[bcode[m] + qcode[m]*ksub]), and collapse the omp parallel /
  omp for split into a single omp parallel for.

### Performance (sg2044)
Cmd: 1M 768 <PQ> 32 100 16 1 1000 1 <metric>  (search ns/query, lower is better)

| #  | CONFIG   | M   | NPROBE | METRIC | F1(ns)  | PQ1(ns) | F2(ns)  | PQ2(ns) | Δ_PQ%   | Δ_F%   |
|----|----------|-----|--------|--------|---------|---------|---------|---------|---------|--------|
| 01 | PQ8x4    | 4   | 8      | L2     | 6656870 | 536988  | 6582134 | 495970  | -7.64%  | -1.12% |
| 02 | PQ8x4    | 4   | 8      | IP     | 6228497 | 475320  | 6164081 | 481118  | +1.22%  | -1.03% |
| 03 | PQ8x8    | 8   | 8      | L2     | 6626171 | 545230  | 6580586 | 500343  | -8.23%  | -0.69% |
| 04 | PQ8x8    | 8   | 8      | IP     | 6228452 | 519710  | 6165707 | 479864  | -7.67%  | -1.01% |
| 05 | PQ8x16   | 16  | 8      | L2     | 6615305 | 697070  | 6582239 | 624059  | -10.47% | -0.50% |
| 06 | PQ8x16   | 16  | 8      | IP     | 6227067 | 642949  | 6164572 | 587271  | -8.66%  | -1.00% |
| 07 | PQ8x32   | 32  | 8      | L2     | 6624323 | 1185655 | 6581329 | 902298  | -23.90% | -0.65% |
| 08 | PQ8x32   | 32  | 8      | IP     | 6239930 | 1155545 | 6164198 | 785403  | -32.03% | -1.21% |
| 09 | PQ8x64   | 64  | 8      | L2     | 6624196 | 2006275 | 6578815 | 1687191 | -15.90% | -0.69% |
| 10 | PQ8x64   | 64  | 8      | IP     | 6225719 | 1800678 | 6164767 | 1512760 | -15.99% | -0.98% |
| 11 | PQ8x96   | 96  | 8      | L2     | 6617525 | 3108377 | 6582946 | 2701758 | -13.08% | -0.52% |
| 12 | PQ8x96   | 96  | 8      | IP     | 6239711 | 2657958 | 6170006 | 2320803 | -12.68% | -1.12% |
| 13 | PQ8x384  | 384 | 8      | L2     | 6620602 | 14029275| 6583820 | 12318712| -12.19% | -0.56% |
| 14 | PQ8x384  | 384 | 8      | IP     | 6228776 | 12089134| 6166143 | 10509785| -13.06% | -1.01% |
| 15 | PQ8x32   | 32  | 4      | L2     | 3321625 | 773663  | 3298874 | 491225  | -36.51% | -0.68% |
| 16 | PQ8x32   | 32  | 16     | L2     |13223858 | 2184906 |13152640 | 1645444 | -24.69% | -0.54% |
| 17 | PQ8x32   | 32  | 32     | L2     |26430233 | 3405062 |26331426 | 3138563 | -7.83%  | -0.37% |
| 18 | PQ8x64   | 64  | 4      | L2     | 3320850 | 1191054 | 3298426 | 969309  | -18.62% | -0.68% |
| 19 | PQ8x64   | 64  | 16     | L2     |13207340 | 3944868 |13149902 | 3252654 | -17.55% | -0.43% |
| 20 | PQ8x64   | 64  | 32     | L2     |26467696 | 6725098 |26335327 | 6667493 | -0.86%  | -0.50% |
| 21 | PQ8x16   | 16  | 4      | L2     | 3316496 | 427653  | 3304051 | 367407  | -14.09% | -0.38% |
| 22 | PQ8x16   | 16  | 16     | L2     |13203491 | 1198002 |13150061 | 1121421 | -6.39%  | -0.40% |
| 23 | PQ8x16   | 16  | 32     | L2     |26438401 | 2199527 |26280149 | 2143973 | -2.53%  | -0.60% |

Δ_PQ%: PQ baseline -> RVV; Δ_F%: Flat baseline -> RVV.
