### PR TITLE
ci: verify pip wheels install through uv

### DIFF
--- a/.github/workflows/build-pip.yml
+++ b/.github/workflows/build-pip.yml
@@ -52,6 +52,25 @@ jobs:
         env:
           CIBW_BUILD_VERBOSITY: 1
 
+      # Verify the freshly-built wheels install through `uv`, the resolution
+      # path users hit in issue #4510 ("faiss can only be installed by conda").
+      # cibuildwheel already runs the smoke tests via pip inside its test
+      # containers; this step additionally guarantees the wheels are resolvable
+      # and importable when installed with `uv pip install` from the wheelhouse.
+      # The smoke tests are dependency-light, so we do not need scipy here.
+      - name: Verify uv install
+        shell: bash
+        run: |
+          python -m pip install --quiet uv
+          uv venv --python 3.12 .uv-smoke
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            UV_PY=.uv-smoke/Scripts/python.exe
+          else
+            UV_PY=.uv-smoke/bin/python
+          fi
+          uv pip install --python "$UV_PY" numpy pytest wheelhouse/
+          "$UV_PY" -m pytest tests/test_wheel_smoke.py -v
+
       - name: Upload wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:


### PR DESCRIPTION
Closes #4510

## What
Add a **"Verify uv install"** step to the CPU wheel build workflow (`.github/workflows/build-pip.yml`) so every freshly-built wheel is validated with `uv pip install` before it is uploaded/published.

## Why
Issue #4510 reports that faiss was effectively "conda-only" and could not be installed with `uv` (`uv pip install faiss-gpu` failed to resolve). The current release line publishes abi3 wheels on PyPI, but nothing in CI ever verifies the wheels actually install through `uv` — cibuildwheel only tests them with `pip` inside its build containers. This step closes that gap and prevents regressions.

## How
In `build-wheels`, after `cibuildwheel` produces `wheelhouse/`:
1. Install `uv`
2. Create a clean Python 3.12 venv with `uv venv`
3. `uv pip install` numpy + pytest + the built wheel(s) from `wheelhouse/`
4. Run `tests/test_wheel_smoke.py` against the uv-installed package

The step uses `shell: bash` so it works uniformly across the Linux/macOS/Windows/ARM matrix; on Windows it points `uv` at the `Scripts/` layout, on POSIX at `bin/`.

## Verification
- YAML parses cleanly (workflow has the new step between build and upload).
- Smoke tests are dependency-light (no scipy), matching the existing musllinux/win-arm64 handling, so they run in the fresh uv venv without extra requirements.

This is a CI-only change; no runtime code is touched.
