### PR TITLE
RaBitQ: add dense multi-bit SIMD scoring

### DIFF
--- a/benchs/bench_rabitq_simd.cpp
+++ b/benchs/bench_rabitq_simd.cpp
@@ -9,8 +9,21 @@
 #include <faiss/utils/AlignedTable.h>
 #include <faiss/utils/rabitq_simd.h>
 #include <faiss/utils/random.h>
+#include <faiss/utils/simd_levels.h>
 
 namespace faiss {
+
+template <SIMDLevel SL>
+bool check_simd_available(benchmark::State& state) {
+    if constexpr (SL != SIMDLevel::NONE) {
+        if (!SIMDConfig::is_simd_level_available(SL)) {
+            state.SkipWithError(
+                    "requested SIMD level is unavailable on this CPU");
+            return false;
+        }
+    }
+    return true;
+}
 
 const auto& randomData() {
     static auto data = [] {
@@ -96,6 +109,9 @@ void bench_rabitq_and_dot_product_with_sum_fused(benchmark::State& state) {
 
 template <SIMDLevel SL>
 void bench_rabitq_rearrange_impl(benchmark::State& state) {
+    if (!check_simd_available<SL>(state)) {
+        return;
+    }
     size_t qb = state.range(0);
     size_t d = state.range(1);
     size_t offset = (d + 7) / 8;
@@ -126,8 +142,57 @@ void bench_rabitq_rearrange_avx2(benchmark::State& state) {
 }
 #endif
 
+template <SIMDLevel SL>
+void bench_rabitq_selected_float_sum(benchmark::State& state) {
+    if (!check_simd_available<SL>(state)) {
+        return;
+    }
+    const size_t d = state.range(0);
+    AlignedTable<uint8_t> sign_bits((d + 7) / 8);
+    AlignedTable<float> values(d);
+    byte_rand(sign_bits.data(), sign_bits.size(), 721);
+    float_rand(values.data(), values.size(), 812);
+
+    for (auto _ : state) {
+        float result = rabitq::selected_float_sum<SL>(
+                sign_bits.data(), values.data(), d);
+        benchmark::DoNotOptimize(result);
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+
+template <SIMDLevel SL>
+void bench_rabitq_multibit_inner_product(benchmark::State& state) {
+    if (!check_simd_available<SL>(state)) {
+        return;
+    }
+    const size_t ex_bits = state.range(0);
+    const size_t d = state.range(1);
+    AlignedTable<uint8_t> sign_bits((d + 7) / 8);
+    // Padding keeps the benchmark input valid for kernels that load a complete
+    // machine word at the end of a bit-packed code.
+    AlignedTable<uint8_t> extra_code((d * ex_bits + 7) / 8 + 8);
+    AlignedTable<float> query(d);
+    byte_rand(sign_bits.data(), sign_bits.size(), 913);
+    byte_rand(extra_code.data(), extra_code.size(), 114);
+    float_rand(query.data(), query.size(), 315);
+
+    for (auto _ : state) {
+        float result = rabitq::multibit::compute_inner_product<SL>(
+                sign_bits.data(),
+                extra_code.data(),
+                query.data(),
+                d,
+                ex_bits,
+                -3.25f);
+        benchmark::DoNotOptimize(result);
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+
 const std::vector<int64_t> qbs{1, 2, 4, 8};
 const std::vector<int64_t> dims{64, 100, 256, 512, 1000, 1024, 3072};
+const std::vector<int64_t> scorer_dims{128, 768, 1537};
 
 BENCHMARK(bench_rabitq_sum)->ArgsProduct({{0}, dims})->ArgNames({"qb", "d"});
 BENCHMARK(bench_rabitq_and_dot_product)
@@ -149,7 +214,27 @@ BENCHMARK(bench_rabitq_rearrange_scalar)
 BENCHMARK(bench_rabitq_rearrange_avx2)
         ->ArgsProduct({qbs, dims})
         ->ArgNames({"qb", "d"});
+
+BENCHMARK_TEMPLATE(bench_rabitq_selected_float_sum, SIMDLevel::NONE)
+        ->ArgsProduct({scorer_dims})
+        ->ArgNames({"d"});
+BENCHMARK_TEMPLATE(bench_rabitq_selected_float_sum, SIMDLevel::AVX2)
+        ->ArgsProduct({scorer_dims})
+        ->ArgNames({"d"});
+BENCHMARK_TEMPLATE(bench_rabitq_selected_float_sum, SIMDLevel::AVX512)
+        ->ArgsProduct({scorer_dims})
+        ->ArgNames({"d"});
+BENCHMARK_TEMPLATE(bench_rabitq_multibit_inner_product, SIMDLevel::NONE)
+        ->ArgsProduct({{1, 3, 7}, scorer_dims})
+        ->ArgNames({"extra_bits", "d"});
+BENCHMARK_TEMPLATE(bench_rabitq_multibit_inner_product, SIMDLevel::AVX2)
+        ->ArgsProduct({{1, 3, 7}, scorer_dims})
+        ->ArgNames({"extra_bits", "d"});
+BENCHMARK_TEMPLATE(bench_rabitq_multibit_inner_product, SIMDLevel::AVX512)
+        ->ArgsProduct({{1, 3, 7}, scorer_dims})
+        ->ArgNames({"extra_bits", "d"});
 #endif
-BENCHMARK_MAIN();
 
 } // namespace faiss
+
+BENCHMARK_MAIN();

--- a/faiss/IndexRaBitQ.cpp
+++ b/faiss/IndexRaBitQ.cpp
@@ -21,10 +21,22 @@ using rabitq_utils::SignBitFactorsWithError;
 
 IndexRaBitQ::IndexRaBitQ() = default;
 
-IndexRaBitQ::IndexRaBitQ(idx_t d_in, MetricType metric, uint8_t nb_bits_in)
-        : IndexFlatCodes(0, d_in, metric), rabitq(d_in, metric, nb_bits_in) {
+IndexRaBitQ::IndexRaBitQ(
+        idx_t d_in,
+        MetricType metric,
+        uint8_t nb_bits_in,
+        bool dense_layout)
+        : IndexFlatCodes(0, d_in, metric),
+          rabitq(d_in, metric, nb_bits_in, dense_layout) {
     // Update code size based on nb_bits
     code_size = rabitq.code_size;
+
+    // Dense codes currently use the FP32-query distance computer. Keep the
+    // constructor valid on its own instead of requiring every caller to
+    // override the legacy qb=4 default before the first search.
+    if (dense_layout) {
+        qb = 0;
+    }
 
     is_trained = false;
 }
@@ -137,7 +149,10 @@ struct Run_search_with_dc_res {
                             float est_distance =
                                     dc->distance_to_code_1bit(code);
 
-                            size_t code_size_base = (index->d + 7) / 8;
+                            const size_t code_size_base =
+                                    index->rabitq.dense_layout
+                                    ? (index->d * index->rabitq.nb_bits + 7) / 8
+                                    : (index->d + 7) / 8;
                             const rabitq_utils::SignBitFactorsWithError*
                                     base_fac = reinterpret_cast<
                                             const rabitq_utils::

--- a/faiss/IndexRaBitQ.h
+++ b/faiss/IndexRaBitQ.h
@@ -37,7 +37,8 @@ struct IndexRaBitQ : IndexFlatCodes {
     explicit IndexRaBitQ(
             idx_t d,
             MetricType metric = METRIC_L2,
-            uint8_t nb_bits = 1);
+            uint8_t nb_bits = 1,
+            bool dense_layout = false);
 
     void train(idx_t n, const float* x) override;
 

--- a/faiss/IndexRaBitQFastScan.cpp
+++ b/faiss/IndexRaBitQFastScan.cpp
@@ -111,6 +111,9 @@ IndexRaBitQFastScan::IndexRaBitQFastScan(const IndexRaBitQ& orig, int bbs_in)
             orig.metric_type == METRIC_L2 ||
                     orig.metric_type == METRIC_INNER_PRODUCT,
             "RaBitQ FastScan only supports L2 and Inner Product metrics");
+    FAISS_THROW_IF_NOT_MSG(
+            !orig.rabitq.dense_layout,
+            "RaBitQ FastScan conversion does not support dense codes");
 
     // RaBitQ uses 1 bit per dimension packed into 4-bit FastScan sub-quantizers
     // Each FastScan sub-quantizer handles 4 RaBitQ dimensions

--- a/faiss/impl/RaBitQuantizer.cpp
+++ b/faiss/impl/RaBitQuantizer.cpp
@@ -33,12 +33,15 @@ using rabitq_utils::SignBitFactorsWithError;
 RaBitQuantizer::RaBitQuantizer(
         size_t d_in,
         MetricType metric,
-        size_t nb_bits_in)
+        size_t nb_bits_in,
+        bool dense_layout_in)
         : Quantizer(d_in, 0), // code_size will be set below
           metric_type{metric},
-          nb_bits{nb_bits_in} {
+          nb_bits{nb_bits_in},
+          dense_layout{dense_layout_in} {
     // Validate nb_bits range
     FAISS_THROW_IF_NOT(nb_bits >= 1 && nb_bits <= 9);
+    FAISS_THROW_IF_NOT(!dense_layout || nb_bits > 1);
 
     // Set code_size using compute_code_size
     code_size = compute_code_size(d, nb_bits);
@@ -49,6 +52,12 @@ size_t RaBitQuantizer::compute_code_size(size_t d_in, size_t num_bits) const {
     FAISS_THROW_IF_NOT(num_bits >= 1 && num_bits <= 9);
 
     size_t ex_bits = num_bits - 1;
+
+    if (dense_layout) {
+        FAISS_THROW_IF_NOT(num_bits > 1);
+        return (d_in * num_bits + 7) / 8 + sizeof(SignBitFactorsWithError) +
+                sizeof(ExtraBitsFactors);
+    }
 
     // Base: 1-bit codes + base factors
     // Layout for 1-bit: [binary_code: (d+7)/8 bytes][SignBitFactors: 8 bytes]
@@ -113,6 +122,8 @@ void RaBitQuantizer::compute_codes_core(
         // 12 bytes]
         //                [ex_code: (d*ex_bits+7)/8 bytes][ex_factors: 8 bytes]
         uint8_t* binary_code = code;
+        const size_t base_code_size =
+                dense_layout ? (d * nb_bits + 7) / 8 : (d + 7) / 8;
 
         // Step 1: Compute 1-bit quantization and base factors
         // Store residual for potential ex-bits quantization
@@ -134,7 +145,7 @@ void RaBitQuantizer::compute_codes_core(
             // For multi-bit: write full SignBitFactorsWithError (12 bytes)
             SignBitFactorsWithError* full_factors =
                     reinterpret_cast<SignBitFactorsWithError*>(
-                            code + (d + 7) / 8);
+                            code + base_code_size);
             *full_factors = factors_data;
         }
 
@@ -149,7 +160,7 @@ void RaBitQuantizer::compute_codes_core(
             const bool xb = (or_minus_c > 0.0f);
 
             // Store the 1-bit sign code
-            if (xb) {
+            if (xb && !dense_layout) {
                 rabitq_utils::set_bit_standard(binary_code, j);
             }
         }
@@ -158,10 +169,18 @@ void RaBitQuantizer::compute_codes_core(
         if (ex_bits > 0) {
             // Pointer to ex-bit code section
             uint8_t* ex_code =
-                    code + (d + 7) / 8 + sizeof(SignBitFactorsWithError);
+                    code + base_code_size + sizeof(SignBitFactorsWithError);
+            std::vector<uint8_t> packed_ex_code;
+            if (dense_layout) {
+                packed_ex_code.resize((d * ex_bits + 7) / 8);
+                ex_code = packed_ex_code.data();
+            }
             // Pointer to ex-factors section
-            ExtraBitsFactors* ex_factors = reinterpret_cast<ExtraBitsFactors*>(
-                    ex_code + (d * ex_bits + 7) / 8);
+            ExtraBitsFactors byte_ex_factors;
+            ExtraBitsFactors* ex_factors = dense_layout
+                    ? &byte_ex_factors
+                    : reinterpret_cast<ExtraBitsFactors*>(
+                              ex_code + (d * ex_bits + 7) / 8);
 
             // Quantize residual to ex-bits (pass centroid for IP metric)
             rabitq_multibit::quantize_ex_bits(
@@ -172,6 +191,32 @@ void RaBitQuantizer::compute_codes_core(
                     *ex_factors,
                     metric_type,
                     centroid_in);
+
+            if (dense_layout) {
+                for (size_t j = 0; j < d; j++) {
+                    const uint16_t sign = residual[j] > 0.0f
+                            ? static_cast<uint16_t>(1u << ex_bits)
+                            : 0;
+                    const uint16_t value =
+                            sign |
+                            static_cast<uint16_t>(
+                                    rabitq_utils::extract_code_inline(
+                                            ex_code, j, ex_bits));
+                    const size_t bit_pos = j * nb_bits;
+                    const size_t byte_pos = bit_pos / 8;
+                    const size_t shift = bit_pos % 8;
+                    const uint32_t shifted = static_cast<uint32_t>(value)
+                            << shift;
+                    const size_t nbytes = (shift + nb_bits + 7) / 8;
+                    for (size_t b = 0; b < nbytes; b++) {
+                        binary_code[byte_pos + b] |=
+                                static_cast<uint8_t>(shifted >> (8 * b));
+                    }
+                }
+                memcpy(code + base_code_size + sizeof(SignBitFactorsWithError),
+                       ex_factors,
+                       sizeof(ExtraBitsFactors));
+            }
         }
     }
 }
@@ -204,10 +249,12 @@ void RaBitQuantizer::decode_core(
         // For 1-bit: use SignBitFactors (8 bytes)
         // For multi-bit: use SignBitFactorsWithError (12 bytes, but only first
         // 8 bytes used for decode)
+        const size_t base_code_size =
+                dense_layout ? (d * nb_bits + 7) / 8 : (d + 7) / 8;
         const SignBitFactors* fac = (ex_bits == 0)
                 ? reinterpret_cast<const SignBitFactors*>(code + (d + 7) / 8)
                 : reinterpret_cast<const SignBitFactorsWithError*>(
-                          code + (d + 7) / 8);
+                          code + base_code_size);
 
         // this is the baseline code
         //
@@ -215,7 +262,13 @@ void RaBitQuantizer::decode_core(
         for (size_t j = 0; j < d; j++) {
             // extract i-th bit
             const uint8_t masker = (1 << (j % 8));
-            const float bit = ((binary_data[j / 8] & masker) == masker) ? 1 : 0;
+            const float bit = dense_layout
+                    ? ((rabitq_utils::extract_code_inline(
+                                binary_data, j, nb_bits) &
+                        (1u << ex_bits)) != 0
+                               ? 1.0f
+                               : 0.0f)
+                    : (((binary_data[j / 8] & masker) == masker) ? 1.0f : 0.0f);
 
             // compute the output code
             x[i * d + j] = (bit - 0.5f) * fac->dp_multiplier * 2 * inv_d_sqrt +
@@ -225,6 +278,55 @@ void RaBitQuantizer::decode_core(
 }
 
 namespace {
+
+template <SIMDLevel SL>
+void distance_to_code_full_batch_4_impl(
+        const uint8_t* const codes[4],
+        size_t d,
+        size_t nb_bits,
+        const float* rotated_q,
+        float qr_base,
+        MetricType metric_type,
+        bool dense_layout,
+        float out[4]) {
+    const size_t ex_bits = nb_bits - 1;
+    if (ex_bits == 0) {
+        FAISS_THROW_MSG("multi-bit batch helper requires extra bits");
+    }
+
+    const size_t code_size_base =
+            dense_layout ? (d * nb_bits + 7) / 8 : (d + 7) / 8;
+    const size_t ex_offset = code_size_base + sizeof(SignBitFactorsWithError);
+    const size_t ex_code_size = (d * ex_bits + 7) / 8;
+    const uint8_t* sign_bits[4];
+    const uint8_t* ex_codes[4];
+    const ExtraBitsFactors* ex_factors[4];
+    for (size_t i = 0; i < 4; i++) {
+        sign_bits[i] = codes[i];
+        ex_codes[i] = dense_layout ? codes[i] : codes[i] + ex_offset;
+        ex_factors[i] = reinterpret_cast<const ExtraBitsFactors*>(
+                dense_layout ? codes[i] + code_size_base +
+                                sizeof(SignBitFactorsWithError)
+                             : ex_codes[i] + ex_code_size);
+    }
+
+    const float cb = -(static_cast<float>(1 << ex_bits) - 0.5f);
+    float inner_products[4];
+    if (dense_layout) {
+        rabitq::multibit::compute_inner_product_dense_batch_4<SL>(
+                ex_codes, rotated_q, d, nb_bits, cb, inner_products);
+    } else {
+        rabitq::multibit::compute_inner_product_batch_4<SL>(
+                sign_bits, ex_codes, rotated_q, d, ex_bits, cb, inner_products);
+    }
+
+    for (size_t i = 0; i < 4; i++) {
+        float distance = qr_base + ex_factors[i]->f_add_ex +
+                ex_factors[i]->f_rescale_ex * inner_products[i];
+        out[i] = metric_type == MetricType::METRIC_L2 ? std::max(0.0f, distance)
+                                                      : distance;
+    }
+}
 
 // Distance computers templatized on SIMDLevel to avoid per-call dynamic
 // dispatch. The SIMDLevel is baked in at construction time via
@@ -237,6 +339,7 @@ struct RaBitQDistanceComputerNotQ final : RaBitQDistanceComputer {
     std::vector<float> rotated_q;
     // some additional numbers for the query
     QueryFactorsData query_fac;
+    bool dense_layout = false;
 
     RaBitQDistanceComputerNotQ() = default;
 
@@ -247,24 +350,11 @@ struct RaBitQDistanceComputerNotQ final : RaBitQDistanceComputer {
         // this is the baseline code
         //
         // compute <q,o> using floats
-        float dot_qo = 0;
-        // It was a willful decision (after the discussion) to not to pre-cache
-        //   the sum of all bits, just in order to reduce the overhead per
-        //   vector.
-        uint64_t sum_q = 0;
-
-        for (size_t i = 0; i < d; i++) {
-            // Extract i-th bit
-            bool bit = rabitq_utils::extract_bit_standard(binary_data, i);
-            // accumulate dp
-            dot_qo += bit ? rotated_q[i] : 0;
-            // accumulate sum-of-bits
-            sum_q += bit ? 1 : 0;
-        }
+        const float dot_qo = rabitq::selected_float_sum<SL>(
+                binary_data, rotated_q.data(), d);
 
         // Apply query factors
-        float final_dot =
-                query_fac.c1 * dot_qo + query_fac.c2 * sum_q - query_fac.c34;
+        float final_dot = query_fac.c1 * dot_qo - query_fac.c34;
 
         // pre_dist = ||or - c||^2 + ||qr - c||^2 -
         //     2 * ||or - c|| * ||qr - c|| * <q,o> - (IP ? ||or||^2 : 0)
@@ -288,13 +378,31 @@ struct RaBitQDistanceComputerNotQ final : RaBitQDistanceComputer {
                  metric_type == MetricType::METRIC_INNER_PRODUCT));
         FAISS_ASSERT(rotated_q.size() == d);
 
-        const size_t code_size_base = (d + 7) / 8;
+        const size_t code_size_base =
+                dense_layout ? (d * nb_bits + 7) / 8 : (d + 7) / 8;
         const size_t ex_bits = nb_bits - 1;
         const SignBitFactors* base_fac = (ex_bits == 0)
                 ? reinterpret_cast<const SignBitFactors*>(code + code_size_base)
                 : reinterpret_cast<const SignBitFactorsWithError*>(
                           code + code_size_base);
-        return distance_to_code_1bit_impl(code, base_fac);
+        if (!dense_layout) {
+            return distance_to_code_1bit_impl(code, base_fac);
+        }
+
+        float dot_qo = 0.0f;
+        for (size_t i = 0; i < d; i++) {
+            if ((rabitq_utils::extract_code_inline(code, i, nb_bits) &
+                 (1u << (nb_bits - 1))) != 0) {
+                dot_qo += rotated_q[i];
+            }
+        }
+        const float final_dot = query_fac.c1 * dot_qo - query_fac.c34;
+        const float pre_dist = base_fac->or_minus_c_l2sqr +
+                query_fac.qr_to_c_L2sqr -
+                2 * base_fac->dp_multiplier * final_dot;
+        return metric_type == MetricType::METRIC_L2
+                ? std::max(0.0f, pre_dist)
+                : -0.5f * (pre_dist - query_fac.qr_norm_L2sqr);
     }
 
     // Compute full distance using 1-bit + ex-bits (accurate)
@@ -314,15 +422,30 @@ struct RaBitQDistanceComputerNotQ final : RaBitQDistanceComputer {
 
         // Extract pointers to code sections
         const uint8_t* binary_data = code;
-        size_t offset = (d + 7) / 8 + sizeof(SignBitFactorsWithError);
-        const uint8_t* ex_code = code + offset;
+        const size_t dense_code_size = (d * nb_bits + 7) / 8;
+        size_t offset = (dense_layout ? dense_code_size : (d + 7) / 8) +
+                sizeof(SignBitFactorsWithError);
+        const uint8_t* ex_code = dense_layout ? code : code + offset;
         const ExtraBitsFactors* ex_fac =
                 reinterpret_cast<const ExtraBitsFactors*>(
-                        ex_code + (d * ex_bits + 7) / 8);
+                        dense_layout ? code + dense_code_size +
+                                        sizeof(SignBitFactorsWithError)
+                                     : ex_code + (d * ex_bits + 7) / 8);
 
         float qr_base = (metric_type == MetricType::METRIC_INNER_PRODUCT)
                 ? query_fac.q_dot_c
                 : query_fac.qr_to_c_L2sqr;
+        if (dense_layout) {
+            const float cb = -(static_cast<float>(1 << ex_bits) - 0.5f);
+            const float ex_ip =
+                    rabitq::multibit::compute_inner_product_dense<SL>(
+                            ex_code, rotated_q.data(), d, nb_bits, cb);
+            const float distance =
+                    qr_base + ex_fac->f_add_ex + ex_fac->f_rescale_ex * ex_ip;
+            return metric_type == MetricType::METRIC_L2
+                    ? std::max(0.0f, distance)
+                    : distance;
+        }
         return rabitq_utils::compute_full_multibit_distance<SL>(
                 binary_data,
                 ex_code,
@@ -332,6 +455,42 @@ struct RaBitQDistanceComputerNotQ final : RaBitQDistanceComputer {
                 d,
                 ex_bits,
                 metric_type);
+    }
+
+    void distance_to_code_batch_4(
+            const uint8_t* code0,
+            const uint8_t* code1,
+            const uint8_t* code2,
+            const uint8_t* code3,
+            float& dis0,
+            float& dis1,
+            float& dis2,
+            float& dis3) final {
+        if (nb_bits == 1) {
+            dis0 = distance_to_code_full(code0);
+            dis1 = distance_to_code_full(code1);
+            dis2 = distance_to_code_full(code2);
+            dis3 = distance_to_code_full(code3);
+            return;
+        }
+        const uint8_t* codes[4] = {code0, code1, code2, code3};
+        float distances[4];
+        const float qr_base = metric_type == MetricType::METRIC_INNER_PRODUCT
+                ? query_fac.q_dot_c
+                : query_fac.qr_to_c_L2sqr;
+        distance_to_code_full_batch_4_impl<SL>(
+                codes,
+                d,
+                nb_bits,
+                rotated_q.data(),
+                qr_base,
+                metric_type,
+                dense_layout,
+                distances);
+        dis0 = distances[0];
+        dis1 = distances[1];
+        dis2 = distances[2];
+        dis3 = distances[3];
     }
 
     void set_query(const float* x) final {
@@ -386,7 +545,8 @@ struct RaBitQDistanceComputerNotQ final : RaBitQDistanceComputer {
             const IDSelector* sel,
             bool keep_max,
             ResultHandler& handler) final {
-        const size_t code_size_base = (d + 7) / 8;
+        const size_t code_size_base =
+                dense_layout ? (d * nb_bits + 7) / 8 : (d + 7) / 8;
         const size_t ex_bits = nb_bits - 1;
         FAISS_ASSERT(ex_bits > 0);
 
@@ -409,8 +569,7 @@ struct RaBitQDistanceComputerNotQ final : RaBitQDistanceComputer {
             const auto* base_fac =
                     reinterpret_cast<const SignBitFactorsWithError*>(
                             codes + code_size_base);
-            const float est_distance =
-                    distance_to_code_1bit_impl(codes, base_fac);
+            const float est_distance = distance_to_code_1bit(codes);
 
             const bool should_refine = rabitq_utils::should_refine_candidate(
                     est_distance,
@@ -553,6 +712,42 @@ struct RaBitQDistanceComputerQ final : RaBitQDistanceComputer {
                 metric_type);
     }
 
+    void distance_to_code_batch_4(
+            const uint8_t* code0,
+            const uint8_t* code1,
+            const uint8_t* code2,
+            const uint8_t* code3,
+            float& dis0,
+            float& dis1,
+            float& dis2,
+            float& dis3) final {
+        if (nb_bits == 1) {
+            dis0 = distance_to_code_full(code0);
+            dis1 = distance_to_code_full(code1);
+            dis2 = distance_to_code_full(code2);
+            dis3 = distance_to_code_full(code3);
+            return;
+        }
+        const uint8_t* codes[4] = {code0, code1, code2, code3};
+        float distances[4];
+        const float qr_base = metric_type == MetricType::METRIC_INNER_PRODUCT
+                ? query_fac.q_dot_c
+                : query_fac.qr_to_c_L2sqr;
+        distance_to_code_full_batch_4_impl<SL>(
+                codes,
+                d,
+                nb_bits,
+                rotated_q.data(),
+                qr_base,
+                metric_type,
+                false,
+                distances);
+        dis0 = distances[0];
+        dis1 = distances[1];
+        dis2 = distances[2];
+        dis3 = distances[3];
+    }
+
     void set_query(const float* x) final {
         q = x;
         FAISS_ASSERT(x != nullptr);
@@ -679,9 +874,13 @@ FlatCodesDistanceComputer* RaBitQuantizer::get_distance_computer(
                     dc->d = d;
                     dc->centroid = centroid_in;
                     dc->nb_bits = nb_bits;
+                    dc->dense_layout = dense_layout;
 
                     return dc.release();
                 } else {
+                    FAISS_THROW_IF_NOT_MSG(
+                            !dense_layout,
+                            "dense-layout RaBitQ currently requires qb=0");
                     auto dc = std::make_unique<RaBitQDistanceComputerQ<SL>>();
                     dc->metric_type = metric_type;
                     dc->d = d;

--- a/faiss/impl/RaBitQuantizer.h
+++ b/faiss/impl/RaBitQuantizer.h
@@ -47,10 +47,16 @@ struct RaBitQuantizer : Quantizer {
     // - nb_bits = 2-9: multi-bit RaBitQ (1 sign bit + ex_bits extra bits)
     size_t nb_bits = 1;
 
+    // Store one complete scalar code per dimension in a dense n-bit stream.
+    // This combines the sign bit and extra bits at build time while retaining
+    // the exact nbits/dimension budget. For nbits=8 this is one byte/dimension.
+    bool dense_layout = false;
+
     RaBitQuantizer(
             size_t d = 0,
             MetricType metric = MetricType::METRIC_L2,
-            size_t nb_bits = 1);
+            size_t nb_bits = 1,
+            bool dense_layout = false);
 
     // Compute code size based on dimensionality and number of bits
     // Returns: size in bytes for one encoded vector

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -1424,7 +1424,8 @@ static void read_RaBitQuantizer(
         RaBitQuantizer& rabitq,
         IOReader* f,
         int expected_d,
-        bool multi_bit = true) {
+        bool multi_bit = true,
+        bool dense_layout = false) {
     READ1(rabitq.d);
     READ1(rabitq.code_size);
     int metric_type_int;
@@ -1436,12 +1437,21 @@ static void read_RaBitQuantizer(
     } else {
         rabitq.nb_bits = 1;
     }
+    rabitq.dense_layout = dense_layout;
 
     FAISS_THROW_IF_NOT_FMT(
             rabitq.d == static_cast<size_t>(expected_d),
             "RaBitQuantizer dimension mismatch: rabitq.d=%zu vs index d=%d",
             rabitq.d,
             expected_d);
+
+    const size_t expected_code_size =
+            rabitq.compute_code_size(rabitq.d, rabitq.nb_bits);
+    FAISS_THROW_IF_NOT_FMT(
+            rabitq.code_size == expected_code_size,
+            "RaBitQuantizer code size mismatch: stored=%zu expected=%zu",
+            rabitq.code_size,
+            expected_code_size);
 }
 
 static void read_EDENScalarQuantizer(
@@ -2861,12 +2871,12 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         // rabitq.nb_bits is already set to 1 by read_RaBitQuantizer
         idxq->code_size = idxq->rabitq.code_size;
         idx = std::move(idxq);
-    } else if (h == fourcc("Ixrr")) {
-        // Ixrr = multi-bit format (new)
+    } else if (h == fourcc("Ixrr") || h == fourcc("Ixrd")) {
+        // Ixrr = split multi-bit format; Ixrd = dense multi-bit format.
         auto idxq = std::make_unique<IndexRaBitQ>();
         read_index_header(*idxq, f);
         read_RaBitQuantizer(
-                idxq->rabitq, f, idxq->d, true); // Reads nb_bits from file
+                idxq->rabitq, f, idxq->d, true, h == fourcc("Ixrd"));
         READVECTOR(idxq->codes);
         READVECTOR(idxq->center);
         READ1(idxq->qb);
@@ -2878,6 +2888,12 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
                 idxq->qb);
 
         idxq->code_size = idxq->rabitq.code_size;
+        FAISS_THROW_IF_NOT_FMT(
+                idxq->codes.size() ==
+                        static_cast<size_t>(idxq->ntotal) * idxq->code_size,
+                "IndexRaBitQ codes size mismatch: stored=%zu expected=%zu",
+                idxq->codes.size(),
+                static_cast<size_t>(idxq->ntotal) * idxq->code_size);
         idx = std::move(idxq);
     } else if (h == fourcc("Iwrq")) {
         auto ivrq = std::make_unique<IndexIVFRaBitQ>();

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -1024,7 +1024,10 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
             write_index_header(idx, f);
             write_RaBitQuantizer(&idxq->rabitq, f, false);
         } else {
-            uint32_t h = fourcc("Ixrr"); // multi-bit (new format)
+            // Dense codes have a different bit layout even though their byte
+            // size is often identical to the split multi-bit representation.
+            uint32_t h =
+                    idxq->rabitq.dense_layout ? fourcc("Ixrd") : fourcc("Ixrr");
             WRITE1(h);
             write_index_header(idx, f);
             write_RaBitQuantizer(&idxq->rabitq, f, true);

--- a/faiss/utils/rabitq_simd.h
+++ b/faiss/utils/rabitq_simd.h
@@ -79,6 +79,13 @@ uint64_t bitwise_xor_dot_product(
 template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
 uint64_t popcount(const uint8_t* data, size_t size);
 
+/** Sum float values selected by one packed sign bit per dimension. */
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
+float selected_float_sum(
+        const uint8_t* sign_bits,
+        const float* values,
+        size_t d);
+
 /**
  * Rearrange per-dimension quantized query codes into bit-plane layout.
  *
@@ -226,6 +233,20 @@ inline uint64_t popcount<SIMDLevel::NONE>(const uint8_t* data, size_t size) {
 }
 
 template <>
+inline float selected_float_sum<SIMDLevel::NONE>(
+        const uint8_t* sign_bits,
+        const float* values,
+        size_t d) {
+    float sum = 0.0f;
+    for (size_t i = 0; i < d; i++) {
+        if ((sign_bits[i / 8] >> (i % 8)) & 1) {
+            sum += values[i];
+        }
+    }
+    return sum;
+}
+
+template <>
 inline void rearrange_bit_planes<SIMDLevel::NONE>(
         const uint8_t* rotated_qq,
         size_t d,
@@ -345,6 +366,143 @@ inline void quantize_query_values<SIMDLevel::NONE>(
  *********************************************************/
 namespace faiss::rabitq::multibit {
 
+inline float ip_byte_scalar(
+        const uint8_t* __restrict code,
+        const float* __restrict query,
+        size_t start,
+        size_t d,
+        float cb) {
+    float result = 0.0f;
+    for (size_t i = start; i < d; i++) {
+        result += query[i] * (static_cast<float>(code[i]) + cb);
+    }
+    return result;
+}
+
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
+float compute_inner_product_byte(
+        const uint8_t* __restrict code,
+        const float* __restrict query,
+        size_t d,
+        float cb);
+
+/** Dot product between an FP32 query and dense packed n-bit scalar codes. */
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
+float compute_inner_product_dense(
+        const uint8_t* __restrict code,
+        const float* __restrict query,
+        size_t d,
+        size_t nbits,
+        float cb);
+
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
+inline void compute_inner_product_byte_batch_4(
+        const uint8_t* const codes[4],
+        const float* __restrict query,
+        size_t d,
+        float cb,
+        float out[4]) {
+    for (size_t i = 0; i < 4; i++) {
+        out[i] = compute_inner_product_byte<SL>(codes[i], query, d, cb);
+    }
+}
+
+template <>
+void compute_inner_product_byte_batch_4<SIMDLevel::AVX2>(
+        const uint8_t* const codes[4],
+        const float* __restrict query,
+        size_t d,
+        float cb,
+        float out[4]);
+
+template <>
+void compute_inner_product_byte_batch_4<SIMDLevel::AVX512>(
+        const uint8_t* const codes[4],
+        const float* __restrict query,
+        size_t d,
+        float cb,
+        float out[4]);
+
+template <>
+void compute_inner_product_byte_batch_4<SIMDLevel::AVX512_SPR>(
+        const uint8_t* const codes[4],
+        const float* __restrict query,
+        size_t d,
+        float cb,
+        float out[4]);
+
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
+inline void compute_inner_product_dense_batch_4(
+        const uint8_t* const codes[4],
+        const float* __restrict query,
+        size_t d,
+        size_t nbits,
+        float cb,
+        float out[4]) {
+    for (size_t i = 0; i < 4; i++) {
+        out[i] = compute_inner_product_dense<SL>(codes[i], query, d, nbits, cb);
+    }
+}
+
+template <>
+void compute_inner_product_dense_batch_4<SIMDLevel::AVX2>(
+        const uint8_t* const codes[4],
+        const float* query,
+        size_t d,
+        size_t nbits,
+        float cb,
+        float out[4]);
+
+template <>
+void compute_inner_product_dense_batch_4<SIMDLevel::AVX512>(
+        const uint8_t* const codes[4],
+        const float* query,
+        size_t d,
+        size_t nbits,
+        float cb,
+        float out[4]);
+
+template <>
+void compute_inner_product_dense_batch_4<SIMDLevel::AVX512_SPR>(
+        const uint8_t* const codes[4],
+        const float* query,
+        size_t d,
+        size_t nbits,
+        float cb,
+        float out[4]);
+
+template <>
+inline float compute_inner_product_byte<SIMDLevel::NONE>(
+        const uint8_t* __restrict code,
+        const float* __restrict query,
+        size_t d,
+        float cb) {
+    return ip_byte_scalar(code, query, 0, d, cb);
+}
+
+template <>
+inline float compute_inner_product_dense<SIMDLevel::NONE>(
+        const uint8_t* __restrict code,
+        const float* __restrict query,
+        size_t d,
+        size_t nbits,
+        float cb) {
+    float result = 0.0f;
+    const uint64_t mask = (uint64_t{1} << nbits) - 1;
+    for (size_t i = 0; i < d; i++) {
+        const size_t bit_pos = i * nbits;
+        const size_t byte_pos = bit_pos / 8;
+        const size_t shift = bit_pos % 8;
+        uint32_t window = code[byte_pos];
+        if (shift + nbits > 8) {
+            window |= uint32_t(code[byte_pos + 1]) << 8;
+        }
+        result +=
+                query[i] * (static_cast<float>((window >> shift) & mask) + cb);
+    }
+    return result;
+}
+
 /// Scalar inner product for multi-bit RaBitQ.
 /// Extracts each code value in O(1) via 64-bit window read + shift + mask.
 /// Also serves as the tail handler for SIMD kernels via the @p start parameter.
@@ -392,6 +550,57 @@ float compute_inner_product(
         size_t d,
         size_t ex_bits,
         float cb);
+
+/** Compute four independent multi-bit inner products against one query.
+ *
+ * HNSW evaluates graph neighbors in groups of four. Keeping the four
+ * accumulators in one dimension loop amortizes query loads and exposes ILP
+ * without requiring the database codes to be contiguous.
+ */
+template <SIMDLevel SL = SINGLE_SIMD_LEVEL>
+inline void compute_inner_product_batch_4(
+        const uint8_t* const sign_bits[4],
+        const uint8_t* const ex_codes[4],
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb,
+        float out[4]) {
+    for (size_t i = 0; i < 4; i++) {
+        out[i] = compute_inner_product<SL>(
+                sign_bits[i], ex_codes[i], rotated_q, d, ex_bits, cb);
+    }
+}
+
+template <>
+void compute_inner_product_batch_4<SIMDLevel::AVX2>(
+        const uint8_t* const sign_bits[4],
+        const uint8_t* const ex_codes[4],
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb,
+        float out[4]);
+
+template <>
+void compute_inner_product_batch_4<SIMDLevel::AVX512>(
+        const uint8_t* const sign_bits[4],
+        const uint8_t* const ex_codes[4],
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb,
+        float out[4]);
+
+template <>
+void compute_inner_product_batch_4<SIMDLevel::AVX512_SPR>(
+        const uint8_t* const sign_bits[4],
+        const uint8_t* const ex_codes[4],
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb,
+        float out[4]);
 
 // NONE specialization — pure scalar
 template <>

--- a/faiss/utils/simd_impl/rabitq_avx2.cpp
+++ b/faiss/utils/simd_impl/rabitq_avx2.cpp
@@ -438,6 +438,32 @@ uint64_t popcount<SIMDLevel::AVX2>(const uint8_t* data, size_t size) {
 }
 
 template <>
+float selected_float_sum<SIMDLevel::AVX2>(
+        const uint8_t* sign_bits,
+        const float* values,
+        size_t d) {
+    const __m256i bit_positions =
+            _mm256_setr_epi32(1, 2, 4, 8, 16, 32, 64, 128);
+    __m256 sum = _mm256_setzero_ps();
+    size_t i = 0;
+    for (; i + 8 <= d; i += 8) {
+        const __m256i packed = _mm256_set1_epi32(sign_bits[i / 8]);
+        const __m256i selected = _mm256_cmpeq_epi32(
+                _mm256_and_si256(packed, bit_positions), bit_positions);
+        const __m256 values_i = _mm256_loadu_ps(values + i);
+        sum = _mm256_add_ps(
+                sum, _mm256_and_ps(values_i, _mm256_castsi256_ps(selected)));
+    }
+    alignas(32) float lanes[8];
+    _mm256_store_ps(lanes, sum);
+    float result = lanes[0] + lanes[1] + lanes[2] + lanes[3] + lanes[4] +
+            lanes[5] + lanes[6] + lanes[7];
+    result += selected_float_sum<SIMDLevel::NONE>(
+            sign_bits + i / 8, values + i, d - i);
+    return result;
+}
+
+template <>
 void rearrange_bit_planes<SIMDLevel::AVX2>(
         const uint8_t* rotated_qq,
         size_t d,
@@ -470,6 +496,211 @@ void rearrange_bit_planes<SIMDLevel::AVX2>(
 namespace faiss::rabitq::multibit {
 
 namespace {
+
+template <size_t NBITS>
+inline __m256 dense_decode_8_avx2(const uint8_t* code) {
+    static_assert(NBITS >= 2 && NBITS <= 8);
+    uint64_t packed = 0;
+    memcpy(&packed, code, NBITS);
+    constexpr uint64_t mask = (uint64_t{1} << NBITS) - 1;
+    const __m256i values = _mm256_setr_epi32(
+            (packed >> (0 * NBITS)) & mask,
+            (packed >> (1 * NBITS)) & mask,
+            (packed >> (2 * NBITS)) & mask,
+            (packed >> (3 * NBITS)) & mask,
+            (packed >> (4 * NBITS)) & mask,
+            (packed >> (5 * NBITS)) & mask,
+            (packed >> (6 * NBITS)) & mask,
+            (packed >> (7 * NBITS)) & mask);
+    return _mm256_cvtepi32_ps(values);
+}
+
+template <size_t NBITS>
+float ip_dense_avx2(
+        const uint8_t* __restrict code,
+        const float* __restrict query,
+        size_t d,
+        float cb) {
+    __m256 acc = _mm256_setzero_ps();
+    const __m256 bias = _mm256_set1_ps(cb);
+    size_t i = 0;
+    for (; i + 8 <= d; i += 8) {
+        const __m256 values =
+                dense_decode_8_avx2<NBITS>(code + (i * NBITS) / 8);
+        acc = _mm256_fmadd_ps(
+                _mm256_loadu_ps(query + i), _mm256_add_ps(values, bias), acc);
+    }
+    float lanes[8];
+    _mm256_storeu_ps(lanes, acc);
+    float result = lanes[0] + lanes[1] + lanes[2] + lanes[3] + lanes[4] +
+            lanes[5] + lanes[6] + lanes[7];
+    return result +
+            compute_inner_product_dense<SIMDLevel::NONE>(
+                    code + (i * NBITS) / 8, query + i, d - i, NBITS, cb);
+}
+
+template <size_t NBITS>
+void ip_dense_batch_4_avx2(
+        const uint8_t* const codes[4],
+        const float* __restrict query,
+        size_t d,
+        float cb,
+        float out[4]) {
+    __m256 acc[4] = {
+            _mm256_setzero_ps(),
+            _mm256_setzero_ps(),
+            _mm256_setzero_ps(),
+            _mm256_setzero_ps()};
+    const __m256 bias = _mm256_set1_ps(cb);
+    size_t i = 0;
+    for (; i + 8 <= d; i += 8) {
+        const __m256 q = _mm256_loadu_ps(query + i);
+        for (size_t j = 0; j < 4; j++) {
+            const __m256 values =
+                    dense_decode_8_avx2<NBITS>(codes[j] + (i * NBITS) / 8);
+            acc[j] = _mm256_fmadd_ps(q, _mm256_add_ps(values, bias), acc[j]);
+        }
+    }
+    for (size_t j = 0; j < 4; j++) {
+        float lanes[8];
+        _mm256_storeu_ps(lanes, acc[j]);
+        out[j] = lanes[0] + lanes[1] + lanes[2] + lanes[3] + lanes[4] +
+                lanes[5] + lanes[6] + lanes[7] +
+                compute_inner_product_dense<SIMDLevel::NONE>(
+                         codes[j] + (i * NBITS) / 8,
+                         query + i,
+                         d - i,
+                         NBITS,
+                         cb);
+    }
+}
+
+} // namespace
+
+template <>
+float compute_inner_product_dense<SIMDLevel::AVX2>(
+        const uint8_t* __restrict code,
+        const float* __restrict query,
+        size_t d,
+        size_t nbits,
+        float cb) {
+#define FAISS_RABITQ_DENSE_CASE(N) \
+    case N:                        \
+        return ip_dense_avx2<N>(code, query, d, cb)
+    switch (nbits) {
+        FAISS_RABITQ_DENSE_CASE(2);
+        FAISS_RABITQ_DENSE_CASE(3);
+        FAISS_RABITQ_DENSE_CASE(4);
+        FAISS_RABITQ_DENSE_CASE(5);
+        FAISS_RABITQ_DENSE_CASE(6);
+        FAISS_RABITQ_DENSE_CASE(7);
+        FAISS_RABITQ_DENSE_CASE(8);
+        default:
+            return compute_inner_product_dense<SIMDLevel::NONE>(
+                    code, query, d, nbits, cb);
+    }
+#undef FAISS_RABITQ_DENSE_CASE
+}
+
+template <>
+void compute_inner_product_dense_batch_4<SIMDLevel::AVX2>(
+        const uint8_t* const codes[4],
+        const float* query,
+        size_t d,
+        size_t nbits,
+        float cb,
+        float out[4]) {
+#define FAISS_RABITQ_DENSE_CASE(N) \
+    case N:                        \
+        return ip_dense_batch_4_avx2<N>(codes, query, d, cb, out)
+    switch (nbits) {
+        FAISS_RABITQ_DENSE_CASE(2);
+        FAISS_RABITQ_DENSE_CASE(3);
+        FAISS_RABITQ_DENSE_CASE(4);
+        FAISS_RABITQ_DENSE_CASE(5);
+        FAISS_RABITQ_DENSE_CASE(6);
+        FAISS_RABITQ_DENSE_CASE(7);
+        FAISS_RABITQ_DENSE_CASE(8);
+        default:
+            for (size_t i = 0; i < 4; i++) {
+                out[i] = compute_inner_product_dense<SIMDLevel::NONE>(
+                        codes[i], query, d, nbits, cb);
+            }
+    }
+#undef FAISS_RABITQ_DENSE_CASE
+}
+
+template <>
+float compute_inner_product_byte<SIMDLevel::AVX2>(
+        const uint8_t* __restrict code,
+        const float* __restrict query,
+        size_t d,
+        float cb) {
+    __m256 acc = _mm256_setzero_ps();
+    const __m256 bias = _mm256_set1_ps(cb);
+    size_t i = 0;
+    for (; i + 8 <= d; i += 8) {
+        const __m128i bytes =
+                _mm_loadl_epi64(reinterpret_cast<const __m128i*>(code + i));
+        const __m256 values = _mm256_cvtepi32_ps(_mm256_cvtepu8_epi32(bytes));
+        acc = _mm256_fmadd_ps(
+                _mm256_loadu_ps(query + i), _mm256_add_ps(values, bias), acc);
+    }
+    float lanes[8];
+    _mm256_storeu_ps(lanes, acc);
+    float result = lanes[0] + lanes[1] + lanes[2] + lanes[3] + lanes[4] +
+            lanes[5] + lanes[6] + lanes[7];
+    return result + ip_byte_scalar(code, query, i, d, cb);
+}
+
+template <>
+void compute_inner_product_byte_batch_4<SIMDLevel::AVX2>(
+        const uint8_t* const codes[4],
+        const float* __restrict query,
+        size_t d,
+        float cb,
+        float out[4]) {
+    __m256 acc[4] = {
+            _mm256_setzero_ps(),
+            _mm256_setzero_ps(),
+            _mm256_setzero_ps(),
+            _mm256_setzero_ps()};
+    const __m256 bias = _mm256_set1_ps(cb);
+    size_t i = 0;
+    for (; i + 8 <= d; i += 8) {
+        const __m256 q = _mm256_loadu_ps(query + i);
+        for (size_t j = 0; j < 4; j++) {
+            const __m128i bytes = _mm_loadl_epi64(
+                    reinterpret_cast<const __m128i*>(codes[j] + i));
+            const __m256 values =
+                    _mm256_cvtepi32_ps(_mm256_cvtepu8_epi32(bytes));
+            acc[j] = _mm256_fmadd_ps(q, _mm256_add_ps(values, bias), acc[j]);
+        }
+    }
+    for (size_t j = 0; j < 4; j++) {
+        float lanes[8];
+        _mm256_storeu_ps(lanes, acc[j]);
+        out[j] = lanes[0] + lanes[1] + lanes[2] + lanes[3] + lanes[4] +
+                lanes[5] + lanes[6] + lanes[7] +
+                ip_byte_scalar(codes[j], query, i, d, cb);
+    }
+}
+
+namespace {
+
+#if (defined(__GNUC__) || defined(__clang__)) && \
+        (defined(__x86_64__) || defined(__i386__))
+#define FAISS_RABITQ_HAS_BMI2_TARGET 1
+#define FAISS_RABITQ_TARGET_BMI2 __attribute__((target("bmi2")))
+
+inline bool cpu_supports_fast_bmi2() {
+    static const bool supported = __builtin_cpu_supports("bmi2");
+    return supported && SIMDConfig::bmi2_fast;
+}
+#else
+#define FAISS_RABITQ_HAS_BMI2_TARGET 0
+#define FAISS_RABITQ_TARGET_BMI2
+#endif
 
 inline float hsum_avx2(__m256 v) {
     __m128 hi = _mm256_extractf128_ps(v, 1);
@@ -517,8 +748,8 @@ inline float ip_1exbit_avx2(
     return result;
 }
 
-#ifdef __BMI2__
-inline float ip_bitplane_avx2(
+#if FAISS_RABITQ_HAS_BMI2_TARGET
+FAISS_RABITQ_TARGET_BMI2 inline float ip_bitplane_avx2(
         const uint8_t* __restrict sign_bits,
         const uint8_t* __restrict ex_code,
         const float* __restrict rotated_q,
@@ -571,7 +802,84 @@ inline float ip_bitplane_avx2(
     result += ip_scalar(sign_bits, ex_code, rotated_q, i, d, ex_bits, cb);
     return result;
 }
-#endif // __BMI2__
+
+FAISS_RABITQ_TARGET_BMI2 inline void ip_bitplane_batch_4_avx2(
+        const uint8_t* const sign_bits[4],
+        const uint8_t* const ex_codes[4],
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb,
+        float out[4]) {
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
+    __m256 acc2 = _mm256_setzero_ps();
+    __m256 acc3 = _mm256_setzero_ps();
+    const __m256 v_one = _mm256_set1_ps(1.0f);
+    const __m256i bit_pos = _mm256_setr_epi32(1, 2, 4, 8, 16, 32, 64, 128);
+    const __m256i zero = _mm256_setzero_si256();
+    const __m256 v_cb = _mm256_set1_ps(cb);
+
+    uint64_t pext_masks[7];
+    __m256 v_weights[8];
+    for (size_t b = 0; b < ex_bits; b++) {
+        uint64_t mask = 0;
+        for (int j = 0; j < 8; j++) {
+            mask |= (1ULL << (b + j * ex_bits));
+        }
+        pext_masks[b] = mask;
+        v_weights[b] = _mm256_set1_ps(static_cast<float>(1u << b));
+    }
+    v_weights[ex_bits] = _mm256_set1_ps(static_cast<float>(1u << ex_bits));
+
+    size_t i = 0;
+    for (; i + 8 <= d; i += 8) {
+        const __m256 query = _mm256_loadu_ps(rotated_q + i);
+
+        auto reconstruct = [&](size_t code_index) FAISS_RABITQ_TARGET_BMI2 {
+            const __m256i sign_cmp = _mm256_cmpgt_epi32(
+                    _mm256_and_si256(
+                            _mm256_set1_epi32(sign_bits[code_index][i / 8]),
+                            bit_pos),
+                    zero);
+            __m256 reconstruction = _mm256_mul_ps(
+                    _mm256_and_ps(_mm256_castsi256_ps(sign_cmp), v_one),
+                    v_weights[ex_bits]);
+
+            uint64_t extra_bits = 0;
+            memcpy(&extra_bits,
+                   ex_codes[code_index] + (i / 8) * ex_bits,
+                   sizeof(extra_bits));
+            for (size_t b = 0; b < ex_bits; b++) {
+                const auto plane = static_cast<uint8_t>(
+                        _pext_u64(extra_bits, pext_masks[b]));
+                const __m256i plane_cmp = _mm256_cmpgt_epi32(
+                        _mm256_and_si256(_mm256_set1_epi32(plane), bit_pos),
+                        zero);
+                const __m256 plane_values =
+                        _mm256_and_ps(_mm256_castsi256_ps(plane_cmp), v_one);
+                reconstruction = _mm256_fmadd_ps(
+                        plane_values, v_weights[b], reconstruction);
+            }
+            return _mm256_add_ps(reconstruction, v_cb);
+        };
+
+        acc0 = _mm256_fmadd_ps(query, reconstruct(0), acc0);
+        acc1 = _mm256_fmadd_ps(query, reconstruct(1), acc1);
+        acc2 = _mm256_fmadd_ps(query, reconstruct(2), acc2);
+        acc3 = _mm256_fmadd_ps(query, reconstruct(3), acc3);
+    }
+
+    out[0] = hsum_avx2(acc0) +
+            ip_scalar(sign_bits[0], ex_codes[0], rotated_q, i, d, ex_bits, cb);
+    out[1] = hsum_avx2(acc1) +
+            ip_scalar(sign_bits[1], ex_codes[1], rotated_q, i, d, ex_bits, cb);
+    out[2] = hsum_avx2(acc2) +
+            ip_scalar(sign_bits[2], ex_codes[2], rotated_q, i, d, ex_bits, cb);
+    out[3] = hsum_avx2(acc3) +
+            ip_scalar(sign_bits[3], ex_codes[3], rotated_q, i, d, ex_bits, cb);
+}
+#endif
 
 } // namespace
 
@@ -587,13 +895,38 @@ float compute_inner_product<SIMDLevel::AVX2>(
         return ip_1exbit_avx2(sign_bits, ex_code, rotated_q, d, cb);
     }
 
-#ifdef __BMI2__
-    if (ex_bits <= 7) {
+#if FAISS_RABITQ_HAS_BMI2_TARGET
+    if (ex_bits <= 7 && cpu_supports_fast_bmi2()) {
         return ip_bitplane_avx2(sign_bits, ex_code, rotated_q, d, ex_bits, cb);
     }
 #endif
     return ip_scalar(sign_bits, ex_code, rotated_q, 0, d, ex_bits, cb);
 }
+
+template <>
+void compute_inner_product_batch_4<SIMDLevel::AVX2>(
+        const uint8_t* const sign_bits[4],
+        const uint8_t* const ex_codes[4],
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb,
+        float out[4]) {
+#if FAISS_RABITQ_HAS_BMI2_TARGET
+    if (ex_bits <= 7 && cpu_supports_fast_bmi2()) {
+        ip_bitplane_batch_4_avx2(
+                sign_bits, ex_codes, rotated_q, d, ex_bits, cb, out);
+        return;
+    }
+#endif
+    for (size_t i = 0; i < 4; i++) {
+        out[i] = compute_inner_product<SIMDLevel::AVX2>(
+                sign_bits[i], ex_codes[i], rotated_q, d, ex_bits, cb);
+    }
+}
+
+#undef FAISS_RABITQ_TARGET_BMI2
+#undef FAISS_RABITQ_HAS_BMI2_TARGET
 
 } // namespace faiss::rabitq::multibit
 

--- a/faiss/utils/simd_impl/rabitq_avx512.cpp
+++ b/faiss/utils/simd_impl/rabitq_avx512.cpp
@@ -583,6 +583,27 @@ uint64_t popcount<SIMDLevel::AVX512>(const uint8_t* data, size_t size) {
 }
 
 template <>
+float selected_float_sum<SIMDLevel::AVX512>(
+        const uint8_t* sign_bits,
+        const float* values,
+        size_t d) {
+    __m512 sum = _mm512_setzero_ps();
+    size_t i = 0;
+    for (; i + 16 <= d; i += 16) {
+        uint16_t packed = 0;
+        memcpy(&packed, sign_bits + i / 8, sizeof(packed));
+        sum = _mm512_add_ps(
+                sum,
+                _mm512_maskz_loadu_ps(
+                        static_cast<__mmask16>(packed), values + i));
+    }
+    float result = _mm512_reduce_add_ps(sum);
+    result += selected_float_sum<SIMDLevel::NONE>(
+            sign_bits + i / 8, values + i, d - i);
+    return result;
+}
+
+template <>
 void rearrange_bit_planes<SIMDLevel::AVX512>(
         const uint8_t* rotated_qq,
         size_t d,
@@ -623,6 +644,508 @@ namespace faiss::rabitq::multibit {
 
 namespace {
 
+template <size_t NBITS>
+inline __m256i dense_decode_8_i32_avx512(const uint8_t* code) {
+    static_assert(NBITS >= 2 && NBITS <= 8);
+    uint64_t packed = 0;
+    memcpy(&packed, code, NBITS);
+    constexpr uint64_t mask = (uint64_t{1} << NBITS) - 1;
+    return _mm256_setr_epi32(
+            (packed >> (0 * NBITS)) & mask,
+            (packed >> (1 * NBITS)) & mask,
+            (packed >> (2 * NBITS)) & mask,
+            (packed >> (3 * NBITS)) & mask,
+            (packed >> (4 * NBITS)) & mask,
+            (packed >> (5 * NBITS)) & mask,
+            (packed >> (6 * NBITS)) & mask,
+            (packed >> (7 * NBITS)) & mask);
+}
+
+template <size_t NBITS>
+inline __m512 dense_decode_16_avx512(const uint8_t* code) {
+    const __m256i lo = dense_decode_8_i32_avx512<NBITS>(code);
+    const __m256i hi = dense_decode_8_i32_avx512<NBITS>(code + NBITS);
+    const __m512i values =
+            _mm512_inserti32x8(_mm512_castsi256_si512(lo), hi, 1);
+    return _mm512_cvtepi32_ps(values);
+}
+
+inline __m512i dense_decode_3_64_u8_avx512(const uint8_t* code) {
+    const __m256i shuf_0 = _mm256_setr_epi8(
+            0,
+            -1,
+            0,
+            1,
+            1,
+            -1,
+            2,
+            -1,
+            3,
+            -1,
+            3,
+            4,
+            4,
+            -1,
+            5,
+            -1,
+            6,
+            -1,
+            6,
+            7,
+            7,
+            -1,
+            8,
+            -1,
+            9,
+            -1,
+            9,
+            10,
+            10,
+            -1,
+            11,
+            -1);
+    const __m256i shuf_1 = _mm256_setr_epi8(
+            0,
+            -1,
+            1,
+            -1,
+            1,
+            2,
+            2,
+            -1,
+            3,
+            -1,
+            4,
+            -1,
+            4,
+            5,
+            5,
+            -1,
+            6,
+            -1,
+            7,
+            -1,
+            7,
+            8,
+            8,
+            -1,
+            9,
+            -1,
+            10,
+            -1,
+            10,
+            11,
+            11,
+            -1);
+    const __m256i shuf_2 = _mm256_setr_epi8(
+            12,
+            -1,
+            12,
+            13,
+            13,
+            -1,
+            14,
+            -1,
+            15,
+            -1,
+            15,
+            0,
+            0,
+            -1,
+            1,
+            -1,
+            2,
+            -1,
+            2,
+            3,
+            3,
+            -1,
+            4,
+            -1,
+            5,
+            -1,
+            5,
+            6,
+            6,
+            -1,
+            7,
+            -1);
+    const __m256i shuf_3 = _mm256_setr_epi8(
+            12,
+            -1,
+            13,
+            -1,
+            13,
+            14,
+            14,
+            -1,
+            15,
+            -1,
+            0,
+            -1,
+            0,
+            1,
+            1,
+            -1,
+            2,
+            -1,
+            3,
+            -1,
+            3,
+            4,
+            4,
+            -1,
+            5,
+            -1,
+            6,
+            -1,
+            6,
+            7,
+            7,
+            -1);
+    const __m512i shuf_02 =
+            _mm512_inserti32x8(_mm512_castsi256_si512(shuf_0), shuf_2, 1);
+    const __m512i shuf_13 =
+            _mm512_inserti32x8(_mm512_castsi256_si512(shuf_1), shuf_3, 1);
+    const __m256i shifts_left =
+            _mm256_setr_epi16(5, 7, 1, 3, 5, 7, 1, 3, 5, 7, 1, 3, 5, 7, 1, 3);
+    const __m256i shifts_right =
+            _mm256_setr_epi16(0, 6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2, 0, 6, 4, 2);
+    const __m512i v_shl = _mm512_inserti32x8(
+            _mm512_castsi256_si512(shifts_left), shifts_left, 1);
+    const __m512i v_shr = _mm512_inserti32x8(
+            _mm512_castsi256_si512(shifts_right), shifts_right, 1);
+
+    const __m128i raw_0 =
+            _mm_loadu_si128(reinterpret_cast<const __m128i*>(code));
+    const __m128i raw_2_low =
+            _mm_loadl_epi64(reinterpret_cast<const __m128i*>(code + 16));
+    const __m128i raw_2 = _mm_blend_epi16(raw_0, raw_2_low, 0x0f);
+    const __m256i raw_01 =
+            _mm256_inserti32x4(_mm256_castsi128_si256(raw_0), raw_0, 1);
+    const __m256i raw_23 =
+            _mm256_inserti32x4(_mm256_castsi128_si256(raw_2), raw_2, 1);
+    const __m512i raw =
+            _mm512_inserti32x8(_mm512_castsi256_si512(raw_01), raw_23, 1);
+    const __m512i right =
+            _mm512_srlv_epi16(_mm512_shuffle_epi8(raw, shuf_02), v_shr);
+    const __m512i left =
+            _mm512_sllv_epi16(_mm512_shuffle_epi8(raw, shuf_13), v_shl);
+    return _mm512_and_si512(
+            _mm512_mask_blend_epi8(0xaaaaaaaaaaaaaaaaULL, right, left),
+            _mm512_set1_epi8(7));
+}
+
+inline __m512i dense_decode_4_64_u8_avx512(const uint8_t* code) {
+    const __m256i packed =
+            _mm256_loadu_si256(reinterpret_cast<const __m256i*>(code));
+    const __m512i widened = _mm512_cvtepu8_epi16(packed);
+    return _mm512_and_si512(
+            _mm512_or_si512(
+                    widened,
+                    _mm512_slli_epi16(_mm512_srli_epi16(widened, 4), 8)),
+            _mm512_set1_epi16(0x0f0f));
+}
+
+inline __m512i dense_decode_5_64_u8_avx512(const uint8_t* code) {
+    const __m512i low = _mm512_zextsi256_si512(
+            _mm256_loadu_si256(reinterpret_cast<const __m256i*>(code)));
+    const __m128i high =
+            _mm_loadl_epi64(reinterpret_cast<const __m128i*>(code + 32));
+    const __m512i raw = _mm512_inserti32x4(low, high, 2);
+    const __m512i spread = _mm512_permutexvar_epi64(
+            _mm512_setr_epi64(0, 1, 1, 2, 2, 3, 3, 4), raw);
+    const __m512i shuf_a = _mm512_setr_epi64(
+            0x04030302ff01ff00ULL,
+            0x09080807ff06ff05ULL,
+            0x06050504ff03ff02ULL,
+            0x0b0a0a09ff08ff07ULL,
+            0x08070706ff05ff04ULL,
+            0x0d0c0c0bff0aff09ULL,
+            0x0a090908ff07ff06ULL,
+            0x0f0e0e0dff0cff0bULL);
+    const __m512i shuf_b = _mm512_setr_epi64(
+            0xff04ff0302010100ULL,
+            0xff09ff0807060605ULL,
+            0xff06ff0504030302ULL,
+            0xff0bff0a09080807ULL,
+            0xff08ff0706050504ULL,
+            0xff0dff0c0b0a0a09ULL,
+            0xff0aff0908070706ULL,
+            0xff0fff0e0d0c0c0bULL);
+    const __m512i right = _mm512_srlv_epi16(
+            _mm512_shuffle_epi8(spread, shuf_a),
+            _mm512_set1_epi64(0x0006000400020000ULL));
+    const __m512i left = _mm512_sllv_epi16(
+            _mm512_shuffle_epi8(spread, shuf_b),
+            _mm512_set1_epi64(0x0005000700010003ULL));
+    return _mm512_and_si512(
+            _mm512_mask_blend_epi8(0xaaaaaaaaaaaaaaaaULL, right, left),
+            _mm512_set1_epi8(0x1f));
+}
+
+inline __m512i dense_decode_6_64_u8_avx512(const uint8_t* code) {
+    const __m512i packed =
+            _mm512_maskz_loadu_epi8((uint64_t{1} << 48) - 1, code);
+    const __m512i expanded = _mm512_permutexvar_epi32(
+            _mm512_setr_epi32(
+                    0, 1, 2, -1, 3, 4, 5, -1, 6, 7, 8, -1, 9, 10, 11, -1),
+            packed);
+    const __m512i shuf_0 = _mm512_broadcast_i32x4(
+            _mm_setr_epi8(0, 1, 1, 2, 3, 4, 4, 5, 6, 7, 7, 8, 9, 10, 10, 11));
+    const __m512i shuf_1 = _mm512_broadcast_i32x4(_mm_setr_epi8(
+            0, 1, 2, -1, 3, 4, 5, -1, 6, 7, 8, -1, 9, 10, 11, -1));
+    const __m512i left = _mm512_sllv_epi16(
+            _mm512_shuffle_epi8(expanded, shuf_1),
+            _mm512_set1_epi32(0x00060002));
+    const __m512i right = _mm512_srlv_epi16(
+            _mm512_shuffle_epi8(expanded, shuf_0),
+            _mm512_set1_epi32(0x00040000));
+    return _mm512_and_si512(
+            _mm512_mask_blend_epi8(0x5555555555555555ULL, left, right),
+            _mm512_set1_epi8(0x3f));
+}
+
+template <size_t NBITS>
+inline __m512i dense_decode_64_u8_avx512(const uint8_t* code) {
+    if constexpr (NBITS == 3) {
+        return dense_decode_3_64_u8_avx512(code);
+    } else if constexpr (NBITS == 4) {
+        return dense_decode_4_64_u8_avx512(code);
+    } else if constexpr (NBITS == 5) {
+        return dense_decode_5_64_u8_avx512(code);
+    } else if constexpr (NBITS == 6) {
+        return dense_decode_6_64_u8_avx512(code);
+    } else {
+        static_assert(NBITS == 8);
+        return _mm512_loadu_si512(code);
+    }
+}
+
+inline void dense_fma_64_avx512(
+        __m512& acc,
+        __m512i decoded,
+        const float* query,
+        __m512 bias) {
+#define FAISS_RABITQ_DENSE_FMA_QUARTER(Q, BYTES)                               \
+    do {                                                                       \
+        const __m512 values = _mm512_cvtepi32_ps(_mm512_cvtepu8_epi32(BYTES)); \
+        acc = _mm512_fmadd_ps(                                                 \
+                _mm512_loadu_ps(query + 16 * (Q)),                             \
+                _mm512_add_ps(values, bias),                                   \
+                acc);                                                          \
+    } while (false)
+    FAISS_RABITQ_DENSE_FMA_QUARTER(0, _mm512_castsi512_si128(decoded));
+    FAISS_RABITQ_DENSE_FMA_QUARTER(1, _mm512_extracti32x4_epi32(decoded, 1));
+    FAISS_RABITQ_DENSE_FMA_QUARTER(2, _mm512_extracti32x4_epi32(decoded, 2));
+    FAISS_RABITQ_DENSE_FMA_QUARTER(3, _mm512_extracti32x4_epi32(decoded, 3));
+#undef FAISS_RABITQ_DENSE_FMA_QUARTER
+}
+
+template <size_t NBITS>
+float ip_dense_avx512(
+        const uint8_t* __restrict code,
+        const float* __restrict query,
+        size_t d,
+        float cb) {
+    __m512 acc = _mm512_setzero_ps();
+    const __m512 bias = _mm512_set1_ps(cb);
+    size_t i = 0;
+    if constexpr ((NBITS >= 3 && NBITS <= 6) || NBITS == 8) {
+        for (; i + 64 <= d; i += 64) {
+            dense_fma_64_avx512(
+                    acc,
+                    dense_decode_64_u8_avx512<NBITS>(code + (i * NBITS) / 8),
+                    query + i,
+                    bias);
+        }
+    }
+    for (; i + 16 <= d; i += 16) {
+        const __m512 values =
+                dense_decode_16_avx512<NBITS>(code + (i * NBITS) / 8);
+        acc = _mm512_fmadd_ps(
+                _mm512_loadu_ps(query + i), _mm512_add_ps(values, bias), acc);
+    }
+    return _mm512_reduce_add_ps(acc) +
+            compute_inner_product_dense<SIMDLevel::NONE>(
+                    code + (i * NBITS) / 8, query + i, d - i, NBITS, cb);
+}
+
+template <size_t NBITS>
+void ip_dense_batch_4_avx512(
+        const uint8_t* const codes[4],
+        const float* __restrict query,
+        size_t d,
+        float cb,
+        float out[4]) {
+    __m512 acc[4] = {
+            _mm512_setzero_ps(),
+            _mm512_setzero_ps(),
+            _mm512_setzero_ps(),
+            _mm512_setzero_ps()};
+    const __m512 bias = _mm512_set1_ps(cb);
+    size_t i = 0;
+    if constexpr ((NBITS >= 3 && NBITS <= 6) || NBITS == 8) {
+        for (; i + 64 <= d; i += 64) {
+            for (size_t j = 0; j < 4; j++) {
+                dense_fma_64_avx512(
+                        acc[j],
+                        dense_decode_64_u8_avx512<NBITS>(
+                                codes[j] + (i * NBITS) / 8),
+                        query + i,
+                        bias);
+            }
+        }
+    }
+    for (; i + 16 <= d; i += 16) {
+        const __m512 q = _mm512_loadu_ps(query + i);
+        for (size_t j = 0; j < 4; j++) {
+            const __m512 values =
+                    dense_decode_16_avx512<NBITS>(codes[j] + (i * NBITS) / 8);
+            acc[j] = _mm512_fmadd_ps(q, _mm512_add_ps(values, bias), acc[j]);
+        }
+    }
+    for (size_t j = 0; j < 4; j++) {
+        out[j] = _mm512_reduce_add_ps(acc[j]) +
+                compute_inner_product_dense<SIMDLevel::NONE>(
+                         codes[j] + (i * NBITS) / 8,
+                         query + i,
+                         d - i,
+                         NBITS,
+                         cb);
+    }
+}
+
+} // namespace
+
+template <>
+float compute_inner_product_dense<SIMDLevel::AVX512>(
+        const uint8_t* __restrict code,
+        const float* __restrict query,
+        size_t d,
+        size_t nbits,
+        float cb) {
+#define FAISS_RABITQ_DENSE_CASE(N) \
+    case N:                        \
+        return ip_dense_avx512<N>(code, query, d, cb)
+    switch (nbits) {
+        FAISS_RABITQ_DENSE_CASE(2);
+        FAISS_RABITQ_DENSE_CASE(3);
+        FAISS_RABITQ_DENSE_CASE(4);
+        FAISS_RABITQ_DENSE_CASE(5);
+        FAISS_RABITQ_DENSE_CASE(6);
+        FAISS_RABITQ_DENSE_CASE(7);
+        FAISS_RABITQ_DENSE_CASE(8);
+        default:
+            return compute_inner_product_dense<SIMDLevel::NONE>(
+                    code, query, d, nbits, cb);
+    }
+#undef FAISS_RABITQ_DENSE_CASE
+}
+
+template <>
+void compute_inner_product_dense_batch_4<SIMDLevel::AVX512>(
+        const uint8_t* const codes[4],
+        const float* query,
+        size_t d,
+        size_t nbits,
+        float cb,
+        float out[4]) {
+#define FAISS_RABITQ_DENSE_CASE(N) \
+    case N:                        \
+        return ip_dense_batch_4_avx512<N>(codes, query, d, cb, out)
+    switch (nbits) {
+        FAISS_RABITQ_DENSE_CASE(2);
+        FAISS_RABITQ_DENSE_CASE(3);
+        FAISS_RABITQ_DENSE_CASE(4);
+        FAISS_RABITQ_DENSE_CASE(5);
+        FAISS_RABITQ_DENSE_CASE(6);
+        FAISS_RABITQ_DENSE_CASE(7);
+        FAISS_RABITQ_DENSE_CASE(8);
+        default:
+            for (size_t i = 0; i < 4; i++) {
+                out[i] = compute_inner_product_dense<SIMDLevel::NONE>(
+                        codes[i], query, d, nbits, cb);
+            }
+    }
+#undef FAISS_RABITQ_DENSE_CASE
+}
+
+template <>
+float compute_inner_product_byte<SIMDLevel::AVX512>(
+        const uint8_t* __restrict code,
+        const float* __restrict query,
+        size_t d,
+        float cb) {
+    __m512 acc = _mm512_setzero_ps();
+    const __m512 bias = _mm512_set1_ps(cb);
+    size_t i = 0;
+    for (; i + 16 <= d; i += 16) {
+        const __m128i bytes =
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(code + i));
+        const __m512 values = _mm512_cvtepi32_ps(_mm512_cvtepu8_epi32(bytes));
+        acc = _mm512_fmadd_ps(
+                _mm512_loadu_ps(query + i), _mm512_add_ps(values, bias), acc);
+    }
+    return _mm512_reduce_add_ps(acc) + ip_byte_scalar(code, query, i, d, cb);
+}
+
+template <>
+void compute_inner_product_byte_batch_4<SIMDLevel::AVX512>(
+        const uint8_t* const codes[4],
+        const float* __restrict query,
+        size_t d,
+        float cb,
+        float out[4]) {
+    __m512 acc[4] = {
+            _mm512_setzero_ps(),
+            _mm512_setzero_ps(),
+            _mm512_setzero_ps(),
+            _mm512_setzero_ps()};
+    const __m512 bias = _mm512_set1_ps(cb);
+    size_t i = 0;
+    for (; i + 16 <= d; i += 16) {
+        const __m512 q = _mm512_loadu_ps(query + i);
+        for (size_t j = 0; j < 4; j++) {
+            const __m128i bytes = _mm_loadu_si128(
+                    reinterpret_cast<const __m128i*>(codes[j] + i));
+            const __m512 values =
+                    _mm512_cvtepi32_ps(_mm512_cvtepu8_epi32(bytes));
+            acc[j] = _mm512_fmadd_ps(q, _mm512_add_ps(values, bias), acc[j]);
+        }
+    }
+    for (size_t j = 0; j < 4; j++) {
+        out[j] = _mm512_reduce_add_ps(acc[j]) +
+                ip_byte_scalar(codes[j], query, i, d, cb);
+    }
+}
+
+namespace {
+
+#if (defined(__GNUC__) || defined(__clang__)) && \
+        (defined(__x86_64__) || defined(__i386__))
+#define FAISS_RABITQ_HAS_BMI2_TARGET 1
+#define FAISS_RABITQ_TARGET_BMI2 __attribute__((target("bmi2")))
+
+inline bool cpu_supports_fast_bmi2() {
+    static const bool supported = __builtin_cpu_supports("bmi2");
+    return supported && SIMDConfig::bmi2_fast;
+}
+#else
+#define FAISS_RABITQ_HAS_BMI2_TARGET 0
+#define FAISS_RABITQ_TARGET_BMI2
+#endif
+
+inline float hsum_avx2(__m256 v) {
+    __m128 hi = _mm256_extractf128_ps(v, 1);
+    __m128 lo = _mm256_castps256_ps128(v);
+    lo = _mm_add_ps(lo, hi);
+    __m128 shuf = _mm_movehdup_ps(lo);
+    lo = _mm_add_ps(lo, shuf);
+    shuf = _mm_movehl_ps(shuf, lo);
+    return _mm_cvtss_f32(_mm_add_ss(lo, shuf));
+}
+
 inline float ip_1exbit_avx512(
         const uint8_t* __restrict sign_bits,
         const uint8_t* __restrict ex_code,
@@ -654,14 +1177,400 @@ inline float ip_1exbit_avx512(
     return result;
 }
 
-// Needs BMI2 for _pext_u64. Some AVX2 CPUs lack it, and FAISS_BMI2_FLAGS can
-// be empty, so the dispatcher falls back to the scalar path without it.
-#ifdef __BMI2__
-// Bitplane kernel for ex_bits >= 2, 16 dims per iteration. A bitplane is
-// already a bitmask, so it goes into a mask register and one masked add
-// applies its weight. Reads of ex_code run a few bytes past the ex-code
-// section into the record's own trailing factors, so they stay in bounds.
-inline float ip_bitplane_avx512(
+// AVX2+BMI2 bitplane kernel used as fallback for ex_bits >= 2.
+// AVX512 TU has AVX2 available. BMI2 guarded separately since
+// VIA Eden X4 has AVX2 without BMI2.
+#if FAISS_RABITQ_HAS_BMI2_TARGET
+FAISS_RABITQ_TARGET_BMI2 inline float ip_bitplane_avx2(
+        const uint8_t* __restrict sign_bits,
+        const uint8_t* __restrict ex_code,
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb) {
+    __m256 acc = _mm256_setzero_ps();
+    const __m256 v_one = _mm256_set1_ps(1.0f);
+    const __m256i bit_pos = _mm256_setr_epi32(1, 2, 4, 8, 16, 32, 64, 128);
+    const __m256i zero = _mm256_setzero_si256();
+    const __m256 v_cb = _mm256_set1_ps(cb);
+
+    uint64_t pext_masks[7];
+    __m256 v_weights[8];
+    for (size_t b = 0; b < ex_bits; b++) {
+        uint64_t m = 0;
+        for (int j = 0; j < 8; j++) {
+            m |= (1ULL << (b + j * ex_bits));
+        }
+        pext_masks[b] = m;
+        v_weights[b] = _mm256_set1_ps(static_cast<float>(1u << b));
+    }
+    v_weights[ex_bits] = _mm256_set1_ps(static_cast<float>(1u << ex_bits));
+
+    size_t i = 0;
+    for (; i + 8 <= d; i += 8) {
+        __m256i sb_cmp = _mm256_cmpgt_epi32(
+                _mm256_and_si256(_mm256_set1_epi32(sign_bits[i / 8]), bit_pos),
+                zero);
+        __m256 recon = _mm256_mul_ps(
+                _mm256_and_ps(_mm256_castsi256_ps(sb_cmp), v_one),
+                v_weights[ex_bits]);
+
+        uint64_t ex64 = 0;
+        memcpy(&ex64, ex_code + (i / 8) * ex_bits, sizeof(uint64_t));
+
+        for (size_t b = 0; b < ex_bits; b++) {
+            auto plane = static_cast<uint8_t>(_pext_u64(ex64, pext_masks[b]));
+            __m256i p_cmp = _mm256_cmpgt_epi32(
+                    _mm256_and_si256(_mm256_set1_epi32(plane), bit_pos), zero);
+            __m256 p_f = _mm256_and_ps(_mm256_castsi256_ps(p_cmp), v_one);
+            recon = _mm256_fmadd_ps(p_f, v_weights[b], recon);
+        }
+
+        __m256 rq = _mm256_loadu_ps(rotated_q + i);
+        acc = _mm256_fmadd_ps(rq, _mm256_add_ps(recon, v_cb), acc);
+    }
+
+    float result = hsum_avx2(acc);
+    result += ip_scalar(sign_bits, ex_code, rotated_q, i, d, ex_bits, cb);
+    return result;
+}
+
+// The 16-lane AVX-512 bit extraction below needs more than one 64-bit PEXT
+// window once ex_bits exceeds four. Keep a genuine four-code path for those
+// wider codes by sharing each query load across four 8-lane reconstructions.
+FAISS_RABITQ_TARGET_BMI2 inline void ip_bitplane_batch_4_avx2(
+        const uint8_t* const sign_bits[4],
+        const uint8_t* const ex_codes[4],
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb,
+        float out[4]) {
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
+    __m256 acc2 = _mm256_setzero_ps();
+    __m256 acc3 = _mm256_setzero_ps();
+    const __m256 v_one = _mm256_set1_ps(1.0f);
+    const __m256i bit_pos = _mm256_setr_epi32(1, 2, 4, 8, 16, 32, 64, 128);
+    const __m256i zero = _mm256_setzero_si256();
+    const __m256 v_cb = _mm256_set1_ps(cb);
+
+    uint64_t pext_masks[7];
+    __m256 v_weights[8];
+    for (size_t b = 0; b < ex_bits; b++) {
+        uint64_t mask = 0;
+        for (int j = 0; j < 8; j++) {
+            mask |= (1ULL << (b + j * ex_bits));
+        }
+        pext_masks[b] = mask;
+        v_weights[b] = _mm256_set1_ps(static_cast<float>(1u << b));
+    }
+    v_weights[ex_bits] = _mm256_set1_ps(static_cast<float>(1u << ex_bits));
+
+    size_t i = 0;
+    for (; i + 8 <= d; i += 8) {
+        const __m256 query = _mm256_loadu_ps(rotated_q + i);
+
+        auto reconstruct = [&](size_t code_index) FAISS_RABITQ_TARGET_BMI2 {
+            const __m256i sign_cmp = _mm256_cmpgt_epi32(
+                    _mm256_and_si256(
+                            _mm256_set1_epi32(sign_bits[code_index][i / 8]),
+                            bit_pos),
+                    zero);
+            __m256 reconstruction = _mm256_mul_ps(
+                    _mm256_and_ps(_mm256_castsi256_ps(sign_cmp), v_one),
+                    v_weights[ex_bits]);
+
+            uint64_t extra_bits = 0;
+            memcpy(&extra_bits,
+                   ex_codes[code_index] + (i / 8) * ex_bits,
+                   sizeof(extra_bits));
+            for (size_t b = 0; b < ex_bits; b++) {
+                const auto plane = static_cast<uint8_t>(
+                        _pext_u64(extra_bits, pext_masks[b]));
+                const __m256i plane_cmp = _mm256_cmpgt_epi32(
+                        _mm256_and_si256(_mm256_set1_epi32(plane), bit_pos),
+                        zero);
+                const __m256 plane_values =
+                        _mm256_and_ps(_mm256_castsi256_ps(plane_cmp), v_one);
+                reconstruction = _mm256_fmadd_ps(
+                        plane_values, v_weights[b], reconstruction);
+            }
+            return _mm256_add_ps(reconstruction, v_cb);
+        };
+
+        acc0 = _mm256_fmadd_ps(query, reconstruct(0), acc0);
+        acc1 = _mm256_fmadd_ps(query, reconstruct(1), acc1);
+        acc2 = _mm256_fmadd_ps(query, reconstruct(2), acc2);
+        acc3 = _mm256_fmadd_ps(query, reconstruct(3), acc3);
+    }
+
+    out[0] = hsum_avx2(acc0) +
+            ip_scalar(sign_bits[0], ex_codes[0], rotated_q, i, d, ex_bits, cb);
+    out[1] = hsum_avx2(acc1) +
+            ip_scalar(sign_bits[1], ex_codes[1], rotated_q, i, d, ex_bits, cb);
+    out[2] = hsum_avx2(acc2) +
+            ip_scalar(sign_bits[2], ex_codes[2], rotated_q, i, d, ex_bits, cb);
+    out[3] = hsum_avx2(acc3) +
+            ip_scalar(sign_bits[3], ex_codes[3], rotated_q, i, d, ex_bits, cb);
+}
+#endif
+
+// For five to seven extra bits, eight packed coordinates still fit in one
+// uint64_t. Extract the per-coordinate integers directly with AVX-512
+// variable shifts instead of rebuilding them one bitplane at a time.
+template <size_t ExBits>
+inline float ip_packed_8_avx512(
+        const uint8_t* __restrict sign_bits,
+        const uint8_t* __restrict ex_code,
+        const float* __restrict rotated_q,
+        size_t d,
+        float cb) {
+    static_assert(ExBits >= 5 && ExBits <= 7);
+    __m256 acc = _mm256_setzero_ps();
+    const __m256i bit_pos = _mm256_setr_epi32(1, 2, 4, 8, 16, 32, 64, 128);
+    const __m256i zero = _mm256_setzero_si256();
+    const __m256 v_cb = _mm256_set1_ps(cb);
+    const __m256 v_sign_weight =
+            _mm256_set1_ps(static_cast<float>(1u << ExBits));
+    const __m512i shifts = _mm512_setr_epi64(
+            0,
+            ExBits,
+            2 * ExBits,
+            3 * ExBits,
+            4 * ExBits,
+            5 * ExBits,
+            6 * ExBits,
+            7 * ExBits);
+    const __m512i value_mask = _mm512_set1_epi64((1u << ExBits) - 1);
+
+    size_t i = 0;
+    for (; i + 8 <= d; i += 8) {
+        uint64_t packed = 0;
+        memcpy(&packed, ex_code + (i / 8) * ExBits, ExBits);
+        const __m512i values = _mm512_and_si512(
+                _mm512_srlv_epi64(_mm512_set1_epi64(packed), shifts),
+                value_mask);
+        const __m256 extra_values =
+                _mm256_cvtepi32_ps(_mm512_cvtepi64_epi32(values));
+
+        const __m256i sign_cmp = _mm256_cmpgt_epi32(
+                _mm256_and_si256(_mm256_set1_epi32(sign_bits[i / 8]), bit_pos),
+                zero);
+        const __m256 sign_values =
+                _mm256_and_ps(_mm256_castsi256_ps(sign_cmp), v_sign_weight);
+        const __m256 reconstruction =
+                _mm256_add_ps(_mm256_add_ps(extra_values, sign_values), v_cb);
+        acc = _mm256_fmadd_ps(
+                _mm256_loadu_ps(rotated_q + i), reconstruction, acc);
+    }
+
+    return hsum_avx2(acc) +
+            ip_scalar(sign_bits, ex_code, rotated_q, i, d, ExBits, cb);
+}
+
+template <size_t ExBits>
+inline void ip_packed_8_batch_4_avx512(
+        const uint8_t* const sign_bits[4],
+        const uint8_t* const ex_codes[4],
+        const float* __restrict rotated_q,
+        size_t d,
+        float cb,
+        float out[4]) {
+    static_assert(ExBits >= 5 && ExBits <= 7);
+    __m256 acc0 = _mm256_setzero_ps();
+    __m256 acc1 = _mm256_setzero_ps();
+    __m256 acc2 = _mm256_setzero_ps();
+    __m256 acc3 = _mm256_setzero_ps();
+    const __m256i bit_pos = _mm256_setr_epi32(1, 2, 4, 8, 16, 32, 64, 128);
+    const __m256i zero = _mm256_setzero_si256();
+    const __m256 v_cb = _mm256_set1_ps(cb);
+    const __m256 v_sign_weight =
+            _mm256_set1_ps(static_cast<float>(1u << ExBits));
+    const __m512i shifts = _mm512_setr_epi64(
+            0,
+            ExBits,
+            2 * ExBits,
+            3 * ExBits,
+            4 * ExBits,
+            5 * ExBits,
+            6 * ExBits,
+            7 * ExBits);
+    const __m512i value_mask = _mm512_set1_epi64((1u << ExBits) - 1);
+
+    size_t i = 0;
+    for (; i + 8 <= d; i += 8) {
+        const __m256 query = _mm256_loadu_ps(rotated_q + i);
+
+        auto reconstruct = [&](size_t code_index) {
+            uint64_t packed = 0;
+            memcpy(&packed, ex_codes[code_index] + (i / 8) * ExBits, ExBits);
+            const __m512i values = _mm512_and_si512(
+                    _mm512_srlv_epi64(_mm512_set1_epi64(packed), shifts),
+                    value_mask);
+            const __m256 extra_values =
+                    _mm256_cvtepi32_ps(_mm512_cvtepi64_epi32(values));
+
+            const __m256i sign_cmp = _mm256_cmpgt_epi32(
+                    _mm256_and_si256(
+                            _mm256_set1_epi32(sign_bits[code_index][i / 8]),
+                            bit_pos),
+                    zero);
+            const __m256 sign_values =
+                    _mm256_and_ps(_mm256_castsi256_ps(sign_cmp), v_sign_weight);
+            return _mm256_add_ps(
+                    _mm256_add_ps(extra_values, sign_values), v_cb);
+        };
+
+        acc0 = _mm256_fmadd_ps(query, reconstruct(0), acc0);
+        acc1 = _mm256_fmadd_ps(query, reconstruct(1), acc1);
+        acc2 = _mm256_fmadd_ps(query, reconstruct(2), acc2);
+        acc3 = _mm256_fmadd_ps(query, reconstruct(3), acc3);
+    }
+
+    out[0] = hsum_avx2(acc0) +
+            ip_scalar(sign_bits[0], ex_codes[0], rotated_q, i, d, ExBits, cb);
+    out[1] = hsum_avx2(acc1) +
+            ip_scalar(sign_bits[1], ex_codes[1], rotated_q, i, d, ExBits, cb);
+    out[2] = hsum_avx2(acc2) +
+            ip_scalar(sign_bits[2], ex_codes[2], rotated_q, i, d, ExBits, cb);
+    out[3] = hsum_avx2(acc3) +
+            ip_scalar(sign_bits[3], ex_codes[3], rotated_q, i, d, ExBits, cb);
+}
+
+template <size_t ExBits>
+inline __m256i unpack_packed_8_avx512(
+        const uint8_t* __restrict ex_code,
+        const __m512i shifts,
+        const __m512i value_mask) {
+    uint64_t packed = 0;
+    memcpy(&packed, ex_code, ExBits);
+    const __m512i values = _mm512_and_si512(
+            _mm512_srlv_epi64(_mm512_set1_epi64(packed), shifts), value_mask);
+    return _mm512_cvtepi64_epi32(values);
+}
+
+template <size_t ExBits>
+inline float ip_packed_16_avx512(
+        const uint8_t* __restrict sign_bits,
+        const uint8_t* __restrict ex_code,
+        const float* __restrict rotated_q,
+        size_t d,
+        float cb) {
+    static_assert(ExBits >= 5 && ExBits <= 7);
+    __m512 acc = _mm512_setzero_ps();
+    const __m512 v_one = _mm512_set1_ps(1.0f);
+    const __m512 v_cb = _mm512_set1_ps(cb);
+    const __m512 v_sign_weight =
+            _mm512_set1_ps(static_cast<float>(1u << ExBits));
+    const __m512i shifts = _mm512_setr_epi64(
+            0,
+            ExBits,
+            2 * ExBits,
+            3 * ExBits,
+            4 * ExBits,
+            5 * ExBits,
+            6 * ExBits,
+            7 * ExBits);
+    const __m512i value_mask = _mm512_set1_epi64((1u << ExBits) - 1);
+
+    size_t i = 0;
+    for (; i + 16 <= d; i += 16) {
+        const uint8_t* block = ex_code + (i / 8) * ExBits;
+        const __m256i lo =
+                unpack_packed_8_avx512<ExBits>(block, shifts, value_mask);
+        const __m256i hi = unpack_packed_8_avx512<ExBits>(
+                block + ExBits, shifts, value_mask);
+        const __m512i values =
+                _mm512_inserti64x4(_mm512_castsi256_si512(lo), hi, 1);
+        const __m512 extra_values = _mm512_cvtepi32_ps(values);
+
+        uint16_t sign_plane = 0;
+        memcpy(&sign_plane, sign_bits + i / 8, sizeof(sign_plane));
+        const __m512 sign_values = _mm512_mul_ps(
+                _mm512_maskz_mov_ps(_cvtu32_mask16(sign_plane), v_one),
+                v_sign_weight);
+        const __m512 reconstruction =
+                _mm512_add_ps(_mm512_add_ps(extra_values, sign_values), v_cb);
+        acc = _mm512_fmadd_ps(
+                _mm512_loadu_ps(rotated_q + i), reconstruction, acc);
+    }
+
+    return _mm512_reduce_add_ps(acc) +
+            ip_scalar(sign_bits, ex_code, rotated_q, i, d, ExBits, cb);
+}
+
+template <size_t ExBits>
+inline void ip_packed_16_batch_4_avx512(
+        const uint8_t* const sign_bits[4],
+        const uint8_t* const ex_codes[4],
+        const float* __restrict rotated_q,
+        size_t d,
+        float cb,
+        float out[4]) {
+    static_assert(ExBits >= 5 && ExBits <= 7);
+    __m512 acc0 = _mm512_setzero_ps();
+    __m512 acc1 = _mm512_setzero_ps();
+    __m512 acc2 = _mm512_setzero_ps();
+    __m512 acc3 = _mm512_setzero_ps();
+    const __m512 v_one = _mm512_set1_ps(1.0f);
+    const __m512 v_cb = _mm512_set1_ps(cb);
+    const __m512 v_sign_weight =
+            _mm512_set1_ps(static_cast<float>(1u << ExBits));
+    const __m512i shifts = _mm512_setr_epi64(
+            0,
+            ExBits,
+            2 * ExBits,
+            3 * ExBits,
+            4 * ExBits,
+            5 * ExBits,
+            6 * ExBits,
+            7 * ExBits);
+    const __m512i value_mask = _mm512_set1_epi64((1u << ExBits) - 1);
+
+    size_t i = 0;
+    for (; i + 16 <= d; i += 16) {
+        const __m512 query = _mm512_loadu_ps(rotated_q + i);
+
+        auto reconstruct = [&](size_t code_index) {
+            const uint8_t* block = ex_codes[code_index] + (i / 8) * ExBits;
+            const __m256i lo =
+                    unpack_packed_8_avx512<ExBits>(block, shifts, value_mask);
+            const __m256i hi = unpack_packed_8_avx512<ExBits>(
+                    block + ExBits, shifts, value_mask);
+            const __m512i values =
+                    _mm512_inserti64x4(_mm512_castsi256_si512(lo), hi, 1);
+            const __m512 extra_values = _mm512_cvtepi32_ps(values);
+
+            uint16_t sign_plane = 0;
+            memcpy(&sign_plane,
+                   sign_bits[code_index] + i / 8,
+                   sizeof(sign_plane));
+            const __m512 sign_values = _mm512_mul_ps(
+                    _mm512_maskz_mov_ps(_cvtu32_mask16(sign_plane), v_one),
+                    v_sign_weight);
+            return _mm512_add_ps(
+                    _mm512_add_ps(extra_values, sign_values), v_cb);
+        };
+
+        acc0 = _mm512_fmadd_ps(query, reconstruct(0), acc0);
+        acc1 = _mm512_fmadd_ps(query, reconstruct(1), acc1);
+        acc2 = _mm512_fmadd_ps(query, reconstruct(2), acc2);
+        acc3 = _mm512_fmadd_ps(query, reconstruct(3), acc3);
+    }
+
+    out[0] = _mm512_reduce_add_ps(acc0) +
+            ip_scalar(sign_bits[0], ex_codes[0], rotated_q, i, d, ExBits, cb);
+    out[1] = _mm512_reduce_add_ps(acc1) +
+            ip_scalar(sign_bits[1], ex_codes[1], rotated_q, i, d, ExBits, cb);
+    out[2] = _mm512_reduce_add_ps(acc2) +
+            ip_scalar(sign_bits[2], ex_codes[2], rotated_q, i, d, ExBits, cb);
+    out[3] = _mm512_reduce_add_ps(acc3) +
+            ip_scalar(sign_bits[3], ex_codes[3], rotated_q, i, d, ExBits, cb);
+}
+
+#if FAISS_RABITQ_HAS_BMI2_TARGET
+FAISS_RABITQ_TARGET_BMI2 inline float ip_bitplane_avx512(
         const uint8_t* __restrict sign_bits,
         const uint8_t* __restrict ex_code,
         const float* __restrict rotated_q,
@@ -669,75 +1578,122 @@ inline float ip_bitplane_avx512(
         size_t ex_bits,
         float cb) {
     __m512 acc = _mm512_setzero_ps();
+    const __m512 v_one = _mm512_set1_ps(1.0f);
     const __m512 v_cb = _mm512_set1_ps(cb);
+    const __m512 v_sign_weight =
+            _mm512_set1_ps(static_cast<float>(1u << ex_bits));
 
-    uint64_t pext_masks[7];
-    __m512 v_weights[8];
+    uint64_t pext_masks[4];
+    __m512 v_weights[4];
     for (size_t b = 0; b < ex_bits; b++) {
-        uint64_t m = 0;
-        for (int j = 0; j < 8; j++) {
-            m |= (1ULL << (b + j * ex_bits));
+        uint64_t mask = 0;
+        for (int j = 0; j < 16; j++) {
+            mask |= (1ULL << (j * ex_bits + b));
         }
-        pext_masks[b] = m;
+        pext_masks[b] = mask;
         v_weights[b] = _mm512_set1_ps(static_cast<float>(1u << b));
     }
-    v_weights[ex_bits] = _mm512_set1_ps(static_cast<float>(1u << ex_bits));
 
     size_t i = 0;
     for (; i + 16 <= d; i += 16) {
-        uint16_t sb = 0;
-        memcpy(&sb, sign_bits + (i / 8), sizeof(uint16_t));
-        __m512 recon = _mm512_maskz_mov_ps(
-                static_cast<__mmask16>(sb), v_weights[ex_bits]);
+        uint16_t sign_plane = 0;
+        memcpy(&sign_plane, sign_bits + i / 8, sizeof(sign_plane));
+        __m512 reconstruction = _mm512_mul_ps(
+                _mm512_maskz_mov_ps(_cvtu32_mask16(sign_plane), v_one),
+                v_sign_weight);
 
-        uint64_t lo64 = 0;
-        uint64_t hi64 = 0;
-        memcpy(&lo64, ex_code + (i / 8) * ex_bits, sizeof(uint64_t));
-        memcpy(&hi64, ex_code + ((i / 8) + 1) * ex_bits, sizeof(uint64_t));
-
+        uint64_t extra_bits = 0;
+        memcpy(&extra_bits, ex_code + (i / 8) * ex_bits, sizeof(extra_bits));
         for (size_t b = 0; b < ex_bits; b++) {
-            const uint32_t plane =
-                    static_cast<uint32_t>(_pext_u64(lo64, pext_masks[b])) |
-                    (static_cast<uint32_t>(_pext_u64(hi64, pext_masks[b]))
-                     << 8);
-            recon = _mm512_mask_add_ps(
-                    recon, static_cast<__mmask16>(plane), recon, v_weights[b]);
+            const uint16_t plane =
+                    static_cast<uint16_t>(_pext_u64(extra_bits, pext_masks[b]));
+            const __m512 plane_values =
+                    _mm512_maskz_mov_ps(_cvtu32_mask16(plane), v_one);
+            reconstruction =
+                    _mm512_fmadd_ps(plane_values, v_weights[b], reconstruction);
         }
 
-        __m512 rq = _mm512_loadu_ps(rotated_q + i);
-        acc = _mm512_fmadd_ps(rq, _mm512_add_ps(recon, v_cb), acc);
-    }
-
-    // Half-width step: keeps the scalar tail under 8 dims when d is a multiple
-    // of 8 but not of 16 (e.g. 200, 1000). The upper 8 lanes are masked off
-    // throughout, and rotated_q is loaded masked so nothing is read past the
-    // end.
-    if (i + 8 <= d) {
-        const __mmask16 low8 = static_cast<__mmask16>(0x00ff);
-        __m512 recon = _mm512_maskz_mov_ps(
-                static_cast<__mmask16>(sign_bits[i / 8]), v_weights[ex_bits]);
-
-        uint64_t lo64 = 0;
-        memcpy(&lo64, ex_code + (i / 8) * ex_bits, sizeof(uint64_t));
-
-        for (size_t b = 0; b < ex_bits; b++) {
-            const uint32_t plane =
-                    static_cast<uint32_t>(_pext_u64(lo64, pext_masks[b]));
-            recon = _mm512_mask_add_ps(
-                    recon, static_cast<__mmask16>(plane), recon, v_weights[b]);
-        }
-
-        __m512 rq = _mm512_maskz_loadu_ps(low8, rotated_q + i);
-        acc = _mm512_fmadd_ps(
-                rq, _mm512_mask_add_ps(recon, low8, recon, v_cb), acc);
-        i += 8;
+        const __m512 query = _mm512_loadu_ps(rotated_q + i);
+        acc = _mm512_fmadd_ps(query, _mm512_add_ps(reconstruction, v_cb), acc);
     }
 
     float result = _mm512_reduce_add_ps(acc);
     result += ip_scalar(sign_bits, ex_code, rotated_q, i, d, ex_bits, cb);
     return result;
 }
-#endif // __BMI2__
+
+FAISS_RABITQ_TARGET_BMI2 inline void ip_bitplane_batch_4_avx512(
+        const uint8_t* const sign_bits[4],
+        const uint8_t* const ex_codes[4],
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb,
+        float out[4]) {
+    __m512 acc0 = _mm512_setzero_ps();
+    __m512 acc1 = _mm512_setzero_ps();
+    __m512 acc2 = _mm512_setzero_ps();
+    __m512 acc3 = _mm512_setzero_ps();
+    const __m512 v_one = _mm512_set1_ps(1.0f);
+    const __m512 v_cb = _mm512_set1_ps(cb);
+    const __m512 v_sign_weight =
+            _mm512_set1_ps(static_cast<float>(1u << ex_bits));
+
+    uint64_t pext_masks[4];
+    __m512 v_weights[4];
+    for (size_t b = 0; b < ex_bits; b++) {
+        uint64_t mask = 0;
+        for (int j = 0; j < 16; j++) {
+            mask |= (1ULL << (j * ex_bits + b));
+        }
+        pext_masks[b] = mask;
+        v_weights[b] = _mm512_set1_ps(static_cast<float>(1u << b));
+    }
+
+    size_t i = 0;
+    for (; i + 16 <= d; i += 16) {
+        const __m512 query = _mm512_loadu_ps(rotated_q + i);
+
+        auto reconstruct = [&](size_t code_index) FAISS_RABITQ_TARGET_BMI2 {
+            uint16_t sign_plane = 0;
+            memcpy(&sign_plane,
+                   sign_bits[code_index] + i / 8,
+                   sizeof(sign_plane));
+            __m512 reconstruction = _mm512_mul_ps(
+                    _mm512_maskz_mov_ps(_cvtu32_mask16(sign_plane), v_one),
+                    v_sign_weight);
+
+            uint64_t extra_bits = 0;
+            memcpy(&extra_bits,
+                   ex_codes[code_index] + (i / 8) * ex_bits,
+                   sizeof(extra_bits));
+            for (size_t b = 0; b < ex_bits; b++) {
+                const uint16_t plane = static_cast<uint16_t>(
+                        _pext_u64(extra_bits, pext_masks[b]));
+                const __m512 plane_values =
+                        _mm512_maskz_mov_ps(_cvtu32_mask16(plane), v_one);
+                reconstruction = _mm512_fmadd_ps(
+                        plane_values, v_weights[b], reconstruction);
+            }
+            return _mm512_add_ps(reconstruction, v_cb);
+        };
+
+        acc0 = _mm512_fmadd_ps(query, reconstruct(0), acc0);
+        acc1 = _mm512_fmadd_ps(query, reconstruct(1), acc1);
+        acc2 = _mm512_fmadd_ps(query, reconstruct(2), acc2);
+        acc3 = _mm512_fmadd_ps(query, reconstruct(3), acc3);
+    }
+
+    out[0] = _mm512_reduce_add_ps(acc0) +
+            ip_scalar(sign_bits[0], ex_codes[0], rotated_q, i, d, ex_bits, cb);
+    out[1] = _mm512_reduce_add_ps(acc1) +
+            ip_scalar(sign_bits[1], ex_codes[1], rotated_q, i, d, ex_bits, cb);
+    out[2] = _mm512_reduce_add_ps(acc2) +
+            ip_scalar(sign_bits[2], ex_codes[2], rotated_q, i, d, ex_bits, cb);
+    out[3] = _mm512_reduce_add_ps(acc3) +
+            ip_scalar(sign_bits[3], ex_codes[3], rotated_q, i, d, ex_bits, cb);
+}
+#endif
 
 } // namespace
 
@@ -753,14 +1709,74 @@ float compute_inner_product<SIMDLevel::AVX512>(
         return ip_1exbit_avx512(sign_bits, ex_code, rotated_q, d, cb);
     }
 
-#ifdef __BMI2__
-    if (ex_bits <= 7) {
+    switch (ex_bits) {
+        case 5:
+            return ip_packed_16_avx512<5>(sign_bits, ex_code, rotated_q, d, cb);
+        case 6:
+            return ip_packed_16_avx512<6>(sign_bits, ex_code, rotated_q, d, cb);
+        case 7:
+            return ip_packed_16_avx512<7>(sign_bits, ex_code, rotated_q, d, cb);
+        default:
+            break;
+    }
+
+#if FAISS_RABITQ_HAS_BMI2_TARGET
+    if (ex_bits <= 4 && cpu_supports_fast_bmi2()) {
         return ip_bitplane_avx512(
                 sign_bits, ex_code, rotated_q, d, ex_bits, cb);
+    }
+    if (ex_bits <= 7 && cpu_supports_fast_bmi2()) {
+        return ip_bitplane_avx2(sign_bits, ex_code, rotated_q, d, ex_bits, cb);
     }
 #endif
     return ip_scalar(sign_bits, ex_code, rotated_q, 0, d, ex_bits, cb);
 }
+
+template <>
+void compute_inner_product_batch_4<SIMDLevel::AVX512>(
+        const uint8_t* const sign_bits[4],
+        const uint8_t* const ex_codes[4],
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb,
+        float out[4]) {
+    switch (ex_bits) {
+        case 5:
+            ip_packed_16_batch_4_avx512<5>(
+                    sign_bits, ex_codes, rotated_q, d, cb, out);
+            return;
+        case 6:
+            ip_packed_16_batch_4_avx512<6>(
+                    sign_bits, ex_codes, rotated_q, d, cb, out);
+            return;
+        case 7:
+            ip_packed_16_batch_4_avx512<7>(
+                    sign_bits, ex_codes, rotated_q, d, cb, out);
+            return;
+        default:
+            break;
+    }
+#if FAISS_RABITQ_HAS_BMI2_TARGET
+    if (ex_bits <= 4 && cpu_supports_fast_bmi2()) {
+        ip_bitplane_batch_4_avx512(
+                sign_bits, ex_codes, rotated_q, d, ex_bits, cb, out);
+        return;
+    }
+    if (ex_bits <= 7 && cpu_supports_fast_bmi2()) {
+        ip_bitplane_batch_4_avx2(
+                sign_bits, ex_codes, rotated_q, d, ex_bits, cb, out);
+        return;
+    }
+#endif
+    for (size_t i = 0; i < 4; i++) {
+        out[i] = compute_inner_product<SIMDLevel::AVX512>(
+                sign_bits[i], ex_codes[i], rotated_q, d, ex_bits, cb);
+    }
+}
+
+#undef FAISS_RABITQ_TARGET_BMI2
+#undef FAISS_RABITQ_HAS_BMI2_TARGET
 
 } // namespace faiss::rabitq::multibit
 

--- a/faiss/utils/simd_impl/rabitq_avx512_spr.cpp
+++ b/faiss/utils/simd_impl/rabitq_avx512_spr.cpp
@@ -65,6 +65,11 @@ uint64_t bitwise_xor_dot_product<SIMDLevel::AVX512>(
         size_t qb);
 template <>
 uint64_t popcount<SIMDLevel::AVX512>(const uint8_t* data, size_t size);
+template <>
+float selected_float_sum<SIMDLevel::AVX512>(
+        const uint8_t* sign_bits,
+        const float* values,
+        size_t d);
 
 namespace {
 
@@ -117,8 +122,8 @@ uint64_t bitwise_and_dot_product<SIMDLevel::AVX512_SPR>(
             __m512i v_x = _mm512_loadu_si512(
                     reinterpret_cast<const __m512i*>(data + offset));
             for (size_t j = 0; j < qb; j++) {
-                __m512i v_q = _mm512_loadu_si512(
-                        reinterpret_cast<const __m512i*>(
+                __m512i v_q =
+                        _mm512_loadu_si512(reinterpret_cast<const __m512i*>(
                                 query + j * size + offset));
                 __m512i v_and = _mm512_and_si512(v_q, v_x);
                 __m512i v_popcnt = popcount_512_vpopcntdq(v_and);
@@ -136,8 +141,8 @@ uint64_t bitwise_and_dot_product<SIMDLevel::AVX512_SPR>(
             __m256i v_x = _mm256_loadu_si256(
                     reinterpret_cast<const __m256i*>(data + offset));
             for (size_t j = 0; j < qb; j++) {
-                __m256i v_q = _mm256_loadu_si256(
-                        reinterpret_cast<const __m256i*>(
+                __m256i v_q =
+                        _mm256_loadu_si256(reinterpret_cast<const __m256i*>(
                                 query + j * size + offset));
                 __m256i v_and = _mm256_and_si256(v_q, v_x);
                 __m256i v_popcnt = popcount_256_vpopcntdq(v_and);
@@ -154,9 +159,8 @@ uint64_t bitwise_and_dot_product<SIMDLevel::AVX512_SPR>(
         __m128i v_x = _mm_loadu_si128(
                 reinterpret_cast<const __m128i*>(data + offset));
         for (size_t j = 0; j < qb; j++) {
-            __m128i v_q = _mm_loadu_si128(
-                    reinterpret_cast<const __m128i*>(
-                            query + j * size + offset));
+            __m128i v_q = _mm_loadu_si128(reinterpret_cast<const __m128i*>(
+                    query + j * size + offset));
             __m128i v_and = _mm_and_si128(v_q, v_x);
             __m128i v_popcnt = popcount_128_vpopcntdq(v_and);
             __m128i v_shifted = _mm_slli_epi64(v_popcnt, j);
@@ -204,8 +208,8 @@ BitwiseAndDotProductResult bitwise_and_dot_product_with_popcount<
                     reinterpret_cast<const __m512i*>(data + offset));
             pop_512 = _mm512_add_epi64(pop_512, popcount_512_vpopcntdq(v_x));
             for (size_t j = 0; j < qb; j++) {
-                __m512i v_q = _mm512_loadu_si512(
-                        reinterpret_cast<const __m512i*>(
+                __m512i v_q =
+                        _mm512_loadu_si512(reinterpret_cast<const __m512i*>(
                                 query + j * size + offset));
                 __m512i v_and = _mm512_and_si512(v_q, v_x);
                 __m512i v_popcnt = popcount_512_vpopcntdq(v_and);
@@ -225,8 +229,8 @@ BitwiseAndDotProductResult bitwise_and_dot_product_with_popcount<
                     reinterpret_cast<const __m256i*>(data + offset));
             pop_256 = _mm256_add_epi64(pop_256, popcount_256_vpopcntdq(v_x));
             for (size_t j = 0; j < qb; j++) {
-                __m256i v_q = _mm256_loadu_si256(
-                        reinterpret_cast<const __m256i*>(
+                __m256i v_q =
+                        _mm256_loadu_si256(reinterpret_cast<const __m256i*>(
                                 query + j * size + offset));
                 __m256i v_and = _mm256_and_si256(v_q, v_x);
                 __m256i v_popcnt = popcount_256_vpopcntdq(v_and);
@@ -245,9 +249,8 @@ BitwiseAndDotProductResult bitwise_and_dot_product_with_popcount<
                 reinterpret_cast<const __m128i*>(data + offset));
         pop_128 = _mm_add_epi64(pop_128, popcount_128_vpopcntdq(v_x));
         for (size_t j = 0; j < qb; j++) {
-            __m128i v_q = _mm_loadu_si128(
-                    reinterpret_cast<const __m128i*>(
-                            query + j * size + offset));
+            __m128i v_q = _mm_loadu_si128(reinterpret_cast<const __m128i*>(
+                    query + j * size + offset));
             __m128i v_and = _mm_and_si128(v_q, v_x);
             __m128i v_popcnt = popcount_128_vpopcntdq(v_and);
             __m128i v_shifted = _mm_slli_epi64(v_popcnt, j);
@@ -292,8 +295,8 @@ uint64_t bitwise_xor_dot_product<SIMDLevel::AVX512_SPR>(
             __m512i v_x = _mm512_loadu_si512(
                     reinterpret_cast<const __m512i*>(data + offset));
             for (size_t j = 0; j < qb; j++) {
-                __m512i v_q = _mm512_loadu_si512(
-                        reinterpret_cast<const __m512i*>(
+                __m512i v_q =
+                        _mm512_loadu_si512(reinterpret_cast<const __m512i*>(
                                 query + j * size + offset));
                 __m512i v_xor = _mm512_xor_si512(v_q, v_x);
                 __m512i v_popcnt = popcount_512_vpopcntdq(v_xor);
@@ -310,8 +313,8 @@ uint64_t bitwise_xor_dot_product<SIMDLevel::AVX512_SPR>(
             __m256i v_x = _mm256_loadu_si256(
                     reinterpret_cast<const __m256i*>(data + offset));
             for (size_t j = 0; j < qb; j++) {
-                __m256i v_q = _mm256_loadu_si256(
-                        reinterpret_cast<const __m256i*>(
+                __m256i v_q =
+                        _mm256_loadu_si256(reinterpret_cast<const __m256i*>(
                                 query + j * size + offset));
                 __m256i v_xor = _mm256_xor_si256(v_q, v_x);
                 __m256i v_popcnt = popcount_256_vpopcntdq(v_xor);
@@ -327,9 +330,8 @@ uint64_t bitwise_xor_dot_product<SIMDLevel::AVX512_SPR>(
         __m128i v_x = _mm_loadu_si128(
                 reinterpret_cast<const __m128i*>(data + offset));
         for (size_t j = 0; j < qb; j++) {
-            __m128i v_q = _mm_loadu_si128(
-                    reinterpret_cast<const __m128i*>(
-                            query + j * size + offset));
+            __m128i v_q = _mm_loadu_si128(reinterpret_cast<const __m128i*>(
+                    query + j * size + offset));
             __m128i v_xor = _mm_xor_si128(v_q, v_x);
             __m128i v_popcnt = popcount_128_vpopcntdq(v_xor);
             __m128i v_shifted = _mm_slli_epi64(v_popcnt, j);
@@ -402,9 +404,92 @@ uint64_t popcount<SIMDLevel::AVX512_SPR>(const uint8_t* data, size_t size) {
     return sum;
 }
 
+template <>
+float selected_float_sum<SIMDLevel::AVX512_SPR>(
+        const uint8_t* sign_bits,
+        const float* values,
+        size_t d) {
+    return selected_float_sum<SIMDLevel::AVX512>(sign_bits, values, d);
+}
+
 } // namespace faiss::rabitq
 
 namespace faiss::rabitq::multibit {
+
+template <>
+float compute_inner_product_byte<SIMDLevel::AVX512>(
+        const uint8_t* __restrict code,
+        const float* __restrict query,
+        size_t d,
+        float cb);
+
+template <>
+void compute_inner_product_byte_batch_4<SIMDLevel::AVX512>(
+        const uint8_t* const codes[4],
+        const float* __restrict query,
+        size_t d,
+        float cb,
+        float out[4]);
+
+template <>
+float compute_inner_product_dense<SIMDLevel::AVX512>(
+        const uint8_t* code,
+        const float* query,
+        size_t d,
+        size_t nbits,
+        float cb);
+
+template <>
+void compute_inner_product_dense_batch_4<SIMDLevel::AVX512>(
+        const uint8_t* const codes[4],
+        const float* query,
+        size_t d,
+        size_t nbits,
+        float cb,
+        float out[4]);
+
+template <>
+float compute_inner_product_byte<SIMDLevel::AVX512_SPR>(
+        const uint8_t* __restrict code,
+        const float* __restrict query,
+        size_t d,
+        float cb) {
+    return compute_inner_product_byte<SIMDLevel::AVX512>(code, query, d, cb);
+}
+
+template <>
+void compute_inner_product_byte_batch_4<SIMDLevel::AVX512_SPR>(
+        const uint8_t* const codes[4],
+        const float* __restrict query,
+        size_t d,
+        float cb,
+        float out[4]) {
+    compute_inner_product_byte_batch_4<SIMDLevel::AVX512>(
+            codes, query, d, cb, out);
+}
+
+template <>
+float compute_inner_product_dense<SIMDLevel::AVX512_SPR>(
+        const uint8_t* code,
+        const float* query,
+        size_t d,
+        size_t nbits,
+        float cb) {
+    return compute_inner_product_dense<SIMDLevel::AVX512>(
+            code, query, d, nbits, cb);
+}
+
+template <>
+void compute_inner_product_dense_batch_4<SIMDLevel::AVX512_SPR>(
+        const uint8_t* const codes[4],
+        const float* query,
+        size_t d,
+        size_t nbits,
+        float cb,
+        float out[4]) {
+    compute_inner_product_dense_batch_4<SIMDLevel::AVX512>(
+            codes, query, d, nbits, cb, out);
+}
 
 // Forward-declare the AVX512 floating-point inner-product kernel.
 // VPOPCNTDQ does not help this kernel (it operates on FP32), so we
@@ -419,6 +504,16 @@ float compute_inner_product<SIMDLevel::AVX512>(
         float cb);
 
 template <>
+void compute_inner_product_batch_4<SIMDLevel::AVX512>(
+        const uint8_t* const sign_bits[4],
+        const uint8_t* const ex_codes[4],
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb,
+        float out[4]);
+
+template <>
 float compute_inner_product<SIMDLevel::AVX512_SPR>(
         const uint8_t* __restrict sign_bits,
         const uint8_t* __restrict ex_code,
@@ -428,6 +523,19 @@ float compute_inner_product<SIMDLevel::AVX512_SPR>(
         float cb) {
     return compute_inner_product<SIMDLevel::AVX512>(
             sign_bits, ex_code, rotated_q, d, ex_bits, cb);
+}
+
+template <>
+void compute_inner_product_batch_4<SIMDLevel::AVX512_SPR>(
+        const uint8_t* const sign_bits[4],
+        const uint8_t* const ex_codes[4],
+        const float* __restrict rotated_q,
+        size_t d,
+        size_t ex_bits,
+        float cb,
+        float out[4]) {
+    compute_inner_product_batch_4<SIMDLevel::AVX512>(
+            sign_bits, ex_codes, rotated_q, d, ex_bits, cb, out);
 }
 
 } // namespace faiss::rabitq::multibit

--- a/faiss/utils/simd_impl/rabitq_neon.cpp
+++ b/faiss/utils/simd_impl/rabitq_neon.cpp
@@ -45,6 +45,14 @@ uint64_t popcount<SIMDLevel::ARM_NEON>(const uint8_t* data, size_t size) {
     return popcount<SIMDLevel::NONE>(data, size);
 }
 
+template <>
+float selected_float_sum<SIMDLevel::ARM_NEON>(
+        const uint8_t* sign_bits,
+        const float* values,
+        size_t d) {
+    return selected_float_sum<SIMDLevel::NONE>(sign_bits, values, d);
+}
+
 } // namespace faiss::rabitq
 
 namespace faiss::rabitq::multibit {
@@ -59,6 +67,17 @@ float compute_inner_product<SIMDLevel::ARM_NEON>(
         float cb) {
     return compute_inner_product<SIMDLevel::NONE>(
             sign_bits, ex_code, rotated_q, d, ex_bits, cb);
+}
+
+template <>
+float compute_inner_product_dense<SIMDLevel::ARM_NEON>(
+        const uint8_t* __restrict code,
+        const float* __restrict query,
+        size_t d,
+        size_t nbits,
+        float cb) {
+    return compute_inner_product_dense<SIMDLevel::NONE>(
+            code, query, d, nbits, cb);
 }
 
 } // namespace faiss::rabitq::multibit

--- a/faiss/utils/simd_impl/rabitq_rvv.cpp
+++ b/faiss/utils/simd_impl/rabitq_rvv.cpp
@@ -137,6 +137,14 @@ uint64_t popcount<SIMDLevel::RISCV_RVV>(const uint8_t* data, size_t size) {
     return __riscv_vmv_x_s_u32m1_u32(red);
 }
 
+template <>
+float selected_float_sum<SIMDLevel::RISCV_RVV>(
+        const uint8_t* sign_bits,
+        const float* values,
+        size_t d) {
+    return selected_float_sum<SIMDLevel::NONE>(sign_bits, values, d);
+}
+
 } // namespace faiss::rabitq
 
 namespace faiss::rabitq::multibit {
@@ -185,6 +193,17 @@ compute_inner_product<SIMDLevel::RISCV_RVV>(
     // ex_bits >= 2 needs strided bit-plane extraction (PEXT on x86); RVV has no
     // cheap equivalent without Zvbb, so reuse the scalar kernel.
     return ip_scalar(sign_bits, ex_code, rotated_q, 0, d, ex_bits, cb);
+}
+
+template <>
+float compute_inner_product_dense<SIMDLevel::RISCV_RVV>(
+        const uint8_t* __restrict code,
+        const float* __restrict query,
+        size_t d,
+        size_t nbits,
+        float cb) {
+    return compute_inner_product_dense<SIMDLevel::NONE>(
+            code, query, d, nbits, cb);
 }
 
 } // namespace faiss::rabitq::multibit

--- a/faiss/utils/simd_levels.cpp
+++ b/faiss/utils/simd_levels.cpp
@@ -23,6 +23,7 @@ uint64_t SIMDConfig::supported_simd_levels = 0;
 // Microarchitecture flags (x86). Default false; set by
 // detect_x86_uarch_flags() at load time.
 bool SIMDConfig::avx512_split = false;
+bool SIMDConfig::bmi2_fast = false;
 
 // Resolved here rather than in the header so that dependents, which never see
 // FAISS_ENABLE_DD, still get the answer for the faiss they link against.
@@ -81,8 +82,26 @@ void detect_x86_uarch_flags() {
     asm volatile("cpuid"
                  : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx)
                  : "a"(eax), "c"(ecx));
+    const unsigned int max_basic_leaf = eax;
     const bool is_amd =
             ebx == 0x68747541u && edx == 0x69746e65u && ecx == 0x444d4163u;
+
+    // CPUID.7.0: EBX bit 8 is BMI2 and bit 16 is AVX-512F. All AMD Zen 4+
+    // CPUs implement AVX-512F, whereas AMD CPUs before Zen 4 do not. Use the
+    // latter as a robust generation gate rather than family/model tables,
+    // because family 0x19 contains both Zen 3 and Zen 4 model ranges.
+    bool has_bmi2 = false;
+    bool has_avx512f = false;
+    if (max_basic_leaf >= 7) {
+        eax = 7;
+        ecx = 0;
+        asm volatile("cpuid"
+                     : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx)
+                     : "a"(eax), "c"(ecx));
+        has_bmi2 = (ebx & (1u << 8)) != 0;
+        has_avx512f = (ebx & (1u << 16)) != 0;
+    }
+    SIMDConfig::bmi2_fast = has_bmi2 && (!is_amd || has_avx512f);
 
     // Family/model (CPUID.1 EAX).
     eax = 1;
@@ -115,6 +134,9 @@ void detect_x86_uarch_flags() {}
 static SIMDConfig simd_config_initializer;
 
 SIMDConfig::SIMDConfig(const char** faiss_simd_level_env) {
+    // Initialize microarchitecture flags even when the SIMD level is forced
+    // through FAISS_SIMD_LEVEL.
+    detect_x86_uarch_flags();
     // Support dependency injection for testing
     const char* env_var = faiss_simd_level_env ? *faiss_simd_level_env
                                                : getenv("FAISS_SIMD_LEVEL");

--- a/faiss/utils/simd_levels.h
+++ b/faiss/utils/simd_levels.h
@@ -167,6 +167,11 @@ struct FAISS_API SIMDConfig {
     /// 256-bit kernel.
     static bool avx512_split;
 
+    /// BMI2 PEXT is a fast hardware instruction on Intel and AMD Zen 4+.
+    /// AMD CPUs before Zen 4 advertise BMI2 but execute PEXT very slowly, so
+    /// RaBitQ bit-plane kernels must use their non-BMI2 fallback there.
+    static bool bmi2_fast;
+
     static SIMDLevel auto_detect_simd_level();
 
     /// Whether this faiss build dispatches SIMD at runtime.

--- a/perf_tests/CMakeLists.txt
+++ b/perf_tests/CMakeLists.txt
@@ -31,6 +31,14 @@ include(../cmake/link_to_faiss_lib.cmake)
 
 link_to_faiss_lib(faiss_perf_tests_utils)
 
+if(FAISS_OPT_LEVEL STREQUAL "dd" AND CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|amd64|AMD64)")
+  # The benchmark directly instantiates DD-only AVX2/AVX-512 symbols. Keep it
+  # opt-in so generic/avx2 default builds neither link nor run unavailable ISA.
+  add_executable(bench_rabitq_simd EXCLUDE_FROM_ALL ../benchs/bench_rabitq_simd.cpp)
+  link_to_faiss_lib(bench_rabitq_simd)
+  target_link_libraries(bench_rabitq_simd PRIVATE benchmark::benchmark)
+endif()
+
 set(FAISS_PERF_TEST_SRC
   bench_no_multithreading_rcq_search.cpp
   bench_scalar_quantizer_accuracy.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ set(FAISS_TEST_SRC
   test_simd_levels.cpp
   test_fast_scan_distance_to_code.cpp
   test_rabitq_fastscan.cpp
+  test_rabitq_dense.cpp
   test_super_kmeans_foundations.cpp
 )
 

--- a/tests/test_rabitq_dense.cpp
+++ b/tests/test_rabitq_dense.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+#include <faiss/IndexRaBitQ.h>
+#include <faiss/IndexRaBitQFastScan.h>
+#include <faiss/impl/FaissException.h>
+#include <faiss/impl/io.h>
+#include <faiss/index_io.h>
+
+TEST(RaBitQDense, RoundTripPreservesLayout) {
+    constexpr int d = 128;
+    constexpr int nb = 32;
+    constexpr int nq = 4;
+    constexpr int k = 8;
+    std::mt19937 rng(42);
+    std::normal_distribution<float> distribution;
+    std::vector<float> xb(nb * d), xq(nq * d);
+    for (float& value : xb) {
+        value = distribution(rng);
+    }
+    for (float& value : xq) {
+        value = distribution(rng);
+    }
+
+    faiss::IndexRaBitQ original(d, faiss::METRIC_L2, 4, true);
+    original.train(nb, xb.data());
+    original.add(nb, xb.data());
+
+    std::vector<float> before_distances(nq * k), after_distances(nq * k);
+    std::vector<faiss::idx_t> before_labels(nq * k), after_labels(nq * k);
+    original.search(
+            nq,
+            xq.data(),
+            k,
+            before_distances.data(),
+            before_labels.data());
+
+    faiss::VectorIOWriter writer;
+    faiss::write_index(&original, &writer);
+    ASSERT_GE(writer.data.size(), 4);
+    EXPECT_EQ(
+            std::string(writer.data.begin(), writer.data.begin() + 4),
+            "Ixrd");
+
+    faiss::VectorIOReader reader;
+    reader.data = writer.data;
+    std::unique_ptr<faiss::Index> restored_base(faiss::read_index(&reader));
+    auto* restored =
+            dynamic_cast<faiss::IndexRaBitQ*>(restored_base.get());
+    ASSERT_NE(restored, nullptr);
+    EXPECT_TRUE(restored->rabitq.dense_layout);
+    EXPECT_EQ(restored->code_size, original.code_size);
+    EXPECT_EQ(restored->codes, original.codes);
+
+    restored->search(
+            nq,
+            xq.data(),
+            k,
+            after_distances.data(),
+            after_labels.data());
+    EXPECT_EQ(after_labels, before_labels);
+    EXPECT_EQ(after_distances, before_distances);
+    EXPECT_THROW(
+            {
+                faiss::IndexRaBitQFastScan converted(*restored);
+            },
+            faiss::FaissException);
+}

--- a/tests/test_rabitq_simd.cpp
+++ b/tests/test_rabitq_simd.cpp
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <random>
@@ -376,4 +378,177 @@ TEST(RaBitQBitwiseAndDotProductWithPopcount, Avx2MatchesScalar) {
                     << "d=" << d << " qb=" << qb;
         }
     }
+}
+
+template <SIMDLevel SL>
+static void check_selected_float_sum_matches_scalar() {
+    std::mt19937 rng(20260821);
+    std::uniform_real_distribution<float> value_dist(-10.0f, 10.0f);
+    for (size_t d : kDims) {
+        const auto sign_bits = random_bytes((d + 7) / 8, 81723 + d);
+        std::vector<float> values(d);
+        for (float& value : values) {
+            value = value_dist(rng);
+        }
+        const float expected =
+                faiss::rabitq::selected_float_sum<SIMDLevel::NONE>(
+                        sign_bits.data(), values.data(), d);
+        const float actual = faiss::rabitq::selected_float_sum<SL>(
+                sign_bits.data(), values.data(), d);
+        EXPECT_NEAR(
+                actual, expected, std::max(1e-5f, std::abs(expected) * 1e-5f))
+                << "d=" << d;
+    }
+}
+
+template <SIMDLevel SL>
+static void check_multibit_inner_product_matches_scalar() {
+    std::mt19937 rng(91827);
+    std::uniform_real_distribution<float> value_dist(-2.0f, 2.0f);
+    for (size_t d : kDims) {
+        const auto sign_bits = random_bytes((d + 7) / 8, 71237 + d);
+        std::vector<float> query(d);
+        for (float& value : query) {
+            value = value_dist(rng);
+        }
+        for (size_t extra_bits = 1; extra_bits <= 7; extra_bits++) {
+            const auto extra_code = random_bytes(
+                    (d * extra_bits + 7) / 8 + 8, 51971 + d + extra_bits);
+            constexpr float cb = -3.25f;
+            const float expected =
+                    faiss::rabitq::multibit::compute_inner_product<
+                            SIMDLevel::NONE>(
+                            sign_bits.data(),
+                            extra_code.data(),
+                            query.data(),
+                            d,
+                            extra_bits,
+                            cb);
+            const float actual =
+                    faiss::rabitq::multibit::compute_inner_product<SL>(
+                            sign_bits.data(),
+                            extra_code.data(),
+                            query.data(),
+                            d,
+                            extra_bits,
+                            cb);
+            EXPECT_NEAR(
+                    actual,
+                    expected,
+                    std::max(1e-4f, std::abs(expected) * 1e-5f))
+                    << "d=" << d << " extra_bits=" << extra_bits;
+        }
+    }
+}
+
+template <SIMDLevel SL>
+static void check_multibit_inner_product_batch_4_matches_single() {
+    std::mt19937 rng(20260824);
+    std::uniform_real_distribution<float> value_dist(-2.0f, 2.0f);
+    for (size_t d : kDims) {
+        std::vector<float> query(d);
+        for (float& value : query) {
+            value = value_dist(rng);
+        }
+        for (size_t extra_bits = 1; extra_bits <= 7; extra_bits++) {
+            std::vector<std::vector<uint8_t>> sign_storage(4);
+            std::vector<std::vector<uint8_t>> extra_storage(4);
+            const uint8_t* sign_bits[4];
+            const uint8_t* extra_codes[4];
+            for (size_t i = 0; i < 4; i++) {
+                sign_storage[i] = random_bytes(
+                        (d + 7) / 8, 81237 + d + extra_bits * 17 + i);
+                extra_storage[i] = random_bytes(
+                        (d * extra_bits + 7) / 8 + 8,
+                        61971 + d + extra_bits * 17 + i);
+                sign_bits[i] = sign_storage[i].data();
+                extra_codes[i] = extra_storage[i].data();
+            }
+
+            constexpr float cb = -3.25f;
+            float actual[4];
+            faiss::rabitq::multibit::compute_inner_product_batch_4<SL>(
+                    sign_bits,
+                    extra_codes,
+                    query.data(),
+                    d,
+                    extra_bits,
+                    cb,
+                    actual);
+            for (size_t i = 0; i < 4; i++) {
+                const float expected =
+                        faiss::rabitq::multibit::compute_inner_product<SL>(
+                                sign_bits[i],
+                                extra_codes[i],
+                                query.data(),
+                                d,
+                                extra_bits,
+                                cb);
+                EXPECT_NEAR(
+                        actual[i],
+                        expected,
+                        std::max(1e-4f, std::abs(expected) * 1e-5f))
+                        << "d=" << d << " extra_bits=" << extra_bits
+                        << " code=" << i;
+            }
+        }
+    }
+}
+
+TEST(RaBitQSelectedFloatSum, Avx2MatchesScalar) {
+    if (!faiss::SIMDConfig::is_simd_level_available(SIMDLevel::AVX2)) {
+        GTEST_SKIP() << "AVX2 is not available on this CPU";
+    }
+    check_selected_float_sum_matches_scalar<SIMDLevel::AVX2>();
+}
+
+TEST(RaBitQMultiBitInnerProduct, Avx2MatchesScalar) {
+    if (!faiss::SIMDConfig::is_simd_level_available(SIMDLevel::AVX2)) {
+        GTEST_SKIP() << "AVX2 is not available on this CPU";
+    }
+    check_multibit_inner_product_matches_scalar<SIMDLevel::AVX2>();
+}
+
+TEST(RaBitQMultiBitInnerProductBatch4, Avx2MatchesSingle) {
+    if (!faiss::SIMDConfig::is_simd_level_available(SIMDLevel::AVX2)) {
+        GTEST_SKIP() << "AVX2 is not available on this CPU";
+    }
+    check_multibit_inner_product_batch_4_matches_single<SIMDLevel::AVX2>();
+}
+
+TEST(RaBitQMultiBitInnerProduct, NonBmi2FallbackMatchesScalar) {
+    const bool original_bmi2_fast = faiss::SIMDConfig::bmi2_fast;
+    faiss::SIMDConfig::bmi2_fast = false;
+
+    if (faiss::SIMDConfig::is_simd_level_available(SIMDLevel::AVX2)) {
+        check_multibit_inner_product_matches_scalar<SIMDLevel::AVX2>();
+        check_multibit_inner_product_batch_4_matches_single<SIMDLevel::AVX2>();
+    }
+    if (faiss::SIMDConfig::is_simd_level_available(SIMDLevel::AVX512)) {
+        check_multibit_inner_product_matches_scalar<SIMDLevel::AVX512>();
+        check_multibit_inner_product_batch_4_matches_single<
+                SIMDLevel::AVX512>();
+    }
+
+    faiss::SIMDConfig::bmi2_fast = original_bmi2_fast;
+}
+
+TEST(RaBitQSelectedFloatSum, Avx512MatchesScalar) {
+    if (!faiss::SIMDConfig::is_simd_level_available(SIMDLevel::AVX512)) {
+        GTEST_SKIP() << "AVX512 is not available on this CPU";
+    }
+    check_selected_float_sum_matches_scalar<SIMDLevel::AVX512>();
+}
+
+TEST(RaBitQMultiBitInnerProduct, Avx512MatchesScalar) {
+    if (!faiss::SIMDConfig::is_simd_level_available(SIMDLevel::AVX512)) {
+        GTEST_SKIP() << "AVX512 is not available on this CPU";
+    }
+    check_multibit_inner_product_matches_scalar<SIMDLevel::AVX512>();
+}
+TEST(RaBitQMultiBitInnerProductBatch4, Avx512MatchesSingle) {
+    if (!faiss::SIMDConfig::is_simd_level_available(SIMDLevel::AVX512)) {
+        GTEST_SKIP() << "AVX512 is not available on this CPU";
+    }
+    check_multibit_inner_product_batch_4_matches_single<SIMDLevel::AVX512>();
 }


### PR DESCRIPTION
## Summary

This draft adds an optional dense n-bit-per-dimension layout to the existing multi-bit RaBitQ codec and optimized full-distance kernels for that layout.

The dense representation keeps the same nbits/dimension code budget, but stores each dimension's complete scalar value in one contiguous bit stream instead of separate sign and extra-bit planes. This enables fixed-width decoding and shared-query batch-4 scoring without changing the RaBitQ distance estimator.

The patch includes:

- dense 2-8 bit database codes (1-bit keeps the existing format)
- scalar, AVX2, AVX-512, and Sapphire Rapids dispatch paths
- fixed 16/64-dimensional decode blocks and narrower intermediate integers
- single and batch-4 full-distance scorers
- runtime-gated BMI2 paths with a non-BMI2 fallback
- a distinct Ixrd wire tag, layout/code-size validation, and a FastScan conversion guard
- SIMD equivalence, non-BMI2 fallback, unaligned-dimension, and serialization round-trip tests

## Motivation and measured results

This work was developed for a downstream exact-graph-build HNSW integration. On the same stored codes, replacing the original scalar lane construction with fixed-block dense SIMD decoding improved HNSW RBQ4 QPS by 2.87-3.18x on SIFT while preserving recall point-for-point.

The downstream end-to-end evaluation compared HNSW RBQ8 with HNSW SQ8 at the same primary vector-code budget of 8 bits/dimension. It used 8 search threads, recall@100, `M=30`, `efConstruction=360`, FP32 exact graph construction, FP32 queries, and `ef=100/150/200/250/300/400/500`.

The highest tested `ef` point was:

| Dataset | Metric / dimensions | HNSW RBQ8 recall@100 / QPS | HNSW SQ8 recall@100 / QPS |
|---|---:|---:|---:|
| GIST 1M | L2 / 960D | 0.9746 / 1451 | 0.9653 / 1609 |
| Cohere 1M | IP / 768D | 0.9906 / 1422 | 0.9856 / 1646 |
| OpenAI 500K | IP / 1536D | 0.9948 / 1052 | 0.9865 / 1274 |

These results show a trade-off rather than uniform dominance: RBQ8 reached a higher recall ceiling on all three datasets, while SQ8 remained faster at many lower-recall operating points. Dense RBQ also provides regular 2-8 bit/dimension payload choices; the lower-bit modes are primarily memory/recall trade-off points.

## Relationship to #5526

This PR does not adopt the staged-search or direct-compressed-graph construction contract from #5526. It focuses on a reusable optional storage layout and full-distance kernels for the existing IndexRaBitQ codec. A downstream HNSW owner can use these codes after exact graph construction.

The serialization tags are intentionally separate: Ixrd identifies a dense IndexRaBitQ payload.

## Validation

- Release DD build: faiss_test and bench_rabitq_simd built successfully
- 17/17 targeted scalar/AVX2/AVX-512, batch-4, BMI2 fallback, and dense serialization tests passed
- dense vs split scorer tests cover 2-8 bits and aligned/unaligned dimensions
- dense IndexRaBitQ write/read preserves layout, codes, labels, and distances

This is opened as a draft to get early feedback on the codec/layout boundary, wire format, and SIMD implementation before expanding its scope.
