### PR TITLE
Drop the TurboQuant projection rebuild from SQ deserialization (#5558)

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -1164,8 +1164,13 @@ void read_ScalarQuantizer(
         }
     }
 
-    // TurboQ full types: extract seed and qjl_type from trained,
-    // regenerate projection matrix.
+    // TurboQ full types: extract seed and qjl_type from trained. The
+    // projection is deliberately left uninitialized here. Nothing reads
+    // ScalarQuantizer::turboq_refine's projection state -- the quantizers
+    // and distance computers (QuantizerTurboQuantFull, DCTurboQuantFull)
+    // each rebuild it from `trained` on construction -- and building it
+    // at read time would size a d * d matrix off `d` alone, which no
+    // amount of serialized data has to back.
     if (ScalarQuantizer::TurboQuantRefine::is_turboq_full(ivsc->qtype) &&
         ivsc->trained.size() >= 3) {
         size_t n = ivsc->trained.size();
@@ -1174,7 +1179,6 @@ void read_ScalarQuantizer(
         ivsc->turboq_refine.seed =
                 ScalarQuantizer::TurboQuantRefine::unpack_seed(
                         ivsc->trained[n - 3], ivsc->trained[n - 2]);
-        ivsc->turboq_refine.init_projection(ivsc->d);
     }
 }
 

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -4763,3 +4763,111 @@ TEST(IndexIDMapSafety, SearchRemapsOutOfRangeLabelsToSentinel) {
             idmap.search(1, xq.data(), 1, distances.data(), labels.data()));
     EXPECT_EQ(labels[0], -1);
 }
+
+// -----------------------------------------------------------------------
+// A TurboQuant-full ScalarQuantizer carries a fixed-size `trained` vector
+// (2^(bits-1) centroids + boundaries + seed + qjl_type) regardless of d,
+// so `d` is not backed by any serialized payload. Deserialization must
+// not build the d x d QJL projection from it: the quantizers rebuild the
+// projection from `trained` when they are constructed, and doing it at
+// read time lets a few dozen bytes of input drive an arbitrarily large
+// allocation and QR decomposition (T287092602).
+//
+// The two branches (RR: qjl_type = 2, FWHT: qjl_type = 0) share the
+// entire serialized SQ layout; only `trained[9]` differs. Both branches
+// go through this helper so the layout is described in exactly one
+// place, and drift in a future SQ-serialization change updates both
+// tests together.
+// -----------------------------------------------------------------------
+
+// QT_3bit_tq: mse_bits = 2, k = 4 -> trained.size() = 4 + 3 + 3 = 10.
+// d is 4096 while trained is 40 bytes; the projection this used to
+// build is 4096 * 4096 floats = 64 MB.
+//
+// The trained layout is (k centroids | k - 1 boundaries | seed_lo,
+// seed_hi, qjl_type), matching how `read_ScalarQuantizer` locates the
+// tail. Derive the size and tail offsets from `k` so the helper stays
+// self-consistent if the qtype (and therefore `k`) is ever changed.
+static constexpr size_t kTurboQFullD = 4096;
+static constexpr uint64_t kTurboQFullSeed = 0x0123456789abcdefULL;
+static constexpr size_t kTurboQFullK = 4; // QT_3bit_tq: k = 2^mse_bits
+static constexpr size_t kTurboQFullTrainedSize =
+        kTurboQFullK + (kTurboQFullK - 1) + 3;
+
+static std::vector<uint8_t> build_turboq_full_sq_buf(uint8_t qjl_type) {
+    float seed_f[2];
+    ScalarQuantizer::TurboQuantRefine::pack_seed(kTurboQFullSeed, seed_f);
+    std::vector<float> trained(kTurboQFullTrainedSize, 0.0f);
+    trained[trained.size() - 3] = seed_f[0];
+    trained[trained.size() - 2] = seed_f[1];
+    trained[trained.size() - 1] = static_cast<float>(qjl_type);
+
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IxSQ");
+    push_index_header(buf, /*d=*/static_cast<int>(kTurboQFullD), /*ntotal=*/0);
+    push_val<int>(buf, ScalarQuantizer::QT_3bit_tq);
+    push_val<int>(buf, 0);               // rangestat
+    push_val<float>(buf, 0.0f);          // rangestat_arg
+    push_val<size_t>(buf, kTurboQFullD); // d
+    push_val<size_t>(buf, 0);            // code_size (recomputed on read)
+    push_vector<float>(buf, trained);
+    push_vector<uint8_t>(buf, {}); // codes (ntotal = 0)
+    return buf;
+}
+
+TEST(ReadIndexDeserialize, SQTurboQuantFullSkipsProjectionOnRead) {
+    constexpr uint8_t kQjlRandomRotation = 2;
+
+    std::vector<uint8_t> buf = build_turboq_full_sq_buf(kQjlRandomRotation);
+
+    VectorIOReader reader;
+    reader.data = buf;
+    std::unique_ptr<Index> index;
+    ASSERT_NO_THROW(index = read_index_up(&reader));
+
+    auto* idxs = dynamic_cast<IndexScalarQuantizer*>(index.get());
+    ASSERT_NE(idxs, nullptr);
+    // The cheap descriptors are still recovered from `trained`...
+    EXPECT_EQ(idxs->sq.d, kTurboQFullD);
+    EXPECT_EQ(idxs->sq.turboq_refine.qjl_type, kQjlRandomRotation);
+    EXPECT_EQ(idxs->sq.turboq_refine.seed, kTurboQFullSeed);
+    // ...but no projection state is materialized.
+    EXPECT_TRUE(idxs->sq.turboq_refine.rr_matrix.empty());
+    EXPECT_TRUE(idxs->sq.turboq_refine.fwht_signs.empty());
+    EXPECT_EQ(idxs->sq.turboq_refine.padded_d, 0);
+}
+
+// Same guarantee for the default FWHT branch (qjl_type = 0). Pre-fix,
+// init_projection on this branch would set `padded_d = 4096` and allocate
+// `fwht_signs.size() == 4096`, so `EXPECT_TRUE(fwht_signs.empty())` and
+// `EXPECT_EQ(padded_d, 0)` become genuinely discriminating here (they are
+// vacuous on the RR branch above, where only `rr_matrix.empty()` guards
+// the regression). MyRocks explicitly pins qjl_type = 0 for reproducible
+// codes (see rdb_vector_db.cc), so this is the more-important branch to
+// cover on the read path.
+TEST(ReadIndexDeserialize, SQTurboQuantFullSkipsProjectionOnReadFWHT) {
+    constexpr uint8_t kQjlFwht = 0;
+
+    std::vector<uint8_t> buf = build_turboq_full_sq_buf(kQjlFwht);
+
+    VectorIOReader reader;
+    reader.data = buf;
+    std::unique_ptr<Index> index;
+    ASSERT_NO_THROW(index = read_index_up(&reader));
+
+    auto* idxs = dynamic_cast<IndexScalarQuantizer*>(index.get());
+    ASSERT_NE(idxs, nullptr);
+    // `d` and `seed` are recovered from `trained` (`seed` discriminates:
+    // the default is 42 and the test uses 0x0123456789abcdef).
+    EXPECT_EQ(idxs->sq.d, kTurboQFullD);
+    EXPECT_EQ(idxs->sq.turboq_refine.seed, kTurboQFullSeed);
+    // qjl_type == 0 is also the field's default and the vector fill value,
+    // so this restates intent rather than guarding it -- the RR test above
+    // pins the read-path assignment. Kept for documentation symmetry.
+    EXPECT_EQ(idxs->sq.turboq_refine.qjl_type, kQjlFwht);
+    // The FWHT-branch projection state is not materialized on read.
+    EXPECT_TRUE(idxs->sq.turboq_refine.fwht_signs.empty());
+    EXPECT_EQ(idxs->sq.turboq_refine.padded_d, 0);
+    // rr_matrix stays empty on this branch either way (RR is the other path).
+    EXPECT_TRUE(idxs->sq.turboq_refine.rr_matrix.empty());
+}


### PR DESCRIPTION
Summary:

`read_ScalarQuantizer` called `TurboQuantRefine::init_projection(ivsc->d)` for the TurboQuant-full qtypes (`QT_2bit_tq`..`QT_5bit_tq`), which allocates a `d * d` float matrix and runs a QR decomposition over it. For those qtypes `trained` has a fixed size (`2^(bits-1)` centroids + boundaries + 3) that does not depend on `d`, so nothing in the serialized payload has to back the `d` being used. `d` is bounded only by `read_index_header`'s `FAISS_CHECK_RANGE(idx.d, 0, (1 << 20) + 1)`, which leaves the allocation quadratic in an essentially free input field.

The 127-byte fuzz input in T287092602 sets `d = 65791` with `qtype = QT_3bit_tq` and 10 trained floats, driving `malloc(17313822724)` (17.3 GB) inside `read_index`.

The projection does not need to be built at read time at all. `ScalarQuantizer::turboq_refine` is not serialized — `write_ScalarQuantizer` writes only `qtype`, `rangestat`, `rangestat_arg`, `d`, `code_size` and `trained` — and no reader consumes its projection state: `QuantizerTurboQuantFull` and `DCTurboQuantFull` each rebuild `fwht_signs` / `rr_matrix` from `trained` in their own constructors. A repo-wide search for `turboq_refine` finds only the struct definition, the train path, and this one call, so the read-path call was pure waste; it also cost every legitimate TurboQuant load a `d * d` allocation and a QR for a result nobody reads.

Dropping the call removes both the unbounded allocation and the O(d^3) QR without introducing a size cap, so no legitimate dimension is newly rejected. The cheap `seed` and `qjl_type` recovery is kept.

Reviewer note: `turboq_refine.rr_matrix` is a public member reachable through SWIG, so code that deserialized an index and then read that field directly will now see it empty. Nothing in faiss or its tests does this, and the value is derivable from `trained`.

Differential Revision: D118482363


