### PR TITLE
Remove the dead projection state from ScalarQuantizer::TurboQuantRefine (#5559)

### DIFF
--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -635,29 +635,10 @@ void ScalarQuantizer::train(size_t n, const float* x) {
             trained.push_back(seed_f[0]);
             trained.push_back(seed_f[1]);
             trained.push_back(static_cast<float>(turboq_refine.qjl_type));
-            turboq_refine.init_projection(d);
             break;
         }
         default:
             break;
-    }
-}
-
-void ScalarQuantizer::TurboQuantRefine::init_projection(size_t d) {
-    if (use_fwht()) {
-        padded_d = 1;
-        while (padded_d < d) {
-            padded_d <<= 1;
-        }
-        fwht_signs.resize(padded_d);
-        RandomGenerator rng(seed);
-        for (size_t i = 0; i < padded_d; i++) {
-            fwht_signs[i] = (rng.rand_int(2) == 0) ? 1.0f : -1.0f;
-        }
-    } else {
-        rr_matrix.resize(d * d);
-        float_randn(rr_matrix.data(), d * d, seed);
-        matrix_qr(static_cast<int>(d), static_cast<int>(d), rr_matrix.data());
     }
 }
 

--- a/faiss/impl/ScalarQuantizer.h
+++ b/faiss/impl/ScalarQuantizer.h
@@ -177,18 +177,11 @@ struct ScalarQuantizer : Quantizer {
             return s;
         }
 
+        /// Config only: the QJL projection these select is built from
+        /// `trained` by QuantizerTurboQuantFull / DCTurboQuantFull, which
+        /// own their own copy of it. Do not cache a projection here.
         uint8_t qjl_type = 0;
         uint64_t seed = 42;
-        size_t padded_d = 0;
-        std::vector<float> fwht_signs;
-        std::vector<float> rr_matrix;
-        size_t nb_bits_lo = 0;
-        size_t n_hi_dims = 0;
-
-        void init_projection(size_t d);
-        bool use_fwht() const {
-            return qjl_type == 0;
-        }
 
         struct DistanceComputer : SQDistanceComputer {
             virtual void configure(uint8_t qb, bool int_qjl) = 0;

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -1164,8 +1164,13 @@ void read_ScalarQuantizer(
         }
     }
 
-    // TurboQ full types: extract seed and qjl_type from trained,
-    // regenerate projection matrix.
+    // TurboQ full types: extract seed and qjl_type from trained. The
+    // projection is deliberately left uninitialized here. Nothing reads
+    // ScalarQuantizer::turboq_refine's projection state -- the quantizers
+    // and distance computers (QuantizerTurboQuantFull, DCTurboQuantFull)
+    // each rebuild it from `trained` on construction -- and building it
+    // at read time would size a d * d matrix off `d` alone, which no
+    // amount of serialized data has to back.
     if (ScalarQuantizer::TurboQuantRefine::is_turboq_full(ivsc->qtype) &&
         ivsc->trained.size() >= 3) {
         size_t n = ivsc->trained.size();
@@ -1174,7 +1179,6 @@ void read_ScalarQuantizer(
         ivsc->turboq_refine.seed =
                 ScalarQuantizer::TurboQuantRefine::unpack_seed(
                         ivsc->trained[n - 3], ivsc->trained[n - 2]);
-        ivsc->turboq_refine.init_projection(ivsc->d);
     }
 }
 

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -4767,16 +4767,16 @@ TEST(IndexIDMapSafety, SearchRemapsOutOfRangeLabelsToSentinel) {
 // -----------------------------------------------------------------------
 // A TurboQuant-full ScalarQuantizer carries a fixed-size `trained` vector
 // (2^(bits-1) centroids + boundaries + seed + qjl_type) regardless of d,
-// so `d` is not backed by any serialized payload. Deserialization must
-// not build the d x d QJL projection from it: the quantizers rebuild the
-// projection from `trained` when they are constructed, and doing it at
-// read time lets a few dozen bytes of input drive an arbitrarily large
-// allocation and QR decomposition (T287092602).
+// so `d` is not backed by any serialized payload. Reading one must stay
+// cheap: TurboQuantRefine no longer holds projection state, so the d x d
+// QJL projection is built only by the quantizers, from `trained`, when
+// they are constructed. Building it at read time let a few dozen bytes of
+// input drive an arbitrarily large allocation and QR (T287092602).
 // -----------------------------------------------------------------------
 TEST(ReadIndexDeserialize, SQTurboQuantFullSkipsProjectionOnRead) {
     // QT_3bit_tq: mse_bits = 2, k = 4 -> trained.size() = 4 + 3 + 3 = 10.
-    // d is 4096 while trained is 40 bytes; the projection this used to
-    // build is 4096 * 4096 floats = 64 MB.
+    // d is 4096 while trained is 40 bytes; the projection this once built
+    // at read time is 4096 * 4096 floats = 64 MB.
     constexpr size_t kD = 4096;
     constexpr uint64_t kSeed = 0x0123456789abcdefULL;
     constexpr uint8_t kQjlRandomRotation = 2;
@@ -4806,12 +4806,13 @@ TEST(ReadIndexDeserialize, SQTurboQuantFullSkipsProjectionOnRead) {
 
     auto* idxs = dynamic_cast<IndexScalarQuantizer*>(index.get());
     ASSERT_NE(idxs, nullptr);
-    // The cheap descriptors are still recovered from `trained`...
+    // The cheap descriptors are recovered from `trained`; TurboQuantRefine
+    // has no projection fields left for the reader to populate.
     EXPECT_EQ(idxs->sq.d, kD);
     EXPECT_EQ(idxs->sq.turboq_refine.qjl_type, kQjlRandomRotation);
     EXPECT_EQ(idxs->sq.turboq_refine.seed, kSeed);
-    // ...but no projection state is materialized.
-    EXPECT_TRUE(idxs->sq.turboq_refine.rr_matrix.empty());
-    EXPECT_TRUE(idxs->sq.turboq_refine.fwht_signs.empty());
-    EXPECT_EQ(idxs->sq.turboq_refine.padded_d, 0);
+    static_assert(
+            sizeof(ScalarQuantizer::TurboQuantRefine) <= 2 * sizeof(uint64_t),
+            "TurboQuantRefine must stay a small config struct: growing it back "
+            "into a projection cache reintroduces T287092602");
 }

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -4763,3 +4763,55 @@ TEST(IndexIDMapSafety, SearchRemapsOutOfRangeLabelsToSentinel) {
             idmap.search(1, xq.data(), 1, distances.data(), labels.data()));
     EXPECT_EQ(labels[0], -1);
 }
+
+// -----------------------------------------------------------------------
+// A TurboQuant-full ScalarQuantizer carries a fixed-size `trained` vector
+// (2^(bits-1) centroids + boundaries + seed + qjl_type) regardless of d,
+// so `d` is not backed by any serialized payload. Deserialization must
+// not build the d x d QJL projection from it: the quantizers rebuild the
+// projection from `trained` when they are constructed, and doing it at
+// read time lets a few dozen bytes of input drive an arbitrarily large
+// allocation and QR decomposition (T287092602).
+// -----------------------------------------------------------------------
+TEST(ReadIndexDeserialize, SQTurboQuantFullSkipsProjectionOnRead) {
+    // QT_3bit_tq: mse_bits = 2, k = 4 -> trained.size() = 4 + 3 + 3 = 10.
+    // d is 4096 while trained is 40 bytes; the projection this used to
+    // build is 4096 * 4096 floats = 64 MB.
+    constexpr size_t kD = 4096;
+    constexpr uint64_t kSeed = 0x0123456789abcdefULL;
+    constexpr uint8_t kQjlRandomRotation = 2;
+
+    float seed_f[2];
+    ScalarQuantizer::TurboQuantRefine::pack_seed(kSeed, seed_f);
+    std::vector<float> trained(10, 0.0f);
+    trained[7] = seed_f[0];
+    trained[8] = seed_f[1];
+    trained[9] = static_cast<float>(kQjlRandomRotation);
+
+    std::vector<uint8_t> buf;
+    push_fourcc(buf, "IxSQ");
+    push_index_header(buf, /*d=*/static_cast<int>(kD), /*ntotal=*/0);
+    push_val<int>(buf, ScalarQuantizer::QT_3bit_tq);
+    push_val<int>(buf, 0);      // rangestat
+    push_val<float>(buf, 0.0f); // rangestat_arg
+    push_val<size_t>(buf, kD);  // d
+    push_val<size_t>(buf, 0);   // code_size (recomputed on read)
+    push_vector<float>(buf, trained);
+    push_vector<uint8_t>(buf, {}); // codes (ntotal = 0)
+
+    VectorIOReader reader;
+    reader.data = buf;
+    std::unique_ptr<Index> index;
+    ASSERT_NO_THROW(index = read_index_up(&reader));
+
+    auto* idxs = dynamic_cast<IndexScalarQuantizer*>(index.get());
+    ASSERT_NE(idxs, nullptr);
+    // The cheap descriptors are still recovered from `trained`...
+    EXPECT_EQ(idxs->sq.d, kD);
+    EXPECT_EQ(idxs->sq.turboq_refine.qjl_type, kQjlRandomRotation);
+    EXPECT_EQ(idxs->sq.turboq_refine.seed, kSeed);
+    // ...but no projection state is materialized.
+    EXPECT_TRUE(idxs->sq.turboq_refine.rr_matrix.empty());
+    EXPECT_TRUE(idxs->sq.turboq_refine.fwht_signs.empty());
+    EXPECT_EQ(idxs->sq.turboq_refine.padded_d, 0);
+}


### PR DESCRIPTION
Summary:

Follow-up cleanup to D118482363, which stopped `read_ScalarQuantizer` from calling `TurboQuantRefine::init_projection`. That left `init_projection` with exactly one caller — `ScalarQuantizer::train_or_populate` — whose output is equally unread, so the whole projection half of `TurboQuantRefine` is dead.

Nothing consumes it. `TurboQuantRefine` is not serialized (`write_ScalarQuantizer` writes only `qtype`, `rangestat`, `rangestat_arg`, `d`, `code_size`, `trained`), and the quantizers that actually run the QJL projection — `QuantizerTurboQuantFull` and `DCTurboQuantFull`, which holds one by value — each rebuild `fwht_signs` / `rr_matrix` from `trained` in their own constructors. Outside those, the only references to `turboq_refine` in the repo are the struct definition and the train path.

Removed: `padded_d`, `fwht_signs`, `rr_matrix`, `init_projection()` and `use_fwht()` (written only by `init_projection`, read by nobody), plus `nb_bits_lo` and `n_hi_dims`, which appear only in the struct declaration and are never written or read anywhere. What remains is the genuine pre-train config — `qjl_type` and `seed` — the `is_turboq_full` / `pack_seed` / `unpack_seed` helpers, and the nested `DistanceComputer` interface.

Two reasons this is worth doing beyond tidiness. It makes the T287092602 shape structurally impossible rather than merely absent: there is no longer a `d`-sized buffer on the deserialization side for anyone to repopulate, and a future reader cannot "helpfully" restore the `init_projection` call. And it drops a real cost from every legitimate TurboQuant-full `train()` — a `d * d` allocation plus an O(d^3) QR whose result was discarded (about 64 MB and a 4096^3 QR at d=4096).

Reviewer notes: (1) `nb_bits_lo` / `n_hi_dims` are removed as unused — if they are placeholders for in-flight TurboQuant work, say so and I will restore them. (2) These are public members of an OSS struct, but the Python surface is unaffected: `python/__init__.pyi` does not expose `turboq_refine` on `ScalarQuantizer` at all.

Differential Revision: D118487760
