### PR TITLE
Read archive entry names in bounded chunks (#5563)

### DIFF
--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -9,8 +9,10 @@
 
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
 #include <numeric>
 #include <random>
+#include <string>
 #include <vector>
 
 #include <faiss/Index.h>
@@ -4346,6 +4348,73 @@ TEST(ReadIndexDeserialize, SVSFlatInvalidStreamThrows) {
                 faiss::read_index(&reader);
             },
             faiss::FaissException);
+}
+
+// -----------------------------------------------------------------------
+// Tests: SVS DirectoryArchiver entry validation.
+//
+// An "ISVF" payload carrying DirectoryArchiver::magic_number is unpacked by
+// the vendored SVS archiver, which reads the entry name length, the entry
+// name, and the entry size straight off the stream. All three are
+// attacker-controlled and are consumed before any FAISS-side validation runs
+// — the ReaderStreambuf byte limit only bounds individual reads, so it
+// cannot police either the name length or the resulting path.
+// -----------------------------------------------------------------------
+
+/// DirectoryArchiver::magic_number, from
+/// third-party/svs/v0.4.0/src/include/svs/lib/file.h.
+static constexpr uint64_t kSvsDirectoryArchiverMagic = 0x5e2d58d9f3b4a6c1ULL;
+
+/// Append an "ISVF" index that routes into DirectoryArchiver::unpack carrying
+/// a single archive entry. `declared_name_len` is written to the stream as the
+/// entry's name length and is deliberately separate from `filename` so that a
+/// test can claim a length it does not supply.
+static void push_svs_flat_archive_entry(
+        std::vector<uint8_t>& buf,
+        const std::string& filename,
+        uint64_t declared_name_len,
+        const std::vector<uint8_t>& contents = {}) {
+    push_fourcc(buf, "ISVF");
+    push_index_header(buf, 8, 0);
+    push_val<bool>(buf, true); // initialized -> enters deserialize_impl
+    push_val<uint64_t>(buf, kSvsDirectoryArchiverMagic);
+    push_val<uint64_t>(buf, uint64_t(1)); // num_files
+    push_val<uint64_t>(buf, declared_name_len);
+    buf.insert(buf.end(), filename.begin(), filename.end());
+    push_val<uint64_t>(buf, uint64_t(contents.size()));
+    buf.insert(buf.end(), contents.begin(), contents.end());
+}
+
+// An absolute entry name must not escape the archiver's temp root.
+// std::filesystem::operator/ discards its left operand entirely when the right
+// operand is absolute, so `root / filename` collapses to `filename`.
+TEST(ReadIndexDeserialize, SVSArchiveAbsolutePathEntryRejected) {
+    const auto probe = std::filesystem::temp_directory_path() /
+            "faiss_svs_archive_absolute_probe";
+    std::filesystem::remove(probe);
+
+    const std::string filename = probe.string();
+    std::vector<uint8_t> buf;
+    push_svs_flat_archive_entry(buf, filename, filename.size(), {'x'});
+
+    expect_read_throws_with(buf, "escapes the extraction root");
+    EXPECT_FALSE(std::filesystem::exists(probe));
+}
+
+// Same, for a relative entry name that climbs out of the temp root. The
+// archiver unpacks into temp_directory_path()/svs_flat_load-<uuid>, so a
+// single ".." lands back in temp_directory_path().
+TEST(ReadIndexDeserialize, SVSArchiveParentTraversalEntryRejected) {
+    const auto probe = std::filesystem::temp_directory_path() /
+            "faiss_svs_archive_traversal_probe";
+    std::filesystem::remove(probe);
+
+    const std::string filename = "../faiss_svs_archive_traversal_probe";
+    std::vector<uint8_t> buf;
+    push_svs_flat_archive_entry(buf, filename, filename.size(), {'x'});
+
+    expect_read_throws_with(buf, "escapes the extraction root");
+    EXPECT_FALSE(std::filesystem::exists(probe));
 }
 
 // -----------------------------------------------------------------------

--- a/tests/test_read_index_deserialize.cpp
+++ b/tests/test_read_index_deserialize.cpp
@@ -4417,6 +4417,21 @@ TEST(ReadIndexDeserialize, SVSArchiveParentTraversalEntryRejected) {
     EXPECT_FALSE(std::filesystem::exists(probe));
 }
 
+// Reading an entry name must not pre-allocate the declared length: an 8-byte
+// header would otherwise commit an unbounded amount of memory. A lying length
+// has to surface as stream exhaustion rather than as an allocation failure.
+// The declared value is deliberately far above std::string::max_size() so that
+// a regression here aborts on the allocation attempt itself (length_error, or
+// an allocator abort under ASAN) rather than trying to commit the memory and
+// taking the test host down with it.
+TEST(ReadIndexDeserialize, SVSArchiveOversizedEntryNameThrowsStreamError) {
+    std::vector<uint8_t> buf;
+    push_svs_flat_archive_entry(
+            buf, /*filename=*/"", /*declared_name_len=*/SIZE_MAX / 2);
+
+    expect_read_throws_with(buf, "Error reading from stream");
+}
+
 // -----------------------------------------------------------------------
 // Tests: IndexRefine / IndexRefinePanorama k_factor validation.
 //


### PR DESCRIPTION
Summary:

`svs::lib::Archiver::read_name` reads a raw `uint64` length off the stream and immediately allocates it:

```cpp
auto bytes = read_size(is, size);   // unvalidated, straight off the wire
name.resize(size);                  // allocates BEFORE any read
is.read(name.data(), size);
```

An 8-byte header therefore commits an arbitrarily large allocation, and `resize()` value-initializes, so every page is dirtied — real RSS, not just reserved address space. This is what Lionhead hit in T287110736.

The non-obvious part is why the existing guard cannot stop it. `index_read.cpp` does wire a limit into this exact call site via `ReaderStreambuf rbuf(f, get_deserialization_vector_byte_limit())`, but `ReaderStreambuf` enforces it in `xsgetn` (`faiss/impl/svs_io.cpp`), i.e. **on the read**. The allocation happens one statement earlier and no FAISS code runs in between, so there is no wrapper position from which the resize can be intercepted. Tightening `set_deserialization_vector_byte_limit` does nothing here. D101261327 was written for this defect class and missed this case for exactly this reason. Compare FAISS's own `READVECTOR` (`impl/io_macros.h`), which checks the size *before* allocating.

The fix grows `name` only as fast as the stream actually delivers bytes, in 8 KB chunks — the same idiom `Archiver::read_from_istream` already uses a few lines below in the same header. A truthful `size` behaves exactly as before; a lying `size` now hits the pre-existing `"Error reading from stream!"` throw once the input runs dry. As a side benefit this finally makes the `ReaderStreambuf` per-read limit meaningful on this path.

This is not a regression from any recent change — `archiver.h` is pristine vendored code (`c5e5dbb35bbf`, 2026-06-24, never patched internally). The bug is latent and was newly *detected*. In particular D118089896 should not be reverted; it is a detection change, not a cause.

Needs reporting upstream to Intel via their vulnerability handling process (`src/SECURITY.md`) so it survives the next version bump.

Deliberately not included, to keep this reviewable: `DirectoryArchiver::unpack` also reads an unvalidated `num_files` (`file.h`). Unlike `read_name` it does not amplify — every iteration consumes at least 16 stream bytes, so the loop is bounded by the input length — and with the path containment fix in the parent diff its side effects stay inside the temp root. Worth a follow-up, not urgent.

Reviewed By: mnorris11

Differential Revision: D118494327


