### PR TITLE
Stop the conda recipe asking for a debug Python ABI (#5565)

### DIFF
--- a/conda/faiss/meta.yaml
+++ b/conda/faiss/meta.yaml
@@ -36,7 +36,6 @@ outputs:
         - {{ pin_compatible('libfaiss', exact=True) }}
     requirements:
       build:
-        - python {{ python }}
         - {{ compiler('cxx') }}
         - libcxx =20.1.1  # [osx and arm64]
         - sysroot_linux-64 =2.17 # [linux64]
@@ -44,45 +43,18 @@ outputs:
         - cmake >=3.24.0
         - make =4.2 # [not win and not (osx and arm64)]
         - make =4.4 # [osx and arm64]
-        {% if PY_VER == '3.10' or PY_VER == '3.11' %}
         - mkl-devel >=2024.2.2,<2026  # [x86_64]
-        - python_abi <3.12
-        {% elif PY_VER == '3.12' %}
-        - mkl-devel >=2024.2.2,<2026  # [x86_64 and not win]
-        - mkl-devel >=2024.2.2,<2026  # [x86_64 and win]
-        - python_abi =3.12
-        {% else %}
-        - mkl-devel >=2024.2.2,<2026  # [x86_64 and not win]
-        - mkl-devel >=2024.2.2,<2026  # [x86_64 and win]
-        - python_abi
-        {% endif %}
         - libopenblas =0.3.34  # [osx]
       host:
-        - python {{ python }}
         - libcxx =20.1.1  # [osx and arm64]
         - libsvs-runtime =0.4.0  # [x86_64 and linux]
-        {% if PY_VER == '3.10' or PY_VER == '3.11' %}
         - mkl >=2024.2.2,<2026  # [x86_64]
-        - python_abi <3.12
-        {% elif PY_VER == '3.12' %}
-        - mkl >=2024.2.2,<2026  # [x86_64 and not win]
-        - mkl >=2024.2.2,<2026  # [x86_64 and win]
-        - python_abi =3.12
-        {% endif %}
         - openblas =0.3.34  # [not x86_64]
         - libopenblas =0.3.34  # [osx]
       run:
-        - python {{ python }}
         - libcxx =20.1.1  # [osx and arm64]
         - libsvs-runtime =0.4.0  # [x86_64 and linux]
-        {% if PY_VER == '3.10' or PY_VER == '3.11' %}
         - mkl >=2024.2.2,<2026  # [x86_64]
-        - python_abi <3.12
-        {% elif PY_VER == '3.12' %}
-        - mkl >=2024.2.2,<2026  # [x86_64 and not win]
-        - mkl >=2024.2.2,<2026  # [x86_64 and win]
-        - python_abi =3.12
-        {% endif %}
         - openblas =0.3.34  # [not x86_64]
         - libopenblas =0.3.34  # [osx]
     test:
@@ -114,14 +86,7 @@ outputs:
         - make =4.2 # [not win and not (osx and arm64)]
         - make =4.4 # [osx and arm64]
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64 and not win]
-        {% if PY_VER == '3.10' or PY_VER == '3.11' %}
         - mkl >=2024.2.2,<2026  # [x86_64]
-        - python_abi <3.12
-        {% elif PY_VER == '3.12' %}
-        - mkl >=2024.2.2,<2026  # [x86_64 and not win]
-        - mkl >=2024.2.2,<2026  # [x86_64 and win]
-        - python_abi =3.12
-        {% endif %}
         - libopenblas =0.3.34  # [osx]
       host:
         - python {{ python }}
@@ -130,14 +95,7 @@ outputs:
         - {{ pin_subpackage('libfaiss', exact=True) }}
         - libcxx =20.1.1  # [osx and arm64]
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64 and not win]
-        {% if PY_VER == '3.10' or PY_VER == '3.11' %}
         - mkl >=2024.2.2,<2026  # [x86_64]
-        - python_abi <3.12
-        {% elif PY_VER == '3.12' %}
-        - mkl >=2024.2.2,<2026  # [x86_64 and not win]
-        - mkl >=2024.2.2,<2026  # [x86_64 and win]
-        - python_abi =3.12
-        {% endif %}
         - libopenblas =0.3.34  # [osx]
       run:
         - python {{ python }}
@@ -145,14 +103,7 @@ outputs:
         - packaging
         - {{ pin_subpackage('libfaiss', exact=True) }}
         - libcxx =20.1.1  # [osx and arm64]
-        {% if PY_VER == '3.10' or PY_VER == '3.11' %}
         - mkl >=2024.2.2,<2026  # [x86_64]
-        - python_abi <3.12
-        {% elif PY_VER == '3.12' %}
-        - mkl >=2024.2.2,<2026  # [x86_64 and not win]
-        - mkl >=2024.2.2,<2026  # [x86_64 and win]
-        - python_abi =3.12
-        {% endif %}
         - libopenblas =0.3.34  # [osx]
     test:
       requires:
@@ -160,14 +111,7 @@ outputs:
         - scipy
         - pytorch-cpu >=2.7  # [not win]
         - pytorch >=2.7      # [win]
-        {% if PY_VER == '3.10' or PY_VER == '3.11' %}
         - mkl >=2024.2.2,<2026  # [x86_64]
-        - python_abi <3.12
-        {% elif PY_VER == '3.12' %}
-        - mkl >=2024.2.2,<2026  # [x86_64 and not win]
-        - mkl >=2024.2.2,<2026  # [x86_64 and win]
-        - python_abi =3.12
-        {% endif %}
       commands:
         - python -X faulthandler -m unittest discover -v -s tests/ -p "test_*"
         - python -X faulthandler -m unittest discover -v -s tests/ -p "torch_*"


### PR DESCRIPTION
Summary:

Every faiss OSS `(conda)` PR gate has failed since 10:10 PDT on 2026-09-02: `nothing provides python >=3.12,<3.13.0a0 *_debug_cpython`. No faiss change can get green CI.

Why: `conda/faiss/meta.yaml` hand-declares `python_abi` with no ABI build string, so conda may pick a debug-ABI `python_abi`, whose run_export demands a debug Python no channel ships.

Fix: drop `python`/`python_abi` from `libfaiss` (pure C++) and `python_abi` from `faiss-cpu`, matching `conda/faiss-gpu` — green in the same CI run.

Sentinel-Council-Run: council_1788379412_2bbef99a, council_1788382994_e1ed4fa9
Sentinel-Harness: metacode, claude

*Modify your team agent prompt, check stats, and leave feedback: https://www.internalfb.com/sentinel_agent/rotations/faiss*
Model used: Muse Spark 1.2; Claude Opus 5 (1M context), claude-opus-5[1m]

Differential Revision: D118512697


