### PR TITLE
Apply the deserialization byte limit to SVS IVF

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -3062,7 +3062,8 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         bool initialized;
         READ1_BOOL(initialized);
         if (initialized) {
-            faiss::svs_io::ReaderStreambuf rbuf(f);
+            faiss::svs_io::ReaderStreambuf rbuf(
+                    f, get_deserialization_vector_byte_limit());
             std::istream is(&rbuf);
             svs_ivf->deserialize_impl(is);
         }
@@ -3070,7 +3071,8 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
             bool trained;
             READ1_BOOL(trained);
             if (trained) {
-                faiss::svs_io::ReaderStreambuf rbuf(f);
+                faiss::svs_io::ReaderStreambuf rbuf(
+                        f, get_deserialization_vector_byte_limit());
                 std::istream is(&rbuf);
                 auto* leanvec =
                         dynamic_cast<IndexSVSIVFLeanVec*>(svs_ivf.get());

--- a/tests/test_svs.cpp
+++ b/tests/test_svs.cpp
@@ -23,6 +23,7 @@
 
 #include <faiss/Index.h>
 #include <faiss/impl/AuxIndexStructures.h>
+#include <faiss/impl/FaissException.h>
 #include <faiss/impl/IDSelector.h>
 #include <faiss/index_io.h>
 #include <faiss/svs/IndexSVSFlat.h>
@@ -603,6 +604,45 @@ TEST_F(SVSLL, WriteAndReadIndexSVSIVFLeanVec8x8) {
     faiss::IndexSVSIVFLeanVec index{
             d, 4ul, faiss::METRIC_L2, 0, faiss::SVSStorageKind::SVS_LeanVec8x8};
     write_and_read_ivf_index(index, test_data, n);
+}
+
+// Each SVS family streams its payload to the third-party SVS reader through a
+// ReaderStreambuf, and only a streambuf carrying the deserialization vector
+// byte limit rejects an oversized read. Every family must therefore build one
+// the same way.
+template <typename T>
+void expect_byte_limit_enforced(
+        T& index,
+        const std::vector<float>& xb,
+        size_t n) {
+    index.train(n, xb.data());
+    index.add(n, xb.data());
+
+    std::string temp_filename_template = "/tmp/faiss_svs_limit_test_XXXXXX";
+    Tempfilename filename(&temp_file_mutex, temp_filename_template);
+    ASSERT_NO_THROW({ faiss::write_index(&index, filename.c_str()); });
+
+    const size_t old_limit = faiss::get_deserialization_vector_byte_limit();
+    faiss::set_deserialization_vector_byte_limit(64);
+    EXPECT_THROW(
+            { delete faiss::read_index(filename.c_str()); },
+            faiss::FaissException);
+    faiss::set_deserialization_vector_byte_limit(old_limit);
+
+    faiss::Index* loaded = nullptr;
+    ASSERT_NO_THROW({ loaded = faiss::read_index(filename.c_str()); });
+    EXPECT_NE(loaded, nullptr);
+    delete loaded;
+}
+
+TEST_F(SVS, FlatHonorsDeserializationVectorByteLimit) {
+    faiss::IndexSVSFlat index{d};
+    expect_byte_limit_enforced(index, test_data, n);
+}
+
+TEST_F(SVS, IVFHonorsDeserializationVectorByteLimit) {
+    faiss::IndexSVSIVF index{d, 4ul};
+    expect_byte_limit_enforced(index, test_data, n);
 }
 
 TEST_F(SVS, IVFTrainAndAdd) {


### PR DESCRIPTION
Summary:
`read_index` can cap the bytes one read pulls from an untrusted index file (`set_deserialization_vector_byte_limit`). Three of the five SVS deserialization sites pass it down; the two SVS IVF sites do not, so it is ignored on every SVS IVF index.

Impact: a corrupt or hostile IVF file can drive an unbounded read into the third-party SVS reader. The faiss fuzzers set this limit to stop that.

Fix: pass `get_deserialization_vector_byte_limit()` at both sites, matching Flat and Vamana.

Sentinel-Council-Run: council_1788372198_15590275
Sentinel-Harness: claude

*Modify your team agent prompt, check stats, and leave feedback: https://www.internalfb.com/sentinel_agent/rotations/faiss*
Model used: Claude Opus 5 (1M context), claude-opus-5[1m]

Differential Revision: D118524339


