### PR TITLE
Clamp EDEN unbiased L2 distances to be non-negative

### DIFF
--- a/faiss/impl/scalar_quantizer/EDENQuantizer.cpp
+++ b/faiss/impl/scalar_quantizer/EDENQuantizer.cpp
@@ -319,8 +319,13 @@ struct EDENDistanceComputerBase : EDENFlatCodesDistanceComputer {
             const EDENCodeFactors* factors,
             float code_dot_query) const {
         if (metric_type == MetricType::METRIC_L2) {
-            return query_base + factors->l2_norm_term -
+            // The unbiased scale reports an unbiased estimator of the squared
+            // L2 distance rather than a true squared distance, so the raw
+            // value can dip below zero for strongly-aligned residuals. Clamp
+            // to keep the METRIC_L2 contract (distances are never negative).
+            const float dist = query_base + factors->l2_norm_term -
                     2.0f * factors->scale * code_dot_query;
+            return dist < 0.0f ? 0.0f : dist;
         }
         return query_base + factors->scale * code_dot_query;
     }

--- a/tests/test_eden.py
+++ b/tests/test_eden.py
@@ -104,7 +104,10 @@ def eden_reference_l2_distances(
             + l2_norm_term
             - 2.0 * scale * float(np.dot(q, query_residual))
         )
-    return distances
+    # The unbiased scale reports an estimator of the squared distance that can
+    # go negative; the C++ distance computer clamps it to zero (METRIC_L2
+    # distances are never negative), so the reference must match.
+    return np.maximum(distances, 0.0)
 
 
 class TestEDENScalarQuantizer(unittest.TestCase):
@@ -279,6 +282,32 @@ class TestEDENScalarQuantizer(unittest.TestCase):
                         rtol=1e-5,
                         atol=1e-4,
                     )
+
+    def test_unbiased_l2_distances_are_non_negative(self):
+        # Unbiased 1-bit EDEN reports an unbiased estimator of the squared L2
+        # distance, which can dip below zero for strongly-aligned residuals
+        # (self-query below triggers it). Reported distances must still honor
+        # the METRIC_L2 contract of being non-negative.
+        rs = np.random.RandomState(2468)
+        d, nb = 128, 256
+        xt = rs.randn(400, d).astype("float32")
+        xb = rs.randn(nb, d).astype("float32")
+        xq = xb.copy()
+
+        index = faiss.IndexEDEN(d, faiss.METRIC_L2, 1)
+        index.train(xt)
+        index.add(xb)
+
+        dc = index.get_distance_computer()
+        for q in range(xq.shape[0]):
+            dc.set_query(faiss.swig_ptr(xq[q]))
+            vals = np.array(
+                [dc(i) for i in range(index.ntotal)], dtype="float32"
+            )
+            self.assertTrue(np.all(vals >= 0.0))
+
+        D, _ = index.search(xq, 10)
+        self.assertTrue(np.all(D >= 0.0))
 
     def test_factory_biased_eden_scale(self):
         index = faiss.index_factory(64, "EDEN4BIASED")


### PR DESCRIPTION
Summary:
https://www.internalfb.com/monitoring/oncall_operator?board=1003685189388103&workItem=4614322948811275

---

`IndexEDEN` / `IndexIVFEDEN` with the unbiased 1-bit EDEN scale can return
negative `METRIC_L2` distances, violating the contract that L2 distances are
never negative.

Root cause: for the unbiased scale, `distance_from_code_dot` in
`faiss/impl/scalar_quantizer/EDENQuantizer.cpp` reports
`query_base + l2_norm_term - 2*scale*<q_code, x_res>`, where the encoder sets
`l2_norm_term = ||r||^2` (the *original* residual norm) rather than the
reconstructed-code norm `scale^2 * ||q_code||^2`. Unlike the biased scale
(where the three terms complete the square `||x_res - r_y||^2 >= 0`), the
unbiased branch is an unbiased *estimator* of the squared distance, so for a
query residual that aligns strongly with the code direction the subtracted
term can exceed `query_base + ||r||^2` and the result goes negative. Every
distance path (reference, LUT, and the AVX2/AVX-512 batch variants) routes
through `distance_from_code_dot`, and none of them clamped the result.

Fix: clamp the L2 branch of `distance_from_code_dot` to zero. This is the
single choke point, so it covers every distance and search path. The clamp
only floors estimates that were already below the true minimum of zero.

Design note for reviewers: clamping biases the unbiased estimator upward for
the very closest matches (whose estimates are the ones that dip below zero),
and collapses their fine ordering at exactly zero. The alternative — leaking
negative squared distances to callers that take a sqrt or compare against a
radius — is worse, and this is the most reversible fix. If the team prefers to
preserve the strict unbiased estimator and instead relax the non-negativity
expectation, that is a larger design decision to make separately.

Differential Revision: D118611745


