### PR TITLE
Fix IndexIVFFlatDedup::remove_ids not counting duplicate-id removals (#5570)

### DIFF
--- a/faiss/IndexIVFFlat.cpp
+++ b/faiss/IndexIVFFlat.cpp
@@ -335,8 +335,26 @@ void IndexIVFFlatDedup::search_preassigned(
 }
 
 size_t IndexIVFFlatDedup::remove_ids(const IDSelector& sel) {
+    // The removal accounting below is derived from the invariant
+    // `ntotal == (physical inverted-list entries) + instances.size()`. Check it
+    // before touching anything, so an index whose `instances` has drifted out
+    // of sync (e.g. one filled in by a base-class method that does not know
+    // about the duplicate map) fails cleanly instead of being left half
+    // modified with a corrupted `ntotal`.
+    int64_t n_entries = 0;
+    for (size_t i = 0; i < nlist; i++) {
+        n_entries += invlists->list_size(i);
+    }
+    FAISS_THROW_IF_NOT_MSG(
+            ntotal == n_entries + static_cast<int64_t>(instances.size()),
+            "IndexIVFFlatDedup::remove_ids: ntotal does not match "
+            "inverted-list entries + instances.size()");
+
     std::unordered_map<idx_t, idx_t> replace;
     std::vector<std::pair<idx_t, idx_t>> toadd;
+    // Duplicate ids live only in `instances`, not in the inverted lists, so
+    // their removal must be counted separately from inverted-list shrinkage.
+    const int64_t n_instances_before = static_cast<int64_t>(instances.size());
     for (auto it = instances.begin(); it != instances.end();) {
         if (sel.is_member(it->first)) {
             // then we erase this entry
@@ -404,8 +422,24 @@ size_t IndexIVFFlatDedup::remove_ids(const IDSelector& sel) {
             invlists->resize(i, invlists->list_size(i) - toremove[i]);
         }
     }
-    ntotal -= nremove;
-    return nremove;
+    // `nremove` counts only physically removed inverted-list entries. Removing
+    // a duplicate id (or a stored id replaced by a surviving duplicate) drops
+    // an `instances` entry without shrinking a list, so the net decrease in
+    // `instances` accounts for those logical removals. Given the invariant
+    // checked on entry, the total number of removed ids is exactly
+    // nremove + (instances_before - instances_after).
+    const int64_t total_removed = nremove + n_instances_before -
+            static_cast<int64_t>(instances.size());
+    ntotal -= total_removed;
+    return total_removed;
+}
+
+void IndexIVFFlatDedup::reset() {
+    // `instances` is maintained only by this subclass, so the base-class reset
+    // would leave it holding entries for ids that no longer exist, breaking the
+    // `ntotal == (physical entries) + instances.size()` invariant.
+    IndexIVFFlat::reset();
+    instances.clear();
 }
 
 void IndexIVFFlatDedup::range_search(

--- a/faiss/IndexIVFFlat.h
+++ b/faiss/IndexIVFFlat.h
@@ -127,6 +127,9 @@ struct IndexIVFFlatDedup : IndexIVFFlat {
 
     size_t remove_ids(const IDSelector& sel) override;
 
+    /// also clears the duplicate map
+    void reset() override;
+
     /// not implemented
     void range_search(
             idx_t n,

--- a/tests/test_index_composite.py
+++ b/tests/test_index_composite.py
@@ -490,10 +490,145 @@ class TestIVFFlatDedup(unittest.TestCase):
         index_ref.remove_ids(toremove)
         index_new.remove_ids(toremove)
 
+        # both indexes hold the same ids and removed the same set, so the dedup
+        # index must not be left with a higher count than the plain one
+        self.assertEqual(index_new.ntotal, index_ref.ntotal)
+
         Dref, Iref = index_ref.search(xq, 20)
         Dnew, Inew = index_new.search(xq, 20)
 
         check_ref_knn_with_draws(Dref, Iref, Dnew, Inew)
+
+    def test_remove_ids_counts_duplicates(self):
+        # Regression test: removing an id whose vector duplicates another must
+        # decrement ntotal and be reflected in the return value, even though
+        # duplicates are tracked only in the instances map, not stored as
+        # separate inverted-list entries.
+        d = 8
+        rs = np.random.RandomState(123)
+        xt = rs.rand(200, d).astype('float32')
+        v = rs.rand(d).astype('float32')
+        w = rs.rand(d).astype('float32')
+
+        def build():
+            quantizer = faiss.IndexFlatL2(d)
+            index = faiss.IndexIVFFlatDedup(quantizer, d, 4)
+            index.nprobe = 4
+            index.train(xt)
+            # ids 10 and 11 share vector v; id 12 is the distinct vector w.
+            xb = np.vstack([v, v, w]).astype('float32')
+            index.add_with_ids(xb, np.array([10, 11, 12], dtype=np.int64))
+            return index
+
+        # Remove the non-stored duplicate id (11).
+        index = build()
+        self.assertEqual(index.ntotal, 3)
+        n = index.remove_ids(np.array([11], dtype=np.int64))
+        self.assertEqual(n, 1)
+        self.assertEqual(index.ntotal, 2)
+
+        # Remove the representative id (10) while its duplicate (11) survives:
+        # the vector stays under the surviving id, but one logical id is gone.
+        index = build()
+        n = index.remove_ids(np.array([10], dtype=np.int64))
+        self.assertEqual(n, 1)
+        self.assertEqual(index.ntotal, 2)
+        _, ids = index.search(v.reshape(1, d), 3)
+        found = {int(i) for i in ids[0]} - {-1}
+        self.assertIn(11, found)
+        self.assertNotIn(10, found)
+
+        # Remove a whole duplicate group at once: the stored id and the
+        # duplicate that has no slot of its own both count.
+        index = build()
+        n = index.remove_ids(np.array([10, 11], dtype=np.int64))
+        self.assertEqual(n, 2)
+        self.assertEqual(index.ntotal, 1)
+
+        # Removing the ids one at a time drains the index to empty.
+        index = build()
+        for i, remaining in ((11, 2), (10, 1), (12, 0)):
+            n = index.remove_ids(np.array([i], dtype=np.int64))
+            self.assertEqual(n, 1)
+            self.assertEqual(index.ntotal, remaining)
+
+    def test_remove_ids_representative_with_multiple_survivors(self):
+        # Exercise the `toadd` re-link path in remove_ids: when the removed
+        # id is the inverted-list representative of a duplicate group and
+        # *two or more* surviving ids still share the same vector, the
+        # representative slot is re-linked to one of the survivors and the
+        # remaining survivors stay in the instances map. Only the specific
+        # id passed to remove_ids must count against ntotal.
+        d = 8
+        rs = np.random.RandomState(456)
+        xt = rs.rand(200, d).astype('float32')
+        v = rs.rand(d).astype('float32')
+
+        quantizer = faiss.IndexFlatL2(d)
+        index = faiss.IndexIVFFlatDedup(quantizer, d, 4)
+        index.nprobe = 4
+        index.train(xt)
+        # ids 10, 11, 12 all share vector v (three-way duplicate group).
+        xb = np.vstack([v, v, v]).astype('float32')
+        index.add_with_ids(xb, np.array([10, 11, 12], dtype=np.int64))
+        self.assertEqual(index.ntotal, 3)
+
+        # Remove only the representative (10): the vector must stay in the
+        # inverted list under one of the survivors (11 or 12) and both
+        # survivors must remain searchable.
+        n = index.remove_ids(np.array([10], dtype=np.int64))
+        self.assertEqual(n, 1)
+        self.assertEqual(index.ntotal, 2)
+        _, ids = index.search(v.reshape(1, d), 3)
+        found = {int(i) for i in ids[0]} - {-1}
+        self.assertIn(11, found)
+        self.assertIn(12, found)
+        self.assertNotIn(10, found)
+
+        # Drain the re-linked group one id at a time. If the rebuilt instances
+        # map were inconsistent with the inverted list, the counts would drift.
+        for i, remaining in ((11, 1), (12, 0)):
+            n = index.remove_ids(np.array([i], dtype=np.int64))
+            self.assertEqual(n, 1)
+            self.assertEqual(index.ntotal, remaining)
+
+    def test_reset_clears_duplicate_map(self):
+        # reset() must drop the instances map along with the inverted lists.
+        # Otherwise stale duplicate links survive into the next generation of
+        # the index and remove_ids counts ids that are no longer there.
+        d = 8
+        rs = np.random.RandomState(789)
+        xt = rs.rand(200, d).astype('float32')
+        v = rs.rand(d).astype('float32')
+
+        quantizer = faiss.IndexFlatL2(d)
+        index = faiss.IndexIVFFlatDedup(quantizer, d, 4)
+        index.nprobe = 4
+        index.train(xt)
+        # ids 10 and 11 share vector v, so 11 lives only in the instances map.
+        index.add_with_ids(
+            np.vstack([v, v]).astype('float32'),
+            np.array([10, 11], dtype=np.int64),
+        )
+        self.assertEqual(index.ntotal, 2)
+
+        index.reset()
+        self.assertEqual(index.ntotal, 0)
+
+        # Removing the id that used to be a duplicate must be a no-op.
+        n = index.remove_ids(np.array([11], dtype=np.int64))
+        self.assertEqual(n, 0)
+        self.assertEqual(index.ntotal, 0)
+
+        # The index is reusable and accounts correctly after the reset.
+        index.add_with_ids(
+            np.vstack([v, v]).astype('float32'),
+            np.array([10, 11], dtype=np.int64),
+        )
+        self.assertEqual(index.ntotal, 2)
+        n = index.remove_ids(np.array([11], dtype=np.int64))
+        self.assertEqual(n, 1)
+        self.assertEqual(index.ntotal, 1)
 
 
 class TestSerialize(unittest.TestCase):


### PR DESCRIPTION
Summary:

https://www.internalfb.com/monitoring/oncall_operator?board=1003685189388103&workItem=1079527385016771

---

`IndexIVFFlatDedup::add_with_ids` increments `ntotal` for every added vector,
including duplicates (`n_add++` runs for every id, then `ntotal += n_add`). A
duplicate vector is not stored as a new inverted-list entry; it is recorded
only as an entry in the `instances` multimap that maps a stored representative
id to the duplicate id.

`remove_ids`, however, derived its return value and its `ntotal` decrement
solely from `nremove` — the count of physically shrunk inverted-list entries.
Removing a duplicate-only id (an id that appears only as a value in `instances`)
erases the `instances` entry but shrinks no list, so `nremove` stayed 0:
`remove_ids` returned 0 and left `ntotal` unchanged even though a valid id was
removed. The same undercount happened when a stored representative id was
removed but a surviving duplicate took over its slot (the slot is rewritten,
not shrunk).

The library maintains the invariant
`ntotal == (physical inverted-list entries) + instances.size()`, so the true
number of logically removed ids is
`nremove + (instances_before - instances_after)`. This captures both the
physically removed entries and the net drop in `instances` (erasures minus the
`toadd` re-links used when a representative with several duplicates is removed).
The fix records `instances.size()` before the rebalance and adjusts the count
and `ntotal` decrement accordingly.

## Keeping the invariant true

`instances` is maintained only by the handful of methods `IndexIVFFlatDedup`
overrides, so the accounting above is only as good as the set of methods that
know about it. `IndexIVF::reset()` did not: it clears the inverted lists and
zeroes `ntotal` but leaves every `instances` entry in place. That was latent
while `remove_ids` derived everything from `nremove`, but the new accounting
makes the stale entries load-bearing — a `reset()` followed by removing a
formerly-duplicate id would count a removal against an empty index and drive
`ntotal` negative. `IndexIVFFlatDedup::reset()` now clears `instances`
alongside the base-class reset.

`remove_ids` also checks the invariant on entry, before mutating anything, so
an index whose `instances` has drifted out of sync — for example one populated
by a base-class method that does not carry the duplicate map — fails cleanly
instead of silently corrupting `ntotal`. Checking on entry rather than after
the fact means a failure leaves the index untouched, and it costs no more than
the `O(nlist)` scans `remove_ids` already performs.

Differential Revision: D118606761


