### PR TITLE
Persist `centered` for `IndexRaBitQ` via the `Ixrc` fourcc (#5573)

### DIFF
--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -2861,8 +2861,9 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
         // rabitq.nb_bits is already set to 1 by read_RaBitQuantizer
         idxq->code_size = idxq->rabitq.code_size;
         idx = std::move(idxq);
-    } else if (h == fourcc("Ixrr")) {
-        // Ixrr = multi-bit format (new)
+    } else if (h == fourcc("Ixrr") || h == fourcc("Ixrc")) {
+        // Ixrr = multi-bit format. Ixrc has the same layout and additionally
+        // means `centered`; Ixrq/Ixrr predate that field and leave it off.
         auto idxq = std::make_unique<IndexRaBitQ>();
         read_index_header(*idxq, f);
         read_RaBitQuantizer(
@@ -2876,6 +2877,7 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
                 idxq->qb <= 8,
                 "invalid RaBitQ qb=%d (must be in [0, 8])",
                 idxq->qb);
+        idxq->centered = (h == fourcc("Ixrc"));
 
         idxq->code_size = idxq->rabitq.code_size;
         idx = std::move(idxq);

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -1017,8 +1017,16 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
         WRITEVECTOR(idxqfs->codes);
     } else if (
             const IndexRaBitQ* idxq = dynamic_cast<const IndexRaBitQ*>(idx)) {
-        // Use different fourcc codes for 1-bit vs multi-bit
-        if (idxq->rabitq.nb_bits == 1) {
+        // The fourcc encodes both nb_bits and `centered`. Ixrc is emitted only
+        // when `centered` is set, so an index that leaves it at its default
+        // serializes byte-identically to Ixrq/Ixrr and stays readable by
+        // binaries that predate Ixrc.
+        if (idxq->centered) {
+            uint32_t h = fourcc("Ixrc"); // multi-bit + centered
+            WRITE1(h);
+            write_index_header(idx, f);
+            write_RaBitQuantizer(&idxq->rabitq, f, true);
+        } else if (idxq->rabitq.nb_bits == 1) {
             uint32_t h = fourcc("Ixrq"); // 1-bit (backward compatible)
             WRITE1(h);
             write_index_header(idx, f);

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -660,6 +660,31 @@ class TestIORoundTrip(unittest.TestCase):
         np.testing.assert_array_equal(Iref, I2)
         np.testing.assert_array_equal(Dref, D2)
 
+    def test_index_rabitq_centered(self):
+        """IndexRaBitQ.centered, which selects a different query-side distance
+        formula and so has to survive IO. Only Ixrc carries it: leaving it
+        unset keeps the legacy fourcc, so existing files stay readable."""
+        xt, xb, xq = get_dataset_2(d, nt, nb, nq)
+        for nb_bits, legacy_fourcc in ((1, b"Ixrq"), (4, b"Ixrr")):
+            for centered in (False, True):
+                with self.subTest(nb_bits=nb_bits, centered=centered):
+                    index = faiss.IndexRaBitQ(d, faiss.METRIC_L2, nb_bits)
+                    index.train(xt)
+                    index.add(xb)
+                    index.centered = centered
+                    Dref, Iref = index.search(xq, 5)
+
+                    data = faiss.serialize_index(index)
+                    self.assertEqual(
+                        bytes(data[:4]),
+                        b"Ixrc" if centered else legacy_fourcc,
+                    )
+                    index2 = faiss.deserialize_index(data)
+                    self.assertEqual(index2.centered, centered)
+                    D2, I2 = index2.search(xq, 5)
+                    np.testing.assert_array_equal(Iref, I2)
+                    np.testing.assert_array_equal(Dref, D2)
+
     def test_vector_transform_pca(self):
         """PCAMatrix VectorTransform with output fidelity check."""
         xt, _, xq = get_dataset_2(d, nt, nb, nq)


### PR DESCRIPTION
Summary:

`IndexRaBitQ::centered` selects a different query-side distance formula
(`compute_1bit_adjusted_distance` branches on it), but neither `Ixrq` nor
`Ixrr` writes it. A `centered = true` index therefore reloads as
`centered = false` and silently returns different search results. Among the
RaBitQ family only `IndexIVFRaBitQFastScan` (`Iwrn`) persists the field today.

**Implementation**

- Add fourcc `Ixrc`. It has the same payload as `Ixrr`; the fourcc itself is
  what carries `centered`, so there is no extra byte and no second condition
  to keep in sync. This matches the convention already in this branch, where
  `Ixrq` vs `Ixrr` encodes `nb_bits == 1`.
- Emit `Ixrc` **only when `centered` is set**. An index that leaves the flag at
  its default takes the untouched `Ixrq`/`Ixrr` branch and serializes to
  byte-identical output.
- Read `Ixrc` alongside `Ixrr`, setting `centered` from the fourcc.
  `Ixrq`/`Ixrr` leave it at its default, which reproduces current behavior
  exactly for every existing file.

**Compatibility**

Bidirectional compatibility is not achievable for a format that gains a field,
so the guarantee is asymmetric:

| | old reader | new reader |
|---|---|---|
| old writer | works | works |
| new writer, `centered = false` | works, byte-identical | works |
| new writer, `centered = true` | throws unknown fourcc | works |

Only indexes that opt into `centered` become forward-incompatible, and those
are the ones that are silently wrong today. The failure is a loud
unknown-fourcc throw, not silent corruption.

Appending the field to `Ixrq`/`Ixrr` under the existing fourcc was rejected:
those codes also appear nested inside other indexes (HNSW storage,
`IndexRefine`, `IndexPreTransform`), where an old reader would consume the
stray byte as the head of the next field and corrupt the load silently.

**Rollout**

Land the reader everywhere before any writer emits `Ixrc`. This diff contains
both, so it must be fully deployed to readers before a `centered = true` index
is written anywhere.

**Not in scope**

- `IndexRaBitQFastScan` (`Irfn`) has the same defect. Separate fix.
- `IndexIVFRaBitQ` has no `centered` member at all, only
  `IVFRaBitQSearchParameters` does, so there is nothing to persist without
  first adding public API.
- `IndexRaBitQ::range_search` ignores `centered` entirely. Separate fix.

Differential Revision: D118829453


