### PR TITLE
fix: handle zero terms in Canberra distance

### DIFF
--- a/faiss/utils/simd_impl/distances_autovec-inl.h
+++ b/faiss/utils/simd_impl/distances_autovec-inl.h
@@ -208,7 +208,10 @@ float VectorDistance<METRIC_Canberra, SL>::operator()(
     float accu = 0;
     for (size_t i = 0; i < this->d; i++) {
         float xi = x[i], yi = y[i];
-        accu += fabs(xi - yi) / (fabs(xi) + fabs(yi));
+        float denominator = fabs(xi) + fabs(yi);
+        if (denominator != 0.0f) {
+            accu += fabs(xi - yi) / denominator;
+        }
     }
     return accu;
 }

--- a/tests/test_extra_distances.py
+++ b/tests/test_extra_distances.py
@@ -76,6 +76,32 @@ class TestExtraDistances(unittest.TestCase):
             scipy.spatial.distance.canberra, faiss.METRIC_Canberra
         )
 
+    def test_canberra_zero_denominator(self):
+        xq = np.array([[0.0, 0.0]], dtype="float32")
+        yb = np.array(
+            [
+                [0.0, 0.0],
+                [1.0, 0.0],
+                [0.0, 2.0],
+            ],
+            dtype="float32",
+        )
+        expected = np.array([[0.0, 1.0, 1.0]], dtype="float32")
+
+        distances = faiss.pairwise_distances(
+            xq, yb, faiss.METRIC_Canberra
+        )
+        self.assertTrue(np.all(np.isfinite(distances)))
+        self.assertTrue(np.allclose(distances, expected))
+
+        index = faiss.IndexFlat(2, faiss.METRIC_Canberra)
+        index.add(yb)
+        distances, labels = index.search(xq, 3)
+        self.assertTrue(np.all(np.isfinite(distances)))
+        self.assertNotIn(-1, labels[0])
+        self.assertEqual(set(labels[0].tolist()), {0, 1, 2})
+        self.assertTrue(np.allclose(np.sort(distances[0]), expected[0]))
+
     def test_braycurtis(self):
         self.run_simple_dis_test(
             scipy.spatial.distance.braycurtis, faiss.METRIC_BrayCurtis


### PR DESCRIPTION
Fixes #5557

## Summary

`METRIC_Canberra` produces `NaN` when both vectors contain zero in the same dimension because it evaluates `0 / 0`. During `IndexFlat` search, those `NaN` distances are rejected by the result heap, leaving `FLT_MAX/-1` sentinels.

Skip the division when the denominator is zero so that the dimension contributes zero. The regression covers both `pairwise_distances` and `IndexFlat.search` with shared-zero dimensions.

## Validation

Built the actual C++ library and SWIG bindings in WSL Ubuntu with GCC 13.3, C++20, Release, GPU disabled, and both generic and AVX2 targets. Verified the loaded module was respectively `faiss.swigfaiss` or `faiss.swigfaiss_avx2` from the local build, with no fallback or installed Faiss wheel involved.

- On base `cfbf4ec` with the new regression, the test fails in both builds. Separate native probes also reproduce all-`NaN` pairwise distances and `FLT_MAX/-1` search results.
- With this PR's source, `FAISS_OPT_LEVEL=GENERIC python -m pytest tests/test_extra_distances.py -q`: **14 passed**.
- `FAISS_OPT_LEVEL=AVX2 python -m pytest tests/test_extra_distances.py -q`: **14 passed**.
- An additional local SciPy comparison passed in both builds for dimensions 1, 2, 8, 16, 31, 32, 33, and 65, using signed sparse vectors, shared zeros, and both partial and full-k searches; it checks distance values and their association with returned labels.
- The two changed native source files matched the submitted files by SHA-256. Python compilation, focused Ruff lint, and `git diff --check` passed.

GPU and Meta's internal test suite were not run locally. Implementation and local validation were assisted by Codex.
