### PR TITLE
Reject ID selectors when IndexShards shifts shard IDs

### DIFF
--- a/faiss/IndexShards.cpp
+++ b/faiss/IndexShards.cpp
@@ -219,6 +219,13 @@ void IndexShardsTemplate<IndexT>::search(
         }
     }
 
+    FAISS_THROW_IF_NOT_MSG(
+            !(params && params->sel && !translations.empty() &&
+              translations.back() != 0),
+            "IDSelector search is not supported when "
+            "successive_ids shifts shard IDs; use successive_ids=false "
+            "with globally assigned shard IDs");
+
     auto fn = [n, k, x, params, &all_distances, &all_labels, &translations](
                       int no, const IndexT* index) {
         if (index->verbose) {

--- a/faiss/IndexShards.h
+++ b/faiss/IndexShards.h
@@ -81,6 +81,10 @@ struct IndexShardsTemplate : public ThreadedIndex<IndexT> {
     void add_with_ids(idx_t n, const component_t* x, const idx_t* xids)
             override;
 
+    /// Forward search parameters unchanged to each shard. A non-null
+    /// params->sel is unsupported if successive_ids gives any shard a
+    /// nonzero ID offset. To filter globally assigned IDs, assign them to
+    /// the shards first and use successive_ids=false.
     void search(
             idx_t n,
             const component_t* x,

--- a/tests/test_threaded_index.cpp
+++ b/tests/test_threaded_index.cpp
@@ -5,13 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <faiss/IndexBinaryFlat.h>
+#include <faiss/IndexFlat.h>
+#include <faiss/IndexIVF.h>
 #include <faiss/IndexReplicas.h>
 #include <faiss/IndexShards.h>
+#include <faiss/impl/IDSelector.h>
 #include <faiss/impl/ThreadedIndex.h>
 
 #include <gtest/gtest.h>
+#include <array>
 #include <chrono>
 #include <memory>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -20,6 +26,25 @@ namespace {
 struct TestException : public std::exception {};
 
 using idx_t = faiss::idx_t;
+
+struct RecordingFlatIndex : faiss::IndexFlatL2 {
+    using faiss::IndexFlatL2::IndexFlatL2;
+
+    mutable int search_calls = 0;
+    mutable const faiss::SearchParameters* last_params = nullptr;
+
+    void search(
+            idx_t n,
+            const float* x,
+            idx_t k,
+            float* distances,
+            idx_t* labels,
+            const faiss::SearchParameters* params = nullptr) const override {
+        ++search_calls;
+        last_params = params;
+        faiss::IndexFlatL2::search(n, x, k, distances, labels, params);
+    }
+};
 
 struct MockIndex : public faiss::Index {
     explicit MockIndex(idx_t d_in) : faiss::Index(d_in) {
@@ -256,5 +281,179 @@ TEST(ThreadedIndex, TestShards) {
                     idxs[0]->distancesCalled + i * k * n);
             EXPECT_EQ(idxs[i]->labelsCalled, idxs[0]->labelsCalled + i * k * n);
         }
+    }
+}
+
+TEST(ThreadedIndex, ShardsRejectTranslatedIDSelector) {
+    constexpr idx_t d = 1;
+    const std::array<float, 4> xb = {0.0F, 10.0F, 20.0F, 30.0F};
+    const std::array<float, 1> xq = {20.0F};
+
+    for (bool threaded : {false, true}) {
+        for (idx_t selected_id : {2, 0}) {
+            RecordingFlatIndex first(d);
+            RecordingFlatIndex second(d);
+            first.add(2, xb.data());
+            second.add(2, xb.data() + 2);
+
+            faiss::IndexShards shards(d, threaded, true);
+            shards.add_shard(&first);
+            shards.add_shard(&second);
+
+            faiss::IDSelectorBatch selector(1, &selected_id);
+            faiss::SearchParametersIVF params;
+            params.nprobe = 17;
+            params.sel = &selector;
+
+            std::array<float, 2> distances = {-11.0F, -12.0F};
+            std::array<idx_t, 2> labels = {-21, -22};
+            try {
+                shards.search(
+                        1,
+                        xq.data(),
+                        labels.size(),
+                        distances.data(),
+                        labels.data(),
+                        &params);
+                FAIL() << "expected translated IDSelector search to fail";
+            } catch (const faiss::FaissException& exception) {
+                EXPECT_NE(
+                        std::string(exception.what())
+                                .find("IDSelector search is not supported when "
+                                      "successive_ids shifts shard IDs"),
+                        std::string::npos);
+            }
+
+            EXPECT_EQ(params.sel, &selector);
+            EXPECT_EQ(params.nprobe, 17U);
+            EXPECT_EQ(first.search_calls, 0);
+            EXPECT_EQ(second.search_calls, 0);
+            EXPECT_EQ(distances, (std::array<float, 2>{-11.0F, -12.0F}));
+            EXPECT_EQ(labels, (std::array<idx_t, 2>{-21, -22}));
+        }
+    }
+}
+
+TEST(ThreadedIndex, ShardsAllowSelectorWithoutIDTranslation) {
+    constexpr idx_t d = 1;
+    const std::array<float, 1> xb = {20.0F};
+    const std::array<float, 1> xq = {20.0F};
+    idx_t selected_id = 0;
+    faiss::IDSelectorBatch selector(1, &selected_id);
+    faiss::SearchParameters params;
+    params.sel = &selector;
+
+    for (bool threaded : {false, true}) {
+        faiss::IndexFlatL2 single(d);
+        single.add(1, xb.data());
+        faiss::IndexShards one_shard(d, threaded, true);
+        one_shard.add_shard(&single);
+
+        std::array<float, 1> distances{};
+        std::array<idx_t, 1> labels{};
+        one_shard.search(
+                1, xq.data(), 1, distances.data(), labels.data(), &params);
+        EXPECT_EQ(labels[0], 0);
+        EXPECT_EQ(distances[0], 0.0F);
+
+        faiss::IndexFlatL2 empty(d);
+        faiss::IndexFlatL2 populated(d);
+        populated.add(1, xb.data());
+        faiss::IndexShards zero_offsets(d, threaded, true);
+        zero_offsets.add_shard(&empty);
+        zero_offsets.add_shard(&populated);
+
+        zero_offsets.search(
+                1, xq.data(), 1, distances.data(), labels.data(), &params);
+        EXPECT_EQ(labels[0], 0);
+        EXPECT_EQ(distances[0], 0.0F);
+    }
+}
+
+TEST(ThreadedIndex, ShardsControlsRemainUnchanged) {
+    constexpr idx_t d = 1;
+    const std::array<float, 4> xb = {0.0F, 10.0F, 20.0F, 30.0F};
+    const std::array<float, 1> xq = {20.0F};
+
+    for (bool threaded : {false, true}) {
+        RecordingFlatIndex first(d);
+        RecordingFlatIndex second(d);
+        first.add(2, xb.data());
+        second.add(2, xb.data() + 2);
+        faiss::IndexShards translated(d, threaded, true);
+        translated.add_shard(&first);
+        translated.add_shard(&second);
+
+        std::array<float, 1> distances{};
+        std::array<idx_t, 1> labels{};
+        translated.search(1, xq.data(), 1, distances.data(), labels.data());
+        EXPECT_EQ(labels[0], 2);
+        EXPECT_EQ(distances[0], 0.0F);
+
+        faiss::SearchParametersIVF unfiltered_params;
+        unfiltered_params.nprobe = 17;
+        translated.search(
+                1,
+                xq.data(),
+                1,
+                distances.data(),
+                labels.data(),
+                &unfiltered_params);
+        EXPECT_EQ(labels[0], 2);
+        EXPECT_EQ(first.last_params, &unfiltered_params);
+        EXPECT_EQ(second.last_params, &unfiltered_params);
+        EXPECT_EQ(unfiltered_params.nprobe, 17U);
+        EXPECT_EQ(unfiltered_params.sel, nullptr);
+
+        faiss::IndexFlatL2 local_first(d);
+        faiss::IndexFlatL2 local_second(d);
+        local_first.add(2, xb.data());
+        local_second.add(2, xb.data() + 2);
+        faiss::IndexShards local_ids(d, threaded, false);
+        local_ids.add_shard(&local_first);
+        local_ids.add_shard(&local_second);
+
+        idx_t selected_id = 0;
+        faiss::IDSelectorBatch selector(1, &selected_id);
+        faiss::SearchParameters params;
+        params.sel = &selector;
+        local_ids.search(
+                1, xq.data(), 1, distances.data(), labels.data(), &params);
+        EXPECT_EQ(labels[0], 0);
+        EXPECT_EQ(distances[0], 0.0F);
+    }
+}
+
+TEST(ThreadedIndex, BinaryShardsRejectTranslatedIDSelector) {
+    const uint8_t xb[] = {0, 1};
+    idx_t selected_id = 1;
+    faiss::IDSelectorBatch selector(1, &selected_id);
+    faiss::SearchParameters params;
+    params.sel = &selector;
+
+    for (bool threaded : {false, true}) {
+        faiss::IndexBinaryFlat first(8);
+        faiss::IndexBinaryFlat second(8);
+        first.add(1, xb);
+        second.add(1, xb + 1);
+        faiss::IndexBinaryShards shards(8, threaded, true);
+        shards.add_shard(&first);
+        shards.add_shard(&second);
+
+        int32_t distance = -11;
+        idx_t label = -21;
+        try {
+            shards.search(1, xb, 1, &distance, &label, &params);
+            FAIL() << "expected translated IDSelector search to fail";
+        } catch (const faiss::FaissException& exception) {
+            EXPECT_NE(
+                    std::string(exception.what())
+                            .find("IDSelector search is not supported when "
+                                  "successive_ids shifts shard IDs"),
+                    std::string::npos);
+        }
+        EXPECT_EQ(distance, -11);
+        EXPECT_EQ(label, -21);
+        EXPECT_EQ(params.sel, &selector);
     }
 }


### PR DESCRIPTION
Related to #5581.

## Summary

This PR proposes a narrow fail-fast boundary for selector searches when
`IndexShards` applies nonzero offsets to shard IDs. It prevents the incorrect
filtered results in #5581 without introducing a search-parameter cloning API
or mutating caller-owned parameters across worker threads.

The check runs before any shard search. Searches without a selector,
`successive_ids=false`, and configurations where all shard offsets are zero
retain their existing behavior. A nonzero offset also triggers the check when
that shard is currently empty; the boundary is based on the configured ID
offsets. The public `search` documentation explains
the limitation and the need for globally assigned shard IDs when using
`successive_ids=false` to preserve a global ID space.

## Design question

This is a defensive error, **not** full support for translating global-ID
selectors into each shard's local ID space. This implementation is ready for review; feedback on the preferred approach
in #5581 is welcome. If per-shard selector
adaptation is preferred, that needs a separate mechanism that preserves
derived search parameters without sharing mutable state between workers.

This change covers the `IndexShardsTemplate::search` implementation used by
`IndexShards` and `IndexBinaryShards`. It does not change the separate
`IndexShardsIVF::search` override.

## Validation

- Built the candidate Faiss CPU library from
  `2ed4c106e9fb9686e7727e5daf8ad6ad1e164109` with GCC 13.3 / C++20, generic
  CPU code and BLAS/LAPACK.
- The final `test_threaded_index.cpp` against the unmodified library:
  **2 failed, 6 passed**. Both new rejection tests fail because no exception
  is raised.
- Candidate threaded-index tests: **8 passed**. Coverage includes serial and
  threaded searches, both floating-point failure cases, binary shards,
  unchanged output buffers and parameters, no sub-search before rejection,
  and the no-selector / no-translation controls.
- Combined `test_threaded_index.cpp`, `test_binary_flat.cpp` and
  `test_params_override.cpp`: **28 passed**.
- `clang-format 21.1.8 --dry-run --Werror` on the three changed files and
  `git diff --check` passed.

Tests were compiled directly with the repository-pinned GoogleTest against
the source-built library. Full repository CI, Python bindings, GPU builds
and other platforms were not run locally.
