### PR TITLE
faiss: bound filtered IVF range scans to eligible IDs

### DIFF
--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <cstdint>
 #include <memory>
+#include <typeinfo>
 
 #include <algorithm>
 #include <cinttypes>
@@ -844,6 +845,15 @@ void IndexIVF::range_search_preassigned(
     const size_t max_empty_result_buckets =
             params ? params->max_empty_result_buckets : 0;
     IDSelector* sel = params ? params->sel : nullptr;
+    const IDSelectorRange* selr = dynamic_cast<const IDSelectorRange*>(sel);
+    // Keep generic semantics for custom selector subclasses, iterators, and
+    // pair labels. Plain sorted ID ranges can bound array-backed list scans.
+    if (selr && selr->assume_sorted && !store_pairs &&
+        !invlists->use_iterator && typeid(*sel) == typeid(IDSelectorRange)) {
+        sel = nullptr;
+    } else {
+        selr = nullptr;
+    }
 
     FAISS_THROW_IF_NOT_MSG(
             !invlists->use_iterator ||
@@ -901,23 +911,48 @@ void IndexIVF::range_search_preassigned(
                     return;
                 }
 
-                scanner->set_list(key, coarse_dis[i * cur_nprobe + ik]);
                 const size_t scan_cnt0 = qres.stats.scan_cnt;
-                if (invlists->use_iterator) {
-                    size_t list_size = 0;
-                    std::unique_ptr<InvertedListsIterator> it(
-                            invlists->get_iterator(key, inverted_list_context));
-
-                    scanner->iterate_codes_range(
-                            it.get(), radius, qres, list_size);
-                    qres.stats.scan_cnt += list_size;
-                } else {
-                    InvertedLists::ScopedCodes scodes(invlists, key);
+                if (selr) {
                     InvertedLists::ScopedIds ids(invlists, key);
-                    size_t list_size = invlists->list_size(key);
-
+                    size_t begin, end;
+                    selr->find_sorted_ids_bounds(
+                            invlists->list_size(key), ids.get(), &begin, &end);
+                    if (begin == end) {
+                        nlistv++;
+                        return;
+                    }
+                    // Only the contiguous accepted ID interval can contribute.
+                    InvertedLists::ScopedCodes scodes(invlists, key);
+                    scanner->set_list(key, coarse_dis[i * cur_nprobe + ik]);
                     scanner->scan_codes_range(
-                            list_size, scodes.get(), ids.get(), radius, qres);
+                            end - begin,
+                            scodes.get() + begin * code_size,
+                            ids.get() + begin,
+                            radius,
+                            qres);
+                } else {
+                    scanner->set_list(key, coarse_dis[i * cur_nprobe + ik]);
+                    if (invlists->use_iterator) {
+                        size_t list_size = 0;
+                        std::unique_ptr<InvertedListsIterator> it(
+                                invlists->get_iterator(
+                                        key, inverted_list_context));
+
+                        scanner->iterate_codes_range(
+                                it.get(), radius, qres, list_size);
+                        qres.stats.scan_cnt += list_size;
+                    } else {
+                        InvertedLists::ScopedCodes scodes(invlists, key);
+                        InvertedLists::ScopedIds ids(invlists, key);
+                        size_t list_size = invlists->list_size(key);
+
+                        scanner->scan_codes_range(
+                                list_size,
+                                scodes.get(),
+                                ids.get(),
+                                radius,
+                                qres);
+                    }
                 }
                 nlistv++;
                 ndis += qres.stats.scan_cnt - scan_cnt0;

--- a/tests/test_ivf_index.cpp
+++ b/tests/test_ivf_index.cpp
@@ -7,9 +7,11 @@
 
 #include <omp.h>
 #include <algorithm>
+#include <atomic>
 #include <cstddef>
 #include <limits>
 #include <map>
+#include <memory>
 #include <random>
 #include <set>
 
@@ -510,4 +512,217 @@ TEST(IVF, search_callbacks) {
             << "on_heap_changed should fire when vectors enter the heap";
     EXPECT_GE(distance_count, heap_count)
             << "not every distance computation leads to a heap change";
+}
+
+namespace {
+
+struct SetupCountingScanner : faiss::InvertedListScanner {
+    std::unique_ptr<faiss::InvertedListScanner> inner;
+    std::atomic<size_t>& setup_count;
+    std::atomic<size_t>& range_codes;
+
+    SetupCountingScanner(
+            faiss::InvertedListScanner* inner_in,
+            std::atomic<size_t>& setup_count_in,
+            std::atomic<size_t>& range_codes_in)
+            : inner(inner_in),
+              setup_count(setup_count_in),
+              range_codes(range_codes_in) {}
+
+    void set_query(const float* query) override {
+        inner->set_query(query);
+    }
+
+    void set_list(faiss::idx_t list, float coarse_distance) override {
+        setup_count.fetch_add(1, std::memory_order_relaxed);
+        inner->set_list(list, coarse_distance);
+    }
+
+    void scan_codes_range(
+            size_t n,
+            const uint8_t* codes,
+            const faiss::idx_t* ids,
+            float radius,
+            faiss::RangeQueryResult& result) const override {
+        range_codes.fetch_add(n, std::memory_order_relaxed);
+        inner->scan_codes_range(n, codes, ids, radius, result);
+    }
+
+    float distance_to_code(const uint8_t* code) const override {
+        return inner->distance_to_code(code);
+    }
+
+    size_t scan_codes(
+            size_t n,
+            const uint8_t* codes,
+            const faiss::idx_t* ids,
+            faiss::ResultHandler& handler) const override {
+        return inner->scan_codes(n, codes, ids, handler);
+    }
+};
+
+struct SetupCountingIVF : faiss::IndexIVFFlat {
+    using faiss::IndexIVFFlat::IndexIVFFlat;
+    mutable std::atomic<size_t> setup_count{0};
+    mutable std::atomic<size_t> range_codes{0};
+
+    faiss::InvertedListScanner* get_InvertedListScanner(
+            bool store_pairs,
+            const faiss::IDSelector* selector,
+            const faiss::IVFSearchParameters* params) const override {
+        return new SetupCountingScanner(
+                faiss::IndexIVFFlat::get_InvertedListScanner(
+                        store_pairs, selector, params),
+                setup_count,
+                range_codes);
+    }
+};
+
+} // namespace
+
+TEST(IVF, sorted_range_bounds_range_scan) {
+    omp_set_num_threads(2);
+    faiss::IndexFlatL2 quantizer(1);
+    const float centroids[] = {0, 10};
+    quantizer.add(2, centroids);
+    SetupCountingIVF index(&quantizer, 1, 2);
+    index.is_trained = true;
+    const float database[] = {0, 1, 10, 11};
+    index.add(4, database);
+    const float query = 0;
+    faiss::IDSelectorRange selector(0, 2, true);
+    faiss::SearchParametersIVF params;
+    params.nprobe = 2;
+    params.sel = &selector;
+    for (int mode : {0, 1, 2}) {
+        index.parallel_mode = mode;
+        for (const auto& bounds : std::vector<std::pair<int, int>>{
+                     {-1, 5},
+                     {0, 2},
+                     {2, 4},
+                     {1, 3},
+                     {1, 2},
+                     {2, 2},
+                     {0, 0},
+                     {4, 5}}) {
+            selector.imin = bounds.first;
+            selector.imax = bounds.second;
+            index.setup_count = 0;
+            index.range_codes = 0;
+            faiss::RangeSearchResult results(1);
+            index.range_search(1, &query, 1000, &results, &params);
+            std::set<faiss::idx_t> expected;
+            std::set<faiss::idx_t> lists;
+            for (faiss::idx_t id = 0; id < 4; id++) {
+                if (selector.is_member(id)) {
+                    expected.insert(id);
+                    lists.insert(id / 2);
+                }
+            }
+            EXPECT_EQ(index.setup_count.load(), lists.size());
+            EXPECT_EQ(index.range_codes.load(), expected.size());
+            ASSERT_EQ(results.lims[1], expected.size());
+            std::set<faiss::idx_t> labels;
+            for (size_t i = 0; i < results.lims[1]; i++) {
+                const auto id = results.labels[i];
+                ASSERT_GE(id, 0);
+                ASSERT_LT(id, 4);
+                labels.insert(id);
+                EXPECT_FLOAT_EQ(
+                        results.distances[i], database[id] * database[id]);
+            }
+            EXPECT_EQ(labels, expected);
+        }
+    }
+    index.parallel_mode = 0;
+    faiss::IDSelectorRange empty(4, 5, true);
+    params.sel = &empty;
+    index.setup_count = 0;
+    index.range_codes = 0;
+    faiss::indexIVF_stats.reset();
+    faiss::RangeSearchResult no_results(1);
+    index.range_search(1, &query, 1000, &no_results, &params);
+    EXPECT_EQ(no_results.lims[1], 0);
+    EXPECT_EQ(index.setup_count.load(), 0);
+    EXPECT_EQ(index.range_codes.load(), 0);
+    EXPECT_EQ(faiss::indexIVF_stats.nlist, 2);
+
+    // A subclass can expose context membership unrelated to its range fields.
+    // Preserve that dispatch instead of bypassing it with sorted bounds.
+    struct EvenContext : faiss::IDSelectorWithContext {
+        bool is_member(faiss::idx_t id) const override {
+            return id % 2 == 0;
+        }
+        bool is_member_with_context(
+                faiss::idx_t id,
+                const faiss::IDScanContext&) const override {
+            return id % 2 == 0;
+        }
+    };
+    struct CustomRange : faiss::IDSelectorRange, EvenContext {
+        CustomRange() : faiss::IDSelectorRange(0, 2, true) {}
+    } custom;
+    params.sel = static_cast<faiss::IDSelectorRange*>(&custom);
+    index.setup_count = 0;
+    index.range_codes = 0;
+    faiss::RangeSearchResult custom_results(1);
+    index.range_search(1, &query, 1000, &custom_results, &params);
+    EXPECT_EQ(index.setup_count.load(), 2);
+    EXPECT_EQ(index.range_codes.load(), 4);
+    ASSERT_EQ(custom_results.lims[1], 2);
+    std::set<faiss::idx_t> labels(
+            custom_results.labels, custom_results.labels + 2);
+    EXPECT_EQ(labels, (std::set<faiss::idx_t>{0, 2}));
+}
+
+TEST(IVF, sorted_range_preserves_iterator_and_pair_paths) {
+    omp_set_num_threads(1);
+    faiss::IndexFlatL2 quantizer(1);
+    const float centroids[] = {0, 10};
+    quantizer.add(2, centroids);
+    const float database[] = {0, 1, 10, 11};
+    const float query = 0;
+    faiss::IDSelectorRange selector(1, 3, true);
+    faiss::SearchParametersIVF params;
+    params.nprobe = 2;
+    params.sel = &selector;
+
+    faiss::IndexIVFFlat array_index(&quantizer, 1, 2);
+    array_index.is_trained = true;
+    array_index.add(4, database);
+    const faiss::idx_t keys[] = {0, 1};
+    const float coarse_distances[] = {0, 100};
+    faiss::RangeSearchResult pairs(1);
+    array_index.range_search_preassigned(
+            1, &query, 1000, keys, coarse_distances, &pairs, true, &params);
+    // With store_pairs, the native selector sees encoded pair labels rather
+    // than database IDs. Only list 0, offset 1 lies inside [1, 3).
+    ASSERT_EQ(pairs.lims[1], 1);
+    EXPECT_EQ(pairs.labels[0], 1);
+
+    faiss::IndexIVFFlat iterator_index(&quantizer, 1, 2);
+    TestInvertedLists inverted_lists(2, iterator_index.code_size);
+    iterator_index.replace_invlists(&inverted_lists);
+    iterator_index.is_trained = true;
+    iterator_index.ntotal = 4;
+    TestContext context;
+    for (size_t i = 0; i < 4; i++) {
+        context.save_code(
+                i / 2,
+                reinterpret_cast<const uint8_t*>(database + i),
+                sizeof(float));
+    }
+    params.inverted_list_context = &context;
+    // Sorted-range dispatch must preserve the generic iterator path.
+    faiss::RangeSearchResult results(1), reference(1);
+    iterator_index.range_search(1, &query, 1000, &results, &params);
+    selector.assume_sorted = false;
+    iterator_index.range_search(1, &query, 1000, &reference, &params);
+    ASSERT_EQ(results.lims[1], reference.lims[1]);
+    std::map<faiss::idx_t, float> actual, expected;
+    for (size_t i = 0; i < results.lims[1]; i++) {
+        actual[results.labels[i]] = results.distances[i];
+        expected[reference.labels[i]] = reference.distances[i];
+    }
+    EXPECT_EQ(actual, expected);
 }

--- a/tests/test_search_params.py
+++ b/tests/test_search_params.py
@@ -832,3 +832,42 @@ class TestIVFEarlyTermination(unittest.TestCase):
         self.assertEqual(p.max_lists_num, 5)
         self.assertIs(p.ensure_topk_full, True)
         self.assertEqual(p.max_empty_result_buckets, 2)
+
+
+class TestSortedRangeSearch(unittest.TestCase):
+    def test_exact_bounds_across_scanners(self):
+        rs = np.random.RandomState(123)
+        xt = rs.randn(640, 8).astype("float32")
+        xb = rs.randn(64, 8).astype("float32")
+        xq = xb[:8].copy()
+        for metric in (faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT):
+            for factory in ("IVF4,Flat", "IVF4,PQ2x4", "IVF4,SQ8"):
+                index = faiss.index_factory(8, factory, metric)
+                index.train(xt)
+                index.add(xb)
+                for lo, hi in ((0, 0), (64, 65), (0, 64), (0, 1),
+                               (63, 64), (10, 40), (20, 21)):
+                    for radius in (-100.0, 0.0, 10.0, 1000.0):
+                        with self.subTest(metric=metric, factory=factory,
+                                          bounds=(lo, hi), radius=radius):
+                            outputs = []
+                            counts = []
+                            for sorted_ids in (False, True):
+                                params = faiss.SearchParametersIVF(
+                                    nprobe=4, sel=faiss.IDSelectorRange(
+                                        lo, hi, sorted_ids))
+                                faiss.cvar.indexIVF_stats.reset()
+                                lim, distances, ids = index.range_search(
+                                    xq, radius, params=params)
+                                outputs.append([
+                                    sorted(zip(
+                                        ids[lim[i]:lim[i + 1]].tolist(),
+                                        distances[lim[i]:lim[i + 1]].tolist()))
+                                    for i in range(len(xq))])
+                                counts.append((faiss.cvar.indexIVF_stats.nlist,
+                                               faiss.cvar.indexIVF_stats.ndis))
+                            self.assertEqual(outputs[0], outputs[1])
+                            self.assertEqual(counts[0], counts[1])
+                            for results in outputs[1]:
+                                self.assertTrue(all(lo <= idx < hi
+                                                    for idx, _ in results))


### PR DESCRIPTION
## Summary

Filtered IVF range search can currently enter a list scanner and visit IDs/codes that a plain sorted ID selector will reject anyway.

This change uses the selector's exact sorted ID bounds **before scanner setup**:

* intersect the selected inverted list with the selector's eligible ID interval;
* skip scanner setup when the intersection is empty;
* otherwise scan only the eligible IDs and corresponding codes.

The existing path is preserved for unfiltered searches and selector/list configurations where these bounds are not known to be exact.

## Why

For sparse filtered range searches, the coarse IVF search may select many physical lists even though only a very small fraction of the IDs in those lists are eligible under the selector.

Previously, those excluded IDs could still reach per-list scanner/code work before the selector removed them.

The selector already provides sufficient information to determine the exact eligible contiguous interval, so that filtering can happen before the expensive inner scan without changing which vectors are valid results.

No new persistent metadata or controller state is introduced.

## Scope

The optimized path is limited to the compatible plain sorted ID-selector case.

The original behavior remains unchanged for:

* unfiltered searches;
* custom or context-dependent selectors;
* iterator-backed lists where equivalent bounds are not established;
* pair labels;
* other selector representations that do not provide the required exact sorted interval.

Eligible distance calculations, radius checks, and returned range-search results are unchanged.

## Work reduction

On the representative SIFT1M validation workload:

* `nprobe=256`
* batch size `128`
* selector IDs `[0, 100)`

the original IVFFlat range path presented approximately **32.6 million IDs** to list scanners.

With this change, the scanners receive only **4,226 eligible IDs**.

Of **32,768** selected physical lists, **29,488** have no eligible intersection and therefore avoid scanner setup entirely.

The useful distance calculations remain the same.

## Performance

On the same frozen filtered-range workload, the measured speedups were approximately:

* **IVFFlat**

  * 1 thread: **15.5x**
  * 4 threads: **15.0x**
  * 8 threads: **13.8x**

* **IVFPQ with precomputed tables**

  * 1 thread: **12.6x**
  * 4 threads: **11.9x**
  * 8 threads: **12.6x**

* **IVFPQ without precomputed tables**

  * 1 thread: **11.0x**
  * 4 threads: **10.5x**
  * 8 threads: **9.5x**

These numbers are specific to **sparse filtered range search** and should not be interpreted as a general Faiss speedup.

Unfiltered and unsupported-selector paths retain the existing implementation.

## Correctness

The change preserves the exact eligible ID set and only moves selector-bounding work ahead of scanner/code processing.

Validation covers:

* exact range-result equality;
* empty eligible intersections;
* partial intersections;
* list-boundary cases;
* full intersections;
* multiple inverted lists;
* IVFFlat;
* IVFPQ;
* fallback behavior for unsupported selectors.

Broader exact-output comparisons were also run across the retained implementation.

## Method

The opportunities were identified and validated using WOB/WOB3 techniques.

WOB is an experimental method of refocussing workloads in data-heavy code. I am stress testing various codebases, to develop the method further, and faiss seemed like a worthwhile candidate. The results were good, so I am sharing. Feedback would be greatly appreciated.

WOB is human-designed, human-led, and machine assisted.
