### PR TITLE
Guard a k of 0 in binary scan_codes and document the radius bound (#5586)

### DIFF
--- a/benchs/bench_rabitq.py
+++ b/benchs/bench_rabitq.py
@@ -23,8 +23,8 @@ from faiss.contrib.datasets import SyntheticDataset
 #   d=512  -> size=64  -> 512-bit zmm, 1 iteration per bit-plane
 #   d=768  -> size=96  -> 512-bit zmm + 256-bit tail
 #   d=1024 -> size=128 -> 512-bit zmm only, 2 iterations per bit-plane
-# Sweeping these is useful for verifying the AVX512_SPR (vpopcntdq)
-# specialization in faiss/utils/simd_impl/rabitq_avx512_spr.cpp and for
+# Sweeping these is useful for verifying the AVX512_VPOPCNT specialization in
+# faiss/utils/simd_impl/rabitq_avx512_vpopcnt.cpp and for
 # profiling perf-record annotations across SIMD-width tiers.
 DIMENSIONS = [256, 512, 768, 1024]
 nlist: int = 1000

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -39,15 +39,16 @@ set(FAISS_SIMD_AVX512_SRC
   utils/simd_impl/rabitq_avx512.cpp
   utils/simd_impl/super_kmeans_kernels_avx512.cpp
 )
-# AVX-512 sources that additionally require AVX512_VPOPCNTDQ
-# (Sapphire Rapids and later). Compiled into faiss_avx512_spr only,
-# and into the DD faiss target with an extra per-file -mavx512vpopcntdq
-# flag. Not compiled into faiss_avx512 — that target stops at the
-# baseline AVX-512F/CD/VL/DQ/BW feature set.
+# AVX-512 sources that only require AVX512_VPOPCNTDQ on top of the baseline
+# AVX-512F/CD/VL/DQ/BW feature set. In DD builds these are available on CPUs
+# such as Ice Lake and Zen 4 without requiring the full SPR feature set.
+set(FAISS_SIMD_AVX512_VPOPCNT_SRC
+  utils/simd_impl/rabitq_avx512_vpopcnt.cpp
+  utils/hamming_distance/hamming_avx512_vpopcnt.cpp
+)
+# AVX-512 sources that require the full Sapphire Rapids feature set.
 set(FAISS_SIMD_AVX512_SPR_SRC
   impl/scalar_quantizer/sq-avx512-spr.cpp
-  utils/simd_impl/rabitq_avx512_spr.cpp
-  utils/hamming_distance/hamming_avx512_spr.cpp
 )
 set(FAISS_SIMD_NEON_SRC
   impl/fast_scan/impl-neon.cpp
@@ -80,7 +81,8 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|amd64|AMD64)")
   set(FAISS_SIMD_SRC
     ${FAISS_SIMD_AVX2_SRC}
     ${FAISS_SIMD_AVX512_SRC}
-    ${FAISS_SIMD_AVX512_SPR_SRC} ${FAISS_SIMD_AVX512_SPR_SRC})
+    ${FAISS_SIMD_AVX512_VPOPCNT_SRC}
+    ${FAISS_SIMD_AVX512_SPR_SRC})
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64|arm64|ARM64)")
   set(FAISS_SIMD_SRC ${FAISS_SIMD_NEON_SRC} ${FAISS_SIMD_SVE_SRC})
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(riscv64|riscv)")
@@ -404,7 +406,7 @@ set(FAISS_HEADERS
   utils/hamming_distance/hamming_computer.h
   utils/hamming_distance/hamming_computer-avx2.h
   utils/hamming_distance/hamming_computer-avx512.h
-  utils/hamming_distance/hamming_computer-avx512_spr.h
+  utils/hamming_distance/hamming_computer-avx512_vpopcnt.h
   utils/hamming_distance/hamming_computer-generic.h
   utils/hamming_distance/hamming_computer-neon.h
   utils/hamming_distance/hamming_computer-rvv.h
@@ -496,8 +498,16 @@ else()
   # we need bigobj for the swig wrapper
   add_compile_options(/bigobj)
 endif()
-target_sources(faiss_avx512_spr PRIVATE ${FAISS_SIMD_AVX2_SRC} ${FAISS_SIMD_AVX512_SRC} ${FAISS_SIMD_AVX512_SPR_SRC})
-target_compile_definitions(faiss_avx512_spr PRIVATE COMPILE_SIMD_AVX2 COMPILE_SIMD_AVX512 COMPILE_SIMD_AVX512_SPR)
+target_sources(faiss_avx512_spr PRIVATE
+  ${FAISS_SIMD_AVX2_SRC}
+  ${FAISS_SIMD_AVX512_SRC}
+  ${FAISS_SIMD_AVX512_VPOPCNT_SRC}
+  ${FAISS_SIMD_AVX512_SPR_SRC})
+target_compile_definitions(faiss_avx512_spr PRIVATE
+  COMPILE_SIMD_AVX2
+  COMPILE_SIMD_AVX512
+  COMPILE_SIMD_AVX512_VPOPCNT
+  COMPILE_SIMD_AVX512_SPR)
 
 add_library(faiss_sve ${FAISS_SRC})
 if(NOT FAISS_OPT_LEVEL STREQUAL "sve")
@@ -539,7 +549,10 @@ if(FAISS_OPT_LEVEL STREQUAL "dd")
   # Architecture-specific SIMD definitions for Dynamic Dispatch
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|amd64|AMD64)")
     target_compile_definitions(faiss PRIVATE
-      COMPILE_SIMD_AVX2 COMPILE_SIMD_AVX512 COMPILE_SIMD_AVX512_SPR)
+      COMPILE_SIMD_AVX2
+      COMPILE_SIMD_AVX512
+      COMPILE_SIMD_AVX512_VPOPCNT
+      COMPILE_SIMD_AVX512_SPR)
     if(NOT WIN32)
       # Baseline flags for common files (prevents auto-vectorization)
       target_compile_options(faiss PRIVATE
@@ -554,9 +567,13 @@ if(FAISS_OPT_LEVEL STREQUAL "dd")
         PROPERTIES COMPILE_OPTIONS
           "-mavx512f;-mavx512cd;-mavx512vl;-mavx512dq;-mavx512bw;-mfma;-mf16c;-mpopcnt"
       )
-      # SPR-only sources additionally require AVX512_VPOPCNTDQ.
-      # vpopcntq is the whole point of these files, so the extra flag
-      # is mandatory; without it the intrinsics fail to compile.
+      # VPOPCNT sources only require VPOPCNTDQ in addition to baseline AVX-512.
+      set_source_files_properties(${FAISS_SIMD_AVX512_VPOPCNT_SRC}
+        TARGET_DIRECTORY faiss
+        PROPERTIES COMPILE_OPTIONS
+          "-mavx2;-mfma;-mf16c;-mavx512f;-mavx512cd;-mavx512vl;-mavx512dq;-mavx512bw;-mavx512vpopcntdq;-mpopcnt"
+      )
+      # The remaining SPR sources require the full SPR feature set.
       set_source_files_properties(${FAISS_SIMD_AVX512_SPR_SRC}
         TARGET_DIRECTORY faiss
         PROPERTIES COMPILE_OPTIONS
@@ -573,11 +590,11 @@ if(FAISS_OPT_LEVEL STREQUAL "dd")
         TARGET_DIRECTORY faiss
         PROPERTIES COMPILE_OPTIONS "/arch:AVX512"
       )
-      # MSVC has no per-feature flag for VPOPCNTDQ; /arch:AVX512
-      # enables it as part of the AVX-512 feature set used by recent
-      # toolchains. (Newer MSVC supports __isa_available checks at
-      # runtime; the SPR specialization is gated by COMPILE_SIMD_AVX512_SPR
-      # at the source level, so this is safe.)
+      # MSVC has no per-feature flag for VPOPCNTDQ.
+      set_source_files_properties(${FAISS_SIMD_AVX512_VPOPCNT_SRC}
+        TARGET_DIRECTORY faiss
+        PROPERTIES COMPILE_OPTIONS "/arch:AVX512"
+      )
       set_source_files_properties(${FAISS_SIMD_AVX512_SPR_SRC}
         TARGET_DIRECTORY faiss
         PROPERTIES COMPILE_OPTIONS "/arch:AVX512"

--- a/faiss/IndexBinaryIVF.h
+++ b/faiss/IndexBinaryIVF.h
@@ -234,6 +234,13 @@ struct BinaryInvertedListScanner {
     /** compute the distances to codes. (distances, labels) should be
      * organized as a min- or max-heap
      *
+     * A k of 0 is valid and scans nothing.
+     *
+     * The heap top is the only bound. To keep the k nearest codes inside a
+     * radius, seed every heap slot with that radius instead of the neutral
+     * value; an unfilled slot keeps its label of -1. A seed below zero
+     * admits nothing.
+     *
      * @param n      number of codes to scan
      * @param codes  codes to scan (n * code_size)
      * @param ids        corresponding ids (ignored if store_pairs)

--- a/faiss/IndexFlat.cpp
+++ b/faiss/IndexFlat.cpp
@@ -270,9 +270,11 @@ struct FlatIPDis : FlatCodesDistanceComputer {
 FlatCodesDistanceComputer* IndexFlat::get_FlatCodesDistanceComputer() const {
     FlatCodesDistanceComputer* dc = nullptr;
     if (metric_type == METRIC_L2) {
-        with_simd_level([&]<SIMDLevel SL>() { dc = new FlatL2Dis<SL>(*this); });
+        with_simd_level_a1(
+                [&]<SIMDLevel SL>() { dc = new FlatL2Dis<SL>(*this); });
     } else if (metric_type == METRIC_INNER_PRODUCT) {
-        with_simd_level([&]<SIMDLevel SL>() { dc = new FlatIPDis<SL>(*this); });
+        with_simd_level_a1(
+                [&]<SIMDLevel SL>() { dc = new FlatIPDis<SL>(*this); });
     } else {
         dc = get_extra_distance_computer(d, metric_type, metric_arg, get_xb());
     }
@@ -404,7 +406,7 @@ FlatCodesDistanceComputer* IndexFlatL2::get_FlatCodesDistanceComputer() const {
     if (metric_type == METRIC_L2) {
         if (!cached_l2norms.empty()) {
             FlatCodesDistanceComputer* dc = nullptr;
-            with_simd_level([&]<SIMDLevel SL>() {
+            with_simd_level_a1([&]<SIMDLevel SL>() {
                 dc = new FlatL2WithNormsDis<SL>(*this);
             });
             return dc;
@@ -784,7 +786,7 @@ void IndexFlatPanorama::search_subset(
         idx_t k,
         float* distances,
         idx_t* labels) const {
-    with_simd_level([&]<SIMDLevel SL>() {
+    with_simd_level_a1([&]<SIMDLevel SL>() {
         with_metric_type(metric_type, [&]<MetricType M>() {
             constexpr bool is_sim = is_similarity_metric(M);
             using C = std::conditional_t<

--- a/faiss/IndexFlat.cpp
+++ b/faiss/IndexFlat.cpp
@@ -270,10 +270,10 @@ struct FlatIPDis : FlatCodesDistanceComputer {
 FlatCodesDistanceComputer* IndexFlat::get_FlatCodesDistanceComputer() const {
     FlatCodesDistanceComputer* dc = nullptr;
     if (metric_type == METRIC_L2) {
-        with_simd_level_a1(
+        with_simd_level_with_sve(
                 [&]<SIMDLevel SL>() { dc = new FlatL2Dis<SL>(*this); });
     } else if (metric_type == METRIC_INNER_PRODUCT) {
-        with_simd_level_a1(
+        with_simd_level_with_sve(
                 [&]<SIMDLevel SL>() { dc = new FlatIPDis<SL>(*this); });
     } else {
         dc = get_extra_distance_computer(d, metric_type, metric_arg, get_xb());
@@ -406,7 +406,7 @@ FlatCodesDistanceComputer* IndexFlatL2::get_FlatCodesDistanceComputer() const {
     if (metric_type == METRIC_L2) {
         if (!cached_l2norms.empty()) {
             FlatCodesDistanceComputer* dc = nullptr;
-            with_simd_level_a1([&]<SIMDLevel SL>() {
+            with_simd_level_with_sve([&]<SIMDLevel SL>() {
                 dc = new FlatL2WithNormsDis<SL>(*this);
             });
             return dc;
@@ -786,7 +786,7 @@ void IndexFlatPanorama::search_subset(
         idx_t k,
         float* distances,
         idx_t* labels) const {
-    with_simd_level_a1([&]<SIMDLevel SL>() {
+    with_simd_level_with_sve([&]<SIMDLevel SL>() {
         with_metric_type(metric_type, [&]<MetricType M>() {
             constexpr bool is_sim = is_similarity_metric(M);
             using C = std::conditional_t<

--- a/faiss/SuperKMeans.cpp
+++ b/faiss/SuperKMeans.cpp
@@ -621,7 +621,7 @@ void super_kmeans_assign_iteration(
             }
 
             // One SIMD dispatch per (xi, yj) tile.
-            with_simd_level_a1([&]<SIMDLevel SL>() {
+            with_simd_level_with_sve([&]<SIMDLevel SL>() {
                 [[maybe_unused]] const int omp_chunk_local = cp.omp_chunk;
                 int64_t tile_total = 0;
                 int64_t tile_pruned = 0;

--- a/faiss/SuperKMeans.cpp
+++ b/faiss/SuperKMeans.cpp
@@ -621,7 +621,7 @@ void super_kmeans_assign_iteration(
             }
 
             // One SIMD dispatch per (xi, yj) tile.
-            with_simd_level([&]<SIMDLevel SL>() {
+            with_simd_level_a1([&]<SIMDLevel SL>() {
                 [[maybe_unused]] const int omp_chunk_local = cp.omp_chunk;
                 int64_t tile_total = 0;
                 int64_t tile_pruned = 0;

--- a/faiss/docs/simd_dynamic_dispatch_migration.md
+++ b/faiss/docs/simd_dynamic_dispatch_migration.md
@@ -238,8 +238,9 @@ your own with `(1 << int(SIMDLevel::X)) | ...`):
 |------|--------|---------|
 | `AVAILABLE_SIMD_LEVELS_NONE` | NONE only | Scalar-only functions |
 | `AVAILABLE_SIMD_LEVELS_AVX2_NEON` | NONE, AVX2, ARM_NEON | 256-bit `simdlib` ops (`with_simd_level_256bit`) |
-| `AVAILABLE_SIMD_LEVELS_A0` | NONE, AVX2, AVX512, ARM_NEON, RISCV_RVV | Default (`with_simd_level`) |
-| `AVAILABLE_SIMD_LEVELS_A1` | A0 + ARM_SVE | Functions with dedicated SVE implementations |
+| `AVAILABLE_SIMD_LEVELS_BASE` | NONE, AVX2, AVX512, ARM_NEON, RISCV_RVV | Default (`with_simd_level`). ARM_NEON is part of BASE: NEON is mandatory on aarch64, SVE is optional |
+| `AVAILABLE_SIMD_LEVELS_BASE_WITH_SPR` | BASE + AVX512_SPR | Kernels needing the whole SPR feature set (`with_simd_level_with_spr`) |
+| `AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE` | BASE + ARM_SVE | Functions with dedicated SVE implementations (`with_simd_level_with_sve`) |
 | `AVAILABLE_SIMD_LEVELS_ALL` | All levels | Identity / diagnostic functions |
 
 ### Step 4: Register in build system

--- a/faiss/docs/simd_dynamic_dispatch_migration.md
+++ b/faiss/docs/simd_dynamic_dispatch_migration.md
@@ -215,8 +215,8 @@ ARM_NEON + RISCV_RVV implementations exist. If your function has another subset
 of available implementations, it can be passed with
 `with_selected_simd_levels<mask>` with a bitmask of available levels. Missing
 levels in the mask cause the dispatch to **fall through** to the next lower
-level in the same architecture family (x86: AVX512_SPR → AVX512 → AVX2 →
-NONE; ARM: ARM_SVE → ARM_NEON → NONE; RISC-V: RISCV_RVV → NONE —
+level in the same architecture family (x86: AVX512_SPR → AVX512_VPOPCNT →
+AVX512 → AVX2 → NONE; ARM: ARM_SVE → ARM_NEON → NONE; RISC-V: RISCV_RVV → NONE —
 architecture chains are independent):
 
 ```cpp
@@ -239,7 +239,8 @@ your own with `(1 << int(SIMDLevel::X)) | ...`):
 | `AVAILABLE_SIMD_LEVELS_NONE` | NONE only | Scalar-only functions |
 | `AVAILABLE_SIMD_LEVELS_AVX2_NEON` | NONE, AVX2, ARM_NEON | 256-bit `simdlib` ops (`with_simd_level_256bit`) |
 | `AVAILABLE_SIMD_LEVELS_BASE` | NONE, AVX2, AVX512, ARM_NEON, RISCV_RVV | Default (`with_simd_level`). ARM_NEON is part of BASE: NEON is mandatory on aarch64, SVE is optional |
-| `AVAILABLE_SIMD_LEVELS_BASE_WITH_SPR` | BASE + AVX512_SPR | Kernels needing the whole SPR feature set (`with_simd_level_with_spr`) |
+| `AVAILABLE_SIMD_LEVELS_BASE_WITH_VPOPCNT` | BASE + AVX512_VPOPCNT | Kernels needing only VPOPCNTDQ (`with_simd_level_with_vpopcnt`) |
+| `AVAILABLE_SIMD_LEVELS_BASE_WITH_SPR` | BASE + AVX512_SPR | Kernels needing the whole SPR feature set |
 | `AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE` | BASE + ARM_SVE | Functions with dedicated SVE implementations (`with_simd_level_with_sve`) |
 | `AVAILABLE_SIMD_LEVELS_ALL` | All levels | Identity / diagnostic functions |
 

--- a/faiss/impl/AdditiveQuantizer.cpp
+++ b/faiss/impl/AdditiveQuantizer.cpp
@@ -376,7 +376,7 @@ void AdditiveQuantizer::compute_centroid_norms(float* norms) const {
     size_t ntotal = (size_t)1 << tot_bits;
     int64_t ntotal_signed = ntotal;
     // TODO: make tree of partial sums
-    with_simd_level([&]<SIMDLevel SL>() {
+    with_simd_level_a1([&]<SIMDLevel SL>() {
 #pragma omp parallel
         {
             std::vector<float> tmp(d);

--- a/faiss/impl/AdditiveQuantizer.cpp
+++ b/faiss/impl/AdditiveQuantizer.cpp
@@ -376,7 +376,7 @@ void AdditiveQuantizer::compute_centroid_norms(float* norms) const {
     size_t ntotal = (size_t)1 << tot_bits;
     int64_t ntotal_signed = ntotal;
     // TODO: make tree of partial sums
-    with_simd_level_a1([&]<SIMDLevel SL>() {
+    with_simd_level_with_sve([&]<SIMDLevel SL>() {
 #pragma omp parallel
         {
             std::vector<float> tmp(d);

--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -280,7 +280,6 @@ void compute_1_code(const ProductQuantizer& pq, const float* x, uint8_t* code) {
 } // namespace
 
 void ProductQuantizer::compute_code(const float* x, uint8_t* code) const {
-    // a1: fvec_L2sqr_ny_nearest / _y_transposed have ARM_SVE specializations
     with_simd_level_a1([&]<SIMDLevel SL>() {
         switch (nbits) {
             case 8:
@@ -443,7 +442,6 @@ void ProductQuantizer::compute_codes(const float* x, uint8_t* codes, size_t n)
 
 void ProductQuantizer::compute_distance_table(const float* x, float* dis_table)
         const {
-    // a1: fvec_L2sqr_ny / _transposed have ARM_SVE specializations
     with_simd_level_a1([&]<SIMDLevel SL>() {
         if (transposed_centroids.empty()) {
             // use regular version
@@ -826,7 +824,6 @@ void ProductQuantizer::compute_sdc_table() {
     sdc_table.resize(M * ksub * ksub);
 
     if (dsub < 4) {
-        // a1: fvec_L2sqr_ny has an ARM_SVE specialization
         with_simd_level_a1([&]<SIMDLevel SL>() {
 #pragma omp parallel for
             for (int64_t mk = 0; mk < static_cast<int64_t>(M * ksub); mk++) {

--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -280,7 +280,7 @@ void compute_1_code(const ProductQuantizer& pq, const float* x, uint8_t* code) {
 } // namespace
 
 void ProductQuantizer::compute_code(const float* x, uint8_t* code) const {
-    with_simd_level_a1([&]<SIMDLevel SL>() {
+    with_simd_level_with_sve([&]<SIMDLevel SL>() {
         switch (nbits) {
             case 8:
                 compute_1_code<PQEncoder8, SL>(*this, x, code);
@@ -294,7 +294,7 @@ void ProductQuantizer::compute_code(const float* x, uint8_t* code) const {
                 compute_1_code<PQEncoderGeneric, SL>(*this, x, code);
                 break;
         }
-    }); // with_simd_level_a1
+    }); // with_simd_level_with_sve
 }
 
 template <class PQDecoder>
@@ -442,7 +442,7 @@ void ProductQuantizer::compute_codes(const float* x, uint8_t* codes, size_t n)
 
 void ProductQuantizer::compute_distance_table(const float* x, float* dis_table)
         const {
-    with_simd_level_a1([&]<SIMDLevel SL>() {
+    with_simd_level_with_sve([&]<SIMDLevel SL>() {
         if (transposed_centroids.empty()) {
             // use regular version
             for (size_t m = 0; m < M; m++) {
@@ -824,7 +824,7 @@ void ProductQuantizer::compute_sdc_table() {
     sdc_table.resize(M * ksub * ksub);
 
     if (dsub < 4) {
-        with_simd_level_a1([&]<SIMDLevel SL>() {
+        with_simd_level_with_sve([&]<SIMDLevel SL>() {
 #pragma omp parallel for
             for (int64_t mk = 0; mk < static_cast<int64_t>(M * ksub); mk++) {
                 // allow omp to schedule in a more fine-grained way

--- a/faiss/impl/RaBitQUtils.cpp
+++ b/faiss/impl/RaBitQUtils.cpp
@@ -329,7 +329,7 @@ float compute_full_multibit_distance(
         size_t d,
         size_t ex_bits,
         MetricType metric_type) {
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A0_SPR>(
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SPR>(
             [&]<SIMDLevel SL>() {
                 return compute_full_multibit_distance<SL>(
                         sign_bits,

--- a/faiss/impl/RaBitQUtils.cpp
+++ b/faiss/impl/RaBitQUtils.cpp
@@ -329,7 +329,7 @@ float compute_full_multibit_distance(
         size_t d,
         size_t ex_bits,
         MetricType metric_type) {
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SPR>(
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_VPOPCNT>(
             [&]<SIMDLevel SL>() {
                 return compute_full_multibit_distance<SL>(
                         sign_bits,

--- a/faiss/impl/RaBitQuantizer.cpp
+++ b/faiss/impl/RaBitQuantizer.cpp
@@ -721,12 +721,10 @@ FlatCodesDistanceComputer* RaBitQuantizer::get_distance_computer(
     // call the SIMD-specialized rabitq functions directly (no per-call
     // with_simd_level overhead).
     //
-    // Use BASE_WITH_SPR (which includes AVX512_SPR) so that on Sapphire Rapids
-    // and later x86 microarchitectures the VPOPCNTDQ-based RaBitQ
-    // specialization in rabitq_avx512_spr.cpp is selected. On AVX-512
-    // CPUs without VPOPCNTDQ, dispatch falls through to the AVX512
-    // specialization in rabitq_avx512.cpp.
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SPR>(
+    // VPOPCNT rather than SPR: Ice Lake and Zen 4 have VPOPCNTDQ without the
+    // rest of the SPR feature set. Below it, dispatch falls through to
+    // rabitq_avx512.cpp.
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_VPOPCNT>(
             [&]<SIMDLevel SL>() -> FlatCodesDistanceComputer* {
                 if (qb == 0) {
                     auto dc =

--- a/faiss/impl/RaBitQuantizer.cpp
+++ b/faiss/impl/RaBitQuantizer.cpp
@@ -721,12 +721,12 @@ FlatCodesDistanceComputer* RaBitQuantizer::get_distance_computer(
     // call the SIMD-specialized rabitq functions directly (no per-call
     // with_simd_level overhead).
     //
-    // Use A0_SPR (which includes AVX512_SPR) so that on Sapphire Rapids
+    // Use BASE_WITH_SPR (which includes AVX512_SPR) so that on Sapphire Rapids
     // and later x86 microarchitectures the VPOPCNTDQ-based RaBitQ
     // specialization in rabitq_avx512_spr.cpp is selected. On AVX-512
     // CPUs without VPOPCNTDQ, dispatch falls through to the AVX512
     // specialization in rabitq_avx512.cpp.
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A0_SPR>(
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SPR>(
             [&]<SIMDLevel SL>() -> FlatCodesDistanceComputer* {
                 if (qb == 0) {
                     auto dc =

--- a/faiss/impl/ScalarQuantizer.cpp
+++ b/faiss/impl/ScalarQuantizer.cpp
@@ -665,7 +665,7 @@ ScalarQuantizer::SQuantizer* ScalarQuantizer::select_quantizer() const {
     // A SIMD level's factory returns nullptr when the dimension is
     // incompatible (e.g. AVX-512 needs d % 16 == 0); the dispatcher then falls
     // back to the next-lower level (AVX-512 -> AVX2 -> scalar).
-    return with_simd_level_fallback<AVAILABLE_SIMD_LEVELS_A0_SPR>(
+    return with_simd_level_fallback<AVAILABLE_SIMD_LEVELS_BASE_WITH_SPR>(
             [&]<SIMDLevel SL>() -> SQuantizer* {
                 return scalar_quantizer::sq_select_quantizer<SL>(
                         qtype, d, trained);
@@ -702,7 +702,7 @@ void ScalarQuantizer::decode(const uint8_t* codes, float* x, size_t n) const {
 ScalarQuantizer::SQDistanceComputer* ScalarQuantizer::get_distance_computer(
         MetricType metric) const {
     FAISS_THROW_IF_NOT(metric == METRIC_L2 || metric == METRIC_INNER_PRODUCT);
-    return with_simd_level_fallback<AVAILABLE_SIMD_LEVELS_A0_SPR>(
+    return with_simd_level_fallback<AVAILABLE_SIMD_LEVELS_BASE_WITH_SPR>(
             [&]<SIMDLevel SL>() -> SQDistanceComputer* {
                 return scalar_quantizer::sq_select_distance_computer<SL>(
                         metric, qtype, d, trained);
@@ -715,7 +715,7 @@ InvertedListScanner* ScalarQuantizer::select_InvertedListScanner(
         bool store_pairs,
         const IDSelector* sel,
         bool by_residual) const {
-    return with_simd_level_fallback<AVAILABLE_SIMD_LEVELS_A0_SPR>(
+    return with_simd_level_fallback<AVAILABLE_SIMD_LEVELS_BASE_WITH_SPR>(
             [&]<SIMDLevel SL>() -> InvertedListScanner* {
                 return scalar_quantizer::sq_select_InvertedListScanner<SL>(
                         qtype,

--- a/faiss/impl/binary_hamming/IndexBinaryIVF_impl.h
+++ b/faiss/impl/binary_hamming/IndexBinaryIVF_impl.h
@@ -70,12 +70,21 @@ struct IVFBinaryScannerL2 : BinaryInvertedListScanner {
             size_t k) const override {
         using C = CMax<int32_t, idx_t>;
 
+        if (k == 0 || n == 0) {
+            return 0;
+        }
+
+        // A seed below zero means no code qualifies. Reading it as unsigned
+        // would instead accept every code.
+        uint32_t bound = simi[0] < 0 ? 0 : static_cast<uint32_t>(simi[0]);
+
         size_t nup = 0;
         for (size_t j = 0; j < n; j++) {
             uint32_t dis = hc.hamming(codes);
-            if (dis < static_cast<uint32_t>(simi[0])) {
+            if (dis < bound) {
                 idx_t id = store_pairs ? lo_build(list_no, j) : ids[j];
                 heap_replace_top<C>(k, simi, idxi, dis, id);
+                bound = static_cast<uint32_t>(simi[0]);
                 nup++;
             }
             codes += code_size;

--- a/faiss/impl/pq_code_distance/pq_code_distance-generic.cpp
+++ b/faiss/impl/pq_code_distance/pq_code_distance-generic.cpp
@@ -7,7 +7,7 @@
 
 // This TU provides non-templated PQ code distance dispatch wrappers
 // (pq_code_distance_8bit_single, pq_code_distance_8bit_four) declared
-// in pq_code_distance-inl.h. These use with_simd_level to route to the
+// in pq_code_distance-inl.h. These use with_simd_level_a1 to route to the
 // best available SIMD implementation via pq_code_distance_8bit_*_impl
 // function template specializations.
 //
@@ -34,7 +34,7 @@ void pq_scan_8bit(
         float* heap_dis,
         int64_t* heap_ids,
         bool max_heap) {
-    with_simd_level([&]<SIMDLevel SL>() {
+    with_simd_level_a1([&]<SIMDLevel SL>() {
         pq_scan_8bit_impl<SL>(
                 M, dis_table, codes, ncodes, k, heap_dis, heap_ids, max_heap);
     });
@@ -44,7 +44,7 @@ float pq_code_distance_8bit_single(
         size_t M,
         const float* sim_table,
         const uint8_t* code) {
-    return with_simd_level([&]<SIMDLevel SL>() {
+    return with_simd_level_a1([&]<SIMDLevel SL>() {
         return pq_code_distance_8bit_single_impl<SL>(M, sim_table, code);
     });
 }
@@ -60,7 +60,7 @@ void pq_code_distance_8bit_four(
         float& result1,
         float& result2,
         float& result3) {
-    with_simd_level([&]<SIMDLevel SL>() {
+    with_simd_level_a1([&]<SIMDLevel SL>() {
         pq_code_distance_8bit_four_impl<SL>(
                 M,
                 sim_table,

--- a/faiss/impl/pq_code_distance/pq_code_distance-generic.cpp
+++ b/faiss/impl/pq_code_distance/pq_code_distance-generic.cpp
@@ -7,7 +7,7 @@
 
 // This TU provides non-templated PQ code distance dispatch wrappers
 // (pq_code_distance_8bit_single, pq_code_distance_8bit_four) declared
-// in pq_code_distance-inl.h. These use with_simd_level_a1 to route to the
+// in pq_code_distance-inl.h. These use with_simd_level_with_sve to route to the
 // best available SIMD implementation via pq_code_distance_8bit_*_impl
 // function template specializations.
 //
@@ -34,7 +34,7 @@ void pq_scan_8bit(
         float* heap_dis,
         int64_t* heap_ids,
         bool max_heap) {
-    with_simd_level_a1([&]<SIMDLevel SL>() {
+    with_simd_level_with_sve([&]<SIMDLevel SL>() {
         pq_scan_8bit_impl<SL>(
                 M, dis_table, codes, ncodes, k, heap_dis, heap_ids, max_heap);
     });
@@ -44,7 +44,7 @@ float pq_code_distance_8bit_single(
         size_t M,
         const float* sim_table,
         const uint8_t* code) {
-    return with_simd_level_a1([&]<SIMDLevel SL>() {
+    return with_simd_level_with_sve([&]<SIMDLevel SL>() {
         return pq_code_distance_8bit_single_impl<SL>(M, sim_table, code);
     });
 }
@@ -60,7 +60,7 @@ void pq_code_distance_8bit_four(
         float& result1,
         float& result2,
         float& result3) {
-    with_simd_level_a1([&]<SIMDLevel SL>() {
+    with_simd_level_with_sve([&]<SIMDLevel SL>() {
         pq_code_distance_8bit_four_impl<SL>(
                 M,
                 sim_table,

--- a/faiss/impl/scalar_quantizer/distance_computers.h
+++ b/faiss/impl/scalar_quantizer/distance_computers.h
@@ -78,8 +78,8 @@ template <class Similarity, SIMDLevel SL>
 struct DistanceComputerByte : SQDistanceComputer {};
 
 // Byte-domain distance computer for QT_8bit_direct_signed (storage is
-// value+128). Only specialized for AVX512_SPR; other levels fall back to
-// the float-domain DCTemplate path via the dispatch logic.
+// value+128). A level added to the sq-dispatch.h chain without a
+// specialization here instantiates this empty template.
 template <class Similarity, SIMDLevel SL>
 struct DistanceComputerByteSigned : SQDistanceComputer {};
 

--- a/faiss/impl/scalar_quantizer/sq-dispatch.h
+++ b/faiss/impl/scalar_quantizer/sq-dispatch.h
@@ -28,6 +28,14 @@ namespace scalar_quantizer {
 // Define SL as alias for THE_LEVEL_TO_DISPATCH for use in this file
 constexpr SIMDLevel SL = THE_LEVEL_TO_DISPATCH;
 
+// The SPR scalar-quantizer implementation uses VPOPCNTDQ for its RaBitQ
+// popcount helpers, but those helpers belong to the narrower VPOPCNT
+// capability. Keep the SQ implementation at AVX512_SPR while explicitly
+// reusing the independently dispatched VPOPCNT kernels.
+template <SIMDLevel SL0>
+inline constexpr SIMDLevel rabitq_popcount_level =
+        SL0 == SIMDLevel::AVX512_SPR ? SIMDLevel::AVX512_VPOPCNT : SL0;
+
 /*******************************************************************
  * TurboQuant SIMD kernel: masked_sum
  * Compute sum of arr[j] where bit j of the bitmask is set.
@@ -259,9 +267,11 @@ struct DCTurboQuantFull : ScalarQuantizer::TurboQuantRefine::DistanceComputer {
             if (qb > 0) {
                 // Integer popcount path for 1-bit MSE
                 size_t byte_size = (d + 7) / 8;
-                uint64_t and_result = rabitq::bitwise_and_dot_product<SL2>(
+                uint64_t and_result = rabitq::bitwise_and_dot_product<
+                        rabitq_popcount_level<SL2>>(
                         rearranged_q.data(), code, byte_size, qb);
-                uint64_t pop = rabitq::popcount<SL2>(code, byte_size);
+                uint64_t pop = rabitq::popcount<rabitq_popcount_level<SL2>>(
+                        code, byte_size);
                 mse_dot = mse_base +
                         mse_int_scale * static_cast<float>(and_result) +
                         mse_popcnt_scale * static_cast<float>(pop);
@@ -316,9 +326,11 @@ struct DCTurboQuantFull : ScalarQuantizer::TurboQuantRefine::DistanceComputer {
         float qjl_dot;
         if (qb > 0 && int_qjl) {
             size_t byte_size = (d + 7) / 8;
-            uint64_t and_result = rabitq::bitwise_and_dot_product<SL2>(
-                    rearranged_qproj.data(), qjl_code, byte_size, qb);
-            uint64_t pop = rabitq::popcount<SL2>(qjl_code, byte_size);
+            uint64_t and_result =
+                    rabitq::bitwise_and_dot_product<rabitq_popcount_level<SL2>>(
+                            rearranged_qproj.data(), qjl_code, byte_size, qb);
+            uint64_t pop = rabitq::popcount<rabitq_popcount_level<SL2>>(
+                    qjl_code, byte_size);
             float pos_sum = qjl_popcnt_scale * static_cast<float>(pop) +
                     qjl_int_scale * static_cast<float>(and_result);
             qjl_dot = qjl_coeff * gamma * (2.0f * pos_sum - total_qproj_sum);

--- a/faiss/impl/scalar_quantizer/sq-dispatch.h
+++ b/faiss/impl/scalar_quantizer/sq-dispatch.h
@@ -531,7 +531,8 @@ SQDistanceComputer* select_distance_computer_body(
                     return new DistanceComputerByte<Sim, SL2>(
                             static_cast<int>(d), trained);
                 }
-            } else if constexpr (SL2 == SIMDLevel::AVX2) {
+            } else if constexpr (
+                    SL2 == SIMDLevel::AVX2 || SL2 == SIMDLevel::ARM_NEON) {
                 if (d % 16 == 0) {
                     return new DistanceComputerByte<Sim, SL2>(
                             static_cast<int>(d), trained);
@@ -551,7 +552,8 @@ SQDistanceComputer* select_distance_computer_body(
                     return new DistanceComputerByteSigned<Sim, SL2>(
                             static_cast<int>(d), trained);
                 }
-            } else if constexpr (SL2 == SIMDLevel::AVX2) {
+            } else if constexpr (
+                    SL2 == SIMDLevel::AVX2 || SL2 == SIMDLevel::ARM_NEON) {
                 if (d % 16 == 0) {
                     return new DistanceComputerByteSigned<Sim, SL2>(
                             static_cast<int>(d), trained);
@@ -744,7 +746,8 @@ InvertedListScanner* sq_select_InvertedListScanner<THE_LEVEL_TO_DISPATCH>(
                         return scan.template
                         operator()<DistanceComputerByte<Similarity, SL2>>();
                     }
-                } else if constexpr (SL2 == SIMDLevel::AVX2) {
+                } else if constexpr (
+                        SL2 == SIMDLevel::AVX2 || SL2 == SIMDLevel::ARM_NEON) {
                     if (d % 16 == 0) {
                         return scan.template
                         operator()<DistanceComputerByte<Similarity, SL2>>();
@@ -765,7 +768,8 @@ InvertedListScanner* sq_select_InvertedListScanner<THE_LEVEL_TO_DISPATCH>(
                         return scan.template operator()<
                                 DistanceComputerByteSigned<Similarity, SL2>>();
                     }
-                } else if constexpr (SL2 == SIMDLevel::AVX2) {
+                } else if constexpr (
+                        SL2 == SIMDLevel::AVX2 || SL2 == SIMDLevel::ARM_NEON) {
                     if (d % 16 == 0) {
                         return scan.template operator()<
                                 DistanceComputerByteSigned<Similarity, SL2>>();

--- a/faiss/impl/scalar_quantizer/sq-neon.cpp
+++ b/faiss/impl/scalar_quantizer/sq-neon.cpp
@@ -618,6 +618,64 @@ struct DCTemplate<Quantizer, Similarity, SIMDLevel::ARM_NEON>
     }
 };
 
+// Byte-domain kernels for QT_8bit_direct{,_signed}. The dispatch only
+// selects them when d % 16 == 0, so no loop needs a tail.
+
+namespace {
+
+// The accumulator stays unsigned: a vmull_u8 square reaches 255*255 = 65025,
+// which an int16 lane would read as negative.
+FAISS_ALWAYS_INLINE int neon_byte_l2sqr(
+        const uint8_t* code1,
+        const uint8_t* code2,
+        int d) {
+    uint32x4_t accu = vdupq_n_u32(0);
+    for (int i = 0; i < d; i += 16) {
+        const uint8x16_t diff =
+                vabdq_u8(vld1q_u8(code1 + i), vld1q_u8(code2 + i));
+        accu = vpadalq_u16(
+                accu, vmull_u8(vget_low_u8(diff), vget_low_u8(diff)));
+        accu = vpadalq_u16(
+                accu, vmull_u8(vget_high_u8(diff), vget_high_u8(diff)));
+    }
+    return static_cast<int>(vaddvq_u32(accu));
+}
+
+FAISS_ALWAYS_INLINE int neon_byte_ip(
+        const uint8_t* code1,
+        const uint8_t* code2,
+        int d) {
+    uint32x4_t accu = vdupq_n_u32(0);
+    for (int i = 0; i < d; i += 16) {
+        const uint8x16_t c1 = vld1q_u8(code1 + i);
+        const uint8x16_t c2 = vld1q_u8(code2 + i);
+        accu = vpadalq_u16(accu, vmull_u8(vget_low_u8(c1), vget_low_u8(c2)));
+        accu = vpadalq_u16(accu, vmull_u8(vget_high_u8(c1), vget_high_u8(c2)));
+    }
+    return static_cast<int>(vaddvq_u32(accu));
+}
+
+// The codes store value + 128. For x in 0 to 255, x ^ 0x80 read as int8 is
+// exactly x - 128, which is how the bias comes off before vmull_s8.
+FAISS_ALWAYS_INLINE int neon_byte_ip_unbias(
+        const uint8_t* code1,
+        const uint8_t* code2,
+        int d) {
+    const uint8x16_t bias = vdupq_n_u8(0x80);
+    int32x4_t accu = vdupq_n_s32(0);
+    for (int i = 0; i < d; i += 16) {
+        const int8x16_t c1 =
+                vreinterpretq_s8_u8(veorq_u8(vld1q_u8(code1 + i), bias));
+        const int8x16_t c2 =
+                vreinterpretq_s8_u8(veorq_u8(vld1q_u8(code2 + i), bias));
+        accu = vpadalq_s16(accu, vmull_s8(vget_low_s8(c1), vget_low_s8(c2)));
+        accu = vpadalq_s16(accu, vmull_s8(vget_high_s8(c1), vget_high_s8(c2)));
+    }
+    return static_cast<int>(vaddvq_s32(accu));
+}
+
+} // namespace
+
 template <class Similarity>
 struct DistanceComputerByte<Similarity, SIMDLevel::ARM_NEON>
         : SQDistanceComputer {
@@ -630,21 +688,58 @@ struct DistanceComputerByte<Similarity, SIMDLevel::ARM_NEON>
 
     int compute_code_distance(const uint8_t* code1, const uint8_t* code2)
             const {
-        int accu = 0;
-        for (int i = 0; i < d; i++) {
-            if (Sim::metric_type == METRIC_INNER_PRODUCT) {
-                accu += int(code1[i]) * code2[i];
-            } else {
-                int diff = int(code1[i]) - code2[i];
-                accu += diff * diff;
-            }
+        if constexpr (Sim::metric_type == METRIC_INNER_PRODUCT) {
+            return neon_byte_ip(code1, code2, d);
+        } else {
+            return neon_byte_l2sqr(code1, code2, d);
         }
-        return accu;
     }
 
     void set_query(const float* x) final {
         for (int i = 0; i < d; i++) {
             tmp[i] = int(x[i]);
+        }
+    }
+
+    int compute_distance(const float* x, const uint8_t* code) {
+        set_query(x);
+        return compute_code_distance(tmp.data(), code);
+    }
+
+    float symmetric_dis(idx_t i, idx_t j) override {
+        return compute_code_distance(
+                codes + i * code_size, codes + j * code_size);
+    }
+
+    float query_to_code(const uint8_t* code) const final {
+        return compute_code_distance(tmp.data(), code);
+    }
+};
+
+template <class Similarity>
+struct DistanceComputerByteSigned<Similarity, SIMDLevel::ARM_NEON>
+        : SQDistanceComputer {
+    using Sim = Similarity;
+
+    int d;
+    std::vector<uint8_t> tmp;
+
+    DistanceComputerByteSigned(int d, const std::vector<float>&)
+            : d(d), tmp(d) {}
+
+    int compute_code_distance(const uint8_t* code1, const uint8_t* code2)
+            const {
+        if constexpr (Sim::metric_type == METRIC_INNER_PRODUCT) {
+            return neon_byte_ip_unbias(code1, code2, d);
+        } else {
+            // The bias cancels in the difference.
+            return neon_byte_l2sqr(code1, code2, d);
+        }
+    }
+
+    void set_query(const float* x) final {
+        for (int i = 0; i < d; i++) {
+            tmp[i] = uint8_t(int(x[i]) + 128);
         }
     }
 

--- a/faiss/impl/simd_dispatch.h
+++ b/faiss/impl/simd_dispatch.h
@@ -36,8 +36,13 @@ constexpr int AVAILABLE_SIMD_LEVELS_AVX2_NEON = AVAILABLE_SIMD_LEVELS_NONE |
 constexpr int AVAILABLE_SIMD_LEVELS_BASE = AVAILABLE_SIMD_LEVELS_AVX2_NEON |
         (1 << int(SIMDLevel::AVX512)) | (1 << int(SIMDLevel::RISCV_RVV));
 
-// BASE_WITH_SPR: BASE + AVX512_SPR, for functions with a dedicated SPR
-// specialization on top of an AVX512 fallback.
+// BASE_WITH_VPOPCNT: BASE + AVX512_VPOPCNT, for kernels that need only
+// VPOPCNTDQ on top of baseline AVX-512 (Ice Lake, Zen 4, Zen 5).
+constexpr int AVAILABLE_SIMD_LEVELS_BASE_WITH_VPOPCNT =
+        AVAILABLE_SIMD_LEVELS_BASE | (1 << int(SIMDLevel::AVX512_VPOPCNT));
+
+// BASE_WITH_SPR: BASE + AVX512_SPR, for kernels that need the whole SPR
+// feature set rather than VPOPCNTDQ alone.
 constexpr int AVAILABLE_SIMD_LEVELS_BASE_WITH_SPR =
         AVAILABLE_SIMD_LEVELS_BASE | (1 << int(SIMDLevel::AVX512_SPR));
 
@@ -51,6 +56,8 @@ constexpr int AVAILABLE_SIMD_LEVELS_ALL = -1;
 constexpr SIMDLevel get_simd_fallback(SIMDLevel level) {
     switch (level) {
         case SIMDLevel::AVX512_SPR:
+            return SIMDLevel::AVX512_VPOPCNT;
+        case SIMDLevel::AVX512_VPOPCNT:
             return SIMDLevel::AVX512;
         case SIMDLevel::AVX512:
             return SIMDLevel::AVX2;
@@ -119,6 +126,15 @@ inline auto with_selected_simd_levels(LambdaType&& action) {
             [[fallthrough]];
 #endif
 
+#ifdef COMPILE_SIMD_AVX512_VPOPCNT
+        case SIMDLevel::AVX512_VPOPCNT:
+            if constexpr (
+                    available_levels & (1 << int(SIMDLevel::AVX512_VPOPCNT))) {
+                return action.template operator()<SIMDLevel::AVX512_VPOPCNT>();
+            }
+            [[fallthrough]];
+#endif
+
 #ifdef COMPILE_SIMD_AVX512
         case SIMDLevel::AVX512:
             if constexpr (available_levels & (1 << int(SIMDLevel::AVX512))) {
@@ -166,7 +182,7 @@ inline auto with_selected_simd_levels(LambdaType&& action) {
     // In static mode, SINGLE_SIMD_LEVEL is a constexpr resolved at compile
     // time. We mirror the DD fallthrough behavior at compile time via
     // dispatch_with_fallback, which recursively walks get_simd_fallback:
-    //   x86:   AVX512_SPR -> AVX512 -> AVX2 -> NONE
+    //   x86:   AVX512_SPR -> AVX512_VPOPCNT -> AVX512 -> AVX2 -> NONE
     //   ARM:   ARM_SVE -> ARM_NEON -> NONE
     //   RISCV: RISCV_RVV -> NONE
     // The first level in the chain that appears in available_levels is
@@ -233,25 +249,21 @@ inline auto with_simd_level_256bit(LambdaType&& action) {
             std::forward<LambdaType>(action));
 }
 
-/**
- * Use for functions that have BASE-level implementations plus a dedicated
- * ARM_SVE specialization. Plain with_simd_level() uses BASE, which omits the
- * ARM_SVE bit, so on an SVE host the ARM_SVE case falls through to ARM_NEON
- * and the SVE specialization is never instantiated.
- */
+// Plain with_simd_level() uses BASE, which omits the optional levels below.
+// A call site must opt in, or its specialization is never instantiated.
+
+/// BASE + ARM_SVE.
 template <typename LambdaType>
 inline auto with_simd_level_with_sve(LambdaType&& action) {
     return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE>(
             std::forward<LambdaType>(action));
 }
 
-/**
- * Use for functions that have BASE-level implementations plus an AVX512_SPR
- * specialization (e.g. using VPOPCNTDQ).
- */
+/// BASE + AVX512_VPOPCNT.
 template <typename LambdaType>
-inline auto with_simd_level_with_spr(LambdaType&& action) {
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SPR>(
+inline auto with_simd_level_with_vpopcnt(LambdaType&& action) {
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_VPOPCNT>(
             std::forward<LambdaType>(action));
 }
+
 } // namespace faiss

--- a/faiss/impl/simd_dispatch.h
+++ b/faiss/impl/simd_dispatch.h
@@ -46,11 +46,6 @@ constexpr int AVAILABLE_SIMD_LEVELS_A0_SPR =
 constexpr int AVAILABLE_SIMD_LEVELS_A1 =
         AVAILABLE_SIMD_LEVELS_A0 | (1 << int(SIMDLevel::ARM_SVE));
 
-// A2: NONE + AVX2 + ARM_SVE only (for functions with only these
-// implementations)
-constexpr int AVAILABLE_SIMD_LEVELS_A2 = AVAILABLE_SIMD_LEVELS_NONE |
-        (1 << int(SIMDLevel::AVX2)) | (1 << int(SIMDLevel::ARM_SVE));
-
 constexpr int AVAILABLE_SIMD_LEVELS_ALL = -1;
 
 constexpr SIMDLevel get_simd_fallback(SIMDLevel level) {

--- a/faiss/impl/simd_dispatch.h
+++ b/faiss/impl/simd_dispatch.h
@@ -32,19 +32,19 @@ constexpr int AVAILABLE_SIMD_LEVELS_NONE = (1 << int(SIMDLevel::NONE));
 constexpr int AVAILABLE_SIMD_LEVELS_AVX2_NEON = AVAILABLE_SIMD_LEVELS_NONE |
         (1 << int(SIMDLevel::AVX2)) | (1 << int(SIMDLevel::ARM_NEON));
 
-// A0: same + AVX512 + RISCV_RVV
-constexpr int AVAILABLE_SIMD_LEVELS_A0 = AVAILABLE_SIMD_LEVELS_AVX2_NEON |
+// BASE: AVX2_NEON + AVX512 + RISCV_RVV
+constexpr int AVAILABLE_SIMD_LEVELS_BASE = AVAILABLE_SIMD_LEVELS_AVX2_NEON |
         (1 << int(SIMDLevel::AVX512)) | (1 << int(SIMDLevel::RISCV_RVV));
 
-// A0_SPR: same as A0 + AVX512_SPR (for functions with a dedicated SPR
-// specialization on top of an AVX512 fallback). Currently used by the
-// RaBitQ popcount kernels, which use VPOPCNTDQ on SPR+.
-constexpr int AVAILABLE_SIMD_LEVELS_A0_SPR =
-        AVAILABLE_SIMD_LEVELS_A0 | (1 << int(SIMDLevel::AVX512_SPR));
+// BASE_WITH_SPR: BASE + AVX512_SPR, for functions with a dedicated SPR
+// specialization on top of an AVX512 fallback.
+constexpr int AVAILABLE_SIMD_LEVELS_BASE_WITH_SPR =
+        AVAILABLE_SIMD_LEVELS_BASE | (1 << int(SIMDLevel::AVX512_SPR));
 
-// A1: same + ARM_SVE (for functions with dedicated SVE implementations)
-constexpr int AVAILABLE_SIMD_LEVELS_A1 =
-        AVAILABLE_SIMD_LEVELS_A0 | (1 << int(SIMDLevel::ARM_SVE));
+// BASE_WITH_SVE: BASE + ARM_SVE, for functions with dedicated SVE
+// implementations.
+constexpr int AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE =
+        AVAILABLE_SIMD_LEVELS_BASE | (1 << int(SIMDLevel::ARM_SVE));
 
 constexpr int AVAILABLE_SIMD_LEVELS_ALL = -1;
 
@@ -219,7 +219,7 @@ inline auto with_simd_level_fallback(const LambdaType& action) {
  */
 template <typename LambdaType>
 inline auto with_simd_level(LambdaType&& action) {
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A0>(
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE>(
             std::forward<LambdaType>(action));
 }
 
@@ -234,25 +234,24 @@ inline auto with_simd_level_256bit(LambdaType&& action) {
 }
 
 /**
- * Use for functions that have A0-level implementations plus a dedicated
- * ARM_SVE specialization. Plain with_simd_level() uses A0, which omits the
+ * Use for functions that have BASE-level implementations plus a dedicated
+ * ARM_SVE specialization. Plain with_simd_level() uses BASE, which omits the
  * ARM_SVE bit, so on an SVE host the ARM_SVE case falls through to ARM_NEON
  * and the SVE specialization is never instantiated.
  */
 template <typename LambdaType>
-inline auto with_simd_level_a1(LambdaType&& action) {
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A1>(
+inline auto with_simd_level_with_sve(LambdaType&& action) {
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE>(
             std::forward<LambdaType>(action));
 }
 
 /**
- * Use for functions that have A0-level implementations plus an AVX512_SPR
+ * Use for functions that have BASE-level implementations plus an AVX512_SPR
  * specialization (e.g. using VPOPCNTDQ).
  */
 template <typename LambdaType>
-inline auto with_simd_level_a0_spr(LambdaType&& action) {
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A0_SPR>(
+inline auto with_simd_level_with_spr(LambdaType&& action) {
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SPR>(
             std::forward<LambdaType>(action));
 }
-
 } // namespace faiss

--- a/faiss/python/__init__.pyi
+++ b/faiss/python/__init__.pyi
@@ -3087,6 +3087,7 @@ SIMDLevel_AVX512_SPR: int
 SIMDLevel_ARM_NEON: int
 SIMDLevel_ARM_SVE: int
 SIMDLevel_RISCV_RVV: int
+SIMDLevel_AVX512_VPOPCNT: int
 SIMDLevel_COUNT: int
 
 class SIMDConfig:

--- a/faiss/utils/distances.cpp
+++ b/faiss/utils/distances.cpp
@@ -541,17 +541,19 @@ void exhaustive_L2sqr_blas<Top1BlockResultHandler<CMax<float, int64_t>>>(
         return;
     }
 
-    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A1>([&]<SIMDLevel SL>() {
-        if constexpr (
-                SL == SIMDLevel::AVX2 || SL == SIMDLevel::AVX512 ||
-                SL == SIMDLevel::ARM_SVE) {
-            exhaustive_L2sqr_blas_cmax<SL>(x, y, d, nx, ny, res, y_norms);
-        } else {
-            exhaustive_L2sqr_blas_default_impl<
-                    Top1BlockResultHandler<CMax<float, int64_t>>>(
-                    x, y, d, nx, ny, res, y_norms);
-        }
-    });
+    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE>(
+            [&]<SIMDLevel SL>() {
+                if constexpr (
+                        SL == SIMDLevel::AVX2 || SL == SIMDLevel::AVX512 ||
+                        SL == SIMDLevel::ARM_SVE) {
+                    exhaustive_L2sqr_blas_cmax<SL>(
+                            x, y, d, nx, ny, res, y_norms);
+                } else {
+                    exhaustive_L2sqr_blas_default_impl<
+                            Top1BlockResultHandler<CMax<float, int64_t>>>(
+                            x, y, d, nx, ny, res, y_norms);
+                }
+            });
 }
 
 struct Run_search_inner_product {

--- a/faiss/utils/distances_dispatch.h
+++ b/faiss/utils/distances_dispatch.h
@@ -241,7 +241,7 @@ auto with_VectorDistance(
         if constexpr (!has_simd) {
             return call.template operator()<SIMDLevel::NONE>();
         } else {
-            return with_simd_level(call);
+            return with_simd_level_a1(call);
         }
     };
     return with_metric_type(metric, dispatch_metric);

--- a/faiss/utils/distances_dispatch.h
+++ b/faiss/utils/distances_dispatch.h
@@ -29,22 +29,22 @@
 namespace faiss {
 
 inline float fvec_L1_dispatch(const float* x, const float* y, size_t d) {
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A1>(
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE>(
             [&]<SIMDLevel SL>() { return fvec_L1<SL>(x, y, d); });
 }
 
 inline float fvec_Linf_dispatch(const float* x, const float* y, size_t d) {
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A1>(
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE>(
             [&]<SIMDLevel SL>() { return fvec_Linf<SL>(x, y, d); });
 }
 
 inline float fvec_norm_L2sqr_dispatch(const float* x, size_t d) {
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A1>(
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE>(
             [&]<SIMDLevel SL>() { return fvec_norm_L2sqr<SL>(x, d); });
 }
 
 inline float fvec_L2sqr_dispatch(const float* x, const float* y, size_t d) {
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A1>(
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE>(
             [&]<SIMDLevel SL>() { return fvec_L2sqr<SL>(x, y, d); });
 }
 
@@ -52,7 +52,7 @@ inline float fvec_inner_product_dispatch(
         const float* x,
         const float* y,
         size_t d) {
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A1>(
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE>(
             [&]<SIMDLevel SL>() { return fvec_inner_product<SL>(x, y, d); });
 }
 
@@ -67,10 +67,11 @@ inline void fvec_inner_product_batch_4_dispatch(
         float& dis1,
         float& dis2,
         float& dis3) {
-    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A1>([&]<SIMDLevel SL>() {
-        fvec_inner_product_batch_4<SL>(
-                x, y0, y1, y2, y3, d, dis0, dis1, dis2, dis3);
-    });
+    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE>(
+            [&]<SIMDLevel SL>() {
+                fvec_inner_product_batch_4<SL>(
+                        x, y0, y1, y2, y3, d, dis0, dis1, dis2, dis3);
+            });
 }
 
 inline void fvec_L2sqr_batch_4_dispatch(
@@ -84,9 +85,11 @@ inline void fvec_L2sqr_batch_4_dispatch(
         float& dis1,
         float& dis2,
         float& dis3) {
-    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A1>([&]<SIMDLevel SL>() {
-        fvec_L2sqr_batch_4<SL>(x, y0, y1, y2, y3, d, dis0, dis1, dis2, dis3);
-    });
+    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE>(
+            [&]<SIMDLevel SL>() {
+                fvec_L2sqr_batch_4<SL>(
+                        x, y0, y1, y2, y3, d, dis0, dis1, dis2, dis3);
+            });
 }
 
 inline void fvec_L2sqr_ny_transposed_dispatch(
@@ -97,9 +100,11 @@ inline void fvec_L2sqr_ny_transposed_dispatch(
         size_t d,
         size_t d_offset,
         size_t ny) {
-    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A1>([&]<SIMDLevel SL>() {
-        fvec_L2sqr_ny_transposed<SL>(dis, x, y, y_sqlen, d, d_offset, ny);
-    });
+    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE>(
+            [&]<SIMDLevel SL>() {
+                fvec_L2sqr_ny_transposed<SL>(
+                        dis, x, y, y_sqlen, d, d_offset, ny);
+            });
 }
 
 inline void fvec_inner_products_ny_dispatch(
@@ -108,9 +113,10 @@ inline void fvec_inner_products_ny_dispatch(
         const float* y,
         size_t d,
         size_t ny) {
-    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A1>([&]<SIMDLevel SL>() {
-        fvec_inner_products_ny<SL>(ip, x, y, d, ny);
-    });
+    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE>(
+            [&]<SIMDLevel SL>() {
+                fvec_inner_products_ny<SL>(ip, x, y, d, ny);
+            });
 }
 
 inline void fvec_L2sqr_ny_dispatch(
@@ -119,7 +125,7 @@ inline void fvec_L2sqr_ny_dispatch(
         const float* y,
         size_t d,
         size_t ny) {
-    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A1>(
+    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE>(
             [&]<SIMDLevel SL>() { fvec_L2sqr_ny<SL>(dis, x, y, d, ny); });
 }
 
@@ -129,7 +135,7 @@ inline size_t fvec_L2sqr_ny_nearest_dispatch(
         const float* y,
         size_t d,
         size_t ny) {
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A1>(
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE>(
             [&]<SIMDLevel SL>() {
                 return fvec_L2sqr_ny_nearest<SL>(
                         distances_tmp_buffer, x, y, d, ny);
@@ -144,7 +150,7 @@ inline size_t fvec_L2sqr_ny_nearest_y_transposed_dispatch(
         size_t d,
         size_t d_offset,
         size_t ny) {
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A1>(
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE>(
             [&]<SIMDLevel SL>() {
                 return fvec_L2sqr_ny_nearest_y_transposed<SL>(
                         distances_tmp_buffer, x, y, y_sqlen, d, d_offset, ny);
@@ -157,7 +163,7 @@ inline void fvec_madd_dispatch(
         float bf,
         const float* b,
         float* c) {
-    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A1>(
+    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE>(
             [&]<SIMDLevel SL>() { fvec_madd<SL>(n, a, bf, b, c); });
 }
 
@@ -167,7 +173,7 @@ inline int fvec_madd_and_argmin_dispatch(
         float bf,
         const float* b,
         float* c) {
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A1>(
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE_WITH_SVE>(
             [&]<SIMDLevel SL>() {
                 return fvec_madd_and_argmin<SL>(n, a, bf, b, c);
             });
@@ -241,7 +247,7 @@ auto with_VectorDistance(
         if constexpr (!has_simd) {
             return call.template operator()<SIMDLevel::NONE>();
         } else {
-            return with_simd_level_a1(call);
+            return with_simd_level_with_sve(call);
         }
     };
     return with_metric_type(metric, dispatch_metric);

--- a/faiss/utils/distances_fused/distances_fused.cpp
+++ b/faiss/utils/distances_fused/distances_fused.cpp
@@ -51,7 +51,7 @@ bool exhaustive_L2sqr_fused_cmax(
         return true;
     }
 
-    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A0>(
+    return with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_BASE>(
             [&]<SIMDLevel SL>() {
                 return exhaustive_L2sqr_fused_cmax<SL>(
                         x, y, d, nx, ny, res, y_norms);

--- a/faiss/utils/hamming.cpp
+++ b/faiss/utils/hamming.cpp
@@ -146,7 +146,7 @@ void hammings(
         size_t nb,
         size_t ncodes,
         hamdis_t* __restrict dis) {
-    with_simd_level_a0_spr([&]<SIMDLevel SL>() {
+    with_simd_level_with_spr([&]<SIMDLevel SL>() {
         // Ragged sizes have their own kernel; keeping it out of
         // hammings_fixSL() leaves the word-level paths untouched.
         if (ncodes % 8 != 0) {
@@ -176,7 +176,7 @@ void hammings_knn_hc(
         int order,
         ApproxTopK_mode_t approx_topk_mode,
         const faiss::IDSelector* sel) {
-    with_simd_level_a0_spr([&]<SIMDLevel SL>() {
+    with_simd_level_with_spr([&]<SIMDLevel SL>() {
         hammings_knn_hc_fixSL<SL>(
                 ha, a, b, nb, ncodes, order, approx_topk_mode, sel);
     });
@@ -192,7 +192,7 @@ void hammings_knn_mc(
         int32_t* __restrict distances,
         int64_t* __restrict labels,
         const faiss::IDSelector* sel) {
-    with_simd_level_a0_spr([&]<SIMDLevel SL>() {
+    with_simd_level_with_spr([&]<SIMDLevel SL>() {
         hammings_knn_mc_fixSL<SL>(
                 a, b, na, nb, k, ncodes, distances, labels, sel);
     });
@@ -207,7 +207,7 @@ void hamming_range_search(
         size_t code_size,
         RangeSearchResult* result,
         const faiss::IDSelector* sel) {
-    with_simd_level_a0_spr([&]<SIMDLevel SL>() {
+    with_simd_level_with_spr([&]<SIMDLevel SL>() {
         hamming_range_search_fixSL<SL>(
                 a, b, na, nb, radius, code_size, result, sel);
     });
@@ -221,7 +221,7 @@ void hamming_count_thres(
         hamdis_t ht,
         size_t ncodes,
         size_t* nptr) {
-    with_simd_level_a0_spr([&]<SIMDLevel SL>() {
+    with_simd_level_with_spr([&]<SIMDLevel SL>() {
         hamming_count_thres_fixSL<SL>(bs1, bs2, n1, n2, ht, ncodes, nptr);
     });
 }
@@ -232,7 +232,7 @@ void crosshamming_count_thres(
         hamdis_t ht,
         size_t ncodes,
         size_t* nptr) {
-    with_simd_level_a0_spr([&]<SIMDLevel SL>() {
+    with_simd_level_with_spr([&]<SIMDLevel SL>() {
         crosshamming_count_thres_fixSL<SL>(dbs, n, ht, ncodes, nptr);
     });
 }
@@ -246,7 +246,7 @@ size_t match_hamming_thres(
         size_t ncodes,
         int64_t* idx,
         hamdis_t* dis) {
-    return with_simd_level_a0_spr([&]<SIMDLevel SL>() -> size_t {
+    return with_simd_level_with_spr([&]<SIMDLevel SL>() -> size_t {
         return match_hamming_thres_fixSL<SL>(
                 bs1, bs2, n1, n2, ht, ncodes, idx, dis);
     });
@@ -259,7 +259,7 @@ void generalized_hammings_knn_hc(
         size_t nb,
         size_t code_size,
         int ordered) {
-    with_simd_level_a0_spr([&]<SIMDLevel SL>() {
+    with_simd_level_with_spr([&]<SIMDLevel SL>() {
         generalized_hammings_knn_hc_fixSL<SL>(ha, a, b, nb, code_size, ordered);
     });
 }

--- a/faiss/utils/hamming.cpp
+++ b/faiss/utils/hamming.cpp
@@ -146,7 +146,7 @@ void hammings(
         size_t nb,
         size_t ncodes,
         hamdis_t* __restrict dis) {
-    with_simd_level_with_spr([&]<SIMDLevel SL>() {
+    with_simd_level_with_vpopcnt([&]<SIMDLevel SL>() {
         // Ragged sizes have their own kernel; keeping it out of
         // hammings_fixSL() leaves the word-level paths untouched.
         if (ncodes % 8 != 0) {
@@ -176,7 +176,7 @@ void hammings_knn_hc(
         int order,
         ApproxTopK_mode_t approx_topk_mode,
         const faiss::IDSelector* sel) {
-    with_simd_level_with_spr([&]<SIMDLevel SL>() {
+    with_simd_level_with_vpopcnt([&]<SIMDLevel SL>() {
         hammings_knn_hc_fixSL<SL>(
                 ha, a, b, nb, ncodes, order, approx_topk_mode, sel);
     });
@@ -192,7 +192,7 @@ void hammings_knn_mc(
         int32_t* __restrict distances,
         int64_t* __restrict labels,
         const faiss::IDSelector* sel) {
-    with_simd_level_with_spr([&]<SIMDLevel SL>() {
+    with_simd_level_with_vpopcnt([&]<SIMDLevel SL>() {
         hammings_knn_mc_fixSL<SL>(
                 a, b, na, nb, k, ncodes, distances, labels, sel);
     });
@@ -207,7 +207,7 @@ void hamming_range_search(
         size_t code_size,
         RangeSearchResult* result,
         const faiss::IDSelector* sel) {
-    with_simd_level_with_spr([&]<SIMDLevel SL>() {
+    with_simd_level_with_vpopcnt([&]<SIMDLevel SL>() {
         hamming_range_search_fixSL<SL>(
                 a, b, na, nb, radius, code_size, result, sel);
     });
@@ -221,7 +221,7 @@ void hamming_count_thres(
         hamdis_t ht,
         size_t ncodes,
         size_t* nptr) {
-    with_simd_level_with_spr([&]<SIMDLevel SL>() {
+    with_simd_level_with_vpopcnt([&]<SIMDLevel SL>() {
         hamming_count_thres_fixSL<SL>(bs1, bs2, n1, n2, ht, ncodes, nptr);
     });
 }
@@ -232,7 +232,7 @@ void crosshamming_count_thres(
         hamdis_t ht,
         size_t ncodes,
         size_t* nptr) {
-    with_simd_level_with_spr([&]<SIMDLevel SL>() {
+    with_simd_level_with_vpopcnt([&]<SIMDLevel SL>() {
         crosshamming_count_thres_fixSL<SL>(dbs, n, ht, ncodes, nptr);
     });
 }
@@ -246,7 +246,7 @@ size_t match_hamming_thres(
         size_t ncodes,
         int64_t* idx,
         hamdis_t* dis) {
-    return with_simd_level_with_spr([&]<SIMDLevel SL>() -> size_t {
+    return with_simd_level_with_vpopcnt([&]<SIMDLevel SL>() -> size_t {
         return match_hamming_thres_fixSL<SL>(
                 bs1, bs2, n1, n2, ht, ncodes, idx, dis);
     });
@@ -259,7 +259,7 @@ void generalized_hammings_knn_hc(
         size_t nb,
         size_t code_size,
         int ordered) {
-    with_simd_level_with_spr([&]<SIMDLevel SL>() {
+    with_simd_level_with_vpopcnt([&]<SIMDLevel SL>() {
         generalized_hammings_knn_hc_fixSL<SL>(ha, a, b, nb, code_size, ordered);
     });
 }

--- a/faiss/utils/hamming_distance/hamming_avx512_vpopcnt.cpp
+++ b/faiss/utils/hamming_distance/hamming_avx512_vpopcnt.cpp
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#ifdef COMPILE_SIMD_AVX512_SPR
+#ifdef COMPILE_SIMD_AVX512_VPOPCNT
 
-#define THE_SIMD_LEVEL SIMDLevel::AVX512_SPR
+#define THE_SIMD_LEVEL SIMDLevel::AVX512_VPOPCNT
 // NOLINTNEXTLINE(facebook-hte-InlineHeader)
-#include <faiss/utils/hamming_distance/hamming_computer-avx512_spr.h>
+#include <faiss/utils/hamming_distance/hamming_computer-avx512_vpopcnt.h>
 #include <faiss/utils/hamming_distance/hamming_impl.h>
 
-#endif // COMPILE_SIMD_AVX512_SPR
+#endif // COMPILE_SIMD_AVX512_VPOPCNT

--- a/faiss/utils/hamming_distance/hamming_computer-avx512.h
+++ b/faiss/utils/hamming_distance/hamming_computer-avx512.h
@@ -12,7 +12,7 @@
 // Types without custom AVX512 code inherit from the NONE specializations
 // in hamming_computer-generic.h. HammingComputer64 and
 // HammingComputerDefault use scalar popcount here; the VPOPCNTDQ fast
-// path lives in hamming_computer-avx512_spr.h (AVX512_SPR level).
+// path lives in hamming_computer-avx512_vpopcnt.h (AVX512_VPOPCNT level).
 // GenHammingComputer classes leverage SSE/AVX2 intrinsics.
 
 #include <cassert>

--- a/faiss/utils/hamming_distance/hamming_computer-avx512_vpopcnt.h
+++ b/faiss/utils/hamming_distance/hamming_computer-avx512_vpopcnt.h
@@ -5,14 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#ifndef HAMMING_COMPUTER_AVX512_SPR_H
-#define HAMMING_COMPUTER_AVX512_SPR_H
+#ifndef HAMMING_COMPUTER_AVX512_VPOPCNT_H
+#define HAMMING_COMPUTER_AVX512_VPOPCNT_H
 
-// AVX512_SPR HammingComputer specializations using VPOPCNTDQ.
-// On Sapphire Rapids+, _mm512_popcnt_epi64 (and _mm256_popcnt_epi64 with VL)
-// are unconditionally available. This gives a faster path than the scalar
-// popcount fallback used in the base AVX512 specializations when compiled
-// without -mavx512vpopcntdq.
+// AVX512_VPOPCNT HammingComputer specializations using VPOPCNTDQ. This gives
+// a faster path than the scalar popcount fallback used in the base AVX512
+// specializations when compiled without -mavx512vpopcntdq.
 
 #include <cassert>
 #include <cstdint>
@@ -25,31 +23,31 @@
 namespace faiss {
 
 /***************************************************************************
- * AVX512_SPR inheriting specializations for types without custom SPR code.
+ * AVX512_VPOPCNT inheriting specializations without custom VPOPCNT code.
  ***************************************************************************/
 
-#define FAISS_INHERIT_HAMMING_SPR(Class)                                   \
-    template <>                                                            \
-    struct Class##                                                         \
-            _tpl<SIMDLevel::AVX512_SPR> : Class##_tpl<SIMDLevel::AVX512> { \
-        using Class##_tpl<SIMDLevel::AVX512>::Class##_tpl;                 \
+#define FAISS_INHERIT_HAMMING_VPOPCNT(Class)                                   \
+    template <>                                                                \
+    struct Class##                                                             \
+            _tpl<SIMDLevel::AVX512_VPOPCNT> : Class##_tpl<SIMDLevel::AVX512> { \
+        using Class##_tpl<SIMDLevel::AVX512>::Class##_tpl;                     \
     }
 
-FAISS_INHERIT_HAMMING_SPR(HammingComputer16);
-FAISS_INHERIT_HAMMING_SPR(HammingComputer20);
-FAISS_INHERIT_HAMMING_SPR(GenHammingComputer8);
-FAISS_INHERIT_HAMMING_SPR(GenHammingComputer16);
-FAISS_INHERIT_HAMMING_SPR(GenHammingComputer32);
-FAISS_INHERIT_HAMMING_SPR(GenHammingComputerM8);
+FAISS_INHERIT_HAMMING_VPOPCNT(HammingComputer16);
+FAISS_INHERIT_HAMMING_VPOPCNT(HammingComputer20);
+FAISS_INHERIT_HAMMING_VPOPCNT(GenHammingComputer8);
+FAISS_INHERIT_HAMMING_VPOPCNT(GenHammingComputer16);
+FAISS_INHERIT_HAMMING_VPOPCNT(GenHammingComputer32);
+FAISS_INHERIT_HAMMING_VPOPCNT(GenHammingComputerM8);
 
-#undef FAISS_INHERIT_HAMMING_SPR
+#undef FAISS_INHERIT_HAMMING_VPOPCNT
 
 /***************************************************************************
- * Custom AVX512_SPR specializations using VPOPCNTDQ.
+ * Custom AVX512_VPOPCNT specializations using VPOPCNTDQ.
  ***************************************************************************/
 
 template <>
-struct HammingComputer32_tpl<SIMDLevel::AVX512_SPR> {
+struct HammingComputer32_tpl<SIMDLevel::AVX512_VPOPCNT> {
     const uint8_t* a8;
 
     HammingComputer32_tpl() {}
@@ -81,7 +79,7 @@ struct HammingComputer32_tpl<SIMDLevel::AVX512_SPR> {
 };
 
 template <>
-struct HammingComputer64_tpl<SIMDLevel::AVX512_SPR> {
+struct HammingComputer64_tpl<SIMDLevel::AVX512_VPOPCNT> {
     const uint8_t* a8;
 
     HammingComputer64_tpl() {}
@@ -108,7 +106,7 @@ struct HammingComputer64_tpl<SIMDLevel::AVX512_SPR> {
 };
 
 template <>
-struct HammingComputerDefault_tpl<SIMDLevel::AVX512_SPR> {
+struct HammingComputerDefault_tpl<SIMDLevel::AVX512_VPOPCNT> {
     const uint8_t* a8;
     int quotient8;
     int remainder8;

--- a/faiss/utils/simd_impl/rabitq_avx512_vpopcnt.cpp
+++ b/faiss/utils/simd_impl/rabitq_avx512_vpopcnt.cpp
@@ -6,34 +6,31 @@
  */
 
 /**
- * @file rabitq_avx512_spr.cpp
+ * @file rabitq_avx512_vpopcnt.cpp
  *
- * RaBitQ SIMD kernels specialized for SIMDLevel::AVX512_SPR.
+ * RaBitQ SIMD kernels specialized for SIMDLevel::AVX512_VPOPCNT.
  *
- * Sapphire Rapids (SPR) and later Intel microarchitectures expose
- * AVX-512 VPOPCNTDQ (vpopcntq), which performs a per-lane 64-bit
- * popcount in a single instruction. This is used here to replace the
- * multi-step shuffle/pshufb-based popcount used by the generic AVX-512
- * specialization in rabitq_avx512.cpp. The popcount-heavy kernels
- * (bitwise_and_dot_product, bitwise_xor_dot_product, popcount) become
- * substantially shorter and faster on SPR+ as a result.
+ * AVX-512 VPOPCNTDQ performs a per-lane 64-bit popcount in a single
+ * instruction. It is available on CPUs including Ice Lake, Zen 4, and
+ * Sapphire Rapids, independently of the other SPR-only extensions. This
+ * replaces the multi-step shuffle-based popcount used by the generic
+ * AVX-512 specialization in rabitq_avx512.cpp.
  *
  * Build / dispatch behavior:
  *   - faiss_avx512 (AVX-512 only, no SPR features): NOT compiled.
  *     The existing AVX512 specialization in rabitq_avx512.cpp is used.
- *   - faiss_avx512_spr (statically built for SPR+): compiled. The
- *     SINGLE_SIMD_LEVEL is AVX512_SPR, so this specialization is
- *     selected by static dispatch.
+ *   - faiss_avx512_spr: compiled alongside the full SPR specialization and
+ *     selected through the SPR -> VPOPCNT fallback.
  *   - faiss with FAISS_OPT_LEVEL=dd (dynamic dispatch): compiled with
  *     -mavx512vpopcntdq as a per-file flag. Selected at runtime when
- *     SIMDConfig::level == SIMDLevel::AVX512_SPR.
+ *     the CPU exposes AVX512_VPOPCNTDQ.
  *
  * The floating-point multi-bit inner-product kernel does not benefit
- * from VPOPCNTDQ, so this TU forwards compute_inner_product<SPR> to
+ * from VPOPCNTDQ, so this TU forwards compute_inner_product<VPOPCNT> to
  * the AVX512 implementation to avoid duplicating that code path.
  */
 
-#ifdef COMPILE_SIMD_AVX512_SPR
+#ifdef COMPILE_SIMD_AVX512_VPOPCNT
 
 #include <faiss/utils/popcount.h>
 #include <faiss/utils/rabitq_simd.h>
@@ -47,7 +44,7 @@
 namespace faiss::rabitq {
 
 // Forward declarations for the AVX512 specializations defined in
-// rabitq_avx512.cpp. They live in the same TU group on SPR builds, so
+// rabitq_avx512.cpp. They live in the same TU group in supported builds, so
 // we can reuse them as a tail handler / fallback. Declaring rather
 // than redefining avoids ODR risk and keeps a single source of truth
 // for the floating-point kernel.
@@ -75,8 +72,8 @@ inline __m512i popcount_512_vpopcntdq(__m512i v) {
 }
 
 // 256-bit popcount using AVX-512VL VPOPCNTDQ.
-// AVX512VL is part of the SPR feature set, so vpopcntq is available
-// on 256-bit registers via _mm256_popcnt_epi64.
+// Baseline AVX-512 includes AVX512VL, so VPOPCNTDQ is also available on
+// 256-bit registers via _mm256_popcnt_epi64.
 inline __m256i popcount_256_vpopcntdq(__m256i v) {
     return _mm256_popcnt_epi64(v);
 }
@@ -101,7 +98,7 @@ inline uint64_t reduce_add_128(__m128i v) {
 } // namespace
 
 template <>
-uint64_t bitwise_and_dot_product<SIMDLevel::AVX512_SPR>(
+uint64_t bitwise_and_dot_product<SIMDLevel::AVX512_VPOPCNT>(
         const uint8_t* query,
         const uint8_t* data,
         size_t size,
@@ -187,7 +184,7 @@ uint64_t bitwise_and_dot_product<SIMDLevel::AVX512_SPR>(
 
 template <>
 BitwiseAndDotProductResult bitwise_and_dot_product_with_popcount<
-        SIMDLevel::AVX512_SPR>(
+        SIMDLevel::AVX512_VPOPCNT>(
         const uint8_t* query,
         const uint8_t* data,
         size_t size,
@@ -278,7 +275,7 @@ BitwiseAndDotProductResult bitwise_and_dot_product_with_popcount<
 }
 
 template <>
-uint64_t bitwise_xor_dot_product<SIMDLevel::AVX512_SPR>(
+uint64_t bitwise_xor_dot_product<SIMDLevel::AVX512_VPOPCNT>(
         const uint8_t* query,
         const uint8_t* data,
         size_t size,
@@ -357,7 +354,7 @@ uint64_t bitwise_xor_dot_product<SIMDLevel::AVX512_SPR>(
 }
 
 template <>
-uint64_t popcount<SIMDLevel::AVX512_SPR>(const uint8_t* data, size_t size) {
+uint64_t popcount<SIMDLevel::AVX512_VPOPCNT>(const uint8_t* data, size_t size) {
     uint64_t sum = 0;
     size_t offset = 0;
 
@@ -419,7 +416,7 @@ float compute_inner_product<SIMDLevel::AVX512>(
         float cb);
 
 template <>
-float compute_inner_product<SIMDLevel::AVX512_SPR>(
+float compute_inner_product<SIMDLevel::AVX512_VPOPCNT>(
         const uint8_t* __restrict sign_bits,
         const uint8_t* __restrict ex_code,
         const float* __restrict rotated_q,
@@ -432,4 +429,4 @@ float compute_inner_product<SIMDLevel::AVX512_SPR>(
 
 } // namespace faiss::rabitq::multibit
 
-#endif // COMPILE_SIMD_AVX512_SPR
+#endif // COMPILE_SIMD_AVX512_VPOPCNT

--- a/faiss/utils/simd_impl/super_kmeans_dispatch.h
+++ b/faiss/utils/simd_impl/super_kmeans_dispatch.h
@@ -19,7 +19,7 @@ namespace faiss {
 namespace detail {
 
 inline float block_l2_dispatch(const float* x, const float* y, int n) {
-    return with_simd_level_a1(
+    return with_simd_level_with_sve(
             [&]<SIMDLevel SL>() { return block_l2<SL>(x, y, n); });
 }
 

--- a/faiss/utils/simd_impl/super_kmeans_dispatch.h
+++ b/faiss/utils/simd_impl/super_kmeans_dispatch.h
@@ -11,10 +11,6 @@
 // highest available SIMD specialization at runtime (DD mode) or the
 // compiled-in level (static mode).
 //
-// The A1 level mask is required: plain with_simd_level() omits the ARM_SVE bit,
-// so on an SVE host the SVE specialization would never be instantiated.
-// ARM_NEON has no specialization and falls through to the scalar primary
-// template.
 
 #include <faiss/impl/simd_dispatch.h>
 #include <faiss/utils/simd_impl/super_kmeans_kernels.h>

--- a/faiss/utils/simd_levels.cpp
+++ b/faiss/utils/simd_levels.cpp
@@ -169,6 +169,9 @@ uint64_t compiled_simd_levels() {
 #ifdef COMPILE_SIMD_AVX512
     mask |= uint64_t(1) << static_cast<int>(SIMDLevel::AVX512);
 #endif
+#ifdef COMPILE_SIMD_AVX512_VPOPCNT
+    mask |= uint64_t(1) << static_cast<int>(SIMDLevel::AVX512_VPOPCNT);
+#endif
 #ifdef COMPILE_SIMD_AVX512_SPR
     mask |= uint64_t(1) << static_cast<int>(SIMDLevel::AVX512_SPR);
 #endif
@@ -265,6 +268,11 @@ SIMDLevel SIMDConfig::auto_detect_simd_level() {
         // needed for the SPR detection below. Kept in a local so a later
         // xgetbv cannot clobber it.
         unsigned int cpuid7_edx = regs[3];
+        // Leaf 7 subleaf 0, not leaf 1: leaf 1 ECX holds unrelated bits at
+        // these positions.
+        unsigned int ecx7 = regs[2];
+        [[maybe_unused]] bool has_avx512_vnni = (ecx7 & (1 << 11)) != 0;
+        [[maybe_unused]] bool has_avx512_vpopcntdq = (ecx7 & (1 << 14)) != 0;
 
         uint64_t xcr0 = xgetbv0();
 
@@ -289,19 +297,28 @@ SIMDLevel SIMDConfig::auto_detect_simd_level() {
                 supported_simd_levels |=
                         (1 << static_cast<int>(SIMDLevel::AVX512));
 
+#if defined(COMPILE_SIMD_AVX512_VPOPCNT)
+                if (has_avx512_vpopcntdq) {
+                    detected_level = SIMDLevel::AVX512_VPOPCNT;
+                    supported_simd_levels |=
+                            (1 << static_cast<int>(SIMDLevel::AVX512_VPOPCNT));
+                }
+#endif
+
 #if defined(COMPILE_SIMD_AVX512_SPR)
                 // Check for Sapphire Rapids features.
-                // The SPR code path is compiled with -mavx512fp16, so we
-                // must verify both AVX512_BF16 and AVX512_FP16 before
-                // dispatching to it. AMD Zen 4 (bergamo) has BF16 but
-                // not FP16 — using SPR code there causes SIGILL.
+                // The SPR code path is compiled with AVX512_VNNI, BF16,
+                // FP16, and VPOPCNTDQ, so all four features are required.
+                // AMD Zen 4 has VPOPCNTDQ and BF16 but not FP16, and must
+                // remain on the AVX512_VPOPCNT level.
                 // CPUID EAX=7, ECX=1: EAX bit 5 = AVX512_BF16
                 // CPUID EAX=7, ECX=0: EDX bit 23 = AVX512_FP16
                 // (Linux: X86_FEATURE_AVX512_FP16 = 18*32+23)
                 bool has_avx512_fp16 = (cpuid7_edx & (1 << 23)) != 0;
                 cpuid_count(7, 1, regs);
                 const bool has_avx512_bf16 = (regs[0] & (1 << 5)) != 0;
-                if (has_avx512_bf16 && has_avx512_fp16) {
+                if (has_avx512_vnni && has_avx512_vpopcntdq &&
+                    has_avx512_bf16 && has_avx512_fp16) {
                     detected_level = SIMDLevel::AVX512_SPR;
                     supported_simd_levels |=
                             (1 << static_cast<int>(SIMDLevel::AVX512_SPR));
@@ -395,6 +412,8 @@ SIMDLevel SIMDConfig::auto_detect_simd_level() {
     // In static mode, return the compiled-in level
 #if defined(COMPILE_SIMD_AVX512_SPR)
     return SIMDLevel::AVX512_SPR;
+#elif defined(COMPILE_SIMD_AVX512_VPOPCNT)
+    return SIMDLevel::AVX512_VPOPCNT;
 #elif defined(COMPILE_SIMD_AVX512)
     return SIMDLevel::AVX512;
 #elif defined(COMPILE_SIMD_AVX2)
@@ -429,6 +448,8 @@ std::string to_string(SIMDLevel level) {
             return "AVX2";
         case SIMDLevel::AVX512:
             return "AVX512";
+        case SIMDLevel::AVX512_VPOPCNT:
+            return "AVX512_VPOPCNT";
         case SIMDLevel::AVX512_SPR:
             return "AVX512_SPR";
         case SIMDLevel::ARM_NEON:
@@ -452,6 +473,9 @@ SIMDLevel to_simd_level(const std::string& level_str) {
     }
     if (level_str == "AVX512") {
         return SIMDLevel::AVX512;
+    }
+    if (level_str == "AVX512_VPOPCNT") {
+        return SIMDLevel::AVX512_VPOPCNT;
     }
     if (level_str == "AVX512_SPR") {
         return SIMDLevel::AVX512_SPR;

--- a/faiss/utils/simd_levels.cpp
+++ b/faiss/utils/simd_levels.cpp
@@ -8,6 +8,7 @@
 #include <faiss/utils/simd_levels.h>
 
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 
 #if defined(_MSC_VER)
@@ -156,6 +157,35 @@ void detect_x86_uarch_flags() {}
 // NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
 static SIMDConfig simd_config_initializer;
 
+namespace {
+
+/// Levels this binary holds code for. Must mirror the case labels in
+/// with_selected_simd_levels.
+uint64_t compiled_simd_levels() {
+    uint64_t mask = uint64_t(1) << static_cast<int>(SIMDLevel::NONE);
+#ifdef COMPILE_SIMD_AVX2
+    mask |= uint64_t(1) << static_cast<int>(SIMDLevel::AVX2);
+#endif
+#ifdef COMPILE_SIMD_AVX512
+    mask |= uint64_t(1) << static_cast<int>(SIMDLevel::AVX512);
+#endif
+#ifdef COMPILE_SIMD_AVX512_SPR
+    mask |= uint64_t(1) << static_cast<int>(SIMDLevel::AVX512_SPR);
+#endif
+#ifdef COMPILE_SIMD_ARM_NEON
+    mask |= uint64_t(1) << static_cast<int>(SIMDLevel::ARM_NEON);
+#endif
+#ifdef COMPILE_SIMD_ARM_SVE
+    mask |= uint64_t(1) << static_cast<int>(SIMDLevel::ARM_SVE);
+#endif
+#ifdef COMPILE_SIMD_RISCV_RVV
+    mask |= uint64_t(1) << static_cast<int>(SIMDLevel::RISCV_RVV);
+#endif
+    return mask;
+}
+
+} // namespace
+
 SIMDConfig::SIMDConfig(const char** faiss_simd_level_env) {
     // Support dependency injection for testing
     const char* env_var = faiss_simd_level_env ? *faiss_simd_level_env
@@ -164,7 +194,22 @@ SIMDConfig::SIMDConfig(const char** faiss_simd_level_env) {
     if (!env_var) {
         level = auto_detect_simd_level();
     } else {
-        level = to_simd_level(env_var);
+        // Forcing a level the CPU lacks is allowed. Forcing one the binary
+        // does not hold is not: dispatch would fall to NONE and skip every
+        // level between. Walk down to the nearest compiled level instead.
+        const uint64_t compiled = compiled_simd_levels();
+        const SIMDLevel requested = to_simd_level(env_var);
+        level = requested;
+        while (((compiled >> static_cast<int>(level)) & 1) == 0) {
+            level = get_simd_fallback(level);
+        }
+        if (level != requested) {
+            fprintf(stderr,
+                    "faiss: FAISS_SIMD_LEVEL=%s is not compiled into this "
+                    "build, using %s instead\n",
+                    to_string(requested).c_str(),
+                    to_string(level).c_str());
+        }
         supported_simd_levels = (1 << static_cast<int>(level));
     }
     supported_simd_levels |= (1 << static_cast<int>(SIMDLevel::NONE));

--- a/faiss/utils/simd_levels.h
+++ b/faiss/utils/simd_levels.h
@@ -21,12 +21,16 @@ enum class SIMDLevel {
     // x86
     AVX2,
     AVX512,
-    AVX512_SPR, // Sapphire Rapids: AVX512 + BF16 + FP16 + VNNI
+    AVX512_SPR, // Sapphire Rapids: AVX512 + BF16 + FP16 + VNNI + VPOPCNTDQ
     // arm & aarch64
     ARM_NEON,
     ARM_SVE, // Scalable Vector Extension (ARMv8.2+)
     // riscv
     RISCV_RVV, // RISC-V Vector Extension (rv64gcv)
+
+    // Appended to preserve the numeric values of the existing public enum.
+    // AVX-512 core features plus AVX512_VPOPCNTDQ (Ice Lake, Zen 4, etc.).
+    AVX512_VPOPCNT,
 
     COUNT
 };
@@ -52,6 +56,8 @@ inline constexpr SIMDLevel SINGLE_SIMD_LEVEL = SIMDLevel::NONE;
 #else
 #if defined(COMPILE_SIMD_AVX512_SPR)
 inline constexpr SIMDLevel SINGLE_SIMD_LEVEL = SIMDLevel::AVX512_SPR;
+#elif defined(COMPILE_SIMD_AVX512_VPOPCNT)
+inline constexpr SIMDLevel SINGLE_SIMD_LEVEL = SIMDLevel::AVX512_VPOPCNT;
 #elif defined(COMPILE_SIMD_AVX512)
 inline constexpr SIMDLevel SINGLE_SIMD_LEVEL = SIMDLevel::AVX512;
 #elif defined(COMPILE_SIMD_AVX2)
@@ -71,7 +77,7 @@ inline constexpr SIMDLevel SINGLE_SIMD_LEVEL = SIMDLevel::NONE;
  * Helper to select the appropriate 256-bit SIMD level.
  *
  * For 256-bit SIMD types (simd16uint16, simd32uint8, etc.), maps:
- *   AVX512/AVX512_SPR → AVX2 (256-bit ops use AVX2 instructions)
+ *   AVX512/AVX512_VPOPCNT/AVX512_SPR → AVX2
  *   AVX2 → AVX2
  *   ARM_NEON/ARM_SVE → ARM_NEON
  *   NONE → NONE
@@ -79,7 +85,8 @@ inline constexpr SIMDLevel SINGLE_SIMD_LEVEL = SIMDLevel::NONE;
 template <SIMDLevel SL>
 struct simd256_level_selector {
     static constexpr SIMDLevel value =
-            (SL == SIMDLevel::AVX512 || SL == SIMDLevel::AVX512_SPR)
+            (SL == SIMDLevel::AVX512 || SL == SIMDLevel::AVX512_VPOPCNT ||
+             SL == SIMDLevel::AVX512_SPR)
             ? SIMDLevel::AVX2
             : (SL == SIMDLevel::ARM_SVE             ? SIMDLevel::ARM_NEON
                        : SL == SIMDLevel::RISCV_RVV ? SIMDLevel::NONE
@@ -96,13 +103,14 @@ inline constexpr SIMDLevel SINGLE_SIMD_LEVEL_256 =
  * Helper to select the appropriate 512-bit SIMD level.
  *
  * For 512-bit SIMD types (simd32uint16, simd64uint8, etc.), maps:
- *   AVX512_SPR → AVX512 (512-bit ops share the same instructions)
+ *   AVX512_VPOPCNT/AVX512_SPR → AVX512 for generic 512-bit operations
  *   AVX512 → AVX512
  *   NONE → NONE
  ***************************************************************/
 template <SIMDLevel SL>
 struct simd512_level_selector {
-    static constexpr SIMDLevel value = (SL == SIMDLevel::AVX512_SPR)
+    static constexpr SIMDLevel value =
+            (SL == SIMDLevel::AVX512_SPR || SL == SIMDLevel::AVX512_VPOPCNT)
             ? SIMDLevel::AVX512
             : (SL == SIMDLevel::RISCV_RVV) ? SIMDLevel::NONE
                                            : SL;
@@ -124,12 +132,15 @@ constexpr int simd_width() {
     static_assert(
             SL != SIMDLevel::RISCV_RVV,
             "simd_width<RISCV_RVV> is not supported: RVV is variable-width");
-    if constexpr (SL == SIMDLevel::AVX512 || SL == SIMDLevel::AVX512_SPR)
+    if constexpr (
+            SL == SIMDLevel::AVX512 || SL == SIMDLevel::AVX512_VPOPCNT ||
+            SL == SIMDLevel::AVX512_SPR) {
         return 16;
-    else if constexpr (SL == SIMDLevel::AVX2 || SL == SIMDLevel::ARM_NEON)
+    } else if constexpr (SL == SIMDLevel::AVX2 || SL == SIMDLevel::ARM_NEON) {
         return 8;
-    else
+    } else {
         return 1;
+    }
 }
 
 /// Convert SIMDLevel to string. Throws FaissException for invalid level.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 set(FAISS_TEST_SRC
   test_binary_flat.cpp
+  test_binary_ivf_scanner.cpp
   test_dealloc_invlists.cpp
   test_ivfpq_codec.cpp
   test_ivfpq_indexing.cpp

--- a/tests/common_faiss_tests.py
+++ b/tests/common_faiss_tests.py
@@ -148,6 +148,7 @@ _SIMD_LEVEL_NAMES = {
     faiss.SIMDLevel_ARM_NEON: "ARM_NEON",
     faiss.SIMDLevel_ARM_SVE: "ARM_SVE",
     faiss.SIMDLevel_RISCV_RVV: "RISCV_RVV",
+    faiss.SIMDLevel_AVX512_VPOPCNT: "AVX512_VPOPCNT",
 }
 
 

--- a/tests/test_binary_ivf_scanner.cpp
+++ b/tests/test_binary_ivf_scanner.cpp
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <algorithm>
+#include <bit>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <random>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <faiss/IndexBinaryFlat.h>
+#include <faiss/IndexBinaryIVF.h>
+#include <faiss/utils/Heap.h>
+
+namespace {
+
+using C = faiss::CMax<int32_t, faiss::idx_t>;
+
+// 160-bit codes, the width HammingComputer20 specializes.
+constexpr int kCodeSize = 20;
+constexpr int kDim = kCodeSize * 8;
+
+std::vector<uint8_t> random_codes(std::mt19937& rng, size_t n) {
+    std::uniform_int_distribution<int> byte(0, 255);
+    std::vector<uint8_t> codes(n * kCodeSize);
+    for (auto& b : codes) {
+        b = static_cast<uint8_t>(byte(rng));
+    }
+    return codes;
+}
+
+std::vector<faiss::idx_t> sequential_ids(size_t n) {
+    std::vector<faiss::idx_t> ids(n);
+    for (size_t i = 0; i < n; i++) {
+        ids[i] = static_cast<faiss::idx_t>(i) * 3 + 100;
+    }
+    return ids;
+}
+
+// A Hamming distance written from the definition, so it can disagree with the
+// computer the scanner uses.
+int hamming_of(const uint8_t* a, const uint8_t* b) {
+    int dis = 0;
+    for (int i = 0; i < kCodeSize; i++) {
+        dis += std::popcount(static_cast<unsigned>(a[i] ^ b[i]));
+    }
+    return dis;
+}
+
+std::vector<int> expected_distances(
+        const std::vector<uint8_t>& codes,
+        const std::vector<uint8_t>& query,
+        size_t n,
+        size_t k,
+        uint32_t radius) {
+    std::vector<int> all;
+    for (size_t i = 0; i < n; i++) {
+        const int dis = hamming_of(query.data(), &codes[i * kCodeSize]);
+        if (static_cast<uint32_t>(dis) < radius) {
+            all.push_back(dis);
+        }
+    }
+    std::sort(all.begin(), all.end());
+    if (all.size() > k) {
+        all.resize(k);
+    }
+    return all;
+}
+
+struct ScannerFixture {
+    faiss::IndexBinaryFlat quantizer{kDim};
+    std::unique_ptr<faiss::IndexBinaryIVF> ivf;
+    std::unique_ptr<faiss::BinaryInvertedListScanner> scanner;
+
+    ScannerFixture(std::mt19937& rng, const std::vector<uint8_t>& query) {
+        const auto centroid = random_codes(rng, 1);
+        quantizer.add(1, centroid.data());
+        ivf = std::make_unique<faiss::IndexBinaryIVF>(&quantizer, kDim, 1);
+        ivf->is_trained = true;
+        scanner.reset(ivf->get_InvertedListScanner(false));
+        scanner->set_query(query.data());
+        scanner->set_list(0, 0);
+    }
+};
+
+std::vector<int> run_scan(
+        faiss::BinaryInvertedListScanner& scanner,
+        const std::vector<uint8_t>& codes,
+        const std::vector<faiss::idx_t>& ids,
+        const std::vector<size_t>& slice_sizes,
+        size_t k,
+        std::optional<int32_t> radius = std::nullopt) {
+    std::vector<int32_t> simi(k);
+    std::vector<faiss::idx_t> idxi(k);
+    faiss::heap_heapify<C>(k, simi.data(), idxi.data());
+    if (radius.has_value()) {
+        std::fill(simi.begin(), simi.end(), *radius);
+    }
+
+    size_t offset = 0;
+    for (const size_t count : slice_sizes) {
+        scanner.scan_codes(
+                count,
+                codes.data() + offset * kCodeSize,
+                ids.data() + offset,
+                simi.data(),
+                idxi.data(),
+                k);
+        offset += count;
+    }
+    faiss::heap_reorder<C>(k, simi.data(), idxi.data());
+
+    std::vector<int> found;
+    for (size_t i = 0; i < k; i++) {
+        if (idxi[i] >= 0) {
+            found.push_back(simi[i]);
+        }
+    }
+    return found;
+}
+
+TEST(BinaryIVFScanner, AnUnseededHeapKeepsTheKNearest) {
+    std::mt19937 rng(1234);
+    const size_t n = 2000;
+    const auto query = random_codes(rng, 1);
+    const auto codes = random_codes(rng, n);
+    const auto ids = sequential_ids(n);
+    ScannerFixture fixture(rng, query);
+
+    const size_t k = 10;
+    EXPECT_EQ(
+            run_scan(*fixture.scanner, codes, ids, {n}, k),
+            expected_distances(
+                    codes, query, n, k, std::numeric_limits<uint32_t>::max()));
+}
+
+TEST(BinaryIVFScanner, ASeededHeapAppliesTheRadiusAndKTogether) {
+    std::mt19937 rng(21);
+    const size_t n = 4000;
+    const auto query = random_codes(rng, 1);
+    const auto codes = random_codes(rng, n);
+    const auto ids = sequential_ids(n);
+
+    for (const auto [k, radius] :
+         {std::pair<size_t, int32_t>{64, 60}, {5, 70}}) {
+        ScannerFixture fixture(rng, query);
+        EXPECT_EQ(
+                run_scan(*fixture.scanner, codes, ids, {n}, k, radius),
+                expected_distances(
+                        codes, query, n, k, static_cast<uint32_t>(radius)))
+                << "k=" << k << " radius=" << radius;
+    }
+}
+
+TEST(BinaryIVFScanner, ResultsAccumulateAcrossCalls) {
+    std::mt19937 rng(7);
+    const size_t n = 3000;
+    const auto query = random_codes(rng, 1);
+    const auto codes = random_codes(rng, n);
+    const auto ids = sequential_ids(n);
+
+    const size_t k = 16;
+    const std::vector<std::vector<size_t>> layouts = {
+            {1, n - 1}, {0, n}, {1000, 0, 1000, 1, 999}};
+
+    for (const auto& layout : layouts) {
+        ScannerFixture fixture(rng, query);
+        EXPECT_EQ(
+                run_scan(*fixture.scanner, codes, ids, layout, k, 75),
+                expected_distances(codes, query, n, k, 75))
+                << "slice count " << layout.size();
+    }
+}
+
+TEST(BinaryIVFScanner, ASeededHeapIsExclusive) {
+    std::mt19937 rng(31);
+    const std::vector<uint8_t> query(kCodeSize, 0);
+    const size_t n = 2;
+    std::vector<uint8_t> codes(n * kCodeSize, 0);
+    codes[0] = 0x0f;         // 4 bits set
+    codes[kCodeSize] = 0x1f; // 5 bits set
+    const auto ids = sequential_ids(n);
+
+    ScannerFixture fixture(rng, query);
+    const std::vector<int> expected{4};
+    EXPECT_EQ(run_scan(*fixture.scanner, codes, ids, {n}, 10, 5), expected);
+
+    ScannerFixture none(rng, query);
+    EXPECT_TRUE(run_scan(*none.scanner, codes, ids, {n}, 10, 0).empty());
+
+    // A seed below zero admits nothing rather than everything.
+    ScannerFixture negative(rng, query);
+    EXPECT_TRUE(run_scan(*negative.scanner, codes, ids, {n}, 10, -5).empty());
+}
+
+TEST(BinaryIVFScanner, ZeroKScansNothing) {
+    std::mt19937 rng(51);
+    const size_t n = 64;
+    const auto query = random_codes(rng, 1);
+    const auto codes = random_codes(rng, n);
+    const auto ids = sequential_ids(n);
+
+    // Real buffers, so dropping the guard fails the expectation below
+    // instead of reading through a null pointer.
+    std::vector<int32_t> simi{-1};
+    std::vector<faiss::idx_t> idxi{-1};
+
+    ScannerFixture fixture(rng, query);
+    EXPECT_EQ(
+            fixture.scanner->scan_codes(
+                    n, codes.data(), ids.data(), simi.data(), idxi.data(), 0),
+            0u);
+    EXPECT_EQ(simi[0], -1);
+    EXPECT_EQ(idxi[0], -1);
+}
+
+} // namespace

--- a/tests/test_distances_dispatch.cpp
+++ b/tests/test_distances_dispatch.cpp
@@ -61,6 +61,7 @@ std::vector<SIMDLevel> available_levels() {
             SIMDLevel::AVX2,
             SIMDLevel::AVX512,
             SIMDLevel::AVX512_SPR,
+            SIMDLevel::AVX512_VPOPCNT,
             SIMDLevel::ARM_NEON,
             SIMDLevel::ARM_SVE,
     };

--- a/tests/test_index_accuracy.py
+++ b/tests/test_index_accuracy.py
@@ -386,7 +386,6 @@ class TestSQByte(unittest.TestCase):
             faiss.ScalarQuantizer.QT_8bit_direct,
             faiss.ScalarQuantizer.QT_8bit_direct_signed,
         ):
-            # d % 16 / 32 / 64 exercise the AVX2 / AVX512 / SPR byte kernels
             for d in 13, 16, 24, 32, 64, 128:
                 for metric_type in faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT:
                     self.subtest_8bit_direct(metric_type, d, quantizer)

--- a/tests/test_rabitq_simd.cpp
+++ b/tests/test_rabitq_simd.cpp
@@ -39,8 +39,23 @@ static std::vector<uint8_t> random_bytes(size_t n, uint32_t seed) {
 }
 
 // 32-d chunks and chunk boundaries.
-static const std::vector<size_t> kDims =
-        {1, 8, 16, 31, 32, 33, 255, 256, 257, 512, 1024, 2048};
+static const std::vector<size_t> kDims = {
+        1,
+        8,
+        16,
+        31,
+        32,
+        33,
+        100,
+        128,
+        255,
+        256,
+        257,
+        384,
+        512,
+        768,
+        1024,
+        2048};
 
 template <SIMDLevel SL>
 static void check_quantization_matches_scalar() {
@@ -377,3 +392,51 @@ TEST(RaBitQBitwiseAndDotProductWithPopcount, Avx2MatchesScalar) {
         }
     }
 }
+
+#if defined(FAISS_ENABLE_DD) && defined(__x86_64__)
+
+TEST(RaBitQVpopcnt, BitwiseKernelsMatchScalarAcrossTails) {
+    if (!faiss::SIMDConfig::is_simd_level_available(
+                SIMDLevel::AVX512_VPOPCNT)) {
+        GTEST_SKIP() << "AVX512_VPOPCNT is not available on this CPU";
+    }
+
+    for (size_t d : kDims) {
+        for (size_t qb = 1; qb <= 8; qb++) {
+            const size_t size = (d + 7) / 8;
+            const auto data = random_bytes(size, 19717);
+            const auto q = random_bytes(size * qb, 51691);
+
+            const uint64_t expected_and =
+                    faiss::rabitq::bitwise_and_dot_product<SIMDLevel::NONE>(
+                            q.data(), data.data(), size, qb);
+            const uint64_t expected_xor =
+                    faiss::rabitq::bitwise_xor_dot_product<SIMDLevel::NONE>(
+                            q.data(), data.data(), size, qb);
+            const uint64_t expected_pop =
+                    faiss::rabitq::popcount<SIMDLevel::NONE>(data.data(), size);
+
+            const uint64_t actual_and = faiss::rabitq::bitwise_and_dot_product<
+                    SIMDLevel::AVX512_VPOPCNT>(q.data(), data.data(), size, qb);
+            const uint64_t actual_xor = faiss::rabitq::bitwise_xor_dot_product<
+                    SIMDLevel::AVX512_VPOPCNT>(q.data(), data.data(), size, qb);
+            const uint64_t actual_pop =
+                    faiss::rabitq::popcount<SIMDLevel::AVX512_VPOPCNT>(
+                            data.data(), size);
+            const auto actual_fused =
+                    faiss::rabitq::bitwise_and_dot_product_with_popcount<
+                            SIMDLevel::AVX512_VPOPCNT>(
+                            q.data(), data.data(), size, qb);
+
+            EXPECT_EQ(actual_and, expected_and) << "d=" << d << " qb=" << qb;
+            EXPECT_EQ(actual_xor, expected_xor) << "d=" << d << " qb=" << qb;
+            EXPECT_EQ(actual_pop, expected_pop) << "d=" << d << " qb=" << qb;
+            EXPECT_EQ(actual_fused.dot_product, expected_and)
+                    << "d=" << d << " qb=" << qb;
+            EXPECT_EQ(actual_fused.popcount, expected_pop)
+                    << "d=" << d << " qb=" << qb;
+        }
+    }
+}
+
+#endif

--- a/tests/test_scalar_quantizer_correctness.py
+++ b/tests/test_scalar_quantizer_correctness.py
@@ -603,3 +603,57 @@ class TestTurboQFullDistances(unittest.TestCase):
                 for q in range(len(xq)):
                     for k in range(1, 10):
                         self.assertLessEqual(D[q, k - 1], D[q, k])
+
+
+@for_all_simd_levels
+class TestSQByteDirectAcrossSIMDLevels(unittest.TestCase):
+    """QT_8bit_direct{,_signed} distances are exact integers, so every SIMD
+    level must agree with NONE bit for bit.
+
+    d = 16 and 32 hit the d % 16 == 0 gate in sq-dispatch.h that routes to the
+    byte-domain DistanceComputerByte / DistanceComputerByteSigned kernels. The
+    two tests cover the two independent dispatch chains those kernels are
+    reached from: search() goes through sq_select_InvertedListScanner, and
+    get_distance_computer() through sq_select_distance_computer (the chain
+    Refine(SQ8) uses).
+    """
+
+    def do_test(self, measure):
+        if not faiss.SIMDConfig.is_simd_level_available(faiss.SIMDLevel_NONE):
+            self.skipTest("SIMDLevel.NONE not available")
+        rng = np.random.RandomState(1234)
+        for qtype in (
+            faiss.ScalarQuantizer.QT_8bit_direct,
+            faiss.ScalarQuantizer.QT_8bit_direct_signed,
+        ):
+            lo, hi = (
+                (-128, 128)
+                if qtype == faiss.ScalarQuantizer.QT_8bit_direct_signed
+                else (0, 256)
+            )
+            for metric in (faiss.METRIC_L2, faiss.METRIC_INNER_PRODUCT):
+                for d in (16, 32):
+                    with self.subTest(qtype=qtype, metric=metric, d=d):
+                        xb = rng.randint(lo, hi, (500, d)).astype("float32")
+                        xq = rng.randint(lo, hi, (10, d)).astype("float32")
+                        index = faiss.IndexScalarQuantizer(d, qtype, metric)
+                        index.add(xb)
+                        got = measure(index, xq)
+                        with NoneSIMDLevel():
+                            expect = measure(index, xq)
+                        np.testing.assert_array_equal(got, expect)
+
+    def test_scanner(self):
+        self.do_test(lambda index, xq: np.hstack(index.search(xq, 10)))
+
+    def test_distance_computer(self):
+        def measure(index, xq):
+            dc = index.get_distance_computer()
+            out = np.empty((len(xq), index.ntotal), dtype="float32")
+            for q in range(len(xq)):
+                dc.set_query(faiss.swig_ptr(xq[q]))
+                for i in range(index.ntotal):
+                    out[q, i] = dc(int(i))
+            return out
+
+        self.do_test(measure)

--- a/tests/test_simd_dispatch.py
+++ b/tests/test_simd_dispatch.py
@@ -40,24 +40,36 @@ def get_cpu_flags():
 
 def get_available_simd_levels():
     """
-    Returns SIMD levels that are available on the current platform.
-    NONE is always available. Others depend on architecture.
+    Returns the SIMD levels this build can be forced to with FAISS_SIMD_LEVEL.
+
+    Asks faiss rather than reading /proc/cpuinfo: a level is only honoured
+    when it is compiled into the build, and a CPU feature does not imply
+    that. is_simd_level_available() reports compiled and supported, which is
+    a subset of compiled, so every level it returns is one the override
+    accepts.
+
+    Setting FAISS_SIMD_LEVEL collapses the supported set to the forced level,
+    so the caller must not already have it set.
     """
-    import platform
+    import faiss
 
-    arch = platform.machine().lower()
-
-    # SIMDLevel enum names
-    levels = ["NONE"]
-
-    if arch in ("x86_64", "amd64"):
-        levels.extend(["AVX2", "AVX512"])
-        # AVX512_SPR is typically not enabled in DD builds
-    elif arch in ("aarch64", "arm64"):
-        levels.append("ARM_NEON")
-    elif arch in ("riscv64", "riscv"):
-        levels.append("RISCV_RVV")
-
+    names = [
+        "NONE",
+        "AVX2",
+        "AVX512",
+        "AVX512_VPOPCNT",
+        "AVX512_SPR",
+        "ARM_NEON",
+        "ARM_SVE",
+        "RISCV_RVV",
+    ]
+    levels = []
+    for name in names:
+        level = getattr(faiss, f"SIMDLevel_{name}", None)
+        if level is not None and faiss.SIMDConfig.is_simd_level_available(
+            level
+        ):
+            levels.append(name)
     return levels
 
 
@@ -108,6 +120,12 @@ class TestSIMDDispatch(unittest.TestCase):
                 )
         except ImportError:
             self.skipTest("faiss not available")
+
+        if os.environ.get("FAISS_SIMD_LEVEL"):
+            self.skipTest(
+                "FAISS_SIMD_LEVEL is already set, which collapses the "
+                "supported set"
+            )
 
         levels = get_available_simd_levels()
 
@@ -224,7 +242,7 @@ for lvl in range(int(faiss.SIMDLevel_COUNT)):
         """SPR detection must agree with the CPU's real feature flags. The SPR
         code path is compiled with -mavx512fp16, so AVX512_SPR must be
         reported available if and only if the CPU actually has the full
-        AVX512 core feature set AND AVX512_BF16 AND AVX512_FP16.
+        AVX512 core feature set, VNNI, VPOPCNTDQ, BF16, and FP16.
         """
         import platform
 
@@ -255,6 +273,8 @@ for lvl in range(int(faiss.SIMDLevel_COUNT)):
         }
         spr_capable = (
             avx512_core <= flags
+            and "avx512_vnni" in flags
+            and "avx512_vpopcntdq" in flags
             and "avx512_bf16" in flags
             and "avx512_fp16" in flags
         )
@@ -269,9 +289,60 @@ for lvl in range(int(faiss.SIMDLevel_COUNT)):
             "AVX512_SPR detection disagrees with /proc/cpuinfo: "
             f"detected={spr_detected}, cpu_spr_capable={spr_capable} "
             f"(avx512_core={avx512_core <= flags}, "
-            f"bf16={'avx512_bf16' in flags}, fp16={'avx512_fp16' in flags}). "
+            f"vnni={'avx512_vnni' in flags}, "
+            f"vpopcntdq={'avx512_vpopcntdq' in flags}, "
+            f"bf16={'avx512_bf16' in flags}, "
+            f"fp16={'avx512_fp16' in flags}). "
             "detected=True with fp16=False is the D107684495 regression "
             "(AMD Zen 4 mis-detected as SPR).",
+        )
+
+    def test_vpopcnt_detection_matches_cpu_features(self):
+        """The VPOPCNT level requires baseline AVX-512 and VPOPCNTDQ."""
+        import platform
+
+        try:
+            import faiss
+
+            if "DD" not in faiss.get_compile_options():
+                self.skipTest(
+                    "Not a DD build - SIMD level is fixed at compile time"
+                )
+        except ImportError:
+            self.skipTest("faiss not available")
+
+        if platform.machine().lower() not in ("x86_64", "amd64"):
+            self.skipTest("x86_64-only test")
+
+        if os.environ.get("FAISS_SIMD_LEVEL"):
+            self.skipTest(
+                "FAISS_SIMD_LEVEL is already set, which collapses the "
+                "supported set"
+            )
+
+        flags = get_cpu_flags()
+        if flags is None:
+            self.skipTest("/proc/cpuinfo not available")
+
+        avx512_core = {
+            "avx512f",
+            "avx512cd",
+            "avx512vl",
+            "avx512dq",
+            "avx512bw",
+        }
+        capable = (
+            avx512_core <= flags and "avx512_vpopcntdq" in flags
+        )
+        detected = faiss.SIMDConfig.is_simd_level_available(
+            faiss.SIMDLevel_AVX512_VPOPCNT
+        )
+
+        self.assertEqual(
+            detected,
+            capable,
+            "AVX512_VPOPCNT detection disagrees with /proc/cpuinfo: "
+            f"detected={detected}, cpu_capable={capable}",
         )
 
 

--- a/tests/test_simd_levels.cpp
+++ b/tests/test_simd_levels.cpp
@@ -118,6 +118,9 @@ TEST(SIMDLevel, to_string_all_levels) {
     EXPECT_EQ("NONE", faiss::to_string(faiss::SIMDLevel::NONE));
     EXPECT_EQ("AVX2", faiss::to_string(faiss::SIMDLevel::AVX2));
     EXPECT_EQ("AVX512", faiss::to_string(faiss::SIMDLevel::AVX512));
+    EXPECT_EQ(
+            "AVX512_VPOPCNT",
+            faiss::to_string(faiss::SIMDLevel::AVX512_VPOPCNT));
     EXPECT_EQ("AVX512_SPR", faiss::to_string(faiss::SIMDLevel::AVX512_SPR));
     EXPECT_EQ("ARM_NEON", faiss::to_string(faiss::SIMDLevel::ARM_NEON));
     EXPECT_EQ("ARM_SVE", faiss::to_string(faiss::SIMDLevel::ARM_SVE));
@@ -132,6 +135,9 @@ TEST(SIMDLevel, to_simd_level_all_strings) {
     EXPECT_EQ(faiss::SIMDLevel::NONE, faiss::to_simd_level("NONE"));
     EXPECT_EQ(faiss::SIMDLevel::AVX2, faiss::to_simd_level("AVX2"));
     EXPECT_EQ(faiss::SIMDLevel::AVX512, faiss::to_simd_level("AVX512"));
+    EXPECT_EQ(
+            faiss::SIMDLevel::AVX512_VPOPCNT,
+            faiss::to_simd_level("AVX512_VPOPCNT"));
     EXPECT_EQ(faiss::SIMDLevel::AVX512_SPR, faiss::to_simd_level("AVX512_SPR"));
     EXPECT_EQ(faiss::SIMDLevel::ARM_NEON, faiss::to_simd_level("ARM_NEON"));
     EXPECT_EQ(faiss::SIMDLevel::ARM_SVE, faiss::to_simd_level("ARM_SVE"));


### PR DESCRIPTION
Summary:

**TL;DR:** Guards a `k` of 0 in binary `scan_codes`, which previously read past an empty heap, and documents that a caller bounds a top-k scan by seeding the heap with the radius.

`IVFBinaryScannerL2::scan_codes` reads `simi[0]` to find the heap top. A k of 0 leaves no heap to read, so the scan read past the end of an empty array. This guards that case and returns 0.

The change also records how a caller bounds a top-k scan by a radius, because nothing said so and the answer is not obvious from the code.

The heap top is the only bound the scan applies. A caller that wants the k nearest codes inside a radius therefore seeds every heap slot with that radius, in place of the neutral value that `heap_heapify` writes. The scan then rejects any code at or beyond the radius. A slot the scan never fills keeps its label of -1, which is how the caller tells a result from an empty slot.

That idiom needs no new state on the scanner, and it keeps one rule in the loop: a code must beat the heap top. A second bound would make the loop harder to reason about, and a radius has no meaning for a caller that only wants the k nearest codes.

The loop now holds the heap top in a local. Only an accepted code can lower it, so the loop reads it again inside the branch rather than on every iteration. On a scan that accepts few codes, that turns a load into a register read for almost every code.

Differential Revision: D118925150
