### PR TITLE
Apply the max_codes budget in IndexIVF range search

### DIFF
--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -854,6 +854,15 @@ void IndexIVF::range_search_preassigned(
             max_empty_result_buckets == 0 || parallel_mode == 0,
             "max_empty_result_buckets supported only for parallel_mode = 0");
 
+    FAISS_THROW_IF_NOT_MSG(
+            cur_max_codes == 0 || parallel_mode == 0,
+            "max_codes supported only for parallel_mode = 0");
+
+    const idx_t unlimited_list_size = std::numeric_limits<idx_t>::max();
+    if (cur_max_codes == 0) {
+        cur_max_codes = unlimited_list_size;
+    }
+
     size_t nlistv = 0, ndis = 0;
 
     std::exception_ptr ex;
@@ -884,10 +893,11 @@ void IndexIVF::range_search_preassigned(
 
             auto scan_list_func = [&](size_t i,
                                       size_t ik,
-                                      RangeQueryResult& qres) {
+                                      RangeQueryResult& qres,
+                                      idx_t list_size_max) -> size_t {
                 idx_t key = keys[i * cur_nprobe + ik]; /* select the list */
                 if (key < 0) {
-                    return;
+                    return 0;
                 }
 
                 FAISS_THROW_IF_NOT_FMT(
@@ -898,7 +908,7 @@ void IndexIVF::range_search_preassigned(
                         nlist);
 
                 if (invlists->is_empty(key, inverted_list_context)) {
-                    return;
+                    return 0;
                 }
 
                 scanner->set_list(key, coarse_dis[i * cur_nprobe + ik]);
@@ -915,12 +925,18 @@ void IndexIVF::range_search_preassigned(
                     InvertedLists::ScopedCodes scodes(invlists, key);
                     InvertedLists::ScopedIds ids(invlists, key);
                     size_t list_size = invlists->list_size(key);
+                    if (list_size > (size_t)list_size_max) {
+                        // Truncate to what is left of the max_codes budget.
+                        list_size = (size_t)list_size_max;
+                    }
 
                     scanner->scan_codes_range(
                             list_size, scodes.get(), ids.get(), radius, qres);
                 }
                 nlistv++;
-                ndis += qres.stats.scan_cnt - scan_cnt0;
+                const size_t nscanned = qres.stats.scan_cnt - scan_cnt0;
+                ndis += nscanned;
+                return nscanned;
             };
 
             if (parallel_mode == 0) {
@@ -934,8 +950,16 @@ void IndexIVF::range_search_preassigned(
                         // results. A hit resets the counter.
                         size_t prev_nres = qres.nres;
                         size_t ndup = 0;
+                        idx_t nscan = 0;
                         for (idx_t ik = 0; ik < cur_nprobe; ik++) {
-                            scan_list_func(i, ik, qres);
+                            nscan += scan_list_func(
+                                    i, ik, qres, cur_max_codes - nscan);
+                            // Early-stop check: apply max_codes after each
+                            // list. nscan is the number of codes actually
+                            // scanned.
+                            if (nscan >= cur_max_codes) {
+                                break;
+                            }
                             if (max_empty_result_buckets > 0) {
                                 // Early-stop check: stop range search after
                                 // enough consecutive empty probes.
@@ -960,7 +984,7 @@ void IndexIVF::range_search_preassigned(
 #pragma omp for schedule(dynamic)
                     for (int64_t ik = 0; ik < cur_nprobe; ik++) {
                         try {
-                            scan_list_func(i, ik, qres);
+                            scan_list_func(i, ik, qres, unlimited_list_size);
                         } catch (...) {
                             omp_capture_exception(ex);
                         }
@@ -978,7 +1002,7 @@ void IndexIVF::range_search_preassigned(
                             qres = &pres.new_result(i);
                             scanner->set_query(x + i * d);
                         }
-                        scan_list_func(i, ik, *qres);
+                        scan_list_func(i, ik, *qres, unlimited_list_size);
                     } catch (...) {
                         omp_capture_exception(ex);
                     }

--- a/faiss/IndexIVF.h
+++ b/faiss/IndexIVF.h
@@ -66,8 +66,10 @@ struct Level1Quantizer {
 };
 
 struct SearchParametersIVF : SearchParameters {
-    size_t nprobe = 1;    ///< number of probes at query time
-    size_t max_codes = 0; ///< max nb of codes to visit to do a query
+    size_t nprobe = 1; ///< number of probes at query time
+    /// Max nb of codes to visit to do a query. Supported by generic IVF
+    /// k-NN in parallel_mode 0 and 3, and by range search in parallel_mode 0.
+    size_t max_codes = 0;
 
     /// FastScan k-NN only: maximum number of inverted lists to visit.
     /// 0 means unlimited, i.e. bounded only by nprobe. When set together

--- a/tests/test_ivf_index.cpp
+++ b/tests/test_ivf_index.cpp
@@ -511,3 +511,46 @@ TEST(IVF, search_callbacks) {
     EXPECT_GE(distance_count, heap_count)
             << "not every distance computation leads to a heap change";
 }
+
+// Test: range search applies the SearchParametersIVF::max_codes scan budget.
+// The parameter was read and validated but never handed to the scanner, so
+// every probed list was scanned in full no matter what budget was asked for.
+TEST(IVF, range_search_respects_max_codes) {
+    int d = 4;
+    int nlist = 4;
+    int nb = 200; // >= 39 * nlist, so training does not warn
+
+    faiss::IndexFlatL2 quantizer(d);
+    faiss::IndexIVFFlat idx(&quantizer, d, nlist);
+    idx.own_fields = false;
+
+    std::mt19937 rng(1234);
+    std::uniform_real_distribution<float> u(0.0f, 1.0f);
+    std::vector<float> xb(nb * d);
+    for (size_t i = 0; i < xb.size(); i++) {
+        xb[i] = u(rng);
+    }
+
+    idx.train(nb, xb.data());
+    idx.add(nb, xb.data());
+
+    std::vector<float> xq(d, 0.5f);
+    // With a radius this large every scanned code is in radius, so the number
+    // of results is exactly the number of codes scanned.
+    const float radius = std::numeric_limits<float>::max();
+
+    faiss::SearchParametersIVF params;
+    params.nprobe = nlist;
+
+    // Without a budget the whole database is scanned.
+    faiss::RangeSearchResult unlimited(1);
+    idx.range_search(1, xq.data(), radius, &unlimited, &params);
+    EXPECT_EQ(unlimited.lims[1], (size_t)nb);
+
+    // With a budget the scan stops once it is spent.
+    params.max_codes = 10;
+    faiss::RangeSearchResult limited(1);
+    idx.range_search(1, xq.data(), radius, &limited, &params);
+    EXPECT_LE(limited.lims[1], params.max_codes);
+    EXPECT_GT(limited.lims[1], (size_t)0);
+}


### PR DESCRIPTION
## Summary

Fixes #5579.

`IndexIVF::range_search_preassigned` reads the caller's scan budget and validates it, but never applies it:

```cpp
idx_t cur_max_codes = params ? params->max_codes : this->max_codes;
...
FAISS_THROW_IF_NOT_MSG(
        !invlists->use_iterator ||
                (cur_max_codes == 0 && store_pairs == false),
        "iterable inverted lists don't support max_codes and store_pairs");
```

After that check `cur_max_codes` is never referenced again. It is a dead local, so `scan_codes_range` always receives the full `list_size` and every probed list is scanned in full, whatever budget was requested.

The k-NN path in the same file wires the identical parameter through: it normalises `0` to unlimited, passes the remaining budget into each list scan, and breaks out of the probe loop once the budget is spent.

## Change

The range path now follows that same shape:

- Normalise `0` to unlimited **after** the existing `use_iterator` check, so that check keeps seeing the raw value. This mirrors the k-NN ordering.
- Pass the remaining budget into the list scan and truncate `list_size` to it. Stopping only between probes would overshoot by up to a whole inverted list, which for a large list defeats the purpose of the budget. The k-NN path truncates for the same reason.
- Break out of the probe loop once the budget is spent.

Support is limited to `parallel_mode = 0`, throwing otherwise, matching the guard `max_empty_result_buckets` uses a few lines earlier and the k-NN guard. `max_codes` was silently ignored in every mode before, so no working configuration starts throwing that was not already being ignored.

`scan_list_func` takes the budget as an explicit parameter rather than a defaulted one, so the two call sites in the other parallel modes state that they are unbounded instead of inheriting a default.

The iterator branch needs no truncation: the pre-existing check above already makes `use_iterator` and a non-zero `max_codes` mutually exclusive, so a finite budget cannot reach it.

`SearchParametersIVF::max_codes` now documents which modes honour it, as the neighbouring `ensure_topk_full` and `max_empty_result_buckets` fields already do. Converting that trailing comment to a block comment removes the alignment partner of the `nprobe` comment above it, so clang-format collapses its padding; that one-line change is in the diff for that reason.

## Testing

`IVF.range_search_respects_max_codes` in `tests/test_ivf_index.cpp` indexes 200 vectors over 4 lists and probes all of them with a radius large enough that every scanned code is a result, so the result count is exactly the number of codes scanned. Without a budget it expects all 200; with `max_codes = 10` it expects at most 10.

Verified with a negative control: reverting only `faiss/IndexIVF.cpp` and keeping the test makes it fail with

```
Expected: (limited.lims[1]) <= (params.max_codes), actual: 200 vs 10
```

which is the full sweep of all four probed lists, and the unbounded assertion still passes. Restoring the fix passes.

All 7 `IVF.*` tests pass, including `range_search_preassigned_out_of_range_key`, which covers the same function.

Built and run locally on Windows with MSVC 19.44 and OpenBLAS. I have not run the CUDA or Python test suites; this change is confined to the CPU generic IVF path.
