### PR TITLE
Avoid double-advancing HNSW visited tables

### DIFF
--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -611,6 +611,9 @@ void hnsw_search(
                     res->begin(i);
                     dis->set_query(x + i * index->d);
 
+                    // HNSW::search owns the per-query generation advance. The
+                    // reusable-table acquisition above only clears stale TLS
+                    // state before this thread starts processing queries.
                     HNSWStats stats =
                             hnsw.search(*dis, index, *res, *vt, params);
                     n1 += stats.n1;
@@ -618,7 +621,6 @@ void hnsw_search(
                     ndis += stats.ndis;
                     nhops += stats.nhops;
                     res->end();
-                    vt->advance();
                 } catch (...) {
                     omp_capture_exception(ex, [&] { interrupt = true; });
                 }

--- a/tests/test_hnsw.cpp
+++ b/tests/test_hnsw.cpp
@@ -784,6 +784,26 @@ struct ScopedOmpThreads {
     }
 };
 
+TEST_F(HNSWTest, TEST_search_advances_one_generation_per_query) {
+    ScopedOmpThreads omp_guard;
+    omp_set_num_threads(1);
+    index->hnsw.use_visited_hashset = false;
+
+    auto& reusable = dynamic_cast<faiss::VisitedTableVector&>(
+            faiss::VisitedTable::get_reusable(index->ntotal, false));
+    std::fill(reusable.visited.begin(), reusable.visited.end(), 0);
+    reusable.visno = 10;
+
+    std::vector<faiss::idx_t> labels(k);
+    std::vector<float> distances(k);
+    index->search(1, xq->data(), k, distances.data(), labels.data());
+
+    // Acquiring the reusable table advances 10 -> 11 to clear stale state.
+    // HNSW::search then advances 11 -> 12 after the query. The outer wrapper
+    // must not perform a third advance.
+    EXPECT_EQ(12, reusable.visno);
+}
+
 TEST_F(HNSWTest, TEST_search_reuse_correctness) {
     ScopedOmpThreads omp_guard;
 


### PR DESCRIPTION
 The outer HNSW search loop advanced the reusable visited table after every query, even though HNSW::search() already advances it internally.