### PR TITLE
feat(rvv): add RVV kernels for fvec_add/fvec_sub and PQ dsub=2 distance tables

### DIFF
--- a/faiss/impl/ProductQuantizer.cpp
+++ b/faiss/impl/ProductQuantizer.cpp
@@ -491,7 +491,8 @@ void ProductQuantizer::compute_distance_tables(
         const float* x,
         float* dis_tables) const {
     int64_t nx_signed = nx;
-#if defined(COMPILE_SIMD_AVX2) || defined(COMPILE_SIMD_ARM_NEON)
+#if defined(COMPILE_SIMD_AVX2) || defined(COMPILE_SIMD_ARM_NEON) || \
+        defined(COMPILE_SIMD_RISCV_RVV)
     if (dsub == 2 && nbits < 8) { // interesting for a narrow range of settings
         compute_PQ_dis_tables_dsub2(
                 d, ksub, centroids.data(), nx, x, false, dis_tables);
@@ -526,7 +527,8 @@ void ProductQuantizer::compute_inner_prod_tables(
         const float* x,
         float* dis_tables) const {
     int64_t nx_signed = nx;
-#if defined(COMPILE_SIMD_AVX2) || defined(COMPILE_SIMD_ARM_NEON)
+#if defined(COMPILE_SIMD_AVX2) || defined(COMPILE_SIMD_ARM_NEON) || \
+        defined(COMPILE_SIMD_RISCV_RVV)
     if (dsub == 2 && nbits < 8) {
         compute_PQ_dis_tables_dsub2(
                 d, ksub, centroids.data(), nx, x, true, dis_tables);

--- a/faiss/impl/simd_dispatch.h
+++ b/faiss/impl/simd_dispatch.h
@@ -36,6 +36,16 @@ constexpr int AVAILABLE_SIMD_LEVELS_AVX2_NEON = AVAILABLE_SIMD_LEVELS_NONE |
 constexpr int AVAILABLE_SIMD_LEVELS_A0 = AVAILABLE_SIMD_LEVELS_AVX2_NEON |
         (1 << int(SIMDLevel::AVX512)) | (1 << int(SIMDLevel::RISCV_RVV));
 
+// A0 minus AVX512: functions implemented at NONE, AVX2, ARM_NEON and
+// RISCV_RVV but with no 512-bit specialization, so AVX512 machines fall
+// through to AVX2 in the dispatch switch. The RISCV_RVV entries are native
+// vector-length-agnostic kernels (__riscv_vsetvl-based, in the V-enabled
+// TUs) and dispatch straight to them at their own level - RVV never rides
+// the fixed-width 256-bit simdlib path (simd_dynamic_dispatch_migration.md,
+// pitfall 5).
+constexpr int AVAILABLE_SIMD_LEVELS_A0_NO_AVX512 =
+        AVAILABLE_SIMD_LEVELS_A0 & ~(1 << int(SIMDLevel::AVX512));
+
 // A0_SPR: same as A0 + AVX512_SPR (for functions with a dedicated SPR
 // specialization on top of an AVX512 fallback). Currently used by the
 // RaBitQ popcount kernels, which use VPOPCNTDQ on SPR+.

--- a/faiss/utils/distances_dispatch.h
+++ b/faiss/utils/distances_dispatch.h
@@ -178,7 +178,7 @@ inline void fvec_sub_dispatch(
         const float* a,
         const float* b,
         float* c) {
-    with_simd_level_256bit(
+    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A0_NO_AVX512>(
             [&]<SIMDLevel level>() { fvec_sub<level>(d, a, b, c); });
 }
 
@@ -187,7 +187,7 @@ inline void fvec_add_dispatch(
         const float* a,
         const float* b,
         float* c) {
-    with_simd_level_256bit(
+    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A0_NO_AVX512>(
             [&]<SIMDLevel level>() { fvec_add<level>(d, a, b, c); });
 }
 
@@ -196,7 +196,7 @@ inline void fvec_add_scalar_dispatch(
         const float* a,
         float b,
         float* c) {
-    with_simd_level_256bit(
+    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A0_NO_AVX512>(
             [&]<SIMDLevel level>() { fvec_add<level>(d, a, b, c); });
 }
 
@@ -208,10 +208,17 @@ inline void compute_PQ_dis_tables_dsub2_dispatch(
         const float* x,
         bool is_inner_product,
         float* dis_tables) {
-    with_simd_level_256bit([&]<SIMDLevel level>() {
-        compute_PQ_dis_tables_dsub2<level>(
-                d, ksub, centroids, nx, x, is_inner_product, dis_tables);
-    });
+    with_selected_simd_levels<AVAILABLE_SIMD_LEVELS_A0_NO_AVX512>(
+            [&]<SIMDLevel level>() {
+                compute_PQ_dis_tables_dsub2<level>(
+                        d,
+                        ksub,
+                        centroids,
+                        nx,
+                        x,
+                        is_inner_product,
+                        dis_tables);
+            });
 }
 
 /***************************************************************************

--- a/faiss/utils/simd_impl/distances_rvv.cpp
+++ b/faiss/utils/simd_impl/distances_rvv.cpp
@@ -11,6 +11,7 @@
 
 #ifdef COMPILE_SIMD_RISCV_RVV
 
+#include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/extra_distances.h>
 #include <riscv_vector.h>
 
@@ -336,6 +337,128 @@ int fvec_madd_and_argmin<SIMDLevel::RISCV_RVV>(
     fvec_madd<SIMDLevel::RISCV_RVV>(n, a, bf, b, c);
     const size_t j = rvv_argmin(c, n);
     return j < n ? static_cast<int>(j) : -1;
+}
+
+template <>
+void fvec_add<SIMDLevel::RISCV_RVV>(
+        size_t d,
+        const float* a,
+        const float* b,
+        float* c) {
+    size_t i = 0;
+    while (i < d) {
+        size_t vl = __riscv_vsetvl_e32m8(d - i);
+        vfloat32m8_t va = __riscv_vle32_v_f32m8(a + i, vl);
+        vfloat32m8_t vb = __riscv_vle32_v_f32m8(b + i, vl);
+        va = __riscv_vfadd_vv_f32m8(va, vb, vl);
+        __riscv_vse32_v_f32m8(c + i, va, vl);
+        i += vl;
+    }
+}
+
+template <>
+void fvec_add<SIMDLevel::RISCV_RVV>(
+        size_t d,
+        const float* a,
+        float b,
+        float* c) {
+    size_t i = 0;
+    while (i < d) {
+        size_t vl = __riscv_vsetvl_e32m8(d - i);
+        vfloat32m8_t va = __riscv_vle32_v_f32m8(a + i, vl);
+        va = __riscv_vfadd_vf_f32m8(va, b, vl);
+        __riscv_vse32_v_f32m8(c + i, va, vl);
+        i += vl;
+    }
+}
+
+template <>
+void fvec_sub<SIMDLevel::RISCV_RVV>(
+        size_t d,
+        const float* a,
+        const float* b,
+        float* c) {
+    size_t i = 0;
+    while (i < d) {
+        size_t vl = __riscv_vsetvl_e32m8(d - i);
+        vfloat32m8_t va = __riscv_vle32_v_f32m8(a + i, vl);
+        vfloat32m8_t vb = __riscv_vle32_v_f32m8(b + i, vl);
+        va = __riscv_vfsub_vv_f32m8(va, vb, vl);
+        __riscv_vse32_v_f32m8(c + i, va, vl);
+        i += vl;
+    }
+}
+
+// Distances between one query sub-vector (x0, x1) and the ksub dsub=2
+// centroids of a sub-space. All-centroids layout is (m * ksub + k) * 2, the
+// output layout (i * M + m) * ksub + k. The chunk length comes from vsetvl,
+// so the kernel adapts to any VLEN. Each product/square is rounded before the
+// final add - like the NONE implementation, and unlike a fused vfmacc - so
+// the tables are bit-identical to the scalar ones. (c - x)^2 is computed
+// instead of (x - c)^2, which yields the same bits and saves the broadcast.
+template <bool is_inner_product>
+static void pq2_dis_table_rvv(
+        const float* cents,
+        float x0,
+        float x1,
+        size_t ksub,
+        float* out) {
+    constexpr size_t pair_stride = 2 * sizeof(float);
+    size_t k = 0;
+    while (k < ksub) {
+        size_t vl = __riscv_vsetvl_e32m8(ksub - k);
+        vfloat32m8_t c0 =
+                __riscv_vlse32_v_f32m8(cents + 2 * k, pair_stride, vl);
+        vfloat32m8_t c1 =
+                __riscv_vlse32_v_f32m8(cents + 2 * k + 1, pair_stride, vl);
+        if constexpr (is_inner_product) {
+            c0 = __riscv_vfmul_vf_f32m8(c0, x0, vl);
+            c1 = __riscv_vfmul_vf_f32m8(c1, x1, vl);
+            c0 = __riscv_vfadd_vv_f32m8(c0, c1, vl);
+        } else {
+            c0 = __riscv_vfsub_vf_f32m8(c0, x0, vl);
+            c1 = __riscv_vfsub_vf_f32m8(c1, x1, vl);
+            vfloat32m8_t s0 = __riscv_vfmul_vv_f32m8(c0, c0, vl);
+            vfloat32m8_t s1 = __riscv_vfmul_vv_f32m8(c1, c1, vl);
+            c0 = __riscv_vfadd_vv_f32m8(s0, s1, vl);
+        }
+        __riscv_vse32_v_f32m8(out + k, c0, vl);
+        k += vl;
+    }
+}
+
+template <>
+void compute_PQ_dis_tables_dsub2<SIMDLevel::RISCV_RVV>(
+        size_t d,
+        size_t ksub,
+        const float* all_centroids,
+        size_t nx,
+        const float* x,
+        bool is_inner_product,
+        float* dis_tables) {
+    size_t M = d / 2;
+    FAISS_THROW_IF_NOT(ksub % 8 == 0);
+    for (size_t i = 0; i < nx; i++) {
+        const float* xi = x + i * d;
+        float* out_i = dis_tables + i * M * ksub;
+        for (size_t m = 0; m < M; m++) {
+            if (is_inner_product) {
+                pq2_dis_table_rvv<true>(
+                        all_centroids + m * 2 * ksub,
+                        xi[2 * m],
+                        xi[2 * m + 1],
+                        ksub,
+                        out_i + m * ksub);
+            } else {
+                pq2_dis_table_rvv<false>(
+                        all_centroids + m * 2 * ksub,
+                        xi[2 * m],
+                        xi[2 * m + 1],
+                        ksub,
+                        out_i + m * ksub);
+            }
+        }
+    }
 }
 
 #define DEFINE_VECTOR_DISTANCE_RVV_FALLBACK(metric)                 \


### PR DESCRIPTION
## Summary

On RISC-V, `fvec_add`, `fvec_sub` and `compute_PQ_dis_tables_dsub2` are dispatched through `with_simd_level_256bit`, whose level mask (`AVAILABLE_SIMD_LEVELS_AVX2_NEON`) has no `RISCV_RVV` bit. RVV hosts therefore fall back to the scalar NONE implementation.

This PR adds native RVV kernels for these functions and fixes the dispatch, following the same vector-length-agnostic approach as the RVV kernels already in the tree: the kernels are `__riscv_vsetvl`-based (m8) and adapt to any VLEN at runtime instead of assuming a fixed vector width.

## Changes

- Add RVV kernels in `faiss/utils/simd_impl/distances_rvv.cpp`:
  - `fvec_add` (vector + vector and vector + scalar)
  - `fvec_sub`
  - `compute_PQ_dis_tables_dsub2` (PQ distance tables for dsub = 2, both L2 and inner product). Each product/square is rounded before the final add — like the NONE implementation and unlike a fused `vfmacc` — so the tables are bit-identical to the scalar ones.
- Add `AVAILABLE_SIMD_LEVELS_A0_NO_AVX512` mask in `faiss/impl/simd_dispatch.h` (A0 minus AVX512: functions with NONE/AVX2/ARM_NEON/RISCV_RVV implementations but no 512-bit specialization, so AVX512 machines keep the AVX2 path).
- Route the four dispatchers in `faiss/utils/distances_dispatch.h` through the new mask.
- Enable the PQ dsub = 2 distance table path in `ProductQuantizer::compute_distance_tables` / `compute_inner_prod_tables` on RISC-V (`COMPILE_SIMD_RISCV_RVV`), previously guarded to AVX2/ARM_NEON only. No behavior change on other platforms.

## Performance

Measured on SG2044 (64-core RISC-V, RVV 1.0), Faiss C++ benchmark suite, rcq-search case:

| Metric | Baseline | Patched | Change |
|---|---|---|---|
| instructions | 7.25 T | 6.87 T | -5.2% |
| cycles | 4.60 T | 4.30 T | -6.5% |
| wall time | 238.1 s | 223.6 s | -6.1% |
| branches | 334.6 G | 305.0 G | -8.8% |

`fvec_add` hotspot in perf record drops from 1.06% (scalar NONE) to 0.18% (RVV) of samples.

## Correctness

- `sq-accuracy` reconstruction errors bit-identical to baseline on all 9 quantizer types, `ndiff_for_idempotence=0`.
- The `compute_PQ_dis_tables_dsub2` kernel is bit-identical to the scalar implementation by construction (no fused multiply-add).