### PR TITLE
Optimize RVV direct-signed scalar-quantizer distances

### DIFF
--- a/faiss/impl/scalar_quantizer/sq-rvv.cpp
+++ b/faiss/impl/scalar_quantizer/sq-rvv.cpp
@@ -140,6 +140,124 @@ struct DistanceComputerByte<Similarity, SIMDLevel::RISCV_RVV>
 };
 
 /*************************************************************************
+ * Fast path — QT_8bit_direct_signed (IP and L2)
+ *
+ * Reconstruct signed bytes in float, accumulate in vector registers, and
+ * reduce once after the loop. Tail-undisturbed accumulation preserves
+ * earlier lanes during short final iterations.
+ ************************************************************************/
+
+template <class Similarity>
+struct DCTemplate<
+        Quantizer8bitDirectSigned<SIMDLevel::RISCV_RVV>,
+        Similarity,
+        SIMDLevel::RISCV_RVV> : SQDistanceComputer {
+    using Sim = Similarity;
+
+    size_t d;
+
+    DCTemplate(size_t d_in, const std::vector<float>& /* trained */)
+            : d(d_in) {}
+
+    void set_query(const float* x) final {
+        this->q = x;
+    }
+
+    /// Vectorized reconstruction of code bytes (stored as value+128) into
+    /// the float domain (code[i] - 128), one AVL-sized chunk per iteration.
+    template <bool IS_L2>
+    float distance_to_xf(const float* x, const uint8_t* code) const {
+        const size_t vlmax = __riscv_vsetvlmax_e32m4();
+        vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
+        size_t i = 0;
+        while (i < d) {
+            size_t vl = __riscv_vsetvl_e8m1(d - i);
+            // byte = value + 128, so reconstruct as signed (byte - 128).
+            vuint8m1_t cb = __riscv_vle8_v_u8m1(code + i, vl);
+            vuint32m4_t cu = __riscv_vzext_vf4_u32m4(cb, vl);
+            vint32m4_t cs = __riscv_vreinterpret_v_u32m4_i32m4(cu);
+            cs = __riscv_vsub_vx_i32m4(cs, 128, vl);
+            vfloat32m4_t cf = __riscv_vfcvt_f_x_v_f32m4(cs, vl);
+            vfloat32m4_t vx = __riscv_vle32_v_f32m4(x + i, vl);
+            if constexpr (IS_L2) {
+                vfloat32m4_t diff = __riscv_vfsub_vv_f32m4(vx, cf, vl);
+                acc = __riscv_vfmacc_vv_f32m4_tu(acc, diff, diff, vl);
+            } else {
+                acc = __riscv_vfmacc_vv_f32m4_tu(acc, vx, cf, vl);
+            }
+            i += vl;
+        }
+        // Single final reduction over the whole loop range.
+        vfloat32m1_t init = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+        vfloat32m1_t red = __riscv_vfredusum_vs_f32m4_f32m1(acc, init, vlmax);
+        return __riscv_vfmv_f_s_f32m1_f32(red);
+    }
+
+    template <bool IS_L2>
+    float code_to_code_distance(const uint8_t* code1, const uint8_t* code2)
+            const {
+        const size_t vlmax = __riscv_vsetvlmax_e32m4();
+        vfloat32m4_t acc = __riscv_vfmv_v_f_f32m4(0.0f, vlmax);
+        size_t i = 0;
+        while (i < d) {
+            size_t vl = __riscv_vsetvl_e8m1(d - i);
+            vuint8m1_t a8 = __riscv_vle8_v_u8m1(code1 + i, vl);
+            vuint8m1_t b8 = __riscv_vle8_v_u8m1(code2 + i, vl);
+            vuint32m4_t au = __riscv_vzext_vf4_u32m4(a8, vl);
+            vuint32m4_t bu = __riscv_vzext_vf4_u32m4(b8, vl);
+            vint32m4_t as = __riscv_vreinterpret_v_u32m4_i32m4(au);
+            vint32m4_t bs = __riscv_vreinterpret_v_u32m4_i32m4(bu);
+            as = __riscv_vsub_vx_i32m4(as, 128, vl);
+            bs = __riscv_vsub_vx_i32m4(bs, 128, vl);
+            vfloat32m4_t af = __riscv_vfcvt_f_x_v_f32m4(as, vl);
+            vfloat32m4_t bf = __riscv_vfcvt_f_x_v_f32m4(bs, vl);
+            if constexpr (IS_L2) {
+                // (a - 128) - (b - 128) == a - b
+                vfloat32m4_t diff = __riscv_vfsub_vv_f32m4(af, bf, vl);
+                acc = __riscv_vfmacc_vv_f32m4_tu(acc, diff, diff, vl);
+            } else {
+                acc = __riscv_vfmacc_vv_f32m4_tu(acc, af, bf, vl);
+            }
+            i += vl;
+        }
+        // Single final reduction over the whole loop range.
+        vfloat32m1_t init = __riscv_vfmv_s_f_f32m1(0.0f, 1);
+        vfloat32m1_t red = __riscv_vfredusum_vs_f32m4_f32m1(acc, init, vlmax);
+        return __riscv_vfmv_f_s_f32m1_f32(red);
+    }
+
+    float query_to_code(const uint8_t* code) const final {
+        if constexpr (Sim::metric_type == METRIC_L2) {
+            return distance_to_xf<true>(this->q, code);
+        } else {
+            return distance_to_xf<false>(this->q, code);
+        }
+    }
+
+    float compute_distance(const float* x, const uint8_t* code) const {
+        if constexpr (Sim::metric_type == METRIC_L2) {
+            return distance_to_xf<true>(x, code);
+        } else {
+            return distance_to_xf<false>(x, code);
+        }
+    }
+
+    float compute_code_distance(const uint8_t* code1, const uint8_t* code2)
+            const {
+        if constexpr (Sim::metric_type == METRIC_L2) {
+            return code_to_code_distance<true>(code1, code2);
+        } else {
+            return code_to_code_distance<false>(code1, code2);
+        }
+    }
+
+    float symmetric_dis(idx_t i, idx_t j) override {
+        return compute_code_distance(
+                codes + i * code_size, codes + j * code_size);
+    }
+};
+
+/*************************************************************************
  * Fast path — QT_4bit_uniform + L2
  *
  * 4-bit UNIFORM scaling: every component reconstructs as an affine function

--- a/tests/test_scalar_quantizer.cpp
+++ b/tests/test_scalar_quantizer.cpp
@@ -693,3 +693,57 @@ TEST(ScalarQuantizer, EDENSimdDistancePathParity) {
                 level, faiss::ScalarQuantizer::QT_8bit_eden);
     }
 }
+
+TEST(ScalarQuantizer, RVVDirectSignedDistances) {
+    if (!faiss::SIMDConfig::is_simd_level_available(
+                faiss::SIMDLevel::RISCV_RVV)) {
+        GTEST_SKIP() << "RVV is not available";
+    }
+    ScopedSIMDLevel scoped(faiss::SIMDLevel::RISCV_RVV);
+    const std::array<uint8_t, 4> values = {0, 127, 128, 255};
+    const std::array<float, 4> queries = {-127.75f, -0.5f, 0.25f, 126.75f};
+    for (size_t d : {1, 15, 16, 17, 31, 32, 33, 65}) {
+        SCOPED_TRACE(d);
+        std::vector<uint8_t> codes(2 * d);
+        std::vector<float> query(d);
+        for (size_t i = 0; i < d; ++i) {
+            codes[i] = values[i % values.size()];
+            codes[d + i] = values[(i + 1) % values.size()];
+            query[i] = queries[i % queries.size()];
+        }
+        for (auto metric : {faiss::METRIC_L2, faiss::METRIC_INNER_PRODUCT}) {
+            SCOPED_TRACE(static_cast<int>(metric));
+            faiss::ScalarQuantizer sq(
+                    d, faiss::ScalarQuantizer::QT_8bit_direct_signed);
+            std::unique_ptr<faiss::ScalarQuantizer::SQDistanceComputer> dc(
+                    sq.get_distance_computer(metric));
+            dc->codes = codes.data();
+            dc->code_size = sq.code_size;
+            dc->set_query(query.data());
+            for (size_t k = 0; k < 2; ++k) {
+                double expected = 0;
+                for (size_t i = 0; i < d; ++i) {
+                    const double decoded = int(codes[k * d + i]) - 128;
+                    const double diff = double(query[i]) - decoded;
+                    expected += metric == faiss::METRIC_L2
+                            ? diff * diff
+                            : double(query[i]) * decoded;
+                }
+                EXPECT_NEAR(
+                        dc->query_to_code(codes.data() + k * d),
+                        expected,
+                        2e-6 * std::max(1.0, std::abs(expected)));
+            }
+            double expected = 0;
+            for (size_t i = 0; i < d; ++i) {
+                const double a = int(codes[i]) - 128;
+                const double b = int(codes[d + i]) - 128;
+                expected +=
+                        metric == faiss::METRIC_L2 ? (a - b) * (a - b) : a * b;
+            }
+            // These integer sums are exactly representable in float.
+            EXPECT_EQ(dc->symmetric_dis(0, 1), float(expected));
+            EXPECT_EQ(dc->symmetric_dis(1, 0), float(expected));
+        }
+    }
+}


### PR DESCRIPTION
RVV `QT_8bit_direct_signed` distances currently use the generic distance template. This adds a specialization for L2 and inner product, for both floating-point query-to-code and code-to-code distances.

The specialization reconstructs `code[i] - 128` in float, accumulates in vector registers, and performs one reduction after the loop. Tail-undisturbed accumulation preserves earlier lanes when the last iteration is short. Query values remain floating point, including fractional queries. The new regression test covers byte boundaries, fractional queries, both metrics, symmetric distances, and dimensions around vector tails.

This is an independent change based on `main`. It overlaps the direct-signed distance area of #5539; #5535 also works on RVV scalar-quantizer primitives. This PR offers a narrow implementation with floating-point query semantics and explicit tail coverage. The benchmark below compares with the stated official baseline, and does not compare against either PR's head.

### Performance

Measured on a native SG2044 RISC-V host (VLEN=128), GCC 15.1, Release `-O3`, dynamic dispatch (`FAISS_OPT_LEVEL=dd`), `rv64gcv_zvfhmin/lp64d`, one thread pinned to CPU 2. The baseline is official commit `80a16564f86530dbf0bfaf96c2b71feffeb5093f`; the candidate is that same baseline plus only this kernel change. These measurements were not collected on the newer PR base `2ed4c106e9fb9686e7727e5daf8ad6ad1e164109`. The affected scalar-quantizer source files are unchanged between those bases, and the submitted kernel differs from the measured one only in comments/formatting.

| Public path | Dimension | Baseline ns/element | Candidate ns/element | Paired speedup | 95% interval |
|---|---:|---:|---:|---:|---:|
| IP query-to-code | 16 | 3.341 | 2.162 | 1.545x | [1.537, 1.550] |
| IP query-to-code | 32 | 2.963 | 1.236 | 2.400x | [2.145, 2.406] |
| IP query-to-code | 128 | 2.745 | 0.543 | 5.058x | [4.887, 5.084] |
| IP query-to-code | 768 | 2.628 | 0.360 | 7.261x | [7.213, 7.371] |
| IP code-to-code | 16 | 3.524 | 2.419 | 1.457x | [1.456, 1.458] |
| IP code-to-code | 32 | 3.060 | 1.462 | 2.095x | [2.092, 2.096] |
| IP code-to-code | 128 | 2.769 | 0.749 | 3.700x | [3.693, 3.701] |
| IP code-to-code | 768 | 2.635 | 0.563 | 4.701x | [4.685, 4.706] |
| L2 query-to-code | 16 | 3.410 | 2.248 | 1.515x | [1.512, 1.521] |
| L2 query-to-code | 32 | 3.002 | 1.321 | 2.269x | [2.251, 2.279] |
| L2 query-to-code | 128 | 2.754 | 0.611 | 4.493x | [4.457, 4.512] |
| L2 query-to-code | 768 | 2.630 | 0.428 | 6.187x | [6.103, 6.230] |
| L2 code-to-code | 16 | 3.592 | 2.461 | 1.460x | [1.459, 1.462] |
| L2 code-to-code | 32 | 3.100 | 1.499 | 2.069x | [2.066, 2.070] |
| L2 code-to-code | 128 | 2.778 | 0.777 | 3.573x | [3.568, 3.581] |
| L2 code-to-code | 768 | 2.635 | 0.586 | 4.497x | [4.470, 4.529] |

Geometric mean of the dimension-specific speedups at d=32/128/768: IP query-to-code **4.450x**, IP code-to-code **3.315x**, L2 query-to-code **3.981x**, L2 code-to-code **3.215x**.

There are three consecutive sessions, each with four alternating ABBA/BAAB blocks per dimension/path: **192 paired blocks** for this candidate. A is the baseline and B is the candidate. Each call is calibrated to at least 0.1 s (the shortest formal call in the full campaign was 0.192 s), with three warm-up batches and `n = max(32, floor(32768/d))`. Each block uses the ratio of the two-call geometric mean times. Reported speedup is the median of the three session medians; intervals use 5,000 hierarchical bootstrap resamples, resampling sessions and then blocks within each ABBA/BAAB order stratum. The timing columns are separate medians, so their quotient need not equal the paired speedup. All 192 paired blocks favored this candidate.

The timed operations are public `SQDistanceComputer::query_to_code` and `symmetric_dis` calls over randomly generated codes (fixed seed 718), with fractional floating-point queries.

These results describe public encoding/distance throughput on one non-exclusive host, not end-to-end ANN search speedup. The intervals describe these sessions only, with no multiple-comparison correction; they do not establish portability across machines or vector lengths.

### Validation

- Native public-path oracle: **13,152** distance/index checks; L2/IP, query-to-code, code-to-code, top-k, fractional queries, NaN/Inf, and tails. Float results are checked against a double reference with a dimension-dependent error bound; integer code-to-code sums are required to be exact when the sum of absolute terms is at most 2^24.
- Original benchmark baseline full C++ suite: **273 passed, 7 skipped, 0 failed**.
- Submission version on `2ed4c106e9fb9686e7727e5daf8ad6ad1e164109`: all three independent candidate builds succeeded; this PR's focused C++ suite (`NONE`: 11 passed, 5 skipped, 0 failed; `RISCV_RVV`: 12 passed, 4 skipped, 0 failed) and the public-path oracle above pass on native RISC-V. The newly added RVV regression test is executed and passed in the RVV run, and skipped when RVV is disabled in the NONE run.
- All touched C++ files pass clang-format 21.1.8; `git diff --check` clean.
