### PR TITLE
Vectorize RVV FP16 encoding with scalar-compatible rounding

### DIFF
--- a/faiss/impl/scalar_quantizer/quantizers.h
+++ b/faiss/impl/scalar_quantizer/quantizers.h
@@ -241,7 +241,7 @@ struct QuantizerFP16<SIMDLevel::NONE> : ScalarQuantizer::SQuantizer {
     QuantizerFP16(size_t d_in, const std::vector<float>& /* unused */)
             : d(d_in) {}
 
-    void encode_vector(const float* x, uint8_t* code) const final {
+    void encode_vector(const float* x, uint8_t* code) const override {
         for (size_t i = 0; i < d; i++) {
             ((uint16_t*)code)[i] = encode_fp16(x[i]);
         }

--- a/faiss/impl/scalar_quantizer/sq-rvv.cpp
+++ b/faiss/impl/scalar_quantizer/sq-rvv.cpp
@@ -85,6 +85,46 @@ template <>
 struct QuantizerFP16<SIMDLevel::RISCV_RVV> : QuantizerFP16<SIMDLevel::NONE> {
     QuantizerFP16(size_t d, const std::vector<float>& trained)
             : QuantizerFP16<SIMDLevel::NONE>(d, trained) {}
+
+    void encode_vector(const float* x, uint8_t* code) const final {
+        auto* dst = reinterpret_cast<uint16_t*>(code);
+        size_t i = 0;
+        while (i < this->d) {
+            const size_t vl = __riscv_vsetvl_e32m4(this->d - i);
+            const vfloat32m4_t input = __riscv_vle32_v_f32m4(x + i, vl);
+            const vuint32m4_t bits = __riscv_vreinterpret_v_f32m4_u32m4(input);
+            const vuint32m4_t magnitude =
+                    __riscv_vand_vx_u32m4(bits, 0x7fffffffu, vl);
+            const vbool8_t special =
+                    __riscv_vmsgeu_vx_u32m4_b8(magnitude, 0x7f800000u, vl);
+            // Use the scalar codec for NaN and infinity.
+            if (__riscv_vcpop_m_b8(special, vl)) {
+                for (size_t j = 0; j < vl; ++j) {
+                    dst[i + j] = encode_fp16(x[i + j]);
+                }
+                i += vl;
+                continue;
+            }
+            // The generic codec uses ryg's scale-and-round operation, whose
+            // halfway behavior differs from IEEE round-to-nearest-even FP16.
+            const vuint32m4_t truncated =
+                    __riscv_vand_vx_u32m4(magnitude, 0xfffff000u, vl);
+            const vfloat32m4_t value =
+                    __riscv_vreinterpret_v_u32m4_f32m4(truncated);
+            vfloat32m4_t scaled = __riscv_vfmul_vf_f32m4(value, 0x1p-112f, vl);
+            const vfloat32m4_t limit = __riscv_vreinterpret_v_u32m4_f32m4(
+                    __riscv_vmv_v_x_u32m4((31u << 23) - 0x1000u, vl));
+            scaled = __riscv_vfmin_vv_f32m4(scaled, limit, vl);
+            const vuint32m4_t rounded = __riscv_vadd_vx_u32m4(
+                    __riscv_vreinterpret_v_f32m4_u32m4(scaled), 0x1000u, vl);
+            vuint16m2_t result = __riscv_vnsrl_wx_u16m2(rounded, 13, vl);
+            const vuint16m2_t sign = __riscv_vand_vx_u16m2(
+                    __riscv_vnsrl_wx_u16m2(bits, 16, vl), 0x8000u, vl);
+            result = __riscv_vor_vv_u16m2(result, sign, vl);
+            __riscv_vse16_v_u16m2(dst + i, result, vl);
+            i += vl;
+        }
+    }
 };
 
 template <>

--- a/tests/test_scalar_quantizer.cpp
+++ b/tests/test_scalar_quantizer.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <bit>
 #include <cmath>
 #include <cstring>
 #include <memory>
@@ -304,6 +305,83 @@ void check_eden_roundtrip(
 }
 
 } // namespace
+
+namespace {
+
+void expect_rvv_fp16_codes(const std::vector<float>& values) {
+    for (size_t d : {0, 1, 15, 16, 17, 31, 32, 33, 65}) {
+        SCOPED_TRACE(d);
+        const size_t n = 3;
+        std::vector<float> input(d * n + 1);
+        for (size_t i = 0; i < d * n; ++i) {
+            input[i] = values[i % values.size()];
+        }
+        std::vector<uint16_t> expected(d * n + 16, 0xa55a);
+        std::vector<uint16_t> actual = expected;
+        faiss::scalar_quantizer::QuantizerFP16<faiss::SIMDLevel::NONE> scalar(
+                d, {});
+        for (size_t i = 0; i < n; ++i) {
+            scalar.encode_vector(
+                    input.data() + i * d,
+                    reinterpret_cast<uint8_t*>(expected.data() + 8 + i * d));
+        }
+        faiss::ScalarQuantizer sq(d, faiss::ScalarQuantizer::QT_fp16);
+        sq.compute_codes(
+                input.data(), reinterpret_cast<uint8_t*>(actual.data() + 8), n);
+        EXPECT_EQ(actual, expected);
+    }
+}
+
+} // namespace
+
+TEST(ScalarQuantizer, RVVFP16FiniteEncodingMatchesScalar) {
+    if (!faiss::SIMDConfig::is_simd_level_available(
+                faiss::SIMDLevel::RISCV_RVV)) {
+        GTEST_SKIP() << "RVV is not available";
+    }
+    ScopedSIMDLevel scoped(faiss::SIMDLevel::RISCV_RVV);
+    // Keep finite inputs separate so a NaN/Inf fallback cannot hide a bug
+    // in the vector path. Include ties, subnormals and overflow boundaries.
+    std::vector<float> values;
+    for (uint32_t bits :
+         {0u,
+          1u,
+          0x007fffffu,
+          0x00800000u,
+          0x33000000u,
+          0x33800000u,
+          0x387fc000u,
+          0x38800000u,
+          0x3f801000u,
+          0x3f803000u,
+          0x477fe000u,
+          0x477ff000u,
+          0x47800000u,
+          0x7f7fffffu}) {
+        values.push_back(std::bit_cast<float>(bits));
+        values.push_back(std::bit_cast<float>(bits | 0x80000000u));
+    }
+    expect_rvv_fp16_codes(values);
+}
+
+TEST(ScalarQuantizer, RVVFP16NonFiniteEncodingMatchesScalar) {
+    if (!faiss::SIMDConfig::is_simd_level_available(
+                faiss::SIMDLevel::RISCV_RVV)) {
+        GTEST_SKIP() << "RVV is not available";
+    }
+    ScopedSIMDLevel scoped(faiss::SIMDLevel::RISCV_RVV);
+    std::vector<float> values = {1.0f, -0.0f, 0.25f};
+    for (uint32_t bits :
+         {0x7f800000u,
+          0xff800000u,
+          0x7fc12345u,
+          0xffc12345u,
+          0x7f800001u,
+          0xff800001u}) {
+        values.push_back(std::bit_cast<float>(bits));
+    }
+    expect_rvv_fp16_codes(values);
+}
 
 TEST(ScalarQuantizer, RSQuantilesClamping) {
     int d = 8;


### PR DESCRIPTION
RVV `QT_fp16` currently inherits scalar encoding. This adds an RVV encoder while preserving the generic codec's byte representation, including its rounding behavior.

The generic codec uses ryg's scale-and-round conversion, whose halfway behavior differs from a direct IEEE round-to-nearest-even FP16 conversion. The vector path mirrors its mask, scale, clamp, bias, and sign operations. Chunks containing NaN or infinity use the scalar codec. The generic encoder becomes overridable so the RVV specialization can provide this implementation.

The new regression tests compare encoded bytes with the generic codec for finite values and, separately, for NaN/Inf inputs. Keeping these corpora separate exercises the vector path without allowing special-value fallback to hide an error. Tests include ties, subnormals, overflow boundaries, short tails, and output guards. This PR is independent of the other RVV encoding/distance changes.

### Performance

Measured on a native SG2044 RISC-V host (VLEN=128), GCC 15.1, Release `-O3`, dynamic dispatch (`FAISS_OPT_LEVEL=dd`), `rv64gcv_zvfhmin/lp64d`, one thread pinned to CPU 2. The baseline is official commit `80a16564f86530dbf0bfaf96c2b71feffeb5093f`; the candidate is that same baseline plus only this kernel change. These measurements were not collected on the newer PR base `2ed4c106e9fb9686e7727e5daf8ad6ad1e164109`. The affected scalar-quantizer source files are unchanged between those bases, and the submitted kernel differs from the measured one only in comments/formatting.

| Public path | Dimension | Baseline ns/element | Candidate ns/element | Paired speedup | 95% interval |
|---|---:|---:|---:|---:|---:|
| FP16 encode | 16 | 4.714 | 2.283 | 2.014x | [1.966, 2.089] |
| FP16 encode | 32 | 4.151 | 1.776 | 2.302x | [1.802, 2.346] |
| FP16 encode | 128 | 3.929 | 1.450 | 2.697x | [1.998, 2.712] |
| FP16 encode | 768 | 3.620 | 1.556 | 2.322x | [2.272, 2.380] |

Geometric mean of the dimension-specific speedups at d=32/128/768: FP16 encode **2.434x**.

There are three consecutive sessions, each with four alternating ABBA/BAAB blocks per dimension/path: **48 paired blocks** for this candidate. A is the baseline and B is the candidate. Each call is calibrated to at least 0.1 s (the shortest formal call in the full campaign was 0.192 s), with three warm-up batches and `n = max(32, floor(32768/d))`. Each block uses the ratio of the two-call geometric mean times. Reported speedup is the median of the three session medians; intervals use 5,000 hierarchical bootstrap resamples, resampling sessions and then blocks within each ABBA/BAAB order stratum. The timing columns are separate medians, so their quotient need not equal the paired speedup. All 48 paired blocks favored this candidate.

The timed operation is public `ScalarQuantizer::compute_codes`, using fixed-seed (718) finite input batches. FP16 input values are `float(int(rng()%100000)-50000)/113.f`.

Variability is material at d=32/128: paired-ratio CV is 13.25%/13.47%, and ABBA-vs-BAAB order gaps are 13.46%/4.80%. The d=32/128/768 geometric mean for the individual sessions is 2.419x, 2.040x, and 2.463x. The aggregate 2.434x should therefore not be interpreted as a stable per-run guarantee.

These results describe public encoding/distance throughput on one non-exclusive host, not end-to-end ANN search speedup. The intervals describe these sessions only, with no multiple-comparison correction; they do not establish portability across machines or vector lengths.

### Validation

- Native public encoding oracle: **11,564,775** input elements across the five RISC-V rounding modes; zero differing output bytes or write-guard failures. The corpus covers FP16 values and neighboring floats, ties, subnormals, overflow, signed zeros, and NaN payloads. FP exception flags were recorded, not asserted equivalent.
- Original benchmark baseline full C++ suite: **273 passed, 7 skipped, 0 failed**.
- Submission version on `2ed4c106e9fb9686e7727e5daf8ad6ad1e164109`: all three independent candidate builds succeeded; this PR's focused C++ suite (`NONE`: 11 passed, 6 skipped, 0 failed; `RISCV_RVV`: 13 passed, 4 skipped, 0 failed) and the public-path oracle above pass on native RISC-V. The newly added RVV regression tests are executed and passed in the RVV run, and skipped when RVV is disabled in the NONE run.
- All touched C++ files pass clang-format 21.1.8; `git diff --check` clean.
