### PR TITLE
Forward quantizer_params to the coarse quantizer in the IVF helper APIs

### DIFF
--- a/faiss/IndexIVF.cpp
+++ b/faiss/IndexIVF.cpp
@@ -1160,7 +1160,13 @@ void IndexIVF::search_and_reconstruct(
     std::unique_ptr<idx_t[]> idx(new idx_t[n * cur_nprobe]);
     std::unique_ptr<float[]> coarse_dis(new float[n * cur_nprobe]);
 
-    quantizer->search(n, x, cur_nprobe, coarse_dis.get(), idx.get());
+    quantizer->search(
+            n,
+            x,
+            cur_nprobe,
+            coarse_dis.get(),
+            idx.get(),
+            params ? params->quantizer_params : nullptr);
 
     invlists->prefetch_lists(idx.get(), static_cast<int>(n * cur_nprobe));
 
@@ -1216,7 +1222,13 @@ void IndexIVF::search_and_return_codes(
     std::unique_ptr<idx_t[]> idx(new idx_t[n * cur_nprobe]);
     std::unique_ptr<float[]> coarse_dis(new float[n * cur_nprobe]);
 
-    quantizer->search(n, x, cur_nprobe, coarse_dis.get(), idx.get());
+    quantizer->search(
+            n,
+            x,
+            cur_nprobe,
+            coarse_dis.get(),
+            idx.get(),
+            params ? params->quantizer_params : nullptr);
 
     invlists->prefetch_lists(idx.get(), static_cast<int>(n * cur_nprobe));
 

--- a/tests/test_ivf_index.cpp
+++ b/tests/test_ivf_index.cpp
@@ -19,7 +19,9 @@
 #include <faiss/IndexIVFFlat.h>
 #include <faiss/impl/AuxIndexStructures.h>
 #include <faiss/impl/FaissAssert.h>
+#include <faiss/impl/HNSW.h>
 #include <faiss/impl/ResultHandler.h>
+#include <faiss/index_factory.h>
 
 namespace {
 
@@ -510,4 +512,82 @@ TEST(IVF, search_callbacks) {
             << "on_heap_changed should fire when vectors enter the heap";
     EXPECT_GE(distance_count, heap_count)
             << "not every distance computation leads to a heap change";
+}
+
+// Test: search, search_and_reconstruct, and search_and_return_codes must
+// return the same neighbors when given the same SearchParametersIVF with a
+// nested quantizer_params, on an IVF index with an HNSW coarse quantizer
+// whose result is sensitive to efSearch. The two helper methods searched
+// the coarse quantizer without forwarding quantizer_params, so at a low
+// efSearch they silently used the class-level (higher) efSearch instead
+// and could return a different neighbor than search() for the same params
+// object. d/nt/nb/nq/nlist/efSearch mirror
+// TestSearchParams.test_quantizer_hnsw in tests/test_search_params.py,
+// which already establishes in CI that this combination reliably changes
+// the result relative to the class-level default.
+TEST(IVF, quantizer_params_consistent_across_helpers) {
+    constexpr int d = 32;
+    constexpr int nlist = 200;
+    constexpr int nt = 1000;
+    constexpr int nb = 100;
+    constexpr int nq = 20;
+    constexpr int k = 10;
+
+    std::mt19937 rng(123);
+    std::uniform_real_distribution<float> distrib;
+
+    std::vector<float> xt(nt * d);
+    for (float& v : xt) {
+        v = distrib(rng);
+    }
+    std::vector<float> xb(nb * d);
+    for (float& v : xb) {
+        v = distrib(rng);
+    }
+    std::vector<float> xq(nq * d);
+    for (float& v : xq) {
+        v = distrib(rng);
+    }
+
+    std::unique_ptr<faiss::IndexIVF> index(dynamic_cast<faiss::IndexIVF*>(
+            faiss::index_factory(d, "IVF200_HNSW,Flat")));
+    ASSERT_TRUE(index != nullptr)
+            << "IVF200_HNSW,Flat did not build an IndexIVF";
+
+    index->train(nt, xt.data());
+    index->add(nb, xb.data());
+
+    faiss::SearchParametersHNSW quantizer_params;
+    quantizer_params.efSearch = 5;
+
+    faiss::SearchParametersIVF params;
+    params.nprobe = 10;
+    params.quantizer_params = &quantizer_params;
+
+    std::vector<float> Dref(nq * k);
+    std::vector<faiss::idx_t> Iref(nq * k);
+    index->search(nq, xq.data(), k, Dref.data(), Iref.data(), &params);
+
+    std::vector<float> Drec(nq * k);
+    std::vector<faiss::idx_t> Irec(nq * k);
+    std::vector<float> recons(nq * k * d);
+    index->search_and_reconstruct(
+            nq, xq.data(), k, Drec.data(), Irec.data(), recons.data(), &params);
+    EXPECT_EQ(Iref, Irec);
+    EXPECT_EQ(Dref, Drec);
+
+    std::vector<float> Dcodes(nq * k);
+    std::vector<faiss::idx_t> Icodes(nq * k);
+    std::vector<uint8_t> codes(nq * k * index->code_size);
+    index->search_and_return_codes(
+            nq,
+            xq.data(),
+            k,
+            Dcodes.data(),
+            Icodes.data(),
+            codes.data(),
+            false,
+            &params);
+    EXPECT_EQ(Iref, Icodes);
+    EXPECT_EQ(Dref, Dcodes);
 }


### PR DESCRIPTION
## Summary

Fixes #5589.

`search_and_reconstruct` and `search_and_return_codes` both `dynamic_cast` their params into an `IVFSearchParameters`, the same way `search` does, but never read `params->quantizer_params` out of it before calling `quantizer->search(...)`:

```cpp
const IVFSearchParameters* params = nullptr;
if (params_in) {
    params = dynamic_cast<const IVFSearchParameters*>(params_in);
    FAISS_THROW_IF_NOT_MSG(params, "IndexIVF params have incorrect type");
}
...
quantizer->search(n, x, cur_nprobe, coarse_dis.get(), idx.get());
```

`quantizer->search`'s sixth argument defaults to `nullptr` when omitted, so this compiles silently and, on a flat coarse quantizer, is invisible: `nullptr` behaves the same as no override. On an HNSW coarse quantizer it isn't invisible: these two APIs always search it with the class-level `efSearch`, ignoring whatever `quantizer_params` the caller passed, while `search` on the same index with the same params object honors it.

Three other call sites in this file already do this correctly (the main `search`, `range_search`, and `search1`), each deriving a `quantizer_params` local from the same cast and forwarding it. This makes the two holdouts do the same, passing `params ? params->quantizer_params : nullptr`.

## Testing

Added `IVF.quantizer_params_consistent_across_helpers` to `tests/test_ivf_index.cpp`. It builds an `IVF200_HNSW,Flat` index and calls `search`, `search_and_reconstruct`, and `search_and_return_codes` with the same `SearchParametersIVF` (nested `SearchParametersHNSW{efSearch=5}`), asserting all three return identical labels and distances.

The d/nt/nb/nq/nlist/efSearch values mirror `TestSearchParams.test_quantizer_hnsw` in `tests/test_search_params.py`, which already establishes in CI that this exact combination changes the result relative to the class-level default (`assertFalse(np.all(Inew == I0))`), so the divergence this test relies on isn't a new claim.

Verified with a negative control: reverting only the two call sites and rebuilding, the new test fails on all four assertions (`Iref`/`Irec` labels, `Dref`/`Drec` distances, and the same pair for `Icodes`/`Dcodes`), while every other `IVF.*` test is unaffected. Restoring the fix passes all 7.

I wrote this as a C++ test rather than adding to `tests/test_search_params.py`, which is where `test_quantizer_hnsw` lives and where a maintainer might otherwise expect this. I don't have a working SWIG/Python build available to actually run a Python test locally, and would rather ship a test I've verified than one I'm asking you to trust untested. The fix itself doesn't depend on this either way; happy to add the Python-side test too if you'd prefer it there.

Built and tested locally on Windows with MSVC 19.44 and OpenBLAS.
