### PR TITLE
fix: clear duplicate mappings when resetting IndexIVFFlatDedup

### DIFF
--- a/faiss/IndexIVFFlat.cpp
+++ b/faiss/IndexIVFFlat.cpp
@@ -212,6 +212,11 @@ void IndexIVFFlatDedup::train(idx_t n, const float* x) {
     IndexIVFFlat::train(n2, x2.get());
 }
 
+void IndexIVFFlatDedup::reset() {
+    IndexIVFFlat::reset();
+    instances.clear();
+}
+
 void IndexIVFFlatDedup::add_with_ids(
         idx_t na,
         const float* x,

--- a/faiss/IndexIVFFlat.h
+++ b/faiss/IndexIVFFlat.h
@@ -110,6 +110,8 @@ struct IndexIVFFlatDedup : IndexIVFFlat {
     /// also dedups the training set
     void train(idx_t n, const float* x) override;
 
+    void reset() override;
+
     /// implemented for all IndexIVF* classes
     void add_with_ids(idx_t n, const float* x, const idx_t* xids) override;
 

--- a/tests/test_ivf_index.cpp
+++ b/tests/test_ivf_index.cpp
@@ -148,6 +148,54 @@ class TestInvertedLists : public faiss::InvertedLists {
 };
 } // namespace
 
+TEST(IVF, dedup_reset) {
+    const float vectors[] = {0.0f, 0.0f};
+    const faiss::idx_t ids[] = {403, 404};
+    faiss::IndexFlatL2 quantizer(1);
+    quantizer.add(1, vectors);
+    faiss::IndexIVFFlatDedup index(&quantizer, 1, 1);
+    ASSERT_TRUE(index.is_trained);
+
+    index.add_with_ids(2, vectors, ids);
+    ASSERT_EQ(index.ntotal, 2);
+    float distances[3];
+    faiss::idx_t labels[3];
+    index.search(1, vectors, 2, distances, labels);
+    EXPECT_EQ(
+            (std::set<faiss::idx_t>{403, 404}),
+            (std::set<faiss::idx_t>(labels, labels + 2)));
+
+    // Reset must remove logical duplicates as well as physical entries.
+    index.reset();
+    EXPECT_EQ(index.ntotal, 0);
+    EXPECT_TRUE(index.is_trained);
+    EXPECT_EQ(quantizer.ntotal, 1);
+    index.search(1, vectors, 2, distances, labels);
+    EXPECT_EQ(labels[0], -1);
+    EXPECT_EQ(labels[1], -1);
+    index.reset();
+    EXPECT_EQ(index.ntotal, 0);
+
+    // Reusing the representative ID must not revive its old duplicate.
+    index.add_with_ids(1, vectors, ids);
+    EXPECT_EQ(index.ntotal, 1);
+    index.search(1, vectors, 2, distances, labels);
+    EXPECT_EQ(labels[0], 403);
+    EXPECT_EQ(labels[1], -1);
+    EXPECT_FLOAT_EQ(distances[0], 0.0f);
+
+    // New duplicates must still be returned after reset.
+    const faiss::idx_t new_id = 405;
+    index.add_with_ids(1, vectors, &new_id);
+    EXPECT_EQ(index.ntotal, 2);
+    index.search(1, vectors, 3, distances, labels);
+    EXPECT_EQ(
+            (std::set<faiss::idx_t>{-1, 403, 405}),
+            (std::set<faiss::idx_t>(labels, labels + 3)));
+    EXPECT_FLOAT_EQ(distances[0], 0.0f);
+    EXPECT_FLOAT_EQ(distances[1], 0.0f);
+}
+
 TEST(IVF, list_context) {
     // this test verifies that the context object is passed
     // to the InvertedListsIterator and InvertedLists::add_entry.


### PR DESCRIPTION
## Summary

After `IndexIVFFlatDedup.reset()`, reusing a representative ID can make an old duplicate ID searchable again. For example, adding identical vectors as IDs `403` and `404`, resetting, and adding only `403` returns `[403, 404]` even though `ntotal` is 1. The inherited reset clears the inverted lists and `ntotal` but leaves `instances` populated.

Override `reset()` to run the existing IVF reset and clear `instances`. The same search then returns `[403, -1]`. The regression also checks an empty search after reset, repeated reset, preserved trained state (`is_trained` and the quantizer), and adding a new duplicate after reset.

Fixes #5580. Thanks to @leemeii for the reproduction.

## Validation

- Reproduced the stale `404` result with the new C++ regression linked against unmodified `main` (`2ed4c106e9fb9686e7727e5daf8ad6ad1e164109`).
- Built the repository's `faiss_test` target with CMake/Ninja on Linux, CPU-only with generic optimization.
- `OMP_NUM_THREADS=2 ctest --test-dir build -R '^IVF\.' --output-on-failure --timeout 60`: all 7 tests passed, covering the complete `test_ivf_index.cpp` module.
- Changed-lines check with clang-format 21.1.8 and `git diff --check` passed.

Python/GPU tests and Meta's internal test suite were not run.
