### PR TITLE
Fix IVF factory leak

### DIFF
--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -374,7 +374,9 @@ IndexIVF* parse_IndexIVF(
     auto match = [&sm, &code_string](const std::string pattern) {
         return re_match(code_string, pattern, sm);
     };
-    auto get_q = [&quantizer] { return quantizer.release(); };
+    // we cannot release the quantizer until we know no error happens and destroys the owning
+    // index since in this path the index does not own quantizer
+    auto get_q = [&quantizer] { return quantizer.get(); };
     int d = quantizer->d;
 
     if (match("Flat")) {
@@ -1207,7 +1209,8 @@ std::unique_ptr<Index> index_factory_sub(
                         description.c_str());
                 int M = std::stoi(sm[1].str()), nbit = mres_to_int(sm[2], 8, 1);
                 Index2Layer* index_2l =
-                        new Index2Layer(quantizer.release(), nlist, M, nbit);
+                        new Index2Layer(quantizer.get(), nlist, M, nbit);
+                (void)quantizer.release(); // now owned by index_2l
                 index_2l->q1.own_fields = true;
                 index_2l->q1.quantizer_trains_alone =
                         get_trains_alone(index_2l->q1.quantizer);
@@ -1222,6 +1225,7 @@ std::unique_ptr<Index> index_factory_sub(
                     "could not parse code description %s in %s",
                     code_description.c_str(),
                     description.c_str());
+            (void)quantizer.release(); // now owned by index_ivf
             return std::unique_ptr<Index>(fix_ivf_fields(index_ivf));
         }
     }

--- a/faiss/index_factory.cpp
+++ b/faiss/index_factory.cpp
@@ -374,8 +374,9 @@ IndexIVF* parse_IndexIVF(
     auto match = [&sm, &code_string](const std::string pattern) {
         return re_match(code_string, pattern, sm);
     };
-    // we cannot release the quantizer until we know no error happens and destroys the owning
-    // index since in this path the index does not own quantizer
+    // we cannot release the quantizer until we know no error happens and
+    // destroys the owning index since in this path the index does not own
+    // quantizer
     auto get_q = [&quantizer] { return quantizer.get(); };
     int d = quantizer->d;
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -381,3 +381,16 @@ class TestIVFSpectralHashOwnership(unittest.TestCase):
         index.replace_vt(faiss.ITQTransform(10, 10))
         gc.collect()
         index.vt.d_out  # this should not crash
+
+
+class TestFactoryConstructorFailure(unittest.TestCase):
+    def test_ivf_pq_invalid_M(self):
+        # d = 8 is not divisible by M = 3, PQ throws
+        self.assertRaises(RuntimeError, faiss.index_factory, 8, "IVF4,PQ3")
+
+    def test_ivf_unknown_code(self):
+        self.assertRaises(RuntimeError, faiss.index_factory, 8, "IVF4,XYZ")
+
+    def test_2layer_invalid_M(self):
+        self.assertRaises(RuntimeError, faiss.index_factory, 8, "Residual4,PQ3")
+


### PR DESCRIPTION
The alubsan leak happens when we have constructed the IVF,PQ3 with the broken quantization and the quantizer get released, and then the IVF construction throws and does not clean up the quantizer. The leak looks like this:
```
==88601==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 128 byte(s) in 1 object(s) allocated from:
    #0 0x74b254616222 in operator new(unsigned long) ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:248
    #1 0x588a0cf4c4d7 in faiss::(anonymous namespace)::parse_coarse_quantizer(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, faiss::MetricType, std::vector<std::unique_ptr<faiss::Index, std::default_delete<faiss::Index> >, std::allocator<std::unique_ptr<faiss::Index, std::default_delete<faiss::Index> > > >&, unsigned long&, bool&) [clone .isra.0] (/home/jbajic/Projects/faiss/ivf_quantizer_leak+0xac4d7) (BuildId: 45a0934ffe20c59ae7f414fa8f8845dcec85cc8b)
    #2 0x588a0cf55524 in faiss::(anonymous namespace)::index_factory_sub(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, faiss::MetricType, bool) (/home/jbajic/Projects/faiss/ivf_quantizer_leak+0xb5524) (BuildId: 45a0934ffe20c59ae7f414fa8f8845dcec85cc8b)
    #3 0x588a0cf5618a in faiss::index_factory(int, char const*, faiss::MetricType, bool) (/home/jbajic/Projects/faiss/ivf_quantizer_leak+0xb618a) (BuildId: 45a0934ffe20c59ae7f414fa8f8845dcec85cc8b)

SUMMARY: LeakSanitizer: 128 byte(s) leaked in 1 allocation(s).
```

And it can be reproduced with this example:
```c++
#include <faiss/impl/FaissException.h>
#include <faiss/index_factory.h>
#include <cstdio>

int main() {
    try {
        delete faiss::index_factory(8, "IVF4,PQ3");
    } catch (faiss::FaissException const& e) {
        fprintf(stderr, "threw: %s\n", e.what());
    }
}
```
and run with this: `g++ -std=c++17 -g -fsanitize=leak -I. ivf_quantizer_leak.cpp  build/faiss/libfaiss.a -llapack -lblas -fopenmp -o ivf_quantizer_leak && ./ivf_quantizer_leak`