### PR TITLE
Fix IndexFastScan merge_from add_id

### DIFF
--- a/faiss/IndexFastScan.cpp
+++ b/faiss/IndexFastScan.cpp
@@ -150,7 +150,8 @@ void IndexFastScan::check_compatible_for_merge(const Index& otherIndex) const {
             "can only merge indexes of the same type");
 }
 
-void IndexFastScan::merge_from(Index& otherIndex, idx_t /*add_id*/) {
+void IndexFastScan::merge_from(Index& otherIndex, idx_t add_id) {
+    FAISS_THROW_IF_NOT_MSG(add_id == 0, "cannot set ids in FastScan index");
     check_compatible_for_merge(otherIndex);
     IndexFastScan* other = static_cast<IndexFastScan*>(&otherIndex);
     ntotal2 = roundup(ntotal + other->ntotal, bbs);

--- a/tests/test_merge_index.py
+++ b/tests/test_merge_index.py
@@ -216,6 +216,16 @@ class TestMerge2(unittest.TestCase):
     def test_merge_IndexFastScan_even_M(self):
         self.do_fast_scan_test("PQ10x4fs", 500)
 
+    def test_merge_IndexFastScan_rejects_add_id(self):
+        self.assertRaisesRegex(
+            RuntimeError,
+            ".*cannot set ids in FastScan index.*",
+            self.do_fast_scan_test,
+            "PQ5x4fs",
+            320,
+            True,
+        )
+
     def test_merge_IndexAdditiveQuantizerFastScan(self):
         self.do_fast_scan_test("RQ10x4fs_32_Nrq2x4", 330)
 


### PR DESCRIPTION
Fixes #5590

`IndexFastScan` uses implicit sequential IDs and cannot represent a non-zero
ID offset. Previously, `merge_from` accepted `add_id` but ignored it, silently
returning incorrect labels after a merge.

Reject non-zero `add_id` explicitly, matching `IndexFlatCodes` behaviour, and
add a regression test.

Tests run:
- `TestMerge2.test_merge_IndexFastScan_rejects_add_id`
- `TestMerge2.test_merge_IndexFastScan_complete_block`