### PR TITLE
Fix IndexFastScan::reset() leaving stale ntotal2 (crash on search)

### DIFF
--- a/faiss/IndexFastScan.cpp
+++ b/faiss/IndexFastScan.cpp
@@ -55,7 +55,7 @@ IndexFastScan::IndexFastScan()
 
 void IndexFastScan::reset() {
     codes.resize(0);
-    ntotal = 0;
+    ntotal = ntotal2 = 0;
 }
 
 void IndexFastScan::add(idx_t n, const float* x) {

--- a/tests/test_fast_scan.py
+++ b/tests/test_fast_scan.py
@@ -546,6 +546,25 @@ class TestAdd(unittest.TestCase):
         np.testing.assert_array_equal(D3, Dnew)
         np.testing.assert_array_equal(I3, Inew)
 
+    def test_reset(self):
+        # regression for #5591: reset() must clear ntotal2 (the bbs-padded
+        # scan count), not just ntotal. Otherwise a search after reset scans
+        # ntotal2/bbs blocks over the freed (empty) code buffer -> SIGSEGV.
+        d = 32
+        ds = datasets.SyntheticDataset(d, 2000, 5000, 200)
+
+        index = faiss.IndexPQFastScan(d, d // 2, 4)
+        index.train(ds.get_train())
+        index.add(ds.get_database())
+
+        index.reset()
+        self.assertEqual(index.ntotal, 0)
+        self.assertEqual(index.ntotal2, 0)
+
+        # searching the empty index must be safe and return the -1 sentinel
+        D, I = index.search(ds.get_queries(), 10)
+        np.testing.assert_array_equal(I, -1)
+
 
 class TestAQFastScan(unittest.TestCase):
 


### PR DESCRIPTION
reset() cleared ntotal and the codes buffer but left ntotal2 (the bbs-padded scan count) unchanged. A search after reset then scans ntotal2/bbs blocks over the freed, empty code buffer, dereferencing a null pointer in the SIMD kernel and crashing with SIGSEGV (Fixes #5591).

Clear ntotal2 in reset() too, matching init_fastscan(). This covers all flat FastScan indexes (PQ/AQ/RaBitQ), which share this reset().

Add test_reset reproducing train -> add -> reset -> search: it checks ntotal2 == 0 after reset and that searching the emptied index is safe and returns the -1 sentinel.