### PR TITLE
Fix IndexIDMap2::reset() leaving stale rev_map entries

### DIFF
--- a/faiss/IndexIDMap.cpp
+++ b/faiss/IndexIDMap.cpp
@@ -377,6 +377,12 @@ void IndexIDMap2Template<IndexT>::construct_rev_map() {
 }
 
 template <typename IndexT>
+void IndexIDMap2Template<IndexT>::reset() {
+    IndexIDMapTemplate<IndexT>::reset();
+    rev_map.clear();
+}
+
+template <typename IndexT>
 size_t IndexIDMap2Template<IndexT>::remove_ids(const IDSelector& sel) {
     // This is quite inefficient
     size_t nremove = IndexIDMapTemplate<IndexT>::remove_ids(sel);

--- a/faiss/IndexIDMap.h
+++ b/faiss/IndexIDMap.h
@@ -102,6 +102,8 @@ struct IndexIDMap2Template : IndexIDMapTemplate<IndexT> {
     /// make the rev_map from scratch
     void construct_rev_map();
 
+    void reset() override;
+
     void add_with_ids(idx_t n, const component_t* x, const idx_t* xids)
             override;
     void add_with_ids_ex(

--- a/tests/test_index_composite.py
+++ b/tests/test_index_composite.py
@@ -139,6 +139,38 @@ class TestRemove(unittest.TestCase):
         else:
             raise AssertionError("should have raised an exception")
 
+    def test_reset_id_map(self):
+        # regression for #5578: IndexIDMap2.reset() must also clear rev_map,
+        # otherwise old external IDs stay reconstructable and
+        # check_consistency() fails after a subsequent add.
+        index = faiss.IndexIDMap2(faiss.IndexFlatL2(2))
+        index.add_with_ids(
+            np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float32"),
+            np.array([10, 20], dtype="int64"),
+        )
+
+        index.reset()
+        self.assertEqual(index.ntotal, 0)
+
+        index.add_with_ids(
+            np.array([[9.0, 9.0]], dtype="float32"),
+            np.array([30], dtype="int64"),
+        )
+
+        # the reset IDs must no longer resolve
+        try:
+            index.reconstruct(10)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("should have raised an exception")
+
+        # the newly added ID must reconstruct correctly
+        np.testing.assert_array_equal(index.reconstruct(30), [9.0, 9.0])
+
+        # rev_map and id_map must be back in sync
+        index.check_consistency()
+
     def test_factory_idmap2_suffix(self):
         xb = np.zeros((10, 5), dtype="float32")
         xb[:, 0] = np.arange(10) + 1000


### PR DESCRIPTION
IndexIDMap2Template inherited IndexIDMapTemplate::reset(), which clears the sub-index, id_map and ntotal but not the rev_map. After reset() and a re-add with new IDs, the stale rev_map entries made removed external IDs still reconstructable (resolving to unrelated new vectors), and check_consistency() failed because rev_map.size() != id_map.size() (Fixes #5578).

Override reset() in IndexIDMap2Template to clear rev_map after the base reset(). This covers both IndexIDMap2 and IndexBinaryIDMap2.

Add test_reset_id_map: after reset() and re-add, a removed ID no longer reconstructs, the new ID reconstructs correctly, and check_consistency() passes.