### PR TITLE
Route Flat/RCQ sgemm_ through cblas_sgemm to reach OpenBLAS SME (opt-in)

### DIFF
--- a/faiss/utils/distances.cpp
+++ b/faiss/utils/distances.cpp
@@ -49,7 +49,70 @@ int sgemm_(
         float* beta,
         float* c,
         FINTEGER* ldc);
+
+#ifdef FAISS_SME_CBLAS_SGEMM
+void cblas_sgemm(
+        int Order,
+        int TransA,
+        int TransB,
+        int M,
+        int N,
+        int K,
+        float alpha,
+        const float* A,
+        int lda,
+        const float* B,
+        int ldb,
+        float beta,
+        float* C,
+        int ldc);
+#endif
 }
+
+#ifdef FAISS_SME_CBLAS_SGEMM
+namespace {
+
+constexpr int kCblasRowMajor = 101;
+constexpr int kCblasNoTrans = 111;
+
+void sme_cblas_sgemm_tn(
+        FINTEGER M,
+        FINTEGER N,
+        FINTEGER K,
+        float alpha,
+        const float* A,
+        FINTEGER ldA,
+        const float* B,
+        FINTEGER ldB,
+        float beta,
+        float* C,
+        FINTEGER ldC) {
+    std::vector<float> At((size_t)K * (size_t)M);
+    for (FINTEGER i = 0; i < M; i++) {
+        const float* row = A + (size_t)i * (size_t)ldA;
+        for (FINTEGER l = 0; l < K; l++) {
+            At[(size_t)l * (size_t)M + i] = row[l];
+        }
+    }
+    cblas_sgemm(
+            kCblasRowMajor,
+            kCblasNoTrans,
+            kCblasNoTrans,
+            (int)N,
+            (int)M,
+            (int)K,
+            alpha,
+            B,
+            (int)ldB,
+            At.data(),
+            (int)M,
+            beta,
+            C,
+            (int)ldC);
+}
+
+} // namespace
+#endif
 
 namespace faiss {
 
@@ -397,6 +460,20 @@ void exhaustive_inner_product_blas(
             {
                 float one = 1, zero = 0;
                 FINTEGER nyi = j1 - j0, nxi = i1 - i0, di = d;
+#ifdef FAISS_SME_CBLAS_SGEMM
+                sme_cblas_sgemm_tn(
+                        nyi,
+                        nxi,
+                        di,
+                        one,
+                        y + j0 * d,
+                        di,
+                        x + i0 * d,
+                        di,
+                        zero,
+                        ip_block.get(),
+                        nyi);
+#else
                 sgemm_("Transpose",
                        "Not transpose",
                        &nyi,
@@ -410,6 +487,7 @@ void exhaustive_inner_product_blas(
                        &zero,
                        ip_block.get(),
                        &nyi);
+#endif
             }
 
             res.add_results(j0, j1, ip_block.get());

--- a/faiss/utils/simd_impl/distances_arm_sve.cpp
+++ b/faiss/utils/simd_impl/distances_arm_sve.cpp
@@ -7,6 +7,8 @@
 
 #include <arm_sve.h>
 
+#include <vector>
+
 #include <faiss/utils/distances.h>
 
 #include <faiss/impl/AuxIndexStructures.h>
@@ -34,7 +36,70 @@ int sgemm_(
         float* beta,
         float* c,
         FINTEGER* ldc);
+
+#ifdef FAISS_SME_CBLAS_SGEMM
+void cblas_sgemm(
+        int Order,
+        int TransA,
+        int TransB,
+        int M,
+        int N,
+        int K,
+        float alpha,
+        const float* A,
+        int lda,
+        const float* B,
+        int ldb,
+        float beta,
+        float* C,
+        int ldc);
+#endif
 }
+
+#ifdef FAISS_SME_CBLAS_SGEMM
+namespace {
+
+constexpr int kCblasRowMajor = 101;
+constexpr int kCblasNoTrans = 111;
+
+void sme_cblas_sgemm_tn(
+        FINTEGER M,
+        FINTEGER N,
+        FINTEGER K,
+        float alpha,
+        const float* A,
+        FINTEGER ldA,
+        const float* B,
+        FINTEGER ldB,
+        float beta,
+        float* C,
+        FINTEGER ldC) {
+    std::vector<float> At((size_t)K * (size_t)M);
+    for (FINTEGER i = 0; i < M; i++) {
+        const float* row = A + (size_t)i * (size_t)ldA;
+        for (FINTEGER l = 0; l < K; l++) {
+            At[(size_t)l * (size_t)M + i] = row[l];
+        }
+    }
+    cblas_sgemm(
+            kCblasRowMajor,
+            kCblasNoTrans,
+            kCblasNoTrans,
+            (int)N,
+            (int)M,
+            (int)K,
+            alpha,
+            B,
+            (int)ldB,
+            At.data(),
+            (int)M,
+            beta,
+            C,
+            (int)ldC);
+}
+
+} // namespace
+#endif
 
 #define THE_SIMD_LEVEL SIMDLevel::ARM_SVE
 #include <faiss/utils/simd_impl/distances_autovec-inl.h>
@@ -805,6 +870,20 @@ void exhaustive_L2sqr_blas_cmax<SIMDLevel::ARM_SVE>(
             {
                 float one = 1, zero = 0;
                 FINTEGER nyi = j1 - j0, nxi = i1 - i0, di = d;
+#ifdef FAISS_SME_CBLAS_SGEMM
+                sme_cblas_sgemm_tn(
+                        nyi,
+                        nxi,
+                        di,
+                        one,
+                        y + j0 * d,
+                        di,
+                        x + i0 * d,
+                        di,
+                        zero,
+                        ip_block.get(),
+                        nyi);
+#else
                 sgemm_("Transpose",
                        "Not transpose",
                        &nyi,
@@ -818,6 +897,7 @@ void exhaustive_L2sqr_blas_cmax<SIMDLevel::ARM_SVE>(
                        &zero,
                        ip_block.get(),
                        &nyi);
+#endif
             }
 #pragma omp parallel for schedule(static) if ((i1 - i0) >= 16)
             for (int64_t i = static_cast<int64_t>(i0);


### PR DESCRIPTION
Summary:
Adds a compile-time-guarded path (`FAISS_SME_CBLAS_SGEMM`) that redirects
FAISS's Fortran `sgemm_("Transpose", "Not transpose", ...)` calls at the two
BLAS-dominated hot sites through OpenBLAS's `cblas_sgemm` entry point. Only
the CBLAS entry reaches OpenBLAS's SME direct-sgemm dispatch gate
(`interface/gemm.c`); the Fortran `sgemm_` entry never does. This lets FAISS's
matrix multiplies land on the Arm SME matrix engine (fmopa) on SME-capable
hardware, with zero OpenBLAS source edits.

The macro is opt-in and a strict no-op when undefined: the `#else` branch is
byte-identical to the previous Fortran `sgemm_` call, so builds without the
flag (and all non-SME hardware) are unaffected.

Measured on Arm Oryon-class SME hardware, single-thread
BLAS, both NDK-clang-21 and clang-24, correctness-gated:
- Flat brute-force search (`IndexFlat::search`): 1.4x-2.8x, growing with GEMM
  size (2.0-2.2x at d=128/nb=16384; 2.8x at d>=512).
- RCQ (ResidualCoarseQuantizer) training: 1.47x-1.98x, growing with d.

Implementation:
- `faiss/utils/distances.cpp`: declares `cblas_sgemm` in the existing extern-C
  block (blasint is int in the linked OpenBLAS; CBLAS enums are ints, so no
  vendor header is needed, matching how `sgemm_` is already hand-declared);
  adds an anonymous-namespace helper `sme_cblas_sgemm_tn` that performs the
  Fortran-column-major -> row-major translation (transpose-pack A into a tight
  [K][M] scratch; B is already the row-major left operand); and guards the
  `exhaustive_inner_product_blas` call site (drives the Flat win).
- `faiss/utils/simd_impl/distances_arm_sve.cpp`: same declaration + helper, and
  guards the `exhaustive_L2sqr_blas_cmax<ARM_SVE>` call site (drives the RCQ
  training win). Adds the `<vector>` include the helper needs.

Only these two call sites are converted -- the two sites shown to drive the
confirmed wins. Other `sgemm_` sites are left on the unchanged Fortran path.