### PR TITLE
Improve intermediate precision in exact 1D clustering

### DIFF
--- a/faiss/impl/kmeans1d.cpp
+++ b/faiss/impl/kmeans1d.cpp
@@ -150,7 +150,8 @@ class CostCalculator {
         cumsum.push_back(0.0);
         cumsum2.push_back(0.0);
         for (idx_t i = 0; i < n; ++i) {
-            float x = vec[i];
+            // Promote before squaring, not after the product has been rounded.
+            double x = vec[i];
             cumsum.push_back(x + cumsum[i]);
             cumsum2.push_back(x * x + cumsum2[i]);
         }
@@ -282,8 +283,9 @@ double kmeans1d(const float* x, size_t n, size_t nclusters, float* centroids) {
     idx_t end = n;
     for (idx_t k = nclusters - 1; k >= 0; k--) {
         const idx_t start = T.at(k, end - 1);
-        const float sum =
-                std::accumulate(arr.data() + start, arr.data() + end, 0.0f);
+        // Round the mean only once when storing the float centroid.
+        const double sum =
+                std::accumulate(arr.data() + start, arr.data() + end, 0.0);
         const idx_t size = end - start;
         FAISS_THROW_IF_NOT_FMT(
                 size > 0, "Cluster %d: size %d", int(k), int(size));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 set(FAISS_TEST_SRC
+  test_clustering.cpp
   test_binary_flat.cpp
   test_dealloc_invlists.cpp
   test_ivfpq_codec.cpp

--- a/tests/test_clustering.cpp
+++ b/tests/test_clustering.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <vector>
+
+#include <faiss/Clustering.h>
+
+TEST(Clustering1D, shifted_interval_costs) {
+    // The optimal contiguous groups are [64,96], [136,136], [168,176],
+    // [200], [224,232,232], [296], [360,376,376,384], [408].
+    const std::vector<float> values = {
+            64,
+            96,
+            136,
+            136,
+            168,
+            176,
+            200,
+            224,
+            232,
+            232,
+            296,
+            360,
+            376,
+            376,
+            384,
+            408};
+    const std::vector<double> means = {
+            80, 136, 172, 200, 688.0 / 3, 296, 374, 408};
+
+    for (float offset : {0.0f, 1e8f, -1e8f}) {
+        SCOPED_TRACE(offset);
+        std::vector<float> x = values;
+        for (float& v : x) {
+            v += offset;
+        }
+        std::reverse(x.begin(), x.end());
+        faiss::Clustering1D clustering(int(means.size()));
+        clustering.train_exact(x.size(), x.data());
+
+        ASSERT_EQ(clustering.centroids.size(), means.size());
+        for (size_t i = 0; i < means.size(); ++i) {
+            // Account for unavoidable rounding of the float output, rather
+            // than comparing shifted-back centroids with unshifted centroids.
+            EXPECT_EQ(
+                    clustering.centroids[i],
+                    static_cast<float>(double(offset) + means[i]));
+        }
+        ASSERT_EQ(clustering.iteration_stats.size(), 1);
+        EXPECT_DOUBLE_EQ(clustering.iteration_stats[0].imbalance_factor, 1.25);
+    }
+}
+
+TEST(Clustering1D, constant_cluster_mean) {
+    for (float value : {1000001.0f, -1000001.0f}) {
+        SCOPED_TRACE(value);
+        std::vector<float> x(128, value);
+        faiss::Clustering1D clustering(1);
+        clustering.max_points_per_centroid = 128; // Keep every input point.
+        clustering.train_exact(x.size(), x.data());
+
+        ASSERT_EQ(clustering.centroids.size(), 1);
+        EXPECT_EQ(clustering.centroids[0], value);
+        ASSERT_EQ(clustering.iteration_stats.size(), 1);
+        EXPECT_DOUBLE_EQ(clustering.iteration_stats[0].imbalance_factor, 1.0);
+    }
+}


### PR DESCRIPTION
## Summary

`Clustering1D::train_exact()` can lose precision in two intermediate calculations:

- The interval-cost prefix sums are stored as `double`, but `x * x` is evaluated as `float` first. The rounded squared values can change the partition selected by the dynamic program when the input has a large common offset.
- Cluster means are accumulated in `float`. For example, a single cluster of 128 identical `1000001.0f` values currently returns `1000000.125f` instead of `1000001.0f`.

Promote each value before squaring and accumulate the cluster sum in `double`. Centroids remain `float`; the SMAWK recurrence, cost-table types, public API, and asymptotic complexity are unchanged. Numerical results are not bit-identical: removing intermediate float rounding can change centroids even on well-conditioned inputs, and can also change the selected partition.

The regression tests use the public `Clustering1D::train_exact()` path. They cover a known eight-cluster partition before and after exactly representable positive/negative offsets, including float output rounding, and constant-valued clusters. This is a targeted precision fix: the cost table still uses float, and prefix-sum subtraction remains subject to cancellation.

## Validation

- Built the CPU-only generic `faiss_test` target on Linux against main `6bbb068ad8dab612b84304400846da1b14539085`.
- Both new tests fail with the unchanged implementation and pass with this patch.
- Full public C++ CTest run: 277 passed, 5 skipped (SIMD-specific checks in this generic build), no failures.
- Additional standalone checks compare small cases against an independent quadratic-time dynamic-programming reference, with an allowance for float centroid rounding.
- Changed C++ lines/new test formatting and `git diff --check` pass.
- No Python bindings (including `tests/test_clustering.py`), GPU tests, or Meta-internal tests were run.
