### PR TITLE
High Performance RaBitQ - HNSW RaBitQ support FP32 graph construction

### DIFF
--- a/faiss/IndexHNSW.cpp
+++ b/faiss/IndexHNSW.cpp
@@ -69,7 +69,8 @@ void hnsw_add_vertices(
         size_t n,
         const float* x,
         bool verbose,
-        bool preset_levels = false) {
+        bool preset_levels = false,
+        const Index* construction_storage = nullptr) {
     size_t d = index_hnsw.d;
     HNSW& hnsw = index_hnsw.hnsw;
     size_t ntotal = n0 + n;
@@ -156,8 +157,9 @@ void hnsw_add_vertices(
                 std::unique_ptr<VisitedTable> vt =
                         VisitedTable::create(ntotal, hnsw.use_visited_hashset);
 
-                std::unique_ptr<DistanceComputer> dis(
-                        storage_distance_computer(index_hnsw.storage));
+                std::unique_ptr<DistanceComputer> dis(storage_distance_computer(
+                        construction_storage ? construction_storage
+                                             : index_hnsw.storage));
                 bool do_display = verbose && omp_get_thread_num() == 0;
                 size_t prev_display = 0;
                 size_t counter = 0;
@@ -1182,6 +1184,59 @@ IndexHNSWRaBitQ::IndexHNSWRaBitQ(
     // 1-bit codes store plain SignBitFactors with no f_error, so there is no
     // bound to prune with and the staged path does not apply.
     hnsw.search_method = nb_bits >= 2 ? HNSW::SM_RABITQ : HNSW::SM_DEFAULT;
+}
+
+void IndexHNSWRaBitQ::add(idx_t n, const float* x) {
+    FAISS_THROW_IF_NOT_MSG(
+            !fp32_graph_built,
+            "cannot append to an IndexHNSWRaBitQ whose graph was batch-built "
+            "with FP32 distances; call reset() before rebuilding");
+    IndexHNSW::add(n, x);
+}
+
+void IndexHNSWRaBitQ::add_with_fp32_graph(idx_t n, const float* x) {
+    FAISS_THROW_IF_NOT_MSG(is_trained, "IndexHNSWRaBitQ is not trained");
+    FAISS_THROW_IF_NOT_MSG(
+            ntotal == 0 && storage && storage->ntotal == 0 &&
+                    hnsw.levels.empty() && hnsw.neighbors.size() == 0,
+            "add_with_fp32_graph requires an empty IndexHNSWRaBitQ");
+    FAISS_THROW_IF_NOT_MSG(n >= 0, "number of vectors must be non-negative");
+
+    IndexFlatL2 construction_storage(d);
+    construction_storage.add(n, x);
+
+    storage->add(n, x);
+    ntotal = storage->ntotal;
+    // Set this before graph construction so an interrupted build cannot later
+    // append with a different construction-distance policy.
+    fp32_graph_built = n > 0;
+    bool preset_levels = hnsw.levels.size() == static_cast<size_t>(ntotal);
+
+    if (hnsw_deterministic_build) {
+        hnsw_add_vertices_deterministic(
+                hnsw,
+                0,
+                n,
+                d,
+                init_level0,
+                keep_max_size_level0,
+                preset_levels,
+                verbose,
+                [&construction_storage] {
+                    return storage_distance_computer(&construction_storage);
+                },
+                [this, x](DistanceComputer& dc, HNSW::storage_idx_t pt_id) {
+                    dc.set_query(x + size_t(pt_id) * d);
+                });
+    } else {
+        hnsw_add_vertices(
+                *this, 0, n, x, verbose, preset_levels, &construction_storage);
+    }
+}
+
+void IndexHNSWRaBitQ::reset() {
+    IndexHNSW::reset();
+    fp32_graph_built = false;
 }
 
 /**************************************************************

--- a/faiss/IndexHNSW.h
+++ b/faiss/IndexHNSW.h
@@ -228,12 +228,31 @@ struct IndexHNSWSQ : IndexHNSW {
  * nb_bits = 1 has no error factor and uses ordinary HNSW search.
  */
 struct IndexHNSWRaBitQ : IndexHNSW {
+    /** True when the current topology was built with temporary FP32 storage.
+     *
+     * Such an index is batch-built: appending with add() would silently mix
+     * FP32 and RaBitQ construction distances, so it is rejected until reset().
+     */
+    bool fp32_graph_built = false;
+
     IndexHNSWRaBitQ();
     IndexHNSWRaBitQ(
             int d,
             int M,
             uint8_t nb_bits = 1,
             MetricType metric = METRIC_L2);
+
+    /** Add the first (and only) batch to RaBitQ storage while constructing the
+     * HNSW topology with exact FP32 L2 distances.
+     *
+     * The temporary FP32 storage is released before this function returns and
+     * is never used for serving. The index must be trained and empty. Further
+     * add() calls are rejected; reset() restores ordinary mutable behavior.
+     */
+    void add_with_fp32_graph(idx_t n, const float* x);
+
+    void add(idx_t n, const float* x) override;
+    void reset() override;
 
     IndexHNSWRaBitQ& operator=(const IndexHNSWRaBitQ&) = delete;
 

--- a/faiss/impl/index_read.cpp
+++ b/faiss/impl/index_read.cpp
@@ -2523,7 +2523,8 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
     } else if (
             h == fourcc("IHNf") || h == fourcc("IHNp") || h == fourcc("IHNs") ||
             h == fourcc("IHN2") || h == fourcc("IHNc") || h == fourcc("IHc2") ||
-            h == fourcc("IHfP") || h == fourcc("IHNr") || h == fourcc("IH00")) {
+            h == fourcc("IHfP") || h == fourcc("IHNr") || h == fourcc("IHNg") ||
+            h == fourcc("IH00")) {
         std::unique_ptr<IndexHNSW> idxhnsw;
         if (h == fourcc("IH00")) {
             idxhnsw = std::make_unique<IndexHNSW>();
@@ -2541,7 +2542,7 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
             idxhnsw = std::make_unique<IndexHNSWCagra>();
         } else if (h == fourcc("IHc2")) {
             idxhnsw = std::make_unique<IndexHNSWCagra>();
-        } else if (h == fourcc("IHNr")) {
+        } else if (h == fourcc("IHNr") || h == fourcc("IHNg")) {
             idxhnsw = std::make_unique<IndexHNSWRaBitQ>();
         }
         read_index_header(*idxhnsw, f);
@@ -2611,10 +2612,12 @@ std::unique_ptr<Index> read_index_up(IOReader* f, int io_flags) {
                     idxhnsw->storage->d,
                     idxhnsw->d);
         }
-        if (h == fourcc("IHNr")) {
+        if (h == fourcc("IHNr") || h == fourcc("IHNg")) {
             auto* idx_rabitq = dynamic_cast<IndexHNSWRaBitQ*>(idxhnsw.get());
             FAISS_THROW_IF_NOT_MSG(
-                    idx_rabitq, "IHNr must deserialize to an IndexHNSWRaBitQ");
+                    idx_rabitq,
+                    "IHNr/IHNg must deserialize to an IndexHNSWRaBitQ");
+            idx_rabitq->fp32_graph_built = h == fourcc("IHNg");
             FAISS_THROW_IF_NOT_MSG(
                     idxhnsw->metric_type == METRIC_L2,
                     "IndexHNSWRaBitQ supports only the L2 metric");

--- a/faiss/impl/index_write.cpp
+++ b/faiss/impl/index_write.cpp
@@ -866,6 +866,7 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
         write_index(idxmap->index, f);
         WRITEVECTOR(idxmap->id_map);
     } else if (const IndexHNSW* idxhnsw = dynamic_cast<const IndexHNSW*>(idx)) {
+        const auto* hnsw_rabitq = dynamic_cast<const IndexHNSWRaBitQ*>(idxhnsw);
         uint32_t h = dynamic_cast<const IndexHNSWFlatPanorama*>(idx)
                 ? fourcc("IHfP")
                 : dynamic_cast<const IndexHNSWFlat*>(idx)   ? fourcc("IHNf")
@@ -873,15 +874,16 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
                 : dynamic_cast<const IndexHNSWSQ*>(idx)     ? fourcc("IHNs")
                 : dynamic_cast<const IndexHNSW2Level*>(idx) ? fourcc("IHN2")
                 : dynamic_cast<const IndexHNSWCagra*>(idx)  ? fourcc("IHc2")
-                : dynamic_cast<const IndexHNSWRaBitQ*>(idx) ? fourcc("IHNr")
-                : typeid(*idx) == typeid(IndexHNSW)         ? fourcc("IH00")
-                                                            : 0;
+                : hnsw_rabitq ? hnsw_rabitq->fp32_graph_built ? fourcc("IHNg")
+                                                              : fourcc("IHNr")
+                : typeid(*idx) == typeid(IndexHNSW) ? fourcc("IH00")
+                                                    : 0;
         FAISS_THROW_IF_NOT_FMT(
                 h != 0,
                 "don't know how to serialize this IndexHNSW subtype: %s",
                 typeid(*idx).name());
         const IndexRaBitQ* storage_rabitq = nullptr;
-        if (h == fourcc("IHNr")) {
+        if (h == fourcc("IHNr") || h == fourcc("IHNg")) {
             storage_rabitq = dynamic_cast<const IndexRaBitQ*>(idxhnsw->storage);
             FAISS_THROW_IF_NOT_MSG(
                     storage_rabitq ||
@@ -911,7 +913,7 @@ void write_index(const Index* idx, IOWriter* f, int io_flags) {
         } else {
             write_index(idxhnsw->storage, f);
         }
-        if (h == fourcc("IHNr")) {
+        if (h == fourcc("IHNr") || h == fourcc("IHNg")) {
             // The staged flag is graph-traversal state, so it has to live here:
             // with IO_FLAG_SKIP_STORAGE there is no storage to derive it from.
             // Storage-owned settings are not duplicated in this payload;

--- a/faiss/python/class_wrappers.py
+++ b/faiss/python/class_wrappers.py
@@ -308,6 +308,18 @@ def handle_Index(the_class):
         else:
             self.add_ex(n, swig_ptr(x), numeric_type)
 
+    def replacement_add_with_fp32_graph(self, x):
+        """Add one batch to RaBitQ storage and build its HNSW graph with
+        temporary FP32 distances.
+
+        The index must be trained and empty. This is a batch-only operation;
+        append is rejected until the index is reset.
+        """
+        n, d = x.shape
+        assert d == self.d
+        x = np.ascontiguousarray(x, dtype="float32")
+        self.add_with_fp32_graph_c(n, swig_ptr(x))
+
     def replacement_add_with_ids(self, x, ids, numeric_type=faiss.Float32):
         """Adds vectors with arbitrary ids to the index (not all indexes
         support this).
@@ -961,6 +973,12 @@ def handle_Index(the_class):
         self.permute_entries_c(faiss.swig_ptr(perm))
 
     replace_method(the_class, "add", replacement_add)
+    replace_method(
+        the_class,
+        "add_with_fp32_graph",
+        replacement_add_with_fp32_graph,
+        ignore_missing=True,
+    )
     replace_method(the_class, "add_with_ids", replacement_add_with_ids)
     replace_method(the_class, "assign", replacement_assign)
     replace_method(the_class, "train", replacement_train)

--- a/tests/test_hnsw_rabitq.py
+++ b/tests/test_hnsw_rabitq.py
@@ -110,6 +110,96 @@ class TestHNSWRaBitQ(unittest.TestCase):
         loaded.add(xb[:1])
         self.assertEqual(loaded.ntotal, len(xb) + 1)
 
+    def test_fp32_graph_batch_build_lifecycle(self):
+        xt, xb, xq = self.make_data()
+        native = faiss.IndexHNSWRaBitQ(xt.shape[1], 8, 3, faiss.METRIC_L2)
+        fp32_graph = faiss.IndexHNSWRaBitQ(
+            xt.shape[1], 8, 3, faiss.METRIC_L2
+        )
+        native.train(xt)
+        fp32_graph.train(xt)
+
+        native.add(xb)
+        fp32_graph.add_with_fp32_graph(xb)
+        self.assertTrue(fp32_graph.fp32_graph_built)
+
+        native_storage = faiss.downcast_index(native.storage)
+        fp32_storage = faiss.downcast_index(fp32_graph.storage)
+        np.testing.assert_array_equal(
+            faiss.vector_to_array(fp32_storage.codes),
+            faiss.vector_to_array(native_storage.codes),
+        )
+        np.testing.assert_array_equal(
+            faiss.vector_to_array(fp32_graph.hnsw.levels),
+            faiss.vector_to_array(native.hnsw.levels),
+        )
+        self.assertEqual(fp32_graph.hnsw.entry_point, native.hnsw.entry_point)
+        self.assertEqual(fp32_graph.hnsw.max_level, native.hnsw.max_level)
+        np.testing.assert_array_equal(
+            faiss.vector_to_array(fp32_graph.hnsw.offsets),
+            faiss.vector_to_array(native.hnsw.offsets),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "cannot append"):
+            fp32_graph.add(xb[:1])
+        with self.assertRaisesRegex(RuntimeError, "requires an empty"):
+            fp32_graph.add_with_fp32_graph(xb[:1])
+
+        cloned = faiss.clone_index(fp32_graph)
+        self.assertTrue(cloned.fp32_graph_built)
+        with self.assertRaisesRegex(RuntimeError, "cannot append"):
+            cloned.add(xb[:1])
+
+        loaded = faiss.deserialize_index(faiss.serialize_index(fp32_graph))
+        self.assertIsInstance(loaded, faiss.IndexHNSWRaBitQ)
+        self.assertTrue(loaded.fp32_graph_built)
+        loaded_storage = faiss.downcast_index(loaded.storage)
+        np.testing.assert_array_equal(
+            faiss.vector_to_array(loaded_storage.codes),
+            faiss.vector_to_array(fp32_storage.codes),
+        )
+        with self.assertRaisesRegex(RuntimeError, "cannot append"):
+            loaded.add(xb[:1])
+
+        metadata = faiss.deserialize_index(
+            faiss.serialize_index(fp32_graph, faiss.IO_FLAG_SKIP_STORAGE)
+        )
+        self.assertTrue(metadata.fp32_graph_built)
+        self.assertIsNone(metadata.storage)
+        faiss.serialize_index(metadata, faiss.IO_FLAG_SKIP_STORAGE)
+
+        loaded.reset()
+        self.assertFalse(loaded.fp32_graph_built)
+        loaded.add(xb)
+        self.assertEqual(loaded.ntotal, len(xb))
+        D, I = loaded.search(xq, 10)
+        self.assertTrue(np.all(I >= 0))
+        self.assertTrue(np.all(np.isfinite(D)))
+
+    def test_fp32_graph_matches_deterministic_flat_topology(self):
+        xt, xb, _ = self.make_data(nb=160)
+        fp32_graph = faiss.IndexHNSWRaBitQ(
+            xt.shape[1], 8, 3, faiss.METRIC_L2
+        )
+        flat_graph = faiss.IndexHNSWFlat(xt.shape[1], 8, faiss.METRIC_L2)
+        fp32_graph.train(xt)
+
+        old_deterministic = faiss.cvar.hnsw_deterministic_build
+        try:
+            faiss.cvar.hnsw_deterministic_build = True
+            fp32_graph.add_with_fp32_graph(xb)
+            flat_graph.add(xb)
+        finally:
+            faiss.cvar.hnsw_deterministic_build = old_deterministic
+
+        self.assertEqual(fp32_graph.hnsw.entry_point, flat_graph.hnsw.entry_point)
+        self.assertEqual(fp32_graph.hnsw.max_level, flat_graph.hnsw.max_level)
+        for field in ("levels", "offsets", "neighbors"):
+            np.testing.assert_array_equal(
+                faiss.vector_to_array(getattr(fp32_graph.hnsw, field)),
+                faiss.vector_to_array(getattr(flat_graph.hnsw, field)),
+            )
+
     def test_io_and_reset(self):
         index, xb, xq = self.make_index(nb_bits=4)
         cloned = faiss.clone_index(index)


### PR DESCRIPTION
this builds HNSW with FP32 distances so the graph has better neighbors, while search still uses the same quantized RaBitQ navigation. High quality graph lets queries reach the same recall with a lower efSearch