### PR TITLE
High Performance RaBitQ - fast rotation by parallelize batched query transforms

### DIFF
--- a/faiss/IndexPreTransform.cpp
+++ b/faiss/IndexPreTransform.cpp
@@ -9,9 +9,11 @@
 
 #include <faiss/IndexPreTransform.h>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <exception>
 #include <memory>
 
 #include <faiss/impl/AuxIndexStructures.h>
@@ -135,6 +137,56 @@ const float* IndexPreTransform::apply_chain(idx_t n, const float* x) const {
     return prev_x;
 }
 
+const float* IndexPreTransform::apply_chain_parallel(
+        idx_t n,
+        const float* x,
+        int transform_threads,
+        idx_t block_size) const {
+    FAISS_THROW_IF_NOT_MSG(n >= 0, "negative vector count");
+    FAISS_THROW_IF_NOT_MSG(
+            transform_threads >= 1, "transform_threads must be positive");
+    FAISS_THROW_IF_NOT_MSG(block_size >= 1, "block_size must be positive");
+    if (transform_threads == 1 || n <= block_size || chain.empty()) {
+        return apply_chain(n, x);
+    }
+
+    const idx_t block_count = n / block_size + (n % block_size != 0);
+    const int active_threads =
+            static_cast<int>(std::min<idx_t>(transform_threads, block_count));
+    const float* prev_x = x;
+    std::unique_ptr<const float[]> previous_owner;
+
+    for (const VectorTransform* transform : chain) {
+        auto transformed =
+                std::make_unique<float[]>(size_t(n) * transform->d_out);
+        std::exception_ptr error;
+#pragma omp parallel for num_threads(active_threads) schedule(static)
+        for (idx_t begin = 0; begin < n; begin += block_size) {
+            try {
+                const idx_t count = std::min(block_size, n - begin);
+                transform->apply_noalloc(
+                        count,
+                        prev_x + size_t(begin) * transform->d_in,
+                        transformed.get() + size_t(begin) * transform->d_out);
+            } catch (...) {
+#pragma omp critical
+                {
+                    if (!error) {
+                        error = std::current_exception();
+                    }
+                }
+            }
+        }
+        if (error) {
+            std::rethrow_exception(error);
+        }
+        previous_owner.reset();
+        prev_x = transformed.get();
+        previous_owner = std::move(transformed);
+    }
+    return previous_owner.release();
+}
+
 void IndexPreTransform::reverse_chain(idx_t n, const float* xt, float* x)
         const {
     const float* next_x = xt;
@@ -174,6 +226,19 @@ const SearchParameters* extract_index_search_params(
     return params ? params->index_params : params_in;
 }
 
+const float* apply_chain_for_search(
+        const IndexPreTransform& index,
+        idx_t n,
+        const float* x,
+        const SearchParameters* params_in) {
+    auto params = dynamic_cast<const SearchParametersPreTransform*>(params_in);
+    if (!params || params->transform_threads == 0) {
+        return index.apply_chain(n, x);
+    }
+    return index.apply_chain_parallel(
+            n, x, params->transform_threads, params->transform_block_size);
+}
+
 } // namespace
 
 void IndexPreTransform::search(
@@ -185,7 +250,7 @@ void IndexPreTransform::search(
         const SearchParameters* params) const {
     FAISS_THROW_IF_NOT(k > 0);
     FAISS_THROW_IF_NOT(is_trained);
-    const float* xt = apply_chain(n, x);
+    const float* xt = apply_chain_for_search(*this, n, x, params);
     std::unique_ptr<const float[]> del(xt == x ? nullptr : xt);
     index->search(
             n, xt, k, distances, labels, extract_index_search_params(params));
@@ -198,7 +263,7 @@ void IndexPreTransform::range_search(
         RangeSearchResult* result,
         const SearchParameters* params) const {
     FAISS_THROW_IF_NOT(is_trained);
-    TransformedVectors tv(x, apply_chain(n, x));
+    TransformedVectors tv(x, apply_chain_for_search(*this, n, x, params));
     index->range_search(
             n, tv.x, radius, result, extract_index_search_params(params));
 }
@@ -261,7 +326,7 @@ void IndexPreTransform::search_and_reconstruct(
     FAISS_THROW_IF_NOT(k > 0);
     FAISS_THROW_IF_NOT(is_trained);
 
-    TransformedVectors trans(x, apply_chain(n, x));
+    TransformedVectors trans(x, apply_chain_for_search(*this, n, x, params));
 
     float* recons_temp = chain.empty() ? recons : new float[n * k * index->d];
     std::unique_ptr<float[]> del2(

--- a/faiss/IndexPreTransform.h
+++ b/faiss/IndexPreTransform.h
@@ -15,9 +15,18 @@
 namespace faiss {
 
 struct SearchParametersPreTransform : SearchParameters {
-    // nothing to add here.
-    // as such, encapsulating the search params is considered optional
+    // Sub-index parameters. Encapsulating them remains optional when the
+    // transform uses its default serial execution.
     SearchParameters* index_params = nullptr;
+
+    /** Number of OpenMP threads used for independent query-transform blocks.
+     * 0 preserves the existing serial transform. 1 explicitly requests
+     * serial execution. Values greater than 1 enable block parallelism.
+     */
+    int transform_threads = 0;
+
+    /// Number of queries transformed by each parallel task.
+    idx_t transform_block_size = 64;
 };
 
 /** Index that applies a LinearTransform transform on vectors before
@@ -90,6 +99,16 @@ struct IndexPreTransform : Index {
     /// apply the transforms in the chain. The returned float * may be
     /// equal to x, otherwise it should be deallocated.
     const float* apply_chain(idx_t n, const float* x) const;
+
+    /** Apply each transform in independent query blocks. A barrier between
+     * chain elements preserves the original transform order. The returned
+     * pointer follows the same ownership contract as apply_chain().
+     */
+    const float* apply_chain_parallel(
+            idx_t n,
+            const float* x,
+            int transform_threads,
+            idx_t block_size) const;
 
     /// Reverse the transforms in the chain. May not be implemented for
     /// all transforms in the chain or may return approximate results.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ set(FAISS_TEST_SRC
   test_heap.cpp
   test_pq_code_distance.cpp
   test_hnsw.cpp
+  test_index_pretransform_parallel.cpp
   test_NSG_compressed_graph.cpp
   test_partitioning.cpp
   test_fastscan_perf.cpp

--- a/tests/test_index_pretransform_parallel.cpp
+++ b/tests/test_index_pretransform_parallel.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#include <faiss/IndexFlat.h>
+#include <faiss/IndexHNSW.h>
+#include <faiss/IndexPreTransform.h>
+#include <faiss/impl/FaissException.h>
+#include <faiss/impl/IDSelector.h>
+#include <faiss/utils/random.h>
+
+namespace {
+
+struct OwnedTransformResult {
+    const float* data;
+    std::unique_ptr<const float[]> owner;
+
+    OwnedTransformResult(const float* input, const float* result)
+            : data(result), owner(result == input ? nullptr : result) {}
+};
+
+} // namespace
+
+TEST(IndexPreTransformParallel, BlockTailsAndSearchEquivalence) {
+    constexpr int d = 32;
+    constexpr faiss::idx_t nb = 200;
+    constexpr faiss::idx_t k = 10;
+    faiss::RandomRotationMatrix rotation(d, d);
+    rotation.init(1234);
+    faiss::RandomRotationMatrix second_rotation(d, d);
+    second_rotation.init(4321);
+    faiss::IndexFlatL2 flat(d);
+    faiss::IndexPreTransform index(&rotation, &flat);
+    index.prepend_transform(&second_rotation);
+
+    std::vector<float> database(size_t(nb) * d);
+    faiss::float_rand(database.data(), database.size(), 8765);
+    index.add(nb, database.data());
+
+    for (faiss::idx_t nq : {1, 7, 63, 64, 65, 127, 128, 129, 1000}) {
+        std::vector<float> queries(size_t(nq) * d);
+        faiss::float_rand(queries.data(), queries.size(), 991 + nq);
+        OwnedTransformResult serial(
+                queries.data(), index.apply_chain(nq, queries.data()));
+        OwnedTransformResult parallel(
+                queries.data(),
+                index.apply_chain_parallel(nq, queries.data(), 4, 64));
+        for (size_t i = 0; i < queries.size(); ++i) {
+            EXPECT_NEAR(serial.data[i], parallel.data[i], 4e-6);
+        }
+
+        std::vector<float> serial_distances(size_t(nq) * k);
+        std::vector<float> parallel_distances(size_t(nq) * k);
+        std::vector<faiss::idx_t> serial_labels(size_t(nq) * k);
+        std::vector<faiss::idx_t> parallel_labels(size_t(nq) * k);
+        index.search(
+                nq,
+                queries.data(),
+                k,
+                serial_distances.data(),
+                serial_labels.data());
+        faiss::SearchParametersPreTransform params;
+        params.transform_threads = 4;
+        params.transform_block_size = 64;
+        index.search(
+                nq,
+                queries.data(),
+                k,
+                parallel_distances.data(),
+                parallel_labels.data(),
+                &params);
+        EXPECT_EQ(serial_labels, parallel_labels);
+        for (size_t i = 0; i < serial_distances.size(); ++i) {
+            EXPECT_NEAR(serial_distances[i], parallel_distances[i], 4e-5);
+        }
+    }
+
+    // Exercise actual parallel work below the reference block size as well.
+    std::vector<float> short_queries(size_t(7) * d);
+    faiss::float_rand(short_queries.data(), short_queries.size(), 774);
+    OwnedTransformResult serial(
+            short_queries.data(), index.apply_chain(7, short_queries.data()));
+    OwnedTransformResult parallel(
+            short_queries.data(),
+            index.apply_chain_parallel(7, short_queries.data(), 4, 3));
+    for (size_t i = 0; i < short_queries.size(); ++i) {
+        EXPECT_NEAR(serial.data[i], parallel.data[i], 4e-6);
+    }
+}
+
+TEST(IndexPreTransformParallel, ForwardsSubIndexParameters) {
+    constexpr int d = 16;
+    constexpr faiss::idx_t nb = 100;
+    constexpr faiss::idx_t nq = 65;
+    constexpr faiss::idx_t k = 10;
+    faiss::RandomRotationMatrix rotation(d, d);
+    rotation.init(1234);
+    faiss::IndexHNSWFlat hnsw(d, 16);
+    faiss::IndexPreTransform index(&rotation, &hnsw);
+    std::vector<float> database(size_t(nb) * d);
+    std::vector<float> queries(size_t(nq) * d);
+    faiss::float_rand(database.data(), database.size(), 444);
+    faiss::float_rand(queries.data(), queries.size(), 555);
+    index.add(nb, database.data());
+
+    faiss::IDSelectorRange selector(20, 80);
+    faiss::SearchParametersHNSW inner;
+    inner.efSearch = 100;
+    inner.sel = &selector;
+    faiss::SearchParametersPreTransform outer;
+    outer.index_params = &inner;
+    outer.transform_threads = 4;
+    outer.transform_block_size = 16;
+    std::vector<float> distances(size_t(nq) * k);
+    std::vector<faiss::idx_t> labels(size_t(nq) * k);
+    index.search(
+            nq, queries.data(), k, distances.data(), labels.data(), &outer);
+    for (faiss::idx_t label : labels) {
+        EXPECT_TRUE(label == -1 || (label >= 20 && label < 80));
+    }
+}
+
+TEST(IndexPreTransformParallel, ValidatesOptionsAndPropagatesExceptions) {
+    constexpr int d = 8;
+    faiss::LinearTransform malformed(d, d, false);
+    malformed.is_trained = true;
+    faiss::IndexFlatL2 flat(d);
+    faiss::IndexPreTransform index(&malformed, &flat);
+    std::vector<float> queries(size_t(65) * d);
+
+    EXPECT_THROW(
+            index.apply_chain_parallel(65, queries.data(), 0, 64),
+            faiss::FaissException);
+    EXPECT_THROW(
+            index.apply_chain_parallel(65, queries.data(), 4, 0),
+            faiss::FaissException);
+    // The malformed matrix throws inside an OpenMP worker. It must be
+    // rethrown to the caller rather than terminating the process.
+    EXPECT_THROW(
+            index.apply_chain_parallel(65, queries.data(), 4, 64),
+            faiss::FaissException);
+}


### PR DESCRIPTION
Query rotation was single-threaded even when HNSW search used all available CPU cores. This splits large query batches into blocks and transforms them in parallel, while keeping batch-1 requests on the serial path. The feature is opt-in and does not change global OpenMP or BLAS settings.

the three high perf pq stacked together 

Combined RaBitQ optimizations vs native SQ8, batch=1:

| Dataset / Floor | SQ8 QPS | RaBitQ QPS | Speedup |
|---|---:|---:|---:|
| Cohere 90% | 3,824 | 9,908 | 2.591x |
| Cohere 95% | 1,817 | 6,946 | 3.823x |
| GIST 90% | 457 | 1,941 | 4.250x |
| GIST 95% | 252 | 773 | 3.064x |
| DBpedia 90% | 2,353 | 2,760 | 1.173x |
| DBpedia 95% | 1,133 | 2,118 | 1.869x |
| SIFT 90% | 14,413 | 34,322 | 2.381x |
| SIFT 95% | 8,226 | 18,745 | 2.279x |

  Combined configuration:
  FP32 graph construction + integer ADC/ARM SDOT + parallel query rotation (ignored by batch = 1).
  
  batch = 1000 -> more gainz
