### PR TITLE
High Performance RaBitQ - dd an opt-in FP16 path for single-query transforms

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -49,6 +49,7 @@ set(FAISS_SIMD_AVX512_VPOPCNT_SRC
 # AVX-512 sources that require the full Sapphire Rapids feature set.
 set(FAISS_SIMD_AVX512_SPR_SRC
   impl/scalar_quantizer/sq-avx512-spr.cpp
+  utils/simd_impl/fp16_linear_transform_avx512.cpp
 )
 set(FAISS_SIMD_NEON_SRC
   impl/fast_scan/impl-neon.cpp
@@ -61,6 +62,7 @@ set(FAISS_SIMD_NEON_SRC
   utils/simd_impl/partitioning_neon.cpp
   utils/distances_fused/simdlib_based_neon.cpp
   utils/simd_impl/rabitq_neon.cpp
+  utils/simd_impl/fp16_linear_transform_neon.cpp
 )
 set(FAISS_SIMD_SVE_SRC
   impl/pq_code_distance/pq_code_distance-sve.cpp
@@ -374,6 +376,7 @@ set(FAISS_HEADERS
   utils/fp16-inl.h
   utils/fp16-arm.h
   utils/fp16.h
+  utils/fp16_linear_transform.h
   utils/hamming-inl.h
   utils/hamming.h
   utils/ordered_key_value.h
@@ -439,6 +442,13 @@ endif()
 
 # Export FAISS_HEADERS variable to parent scope.
 set(FAISS_HEADERS ${FAISS_HEADERS} PARENT_SCOPE)
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64|arm64|ARM64)" AND NOT MSVC)
+  # Isolate optional FP16 FML instructions in a runtime-gated translation
+  # unit so the ordinary NEON build remains usable on older ARM CPUs.
+  set_source_files_properties(utils/simd_impl/fp16_linear_transform_neon.cpp
+    PROPERTIES COMPILE_OPTIONS "-march=armv8.2-a+fp16fml")
+endif()
 
 # Detect BMI2 compiler support.
 include(CheckCXXCompilerFlag)

--- a/faiss/IndexPreTransform.cpp
+++ b/faiss/IndexPreTransform.cpp
@@ -135,6 +135,28 @@ const float* IndexPreTransform::apply_chain(idx_t n, const float* x) const {
     return prev_x;
 }
 
+const float* IndexPreTransform::apply_chain_fp16(idx_t n, const float* x)
+        const {
+    FAISS_THROW_IF_NOT_MSG(n >= 0, "negative vector count");
+    if (chain.empty()) {
+        return x;
+    }
+    const float* prev_x = x;
+    std::unique_ptr<const float[]> previous_owner;
+    for (const VectorTransform* transform : chain) {
+        const auto* linear = dynamic_cast<const LinearTransform*>(transform);
+        FAISS_THROW_IF_NOT_MSG(
+                linear != nullptr,
+                "FP16 query transforms require a LinearTransform chain");
+        auto transformed = std::make_unique<float[]>(size_t(n) * linear->d_out);
+        linear->apply_noalloc_fp16(n, prev_x, transformed.get());
+        previous_owner.reset();
+        prev_x = transformed.get();
+        previous_owner = std::move(transformed);
+    }
+    return previous_owner.release();
+}
+
 void IndexPreTransform::reverse_chain(idx_t n, const float* xt, float* x)
         const {
     const float* next_x = xt;
@@ -174,6 +196,18 @@ const SearchParameters* extract_index_search_params(
     return params ? params->index_params : params_in;
 }
 
+const float* apply_chain_for_search(
+        const IndexPreTransform& index,
+        idx_t n,
+        const float* x,
+        const SearchParameters* params_in) {
+    auto params = dynamic_cast<const SearchParametersPreTransform*>(params_in);
+    if (params && params->use_fp16_transform && n == 1) {
+        return index.apply_chain_fp16(n, x);
+    }
+    return index.apply_chain(n, x);
+}
+
 } // namespace
 
 void IndexPreTransform::search(
@@ -185,7 +219,7 @@ void IndexPreTransform::search(
         const SearchParameters* params) const {
     FAISS_THROW_IF_NOT(k > 0);
     FAISS_THROW_IF_NOT(is_trained);
-    const float* xt = apply_chain(n, x);
+    const float* xt = apply_chain_for_search(*this, n, x, params);
     std::unique_ptr<const float[]> del(xt == x ? nullptr : xt);
     index->search(
             n, xt, k, distances, labels, extract_index_search_params(params));
@@ -198,7 +232,7 @@ void IndexPreTransform::range_search(
         RangeSearchResult* result,
         const SearchParameters* params) const {
     FAISS_THROW_IF_NOT(is_trained);
-    TransformedVectors tv(x, apply_chain(n, x));
+    TransformedVectors tv(x, apply_chain_for_search(*this, n, x, params));
     index->range_search(
             n, tv.x, radius, result, extract_index_search_params(params));
 }
@@ -261,7 +295,7 @@ void IndexPreTransform::search_and_reconstruct(
     FAISS_THROW_IF_NOT(k > 0);
     FAISS_THROW_IF_NOT(is_trained);
 
-    TransformedVectors trans(x, apply_chain(n, x));
+    TransformedVectors trans(x, apply_chain_for_search(*this, n, x, params));
 
     float* recons_temp = chain.empty() ? recons : new float[n * k * index->d];
     std::unique_ptr<float[]> del2(

--- a/faiss/IndexPreTransform.h
+++ b/faiss/IndexPreTransform.h
@@ -15,9 +15,12 @@
 namespace faiss {
 
 struct SearchParametersPreTransform : SearchParameters {
-    // nothing to add here.
-    // as such, encapsulating the search params is considered optional
     SearchParameters* index_params = nullptr;
+
+    /** Use a prepared FP16 cache for a single-query transform.
+     * Larger batches retain the ordinary FP32 transform path.
+     */
+    bool use_fp16_transform = false;
 };
 
 /** Index that applies a LinearTransform transform on vectors before
@@ -90,6 +93,9 @@ struct IndexPreTransform : Index {
     /// apply the transforms in the chain. The returned float * may be
     /// equal to x, otherwise it should be deallocated.
     const float* apply_chain(idx_t n, const float* x) const;
+
+    /// Apply a chain of prepared FP16 linear transforms.
+    const float* apply_chain_fp16(idx_t n, const float* x) const;
 
     /// Reverse the transforms in the chain. May not be implemented for
     /// all transforms in the chain or may return approximate results.

--- a/faiss/VectorTransform.cpp
+++ b/faiss/VectorTransform.cpp
@@ -18,7 +18,10 @@
 #include <faiss/IndexPQ.h>
 #include <faiss/impl/FaissAssert.h>
 #include <faiss/utils/distances.h>
+#include <faiss/utils/fp16.h>
+#include <faiss/utils/fp16_linear_transform.h>
 #include <faiss/utils/random.h>
+#include <faiss/utils/simd_levels.h>
 #include <faiss/utils/utils.h>
 
 using namespace faiss;
@@ -237,6 +240,57 @@ void LinearTransform::apply_noalloc(idx_t n, const float* x, float* xt) const {
            &c_factor,
            xt,
            &nbiti);
+}
+
+bool LinearTransform::fp16_supported() const {
+#if defined(COMPILE_SIMD_AVX512_SPR)
+    return SIMDConfig::get_dispatched_level() == SIMDLevel::AVX512_SPR &&
+            fp16_linear_transform::supported();
+#elif defined(COMPILE_SIMD_ARM_NEON)
+    return fp16_linear_transform::supported();
+#else
+    return false;
+#endif
+}
+
+void LinearTransform::prepare_fp16() {
+    FAISS_THROW_IF_NOT_MSG(is_trained, "Transformation not trained yet");
+    FAISS_THROW_IF_NOT_MSG(
+            fp16_supported(), "FP16 linear transforms are unavailable");
+    FAISS_THROW_IF_NOT_MSG(
+            A.size() == static_cast<size_t>(d_out) * d_in,
+            "Transformation matrix not initialized");
+    A_fp16.resize(A.size());
+    for (size_t i = 0; i < A.size(); ++i) {
+        A_fp16[i] = encode_fp16(A[i]);
+    }
+}
+
+void LinearTransform::apply_noalloc_fp16(idx_t n, const float* x, float* xt)
+        const {
+    FAISS_THROW_IF_NOT_MSG(is_trained, "Transformation not trained yet");
+    FAISS_THROW_IF_NOT_MSG(
+            A_fp16.size() == static_cast<size_t>(d_out) * d_in,
+            "FP16 transformation cache is missing or stale");
+#if defined(COMPILE_SIMD_ARM_NEON) || defined(COMPILE_SIMD_AVX512_SPR)
+    FAISS_THROW_IF_NOT_MSG(
+            fp16_supported(), "FP16 linear transforms are unavailable");
+    for (idx_t i = 0; i < n; ++i) {
+        fp16_linear_transform::apply(
+                A_fp16.data(),
+                d_out,
+                d_in,
+                x + size_t(i) * d_in,
+                xt + size_t(i) * d_out);
+        if (have_bias) {
+            for (int j = 0; j < d_out; ++j) {
+                xt[size_t(i) * d_out + j] += b[j];
+            }
+        }
+    }
+#else
+    FAISS_THROW_MSG("FP16 linear transforms are unavailable in this build");
+#endif
 }
 
 void LinearTransform::transform_transpose(idx_t n, const float* y, float* x)

--- a/faiss/VectorTransform.h
+++ b/faiss/VectorTransform.h
@@ -80,6 +80,11 @@ struct LinearTransform : VectorTransform {
     /// bias vector, size d_out
     std::vector<float> b;
 
+    /** Optional FP16 copy of A for the ARM single-query transform path. This
+     * derived runtime cache must be refreshed after A changes.
+     */
+    std::vector<uint16_t> A_fp16;
+
     /// both d_in > d_out and d_out < d_in are supported
     explicit LinearTransform(
             int din = 0,
@@ -88,6 +93,15 @@ struct LinearTransform : VectorTransform {
 
     /// same as apply, but result is pre-allocated
     void apply_noalloc(idx_t n, const float* x, float* xt) const override;
+
+    /// Return whether the running CPU supports the FP16 FML path.
+    bool fp16_supported() const;
+
+    /// Build the derived FP16 matrix cache used by apply_noalloc_fp16().
+    void prepare_fp16();
+
+    /// Apply the cached FP16 matrix with FP32 accumulation.
+    void apply_noalloc_fp16(idx_t n, const float* x, float* xt) const;
 
     /// compute x = A^T * (x - b)
     /// is reverse transform if A has orthonormal lines

--- a/faiss/utils/fp16_linear_transform.h
+++ b/faiss/utils/fp16_linear_transform.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <faiss/impl/platform_macros.h>
+
+namespace faiss::fp16_linear_transform {
+
+#if defined(COMPILE_SIMD_ARM_NEON) || defined(COMPILE_SIMD_AVX512_SPR)
+FAISS_API bool supported();
+
+FAISS_API void apply(
+        const uint16_t* matrix,
+        size_t rows,
+        size_t columns,
+        const float* input,
+        float* output);
+#endif
+
+} // namespace faiss::fp16_linear_transform

--- a/faiss/utils/simd_impl/fp16_linear_transform_avx512.cpp
+++ b/faiss/utils/simd_impl/fp16_linear_transform_avx512.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <faiss/utils/fp16_linear_transform.h>
+
+#include <immintrin.h>
+#include <vector>
+
+#include <faiss/utils/fp16.h>
+
+namespace faiss::fp16_linear_transform {
+
+bool supported() {
+    return true;
+}
+
+void apply(
+        const uint16_t* matrix,
+        size_t rows,
+        size_t columns,
+        const float* input,
+        float* output) {
+    std::vector<uint16_t> input_fp16(columns);
+    size_t column = 0;
+    for (; column + 16 <= columns; column += 16) {
+        const __m512 values = _mm512_loadu_ps(input + column);
+        const __m256i converted =
+                _mm512_cvtps_ph(values, _MM_FROUND_TO_NEAREST_INT);
+        _mm256_storeu_si256(
+                reinterpret_cast<__m256i*>(input_fp16.data() + column),
+                converted);
+    }
+    for (; column < columns; ++column) {
+        input_fp16[column] = encode_fp16(input[column]);
+    }
+
+    for (size_t row = 0; row < rows; ++row) {
+        const uint16_t* weights = matrix + row * columns;
+        __m512 accumulator = _mm512_setzero_ps();
+        column = 0;
+        for (; column + 16 <= columns; column += 16) {
+            const __m256i weights_fp16 = _mm256_loadu_si256(
+                    reinterpret_cast<const __m256i*>(weights + column));
+            const __m256i input_values_fp16 = _mm256_loadu_si256(
+                    reinterpret_cast<const __m256i*>(
+                            input_fp16.data() + column));
+            accumulator = _mm512_fmadd_ps(
+                    _mm512_cvtph_ps(weights_fp16),
+                    _mm512_cvtph_ps(input_values_fp16),
+                    accumulator);
+        }
+        float sum = _mm512_reduce_add_ps(accumulator);
+        for (; column < columns; ++column) {
+            sum += decode_fp16(weights[column]) *
+                    decode_fp16(input_fp16[column]);
+        }
+        output[row] = sum;
+    }
+}
+
+} // namespace faiss::fp16_linear_transform

--- a/faiss/utils/simd_impl/fp16_linear_transform_neon.cpp
+++ b/faiss/utils/simd_impl/fp16_linear_transform_neon.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <faiss/utils/fp16_linear_transform.h>
+
+#include <arm_neon.h>
+#include <vector>
+
+#if defined(__linux__)
+#include <asm/hwcap.h>
+#include <sys/auxv.h>
+#endif
+
+namespace faiss::fp16_linear_transform {
+
+bool supported() {
+#if defined(__linux__) && defined(HWCAP_FPHP) && defined(HWCAP_ASIMDFHM)
+    const unsigned long capabilities = getauxval(AT_HWCAP);
+    return (capabilities & HWCAP_FPHP) != 0 &&
+            (capabilities & HWCAP_ASIMDFHM) != 0;
+#else
+    return false;
+#endif
+}
+
+void apply(
+        const uint16_t* matrix,
+        size_t rows,
+        size_t columns,
+        const float* input,
+        float* output) {
+    std::vector<uint16_t> input_fp16(columns);
+    size_t column = 0;
+    for (; column + 8 <= columns; column += 8) {
+        const float16x8_t converted = vcombine_f16(
+                vcvt_f16_f32(vld1q_f32(input + column)),
+                vcvt_f16_f32(vld1q_f32(input + column + 4)));
+        vst1q_u16(input_fp16.data() + column, vreinterpretq_u16_f16(converted));
+    }
+    for (; column < columns; ++column) {
+        const float32x4_t value = vdupq_n_f32(input[column]);
+        input_fp16[column] =
+                vget_lane_u16(vreinterpret_u16_f16(vcvt_f16_f32(value)), 0);
+    }
+
+    for (size_t row = 0; row < rows; ++row) {
+        const uint16_t* weights = matrix + row * columns;
+        float32x4_t acc0 = vdupq_n_f32(0.0f);
+        float32x4_t acc1 = vdupq_n_f32(0.0f);
+        column = 0;
+        for (; column + 8 <= columns; column += 8) {
+            const float16x8_t w =
+                    vreinterpretq_f16_u16(vld1q_u16(weights + column));
+            const float16x8_t q = vreinterpretq_f16_u16(
+                    vld1q_u16(input_fp16.data() + column));
+            acc0 = vfmlalq_low_f16(acc0, w, q);
+            acc1 = vfmlalq_high_f16(acc1, w, q);
+        }
+        float sum = vaddvq_f32(acc0) + vaddvq_f32(acc1);
+        for (; column < columns; ++column) {
+            const float16x4_t w =
+                    vreinterpret_f16_u16(vdup_n_u16(weights[column]));
+            const float16x4_t q =
+                    vreinterpret_f16_u16(vdup_n_u16(input_fp16[column]));
+            sum += vgetq_lane_f32(vcvt_f32_f16(w), 0) *
+                    vgetq_lane_f32(vcvt_f32_f16(q), 0);
+        }
+        output[row] = sum;
+    }
+}
+
+} // namespace faiss::fp16_linear_transform

--- a/tests/test_fp16_linear_transform.py
+++ b/tests/test_fp16_linear_transform.py
@@ -1,0 +1,117 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import faiss
+import numpy as np
+
+
+class TestFp16LinearTransform(unittest.TestCase):
+    def require_fp16(self):
+        probe = faiss.LinearTransform()
+        if not probe.fp16_supported():
+            self.skipTest("FP16 linear transforms are unavailable")
+
+    def make_transform(self, d_in, d_out, bias, seed):
+        rs = np.random.RandomState(seed)
+        matrix = (rs.randn(d_out, d_in) / np.sqrt(d_in)).astype("float32")
+        transform = faiss.LinearTransform(d_in, d_out, bias is not None)
+        faiss.copy_array_to_vector(matrix.ravel(), transform.A)
+        if bias is not None:
+            faiss.copy_array_to_vector(bias, transform.b)
+        transform.is_trained = True
+        return transform, matrix
+
+    def test_scalar_oracle_tails_zero_and_bias(self):
+        self.require_fp16()
+        for d_in in (1, 7, 8, 15, 16, 17, 31, 32, 33, 65, 128, 768, 1537):
+            d_out = 5
+            rs = np.random.RandomState(1000 + d_in)
+            bias = rs.randn(d_out).astype("float32")
+            transform, matrix = self.make_transform(d_in, d_out, bias, d_in)
+            transform.prepare_fp16()
+            queries = rs.randn(3, d_in).astype("float32")
+            queries[0] = 0
+            actual = np.empty((len(queries), d_out), dtype="float32")
+            transform.apply_noalloc_fp16(
+                len(queries), faiss.swig_ptr(queries), faiss.swig_ptr(actual)
+            )
+
+            half_matrix = matrix.astype("float16").astype("float32")
+            half_queries = queries.astype("float16").astype("float32")
+            expected = np.empty_like(actual)
+            for row in range(len(queries)):
+                for output in range(d_out):
+                    value = np.float32(0)
+                    for column in range(d_in):
+                        value = np.float32(
+                            value
+                            + np.float32(
+                                half_matrix[output, column]
+                                * half_queries[row, column]
+                            )
+                        )
+                    expected[row, output] = value + bias[output]
+            np.testing.assert_allclose(actual, expected, rtol=2e-5, atol=2e-5)
+
+    def test_cache_is_explicit(self):
+        self.require_fp16()
+        transform, _ = self.make_transform(17, 9, None, 123)
+        query = np.zeros(17, dtype="float32")
+        output = np.empty(9, dtype="float32")
+        with self.assertRaisesRegex(RuntimeError, "cache is missing or stale"):
+            transform.apply_noalloc_fp16(
+                1, faiss.swig_ptr(query), faiss.swig_ptr(output)
+            )
+
+    def test_batched_search_retains_fp32_path(self):
+        rs = np.random.RandomState(99)
+        d = 65
+        xb = rs.randn(200, d).astype("float32")
+        xq = rs.randn(3, d).astype("float32")
+        rotation = faiss.RandomRotationMatrix(d, d)
+        rotation.init(1234)
+        storage = faiss.IndexFlatL2(d)
+        index = faiss.IndexPreTransform(rotation, storage)
+        index.own_fields = False
+        index.add(xb)
+
+        reference_distances, reference_ids = index.search(xq, 10)
+        params = faiss.SearchParametersPreTransform()
+        params.use_fp16_transform = True
+        actual_distances, actual_ids = index.search(xq, 10, params=params)
+        np.testing.assert_array_equal(actual_ids, reference_ids)
+        np.testing.assert_array_equal(actual_distances, reference_distances)
+
+    def test_single_query_search_uses_fp16_path(self):
+        self.require_fp16()
+        rs = np.random.RandomState(101)
+        d = 65
+        xb = rs.randn(200, d).astype("float32")
+        xq = rs.randn(1, d).astype("float32")
+        rotation = faiss.RandomRotationMatrix(d, d)
+        rotation.init(1234)
+        storage = faiss.IndexFlatL2(d)
+        index = faiss.IndexPreTransform(rotation, storage)
+        index.own_fields = False
+        index.add(xb)
+
+        rotation.prepare_fp16()
+        transformed = np.empty_like(xq)
+        rotation.apply_noalloc_fp16(
+            1, faiss.swig_ptr(xq), faiss.swig_ptr(transformed)
+        )
+        expected_distances, expected_ids = storage.search(transformed, 10)
+
+        params = faiss.SearchParametersPreTransform()
+        params.use_fp16_transform = True
+        actual_distances, actual_ids = index.search(xq, 10, params=params)
+        np.testing.assert_array_equal(actual_ids, expected_ids)
+        np.testing.assert_array_equal(actual_distances, expected_distances)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds an opt-in ARM FP16/FML path for single-query linear transforms while accumulating in FP32. It reduces the cost of high-dimensional RaBitQ query rotation, while batched queries keep the existing FP32 GEMM path. The path is runtime-gated, and tests cover scalar semantics, tails, bias, missing caches, and exact batched fallback.