### PR TITLE
Migrate cuVS Integrations to the C API

### DIFF
--- a/.github/actions/build_cmake/action.yml
+++ b/.github/actions/build_cmake/action.yml
@@ -87,7 +87,7 @@ runs:
 
         # -p "$CONDA" on every install below: a bare `conda install` targets
         # whatever env is active, which is base regardless of the above.
-        conda install -y -q -p "$CONDA" python=3.12 cmake=3.30.4 make=4.2 swig=4.0 "numpy>=2.0,<3.0" scipy=1.16 pytest=7.4 pytest-timeout gflags=2.2 setuptools
+        conda install -y -q -p "$CONDA" python=3.12 "cmake>=4.0,<5" make=4.2 swig=4.0 "numpy>=2.0,<3.0" scipy=1.16 pytest=7.4 pytest-timeout gflags=2.2 setuptools
 
         # install base packages for ARM64
         if [ "${{ runner.arch }}" = "ARM64" ]; then
@@ -113,7 +113,7 @@ runs:
             # test_gpu_index_serialize). CUDA 13.2 matches both the non-cuVS GPU
             # job and the pip-wheel cuVS build (whose GPU smoke test passes), and
             # the T4 driver. Only libnvJitLink must be 13.3: the conda libcuvs
-            # 26.06 build links it (needs the __nvJitLinkCreate_13_3 symbol), and
+            # 26.10 build links it (needs the __nvJitLinkCreate_13_3 symbol), and
             # it is a standalone package that cuda-nvcc / cuda-cudart-dev /
             # cuda-version do NOT pull to 13.3, so pin it explicitly — otherwise
             # an older libnvJitLink.so.13 is left in the env and libcuvs fails to
@@ -124,7 +124,7 @@ runs:
               'libnvjitlink>=13.3,<14' \
               libcublas-dev libcusolver-dev libcusparse-dev \
               gxx_linux-64=14.2 \
-              libcuvs=26.06 'cuda-version>=13.2,<14' sysroot_linux-64=2.34 \
+              libcuvs=26.10 'dlpack>=0.8' 'cuda-version>=13.2,<14' sysroot_linux-64=2.34 \
               -c rapidsai -c rapidsai-nightly -c conda-forge -c nvidia
             conda clean --index-cache 2>/dev/null || true
           else
@@ -152,7 +152,7 @@ runs:
           # cuVS builds previously got pytorch-gpu from conda, now unified to pip.
           # torch's cu132 wheels bundle a CUDA 13.2 nvidia-nvjitlink; when torch is
           # imported it dlopens that libnvJitLink.so.13 RTLD_GLOBAL and shadows the
-          # conda 13.3 lib that cuVS 26.06 needs, so faiss then fails to load with
+          # conda 13.3 lib that cuVS 26.10 needs, so faiss then fails to load with
           # "undefined symbol __nvJitLinkCreate_13_3". No torch cu133 build exists,
           # so upgrade the pip nvjitlink to 13.3 (symbol-complete, CUDA-13 forward
           # compatible). cuVS-only: the non-cuVS GPU path does not use libcuvs.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,9 +121,9 @@ if(FAISS_ENABLE_GPU)
   endif()
 endif()
 
-if(FAISS_ENABLE_CUVS AND NOT TARGET cuvs::cuvs)
-   find_package(cuvs)
- endif()
+if(FAISS_ENABLE_CUVS AND (NOT TARGET cuvs::cuvs OR NOT TARGET cuvs::c_api))
+  find_package(cuvs REQUIRED COMPONENTS cuvs_shared c_api)
+endif()
 
 if(FAISS_ENABLE_CUVS AND NOT TARGET rmm::rmm)
   find_package(rmm REQUIRED)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@ pre-release nightly builds.
 
 - The CPU-only faiss-cpu conda package is currently available on Linux (x86-64 and aarch64), OSX (arm64 only), and Windows (x86-64)
 - faiss-gpu, containing both CPU and GPU indices, is available on Linux (x86-64 only) for CUDA 11.4 and 12.1
-- faiss-gpu-cuvs package containing GPU indices provided by [NVIDIA cuVS](https://github.com/rapidsai/cuvs/) version 26.06, is available on Linux (x86-64 only) for CUDA 13.2.
+- faiss-gpu-cuvs package containing GPU indices provided by [NVIDIA cuVS](https://github.com/rapidsai/cuvs/) version 26.10, is available on Linux (x86-64 only) for CUDA 13.2.
 
 To install the latest stable release:
 
@@ -90,7 +90,9 @@ The optional requirements are:
 - for AMD GPUs:
   - AMD ROCm,
 - for using NVIDIA cuVS implementations:
-  - libcuvs=26.06
+  - libcuvs=26.10
+  - CMake >=4.0,
+  - dlpack>=0.8
 - for the python bindings:
   - python 3,
   - numpy,
@@ -105,9 +107,9 @@ section of the wiki](https://github.com/facebookresearch/faiss/wiki/Troubleshoot
 
 The libcuvs dependency should be installed via conda:
 ```
-conda install -c rapidsai -c conda-forge -c nvidia libcuvs=26.06 'cuda-version=13.2'
+conda install -c rapidsai -c conda-forge -c nvidia libcuvs=26.10 'dlpack>=0.8' 'cuda-version=13.2'
 ```
-For more ways to install cuVS 26.06, refer to the [RAPIDS Installation Guide](https://docs.rapids.ai/install).
+For more ways to install cuVS 26.10, refer to the [RAPIDS Installation Guide](https://docs.rapids.ai/install).
 
 ### Building with Intel(R) SVS
 

--- a/cmake/thirdparty/fetch_rapids.cmake
+++ b/cmake/thirdparty/fetch_rapids.cmake
@@ -15,7 +15,7 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
-set(RAPIDS_VERSION "26.06")
+set(RAPIDS_VERSION "26.10")
 set(rapids-cmake-version ${RAPIDS_VERSION})
 set(rapids-cmake-branch "release/${RAPIDS_VERSION}")
 

--- a/conda/faiss-gpu-cuvs/meta.yaml
+++ b/conda/faiss-gpu-cuvs/meta.yaml
@@ -46,7 +46,7 @@ outputs:
         - {{ compiler('cxx') }} =12.4
         - sysroot_linux-64 =2.17 # [linux64]
         - llvm-openmp  # [osx]
-        - cmake >=3.30.4
+        - cmake >=4.0
         - make =4.2 # [not win]
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
         - mkl >=2024.2.2,<2026  # [x86_64]
@@ -62,7 +62,8 @@ outputs:
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
         - mkl >=2024.2.2,<2026  # [x86_64]
         - openblas =0.3.34 # [not x86_64]
-        - libcuvs =26.06
+        - libcuvs =26.10
+        - dlpack >=0.8
         - cuda-version {{ cuda_constraints }}
         - libsvs-runtime =0.4.0  # [x86_64 and linux]
       run:
@@ -71,7 +72,8 @@ outputs:
         - openblas =0.3.34 # [not x86_64]
         - cuda-cudart {{ cuda_constraints }}
         - libcublas {{ libcublas_constraints }}
-        - libcuvs =26.06
+        - libcuvs =26.10
+        - dlpack >=0.8
         - cuda-version {{ cuda_constraints }}
         - libnvjitlink
         - libsvs-runtime =0.4.0  # [x86_64 and linux]
@@ -96,7 +98,7 @@ outputs:
         - {{ compiler('cxx') }} =14.2
         - sysroot_linux-64 =2.34 # [linux64]
         - swig =4.0
-        - cmake >=3.30.4
+        - cmake >=4.0
         - make =4.2 # [not win]
         - _openmp_mutex =4.5=2_kmp_llvm  # [x86_64]
         - mkl >=2024.2.2,<2026  # [x86_64]

--- a/faiss/gpu/CMakeLists.txt
+++ b/faiss/gpu/CMakeLists.txt
@@ -363,7 +363,13 @@ else()
 
 
   find_package(CUDAToolkit REQUIRED)
-  target_link_libraries(faiss_gpu_objs PRIVATE ${CUDA_LIBS} $<$<BOOL:${FAISS_ENABLE_CUVS}>:cuvs::cuvs> $<$<BOOL:${FAISS_ENABLE_CUVS}>:rmm::rmm> $<$<BOOL:${FAISS_ENABLE_CUVS}>:OpenMP::OpenMP_CXX>)
+  target_link_libraries(faiss_gpu_objs PRIVATE
+    ${CUDA_LIBS}
+    $<$<BOOL:${FAISS_ENABLE_CUVS}>:cuvs::cuvs>
+    $<$<BOOL:${FAISS_ENABLE_CUVS}>:cuvs::c_api>
+    $<$<BOOL:${FAISS_ENABLE_CUVS}>:rmm::rmm>
+    $<$<BOOL:${FAISS_ENABLE_CUVS}>:OpenMP::OpenMP_CXX>
+  )
   target_compile_options(faiss_gpu_objs PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:-Xfatbin=-compress-all
     --expt-extended-lambda --expt-relaxed-constexpr

--- a/faiss/gpu/GpuDistance.cu
+++ b/faiss/gpu/GpuDistance.cu
@@ -34,6 +34,7 @@
 #include <optional>
 
 #if defined USE_NVIDIA_CUVS
+#include <cuvs/neighbors/brute_force.h>
 #include <cuvs/neighbors/brute_force.hpp>
 #include <faiss/gpu/utils/CuvsUtils.h>
 #include <raft/core/device_mdspan.hpp>
@@ -264,7 +265,6 @@ void bfKnn(GpuResourcesProvider* prov, const GpuDistanceParams& args) {
 
         DeviceScope scope(device);
         raft::device_resources& handle = res->getRaftHandleCurrentDevice();
-        auto stream = res->getDefaultStreamCurrentDevice();
 
         int64_t dims = args.dims;
         int64_t num_vectors = args.numVectors;
@@ -282,6 +282,42 @@ void bfKnn(GpuResourcesProvider* prov, const GpuDistanceParams& args) {
                         handle,
                         reinterpret_cast<float*>(args.outDistances),
                         raft::matrix_extent<int64_t>(num_queries, (int64_t)k));
+
+        auto indicesTensor = makeCuvsTensor(
+                inds.view().data_handle(),
+                num_queries,
+                static_cast<int64_t>(k));
+        auto distancesTensor = makeCuvsTensor(
+                dists.view().data_handle(),
+                num_queries,
+                static_cast<int64_t>(k));
+        auto cuvsResources = cuvsResourcesFromGpuResources(res);
+        auto searchCuvs = [&](DLManagedTensor* indexTensor,
+                              DLManagedTensor* queryTensor) {
+            cuvsBruteForceIndex_t index = nullptr;
+            cuvsCheck(
+                    cuvsBruteForceIndexCreate(&index),
+                    "cuvsBruteForceIndexCreate");
+            CuvsUniquePtr<cuvsBruteForceIndex, cuvsBruteForceIndexDestroy>
+                    indexHolder(index);
+            cuvsCheck(
+                    cuvsBruteForceBuild(
+                            cuvsResources,
+                            indexTensor,
+                            distance,
+                            metric_arg,
+                            index),
+                    "cuvsBruteForceBuild");
+            cuvsCheck(
+                    cuvsBruteForceSearch(
+                            cuvsResources,
+                            index,
+                            queryTensor,
+                            indicesTensor.get(),
+                            distancesTensor.get(),
+                            cuvsFilter{0, NO_FILTER}),
+                    "cuvsBruteForceSearch");
+        };
 
         if (args.queriesRowMajor) {
             auto index = raft::make_readonly_temporary_device_buffer<
@@ -302,33 +338,39 @@ void bfKnn(GpuResourcesProvider* prov, const GpuDistanceParams& args) {
                             reinterpret_cast<const float*>(args.queries)),
                     raft::matrix_extent<int64_t>(num_queries, dims));
 
-            // get device_vector_view to the precalculate norms if available
-            std::optional<raft::temporary_device_buffer<
-                    const float,
-                    raft::vector_extent<int64_t>>>
-                    norms;
-            std::optional<raft::device_vector_view<const float, int64_t>>
-                    norms_view;
+            // Compatibility note: release/26.10's brute-force C API does not
+            // accept caller-provided L2 norms. Preserve that optimization via
+            // C++ only when vectorNorms is explicitly supplied.
             if (args.vectorNorms) {
-                norms = raft::make_readonly_temporary_device_buffer<
+                auto norms = raft::make_readonly_temporary_device_buffer<
                         const float,
                         int64_t>(
                         handle,
                         args.vectorNorms,
-                        raft::vector_extent<int64_t>(num_queries));
-                norms_view = norms->view();
+                        raft::vector_extent<int64_t>(num_vectors));
+                std::optional<raft::device_vector_view<const float, int64_t>>
+                        normsView = norms.view();
+                cuvs::neighbors::brute_force::index<float> indexCpp(
+                        handle,
+                        index.view(),
+                        normsView,
+                        static_cast<cuvs::distance::DistanceType>(distance),
+                        metric_arg);
+                cuvs::neighbors::brute_force::search_params searchParams;
+                cuvs::neighbors::brute_force::search(
+                        handle,
+                        searchParams,
+                        indexCpp,
+                        search.view(),
+                        inds.view(),
+                        dists.view());
+            } else {
+                auto indexTensor = makeCuvsTensor(
+                        index.view().data_handle(), num_vectors, dims);
+                auto queryTensor = makeCuvsTensor(
+                        search.view().data_handle(), num_queries, dims);
+                searchCuvs(indexTensor.get(), queryTensor.get());
             }
-
-            cuvs::neighbors::brute_force::index<float> idx(
-                    handle, index.view(), norms_view, distance, metric_arg);
-            cuvs::neighbors::brute_force::search_params search_params_bf;
-            cuvs::neighbors::brute_force::search(
-                    handle,
-                    search_params_bf,
-                    idx,
-                    search.view(),
-                    inds.view(),
-                    dists.view());
         } else {
             auto index = raft::make_readonly_temporary_device_buffer<
                     const float,
@@ -348,32 +390,42 @@ void bfKnn(GpuResourcesProvider* prov, const GpuDistanceParams& args) {
                             reinterpret_cast<const float*>(args.queries)),
                     raft::matrix_extent<int64_t>(num_queries, dims));
 
-            std::optional<raft::temporary_device_buffer<
-                    const float,
-                    raft::vector_extent<int64_t>>>
-                    norms;
-            std::optional<raft::device_vector_view<const float, int64_t>>
-                    norms_view;
             if (args.vectorNorms) {
-                norms = raft::make_readonly_temporary_device_buffer<
+                auto norms = raft::make_readonly_temporary_device_buffer<
                         const float,
                         int64_t>(
                         handle,
                         args.vectorNorms,
-                        raft::vector_extent<int64_t>(num_queries));
-                norms_view = norms->view();
+                        raft::vector_extent<int64_t>(num_vectors));
+                std::optional<raft::device_vector_view<const float, int64_t>>
+                        normsView = norms.view();
+                cuvs::neighbors::brute_force::index<float> indexCpp(
+                        handle,
+                        index.view(),
+                        normsView,
+                        static_cast<cuvs::distance::DistanceType>(distance),
+                        metric_arg);
+                cuvs::neighbors::brute_force::search_params searchParams;
+                cuvs::neighbors::brute_force::search(
+                        handle,
+                        searchParams,
+                        indexCpp,
+                        search.view(),
+                        inds.view(),
+                        dists.view());
+            } else {
+                CuvsTensor<const float, 2> indexTensor(
+                        index.view().data_handle(),
+                        CuvsTensorLayout::ColumnMajor,
+                        num_vectors,
+                        dims);
+                CuvsTensor<const float, 2> queryTensor(
+                        search.view().data_handle(),
+                        CuvsTensorLayout::ColumnMajor,
+                        num_queries,
+                        dims);
+                searchCuvs(indexTensor.get(), queryTensor.get());
             }
-
-            cuvs::neighbors::brute_force::index<float> idx(
-                    handle, index.view(), norms_view, distance, metric_arg);
-            cuvs::neighbors::brute_force::search_params search_params_bf;
-            cuvs::neighbors::brute_force::search(
-                    handle,
-                    search_params_bf,
-                    idx,
-                    search.view(),
-                    inds.view(),
-                    dists.view());
         }
 
         if (args.metric == MetricType::METRIC_Lp) {

--- a/faiss/gpu/GpuDistance.cu
+++ b/faiss/gpu/GpuDistance.cu
@@ -31,11 +31,8 @@
 #include <faiss/gpu/utils/CopyUtils.cuh>
 #include <faiss/gpu/utils/DeviceTensor.cuh>
 #include <faiss/gpu/utils/Float16.cuh>
-#include <optional>
-
 #if defined USE_NVIDIA_CUVS
 #include <cuvs/neighbors/brute_force.h>
-#include <cuvs/neighbors/brute_force.hpp>
 #include <faiss/gpu/utils/CuvsUtils.h>
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/device_resources.hpp>
@@ -293,6 +290,7 @@ void bfKnn(GpuResourcesProvider* prov, const GpuDistanceParams& args) {
                 static_cast<int64_t>(k));
         auto cuvsResources = cuvsResourcesFromGpuResources(res);
         auto searchCuvs = [&](DLManagedTensor* indexTensor,
+                              DLManagedTensor* normsTensor,
                               DLManagedTensor* queryTensor) {
             cuvsBruteForceIndex_t index = nullptr;
             cuvsCheck(
@@ -300,14 +298,26 @@ void bfKnn(GpuResourcesProvider* prov, const GpuDistanceParams& args) {
                     "cuvsBruteForceIndexCreate");
             CuvsUniquePtr<cuvsBruteForceIndex, cuvsBruteForceIndexDestroy>
                     indexHolder(index);
-            cuvsCheck(
-                    cuvsBruteForceBuild(
-                            cuvsResources,
-                            indexTensor,
-                            distance,
-                            metric_arg,
-                            index),
-                    "cuvsBruteForceBuild");
+            if (normsTensor) {
+                cuvsCheck(
+                        cuvsBruteForceBuildWithNorms(
+                                cuvsResources,
+                                indexTensor,
+                                normsTensor,
+                                distance,
+                                metric_arg,
+                                index),
+                        "cuvsBruteForceBuildWithNorms");
+            } else {
+                cuvsCheck(
+                        cuvsBruteForceBuild(
+                                cuvsResources,
+                                indexTensor,
+                                distance,
+                                metric_arg,
+                                index),
+                        "cuvsBruteForceBuild");
+            }
             cuvsCheck(
                     cuvsBruteForceSearch(
                             cuvsResources,
@@ -338,9 +348,10 @@ void bfKnn(GpuResourcesProvider* prov, const GpuDistanceParams& args) {
                             reinterpret_cast<const float*>(args.queries)),
                     raft::matrix_extent<int64_t>(num_queries, dims));
 
-            // Compatibility note: release/26.10's brute-force C API does not
-            // accept caller-provided L2 norms. Preserve that optimization via
-            // C++ only when vectorNorms is explicitly supplied.
+            auto indexTensor = makeCuvsTensor(
+                    index.view().data_handle(), num_vectors, dims);
+            auto queryTensor = makeCuvsTensor(
+                    search.view().data_handle(), num_queries, dims);
             if (args.vectorNorms) {
                 auto norms = raft::make_readonly_temporary_device_buffer<
                         const float,
@@ -348,28 +359,14 @@ void bfKnn(GpuResourcesProvider* prov, const GpuDistanceParams& args) {
                         handle,
                         args.vectorNorms,
                         raft::vector_extent<int64_t>(num_vectors));
-                std::optional<raft::device_vector_view<const float, int64_t>>
-                        normsView = norms.view();
-                cuvs::neighbors::brute_force::index<float> indexCpp(
-                        handle,
-                        index.view(),
-                        normsView,
-                        static_cast<cuvs::distance::DistanceType>(distance),
-                        metric_arg);
-                cuvs::neighbors::brute_force::search_params searchParams;
-                cuvs::neighbors::brute_force::search(
-                        handle,
-                        searchParams,
-                        indexCpp,
-                        search.view(),
-                        inds.view(),
-                        dists.view());
+                auto normsTensor =
+                        makeCuvsTensor(norms.view().data_handle(), num_vectors);
+                searchCuvs(
+                        indexTensor.get(),
+                        normsTensor.get(),
+                        queryTensor.get());
             } else {
-                auto indexTensor = makeCuvsTensor(
-                        index.view().data_handle(), num_vectors, dims);
-                auto queryTensor = makeCuvsTensor(
-                        search.view().data_handle(), num_queries, dims);
-                searchCuvs(indexTensor.get(), queryTensor.get());
+                searchCuvs(indexTensor.get(), nullptr, queryTensor.get());
             }
         } else {
             auto index = raft::make_readonly_temporary_device_buffer<
@@ -390,6 +387,16 @@ void bfKnn(GpuResourcesProvider* prov, const GpuDistanceParams& args) {
                             reinterpret_cast<const float*>(args.queries)),
                     raft::matrix_extent<int64_t>(num_queries, dims));
 
+            CuvsTensor<const float, 2> indexTensor(
+                    index.view().data_handle(),
+                    CuvsTensorLayout::ColumnMajor,
+                    num_vectors,
+                    dims);
+            CuvsTensor<const float, 2> queryTensor(
+                    search.view().data_handle(),
+                    CuvsTensorLayout::ColumnMajor,
+                    num_queries,
+                    dims);
             if (args.vectorNorms) {
                 auto norms = raft::make_readonly_temporary_device_buffer<
                         const float,
@@ -397,34 +404,14 @@ void bfKnn(GpuResourcesProvider* prov, const GpuDistanceParams& args) {
                         handle,
                         args.vectorNorms,
                         raft::vector_extent<int64_t>(num_vectors));
-                std::optional<raft::device_vector_view<const float, int64_t>>
-                        normsView = norms.view();
-                cuvs::neighbors::brute_force::index<float> indexCpp(
-                        handle,
-                        index.view(),
-                        normsView,
-                        static_cast<cuvs::distance::DistanceType>(distance),
-                        metric_arg);
-                cuvs::neighbors::brute_force::search_params searchParams;
-                cuvs::neighbors::brute_force::search(
-                        handle,
-                        searchParams,
-                        indexCpp,
-                        search.view(),
-                        inds.view(),
-                        dists.view());
+                auto normsTensor =
+                        makeCuvsTensor(norms.view().data_handle(), num_vectors);
+                searchCuvs(
+                        indexTensor.get(),
+                        normsTensor.get(),
+                        queryTensor.get());
             } else {
-                CuvsTensor<const float, 2> indexTensor(
-                        index.view().data_handle(),
-                        CuvsTensorLayout::ColumnMajor,
-                        num_vectors,
-                        dims);
-                CuvsTensor<const float, 2> queryTensor(
-                        search.view().data_handle(),
-                        CuvsTensorLayout::ColumnMajor,
-                        num_queries,
-                        dims);
-                searchCuvs(indexTensor.get(), queryTensor.get());
+                searchCuvs(indexTensor.get(), nullptr, queryTensor.get());
             }
         }
 

--- a/faiss/gpu/GpuIndexCagra.cu
+++ b/faiss/gpu/GpuIndexCagra.cu
@@ -31,6 +31,7 @@
 #include <optional>
 #include <type_traits>
 
+#include <cuvs/neighbors/all_neighbors.h>
 #include <cuvs/neighbors/all_neighbors.hpp>
 #include <cuvs/neighbors/cagra.hpp>
 #include <faiss/gpu/utils/CuvsUtils.h>
@@ -42,8 +43,9 @@
 // Some cuVS versions put helpers::optimize in its own header.
 #include <cuvs/neighbors/cagra_optimize.hpp>
 #endif
-// TEMPORARY. cuVS has no public API to prune a graph that is already on the
-// device, so we reach into its internals when they happen to be available.
+// Compatibility note: release/26.10 has no C API to prune an already-built
+// neighbor graph. Use the public C++ host helper by default, or the existing
+// private device helper when FAISS_CAGRA_DEVICE_OPTIMIZE is enabled.
 // Delete this and the branch it guards once that API ships upstream.
 #if defined(FAISS_CAGRA_DEVICE_OPTIMIZE)
 #include <neighbors/detail/cagra/graph_core.cuh>
@@ -106,41 +108,6 @@ void GpuIndexCagra::train_ex(idx_t n, const void* x, NumericType numeric_type) {
     // CuvsCagra not initialized
     FAISS_ASSERT(!index_is_initialized);
 
-    std::optional<cuvs::neighbors::ivf_pq::index_params> ivf_pq_params =
-            std::nullopt;
-    std::optional<cuvs::neighbors::ivf_pq::search_params> ivf_pq_search_params =
-            std::nullopt;
-    if (cagraConfig_.ivf_pq_params != nullptr) {
-        ivf_pq_params =
-                std::make_optional<cuvs::neighbors::ivf_pq::index_params>();
-        ivf_pq_params->n_lists = cagraConfig_.ivf_pq_params->n_lists;
-        ivf_pq_params->kmeans_n_iters =
-                cagraConfig_.ivf_pq_params->kmeans_n_iters;
-        ivf_pq_params->kmeans_trainset_fraction =
-                cagraConfig_.ivf_pq_params->kmeans_trainset_fraction;
-        ivf_pq_params->pq_bits = cagraConfig_.ivf_pq_params->pq_bits;
-        ivf_pq_params->pq_dim = cagraConfig_.ivf_pq_params->pq_dim;
-        ivf_pq_params->codebook_kind =
-                static_cast<cuvs::neighbors::ivf_pq::codebook_gen>(
-                        cagraConfig_.ivf_pq_params->codebook_kind);
-        ivf_pq_params->force_random_rotation =
-                cagraConfig_.ivf_pq_params->force_random_rotation;
-        ivf_pq_params->conservative_memory_allocation =
-                cagraConfig_.ivf_pq_params->conservative_memory_allocation;
-    }
-    if (cagraConfig_.ivf_pq_search_params != nullptr) {
-        ivf_pq_search_params =
-                std::make_optional<cuvs::neighbors::ivf_pq::search_params>();
-        ivf_pq_search_params->n_probes =
-                cagraConfig_.ivf_pq_search_params->n_probes;
-        ivf_pq_search_params->lut_dtype =
-                cagraConfig_.ivf_pq_search_params->lut_dtype;
-        ivf_pq_search_params->preferred_shmem_carveout =
-                cagraConfig_.ivf_pq_search_params->preferred_shmem_carveout;
-        ivf_pq_search_params->max_internal_batch_size =
-                cagraConfig_.ivf_pq_search_params->max_internal_batch_size;
-    }
-
     if (numeric_type == NumericType::Float32) {
         index_ = std::make_shared<CuvsCagra<float>>(
                 this->resources_.get(),
@@ -153,8 +120,8 @@ void GpuIndexCagra::train_ex(idx_t n, const void* x, NumericType numeric_type) {
                 this->metric_type,
                 this->metric_arg,
                 INDICES_64_BIT,
-                ivf_pq_params,
-                ivf_pq_search_params,
+                cagraConfig_.ivf_pq_params.get(),
+                cagraConfig_.ivf_pq_search_params.get(),
                 cagraConfig_.refine_rate,
                 cagraConfig_.guarantee_connectivity);
         std::get<std::shared_ptr<CuvsCagra<float>>>(index_)->train(
@@ -171,8 +138,8 @@ void GpuIndexCagra::train_ex(idx_t n, const void* x, NumericType numeric_type) {
                 this->metric_type,
                 this->metric_arg,
                 INDICES_64_BIT,
-                ivf_pq_params,
-                ivf_pq_search_params,
+                cagraConfig_.ivf_pq_params.get(),
+                cagraConfig_.ivf_pq_search_params.get(),
                 cagraConfig_.refine_rate,
                 cagraConfig_.guarantee_connectivity);
         std::get<std::shared_ptr<CuvsCagra<half>>>(index_)->train(
@@ -189,8 +156,8 @@ void GpuIndexCagra::train_ex(idx_t n, const void* x, NumericType numeric_type) {
                 this->metric_type,
                 this->metric_arg,
                 INDICES_64_BIT,
-                ivf_pq_params,
-                ivf_pq_search_params,
+                cagraConfig_.ivf_pq_params.get(),
+                cagraConfig_.ivf_pq_search_params.get(),
                 cagraConfig_.refine_rate,
                 cagraConfig_.guarantee_connectivity);
         std::get<std::shared_ptr<CuvsCagra<int8_t>>>(index_)->train(
@@ -381,44 +348,57 @@ void GpuIndexCagra::trainAllNeighbors_(idx_t n, const float* x) {
     {
         raft::device_resources_snmg clique(devices);
 
-        cuvs::neighbors::all_neighbors::all_neighbors_params an_params;
-        int num_gpus = static_cast<int>(devices.size());
-        an_params.n_clusters = an_config.n_clusters > 0
+        const int numGpus = static_cast<int>(devices.size());
+        const size_t nClusters = an_config.n_clusters > 0
                 ? an_config.n_clusters
-                : static_cast<size_t>(std::max(num_gpus * 2, 4));
-        an_params.overlap_factor = an_config.overlap_factor;
-        an_params.metric = metricFaissToCuvs(this->metric_type, false);
+                : static_cast<size_t>(std::max(numGpus * 2, 4));
+        const size_t overlapFactor = an_config.overlap_factor;
 
-        const char* algo_name = "nn_descent";
+        cuvsAllNeighborsIndexParams_t cParams = nullptr;
+        cuvsCheck(
+                cuvsAllNeighborsIndexParamsCreate(&cParams),
+                "cuvsAllNeighborsIndexParamsCreate");
+        CuvsUniquePtr<
+                cuvsAllNeighborsIndexParams,
+                cuvsAllNeighborsIndexParamsDestroy>
+                cParamsHolder(cParams);
+        cParams->n_clusters = nClusters;
+        cParams->overlap_factor = overlapFactor;
+        cParams->metric = metricFaissToCuvs(this->metric_type, false);
+
+        // Compatibility note: release/26.10's all-neighbors C parameters do
+        // not expose IVF-PQ search batch size or refinement rate and cannot
+        // derive IVF-PQ defaults from a caller-selected cluster size. Keep the
+        // IVF-PQ variant on C++ until those controls are available in C.
+        std::optional<cuvs::neighbors::all_neighbors::all_neighbors_params>
+                cppParams;
+        const char* algoName = "nn_descent";
         switch (cagraConfig_.build_algo) {
-            case graph_build_algo::BRUTE_FORCE: {
-                // Exact kNN via tiled GEMM, O(N^2 D) per cluster
-                cuvs::neighbors::all_neighbors::graph_build_params::
-                        brute_force_params bf_params;
-                an_params.graph_build_params = bf_params;
-                algo_name = "brute_force";
+            case graph_build_algo::BRUTE_FORCE:
+                cParams->algo = CUVS_ALL_NEIGHBORS_ALGO_BRUTE_FORCE;
+                algoName = "brute_force";
                 break;
-            }
             case graph_build_algo::IVF_PQ: {
-                // cuVS derives good IVF-PQ params from the dataset shape,
-                // so only override what it cannot infer. See
-                // AllNeighborsCagraConfig::ivf_pq_size_from_cluster.
-                idx_t sizing_rows = n;
+                cppParams.emplace();
+                cppParams->n_clusters = nClusters;
+                cppParams->overlap_factor = overlapFactor;
+                cppParams->metric = static_cast<cuvs::distance::DistanceType>(
+                        metricFaissToCuvs(this->metric_type, false));
+
+                idx_t sizingRows = n;
                 if (an_config.ivf_pq_size_from_cluster) {
-                    sizing_rows = std::max<idx_t>(
+                    sizingRows = std::max<idx_t>(
                             1,
-                            (idx_t)((double)n * an_params.overlap_factor /
-                                    (double)an_params.n_clusters));
+                            (idx_t)((double)n * overlapFactor /
+                                    (double)nClusters));
                 }
-                auto dataset_ext = raft::make_extents<int64_t>(
-                        sizing_rows, static_cast<int64_t>(this->d));
+                auto datasetExtents = raft::make_extents<int64_t>(
+                        sizingRows, static_cast<int64_t>(this->d));
                 cuvs::neighbors::all_neighbors::graph_build_params::
-                        ivf_pq_params ivfpq_params(dataset_ext);
-                ivfpq_params.refinement_rate = an_config.refinement_rate;
-                // Bounds search memory; batches the search rather than
-                // changing its result.
+                        ivf_pq_params ivfPqParams(datasetExtents);
+                ivfPqParams.refinement_rate = an_config.refinement_rate;
                 if (an_config.ivf_pq_search_batch_size > 0) {
-                    ivfpq_params.search_params.max_internal_batch_size =
+                    ivfPqParams.search_params.max_internal_batch_size =
                             an_config.ivf_pq_search_batch_size;
                 }
                 fprintf(stderr,
@@ -427,33 +407,33 @@ void GpuIndexCagra::trainAllNeighbors_(idx_t n, const float* x) {
                         "kmeans_trainset_fraction=%.4f refine=%.2f\n",
                         an_config.ivf_pq_size_from_cluster ? "cluster"
                                                            : "full dataset",
-                        (long)sizing_rows,
-                        ivfpq_params.build_params.n_lists,
-                        ivfpq_params.search_params.n_probes,
-                        ivfpq_params.build_params.kmeans_trainset_fraction,
-                        ivfpq_params.refinement_rate);
-                an_params.graph_build_params = ivfpq_params;
-                algo_name = "ivf_pq";
+                        (long)sizingRows,
+                        ivfPqParams.build_params.n_lists,
+                        ivfPqParams.search_params.n_probes,
+                        ivfPqParams.build_params.kmeans_trainset_fraction,
+                        ivfPqParams.refinement_rate);
+                cppParams->graph_build_params = ivfPqParams;
+                algoName = "ivf_pq";
                 break;
             }
-            case graph_build_algo::NN_DESCENT: {
-                cuvs::neighbors::all_neighbors::graph_build_params::
-                        nn_descent_params nn_params;
-                nn_params.graph_degree = intermediate_degree;
-                nn_params.max_iterations = cagraConfig_.nn_descent_niter;
-                an_params.graph_build_params = nn_params;
+            case graph_build_algo::NN_DESCENT:
+                cParams->algo = CUVS_ALL_NEIGHBORS_ALGO_NN_DESCENT;
+                cuvsCheck(
+                        cuvsNNDescentIndexParamsCreate(
+                                &cParams->nn_descent_params),
+                        "cuvsNNDescentIndexParamsCreate");
+                cParams->nn_descent_params->metric = cParams->metric;
+                cParams->nn_descent_params->graph_degree = intermediate_degree;
+                cParams->nn_descent_params->max_iterations =
+                        cagraConfig_.nn_descent_niter;
                 break;
-            }
             default:
                 FAISS_THROW_MSG(
                         "multi-GPU CAGRA build supports build_algo IVF_PQ, "
                         "NN_DESCENT or BRUTE_FORCE");
         }
 
-        auto dataset = raft::make_host_matrix_view<const float, int64_t>(
-                x, n, static_cast<int64_t>(this->d));
-
-        auto d_indices = raft::make_device_matrix<int64_t, int64_t>(
+        auto dIndices = raft::make_device_matrix<int64_t, int64_t>(
                 clique, n, static_cast<int64_t>(intermediate_degree));
 
         fprintf(stderr,
@@ -462,15 +442,36 @@ void GpuIndexCagra::trainAllNeighbors_(idx_t n, const float* x) {
                 "algo=%s, refinement_rate=%.2f\n",
                 (long)n,
                 (long)intermediate_degree,
-                an_params.n_clusters,
-                an_params.overlap_factor,
-                algo_name,
+                nClusters,
+                overlapFactor,
+                algoName,
                 cagraConfig_.build_algo == graph_build_algo::IVF_PQ
                         ? an_config.refinement_rate
                         : 0.0f);
 
-        cuvs::neighbors::all_neighbors::build(
-                clique, an_params, dataset, d_indices.view());
+        if (cppParams) {
+            auto dataset = raft::make_host_matrix_view<const float, int64_t>(
+                    x, n, static_cast<int64_t>(this->d));
+            cuvs::neighbors::all_neighbors::build(
+                    clique, *cppParams, dataset, dIndices.view());
+        } else {
+            auto datasetTensor = makeCuvsTensor(
+                    const_cast<float*>(x), (int64_t)n, (int64_t)this->d);
+            auto indexTensor = makeCuvsTensor(
+                    dIndices.data_handle(),
+                    (int64_t)n,
+                    (int64_t)intermediate_degree);
+            cuvsCheck(
+                    cuvsAllNeighborsBuild(
+                            reinterpret_cast<cuvsResources_t>(&clique),
+                            cParams,
+                            datasetTensor.get(),
+                            indexTensor.get(),
+                            nullptr,
+                            nullptr,
+                            1.0f),
+                    "cuvsAllNeighborsBuild");
+        }
 
         auto t_now = std::chrono::high_resolution_clock::now();
         fprintf(stderr,
@@ -483,7 +484,7 @@ void GpuIndexCagra::trainAllNeighbors_(idx_t n, const float* x) {
         const int blocks = (int)std::min<size_t>(
                 (knn_count + kThreads - 1) / kThreads, 65535);
         kern_narrow_indices<<<blocks, kThreads>>>(
-                d_indices.data_handle(), d_knn.data_handle(), knn_count);
+                dIndices.data_handle(), d_knn.data_handle(), knn_count);
         CUDA_VERIFY(cudaGetLastError());
         CUDA_VERIFY(cudaDeviceSynchronize());
     } // clique + d_indices destroyed here, freeing all GPU resources
@@ -937,8 +938,8 @@ void GpuIndexCagra::buildHnswUpperLevelsGpu_(
                     this->metric_type,
                     this->metric_arg,
                     INDICES_64_BIT,
-                    std::nullopt,
-                    std::nullopt,
+                    nullptr,
+                    nullptr,
                     cagraConfig_.refine_rate,
                     cagraConfig_.gpu_hnsw_guarantee_connectivity);
             sub.train(n_lvl, sub_x.data());

--- a/faiss/gpu/GpuIndexCagra.cu
+++ b/faiss/gpu/GpuIndexCagra.cu
@@ -28,29 +28,15 @@
 #include <cstddef>
 #include <cstdio>
 #include <faiss/gpu/impl/CuvsCagra.cuh>
-#include <optional>
 #include <type_traits>
 
 #include <cuvs/neighbors/all_neighbors.h>
-#include <cuvs/neighbors/all_neighbors.hpp>
-#include <cuvs/neighbors/cagra.hpp>
+#include <cuvs/neighbors/cagra.h>
 #include <faiss/gpu/utils/CuvsUtils.h>
 #include <faiss/gpu/utils/DeviceUtils.h>
+#include <raft/core/device_mdarray.hpp>
 #include <raft/core/device_resources_snmg.hpp>
 #include <raft/core/resource/multi_gpu.hpp>
-// clang-format off
-#if __has_include(<cuvs/neighbors/cagra_optimize.hpp>)
-// Some cuVS versions put helpers::optimize in its own header.
-#include <cuvs/neighbors/cagra_optimize.hpp>
-#endif
-// Compatibility note: release/26.10 has no C API to prune an already-built
-// neighbor graph. Use the public C++ host helper by default, or the existing
-// private device helper when FAISS_CAGRA_DEVICE_OPTIMIZE is enabled.
-// Delete this and the branch it guards once that API ships upstream.
-#if defined(FAISS_CAGRA_DEVICE_OPTIMIZE)
-#include <neighbors/detail/cagra/graph_core.cuh>
-#endif
-// clang-format on
 
 namespace {
 
@@ -366,12 +352,6 @@ void GpuIndexCagra::trainAllNeighbors_(idx_t n, const float* x) {
         cParams->overlap_factor = overlapFactor;
         cParams->metric = metricFaissToCuvs(this->metric_type, false);
 
-        // Compatibility note: release/26.10's all-neighbors C parameters do
-        // not expose IVF-PQ search batch size or refinement rate and cannot
-        // derive IVF-PQ defaults from a caller-selected cluster size. Keep the
-        // IVF-PQ variant on C++ until those controls are available in C.
-        std::optional<cuvs::neighbors::all_neighbors::all_neighbors_params>
-                cppParams;
         const char* algoName = "nn_descent";
         switch (cagraConfig_.build_algo) {
             case graph_build_algo::BRUTE_FORCE:
@@ -379,12 +359,6 @@ void GpuIndexCagra::trainAllNeighbors_(idx_t n, const float* x) {
                 algoName = "brute_force";
                 break;
             case graph_build_algo::IVF_PQ: {
-                cppParams.emplace();
-                cppParams->n_clusters = nClusters;
-                cppParams->overlap_factor = overlapFactor;
-                cppParams->metric = static_cast<cuvs::distance::DistanceType>(
-                        metricFaissToCuvs(this->metric_type, false));
-
                 idx_t sizingRows = n;
                 if (an_config.ivf_pq_size_from_cluster) {
                     sizingRows = std::max<idx_t>(
@@ -392,27 +366,25 @@ void GpuIndexCagra::trainAllNeighbors_(idx_t n, const float* x) {
                             (idx_t)((double)n * overlapFactor /
                                     (double)nClusters));
                 }
-                auto datasetExtents = raft::make_extents<int64_t>(
-                        sizingRows, static_cast<int64_t>(this->d));
-                cuvs::neighbors::all_neighbors::graph_build_params::
-                        ivf_pq_params ivfPqParams(datasetExtents);
-                ivfPqParams.refinement_rate = an_config.refinement_rate;
+                cParams->algo = CUVS_ALL_NEIGHBORS_ALGO_IVF_PQ;
+                cParams->ivf_pq_sizing_rows = sizingRows;
+                cParams->ivf_pq_refinement_rate = an_config.refinement_rate;
+                cuvsCheck(
+                        cuvsIvfPqSearchParamsCreate(
+                                &cParams->ivf_pq_search_params),
+                        "cuvsIvfPqSearchParamsCreate");
                 if (an_config.ivf_pq_search_batch_size > 0) {
-                    ivfPqParams.search_params.max_internal_batch_size =
+                    cParams->ivf_pq_search_params->max_internal_batch_size =
                             an_config.ivf_pq_search_batch_size;
                 }
                 fprintf(stderr,
                         "  [trainAllNeighbors] IVF-PQ sized from %s "
-                        "(%ld rows): n_lists=%u n_probes=%u "
-                        "kmeans_trainset_fraction=%.4f refine=%.2f\n",
+                        "(%ld rows): refine=%.2f, search_batch=%u\n",
                         an_config.ivf_pq_size_from_cluster ? "cluster"
                                                            : "full dataset",
                         (long)sizingRows,
-                        ivfPqParams.build_params.n_lists,
-                        ivfPqParams.search_params.n_probes,
-                        ivfPqParams.build_params.kmeans_trainset_fraction,
-                        ivfPqParams.refinement_rate);
-                cppParams->graph_build_params = ivfPqParams;
+                        an_config.refinement_rate,
+                        an_config.ivf_pq_search_batch_size);
                 algoName = "ivf_pq";
                 break;
             }
@@ -449,29 +421,22 @@ void GpuIndexCagra::trainAllNeighbors_(idx_t n, const float* x) {
                         ? an_config.refinement_rate
                         : 0.0f);
 
-        if (cppParams) {
-            auto dataset = raft::make_host_matrix_view<const float, int64_t>(
-                    x, n, static_cast<int64_t>(this->d));
-            cuvs::neighbors::all_neighbors::build(
-                    clique, *cppParams, dataset, dIndices.view());
-        } else {
-            auto datasetTensor = makeCuvsTensor(
-                    const_cast<float*>(x), (int64_t)n, (int64_t)this->d);
-            auto indexTensor = makeCuvsTensor(
-                    dIndices.data_handle(),
-                    (int64_t)n,
-                    (int64_t)intermediate_degree);
-            cuvsCheck(
-                    cuvsAllNeighborsBuild(
-                            reinterpret_cast<cuvsResources_t>(&clique),
-                            cParams,
-                            datasetTensor.get(),
-                            indexTensor.get(),
-                            nullptr,
-                            nullptr,
-                            1.0f),
-                    "cuvsAllNeighborsBuild");
-        }
+        auto datasetTensor = makeCuvsTensor(
+                const_cast<float*>(x), (int64_t)n, (int64_t)this->d);
+        auto indexTensor = makeCuvsTensor(
+                dIndices.data_handle(),
+                (int64_t)n,
+                (int64_t)intermediate_degree);
+        cuvsCheck(
+                cuvsAllNeighborsBuild(
+                        reinterpret_cast<cuvsResources_t>(&clique),
+                        cParams,
+                        datasetTensor.get(),
+                        indexTensor.get(),
+                        nullptr,
+                        nullptr,
+                        1.0f),
+                "cuvsAllNeighborsBuild");
 
         auto t_now = std::chrono::high_resolution_clock::now();
         fprintf(stderr,
@@ -499,34 +464,19 @@ void GpuIndexCagra::trainAllNeighbors_(idx_t n, const float* x) {
     const size_t out_count = (size_t)n * graph_degree;
     std::vector<uint32_t> h_cagra(out_count);
 
-#if !defined(FAISS_CAGRA_DEVICE_OPTIMIZE)
-    // Public API: host matrices only, so the graph makes a round trip it does
-    // not need. Some cuVS versions also read the input as host memory whatever
-    // accessor you hand them, so passing device pointers here is not an option.
-    auto h_knn =
-            raft::make_host_matrix<uint32_t, int64_t>(n, intermediate_degree);
-    raft::copy(
-            h_knn.data_handle(),
-            d_knn.data_handle(),
-            knn_count,
-            raft::resource::get_cuda_stream(single_gpu_res));
-    raft::resource::sync_stream(single_gpu_res);
-
-    auto h_cagra_view = raft::make_host_matrix_view<uint32_t, int64_t>(
-            h_cagra.data(), n, graph_degree);
-    cuvs::neighbors::cagra::helpers::optimize(
-            single_gpu_res, h_knn.view(), h_cagra_view);
-    const char* optimize_where = "host (public API)";
-#else
     auto d_cagra = raft::make_device_matrix<uint32_t, int64_t>(
             single_gpu_res, n, graph_degree);
-
-    cuvs::neighbors::cagra::detail::graph::optimize<uint32_t>(
-            single_gpu_res,
-            d_knn.view(),
-            d_cagra.view(),
-            cagraConfig_.guarantee_connectivity);
-    raft::resource::sync_stream(single_gpu_res);
+    auto knnTensor = makeCuvsTensor(
+            d_knn.data_handle(), (int64_t)n, (int64_t)intermediate_degree);
+    auto cagraTensor = makeCuvsTensor(
+            d_cagra.data_handle(), (int64_t)n, (int64_t)graph_degree);
+    cuvsCheck(
+            cuvsCagraOptimizeGraph(
+                    reinterpret_cast<cuvsResources_t>(&single_gpu_res),
+                    knnTensor.get(),
+                    cagraTensor.get(),
+                    cagraConfig_.guarantee_connectivity),
+            "cuvsCagraOptimizeGraph");
     raft::copy(
             h_cagra.data(),
             d_cagra.data_handle(),
@@ -534,7 +484,6 @@ void GpuIndexCagra::trainAllNeighbors_(idx_t n, const float* x) {
             raft::resource::get_cuda_stream(single_gpu_res));
     raft::resource::sync_stream(single_gpu_res);
     const char* optimize_where = "device-resident";
-#endif
 
     t_now = std::chrono::high_resolution_clock::now();
     fprintf(stderr,

--- a/faiss/gpu/GpuIndexIVFFlat.cu
+++ b/faiss/gpu/GpuIndexIVFFlat.cu
@@ -16,7 +16,7 @@
 #include <faiss/gpu/utils/Float16.cuh>
 
 #if defined USE_NVIDIA_CUVS
-#include <cuvs/neighbors/ivf_flat.hpp>
+#include <cuvs/neighbors/ivf_flat.h>
 #include <faiss/gpu/utils/CuvsUtils.h>
 #include <faiss/gpu/impl/CuvsIVFFlat.cuh>
 #endif
@@ -231,49 +231,59 @@ void GpuIndexIVFFlat::train(idx_t n, const float* x) {
         const raft::device_resources& raft_handle =
                 resources_->getRaftHandleCurrentDevice();
 
-        cuvs::neighbors::ivf_flat::index_params cuvs_index_params;
-        cuvs_index_params.n_lists = nlist;
-        cuvs_index_params.metric = metricFaissToCuvs(metric_type, false);
-        cuvs_index_params.add_data_on_build = false;
-        // kmeans_trainset_fraction and kmeans_n_iters intentionally left
-        // at cuVS defaults (0.5 and 20). Faiss's cp.max_points_per_centroid
-        // (256) was designed for CPU k-means and produces severely
-        // underparameterized training at scale through cuVS.
+        cuvsIvfFlatIndexParams_t indexParams = nullptr;
+        cuvsCheck(
+                cuvsIvfFlatIndexParamsCreate(&indexParams),
+                "cuvsIvfFlatIndexParamsCreate");
+        CuvsUniquePtr<cuvsIvfFlatIndexParams, cuvsIvfFlatIndexParamsDestroy>
+                indexParamsHolder(indexParams);
+        indexParams->n_lists = nlist;
+        indexParams->metric = metricFaissToCuvs(metric_type, false);
+        indexParams->metric_arg = metric_arg;
+        indexParams->add_data_on_build = false;
+        // kmeans_trainset_fraction and kmeans_n_iters intentionally remain
+        // at the cuVS defaults (0.5 and 20).
 
-        auto cuvsIndex_ =
-                std::static_pointer_cast<CuvsIVFFlat, IVFFlat>(index_);
+        cuvsIvfFlatIndex_t cuvsIndex = nullptr;
+        cuvsCheck(cuvsIvfFlatIndexCreate(&cuvsIndex), "cuvsIvfFlatIndexCreate");
+        CuvsUniquePtr<cuvsIvfFlatIndex, cuvsIvfFlatIndexDestroy>
+                cuvsIndexHolder(cuvsIndex);
+        auto trainingData = toDeviceTemporary<float, 2>(
+                resources_.get(),
+                config_.device,
+                const_cast<float*>(x),
+                raft_handle.get_stream(),
+                {n, d});
+        auto datasetTensor = makeCuvsTensor(
+                trainingData.data(),
+                static_cast<int64_t>(n),
+                static_cast<int64_t>(d));
+        cuvsCheck(
+                cuvsIvfFlatBuild(
+                        cuvsResourcesFromGpuResources(resources_.get()),
+                        indexParams,
+                        datasetTensor.get(),
+                        cuvsIndex),
+                "cuvsIvfFlatBuild");
 
-        std::optional<cuvs::neighbors::ivf_flat::index<float, idx_t>>
-                cuvs_ivfflat_index;
-
-        if (getDeviceForAddress(x) >= 0) {
-            auto dataset_d =
-                    raft::make_device_matrix_view<const float, idx_t>(x, n, d);
-            cuvs_ivfflat_index = cuvs::neighbors::ivf_flat::build(
-                    raft_handle, cuvs_index_params, dataset_d);
-        } else {
-            auto dataset_h =
-                    raft::make_host_matrix_view<const float, idx_t>(x, n, d);
-            cuvs_ivfflat_index = cuvs::neighbors::ivf_flat::build(
-                    raft_handle, cuvs_index_params, dataset_h);
-        }
-
+        CuvsOutputTensor centersTensor;
+        cuvsCheck(
+                cuvsIvfFlatIndexGetCenters(cuvsIndex, centersTensor.get()),
+                "cuvsIvfFlatIndexGetCenters");
+        auto centers = centersTensor.data<float>();
         if (isGpuIndex(quantizer)) {
-            quantizer->train(
-                    nlist, cuvs_ivfflat_index.value().centers().data_handle());
-            quantizer->add(
-                    nlist, cuvs_ivfflat_index.value().centers().data_handle());
+            quantizer->train(nlist, centers);
+            quantizer->add(nlist, centers);
         } else {
-            // transfer centroids to host
-            auto host_centroids = toHost<float, 2>(
-                    cuvs_ivfflat_index.value().centers().data_handle(),
-                    raft_handle.get_stream(),
-                    {idx_t(nlist), this->d});
-            quantizer->train(nlist, host_centroids.data());
-            quantizer->add(nlist, host_centroids.data());
+            auto hostCentroids = toHost<float, 2>(
+                    centers, raft_handle.get_stream(), {idx_t(nlist), this->d});
+            quantizer->train(nlist, hostCentroids.data());
+            quantizer->add(nlist, hostCentroids.data());
         }
 
-        cuvsIndex_->setCuvsIndex(std::move(*cuvs_ivfflat_index));
+        auto faissCuvsIndex =
+                std::static_pointer_cast<CuvsIVFFlat, IVFFlat>(index_);
+        faissCuvsIndex->setCuvsIndex(cuvsIndexHolder.release());
 #else
         FAISS_THROW_MSG(
                 "cuVS has not been compiled into the current version so it cannot be used.");

--- a/faiss/gpu/GpuIndexIVFPQ.cu
+++ b/faiss/gpu/GpuIndexIVFPQ.cu
@@ -16,8 +16,10 @@
 #include <faiss/gpu/utils/CopyUtils.cuh>
 
 #if defined USE_NVIDIA_CUVS
-#include <cuvs/neighbors/ivf_pq.hpp>
+#include <cuvs/neighbors/ivf_pq.h>
 #include <faiss/gpu/utils/CuvsUtils.h>
+#include <raft/core/device_mdarray.hpp>
+#include <raft/util/cudart_utils.hpp>
 #include <faiss/gpu/impl/CuvsIVFPQ.cuh>
 #endif
 
@@ -389,61 +391,90 @@ void GpuIndexIVFPQ::train(idx_t n, const float* x) {
         const raft::device_resources& raft_handle =
                 resources_->getRaftHandleCurrentDevice();
 
-        cuvs::neighbors::ivf_pq::index_params cuvs_index_params;
-        cuvs_index_params.n_lists = nlist;
-        cuvs_index_params.metric = metricFaissToCuvs(metric_type, false);
-        // kmeans_trainset_fraction and kmeans_n_iters intentionally left
-        // at cuVS defaults (0.5 and 20). Faiss's cp.max_points_per_centroid
-        // (256) was designed for CPU k-means and produces severely
-        // underparameterized training at scale through cuVS.
-        cuvs_index_params.pq_bits = bitsPerCode_;
-        cuvs_index_params.pq_dim = subQuantizers_;
-        cuvs_index_params.conservative_memory_allocation = false;
-        cuvs_index_params.add_data_on_build = false;
+        cuvsIvfPqIndexParams_t indexParams = nullptr;
+        cuvsCheck(
+                cuvsIvfPqIndexParamsCreate(&indexParams),
+                "cuvsIvfPqIndexParamsCreate");
+        CuvsUniquePtr<cuvsIvfPqIndexParams, cuvsIvfPqIndexParamsDestroy>
+                indexParamsHolder(indexParams);
+        indexParams->n_lists = nlist;
+        indexParams->metric = metricFaissToCuvs(metric_type, false);
+        indexParams->metric_arg = metric_arg;
+        // kmeans_trainset_fraction and kmeans_n_iters intentionally remain
+        // at the cuVS defaults (0.5 and 20).
+        indexParams->pq_bits = bitsPerCode_;
+        indexParams->pq_dim = subQuantizers_;
+        indexParams->codebook_kind = CUVS_IVF_PQ_CODEBOOK_GEN_PER_SUBSPACE;
+        indexParams->conservative_memory_allocation = false;
+        indexParams->add_data_on_build = false;
+        indexParams->codes_layout = CUVS_IVF_PQ_LIST_LAYOUT_INTERLEAVED;
 
-        auto cuvsIndex_ = std::static_pointer_cast<CuvsIVFPQ, IVFPQ>(index_);
+        cuvsIvfPqIndex_t cuvsIndex = nullptr;
+        cuvsCheck(cuvsIvfPqIndexCreate(&cuvsIndex), "cuvsIvfPqIndexCreate");
+        CuvsUniquePtr<cuvsIvfPqIndex, cuvsIvfPqIndexDestroy> cuvsIndexHolder(
+                cuvsIndex);
+        auto trainingData = toDeviceTemporary<float, 2>(
+                resources_.get(),
+                config_.device,
+                const_cast<float*>(x),
+                raft_handle.get_stream(),
+                {n, d});
+        auto datasetTensor = makeCuvsTensor(
+                trainingData.data(),
+                static_cast<int64_t>(n),
+                static_cast<int64_t>(d));
+        cuvsCheck(
+                cuvsIvfPqBuild(
+                        cuvsResourcesFromGpuResources(resources_.get()),
+                        indexParams,
+                        datasetTensor.get(),
+                        cuvsIndex),
+                "cuvsIvfPqBuild");
 
-        std::optional<cuvs::neighbors::ivf_pq::index<idx_t>> cuvs_ivfpq_index;
-
-        if (getDeviceForAddress(x) >= 0) {
-            auto dataset_d =
-                    raft::make_device_matrix_view<const float, idx_t>(x, n, d);
-            cuvs_ivfpq_index = cuvs::neighbors::ivf_pq::build(
-                    raft_handle, cuvs_index_params, dataset_d);
-        } else {
-            auto dataset_h =
-                    raft::make_host_matrix_view<const float, idx_t>(x, n, d);
-            cuvs_ivfpq_index = cuvs::neighbors::ivf_pq::build(
-                    raft_handle, cuvs_index_params, dataset_h);
-        }
-
-        auto cluster_centers = raft::make_device_matrix<float>(
-                raft_handle,
-                cuvs_ivfpq_index.value().n_lists(),
-                cuvs_ivfpq_index.value().dim());
-        cuvs::neighbors::ivf_pq::helpers::extract_centers(
-                raft_handle, cuvs_ivfpq_index.value(), cluster_centers.view());
+        CuvsOutputTensor centersView;
+        cuvsCheck(
+                cuvsIvfPqIndexGetCenters(cuvsIndex, centersView.get()),
+                "cuvsIvfPqIndexGetCenters");
+        auto clusterCenters = raft::make_device_matrix<float, int64_t>(
+                raft_handle, (int64_t)nlist, (int64_t)d);
+        auto centerStride = centersView.get()->dl_tensor.strides
+                ? centersView.get()->dl_tensor.strides[0]
+                : centersView.extent(1);
+        raft::copy_matrix(
+                clusterCenters.data_handle(),
+                d,
+                centersView.data<float>(),
+                centerStride,
+                d,
+                nlist,
+                raft_handle.get_stream());
 
         if (isGpuIndex(quantizer)) {
-            quantizer->train(nlist, cluster_centers.data_handle());
-            quantizer->add(nlist, cluster_centers.data_handle());
+            quantizer->train(nlist, clusterCenters.data_handle());
+            quantizer->add(nlist, clusterCenters.data_handle());
         } else {
-            // transfer centroids to host
-            auto host_centroids = toHost<float, 2>(
-                    cluster_centers.data_handle(),
+            auto hostCentroids = toHost<float, 2>(
+                    clusterCenters.data_handle(),
                     raft_handle.get_stream(),
                     {idx_t(nlist), this->d});
-            quantizer->train(nlist, host_centroids.data());
-            quantizer->add(nlist, host_centroids.data());
+            quantizer->train(nlist, hostCentroids.data());
+            quantizer->add(nlist, hostCentroids.data());
         }
 
+        CuvsOutputTensor pqCenters;
+        cuvsCheck(
+                cuvsIvfPqIndexGetPqCenters(cuvsIndex, pqCenters.get()),
+                "cuvsIvfPqIndexGetPqCenters");
         raft::copy(
                 pq.get_centroids(0, 0),
-                cuvs_ivfpq_index.value().pq_centers().data_handle(),
-                cuvs_ivfpq_index.value().pq_centers().size(),
+                pqCenters.data<float>(),
+                pqCenters.extent(0) * pqCenters.extent(1) * pqCenters.extent(2),
                 raft_handle.get_stream());
         raft_handle.sync_stream();
-        cuvsIndex_->setCuvsIndex(std::move(*cuvs_ivfpq_index));
+
+        auto faissCuvsIndex =
+                std::static_pointer_cast<CuvsIVFPQ, IVFPQ>(index_);
+        faissCuvsIndex->setCuvsIndex(cuvsIndexHolder.release());
 #else
         FAISS_THROW_MSG(
                 "cuVS has not been compiled into the current version so it cannot be used.");

--- a/faiss/gpu/GpuIndexIVFScalarQuantizer.cu
+++ b/faiss/gpu/GpuIndexIVFScalarQuantizer.cu
@@ -14,13 +14,12 @@
 #include <faiss/gpu/utils/CopyUtils.cuh>
 
 #if defined(USE_NVIDIA_CUVS) && !defined(FAISS_CUVS_NO_IVFSQ)
-#include <cuvs/neighbors/ivf_sq.hpp>
+#include <cuvs/neighbors/ivf_sq.h>
 #include <faiss/gpu/utils/CuvsUtils.h>
 #include <faiss/gpu/impl/CuvsIVFSQ.cuh>
 #endif
 
 #include <limits>
-#include <optional>
 #include <vector>
 
 namespace faiss {
@@ -347,45 +346,61 @@ void GpuIndexIVFScalarQuantizer::train(idx_t n, const float* x) {
                 ivfSQConfig_.indicesOptions,
                 config_.memorySpace);
 
-        auto cuvsIndex_ = std::static_pointer_cast<CuvsIVFSQ, IVFFlat>(index_);
-
         const raft::device_resources& raft_handle =
                 resources_->getRaftHandleCurrentDevice();
 
-        cuvs::neighbors::ivf_sq::index_params cuvs_index_params;
-        cuvs_index_params.n_lists = nlist;
-        cuvs_index_params.metric = metricFaissToCuvs(metric_type, false);
-        cuvs_index_params.add_data_on_build = false;
+        cuvsIvfSqIndexParams_t indexParams = nullptr;
+        cuvsCheck(
+                cuvsIvfSqIndexParamsCreate(&indexParams),
+                "cuvsIvfSqIndexParamsCreate");
+        CuvsUniquePtr<cuvsIvfSqIndexParams, cuvsIvfSqIndexParamsDestroy>
+                indexParamsHolder(indexParams);
+        indexParams->n_lists = nlist;
+        indexParams->metric = metricFaissToCuvs(metric_type, false);
+        indexParams->metric_arg = metric_arg;
+        indexParams->add_data_on_build = false;
 
-        std::optional<cuvs::neighbors::ivf_sq::index<uint8_t>> cuvs_ivfsq_index;
+        cuvsIvfSqIndex_t cuvsIndex = nullptr;
+        cuvsCheck(cuvsIvfSqIndexCreate(&cuvsIndex), "cuvsIvfSqIndexCreate");
+        CuvsUniquePtr<cuvsIvfSqIndex, cuvsIvfSqIndexDestroy> cuvsIndexHolder(
+                cuvsIndex);
+        auto trainingData = toDeviceTemporary<float, 2>(
+                resources_.get(),
+                config_.device,
+                const_cast<float*>(x),
+                raft_handle.get_stream(),
+                {n, d});
+        auto datasetTensor = makeCuvsTensor(
+                trainingData.data(),
+                static_cast<int64_t>(n),
+                static_cast<int64_t>(d));
+        cuvsCheck(
+                cuvsIvfSqBuild(
+                        cuvsResourcesFromGpuResources(resources_.get()),
+                        indexParams,
+                        datasetTensor.get(),
+                        cuvsIndex),
+                "cuvsIvfSqBuild");
 
-        if (getDeviceForAddress(x) >= 0) {
-            auto dataset_d =
-                    raft::make_device_matrix_view<const float, idx_t>(x, n, d);
-            cuvs_ivfsq_index = cuvs::neighbors::ivf_sq::build(
-                    raft_handle, cuvs_index_params, dataset_d);
-        } else {
-            auto dataset_h =
-                    raft::make_host_matrix_view<const float, idx_t>(x, n, d);
-            cuvs_ivfsq_index = cuvs::neighbors::ivf_sq::build(
-                    raft_handle, cuvs_index_params, dataset_h);
-        }
-
+        CuvsOutputTensor centers;
+        cuvsCheck(
+                cuvsIvfSqIndexGetCenters(cuvsIndex, centers.get()),
+                "cuvsIvfSqIndexGetCenters");
         if (isGpuIndex(quantizer)) {
-            quantizer->train(
-                    nlist, cuvs_ivfsq_index.value().centers().data_handle());
-            quantizer->add(
-                    nlist, cuvs_ivfsq_index.value().centers().data_handle());
+            quantizer->train(nlist, centers.data<float>());
+            quantizer->add(nlist, centers.data<float>());
         } else {
-            auto host_centroids = toHost<float, 2>(
-                    cuvs_ivfsq_index.value().centers().data_handle(),
+            auto hostCentroids = toHost<float, 2>(
+                    centers.data<float>(),
                     raft_handle.get_stream(),
                     {idx_t(nlist), this->d});
-            quantizer->train(nlist, host_centroids.data());
-            quantizer->add(nlist, host_centroids.data());
+            quantizer->train(nlist, hostCentroids.data());
+            quantizer->add(nlist, hostCentroids.data());
         }
 
-        cuvsIndex_->setCuvsIndex(std::move(*cuvs_ivfsq_index));
+        auto faissCuvsIndex =
+                std::static_pointer_cast<CuvsIVFSQ, IVFFlat>(index_);
+        faissCuvsIndex->setCuvsIndex(cuvsIndexHolder.release());
 #else
         FAISS_THROW_MSG(
                 "cuVS has not been compiled into the current version so it cannot be used.");

--- a/faiss/gpu/impl/BinaryCuvsCagra.cu
+++ b/faiss/gpu/impl/BinaryCuvsCagra.cu
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,18 +27,41 @@
 #include <faiss/gpu/utils/DeviceUtils.h>
 #include <faiss/gpu/impl/BinaryCuvsCagra.cuh>
 
-#include <cuvs/core/bitset.hpp>
-#include <cuvs/neighbors/cagra.hpp>
-#include <raft/core/device_mdspan.hpp>
+#include <cuvs/neighbors/cagra.h>
 #include <raft/core/device_resources.hpp>
-#include <raft/core/resource/thrust_policy.hpp>
 #include <raft/linalg/map.cuh>
 
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
 
+#include <algorithm>
+#include <memory>
+#include <vector>
+
 namespace faiss {
 namespace gpu {
+
+namespace {
+
+cuvsDataset_t makeAndAttachPaddedDataset(
+        GpuResources* resources,
+        const uint8_t* data,
+        int64_t rows,
+        int64_t cols,
+        cuvsCagraIndex_t index) {
+    cuvsDataset_t paddedDataset =
+            makeCuvsPaddedDataset(resources, data, rows, cols);
+    CuvsUniquePtr<cuvsDataset, cuvsDatasetDestroy> paddedHolder(paddedDataset);
+    cuvsCheck(
+            cuvsCagraUpdateDataset(
+                    cuvsResourcesFromGpuResources(resources),
+                    paddedDataset,
+                    index),
+            "cuvsCagraUpdateDataset");
+    return paddedHolder.release();
+}
+
+} // namespace
 
 BinaryCuvsCagra::BinaryCuvsCagra(
         GpuResources* resources,
@@ -50,28 +73,23 @@ BinaryCuvsCagra::BinaryCuvsCagra(
         bool store_dataset,
         IndicesOptions indicesOptions)
         : resources_(resources),
+          storage_(nullptr),
+          n_(0),
           dim_(dim),
           store_dataset_(store_dataset),
           graph_build_algo_(graph_build_algo),
+          intermediate_graph_degree_(intermediate_graph_degree),
+          graph_degree_(graph_degree),
           nn_descent_niter_(nn_descent_niter) {
     FAISS_THROW_IF_NOT_MSG(
             indicesOptions == faiss::gpu::INDICES_64_BIT,
             "only INDICES_64_BIT is supported for cuVS CAGRA index");
 
-    index_params_.intermediate_graph_degree = intermediate_graph_degree;
-    index_params_.graph_degree = graph_degree;
-    index_params_.attach_dataset_on_build = store_dataset;
-
-    index_params_.metric = cuvs::distance::DistanceType::BitwiseHamming;
-
-    // default to NN_DESCENT if IVF_PQ is set
     if (graph_build_algo == faiss::cagra_build_algo::IVF_PQ) {
         fprintf(stderr,
                 "WARNING: IVF_PQ is not supported for binary CAGRA. "
                 "Defaulting to NN_DESCENT\n");
     }
-
-    reset();
 }
 
 BinaryCuvsCagra::BinaryCuvsCagra(
@@ -82,109 +100,160 @@ BinaryCuvsCagra::BinaryCuvsCagra(
         const uint8_t* train_dataset,
         const idx_t* knn_graph,
         IndicesOptions indicesOptions)
-        : resources_(resources), dim_(dim) {
+        : resources_(resources),
+          storage_(train_dataset),
+          n_(n),
+          dim_(dim),
+          graph_build_algo_(faiss::cagra_build_algo::NN_DESCENT),
+          intermediate_graph_degree_(graph_degree),
+          graph_degree_(graph_degree) {
     FAISS_THROW_IF_NOT_MSG(
             indicesOptions == faiss::gpu::INDICES_64_BIT,
             "only INDICES_64_BIT is supported for cuVS CAGRA index");
 
-    bool distances_on_gpu = getDeviceForAddress(train_dataset) >= 0;
-    bool knn_graph_on_gpu = getDeviceForAddress(knn_graph) >= 0;
+    const bool datasetOnGpu = getDeviceForAddress(train_dataset) >= 0;
+    const bool graphOnGpu = getDeviceForAddress(knn_graph) >= 0;
+    FAISS_THROW_IF_NOT_MSG(
+            datasetOnGpu == graphOnGpu,
+            "dataset and knn_graph must both be in device or host memory");
 
-    FAISS_ASSERT(distances_on_gpu == knn_graph_on_gpu);
-
-    storage_ = train_dataset;
-    n_ = n;
-
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-
-    if (distances_on_gpu && knn_graph_on_gpu) {
-        raft_handle.sync_stream();
-        // Copying to host so that cuvs::neighbors::cagra::index
-        // creates an owning copy of the knn graph on device
-        auto knn_graph_copy =
-                raft::make_host_matrix<uint32_t, int64_t>(n, graph_degree);
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+    std::vector<uint32_t> hostGraph(n * graph_degree);
+    if (graphOnGpu) {
+        raftHandle.sync_stream();
         thrust::copy(
                 thrust::device_ptr<const idx_t>(knn_graph),
-                thrust::device_ptr<const idx_t>(knn_graph + (n * graph_degree)),
-                knn_graph_copy.data_handle());
-
-        auto dataset_mds =
-                raft::make_device_matrix_view<const uint8_t, int64_t>(
-                        train_dataset, n, dim / 8);
-
-        cuvs_index = std::make_shared<
-                cuvs::neighbors::cagra::index<uint8_t, uint32_t>>(
-                raft_handle,
-                cuvs::distance::DistanceType::BitwiseHamming,
-                dataset_mds,
-                raft::make_const_mdspan(knn_graph_copy.view()));
-    } else if (!distances_on_gpu && !knn_graph_on_gpu) {
-        // copy idx_t (int64_t) host knn_graph to uint32_t host knn_graph
-        auto knn_graph_copy =
-                raft::make_host_matrix<uint32_t, int64_t>(n, graph_degree);
-        std::copy(
-                knn_graph,
-                knn_graph + (n * graph_degree),
-                knn_graph_copy.data_handle());
-
-        auto dataset_mds = raft::make_host_matrix_view<const uint8_t, int64_t>(
-                train_dataset, n, dim / 8);
-
-        cuvs_index = std::make_shared<
-                cuvs::neighbors::cagra::index<uint8_t, uint32_t>>(
-                raft_handle,
-                cuvs::distance::DistanceType::BitwiseHamming,
-                dataset_mds,
-                raft::make_const_mdspan(knn_graph_copy.view()));
+                thrust::device_ptr<const idx_t>(knn_graph + n * graph_degree),
+                hostGraph.data());
     } else {
-        FAISS_THROW_MSG(
-                "distances and knn_graph must both be in device or host memory");
+        std::transform(
+                knn_graph,
+                knn_graph + n * graph_degree,
+                hostGraph.begin(),
+                [](idx_t value) { return static_cast<uint32_t>(value); });
+    }
+
+    if (!datasetOnGpu || cuvsPaddedDatasetNeedsView(train_dataset, dim_ / 8)) {
+        ownedDataset_ = DeviceTensor<uint8_t, 2, true>(
+                resources_,
+                AllocInfo(
+                        AllocType::Other,
+                        getCurrentDevice(),
+                        MemorySpace::Device,
+                        raftHandle.get_stream()),
+                {n, dim_ / 8});
+        raft::copy(
+                ownedDataset_.data(),
+                train_dataset,
+                ownedDataset_.numElements(),
+                raftHandle.get_stream());
+        storage_ = ownedDataset_.data();
+    }
+
+    auto graphTensor =
+            makeCuvsTensor(hostGraph.data(), (int64_t)n, (int64_t)graph_degree);
+    auto datasetTensor = makeCuvsTensor(
+            const_cast<uint8_t*>(storage_), (int64_t)n, (int64_t)(dim_ / 8));
+
+    cuvsCagraIndex_t index = nullptr;
+    cuvsCheck(cuvsCagraIndexCreate(&index), "cuvsCagraIndexCreate");
+    CuvsUniquePtr<cuvsCagraIndex, cuvsCagraIndexDestroy> indexHolder(index);
+    cuvsCheck(
+            cuvsCagraIndexFromArgs(
+                    cuvsResourcesFromGpuResources(resources_),
+                    BitwiseHamming,
+                    graphTensor.get(),
+                    datasetTensor.get(),
+                    index),
+            "cuvsCagraIndexFromArgs");
+    cuvs_dataset_ = makeAndAttachPaddedDataset(
+            resources_,
+            datasetOnGpu ? storage_ : train_dataset,
+            (int64_t)n_,
+            (int64_t)(dim_ / 8),
+            index);
+    raftHandle.sync_stream();
+    cuvs_index = indexHolder.release();
+}
+
+BinaryCuvsCagra::~BinaryCuvsCagra() {
+    if (cuvs_index) {
+        cuvsCagraIndexDestroy(cuvs_index);
+    }
+    if (cuvs_dataset_) {
+        cuvsDatasetDestroy(cuvs_dataset_);
     }
 }
 
 void BinaryCuvsCagra::train(idx_t n, const uint8_t* x) {
+    reset();
     storage_ = x;
     n_ = n;
 
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-
-    // IVF-PQ is not supported as the graph building algorithm
-    if (graph_build_algo_ == faiss::cagra_build_algo::NN_DESCENT ||
-        graph_build_algo_ == faiss::cagra_build_algo::IVF_PQ) {
-        cuvs::neighbors::cagra::graph_build_params::nn_descent_params
-                graph_build_params(index_params_.intermediate_graph_degree);
-        graph_build_params.max_iterations = nn_descent_niter_;
-        graph_build_params.metric =
-                cuvs::distance::DistanceType::BitwiseHamming;
-        index_params_.graph_build_params = graph_build_params;
-    } else {
-        cuvs::neighbors::cagra::graph_build_params::iterative_search_params
-                graph_build_params;
-        index_params_.graph_build_params = graph_build_params;
-        if (index_params_.graph_degree ==
-            index_params_.intermediate_graph_degree) {
-            index_params_.intermediate_graph_degree =
-                    1.5 * index_params_.graph_degree;
-        }
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+    const uint8_t* buildData = x;
+    if (store_dataset_ && cuvsPaddedDatasetNeedsView(x, dim_ / 8)) {
+        ownedDataset_ = DeviceTensor<uint8_t, 2, true>(
+                resources_,
+                AllocInfo(
+                        AllocType::Other,
+                        getCurrentDevice(),
+                        MemorySpace::Device,
+                        raftHandle.get_stream()),
+                {n, dim_ / 8});
+        raft::copy(
+                ownedDataset_.data(),
+                x,
+                ownedDataset_.numElements(),
+                raftHandle.get_stream());
+        storage_ = ownedDataset_.data();
+        buildData = storage_;
     }
 
-    if (getDeviceForAddress(x) >= 0) {
-        auto dataset = raft::make_device_matrix_view<const uint8_t, int64_t>(
-                x, n, dim_ / 8);
-        cuvs_index = std::make_shared<
-                cuvs::neighbors::cagra::index<uint8_t, uint32_t>>(
-                cuvs::neighbors::cagra::build(
-                        raft_handle, index_params_, dataset));
+    auto sourceTensor = makeCuvsTensor(
+            const_cast<uint8_t*>(buildData), (int64_t)n, (int64_t)(dim_ / 8));
+    cuvsDataset_t dataset = nullptr;
+    if (store_dataset_) {
+        dataset = makeCuvsPaddedDataset(
+                resources_, buildData, (int64_t)n, (int64_t)(dim_ / 8));
     } else {
-        auto dataset = raft::make_host_matrix_view<const uint8_t, int64_t>(
-                x, n, dim_ / 8);
-        cuvs_index = std::make_shared<
-                cuvs::neighbors::cagra::index<uint8_t, uint32_t>>(
-                cuvs::neighbors::cagra::build(
-                        raft_handle, index_params_, dataset));
+        cuvsCheck(
+                cuvsDatasetMakeStandardView(
+                        cuvsResourcesFromGpuResources(resources_),
+                        sourceTensor.get(),
+                        &dataset),
+                "cuvsDatasetMakeStandardView");
     }
+    CuvsUniquePtr<cuvsDataset, cuvsDatasetDestroy> datasetHolder(dataset);
+
+    cuvsCagraIndexParams_t params = nullptr;
+    cuvsCheck(
+            cuvsCagraIndexParamsCreate(&params), "cuvsCagraIndexParamsCreate");
+    CuvsUniquePtr<cuvsCagraIndexParams, cuvsCagraIndexParamsDestroy>
+            paramsHolder(params);
+    // The C factory preallocates an IVF-PQ block, but binary CAGRA always uses
+    // NN-descent. Detach and destroy the unused block explicitly.
+    std::unique_ptr<cuvsIvfPqParams> unusedIvfPqParams(
+            static_cast<cuvsIvfPqParams*>(params->graph_build_params));
+    params->graph_build_params = nullptr;
+    params->metric = BitwiseHamming;
+    params->intermediate_graph_degree = intermediate_graph_degree_;
+    params->graph_degree = graph_degree_;
+    params->build_algo = NN_DESCENT;
+    params->nn_descent_niter = nn_descent_niter_;
+
+    cuvsCagraIndex_t index = nullptr;
+    cuvsCheck(cuvsCagraIndexCreate(&index), "cuvsCagraIndexCreate");
+    CuvsUniquePtr<cuvsCagraIndex, cuvsCagraIndexDestroy> indexHolder(index);
+    cuvsCheck(
+            cuvsCagraBuild(
+                    cuvsResourcesFromGpuResources(resources_),
+                    params,
+                    dataset,
+                    index),
+            "cuvsCagraBuild");
+    cuvs_dataset_ = datasetHolder.release();
+    cuvs_index = indexHolder.release();
 }
 
 void BinaryCuvsCagra::search(
@@ -206,134 +275,144 @@ void BinaryCuvsCagra::search(
         idx_t num_random_samplings,
         idx_t rand_xor_mask,
         const IDSelector* sel) {
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-    idx_t numQueries = queries.getSize(0);
-    idx_t cols = queries.getSize(1);
-    idx_t k_ = k;
-    auto distances_float =
-            raft::make_device_matrix<float>(raft_handle, numQueries, k_);
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+    const idx_t numQueries = queries.getSize(0);
+    const idx_t cols = queries.getSize(1);
 
     FAISS_ASSERT(cuvs_index);
     FAISS_ASSERT(numQueries > 0);
     FAISS_ASSERT(cols == dim_ / 8);
 
     if (!store_dataset_) {
-        if (getDeviceForAddress(storage_) >= 0) {
-            auto dataset =
-                    raft::make_device_matrix_view<const uint8_t, int64_t>(
-                            storage_, n_, dim_ / 8);
-            cuvs_index->update_dataset(raft_handle, dataset);
-        } else {
-            auto dataset = raft::make_host_matrix_view<const uint8_t, int64_t>(
-                    storage_, n_, dim_ / 8);
-            cuvs_index->update_dataset(raft_handle, dataset);
+        if (cuvsPaddedDatasetNeedsView(storage_, dim_ / 8)) {
+            ownedDataset_ = DeviceTensor<uint8_t, 2, true>(
+                    resources_,
+                    AllocInfo(
+                            AllocType::Other,
+                            getCurrentDevice(),
+                            MemorySpace::Device,
+                            raftHandle.get_stream()),
+                    {n_, dim_ / 8});
+            raft::copy(
+                    ownedDataset_.data(),
+                    storage_,
+                    ownedDataset_.numElements(),
+                    raftHandle.get_stream());
+            storage_ = ownedDataset_.data();
         }
+        auto paddedDataset = makeAndAttachPaddedDataset(
+                resources_,
+                storage_,
+                (int64_t)n_,
+                (int64_t)(dim_ / 8),
+                cuvs_index);
+        if (cuvs_dataset_) {
+            cuvsCheck(cuvsDatasetDestroy(cuvs_dataset_), "cuvsDatasetDestroy");
+        }
+        cuvs_dataset_ = paddedDataset;
         store_dataset_ = true;
     }
 
-    auto indices_view = raft::make_device_matrix_view<idx_t, int64_t>(
-            outIndices.data(), numQueries, k_);
+    cuvsCagraSearchParams_t params = nullptr;
+    cuvsCheck(
+            cuvsCagraSearchParamsCreate(&params),
+            "cuvsCagraSearchParamsCreate");
+    CuvsUniquePtr<cuvsCagraSearchParams, cuvsCagraSearchParamsDestroy>
+            paramsHolder(params);
+    params->max_queries = max_queries;
+    params->itopk_size = itopk_size;
+    params->max_iterations = max_iterations;
+    params->algo = static_cast<cuvsCagraSearchAlgo>(graph_search_algo);
+    params->team_size = team_size;
+    params->search_width = search_width;
+    params->min_iterations = min_iterations;
+    params->thread_block_size = thread_block_size;
+    params->hashmap_mode = static_cast<cuvsCagraHashMode>(hash_mode);
+    params->hashmap_min_bitlen = hashmap_min_bitlen;
+    params->hashmap_max_fill_rate = hashmap_max_fill_rate;
+    params->num_random_samplings = num_random_samplings;
+    params->rand_xor_mask = rand_xor_mask;
 
-    cuvs::neighbors::cagra::search_params search_pams;
-    search_pams.max_queries = max_queries;
-    search_pams.itopk_size = itopk_size;
-    search_pams.max_iterations = max_iterations;
-    search_pams.algo =
-            static_cast<cuvs::neighbors::cagra::search_algo>(graph_search_algo);
-    search_pams.team_size = team_size;
-    search_pams.search_width = search_width;
-    search_pams.min_iterations = min_iterations;
-    search_pams.thread_block_size = thread_block_size;
-    search_pams.hashmap_mode =
-            static_cast<cuvs::neighbors::cagra::hash_mode>(hash_mode);
-    search_pams.hashmap_min_bitlen = hashmap_min_bitlen;
-    search_pams.hashmap_max_fill_rate = hashmap_max_fill_rate;
-    search_pams.num_random_samplings = num_random_samplings;
-    search_pams.rand_xor_mask = rand_xor_mask;
+    auto indexCopy = raft::make_device_matrix<uint32_t, int64_t>(
+            raftHandle, numQueries, k);
+    auto distanceCopy =
+            raft::make_device_matrix<float, int64_t>(raftHandle, numQueries, k);
+    auto queryTensor =
+            makeCuvsTensor(queries.data(), (int64_t)numQueries, (int64_t)cols);
+    auto indexTensor = makeCuvsTensor(
+            indexCopy.data_handle(), (int64_t)numQueries, (int64_t)k);
+    auto distanceTensor = makeCuvsTensor(
+            distanceCopy.data_handle(), (int64_t)numQueries, (int64_t)k);
+    CuvsFilter filter(resources_, sel, n_);
 
-    auto queries_view = raft::make_device_matrix_view<const uint8_t, int64_t>(
-            queries.data(), numQueries, cols);
-    auto indices_copy = raft::make_device_matrix<uint32_t, int64_t>(
-            raft_handle, numQueries, k_);
-    auto distances_float_view = distances_float.view();
-
-    std::optional<cuvs::core::bitset<uint32_t, int64_t>> bitset_holder;
-    std::optional<cuvs::neighbors::filtering::bitset_filter<uint32_t, int64_t>>
-            bitset_filter;
-    cuvs::neighbors::filtering::none_sample_filter none_filter;
-
-    if (sel) {
-        bitset_holder =
-                cuvs::core::bitset<uint32_t, int64_t>(raft_handle, n_, false);
-        faiss::gpu::convert_to_bitset(resources_, *sel, bitset_holder->view());
-        bitset_filter.emplace(bitset_holder->view());
-    }
-    const cuvs::neighbors::filtering::base_filter& filter_ref = sel
-            ? static_cast<const cuvs::neighbors::filtering::base_filter&>(
-                      bitset_filter.value())
-            : static_cast<const cuvs::neighbors::filtering::base_filter&>(
-                      none_filter);
-
-    cuvs::neighbors::cagra::search(
-            raft_handle,
-            search_pams,
-            *cuvs_index,
-            queries_view,
-            indices_copy.view(),
-            distances_float_view,
-            filter_ref);
-
-    faiss::gpu::sanitizeCuvsIndices(
+    cuvsCheck(
+            cuvsCagraSearch(
+                    cuvsResourcesFromGpuResources(resources_),
+                    params,
+                    cuvs_index,
+                    queryTensor.get(),
+                    indexTensor.get(),
+                    distanceTensor.get(),
+                    filter.get()),
+            "cuvsCagraSearch");
+    sanitizeCuvsIndices(
             resources_,
-            indices_copy.data_handle(),
-            indices_view.data_handle(),
-            indices_copy.size(),
+            indexCopy.data_handle(),
+            outIndices.data(),
+            indexCopy.size(),
             n_);
-    auto distances_view = raft::make_device_matrix_view(
-            outDistances.data(),
-            static_cast<int64_t>(numQueries),
-            static_cast<int64_t>(k));
 
+    auto distancesView = raft::make_device_matrix_view(
+            outDistances.data(), (int64_t)numQueries, (int64_t)k);
+    auto distanceCopyView = distanceCopy.view();
     raft::linalg::map_offset(
-            raft_handle,
-            distances_view,
-            [distances_float_view, k_] __device__(size_t i) {
-                int row_idx = i / k_;
-                int col_idx = i % k_;
-                return static_cast<int>(distances_float_view(row_idx, col_idx));
+            raftHandle,
+            distancesView,
+            [distanceCopyView, k] __device__(size_t i) {
+                const int row = i / k;
+                const int col = i % k;
+                return static_cast<int>(distanceCopyView(row, col));
             });
 }
 
 void BinaryCuvsCagra::reset() {
-    cuvs_index.reset();
+    if (cuvs_index) {
+        cuvsCheck(cuvsCagraIndexDestroy(cuvs_index), "cuvsCagraIndexDestroy");
+        cuvs_index = nullptr;
+    }
+    if (cuvs_dataset_) {
+        cuvsCheck(cuvsDatasetDestroy(cuvs_dataset_), "cuvsDatasetDestroy");
+        cuvs_dataset_ = nullptr;
+    }
 }
 
 idx_t BinaryCuvsCagra::get_knngraph_degree() const {
     FAISS_ASSERT(cuvs_index);
-    return static_cast<idx_t>(cuvs_index->graph_degree());
+    int64_t degree = 0;
+    cuvsCheck(
+            cuvsCagraIndexGetGraphDegree(cuvs_index, &degree),
+            "cuvsCagraIndexGetGraphDegree");
+    return static_cast<idx_t>(degree);
 }
 
 std::vector<idx_t> BinaryCuvsCagra::get_knngraph() const {
     FAISS_ASSERT(cuvs_index);
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-    auto stream = raft_handle.get_stream();
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
 
-    auto device_graph = cuvs_index->graph();
+    CuvsOutputTensor graphTensor;
+    cuvsCheck(
+            cuvsCagraIndexGetGraph(cuvs_index, graphTensor.get()),
+            "cuvsCagraIndexGetGraph");
+    const uint32_t* graphData = graphTensor.data<uint32_t>();
+    const size_t graphSize = graphTensor.extent(0) * graphTensor.extent(1);
 
-    std::vector<idx_t> host_graph(
-            device_graph.extent(0) * device_graph.extent(1));
-
-    raft_handle.sync_stream();
-
+    std::vector<idx_t> hostGraph(graphSize);
+    raftHandle.sync_stream();
     thrust::copy(
-            thrust::device_ptr<const uint32_t>(device_graph.data_handle()),
-            thrust::device_ptr<const uint32_t>(
-                    device_graph.data_handle() + device_graph.size()),
-            host_graph.data());
-
-    return host_graph;
+            thrust::device_ptr<const uint32_t>(graphData),
+            thrust::device_ptr<const uint32_t>(graphData + graphSize),
+            hostGraph.data());
+    return hostGraph;
 }
 
 const uint8_t* BinaryCuvsCagra::get_training_dataset() const {

--- a/faiss/gpu/impl/BinaryCuvsCagra.cuh
+++ b/faiss/gpu/impl/BinaryCuvsCagra.cuh
@@ -23,17 +23,19 @@
 
 #pragma once
 
+#include <cuvs/core/dataset.h>
+#include <cuvs/neighbors/cagra.h>
 #include <faiss/gpu/GpuIndicesOptions.h>
 #include <faiss/gpu/GpuResources.h>
-#include <cstddef>
 #include <faiss/gpu/impl/CuvsCagra.cuh>
+#include <faiss/gpu/utils/DeviceTensor.cuh>
 #include <faiss/gpu/utils/Tensor.cuh>
-#include <optional>
 
 #include <faiss/MetricType.h>
 #include <faiss/impl/IDSelector.h>
 
-#include <cuvs/neighbors/cagra.hpp>
+#include <cstddef>
+#include <vector>
 
 namespace faiss {
 
@@ -60,7 +62,7 @@ class BinaryCuvsCagra {
             const idx_t* knn_graph,
             IndicesOptions indicesOptions);
 
-    ~BinaryCuvsCagra() = default;
+    ~BinaryCuvsCagra();
 
     void train(idx_t n, const uint8_t* x);
 
@@ -112,14 +114,20 @@ class BinaryCuvsCagra {
 
     /// Parameters to build cuVS CAGRA index
     faiss::cagra_build_algo graph_build_algo_;
-    cuvs::neighbors::cagra::index_params index_params_;
+    size_t intermediate_graph_degree_;
+    size_t graph_degree_;
 
     /// Parameters to build CAGRA graph using NN Descent
     size_t nn_descent_niter_ = 20;
 
+    /// Device storage used when cuvsCagraIndexFromArgs receives host data.
+    DeviceTensor<uint8_t, 2, true> ownedDataset_;
+
+    /// Dataset object whose storage/view is referenced by the CAGRA index.
+    cuvsDataset_t cuvs_dataset_{nullptr};
+
     /// Instance of trained cuVS CAGRA index
-    std::shared_ptr<cuvs::neighbors::cagra::index<uint8_t, uint32_t>>
-            cuvs_index{nullptr};
+    cuvsCagraIndex_t cuvs_index{nullptr};
 };
 
 } // namespace gpu

--- a/faiss/gpu/impl/CuvsCagra.cu
+++ b/faiss/gpu/impl/CuvsCagra.cu
@@ -29,8 +29,6 @@
 #include <faiss/gpu/impl/CuvsCagra.cuh>
 
 #include <cuvs/neighbors/cagra.h>
-#include <cuvs/neighbors/cagra.hpp>
-#include <cuvs/neighbors/ivf_pq.hpp>
 #include <raft/core/bitset.hpp>
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/device_resources.hpp>
@@ -38,55 +36,13 @@
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
 
-#include <algorithm>
 #include <memory>
-#include <optional>
 #include <vector>
 
 namespace faiss {
 namespace gpu {
 
 namespace {
-
-cuvs::distance::DistanceType cppMetric(faiss::MetricType metric) {
-    return static_cast<cuvs::distance::DistanceType>(
-            metricFaissToCuvs(metric, false));
-}
-
-void configureCppIvfPqParams(
-        cuvs::neighbors::ivf_pq::index_params& params,
-        const IVFPQBuildCagraConfig* config,
-        faiss::MetricType metric) {
-    if (!config) {
-        return;
-    }
-
-    params.metric = cppMetric(metric);
-    params.n_lists = config->n_lists;
-    params.kmeans_n_iters = config->kmeans_n_iters;
-    params.kmeans_trainset_fraction = config->kmeans_trainset_fraction;
-    params.pq_bits = config->pq_bits;
-    params.pq_dim = config->pq_dim;
-    params.codebook_kind = static_cast<cuvs::neighbors::ivf_pq::codebook_gen>(
-            config->codebook_kind);
-    params.force_random_rotation = config->force_random_rotation;
-    params.conservative_memory_allocation =
-            config->conservative_memory_allocation;
-}
-
-void configureCppIvfPqSearchParams(
-        cuvs::neighbors::ivf_pq::search_params& params,
-        const IVFPQSearchCagraConfig* config) {
-    if (!config) {
-        return;
-    }
-
-    params.n_probes = config->n_probes;
-    params.lut_dtype = config->lut_dtype;
-    params.internal_distance_dtype = config->internal_distance_dtype;
-    params.preferred_shmem_carveout = config->preferred_shmem_carveout;
-    params.max_internal_batch_size = config->max_internal_batch_size;
-}
 
 void configureCIvfPqParams(
         cuvsIvfPqIndexParams_t params,
@@ -288,94 +244,6 @@ void CuvsCagra<data_t>::train(idx_t n, const data_t* x) {
 
     const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
 
-    // Compatibility note: release/26.10 has no C API field corresponding to
-    // cagra::index_params::guarantee_connectivity, and its CAGRA bridge does
-    // not propagate IVF-PQ search_params::max_internal_batch_size. Use C++
-    // only to build graphs needing either setting, then put the result back
-    // behind a C API index handle.
-    const bool needsCppGraphBuild = guarantee_connectivity_ ||
-            (graph_build_algo_ == faiss::cagra_build_algo::IVF_PQ &&
-             ivf_pq_search_params_);
-    if (needsCppGraphBuild) {
-        cuvs::neighbors::cagra::index_params params;
-        params.metric = cppMetric(metric_);
-        params.intermediate_graph_degree = intermediate_graph_degree_;
-        params.graph_degree = graph_degree_;
-        params.attach_dataset_on_build = false;
-        params.guarantee_connectivity = guarantee_connectivity_;
-
-        if (graph_build_algo_ == faiss::cagra_build_algo::IVF_PQ) {
-            cuvs::neighbors::cagra::graph_build_params::ivf_pq_params build(
-                    raft::make_extents<uint32_t>(
-                            static_cast<uint32_t>(n_),
-                            static_cast<uint32_t>(dim_)),
-                    cppMetric(metric_));
-            configureCppIvfPqParams(
-                    build.build_params, ivf_pq_params_, metric_);
-            configureCppIvfPqSearchParams(
-                    build.search_params, ivf_pq_search_params_);
-            build.refinement_rate = refine_rate_;
-            params.graph_build_params = build;
-            if (params.graph_degree == params.intermediate_graph_degree) {
-                params.intermediate_graph_degree =
-                        static_cast<size_t>(1.5 * params.graph_degree);
-            }
-        } else {
-            cuvs::neighbors::cagra::graph_build_params::nn_descent_params build(
-                    params.intermediate_graph_degree);
-            build.max_iterations = nn_descent_niter_;
-            build.metric = cppMetric(metric_);
-            params.graph_build_params = build;
-        }
-
-        ownedDataset_ = DeviceTensor<data_t, 2, true>(
-                resources_,
-                AllocInfo(
-                        AllocType::Other,
-                        getCurrentDevice(),
-                        MemorySpace::Device,
-                        raftHandle.get_stream()),
-                {n, dim_});
-        raft::copy(
-                ownedDataset_.data(),
-                x,
-                ownedDataset_.numElements(),
-                raftHandle.get_stream());
-        storage_ = ownedDataset_.data();
-
-        auto sourceView = raft::make_device_matrix_view<const data_t, int64_t>(
-                storage_, n, dim_);
-        auto paddedDataset = cuvs::neighbors::make_device_padded_dataset(
-                raftHandle, sourceView);
-        auto cppIndex = cuvs::neighbors::cagra::build(
-                raftHandle, params, paddedDataset->as_dataset_view());
-        auto graph = cppIndex.graph();
-        auto graphTensor = makeCuvsTensor(
-                graph.data_handle(),
-                static_cast<int64_t>(graph.extent(0)),
-                static_cast<int64_t>(graph.extent(1)));
-        auto datasetTensor =
-                makeCuvsTensor(ownedDataset_.data(), (int64_t)n, (int64_t)dim_);
-
-        cuvsCagraIndex_t index = nullptr;
-        cuvsCheck(cuvsCagraIndexCreate(&index), "cuvsCagraIndexCreate");
-        CuvsUniquePtr<cuvsCagraIndex, cuvsCagraIndexDestroy> indexHolder(index);
-        cuvsCheck(
-                cuvsCagraIndexFromArgs(
-                        cuvsResourcesFromGpuResources(resources_),
-                        metricFaissToCuvs(metric_, false),
-                        graphTensor.get(),
-                        datasetTensor.get(),
-                        index),
-                "cuvsCagraIndexFromArgs");
-        cuvs_dataset_ = makeAndAttachPaddedDataset(
-                resources_, storage_, (int64_t)n_, (int64_t)dim_, index);
-        raftHandle.sync_stream();
-        cuvs_index = indexHolder.release();
-        store_dataset_ = true;
-        return;
-    }
-
     const data_t* buildData = x;
     if (store_dataset_ && cuvsPaddedDatasetNeedsView(x, dim_)) {
         ownedDataset_ = DeviceTensor<data_t, 2, true>(
@@ -426,6 +294,7 @@ void CuvsCagra<data_t>::train(idx_t n, const data_t* x) {
     params->intermediate_graph_degree = intermediate_graph_degree_;
     params->graph_degree = graph_degree_;
     params->nn_descent_niter = nn_descent_niter_;
+    params->guarantee_connectivity = guarantee_connectivity_;
 
     cuvsIvfPqIndexParams_t ivfBuildParams = nullptr;
     cuvsIvfPqSearchParams_t ivfSearchParams = nullptr;

--- a/faiss/gpu/impl/CuvsCagra.cu
+++ b/faiss/gpu/impl/CuvsCagra.cu
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,24 +21,120 @@
  * limitations under the License.
  */
 
+#include <faiss/gpu/GpuIndexCagra.h>
 #include <faiss/gpu/StandardGpuResources.h>
 #include <faiss/gpu/utils/CuvsFilterConvert.h>
 #include <faiss/gpu/utils/CuvsUtils.h>
 #include <faiss/gpu/utils/DeviceUtils.h>
 #include <faiss/gpu/impl/CuvsCagra.cuh>
 
-#include <cuvs/core/bitset.hpp>
+#include <cuvs/neighbors/cagra.h>
 #include <cuvs/neighbors/cagra.hpp>
+#include <cuvs/neighbors/ivf_pq.hpp>
+#include <raft/core/bitset.hpp>
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/device_resources.hpp>
-#include <raft/core/resource/thrust_policy.hpp>
 
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
+
+#include <algorithm>
+#include <memory>
 #include <optional>
+#include <vector>
 
 namespace faiss {
 namespace gpu {
+
+namespace {
+
+cuvs::distance::DistanceType cppMetric(faiss::MetricType metric) {
+    return static_cast<cuvs::distance::DistanceType>(
+            metricFaissToCuvs(metric, false));
+}
+
+void configureCppIvfPqParams(
+        cuvs::neighbors::ivf_pq::index_params& params,
+        const IVFPQBuildCagraConfig* config,
+        faiss::MetricType metric) {
+    if (!config) {
+        return;
+    }
+
+    params.metric = cppMetric(metric);
+    params.n_lists = config->n_lists;
+    params.kmeans_n_iters = config->kmeans_n_iters;
+    params.kmeans_trainset_fraction = config->kmeans_trainset_fraction;
+    params.pq_bits = config->pq_bits;
+    params.pq_dim = config->pq_dim;
+    params.codebook_kind = static_cast<cuvs::neighbors::ivf_pq::codebook_gen>(
+            config->codebook_kind);
+    params.force_random_rotation = config->force_random_rotation;
+    params.conservative_memory_allocation =
+            config->conservative_memory_allocation;
+}
+
+void configureCppIvfPqSearchParams(
+        cuvs::neighbors::ivf_pq::search_params& params,
+        const IVFPQSearchCagraConfig* config) {
+    if (!config) {
+        return;
+    }
+
+    params.n_probes = config->n_probes;
+    params.lut_dtype = config->lut_dtype;
+    params.internal_distance_dtype = config->internal_distance_dtype;
+    params.preferred_shmem_carveout = config->preferred_shmem_carveout;
+    params.max_internal_batch_size = config->max_internal_batch_size;
+}
+
+void configureCIvfPqParams(
+        cuvsIvfPqIndexParams_t params,
+        const IVFPQBuildCagraConfig& config,
+        faiss::MetricType metric) {
+    params->metric = metricFaissToCuvs(metric, false);
+    params->n_lists = config.n_lists;
+    params->kmeans_n_iters = config.kmeans_n_iters;
+    params->kmeans_trainset_fraction = config.kmeans_trainset_fraction;
+    params->pq_bits = config.pq_bits;
+    params->pq_dim = config.pq_dim;
+    params->codebook_kind =
+            static_cast<cuvsIvfPqCodebookGen>(config.codebook_kind);
+    params->force_random_rotation = config.force_random_rotation;
+    params->conservative_memory_allocation =
+            config.conservative_memory_allocation;
+}
+
+void configureCIvfPqSearchParams(
+        cuvsIvfPqSearchParams_t params,
+        const IVFPQSearchCagraConfig& config) {
+    params->n_probes = config.n_probes;
+    params->lut_dtype = config.lut_dtype;
+    params->internal_distance_dtype = config.internal_distance_dtype;
+    params->preferred_shmem_carveout = config.preferred_shmem_carveout;
+    params->max_internal_batch_size = config.max_internal_batch_size;
+}
+
+template <typename T>
+cuvsDataset_t makeAndAttachPaddedDataset(
+        GpuResources* resources,
+        const T* data,
+        int64_t rows,
+        int64_t cols,
+        cuvsCagraIndex_t index) {
+    cuvsDataset_t paddedDataset =
+            makeCuvsPaddedDataset(resources, data, rows, cols);
+    CuvsUniquePtr<cuvsDataset, cuvsDatasetDestroy> paddedHolder(paddedDataset);
+    cuvsCheck(
+            cuvsCagraUpdateDataset(
+                    cuvsResourcesFromGpuResources(resources),
+                    paddedDataset,
+                    index),
+            "cuvsCagraUpdateDataset");
+    return paddedHolder.release();
+}
+
+} // namespace
 
 template <typename data_t>
 CuvsCagra<data_t>::CuvsCagra(
@@ -52,22 +148,24 @@ CuvsCagra<data_t>::CuvsCagra(
         faiss::MetricType metric,
         float metricArg,
         IndicesOptions indicesOptions,
-        std::optional<cuvs::neighbors::ivf_pq::index_params> ivf_pq_params,
-        std::optional<cuvs::neighbors::ivf_pq::search_params>
-                ivf_pq_search_params,
+        const IVFPQBuildCagraConfig* ivf_pq_params,
+        const IVFPQSearchCagraConfig* ivf_pq_search_params,
         float refine_rate,
         bool guarantee_connectivity)
         : resources_(resources),
+          storage_(nullptr),
+          n_(0),
           dim_(dim),
-          graph_build_algo_(graph_build_algo),
-          nn_descent_niter_(nn_descent_niter),
           store_dataset_(store_dataset),
           metric_(metric),
           metricArg_(metricArg),
-          index_params_(),
+          graph_build_algo_(graph_build_algo),
+          intermediate_graph_degree_(intermediate_graph_degree),
+          graph_degree_(graph_degree),
           ivf_pq_params_(ivf_pq_params),
           ivf_pq_search_params_(ivf_pq_search_params),
           refine_rate_(refine_rate),
+          nn_descent_niter_(nn_descent_niter),
           guarantee_connectivity_(guarantee_connectivity) {
     FAISS_THROW_IF_NOT_MSG(
             metric == faiss::METRIC_L2 || metric == faiss::METRIC_INNER_PRODUCT,
@@ -75,19 +173,6 @@ CuvsCagra<data_t>::CuvsCagra(
     FAISS_THROW_IF_NOT_MSG(
             indicesOptions == faiss::gpu::INDICES_64_BIT,
             "only INDICES_64_BIT is supported for cuVS CAGRA index");
-
-    index_params_.intermediate_graph_degree = intermediate_graph_degree;
-    index_params_.graph_degree = graph_degree;
-    index_params_.attach_dataset_on_build = store_dataset;
-    index_params_.guarantee_connectivity = guarantee_connectivity;
-
-    if (!ivf_pq_search_params_) {
-        ivf_pq_search_params_ =
-                std::make_optional<cuvs::neighbors::ivf_pq::search_params>();
-    }
-    index_params_.metric = metricFaissToCuvs(metric_, false);
-
-    reset();
 }
 
 template <typename data_t>
@@ -102,9 +187,17 @@ CuvsCagra<data_t>::CuvsCagra(
         float metricArg,
         IndicesOptions indicesOptions)
         : resources_(resources),
+          storage_(dataset),
+          n_(n),
           dim_(dim),
           metric_(metric),
-          metricArg_(metricArg) {
+          metricArg_(metricArg),
+          graph_build_algo_(faiss::cagra_build_algo::IVF_PQ),
+          intermediate_graph_degree_(graph_degree),
+          graph_degree_(graph_degree),
+          ivf_pq_params_(nullptr),
+          ivf_pq_search_params_(nullptr),
+          refine_rate_(2.0f) {
     FAISS_THROW_IF_NOT_MSG(
             metric == faiss::METRIC_L2 || metric == faiss::METRIC_INNER_PRODUCT,
             "CAGRA currently only supports L2 or Inner Product metric.");
@@ -112,112 +205,280 @@ CuvsCagra<data_t>::CuvsCagra(
             indicesOptions == faiss::gpu::INDICES_64_BIT,
             "only INDICES_64_BIT is supported for cuVS CAGRA index");
 
-    auto dataset_on_gpu = getDeviceForAddress(dataset) >= 0;
-    auto knn_graph_on_gpu = getDeviceForAddress(knn_graph) >= 0;
+    const bool datasetOnGpu = getDeviceForAddress(dataset) >= 0;
+    const bool graphOnGpu = getDeviceForAddress(knn_graph) >= 0;
+    FAISS_THROW_IF_NOT_MSG(
+            datasetOnGpu == graphOnGpu,
+            "dataset and knn_graph must both be in device or host memory");
 
-    FAISS_ASSERT(dataset_on_gpu == knn_graph_on_gpu);
-
-    storage_ = dataset;
-    n_ = n;
-
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-
-    if (dataset_on_gpu && knn_graph_on_gpu) {
-        raft_handle.sync_stream();
-        // Copying to host so that cuvs::neighbors::cagra::index
-        // creates an owning copy of the knn graph on device
-        auto knn_graph_copy =
-                raft::make_host_matrix<uint32_t, int64_t>(n, graph_degree);
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+    std::vector<uint32_t> hostGraph(n * graph_degree);
+    if (graphOnGpu) {
+        raftHandle.sync_stream();
         thrust::copy(
                 thrust::device_ptr<const idx_t>(knn_graph),
-                thrust::device_ptr<const idx_t>(knn_graph + (n * graph_degree)),
-                knn_graph_copy.data_handle());
-
-        auto dataset_mds = raft::make_device_matrix_view<const data_t, int64_t>(
-                dataset, n, dim);
-
-        cuvs_index = std::make_shared<
-                cuvs::neighbors::cagra::index<data_t, uint32_t>>(
-                raft_handle,
-                metricFaissToCuvs(metric_, false),
-                dataset_mds,
-                raft::make_const_mdspan(knn_graph_copy.view()));
-    } else if (!dataset_on_gpu && !knn_graph_on_gpu) {
-        // copy idx_t (int64_t) host knn_graph to uint32_t host knn_graph
-        auto knn_graph_copy =
-                raft::make_host_matrix<uint32_t, int64_t>(n, graph_degree);
-        std::copy(
-                knn_graph,
-                knn_graph + (n * graph_degree),
-                knn_graph_copy.data_handle());
-
-        auto dataset_mds = raft::make_host_matrix_view<const data_t, int64_t>(
-                dataset, n, dim);
-
-        cuvs_index = std::make_shared<
-                cuvs::neighbors::cagra::index<data_t, uint32_t>>(
-                raft_handle,
-                metricFaissToCuvs(metric_, false),
-                dataset_mds,
-                raft::make_const_mdspan(knn_graph_copy.view()));
+                thrust::device_ptr<const idx_t>(knn_graph + n * graph_degree),
+                hostGraph.data());
     } else {
-        FAISS_THROW_MSG(
-                "dataset and knn_graph must both be in device or host memory");
+        std::transform(
+                knn_graph,
+                knn_graph + n * graph_degree,
+                hostGraph.begin(),
+                [](idx_t value) { return static_cast<uint32_t>(value); });
+    }
+
+    if (!datasetOnGpu || cuvsPaddedDatasetNeedsView(dataset, dim_)) {
+        ownedDataset_ = DeviceTensor<data_t, 2, true>(
+                resources_,
+                AllocInfo(
+                        AllocType::Other,
+                        getCurrentDevice(),
+                        MemorySpace::Device,
+                        raftHandle.get_stream()),
+                {n, dim_});
+        raft::copy(
+                ownedDataset_.data(),
+                dataset,
+                ownedDataset_.numElements(),
+                raftHandle.get_stream());
+        storage_ = ownedDataset_.data();
+    }
+
+    auto graphTensor =
+            makeCuvsTensor(hostGraph.data(), (int64_t)n, (int64_t)graph_degree);
+    auto datasetTensor = makeCuvsTensor(
+            const_cast<data_t*>(storage_), (int64_t)n, (int64_t)dim_);
+
+    cuvsCagraIndex_t index = nullptr;
+    cuvsCheck(cuvsCagraIndexCreate(&index), "cuvsCagraIndexCreate");
+    CuvsUniquePtr<cuvsCagraIndex, cuvsCagraIndexDestroy> indexHolder(index);
+    cuvsCheck(
+            cuvsCagraIndexFromArgs(
+                    cuvsResourcesFromGpuResources(resources_),
+                    metricFaissToCuvs(metric_, false),
+                    graphTensor.get(),
+                    datasetTensor.get(),
+                    index),
+            "cuvsCagraIndexFromArgs");
+    cuvs_dataset_ = makeAndAttachPaddedDataset(
+            resources_,
+            datasetOnGpu ? storage_ : dataset,
+            (int64_t)n_,
+            (int64_t)dim_,
+            index);
+    raftHandle.sync_stream();
+    cuvs_index = indexHolder.release();
+}
+
+template <typename data_t>
+CuvsCagra<data_t>::~CuvsCagra() {
+    if (cuvs_index) {
+        cuvsCagraIndexDestroy(cuvs_index);
+    }
+    if (cuvs_dataset_) {
+        cuvsDatasetDestroy(cuvs_dataset_);
     }
 }
 
 template <typename data_t>
 void CuvsCagra<data_t>::train(idx_t n, const data_t* x) {
+    reset();
     storage_ = x;
     n_ = n;
 
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
 
-    if (!ivf_pq_params_) {
-        ivf_pq_params_ = cuvs::neighbors::ivf_pq::index_params::from_dataset(
-                raft::make_extents<uint32_t>(
-                        static_cast<uint32_t>(n_), static_cast<uint32_t>(dim_)),
-                metricFaissToCuvs(metric_, false));
-    }
-    if (graph_build_algo_ == faiss::cagra_build_algo::IVF_PQ) {
-        cuvs::neighbors::cagra::graph_build_params::ivf_pq_params
-                graph_build_params;
-        graph_build_params.build_params = ivf_pq_params_.value();
-        graph_build_params.build_params.metric =
-                metricFaissToCuvs(metric_, false);
-        graph_build_params.search_params = ivf_pq_search_params_.value();
-        graph_build_params.refinement_rate = refine_rate_.value();
-        index_params_.graph_build_params = graph_build_params;
-        if (index_params_.graph_degree ==
-            index_params_.intermediate_graph_degree) {
-            index_params_.intermediate_graph_degree =
-                    1.5 * index_params_.graph_degree;
+    // Compatibility note: release/26.10 has no C API field corresponding to
+    // cagra::index_params::guarantee_connectivity, and its CAGRA bridge does
+    // not propagate IVF-PQ search_params::max_internal_batch_size. Use C++
+    // only to build graphs needing either setting, then put the result back
+    // behind a C API index handle.
+    const bool needsCppGraphBuild = guarantee_connectivity_ ||
+            (graph_build_algo_ == faiss::cagra_build_algo::IVF_PQ &&
+             ivf_pq_search_params_);
+    if (needsCppGraphBuild) {
+        cuvs::neighbors::cagra::index_params params;
+        params.metric = cppMetric(metric_);
+        params.intermediate_graph_degree = intermediate_graph_degree_;
+        params.graph_degree = graph_degree_;
+        params.attach_dataset_on_build = false;
+        params.guarantee_connectivity = guarantee_connectivity_;
+
+        if (graph_build_algo_ == faiss::cagra_build_algo::IVF_PQ) {
+            cuvs::neighbors::cagra::graph_build_params::ivf_pq_params build(
+                    raft::make_extents<uint32_t>(
+                            static_cast<uint32_t>(n_),
+                            static_cast<uint32_t>(dim_)),
+                    cppMetric(metric_));
+            configureCppIvfPqParams(
+                    build.build_params, ivf_pq_params_, metric_);
+            configureCppIvfPqSearchParams(
+                    build.search_params, ivf_pq_search_params_);
+            build.refinement_rate = refine_rate_;
+            params.graph_build_params = build;
+            if (params.graph_degree == params.intermediate_graph_degree) {
+                params.intermediate_graph_degree =
+                        static_cast<size_t>(1.5 * params.graph_degree);
+            }
+        } else {
+            cuvs::neighbors::cagra::graph_build_params::nn_descent_params build(
+                    params.intermediate_graph_degree);
+            build.max_iterations = nn_descent_niter_;
+            build.metric = cppMetric(metric_);
+            params.graph_build_params = build;
         }
-    } else {
-        cuvs::neighbors::cagra::graph_build_params::nn_descent_params
-                graph_build_params(index_params_.intermediate_graph_degree);
-        graph_build_params.max_iterations = nn_descent_niter_;
-        graph_build_params.metric = metricFaissToCuvs(metric_, false);
-        index_params_.graph_build_params = graph_build_params;
+
+        ownedDataset_ = DeviceTensor<data_t, 2, true>(
+                resources_,
+                AllocInfo(
+                        AllocType::Other,
+                        getCurrentDevice(),
+                        MemorySpace::Device,
+                        raftHandle.get_stream()),
+                {n, dim_});
+        raft::copy(
+                ownedDataset_.data(),
+                x,
+                ownedDataset_.numElements(),
+                raftHandle.get_stream());
+        storage_ = ownedDataset_.data();
+
+        auto sourceView = raft::make_device_matrix_view<const data_t, int64_t>(
+                storage_, n, dim_);
+        auto paddedDataset = cuvs::neighbors::make_device_padded_dataset(
+                raftHandle, sourceView);
+        auto cppIndex = cuvs::neighbors::cagra::build(
+                raftHandle, params, paddedDataset->as_dataset_view());
+        auto graph = cppIndex.graph();
+        auto graphTensor = makeCuvsTensor(
+                graph.data_handle(),
+                static_cast<int64_t>(graph.extent(0)),
+                static_cast<int64_t>(graph.extent(1)));
+        auto datasetTensor =
+                makeCuvsTensor(ownedDataset_.data(), (int64_t)n, (int64_t)dim_);
+
+        cuvsCagraIndex_t index = nullptr;
+        cuvsCheck(cuvsCagraIndexCreate(&index), "cuvsCagraIndexCreate");
+        CuvsUniquePtr<cuvsCagraIndex, cuvsCagraIndexDestroy> indexHolder(index);
+        cuvsCheck(
+                cuvsCagraIndexFromArgs(
+                        cuvsResourcesFromGpuResources(resources_),
+                        metricFaissToCuvs(metric_, false),
+                        graphTensor.get(),
+                        datasetTensor.get(),
+                        index),
+                "cuvsCagraIndexFromArgs");
+        cuvs_dataset_ = makeAndAttachPaddedDataset(
+                resources_, storage_, (int64_t)n_, (int64_t)dim_, index);
+        raftHandle.sync_stream();
+        cuvs_index = indexHolder.release();
+        store_dataset_ = true;
+        return;
     }
 
-    if (getDeviceForAddress(x) >= 0) {
-        auto dataset = raft::make_device_matrix_view<const data_t, int64_t>(
-                x, n, dim_);
-        cuvs_index = std::make_shared<
-                cuvs::neighbors::cagra::index<data_t, uint32_t>>(
-                cuvs::neighbors::cagra::build(
-                        raft_handle, index_params_, dataset));
-    } else {
-        auto dataset =
-                raft::make_host_matrix_view<const data_t, int64_t>(x, n, dim_);
-        cuvs_index = std::make_shared<
-                cuvs::neighbors::cagra::index<data_t, uint32_t>>(
-                cuvs::neighbors::cagra::build(
-                        raft_handle, index_params_, dataset));
+    const data_t* buildData = x;
+    if (store_dataset_ && cuvsPaddedDatasetNeedsView(x, dim_)) {
+        ownedDataset_ = DeviceTensor<data_t, 2, true>(
+                resources_,
+                AllocInfo(
+                        AllocType::Other,
+                        getCurrentDevice(),
+                        MemorySpace::Device,
+                        raftHandle.get_stream()),
+                {n, dim_});
+        raft::copy(
+                ownedDataset_.data(),
+                x,
+                ownedDataset_.numElements(),
+                raftHandle.get_stream());
+        storage_ = ownedDataset_.data();
+        buildData = storage_;
     }
+
+    auto sourceTensor = makeCuvsTensor(
+            const_cast<data_t*>(buildData), (int64_t)n, (int64_t)dim_);
+    cuvsDataset_t dataset = nullptr;
+    if (store_dataset_) {
+        dataset = makeCuvsPaddedDataset(
+                resources_, buildData, (int64_t)n, (int64_t)dim_);
+    } else {
+        cuvsCheck(
+                cuvsDatasetMakeStandardView(
+                        cuvsResourcesFromGpuResources(resources_),
+                        sourceTensor.get(),
+                        &dataset),
+                "cuvsDatasetMakeStandardView");
+    }
+    CuvsUniquePtr<cuvsDataset, cuvsDatasetDestroy> datasetHolder(dataset);
+
+    cuvsCagraIndexParams_t params = nullptr;
+    cuvsCheck(
+            cuvsCagraIndexParamsCreate(&params), "cuvsCagraIndexParamsCreate");
+    CuvsUniquePtr<cuvsCagraIndexParams, cuvsCagraIndexParamsDestroy>
+            paramsHolder(params);
+    // The C factory owns and preallocates this nested IVF-PQ block. Detach it
+    // while selecting the build algorithm so destruction follows C ownership.
+    std::unique_ptr<cuvsIvfPqParams> ivfPqParams(
+            static_cast<cuvsIvfPqParams*>(params->graph_build_params));
+    params->graph_build_params = nullptr;
+    ivfPqParams->refinement_rate = refine_rate_;
+    params->metric = metricFaissToCuvs(metric_, false);
+    params->intermediate_graph_degree = intermediate_graph_degree_;
+    params->graph_degree = graph_degree_;
+    params->nn_descent_niter = nn_descent_niter_;
+
+    cuvsIvfPqIndexParams_t ivfBuildParams = nullptr;
+    cuvsIvfPqSearchParams_t ivfSearchParams = nullptr;
+    std::unique_ptr<
+            cuvsIvfPqIndexParams,
+            CuvsDeleter<cuvsIvfPqIndexParams, cuvsIvfPqIndexParamsDestroy>>
+            ivfBuildHolder;
+    std::unique_ptr<
+            cuvsIvfPqSearchParams,
+            CuvsDeleter<cuvsIvfPqSearchParams, cuvsIvfPqSearchParamsDestroy>>
+            ivfSearchHolder;
+    if (graph_build_algo_ == faiss::cagra_build_algo::IVF_PQ) {
+        params->build_algo = IVF_PQ;
+        if (params->graph_degree == params->intermediate_graph_degree) {
+            params->intermediate_graph_degree =
+                    static_cast<size_t>(1.5 * params->graph_degree);
+        }
+        if (ivf_pq_params_) {
+            cuvsCheck(
+                    cuvsIvfPqIndexParamsCreate(&ivfBuildParams),
+                    "cuvsIvfPqIndexParamsCreate");
+            ivfBuildHolder.reset(ivfBuildParams);
+            configureCIvfPqParams(ivfBuildParams, *ivf_pq_params_, metric_);
+            ivfPqParams->ivf_pq_build_params = ivfBuildParams;
+        }
+        if (ivf_pq_search_params_) {
+            cuvsCheck(
+                    cuvsIvfPqSearchParamsCreate(&ivfSearchParams),
+                    "cuvsIvfPqSearchParamsCreate");
+            ivfSearchHolder.reset(ivfSearchParams);
+            configureCIvfPqSearchParams(
+                    ivfSearchParams, *ivf_pq_search_params_);
+            ivfPqParams->ivf_pq_search_params = ivfSearchParams;
+        }
+        params->graph_build_params = ivfPqParams.release();
+    } else {
+        params->build_algo = NN_DESCENT;
+        params->graph_build_params = nullptr;
+    }
+
+    cuvsCagraIndex_t index = nullptr;
+    cuvsCheck(cuvsCagraIndexCreate(&index), "cuvsCagraIndexCreate");
+    CuvsUniquePtr<cuvsCagraIndex, cuvsCagraIndexDestroy> indexHolder(index);
+    cuvsCheck(
+            cuvsCagraBuild(
+                    cuvsResourcesFromGpuResources(resources_),
+                    params,
+                    dataset,
+                    index),
+            "cuvsCagraBuild");
+
+    cuvs_dataset_ = datasetHolder.release();
+    cuvs_index = indexHolder.release();
 }
 
 template <typename data_t>
@@ -240,121 +501,130 @@ void CuvsCagra<data_t>::search(
         idx_t num_random_samplings,
         idx_t rand_xor_mask,
         const IDSelector* sel) {
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-    idx_t numQueries = queries.getSize(0);
-    idx_t cols = queries.getSize(1);
-    idx_t k_ = k;
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+    const idx_t numQueries = queries.getSize(0);
+    const idx_t cols = queries.getSize(1);
 
     FAISS_ASSERT(cuvs_index);
     FAISS_ASSERT(numQueries > 0);
     FAISS_ASSERT(cols == dim_);
 
     if (!store_dataset_) {
-        if (getDeviceForAddress(storage_) >= 0) {
-            auto dataset = raft::make_device_matrix_view<const data_t, int64_t>(
-                    storage_, n_, dim_);
-            cuvs_index->update_dataset(raft_handle, dataset);
-        } else {
-            auto dataset = raft::make_host_matrix_view<const data_t, int64_t>(
-                    storage_, n_, dim_);
-            cuvs_index->update_dataset(raft_handle, dataset);
+        if (cuvsPaddedDatasetNeedsView(storage_, dim_)) {
+            ownedDataset_ = DeviceTensor<data_t, 2, true>(
+                    resources_,
+                    AllocInfo(
+                            AllocType::Other,
+                            getCurrentDevice(),
+                            MemorySpace::Device,
+                            raftHandle.get_stream()),
+                    {n_, dim_});
+            raft::copy(
+                    ownedDataset_.data(),
+                    storage_,
+                    ownedDataset_.numElements(),
+                    raftHandle.get_stream());
+            storage_ = ownedDataset_.data();
         }
+        auto paddedDataset = makeAndAttachPaddedDataset(
+                resources_, storage_, (int64_t)n_, (int64_t)dim_, cuvs_index);
+        if (cuvs_dataset_) {
+            cuvsCheck(cuvsDatasetDestroy(cuvs_dataset_), "cuvsDatasetDestroy");
+        }
+        cuvs_dataset_ = paddedDataset;
         store_dataset_ = true;
     }
 
-    auto queries_view = raft::make_device_matrix_view<const data_t, int64_t>(
-            queries.data(), numQueries, cols);
-    auto distances_view = raft::make_device_matrix_view<float, int64_t>(
-            outDistances.data(), numQueries, k_);
-    auto indices_view = raft::make_device_matrix_view<idx_t, int64_t>(
-            outIndices.data(), numQueries, k_);
+    cuvsCagraSearchParams_t params = nullptr;
+    cuvsCheck(
+            cuvsCagraSearchParamsCreate(&params),
+            "cuvsCagraSearchParamsCreate");
+    CuvsUniquePtr<cuvsCagraSearchParams, cuvsCagraSearchParamsDestroy>
+            paramsHolder(params);
+    params->max_queries = max_queries;
+    params->itopk_size = itopk_size;
+    params->max_iterations = max_iterations;
+    params->algo = static_cast<cuvsCagraSearchAlgo>(graph_search_algo);
+    params->team_size = team_size;
+    params->search_width = search_width;
+    params->min_iterations = min_iterations;
+    params->thread_block_size = thread_block_size;
+    params->hashmap_mode = static_cast<cuvsCagraHashMode>(hash_mode);
+    params->hashmap_min_bitlen = hashmap_min_bitlen;
+    params->hashmap_max_fill_rate = hashmap_max_fill_rate;
+    params->num_random_samplings = num_random_samplings;
+    params->rand_xor_mask = rand_xor_mask;
 
-    cuvs::neighbors::cagra::search_params search_pams;
-    search_pams.max_queries = max_queries;
-    search_pams.itopk_size = itopk_size;
-    search_pams.max_iterations = max_iterations;
-    search_pams.algo =
-            static_cast<cuvs::neighbors::cagra::search_algo>(graph_search_algo);
-    search_pams.team_size = team_size;
-    search_pams.search_width = search_width;
-    search_pams.min_iterations = min_iterations;
-    search_pams.thread_block_size = thread_block_size;
-    search_pams.hashmap_mode =
-            static_cast<cuvs::neighbors::cagra::hash_mode>(hash_mode);
-    search_pams.hashmap_min_bitlen = hashmap_min_bitlen;
-    search_pams.hashmap_max_fill_rate = hashmap_max_fill_rate;
-    search_pams.num_random_samplings = num_random_samplings;
-    search_pams.rand_xor_mask = rand_xor_mask;
+    auto indexCopy = raft::make_device_matrix<uint32_t, int64_t>(
+            raftHandle, numQueries, k);
+    auto queryTensor =
+            makeCuvsTensor(queries.data(), (int64_t)numQueries, (int64_t)cols);
+    auto indexTensor = makeCuvsTensor(
+            indexCopy.data_handle(), (int64_t)numQueries, (int64_t)k);
+    auto distanceTensor = makeCuvsTensor(
+            outDistances.data(), (int64_t)numQueries, (int64_t)k);
+    CuvsFilter filter(resources_, sel, n_);
 
-    auto indices_copy = raft::make_device_matrix<uint32_t, int64_t>(
-            raft_handle, numQueries, k_);
-
-    std::optional<cuvs::core::bitset<uint32_t, int64_t>> bitset_holder;
-    std::optional<cuvs::neighbors::filtering::bitset_filter<uint32_t, int64_t>>
-            bitset_filter;
-    cuvs::neighbors::filtering::none_sample_filter none_filter;
-
-    if (sel) {
-        bitset_holder =
-                cuvs::core::bitset<uint32_t, int64_t>(raft_handle, n_, false);
-        faiss::gpu::convert_to_bitset(resources_, *sel, bitset_holder->view());
-        bitset_filter.emplace(bitset_holder->view());
-    }
-    const cuvs::neighbors::filtering::base_filter& filter_ref = sel
-            ? static_cast<const cuvs::neighbors::filtering::base_filter&>(
-                      bitset_filter.value())
-            : static_cast<const cuvs::neighbors::filtering::base_filter&>(
-                      none_filter);
-
-    cuvs::neighbors::cagra::search(
-            raft_handle,
-            search_pams,
-            *cuvs_index,
-            queries_view,
-            indices_copy.view(),
-            distances_view,
-            filter_ref);
-    faiss::gpu::sanitizeCuvsIndices(
+    cuvsCheck(
+            cuvsCagraSearch(
+                    cuvsResourcesFromGpuResources(resources_),
+                    params,
+                    cuvs_index,
+                    queryTensor.get(),
+                    indexTensor.get(),
+                    distanceTensor.get(),
+                    filter.get()),
+            "cuvsCagraSearch");
+    sanitizeCuvsIndices(
             resources_,
-            indices_copy.data_handle(),
-            indices_view.data_handle(),
-            indices_copy.size(),
+            indexCopy.data_handle(),
+            outIndices.data(),
+            indexCopy.size(),
             n_);
 }
 
 template <typename data_t>
 void CuvsCagra<data_t>::reset() {
-    cuvs_index.reset();
+    if (cuvs_index) {
+        cuvsCheck(cuvsCagraIndexDestroy(cuvs_index), "cuvsCagraIndexDestroy");
+        cuvs_index = nullptr;
+    }
+    if (cuvs_dataset_) {
+        cuvsCheck(cuvsDatasetDestroy(cuvs_dataset_), "cuvsDatasetDestroy");
+        cuvs_dataset_ = nullptr;
+    }
 }
 
 template <typename data_t>
 idx_t CuvsCagra<data_t>::get_knngraph_degree() const {
     FAISS_ASSERT(cuvs_index);
-    return static_cast<idx_t>(cuvs_index->graph_degree());
+
+    int64_t degree = 0;
+    cuvsCheck(
+            cuvsCagraIndexGetGraphDegree(cuvs_index, &degree),
+            "cuvsCagraIndexGetGraphDegree");
+    return static_cast<idx_t>(degree);
 }
 
 template <typename data_t>
 std::vector<idx_t> CuvsCagra<data_t>::get_knngraph() const {
     FAISS_ASSERT(cuvs_index);
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-    auto stream = raft_handle.get_stream();
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
 
-    auto device_graph = cuvs_index->graph();
+    CuvsOutputTensor graphTensor;
+    cuvsCheck(
+            cuvsCagraIndexGetGraph(cuvs_index, graphTensor.get()),
+            "cuvsCagraIndexGetGraph");
+    const uint32_t* graphData = graphTensor.data<uint32_t>();
+    const size_t graphSize = graphTensor.extent(0) * graphTensor.extent(1);
 
-    std::vector<idx_t> host_graph(
-            device_graph.extent(0) * device_graph.extent(1));
-
-    raft_handle.sync_stream();
-
+    std::vector<idx_t> hostGraph(graphSize);
+    raftHandle.sync_stream();
     thrust::copy(
-            thrust::device_ptr<const uint32_t>(device_graph.data_handle()),
-            thrust::device_ptr<const uint32_t>(
-                    device_graph.data_handle() + device_graph.size()),
-            host_graph.data());
-
-    return host_graph;
+            thrust::device_ptr<const uint32_t>(graphData),
+            thrust::device_ptr<const uint32_t>(graphData + graphSize),
+            hostGraph.data());
+    return hostGraph;
 }
 
 template <typename data_t>

--- a/faiss/gpu/impl/CuvsCagra.cuh
+++ b/faiss/gpu/impl/CuvsCagra.cuh
@@ -23,17 +23,17 @@
 
 #pragma once
 
+#include <cuvs/core/dataset.h>
+#include <cuvs/neighbors/cagra.h>
 #include <faiss/gpu/GpuIndicesOptions.h>
 #include <faiss/gpu/GpuResources.h>
-#include <cstddef>
+#include <faiss/gpu/utils/DeviceTensor.cuh>
 #include <faiss/gpu/utils/Tensor.cuh>
-#include <optional>
 
 #include <faiss/MetricType.h>
 #include <faiss/impl/IDSelector.h>
 
-#include <cuvs/neighbors/cagra.hpp>
-#include <cuvs/neighbors/ivf_pq.hpp>
+#include <cstddef>
 
 namespace faiss {
 
@@ -51,6 +51,9 @@ enum class cagra_hash_mode { HASH = 0, SMALL = 1, AUTO = 100 };
 
 namespace gpu {
 
+struct IVFPQBuildCagraConfig;
+struct IVFPQSearchCagraConfig;
+
 template <typename data_t = float>
 class CuvsCagra {
    public:
@@ -65,10 +68,8 @@ class CuvsCagra {
             faiss::MetricType metric,
             float metricArg,
             IndicesOptions indicesOptions,
-            std::optional<cuvs::neighbors::ivf_pq::index_params> ivf_pq_params =
-                    std::nullopt,
-            std::optional<cuvs::neighbors::ivf_pq::search_params>
-                    ivf_pq_search_params = std::nullopt,
+            const IVFPQBuildCagraConfig* ivf_pq_params = nullptr,
+            const IVFPQSearchCagraConfig* ivf_pq_search_params = nullptr,
             float refine_rate = 2.0f,
             bool guarantee_connectivity = false);
 
@@ -83,7 +84,7 @@ class CuvsCagra {
             float metricArg,
             IndicesOptions indicesOptions);
 
-    ~CuvsCagra() = default;
+    ~CuvsCagra();
 
     void train(idx_t n, const data_t* x);
 
@@ -141,22 +142,30 @@ class CuvsCagra {
 
     /// Parameters to build cuVS CAGRA index
     faiss::cagra_build_algo graph_build_algo_;
-    cuvs::neighbors::cagra::index_params index_params_;
+    size_t intermediate_graph_degree_;
+    size_t graph_degree_;
 
     /// Parameters to build CAGRA graph using IVF PQ
-    std::optional<cuvs::neighbors::ivf_pq::index_params> ivf_pq_params_;
-    std::optional<cuvs::neighbors::ivf_pq::search_params> ivf_pq_search_params_;
-    std::optional<float> refine_rate_;
+    const IVFPQBuildCagraConfig* ivf_pq_params_;
+    const IVFPQSearchCagraConfig* ivf_pq_search_params_;
+    float refine_rate_;
 
     /// Parameters to build CAGRA graph using NN Descent
     size_t nn_descent_niter_ = 20;
 
-    /// Parameter to use MST optimization to guarantee graph connectivity
+    /// release/26.10 has no C parameter for guarantee_connectivity and its
+    /// CAGRA bridge omits IVF-PQ max_internal_batch_size. train() uses a
+    /// narrow C++ graph-build fallback when either setting is requested.
     bool guarantee_connectivity_ = false;
 
+    /// Device storage used when cuvsCagraIndexFromArgs receives host data.
+    DeviceTensor<data_t, 2, true> ownedDataset_;
+
+    /// Dataset object whose storage/view is referenced by the CAGRA index.
+    cuvsDataset_t cuvs_dataset_{nullptr};
+
     /// Instance of trained cuVS CAGRA index
-    std::shared_ptr<cuvs::neighbors::cagra::index<data_t, uint32_t>> cuvs_index{
-            nullptr};
+    cuvsCagraIndex_t cuvs_index{nullptr};
 };
 } // namespace gpu
 } // namespace faiss

--- a/faiss/gpu/impl/CuvsFlatIndex.cu
+++ b/faiss/gpu/impl/CuvsFlatIndex.cu
@@ -26,21 +26,13 @@
 #include <faiss/gpu/impl/CuvsFlatIndex.cuh>
 #include <faiss/gpu/utils/ConversionOperators.cuh>
 
-#include <optional>
-#include <vector>
-
 #include <cuvs/neighbors/brute_force.h>
-#include <cuvs/neighbors/brute_force.hpp>
 #include <raft/core/device_mdspan.hpp>
-#include <raft/core/logger.hpp>
 #include <raft/linalg/unary_op.cuh>
 
 namespace faiss {
 namespace gpu {
 
-// Compatibility note: release/26.10's brute-force C API does not accept
-// caller-provided L2 norms. Preserve Faiss's cached-norm optimization through
-// C++ only for L2; all other flat searches use the C API below.
 template <typename T>
 void searchWithPrecomputedL2Norms(
         GpuResources* resources,
@@ -51,49 +43,42 @@ void searchWithPrecomputedL2Norms(
         Tensor<idx_t, 2, true>& outIndices,
         float metricArg,
         const IDSelector* sel) {
-    auto& handle = resources->getRaftHandleCurrentDevice();
-    auto databaseView = raft::make_device_matrix_view<const T, int64_t>(
+    auto databaseTensor = makeCuvsTensor(
             database.data(), database.getSize(0), database.getSize(1));
-    auto queryView = raft::make_device_matrix_view<const T, int64_t>(
+    auto normsTensor = makeCuvsTensor(norms.data(), norms.getSize(0));
+    auto queryTensor = makeCuvsTensor(
             queries.data(), queries.getSize(0), queries.getSize(1));
-    auto indexView = raft::make_device_matrix_view<idx_t, int64_t>(
+    auto indicesTensor = makeCuvsTensor(
             outIndices.data(), outIndices.getSize(0), outIndices.getSize(1));
-    auto distanceView = raft::make_device_matrix_view<float, int64_t>(
+    auto distancesTensor = makeCuvsTensor(
             outDistances.data(),
             outDistances.getSize(0),
             outDistances.getSize(1));
-    std::optional<raft::device_vector_view<const float, int64_t>> normsView =
-            raft::make_device_vector_view(norms.data(), norms.getSize(0));
-    cuvs::neighbors::brute_force::index<T, float> index(
-            handle,
-            databaseView,
-            normsView,
-            cuvs::distance::DistanceType::L2Expanded,
-            metricArg);
 
-    if (sel) {
-        raft::core::bitset<uint32_t, int64_t> bitset(
-                handle, database.getSize(0), false);
-        convert_to_bitset(resources, *sel, bitset.view());
-        cuvs::neighbors::filtering::bitset_filter<uint32_t, int64_t> filter(
-                bitset.view());
-        cuvs::neighbors::brute_force::search(
-                handle,
-                cuvs::neighbors::brute_force::search_params{},
-                index,
-                queryView,
-                indexView,
-                distanceView,
-                filter);
-    } else {
-        cuvs::neighbors::brute_force::search(
-                handle,
-                cuvs::neighbors::brute_force::search_params{},
-                index,
-                queryView,
-                indexView,
-                distanceView);
-    }
+    cuvsBruteForceIndex_t index = nullptr;
+    cuvsCheck(cuvsBruteForceIndexCreate(&index), "cuvsBruteForceIndexCreate");
+    CuvsUniquePtr<cuvsBruteForceIndex, cuvsBruteForceIndexDestroy> indexHolder(
+            index);
+    auto cuvsResources = cuvsResourcesFromGpuResources(resources);
+    cuvsCheck(
+            cuvsBruteForceBuildWithNorms(
+                    cuvsResources,
+                    databaseTensor.get(),
+                    normsTensor.get(),
+                    L2Expanded,
+                    metricArg,
+                    index),
+            "cuvsBruteForceBuildWithNorms");
+    CuvsFilter filter(resources, sel, database.getSize(0));
+    cuvsCheck(
+            cuvsBruteForceSearch(
+                    cuvsResources,
+                    index,
+                    queryTensor.get(),
+                    indicesTensor.get(),
+                    distancesTensor.get(),
+                    filter.get()),
+            "cuvsBruteForceSearch");
 }
 
 CuvsFlatIndex::CuvsFlatIndex(

--- a/faiss/gpu/impl/CuvsFlatIndex.cu
+++ b/faiss/gpu/impl/CuvsFlatIndex.cu
@@ -29,8 +29,7 @@
 #include <optional>
 #include <vector>
 
-#include <cuvs/core/bitset.hpp>
-#include <cuvs/distance/distance.h>
+#include <cuvs/neighbors/brute_force.h>
 #include <cuvs/neighbors/brute_force.hpp>
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/logger.hpp>
@@ -39,8 +38,63 @@
 namespace faiss {
 namespace gpu {
 
-using namespace cuvs::distance;
-using namespace cuvs::neighbors;
+// Compatibility note: release/26.10's brute-force C API does not accept
+// caller-provided L2 norms. Preserve Faiss's cached-norm optimization through
+// C++ only for L2; all other flat searches use the C API below.
+template <typename T>
+void searchWithPrecomputedL2Norms(
+        GpuResources* resources,
+        Tensor<T, 2, true>& database,
+        Tensor<float, 1, true>& norms,
+        Tensor<T, 2, true>& queries,
+        Tensor<float, 2, true>& outDistances,
+        Tensor<idx_t, 2, true>& outIndices,
+        float metricArg,
+        const IDSelector* sel) {
+    auto& handle = resources->getRaftHandleCurrentDevice();
+    auto databaseView = raft::make_device_matrix_view<const T, int64_t>(
+            database.data(), database.getSize(0), database.getSize(1));
+    auto queryView = raft::make_device_matrix_view<const T, int64_t>(
+            queries.data(), queries.getSize(0), queries.getSize(1));
+    auto indexView = raft::make_device_matrix_view<idx_t, int64_t>(
+            outIndices.data(), outIndices.getSize(0), outIndices.getSize(1));
+    auto distanceView = raft::make_device_matrix_view<float, int64_t>(
+            outDistances.data(),
+            outDistances.getSize(0),
+            outDistances.getSize(1));
+    std::optional<raft::device_vector_view<const float, int64_t>> normsView =
+            raft::make_device_vector_view(norms.data(), norms.getSize(0));
+    cuvs::neighbors::brute_force::index<T, float> index(
+            handle,
+            databaseView,
+            normsView,
+            cuvs::distance::DistanceType::L2Expanded,
+            metricArg);
+
+    if (sel) {
+        raft::core::bitset<uint32_t, int64_t> bitset(
+                handle, database.getSize(0), false);
+        convert_to_bitset(resources, *sel, bitset.view());
+        cuvs::neighbors::filtering::bitset_filter<uint32_t, int64_t> filter(
+                bitset.view());
+        cuvs::neighbors::brute_force::search(
+                handle,
+                cuvs::neighbors::brute_force::search_params{},
+                index,
+                queryView,
+                indexView,
+                distanceView,
+                filter);
+    } else {
+        cuvs::neighbors::brute_force::search(
+                handle,
+                cuvs::neighbors::brute_force::search_params{},
+                index,
+                queryView,
+                indexView,
+                distanceView);
+    }
+}
 
 CuvsFlatIndex::CuvsFlatIndex(
         GpuResources* res,
@@ -76,11 +130,6 @@ void CuvsFlatIndex::query(
         raft::device_resources& handle =
                 resources_->getRaftHandleCurrentDevice();
 
-        auto index = raft::make_device_matrix_view<const float, int64_t>(
-                vectors_.data(), vectors_.getSize(0), vectors_.getSize(1));
-        auto search = raft::make_device_matrix_view<const float, int64_t>(
-                input.data(), input.getSize(0), input.getSize(1));
-
         auto inds = raft::make_device_matrix_view<idx_t, int64_t>(
                 outIndices.data(),
                 outIndices.getSize(0),
@@ -91,37 +140,56 @@ void CuvsFlatIndex::query(
                 outDistances.getSize(1));
 
         auto distance = metricFaissToCuvs(metric, exactDistance);
+        if (metric == MetricType::METRIC_L2) {
+            searchWithPrecomputedL2Norms(
+                    resources_,
+                    vectors_,
+                    norms_,
+                    input,
+                    outDistances,
+                    outIndices,
+                    metricArg,
+                    sel);
+        } else {
+            auto indexTensor = makeCuvsTensor(
+                    vectors_.data(), vectors_.getSize(0), vectors_.getSize(1));
+            auto queryTensor = makeCuvsTensor(
+                    input.data(), input.getSize(0), input.getSize(1));
+            auto indicesTensor = makeCuvsTensor(
+                    outIndices.data(),
+                    outIndices.getSize(0),
+                    outIndices.getSize(1));
+            auto distancesTensor = makeCuvsTensor(
+                    outDistances.data(),
+                    outDistances.getSize(0),
+                    outDistances.getSize(1));
 
-        std::optional<raft::device_vector_view<const float, int64_t>>
-                norms_view = raft::make_device_vector_view(
-                        norms_.data(), norms_.getSize(0));
-
-        cuvs::neighbors::brute_force::index idx(
-                handle, index, norms_view, distance, metricArg);
-
-        std::optional<cuvs::core::bitset<uint32_t, int64_t>> bitset_cuvs;
-        std::optional<
-                cuvs::neighbors::filtering::bitset_filter<uint32_t, int64_t>>
-                bitset_filter_cuvs;
-        cuvs::neighbors::filtering::none_sample_filter none_filter;
-
-        if (sel) {
-            bitset_cuvs = cuvs::core::bitset<uint32_t, int64_t>(
-                    handle, vectors_.getSize(0), false);
-            faiss::gpu::convert_to_bitset(
-                    resources_, *sel, bitset_cuvs->view());
-            bitset_filter_cuvs.emplace(bitset_cuvs->view());
+            cuvsBruteForceIndex_t index = nullptr;
+            cuvsCheck(
+                    cuvsBruteForceIndexCreate(&index),
+                    "cuvsBruteForceIndexCreate");
+            CuvsUniquePtr<cuvsBruteForceIndex, cuvsBruteForceIndexDestroy>
+                    indexHolder(index);
+            auto cuvsResources = cuvsResourcesFromGpuResources(resources_);
+            cuvsCheck(
+                    cuvsBruteForceBuild(
+                            cuvsResources,
+                            indexTensor.get(),
+                            distance,
+                            metricArg,
+                            index),
+                    "cuvsBruteForceBuild");
+            CuvsFilter filter(resources_, sel, vectors_.getSize(0));
+            cuvsCheck(
+                    cuvsBruteForceSearch(
+                            cuvsResources,
+                            index,
+                            queryTensor.get(),
+                            indicesTensor.get(),
+                            distancesTensor.get(),
+                            filter.get()),
+                    "cuvsBruteForceSearch");
         }
-        const cuvs::neighbors::filtering::base_filter& filter_ref = sel
-                ? static_cast<const cuvs::neighbors::filtering::base_filter&>(
-                          bitset_filter_cuvs.value())
-                : static_cast<const cuvs::neighbors::filtering::base_filter&>(
-                          none_filter);
-        cuvs::neighbors::brute_force::search_params search_params_bf;
-
-        cuvs::neighbors::brute_force::search(
-                handle, search_params_bf, idx, search, inds, dists, filter_ref);
-
         if (metric == MetricType::METRIC_Lp) {
             raft::linalg::unary_op(
                     handle,
@@ -153,15 +221,6 @@ void CuvsFlatIndex::query(
 
     raft::device_resources& handle = resources_->getRaftHandleCurrentDevice();
 
-    auto index = raft::make_device_matrix_view<const half, int64_t>(
-            vectorsHalf_.data(),
-            vectorsHalf_.getSize(0),
-            vectorsHalf_.getSize(1));
-    auto search = raft::make_device_matrix_view<const half, int64_t>(
-            vecs.data(), vecs.getSize(0), vecs.getSize(1));
-
-    auto inds = raft::make_device_matrix_view<idx_t, int64_t>(
-            outIndices.data(), outIndices.getSize(0), outIndices.getSize(1));
     auto dists = raft::make_device_matrix_view<float, int64_t>(
             outDistances.data(),
             outDistances.getSize(0),
@@ -169,33 +228,57 @@ void CuvsFlatIndex::query(
 
     auto distance = metricFaissToCuvs(metric, exactDistance);
 
-    std::optional<raft::device_vector_view<const float, int64_t>> norms_view =
-            raft::make_device_vector_view(norms_.data(), norms_.getSize(0));
+    if (metric == MetricType::METRIC_L2) {
+        searchWithPrecomputedL2Norms(
+                resources_,
+                vectorsHalf_,
+                norms_,
+                vecs,
+                outDistances,
+                outIndices,
+                metricArg,
+                sel);
+    } else {
+        auto indexTensor = makeCuvsTensor(
+                vectorsHalf_.data(),
+                vectorsHalf_.getSize(0),
+                vectorsHalf_.getSize(1));
+        auto queryTensor =
+                makeCuvsTensor(vecs.data(), vecs.getSize(0), vecs.getSize(1));
+        auto indicesTensor = makeCuvsTensor(
+                outIndices.data(),
+                outIndices.getSize(0),
+                outIndices.getSize(1));
+        auto distancesTensor = makeCuvsTensor(
+                outDistances.data(),
+                outDistances.getSize(0),
+                outDistances.getSize(1));
 
-    cuvs::neighbors::brute_force::index<half, float> idx(
-            handle, index, norms_view, distance, metricArg);
-
-    std::optional<cuvs::core::bitset<uint32_t, int64_t>> bitset_cuvs;
-    std::optional<cuvs::neighbors::filtering::bitset_filter<uint32_t, int64_t>>
-            bitset_filter_cuvs;
-    cuvs::neighbors::filtering::none_sample_filter none_filter;
-
-    if (sel) {
-        bitset_cuvs = cuvs::core::bitset<uint32_t, int64_t>(
-                handle, vectorsHalf_.getSize(0), false);
-        faiss::gpu::convert_to_bitset(resources_, *sel, bitset_cuvs->view());
-        bitset_filter_cuvs.emplace(bitset_cuvs->view());
+        cuvsBruteForceIndex_t index = nullptr;
+        cuvsCheck(
+                cuvsBruteForceIndexCreate(&index), "cuvsBruteForceIndexCreate");
+        CuvsUniquePtr<cuvsBruteForceIndex, cuvsBruteForceIndexDestroy>
+                indexHolder(index);
+        auto cuvsResources = cuvsResourcesFromGpuResources(resources_);
+        cuvsCheck(
+                cuvsBruteForceBuild(
+                        cuvsResources,
+                        indexTensor.get(),
+                        distance,
+                        metricArg,
+                        index),
+                "cuvsBruteForceBuild");
+        CuvsFilter filter(resources_, sel, vectorsHalf_.getSize(0));
+        cuvsCheck(
+                cuvsBruteForceSearch(
+                        cuvsResources,
+                        index,
+                        queryTensor.get(),
+                        indicesTensor.get(),
+                        distancesTensor.get(),
+                        filter.get()),
+                "cuvsBruteForceSearch");
     }
-    const cuvs::neighbors::filtering::base_filter& filter_ref = sel
-            ? static_cast<const cuvs::neighbors::filtering::base_filter&>(
-                      bitset_filter_cuvs.value())
-            : static_cast<const cuvs::neighbors::filtering::base_filter&>(
-                      none_filter);
-    cuvs::neighbors::brute_force::search_params search_params_bf;
-
-    cuvs::neighbors::brute_force::search(
-            handle, search_params_bf, idx, search, inds, dists, filter_ref);
-
     if (metric == MetricType::METRIC_Lp) {
         raft::linalg::unary_op(
                 handle,

--- a/faiss/gpu/impl/CuvsIVFFlat.cu
+++ b/faiss/gpu/impl/CuvsIVFFlat.cu
@@ -20,10 +20,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cmath>
 #include <cstddef>
 #include <cstdint>
 
+#include <cuvs/neighbors/ivf_flat.h>
 #include <faiss/gpu/GpuIndexFlat.h>
 #include <faiss/gpu/StandardGpuResources.h>
 #include <faiss/gpu/utils/CuvsFilterConvert.h>
@@ -31,10 +31,6 @@
 #include <faiss/gpu/impl/CuvsIVFFlat.cuh>
 #include <faiss/gpu/impl/FlatIndex.cuh>
 #include <faiss/gpu/impl/IVFFlat.cuh>
-#include <faiss/gpu/utils/Transpose.cuh>
-
-#include <cuvs/neighbors/ivf_flat.h>
-#include <cuvs/neighbors/ivf_flat.hpp>
 #include <raft/linalg/map.cuh>
 #include <raft/linalg/norm.cuh>
 
@@ -43,18 +39,6 @@
 
 namespace faiss {
 namespace gpu {
-
-// Compatibility note: release/26.10 has no C API for resetting an IVF-Flat
-// index, constructing one from caller-provided coarse centers, querying its
-// total size or list internals, or importing/exporting and packing raw
-// inverted-list storage. Public build, search, extend, and
-// available getter operations use C; these C++ helpers are retained only for
-// Faiss inverted-list interoperability.
-using CuvsIVFFlatCppIndex = cuvs::neighbors::ivf_flat::index<float, idx_t>;
-
-static CuvsIVFFlatCppIndex* getCppIndex(cuvsIvfFlatIndex_t index) {
-    return reinterpret_cast<CuvsIVFFlatCppIndex*>(index->addr);
-}
 
 CuvsIVFFlat::CuvsIVFFlat(
         GpuResources* res,
@@ -96,11 +80,11 @@ void CuvsIVFFlat::reserveMemory(idx_t numVecs) {
 }
 
 void CuvsIVFFlat::reset() {
-    if (cuvs_index != nullptr) {
-        const raft::device_resources& raft_handle =
-                resources_->getRaftHandleCurrentDevice();
-        cuvs::neighbors::ivf_flat::helpers::reset_index(
-                raft_handle, getCppIndex(cuvs_index));
+    if (cuvs_index) {
+        cuvsCheck(
+                cuvsIvfFlatIndexReset(
+                        cuvsResourcesFromGpuResources(resources_), cuvs_index),
+                "cuvsIvfFlatIndexReset");
     }
 }
 
@@ -150,7 +134,11 @@ void CuvsIVFFlat::search(
             makeCuvsTensor(outIndices.data(), (int64_t)numQueries, (int64_t)k_);
     auto distancesTensor = makeCuvsTensor(
             outDistances.data(), (int64_t)numQueries, (int64_t)k_);
-    CuvsFilter filter(resources_, sel, getCppIndex(cuvs_index)->size());
+    int64_t indexSize = 0;
+    cuvsCheck(
+            cuvsIvfFlatIndexGetSize(cuvs_index, &indexSize),
+            "cuvsIvfFlatIndexGetSize");
+    CuvsFilter filter(resources_, sel, indexSize);
 
     cuvsCheck(
             cuvsIvfFlatSearch(
@@ -223,47 +211,50 @@ idx_t CuvsIVFFlat::addVectors(
 
 idx_t CuvsIVFFlat::getListLength(idx_t listId) const {
     FAISS_ASSERT(cuvs_index != nullptr);
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+    CuvsOutputTensor listSizes;
+    cuvsCheck(
+            cuvsIvfFlatIndexGetListSizes(cuvs_index, listSizes.get()),
+            "cuvsIvfFlatIndexGetListSizes");
 
     uint32_t size;
     raft::update_host(
             &size,
-            getCppIndex(cuvs_index)->list_sizes().data_handle() + listId,
+            listSizes.data<uint32_t>() + listId,
             1,
-            raft_handle.get_stream());
-    raft_handle.sync_stream();
+            raftHandle.get_stream());
+    raftHandle.sync_stream();
 
-    return static_cast<int>(size);
+    return static_cast<idx_t>(size);
 }
 
 /// Return the list indices of a particular list back to the CPU
 std::vector<idx_t> CuvsIVFFlat::getListIndices(idx_t listId) const {
     FAISS_ASSERT(cuvs_index != nullptr);
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-    auto stream = raft_handle.get_stream();
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+    const idx_t listSize = getListLength(listId);
 
-    idx_t listSize = getListLength(listId);
+    std::vector<idx_t> indices(listSize);
+    if (listSize == 0) {
+        return indices;
+    }
 
-    std::vector<idx_t> vec(listSize);
-
-    // fetch the list indices ptr on host
-    idx_t* list_indices_ptr;
+    CuvsOutputTensor listIndices;
+    cuvsCheck(
+            cuvsIvfFlatIndexGetListIndices(
+                    cuvs_index,
+                    static_cast<uint32_t>(listId),
+                    listIndices.get()),
+            "cuvsIvfFlatIndexGetListIndices");
 
     raft::update_host(
-            &list_indices_ptr,
-            const_cast<idx_t**>(
-                    getCppIndex(cuvs_index)->inds_ptrs().data_handle()) +
-                    listId,
-            1,
-            stream);
-    raft_handle.sync_stream();
+            indices.data(),
+            listIndices.data<idx_t>(),
+            listSize,
+            raftHandle.get_stream());
+    raftHandle.sync_stream();
 
-    raft::update_host(vec.data(), list_indices_ptr, listSize, stream);
-    raft_handle.sync_stream();
-
-    return vec;
+    return indices;
 }
 
 /// Return the encoded vectors of a particular list back to the CPU
@@ -275,41 +266,36 @@ std::vector<uint8_t> CuvsIVFFlat::getListVectorData(
     }
     FAISS_ASSERT(cuvs_index != nullptr);
 
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-    auto stream = raft_handle.get_stream();
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+    const idx_t listSize = getListLength(listId);
 
-    idx_t listSize = getListLength(listId);
+    std::vector<uint8_t> flatCodes(getCpuVectorsEncodingSize_(listSize));
+    if (listSize == 0) {
+        return flatCodes;
+    }
 
-    // the interleaved block can be slightly larger than the list size (it's
-    // rounded up)
-    auto gpuListSizeInBytes = getGpuVectorsEncodingSize_(listSize);
-    auto cpuListSizeInBytes = getCpuVectorsEncodingSize_(listSize);
+    auto vectorsDevice = raft::make_device_matrix<float, uint32_t>(
+            raftHandle,
+            static_cast<uint32_t>(listSize),
+            static_cast<uint32_t>(dim_));
+    auto vectorsTensor = makeCuvsTensor(
+            vectorsDevice.data_handle(), (int64_t)listSize, (int64_t)dim_);
+    cuvsCheck(
+            cuvsIvfFlatIndexUnpackContiguousListData(
+                    cuvsResourcesFromGpuResources(resources_),
+                    cuvs_index,
+                    vectorsTensor.get(),
+                    static_cast<uint32_t>(listId),
+                    0),
+            "cuvsIvfFlatIndexUnpackContiguousListData");
 
-    std::vector<uint8_t> interleaved_codes(gpuListSizeInBytes);
-    std::vector<uint8_t> flat_codes(cpuListSizeInBytes);
-
-    float* list_data_ptr;
-
-    // fetch the list data ptr on host
     raft::update_host(
-            &list_data_ptr,
-            getCppIndex(cuvs_index)->data_ptrs().data_handle() + listId,
-            1,
-            stream);
-    raft_handle.sync_stream();
-
-    raft::update_host(
-            interleaved_codes.data(),
-            reinterpret_cast<uint8_t*>(list_data_ptr),
-            gpuListSizeInBytes,
-            stream);
-    raft_handle.sync_stream();
-
-    CuvsIVFFlatCodePackerInterleaved packer(
-            (size_t)listSize, dim_, getCppIndex(cuvs_index)->veclen());
-    packer.unpack_all(interleaved_codes.data(), flat_codes.data());
-    return flat_codes;
+            flatCodes.data(),
+            reinterpret_cast<const uint8_t*>(vectorsDevice.data_handle()),
+            flatCodes.size(),
+            raftHandle.get_stream());
+    raftHandle.sync_stream();
+    return flatCodes;
 }
 
 /// Performs search when we are already given the IVF cells to look at
@@ -333,141 +319,92 @@ void CuvsIVFFlat::updateQuantizer(Index* quantizer) {
     FAISS_THROW_IF_NOT(quantizer->d == getDim());
     FAISS_THROW_IF_NOT(quantizer->ntotal == getNumLists());
 
-    // Compatibility note: release/26.10 has no C API that constructs an
-    // empty IVF-Flat index from caller-provided coarse centers. Keep the C++
-    // constructor for this path so updating a Faiss quantizer does not rerun
-    // k-means or reorder its centers. The resulting index is returned to the
-    // C API handle used by all supported operations.
-    const raft::device_resources& raftHandle =
-            resources_->getRaftHandleCurrentDevice();
-    cuvs::neighbors::ivf_flat::index_params params;
-    params.add_data_on_build = false;
-    params.metric = static_cast<cuvs::distance::DistanceType>(
-            metricFaissToCuvs(metric_, false));
-    params.metric_arg = metricArg_;
-    params.n_lists = numLists_;
-    auto replacement = std::make_unique<CuvsIVFFlatCppIndex>(
-            raftHandle, params, static_cast<uint32_t>(dim_));
-    cuvs::neighbors::ivf_flat::helpers::reset_index(
-            raftHandle, replacement.get());
-
     const size_t totalElements =
             static_cast<size_t>(quantizer->ntotal) * quantizer->d;
     auto stream = resources_->getDefaultStreamCurrentDevice();
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+    DeviceTensor<float, 2, true> centers(
+            resources_,
+            makeSpaceAlloc(AllocType::Quantizer, space_, stream),
+            {getNumLists(), getDim()});
     auto gpuQ = dynamic_cast<GpuIndexFlat*>(quantizer);
     if (gpuQ) {
         auto gpuData = gpuQ->getGpuData();
         if (gpuData->getUseFloat16()) {
-            DeviceTensor<float, 2, true> centroids(
-                    resources_,
-                    makeSpaceAlloc(AllocType::FlatData, space_, stream),
-                    {getNumLists(), getDim()});
-            gpuData->reconstruct(0, gpuData->getSize(), centroids);
-            raft::update_device(
-                    replacement->centers().data_handle(),
-                    centroids.data(),
-                    totalElements,
-                    stream);
+            gpuData->reconstruct(0, gpuData->getSize(), centers);
         } else {
-            auto centroids = gpuData->getVectorsFloat32Ref();
-            raft::update_device(
-                    replacement->centers().data_handle(),
-                    centroids.data(),
-                    totalElements,
-                    stream);
+            auto source = gpuData->getVectorsFloat32Ref();
+            raft::copy(centers.data(), source.data(), totalElements, stream);
         }
     } else {
-        std::vector<float> centroids(totalElements);
-        quantizer->reconstruct_n(0, quantizer->ntotal, centroids.data());
+        std::vector<float> hostCenters(totalElements);
+        quantizer->reconstruct_n(0, quantizer->ntotal, hostCenters.data());
         raft::update_device(
-                replacement->centers().data_handle(),
-                centroids.data(),
-                totalElements,
-                stream);
+                centers.data(), hostCenters.data(), totalElements, stream);
     }
-    raftHandle.sync_stream();
+
+    DeviceTensor<float, 1, true> centerNorms;
+    std::unique_ptr<CuvsTensor<float, 1>> centerNormsTensor;
+    if (metric_ == faiss::METRIC_L2) {
+        centerNorms = DeviceTensor<float, 1, true>(
+                resources_,
+                makeSpaceAlloc(AllocType::Quantizer, space_, stream),
+                {getNumLists()});
+        raft::linalg::rowNorm<raft::linalg::L2Norm, true, float, uint32_t>(
+                centerNorms.data(),
+                centers.data(),
+                dim_,
+                static_cast<uint32_t>(numLists_),
+                stream);
+        centerNormsTensor = std::make_unique<CuvsTensor<float, 1>>(
+                centerNorms.data(), (int64_t)numLists_);
+    }
+
+    cuvsIvfFlatIndexParams_t params = nullptr;
+    cuvsCheck(
+            cuvsIvfFlatIndexParamsCreate(&params),
+            "cuvsIvfFlatIndexParamsCreate");
+    CuvsUniquePtr<cuvsIvfFlatIndexParams, cuvsIvfFlatIndexParamsDestroy>
+            paramsHolder(params);
+    params->add_data_on_build = false;
+    params->metric = metricFaissToCuvs(metric_, false);
+    params->metric_arg = metricArg_;
+    params->n_lists = numLists_;
+
+    auto centersTensor =
+            makeCuvsTensor(centers.data(), (int64_t)numLists_, (int64_t)dim_);
 
     cuvsIvfFlatIndex_t index = nullptr;
     cuvsCheck(cuvsIvfFlatIndexCreate(&index), "cuvsIvfFlatIndexCreate");
     CuvsUniquePtr<cuvsIvfFlatIndex, cuvsIvfFlatIndexDestroy> indexHolder(index);
-    index->addr = reinterpret_cast<uintptr_t>(replacement.release());
-    index->dtype = cuvsDtype<float>();
+    cuvsCheck(
+            cuvsIvfFlatBuildFromCenters(
+                    cuvsResourcesFromGpuResources(resources_),
+                    params,
+                    cuvsDtype<float>(),
+                    centersTensor.get(),
+                    centerNormsTensor ? centerNormsTensor->get() : nullptr,
+                    index),
+            "cuvsIvfFlatBuildFromCenters");
+    raftHandle.sync_stream();
     setCuvsIndex(indexHolder.release());
 }
 
 void CuvsIVFFlat::copyInvertedListsFrom(const InvertedLists* ivf) {
-    size_t nlist = ivf ? ivf->nlist : 0;
-    size_t ntotal = ivf ? ivf->compute_ntotal() : 0;
-
-    raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-
-    std::vector<uint32_t> list_sizes_(nlist);
-    std::vector<idx_t> indices_(ntotal);
-
-    // the index must already exist
+    const size_t nlist = ivf ? ivf->nlist : 0;
+    FAISS_THROW_IF_NOT(nlist <= static_cast<size_t>(numLists_));
     FAISS_ASSERT(cuvs_index != nullptr);
 
-    auto& cuvs_index_lists = getCppIndex(cuvs_index)->lists();
-
-    // conservative memory alloc for cloning cpu inverted lists
-    cuvs::neighbors::ivf_flat::list_spec<uint32_t, float, idx_t> ivf_list_spec{
-            static_cast<uint32_t>(dim_), true};
-
     for (size_t i = 0; i < nlist; ++i) {
-        size_t listSize = ivf->list_size(i);
-
-        // GPU index can only support max int entries per list
+        const size_t listSize = ivf->list_size(i);
         FAISS_THROW_IF_NOT_FMT(
                 listSize <= (size_t)std::numeric_limits<int>::max(),
-                "GPU inverted list can only support "
-                "%zu entries; %zu found",
+                "GPU inverted list can only support %zu entries; %zu found",
                 (size_t)std::numeric_limits<int>::max(),
                 listSize);
-
-        // store the list size
-        list_sizes_[i] = static_cast<uint32_t>(listSize);
-
-        // This cuVS list must currently be empty
         FAISS_ASSERT(getListLength(i) == 0);
-
-        cuvs::neighbors::ivf::resize_list(
-                raft_handle,
-                cuvs_index_lists[i],
-                ivf_list_spec,
-                (uint32_t)listSize,
-                (uint32_t)0);
-    }
-
-    // Update the pointers and the sizes
-    cuvs::neighbors::ivf_flat::helpers::recompute_internal_state(
-            raft_handle, getCppIndex(cuvs_index));
-
-    for (size_t i = 0; i < nlist; ++i) {
-        size_t listSize = ivf->list_size(i);
         addEncodedVectorsToList_(
                 i, ivf->get_codes(i), ivf->get_ids(i), listSize);
-    }
-
-    raft::update_device(
-            getCppIndex(cuvs_index)->list_sizes().data_handle(),
-            list_sizes_.data(),
-            nlist,
-            raft_handle.get_stream());
-
-    // Precompute the centers vector norms for L2Expanded distance
-    if (this->metric_ == faiss::METRIC_L2) {
-        getCppIndex(cuvs_index)->allocate_center_norms(raft_handle);
-        CuvsOutputTensor centers;
-        cuvsCheck(
-                cuvsIvfFlatIndexGetCenters(cuvs_index, centers.get()),
-                "cuvsIvfFlatIndexGetCenters");
-        raft::linalg::rowNorm<raft::linalg::L2Norm, true, float, uint32_t>(
-                getCppIndex(cuvs_index)->center_norms().value().data_handle(),
-                centers.data<float>(),
-                dim_,
-                (uint32_t)nlist,
-                raft_handle.get_stream());
     }
 }
 
@@ -481,8 +418,7 @@ size_t CuvsIVFFlat::getGpuVectorsEncodingSize_(idx_t numVecs) const {
     idx_t bytesPerBlock = bytesPerDimBlock * dim_;
 
     // number of blocks of 32 vectors we have
-    idx_t numBlocks =
-            utils::divUp(numVecs, cuvs::neighbors::ivf_flat::kIndexGroupSize);
+    idx_t numBlocks = utils::divUp(numVecs, 32);
 
     // total size to encode numVecs
     return bytesPerBlock * numBlocks;
@@ -493,99 +429,44 @@ void CuvsIVFFlat::addEncodedVectorsToList_(
         const void* codes,
         const idx_t* indices,
         idx_t numVecs) {
-    auto stream = resources_->getDefaultStreamCurrentDevice();
-
-    // If there's nothing to add, then there's nothing we have to do
     if (numVecs == 0) {
         return;
     }
 
-    // The GPU might have a different layout of the memory
-    auto gpuListSizeInBytes = getGpuVectorsEncodingSize_(numVecs);
+    auto stream = resources_->getDefaultStreamCurrentDevice();
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+    constexpr idx_t maxBatchSize = 4096;
+    for (idx_t offset = 0; offset < numVecs; offset += maxBatchSize) {
+        uint32_t batchSize = min(maxBatchSize, numVecs - offset);
+        auto vectorsDevice = raft::make_device_matrix<float, uint32_t>(
+                raftHandle, batchSize, static_cast<uint32_t>(dim_));
+        auto indicesDevice = raft::make_device_vector<idx_t, uint32_t>(
+                raftHandle, batchSize);
 
-    // We only have int32 length representations on the GPU per each
-    // list; the length is in sizeof(char)
-    FAISS_ASSERT(gpuListSizeInBytes <= (size_t)std::numeric_limits<int>::max());
+        raft::update_device(
+                vectorsDevice.data_handle(),
+                reinterpret_cast<const float*>(codes) + offset * dim_,
+                static_cast<size_t>(batchSize) * dim_,
+                stream);
 
-    std::vector<uint8_t> interleaved_codes(gpuListSizeInBytes);
-    CuvsIVFFlatCodePackerInterleaved packer(
-            (size_t)numVecs, (uint32_t)dim_, getCppIndex(cuvs_index)->veclen());
-
-    packer.pack_all(
-            reinterpret_cast<const uint8_t*>(codes), interleaved_codes.data());
-
-    float* list_data_ptr;
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-
-    /// fetch the list data ptr on host
-    raft::update_host(
-            &list_data_ptr,
-            getCppIndex(cuvs_index)->data_ptrs().data_handle() + listId,
-            1,
-            stream);
-    raft_handle.sync_stream();
-
-    raft::update_device(
-            reinterpret_cast<uint8_t*>(list_data_ptr),
-            interleaved_codes.data(),
-            gpuListSizeInBytes,
-            stream);
-
-    /// Handle the indices as well
-    idx_t* list_indices_ptr;
-
-    // fetch the list indices ptr on host
-    raft::update_host(
-            &list_indices_ptr,
-            getCppIndex(cuvs_index)->inds_ptrs().data_handle() + listId,
-            1,
-            stream);
-    raft_handle.sync_stream();
-
-    raft::update_device(list_indices_ptr, indices, numVecs, stream);
-}
-
-CuvsIVFFlatCodePackerInterleaved::CuvsIVFFlatCodePackerInterleaved(
-        size_t list_size,
-        uint32_t dim,
-        uint32_t chunk_size) {
-    this->dim = dim;
-    this->chunk_size = chunk_size;
-    // NB: dim should be divisible by the number of 4 byte records in one chunk
-    FAISS_ASSERT(dim % chunk_size == 0);
-    nvec = list_size;
-    code_size = dim * 4;
-    block_size =
-            utils::roundUp(nvec, cuvs::neighbors::ivf_flat::kIndexGroupSize);
-}
-
-void CuvsIVFFlatCodePackerInterleaved::pack_1(
-        const uint8_t* flat_code,
-        size_t offset,
-        uint8_t* block) const {
-    cuvs::neighbors::ivf_flat::helpers::codepacker::pack_1(
-            reinterpret_cast<const float*>(flat_code),
-            reinterpret_cast<float*>(block),
-            dim,
-            chunk_size,
-            static_cast<uint32_t>(offset));
-}
-
-void CuvsIVFFlatCodePackerInterleaved::unpack_1(
-        const uint8_t* block,
-        size_t offset,
-        uint8_t* flat_code) const {
-    cuvs::neighbors::ivf_flat::helpers::codepacker::unpack_1(
-            reinterpret_cast<const float*>(block),
-            reinterpret_cast<float*>(flat_code),
-            dim,
-            chunk_size,
-            static_cast<uint32_t>(offset));
-}
-
-CodePacker* CuvsIVFFlatCodePackerInterleaved::clone() const {
-    return new CuvsIVFFlatCodePackerInterleaved(*this);
+        raft::update_device(
+                indicesDevice.data_handle(),
+                indices + offset,
+                batchSize,
+                stream);
+        auto vectorsTensor = makeCuvsTensor(
+                vectorsDevice.data_handle(), (int64_t)batchSize, (int64_t)dim_);
+        auto indicesTensor =
+                makeCuvsTensor(indicesDevice.data_handle(), (int64_t)batchSize);
+        cuvsCheck(
+                cuvsIvfFlatIndexExtendList(
+                        cuvsResourcesFromGpuResources(resources_),
+                        cuvs_index,
+                        vectorsTensor.get(),
+                        indicesTensor.get(),
+                        static_cast<uint32_t>(listId)),
+                "cuvsIvfFlatIndexExtendList");
+    }
 }
 
 } // namespace gpu

--- a/faiss/gpu/impl/CuvsIVFFlat.cu
+++ b/faiss/gpu/impl/CuvsIVFFlat.cu
@@ -33,10 +33,8 @@
 #include <faiss/gpu/impl/IVFFlat.cuh>
 #include <faiss/gpu/utils/Transpose.cuh>
 
-#include <cuvs/core/bitset.hpp>
-#include <cuvs/neighbors/common.hpp>
+#include <cuvs/neighbors/ivf_flat.h>
 #include <cuvs/neighbors/ivf_flat.hpp>
-#include <optional>
 #include <raft/linalg/map.cuh>
 #include <raft/linalg/norm.cuh>
 
@@ -45,6 +43,18 @@
 
 namespace faiss {
 namespace gpu {
+
+// Compatibility note: release/26.10 has no C API for resetting an IVF-Flat
+// index, constructing one from caller-provided coarse centers, querying its
+// total size or list internals, or importing/exporting and packing raw
+// inverted-list storage. Public build, search, extend, and
+// available getter operations use C; these C++ helpers are retained only for
+// Faiss inverted-list interoperability.
+using CuvsIVFFlatCppIndex = cuvs::neighbors::ivf_flat::index<float, idx_t>;
+
+static CuvsIVFFlatCppIndex* getCppIndex(cuvsIvfFlatIndex_t index) {
+    return reinterpret_cast<CuvsIVFFlatCppIndex*>(index->addr);
+}
 
 CuvsIVFFlat::CuvsIVFFlat(
         GpuResources* res,
@@ -74,7 +84,11 @@ CuvsIVFFlat::CuvsIVFFlat(
             "only INDICES_64_BIT is supported for cuVS index");
 }
 
-CuvsIVFFlat::~CuvsIVFFlat() {}
+CuvsIVFFlat::~CuvsIVFFlat() {
+    if (cuvs_index) {
+        cuvsIvfFlatIndexDestroy(cuvs_index);
+    }
+}
 
 void CuvsIVFFlat::reserveMemory(idx_t numVecs) {
     fprintf(stderr,
@@ -86,15 +100,16 @@ void CuvsIVFFlat::reset() {
         const raft::device_resources& raft_handle =
                 resources_->getRaftHandleCurrentDevice();
         cuvs::neighbors::ivf_flat::helpers::reset_index(
-                raft_handle, cuvs_index.get());
+                raft_handle, getCppIndex(cuvs_index));
     }
 }
 
-void CuvsIVFFlat::setCuvsIndex(
-        cuvs::neighbors::ivf_flat::index<float, idx_t>&& idx) {
-    cuvs_index =
-            std::make_shared<cuvs::neighbors::ivf_flat::index<float, idx_t>>(
-                    std::move(idx));
+void CuvsIVFFlat::setCuvsIndex(cuvsIvfFlatIndex_t index) {
+    if (cuvs_index) {
+        cuvsCheck(
+                cuvsIvfFlatIndexDestroy(cuvs_index), "cuvsIvfFlatIndexDestroy");
+    }
+    cuvs_index = index;
 }
 
 void CuvsIVFFlat::search(
@@ -121,41 +136,32 @@ void CuvsIVFFlat::search(
 
     const raft::device_resources& raft_handle =
             resources_->getRaftHandleCurrentDevice();
-    cuvs::neighbors::ivf_flat::search_params pams;
-    pams.n_probes = nprobe;
+    cuvsIvfFlatSearchParams_t searchParams = nullptr;
+    cuvsCheck(
+            cuvsIvfFlatSearchParamsCreate(&searchParams),
+            "cuvsIvfFlatSearchParamsCreate");
+    CuvsUniquePtr<cuvsIvfFlatSearchParams, cuvsIvfFlatSearchParamsDestroy>
+            searchParamsHolder(searchParams);
+    searchParams->n_probes = nprobe;
 
-    auto queries_view = raft::make_device_matrix_view<const float, idx_t>(
-            queries.data(), (idx_t)numQueries, (idx_t)cols);
-    auto out_inds_view = raft::make_device_matrix_view<idx_t, idx_t>(
-            outIndices.data(), (idx_t)numQueries, (idx_t)k_);
-    auto out_dists_view = raft::make_device_matrix_view<float, idx_t>(
-            outDistances.data(), (idx_t)numQueries, (idx_t)k_);
+    auto queriesTensor =
+            makeCuvsTensor(queries.data(), (int64_t)numQueries, (int64_t)cols);
+    auto indicesTensor =
+            makeCuvsTensor(outIndices.data(), (int64_t)numQueries, (int64_t)k_);
+    auto distancesTensor = makeCuvsTensor(
+            outDistances.data(), (int64_t)numQueries, (int64_t)k_);
+    CuvsFilter filter(resources_, sel, getCppIndex(cuvs_index)->size());
 
-    std::optional<cuvs::core::bitset<uint32_t, int64_t>> bitset_cuvs;
-    std::optional<cuvs::neighbors::filtering::bitset_filter<uint32_t, int64_t>>
-            bitset_filter_cuvs;
-    cuvs::neighbors::filtering::none_sample_filter none_filter;
-
-    if (sel) {
-        bitset_cuvs = cuvs::core::bitset<uint32_t, int64_t>(
-                raft_handle, cuvs_index->size(), false);
-        faiss::gpu::convert_to_bitset(resources_, *sel, bitset_cuvs->view());
-        bitset_filter_cuvs.emplace(bitset_cuvs->view());
-    }
-    const cuvs::neighbors::filtering::base_filter& filter_ref = sel
-            ? static_cast<const cuvs::neighbors::filtering::base_filter&>(
-                      bitset_filter_cuvs.value())
-            : static_cast<const cuvs::neighbors::filtering::base_filter&>(
-                      none_filter);
-
-    cuvs::neighbors::ivf_flat::search(
-            raft_handle,
-            pams,
-            *cuvs_index,
-            queries_view,
-            out_inds_view,
-            out_dists_view,
-            filter_ref);
+    cuvsCheck(
+            cuvsIvfFlatSearch(
+                    cuvsResourcesFromGpuResources(resources_),
+                    searchParams,
+                    cuvs_index,
+                    queriesTensor.get(),
+                    indicesTensor.get(),
+                    distancesTensor.get(),
+                    filter.get()),
+            "cuvsIvfFlatSearch");
 
     /// Identify NaN rows and mask their nearest neighbors
     auto nan_flag = raft::make_device_vector<bool>(raft_handle, numQueries);
@@ -199,20 +205,18 @@ idx_t CuvsIVFFlat::addVectors(
 
     FAISS_ASSERT(cuvs_index != nullptr);
 
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-
     /// Remove rows containing NaNs
     idx_t n_rows_valid = inplaceGatherFilteredRows(resources_, vecs, indices);
 
-    cuvs::neighbors::ivf_flat::extend(
-            raft_handle,
-            raft::make_device_matrix_view<const float, idx_t>(
-                    vecs.data(), n_rows_valid, dim_),
-            std::make_optional<raft::device_vector_view<const idx_t, idx_t>>(
-                    raft::make_device_vector_view<const idx_t, idx_t>(
-                            indices.data(), n_rows_valid)),
-            cuvs_index.get());
+    auto vectorsTensor = makeCuvsTensor(vecs.data(), n_rows_valid, (idx_t)dim_);
+    auto indicesTensor = makeCuvsTensor(indices.data(), n_rows_valid);
+    cuvsCheck(
+            cuvsIvfFlatExtend(
+                    cuvsResourcesFromGpuResources(resources_),
+                    vectorsTensor.get(),
+                    indicesTensor.get(),
+                    cuvs_index),
+            "cuvsIvfFlatExtend");
 
     return n_rows_valid;
 }
@@ -225,7 +229,7 @@ idx_t CuvsIVFFlat::getListLength(idx_t listId) const {
     uint32_t size;
     raft::update_host(
             &size,
-            cuvs_index->list_sizes().data_handle() + listId,
+            getCppIndex(cuvs_index)->list_sizes().data_handle() + listId,
             1,
             raft_handle.get_stream());
     raft_handle.sync_stream();
@@ -249,7 +253,9 @@ std::vector<idx_t> CuvsIVFFlat::getListIndices(idx_t listId) const {
 
     raft::update_host(
             &list_indices_ptr,
-            const_cast<idx_t**>(cuvs_index->inds_ptrs().data_handle()) + listId,
+            const_cast<idx_t**>(
+                    getCppIndex(cuvs_index)->inds_ptrs().data_handle()) +
+                    listId,
             1,
             stream);
     raft_handle.sync_stream();
@@ -288,7 +294,7 @@ std::vector<uint8_t> CuvsIVFFlat::getListVectorData(
     // fetch the list data ptr on host
     raft::update_host(
             &list_data_ptr,
-            cuvs_index->data_ptrs().data_handle() + listId,
+            getCppIndex(cuvs_index)->data_ptrs().data_handle() + listId,
             1,
             stream);
     raft_handle.sync_stream();
@@ -301,7 +307,7 @@ std::vector<uint8_t> CuvsIVFFlat::getListVectorData(
     raft_handle.sync_stream();
 
     CuvsIVFFlatCodePackerInterleaved packer(
-            (size_t)listSize, dim_, cuvs_index->veclen());
+            (size_t)listSize, dim_, getCppIndex(cuvs_index)->veclen());
     packer.unpack_all(interleaved_codes.data(), flat_codes.data());
     return flat_codes;
 }
@@ -324,71 +330,69 @@ void CuvsIVFFlat::searchPreassigned(
 
 void CuvsIVFFlat::updateQuantizer(Index* quantizer) {
     FAISS_THROW_IF_NOT(quantizer->is_trained);
-
-    // Must match our basic IVF parameters
     FAISS_THROW_IF_NOT(quantizer->d == getDim());
     FAISS_THROW_IF_NOT(quantizer->ntotal == getNumLists());
 
-    size_t total_elems = quantizer->ntotal * quantizer->d;
-
-    auto stream = resources_->getDefaultStreamCurrentDevice();
-    const raft::device_resources& raft_handle =
+    // Compatibility note: release/26.10 has no C API that constructs an
+    // empty IVF-Flat index from caller-provided coarse centers. Keep the C++
+    // constructor for this path so updating a Faiss quantizer does not rerun
+    // k-means or reorder its centers. The resulting index is returned to the
+    // C API handle used by all supported operations.
+    const raft::device_resources& raftHandle =
             resources_->getRaftHandleCurrentDevice();
-
-    cuvs::neighbors::ivf_flat::index_params pams;
-    pams.add_data_on_build = false;
-    pams.metric = metricFaissToCuvs(metric_, false);
-    pams.n_lists = numLists_;
-    cuvs_index =
-            std::make_shared<cuvs::neighbors::ivf_flat::index<float, idx_t>>(
-                    raft_handle, pams, static_cast<uint32_t>(dim_));
+    cuvs::neighbors::ivf_flat::index_params params;
+    params.add_data_on_build = false;
+    params.metric = static_cast<cuvs::distance::DistanceType>(
+            metricFaissToCuvs(metric_, false));
+    params.metric_arg = metricArg_;
+    params.n_lists = numLists_;
+    auto replacement = std::make_unique<CuvsIVFFlatCppIndex>(
+            raftHandle, params, static_cast<uint32_t>(dim_));
     cuvs::neighbors::ivf_flat::helpers::reset_index(
-            raft_handle, cuvs_index.get());
+            raftHandle, replacement.get());
 
-    // If the index instance is a GpuIndexFlat, then we can use direct access to
-    // the centroids within.
+    const size_t totalElements =
+            static_cast<size_t>(quantizer->ntotal) * quantizer->d;
+    auto stream = resources_->getDefaultStreamCurrentDevice();
     auto gpuQ = dynamic_cast<GpuIndexFlat*>(quantizer);
     if (gpuQ) {
         auto gpuData = gpuQ->getGpuData();
-
         if (gpuData->getUseFloat16()) {
-            // The FlatIndex keeps its data in float16; we need to reconstruct
-            // as float32 and store locally
             DeviceTensor<float, 2, true> centroids(
                     resources_,
                     makeSpaceAlloc(AllocType::FlatData, space_, stream),
                     {getNumLists(), getDim()});
-
             gpuData->reconstruct(0, gpuData->getSize(), centroids);
-
             raft::update_device(
-                    cuvs_index->centers().data_handle(),
+                    replacement->centers().data_handle(),
                     centroids.data(),
-                    total_elems,
+                    totalElements,
                     stream);
         } else {
-            /// No reconstruct needed since the centers are already in float32
             auto centroids = gpuData->getVectorsFloat32Ref();
-
             raft::update_device(
-                    cuvs_index->centers().data_handle(),
+                    replacement->centers().data_handle(),
                     centroids.data(),
-                    total_elems,
+                    totalElements,
                     stream);
         }
     } else {
-        // Otherwise, we need to reconstruct all vectors from the index and copy
-        // them to the GPU, in order to have access as needed for residual
-        // computation
-        auto vecs = std::vector<float>(getNumLists() * getDim());
-        quantizer->reconstruct_n(0, quantizer->ntotal, vecs.data());
-
+        std::vector<float> centroids(totalElements);
+        quantizer->reconstruct_n(0, quantizer->ntotal, centroids.data());
         raft::update_device(
-                cuvs_index->centers().data_handle(),
-                vecs.data(),
-                total_elems,
+                replacement->centers().data_handle(),
+                centroids.data(),
+                totalElements,
                 stream);
     }
+    raftHandle.sync_stream();
+
+    cuvsIvfFlatIndex_t index = nullptr;
+    cuvsCheck(cuvsIvfFlatIndexCreate(&index), "cuvsIvfFlatIndexCreate");
+    CuvsUniquePtr<cuvsIvfFlatIndex, cuvsIvfFlatIndexDestroy> indexHolder(index);
+    index->addr = reinterpret_cast<uintptr_t>(replacement.release());
+    index->dtype = cuvsDtype<float>();
+    setCuvsIndex(indexHolder.release());
 }
 
 void CuvsIVFFlat::copyInvertedListsFrom(const InvertedLists* ivf) {
@@ -404,7 +408,7 @@ void CuvsIVFFlat::copyInvertedListsFrom(const InvertedLists* ivf) {
     // the index must already exist
     FAISS_ASSERT(cuvs_index != nullptr);
 
-    auto& cuvs_index_lists = cuvs_index->lists();
+    auto& cuvs_index_lists = getCppIndex(cuvs_index)->lists();
 
     // conservative memory alloc for cloning cpu inverted lists
     cuvs::neighbors::ivf_flat::list_spec<uint32_t, float, idx_t> ivf_list_spec{
@@ -437,7 +441,7 @@ void CuvsIVFFlat::copyInvertedListsFrom(const InvertedLists* ivf) {
 
     // Update the pointers and the sizes
     cuvs::neighbors::ivf_flat::helpers::recompute_internal_state(
-            raft_handle, cuvs_index.get());
+            raft_handle, getCppIndex(cuvs_index));
 
     for (size_t i = 0; i < nlist; ++i) {
         size_t listSize = ivf->list_size(i);
@@ -446,18 +450,22 @@ void CuvsIVFFlat::copyInvertedListsFrom(const InvertedLists* ivf) {
     }
 
     raft::update_device(
-            cuvs_index->list_sizes().data_handle(),
+            getCppIndex(cuvs_index)->list_sizes().data_handle(),
             list_sizes_.data(),
             nlist,
             raft_handle.get_stream());
 
     // Precompute the centers vector norms for L2Expanded distance
     if (this->metric_ == faiss::METRIC_L2) {
-        cuvs_index->allocate_center_norms(raft_handle);
+        getCppIndex(cuvs_index)->allocate_center_norms(raft_handle);
+        CuvsOutputTensor centers;
+        cuvsCheck(
+                cuvsIvfFlatIndexGetCenters(cuvs_index, centers.get()),
+                "cuvsIvfFlatIndexGetCenters");
         raft::linalg::rowNorm<raft::linalg::L2Norm, true, float, uint32_t>(
-                cuvs_index->center_norms().value().data_handle(),
-                cuvs_index->centers().data_handle(),
-                cuvs_index->dim(),
+                getCppIndex(cuvs_index)->center_norms().value().data_handle(),
+                centers.data<float>(),
+                dim_,
                 (uint32_t)nlist,
                 raft_handle.get_stream());
     }
@@ -501,7 +509,7 @@ void CuvsIVFFlat::addEncodedVectorsToList_(
 
     std::vector<uint8_t> interleaved_codes(gpuListSizeInBytes);
     CuvsIVFFlatCodePackerInterleaved packer(
-            (size_t)numVecs, (uint32_t)dim_, cuvs_index->veclen());
+            (size_t)numVecs, (uint32_t)dim_, getCppIndex(cuvs_index)->veclen());
 
     packer.pack_all(
             reinterpret_cast<const uint8_t*>(codes), interleaved_codes.data());
@@ -513,7 +521,7 @@ void CuvsIVFFlat::addEncodedVectorsToList_(
     /// fetch the list data ptr on host
     raft::update_host(
             &list_data_ptr,
-            cuvs_index->data_ptrs().data_handle() + listId,
+            getCppIndex(cuvs_index)->data_ptrs().data_handle() + listId,
             1,
             stream);
     raft_handle.sync_stream();
@@ -530,7 +538,7 @@ void CuvsIVFFlat::addEncodedVectorsToList_(
     // fetch the list indices ptr on host
     raft::update_host(
             &list_indices_ptr,
-            cuvs_index->inds_ptrs().data_handle() + listId,
+            getCppIndex(cuvs_index)->inds_ptrs().data_handle() + listId,
             1,
             stream);
     raft_handle.sync_stream();

--- a/faiss/gpu/impl/CuvsIVFFlat.cu
+++ b/faiss/gpu/impl/CuvsIVFFlat.cu
@@ -281,13 +281,13 @@ std::vector<uint8_t> CuvsIVFFlat::getListVectorData(
     auto vectorsTensor = makeCuvsTensor(
             vectorsDevice.data_handle(), (int64_t)listSize, (int64_t)dim_);
     cuvsCheck(
-            cuvsIvfFlatIndexUnpackContiguousListData(
+            cuvsIvfFlatIndexUnpackListData(
                     cuvsResourcesFromGpuResources(resources_),
                     cuvs_index,
                     vectorsTensor.get(),
                     static_cast<uint32_t>(listId),
                     0),
-            "cuvsIvfFlatIndexUnpackContiguousListData");
+            "cuvsIvfFlatIndexUnpackListData");
 
     raft::update_host(
             flatCodes.data(),

--- a/faiss/gpu/impl/CuvsIVFFlat.cuh
+++ b/faiss/gpu/impl/CuvsIVFFlat.cuh
@@ -28,9 +28,7 @@
 #include <faiss/gpu/impl/GpuScalarQuantizer.cuh>
 #include <faiss/gpu/impl/IVFFlat.cuh>
 
-#include <cuvs/neighbors/ivf_flat.hpp>
-
-#include <optional>
+#include <cuvs/neighbors/ivf_flat.h>
 
 #pragma GCC visibility push(default)
 namespace faiss {
@@ -110,7 +108,7 @@ class CuvsIVFFlat : public IVFFlat {
     void copyInvertedListsFrom(const InvertedLists* ivf) override;
 
     /// Replace the cuVS index
-    void setCuvsIndex(cuvs::neighbors::ivf_flat::index<float, idx_t>&& idx);
+    void setCuvsIndex(cuvsIvfFlatIndex_t index);
 
    private:
     /// Adds a set of codes and indices to a list, with the representation
@@ -129,8 +127,7 @@ class CuvsIVFFlat : public IVFFlat {
     /// this is the size for an entire IVF list
     size_t getGpuVectorsEncodingSize_(idx_t numVecs) const override;
 
-    std::shared_ptr<cuvs::neighbors::ivf_flat::index<float, idx_t>> cuvs_index{
-            nullptr};
+    cuvsIvfFlatIndex_t cuvs_index{nullptr};
 };
 
 struct CuvsIVFFlatCodePackerInterleaved : CodePacker {

--- a/faiss/gpu/impl/CuvsIVFFlat.cuh
+++ b/faiss/gpu/impl/CuvsIVFFlat.cuh
@@ -23,7 +23,6 @@
 
 #pragma once
 
-#include <faiss/impl/CodePacker.h>
 #include <faiss/impl/IDSelector.h>
 #include <faiss/gpu/impl/GpuScalarQuantizer.cuh>
 #include <faiss/gpu/impl/IVFFlat.cuh>
@@ -128,22 +127,6 @@ class CuvsIVFFlat : public IVFFlat {
     size_t getGpuVectorsEncodingSize_(idx_t numVecs) const override;
 
     cuvsIvfFlatIndex_t cuvs_index{nullptr};
-};
-
-struct CuvsIVFFlatCodePackerInterleaved : CodePacker {
-    CuvsIVFFlatCodePackerInterleaved(
-            size_t list_size,
-            uint32_t dim,
-            uint32_t chunk_size);
-    CodePacker* clone() const final;
-    void pack_1(const uint8_t* flat_code, size_t offset, uint8_t* block)
-            const final;
-    void unpack_1(const uint8_t* block, size_t offset, uint8_t* flat_code)
-            const final;
-
-   protected:
-    uint32_t chunk_size;
-    uint32_t dim;
 };
 
 } // namespace gpu

--- a/faiss/gpu/impl/CuvsIVFPQ.cu
+++ b/faiss/gpu/impl/CuvsIVFPQ.cu
@@ -30,7 +30,6 @@
 #include <faiss/gpu/utils/Transpose.cuh>
 
 #include <cuvs/neighbors/ivf_pq.h>
-#include <cuvs/neighbors/ivf_pq.hpp>
 #include <raft/util/cudart_utils.hpp>
 #include <raft/linalg/map.cuh>
 #include <raft/linalg/norm.cuh>
@@ -40,16 +39,6 @@
 
 namespace faiss {
 namespace gpu {
-
-// Compatibility note: release/26.10 has no C API for resetting,
-// importing/exporting, resizing, recomputing, or packing raw IVF-PQ list
-// storage. Public build, search, extend, and getter operations use C except for
-// the selector-only search fallback documented below.
-using CuvsIVFPQCppIndex = cuvs::neighbors::ivf_pq::index<idx_t>;
-
-static CuvsIVFPQCppIndex* getCppIndex(cuvsIvfPqIndex_t index) {
-    return reinterpret_cast<CuvsIVFPQCppIndex*>(index->addr);
-}
 
 CuvsIVFPQ::CuvsIVFPQ(
         GpuResources* resources,
@@ -98,9 +87,10 @@ void CuvsIVFPQ::reserveMemory(idx_t numVecs) {
 
 void CuvsIVFPQ::reset() {
     if (cuvs_index) {
-        const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
-        cuvs::neighbors::ivf_pq::helpers::reset_index(
-                raftHandle, getCppIndex(cuvs_index));
+        cuvsCheck(
+                cuvsIvfPqIndexReset(
+                        cuvsResourcesFromGpuResources(resources_), cuvs_index),
+                "cuvsIvfPqIndexReset");
     }
 }
 
@@ -269,6 +259,11 @@ void CuvsIVFPQ::updateQuantizer(Index* quantizer) {
 /// Return the list indices of a particular list back to the CPU
 std::vector<idx_t> CuvsIVFPQ::getListIndices(idx_t listId) const {
     FAISS_ASSERT(cuvs_index);
+    idx_t listSize = getListLength(listId);
+    if (listSize == 0) {
+        return {};
+    }
+
     const raft::device_resources& raftHandle =
             resources_->getRaftHandleCurrentDevice();
     auto stream = raftHandle.get_stream();
@@ -277,8 +272,6 @@ std::vector<idx_t> CuvsIVFPQ::getListIndices(idx_t listId) const {
             cuvsIvfPqIndexGetListIndices(
                     cuvs_index, (uint32_t)listId, listIndices.get()),
             "cuvsIvfPqIndexGetListIndices");
-
-    idx_t listSize = getListLength(listId);
     std::vector<idx_t> vec(listSize);
     raft::update_host(vec.data(), listIndices.data<idx_t>(), listSize, stream);
     raftHandle.sync_stream();
@@ -300,11 +293,6 @@ void CuvsIVFPQ::searchPreassigned(
     // TODO: Fill this in!
     // Reference issue: https://github.com/facebookresearch/faiss/issues/3243
     FAISS_THROW_MSG("searchPreassigned is not implemented for cuVS index");
-}
-
-size_t CuvsIVFPQ::getGpuListEncodingSize_(idx_t listId) {
-    return static_cast<size_t>(
-            getCppIndex(cuvs_index)->get_list_size_in_bytes(listId));
 }
 
 /// Return the encoded vectors of a particular list back to the CPU
@@ -387,60 +375,32 @@ void CuvsIVFPQ::search(
     FAISS_THROW_IF_NOT(nprobe > 0 && nprobe <= numLists_);
     const raft::device_resources& raft_handle =
             resources_->getRaftHandleCurrentDevice();
-    // Compatibility note: release/26.10's IVF-PQ C search has no filter
-    // argument. Retain C++ search only when a Faiss IDSelector is supplied.
-    if (sel) {
-        cuvs::neighbors::ivf_pq::search_params searchParams;
-        searchParams.n_probes = nprobe;
-        searchParams.lut_dtype =
-                useFloat16LookupTables_ ? CUDA_R_16F : CUDA_R_32F;
+    cuvsIvfPqSearchParams_t searchParams = nullptr;
+    cuvsCheck(
+            cuvsIvfPqSearchParamsCreate(&searchParams),
+            "cuvsIvfPqSearchParamsCreate");
+    CuvsUniquePtr<cuvsIvfPqSearchParams, cuvsIvfPqSearchParamsDestroy>
+            searchParamsHolder(searchParams);
+    searchParams->n_probes = nprobe;
+    searchParams->lut_dtype = useFloat16LookupTables_ ? CUDA_R_16F : CUDA_R_32F;
 
-        auto queryView = raft::make_device_matrix_view<const float, idx_t>(
-                queries.data(), (idx_t)numQueries, (idx_t)cols);
-        auto indexView = raft::make_device_matrix_view<idx_t, idx_t>(
-                outIndices.data(), (idx_t)numQueries, k_);
-        auto distanceView = raft::make_device_matrix_view<float, idx_t>(
-                outDistances.data(), (idx_t)numQueries, k_);
-        raft::core::bitset<uint32_t, int64_t> bitset(
-                raft_handle, indexSize, false);
-        convert_to_bitset(resources_, *sel, bitset.view());
-        cuvs::neighbors::filtering::bitset_filter<uint32_t, int64_t> filter(
-                bitset.view());
-        cuvs::neighbors::ivf_pq::search(
-                raft_handle,
-                searchParams,
-                *getCppIndex(cuvs_index),
-                queryView,
-                indexView,
-                distanceView,
-                filter);
-    } else {
-        cuvsIvfPqSearchParams_t searchParams = nullptr;
-        cuvsCheck(
-                cuvsIvfPqSearchParamsCreate(&searchParams),
-                "cuvsIvfPqSearchParamsCreate");
-        CuvsUniquePtr<cuvsIvfPqSearchParams, cuvsIvfPqSearchParamsDestroy>
-                searchParamsHolder(searchParams);
-        searchParams->n_probes = nprobe;
-        searchParams->lut_dtype =
-                useFloat16LookupTables_ ? CUDA_R_16F : CUDA_R_32F;
-
-        auto queriesTensor = makeCuvsTensor(
-                queries.data(), (int64_t)numQueries, (int64_t)cols);
-        auto indicesTensor = makeCuvsTensor(
-                outIndices.data(), (int64_t)numQueries, (int64_t)k_);
-        auto distancesTensor = makeCuvsTensor(
-                outDistances.data(), (int64_t)numQueries, (int64_t)k_);
-        cuvsCheck(
-                cuvsIvfPqSearch(
-                        cuvsResourcesFromGpuResources(resources_),
-                        searchParams,
-                        cuvs_index,
-                        queriesTensor.get(),
-                        indicesTensor.get(),
-                        distancesTensor.get()),
-                "cuvsIvfPqSearch");
-    }
+    auto queriesTensor =
+            makeCuvsTensor(queries.data(), (int64_t)numQueries, (int64_t)cols);
+    auto indicesTensor =
+            makeCuvsTensor(outIndices.data(), (int64_t)numQueries, (int64_t)k_);
+    auto distancesTensor = makeCuvsTensor(
+            outDistances.data(), (int64_t)numQueries, (int64_t)k_);
+    CuvsFilter filter(resources_, sel, indexSize);
+    cuvsCheck(
+            cuvsIvfPqSearchWithFilter(
+                    cuvsResourcesFromGpuResources(resources_),
+                    searchParams,
+                    cuvs_index,
+                    queriesTensor.get(),
+                    indicesTensor.get(),
+                    distancesTensor.get(),
+                    filter.get()),
+            "cuvsIvfPqSearchWithFilter");
 
     /// Identify NaN rows and mask their nearest neighbors
     auto nan_flag = raft::make_device_vector<bool>(raft_handle, numQueries);
@@ -502,64 +462,18 @@ idx_t CuvsIVFPQ::addVectors(
 }
 
 void CuvsIVFPQ::copyInvertedListsFrom(const InvertedLists* ivf) {
-    size_t nlist = ivf ? ivf->nlist : 0;
-    size_t ntotal = ivf ? ivf->compute_ntotal() : 0;
-
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-
-    std::vector<uint32_t> list_sizes_(nlist);
-    std::vector<idx_t> indices_(ntotal);
-
-    // the index must already exist
+    const size_t nlist = ivf ? ivf->nlist : 0;
+    FAISS_THROW_IF_NOT(nlist <= static_cast<size_t>(numLists_));
     FAISS_ASSERT(cuvs_index);
 
-    auto& cuvs_index_lists = getCppIndex(cuvs_index)->lists();
-
-    // conservative memory alloc for cloning cpu inverted lists
-    cuvs::neighbors::ivf_pq::list_spec_interleaved<uint32_t, idx_t>
-            ivf_list_spec{
-                    static_cast<uint32_t>(bitsPerSubQuantizer_),
-                    static_cast<uint32_t>(numSubQuantizers_),
-                    true};
-
     for (size_t i = 0; i < nlist; ++i) {
-        size_t listSize = ivf->list_size(i);
-
-        // GPU index can only support max int entries per list
+        const size_t listSize = ivf->list_size(i);
         FAISS_THROW_IF_NOT_FMT(
                 listSize <= (size_t)std::numeric_limits<int>::max(),
-                "GPU inverted list can only support "
-                "%zu entries; %zu found",
+                "GPU inverted list can only support %zu entries; %zu found",
                 (size_t)std::numeric_limits<int>::max(),
                 listSize);
-
-        // store the list size
-        list_sizes_[i] = static_cast<uint32_t>(listSize);
-
-        // This cuVS list must currently be empty
         FAISS_ASSERT(getListLength(i) == 0);
-
-        cuvs::neighbors::ivf_pq::helpers::resize_list(
-                raft_handle,
-                cuvs_index_lists[i],
-                ivf_list_spec,
-                static_cast<uint32_t>(listSize),
-                static_cast<uint32_t>(0));
-    }
-
-    raft::update_device(
-            getCppIndex(cuvs_index)->list_sizes().data_handle(),
-            list_sizes_.data(),
-            nlist,
-            raft_handle.get_stream());
-
-    //     Update the pointers and the sizes
-    cuvs::neighbors::ivf_pq::helpers::recompute_internal_state(
-            raft_handle, getCppIndex(cuvs_index));
-
-    for (size_t i = 0; i < nlist; ++i) {
-        size_t listSize = ivf->list_size(i);
         addEncodedVectorsToList_(
                 i, ivf->get_codes(i), ivf->get_ids(i), listSize);
     }
@@ -578,58 +492,46 @@ void CuvsIVFPQ::addEncodedVectorsToList_(
         const void* codes,
         const idx_t* indices,
         idx_t numVecs) {
-    auto stream = resources_->getDefaultStreamCurrentDevice();
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-
-    // If there's nothing to add, then there's nothing we have to do
     if (numVecs == 0) {
         return;
     }
 
-    // The GPU might have a different layout of the memory
-    auto gpuListSizeInBytes = getGpuListEncodingSize_(listId);
-
-    // We only have int32 length representations on the GPU per each
-    // list; the length is in sizeof(char)
-    FAISS_ASSERT(gpuListSizeInBytes <= (size_t)std::numeric_limits<int>::max());
-
-    idx_t maxBatchSize = 4096;
-    for (idx_t offset_b = 0; offset_b < numVecs; offset_b += maxBatchSize) {
-        uint32_t batchSize = min(maxBatchSize, numVecs - offset_b);
+    auto stream = resources_->getDefaultStreamCurrentDevice();
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+    constexpr idx_t maxBatchSize = 4096;
+    for (idx_t offset = 0; offset < numVecs; offset += maxBatchSize) {
+        uint32_t batchSize = min(maxBatchSize, numVecs - offset);
         uint32_t bufferSize = getCpuVectorsEncodingSize_(batchSize);
-        uint32_t codesOffset = getCpuVectorsEncodingSize_(offset_b);
-
-        // Translate the codes as needed to our preferred form
-        auto codes_d = raft::make_device_vector<uint8_t>(
-                raft_handle, static_cast<uint32_t>(bufferSize));
+        uint32_t codesOffset = getCpuVectorsEncodingSize_(offset);
+        auto codesDevice = raft::make_device_vector<uint8_t>(
+                raftHandle, static_cast<uint32_t>(bufferSize));
+        auto indicesDevice = raft::make_device_vector<idx_t>(
+                raftHandle, static_cast<uint32_t>(batchSize));
         raft::update_device(
-                codes_d.data_handle(),
+                codesDevice.data_handle(),
                 static_cast<const uint8_t*>(codes) + codesOffset,
                 bufferSize,
                 stream);
-
-        cuvs::neighbors::ivf_pq::helpers::codepacker::pack_contiguous_list_data(
-                raft_handle,
-                getCppIndex(cuvs_index),
-                codes_d.data_handle(),
+        raft::update_device(
+                indicesDevice.data_handle(),
+                indices + offset,
                 batchSize,
-                listId,
-                offset_b);
+                stream);
+        auto codesTensor = makeCuvsTensor(
+                codesDevice.data_handle(),
+                (int64_t)batchSize,
+                (int64_t)(bufferSize / batchSize));
+        auto indicesTensor =
+                makeCuvsTensor(indicesDevice.data_handle(), (int64_t)batchSize);
+        cuvsCheck(
+                cuvsIvfPqIndexExtendList(
+                        cuvsResourcesFromGpuResources(resources_),
+                        cuvs_index,
+                        codesTensor.get(),
+                        indicesTensor.get(),
+                        static_cast<uint32_t>(listId)),
+                "cuvsIvfPqIndexExtendList");
     }
-
-    /// Handle the indices as well
-    idx_t* list_indices_ptr;
-
-    // fetch the list indices ptr on host
-    raft::update_host(
-            &list_indices_ptr,
-            getCppIndex(cuvs_index)->inds_ptrs().data_handle() + listId,
-            1,
-            stream);
-    raft_handle.sync_stream();
-
-    raft::update_device(list_indices_ptr, indices, numVecs, stream);
 }
 
 void CuvsIVFPQ::setPQCentroids_() {

--- a/faiss/gpu/impl/CuvsIVFPQ.cu
+++ b/faiss/gpu/impl/CuvsIVFPQ.cu
@@ -29,17 +29,27 @@
 #include <faiss/gpu/impl/FlatIndex.cuh>
 #include <faiss/gpu/utils/Transpose.cuh>
 
-#include <cuvs/core/bitset.hpp>
-#include <cuvs/neighbors/common.hpp>
+#include <cuvs/neighbors/ivf_pq.h>
 #include <cuvs/neighbors/ivf_pq.hpp>
+#include <raft/util/cudart_utils.hpp>
 #include <raft/linalg/map.cuh>
+#include <raft/linalg/norm.cuh>
 
 #include <limits>
 #include <memory>
-#include <optional>
 
 namespace faiss {
 namespace gpu {
+
+// Compatibility note: release/26.10 has no C API for resetting,
+// importing/exporting, resizing, recomputing, or packing raw IVF-PQ list
+// storage. Public build, search, extend, and getter operations use C except for
+// the selector-only search fallback documented below.
+using CuvsIVFPQCppIndex = cuvs::neighbors::ivf_pq::index<idx_t>;
+
+static CuvsIVFPQCppIndex* getCppIndex(cuvsIvfPqIndex_t index) {
+    return reinterpret_cast<CuvsIVFPQCppIndex*>(index->addr);
+}
 
 CuvsIVFPQ::CuvsIVFPQ(
         GpuResources* resources,
@@ -75,7 +85,11 @@ CuvsIVFPQ::CuvsIVFPQ(
             "only INDICES_64_BIT is supported for cuVS index");
 }
 
-CuvsIVFPQ::~CuvsIVFPQ() {}
+CuvsIVFPQ::~CuvsIVFPQ() {
+    if (cuvs_index) {
+        cuvsIvfPqIndexDestroy(cuvs_index);
+    }
+}
 
 void CuvsIVFPQ::reserveMemory(idx_t numVecs) {
     fprintf(stderr,
@@ -83,7 +97,11 @@ void CuvsIVFPQ::reserveMemory(idx_t numVecs) {
 }
 
 void CuvsIVFPQ::reset() {
-    cuvs_index.reset();
+    if (cuvs_index) {
+        const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+        cuvs::neighbors::ivf_pq::helpers::reset_index(
+                raftHandle, getCppIndex(cuvs_index));
+    }
 }
 
 size_t CuvsIVFPQ::reclaimMemory() {
@@ -96,16 +114,20 @@ void CuvsIVFPQ::setPrecomputedCodes(Index* quantizer, bool enable) {}
 
 idx_t CuvsIVFPQ::getListLength(idx_t listId) const {
     FAISS_ASSERT(cuvs_index);
-    const raft::device_resources& raft_handle =
+    const raft::device_resources& raftHandle =
             resources_->getRaftHandleCurrentDevice();
+    CuvsOutputTensor listSizes;
+    cuvsCheck(
+            cuvsIvfPqIndexGetListSizes(cuvs_index, listSizes.get()),
+            "cuvsIvfPqIndexGetListSizes");
 
     uint32_t size;
     raft::update_host(
             &size,
-            cuvs_index->list_sizes().data_handle() + listId,
+            listSizes.data<uint32_t>() + listId,
             1,
-            raft_handle.get_stream());
-    raft_handle.sync_stream();
+            raftHandle.get_stream());
+    raftHandle.sync_stream();
 
     return static_cast<int>(size);
 }
@@ -116,169 +138,150 @@ void CuvsIVFPQ::updateQuantizer(Index* quantizer) {
     // Must match our basic IVF parameters
     FAISS_THROW_IF_NOT(quantizer->d == getDim());
     FAISS_THROW_IF_NOT(quantizer->ntotal == getNumLists());
-
     auto stream = resources_->getDefaultStreamCurrentDevice();
-    const raft::device_resources& raft_handle =
+    const raft::device_resources& raftHandle =
             resources_->getRaftHandleCurrentDevice();
+    const uint32_t dimExt = utils::roundUp((uint32_t)dim_ + 1, 8u);
 
-    cuvs::neighbors::ivf_pq::index_params pams;
-    pams.metric = metricFaissToCuvs(metric_, false);
-    pams.codebook_kind = cuvs::neighbors::ivf_pq::codebook_gen::PER_SUBSPACE;
-    pams.n_lists = numLists_;
-    pams.pq_bits = bitsPerSubQuantizer_;
-    pams.pq_dim = numSubQuantizers_;
-    cuvs_index = std::make_shared<cuvs::neighbors::ivf_pq::index<idx_t>>(
-            raft_handle, pams, static_cast<uint32_t>(dim_));
+    cuvsPaddedCenters_ = DeviceTensor<float, 2, true>(
+            resources_,
+            makeSpaceAlloc(AllocType::Quantizer, space_, stream),
+            {numLists_, dimExt});
+    cuvsRotatedCenters_ = DeviceTensor<float, 2, true>(
+            resources_,
+            makeSpaceAlloc(AllocType::Quantizer, space_, stream),
+            {numLists_, dim_});
+    cuvsRotationMatrix_ = DeviceTensor<float, 2, true>(
+            resources_,
+            makeSpaceAlloc(AllocType::Quantizer, space_, stream),
+            {dim_, dim_});
 
-    cuvs::neighbors::ivf_pq::helpers::reset_index(
-            raft_handle, cuvs_index.get());
-    auto mutable_rotation_matrix_view =
-            raft::make_device_matrix_view<float, uint32_t>(
-                    const_cast<float*>(
-                            cuvs_index->rotation_matrix().data_handle()),
-                    cuvs_index->rotation_matrix().extent(0),
-                    cuvs_index->rotation_matrix().extent(1));
-    cuvs::neighbors::ivf_pq::helpers::make_rotation_matrix(
-            raft_handle, mutable_rotation_matrix_view, false);
+    auto prepareCenters = [&](const float* centers) {
+        raft::update_device(
+                cuvsRotatedCenters_.data(),
+                centers,
+                (size_t)numLists_ * dim_,
+                stream);
+        cuvsPaddedCenters_.zero(stream);
+        raft::copy_matrix(
+                cuvsPaddedCenters_.data(),
+                dimExt,
+                cuvsRotatedCenters_.data(),
+                dim_,
+                dim_,
+                numLists_,
+                stream);
 
-    // If the index instance is a GpuIndexFlat, then we can use direct access to
-    // the centroids within.
+        auto centerNorms = raft::make_device_vector<float, uint32_t>(
+                raftHandle, numLists_);
+        raft::linalg::norm<raft::linalg::L2Norm, raft::Apply::ALONG_ROWS>(
+                raftHandle,
+                raft::make_device_matrix_view<const float, uint32_t>(
+                        cuvsRotatedCenters_.data(), numLists_, dim_),
+                centerNorms.view());
+        raft::copy_matrix(
+                cuvsPaddedCenters_.data() + dim_,
+                dimExt,
+                centerNorms.data_handle(),
+                1,
+                1,
+                numLists_,
+                stream);
+
+        raft::linalg::map_offset(
+                raftHandle,
+                raft::make_device_vector_view(
+                        cuvsRotationMatrix_.data(), (uint32_t)(dim_ * dim_)),
+                [stride = (uint32_t)dim_ + 1] __device__(uint32_t i) {
+                    return static_cast<float>(i % stride == 0);
+                });
+    };
+
     auto gpuQ = dynamic_cast<GpuIndexFlat*>(quantizer);
-
     if (gpuQ) {
         auto gpuData = gpuQ->getGpuData();
-
         if (gpuData->getUseFloat16()) {
             DeviceTensor<float, 2, true> centroids(
                     resources_,
                     makeSpaceAlloc(AllocType::FlatData, space_, stream),
                     {getNumLists(), getDim()});
-
-            // The FlatIndex keeps its data in float16; we need to reconstruct
-            // as float32 and store locally
             gpuData->reconstruct(0, gpuData->getSize(), centroids);
-
-            auto mutable_centers_view =
-                    raft::make_device_matrix_view<float, uint32_t>(
-                            const_cast<float*>(
-                                    cuvs_index->centers().data_handle()),
-                            numLists_,
-                            cuvs_index->centers().extent(1));
-            auto mutable_centers_rot_view =
-                    raft::make_device_matrix_view<float, uint32_t>(
-                            const_cast<float*>(
-                                    cuvs_index->centers_rot().data_handle()),
-                            cuvs_index->centers_rot().extent(0),
-                            cuvs_index->centers_rot().extent(1));
-
-            cuvs::neighbors::ivf_pq::helpers::pad_centers_with_norms(
-                    raft_handle,
-                    raft::make_const_mdspan(
-                            raft::make_device_matrix_view<float, uint32_t>(
-                                    centroids.data(), numLists_, dim_)),
-                    mutable_centers_view);
-            cuvs::neighbors::ivf_pq::helpers::rotate_padded_centers(
-                    raft_handle,
-                    cuvs_index->centers(),
-                    cuvs_index->rotation_matrix(),
-                    mutable_centers_rot_view);
+            prepareCenters(centroids.data());
         } else {
-            /// No reconstruct needed since the centers are already in float32
-            // The FlatIndex keeps its data in float32, so we can merely
-            // reference it
             auto centroids = gpuData->getVectorsFloat32Ref();
-
-            auto mutable_centers_view =
-                    raft::make_device_matrix_view<float, uint32_t>(
-                            const_cast<float*>(
-                                    cuvs_index->centers().data_handle()),
-                            numLists_,
-                            cuvs_index->centers().extent(1));
-            auto mutable_centers_rot_view =
-                    raft::make_device_matrix_view<float, uint32_t>(
-                            const_cast<float*>(
-                                    cuvs_index->centers_rot().data_handle()),
-                            cuvs_index->centers_rot().extent(0),
-                            cuvs_index->centers_rot().extent(1));
-
-            cuvs::neighbors::ivf_pq::helpers::pad_centers_with_norms(
-                    raft_handle,
-                    raft::make_const_mdspan(
-                            raft::make_device_matrix_view<float, uint32_t>(
-                                    centroids.data(), numLists_, dim_)),
-                    mutable_centers_view);
-            cuvs::neighbors::ivf_pq::helpers::rotate_padded_centers(
-                    raft_handle,
-                    cuvs_index->centers(),
-                    cuvs_index->rotation_matrix(),
-                    mutable_centers_rot_view);
+            prepareCenters(centroids.data());
         }
     } else {
-        DeviceTensor<float, 2, true> centroids(
-                resources_,
-                makeSpaceAlloc(AllocType::FlatData, space_, stream),
-                {getNumLists(), getDim()});
-
-        // Otherwise, we need to reconstruct all vectors from the index and copy
-        // them to the GPU, in order to have access as needed for residual
-        // computation
-        auto vecs = std::vector<float>(getNumLists() * getDim());
-        quantizer->reconstruct_n(0, quantizer->ntotal, vecs.data());
-
-        centroids.copyFrom(vecs, stream);
-
-        // Create mutable views for output parameters
-        auto mutable_centers_view =
-                raft::make_device_matrix_view<float, uint32_t>(
-                        const_cast<float*>(cuvs_index->centers().data_handle()),
-                        numLists_,
-                        cuvs_index->centers().extent(1));
-        auto mutable_centers_rot_view =
-                raft::make_device_matrix_view<float, uint32_t>(
-                        const_cast<float*>(
-                                cuvs_index->centers_rot().data_handle()),
-                        cuvs_index->centers_rot().extent(0),
-                        cuvs_index->centers_rot().extent(1));
-
-        cuvs::neighbors::ivf_pq::helpers::pad_centers_with_norms(
-                raft_handle,
-                raft::make_const_mdspan(
-                        raft::make_device_matrix_view<float, uint32_t>(
-                                centroids.data(), numLists_, dim_)),
-                mutable_centers_view);
-        cuvs::neighbors::ivf_pq::helpers::rotate_padded_centers(
-                raft_handle,
-                cuvs_index->centers(),
-                cuvs_index->rotation_matrix(),
-                mutable_centers_rot_view);
+        auto centroids = std::vector<float>(getNumLists() * getDim());
+        quantizer->reconstruct_n(0, quantizer->ntotal, centroids.data());
+        prepareCenters(centroids.data());
     }
 
+    cuvsIvfPqIndexParams_t params = nullptr;
+    cuvsCheck(
+            cuvsIvfPqIndexParamsCreate(&params), "cuvsIvfPqIndexParamsCreate");
+    CuvsUniquePtr<cuvsIvfPqIndexParams, cuvsIvfPqIndexParamsDestroy>
+            paramsHolder(params);
+    params->metric = metricFaissToCuvs(metric_, false);
+    params->metric_arg = metricArg_;
+    params->add_data_on_build = false;
+    params->n_lists = numLists_;
+    params->pq_bits = bitsPerSubQuantizer_;
+    params->pq_dim = numSubQuantizers_;
+    params->codebook_kind = CUVS_IVF_PQ_CODEBOOK_GEN_PER_SUBSPACE;
+    params->force_random_rotation = false;
+    params->codes_layout = CUVS_IVF_PQ_LIST_LAYOUT_INTERLEAVED;
+
+    auto pqCentersTensor = makeCuvsTensor(
+            pqCentroidsInnermostCode_.data(),
+            (int64_t)numSubQuantizers_,
+            (int64_t)dimPerSubQuantizer_,
+            (int64_t)numSubQuantizerCodes_);
+    auto paddedCentersTensor = makeCuvsTensor(
+            cuvsPaddedCenters_.data(), (int64_t)numLists_, (int64_t)dimExt);
+    auto rotatedCentersTensor = makeCuvsTensor(
+            cuvsRotatedCenters_.data(), (int64_t)numLists_, (int64_t)dim_);
+    auto rotationTensor = makeCuvsTensor(
+            cuvsRotationMatrix_.data(), (int64_t)dim_, (int64_t)dim_);
+
+    cuvsIvfPqIndex_t index = nullptr;
+    cuvsCheck(cuvsIvfPqIndexCreate(&index), "cuvsIvfPqIndexCreate");
+    CuvsUniquePtr<cuvsIvfPqIndex, cuvsIvfPqIndexDestroy> indexHolder(index);
+    cuvsCheck(
+            cuvsIvfPqBuildPrecomputed(
+                    cuvsResourcesFromGpuResources(resources_),
+                    params,
+                    dim_,
+                    pqCentersTensor.get(),
+                    paddedCentersTensor.get(),
+                    rotatedCentersTensor.get(),
+                    rotationTensor.get(),
+                    index),
+            "cuvsIvfPqBuildPrecomputed");
+
+    if (cuvs_index) {
+        cuvsCheck(cuvsIvfPqIndexDestroy(cuvs_index), "cuvsIvfPqIndexDestroy");
+    }
+    cuvs_index = indexHolder.release();
     setPQCentroids_();
 }
 
 /// Return the list indices of a particular list back to the CPU
 std::vector<idx_t> CuvsIVFPQ::getListIndices(idx_t listId) const {
     FAISS_ASSERT(cuvs_index);
-    const raft::device_resources& raft_handle =
+    const raft::device_resources& raftHandle =
             resources_->getRaftHandleCurrentDevice();
-    auto stream = raft_handle.get_stream();
+    auto stream = raftHandle.get_stream();
+    CuvsOutputTensor listIndices;
+    cuvsCheck(
+            cuvsIvfPqIndexGetListIndices(
+                    cuvs_index, (uint32_t)listId, listIndices.get()),
+            "cuvsIvfPqIndexGetListIndices");
 
     idx_t listSize = getListLength(listId);
-
     std::vector<idx_t> vec(listSize);
-
-    // fetch the list indices ptr on host
-    idx_t* list_indices_ptr;
-
-    raft::update_host(
-            &list_indices_ptr,
-            const_cast<idx_t**>(cuvs_index->inds_ptrs().data_handle()) + listId,
-            1,
-            stream);
-    raft_handle.sync_stream();
-
-    raft::update_host(vec.data(), list_indices_ptr, listSize, stream);
-    raft_handle.sync_stream();
+    raft::update_host(vec.data(), listIndices.data<idx_t>(), listSize, stream);
+    raftHandle.sync_stream();
 
     return vec;
 }
@@ -300,7 +303,8 @@ void CuvsIVFPQ::searchPreassigned(
 }
 
 size_t CuvsIVFPQ::getGpuListEncodingSize_(idx_t listId) {
-    return static_cast<size_t>(cuvs_index->get_list_size_in_bytes(listId));
+    return static_cast<size_t>(
+            getCppIndex(cuvs_index)->get_list_size_in_bytes(listId));
 }
 
 /// Return the encoded vectors of a particular list back to the CPU
@@ -333,14 +337,18 @@ std::vector<uint8_t> CuvsIVFPQ::getListVectorData(idx_t listId, bool gpuFormat)
         auto codes_d = raft::make_device_vector<uint8_t>(
                 raft_handle, static_cast<uint32_t>(bufferSize));
 
-        cuvs::neighbors::ivf_pq::helpers::codepacker::
-                unpack_contiguous_list_data(
-                        raft_handle,
-                        *cuvs_index,
-                        codes_d.data_handle(),
-                        batchSize,
-                        listId,
-                        offset_b);
+        auto codesTensor = makeCuvsTensor(
+                codes_d.data_handle(),
+                (int64_t)batchSize,
+                (int64_t)(bufferSize / batchSize));
+        cuvsCheck(
+                cuvsIvfPqIndexUnpackContiguousListData(
+                        cuvsResourcesFromGpuResources(resources_),
+                        cuvs_index,
+                        codesTensor.get(),
+                        (uint32_t)listId,
+                        (uint32_t)offset_b),
+                "cuvsIvfPqIndexUnpackContiguousListData");
 
         // Copy the flat PQ codes to host
         raft::update_host(
@@ -364,54 +372,75 @@ void CuvsIVFPQ::search(
         Tensor<float, 2, true>& outDistances,
         Tensor<idx_t, 2, true>& outIndices,
         const IDSelector* sel) {
+    FAISS_ASSERT(cuvs_index);
     uint32_t numQueries = queries.getSize(0);
     uint32_t cols = queries.getSize(1);
-    idx_t k_ = std::min(static_cast<idx_t>(k), cuvs_index->size());
+    int64_t indexSize = 0;
+    cuvsCheck(
+            cuvsIvfPqIndexGetSize(cuvs_index, &indexSize),
+            "cuvsIvfPqIndexGetSize");
+    idx_t k_ = std::min(static_cast<idx_t>(k), (idx_t)indexSize);
 
     // Device is already set in GpuIndex::search
-    FAISS_ASSERT(cuvs_index);
     FAISS_ASSERT(numQueries > 0);
     FAISS_ASSERT(cols == dim_);
     FAISS_THROW_IF_NOT(nprobe > 0 && nprobe <= numLists_);
-
     const raft::device_resources& raft_handle =
             resources_->getRaftHandleCurrentDevice();
-    cuvs::neighbors::ivf_pq::search_params pams;
-    pams.n_probes = nprobe;
-    pams.lut_dtype = useFloat16LookupTables_ ? CUDA_R_16F : CUDA_R_32F;
-
-    auto queries_view = raft::make_device_matrix_view<const float, idx_t>(
-            queries.data(), (idx_t)numQueries, (idx_t)cols);
-    auto out_inds_view = raft::make_device_matrix_view<idx_t, idx_t>(
-            outIndices.data(), (idx_t)numQueries, (idx_t)k_);
-    auto out_dists_view = raft::make_device_matrix_view<float, idx_t>(
-            outDistances.data(), (idx_t)numQueries, (idx_t)k_);
-
-    std::optional<cuvs::core::bitset<uint32_t, int64_t>> bitset_cuvs;
-    std::optional<cuvs::neighbors::filtering::bitset_filter<uint32_t, int64_t>>
-            bitset_filter_cuvs;
-    cuvs::neighbors::filtering::none_sample_filter none_filter;
-
+    // Compatibility note: release/26.10's IVF-PQ C search has no filter
+    // argument. Retain C++ search only when a Faiss IDSelector is supplied.
     if (sel) {
-        bitset_cuvs = cuvs::core::bitset<uint32_t, int64_t>(
-                raft_handle, cuvs_index->size(), false);
-        faiss::gpu::convert_to_bitset(resources_, *sel, bitset_cuvs->view());
-        bitset_filter_cuvs.emplace(bitset_cuvs->view());
-    }
-    const cuvs::neighbors::filtering::base_filter& filter_ref = sel
-            ? static_cast<const cuvs::neighbors::filtering::base_filter&>(
-                      bitset_filter_cuvs.value())
-            : static_cast<const cuvs::neighbors::filtering::base_filter&>(
-                      none_filter);
+        cuvs::neighbors::ivf_pq::search_params searchParams;
+        searchParams.n_probes = nprobe;
+        searchParams.lut_dtype =
+                useFloat16LookupTables_ ? CUDA_R_16F : CUDA_R_32F;
 
-    cuvs::neighbors::ivf_pq::search(
-            raft_handle,
-            pams,
-            *cuvs_index,
-            queries_view,
-            out_inds_view,
-            out_dists_view,
-            filter_ref);
+        auto queryView = raft::make_device_matrix_view<const float, idx_t>(
+                queries.data(), (idx_t)numQueries, (idx_t)cols);
+        auto indexView = raft::make_device_matrix_view<idx_t, idx_t>(
+                outIndices.data(), (idx_t)numQueries, k_);
+        auto distanceView = raft::make_device_matrix_view<float, idx_t>(
+                outDistances.data(), (idx_t)numQueries, k_);
+        raft::core::bitset<uint32_t, int64_t> bitset(
+                raft_handle, indexSize, false);
+        convert_to_bitset(resources_, *sel, bitset.view());
+        cuvs::neighbors::filtering::bitset_filter<uint32_t, int64_t> filter(
+                bitset.view());
+        cuvs::neighbors::ivf_pq::search(
+                raft_handle,
+                searchParams,
+                *getCppIndex(cuvs_index),
+                queryView,
+                indexView,
+                distanceView,
+                filter);
+    } else {
+        cuvsIvfPqSearchParams_t searchParams = nullptr;
+        cuvsCheck(
+                cuvsIvfPqSearchParamsCreate(&searchParams),
+                "cuvsIvfPqSearchParamsCreate");
+        CuvsUniquePtr<cuvsIvfPqSearchParams, cuvsIvfPqSearchParamsDestroy>
+                searchParamsHolder(searchParams);
+        searchParams->n_probes = nprobe;
+        searchParams->lut_dtype =
+                useFloat16LookupTables_ ? CUDA_R_16F : CUDA_R_32F;
+
+        auto queriesTensor = makeCuvsTensor(
+                queries.data(), (int64_t)numQueries, (int64_t)cols);
+        auto indicesTensor = makeCuvsTensor(
+                outIndices.data(), (int64_t)numQueries, (int64_t)k_);
+        auto distancesTensor = makeCuvsTensor(
+                outDistances.data(), (int64_t)numQueries, (int64_t)k_);
+        cuvsCheck(
+                cuvsIvfPqSearch(
+                        cuvsResourcesFromGpuResources(resources_),
+                        searchParams,
+                        cuvs_index,
+                        queriesTensor.get(),
+                        indicesTensor.get(),
+                        distancesTensor.get()),
+                "cuvsIvfPqSearch");
+    }
 
     /// Identify NaN rows and mask their nearest neighbors
     auto nan_flag = raft::make_device_vector<bool>(raft_handle, numQueries);
@@ -456,19 +485,18 @@ idx_t CuvsIVFPQ::addVectors(
 
     FAISS_ASSERT(cuvs_index);
 
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-
     /// Remove rows containing NaNs
     idx_t n_rows_valid = inplaceGatherFilteredRows(resources_, vecs, indices);
 
-    cuvs::neighbors::ivf_pq::extend(
-            raft_handle,
-            raft::make_device_matrix_view<const float, idx_t>(
-                    vecs.data(), n_rows_valid, dim_),
-            raft::make_device_vector_view<const idx_t, idx_t>(
-                    indices.data(), n_rows_valid),
-            cuvs_index.get());
+    auto vectorsTensor = makeCuvsTensor(vecs.data(), n_rows_valid, (idx_t)dim_);
+    auto indicesTensor = makeCuvsTensor(indices.data(), n_rows_valid);
+    cuvsCheck(
+            cuvsIvfPqExtend(
+                    cuvsResourcesFromGpuResources(resources_),
+                    vectorsTensor.get(),
+                    indicesTensor.get(),
+                    cuvs_index),
+            "cuvsIvfPqExtend");
 
     return n_rows_valid;
 }
@@ -486,7 +514,7 @@ void CuvsIVFPQ::copyInvertedListsFrom(const InvertedLists* ivf) {
     // the index must already exist
     FAISS_ASSERT(cuvs_index);
 
-    auto& cuvs_index_lists = cuvs_index->lists();
+    auto& cuvs_index_lists = getCppIndex(cuvs_index)->lists();
 
     // conservative memory alloc for cloning cpu inverted lists
     cuvs::neighbors::ivf_pq::list_spec_interleaved<uint32_t, idx_t>
@@ -521,14 +549,14 @@ void CuvsIVFPQ::copyInvertedListsFrom(const InvertedLists* ivf) {
     }
 
     raft::update_device(
-            cuvs_index->list_sizes().data_handle(),
+            getCppIndex(cuvs_index)->list_sizes().data_handle(),
             list_sizes_.data(),
             nlist,
             raft_handle.get_stream());
 
     //     Update the pointers and the sizes
     cuvs::neighbors::ivf_pq::helpers::recompute_internal_state(
-            raft_handle, cuvs_index.get());
+            raft_handle, getCppIndex(cuvs_index));
 
     for (size_t i = 0; i < nlist; ++i) {
         size_t listSize = ivf->list_size(i);
@@ -537,9 +565,11 @@ void CuvsIVFPQ::copyInvertedListsFrom(const InvertedLists* ivf) {
     }
 }
 
-void CuvsIVFPQ::setCuvsIndex(cuvs::neighbors::ivf_pq::index<idx_t>&& idx) {
-    cuvs_index = std::make_shared<cuvs::neighbors::ivf_pq::index<idx_t>>(
-            std::move(idx));
+void CuvsIVFPQ::setCuvsIndex(cuvsIvfPqIndex_t index) {
+    if (cuvs_index) {
+        cuvsCheck(cuvsIvfPqIndexDestroy(cuvs_index), "cuvsIvfPqIndexDestroy");
+    }
+    cuvs_index = index;
     setBasePQCentroids_();
 }
 
@@ -581,7 +611,7 @@ void CuvsIVFPQ::addEncodedVectorsToList_(
 
         cuvs::neighbors::ivf_pq::helpers::codepacker::pack_contiguous_list_data(
                 raft_handle,
-                cuvs_index.get(),
+                getCppIndex(cuvs_index),
                 codes_d.data_handle(),
                 batchSize,
                 listId,
@@ -594,7 +624,7 @@ void CuvsIVFPQ::addEncodedVectorsToList_(
     // fetch the list indices ptr on host
     raft::update_host(
             &list_indices_ptr,
-            cuvs_index->inds_ptrs().data_handle() + listId,
+            getCppIndex(cuvs_index)->inds_ptrs().data_handle() + listId,
             1,
             stream);
     raft_handle.sync_stream();
@@ -604,9 +634,12 @@ void CuvsIVFPQ::addEncodedVectorsToList_(
 
 void CuvsIVFPQ::setPQCentroids_() {
     auto stream = resources_->getDefaultStreamCurrentDevice();
-
+    CuvsOutputTensor pqCenters;
+    cuvsCheck(
+            cuvsIvfPqIndexGetPqCenters(cuvs_index, pqCenters.get()),
+            "cuvsIvfPqIndexGetPqCenters");
     raft::copy(
-            const_cast<float*>(cuvs_index->pq_centers().data_handle()),
+            pqCenters.data<float>(),
             pqCentroidsInnermostCode_.data(),
             pqCentroidsInnermostCode_.numElements(),
             stream);
@@ -614,11 +647,14 @@ void CuvsIVFPQ::setPQCentroids_() {
 
 void CuvsIVFPQ::setBasePQCentroids_() {
     auto stream = resources_->getDefaultStreamCurrentDevice();
-
+    CuvsOutputTensor pqCenters;
+    cuvsCheck(
+            cuvsIvfPqIndexGetPqCenters(cuvs_index, pqCenters.get()),
+            "cuvsIvfPqIndexGetPqCenters");
     raft::copy(
             pqCentroidsInnermostCode_.data(),
-            cuvs_index->pq_centers().data_handle(),
-            cuvs_index->pq_centers().size(),
+            pqCenters.data<float>(),
+            pqCentroidsInnermostCode_.numElements(),
             stream);
 
     DeviceTensor<float, 3, true> pqCentroidsMiddleCode(

--- a/faiss/gpu/impl/CuvsIVFPQ.cuh
+++ b/faiss/gpu/impl/CuvsIVFPQ.cuh
@@ -129,9 +129,6 @@ class CuvsIVFPQ : public IVFPQ {
             const idx_t* indices,
             idx_t numVecs) override;
 
-    /// Returns the encoding size for a PQ-encoded IVF list
-    size_t getGpuListEncodingSize_(idx_t listId);
-
     /// Copy the PQ centroids to the cuVS index. The data is already in the
     /// preferred format with the transpose performed by the IVFPQ class helper.
     void setPQCentroids_();

--- a/faiss/gpu/impl/CuvsIVFPQ.cuh
+++ b/faiss/gpu/impl/CuvsIVFPQ.cuh
@@ -26,10 +26,7 @@
 #include <faiss/gpu/impl/GpuScalarQuantizer.cuh>
 #include <faiss/gpu/impl/IVFPQ.cuh>
 
-#include <cuvs/neighbors/ivf_pq.hpp>
-
-#include <memory>
-#include <optional>
+#include <cuvs/neighbors/ivf_pq.h>
 
 #pragma GCC visibility push(default)
 namespace faiss {
@@ -103,7 +100,7 @@ class CuvsIVFPQ : public IVFPQ {
     void copyInvertedListsFrom(const InvertedLists* ivf) override;
 
     /// Replace the cuVS index
-    void setCuvsIndex(cuvs::neighbors::ivf_pq::index<idx_t>&& idx);
+    void setCuvsIndex(cuvsIvfPqIndex_t index);
 
     /// Classify and encode/add vectors to our IVF lists.
     /// The input data must be on our current device.
@@ -143,8 +140,14 @@ class CuvsIVFPQ : public IVFPQ {
     /// Used when the cuVS index was updated externally.
     void setBasePQCentroids_();
 
+    /// Storage referenced by cuvsIvfPqBuildPrecomputed. Faiss PQ dimensions
+    /// divide the input dimension, so the rotation is square and identity.
+    DeviceTensor<float, 2, true> cuvsPaddedCenters_;
+    DeviceTensor<float, 2, true> cuvsRotatedCenters_;
+    DeviceTensor<float, 2, true> cuvsRotationMatrix_;
+
     /// cuVS IVF-PQ index
-    std::shared_ptr<cuvs::neighbors::ivf_pq::index<idx_t>> cuvs_index{nullptr};
+    cuvsIvfPqIndex_t cuvs_index{nullptr};
 };
 
 } // namespace gpu

--- a/faiss/gpu/impl/CuvsIVFSQ.cu
+++ b/faiss/gpu/impl/CuvsIVFSQ.cu
@@ -33,8 +33,7 @@
 #include <faiss/gpu/impl/FlatIndex.cuh>
 #include <faiss/gpu/utils/CopyUtils.cuh>
 
-#include <cuvs/core/bitset.hpp>
-#include <cuvs/neighbors/common.hpp>
+#include <cuvs/neighbors/ivf_sq.h>
 #include <cuvs/neighbors/ivf_sq.hpp>
 #include <raft/core/resource/thrust_policy.hpp>
 #include <thrust/extrema.h>
@@ -45,7 +44,6 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
-#include <optional>
 #include <vector>
 
 namespace faiss {
@@ -53,10 +51,20 @@ namespace gpu {
 
 namespace {
 
+// Compatibility note: release/26.10 has no C API for resetting, constructing
+// from caller-provided coarse centers and scalar-quantizer state, or importing
+// and exporting, resizing, inspecting, and packing raw IVF-SQ list storage.
+// build, search, extend, total-size, and centers operations use C; these C++
+// types/helpers are retained only for Faiss inverted-list interoperability.
 constexpr float kFaissSQ8Levels = 255.0f;
 using CuvsSQListSpec =
         cuvs::neighbors::ivf_sq::list_spec<uint32_t, uint8_t, int64_t>;
 constexpr uint32_t kCuvsSQVecLen = CuvsSQListSpec::kVecLen;
+using CuvsIVFSQCppIndex = cuvs::neighbors::ivf_sq::index<uint8_t>;
+
+CuvsIVFSQCppIndex* getCppIndex(cuvsIvfSqIndex_t index) {
+    return reinterpret_cast<CuvsIVFSQCppIndex*>(index->addr);
+}
 
 uint32_t roundUpTo(uint32_t value, uint32_t align) {
     return ((value + align - 1) / align) * align;
@@ -98,7 +106,11 @@ CuvsIVFSQ::CuvsIVFSQ(
             "cuVS IVF-SQ supports only QT_8bit scalar quantization");
 }
 
-CuvsIVFSQ::~CuvsIVFSQ() {}
+CuvsIVFSQ::~CuvsIVFSQ() {
+    if (cuvs_index) {
+        cuvsIvfSqIndexDestroy(cuvs_index);
+    }
+}
 
 void CuvsIVFSQ::reserveMemory(idx_t /* numVecs */) {
     fprintf(stderr,
@@ -118,42 +130,59 @@ void CuvsIVFSQ::reset() {
         return;
     }
 
-    const raft::device_resources& raft_handle =
+    // Compatibility note: release/26.10 has no IVF-SQ C reset operation.
+    // Reconstruct an empty C++ index with the existing training state, then
+    // place it back behind the public C handle used by the rest of this class.
+    const raft::device_resources& raftHandle =
             resources_->getRaftHandleCurrentDevice();
-    auto stream = raft_handle.get_stream();
+    auto* current = getCppIndex(cuvs_index);
+    auto replacement = std::make_unique<CuvsIVFSQCppIndex>(
+            raftHandle,
+            current->metric(),
+            current->n_lists(),
+            current->dim(),
+            current->conservative_memory_allocation());
 
-    auto new_index = std::make_shared<cuvs::neighbors::ivf_sq::index<uint8_t>>(
-            raft_handle,
-            cuvs_index->metric(),
-            cuvs_index->n_lists(),
-            cuvs_index->dim(),
-            cuvs_index->conservative_memory_allocation());
-
+    CuvsOutputTensor centers;
+    cuvsCheck(
+            cuvsIvfSqIndexGetCenters(cuvs_index, centers.get()),
+            "cuvsIvfSqIndexGetCenters");
+    auto stream = raftHandle.get_stream();
     raft::copy(
-            new_index->centers().data_handle(),
-            cuvs_index->centers().data_handle(),
+            replacement->centers().data_handle(),
+            centers.data<float>(),
             static_cast<size_t>(numLists_) * dim_,
             stream);
     raft::copy(
-            new_index->sq_vmin().data_handle(),
-            cuvs_index->sq_vmin().data_handle(),
+            replacement->sq_vmin().data_handle(),
+            current->sq_vmin().data_handle(),
             dim_,
             stream);
     raft::copy(
-            new_index->sq_delta().data_handle(),
-            cuvs_index->sq_delta().data_handle(),
+            replacement->sq_delta().data_handle(),
+            current->sq_delta().data_handle(),
             dim_,
             stream);
 
-    cuvs_index = std::move(new_index);
+    cuvsIvfSqIndex_t newIndex = nullptr;
+    cuvsCheck(cuvsIvfSqIndexCreate(&newIndex), "cuvsIvfSqIndexCreate");
+    CuvsUniquePtr<cuvsIvfSqIndex, cuvsIvfSqIndexDestroy> newIndexHolder(
+            newIndex);
+    newIndex->addr = reinterpret_cast<uintptr_t>(replacement.release());
+    newIndex->dtype = cuvs_index->dtype;
+    raftHandle.sync_stream();
+
+    cuvsCheck(cuvsIvfSqIndexDestroy(cuvs_index), "cuvsIvfSqIndexDestroy");
+    cuvs_index = newIndexHolder.release();
     computeCenterNorms_();
 }
 
-void CuvsIVFSQ::setCuvsIndex(cuvs::neighbors::ivf_sq::index<uint8_t>&& idx) {
-    cuvs_index = std::make_shared<cuvs::neighbors::ivf_sq::index<uint8_t>>(
-            std::move(idx));
-    // Callers install a freshly-built index that has no vectors yet (the coarse
-    // quantizer is built with add_data_on_build = false); reset id tracking.
+void CuvsIVFSQ::setCuvsIndex(cuvsIvfSqIndex_t index) {
+    if (cuvs_index) {
+        cuvsCheck(cuvsIvfSqIndexDestroy(cuvs_index), "cuvsIvfSqIndexDestroy");
+    }
+    cuvs_index = index;
+    // Callers install a freshly-built index that has no vectors yet.
     maxVectorId_ = -1;
     hasNegativeVectorId_ = false;
     copyCuvsSQToFaiss_(faissSQ_);
@@ -183,42 +212,31 @@ void CuvsIVFSQ::search(
 
     const raft::device_resources& raft_handle =
             resources_->getRaftHandleCurrentDevice();
-    cuvs::neighbors::ivf_sq::search_params pams;
-    pams.n_probes = nprobe;
+    cuvsIvfSqSearchParams_t searchParams = nullptr;
+    cuvsCheck(
+            cuvsIvfSqSearchParamsCreate(&searchParams),
+            "cuvsIvfSqSearchParamsCreate");
+    CuvsUniquePtr<cuvsIvfSqSearchParams, cuvsIvfSqSearchParamsDestroy>
+            searchParamsHolder(searchParams);
+    searchParams->n_probes = nprobe;
 
-    auto queries_view = raft::make_device_matrix_view<const float, idx_t>(
-            queries.data(), (idx_t)numQueries, (idx_t)cols);
-    auto out_inds_view = raft::make_device_matrix_view<idx_t, idx_t>(
-            outIndices.data(), (idx_t)numQueries, (idx_t)k_);
-    auto out_dists_view = raft::make_device_matrix_view<float, idx_t>(
-            outDistances.data(), (idx_t)numQueries, (idx_t)k_);
-
-    std::optional<cuvs::core::bitset<uint32_t, int64_t>> bitset_cuvs;
-    std::optional<cuvs::neighbors::filtering::bitset_filter<uint32_t, int64_t>>
-            bitset_filter_cuvs;
-    cuvs::neighbors::filtering::none_sample_filter none_filter;
-
-    if (sel) {
-        bitset_cuvs = cuvs::core::bitset<uint32_t, int64_t>(
-                raft_handle, getBitsetSizeForFiltering_(), false);
-        faiss::gpu::convert_to_bitset(resources_, *sel, bitset_cuvs->view());
-        bitset_filter_cuvs.emplace(bitset_cuvs->view());
-    }
-
-    const cuvs::neighbors::filtering::base_filter& filter_ref = sel
-            ? static_cast<const cuvs::neighbors::filtering::base_filter&>(
-                      bitset_filter_cuvs.value())
-            : static_cast<const cuvs::neighbors::filtering::base_filter&>(
-                      none_filter);
-
-    cuvs::neighbors::ivf_sq::search(
-            raft_handle,
-            pams,
-            *cuvs_index,
-            queries_view,
-            out_inds_view,
-            out_dists_view,
-            filter_ref);
+    auto queriesTensor =
+            makeCuvsTensor(queries.data(), (int64_t)numQueries, (int64_t)cols);
+    auto indicesTensor =
+            makeCuvsTensor(outIndices.data(), (int64_t)numQueries, (int64_t)k_);
+    auto distancesTensor = makeCuvsTensor(
+            outDistances.data(), (int64_t)numQueries, (int64_t)k_);
+    CuvsFilter filter(resources_, sel, getBitsetSizeForFiltering_());
+    cuvsCheck(
+            cuvsIvfSqSearch(
+                    cuvsResourcesFromGpuResources(resources_),
+                    searchParams,
+                    cuvs_index,
+                    queriesTensor.get(),
+                    indicesTensor.get(),
+                    distancesTensor.get(),
+                    filter.get()),
+            "cuvsIvfSqSearch");
 
     /// Identify NaN rows and mask their nearest neighbors
     auto nan_flag = raft::make_device_vector<bool>(raft_handle, numQueries);
@@ -286,14 +304,15 @@ idx_t CuvsIVFSQ::addVectors(
     /// Remove rows containing NaNs
     idx_t n_rows_valid = inplaceGatherFilteredRows(resources_, vecs, indices);
 
-    cuvs::neighbors::ivf_sq::extend(
-            raft_handle,
-            raft::make_device_matrix_view<const float, idx_t>(
-                    vecs.data(), n_rows_valid, dim_),
-            std::make_optional<raft::device_vector_view<const idx_t, idx_t>>(
-                    raft::make_device_vector_view<const idx_t, idx_t>(
-                            indices.data(), n_rows_valid)),
-            cuvs_index.get());
+    auto vectorsTensor = makeCuvsTensor(vecs.data(), n_rows_valid, (idx_t)dim_);
+    auto indicesTensor = makeCuvsTensor(indices.data(), n_rows_valid);
+    cuvsCheck(
+            cuvsIvfSqExtend(
+                    cuvsResourcesFromGpuResources(resources_),
+                    vectorsTensor.get(),
+                    indicesTensor.get(),
+                    cuvs_index),
+            "cuvsIvfSqExtend");
 
     /// Track the id range once at add time so getBitsetSizeForFiltering_() does
     /// not have to read back the whole index on every filtered search. A single
@@ -326,7 +345,7 @@ idx_t CuvsIVFSQ::getListLength(idx_t listId) const {
     uint32_t size;
     raft::update_host(
             &size,
-            cuvs_index->list_sizes().data_handle() + listId,
+            getCppIndex(cuvs_index)->list_sizes().data_handle() + listId,
             1,
             raft_handle.get_stream());
     raft_handle.sync_stream();
@@ -349,7 +368,9 @@ std::vector<idx_t> CuvsIVFSQ::getListIndices(idx_t listId) const {
     idx_t* list_indices_ptr;
     raft::update_host(
             &list_indices_ptr,
-            const_cast<idx_t**>(cuvs_index->inds_ptrs().data_handle()) + listId,
+            const_cast<idx_t**>(
+                    getCppIndex(cuvs_index)->inds_ptrs().data_handle()) +
+                    listId,
             1,
             stream);
     raft_handle.sync_stream();
@@ -384,7 +405,8 @@ std::vector<uint8_t> CuvsIVFSQ::getListVectorData(idx_t listId, bool gpuFormat)
     uint8_t* list_data_ptr;
     raft::update_host(
             &list_data_ptr,
-            const_cast<uint8_t**>(cuvs_index->data_ptrs().data_handle()) +
+            const_cast<uint8_t**>(
+                    getCppIndex(cuvs_index)->data_ptrs().data_handle()) +
                     listId,
             1,
             stream);
@@ -404,68 +426,82 @@ std::vector<uint8_t> CuvsIVFSQ::getListVectorData(idx_t listId, bool gpuFormat)
 
 void CuvsIVFSQ::updateQuantizer(Index* quantizer) {
     FAISS_THROW_IF_NOT(quantizer->is_trained);
-
-    // Must match our basic IVF parameters
     FAISS_THROW_IF_NOT(quantizer->d == getDim());
     FAISS_THROW_IF_NOT(quantizer->ntotal == getNumLists());
 
-    // Rebuilding the cuVS index from new centers discards any stored lists, so
-    // this must run before vectors are added (not after).
+    int64_t indexSize = 0;
+    if (cuvs_index) {
+        cuvsCheck(
+                cuvsIvfSqIndexGetSize(cuvs_index, &indexSize),
+                "cuvsIvfSqIndexGetSize");
+    }
     FAISS_THROW_IF_NOT_MSG(
-            cuvs_index == nullptr || cuvs_index->size() == 0,
+            indexSize == 0,
             "updateQuantizer() cannot be called after vectors have been added: "
             "it would discard the stored inverted lists");
 
-    size_t total_elems = quantizer->ntotal * quantizer->d;
-
-    auto stream = resources_->getDefaultStreamCurrentDevice();
-    const raft::device_resources& raft_handle =
+    // Compatibility note: release/26.10 has no C API that constructs an
+    // empty IVF-SQ index from caller-provided coarse centers and scalar
+    // quantizer state. Preserve that state with the C++ constructor, then put
+    // the replacement behind the C handle used by supported operations.
+    const raft::device_resources& raftHandle =
             resources_->getRaftHandleCurrentDevice();
+    cuvs::neighbors::ivf_sq::index_params params;
+    params.add_data_on_build = false;
+    params.metric = static_cast<cuvs::distance::DistanceType>(
+            metricFaissToCuvs(metric_, false));
+    params.metric_arg = metricArg_;
+    params.n_lists = numLists_;
+    auto replacement = std::make_unique<CuvsIVFSQCppIndex>(
+            raftHandle, params, static_cast<uint32_t>(dim_));
 
-    cuvs::neighbors::ivf_sq::index_params pams;
-    pams.add_data_on_build = false;
-    pams.metric = metricFaissToCuvs(metric_, false);
-    pams.n_lists = numLists_;
-    cuvs_index = std::make_shared<cuvs::neighbors::ivf_sq::index<uint8_t>>(
-            raft_handle, pams, static_cast<uint32_t>(dim_));
-
+    const size_t totalElements =
+            static_cast<size_t>(quantizer->ntotal) * quantizer->d;
+    auto stream = resources_->getDefaultStreamCurrentDevice();
     auto gpuQ = dynamic_cast<GpuIndexFlat*>(quantizer);
     if (gpuQ) {
         auto gpuData = gpuQ->getGpuData();
-
         if (gpuData->getUseFloat16()) {
             DeviceTensor<float, 2, true> centroids(
                     resources_,
                     makeSpaceAlloc(AllocType::FlatData, space_, stream),
                     {getNumLists(), getDim()});
-
             gpuData->reconstruct(0, gpuData->getSize(), centroids);
-
-            raft::copy(
-                    cuvs_index->centers().data_handle(),
+            raft::update_device(
+                    replacement->centers().data_handle(),
                     centroids.data(),
-                    total_elems,
+                    totalElements,
                     stream);
         } else {
             auto centroids = gpuData->getVectorsFloat32Ref();
-
-            raft::copy(
-                    cuvs_index->centers().data_handle(),
+            raft::update_device(
+                    replacement->centers().data_handle(),
                     centroids.data(),
-                    total_elems,
+                    totalElements,
                     stream);
         }
     } else {
-        auto vecs = std::vector<float>(getNumLists() * getDim());
-        quantizer->reconstruct_n(0, quantizer->ntotal, vecs.data());
-
+        std::vector<float> centroids(totalElements);
+        quantizer->reconstruct_n(0, quantizer->ntotal, centroids.data());
         raft::update_device(
-                cuvs_index->centers().data_handle(),
-                vecs.data(),
-                total_elems,
+                replacement->centers().data_handle(),
+                centroids.data(),
+                totalElements,
                 stream);
     }
+    raftHandle.sync_stream();
 
+    cuvsIvfSqIndex_t index = nullptr;
+    cuvsCheck(cuvsIvfSqIndexCreate(&index), "cuvsIvfSqIndexCreate");
+    CuvsUniquePtr<cuvsIvfSqIndex, cuvsIvfSqIndexDestroy> indexHolder(index);
+    index->addr = reinterpret_cast<uintptr_t>(replacement.release());
+    index->dtype = cuvsDtype<float>();
+    if (cuvs_index) {
+        cuvsCheck(cuvsIvfSqIndexDestroy(cuvs_index), "cuvsIvfSqIndexDestroy");
+    }
+    cuvs_index = indexHolder.release();
+    maxVectorId_ = -1;
+    hasNegativeVectorId_ = false;
     copyFaissSQToCuvs_();
     computeCenterNorms_();
 }
@@ -486,7 +522,7 @@ void CuvsIVFSQ::copyInvertedListsFrom(const InvertedLists* ivf) {
     const raft::device_resources& raft_handle =
             resources_->getRaftHandleCurrentDevice();
     std::vector<uint32_t> listSizes(nlist);
-    auto& cuvsIndexLists = cuvs_index->lists();
+    auto& cuvsIndexLists = getCppIndex(cuvs_index)->lists();
     CuvsSQListSpec listSpec{
             static_cast<uint32_t>(dim_),
             true /* conservative_memory_allocation */};
@@ -555,17 +591,17 @@ void CuvsIVFSQ::reconstruct_n(idx_t i0, idx_t ni, float* out) {
     std::vector<uint8_t*> dataPtrs(numLists_);
     raft::update_host(
             listSizes.data(),
-            cuvs_index->list_sizes().data_handle(),
+            getCppIndex(cuvs_index)->list_sizes().data_handle(),
             numLists_,
             stream);
     raft::update_host(
             indsPtrs.data(),
-            cuvs_index->inds_ptrs().data_handle(),
+            getCppIndex(cuvs_index)->inds_ptrs().data_handle(),
             numLists_,
             stream);
     raft::update_host(
             dataPtrs.data(),
-            cuvs_index->data_ptrs().data_handle(),
+            getCppIndex(cuvs_index)->data_ptrs().data_handle(),
             numLists_,
             stream);
     raft_handle.sync_stream();
@@ -658,7 +694,7 @@ void CuvsIVFSQ::addEncodedVectorsToList_(
     uint8_t* listDataPtr;
     raft::update_host(
             &listDataPtr,
-            cuvs_index->data_ptrs().data_handle() + listId,
+            getCppIndex(cuvs_index)->data_ptrs().data_handle() + listId,
             1,
             stream);
     raft_handle.sync_stream();
@@ -669,7 +705,7 @@ void CuvsIVFSQ::addEncodedVectorsToList_(
     idx_t* listIndicesPtr;
     raft::update_host(
             &listIndicesPtr,
-            cuvs_index->inds_ptrs().data_handle() + listId,
+            getCppIndex(cuvs_index)->inds_ptrs().data_handle() + listId,
             1,
             stream);
     raft_handle.sync_stream();
@@ -696,9 +732,15 @@ void CuvsIVFSQ::copyFaissSQToCuvs_() {
 
     auto stream = resources_->getDefaultStreamCurrentDevice();
     raft::update_device(
-            cuvs_index->sq_vmin().data_handle(), vmin.data(), dim_, stream);
+            getCppIndex(cuvs_index)->sq_vmin().data_handle(),
+            vmin.data(),
+            dim_,
+            stream);
     raft::update_device(
-            cuvs_index->sq_delta().data_handle(), delta.data(), dim_, stream);
+            getCppIndex(cuvs_index)->sq_delta().data_handle(),
+            delta.data(),
+            dim_,
+            stream);
 }
 
 void CuvsIVFSQ::copyCuvsSQToFaiss_(faiss::ScalarQuantizer* sq) const {
@@ -712,9 +754,15 @@ void CuvsIVFSQ::copyCuvsSQToFaiss_(faiss::ScalarQuantizer* sq) const {
     std::vector<float> vmin(dim_);
     std::vector<float> delta(dim_);
     raft::update_host(
-            vmin.data(), cuvs_index->sq_vmin().data_handle(), dim_, stream);
+            vmin.data(),
+            getCppIndex(cuvs_index)->sq_vmin().data_handle(),
+            dim_,
+            stream);
     raft::update_host(
-            delta.data(), cuvs_index->sq_delta().data_handle(), dim_, stream);
+            delta.data(),
+            getCppIndex(cuvs_index)->sq_delta().data_handle(),
+            dim_,
+            stream);
     raft_handle.sync_stream();
 
     sq->d = dim_;
@@ -736,11 +784,15 @@ void CuvsIVFSQ::computeCenterNorms_() {
 
     const raft::device_resources& raft_handle =
             resources_->getRaftHandleCurrentDevice();
-    cuvs_index->allocate_center_norms(raft_handle);
+    getCppIndex(cuvs_index)->allocate_center_norms(raft_handle);
+    CuvsOutputTensor centers;
+    cuvsCheck(
+            cuvsIvfSqIndexGetCenters(cuvs_index, centers.get()),
+            "cuvsIvfSqIndexGetCenters");
     raft::linalg::rowNorm<raft::linalg::L2Norm, true, float, uint32_t>(
-            cuvs_index->center_norms().value().data_handle(),
-            cuvs_index->centers().data_handle(),
-            cuvs_index->dim(),
+            getCppIndex(cuvs_index)->center_norms().value().data_handle(),
+            centers.data<float>(),
+            dim_,
             static_cast<uint32_t>(numLists_),
             raft_handle.get_stream());
 }
@@ -755,24 +807,24 @@ void CuvsIVFSQ::recomputeListState_(const std::vector<uint32_t>& listSizes) {
 
     std::vector<uint8_t*> dataPtrs(numLists_);
     std::vector<idx_t*> indsPtrs(numLists_);
-    auto& lists = cuvs_index->lists();
+    auto& lists = getCppIndex(cuvs_index)->lists();
     for (idx_t i = 0; i < numLists_; ++i) {
         dataPtrs[i] = lists[i] ? lists[i]->data_ptr() : nullptr;
         indsPtrs[i] = lists[i] ? lists[i]->indices_ptr() : nullptr;
     }
 
     raft::update_device(
-            cuvs_index->data_ptrs().data_handle(),
+            getCppIndex(cuvs_index)->data_ptrs().data_handle(),
             dataPtrs.data(),
             dataPtrs.size(),
             stream);
     raft::update_device(
-            cuvs_index->inds_ptrs().data_handle(),
+            getCppIndex(cuvs_index)->inds_ptrs().data_handle(),
             indsPtrs.data(),
             indsPtrs.size(),
             stream);
     raft::update_device(
-            cuvs_index->list_sizes().data_handle(),
+            getCppIndex(cuvs_index)->list_sizes().data_handle(),
             listSizes.data(),
             listSizes.size(),
             stream);
@@ -783,7 +835,7 @@ void CuvsIVFSQ::recomputeListState_(const std::vector<uint32_t>& listSizes) {
             sortedListSizes.end(),
             [](uint32_t a, uint32_t b) { return a > b; });
 
-    auto accumSortedSizes = cuvs_index->accum_sorted_sizes();
+    auto accumSortedSizes = getCppIndex(cuvs_index)->accum_sorted_sizes();
     accumSortedSizes(0) = 0;
     for (size_t i = 0; i < sortedListSizes.size(); ++i) {
         accumSortedSizes(i + 1) = accumSortedSizes(i) + sortedListSizes[i];
@@ -801,14 +853,18 @@ idx_t CuvsIVFSQ::getBitsetSizeForFiltering_() const {
             "cuVS IVF-SQ IDSelector filtering does not support "
             "negative vector ids");
 
+    int64_t indexSize = 0;
+    cuvsCheck(
+            cuvsIvfSqIndexGetSize(cuvs_index, &indexSize),
+            "cuvsIvfSqIndexGetSize");
     if (maxVectorId_ < 0) {
-        return cuvs_index->size();
+        return static_cast<idx_t>(indexSize);
     }
     FAISS_THROW_IF_NOT_MSG(
             maxVectorId_ < std::numeric_limits<idx_t>::max(),
             "cuVS IVF-SQ IDSelector filtering cannot represent the largest "
             "idx_t value");
-    return std::max(cuvs_index->size(), maxVectorId_ + 1);
+    return std::max(static_cast<idx_t>(indexSize), maxVectorId_ + 1);
 }
 
 std::vector<float> CuvsIVFSQ::getCentersHost_() const {
@@ -818,10 +874,14 @@ std::vector<float> CuvsIVFSQ::getCentersHost_() const {
             resources_->getRaftHandleCurrentDevice();
     auto stream = raft_handle.get_stream();
 
+    CuvsOutputTensor centersTensor;
+    cuvsCheck(
+            cuvsIvfSqIndexGetCenters(cuvs_index, centersTensor.get()),
+            "cuvsIvfSqIndexGetCenters");
     std::vector<float> centers(static_cast<size_t>(numLists_) * dim_);
     raft::update_host(
             centers.data(),
-            cuvs_index->centers().data_handle(),
+            centersTensor.data<float>(),
             centers.size(),
             stream);
     raft_handle.sync_stream();

--- a/faiss/gpu/impl/CuvsIVFSQ.cu
+++ b/faiss/gpu/impl/CuvsIVFSQ.cu
@@ -341,13 +341,13 @@ std::vector<uint8_t> CuvsIVFSQ::getListVectorData(idx_t listId, bool gpuFormat)
     auto codesTensor = makeCuvsTensor(
             codesDevice.data_handle(), (int64_t)listSize, (int64_t)dim_);
     cuvsCheck(
-            cuvsIvfSqIndexUnpackContiguousListData(
+            cuvsIvfSqIndexUnpackListData(
                     cuvsResourcesFromGpuResources(resources_),
                     cuvs_index,
                     codesTensor.get(),
                     static_cast<uint32_t>(listId),
                     0),
-            "cuvsIvfSqIndexUnpackContiguousListData");
+            "cuvsIvfSqIndexUnpackListData");
 
     raft::update_host(
             flatCodes.data(),

--- a/faiss/gpu/impl/CuvsIVFSQ.cu
+++ b/faiss/gpu/impl/CuvsIVFSQ.cu
@@ -21,22 +21,18 @@
  * limitations under the License.
  */
 
-#include <cmath>
 #include <cstddef>
 #include <cstdint>
 
+#include <cuvs/neighbors/ivf_sq.h>
 #include <faiss/gpu/GpuIndexFlat.h>
 #include <faiss/gpu/StandardGpuResources.h>
 #include <faiss/gpu/utils/CuvsFilterConvert.h>
 #include <faiss/gpu/utils/CuvsUtils.h>
-#include <faiss/gpu/impl/CuvsIVFSQ.cuh>
-#include <faiss/gpu/impl/FlatIndex.cuh>
-#include <faiss/gpu/utils/CopyUtils.cuh>
-
-#include <cuvs/neighbors/ivf_sq.h>
-#include <cuvs/neighbors/ivf_sq.hpp>
 #include <raft/core/resource/thrust_policy.hpp>
 #include <thrust/extrema.h>
+#include <faiss/gpu/impl/CuvsIVFSQ.cuh>
+#include <faiss/gpu/impl/FlatIndex.cuh>
 #include <raft/core/copy.cuh>
 #include <raft/linalg/map.cuh>
 #include <raft/linalg/norm.cuh>
@@ -51,20 +47,7 @@ namespace gpu {
 
 namespace {
 
-// Compatibility note: release/26.10 has no C API for resetting, constructing
-// from caller-provided coarse centers and scalar-quantizer state, or importing
-// and exporting, resizing, inspecting, and packing raw IVF-SQ list storage.
-// build, search, extend, total-size, and centers operations use C; these C++
-// types/helpers are retained only for Faiss inverted-list interoperability.
 constexpr float kFaissSQ8Levels = 255.0f;
-using CuvsSQListSpec =
-        cuvs::neighbors::ivf_sq::list_spec<uint32_t, uint8_t, int64_t>;
-constexpr uint32_t kCuvsSQVecLen = CuvsSQListSpec::kVecLen;
-using CuvsIVFSQCppIndex = cuvs::neighbors::ivf_sq::index<uint8_t>;
-
-CuvsIVFSQCppIndex* getCppIndex(cuvsIvfSqIndex_t index) {
-    return reinterpret_cast<CuvsIVFSQCppIndex*>(index->addr);
-}
 
 uint32_t roundUpTo(uint32_t value, uint32_t align) {
     return ((value + align - 1) / align) * align;
@@ -126,55 +109,12 @@ size_t CuvsIVFSQ::reclaimMemory() {
 void CuvsIVFSQ::reset() {
     maxVectorId_ = -1;
     hasNegativeVectorId_ = false;
-    if (cuvs_index == nullptr) {
-        return;
+    if (cuvs_index) {
+        cuvsCheck(
+                cuvsIvfSqIndexReset(
+                        cuvsResourcesFromGpuResources(resources_), cuvs_index),
+                "cuvsIvfSqIndexReset");
     }
-
-    // Compatibility note: release/26.10 has no IVF-SQ C reset operation.
-    // Reconstruct an empty C++ index with the existing training state, then
-    // place it back behind the public C handle used by the rest of this class.
-    const raft::device_resources& raftHandle =
-            resources_->getRaftHandleCurrentDevice();
-    auto* current = getCppIndex(cuvs_index);
-    auto replacement = std::make_unique<CuvsIVFSQCppIndex>(
-            raftHandle,
-            current->metric(),
-            current->n_lists(),
-            current->dim(),
-            current->conservative_memory_allocation());
-
-    CuvsOutputTensor centers;
-    cuvsCheck(
-            cuvsIvfSqIndexGetCenters(cuvs_index, centers.get()),
-            "cuvsIvfSqIndexGetCenters");
-    auto stream = raftHandle.get_stream();
-    raft::copy(
-            replacement->centers().data_handle(),
-            centers.data<float>(),
-            static_cast<size_t>(numLists_) * dim_,
-            stream);
-    raft::copy(
-            replacement->sq_vmin().data_handle(),
-            current->sq_vmin().data_handle(),
-            dim_,
-            stream);
-    raft::copy(
-            replacement->sq_delta().data_handle(),
-            current->sq_delta().data_handle(),
-            dim_,
-            stream);
-
-    cuvsIvfSqIndex_t newIndex = nullptr;
-    cuvsCheck(cuvsIvfSqIndexCreate(&newIndex), "cuvsIvfSqIndexCreate");
-    CuvsUniquePtr<cuvsIvfSqIndex, cuvsIvfSqIndexDestroy> newIndexHolder(
-            newIndex);
-    newIndex->addr = reinterpret_cast<uintptr_t>(replacement.release());
-    newIndex->dtype = cuvs_index->dtype;
-    raftHandle.sync_stream();
-
-    cuvsCheck(cuvsIvfSqIndexDestroy(cuvs_index), "cuvsIvfSqIndexDestroy");
-    cuvs_index = newIndexHolder.release();
-    computeCenterNorms_();
 }
 
 void CuvsIVFSQ::setCuvsIndex(cuvsIvfSqIndex_t index) {
@@ -182,11 +122,9 @@ void CuvsIVFSQ::setCuvsIndex(cuvsIvfSqIndex_t index) {
         cuvsCheck(cuvsIvfSqIndexDestroy(cuvs_index), "cuvsIvfSqIndexDestroy");
     }
     cuvs_index = index;
-    // Callers install a freshly-built index that has no vectors yet.
     maxVectorId_ = -1;
     hasNegativeVectorId_ = false;
     copyCuvsSQToFaiss_(faissSQ_);
-    computeCenterNorms_();
 }
 
 void CuvsIVFSQ::search(
@@ -339,46 +277,47 @@ idx_t CuvsIVFSQ::addVectors(
 
 idx_t CuvsIVFSQ::getListLength(idx_t listId) const {
     FAISS_ASSERT(cuvs_index != nullptr);
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+    CuvsOutputTensor listSizes;
+    cuvsCheck(
+            cuvsIvfSqIndexGetListSizes(cuvs_index, listSizes.get()),
+            "cuvsIvfSqIndexGetListSizes");
 
     uint32_t size;
     raft::update_host(
             &size,
-            getCppIndex(cuvs_index)->list_sizes().data_handle() + listId,
+            listSizes.data<uint32_t>() + listId,
             1,
-            raft_handle.get_stream());
-    raft_handle.sync_stream();
+            raftHandle.get_stream());
+    raftHandle.sync_stream();
 
     return static_cast<idx_t>(size);
 }
 
 std::vector<idx_t> CuvsIVFSQ::getListIndices(idx_t listId) const {
     FAISS_ASSERT(cuvs_index != nullptr);
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-    auto stream = raft_handle.get_stream();
-
-    idx_t listSize = getListLength(listId);
-    std::vector<idx_t> vec(listSize);
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+    const idx_t listSize = getListLength(listId);
+    std::vector<idx_t> indices(listSize);
     if (listSize == 0) {
-        return vec;
+        return indices;
     }
+    CuvsOutputTensor listIndices;
+    cuvsCheck(
+            cuvsIvfSqIndexGetListIndices(
+                    cuvs_index,
+                    static_cast<uint32_t>(listId),
+                    listIndices.get()),
+            "cuvsIvfSqIndexGetListIndices");
 
-    idx_t* list_indices_ptr;
     raft::update_host(
-            &list_indices_ptr,
-            const_cast<idx_t**>(
-                    getCppIndex(cuvs_index)->inds_ptrs().data_handle()) +
-                    listId,
-            1,
-            stream);
-    raft_handle.sync_stream();
+            indices.data(),
+            listIndices.data<idx_t>(),
+            listSize,
+            raftHandle.get_stream());
+    raftHandle.sync_stream();
 
-    raft::update_host(vec.data(), list_indices_ptr, listSize, stream);
-    raft_handle.sync_stream();
-
-    return vec;
+    return indices;
 }
 
 std::vector<uint8_t> CuvsIVFSQ::getListVectorData(idx_t listId, bool gpuFormat)
@@ -388,46 +327,45 @@ std::vector<uint8_t> CuvsIVFSQ::getListVectorData(idx_t listId, bool gpuFormat)
     }
     FAISS_ASSERT(cuvs_index != nullptr);
 
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-    auto stream = raft_handle.get_stream();
-
-    idx_t listSize = getListLength(listId);
-    auto cpuListSizeInBytes = getCpuVectorsEncodingSize_(listSize);
-    std::vector<uint8_t> flat_codes(cpuListSizeInBytes);
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+    const idx_t listSize = getListLength(listId);
+    std::vector<uint8_t> flatCodes(getCpuVectorsEncodingSize_(listSize));
     if (listSize == 0) {
-        return flat_codes;
+        return flatCodes;
     }
 
-    auto gpuListSizeInBytes = getGpuVectorsEncodingSize_(listSize);
-    std::vector<uint8_t> interleaved_codes(gpuListSizeInBytes);
+    auto codesDevice = raft::make_device_matrix<uint8_t, uint32_t>(
+            raftHandle,
+            static_cast<uint32_t>(listSize),
+            static_cast<uint32_t>(dim_));
+    auto codesTensor = makeCuvsTensor(
+            codesDevice.data_handle(), (int64_t)listSize, (int64_t)dim_);
+    cuvsCheck(
+            cuvsIvfSqIndexUnpackContiguousListData(
+                    cuvsResourcesFromGpuResources(resources_),
+                    cuvs_index,
+                    codesTensor.get(),
+                    static_cast<uint32_t>(listId),
+                    0),
+            "cuvsIvfSqIndexUnpackContiguousListData");
 
-    uint8_t* list_data_ptr;
     raft::update_host(
-            &list_data_ptr,
-            const_cast<uint8_t**>(
-                    getCppIndex(cuvs_index)->data_ptrs().data_handle()) +
-                    listId,
-            1,
-            stream);
-    raft_handle.sync_stream();
-
-    raft::update_host(
-            interleaved_codes.data(),
-            list_data_ptr,
-            gpuListSizeInBytes,
-            stream);
-    raft_handle.sync_stream();
-
-    CuvsIVFSQCodePackerInterleaved packer((size_t)listSize, dim_);
-    packer.unpack_all(interleaved_codes.data(), flat_codes.data());
-    return flat_codes;
+            flatCodes.data(),
+            codesDevice.data_handle(),
+            flatCodes.size(),
+            raftHandle.get_stream());
+    raftHandle.sync_stream();
+    return flatCodes;
 }
 
 void CuvsIVFSQ::updateQuantizer(Index* quantizer) {
     FAISS_THROW_IF_NOT(quantizer->is_trained);
     FAISS_THROW_IF_NOT(quantizer->d == getDim());
     FAISS_THROW_IF_NOT(quantizer->ntotal == getNumLists());
+    FAISS_ASSERT(faissSQ_ != nullptr);
+    FAISS_THROW_IF_NOT_MSG(
+            faissSQ_->trained.size() == 2 * static_cast<size_t>(dim_),
+            "cuVS IVF-SQ requires trained QT_8bit range data");
 
     int64_t indexSize = 0;
     if (cuvs_index) {
@@ -440,116 +378,111 @@ void CuvsIVFSQ::updateQuantizer(Index* quantizer) {
             "updateQuantizer() cannot be called after vectors have been added: "
             "it would discard the stored inverted lists");
 
-    // Compatibility note: release/26.10 has no C API that constructs an
-    // empty IVF-SQ index from caller-provided coarse centers and scalar
-    // quantizer state. Preserve that state with the C++ constructor, then put
-    // the replacement behind the C handle used by supported operations.
-    const raft::device_resources& raftHandle =
-            resources_->getRaftHandleCurrentDevice();
-    cuvs::neighbors::ivf_sq::index_params params;
-    params.add_data_on_build = false;
-    params.metric = static_cast<cuvs::distance::DistanceType>(
-            metricFaissToCuvs(metric_, false));
-    params.metric_arg = metricArg_;
-    params.n_lists = numLists_;
-    auto replacement = std::make_unique<CuvsIVFSQCppIndex>(
-            raftHandle, params, static_cast<uint32_t>(dim_));
-
     const size_t totalElements =
             static_cast<size_t>(quantizer->ntotal) * quantizer->d;
     auto stream = resources_->getDefaultStreamCurrentDevice();
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+    DeviceTensor<float, 2, true> centers(
+            resources_,
+            makeSpaceAlloc(AllocType::Quantizer, space_, stream),
+            {getNumLists(), getDim()});
     auto gpuQ = dynamic_cast<GpuIndexFlat*>(quantizer);
     if (gpuQ) {
         auto gpuData = gpuQ->getGpuData();
         if (gpuData->getUseFloat16()) {
-            DeviceTensor<float, 2, true> centroids(
-                    resources_,
-                    makeSpaceAlloc(AllocType::FlatData, space_, stream),
-                    {getNumLists(), getDim()});
-            gpuData->reconstruct(0, gpuData->getSize(), centroids);
-            raft::update_device(
-                    replacement->centers().data_handle(),
-                    centroids.data(),
-                    totalElements,
-                    stream);
+            gpuData->reconstruct(0, gpuData->getSize(), centers);
         } else {
-            auto centroids = gpuData->getVectorsFloat32Ref();
-            raft::update_device(
-                    replacement->centers().data_handle(),
-                    centroids.data(),
-                    totalElements,
-                    stream);
+            auto source = gpuData->getVectorsFloat32Ref();
+            raft::copy(centers.data(), source.data(), totalElements, stream);
         }
     } else {
-        std::vector<float> centroids(totalElements);
-        quantizer->reconstruct_n(0, quantizer->ntotal, centroids.data());
+        std::vector<float> hostCenters(totalElements);
+        quantizer->reconstruct_n(0, quantizer->ntotal, hostCenters.data());
         raft::update_device(
-                replacement->centers().data_handle(),
-                centroids.data(),
-                totalElements,
-                stream);
+                centers.data(), hostCenters.data(), totalElements, stream);
     }
-    raftHandle.sync_stream();
+
+    std::vector<float> hostVmin(dim_);
+    std::vector<float> hostDelta(dim_);
+    for (int d = 0; d < dim_; ++d) {
+        hostDelta[d] = faissSQ_->trained[dim_ + d] / kFaissSQ8Levels;
+        hostVmin[d] = faissSQ_->trained[d] + 0.5f * hostDelta[d];
+    }
+    DeviceTensor<float, 1, true> vmin(
+            resources_,
+            makeSpaceAlloc(AllocType::Quantizer, space_, stream),
+            {getDim()});
+    DeviceTensor<float, 1, true> delta(
+            resources_,
+            makeSpaceAlloc(AllocType::Quantizer, space_, stream),
+            {getDim()});
+    raft::update_device(vmin.data(), hostVmin.data(), dim_, stream);
+    raft::update_device(delta.data(), hostDelta.data(), dim_, stream);
+
+    DeviceTensor<float, 1, true> centerNorms;
+    std::unique_ptr<CuvsTensor<float, 1>> centerNormsTensor;
+    if (metric_ == faiss::METRIC_L2) {
+        centerNorms = DeviceTensor<float, 1, true>(
+                resources_,
+                makeSpaceAlloc(AllocType::Quantizer, space_, stream),
+                {getNumLists()});
+        raft::linalg::rowNorm<raft::linalg::L2Norm, true, float, uint32_t>(
+                centerNorms.data(),
+                centers.data(),
+                dim_,
+                static_cast<uint32_t>(numLists_),
+                stream);
+        centerNormsTensor = std::make_unique<CuvsTensor<float, 1>>(
+                centerNorms.data(), (int64_t)numLists_);
+    }
+
+    cuvsIvfSqIndexParams_t params = nullptr;
+    cuvsCheck(
+            cuvsIvfSqIndexParamsCreate(&params), "cuvsIvfSqIndexParamsCreate");
+    CuvsUniquePtr<cuvsIvfSqIndexParams, cuvsIvfSqIndexParamsDestroy>
+            paramsHolder(params);
+    params->add_data_on_build = false;
+    params->metric = metricFaissToCuvs(metric_, false);
+    params->metric_arg = metricArg_;
+    params->n_lists = numLists_;
+
+    auto centersTensor =
+            makeCuvsTensor(centers.data(), (int64_t)numLists_, (int64_t)dim_);
+    auto vminTensor = makeCuvsTensor(vmin.data(), (int64_t)dim_);
+    auto deltaTensor = makeCuvsTensor(delta.data(), (int64_t)dim_);
 
     cuvsIvfSqIndex_t index = nullptr;
     cuvsCheck(cuvsIvfSqIndexCreate(&index), "cuvsIvfSqIndexCreate");
     CuvsUniquePtr<cuvsIvfSqIndex, cuvsIvfSqIndexDestroy> indexHolder(index);
-    index->addr = reinterpret_cast<uintptr_t>(replacement.release());
-    index->dtype = cuvsDtype<float>();
-    if (cuvs_index) {
-        cuvsCheck(cuvsIvfSqIndexDestroy(cuvs_index), "cuvsIvfSqIndexDestroy");
-    }
-    cuvs_index = indexHolder.release();
-    maxVectorId_ = -1;
-    hasNegativeVectorId_ = false;
-    copyFaissSQToCuvs_();
-    computeCenterNorms_();
+    cuvsCheck(
+            cuvsIvfSqBuildFromCenters(
+                    cuvsResourcesFromGpuResources(resources_),
+                    params,
+                    cuvsDtype<float>(),
+                    centersTensor.get(),
+                    centerNormsTensor ? centerNormsTensor->get() : nullptr,
+                    vminTensor.get(),
+                    deltaTensor.get(),
+                    index),
+            "cuvsIvfSqBuildFromCenters");
+    raftHandle.sync_stream();
+    setCuvsIndex(indexHolder.release());
 }
 
 void CuvsIVFSQ::copyInvertedListsFrom(const InvertedLists* ivf) {
-    size_t nlist = ivf ? ivf->nlist : 0;
+    const size_t nlist = ivf ? ivf->nlist : 0;
 
     FAISS_ASSERT(cuvs_index != nullptr);
-    FAISS_ASSERT(faissSQ_ != nullptr);
     FAISS_THROW_IF_NOT(nlist == static_cast<size_t>(numLists_));
-    FAISS_THROW_IF_NOT_MSG(
-            faissSQ_->qtype == faiss::ScalarQuantizer::QT_8bit,
-            "cuVS IVF-SQ supports only QT_8bit scalar quantization");
-    FAISS_THROW_IF_NOT_MSG(
-            faissSQ_->trained.size() == 2 * static_cast<size_t>(dim_),
-            "cuVS IVF-SQ requires trained QT_8bit range data");
-
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-    std::vector<uint32_t> listSizes(nlist);
-    auto& cuvsIndexLists = getCppIndex(cuvs_index)->lists();
-    CuvsSQListSpec listSpec{
-            static_cast<uint32_t>(dim_),
-            true /* conservative_memory_allocation */};
 
     for (size_t i = 0; i < nlist; ++i) {
-        size_t listSize = ivf->list_size(i);
+        const size_t listSize = ivf->list_size(i);
         FAISS_THROW_IF_NOT_FMT(
                 listSize <= (size_t)std::numeric_limits<int>::max(),
-                "GPU inverted list can only support "
-                "%zu entries; %zu found",
+                "GPU inverted list can only support %zu entries; %zu found",
                 (size_t)std::numeric_limits<int>::max(),
                 listSize);
-
-        listSizes[i] = static_cast<uint32_t>(listSize);
         FAISS_ASSERT(getListLength(i) == 0);
-        cuvs::neighbors::ivf::resize_list(
-                raft_handle,
-                cuvsIndexLists[i],
-                listSpec,
-                static_cast<uint32_t>(listSize),
-                static_cast<uint32_t>(0));
-    }
-
-    recomputeListState_(listSizes);
-
-    for (size_t i = 0; i < nlist; ++i) {
-        size_t listSize = ivf->list_size(i);
         const idx_t* ids = ivf->get_ids(i);
         for (size_t j = 0; j < listSize; ++j) {
             if (ids[j] < 0) {
@@ -560,8 +493,6 @@ void CuvsIVFSQ::copyInvertedListsFrom(const InvertedLists* ivf) {
         }
         addEncodedVectorsToList_(i, ivf->get_codes(i), ids, listSize);
     }
-
-    computeCenterNorms_();
 }
 
 void CuvsIVFSQ::setFaissSQFromCuvs(faiss::ScalarQuantizer* sq) const {
@@ -578,46 +509,8 @@ void CuvsIVFSQ::reconstruct_n(idx_t i0, idx_t ni, float* out) {
 
     std::fill(out, out + ni * dim_, 0.0f);
     auto centers = getCentersHost_();
-
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-    auto stream = raft_handle.get_stream();
-
-    // Read all per-list metadata in three batched copies rather than syncing
-    // once per list as getListLength()/getListIndices()/getListVectorData()
-    // would; those helpers each issue their own sync_stream().
-    std::vector<uint32_t> listSizes(numLists_);
-    std::vector<idx_t*> indsPtrs(numLists_);
-    std::vector<uint8_t*> dataPtrs(numLists_);
-    raft::update_host(
-            listSizes.data(),
-            getCppIndex(cuvs_index)->list_sizes().data_handle(),
-            numLists_,
-            stream);
-    raft::update_host(
-            indsPtrs.data(),
-            getCppIndex(cuvs_index)->inds_ptrs().data_handle(),
-            numLists_,
-            stream);
-    raft::update_host(
-            dataPtrs.data(),
-            getCppIndex(cuvs_index)->data_ptrs().data_handle(),
-            numLists_,
-            stream);
-    raft_handle.sync_stream();
-
     for (idx_t listId = 0; listId < numLists_; ++listId) {
-        idx_t listSize = listSizes[listId];
-        if (listSize == 0) {
-            continue;
-        }
-
-        std::vector<idx_t> ids(listSize);
-        raft::update_host(ids.data(), indsPtrs[listId], listSize, stream);
-        raft_handle.sync_stream();
-
-        // Skip the (expensive) code readback + decode unless this list holds at
-        // least one id in the requested [i0, i0 + ni) range.
+        auto ids = getListIndices(listId);
         bool hasIdInRange = false;
         for (idx_t id : ids) {
             if (id >= i0 && id < i0 + ni) {
@@ -629,26 +522,15 @@ void CuvsIVFSQ::reconstruct_n(idx_t i0, idx_t ni, float* out) {
             continue;
         }
 
-        auto gpuListSizeInBytes = getGpuVectorsEncodingSize_(listSize);
-        std::vector<uint8_t> interleavedCodes(gpuListSizeInBytes);
-        raft::update_host(
-                interleavedCodes.data(),
-                dataPtrs[listId],
-                gpuListSizeInBytes,
-                stream);
-        raft_handle.sync_stream();
+        auto flatCodes = getListVectorData(listId, false);
 
-        std::vector<uint8_t> flatCodes(getCpuVectorsEncodingSize_(listSize));
-        CuvsIVFSQCodePackerInterleaved packer((size_t)listSize, dim_);
-        packer.unpack_all(interleavedCodes.data(), flatCodes.data());
-
-        std::vector<float> decoded(listSize * dim_);
-        faissSQ_->decode(flatCodes.data(), decoded.data(), listSize);
+        std::vector<float> decoded(ids.size() * dim_);
+        faissSQ_->decode(flatCodes.data(), decoded.data(), ids.size());
 
         const float* center = centers.data() + listId * dim_;
-        for (idx_t offset = 0; offset < listSize; ++offset) {
-            idx_t id = ids[offset];
-            if (!(id >= i0 && id < i0 + ni)) {
+        for (size_t offset = 0; offset < ids.size(); ++offset) {
+            const idx_t id = ids[offset];
+            if (id < i0 || id >= i0 + ni) {
                 continue;
             }
 
@@ -662,10 +544,11 @@ void CuvsIVFSQ::reconstruct_n(idx_t i0, idx_t ni, float* out) {
 }
 
 size_t CuvsIVFSQ::getGpuVectorsEncodingSize_(idx_t numVecs) const {
-    idx_t paddedDim = roundUpTo(dim_, kCuvsSQVecLen);
-    idx_t numBlocks =
-            utils::divUp(numVecs, cuvs::neighbors::ivf_sq::kIndexGroupSize);
-    return numBlocks * cuvs::neighbors::ivf_sq::kIndexGroupSize * paddedDim;
+    constexpr idx_t indexGroupSize = 32;
+    constexpr idx_t vectorLength = 16;
+    idx_t paddedDim = roundUpTo(dim_, vectorLength);
+    idx_t numBlocks = utils::divUp(numVecs, indexGroupSize);
+    return numBlocks * indexGroupSize * paddedDim;
 }
 
 void CuvsIVFSQ::addEncodedVectorsToList_(
@@ -680,90 +563,66 @@ void CuvsIVFSQ::addEncodedVectorsToList_(
     FAISS_ASSERT(cuvs_index != nullptr);
 
     auto stream = resources_->getDefaultStreamCurrentDevice();
-    auto gpuListSizeInBytes = getGpuVectorsEncodingSize_(numVecs);
-    FAISS_ASSERT(gpuListSizeInBytes <= (size_t)std::numeric_limits<int>::max());
-
-    std::vector<uint8_t> interleavedCodes(gpuListSizeInBytes);
-    CuvsIVFSQCodePackerInterleaved packer((size_t)numVecs, dim_);
-    packer.pack_all(
-            reinterpret_cast<const uint8_t*>(codes), interleavedCodes.data());
-
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-
-    uint8_t* listDataPtr;
-    raft::update_host(
-            &listDataPtr,
-            getCppIndex(cuvs_index)->data_ptrs().data_handle() + listId,
-            1,
-            stream);
-    raft_handle.sync_stream();
-
-    raft::update_device(
-            listDataPtr, interleavedCodes.data(), gpuListSizeInBytes, stream);
-
-    idx_t* listIndicesPtr;
-    raft::update_host(
-            &listIndicesPtr,
-            getCppIndex(cuvs_index)->inds_ptrs().data_handle() + listId,
-            1,
-            stream);
-    raft_handle.sync_stream();
-
-    raft::update_device(listIndicesPtr, indices, numVecs, stream);
-}
-
-void CuvsIVFSQ::copyFaissSQToCuvs_() {
-    FAISS_ASSERT(cuvs_index != nullptr);
-    FAISS_ASSERT(faissSQ_ != nullptr);
-    FAISS_THROW_IF_NOT_MSG(
-            faissSQ_->qtype == faiss::ScalarQuantizer::QT_8bit,
-            "cuVS IVF-SQ supports only QT_8bit scalar quantization");
-    FAISS_THROW_IF_NOT_MSG(
-            faissSQ_->trained.size() == 2 * static_cast<size_t>(dim_),
-            "cuVS IVF-SQ requires trained QT_8bit range data");
-
-    std::vector<float> vmin(dim_);
-    std::vector<float> delta(dim_);
-    for (int d = 0; d < dim_; ++d) {
-        delta[d] = faissSQ_->trained[dim_ + d] / kFaissSQ8Levels;
-        vmin[d] = faissSQ_->trained[d] + 0.5f * delta[d];
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+    constexpr idx_t maxBatchSize = 4096;
+    for (idx_t offset = 0; offset < numVecs; offset += maxBatchSize) {
+        uint32_t batchSize = min(maxBatchSize, numVecs - offset);
+        auto codesDevice = raft::make_device_matrix<uint8_t, uint32_t>(
+                raftHandle, batchSize, static_cast<uint32_t>(dim_));
+        auto indicesDevice = raft::make_device_vector<idx_t, uint32_t>(
+                raftHandle, batchSize);
+        raft::update_device(
+                codesDevice.data_handle(),
+                static_cast<const uint8_t*>(codes) + offset * dim_,
+                static_cast<size_t>(batchSize) * dim_,
+                stream);
+        raft::update_device(
+                indicesDevice.data_handle(),
+                indices + offset,
+                batchSize,
+                stream);
+        auto codesTensor = makeCuvsTensor(
+                codesDevice.data_handle(), (int64_t)batchSize, (int64_t)dim_);
+        auto indicesTensor =
+                makeCuvsTensor(indicesDevice.data_handle(), (int64_t)batchSize);
+        cuvsCheck(
+                cuvsIvfSqIndexExtendList(
+                        cuvsResourcesFromGpuResources(resources_),
+                        cuvs_index,
+                        codesTensor.get(),
+                        indicesTensor.get(),
+                        static_cast<uint32_t>(listId)),
+                "cuvsIvfSqIndexExtendList");
     }
-
-    auto stream = resources_->getDefaultStreamCurrentDevice();
-    raft::update_device(
-            getCppIndex(cuvs_index)->sq_vmin().data_handle(),
-            vmin.data(),
-            dim_,
-            stream);
-    raft::update_device(
-            getCppIndex(cuvs_index)->sq_delta().data_handle(),
-            delta.data(),
-            dim_,
-            stream);
 }
 
 void CuvsIVFSQ::copyCuvsSQToFaiss_(faiss::ScalarQuantizer* sq) const {
     FAISS_ASSERT(cuvs_index != nullptr);
     FAISS_THROW_IF_NOT_MSG(sq, "ScalarQuantizer pointer cannot be null");
 
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-    auto stream = raft_handle.get_stream();
+    const auto& raftHandle = resources_->getRaftHandleCurrentDevice();
+    CuvsOutputTensor vminTensor;
+    CuvsOutputTensor deltaTensor;
+    cuvsCheck(
+            cuvsIvfSqIndexGetVMin(cuvs_index, vminTensor.get()),
+            "cuvsIvfSqIndexGetVMin");
+    cuvsCheck(
+            cuvsIvfSqIndexGetDelta(cuvs_index, deltaTensor.get()),
+            "cuvsIvfSqIndexGetDelta");
 
     std::vector<float> vmin(dim_);
     std::vector<float> delta(dim_);
     raft::update_host(
             vmin.data(),
-            getCppIndex(cuvs_index)->sq_vmin().data_handle(),
+            vminTensor.data<float>(),
             dim_,
-            stream);
+            raftHandle.get_stream());
     raft::update_host(
             delta.data(),
-            getCppIndex(cuvs_index)->sq_delta().data_handle(),
+            deltaTensor.data<float>(),
             dim_,
-            stream);
-    raft_handle.sync_stream();
+            raftHandle.get_stream());
+    raftHandle.sync_stream();
 
     sq->d = dim_;
     sq->qtype = faiss::ScalarQuantizer::QT_8bit;
@@ -773,74 +632,6 @@ void CuvsIVFSQ::copyCuvsSQToFaiss_(faiss::ScalarQuantizer* sq) const {
         sq->trained[d] = vmin[d] - 0.5f * delta[d];
         sq->trained[dim_ + d] = kFaissSQ8Levels * delta[d];
     }
-}
-
-void CuvsIVFSQ::computeCenterNorms_() {
-    FAISS_ASSERT(cuvs_index != nullptr);
-
-    if (metric_ != faiss::METRIC_L2) {
-        return;
-    }
-
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-    getCppIndex(cuvs_index)->allocate_center_norms(raft_handle);
-    CuvsOutputTensor centers;
-    cuvsCheck(
-            cuvsIvfSqIndexGetCenters(cuvs_index, centers.get()),
-            "cuvsIvfSqIndexGetCenters");
-    raft::linalg::rowNorm<raft::linalg::L2Norm, true, float, uint32_t>(
-            getCppIndex(cuvs_index)->center_norms().value().data_handle(),
-            centers.data<float>(),
-            dim_,
-            static_cast<uint32_t>(numLists_),
-            raft_handle.get_stream());
-}
-
-void CuvsIVFSQ::recomputeListState_(const std::vector<uint32_t>& listSizes) {
-    FAISS_ASSERT(cuvs_index != nullptr);
-    FAISS_THROW_IF_NOT(listSizes.size() == static_cast<size_t>(numLists_));
-
-    const raft::device_resources& raft_handle =
-            resources_->getRaftHandleCurrentDevice();
-    auto stream = raft_handle.get_stream();
-
-    std::vector<uint8_t*> dataPtrs(numLists_);
-    std::vector<idx_t*> indsPtrs(numLists_);
-    auto& lists = getCppIndex(cuvs_index)->lists();
-    for (idx_t i = 0; i < numLists_; ++i) {
-        dataPtrs[i] = lists[i] ? lists[i]->data_ptr() : nullptr;
-        indsPtrs[i] = lists[i] ? lists[i]->indices_ptr() : nullptr;
-    }
-
-    raft::update_device(
-            getCppIndex(cuvs_index)->data_ptrs().data_handle(),
-            dataPtrs.data(),
-            dataPtrs.size(),
-            stream);
-    raft::update_device(
-            getCppIndex(cuvs_index)->inds_ptrs().data_handle(),
-            indsPtrs.data(),
-            indsPtrs.size(),
-            stream);
-    raft::update_device(
-            getCppIndex(cuvs_index)->list_sizes().data_handle(),
-            listSizes.data(),
-            listSizes.size(),
-            stream);
-
-    auto sortedListSizes = listSizes;
-    std::sort(
-            sortedListSizes.begin(),
-            sortedListSizes.end(),
-            [](uint32_t a, uint32_t b) { return a > b; });
-
-    auto accumSortedSizes = getCppIndex(cuvs_index)->accum_sorted_sizes();
-    accumSortedSizes(0) = 0;
-    for (size_t i = 0; i < sortedListSizes.size(); ++i) {
-        accumSortedSizes(i + 1) = accumSortedSizes(i) + sortedListSizes[i];
-    }
-    raft_handle.sync_stream();
 }
 
 idx_t CuvsIVFSQ::getBitsetSizeForFiltering_() const {
@@ -886,62 +677,6 @@ std::vector<float> CuvsIVFSQ::getCentersHost_() const {
             stream);
     raft_handle.sync_stream();
     return centers;
-}
-
-CuvsIVFSQCodePackerInterleaved::CuvsIVFSQCodePackerInterleaved(
-        size_t list_size,
-        uint32_t dim) {
-    this->dim = dim;
-    this->padded_dim = roundUpTo(dim, kCuvsSQVecLen);
-    nvec = list_size;
-    code_size = dim;
-    block_size =
-            utils::roundUp(nvec, cuvs::neighbors::ivf_sq::kIndexGroupSize) *
-            padded_dim;
-}
-
-void CuvsIVFSQCodePackerInterleaved::pack_1(
-        const uint8_t* flat_code,
-        size_t offset,
-        uint8_t* block) const {
-    const uint32_t groupOffset =
-            (offset / cuvs::neighbors::ivf_sq::kIndexGroupSize) *
-            cuvs::neighbors::ivf_sq::kIndexGroupSize;
-    const uint32_t ingroupId =
-            offset % cuvs::neighbors::ivf_sq::kIndexGroupSize;
-    uint8_t* group = block + static_cast<size_t>(groupOffset) * padded_dim;
-
-    for (uint32_t d = 0; d < dim; ++d) {
-        uint32_t l = (d / kCuvsSQVecLen) * kCuvsSQVecLen;
-        uint32_t j = d % kCuvsSQVecLen;
-        group[l * cuvs::neighbors::ivf_sq::kIndexGroupSize +
-              ingroupId * kCuvsSQVecLen + j] = flat_code[d];
-    }
-}
-
-void CuvsIVFSQCodePackerInterleaved::unpack_1(
-        const uint8_t* block,
-        size_t offset,
-        uint8_t* flat_code) const {
-    const uint32_t groupOffset =
-            (offset / cuvs::neighbors::ivf_sq::kIndexGroupSize) *
-            cuvs::neighbors::ivf_sq::kIndexGroupSize;
-    const uint32_t ingroupId =
-            offset % cuvs::neighbors::ivf_sq::kIndexGroupSize;
-    const uint8_t* group =
-            block + static_cast<size_t>(groupOffset) * padded_dim;
-
-    for (uint32_t d = 0; d < dim; ++d) {
-        uint32_t l = (d / kCuvsSQVecLen) * kCuvsSQVecLen;
-        uint32_t j = d % kCuvsSQVecLen;
-        flat_code[d] =
-                group[l * cuvs::neighbors::ivf_sq::kIndexGroupSize +
-                      ingroupId * kCuvsSQVecLen + j];
-    }
-}
-
-CodePacker* CuvsIVFSQCodePackerInterleaved::clone() const {
-    return new CuvsIVFSQCodePackerInterleaved(*this);
 }
 
 } // namespace gpu

--- a/faiss/gpu/impl/CuvsIVFSQ.cuh
+++ b/faiss/gpu/impl/CuvsIVFSQ.cuh
@@ -23,7 +23,6 @@
 
 #pragma once
 
-#include <faiss/impl/CodePacker.h>
 #include <faiss/impl/IDSelector.h>
 #include <faiss/gpu/impl/GpuScalarQuantizer.cuh>
 #include <faiss/gpu/impl/IVFFlat.cuh>
@@ -138,10 +137,7 @@ class CuvsIVFSQ : public IVFFlat {
     /// this is the size for an entire IVF list
     size_t getGpuVectorsEncodingSize_(idx_t numVecs) const override;
 
-    void copyFaissSQToCuvs_();
     void copyCuvsSQToFaiss_(faiss::ScalarQuantizer* sq) const;
-    void computeCenterNorms_();
-    void recomputeListState_(const std::vector<uint32_t>& listSizes);
     idx_t getBitsetSizeForFiltering_() const;
     std::vector<float> getCentersHost_() const;
 
@@ -157,19 +153,6 @@ class CuvsIVFSQ : public IVFFlat {
     bool hasNegativeVectorId_{false};
 
     cuvsIvfSqIndex_t cuvs_index{nullptr};
-};
-
-struct CuvsIVFSQCodePackerInterleaved : CodePacker {
-    CuvsIVFSQCodePackerInterleaved(size_t list_size, uint32_t dim);
-    CodePacker* clone() const final;
-    void pack_1(const uint8_t* flat_code, size_t offset, uint8_t* block)
-            const final;
-    void unpack_1(const uint8_t* block, size_t offset, uint8_t* flat_code)
-            const final;
-
-   protected:
-    uint32_t dim;
-    uint32_t padded_dim;
 };
 
 } // namespace gpu

--- a/faiss/gpu/impl/CuvsIVFSQ.cuh
+++ b/faiss/gpu/impl/CuvsIVFSQ.cuh
@@ -28,9 +28,8 @@
 #include <faiss/gpu/impl/GpuScalarQuantizer.cuh>
 #include <faiss/gpu/impl/IVFFlat.cuh>
 
-#include <cuvs/neighbors/ivf_sq.hpp>
+#include <cuvs/neighbors/ivf_sq.h>
 
-#include <memory>
 #include <vector>
 
 #pragma GCC visibility push(default)
@@ -114,7 +113,7 @@ class CuvsIVFSQ : public IVFFlat {
     void copyInvertedListsFrom(const InvertedLists* ivf) override;
 
     /// Replace the cuVS index
-    void setCuvsIndex(cuvs::neighbors::ivf_sq::index<uint8_t>&& idx);
+    void setCuvsIndex(cuvsIvfSqIndex_t index);
 
     /// Copy the cuVS SQ range state back to a FAISS scalar quantizer
     void setFaissSQFromCuvs(faiss::ScalarQuantizer* sq) const;
@@ -157,8 +156,7 @@ class CuvsIVFSQ : public IVFFlat {
     /// Whether any stored vector has a negative id (unsupported for filtering)
     bool hasNegativeVectorId_{false};
 
-    std::shared_ptr<cuvs::neighbors::ivf_sq::index<uint8_t>> cuvs_index{
-            nullptr};
+    cuvsIvfSqIndex_t cuvs_index{nullptr};
 };
 
 struct CuvsIVFSQCodePackerInterleaved : CodePacker {

--- a/faiss/gpu/test/TestGpuFilterConvert.cu
+++ b/faiss/gpu/test/TestGpuFilterConvert.cu
@@ -89,8 +89,8 @@ void run_complex() {
     auto xor_selector =
             faiss::IDSelectorXOr(&or_selector, &not_bitmap_selector);
 
-    // convert to cuVS bitset
-    auto bitset = cuvs::core::bitset<bitset_t, indexing_t>(
+    // convert to RAFT bitset
+    auto bitset = raft::core::bitset<bitset_t, indexing_t>(
             raft_handle, spec.bitset_len, false);
     faiss::gpu::convert_to_bitset(gpuRes.get(), xor_selector, bitset.view());
 
@@ -98,7 +98,7 @@ void run_complex() {
     auto bitset_converted_cpu =
             raft::make_host_vector<bitset_t, indexing_t>(bitset.n_elements());
     auto bitset_converted_cpu_view =
-            cuvs::core::bitset_view<bitset_t, indexing_t>(
+            raft::core::bitset_view<bitset_t, indexing_t>(
                     bitset_converted_cpu.data_handle(), spec.bitset_len);
     raft::copy(raft_handle, bitset_converted_cpu.view(), bitset.to_mdspan());
     raft::resource::sync_stream(raft_handle);
@@ -128,7 +128,7 @@ void run_range() {
     if (imin > imax)
         std::swap(imin, imax);
     auto selector = faiss::IDSelectorRange(imin, imax);
-    auto bitset = cuvs::core::bitset<bitset_t, indexing_t>(
+    auto bitset = raft::core::bitset<bitset_t, indexing_t>(
             raft_handle, spec.bitset_len, false);
     auto nbits = sizeof(bitset_t) * 8;
 
@@ -137,7 +137,7 @@ void run_range() {
             raft::make_host_vector<bitset_t, indexing_t>(bitset.n_elements());
     raft::copy(raft_handle, bitset_converted_cpu.view(), bitset.to_mdspan());
     raft::resource::sync_stream(raft_handle);
-    auto bitset_view_cpu = cuvs::core::bitset_view<bitset_t, indexing_t>(
+    auto bitset_view_cpu = raft::core::bitset_view<bitset_t, indexing_t>(
             bitset_converted_cpu.data_handle(), spec.bitset_len);
     for (indexing_t i = 0; i < spec.bitset_len; i++) {
         if (bitset_view_cpu.test(i) != selector.is_member(i)) {
@@ -169,7 +169,7 @@ void run_bitmap() {
     }
     auto bitmap_selector = faiss::IDSelectorBitmap(
             bitmap_faiss_cpu.size(), bitmap_faiss_cpu.data());
-    auto bitset = cuvs::core::bitset<bitset_t, indexing_t>(
+    auto bitset = raft::core::bitset<bitset_t, indexing_t>(
             raft_handle, spec.bitset_len, false);
     faiss::gpu::convert_to_bitset(gpuRes.get(), bitmap_selector, bitset.view());
 
@@ -178,7 +178,7 @@ void run_bitmap() {
     raft::copy(raft_handle, bitset_converted_cpu.view(), bitset.to_mdspan());
     raft::resource::sync_stream(raft_handle);
     auto bitset_converted_cpu_view =
-            cuvs::core::bitset_view<bitset_t, indexing_t>(
+            raft::core::bitset_view<bitset_t, indexing_t>(
                     bitset_converted_cpu.data_handle(), spec.bitset_len);
     for (indexing_t i = 0; i < spec.bitset_len; i++) {
         if (bitset_converted_cpu_view.test(i) != bitmap_selector.is_member(i)) {
@@ -210,7 +210,7 @@ void run_array() {
     }
     auto array_selector =
             faiss::IDSelectorArray(n, array_selector_indices.data());
-    auto bitset = cuvs::core::bitset<bitset_t, indexing_t>(
+    auto bitset = raft::core::bitset<bitset_t, indexing_t>(
             raft_handle, spec.bitset_len, false);
     faiss::gpu::convert_to_bitset(gpuRes.get(), array_selector, bitset.view());
 
@@ -219,7 +219,7 @@ void run_array() {
     raft::copy(raft_handle, bitset_converted_cpu.view(), bitset.to_mdspan());
     raft::resource::sync_stream(raft_handle);
     auto bitset_converted_cpu_view =
-            cuvs::core::bitset_view<bitset_t, indexing_t>(
+            raft::core::bitset_view<bitset_t, indexing_t>(
                     bitset_converted_cpu.data_handle(), spec.bitset_len);
     for (indexing_t i = 0; i < spec.bitset_len; i++) {
         if (bitset_converted_cpu_view.test(i) != array_selector.is_member(i)) {
@@ -261,7 +261,7 @@ void run_bitmap_byte_convention() {
             faiss::IDSelectorBitmap(byte_count, bitmap_faiss_cpu.data());
 
     // Create bitset with the actual number of bits
-    auto bitset = cuvs::core::bitset<bitset_t, indexing_t>(
+    auto bitset = raft::core::bitset<bitset_t, indexing_t>(
             raft_handle, bit_count, false);
 
     faiss::gpu::convert_to_bitset(gpuRes.get(), bitmap_selector, bitset.view());
@@ -272,7 +272,7 @@ void run_bitmap_byte_convention() {
     raft::copy(raft_handle, bitset_converted_cpu.view(), bitset.to_mdspan());
     raft::resource::sync_stream(raft_handle);
     auto bitset_converted_cpu_view =
-            cuvs::core::bitset_view<bitset_t, indexing_t>(
+            raft::core::bitset_view<bitset_t, indexing_t>(
                     bitset_converted_cpu.data_handle(), bit_count);
     for (indexing_t i = 0; i < static_cast<indexing_t>(bit_count); i++) {
         if (bitset_converted_cpu_view.test(i) != bitmap_selector.is_member(i)) {

--- a/faiss/gpu/utils/CuvsFilterConvert.cu
+++ b/faiss/gpu/utils/CuvsFilterConvert.cu
@@ -21,7 +21,6 @@
  * limitations under the License.
  */
 
-#include <cuvs/core/bitset.hpp>
 #include <faiss/gpu/GpuResources.h>
 #include <faiss/impl/IDSelector.h>
 #include <omp.h>
@@ -68,7 +67,7 @@ RAFT_KERNEL set_range_kernel(
 void convert_to_bitset_range(
         raft::resources const& res,
         const faiss::IDSelectorRange& selector,
-        cuvs::core::bitset_view<uint32_t, int64_t> bitset) {
+        raft::core::bitset_view<uint32_t, int64_t> bitset) {
     const uint32_t nbits = sizeof(uint32_t) * 8;
     auto original_nbits = bitset.get_original_nbits();
     if (original_nbits == 0) {
@@ -109,7 +108,7 @@ void convert_to_bitset_range(
 void convert_to_bitset_array(
         raft::resources const& res,
         const faiss::IDSelectorArray& selector,
-        cuvs::core::bitset_view<uint32_t, int64_t> bitset) {
+        raft::core::bitset_view<uint32_t, int64_t> bitset) {
     // Ids outside [0, bitset.size()) cannot correspond to any stored vector, so
     // drop them rather than indexing out of the bitset. Selecting an id that is
     // not in the index simply matches nothing.
@@ -165,7 +164,7 @@ RAFT_KERNEL set_bitmap_kernel(
 void convert_to_bitset_bitmap(
         raft::resources const& res,
         const faiss::IDSelectorBitmap& selector,
-        cuvs::core::bitset_view<uint32_t, int64_t> bitset) {
+        raft::core::bitset_view<uint32_t, int64_t> bitset) {
     // IDSelectorBitmap.n is the byte count of the bitmap array (number of
     // uint8_t elements). This matches the documented C++ API:
     //   @param n size of the bitmap array
@@ -201,7 +200,7 @@ void convert_to_bitset_bitmap(
 void convert_to_bitset_bruteforce(
         raft::resources const& res,
         const faiss::IDSelector& selector,
-        cuvs::core::bitset_view<uint32_t, int64_t> bitset,
+        raft::core::bitset_view<uint32_t, int64_t> bitset,
         int num_threads = 0) {
     auto bitset_cpu =
             raft::make_host_vector<uint32_t, int64_t>(bitset.n_elements());
@@ -226,7 +225,7 @@ void convert_to_bitset_bruteforce(
 void convert_to_bitset(
         faiss::gpu::GpuResources* res,
         const faiss::IDSelector& selector,
-        cuvs::core::bitset_view<uint32_t, int64_t> bitset,
+        raft::core::bitset_view<uint32_t, int64_t> bitset,
         int num_threads) {
     raft::device_resources& raft_handle = res->getRaftHandleCurrentDevice();
     // If the selector is simple, we can use the specialized functions

--- a/faiss/gpu/utils/CuvsFilterConvert.h
+++ b/faiss/gpu/utils/CuvsFilterConvert.h
@@ -21,21 +21,56 @@
  * limitations under the License.
  */
 
-#include <cuvs/core/bitset.hpp>
+#include <cuvs/neighbors/common.h>
 #include <faiss/gpu/GpuResources.h>
+#include <faiss/gpu/utils/CuvsUtils.h>
 #include <faiss/impl/IDSelector.h>
+#include <raft/core/bitset.hpp>
+
+#include <optional>
 
 #pragma GCC visibility push(default)
 namespace faiss::gpu {
-/// Convert a Faiss IDSelector to a cuvs::core::bitset_view
+/// Convert a Faiss IDSelector to a RAFT bitset consumed by the cuVS C API.
 /// @param res The GpuResources object to use for the conversion
 /// @param selector The Faiss IDSelector to convert
-/// @param bitset The cuvs::core::bitset_view to store the result
+/// @param bitset The bitset view to store the result
 /// @param num_threads Number of threads to use for the conversion. If 0, the
 /// number of threads is set to the number of available threads.
 void convert_to_bitset(
         faiss::gpu::GpuResources* res,
         const faiss::IDSelector& selector,
-        cuvs::core::bitset_view<uint32_t, int64_t> bitset,
+        raft::core::bitset_view<uint32_t, int64_t> bitset,
         int num_threads = 0);
+
+/// Owns the device bitset and DLPack metadata referenced by a cuvsFilter.
+class CuvsFilter {
+   public:
+    CuvsFilter(
+            GpuResources* resources,
+            const IDSelector* selector,
+            int64_t bitCount)
+            : filter_{0, NO_FILTER} {
+        if (!selector) {
+            return;
+        }
+
+        auto& raftResources = resources->getRaftHandleCurrentDevice();
+        bitset_.emplace(raftResources, bitCount, false);
+        convert_to_bitset(resources, *selector, bitset_->view());
+        tensor_.emplace(
+                bitset_->data(), static_cast<int64_t>(bitset_->n_elements()));
+        filter_ =
+                cuvsFilter{reinterpret_cast<uintptr_t>(tensor_->get()), BITSET};
+    }
+
+    cuvsFilter get() const {
+        return filter_;
+    }
+
+   private:
+    std::optional<raft::core::bitset<uint32_t, int64_t>> bitset_;
+    std::optional<CuvsTensor<uint32_t, 1>> tensor_;
+    cuvsFilter filter_;
+};
 } // namespace faiss::gpu

--- a/faiss/gpu/utils/CuvsUtils.h
+++ b/faiss/gpu/utils/CuvsUtils.h
@@ -107,6 +107,47 @@ constexpr DLDataType cuvsDtype() {
     }
 }
 
+inline DLDevice cuvsDlDeviceForAddress(const void* data) {
+    if (!data) {
+        return DLDevice{kDLCPU, 0};
+    }
+
+    cudaPointerAttributes attributes{};
+    cudaError_t error = cudaPointerGetAttributes(&attributes, data);
+    if (error == cudaErrorInvalidValue) {
+        cudaGetLastError();
+        return DLDevice{kDLCPU, 0};
+    }
+    FAISS_THROW_IF_NOT_FMT(
+            error == cudaSuccess,
+            "cudaPointerGetAttributes failed: %s",
+            cudaGetErrorString(error));
+
+#if CUDA_VERSION >= 10000
+    switch (attributes.type) {
+        case cudaMemoryTypeDevice:
+            return DLDevice{kDLCUDA, attributes.device};
+        case cudaMemoryTypeManaged:
+            return DLDevice{kDLCUDAManaged, attributes.device};
+        case cudaMemoryTypeHost:
+            return DLDevice{kDLCUDAHost, 0};
+        default:
+            return DLDevice{kDLCPU, 0};
+    }
+#else
+    if (attributes.isManaged) {
+        return DLDevice{kDLCUDAManaged, attributes.device};
+    }
+    if (attributes.memoryType == cudaMemoryTypeDevice) {
+        return DLDevice{kDLCUDA, attributes.device};
+    }
+    if (attributes.memoryType == cudaMemoryTypeHost) {
+        return DLDevice{kDLCUDAHost, 0};
+    }
+    return DLDevice{kDLCPU, 0};
+#endif
+}
+
 enum class CuvsTensorLayout { RowMajor, ColumnMajor };
 
 /// A non-owning DLPack view whose metadata remains valid for this object's
@@ -139,12 +180,9 @@ class CuvsTensor {
             }
         }
 
-        auto device = getDeviceForAddress(data);
         tensor_.dl_tensor = DLTensor{
                 const_cast<std::remove_const_t<T>*>(data),
-                DLDevice{
-                        device >= 0 ? kDLCUDA : kDLCPU,
-                        device >= 0 ? device : 0},
+                cuvsDlDeviceForAddress(data),
                 static_cast<int32_t>(Rank),
                 cuvsDtype<T>(),
                 shape_.data(),

--- a/faiss/gpu/utils/CuvsUtils.h
+++ b/faiss/gpu/utils/CuvsUtils.h
@@ -25,38 +25,236 @@
 
 #include <faiss/MetricType.h>
 #include <faiss/gpu/GpuResources.h>
+#include <faiss/gpu/utils/DeviceUtils.h>
+#include <faiss/impl/FaissAssert.h>
 #include <faiss/gpu/utils/Tensor.cuh>
 
-#include <cuvs/distance/distance.hpp>
+#include <cuvs/core/c_api.h>
+#include <cuvs/core/dataset.h>
+#include <cuvs/distance/distance.h>
+#include <dlpack/dlpack.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <type_traits>
 
 #pragma GCC visibility push(default)
 namespace faiss {
 namespace gpu {
 
-inline cuvs::distance::DistanceType metricFaissToCuvs(
+inline cuvsDistanceType metricFaissToCuvs(
         MetricType metric,
         bool exactDistance) {
+    (void)exactDistance;
     switch (metric) {
         case MetricType::METRIC_INNER_PRODUCT:
-            return cuvs::distance::DistanceType::InnerProduct;
+            return InnerProduct;
         case MetricType::METRIC_L2:
-            return cuvs::distance::DistanceType::L2Expanded;
+            return L2Expanded;
         case MetricType::METRIC_L1:
-            return cuvs::distance::DistanceType::L1;
+            return L1;
         case MetricType::METRIC_Linf:
-            return cuvs::distance::DistanceType::Linf;
+            return Linf;
         case MetricType::METRIC_Lp:
-            return cuvs::distance::DistanceType::LpUnexpanded;
+            return LpUnexpanded;
         case MetricType::METRIC_Canberra:
-            return cuvs::distance::DistanceType::Canberra;
+            return Canberra;
         case MetricType::METRIC_BrayCurtis:
-            return cuvs::distance::DistanceType::BrayCurtis;
+            return BrayCurtis;
         case MetricType::METRIC_JensenShannon:
-            return cuvs::distance::DistanceType::JensenShannon;
+            return JensenShannon;
         default:
             RAFT_FAIL("Distance type not supported");
     }
 }
+
+inline void cuvsCheck(cuvsError_t status, const char* operation) {
+    FAISS_THROW_IF_NOT_FMT(
+            status == CUVS_SUCCESS,
+            "%s failed: %s",
+            operation,
+            cuvsGetLastErrorText());
+}
+
+inline cuvsResources_t cuvsResourcesFromGpuResources(GpuResources* resources) {
+    return reinterpret_cast<cuvsResources_t>(
+            &resources->getRaftHandleCurrentDevice());
+}
+
+template <typename T>
+constexpr DLDataType cuvsDtype() {
+    using Value = std::remove_cv_t<T>;
+    if constexpr (std::is_same_v<Value, float>) {
+        return DLDataType{kDLFloat, 32, 1};
+    } else if constexpr (std::is_same_v<Value, half>) {
+        return DLDataType{kDLFloat, 16, 1};
+    } else if constexpr (std::is_same_v<Value, int64_t>) {
+        return DLDataType{kDLInt, 64, 1};
+    } else if constexpr (std::is_same_v<Value, uint64_t>) {
+        return DLDataType{kDLUInt, 64, 1};
+    } else if constexpr (std::is_same_v<Value, int32_t>) {
+        return DLDataType{kDLInt, 32, 1};
+    } else if constexpr (std::is_same_v<Value, uint32_t>) {
+        return DLDataType{kDLUInt, 32, 1};
+    } else if constexpr (std::is_same_v<Value, int8_t>) {
+        return DLDataType{kDLInt, 8, 1};
+    } else if constexpr (std::is_same_v<Value, uint8_t>) {
+        return DLDataType{kDLUInt, 8, 1};
+    } else {
+        static_assert(!sizeof(T), "unsupported DLPack data type");
+    }
+}
+
+enum class CuvsTensorLayout { RowMajor, ColumnMajor };
+
+/// A non-owning DLPack view whose metadata remains valid for this object's
+/// lifetime. The data pointer can refer to host or device memory.
+template <typename T, size_t Rank>
+class CuvsTensor {
+   public:
+    template <typename... Extents>
+    explicit CuvsTensor(T* data, Extents... extents)
+            : CuvsTensor(
+                      data,
+                      CuvsTensorLayout::RowMajor,
+                      static_cast<int64_t>(extents)...) {}
+
+    template <typename... Extents>
+    CuvsTensor(T* data, CuvsTensorLayout layout, Extents... extents)
+            : shape_{static_cast<int64_t>(extents)...} {
+        static_assert(sizeof...(Extents) == Rank);
+        static_assert(Rank > 0);
+
+        if (layout == CuvsTensorLayout::RowMajor) {
+            strides_[Rank - 1] = 1;
+            for (size_t i = Rank - 1; i > 0; --i) {
+                strides_[i - 1] = strides_[i] * shape_[i];
+            }
+        } else {
+            strides_[0] = 1;
+            for (size_t i = 1; i < Rank; ++i) {
+                strides_[i] = strides_[i - 1] * shape_[i - 1];
+            }
+        }
+
+        auto device = getDeviceForAddress(data);
+        tensor_.dl_tensor = DLTensor{
+                const_cast<std::remove_const_t<T>*>(data),
+                DLDevice{
+                        device >= 0 ? kDLCUDA : kDLCPU,
+                        device >= 0 ? device : 0},
+                static_cast<int32_t>(Rank),
+                cuvsDtype<T>(),
+                shape_.data(),
+                layout == CuvsTensorLayout::RowMajor ? nullptr
+                                                     : strides_.data(),
+                0};
+        tensor_.manager_ctx = nullptr;
+        tensor_.deleter = nullptr;
+    }
+
+    CuvsTensor(const CuvsTensor&) = delete;
+    CuvsTensor& operator=(const CuvsTensor&) = delete;
+
+    DLManagedTensor* get() {
+        return &tensor_;
+    }
+
+   private:
+    std::array<int64_t, Rank> shape_{};
+    std::array<int64_t, Rank> strides_{};
+    DLManagedTensor tensor_{};
+};
+
+/// Owns only the metadata populated by cuVS C API getter functions. The
+/// underlying data remains owned by the cuVS index.
+class CuvsOutputTensor {
+   public:
+    CuvsOutputTensor() = default;
+    CuvsOutputTensor(const CuvsOutputTensor&) = delete;
+    CuvsOutputTensor& operator=(const CuvsOutputTensor&) = delete;
+
+    ~CuvsOutputTensor() {
+        if (tensor_.deleter) {
+            tensor_.deleter(&tensor_);
+        }
+    }
+
+    DLManagedTensor* get() {
+        return &tensor_;
+    }
+
+    template <typename T>
+    T* data() const {
+        return reinterpret_cast<T*>(
+                static_cast<uint8_t*>(tensor_.dl_tensor.data) +
+                tensor_.dl_tensor.byte_offset);
+    }
+
+    int64_t extent(size_t dimension) const {
+        FAISS_ASSERT(dimension < static_cast<size_t>(tensor_.dl_tensor.ndim));
+        return tensor_.dl_tensor.shape[dimension];
+    }
+
+   private:
+    DLManagedTensor tensor_{};
+};
+
+template <typename T, typename... Extents>
+auto makeCuvsTensor(T* data, Extents... extents) {
+    return CuvsTensor<T, sizeof...(Extents)>(data, extents...);
+}
+
+/// release/26.10 rejects an owning padded copy when a device tensor is
+/// already 16-byte row aligned; that case must use a padded view.
+template <typename T>
+bool cuvsPaddedDatasetNeedsView(const T* data, int64_t columns) {
+    return getDeviceForAddress(data) >= 0 &&
+            (columns * static_cast<int64_t>(sizeof(T))) % 16 == 0;
+}
+
+/// Construct the C dataset form required by CAGRA from a raw pointer. The
+/// returned handle owns padded storage unless release/26.10 requires a view.
+template <typename T>
+cuvsDataset_t makeCuvsPaddedDataset(
+        GpuResources* resources,
+        const T* data,
+        int64_t rows,
+        int64_t columns) {
+    auto sourceTensor = makeCuvsTensor(const_cast<T*>(data), rows, columns);
+    cuvsDataset_t dataset = nullptr;
+    if (cuvsPaddedDatasetNeedsView(data, columns)) {
+        cuvsCheck(
+                cuvsDatasetMakePaddedView(
+                        cuvsResourcesFromGpuResources(resources),
+                        sourceTensor.get(),
+                        &dataset),
+                "cuvsDatasetMakePaddedView");
+    } else {
+        cuvsCheck(
+                cuvsDatasetMakePadded(
+                        cuvsResourcesFromGpuResources(resources),
+                        sourceTensor.get(),
+                        CUVS_DATASET_MEM_TYPE_DEVICE,
+                        &dataset),
+                "cuvsDatasetMakePadded");
+    }
+    return dataset;
+}
+
+template <typename Handle, cuvsError_t (*Destroy)(Handle*)>
+struct CuvsDeleter {
+    void operator()(Handle* handle) const noexcept {
+        if (handle) {
+            Destroy(handle);
+        }
+    }
+};
+
+template <typename Handle, cuvsError_t (*Destroy)(Handle*)>
+using CuvsUniquePtr = std::unique_ptr<Handle, CuvsDeleter<Handle, Destroy>>;
 
 /// Identify matrix rows containing non NaN values. validRows[i] is false if row
 /// i contains a NaN value and true otherwise.

--- a/faiss/python/__init__.py
+++ b/faiss/python/__init__.py
@@ -121,7 +121,7 @@ def _preload_gpu_libs():
         raise RuntimeError(
             "faiss-gpu-cuvs installed but the cuVS runtime wheels are "
             "missing — "
-            "pip install 'libcuvs-cu13>=26.06,<27' "
+            "pip install 'libcuvs-cu13>=26.10,<27' "
             "--extra-index-url https://pypi.nvidia.com"
         ) from e
 

--- a/pyproject-gpu-cuvs.toml
+++ b/pyproject-gpu-cuvs.toml
@@ -4,8 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 [build-system]
-# cuVS requires rapids-cmake which needs cmake >= 3.30.4.
-requires = ["scikit-build-core>=0.10", "swig>=4.2,<5", "numpy>=2.0", "cmake>=3.30.4", "ninja"]
+# cuVS requires rapids-cmake which needs cmake >= 4.0.
+requires = ["scikit-build-core>=0.10", "swig>=4.2,<5", "numpy>=2.0", "cmake>=4.0,<5", "ninja"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -44,8 +44,8 @@ dependencies = [
   "nvidia-cublas>=13.2,<14",
   "nvidia-curand>=10.3.7,<11",
   "nvidia-nvjitlink>=13.2,<14",
-  "libcuvs-cu13>=26.06,<27",
-  "librmm-cu13>=26.06,<27",
+  "libcuvs-cu13>=26.10,<27",
+  "librmm-cu13>=26.10,<27",
 ]
 
 [project.urls]
@@ -93,7 +93,7 @@ BUILD_SHARED_LIBS = "ON"
 # mirroring the conda build — no explicit *_DIR, agnostic to lib/ vs lib64/.
 
 # Stable ABI (abi3): one cp311 wheel covers all 3.11+.
-# Floor is 3.11 because the runtime dep libcuvs-cu13>=26.06 (RAPIDS) requires
+# Floor is 3.11 because the runtime dep libcuvs-cu13>=26.10 (RAPIDS) requires
 # Python >=3.11 — RAPIDS dropped 3.10 in the 26.04 release.
 # GPU is Linux-only; free-threaded Python (cp3*t) cannot use abi3.
 [[tool.scikit-build.overrides]]
@@ -114,8 +114,8 @@ test-requires = [
   "nvidia-cublas>=13.2,<14",
   "nvidia-curand>=10.3.7,<11",
   "nvidia-nvjitlink>=13.2,<14",
-  "libcuvs-cu13>=26.06,<27",
-  "librmm-cu13>=26.06,<27",
+  "libcuvs-cu13>=26.10,<27",
+  "librmm-cu13>=26.10,<27",
 ]
 test-command = "python -m pytest {project}/tests/test_wheel_smoke_gpu.py -v"
 
@@ -131,7 +131,7 @@ test-command = "python -m pytest {project}/tests/test_wheel_smoke_gpu.py -v"
 # `pip install --target /opt/cuvs` — ABI-clean, so no libstdc++/libgcc_s/libgomp strip
 # or RMM symlink shim. cp311 interpreter is explicit (manylinux puts no `pip` on PATH).
 manylinux-x86_64-image = "manylinux_2_28"
-before-all = "dnf install -y gcc-toolset-14 epel-release && dnf install -y openblas-devel openblas-openmp swig && dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && dnf install -y --setopt=obsoletes=0 cuda-toolkit-13-2 && /opt/python/cp311-cp311/bin/python -m pip install --target /opt/cuvs --no-deps --only-binary ':all:' --extra-index-url https://pypi.nvidia.com 'libcuvs-cu13==26.06.*' 'libraft-cu13==26.06.*' 'librmm-cu13==26.06.*' 'rapids-logger'"
+before-all = "dnf install -y gcc-toolset-14 epel-release && dnf install -y openblas-devel openblas-openmp swig git && dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && dnf install -y --setopt=obsoletes=0 cuda-toolkit-13-2 && /opt/python/cp311-cp311/bin/python -m pip install --target /opt/cuvs --no-deps --only-binary ':all:' --extra-index-url https://pypi.nvidia.com 'libcuvs-cu13==26.10.*' 'libraft-cu13==26.10.*' 'librmm-cu13==26.10.*' 'rapids-logger' && git clone --depth 1 --branch v0.8 https://github.com/dmlc/dlpack.git /tmp/dlpack && cp -r /tmp/dlpack/include/dlpack /opt/cuvs/libcuvs/include/"
 # auditwheel excludes (not vendored; supplied at runtime by nvidia-* / libcuvs-cu13
 # wheels): host driver libcuda, CUDA runtime/math libs (cusparse/cusolver are explicit —
 # under the cuda-toolkit RPM, not /opt/cuvs), and every RAPIDS .so found under /opt/cuvs.


### PR DESCRIPTION
C API offers ABI stability guarantees, which should make this more robust to C++ breaking changes. Users can upgrade libcuvs underneath without affecting Faiss code. Some of the cuVS C APIs are still not up to date and need fallback on the C++ APIs.