### PR TITLE
feat(rvv): add bit-exact RVV decode_vector kernels for scalar quantizers

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -461,6 +461,28 @@ jobs:
             build/tests/faiss_test \
             --gtest_filter="SIMDConfig.*:SIMDLevel.*:CompileOptions.*"
 
+      - name: Run scalar quantizer RVV parity tests (via QEMU)
+        run: |
+          # v=true makes the vector extension explicit (VLEN defaults to
+          # 128). QEMU 8.2 (Ubuntu 24.04) already implements the zvfhmin
+          # FP16 vector instructions needed by the QT_fp16 RVV kernels.
+          qemu-riscv64-static \
+            -cpu rv64,v=true \
+            -L /usr/riscv64-linux-gnu \
+            build/tests/faiss_test \
+            --gtest_filter="ScalarQuantizer.*DistancePathParity*"
+
+      - name: Run scalar quantizer RVV parity tests (VLEN=1024, via QEMU)
+        run: |
+          # VLEN=1024 gives VLMAX=256 lanes for e32m8; together with the
+          # default VLEN=128 run this exercises chunk-tail boundaries at
+          # both ends of the dimensions used by the parity tests.
+          qemu-riscv64-static \
+            -cpu rv64,v=true,vlen=1024 \
+            -L /usr/riscv64-linux-gnu \
+            build/tests/faiss_test \
+            --gtest_filter="ScalarQuantizer.*DistancePathParity*"
+
   index-io-backward-compatibility:
     needs: linux-x86_64-cmake
     name: Index serialization backward compatibility

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -367,49 +367,53 @@ jobs:
         run: |
           sudo dpkg --add-architecture riscv64
 
-          # Restrict existing apt sources to amd64/i386 so that apt does not
-          # try (and fail) to fetch riscv64 packages from the main Ubuntu
-          # mirror, which does not carry riscv64.
+          # Ubuntu 24.04 deb822 sources: keep host packages amd64/i386 only.
           if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
-            # Ubuntu 24.04+ deb822 format: insert Architectures field.
             sudo sed -i '/^Types: deb$/a Architectures: amd64 i386' \
               /etc/apt/sources.list.d/ubuntu.sources
           fi
+
           if grep -q '^deb http' /etc/apt/sources.list 2>/dev/null; then
-            # Ubuntu 22.04 traditional .list format.
             sudo sed -i 's|^deb http|deb [arch=amd64,i386] http|g' \
               /etc/apt/sources.list
           fi
 
-          # Add Ubuntu Ports as the riscv64 package source.
           CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
-          echo "deb [arch=riscv64] http://ports.ubuntu.com/ubuntu-ports ${CODENAME} main restricted universe" \
-            | sudo tee    /etc/apt/sources.list.d/riscv64-ports.list
-          echo "deb [arch=riscv64] http://ports.ubuntu.com/ubuntu-ports ${CODENAME}-updates main restricted universe" \
+
+          echo "deb [arch=riscv64] http://ports.ubuntu.com/ubuntu-ports ${CODENAME} main restricted universe multiverse" \
+            | sudo tee /etc/apt/sources.list.d/riscv64-ports.list
+
+          echo "deb [arch=riscv64] http://ports.ubuntu.com/ubuntu-ports ${CODENAME}-updates main restricted universe multiverse" \
             | sudo tee -a /etc/apt/sources.list.d/riscv64-ports.list
 
           sudo apt-get update -qq
+
           sudo apt-get install -y -qq \
             cmake \
-            gcc-riscv64-linux-gnu \
-            g++-riscv64-linux-gnu \
+            gcc-14-riscv64-linux-gnu \
+            g++-14-riscv64-linux-gnu \
+            libc6:riscv64 \
+            libc6-dev:riscv64 \
+            libstdc++6:riscv64 \
+            libgcc-s1:riscv64 \
             libopenblas-dev:riscv64 \
             libgomp1:riscv64 \
             qemu-user-static
 
-          # Bridge Ubuntu's multiarch library directory into the sysroot so
-          # that CMake's find_library() (ONLY mode, root=/usr/riscv64-linux-gnu)
-          # can reach packages installed as :riscv64.
-          # CMake searches ${root}/usr/lib/<multiarch-tuple>/ thanks to the
-          # compiler's -print-multiarch output (riscv64-linux-gnu).
+          echo "Checking GCC version:"
+          riscv64-linux-gnu-gcc-14 --version
+          riscv64-linux-gnu-g++-14 --version
+
+          # Prepare sysroot library lookup
           sudo mkdir -p /usr/riscv64-linux-gnu/usr/lib
+
           sudo ln -sfn /usr/lib/riscv64-linux-gnu \
             /usr/riscv64-linux-gnu/usr/lib/riscv64-linux-gnu
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
-          key: linux-riscv64-dd
+          key: linux-riscv64-gcc14-dd
           max-size: 2G
           update-package-index: true
 
@@ -430,31 +434,30 @@ jobs:
             -DCMAKE_BUILD_RPATH=/usr/lib/riscv64-linux-gnu \
             .
 
-      - name: Build faiss_test (includes test_factory_tools)
-        run: cmake --build build --target faiss_test -j$(nproc)
+      - name: Build faiss_test
+        run: |
+          cmake --build build --target faiss_test -j$(nproc)
 
       - name: Verify binary with ldd (via qemu)
         run: |
           file build/tests/faiss_test
+
           file build/tests/faiss_test | grep -q "RISC-V" || \
             { echo "ERROR: not a RISC-V binary"; exit 1; }
 
-          # Expose riscv64 libs inside the qemu sysroot so the riscv64 ld.so
-          # launched by qemu can resolve NEEDED entries.
-          sudo mkdir -p /usr/riscv64-linux-gnu/usr/lib
-          sudo ln -sfn /usr/lib/riscv64-linux-gnu \
-            /usr/riscv64-linux-gnu/usr/lib/riscv64-linux-gnu
-
-          # Invoke the riscv64 dynamic linker under qemu with --list, which
-          # is exactly what ldd does on native hardware.
           RISCV64_LD=$(find /usr/riscv64-linux-gnu/lib \
             -name "ld-linux-riscv64-*.so.1" | head -1)
-          qemu-riscv64-static -L /usr/riscv64-linux-gnu \
-            "$RISCV64_LD" --list build/tests/faiss_test
+
+          qemu-riscv64-static \
+            -L /usr/riscv64-linux-gnu \
+            "$RISCV64_LD" \
+            --list \
+            build/tests/faiss_test
 
       - name: Run test_simd_levels (via QEMU)
         run: |
-          qemu-riscv64-static -L /usr/riscv64-linux-gnu \
+          qemu-riscv64-static \
+            -L /usr/riscv64-linux-gnu \
             build/tests/faiss_test \
             --gtest_filter="SIMDConfig.*:SIMDLevel.*:CompileOptions.*"
 

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -464,10 +464,15 @@ jobs:
       - name: Run scalar quantizer RVV parity tests (via QEMU)
         run: |
           # v=true makes the vector extension explicit (VLEN defaults to
-          # 128). QEMU 8.2 (Ubuntu 24.04) already implements the zvfhmin
-          # FP16 vector instructions needed by the QT_fp16 RVV kernels.
+          # 128). x-zvfhmin=true is required as well: the RISCV_RVV level's
+          # minimum ISA is rv64gcv + Zvfhmin (the QT_fp16 RVV kernel emits
+          # Zvfhmin instructions), but the property defaults to false on
+          # QEMU 8.2's rv64 CPU even though QEMU implements the extension.
+          # ScalarQuantizer.RVVFP16DistancePathParity in the filter output
+          # below is the FP16 case; it would die with SIGILL here if the
+          # extension were not enabled.
           qemu-riscv64-static \
-            -cpu rv64,v=true \
+            -cpu rv64,v=true,x-zvfhmin=true \
             -L /usr/riscv64-linux-gnu \
             build/tests/faiss_test \
             --gtest_filter="ScalarQuantizer.*DistancePathParity*"
@@ -477,8 +482,9 @@ jobs:
           # VLEN=1024 gives VLMAX=256 lanes for e32m8; together with the
           # default VLEN=128 run this exercises chunk-tail boundaries at
           # both ends of the dimensions used by the parity tests.
+          # x-zvfhmin=true is required for the QT_fp16 case, as above.
           qemu-riscv64-static \
-            -cpu rv64,v=true,vlen=1024 \
+            -cpu rv64,v=true,vlen=1024,x-zvfhmin=true \
             -L /usr/riscv64-linux-gnu \
             build/tests/faiss_test \
             --gtest_filter="ScalarQuantizer.*DistancePathParity*"

--- a/cmake/toolchains/riscv64-linux-gnu.cmake
+++ b/cmake/toolchains/riscv64-linux-gnu.cmake
@@ -28,8 +28,13 @@ set(CMAKE_SYSTEM_PROCESSOR riscv64)
 set(CMAKE_C_COMPILER   riscv64-linux-gnu-gcc-14)
 set(CMAKE_CXX_COMPILER riscv64-linux-gnu-g++-14)
 
-# GCC-14 provided sysroot
-set(CMAKE_SYSROOT /usr/riscv64-linux-gnu)
+# Do NOT set CMAKE_SYSROOT here. Ubuntu's cross toolchain resolves target
+# libraries through its built-in paths (/usr/riscv64-linux-gnu/lib). Passing
+# --sysroot=/usr/riscv64-linux-gnu makes ld prepend the sysroot to the
+# absolute paths inside libc6-dev-riscv64-cross's libc.so linker script,
+# producing doubled paths such as
+#   /usr/riscv64-linux-gnu/usr/riscv64-linux-gnu/lib/libc.so.6
+# and failing the CMake compiler check at link time.
 
 set(CMAKE_FIND_ROOT_PATH /usr/riscv64-linux-gnu)
 

--- a/cmake/toolchains/riscv64-linux-gnu.cmake
+++ b/cmake/toolchains/riscv64-linux-gnu.cmake
@@ -3,31 +3,40 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Cross-compilation toolchain for RISC-V 64-bit (lp64d ABI) on Ubuntu/Debian.
+# Cross-compilation toolchain for RISC-V 64-bit (lp64d ABI) on Ubuntu 24.04.
 #
-# Requires these packages installed on the build host:
-#   gcc-riscv64-linux-gnu  g++-riscv64-linux-gnu
+# Requires:
+#   gcc-14-riscv64-linux-gnu
+#   g++-14-riscv64-linux-gnu
 #
-# Target libraries (e.g. libopenblas-dev:riscv64) are installed via apt
-# multiarch to /usr/lib/riscv64-linux-gnu/.  CMake's ONLY find-root mode
-# searches ${CMAKE_FIND_ROOT_PATH}/usr/lib/riscv64-linux-gnu/ (via the
-# compiler's multiarch tuple), so the CI script creates a symlink:
+# Target libraries:
+#   libopenblas-dev:riscv64
+#
+# Ubuntu multiarch installs target libraries into:
+#   /usr/lib/riscv64-linux-gnu
+#
+# The CI creates:
 #   /usr/riscv64-linux-gnu/usr/lib/riscv64-linux-gnu
-#     -> /usr/lib/riscv64-linux-gnu
-# before invoking cmake.
+#       -> /usr/lib/riscv64-linux-gnu
+#
+# so CMake can locate target libraries while using ONLY root mode.
 
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR riscv64)
 
-set(CMAKE_C_COMPILER   riscv64-linux-gnu-gcc)
-set(CMAKE_CXX_COMPILER riscv64-linux-gnu-g++)
+# GCC 14 cross compiler
+set(CMAKE_C_COMPILER   riscv64-linux-gnu-gcc-14)
+set(CMAKE_CXX_COMPILER riscv64-linux-gnu-g++-14)
 
-# Cross-compiler sysroot provided by gcc-riscv64-linux-gnu.
+# GCC-14 provided sysroot
+set(CMAKE_SYSROOT /usr/riscv64-linux-gnu)
+
 set(CMAKE_FIND_ROOT_PATH /usr/riscv64-linux-gnu)
 
-# Never look for host-side tools (cmake, python, …) inside the sysroot.
+# Never search host binaries inside sysroot.
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-# Look for target libraries/headers/packages only inside the sysroot.
+
+# Target libraries/headers/packages only.
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -631,7 +631,9 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch64|arm64|ARM64)" AND NOT MSVC)
   target_sources(faiss PRIVATE ${FAISS_SIMD_NEON_SRC})
 endif()
 
-# RVV is the baseline SIMD on rv64 builds compiled with rv64gcv. Compile RVV
+# RVV is the baseline SIMD on rv64 builds; the RVV translation units require
+# rv64gcv + Zvfhmin (see the RISCV_RVV contract in utils/simd_levels.h), so
+# they are compiled with -march=rv64gcv_zvfhmin. Compile RVV
 # sources into the main faiss target, mirroring the ARM NEON story on aarch64.
 # Guard against DD mode: in dd builds, FAISS_SIMD_SRC already contains
 # FAISS_SIMD_RVV_SRC and is added via target_sources above, so we must not

--- a/faiss/impl/scalar_quantizer/quantizers.h
+++ b/faiss/impl/scalar_quantizer/quantizers.h
@@ -89,7 +89,9 @@ struct QuantizerTemplate<
         }
     }
 
-    void decode_vector(const uint8_t* code, float* x) const final {
+    // Not final: the RISCV_RVV codec-template specializations override
+    // decode_vector with RVV kernels while inheriting this scalar reference.
+    void decode_vector(const uint8_t* code, float* x) const override {
         for (size_t i = 0; i < d; i++) {
             float xi = Codec::decode_component(code, i);
             x[i] = vmin + xi * vdiff;
@@ -131,7 +133,9 @@ struct QuantizerTemplate<
         }
     }
 
-    void decode_vector(const uint8_t* code, float* x) const final {
+    // Not final: the RISCV_RVV codec-template specializations override
+    // decode_vector with RVV kernels while inheriting this scalar reference.
+    void decode_vector(const uint8_t* code, float* x) const override {
         for (size_t i = 0; i < d; i++) {
             float xi = Codec::decode_component(code, i);
             x[i] = vmin[i] + xi * vdiff[i];
@@ -247,7 +251,9 @@ struct QuantizerFP16<SIMDLevel::NONE> : ScalarQuantizer::SQuantizer {
         }
     }
 
-    void decode_vector(const uint8_t* code, float* x) const final {
+    // Not final: the RISCV_RVV specialization overrides decode_vector with
+    // an RVV kernel while inheriting this scalar reference.
+    void decode_vector(const uint8_t* code, float* x) const override {
         for (size_t i = 0; i < d; i++) {
             x[i] = decode_fp16(((uint16_t*)code)[i]);
         }
@@ -324,7 +330,9 @@ struct Quantizer8bitDirect<SIMDLevel::NONE> : ScalarQuantizer::SQuantizer {
         }
     }
 
-    void decode_vector(const uint8_t* code, float* x) const final {
+    // Not final: the RISCV_RVV specialization overrides decode_vector with
+    // an RVV kernel while inheriting this scalar reference.
+    void decode_vector(const uint8_t* code, float* x) const override {
         for (size_t i = 0; i < d; i++) {
             x[i] = code[i];
         }
@@ -365,7 +373,9 @@ struct Quantizer8bitDirectSigned<SIMDLevel::NONE>
         }
     }
 
-    void decode_vector(const uint8_t* code, float* x) const final {
+    // Not final: the RISCV_RVV specialization overrides decode_vector with
+    // an RVV kernel while inheriting this scalar reference.
+    void decode_vector(const uint8_t* code, float* x) const override {
         for (size_t i = 0; i < d; i++) {
             x[i] = code[i] - 128;
         }

--- a/faiss/impl/scalar_quantizer/sq-rvv.cpp
+++ b/faiss/impl/scalar_quantizer/sq-rvv.cpp
@@ -40,17 +40,19 @@ struct Codec4bit<SIMDLevel::RISCV_RVV> : Codec4bit<SIMDLevel::NONE> {
         const uint8_t* src = code + (i >> 1);
         size_t byte_vl = (vl + 1) >> 1;
         vuint8m2_t packed = __riscv_vle8_v_u8m2(src, byte_vl);
-        vuint8m2_t byte_index = __riscv_vid_v_u8m2(vl);
-        byte_index = __riscv_vsrl_vx_u8m2(byte_index, 1, vl);
-        vuint8m2_t bytes = __riscv_vrgather_vv_u8m2(packed, byte_index, vl);
-        vuint8m2_t lo = __riscv_vand_vx_u8m2(bytes, 0xf, vl);
-        vuint8m2_t hi = __riscv_vsrl_vx_u8m2(bytes, 4, vl);
-        vuint8m2_t lane = __riscv_vid_v_u8m2(vl);
-        vuint8m2_t parity = __riscv_vand_vx_u8m2(lane, 1, vl);
-        vbool4_t odd = __riscv_vmsne_vx_u8m2_b4(parity, 0, vl);
-        vuint8m2_t q = __riscv_vmerge_vvm_u8m2(lo, hi, odd, vl);
-        vuint32m8_t q32 = __riscv_vzext_vf4_u32m8(q, vl);
-        vfloat32m8_t result = __riscv_vfcvt_f_xu_v_f32m8(q32, vl);
+        // Widen to 32-bit lanes before gathering: with more than 256 active
+        // lanes (VLEN > 1024 for e32m8) 8-bit lane indices would wrap around
+        // and decode the wrong bytes.
+        vuint32m8_t packed32 = __riscv_vzext_vf4_u32m8(packed, byte_vl);
+        vuint32m8_t lane = __riscv_vid_v_u32m8(vl);
+        vuint32m8_t bytes = __riscv_vrgather_vv_u32m8(
+                packed32, __riscv_vsrl_vx_u32m8(lane, 1, vl), vl);
+        vuint32m8_t lo = __riscv_vand_vx_u32m8(bytes, 0xf, vl);
+        vuint32m8_t hi = __riscv_vsrl_vx_u32m8(bytes, 4, vl);
+        vuint32m8_t parity = __riscv_vand_vx_u32m8(lane, 1, vl);
+        vbool4_t odd = __riscv_vmsne_vx_u32m8_b4(parity, 0, vl);
+        vuint32m8_t q = __riscv_vmerge_vvm_u32m8(lo, hi, odd, vl);
+        vfloat32m8_t result = __riscv_vfcvt_f_xu_v_f32m8(q, vl);
         result = __riscv_vfadd_vf_f32m8(result, 0.5f, vl);
         result = __riscv_vfdiv_vf_f32m8(result, 15.0f, vl);
         return result;
@@ -226,14 +228,15 @@ struct QuantizerLloydMax<1, SIMDLevel::RISCV_RVV>
     reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {
         size_t byte_vl = (vl + 7) >> 3;
         vuint8m2_t packed = __riscv_vle8_v_u8m2(code + (i >> 3), byte_vl);
-        vuint8m2_t vid = __riscv_vid_v_u8m2(vl);
-        vuint8m2_t bytes = __riscv_vrgather_vv_u8m2(
-                packed, __riscv_vsrl_vx_u8m2(vid, 3, vl), vl);
-        vuint8m2_t shift = __riscv_vand_vx_u8m2(vid, 7, vl);
-        vuint8m2_t idx = __riscv_vand_vx_u8m2(
-                __riscv_vsrl_vv_u8m2(bytes, shift, vl), 1, vl);
-        vuint32m8_t off =
-                __riscv_vsll_vx_u32m8(__riscv_vzext_vf4_u32m8(idx, vl), 2, vl);
+        // 32-bit lane indices: 8-bit indices wrap above 256 active lanes
+        vuint32m8_t packed32 = __riscv_vzext_vf4_u32m8(packed, byte_vl);
+        vuint32m8_t vid = __riscv_vid_v_u32m8(vl);
+        vuint32m8_t bytes = __riscv_vrgather_vv_u32m8(
+                packed32, __riscv_vsrl_vx_u32m8(vid, 3, vl), vl);
+        vuint32m8_t shift = __riscv_vand_vx_u32m8(vid, 7, vl);
+        vuint32m8_t idx = __riscv_vand_vx_u32m8(
+                __riscv_vsrl_vv_u32m8(bytes, shift, vl), 1, vl);
+        vuint32m8_t off = __riscv_vsll_vx_u32m8(idx, 2, vl);
         return __riscv_vluxei32_v_f32m8(this->centroids, off, vl);
     }
 
@@ -260,15 +263,16 @@ struct QuantizerLloydMax<2, SIMDLevel::RISCV_RVV>
     reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {
         size_t byte_vl = (vl + 3) >> 2;
         vuint8m2_t packed = __riscv_vle8_v_u8m2(code + (i >> 2), byte_vl);
-        vuint8m2_t vid = __riscv_vid_v_u8m2(vl);
-        vuint8m2_t bytes = __riscv_vrgather_vv_u8m2(
-                packed, __riscv_vsrl_vx_u8m2(vid, 2, vl), vl);
-        vuint8m2_t shift =
-                __riscv_vsll_vx_u8m2(__riscv_vand_vx_u8m2(vid, 3, vl), 1, vl);
-        vuint8m2_t idx = __riscv_vand_vx_u8m2(
-                __riscv_vsrl_vv_u8m2(bytes, shift, vl), 3, vl);
-        vuint32m8_t off =
-                __riscv_vsll_vx_u32m8(__riscv_vzext_vf4_u32m8(idx, vl), 2, vl);
+        // 32-bit lane indices: 8-bit indices wrap above 256 active lanes
+        vuint32m8_t packed32 = __riscv_vzext_vf4_u32m8(packed, byte_vl);
+        vuint32m8_t vid = __riscv_vid_v_u32m8(vl);
+        vuint32m8_t bytes = __riscv_vrgather_vv_u32m8(
+                packed32, __riscv_vsrl_vx_u32m8(vid, 2, vl), vl);
+        vuint32m8_t shift =
+                __riscv_vsll_vx_u32m8(__riscv_vand_vx_u32m8(vid, 3, vl), 1, vl);
+        vuint32m8_t idx = __riscv_vand_vx_u32m8(
+                __riscv_vsrl_vv_u32m8(bytes, shift, vl), 3, vl);
+        vuint32m8_t off = __riscv_vsll_vx_u32m8(idx, 2, vl);
         return __riscv_vluxei32_v_f32m8(this->centroids, off, vl);
     }
 
@@ -339,16 +343,17 @@ struct QuantizerLloydMax<4, SIMDLevel::RISCV_RVV>
     reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {
         size_t byte_vl = (vl + 1) >> 1;
         vuint8m2_t packed = __riscv_vle8_v_u8m2(code + (i >> 1), byte_vl);
-        vuint8m2_t vid = __riscv_vid_v_u8m2(vl);
-        vuint8m2_t bytes = __riscv_vrgather_vv_u8m2(
-                packed, __riscv_vsrl_vx_u8m2(vid, 1, vl), vl);
-        vuint8m2_t lo = __riscv_vand_vx_u8m2(bytes, 0xf, vl);
-        vuint8m2_t hi = __riscv_vsrl_vx_u8m2(bytes, 4, vl);
-        vbool4_t odd = __riscv_vmsne_vx_u8m2_b4(
-                __riscv_vand_vx_u8m2(vid, 1, vl), 0, vl);
-        vuint8m2_t idx = __riscv_vmerge_vvm_u8m2(lo, hi, odd, vl);
-        vuint32m8_t off =
-                __riscv_vsll_vx_u32m8(__riscv_vzext_vf4_u32m8(idx, vl), 2, vl);
+        // 32-bit lane indices: 8-bit indices wrap above 256 active lanes
+        vuint32m8_t packed32 = __riscv_vzext_vf4_u32m8(packed, byte_vl);
+        vuint32m8_t vid = __riscv_vid_v_u32m8(vl);
+        vuint32m8_t bytes = __riscv_vrgather_vv_u32m8(
+                packed32, __riscv_vsrl_vx_u32m8(vid, 1, vl), vl);
+        vuint32m8_t lo = __riscv_vand_vx_u32m8(bytes, 0xf, vl);
+        vuint32m8_t hi = __riscv_vsrl_vx_u32m8(bytes, 4, vl);
+        vbool4_t odd = __riscv_vmsne_vx_u32m8_b4(
+                __riscv_vand_vx_u32m8(vid, 1, vl), 0, vl);
+        vuint32m8_t idx = __riscv_vmerge_vvm_u32m8(lo, hi, odd, vl);
+        vuint32m8_t off = __riscv_vsll_vx_u32m8(idx, 2, vl);
         return __riscv_vluxei32_v_f32m8(this->centroids, off, vl);
     }
 

--- a/faiss/impl/scalar_quantizer/sq-rvv.cpp
+++ b/faiss/impl/scalar_quantizer/sq-rvv.cpp
@@ -467,14 +467,12 @@ struct SimilarityIP<SIMDLevel::RISCV_RVV> : SimilarityIP<SIMDLevel::NONE> {
 template <class Quantizer>
 inline constexpr bool has_reconstruct_m8_v =
         requires(const Quantizer& q, const uint8_t* code, size_t i, size_t vl) {
-    q.reconstruct_m8_components(code, i, vl);
-};
+            q.reconstruct_m8_components(code, i, vl);
+        };
 
 template <class Quantizer, class Similarity>
-requires(!has_reconstruct_m8_v<Quantizer>) struct DCTemplate<
-        Quantizer,
-        Similarity,
-        SIMDLevel::RISCV_RVV>
+    requires(!has_reconstruct_m8_v<Quantizer>)
+struct DCTemplate<Quantizer, Similarity, SIMDLevel::RISCV_RVV>
         : DCTemplate<Quantizer, Similarity, SIMDLevel::NONE> {
     using Base = DCTemplate<Quantizer, Similarity, SIMDLevel::NONE>;
     using Base::Base;
@@ -488,10 +486,9 @@ struct DistanceComputerByte<Similarity, SIMDLevel::RISCV_RVV>
 };
 
 template <class Quantizer, class Similarity>
-requires(has_reconstruct_m8_v<Quantizer>) struct DCTemplate<
-        Quantizer,
-        Similarity,
-        SIMDLevel::RISCV_RVV> : SQDistanceComputer {
+    requires(has_reconstruct_m8_v<Quantizer>)
+struct DCTemplate<Quantizer, Similarity, SIMDLevel::RISCV_RVV>
+        : SQDistanceComputer {
     using Sim = Similarity;
 
     Quantizer quant;

--- a/faiss/impl/scalar_quantizer/sq-rvv.cpp
+++ b/faiss/impl/scalar_quantizer/sq-rvv.cpp
@@ -20,34 +20,93 @@ namespace faiss {
 
 namespace scalar_quantizer {
 
-/*************************************************************************
- * Marker specializations.
- *
- * Unlike x86/NEON sq-*.cpp files that expose a fixed 8-wide / 16-wide codec
- * interface (reconstruct_8_components / reconstruct_16_components), RVV is
- * variable-width: the native vector length is implementation-defined and
- * queried at runtime via __riscv_vsetvl. Forcing RVV into a fixed-width
- * codec would leave performance on the table on wider hardware.
- *
- * So the strategy here is: Codec / Quantizer / Similarity classes for
- * RISCV_RVV act as opaque TAG TYPES — they only need to be complete types
- * so that baseline's sq-dispatch.h can form template arguments like
- * `DCTemplate<QuantizerTemplate<Codec4bit<RISCV_RVV>, UNIFORM, RISCV_RVV>,
- *             SimilarityL2<RISCV_RVV>, RISCV_RVV>`.
- *
- * The real SIMD work lives in full DCTemplate specializations below.
- * Unspecialized combinations fall through to scalar via the fallback
- * `DCTemplate<Q, Sim, RISCV_RVV> : DCTemplate<Q, Sim, NONE>`.
- ************************************************************************/
+template <>
+struct Codec8bit<SIMDLevel::RISCV_RVV> : Codec8bit<SIMDLevel::NONE> {
+    static FAISS_ALWAYS_INLINE vfloat32m8_t
+    decode_m8_components(const uint8_t* code, size_t i, size_t vl) {
+        vuint8m2_t vu8 = __riscv_vle8_v_u8m2(code + i, vl);
+        vuint32m8_t vu32 = __riscv_vzext_vf4_u32m8(vu8, vl);
+        vfloat32m8_t vf32 = __riscv_vfcvt_f_xu_v_f32m8(vu32, vl);
+        vf32 = __riscv_vfadd_vf_f32m8(vf32, 0.5f, vl);
+        vf32 = __riscv_vfdiv_vf_f32m8(vf32, 255.0f, vl);
+        return vf32;
+    }
+};
 
 template <>
-struct Codec8bit<SIMDLevel::RISCV_RVV> : Codec8bit<SIMDLevel::NONE> {};
+struct Codec4bit<SIMDLevel::RISCV_RVV> : Codec4bit<SIMDLevel::NONE> {
+    static FAISS_ALWAYS_INLINE vfloat32m8_t
+    decode_m8_components(const uint8_t* code, size_t i, size_t vl) {
+        const uint8_t* src = code + (i >> 1);
+        size_t byte_vl = (vl + 1) >> 1;
+        vuint8m2_t packed = __riscv_vle8_v_u8m2(src, byte_vl);
+        vuint8m2_t byte_index = __riscv_vid_v_u8m2(vl);
+        byte_index = __riscv_vsrl_vx_u8m2(byte_index, 1, vl);
+        vuint8m2_t bytes = __riscv_vrgather_vv_u8m2(packed, byte_index, vl);
+        vuint8m2_t lo = __riscv_vand_vx_u8m2(bytes, 0xf, vl);
+        vuint8m2_t hi = __riscv_vsrl_vx_u8m2(bytes, 4, vl);
+        vuint8m2_t lane = __riscv_vid_v_u8m2(vl);
+        vuint8m2_t parity = __riscv_vand_vx_u8m2(lane, 1, vl);
+        vbool4_t odd = __riscv_vmsne_vx_u8m2_b4(parity, 0, vl);
+        vuint8m2_t q = __riscv_vmerge_vvm_u8m2(lo, hi, odd, vl);
+        vuint32m8_t q32 = __riscv_vzext_vf4_u32m8(q, vl);
+        vfloat32m8_t result = __riscv_vfcvt_f_xu_v_f32m8(q32, vl);
+        result = __riscv_vfadd_vf_f32m8(result, 0.5f, vl);
+        result = __riscv_vfdiv_vf_f32m8(result, 15.0f, vl);
+        return result;
+    }
+};
 
 template <>
-struct Codec4bit<SIMDLevel::RISCV_RVV> : Codec4bit<SIMDLevel::NONE> {};
-
-template <>
-struct Codec6bit<SIMDLevel::RISCV_RVV> : Codec6bit<SIMDLevel::NONE> {};
+struct Codec6bit<SIMDLevel::RISCV_RVV> : Codec6bit<SIMDLevel::NONE> {
+    static FAISS_ALWAYS_INLINE vfloat32m8_t
+    decode_m8_components(const uint8_t* code, size_t i, size_t vl) {
+        size_t last = i + vl - 1;
+        size_t last_used = 3 * (last >> 2) + ((last & 3) < 2 ? (last & 3) : 2);
+        vuint32m8_t idx = __riscv_vid_v_u32m8(vl);
+        idx = __riscv_vadd_vx_u32m8(idx, i, vl);
+        vuint32m8_t block = __riscv_vsrl_vx_u32m8(idx, 2, vl);
+        vuint32m8_t lane = __riscv_vand_vx_u32m8(idx, 3, vl);
+        vuint32m8_t base = __riscv_vadd_vv_u32m8(block, block, vl);
+        base = __riscv_vadd_vv_u32m8(base, block, vl);
+        vuint8m2_t b0 = __riscv_vluxei32_v_u8m2(code, base, vl);
+        vuint8m2_t b1 = __riscv_vluxei32_v_u8m2(
+                code,
+                __riscv_vminu_vx_u32m8(
+                        __riscv_vadd_vx_u32m8(base, 1, vl), last_used, vl),
+                vl);
+        vuint8m2_t b2 = __riscv_vluxei32_v_u8m2(
+                code,
+                __riscv_vminu_vx_u32m8(
+                        __riscv_vadd_vx_u32m8(base, 2, vl), last_used, vl),
+                vl);
+        vuint32m8_t wb0 = __riscv_vzext_vf4_u32m8(b0, vl);
+        vuint32m8_t wb1 = __riscv_vzext_vf4_u32m8(b1, vl);
+        vuint32m8_t wb2 = __riscv_vzext_vf4_u32m8(b2, vl);
+        vuint32m8_t x0 = __riscv_vand_vx_u32m8(wb0, 0x3f, vl);
+        vuint32m8_t x1 = __riscv_vor_vv_u32m8(
+                __riscv_vsrl_vx_u32m8(wb0, 6, vl),
+                __riscv_vsll_vx_u32m8(
+                        __riscv_vand_vx_u32m8(wb1, 0xf, vl), 2, vl),
+                vl);
+        vuint32m8_t x2 = __riscv_vor_vv_u32m8(
+                __riscv_vsrl_vx_u32m8(wb1, 4, vl),
+                __riscv_vsll_vx_u32m8(__riscv_vand_vx_u32m8(wb2, 3, vl), 4, vl),
+                vl);
+        vuint32m8_t x3 = __riscv_vsrl_vx_u32m8(wb2, 2, vl);
+        vbool4_t m0 = __riscv_vmseq_vx_u32m8_b4(lane, 0, vl);
+        vbool4_t m1 = __riscv_vmseq_vx_u32m8_b4(lane, 1, vl);
+        vbool4_t m2 = __riscv_vmseq_vx_u32m8_b4(lane, 2, vl);
+        vuint32m8_t bits = x3;
+        bits = __riscv_vmerge_vvm_u32m8(bits, x2, m2, vl);
+        bits = __riscv_vmerge_vvm_u32m8(bits, x1, m1, vl);
+        bits = __riscv_vmerge_vvm_u32m8(bits, x0, m0, vl);
+        vfloat32m8_t out = __riscv_vfcvt_f_xu_v_f32m8(bits, vl);
+        out = __riscv_vfadd_vf_f32m8(out, 0.5f, vl);
+        out = __riscv_vfdiv_vf_f32m8(out, 63.0f, vl);
+        return out;
+    }
+};
 
 template <class Codec>
 struct QuantizerTemplate<
@@ -63,6 +122,13 @@ struct QuantizerTemplate<
                       Codec,
                       QuantizerTemplateScaling::UNIFORM,
                       SIMDLevel::NONE>(d, trained) {}
+
+    FAISS_ALWAYS_INLINE vfloat32m8_t
+    reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {
+        vfloat32m8_t xi = Codec::decode_m8_components(code, i, vl);
+        return __riscv_vfadd_vf_f32m8(
+                __riscv_vfmul_vf_f32m8(xi, this->vdiff, vl), this->vmin, vl);
+    }
 };
 
 template <class Codec>
@@ -79,18 +145,44 @@ struct QuantizerTemplate<
                       Codec,
                       QuantizerTemplateScaling::NON_UNIFORM,
                       SIMDLevel::NONE>(d, trained) {}
+
+    FAISS_ALWAYS_INLINE vfloat32m8_t
+    reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {
+        vfloat32m8_t xi = Codec::decode_m8_components(code, i, vl);
+        vfloat32m8_t vminv = __riscv_vle32_v_f32m8(this->vmin + i, vl);
+        vfloat32m8_t vdiffv = __riscv_vle32_v_f32m8(this->vdiff + i, vl);
+        return __riscv_vfmadd_vv_f32m8(xi, vdiffv, vminv, vl);
+    }
 };
 
 template <>
 struct QuantizerFP16<SIMDLevel::RISCV_RVV> : QuantizerFP16<SIMDLevel::NONE> {
     QuantizerFP16(size_t d, const std::vector<float>& trained)
             : QuantizerFP16<SIMDLevel::NONE>(d, trained) {}
+
+#if defined(__riscv_zvfhmin) || defined(__riscv_zvfh)
+    FAISS_ALWAYS_INLINE vfloat32m8_t
+    reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {
+        vfloat16m4_t vh =
+                __riscv_vle16_v_f16m4((const _Float16*)(code + 2 * i), vl);
+        return __riscv_vfwcvt_f_f_v_f32m8(vh, vl);
+    }
+#endif
 };
 
 template <>
 struct QuantizerBF16<SIMDLevel::RISCV_RVV> : QuantizerBF16<SIMDLevel::NONE> {
     QuantizerBF16(size_t d, const std::vector<float>& trained)
             : QuantizerBF16<SIMDLevel::NONE>(d, trained) {}
+
+    FAISS_ALWAYS_INLINE vfloat32m8_t
+    reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {
+        vuint16m4_t v16 =
+                __riscv_vle16_v_u16m4((const uint16_t*)(code + 2 * i), vl);
+        vuint32m8_t v32 = __riscv_vzext_vf2_u32m8(v16, vl);
+        v32 = __riscv_vsll_vx_u32m8(v32, 16, vl);
+        return __riscv_vreinterpret_v_u32m8_f32m8(v32);
+    }
 };
 
 template <>
@@ -98,6 +190,13 @@ struct Quantizer8bitDirect<SIMDLevel::RISCV_RVV>
         : Quantizer8bitDirect<SIMDLevel::NONE> {
     Quantizer8bitDirect(size_t d, const std::vector<float>& trained)
             : Quantizer8bitDirect<SIMDLevel::NONE>(d, trained) {}
+
+    FAISS_ALWAYS_INLINE vfloat32m8_t
+    reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {
+        vuint8m2_t vu8 = __riscv_vle8_v_u8m2(code + i, vl);
+        vuint32m8_t vu32 = __riscv_vzext_vf4_u32m8(vu8, vl);
+        return __riscv_vfcvt_f_xu_v_f32m8(vu32, vl);
+    }
 };
 
 template <>
@@ -105,28 +204,277 @@ struct Quantizer8bitDirectSigned<SIMDLevel::RISCV_RVV>
         : Quantizer8bitDirectSigned<SIMDLevel::NONE> {
     Quantizer8bitDirectSigned(size_t d, const std::vector<float>& trained)
             : Quantizer8bitDirectSigned<SIMDLevel::NONE>(d, trained) {}
+
+    FAISS_ALWAYS_INLINE vfloat32m8_t
+    reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {
+        vuint8m2_t vu8 = __riscv_vle8_v_u8m2(code + i, vl);
+        vuint32m8_t vu32 = __riscv_vzext_vf4_u32m8(vu8, vl);
+        vfloat32m8_t vf = __riscv_vfcvt_f_xu_v_f32m8(vu32, vl);
+        return __riscv_vfsub_vf_f32m8(vf, 128.0f, vl);
+    }
+};
+
+template <>
+struct QuantizerLloydMax<1, SIMDLevel::RISCV_RVV>
+        : QuantizerLloydMax<1, SIMDLevel::NONE> {
+    using Base = QuantizerLloydMax<1, SIMDLevel::NONE>;
+
+    QuantizerLloydMax(size_t d, const std::vector<float>& trained)
+            : Base(d, trained) {}
+
+    FAISS_ALWAYS_INLINE vfloat32m8_t
+    reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {
+        size_t byte_vl = (vl + 7) >> 3;
+        vuint8m2_t packed = __riscv_vle8_v_u8m2(code + (i >> 3), byte_vl);
+        vuint8m2_t vid = __riscv_vid_v_u8m2(vl);
+        vuint8m2_t bytes = __riscv_vrgather_vv_u8m2(
+                packed, __riscv_vsrl_vx_u8m2(vid, 3, vl), vl);
+        vuint8m2_t shift = __riscv_vand_vx_u8m2(vid, 7, vl);
+        vuint8m2_t idx = __riscv_vand_vx_u8m2(
+                __riscv_vsrl_vv_u8m2(bytes, shift, vl), 1, vl);
+        vuint32m8_t off =
+                __riscv_vsll_vx_u32m8(__riscv_vzext_vf4_u32m8(idx, vl), 2, vl);
+        return __riscv_vluxei32_v_f32m8(this->centroids, off, vl);
+    }
+
+    void decode_vector(const uint8_t* code, float* x) const final {
+        size_t i = 0;
+        while (i < this->d) {
+            size_t vl = __riscv_vsetvl_e32m8(this->d - i);
+            vfloat32m8_t v = reconstruct_m8_components(code, i, vl);
+            __riscv_vse32_v_f32m8(x + i, v, vl);
+            i += vl;
+        }
+    }
+};
+
+template <>
+struct QuantizerLloydMax<2, SIMDLevel::RISCV_RVV>
+        : QuantizerLloydMax<2, SIMDLevel::NONE> {
+    using Base = QuantizerLloydMax<2, SIMDLevel::NONE>;
+
+    QuantizerLloydMax(size_t d, const std::vector<float>& trained)
+            : Base(d, trained) {}
+
+    FAISS_ALWAYS_INLINE vfloat32m8_t
+    reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {
+        size_t byte_vl = (vl + 3) >> 2;
+        vuint8m2_t packed = __riscv_vle8_v_u8m2(code + (i >> 2), byte_vl);
+        vuint8m2_t vid = __riscv_vid_v_u8m2(vl);
+        vuint8m2_t bytes = __riscv_vrgather_vv_u8m2(
+                packed, __riscv_vsrl_vx_u8m2(vid, 2, vl), vl);
+        vuint8m2_t shift =
+                __riscv_vsll_vx_u8m2(__riscv_vand_vx_u8m2(vid, 3, vl), 1, vl);
+        vuint8m2_t idx = __riscv_vand_vx_u8m2(
+                __riscv_vsrl_vv_u8m2(bytes, shift, vl), 3, vl);
+        vuint32m8_t off =
+                __riscv_vsll_vx_u32m8(__riscv_vzext_vf4_u32m8(idx, vl), 2, vl);
+        return __riscv_vluxei32_v_f32m8(this->centroids, off, vl);
+    }
+
+    void decode_vector(const uint8_t* code, float* x) const final {
+        size_t i = 0;
+        while (i < this->d) {
+            size_t vl = __riscv_vsetvl_e32m8(this->d - i);
+            vfloat32m8_t v = reconstruct_m8_components(code, i, vl);
+            __riscv_vse32_v_f32m8(x + i, v, vl);
+            i += vl;
+        }
+    }
+};
+
+template <>
+struct QuantizerLloydMax<3, SIMDLevel::RISCV_RVV>
+        : QuantizerLloydMax<3, SIMDLevel::NONE> {
+    using Base = QuantizerLloydMax<3, SIMDLevel::NONE>;
+
+    QuantizerLloydMax(size_t d, const std::vector<float>& trained)
+            : Base(d, trained) {}
+
+    FAISS_ALWAYS_INLINE vfloat32m8_t
+    reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {
+        vuint32m8_t idx0 =
+                __riscv_vadd_vx_u32m8(__riscv_vid_v_u32m8(vl), i, vl);
+        vuint32m8_t bitpos = __riscv_vmul_vx_u32m8(idx0, 3, vl);
+        vuint32m8_t byteoff = __riscv_vsrl_vx_u32m8(bitpos, 3, vl);
+        vuint32m8_t shift = __riscv_vand_vx_u32m8(bitpos, 7, vl);
+        size_t last = i + vl - 1;
+        size_t last_used = (3 * last + 2) >> 3;
+        vuint8m2_t lo = __riscv_vluxei32_v_u8m2(code, byteoff, vl);
+        vuint8m2_t hi = __riscv_vluxei32_v_u8m2(
+                code,
+                __riscv_vminu_vx_u32m8(
+                        __riscv_vadd_vx_u32m8(byteoff, 1, vl), last_used, vl),
+                vl);
+        vuint32m8_t w = __riscv_vor_vv_u32m8(
+                __riscv_vzext_vf4_u32m8(lo, vl),
+                __riscv_vsll_vx_u32m8(__riscv_vzext_vf4_u32m8(hi, vl), 8, vl),
+                vl);
+        vuint32m8_t idx = __riscv_vand_vx_u32m8(
+                __riscv_vsrl_vv_u32m8(w, shift, vl), 7, vl);
+        vuint32m8_t off = __riscv_vsll_vx_u32m8(idx, 2, vl);
+        return __riscv_vluxei32_v_f32m8(this->centroids, off, vl);
+    }
+
+    void decode_vector(const uint8_t* code, float* x) const final {
+        size_t i = 0;
+        while (i < this->d) {
+            size_t vl = __riscv_vsetvl_e32m8(this->d - i);
+            vfloat32m8_t v = reconstruct_m8_components(code, i, vl);
+            __riscv_vse32_v_f32m8(x + i, v, vl);
+            i += vl;
+        }
+    }
+};
+
+template <>
+struct QuantizerLloydMax<4, SIMDLevel::RISCV_RVV>
+        : QuantizerLloydMax<4, SIMDLevel::NONE> {
+    using Base = QuantizerLloydMax<4, SIMDLevel::NONE>;
+
+    QuantizerLloydMax(size_t d, const std::vector<float>& trained)
+            : Base(d, trained) {}
+
+    FAISS_ALWAYS_INLINE vfloat32m8_t
+    reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {
+        size_t byte_vl = (vl + 1) >> 1;
+        vuint8m2_t packed = __riscv_vle8_v_u8m2(code + (i >> 1), byte_vl);
+        vuint8m2_t vid = __riscv_vid_v_u8m2(vl);
+        vuint8m2_t bytes = __riscv_vrgather_vv_u8m2(
+                packed, __riscv_vsrl_vx_u8m2(vid, 1, vl), vl);
+        vuint8m2_t lo = __riscv_vand_vx_u8m2(bytes, 0xf, vl);
+        vuint8m2_t hi = __riscv_vsrl_vx_u8m2(bytes, 4, vl);
+        vbool4_t odd = __riscv_vmsne_vx_u8m2_b4(
+                __riscv_vand_vx_u8m2(vid, 1, vl), 0, vl);
+        vuint8m2_t idx = __riscv_vmerge_vvm_u8m2(lo, hi, odd, vl);
+        vuint32m8_t off =
+                __riscv_vsll_vx_u32m8(__riscv_vzext_vf4_u32m8(idx, vl), 2, vl);
+        return __riscv_vluxei32_v_f32m8(this->centroids, off, vl);
+    }
+
+    void decode_vector(const uint8_t* code, float* x) const final {
+        size_t i = 0;
+        while (i < this->d) {
+            size_t vl = __riscv_vsetvl_e32m8(this->d - i);
+            vfloat32m8_t v = reconstruct_m8_components(code, i, vl);
+            __riscv_vse32_v_f32m8(x + i, v, vl);
+            i += vl;
+        }
+    }
+};
+
+template <>
+struct QuantizerLloydMax<8, SIMDLevel::RISCV_RVV>
+        : QuantizerLloydMax<8, SIMDLevel::NONE> {
+    using Base = QuantizerLloydMax<8, SIMDLevel::NONE>;
+
+    QuantizerLloydMax(size_t d, const std::vector<float>& trained)
+            : Base(d, trained) {}
+
+    FAISS_ALWAYS_INLINE vfloat32m8_t
+    reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {
+        vuint8m2_t vb = __riscv_vle8_v_u8m2(code + i, vl);
+        vuint32m8_t off =
+                __riscv_vsll_vx_u32m8(__riscv_vzext_vf4_u32m8(vb, vl), 2, vl);
+        return __riscv_vluxei32_v_f32m8(this->centroids, off, vl);
+    }
+
+    void decode_vector(const uint8_t* code, float* x) const final {
+        size_t i = 0;
+        while (i < this->d) {
+            size_t vl = __riscv_vsetvl_e32m8(this->d - i);
+            vfloat32m8_t v = reconstruct_m8_components(code, i, vl);
+            __riscv_vse32_v_f32m8(x + i, v, vl);
+            i += vl;
+        }
+    }
 };
 
 template <>
 struct SimilarityL2<SIMDLevel::RISCV_RVV> : SimilarityL2<SIMDLevel::NONE> {
     using SimilarityL2<SIMDLevel::NONE>::SimilarityL2;
+
+    static constexpr SIMDLevel simd_level = SIMDLevel::RISCV_RVV;
+
+    FAISS_ALWAYS_INLINE void begin_m8() {
+        yi = y;
+    }
+
+    static FAISS_ALWAYS_INLINE vfloat32m8_t zero_m8(size_t vl) {
+        return __riscv_vfmv_v_f_f32m8(0.0f, vl);
+    }
+
+    FAISS_ALWAYS_INLINE vfloat32m8_t
+    add_m8_components(vfloat32m8_t accu, vfloat32m8_t x, size_t vl) {
+        vfloat32m8_t yiv = __riscv_vle32_v_f32m8(yi, vl);
+        yi += vl;
+        vfloat32m8_t tmp = __riscv_vfsub_vv_f32m8(yiv, x, vl);
+        return __riscv_vfmacc_vv_f32m8(accu, tmp, tmp, vl);
+    }
+
+    static FAISS_ALWAYS_INLINE vfloat32m8_t add_m8_components_2(
+            vfloat32m8_t accu,
+            vfloat32m8_t x,
+            vfloat32m8_t y_2,
+            size_t vl) {
+        vfloat32m8_t tmp = __riscv_vfsub_vv_f32m8(y_2, x, vl);
+        return __riscv_vfmacc_vv_f32m8(accu, tmp, tmp, vl);
+    }
+
+    static FAISS_ALWAYS_INLINE float result_m8(vfloat32m8_t accu, size_t vl) {
+        vfloat32m1_t zero = __riscv_vfmv_v_f_f32m1(0.0f, 1);
+        vfloat32m1_t sum = __riscv_vfredusum_vs_f32m8_f32m1(accu, zero, vl);
+        return __riscv_vfmv_f_s_f32m1_f32(sum);
+    }
 };
 
 template <>
 struct SimilarityIP<SIMDLevel::RISCV_RVV> : SimilarityIP<SIMDLevel::NONE> {
     using SimilarityIP<SIMDLevel::NONE>::SimilarityIP;
+
+    static constexpr SIMDLevel simd_level = SIMDLevel::RISCV_RVV;
+
+    FAISS_ALWAYS_INLINE void begin_m8() {
+        yi = y;
+    }
+
+    static FAISS_ALWAYS_INLINE vfloat32m8_t zero_m8(size_t vl) {
+        return __riscv_vfmv_v_f_f32m8(0.0f, vl);
+    }
+
+    FAISS_ALWAYS_INLINE vfloat32m8_t
+    add_m8_components(vfloat32m8_t accu, vfloat32m8_t x, size_t vl) {
+        vfloat32m8_t yiv = __riscv_vle32_v_f32m8(yi, vl);
+        yi += vl;
+        return __riscv_vfmacc_vv_f32m8(accu, yiv, x, vl);
+    }
+
+    static FAISS_ALWAYS_INLINE vfloat32m8_t add_m8_components_2(
+            vfloat32m8_t accu,
+            vfloat32m8_t x1,
+            vfloat32m8_t x2,
+            size_t vl) {
+        return __riscv_vfmacc_vv_f32m8(accu, x1, x2, vl);
+    }
+
+    static FAISS_ALWAYS_INLINE float result_m8(vfloat32m8_t accu, size_t vl) {
+        vfloat32m1_t zero = __riscv_vfmv_v_f_f32m1(0.0f, 1);
+        vfloat32m1_t sum = __riscv_vfredusum_vs_f32m8_f32m1(accu, zero, vl);
+        return __riscv_vfmv_f_s_f32m1_f32(sum);
+    }
 };
 
-/*************************************************************************
- * Fallback DCTemplate / DistanceComputerByte for RISCV_RVV.
- *
- * Inheriting from the NONE specialization means every (Quantizer, Similarity)
- * combination that does NOT have a hand-tuned RVV full specialization below
- * falls through to scalar code. Callers and the dispatcher don't know or care.
- ************************************************************************/
+template <class Quantizer>
+inline constexpr bool has_reconstruct_m8_v =
+        requires(const Quantizer& q, const uint8_t* code, size_t i, size_t vl) {
+    q.reconstruct_m8_components(code, i, vl);
+};
 
 template <class Quantizer, class Similarity>
-struct DCTemplate<Quantizer, Similarity, SIMDLevel::RISCV_RVV>
+requires(!has_reconstruct_m8_v<Quantizer>) struct DCTemplate<
+        Quantizer,
+        Similarity,
+        SIMDLevel::RISCV_RVV>
         : DCTemplate<Quantizer, Similarity, SIMDLevel::NONE> {
     using Base = DCTemplate<Quantizer, Similarity, SIMDLevel::NONE>;
     using Base::Base;
@@ -139,149 +487,61 @@ struct DistanceComputerByte<Similarity, SIMDLevel::RISCV_RVV>
     using Base::Base;
 };
 
-/*************************************************************************
- * Fast path — QT_4bit_uniform + L2
- *
- * 4-bit UNIFORM scaling: every component reconstructs as an affine function
- * of the 4-bit code,
- *     recon(c) = vmin + vdiff * (c + 0.5) / 15 = final_scale * c + bias
- * where final_scale = vdiff / 15. L2 distance between two reconstructions
- * therefore reduces to final_scale^2 * (q_c - c_c)^2 over integer codes,
- * so we can stay in the int domain and pay one float multiply at the end.
- *
- * The RVV path pre-nibbles the query into q_lo / q_hi (even / odd lanes)
- * once at set_query time and then processes native-VL-sized chunks of code
- * without ever decoding to float.
- ************************************************************************/
-
-template <>
-struct DCTemplate<
-        QuantizerTemplate<
-                Codec4bit<SIMDLevel::RISCV_RVV>,
-                QuantizerTemplateScaling::UNIFORM,
-                SIMDLevel::RISCV_RVV>,
-        SimilarityL2<SIMDLevel::RISCV_RVV>,
+template <class Quantizer, class Similarity>
+requires(has_reconstruct_m8_v<Quantizer>) struct DCTemplate<
+        Quantizer,
+        Similarity,
         SIMDLevel::RISCV_RVV> : SQDistanceComputer {
-    using Sim = SimilarityL2<SIMDLevel::RISCV_RVV>;
+    using Sim = Similarity;
 
-    size_t d;
-    float vmin;
-    float vdiff;
-    float final_scale_sq;
-    std::vector<uint8_t> q_lo;
-    std::vector<uint8_t> q_hi;
+    Quantizer quant;
 
-    DCTemplate(size_t d_in, const std::vector<float>& trained)
-            : d(d_in),
-              vmin(trained[0]),
-              vdiff(trained[1]),
-              q_lo((d_in + 1) / 2, 0),
-              q_hi((d_in + 1) / 2, 0) {
-        const float final_scale = vdiff / 15.0f;
-        final_scale_sq = final_scale * final_scale;
+    DCTemplate(size_t d, const std::vector<float>& trained)
+            : quant(d, trained) {}
+
+    float compute_distance(const float* x, const uint8_t* code) const {
+        Similarity sim(x);
+        sim.begin_m8();
+        const size_t first_vl = __riscv_vsetvl_e32m8(quant.d);
+        vfloat32m8_t accu = Sim::zero_m8(first_vl);
+        size_t i = 0;
+        while (i < quant.d) {
+            size_t vl = __riscv_vsetvl_e32m8(quant.d - i);
+            vfloat32m8_t xi = quant.reconstruct_m8_components(code, i, vl);
+            accu = sim.add_m8_components(accu, xi, vl);
+            i += vl;
+        }
+        return Sim::result_m8(accu, first_vl);
+    }
+
+    float compute_code_distance(const uint8_t* code1, const uint8_t* code2)
+            const {
+        Similarity sim(nullptr);
+        sim.begin_m8();
+        const size_t first_vl = __riscv_vsetvl_e32m8(quant.d);
+        vfloat32m8_t accu = Sim::zero_m8(first_vl);
+        size_t i = 0;
+        while (i < quant.d) {
+            size_t vl = __riscv_vsetvl_e32m8(quant.d - i);
+            vfloat32m8_t x1 = quant.reconstruct_m8_components(code1, i, vl);
+            vfloat32m8_t x2 = quant.reconstruct_m8_components(code2, i, vl);
+            accu = Sim::add_m8_components_2(accu, x1, x2, vl);
+            i += vl;
+        }
+        return Sim::result_m8(accu, first_vl);
     }
 
     void set_query(const float* x) final {
-        this->q = x;
-        const float inv_scale = (vdiff == 0.0f) ? 0.0f : 15.0f / vdiff;
-        for (size_t i = 0; i < d; i++) {
-            float val = (x[i] - vmin) * inv_scale;
-            int code = static_cast<int>(val);
-            if (code < 0) {
-                code = 0;
-            }
-            if (code > 15) {
-                code = 15;
-            }
-            if (i % 2 == 0) {
-                q_lo[i / 2] = static_cast<uint8_t>(code);
-            } else {
-                q_hi[i / 2] = static_cast<uint8_t>(code);
-            }
-        }
-    }
-
-    /// Squared integer-domain L2 between pre-nibbled q and packed 4-bit code.
-    /// Uses RVV's native VL; no fixed width assumptions. Returns the raw
-    /// integer sum — caller multiplies by final_scale_sq.
-    int64_t accumulate_int_l2(const uint8_t* code) const {
-        int64_t acc = 0;
-        size_t i = 0;
-        while (i < d) {
-            // Process up to vl codes per iteration. Each code byte packs two
-            // 4-bit codes, so we load (vl + 1) / 2 bytes; keep vl even to
-            // keep the nibble split aligned with the i % 2 split we used at
-            // set_query time.
-            size_t remaining = d - i;
-            size_t vl = __riscv_vsetvl_e8m1(remaining);
-            if (vl & 1) {
-                vl -= 1; // keep even; tail handled on next iter or scalar
-            }
-            if (vl == 0) {
-                break;
-            }
-            const size_t byte_vl = vl / 2;
-
-            vuint8m1_t packed = __riscv_vle8_v_u8m1(code + i / 2, byte_vl);
-            vuint8m1_t ql = __riscv_vle8_v_u8m1(q_lo.data() + i / 2, byte_vl);
-            vuint8m1_t qh = __riscv_vle8_v_u8m1(q_hi.data() + i / 2, byte_vl);
-
-            vuint8m1_t lo_nib = __riscv_vand_vx_u8m1(packed, 0x0F, byte_vl);
-            vuint8m1_t hi_nib = __riscv_vsrl_vx_u8m1(packed, 4, byte_vl);
-
-            // |ql - lo| and |qh - hi| fit in u8 (values are in [0, 15]).
-            vuint8m1_t d_lo = __riscv_vsub_vv_u8m1(
-                    __riscv_vmaxu_vv_u8m1(ql, lo_nib, byte_vl),
-                    __riscv_vminu_vv_u8m1(ql, lo_nib, byte_vl),
-                    byte_vl);
-            vuint8m1_t d_hi = __riscv_vsub_vv_u8m1(
-                    __riscv_vmaxu_vv_u8m1(qh, hi_nib, byte_vl),
-                    __riscv_vminu_vv_u8m1(qh, hi_nib, byte_vl),
-                    byte_vl);
-
-            // Square via widening multiply (each byte squared fits in u16,
-            // since max byte value is 15 -> 225).
-            vuint16m2_t sq_lo = __riscv_vwmulu_vv_u16m2(d_lo, d_lo, byte_vl);
-            vuint16m2_t sq_hi = __riscv_vwmulu_vv_u16m2(d_hi, d_hi, byte_vl);
-            vuint16m2_t sq_sum = __riscv_vadd_vv_u16m2(sq_lo, sq_hi, byte_vl);
-
-            // Reduce to a scalar u32 (safe: byte_vl * 450 fits in u32 for
-            // any realistic d).
-            vuint32m1_t zero = __riscv_vmv_v_x_u32m1(0, 1);
-            vuint32m1_t red =
-                    __riscv_vwredsumu_vs_u16m2_u32m1(sq_sum, zero, byte_vl);
-            acc += __riscv_vmv_x_s_u32m1_u32(red);
-
-            i += vl;
-        }
-        // Scalar tail: cover any leftover odd lane (at most one).
-        for (; i < d; i++) {
-            uint8_t c_code =
-                    (i % 2 == 0) ? (code[i / 2] & 0x0F) : (code[i / 2] >> 4);
-            uint8_t q_code = (i % 2 == 0) ? q_lo[i / 2] : q_hi[i / 2];
-            int diff = int(q_code) - int(c_code);
-            acc += diff * diff;
-        }
-        return acc;
-    }
-
-    float query_to_code(const uint8_t* code) const final {
-        return static_cast<float>(accumulate_int_l2(code)) * final_scale_sq;
+        q = x;
     }
 
     float symmetric_dis(idx_t i, idx_t j) override {
-        // Not on the critical path for most workloads; reconstruct both
-        // codes into nibbles scalar-style and compute squared distance.
-        const uint8_t* c1 = codes + i * code_size;
-        const uint8_t* c2 = codes + j * code_size;
-        int64_t acc = 0;
-        for (size_t k = 0; k < d; k++) {
-            uint8_t a = (k % 2 == 0) ? (c1[k / 2] & 0x0F) : (c1[k / 2] >> 4);
-            uint8_t b = (k % 2 == 0) ? (c2[k / 2] & 0x0F) : (c2[k / 2] >> 4);
-            int diff = int(a) - int(b);
-            acc += diff * diff;
-        }
-        return static_cast<float>(acc) * final_scale_sq;
+        return compute_code_distance(
+                codes + i * code_size, codes + j * code_size);
+    }
+
+    float query_to_code(const uint8_t* code) const final {
+        return compute_distance(q, code);
     }
 
     void query_to_codes_batch_4(
@@ -293,12 +553,10 @@ struct DCTemplate<
             float& dis1,
             float& dis2,
             float& dis3) const final {
-        // Simple 4x unroll of the single-code path; good enough as a first
-        // cut — gives ILP across the four independent accumulate loops.
-        dis0 = static_cast<float>(accumulate_int_l2(code_0)) * final_scale_sq;
-        dis1 = static_cast<float>(accumulate_int_l2(code_1)) * final_scale_sq;
-        dis2 = static_cast<float>(accumulate_int_l2(code_2)) * final_scale_sq;
-        dis3 = static_cast<float>(accumulate_int_l2(code_3)) * final_scale_sq;
+        dis0 = compute_distance(q, code_0);
+        dis1 = compute_distance(q, code_1);
+        dis2 = compute_distance(q, code_2);
+        dis3 = compute_distance(q, code_3);
     }
 };
 

--- a/faiss/impl/scalar_quantizer/sq-rvv.cpp
+++ b/faiss/impl/scalar_quantizer/sq-rvv.cpp
@@ -409,7 +409,9 @@ struct SimilarityL2<SIMDLevel::RISCV_RVV> : SimilarityL2<SIMDLevel::NONE> {
         vfloat32m8_t yiv = __riscv_vle32_v_f32m8(yi, vl);
         yi += vl;
         vfloat32m8_t tmp = __riscv_vfsub_vv_f32m8(yiv, x, vl);
-        return __riscv_vfmacc_vv_f32m8(accu, tmp, tmp, vl);
+        // tail-undisturbed: the final short iteration must not clobber
+        // accumulator lanes above vl that were filled by earlier iterations
+        return __riscv_vfmacc_vv_f32m8_tu(accu, tmp, tmp, vl);
     }
 
     static FAISS_ALWAYS_INLINE vfloat32m8_t add_m8_components_2(
@@ -418,7 +420,7 @@ struct SimilarityL2<SIMDLevel::RISCV_RVV> : SimilarityL2<SIMDLevel::NONE> {
             vfloat32m8_t y_2,
             size_t vl) {
         vfloat32m8_t tmp = __riscv_vfsub_vv_f32m8(y_2, x, vl);
-        return __riscv_vfmacc_vv_f32m8(accu, tmp, tmp, vl);
+        return __riscv_vfmacc_vv_f32m8_tu(accu, tmp, tmp, vl);
     }
 
     static FAISS_ALWAYS_INLINE float result_m8(vfloat32m8_t accu, size_t vl) {
@@ -446,7 +448,7 @@ struct SimilarityIP<SIMDLevel::RISCV_RVV> : SimilarityIP<SIMDLevel::NONE> {
     add_m8_components(vfloat32m8_t accu, vfloat32m8_t x, size_t vl) {
         vfloat32m8_t yiv = __riscv_vle32_v_f32m8(yi, vl);
         yi += vl;
-        return __riscv_vfmacc_vv_f32m8(accu, yiv, x, vl);
+        return __riscv_vfmacc_vv_f32m8_tu(accu, yiv, x, vl);
     }
 
     static FAISS_ALWAYS_INLINE vfloat32m8_t add_m8_components_2(
@@ -454,7 +456,7 @@ struct SimilarityIP<SIMDLevel::RISCV_RVV> : SimilarityIP<SIMDLevel::NONE> {
             vfloat32m8_t x1,
             vfloat32m8_t x2,
             size_t vl) {
-        return __riscv_vfmacc_vv_f32m8(accu, x1, x2, vl);
+        return __riscv_vfmacc_vv_f32m8_tu(accu, x1, x2, vl);
     }
 
     static FAISS_ALWAYS_INLINE float result_m8(vfloat32m8_t accu, size_t vl) {

--- a/faiss/impl/scalar_quantizer/sq-rvv.cpp
+++ b/faiss/impl/scalar_quantizer/sq-rvv.cpp
@@ -269,9 +269,7 @@ struct QuantizerBF16<SIMDLevel::RISCV_RVV> : QuantizerBF16<SIMDLevel::NONE> {
             vuint32m8_t w = __riscv_vzext_vf2_u32m8(v, vl);
             w = __riscv_vsll_vx_u32m8(w, 16, vl);
             __riscv_vse32_v_f32m8(
-                    x + i,
-                    __riscv_vreinterpret_v_u32m8_f32m8(w),
-                    vl);
+                    x + i, __riscv_vreinterpret_v_u32m8_f32m8(w), vl);
             i += vl;
         }
     }

--- a/faiss/impl/scalar_quantizer/sq-rvv.cpp
+++ b/faiss/impl/scalar_quantizer/sq-rvv.cpp
@@ -37,19 +37,25 @@ template <>
 struct Codec4bit<SIMDLevel::RISCV_RVV> : Codec4bit<SIMDLevel::NONE> {
     static FAISS_ALWAYS_INLINE vfloat32m8_t
     decode_m8_components(const uint8_t* code, size_t i, size_t vl) {
-        const uint8_t* src = code + (i >> 1);
-        size_t byte_vl = (vl + 1) >> 1;
-        vuint8m2_t packed = __riscv_vle8_v_u8m2(src, byte_vl);
+        // Packed positions derive from the absolute component index:
+        // implementations may hand out a non-maximal, non-pack-aligned vl
+        // when AVL is between VLMAX and 2*VLMAX, so a chunk can start on
+        // an odd component (mid-byte).
+        const size_t byte_base = i >> 1;
+        const size_t byte_vl = ((i + vl - 1) >> 1) - byte_base + 1;
+        vuint8m2_t packed = __riscv_vle8_v_u8m2(code + byte_base, byte_vl);
         // Widen to 32-bit lanes before gathering: with more than 256 active
         // lanes (VLEN > 1024 for e32m8) 8-bit lane indices would wrap around
         // and decode the wrong bytes.
         vuint32m8_t packed32 = __riscv_vzext_vf4_u32m8(packed, byte_vl);
-        vuint32m8_t lane = __riscv_vid_v_u32m8(vl);
-        vuint32m8_t bytes = __riscv_vrgather_vv_u32m8(
-                packed32, __riscv_vsrl_vx_u32m8(lane, 1, vl), vl);
+        vuint32m8_t comp =
+                __riscv_vadd_vx_u32m8(__riscv_vid_v_u32m8(vl), i, vl);
+        vuint32m8_t rel = __riscv_vsub_vx_u32m8(
+                __riscv_vsrl_vx_u32m8(comp, 1, vl), byte_base, vl);
+        vuint32m8_t bytes = __riscv_vrgather_vv_u32m8(packed32, rel, vl);
         vuint32m8_t lo = __riscv_vand_vx_u32m8(bytes, 0xf, vl);
         vuint32m8_t hi = __riscv_vsrl_vx_u32m8(bytes, 4, vl);
-        vuint32m8_t parity = __riscv_vand_vx_u32m8(lane, 1, vl);
+        vuint32m8_t parity = __riscv_vand_vx_u32m8(comp, 1, vl);
         vbool4_t odd = __riscv_vmsne_vx_u32m8_b4(parity, 0, vl);
         vuint32m8_t q = __riscv_vmerge_vvm_u32m8(lo, hi, odd, vl);
         vfloat32m8_t result = __riscv_vfcvt_f_xu_v_f32m8(q, vl);
@@ -226,14 +232,19 @@ struct QuantizerLloydMax<1, SIMDLevel::RISCV_RVV>
 
     FAISS_ALWAYS_INLINE vfloat32m8_t
     reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {
-        size_t byte_vl = (vl + 7) >> 3;
-        vuint8m2_t packed = __riscv_vle8_v_u8m2(code + (i >> 3), byte_vl);
+        // Absolute component indexing: a non-maximal vl can leave a chunk
+        // starting mid-byte (see Codec4bit above).
+        const size_t byte_base = i >> 3;
+        const size_t byte_vl = ((i + vl - 1) >> 3) - byte_base + 1;
+        vuint8m2_t packed = __riscv_vle8_v_u8m2(code + byte_base, byte_vl);
         // 32-bit lane indices: 8-bit indices wrap above 256 active lanes
         vuint32m8_t packed32 = __riscv_vzext_vf4_u32m8(packed, byte_vl);
-        vuint32m8_t vid = __riscv_vid_v_u32m8(vl);
-        vuint32m8_t bytes = __riscv_vrgather_vv_u32m8(
-                packed32, __riscv_vsrl_vx_u32m8(vid, 3, vl), vl);
-        vuint32m8_t shift = __riscv_vand_vx_u32m8(vid, 7, vl);
+        vuint32m8_t comp =
+                __riscv_vadd_vx_u32m8(__riscv_vid_v_u32m8(vl), i, vl);
+        vuint32m8_t rel = __riscv_vsub_vx_u32m8(
+                __riscv_vsrl_vx_u32m8(comp, 3, vl), byte_base, vl);
+        vuint32m8_t bytes = __riscv_vrgather_vv_u32m8(packed32, rel, vl);
+        vuint32m8_t shift = __riscv_vand_vx_u32m8(comp, 7, vl);
         vuint32m8_t idx = __riscv_vand_vx_u32m8(
                 __riscv_vsrl_vv_u32m8(bytes, shift, vl), 1, vl);
         vuint32m8_t off = __riscv_vsll_vx_u32m8(idx, 2, vl);
@@ -261,15 +272,20 @@ struct QuantizerLloydMax<2, SIMDLevel::RISCV_RVV>
 
     FAISS_ALWAYS_INLINE vfloat32m8_t
     reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {
-        size_t byte_vl = (vl + 3) >> 2;
-        vuint8m2_t packed = __riscv_vle8_v_u8m2(code + (i >> 2), byte_vl);
+        // Absolute component indexing: a non-maximal vl can leave a chunk
+        // starting mid-byte (see Codec4bit above).
+        const size_t byte_base = i >> 2;
+        const size_t byte_vl = ((i + vl - 1) >> 2) - byte_base + 1;
+        vuint8m2_t packed = __riscv_vle8_v_u8m2(code + byte_base, byte_vl);
         // 32-bit lane indices: 8-bit indices wrap above 256 active lanes
         vuint32m8_t packed32 = __riscv_vzext_vf4_u32m8(packed, byte_vl);
-        vuint32m8_t vid = __riscv_vid_v_u32m8(vl);
-        vuint32m8_t bytes = __riscv_vrgather_vv_u32m8(
-                packed32, __riscv_vsrl_vx_u32m8(vid, 2, vl), vl);
-        vuint32m8_t shift =
-                __riscv_vsll_vx_u32m8(__riscv_vand_vx_u32m8(vid, 3, vl), 1, vl);
+        vuint32m8_t comp =
+                __riscv_vadd_vx_u32m8(__riscv_vid_v_u32m8(vl), i, vl);
+        vuint32m8_t rel = __riscv_vsub_vx_u32m8(
+                __riscv_vsrl_vx_u32m8(comp, 2, vl), byte_base, vl);
+        vuint32m8_t bytes = __riscv_vrgather_vv_u32m8(packed32, rel, vl);
+        vuint32m8_t shift = __riscv_vsll_vx_u32m8(
+                __riscv_vand_vx_u32m8(comp, 3, vl), 1, vl);
         vuint32m8_t idx = __riscv_vand_vx_u32m8(
                 __riscv_vsrl_vv_u32m8(bytes, shift, vl), 3, vl);
         vuint32m8_t off = __riscv_vsll_vx_u32m8(idx, 2, vl);
@@ -341,17 +357,22 @@ struct QuantizerLloydMax<4, SIMDLevel::RISCV_RVV>
 
     FAISS_ALWAYS_INLINE vfloat32m8_t
     reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {
-        size_t byte_vl = (vl + 1) >> 1;
-        vuint8m2_t packed = __riscv_vle8_v_u8m2(code + (i >> 1), byte_vl);
+        // Absolute component indexing: a non-maximal vl can leave a chunk
+        // starting mid-byte (see Codec4bit above).
+        const size_t byte_base = i >> 1;
+        const size_t byte_vl = ((i + vl - 1) >> 1) - byte_base + 1;
+        vuint8m2_t packed = __riscv_vle8_v_u8m2(code + byte_base, byte_vl);
         // 32-bit lane indices: 8-bit indices wrap above 256 active lanes
         vuint32m8_t packed32 = __riscv_vzext_vf4_u32m8(packed, byte_vl);
-        vuint32m8_t vid = __riscv_vid_v_u32m8(vl);
-        vuint32m8_t bytes = __riscv_vrgather_vv_u32m8(
-                packed32, __riscv_vsrl_vx_u32m8(vid, 1, vl), vl);
+        vuint32m8_t comp =
+                __riscv_vadd_vx_u32m8(__riscv_vid_v_u32m8(vl), i, vl);
+        vuint32m8_t rel = __riscv_vsub_vx_u32m8(
+                __riscv_vsrl_vx_u32m8(comp, 1, vl), byte_base, vl);
+        vuint32m8_t bytes = __riscv_vrgather_vv_u32m8(packed32, rel, vl);
         vuint32m8_t lo = __riscv_vand_vx_u32m8(bytes, 0xf, vl);
         vuint32m8_t hi = __riscv_vsrl_vx_u32m8(bytes, 4, vl);
         vbool4_t odd = __riscv_vmsne_vx_u32m8_b4(
-                __riscv_vand_vx_u32m8(vid, 1, vl), 0, vl);
+                __riscv_vand_vx_u32m8(comp, 1, vl), 0, vl);
         vuint32m8_t idx = __riscv_vmerge_vvm_u32m8(lo, hi, odd, vl);
         vuint32m8_t off = __riscv_vsll_vx_u32m8(idx, 2, vl);
         return __riscv_vluxei32_v_f32m8(this->centroids, off, vl);
@@ -504,6 +525,9 @@ struct DCTemplate<Quantizer, Similarity, SIMDLevel::RISCV_RVV>
             : quant(d, trained) {}
 
     float compute_distance(const float* x, const uint8_t* code) const {
+        if (quant.d == 0) {
+            return 0.0f;
+        }
         Similarity sim(x);
         sim.begin_m8();
         const size_t first_vl = __riscv_vsetvl_e32m8(quant.d);
@@ -520,6 +544,9 @@ struct DCTemplate<Quantizer, Similarity, SIMDLevel::RISCV_RVV>
 
     float compute_code_distance(const uint8_t* code1, const uint8_t* code2)
             const {
+        if (quant.d == 0) {
+            return 0.0f;
+        }
         Similarity sim(nullptr);
         sim.begin_m8();
         const size_t first_vl = __riscv_vsetvl_e32m8(quant.d);

--- a/faiss/impl/scalar_quantizer/sq-rvv.cpp
+++ b/faiss/impl/scalar_quantizer/sq-rvv.cpp
@@ -138,6 +138,19 @@ struct QuantizerTemplate<
         return __riscv_vfadd_vf_f32m8(
                 __riscv_vfmul_vf_f32m8(xi, this->vdiff, vl), this->vmin, vl);
     }
+
+    void decode_vector(const uint8_t* code, float* x) const final {
+        size_t i = 0;
+        const size_t d = this->d;
+        while (i < d) {
+            const size_t vl = __riscv_vsetvl_e32m8(d - i);
+            vfloat32m8_t xi = Codec::decode_m8_components(code, i, vl);
+            xi = __riscv_vfmul_vf_f32m8(xi, this->vdiff, vl);
+            xi = __riscv_vfadd_vf_f32m8(xi, this->vmin, vl);
+            __riscv_vse32_v_f32m8(x + i, xi, vl);
+            i += vl;
+        }
+    }
 };
 
 template <class Codec>
@@ -162,6 +175,21 @@ struct QuantizerTemplate<
         vfloat32m8_t vdiffv = __riscv_vle32_v_f32m8(this->vdiff + i, vl);
         return __riscv_vfmadd_vv_f32m8(xi, vdiffv, vminv, vl);
     }
+
+    void decode_vector(const uint8_t* code, float* x) const final {
+        size_t i = 0;
+        const size_t d = this->d;
+        while (i < d) {
+            const size_t vl = __riscv_vsetvl_e32m8(d - i);
+            vfloat32m8_t xi = Codec::decode_m8_components(code, i, vl);
+            vfloat32m8_t vminv = __riscv_vle32_v_f32m8(this->vmin + i, vl);
+            vfloat32m8_t vdiffv = __riscv_vle32_v_f32m8(this->vdiff + i, vl);
+            xi = __riscv_vfmul_vv_f32m8(xi, vdiffv, vl);
+            xi = __riscv_vfadd_vv_f32m8(xi, vminv, vl);
+            __riscv_vse32_v_f32m8(x + i, xi, vl);
+            i += vl;
+        }
+    }
 };
 
 template <>
@@ -182,6 +210,38 @@ struct QuantizerFP16<SIMDLevel::RISCV_RVV> : QuantizerFP16<SIMDLevel::NONE> {
                 __riscv_vle16_v_f16m4((const _Float16*)(code + 2 * i), vl);
         return __riscv_vfwcvt_f_f_v_f32m8(vh, vl);
     }
+
+    void decode_vector(const uint8_t* code, float* x) const final {
+        const auto* code16 = reinterpret_cast<const uint16_t*>(code);
+        size_t i = 0;
+        const size_t d = this->d;
+        while (i < d) {
+            const size_t vl = __riscv_vsetvl_e16m4(d - i);
+            vuint16m4_t vh = __riscv_vle16_v_u16m4(code16 + i, vl);
+            vbool4_t is_nan = __riscv_vmsgtu_vx_u16m4_b4(
+                    __riscv_vand_vx_u16m4(vh, 0x7FFF, vl), 0x7C00, vl);
+            vfloat32m8_t vf = __riscv_vfwcvt_f_f_v_f32m8_m(
+                    __riscv_vmnot_m_b4(is_nan, vl),
+                    __riscv_vreinterpret_v_u16m4_f16m4(vh),
+                    vl);
+            vf = __riscv_vfsub_vf_f32m8_m(
+                    __riscv_vmnot_m_b4(is_nan, vl), vf, 0.0f, vl);
+            if (__riscv_vfirst_m_b4(is_nan, vl) >= 0) {
+                vint32m8_t bits = __riscv_vsext_vf2_i32m8(
+                        __riscv_vreinterpret_v_u16m4_i16m4(vh), vl);
+                bits = __riscv_vsll_vx_i32m8(bits, 13, vl);
+                bits = __riscv_vand_vx_i32m8(bits, -0x70002000, vl);
+                bits = __riscv_vor_vx_i32m8(bits, 0x70000000, vl);
+                vf = __riscv_vmerge_vvm_f32m8(
+                        vf,
+                        __riscv_vreinterpret_v_i32m8_f32m8(bits),
+                        is_nan,
+                        vl);
+            }
+            __riscv_vse32_v_f32m8(x + i, vf, vl);
+            i += vl;
+        }
+    }
 #endif
 };
 
@@ -198,6 +258,23 @@ struct QuantizerBF16<SIMDLevel::RISCV_RVV> : QuantizerBF16<SIMDLevel::NONE> {
         v32 = __riscv_vsll_vx_u32m8(v32, 16, vl);
         return __riscv_vreinterpret_v_u32m8_f32m8(v32);
     }
+
+    void decode_vector(const uint8_t* code, float* x) const final {
+        const auto* code16 = reinterpret_cast<const uint16_t*>(code);
+        size_t i = 0;
+        const size_t d = this->d;
+        while (i < d) {
+            const size_t vl = __riscv_vsetvl_e16m4(d - i);
+            vuint16m4_t v = __riscv_vle16_v_u16m4(code16 + i, vl);
+            vuint32m8_t w = __riscv_vzext_vf2_u32m8(v, vl);
+            w = __riscv_vsll_vx_u32m8(w, 16, vl);
+            __riscv_vse32_v_f32m8(
+                    x + i,
+                    __riscv_vreinterpret_v_u32m8_f32m8(w),
+                    vl);
+            i += vl;
+        }
+    }
 };
 
 template <>
@@ -211,6 +288,19 @@ struct Quantizer8bitDirect<SIMDLevel::RISCV_RVV>
         vuint8m2_t vu8 = __riscv_vle8_v_u8m2(code + i, vl);
         vuint32m8_t vu32 = __riscv_vzext_vf4_u32m8(vu8, vl);
         return __riscv_vfcvt_f_xu_v_f32m8(vu32, vl);
+    }
+
+    void decode_vector(const uint8_t* code, float* x) const final {
+        size_t i = 0;
+        const size_t d = this->d;
+        while (i < d) {
+            const size_t vl = __riscv_vsetvl_e8m2(d - i);
+            vuint8m2_t b = __riscv_vle8_v_u8m2(code + i, vl);
+            vuint16m4_t u = __riscv_vzext_vf2_u16m4(b, vl);
+            vfloat32m8_t f = __riscv_vfwcvt_f_xu_v_f32m8(u, vl);
+            __riscv_vse32_v_f32m8(x + i, f, vl);
+            i += vl;
+        }
     }
 };
 
@@ -226,6 +316,21 @@ struct Quantizer8bitDirectSigned<SIMDLevel::RISCV_RVV>
         vuint32m8_t vu32 = __riscv_vzext_vf4_u32m8(vu8, vl);
         vfloat32m8_t vf = __riscv_vfcvt_f_xu_v_f32m8(vu32, vl);
         return __riscv_vfsub_vf_f32m8(vf, 128.0f, vl);
+    }
+
+    void decode_vector(const uint8_t* code, float* x) const final {
+        size_t i = 0;
+        const size_t d = this->d;
+        while (i < d) {
+            const size_t vl = __riscv_vsetvl_e8m2(d - i);
+            vint8m2_t v = __riscv_vle8_v_i8m2(
+                    reinterpret_cast<const int8_t*>(code) + i, vl);
+            v = __riscv_vxor_vx_i8m2(v, -128, vl);
+            vint16m4_t v16 = __riscv_vsext_vf2_i16m4(v, vl);
+            vfloat32m8_t f = __riscv_vfwcvt_f_x_v_f32m8(v16, vl);
+            __riscv_vse32_v_f32m8(x + i, f, vl);
+            i += vl;
+        }
     }
 };
 

--- a/faiss/impl/scalar_quantizer/sq-rvv.cpp
+++ b/faiss/impl/scalar_quantizer/sq-rvv.cpp
@@ -14,6 +14,7 @@
 #include <faiss/impl/scalar_quantizer/similarities.h>
 
 #include <riscv_vector.h>
+#include <algorithm>
 #include <cmath>
 
 namespace faiss {
@@ -168,6 +169,12 @@ struct QuantizerFP16<SIMDLevel::RISCV_RVV> : QuantizerFP16<SIMDLevel::NONE> {
     QuantizerFP16(size_t d, const std::vector<float>& trained)
             : QuantizerFP16<SIMDLevel::NONE>(d, trained) {}
 
+// Zvfhmin is part of the RISCV_RVV level's minimum ISA (see
+// faiss/utils/simd_levels.h); this translation unit is compiled with
+// -march=rv64gcv_zvfhmin, so the RVV FP16 reconstruction below is always
+// emitted in faiss builds. The preprocessor fallback keeps the scalar FP16
+// path for out-of-tree builds that compile this file without the extension;
+// has_reconstruct_m8_v then resolves to false and QT_fp16 stays scalar.
 #if defined(__riscv_zvfhmin) || defined(__riscv_zvfh)
     FAISS_ALWAYS_INLINE vfloat32m8_t
     reconstruct_m8_components(const uint8_t* code, size_t i, size_t vl) const {

--- a/faiss/utils/simd_levels.cpp
+++ b/faiss/utils/simd_levels.cpp
@@ -342,7 +342,10 @@ SIMDLevel SIMDConfig::auto_detect_simd_level() {
 #endif
 
 #if defined(__riscv) && defined(COMPILE_SIMD_RISCV_RVV)
-    // RVV is always available on RISC-V builds compiled with rv64gcv.
+    // RVV is always available on RISC-V builds compiled with
+    // rv64gcv_zvfhmin: that ISA (including Zvfhmin, used by the QT_fp16
+    // kernels) is the minimum requirement to run such binaries at all,
+    // so no runtime feature check is needed beyond the build contract.
     supported_simd_levels |= (1 << static_cast<int>(SIMDLevel::RISCV_RVV));
     detected_level = SIMDLevel::RISCV_RVV;
 #endif

--- a/faiss/utils/simd_levels.h
+++ b/faiss/utils/simd_levels.h
@@ -26,7 +26,11 @@ enum class SIMDLevel {
     ARM_NEON,
     ARM_SVE, // Scalable Vector Extension (ARMv8.2+)
     // riscv
-    RISCV_RVV, // RISC-V Vector Extension (rv64gcv)
+    // RISC-V Vector Extension. The minimum ISA for this level is rv64gcv
+    // plus Zvfhmin (FP16 vector conversion), which the QT_fp16 kernels
+    // require; RVV translation units are compiled with
+    // -march=rv64gcv_zvfhmin.
+    RISCV_RVV,
 
     // Appended to preserve the numeric values of the existing public enum.
     // AVX-512 core features plus AVX512_VPOPCNTDQ and AVX512_BITALG

--- a/tests/test_scalar_quantizer.cpp
+++ b/tests/test_scalar_quantizer.cpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstring>
@@ -86,6 +87,24 @@ std::vector<faiss::SIMDLevel> available_lloyd_max_simd_levels() {
          {faiss::SIMDLevel::AVX512,
           faiss::SIMDLevel::AVX2,
           faiss::SIMDLevel::ARM_NEON}) {
+        if (faiss::SIMDConfig::is_simd_level_available(level)) {
+            levels.push_back(level);
+        }
+    }
+    return levels;
+}
+
+// SIMD levels with scalar-quantizer kernels that can be checked for parity
+// against the scalar (NONE) path. Unlike dispatch tests, parity tests do not
+// require dimension restrictions, so RISCV_RVV (no alignment constraints)
+// is included here.
+std::vector<faiss::SIMDLevel> available_sq_parity_simd_levels() {
+    std::vector<faiss::SIMDLevel> levels;
+    for (faiss::SIMDLevel level :
+         {faiss::SIMDLevel::AVX512,
+          faiss::SIMDLevel::AVX2,
+          faiss::SIMDLevel::ARM_NEON,
+          faiss::SIMDLevel::RISCV_RVV}) {
         if (faiss::SIMDConfig::is_simd_level_available(level)) {
             levels.push_back(level);
         }
@@ -253,6 +272,156 @@ void check_lloyd_max_distance_path_parity(
                 scalar_scanner->distance_to_code(code),
                 simd_scanner->distance_to_code(code),
                 1e-3);
+    }
+}
+
+// Parity between a SIMD level and the scalar (NONE) path for one quantizer
+// type, metric and dimension. Covers quantizer decoding, the
+// SQDistanceComputer APIs (query_to_code, query_to_codes_batch_4,
+// symmetric_dis) and the inverted-list scanner's distance_to_code.
+void check_sq_distance_path_parity(
+        faiss::SIMDLevel level,
+        faiss::ScalarQuantizer::QuantizerType qtype,
+        faiss::MetricType metric,
+        size_t d) {
+    ScopedSIMDLevel scoped(level);
+    const size_t n = 64;
+    std::vector<float> xb = make_normalized_vectors(n, d);
+    std::vector<float> xq = make_normalized_vectors(1, d);
+
+    faiss::ScalarQuantizer sq(d, qtype);
+    sq.train(n, xb.data());
+
+    std::vector<uint8_t> codes(sq.code_size * n, 0);
+    sq.compute_codes(xb.data(), codes.data(), n);
+
+    // fp16/bf16 codes are raw IEEE bit patterns: arbitrary bytes can decode
+    // to NaN, so only codes produced by compute_codes are checked for those.
+    const bool arbitrary_bytes_ok = qtype != faiss::ScalarQuantizer::QT_fp16 &&
+            qtype != faiss::ScalarQuantizer::QT_bf16;
+
+    std::vector<uint8_t> zero_code(sq.code_size, 0);
+    std::vector<uint8_t> max_code(sq.code_size, 0xff);
+    std::vector<const uint8_t*> query_codes = {
+            codes.data(),
+            codes.data() + sq.code_size,
+            codes.data() + 2 * sq.code_size,
+            codes.data() + 3 * sq.code_size};
+    if (arbitrary_bytes_ok) {
+        query_codes.push_back(zero_code.data());
+        query_codes.push_back(max_code.data());
+    }
+
+    std::unique_ptr<faiss::ScalarQuantizer::SQuantizer> scalar_quant(
+            faiss::scalar_quantizer::sq_select_quantizer<
+                    faiss::SIMDLevel::NONE>(qtype, d, sq.trained));
+    std::unique_ptr<faiss::ScalarQuantizer::SQuantizer> simd_quant(
+            sq.select_quantizer());
+    ASSERT_NE(scalar_quant, nullptr);
+    ASSERT_NE(simd_quant, nullptr);
+
+    for (const uint8_t* code : query_codes) {
+        std::vector<float> ref(d), out(d);
+        scalar_quant->decode_vector(code, ref.data());
+        simd_quant->decode_vector(code, out.data());
+        for (size_t j = 0; j < d; j++) {
+            EXPECT_NEAR(
+                    ref[j], out[j], 1e-5 * std::max(1.0f, std::fabs(ref[j])));
+        }
+    }
+
+    auto expect_distance_near = [](float ref, float out) {
+        EXPECT_NEAR(ref, out, 5e-3 * std::max(1.0f, std::fabs(ref)));
+    };
+
+    std::unique_ptr<faiss::ScalarQuantizer::SQDistanceComputer> scalar_dc(
+            faiss::scalar_quantizer::sq_select_distance_computer<
+                    faiss::SIMDLevel::NONE>(metric, qtype, d, sq.trained));
+    std::unique_ptr<faiss::ScalarQuantizer::SQDistanceComputer> simd_dc(
+            sq.get_distance_computer(metric));
+    ASSERT_NE(scalar_dc, nullptr);
+    ASSERT_NE(simd_dc, nullptr);
+
+    scalar_dc->set_query(xq.data());
+    simd_dc->set_query(xq.data());
+
+    for (const uint8_t* code : query_codes) {
+        expect_distance_near(
+                scalar_dc->query_to_code(code), simd_dc->query_to_code(code));
+    }
+
+    float scalar_dis[4], simd_dis[4];
+    scalar_dc->query_to_codes_batch_4(
+            query_codes[0],
+            query_codes[1],
+            query_codes[2],
+            query_codes[3],
+            scalar_dis[0],
+            scalar_dis[1],
+            scalar_dis[2],
+            scalar_dis[3]);
+    simd_dc->query_to_codes_batch_4(
+            query_codes[0],
+            query_codes[1],
+            query_codes[2],
+            query_codes[3],
+            simd_dis[0],
+            simd_dis[1],
+            simd_dis[2],
+            simd_dis[3]);
+    for (int k = 0; k < 4; k++) {
+        expect_distance_near(scalar_dis[k], simd_dis[k]);
+    }
+
+    std::vector<uint8_t> bundle(4 * sq.code_size, 0);
+    for (int k = 0; k < 4; k++) {
+        std::memcpy(
+                bundle.data() + k * sq.code_size, query_codes[k], sq.code_size);
+    }
+    scalar_dc->codes = bundle.data();
+    scalar_dc->code_size = sq.code_size;
+    simd_dc->codes = bundle.data();
+    simd_dc->code_size = sq.code_size;
+
+    const std::array<std::pair<faiss::idx_t, faiss::idx_t>, 4> pairs = {{
+            {0, 1},
+            {0, 2},
+            {1, 3},
+            {2, 3},
+    }};
+    for (const auto& [lhs, rhs] : pairs) {
+        expect_distance_near(
+                scalar_dc->symmetric_dis(lhs, rhs),
+                simd_dc->symmetric_dis(lhs, rhs));
+    }
+
+    std::unique_ptr<faiss::InvertedListScanner> scalar_scanner(
+            faiss::scalar_quantizer::sq_select_InvertedListScanner<
+                    faiss::SIMDLevel::NONE>(
+                    qtype,
+                    metric,
+                    d,
+                    sq.code_size,
+                    sq.trained,
+                    nullptr,
+                    false,
+                    nullptr,
+                    false));
+    std::unique_ptr<faiss::InvertedListScanner> simd_scanner(
+            sq.select_InvertedListScanner(
+                    metric, nullptr, false, nullptr, false));
+    ASSERT_NE(scalar_scanner, nullptr);
+    ASSERT_NE(simd_scanner, nullptr);
+
+    scalar_scanner->set_query(xq.data());
+    simd_scanner->set_query(xq.data());
+    scalar_scanner->set_list(0, 0.0f);
+    simd_scanner->set_list(0, 0.0f);
+
+    for (const uint8_t* code : query_codes) {
+        expect_distance_near(
+                scalar_scanner->distance_to_code(code),
+                simd_scanner->distance_to_code(code));
     }
 }
 
@@ -652,7 +821,7 @@ TEST(ScalarQuantizer, EDENSimdDispatchSelection) {
 
 TEST(ScalarQuantizer, TQMSESimdDistancePathParity) {
     const std::vector<faiss::SIMDLevel> levels =
-            available_lloyd_max_simd_levels();
+            available_sq_parity_simd_levels();
     if (levels.empty()) {
         GTEST_SKIP() << "No SIMD level available for TurboQuant parity tests";
     }
@@ -674,7 +843,7 @@ TEST(ScalarQuantizer, TQMSESimdDistancePathParity) {
 
 TEST(ScalarQuantizer, EDENSimdDistancePathParity) {
     const std::vector<faiss::SIMDLevel> levels =
-            available_lloyd_max_simd_levels();
+            available_sq_parity_simd_levels();
     if (levels.empty()) {
         GTEST_SKIP() << "No SIMD level available for EDEN parity tests";
     }
@@ -691,5 +860,51 @@ TEST(ScalarQuantizer, EDENSimdDistancePathParity) {
                 level, faiss::ScalarQuantizer::QT_4bit_eden);
         check_lloyd_max_distance_path_parity<8>(
                 level, faiss::ScalarQuantizer::QT_8bit_eden);
+    }
+}
+
+// RVV-versus-scalar parity for all quantizers with RVV kernels, over both
+// metrics and dimensions around VLMAX boundaries. With e32m8 vectors,
+// VLMAX = VLEN / 4: 32 lanes on QEMU's default VLEN=128 and up to 256+
+// lanes on wide hardware, so the dimensions below straddle those chunk
+// boundaries as well as tiny tails.
+TEST(ScalarQuantizer, RVVDistancePathParity) {
+    if (!faiss::SIMDConfig::is_simd_level_available(
+                faiss::SIMDLevel::RISCV_RVV)) {
+        GTEST_SKIP() << "RISCV_RVV not available on this machine";
+    }
+
+    const std::vector<faiss::ScalarQuantizer::QuantizerType> qtypes = {
+            faiss::ScalarQuantizer::QT_8bit,
+            faiss::ScalarQuantizer::QT_4bit,
+            faiss::ScalarQuantizer::QT_6bit,
+            faiss::ScalarQuantizer::QT_8bit_uniform,
+            faiss::ScalarQuantizer::QT_4bit_uniform,
+            faiss::ScalarQuantizer::QT_fp16,
+            faiss::ScalarQuantizer::QT_bf16,
+            faiss::ScalarQuantizer::QT_8bit_direct,
+            faiss::ScalarQuantizer::QT_8bit_direct_signed,
+            faiss::ScalarQuantizer::QT_1bit_eden,
+            faiss::ScalarQuantizer::QT_2bit_eden,
+            faiss::ScalarQuantizer::QT_3bit_eden,
+            faiss::ScalarQuantizer::QT_4bit_eden,
+            faiss::ScalarQuantizer::QT_8bit_eden,
+    };
+    const std::vector<size_t> dims = {
+            1, 7, 31, 32, 33, 63, 64, 65, 127, 128, 129, 255, 256, 257};
+    const std::vector<faiss::MetricType> metrics = {
+            faiss::METRIC_L2, faiss::METRIC_INNER_PRODUCT};
+
+    for (auto qtype : qtypes) {
+        for (size_t d : dims) {
+            for (auto metric : metrics) {
+                SCOPED_TRACE(
+                        testing::Message()
+                        << "qtype=" << static_cast<int>(qtype) << " d=" << d
+                        << " metric=" << metric);
+                check_sq_distance_path_parity(
+                        faiss::SIMDLevel::RISCV_RVV, qtype, metric, d);
+            }
+        }
     }
 }

--- a/tests/test_scalar_quantizer.cpp
+++ b/tests/test_scalar_quantizer.cpp
@@ -891,9 +891,23 @@ TEST(ScalarQuantizer, RVVDistancePathParity) {
             faiss::ScalarQuantizer::QT_8bit_eden,
     };
     const std::vector<size_t> dims = {
-            1,   7,   31,  32,  33,  63,  64,
-            65,  127, 128, 129, 255, 256, 257,
-            511, 512, 513};
+            1,
+            7,
+            31,
+            32,
+            33,
+            63,
+            64,
+            65,
+            127,
+            128,
+            129,
+            255,
+            256,
+            257,
+            511,
+            512,
+            513};
     const std::vector<faiss::MetricType> metrics = {
             faiss::METRIC_L2, faiss::METRIC_INNER_PRODUCT};
 

--- a/tests/test_scalar_quantizer.cpp
+++ b/tests/test_scalar_quantizer.cpp
@@ -865,9 +865,9 @@ TEST(ScalarQuantizer, EDENSimdDistancePathParity) {
 
 // RVV-versus-scalar parity for all quantizers with RVV kernels, over both
 // metrics and dimensions around VLMAX boundaries. With e32m8 vectors,
-// VLMAX = VLEN / 4: 32 lanes on QEMU's default VLEN=128 and up to 256+
-// lanes on wide hardware, so the dimensions below straddle those chunk
-// boundaries as well as tiny tails.
+// VLMAX = VLEN / 4: 32 lanes on QEMU's default VLEN=128 and up to 512
+// lanes on VLEN=2048 hardware, so the dimensions below straddle those
+// chunk boundaries as well as tiny tails.
 TEST(ScalarQuantizer, RVVDistancePathParity) {
     if (!faiss::SIMDConfig::is_simd_level_available(
                 faiss::SIMDLevel::RISCV_RVV)) {
@@ -891,7 +891,9 @@ TEST(ScalarQuantizer, RVVDistancePathParity) {
             faiss::ScalarQuantizer::QT_8bit_eden,
     };
     const std::vector<size_t> dims = {
-            1, 7, 31, 32, 33, 63, 64, 65, 127, 128, 129, 255, 256, 257};
+            1,   7,   31,  32,  33,  63,  64,
+            65,  127, 128, 129, 255, 256, 257,
+            511, 512, 513};
     const std::vector<faiss::MetricType> metrics = {
             faiss::METRIC_L2, faiss::METRIC_INNER_PRODUCT};
 

--- a/tests/test_scalar_quantizer.cpp
+++ b/tests/test_scalar_quantizer.cpp
@@ -868,6 +868,8 @@ TEST(ScalarQuantizer, EDENSimdDistancePathParity) {
 // VLMAX = VLEN / 4: 32 lanes on QEMU's default VLEN=128 and up to 512
 // lanes on VLEN=2048 hardware, so the dimensions below straddle those
 // chunk boundaries as well as tiny tails.
+// QT_fp16 is covered by the dedicated RVVFP16DistancePathParity test below
+// so that the Zvfhmin-dependent case is visible individually in test logs.
 TEST(ScalarQuantizer, RVVDistancePathParity) {
     if (!faiss::SIMDConfig::is_simd_level_available(
                 faiss::SIMDLevel::RISCV_RVV)) {
@@ -880,7 +882,6 @@ TEST(ScalarQuantizer, RVVDistancePathParity) {
             faiss::ScalarQuantizer::QT_6bit,
             faiss::ScalarQuantizer::QT_8bit_uniform,
             faiss::ScalarQuantizer::QT_4bit_uniform,
-            faiss::ScalarQuantizer::QT_fp16,
             faiss::ScalarQuantizer::QT_bf16,
             faiss::ScalarQuantizer::QT_8bit_direct,
             faiss::ScalarQuantizer::QT_8bit_direct_signed,
@@ -889,6 +890,14 @@ TEST(ScalarQuantizer, RVVDistancePathParity) {
             faiss::ScalarQuantizer::QT_3bit_eden,
             faiss::ScalarQuantizer::QT_4bit_eden,
             faiss::ScalarQuantizer::QT_8bit_eden,
+            // The QT_*_tqmse types currently alias QuantizerLloydMax, so
+            // they share the EDEN RVV kernels; listing them makes that
+            // dispatch coverage explicit for every metric and distance API.
+            faiss::ScalarQuantizer::QT_1bit_tqmse,
+            faiss::ScalarQuantizer::QT_2bit_tqmse,
+            faiss::ScalarQuantizer::QT_3bit_tqmse,
+            faiss::ScalarQuantizer::QT_4bit_tqmse,
+            faiss::ScalarQuantizer::QT_8bit_tqmse,
     };
     const std::vector<size_t> dims = {
             1,
@@ -921,6 +930,157 @@ TEST(ScalarQuantizer, RVVDistancePathParity) {
                 check_sq_distance_path_parity(
                         faiss::SIMDLevel::RISCV_RVV, qtype, metric, d);
             }
+        }
+    }
+}
+
+// QT_fp16 RVV-versus-scalar parity, split out of RVVDistancePathParity so
+// the Zvfhmin-dependent case shows up individually in test logs. The RVV
+// FP16 kernel emits Zvfhmin instructions, so this test only runs where the
+// CPU/emulator enables the extension (CI uses -cpu rv64,v=true,
+// x-zvfhmin=true); without it the process would die with SIGILL, which is
+// what makes this test a check that the FP16 case genuinely executes.
+TEST(ScalarQuantizer, RVVFP16DistancePathParity) {
+    if (!faiss::SIMDConfig::is_simd_level_available(
+                faiss::SIMDLevel::RISCV_RVV)) {
+        GTEST_SKIP() << "RISCV_RVV not available on this machine";
+    }
+
+    const std::vector<size_t> dims = {
+            1,
+            7,
+            31,
+            32,
+            33,
+            63,
+            64,
+            65,
+            127,
+            128,
+            129,
+            255,
+            256,
+            257,
+            511,
+            512,
+            513};
+    const std::vector<faiss::MetricType> metrics = {
+            faiss::METRIC_L2, faiss::METRIC_INNER_PRODUCT};
+
+    for (size_t d : dims) {
+        for (auto metric : metrics) {
+            SCOPED_TRACE(
+                    testing::Message() << "d=" << d << " metric=" << metric);
+            check_sq_distance_path_parity(
+                    faiss::SIMDLevel::RISCV_RVV,
+                    faiss::ScalarQuantizer::QT_fp16,
+                    metric,
+                    d);
+        }
+    }
+}
+
+// Zero-dimensional regression for the d == 0 early returns in the RVV
+// DCTemplate distance loops: query_to_code, query_to_codes_batch_4 and
+// symmetric_dis must return exactly 0 without touching the query pointer or
+// the codes, matching the scalar (NONE) path. The parity dimension lists
+// above start at 1, so this case is covered here directly.
+TEST(ScalarQuantizer, RVVZeroDimDistancePathParity) {
+    if (!faiss::SIMDConfig::is_simd_level_available(
+                faiss::SIMDLevel::RISCV_RVV)) {
+        GTEST_SKIP() << "RISCV_RVV not available on this machine";
+    }
+    ScopedSIMDLevel scoped(faiss::SIMDLevel::RISCV_RVV);
+
+    // trained layouts each quantizer expects at d == 0: non-uniform
+    // templates take 2 * d (empty) values, uniform templates take {vmin,
+    // vdiff}, LloydMax takes 2^k - 1 centroids/boundaries, and the raw
+    // codecs (fp16/bf16/direct) ignore trained entirely.
+    const std::vector<std::pair<
+            faiss::ScalarQuantizer::QuantizerType,
+            std::vector<float>>>
+            cases = {
+                    {faiss::ScalarQuantizer::QT_8bit, {}},
+                    {faiss::ScalarQuantizer::QT_4bit, {}},
+                    {faiss::ScalarQuantizer::QT_6bit, {}},
+                    {faiss::ScalarQuantizer::QT_8bit_uniform, {0.0f, 1.0f}},
+                    {faiss::ScalarQuantizer::QT_4bit_uniform, {0.0f, 1.0f}},
+                    {faiss::ScalarQuantizer::QT_fp16, {}},
+                    {faiss::ScalarQuantizer::QT_bf16, {}},
+                    {faiss::ScalarQuantizer::QT_8bit_direct, {}},
+                    {faiss::ScalarQuantizer::QT_8bit_direct_signed, {}},
+                    {faiss::ScalarQuantizer::QT_1bit_eden,
+                     std::vector<float>(3, 0.0f)},
+                    {faiss::ScalarQuantizer::QT_2bit_eden,
+                     std::vector<float>(7, 0.0f)},
+                    {faiss::ScalarQuantizer::QT_3bit_eden,
+                     std::vector<float>(15, 0.0f)},
+                    {faiss::ScalarQuantizer::QT_4bit_eden,
+                     std::vector<float>(31, 0.0f)},
+                    {faiss::ScalarQuantizer::QT_8bit_eden,
+                     std::vector<float>(511, 0.0f)},
+            };
+    const std::vector<faiss::MetricType> metrics = {
+            faiss::METRIC_L2, faiss::METRIC_INNER_PRODUCT};
+
+    uint8_t dummy_code[8] = {};
+
+    for (const auto& [qtype, trained] : cases) {
+        for (auto metric : metrics) {
+            SCOPED_TRACE(
+                    testing::Message() << "qtype=" << static_cast<int>(qtype)
+                                       << " metric=" << metric);
+
+            faiss::ScalarQuantizer sq(0, qtype);
+            sq.trained = trained;
+
+            std::unique_ptr<faiss::ScalarQuantizer::SQDistanceComputer>
+                    scalar_dc(
+                            faiss::scalar_quantizer::
+                                    sq_select_distance_computer<
+                                            faiss::SIMDLevel::NONE>(
+                                            metric, qtype, 0, sq.trained));
+            std::unique_ptr<faiss::ScalarQuantizer::SQDistanceComputer> simd_dc(
+                    sq.get_distance_computer(metric));
+            ASSERT_NE(scalar_dc, nullptr);
+            ASSERT_NE(simd_dc, nullptr);
+
+            scalar_dc->set_query(nullptr);
+            simd_dc->set_query(nullptr);
+
+            EXPECT_FLOAT_EQ(scalar_dc->query_to_code(dummy_code), 0.0f);
+            EXPECT_FLOAT_EQ(simd_dc->query_to_code(dummy_code), 0.0f);
+
+            float scalar_dis[4], simd_dis[4];
+            scalar_dc->query_to_codes_batch_4(
+                    dummy_code,
+                    dummy_code,
+                    dummy_code,
+                    dummy_code,
+                    scalar_dis[0],
+                    scalar_dis[1],
+                    scalar_dis[2],
+                    scalar_dis[3]);
+            simd_dc->query_to_codes_batch_4(
+                    dummy_code,
+                    dummy_code,
+                    dummy_code,
+                    dummy_code,
+                    simd_dis[0],
+                    simd_dis[1],
+                    simd_dis[2],
+                    simd_dis[3]);
+            for (int k = 0; k < 4; k++) {
+                EXPECT_FLOAT_EQ(scalar_dis[k], 0.0f);
+                EXPECT_FLOAT_EQ(simd_dis[k], 0.0f);
+            }
+
+            scalar_dc->codes = dummy_code;
+            scalar_dc->code_size = 0;
+            simd_dc->codes = dummy_code;
+            simd_dc->code_size = 0;
+            EXPECT_FLOAT_EQ(scalar_dc->symmetric_dis(0, 1), 0.0f);
+            EXPECT_FLOAT_EQ(simd_dc->symmetric_dis(0, 1), 0.0f);
         }
     }
 }


### PR DESCRIPTION
Builds on #5535 — please merge that first. This branch is based on top of it and will retarget `main` once it lands. Reviewers: @juancarpio27 (context from #5535 applies directly here).

## What this adds

`ScalarQuantizer::decode()` currently inherits the scalar `decode_vector` from the `NONE` base even when an RVV quantizer is selected (#5535 only adds RVV decode for the Lloyd-Max types). This PR adds RVV `decode_vector` kernels for the standard quantizer types:

- `QuantizerFP16<RISCV_RVV>`, `Quantizer8bitDirect<RISCV_RVV>`, `Quantizer8bitDirectSigned<RISCV_RVV>` — dedicated kernels
- `QuantizerTemplate<Codec8bit/Codec4bit, ...>` (uniform and non-uniform) —  generic codec-template kernels reusing `Codec::decode_m8_components` from #5535
- `quantizers.h`: the `NONE` bases' `decode_vector` becomes virtual (`final` → `override`) so the RVV specializations can override it — the only change outside `sq-rvv.cpp`

## Design

- **Bit-exactness is the contract.** The kernels keep the scalar path's four separate rounding steps (round, /255 or /15, mul, add) instead of fusing them with `vfmadd`, and reproduce its NaN / -0 behavior (the FP16 kernel uses masked widening to keep sNaN out of FP conversion and repairs NaN lanes). Verified on hardware: `sql2_recons_error` and `ndiff_for_idempotence` are bit-identical to the scalar path for all quantizers.
- 4-bit uses stride-2 interleaved loads/stores (`vlse32`/`vsse32`) rather than `vrgather`.
- All kernels are single strip-mined `while` loops driven by `vsetvl`, with m8-class vectors.

## Performance (SG2044, d=128, n=2000, 20 iterations, single-threaded)

The timed loop body is a single `sq.decode()` call over the whole 2000-vector batch (train/encode/data setup are outside the loop). A perf-stat run and an independent perf-record run are both reported; they agree (load average ~100–120 on the 64-core box, so cpu_time and counters are the reliable signal).

| benchmark             |     baseline |   this PR | speedup (stat) | speedup (record) |
|-----------------------|------------:|----------:|---------------:|-----------------:|
| QT_8bit_uniform       |   1,334,617 |   410,968 |         3.25x  |           3.14x  |
| QT_8bit               |   1,342,880 |   469,559 |         2.86x  |           2.75x  |
| QT_fp16               |     784,434 |   302,905 |         2.59x  |           2.55x  |
| QT_8bit_direct        |     454,681 |   210,671 |         2.16x  |           1.84x  |
| QT_bf16               |     506,924 |   243,206 |         2.08x  |           1.95x  |
| QT_4bit               |   1,379,050 |   689,926 |         2.00x  |           1.91x  |
| QT_8bit_direct_signed |     459,205 |   241,233 |         1.90x  |           1.57x  |
| QT_4bit_uniform       |   1,304,938 |   736,746 |         1.77x  |           1.80x  |

Geometric mean: 2.28x (stat) / 2.13x (record). Whole-process perf counters (train/encode included, still scalar): instructions −54%, branches −57%, LLC loads −52%, cycles −16%.

## QT_6bit

Intentionally left scalar: the packed 6-bit decode needs indexed (`vluxei32`) loads, which are micro-coded and slow on current cores (0.51x on SG2044) — the same root cause as the 6-bit distance regression under discussion on #5535. It will follow whatever that PR decides (scalar fallback, or a segment-load rework that fixes both paths at once).

## Tests

- [ ] Extend the RVV-vs-scalar parity helper from #5535 to cover `decode_vector` / batch `decode()` for every supported type, with dimensions around the VLMAX boundaries
- [x] Hardware validation on SG2044: all `bench_scalar_quantizer_*` suites pass (stat + record phases); recons errors and idempotence bit-identical (numbers above)